### PR TITLE
Add types and selectors for guest agent info

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/file-system-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/file-system-info.ts
@@ -1,0 +1,35 @@
+import {
+  V1VirtualMachineInstanceFileSystem,
+  V1VirtualMachineInstanceFileSystemInfo,
+  V1VirtualMachineInstanceFileSystemList,
+} from '../../types/vmi-guest-data-info/vmi-guest-agent-info';
+
+// Selectors for V1VirtualMachineInstanceFileSystem
+export const getFileSystemDiskName = (fileSystem: V1VirtualMachineInstanceFileSystem): string =>
+  fileSystem?.diskName;
+
+export const getFileSystemType = (fileSystem: V1VirtualMachineInstanceFileSystem): string =>
+  fileSystem?.fileSystemType;
+
+export const getFileSystemMountPoint = (fileSystem: V1VirtualMachineInstanceFileSystem): string =>
+  fileSystem?.mountPoint;
+
+export const getFileSystemTotalBytes = (fileSystem: V1VirtualMachineInstanceFileSystem): number =>
+  fileSystem?.totalBytes;
+
+export const getFileSystemUsedBytes = (fileSystem: V1VirtualMachineInstanceFileSystem): number =>
+  fileSystem?.usedBytes;
+
+// Selectors for V1VirtualMachineInstanceFileSystemInfo
+export const getFileSystemInfoDisks = (
+  fileSystemInfo: V1VirtualMachineInstanceFileSystemInfo,
+): V1VirtualMachineInstanceFileSystem[] => fileSystemInfo?.disks;
+
+// Selectors for V1VirtualMachineInstanceFileSystemList
+export const getFileSystemListAPIVersion = (
+  fileSystemList: V1VirtualMachineInstanceFileSystemList,
+): string => fileSystemList?.apiVersion;
+
+export const getFileSystemListItems = (
+  fileSystemList: V1VirtualMachineInstanceFileSystemList,
+): V1VirtualMachineInstanceFileSystem[] => fileSystemList?.items;

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/guest-agent-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/guest-agent-info.ts
@@ -1,0 +1,34 @@
+import {
+  V1VirtualMachineInstanceFileSystemInfo,
+  V1VirtualMachineInstanceGuestAgentInfo,
+  V1VirtualMachineInstanceGuestOSInfo,
+  V1VirtualMachineInstanceGuestOSUser,
+} from '../../types/vmi-guest-data-info/vmi-guest-agent-info';
+
+export const getGuestAgentInfoAPIVersion = (
+  guestAgentInfo: V1VirtualMachineInstanceGuestAgentInfo,
+): string => guestAgentInfo?.apiVersion;
+
+export const getGuestAgentInfoFSInfo = (
+  guestAgentInfo: V1VirtualMachineInstanceGuestAgentInfo,
+): V1VirtualMachineInstanceFileSystemInfo => guestAgentInfo?.fsInfo;
+
+export const getGuestAgentInfoGAVersion = (
+  guestAgentInfo: V1VirtualMachineInstanceGuestAgentInfo,
+): string => guestAgentInfo?.guestAgentVersion;
+
+export const getGuestAgentInfoHostname = (
+  guestAgentInfo: V1VirtualMachineInstanceGuestAgentInfo,
+): string => guestAgentInfo?.hostname;
+
+export const getGuestAgentInfoOS = (
+  guestAgentInfo: V1VirtualMachineInstanceGuestAgentInfo,
+): V1VirtualMachineInstanceGuestOSInfo => guestAgentInfo?.os;
+
+export const getGuestAgentInfoTimezone = (
+  guestAgentInfo: V1VirtualMachineInstanceGuestAgentInfo,
+): string => guestAgentInfo?.timezone;
+
+export const getGuestAgentInfoUserList = (
+  guestAgentInfo: V1VirtualMachineInstanceGuestAgentInfo,
+): V1VirtualMachineInstanceGuestOSUser[] => guestAgentInfo?.userList;

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/guest-os-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/guest-os-info.ts
@@ -1,0 +1,25 @@
+import { V1VirtualMachineInstanceGuestOSInfo } from '../../types/vmi-guest-data-info/vmi-guest-agent-info';
+
+export const getGuestOSID = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.id;
+
+export const getGuestOSKernelRelease = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.kernelRelease;
+
+export const getGuestOSKernelVersion = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.kernelVersion;
+
+export const getGuestOSMachine = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.machine;
+
+export const getGuestOSName = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.name;
+
+export const getGuestOSPrettyName = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.prettyName;
+
+export const getGuestOSVersion = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.version;
+
+export const getGuestOSVersionId = (guestOSInfo: V1VirtualMachineInstanceGuestOSInfo): string =>
+  guestOSInfo?.versionId;

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/guest-os-user-list.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi-guest-agent-info/guest-os-user-list.ts
@@ -1,0 +1,23 @@
+import {
+  V1VirtualMachineInstanceGuestOSUser,
+  V1VirtualMachineInstanceGuestOSUserList,
+} from '../../types/vmi-guest-data-info/vmi-guest-agent-info';
+
+// Selectors for V1VirtualMachineInstanceGuestOSUser
+export const getGuestOSUserDomain = (guestOSUser: V1VirtualMachineInstanceGuestOSUser): string =>
+  guestOSUser?.domain;
+
+export const getGuestOSUserLoginTime = (guestOSUser: V1VirtualMachineInstanceGuestOSUser): number =>
+  guestOSUser?.loginTime;
+
+export const getGuestOSUserUserName = (guestOSUser: V1VirtualMachineInstanceGuestOSUser): string =>
+  guestOSUser?.userName;
+
+// Selectors for V1VirtualMachineInstanceGuestOSUserList
+export const getGuestOSUserListAPIVersion = (
+  guestOSUserList: V1VirtualMachineInstanceGuestOSUserList,
+): string => guestOSUserList?.apiVersion;
+
+export const getGuestOSUserListItems = (
+  guestOSUserList: V1VirtualMachineInstanceGuestOSUserList,
+): V1VirtualMachineInstanceGuestOSUser[] => guestOSUserList?.items;

--- a/frontend/packages/kubevirt-plugin/src/types/vmi-guest-data-info/vmi-guest-agent-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vmi-guest-data-info/vmi-guest-agent-info.ts
@@ -1,0 +1,62 @@
+import { ObjectMetadata } from '@console/internal/module/k8s';
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestosinfo
+export type V1VirtualMachineInstanceGuestOSInfo = {
+  id?: string;
+  kernelRelease?: string;
+  kernelVersion?: string;
+  machine?: string;
+  name?: string;
+  prettyName?: string;
+  version?: string;
+  versionId?: string;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestosuser
+export type V1VirtualMachineInstanceGuestOSUser = {
+  domain?: string;
+  loginTime?: number;
+  userName: string;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestosuserlist
+export type V1VirtualMachineInstanceGuestOSUserList = {
+  apiVersion?: string;
+  items: V1VirtualMachineInstanceGuestOSUser[];
+  kind?: string;
+  metadata?: ObjectMetadata;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesystem
+export type V1VirtualMachineInstanceFileSystem = {
+  diskName?: string;
+  fileSystemType: string;
+  mountPoint: string;
+  totalBytes: number;
+  usedBytes: number;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesysteminfo
+export type V1VirtualMachineInstanceFileSystemInfo = {
+  disks: V1VirtualMachineInstanceFileSystem[];
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesystemlist
+export type V1VirtualMachineInstanceFileSystemList = {
+  apiVersion?: string;
+  items: V1VirtualMachineInstanceFileSystem[];
+  kind?: string;
+  metadata?: ObjectMetadata;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestagentinfo
+export type V1VirtualMachineInstanceGuestAgentInfo = {
+  apiVersion?: string;
+  fsInfo?: V1VirtualMachineInstanceFileSystemInfo;
+  guestAgentVersion?: string;
+  hostname?: string;
+  kind?: string;
+  os?: V1VirtualMachineInstanceGuestOSInfo;
+  timezone?: string;
+  userList?: V1VirtualMachineInstanceGuestOSUser[];
+};


### PR DESCRIPTION
This PR adds support for using the guest agent information added to kubevirt in [1] and [2].

[1] https://github.com/kubevirt/kubevirt/pull/2827
[2] https://github.com/kubevirt/kubevirt/pull/3039