### PR TITLE
Bug 1839883: Pipeline Builder supports invalid task refs

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/const.ts
@@ -6,6 +6,7 @@ export enum UpdateOperationType {
   UPDATE_TASK,
   REMOVE_TASK,
   DELETE_LIST_TASK,
+  FIX_INVALID_LIST_TASK,
 }
 
 export enum TaskErrorType {

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/types.ts
@@ -67,6 +67,11 @@ export type UpdateOperationConvertToTaskData = UpdateOperationBaseData & {
   resource: PipelineResourceTask;
   runAfter?: string[];
 };
+export type UpdateOperationFixInvalidTaskListData = UpdateOperationBaseData & {
+  existingName: string;
+  resource: PipelineResourceTask;
+  runAfter?: string[];
+};
 export type UpdateOperationDeleteListTaskData = UpdateOperationBaseData & {
   listTaskName: string;
 };

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -19,6 +19,7 @@ import {
   UpdateOperationAddData,
   UpdateOperationConvertToTaskData,
   UpdateOperationDeleteListTaskData,
+  UpdateOperationFixInvalidTaskListData,
   UpdateOperationRemoveTaskData,
   UpdateOperationUpdateTaskData,
   UpdateTaskParamData,
@@ -376,6 +377,29 @@ const updateTask: UpdateOperationAction<UpdateOperationUpdateTaskData> = (
   };
 };
 
+const fixInvalidListTask: UpdateOperationAction<UpdateOperationFixInvalidTaskListData> = (
+  tasks,
+  listTasks,
+  data,
+) => {
+  const { existingName, resource, runAfter } = data;
+
+  const newPipelineTask: PipelineTask = convertResourceToTask(resource, runAfter);
+
+  return {
+    tasks: [
+      ...tasks
+        .filter((pipelineTask) => pipelineTask.name !== existingName)
+        .map((pipelineTask) =>
+          mapReplaceRelatedInOthers(newPipelineTask.name, existingName, pipelineTask),
+        ),
+      newPipelineTask,
+    ],
+    listTasks,
+    errors: getErrors(newPipelineTask, resource),
+  };
+};
+
 export const applyChange = (
   taskGroup: PipelineBuilderTaskGroup,
   op: UpdateOperation,
@@ -394,6 +418,8 @@ export const applyChange = (
       return removeTask(tasks, listTasks, data as UpdateOperationRemoveTaskData);
     case UpdateOperationType.UPDATE_TASK:
       return updateTask(tasks, listTasks, data as UpdateOperationUpdateTaskData);
+    case UpdateOperationType.FIX_INVALID_LIST_TASK:
+      return fixInvalidListTask(tasks, listTasks, data as UpdateOperationFixInvalidTaskListData);
     default:
       throw new Error(`Invalid update operation ${type}`);
   }

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/BuilderNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/BuilderNode.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Node, observer } from '@console/topology';
+import { Node, NodeModel, observer } from '@console/topology';
 import {
   AddNodeDirection,
   BUILDER_NODE_ADD_RADIUS,
@@ -12,10 +12,14 @@ import TaskNode from './TaskNode';
 import { BuilderNodeModelData } from './types';
 import { TooltipPosition } from '@patternfly/react-core';
 
-const BuilderNode: React.FC<{ element: Node }> = ({ element }) => {
+type BuilderNodeProps = {
+  element: Node<NodeModel, BuilderNodeModelData>;
+};
+
+const BuilderNode: React.FC<BuilderNodeProps> = ({ element }) => {
   const [showAdd, setShowAdd] = React.useState(false);
   const { width, height } = element.getBounds();
-  const data: BuilderNodeModelData = element.getData();
+  const data = element.getData();
   const { error, onAddNode, onNodeSelection } = data;
 
   return (

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/InvalidTaskListNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/InvalidTaskListNode.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Node, NodeModel, observer } from '@console/topology';
+import { BUILDER_NODE_ERROR_RADIUS } from './const';
+import ErrorNodeDecorator from './ErrorNodeDecorator';
+import TaskListNode from './TaskListNode';
+import { TaskListNodeModelData } from './types';
+
+type InvalidTaskListNodeProps = {
+  element: Node<NodeModel, TaskListNodeModelData>;
+};
+
+const InvalidTaskListNode: React.FC<InvalidTaskListNodeProps> = ({ element }) => {
+  const {
+    task: { name },
+  } = element.getData();
+
+  return (
+    <g>
+      <TaskListNode element={element} unselectedText={name} />
+      <ErrorNodeDecorator
+        x={BUILDER_NODE_ERROR_RADIUS / 2}
+        y={BUILDER_NODE_ERROR_RADIUS / 4}
+        errorStr="Task does not exist"
+      />
+    </g>
+  );
+};
+
+export default observer(InvalidTaskListNode);

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.scss
@@ -1,6 +1,11 @@
 .odc-task-list-node {
   border: 1px solid var(--pf-global--BorderColor--light-100);
 
+  &__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   &__trigger-background {
     background: var(--pf-global--BackgroundColor--light-100);
   }

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import * as FocusTrap from 'focus-trap-react';
-import { Button } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import Popper from '@console/shared/src/components/popper/Popper';
 import { KebabItem, KebabOption } from '@console/internal/components/utils';
-import { observer, Node } from '@console/topology';
+import { observer, Node, NodeModel } from '@console/topology';
 import { PipelineResourceTask } from '../../../utils/pipeline-augment';
 import { NewTaskNodeCallback, TaskListNodeModelData } from './types';
 
@@ -23,16 +23,16 @@ const taskToOption = (task: PipelineResourceTask, callback: NewTaskNodeCallback)
   };
 };
 
-const TaskListNode: React.FC<{ element: Node }> = ({ element }) => {
+type TaskListNodeProps = {
+  element: Node<NodeModel, TaskListNodeModelData>;
+  unselectedText?: string;
+};
+
+const TaskListNode: React.FC<TaskListNodeProps> = ({ element, unselectedText }) => {
   const triggerRef = React.useRef(null);
   const [isMenuOpen, setMenuOpen] = React.useState(false);
   const { height, width } = element.getBounds();
-  const {
-    clusterTaskList,
-    namespaceTaskList,
-    onNewTask,
-    onRemoveTask,
-  } = element.getData() as TaskListNodeModelData;
+  const { clusterTaskList, namespaceTaskList, onNewTask, onRemoveTask } = element.getData();
 
   const options = [
     ...namespaceTaskList.map((task) => taskToOption(task, onNewTask)),
@@ -53,9 +53,22 @@ const TaskListNode: React.FC<{ element: Node }> = ({ element }) => {
           {options.length === 0 ? (
             'No Tasks'
           ) : (
-            <>
-              Select task <CaretDownIcon />
-            </>
+            <Flex
+              breakpointMods={[
+                { modifier: FlexModifiers.nowrap },
+                { modifier: FlexModifiers['space-items-none'] },
+              ]}
+            >
+              <FlexItem
+                className="odc-task-list-node__label"
+                breakpointMods={[{ modifier: FlexModifiers.grow }]}
+              >
+                {unselectedText || 'Select task'}
+              </FlexItem>
+              <FlexItem>
+                <CaretDownIcon />
+              </FlexItem>
+            </Flex>
           )}
         </Button>
       </div>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskNode.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
-import { observer, Node } from '@console/topology';
+import { observer, Node, NodeModel } from '@console/topology';
 import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
 import { PipelineVisualizationTask } from '../detail-page-tabs/pipeline-details/PipelineVisualizationTask';
 import { DROP_SHADOW_SPACING } from './const';
 import { TaskNodeModelData } from './types';
 
-const TaskNode: React.FC<{ element: Node; disableTooltip?: boolean }> = ({
-  element,
-  disableTooltip,
-}) => {
+type TaskNodeProps = {
+  element: Node<NodeModel, TaskNodeModelData>;
+  disableTooltip?: boolean;
+};
+
+const TaskNode: React.FC<TaskNodeProps> = ({ element, disableTooltip }) => {
   const { height, width } = element.getBounds();
-  const { pipeline, pipelineRun, task, selected } = element.getData() as TaskNodeModelData;
+  const { pipeline, pipelineRun, task, selected } = element.getData();
 
   return (
     <foreignObject width={width} height={height + DROP_SHADOW_SPACING}>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/const.ts
@@ -15,6 +15,7 @@ export enum NodeType {
   SPACER_NODE = 'spacer',
   TASK_LIST_NODE = 'task-list',
   BUILDER_NODE = 'builder',
+  INVALID_TASK_LIST_NODE = 'invalid-task-list',
 }
 export enum DrawDesign {
   INTEGRAL_SHAPE = 'integral-shape',

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/factories.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/factories.ts
@@ -7,11 +7,12 @@ import {
   Graph,
 } from '@console/topology';
 import { NodeType, PipelineLayout } from './const';
+import BuilderNode from './BuilderNode';
+import InvalidTaskListNode from './InvalidTaskListNode';
 import SpacerNode from './SpacerNode';
 import TaskNode from './TaskNode';
 import TaskEdge from './TaskEdge';
 import TaskListNode from './TaskListNode';
-import BuilderNode from './BuilderNode';
 import { getLayoutData } from './utils';
 
 export const componentFactory: ComponentFactory = (kind: ModelKind, type: string) => {
@@ -28,6 +29,8 @@ export const componentFactory: ComponentFactory = (kind: ModelKind, type: string
           return SpacerNode;
         case NodeType.TASK_LIST_NODE:
           return TaskListNode;
+        case NodeType.INVALID_TASK_LIST_NODE:
+          return InvalidTaskListNode;
         case NodeType.BUILDER_NODE:
           return BuilderNode;
         default:

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/utils.ts
@@ -41,6 +41,9 @@ export const createSpacerNode: NodeCreator<SpacerNodeModelData> = createGenericN
 export const createTaskListNode: NodeCreator<TaskListNodeModelData> = createGenericNode(
   NodeType.TASK_LIST_NODE,
 );
+export const createInvalidTaskListNode: NodeCreator<TaskListNodeModelData> = createGenericNode(
+  NodeType.INVALID_TASK_LIST_NODE,
+);
 export const createBuilderNode: NodeCreator<BuilderNodeModelData> = createGenericNode(
   NodeType.BUILDER_NODE,
 );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3578

**Analysis / Root cause**: 
When uploading a Pipeline that references tasks that do not exist, the app would white-screen if you try to click on that bubble in the Pipeline Builder.

**Solution Description**: 
Check on creation of the nodes if they reference a valid task. If they do not, swap the node for an invalid list item forcing a re-selection.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

![Kapture 2020-05-25 at 16 06 33](https://user-images.githubusercontent.com/8126518/82840802-e0672200-9ea1-11ea-966c-b76d716e2ac9.gif)

**Unit test coverage report**: 

See https://github.com/openshift/console/pull/4805 for upgrades to the tests. 

**Test setup:**

- Pipeline Operator
- A Pipeline that references a task that does not exist (use a Pipeline and just change the taskRef name to something that doesn't exist)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge