### PR TITLE
Bug 1840355: self-provisioner cannot find command line terminal workspace

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/TerminalLoadingBox.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/TerminalLoadingBox.tsx
@@ -6,7 +6,7 @@ type TerminalLoadingBoxProps = {
 };
 
 const TerminalLoadingBox: React.FC<TerminalLoadingBoxProps> = ({ message }) => (
-  <LoadingBox message={message || 'Connecting to your OpenShift command line terminal ...'} />
+  <LoadingBox message={message ?? 'Connecting to your OpenShift command line terminal ...'} />
 );
 
 export default TerminalLoadingBox;

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
-import store from '@console/internal/redux';
+import { shallow } from 'enzyme';
 import CloudShellTab from '../CloudShellTab';
 import CloudShellTerminal from '../CloudShellTerminal';
 
-describe('CloudShell Tab Test', () => {
-  it('should render cloudshellterminal', () => {
-    const cloudShellTabWrapper = mount(<CloudShellTab />, {
-      wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,
-    });
+describe('CloudShellTab', () => {
+  it('should render CloudShellTerminal', () => {
+    const cloudShellTabWrapper = shallow(<CloudShellTab />);
     expect(cloudShellTabWrapper.find(CloudShellTerminal).exists()).toBe(true);
   });
 });

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
@@ -1,31 +1,31 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { StatusBox } from '@console/internal/components/utils/status-box';
 import { InternalCloudShellTerminal } from '../CloudShellTerminal';
 import TerminalLoadingBox from '../TerminalLoadingBox';
 import CloudShellSetup from '../setup/CloudShellSetup';
 import { user } from './cloud-shell-test-data';
+import useCloudShellWorkspace from '../useCloudShellWorkspace';
 
-jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
-  useK8sWatchResource: jest.fn(),
+jest.mock('../useCloudShellWorkspace', () => ({
+  default: jest.fn(),
 }));
 
 describe('CloudShellTerminal', () => {
   it('should display loading box', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, false]);
+    (useCloudShellWorkspace as jest.Mock).mockReturnValueOnce([null, false]);
     const wrapper = shallow(<InternalCloudShellTerminal user={user} />);
     expect(wrapper.find(TerminalLoadingBox)).toHaveLength(1);
   });
 
   it('should display error statusBox', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, false, true]);
+    (useCloudShellWorkspace as jest.Mock).mockReturnValueOnce([null, false, true]);
     const wrapper = shallow(<InternalCloudShellTerminal user={user} />);
     expect(wrapper.find(StatusBox)).toHaveLength(1);
   });
 
   it('should display form if loaded and no workspace', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useCloudShellWorkspace as jest.Mock).mockReturnValueOnce([[], true]);
     const wrapper = shallow(<InternalCloudShellTerminal user={user} />);
     expect(wrapper.find(CloudShellSetup)).toHaveLength(1);
   });

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -1,6 +1,9 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
-import { getRandomChars } from '@console/shared';
+import { K8sResourceKind, k8sPatch } from '@console/internal/module/k8s';
+import { STORAGE_PREFIX, getRandomChars } from '@console/shared';
 import { coFetchJSON, coFetch } from '@console/internal/co-fetch';
+import { WorkspaceModel } from '../../models';
+
+const CLOUD_SHELL_NAMESPACE = `${STORAGE_PREFIX}/command-line-terminal-namespace`;
 
 type environment = {
   value: string;
@@ -33,6 +36,7 @@ export type CloudShellResource = K8sResourceKind & {
   spec?: {
     started?: boolean;
     devfile?: Devfile;
+    routingClass?: string;
   };
 };
 
@@ -59,6 +63,7 @@ export const newCloudShellWorkSpace = (name: string, namespace: string): CloudSh
   },
   spec: {
     started: true,
+    routingClass: 'openshift-terminal',
     devfile: {
       apiVersion: '1.0.0',
       metadata: {
@@ -74,6 +79,16 @@ export const newCloudShellWorkSpace = (name: string, namespace: string): CloudSh
     },
   },
 });
+
+export const startWorkspace = (workspace: CloudShellResource) => {
+  return k8sPatch(WorkspaceModel, workspace, [
+    {
+      path: '/spec/started',
+      op: 'replace',
+      value: true,
+    },
+  ]);
+};
 
 export const initTerminal = (
   username: string,
@@ -95,3 +110,12 @@ export const sendActivityTick = (workspaceName: string, namespace: string): void
 };
 
 export const checkTerminalAvailable = () => coFetch('/api/terminal/available');
+
+export const getCloudShellNamespace = () => localStorage.getItem(CLOUD_SHELL_NAMESPACE);
+export const setCloudShellNamespace = (namespace: string) => {
+  if (!namespace) {
+    localStorage.removeItem(CLOUD_SHELL_NAMESPACE);
+  } else {
+    localStorage.setItem(CLOUD_SHELL_NAMESPACE, namespace);
+  }
+};

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -38,7 +38,7 @@ export type CloudShellResource = K8sResourceKind & {
 
 export type TerminalInitData = { pod: string; container: string; cmd: string[] };
 
-export const CLOUD_SHELL_LABEL = 'console.openshift.io/cloudshell';
+export const CLOUD_SHELL_LABEL = 'console.openshift.io/terminal';
 export const CLOUD_SHELL_CREATOR_LABEL = 'org.eclipse.che.workspace/creator';
 export const CLOUD_SHELL_IMMUTABLE_ANNOTATION = 'org.eclipse.che.workspace/immutable';
 

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellSetup.tsx
@@ -21,7 +21,7 @@ interface StateProps {
 }
 
 type Props = StateProps & {
-  onSubmit?: () => void;
+  onSubmit?: (namespace: string) => void;
   onCancel?: () => void;
 };
 
@@ -50,7 +50,7 @@ const CloudShellSetup: React.FunctionComponent<Props> = ({
         WorkspaceModel,
         newCloudShellWorkSpace(createCloudShellResourceName(), namespace),
       );
-      onSubmit && onSubmit();
+      onSubmit && onSubmit(namespace);
     } catch (err) {
       actions.setStatus({ submitError: err.message });
     }

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { UserKind, referenceForModel, k8sList } from '@console/internal/module/k8s';
+import {
+  WatchK8sResource,
+  useK8sWatchResource,
+  WatchK8sResult,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import {
+  CLOUD_SHELL_LABEL,
+  CLOUD_SHELL_CREATOR_LABEL,
+  CloudShellResource,
+  CLOUD_SHELL_IMMUTABLE_ANNOTATION,
+  startWorkspace,
+} from './cloud-shell-utils';
+import { useAccessReview2 } from '@console/internal/components/utils';
+import { ProjectModel } from '@console/internal/models';
+import { useSafetyFirst } from '@console/internal/components/safety-first';
+import { WorkspaceModel } from '../../models';
+
+const findWorkspace = (data?: CloudShellResource[]): CloudShellResource | undefined => {
+  if (Array.isArray(data)) {
+    return data.find(
+      (d) =>
+        d?.metadata?.annotations?.[CLOUD_SHELL_IMMUTABLE_ANNOTATION] === 'true' &&
+        !d?.metadata?.deletionTimestamp,
+    );
+  }
+  return undefined;
+};
+
+const useCloudShellWorkspace = (
+  user: UserKind,
+  defaultNamespace?: string,
+): WatchK8sResult<CloudShellResource> => {
+  const [namespace, setNamespace] = useSafetyFirst(defaultNamespace);
+  const [searching, setSearching] = useSafetyFirst<boolean>(false);
+  const [noNamespaceFound, setNoNamespaceFound] = useSafetyFirst<boolean>(false);
+
+  // sync defaultNamespace to namespace
+  React.useEffect(() => {
+    setNamespace(defaultNamespace);
+    // a new namespace means we can start a new search
+    setNoNamespaceFound(false);
+  }, [defaultNamespace, setNamespace, setNoNamespaceFound]);
+
+  const [canListWorkspaces, loadingAccessReview] = useAccessReview2({
+    group: WorkspaceModel.apiGroup,
+    resource: WorkspaceModel.plural,
+    verb: 'list',
+  });
+
+  const uid = user?.metadata?.uid;
+  const username = user?.metadata?.name;
+  const isKubeAdmin = !uid && username === 'kube:admin';
+  const resource = React.useMemo<WatchK8sResource>(() => {
+    if (loadingAccessReview || (!canListWorkspaces && !namespace)) {
+      return undefined;
+    }
+    const result: WatchK8sResource = {
+      kind: referenceForModel(WorkspaceModel),
+      isList: true,
+      selector: {
+        matchLabels: {
+          [CLOUD_SHELL_LABEL]: 'true',
+          [CLOUD_SHELL_CREATOR_LABEL]: isKubeAdmin ? '' : uid,
+        },
+      },
+    };
+
+    if (!canListWorkspaces) {
+      result.namespace = namespace;
+    }
+    return result;
+  }, [isKubeAdmin, uid, namespace, loadingAccessReview, canListWorkspaces]);
+
+  // call k8s api to fetch workspace
+  const [data, loaded, loadError] = useK8sWatchResource<CloudShellResource[]>(resource);
+  const workspace = findWorkspace(data);
+
+  const searchNamespaces =
+    // wait for access review to return
+    !loadingAccessReview &&
+    // user cannot list workspaces at the cluster scope
+    !canListWorkspaces &&
+    // fetching the workspace succeeded or failed
+    (loaded || loadError) &&
+    // was a workspace was found
+    !workspace &&
+    // did a previous search result in no namespace found
+    !noNamespaceFound &&
+    // are we currently searching
+    !searching;
+
+  // FIXME need to use a service account on the backend to find the workspace instead of inefficiently looping through namespaces
+  React.useEffect(() => {
+    let unmounted = false;
+    if (searchNamespaces) {
+      (async () => {
+        setNoNamespaceFound(false);
+        setSearching(true);
+        setNamespace(undefined);
+        try {
+          const projects = await k8sList(ProjectModel);
+          if (unmounted) return;
+          if (Array.isArray(projects)) {
+            for (const project of projects) {
+              const projectName = project.metadata.name;
+              try {
+                // search each project sequentially
+                // eslint-disable-next-line no-await-in-loop
+                const workspaceList = await k8sList(WorkspaceModel, {
+                  ns: projectName,
+                  labelSelector: {
+                    matchLabels: {
+                      [CLOUD_SHELL_LABEL]: 'true',
+                      [CLOUD_SHELL_CREATOR_LABEL]: isKubeAdmin ? '' : uid,
+                    },
+                  },
+                });
+                if (unmounted) return;
+                const foundWorkspace = findWorkspace(workspaceList);
+                if (foundWorkspace) {
+                  setNamespace(projectName);
+                  return;
+                }
+              } catch {
+                // ignore and move on to the next namespace
+              }
+            }
+          }
+          setNoNamespaceFound(true);
+        } catch (e) {
+          setNoNamespaceFound(true);
+        } finally {
+          setSearching(false);
+        }
+      })();
+    }
+    return () => {
+      unmounted = true;
+    };
+  }, [isKubeAdmin, searchNamespaces, setNamespace, uid, setNoNamespaceFound, setSearching]);
+
+  React.useEffect(() => {
+    if (workspace?.spec && !workspace.spec.started) {
+      startWorkspace(workspace);
+    }
+    // Run this effect if the workspace name or namespace changes.
+    // This effect should only be run once per workspace.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace?.metadata?.name, workspace?.metadata?.namespace]);
+
+  return [
+    workspace,
+    // loaded if we have a resource loaded and currently not searching
+    // or if the search resulted in no namespace found
+    (!!resource && !searching && !searchNamespaces && loaded) || noNamespaceFound,
+    // provide the error associated with fetching the workspace
+    resource && !searching && !searchNamespaces ? loadError : undefined,
+  ];
+};
+
+export default useCloudShellWorkspace;

--- a/frontend/public/components/safety-first.tsx
+++ b/frontend/public/components/safety-first.tsx
@@ -11,11 +11,11 @@ export const useSafetyFirst = <S extends any>(
   React.useEffect(() => () => (mounted.current = false), []);
 
   const [value, setValue] = React.useState(initialState);
-  const setValueSafe = (newValue: S) => {
+  const setValueSafe = React.useCallback((newValue: S) => {
     if (mounted.current) {
       setValue(newValue);
     }
-  };
+  }, []);
 
   return [value, setValueSafe];
 };

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -87,10 +87,11 @@ export const checkAccess = (
   );
 };
 
-export const useAccessReview = (
+export const useAccessReview2 = (
   resourceAttributes: AccessReviewResourceAttributes,
   impersonate?,
-): boolean => {
+): [boolean, boolean] => {
+  const [loading, setLoading] = useSafetyFirst(true);
   const [isAllowed, setAllowed] = useSafetyFirst(false);
   // Destructure the attributes to pass them as dependencies to `useEffect`,
   // which doesn't do deep comparison of object dependencies.
@@ -107,6 +108,7 @@ export const useAccessReview = (
     checkAccessInternal(group, resource, subresource, verb, name, namespace, impersonateKey)
       .then((result: SelfSubjectAccessReviewKind) => {
         setAllowed(result.status.allowed);
+        setLoading(false);
       })
       .catch((e) => {
         // eslint-disable-next-line no-console
@@ -115,11 +117,17 @@ export const useAccessReview = (
         // don't incorrectly block users from actions they can perform. The server
         // still enforces access control.
         setAllowed(true);
+        setLoading(false);
       });
-  }, [setAllowed, group, resource, subresource, verb, name, namespace, impersonateKey]);
+  }, [setLoading, setAllowed, group, resource, subresource, verb, name, namespace, impersonateKey]);
 
-  return isAllowed;
+  return [isAllowed, loading];
 };
+
+export const useAccessReview = (
+  resourceAttributes: AccessReviewResourceAttributes,
+  impersonate?,
+): boolean => useAccessReview2(resourceAttributes, impersonate)[0];
 
 const RequireCreatePermission_: React.FC<RequireCreatePermissionProps> = ({
   model,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3794

**Analysis / Root cause**: 
A user with only self-provisioner access is unable to list workspace resources at the cluster scope. Therefore they always get an error when trying to open the command line terminal

**Solution Description**: 
If the user does not have access to list workspace resources at the cluster scope, loop through all available namespaces looking for a matching command line terminal namespace. Once found, save the namespace in localstorage to shortcut this lookup process in the future.

**Screen shots / Gifs for design review**: 
No UI changes.

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/14068621/82939995-297eab00-9f62-11ea-900e-53bb0c6977ae.png)

**Test setup:**
Depends on
https://github.com/openshift/console/pull/5332
https://github.com/openshift/console-operator/pull/432

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
