### PR TITLE
Bug 1834163: Don't show error on unedited form

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
@@ -44,14 +44,22 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
     onExpressionAdd,
     onExpressionChange,
     onExpressionDelete,
+    initialAffinityExpressionChanged,
   ] = useIDEntities<AffinityLabel>(affinity?.expressions);
 
   const onLabelExpressionAdd = () =>
     onExpressionAdd({ id: null, key: '', values: [], operator: 'In' } as AffinityLabel);
 
-  const [affinityFields, , onFieldAdd, onFieldChange, onFieldDelete] = useIDEntities<AffinityLabel>(
-    affinity?.fields,
-  );
+  const [
+    affinityFields,
+    ,
+    onFieldAdd,
+    onFieldChange,
+    onFieldDelete,
+    initialAffinityFieldChanged,
+  ] = useIDEntities<AffinityLabel>(affinity?.fields);
+
+  const initialAffinityChanged = initialAffinityFieldChanged || initialAffinityExpressionChanged;
 
   const onLabelFieldAdd = () =>
     onFieldAdd({ id: null, key: '', values: [], operator: 'In' } as AffinityLabel);
@@ -196,9 +204,11 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
           <FormRow
             title={isNodeAffinity ? 'Node Labels' : 'Workload Labels'}
             fieldId={'expressions'}
-            validationType={isExpressionsInvalid && ValidationErrorType.Error}
+            validationType={
+              isExpressionsInvalid && initialAffinityChanged && ValidationErrorType.Error
+            }
             validationMessage={
-              isExpressionsInvalid && isNodeAffinity
+              isExpressionsInvalid && initialAffinityChanged && isNodeAffinity
                 ? 'Missing fields in node labels'
                 : 'Missing fields in workload labels'
             }
@@ -240,8 +250,12 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
               <FormRow
                 title="Node Fields"
                 fieldId={'fields'}
-                validationType={isFieldsInvalid && ValidationErrorType.Error}
-                validationMessage={isFieldsInvalid && 'Missing fields in node fields'}
+                validationType={
+                  isFieldsInvalid && initialAffinityChanged && ValidationErrorType.Error
+                }
+                validationMessage={
+                  isFieldsInvalid && initialAffinityChanged && 'Missing fields in node fields'
+                }
               >
                 <div className="scheduling-modals__desc-container">
                   <>

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-id-entities.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-id-entities.ts
@@ -5,9 +5,11 @@ export const useIDEntities = <T extends IDEntity = IDEntity>(
   initialEntities: T[] = [],
 ): useIDEntitiesValues<T> => {
   const [entities, setEntities] = React.useState<T[]>(initialEntities);
+  const [initialEntitiesChanged, setInitialEntitiesChanged] = React.useState<boolean>(false);
 
   const onEntityAdd = React.useCallback(
     (newEntity: T) => {
+      setInitialEntitiesChanged(true);
       const id = entities[entities.length - 1]?.id + 1 || 0;
       setEntities([...entities, { ...newEntity, id }]);
     },
@@ -15,7 +17,8 @@ export const useIDEntities = <T extends IDEntity = IDEntity>(
   );
 
   const onEntityChange = React.useCallback(
-    (updatedEntity: T) =>
+    (updatedEntity: T) => {
+      setInitialEntitiesChanged(true);
       setEntities(
         entities.map((entity) => {
           if (entity.id === updatedEntity.id) {
@@ -23,18 +26,27 @@ export const useIDEntities = <T extends IDEntity = IDEntity>(
           }
           return entity;
         }),
-      ),
+      );
+    },
     [entities],
   );
 
   const onEntityDelete = React.useCallback(
     (idToDelete: number) => {
+      setInitialEntitiesChanged(true);
       setEntities(entities.filter(({ id }) => id !== idToDelete));
     },
     [entities],
   );
 
-  return [entities, setEntities, onEntityAdd, onEntityChange, onEntityDelete];
+  return [
+    entities,
+    setEntities,
+    onEntityAdd,
+    onEntityChange,
+    onEntityDelete,
+    initialEntitiesChanged,
+  ];
 };
 
 type useIDEntitiesValues<T> = [
@@ -43,4 +55,5 @@ type useIDEntitiesValues<T> = [
   (newEntity: T) => void, // addEntity()
   (updatedEntity: T) => void, // changeEntity()
   (idToDelete: number) => void, // deleteEntity()
+  boolean, // initialEntitiesChanged
 ];


### PR DESCRIPTION
On the Affinity form, when we add an affinity we show a form with an error message before users start to edit the form,

This PR adds a check that form is changed before showing the error message.