### PR TITLE
Bug 1840137: Fix the Pipeline Builder sidebar required asterisk

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -151,28 +151,32 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
         }}
       >
         {() => (
-          <TaskSidebar
-            // Intentional remount when selection changes
-            key={selectedTask.taskIndex}
-            resourceList={values.resources || []}
-            errorMap={status?.tasks || {}}
-            onUpdateTask={(data: UpdateOperationUpdateTaskData) => {
-              updateTasks(applyChange(taskGroup, { type: UpdateOperationType.UPDATE_TASK, data }));
-            }}
-            onRemoveTask={(taskName) => {
-              removeTaskModal(taskName, () => {
-                setSelectedTask(null);
+          <div className="pf-c-form">
+            <TaskSidebar
+              // Intentional remount when selection changes
+              key={selectedTask.taskIndex}
+              resourceList={values.resources || []}
+              errorMap={status?.tasks || {}}
+              onUpdateTask={(data: UpdateOperationUpdateTaskData) => {
                 updateTasks(
-                  applyChange(taskGroup, {
-                    type: UpdateOperationType.REMOVE_TASK,
-                    data: { taskName },
-                  }),
+                  applyChange(taskGroup, { type: UpdateOperationType.UPDATE_TASK, data }),
                 );
-              });
-            }}
-            selectedPipelineTaskIndex={selectedTask.taskIndex}
-            taskResource={selectedTask.resource}
-          />
+              }}
+              onRemoveTask={(taskName) => {
+                removeTaskModal(taskName, () => {
+                  setSelectedTask(null);
+                  updateTasks(
+                    applyChange(taskGroup, {
+                      type: UpdateOperationType.REMOVE_TASK,
+                      data: { taskName },
+                    }),
+                  );
+                });
+              }}
+              selectedPipelineTaskIndex={selectedTask.taskIndex}
+              taskResource={selectedTask.resource}
+            />
+          </div>
         )}
       </Sidebar>
     </>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3986

**Analysis / Root cause**: 
When the Pipeline Builder sticky footer was implemented (as part of #5415) the sidebar moved outside of the form and thus lost the pf variables that styled the asterisk.

**Solution Description**: 
Wrap the sidebar content in a form style wrapper.

**Screen shots / Gifs for design review**: 

Before:
![image](https://user-images.githubusercontent.com/8126518/82903157-8bbdb880-9f2e-11ea-87fe-bf8d1df07216.png)

After:
![image](https://user-images.githubusercontent.com/8126518/82903115-7b0d4280-9f2e-11ea-954e-847334f0927a.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge