### PR TITLE
Bug 1840139: fix Request Type Container Command throws an error in Edit Health Checks Form

### DIFF
--- a/frontend/packages/dev-console/src/components/health-checks/RequestTypeForms.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/RequestTypeForms.tsx
@@ -100,7 +100,7 @@ export const CommandRequestTypeForm: React.FC<RequestTypeFormProps> = ({ probeTy
   const {
     values: { healthChecks },
   } = useFormikContext<FormikValues>();
-  const commands = healthChecks?.[probeType]?.data?.exec?.command;
+  const commands = healthChecks?.[probeType]?.data?.exec?.command || [''];
   return (
     <TextColumnField
       name={`healthChecks.${probeType}.data.exec.command`}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3842

**Analysis / Root cause**: 
An error occurs on editing health checks when request type `Container Command` is selected from the dropdown.

**Solution Description**: 
Add initial state of command field.

**Screen shots / Gifs for design review**: 
![command-health](https://user-images.githubusercontent.com/2561818/82904445-1ed30e80-9f80-11ea-9ed8-d2cd57bf556f.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
