### PR TITLE
Bug 1840256: Fix for re-display of EventSources with links in topology

### DIFF
--- a/frontend/packages/topology/src/anchors/SVGAnchor.ts
+++ b/frontend/packages/topology/src/anchors/SVGAnchor.ts
@@ -16,7 +16,7 @@ export default class SVGAnchor extends AbstractAnchor {
     this.svgElement = svgElement;
   }
 
-  getCircleLocation(circle: SVGCircleElement, reference: Point): Point {
+  private getCircleLocation(circle: SVGCircleElement, reference: Point): Point {
     const center: Point = new Point(circle.cx.baseVal.value, circle.cy.baseVal.value);
     this.owner.translateToParent(center);
     const diameter = circle.r.baseVal.value * 2 + this.offset * 2;
@@ -24,7 +24,7 @@ export default class SVGAnchor extends AbstractAnchor {
     return getEllipseAnchorPoint(center, diameter, diameter, reference);
   }
 
-  getEllipseLocation(ellipse: SVGEllipseElement, reference: Point): Point {
+  private getEllipseLocation(ellipse: SVGEllipseElement, reference: Point): Point {
     const center: Point = new Point(ellipse.cx.baseVal.value, ellipse.cy.baseVal.value);
     this.owner.translateToParent(center);
     const offset2x = this.offset * 2;
@@ -34,7 +34,7 @@ export default class SVGAnchor extends AbstractAnchor {
     return getEllipseAnchorPoint(center, width, height, reference);
   }
 
-  getRectLocation(rect: SVGRectElement, reference: Point): Point {
+  private getRectLocation(rect: SVGRectElement, reference: Point): Point {
     const width = rect.width.baseVal.value;
     const height = rect.height.baseVal.value;
 
@@ -48,7 +48,7 @@ export default class SVGAnchor extends AbstractAnchor {
     return getRectAnchorPoint(center, width + offset2x, height + offset2x, reference);
   }
 
-  getPathLocation(path: SVGPathElement, reference: Point): Point {
+  private getPathLocation(path: SVGPathElement, reference: Point): Point {
     const translatedRef = reference.clone();
     this.owner.translateFromParent(translatedRef);
     const anchorPoint = getPathAnchorPoint(path, translatedRef);
@@ -56,7 +56,7 @@ export default class SVGAnchor extends AbstractAnchor {
     return anchorPoint;
   }
 
-  getPolygonLocation(polygon: SVGPolygonElement, reference: Point): Point {
+  private getPolygonLocation(polygon: SVGPolygonElement, reference: Point): Point {
     const translatedRef = reference.clone();
     this.owner.translateFromParent(translatedRef);
     const anchorPoint = getPolygonAnchorPoint(polygon, translatedRef);
@@ -65,24 +65,26 @@ export default class SVGAnchor extends AbstractAnchor {
   }
 
   getLocation(reference: Point): Point {
-    if (this.svgElement instanceof SVGCircleElement) {
-      return this.getCircleLocation(this.svgElement, reference);
-    }
+    if (this.svgElement?.viewportElement) {
+      if (this.svgElement instanceof SVGCircleElement) {
+        return this.getCircleLocation(this.svgElement, reference);
+      }
 
-    if (this.svgElement instanceof SVGEllipseElement) {
-      return this.getEllipseLocation(this.svgElement, reference);
-    }
+      if (this.svgElement instanceof SVGEllipseElement) {
+        return this.getEllipseLocation(this.svgElement, reference);
+      }
 
-    if (this.svgElement instanceof SVGRectElement) {
-      return this.getRectLocation(this.svgElement, reference);
-    }
+      if (this.svgElement instanceof SVGRectElement) {
+        return this.getRectLocation(this.svgElement, reference);
+      }
 
-    if (this.svgElement instanceof SVGPathElement) {
-      return this.getPathLocation(this.svgElement, reference);
-    }
+      if (this.svgElement instanceof SVGPathElement) {
+        return this.getPathLocation(this.svgElement, reference);
+      }
 
-    if (this.svgElement instanceof SVGPolygonElement) {
-      return this.getPolygonLocation(this.svgElement, reference);
+      if (this.svgElement instanceof SVGPolygonElement) {
+        return this.getPolygonLocation(this.svgElement, reference);
+      }
     }
 
     return this.owner.getBounds().getCenter();
@@ -90,11 +92,12 @@ export default class SVGAnchor extends AbstractAnchor {
 
   getReferencePoint(): Point {
     if (
-      this.svgElement instanceof SVGCircleElement ||
-      this.svgElement instanceof SVGEllipseElement ||
-      this.svgElement instanceof SVGRectElement ||
-      this.svgElement instanceof SVGPathElement ||
-      this.svgElement instanceof SVGPolygonElement
+      this.svgElement?.viewportElement &&
+      (this.svgElement instanceof SVGCircleElement ||
+        this.svgElement instanceof SVGEllipseElement ||
+        this.svgElement instanceof SVGRectElement ||
+        this.svgElement instanceof SVGPathElement ||
+        this.svgElement instanceof SVGPolygonElement)
     ) {
       const bbox = this.svgElement.getBBox();
       const ref = new Point(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3942

**Analysis / Root cause**: 
Re-calculating the endpoint for the event source link edge is done before the event source has been redrawn and the svg element is not yet ready to compute the location.

**Solution Description**: 
Check for a valid svg element prior to computing the anchor location.

/kind bug