### PR TITLE
Bug 1811031: Change dashboard activation mechanism

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { match } from 'react-router';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch } from 'react-redux';
 import {
   ButtonBar,
   withHandlePromise,
@@ -27,10 +30,13 @@ import {
 } from '@patternfly/react-core';
 import { history } from '@console/internal/components/utils/router';
 import { SecretModel } from '@console/internal/models';
+import { setFlag } from '@console/internal/actions/features';
 import { getName } from '@console/shared';
 import { OCSServiceModel } from '../../models';
 import FileUpload from './fileUpload';
 import { isValidJSON, checkError, prettifyJSON } from './utils';
+import { OCS_INDEPENDENT_FLAG, OCS_FLAG } from '../../features';
+import { OCS_INDEPENDENT_CR_NAME } from '../../constants';
 import './install.scss';
 
 const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterProps) => {
@@ -47,6 +53,7 @@ const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterP
   const [clusterServiceVersion, setClusterServiceVersion] = React.useState(null);
   const [fileData, setFileData] = React.useState('');
   const [dataError, setDataError] = React.useState('');
+  const dispatch = useDispatch();
 
   const plainKeys = _.concat(configMaps, storageClasses);
 
@@ -88,7 +95,7 @@ const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterP
       apiVersion: apiVersionForModel(OCSServiceModel),
       kind: OCSServiceModel.kind,
       metadata: {
-        name: 'ocs-independent-storagecluster',
+        name: OCS_INDEPENDENT_CR_NAME,
         namespace: ns,
       },
       spec: {
@@ -100,6 +107,8 @@ const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterP
 
     handlePromise(Promise.all([k8sCreate(SecretModel, secret), k8sCreate(OCSServiceModel, ocsObj)]))
       .then((data) => {
+        dispatch(setFlag(OCS_INDEPENDENT_FLAG, true));
+        dispatch(setFlag(OCS_FLAG, true));
         history.push(
           `/k8s/ns/${ns}/clusterserviceversions/${getName(
             clusterServiceVersion,

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { match } from 'react-router';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch } from 'react-redux';
 import { Alert, ActionGroup, Button, Form, FormGroup } from '@patternfly/react-core';
 import {
   NodeKind,
@@ -19,6 +22,7 @@ import {
   FieldLevelHelp,
   ButtonBar,
 } from '@console/internal/components/utils';
+import { setFlag } from '@console/internal/actions/features';
 import {
   ocsRequestData,
   labelTooltip,
@@ -33,6 +37,7 @@ import { OSDSizeDropdown } from '../../utils/osd-size-dropdown';
 import { cephStorageLabel } from '../../selectors';
 import NodeTable from './node-list';
 import { PVsAvailableCapacity } from './pvs-available-capacity';
+import { OCS_FLAG, OCS_CONVERGED_FLAG } from '../../features';
 import './ocs-install.scss';
 
 const makeLabelNodesRequest = (selectedNodes: NodeKind[]): Promise<NodeKind>[] => {
@@ -95,11 +100,14 @@ export const CreateOCSServiceForm = withHandlePromise<
   const [visibleRows, setVisibleRows] = React.useState<NodeKind[]>(null);
   const [osdSize, setOSDSize] = React.useState(defaultRequestSize.NON_BAREMETAL);
   const [storageClass, setStorageClass] = React.useState<StorageClassResourceKind>(null);
+  const dispatch = useDispatch();
 
   const submit = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     // eslint-disable-next-line promise/catch-or-return
     handlePromise(makeOCSRequest(selectedNodes, storageClass, osdSize)).then(() => {
+      dispatch(setFlag(OCS_CONVERGED_FLAG, true));
+      dispatch(setFlag(OCS_FLAG, true));
       history.push(
         `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(
           OCSServiceModel,

--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -10,5 +10,6 @@ export const BY_USED = 'By Used Capacity';
 export const BY_REQUESTED = 'By Requested Capacity';
 export const OCS_OPERATOR = 'ocs-operator';
 export const OCS_INDEPENDENT_CR_NAME = 'ocs-independent-storagecluster';
+export const OCS_CONVERGED_CR_NAME = 'ocs-storagecluster';
 export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';
 export const OCS_SUPPORT_ANNOTATION = 'features.ocs.openshift.io/enabled';

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -1,30 +1,24 @@
 import * as _ from 'lodash';
-import { k8sGet, K8sResourceKind } from '@console/internal/module/k8s';
+import { Dispatch } from 'react-redux';
+import { k8sGet } from '@console/internal/module/k8s';
 import { ClusterServiceVersionModel, SubscriptionModel } from '@console/operator-lifecycle-manager';
-import { handleError, setFlag } from '@console/internal/actions/features';
+import { setFlag } from '@console/internal/actions/features';
 import { FeatureDetector } from '@console/plugin-sdk';
+import { getAnnotations } from '@console/shared/src/selectors/common';
 import { OCSServiceModel } from './models';
 import {
   OCS_INDEPENDENT_CR_NAME,
   CEPH_STORAGE_NAMESPACE,
   OCS_SUPPORT_ANNOTATION,
+  OCS_CONVERGED_CR_NAME,
 } from './constants';
-import { getAnnotations } from '@console/shared/src/selectors/common';
 
 export const OCS_INDEPENDENT_FLAG = 'OCS_INDEPENDENT';
-
-const isIndependent = (data: K8sResourceKind): boolean =>
-  data.spec?.externalStorage?.enable ?? false;
-
-export const detectIndependentMode: FeatureDetector = (dispatch) =>
-  k8sGet(OCSServiceModel, OCS_INDEPENDENT_CR_NAME, CEPH_STORAGE_NAMESPACE).then(
-    (obj: K8sResourceKind) => dispatch(setFlag(OCS_INDEPENDENT_FLAG, isIndependent(obj))),
-    (err) => {
-      err?.response?.status === 404
-        ? dispatch(setFlag(OCS_INDEPENDENT_FLAG, false))
-        : handleError(err, OCS_INDEPENDENT_FLAG, dispatch, detectIndependentMode);
-    },
-  );
+export const OCS_CONVERGED_FLAG = 'OCS_CONVERGED';
+// Used to activate NooBaa dashboard
+export const OCS_FLAG = 'OCS';
+// Todo(bipuladh): Remove this completely in 4.6
+export const CEPH_FLAG = 'CEPH';
 
 /* Key and Value should be same value received in CSV  */
 export const OCS_SUPPORT_FLAGS = {
@@ -32,15 +26,36 @@ export const OCS_SUPPORT_FLAGS = {
   EXTERNAL: 'EXTERNAL',
 };
 
-const handleOCSError = (res, flags, dispatch, cb) => {
+const handleError = (res: any, flags: string[], dispatch: Dispatch, cb: FeatureDetector) => {
   const status = res?.response?.status;
   if (_.includes([403, 502], status)) {
-    _.keys(flags).forEach((feature) => {
+    flags.forEach((feature) => {
       dispatch(setFlag(feature, undefined));
     });
   }
   if (!_.includes([401, 403, 500], status)) {
     setTimeout(() => cb(dispatch), 15000);
+  }
+};
+
+export const detectOCS: FeatureDetector = async (dispatch) => {
+  try {
+    await k8sGet(OCSServiceModel, OCS_CONVERGED_CR_NAME, CEPH_STORAGE_NAMESPACE);
+    dispatch(setFlag(OCS_FLAG, true));
+    dispatch(setFlag(OCS_CONVERGED_FLAG, true));
+  } catch (e) {
+    e?.response?.status !== 404
+      ? handleError(e, [OCS_CONVERGED_FLAG], dispatch, detectOCS)
+      : dispatch(setFlag(OCS_CONVERGED_FLAG, false));
+    try {
+      await k8sGet(OCSServiceModel, OCS_INDEPENDENT_CR_NAME, CEPH_STORAGE_NAMESPACE);
+      dispatch(setFlag(OCS_FLAG, true));
+      dispatch(setFlag(OCS_INDEPENDENT_FLAG, true));
+    } catch (err) {
+      err?.response?.status !== 404
+        ? handleError(err, [OCS_INDEPENDENT_FLAG], dispatch, detectOCS)
+        : dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
+    }
   }
 };
 
@@ -66,6 +81,6 @@ export const detectOCSSupportedFeatures: FeatureDetector = async (dispatch) => {
       ? _.keys(OCS_SUPPORT_FLAGS).forEach((feature) => {
           dispatch(setFlag(feature, false));
         })
-      : handleOCSError(error, OCS_SUPPORT_FLAGS, dispatch, detectOCSSupportedFeatures);
+      : handleError(error, _.keys(OCS_SUPPORT_FLAGS), dispatch, detectOCSSupportedFeatures);
   }
 };

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -18,10 +18,12 @@ import {
   CustomFeatureFlag,
 } from '@console/plugin-sdk';
 import {
-  OCS_INDEPENDENT_FLAG,
-  detectIndependentMode,
+  detectOCS,
   detectOCSSupportedFeatures,
+  CEPH_FLAG,
+  OCS_INDEPENDENT_FLAG,
   OCS_SUPPORT_FLAGS,
+  OCS_CONVERGED_FLAG,
 } from './features';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { GridPosition } from '@console/shared/src/components/dashboard/DashboardGrid';
@@ -49,8 +51,6 @@ type ConsumedExtensions =
   | KebabActions
   | DashboardsOverviewResourceActivity;
 
-const CEPH_FLAG = 'CEPH';
-
 const apiObjectRef = referenceForModel(models.OCSServiceModel);
 
 const plugin: Plugin<ConsumedExtensions> = [
@@ -71,6 +71,12 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'FeatureFlag/Custom',
     properties: {
       detect: detectOCSSupportedFeatures,
+    },
+  },
+  {
+    type: 'FeatureFlag/Custom',
+    properties: {
+      detect: detectOCS,
     },
   },
   {
@@ -95,7 +101,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       title: 'Persistent Storage',
     },
     flags: {
-      required: [CEPH_FLAG],
+      required: [OCS_CONVERGED_FLAG],
       disallowed: [OCS_INDEPENDENT_FLAG],
     },
   },
@@ -108,7 +114,6 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/ocs-install/install-page' /* webpackChunkName: "install-page" */).then(
           (m) => m.default,
         ),
-      required: CEPH_FLAG,
     },
   },
   // Ceph Storage Dashboard Left cards
@@ -258,13 +263,6 @@ const plugin: Plugin<ConsumedExtensions> = [
           './components/converged-credentials/credentials' /* webpackChunkName: "ceph-storage-export-credentials" */
         ).then((m) => m.default({})),
       disallowed: [OCS_INDEPENDENT_FLAG],
-    },
-  },
-  // Independent mode dashboard
-  {
-    type: 'FeatureFlag/Custom',
-    properties: {
-      detect: detectIndependentMode,
     },
   },
   {

--- a/frontend/packages/console-shared/src/utils/storage-utils.ts
+++ b/frontend/packages/console-shared/src/utils/storage-utils.ts
@@ -9,7 +9,7 @@ export const cephStorageProvisioners = [
 
 const objectStorageProvisioners = [
   'openshift-storage.noobaa.io/obc',
-  'openshift-storage-ceph.rook.io/bucket',
+  'openshift-storage.ceph.rook.io/bucket',
 ];
 
 // To check if the provisioner is OCS based

--- a/frontend/packages/metal3-plugin/src/features.ts
+++ b/frontend/packages/metal3-plugin/src/features.ts
@@ -6,7 +6,6 @@ import { FeatureDetector } from '@console/plugin-sdk';
 
 export const BAREMETAL_FLAG = 'BAREMETAL';
 export const NODE_MAINTENANCE_FLAG = 'NODE_MAINTENANCE';
-export const CEPH_FLAG = 'CEPH';
 
 export const detectBaremetalPlatform: FeatureDetector = (dispatch) =>
   k8sGet(InfrastructureModel, 'cluster').then(

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -15,6 +15,7 @@ import {
 import { GridPosition } from '@console/shared/src/components/dashboard/DashboardGrid';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
+import { OCS_FLAG } from '@console/ceph-storage-plugin/src/features';
 import * as models from './models';
 
 type ConsumedExtensions =
@@ -96,7 +97,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       title: 'Object Service',
     },
     flags: {
-      required: [NOOBAA_FLAG],
+      required: [NOOBAA_FLAG, OCS_FLAG],
     },
   },
   {


### PR DESCRIPTION
Move the dashboard activation mechanism from CRD based to CR based.
Motivation: Until the Storage Cluster is created we don't know which dashboard to activate. We should not activate without being sure which dashboard to activate.