### PR TITLE
Bug 1810568: fix for opening drawer when tabbing through page components (CSS only fix)

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -296,6 +296,19 @@ h6 {
   }
 }
 
+// Fix for the notification drawer appearing due to tabbing through components
+// Remove this when the pf4 breaking changes dependency is contributed
+@keyframes pf-c-drawer-hide-panel {
+  to {
+    visibility: hidden;
+  }
+}
+.pf-c-drawer__panel[hidden] {
+  animation-name: pf-c-drawer-hide-panel;
+  animation-delay: var(--pf-c-drawer__panel--TransitionDuration);
+  animation-fill-mode: forwards;
+}
+
 .pf-c-page__sidebar {
   --pf-c-page__sidebar-body--PaddingTop: 0;
   bottom: 0;


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1810568

The upstream fix for this will be ready in the v4 breaking changes release, but this is a css only, in product, fix that can sustain us until 4.6. Provided by mnolting and mcoker

cc: @christianvogt 