### PR TITLE
Bug 1839073: Calculate max width for VM wizard general form

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.scss
@@ -4,6 +4,16 @@
   flex-direction: column;
 }
 
+.kubevirt-create-vm-modal__form {
+  @media (min-width: 1200px) {
+    // match OCP form width by compensating for PF wizard padding (32px)
+    // and wizard nav (150px) and then removing OCP padding (60px)
+    max-width: calc(50% + 32px + 150px - 60px);
+  }
+  margin: 0;
+  padding: 0;
+}
+
 .kubevirt-create-vm-modal__wizard-content {
   flex-flow: wrap
 }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
@@ -33,13 +33,14 @@ import {
   CloudInitDataHelper,
   formAllowedKeys,
 } from '../../../../k8s/wrapper/vm/cloud-init-data-helper';
-
-import './cloud-init-tab.scss';
 import {
   hasStepCreateDisabled,
   hasStepDeleteDisabled,
   hasStepUpdateDisabled,
 } from '../../selectors/immutable/wizard-selectors';
+
+import '../../create-vm-wizard-footer.scss';
+import './cloud-init-tab.scss';
 
 type CustomScriptProps = {
   id: string;
@@ -274,7 +275,7 @@ const CloudInitTabComponent: React.FC<ResultTabComponentProps> = ({
     }
   };
   return (
-    <div className={isForm && 'co-m-pane__body co-m-pane__form'}>
+    <div className={isForm && 'co-m-pane__body co-m-pane__form kubevirt-create-vm-modal__form'}>
       {!isDisabled && !isEditable && (
         <Errors
           endMargin

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/import-providers-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/import-providers-tab.tsx
@@ -13,6 +13,8 @@ import { VMWareImportProvider } from './providers/vmware-import-provider/vmware-
 import { iGetImportProviders } from '../../selectors/immutable/import-providers';
 import { OvirtImportProvider } from './providers/ovirt-import-provider/ovirt-import-provider';
 
+import '../../create-vm-wizard-footer.scss';
+
 class ImportProvidersTabComponent extends React.Component<ImportProvidersTabComponentProps> {
   getField = (key: ImportProvidersField) => iGet(this.props.importProviders, key);
 
@@ -28,7 +30,7 @@ class ImportProvidersTabComponent extends React.Component<ImportProvidersTabComp
     const { wizardReduxID } = this.props;
 
     return (
-      <Form className="co-m-pane__body co-m-pane__form">
+      <Form className="co-m-pane__body co-m-pane__form kubevirt-create-vm-modal__form">
         <FormFieldMemoRow
           field={this.getField(ImportProvidersField.PROVIDER)}
           fieldType={FormFieldType.SELECT}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -24,6 +24,7 @@ import { MemoryCPU } from './memory-cpu';
 import { ContainerSource } from './container-source';
 import { URLSource } from './url-source';
 
+import '../../create-vm-wizard-footer.scss';
 import './vm-settings-tab.scss';
 
 export class VMSettingsTabComponent extends React.Component<VMSettingsTabComponentProps> {
@@ -47,7 +48,7 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
     } = this.props;
 
     return (
-      <Form className="co-m-pane__body co-m-pane__form">
+      <Form className="co-m-pane__body co-m-pane__form kubevirt-create-vm-modal__form">
         <FormFieldMemoRow
           field={this.getField(VMSettingsField.NAME)}
           fieldType={FormFieldType.TEXT}


### PR DESCRIPTION
Currently, the width of the general tab form in the VM wizard is narrower than other forms at larger viewport sizes. This is due to additional padding added by the `pf-c-wizard--main` class and the added width of the wizard side navigation. This PR calculates the `max-width` of the form, compensating for these additional values.