### PR TITLE
Bug 1840493: Monitoring: Fix alert details page's "View in Metrics" link

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -857,17 +857,14 @@ const QueryBrowserWrapper_: React.FC<QueryBrowserWrapperProps> = ({
 }) => {
   const queries = queriesList.toJS();
 
-  const isInitRef = React.useRef(true);
-
   // Initialize queries from URL parameters
-  if (isInitRef.current) {
+  React.useEffect(() => {
     const searchParams = getURLSearchParams();
     for (let i = 0; _.has(searchParams, `query${i}`); ++i) {
       const query = searchParams[`query${i}`];
       patchQuery(i, { isEnabled: true, isExpanded: true, query, text: query });
     }
-    isInitRef.current = false;
-  }
+  }, [patchQuery]);
 
   /* eslint-disable react-hooks/exhaustive-deps */
   // Use React.useMemo() to prevent these two arrays being recreated on every render, which would trigger unnecessary


### PR DESCRIPTION
Bug was introduced by https://github.com/openshift/console/pull/5556

The problem was that the queries were initialized directly in the query browser render function (gated by `isInitRef`), which meant it was run before the `useEffect` cleanup function from the alert details page.

I'm not sure why the `isInitRef` approach was originally used here, but it doesn't seem to be necessary and switching to the more normal `React.useEffect` approach fixes the invocation order.