### PR TITLE
Bug 1840478: Fetch kibanaApp public url

### DIFF
--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -193,11 +193,12 @@ const detectCanCreateProject = (dispatch) =>
     },
   );
 
-const loggingConfigMapPath = `${k8sBasePath}/api/v1/namespaces/openshift-logging/configmaps/sharing-config`;
 const detectLoggingURL = (dispatch) =>
-  coFetchJSON(loggingConfigMapPath).then(
+  coFetchJSON(
+    '/api/kubernetes/apis/console.openshift.io/v1/consolelinks/kibana-app-public-url',
+  ).then(
     (res) => {
-      const { kibanaAppURL } = res.data;
+      const kibanaAppURL = res?.spec?.href;
       if (!_.isEmpty(kibanaAppURL)) {
         dispatch(setMonitoringURL(MonitoringRoutes.Kibana, kibanaAppURL));
       }


### PR DESCRIPTION
Since logging-operator is not creating the `shared-config` anymore and instead is utilising the `ConsoleLink` CRD we need to fetch directly the `kibana-app-public-url` CR.
We already have the link for the Logging in the Application menu this feels kinda like a dup. On the Other hand this close to release I think would be better to fix it and remove the navbar Loging link in the following release. Thoughts ?

FYI @periklis 

/assign @spadgett 