### PR TITLE
Bug 1840594: Add fallback icon also to the "Instantiate Template"

### DIFF
--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -6,6 +6,7 @@ import * as classNames from 'classnames';
 import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { ANNOTATIONS } from '@console/shared';
+import * as catalogImg from '../imgs/logos/catalog-icon.svg';
 import {
   getImageForIconClass,
   getTemplateIcon,
@@ -57,7 +58,7 @@ const TemplateInfo: React.FC<TemplateInfoProps> = ({ template }) => {
   const { description } = annotations;
   const displayName = annotations[ANNOTATIONS.displayName] || template.metadata.name;
   const iconClass = getTemplateIcon(template);
-  const imgURL = getImageForIconClass(iconClass);
+  const imgURL = iconClass ? getImageForIconClass(iconClass) : catalogImg;
   const tags = (annotations.tags || '').split(/\s*,\s*/);
   const documentationURL = annotations[ANNOTATIONS.documentationURL];
   const supportURL = annotations[ANNOTATIONS.supportURL];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4056

**Analysis / Root cause**: 
The PR https://github.com/openshift/console/pull/5426 added the fallback icon only for the "Developer Catalog" itself. In one of the 3 cases (no icon defined at all) a fallback icon was shown in the "Developer Catalog" but not on the "Instantiate Template" screen.

**Solution Description**: 
Add the fallback icon also this the "Instantiate Template" screen.

**Screen shots / Gifs for design review**: 
Case 1, before and after:
![case1](https://user-images.githubusercontent.com/139310/82992018-d4dd3d80-9ffe-11ea-96ed-14c8632c78c0.png)

Case 2, before and after:
![case2](https://user-images.githubusercontent.com/139310/82992030-d9a1f180-9ffe-11ea-9e34-a9b77500bc96.png)

Case 3, new icon on the right hand side:
![case3](https://user-images.githubusercontent.com/139310/82992036-dc9ce200-9ffe-11ea-8927-625c46c87e0d.png)

**Unit test coverage report**: 
Not affected

**Test setup:**
As described in https://bugzilla.redhat.com/show_bug.cgi?id=1832609 by Sergio:

1. Create a template with a custom icon: metadata.annotations.iconClass = "fa fa-fill-drip"
2. Find the template in the catalog and see how the icon is not shown
3. Click on the template to see the details and see how the icon is properly shown
4. Click on "instantiate template" and see how the icon is properly shown in the next screen
I recommend to create a project first and import then the template files with `oc create -f template-test.yaml -n yourProject`. I uploaded 3 template files to bugzilla.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
