### PR TITLE
Bug 1840545: Fix project selector in helm release list page

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
@@ -14,20 +14,22 @@ export const HelmReleaseListPage: React.FC<HelmReleaseListPageProps> = (props) =
       params: { ns: namespace },
     },
   } = props;
-  return namespace ? (
+  return (
     <NamespacedPage variant={NamespacedPageVariants.light} hideApplications>
       <Helmet>
         <title>Helm Releases</title>
       </Helmet>
-      <div>
-        <PageHeading title="Helm Releases" />
-        <HelmReleaseList namespace={namespace} />
-      </div>
+      {namespace ? (
+        <div>
+          <PageHeading title="Helm Releases" />
+          <HelmReleaseList namespace={namespace} />
+        </div>
+      ) : (
+        <ProjectListPage title="Helm Releases">
+          Select a project to view the list of Helm Releases
+        </ProjectListPage>
+      )}
     </NamespacedPage>
-  ) : (
-    <ProjectListPage title="Helm Releases">
-      Select a project to view the list of Helm Releases
-    </ProjectListPage>
   );
 };
 


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3972

This PR - 
- Adds project selector on Helm release list page when all namespaces is selected.

Screenshots - 
cc: @openshift/team-devconsole-ux 

![Screenshot from 2020-05-27 13-27-32](https://user-images.githubusercontent.com/6041994/82993172-d1a57a00-a01d-11ea-8630-3fe74f437e12.png)
