### PR TITLE
Bug 1840567: Fix helm action menu in topology sidebar

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
@@ -72,7 +72,7 @@ export const mockHelmReleases: HelmRelease[] = [
       deleted: '',
       description: 'Install complete',
       status: 'failed',
-      notes: 'node-test-chart release notes',
+      notes: '',
     },
     chart: {
       metadata: {

--- a/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
@@ -13,17 +13,17 @@ import { DetailsPage } from '@console/internal/components/factory';
 import { K8sResourceKindReference } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
 import { Badge } from '@patternfly/react-core';
-import { fetchHelmReleases } from '../helm-utils';
-import HelmReleaseResources from './resources/HelmReleaseResources';
-import HelmReleaseOverview from './overview/HelmReleaseOverview';
-import HelmReleaseHistory from './history/HelmReleaseHistory';
 import {
   deleteHelmRelease,
   upgradeHelmRelease,
   rollbackHelmRelease,
 } from '../../../actions/modify-helm-release';
-import HelmReleaseNotes from './HelmReleaseNotes';
 import { HelmRelease, HelmActionOrigins } from '../helm-types';
+import { fetchHelmReleases } from '../helm-utils';
+import HelmReleaseResources from './resources/HelmReleaseResources';
+import HelmReleaseOverview from './overview/HelmReleaseOverview';
+import HelmReleaseHistory from './history/HelmReleaseHistory';
+import HelmReleaseNotes from './notes/HelmReleaseNotes';
 
 const SecretReference: K8sResourceKindReference = 'Secret';
 const HelmReleaseReference = 'HelmRelease';

--- a/frontend/packages/dev-console/src/components/helm/details/__tests__/HelmReleaseNotes.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/__tests__/HelmReleaseNotes.spec.tsx
@@ -2,11 +2,17 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 import { mockHelmReleases } from '../../__tests__/helm-release-mock-data';
-import HelmReleaseNotes from '../HelmReleaseNotes';
+import HelmReleaseNotes from '../notes/HelmReleaseNotes';
+import HelmReleaseNotesEmptyState from '../notes/HelmReleaseNotesEmptyState';
 
 describe('HelmReleaseNotes', () => {
   it('should render the SyncMarkdownView component when notes are available', () => {
     const helmReleaseResources = mount(<HelmReleaseNotes customData={mockHelmReleases[0]} />);
     expect(helmReleaseResources.find(SyncMarkdownView).exists()).toBe(true);
+  });
+
+  it('should render empty state when release notes are not given', () => {
+    const component = mount(<HelmReleaseNotes customData={mockHelmReleases[1]} />);
+    expect(component.find(HelmReleaseNotesEmptyState)).toHaveLength(1);
   });
 });

--- a/frontend/packages/dev-console/src/components/helm/details/notes/HelmReleaseNotes.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/notes/HelmReleaseNotes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
-import { HelmRelease } from '../helm-types';
+import { HelmRelease } from '../../helm-types';
+import HelmReleaseNotesEmptyState from './HelmReleaseNotesEmptyState';
 
 export interface HelmReleaseNotesProps {
   customData: HelmRelease;
@@ -8,10 +9,12 @@ export interface HelmReleaseNotesProps {
 
 const HelmReleaseNotes: React.FC<HelmReleaseNotesProps> = ({ customData }) => {
   const helmReleaseNotes = customData?.info?.notes ?? '';
-  return (
+  return helmReleaseNotes ? (
     <div className="co-m-pane__body">
       <SyncMarkdownView content={helmReleaseNotes} />
     </div>
+  ) : (
+    <HelmReleaseNotesEmptyState />
   );
 };
 

--- a/frontend/packages/dev-console/src/components/helm/details/notes/HelmReleaseNotesEmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/notes/HelmReleaseNotesEmptyState.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import {
+  Title,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+
+const HelmReleaseNotesEmptyState: React.FC = () => (
+  <EmptyState variant={EmptyStateVariant.full}>
+    <EmptyStateIcon icon={InfoCircleIcon} />
+    <Title size="md">No Release Notes Available</Title>
+    <EmptyStateBody>Release Notes are not available for this Helm Chart.</EmptyStateBody>
+  </EmptyState>
+);
+
+export default HelmReleaseNotesEmptyState;

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseNotesPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseNotesPanel.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import HelmReleaseNotesEmptyState from '../../helm/details/notes/HelmReleaseNotesEmptyState';
 
 type TopologyHelmReleaseNotesPanelProps = {
   releaseNotes: string;
@@ -7,10 +8,13 @@ type TopologyHelmReleaseNotesPanelProps = {
 
 const TopologyHelmReleaseNotesPanel: React.SFC<TopologyHelmReleaseNotesPanelProps> = ({
   releaseNotes,
-}) => (
-  <div className="overview__sidebar-pane-body">
-    {releaseNotes && <SyncMarkdownView content={releaseNotes} />}
-  </div>
-);
+}) =>
+  releaseNotes ? (
+    <div className="overview__sidebar-pane-body">
+      <SyncMarkdownView content={releaseNotes} />
+    </div>
+  ) : (
+    <HelmReleaseNotesEmptyState />
+  );
 
 export default TopologyHelmReleaseNotesPanel;

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
@@ -64,8 +64,7 @@ export const ConnectedTopologyHelmReleasePanel: React.FC<TopologyHelmReleasePane
       />
     ) : null;
 
-  const releaseNotesComponent = () =>
-    releaseNotes ? <TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} /> : null;
+  const releaseNotesComponent = () => <TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} />;
 
   const actions = helmReleaseActions(helmRelease);
   return (

--- a/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
@@ -6,6 +6,7 @@ import TopologyHelmReleaseResourcesPanel from '../TopologyHelmReleaseResourcesPa
 import TopologyHelmReleaseNotesPanel from '../TopologyHelmReleaseNotesPanel';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 import { ConnectedTopologyHelmReleasePanel } from '../TopologyHelmReleasePanel';
+import HelmReleaseNotesEmptyState from '../../../helm/details/notes/HelmReleaseNotesEmptyState';
 
 describe('TopologyHelmReleasePanel', () => {
   it('should render the resources tab by default', () => {
@@ -56,10 +57,12 @@ describe('TopologyHelmReleaseNotesPanel', () => {
   const releaseNotes = mockReleaseNotes;
 
   it('should render markdown when release notes are given', () => {
-    let component = mount(<TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} />);
+    const component = mount(<TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} />);
     expect(component.find(SyncMarkdownView)).toHaveLength(1);
+  });
 
-    component = mount(<TopologyHelmReleaseNotesPanel releaseNotes="" />);
-    expect(component.find(SyncMarkdownView)).toHaveLength(0);
+  it('should render empty state when release notes are not given', () => {
+    const component = mount(<TopologyHelmReleaseNotesPanel releaseNotes="" />);
+    expect(component.find(HelmReleaseNotesEmptyState)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3949

This PR -
- Fixes the issue where helm action menu is cut off from bottom when there are no release notes in a helm release.
- Adds empty state for helm releases without any release notes,

Screenshots - 
cc: @openshift/team-devconsole-ux 

Before -
![Screenshot from 2020-05-27 13-51-32](https://user-images.githubusercontent.com/6041994/82997119-97d77200-a023-11ea-9a62-e0211708d90d.png)

After - 
![Screenshot from 2020-05-27 17-57-10](https://user-images.githubusercontent.com/6041994/83021168-3b864980-a047-11ea-8e28-557dddcdec97.png)
![Screenshot from 2020-05-27 17-57-30](https://user-images.githubusercontent.com/6041994/83021170-3cb77680-a047-11ea-9a7d-c454686e870e.png)


