### PR TITLE
Bug 1840583: Fix helm home link on catalog sidebar

### DIFF
--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -242,7 +242,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
             </>
           );
 
-          const homePage = (
+          const homePage = chart.home && (
             <ExternalLink href={chart.home} additionalClassName="co-break-all" text={chart.home} />
           );
 
@@ -250,7 +250,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
             <>
               <PropertyItem label="Chart Version" value={chartVersion} />
               <PropertyItem label="App Version" value={appVersion} />
-              <PropertyItem label="Home Page" value={homePage} />
+              {homePage && <PropertyItem label="Home Page" value={homePage} />}
               {maintainers && <PropertyItem label="Maintainers" value={maintainers} />}
             </>
           );


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3996

This PR - 
- Hides the helm home link in catalog sidebar when home link is not present in the metadata.

Screenshots - 
cc: @openshift/team-devconsole-ux 

Before - 

![Screenshot from 2020-05-27 14-55-43](https://user-images.githubusercontent.com/6041994/83002001-20f1a780-a02a-11ea-8560-3ebb3c16f519.png)

After - 

![Screenshot from 2020-05-27 14-48-52](https://user-images.githubusercontent.com/6041994/83002033-2c44d300-a02a-11ea-9d32-04d1bee78492.png)

