### PR TITLE
open the VNC console in a new window

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/connected-vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/connected-vm-console.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { PodModel, ServiceModel } from '@console/internal/models';
+import { getVMStatus } from '../../statuses/vm/vm-status';
+import { VMImportKind } from '../../types/vm-import/ovirt/vm-import';
+import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
+import {
+  DataVolumeModel,
+  VirtualMachineImportModel,
+  VirtualMachineInstanceMigrationModel,
+  VirtualMachineInstanceModel,
+  VirtualMachineModel,
+} from '../../models';
+import { VMIKind, VMKind } from '../../types/vm';
+import { Firehose, FirehoseResult } from '@console/internal/components/utils';
+import { VMConsolesWrapper } from '../vms/vm-console';
+import { getLoadedData } from '../../utils';
+import { ConsoleEmptyState } from './vm-console-empty-state';
+import { ConsoleType } from '../../constants/vm/console-type';
+
+const ConnectedVMConsole: React.FC<ConnectedVMConsoleProps> = ({
+  type,
+  vm,
+  vmis,
+  pods,
+  migrations,
+  dataVolumes,
+  vmImports,
+}) => {
+  const loadedVM = getLoadedData(vm);
+  const loadedVMIs = getLoadedData(vmis);
+  const loadedPods = getLoadedData(pods);
+  const loadedMigrations = getLoadedData(migrations);
+  const loadedDataVolumes = getLoadedData(dataVolumes);
+  const loadedImports = getLoadedData(vmImports);
+  const vmi = loadedVMIs?.[0];
+
+  const vmStatusBundle = getVMStatus({
+    vm: loadedVM,
+    vmi,
+    pods: loadedPods,
+    migrations: loadedMigrations,
+    dataVolumes: loadedDataVolumes,
+    vmImports: loadedImports,
+  });
+
+  return (
+    <VMConsolesWrapper
+      vm={loadedVM}
+      vmi={vmi}
+      vmStatusBundle={vmStatusBundle}
+      pods={loadedPods}
+      type={type}
+      showOpenInNewWindow={false}
+    />
+  );
+};
+
+type ConnectedVMConsoleProps = {
+  type: ConsoleType;
+  vm?: FirehoseResult<VMKind>;
+  vmis?: FirehoseResult<VMIKind[]>;
+  pods?: FirehoseResult<PodKind[]>;
+  migrations?: FirehoseResult<K8sResourceKind[]>;
+  dataVolumes?: FirehoseResult<V1alpha1DataVolume[]>;
+  vmImports?: FirehoseResult<VMImportKind[]>;
+  services?: FirehoseResult;
+};
+
+const FirehoseVMConsole: React.FC<FirehoseVMConsoleProps> = ({
+  type,
+  namespace,
+  name,
+  isKubevirt,
+}) => {
+  const resources = [
+    {
+      kind: VirtualMachineModel.kind,
+      name,
+      namespace,
+      prop: 'vm',
+    },
+    {
+      kind: VirtualMachineInstanceModel.kind,
+      namespace,
+      isList: true,
+      prop: 'vmis',
+      optional: true,
+      fieldSelector: `metadata.name=${name}`,
+    },
+    {
+      kind: PodModel.kind,
+      namespace,
+      isList: true,
+      prop: 'pods',
+    },
+    {
+      kind: VirtualMachineInstanceMigrationModel.kind,
+      isList: true,
+      namespace,
+      prop: 'migrations',
+    },
+    {
+      kind: VirtualMachineImportModel.kind,
+      isList: true,
+      namespace,
+      prop: 'vmImports',
+      optional: true,
+    },
+    {
+      kind: DataVolumeModel.kind,
+      isList: true,
+      namespace,
+      prop: 'dataVolumes',
+    },
+    { kind: ServiceModel.kind, namespace, prop: 'services' },
+  ];
+  return isKubevirt ? (
+    <Firehose resources={resources}>
+      <ConnectedVMConsole type={type} />
+    </Firehose>
+  ) : (
+    <ConsoleEmptyState isKubevirt={isKubevirt} />
+  );
+};
+
+type FirehoseVMConsoleProps = {
+  type: ConsoleType;
+  namespace: string;
+  name: string;
+  isKubevirt: boolean;
+};
+
+export default FirehoseVMConsole;

--- a/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/vm-console-empty-state.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/vm-console-empty-state.scss
@@ -1,0 +1,4 @@
+.kv-cloud-vm-console-empty {
+  display: flex;
+  justify-content: center;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/vm-console-empty-state.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/vm-console-empty-state.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Title, EmptyState, EmptyStateIcon, EmptyStateBody, Spinner } from '@patternfly/react-core';
+import { PlugIcon } from '@patternfly/react-icons';
+import './vm-console-empty-state.scss';
+
+export interface ConsoleEmptyStateProps {
+  isKubevirt: boolean;
+}
+
+export const ConsoleEmptyState: React.SFC<ConsoleEmptyStateProps> = ({ isKubevirt }) => (
+  <div className="kv-cloud-vm-console-empty">
+    <EmptyState>
+      {isKubevirt === undefined ? (
+        <>
+          <EmptyStateIcon variant="container" component={Spinner} />
+          <Title size="lg" headingLevel="h4">
+            Loading
+          </Title>
+        </>
+      ) : (
+        <>
+          <EmptyStateIcon icon={PlugIcon} />
+          <Title size="lg" headingLevel="h4">
+            Kubevirt Plugin was not found
+          </Title>
+          <EmptyStateBody>
+            Accessing the VNC Console is not possible. Please install Kubevirt
+          </EmptyStateBody>
+        </>
+      )}
+    </EmptyState>
+  </div>
+);

--- a/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/vm-console-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/vm-console-page.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import ConnectedVMConsole from '@console/kubevirt-plugin/src/components/connected-vm-console/connected-vm-console';
+import { ConsoleType } from '@console/kubevirt-plugin/src/constants/vm/console-type';
+import { FLAG_KUBEVIRT } from '@console/kubevirt-plugin/src/plugin';
+import { useFlag } from '@console/shared/src/hooks/flag';
+
+export const VMConsolePage: React.FC<VMConsolePageProps> = ({ match, location }) => {
+  const isKubevirt = useFlag(FLAG_KUBEVIRT);
+  const params = new URLSearchParams(location.search);
+  const type = ConsoleType.fromString(params.get('type'));
+  const { name, ns: namespace } = match.params;
+
+  return (
+    <ConnectedVMConsole isKubevirt={isKubevirt} type={type} namespace={namespace} name={name} />
+  );
+};
+
+type VMConsolePageProps = {
+  location: Location;
+  match: any;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -278,6 +278,14 @@ export const menuActionDeleteVMI = (kindObj: K8sKind, vmi: VMIKind): KebabOption
   accessReview: asAccessReview(kindObj, vmi, 'delete'),
 });
 
+export const menuActionOpenConsole = (kindObj: K8sKind, vmi: VMIKind): KebabOption => ({
+  label: `Open Console`,
+  callback: () =>
+    window.open(
+      `/k8s/ns/${getNamespace(vmi)}/virtualmachineinstances/${getName(vmi)}/standaloneconsole`,
+    ),
+});
+
 export const vmMenuActions = [
   menuActionStart,
   menuActionStop,
@@ -287,6 +295,7 @@ export const vmMenuActions = [
   menuActionCancelMigration,
   menuActionClone,
   menuActionCdEdit,
+  menuActionOpenConsole,
   Kebab.factory.ModifyLabels,
   Kebab.factory.ModifyAnnotations,
   menuActionDeleteVMorCancelImport,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
@@ -16,6 +16,7 @@ export type VMTabProps = {
   customData: {
     kindObj: K8sKind;
   };
+  showOpenInNewWindow?: boolean;
 };
 
 export type VMLikeEntityTabProps = {

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/console-type.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/console-type.ts
@@ -1,0 +1,44 @@
+/* eslint-disable lines-between-class-members */
+import { AccessConsoles } from '@patternfly/react-console/dist/js';
+import { ObjectEnum } from '../object-enum';
+
+const {
+  VNC_CONSOLE_TYPE,
+  SERIAL_CONSOLE_TYPE,
+  DESKTOP_VIEWER_CONSOLE_TYPE,
+  RDP_CONSOLE_TYPE,
+} = AccessConsoles.constants;
+
+export class ConsoleType extends ObjectEnum<string> {
+  static readonly VNC = new ConsoleType('vnc', VNC_CONSOLE_TYPE);
+  static readonly RDP = new ConsoleType('rdp', RDP_CONSOLE_TYPE);
+  static readonly SERIAL = new ConsoleType('serial', SERIAL_CONSOLE_TYPE);
+  static readonly DESKTOP_VIEWER = new ConsoleType('desktop-viewer', DESKTOP_VIEWER_CONSOLE_TYPE);
+
+  private readonly patternflyLabel: string;
+
+  protected constructor(value: string, patternflyLabel: string) {
+    super(value);
+    this.patternflyLabel = patternflyLabel;
+  }
+
+  private static readonly ALL = Object.freeze(
+    ObjectEnum.getAllClassEnumProperties<ConsoleType>(ConsoleType),
+  );
+
+  private static readonly stringMapper = ConsoleType.ALL.reduce(
+    (accumulator, consoleType: ConsoleType) => ({
+      ...accumulator,
+      [consoleType.value]: consoleType,
+    }),
+    {},
+  );
+
+  static getAll = () => ConsoleType.ALL;
+
+  static fromString = (model: string): ConsoleType => ConsoleType.stringMapper[model];
+
+  toPatternflyLabel() {
+    return this.patternflyLabel;
+  }
+}

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -182,3 +182,9 @@ export const getNodeSelector = (vm: VMKind) => vm?.spec?.template?.spec?.nodeSel
 export const getTolerations = (vm: VMKind) => vm?.spec?.template?.spec?.tolerations;
 
 export const getAffinity = (vm: VMKind) => vm?.spec?.template?.spec?.affinity;
+
+export const getIsGraphicsConsoleAttached = (vm: VMKind) =>
+  vm?.spec?.template?.spec?.domain?.devices?.autoattachGraphicsDevice;
+
+export const getIsSerialConsoleAttached = (vm: VMKind) =>
+  vm?.spec?.template?.spec?.domain?.devices?.autoattachSerialConsole;

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -13,13 +13,17 @@ import { getBrandingDetails, Masthead } from './masthead';
 import { ConsoleNotifier } from './console-notifier';
 import { ConnectedNotificationDrawer } from './notification-drawer';
 import { Navigation } from './nav';
-import { history } from './utils';
+import { history, AsyncComponent } from './utils';
 import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources } from '../module/k8s';
 import { receivedResources, watchAPIServices } from '../actions/k8s';
 // cloud shell imports must come later than features
 import CloudShell from '@console/app/src/components/cloud-shell/CloudShell';
 import CloudShellTab from '@console/app/src/components/cloud-shell/CloudShellTab';
+const consoleLoader = () =>
+  import(
+    '@console/kubevirt-plugin/src/components/connected-vm-console/vm-console-page' /* webpackChunkName: "kubevirt" */
+  ).then((m) => m.VMConsolePage);
 import '../vendor.scss';
 import '../style.scss';
 
@@ -28,7 +32,6 @@ import { Page } from '@patternfly/react-core';
 
 const breakpointMD = 768;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
-
 // Edge lacks URLSearchParams
 import 'url-search-params-polyfill';
 
@@ -215,6 +218,10 @@ render(
   <Provider store={store}>
     <Router history={history} basename={window.SERVER_FLAGS.basePath}>
       <Switch>
+        <Route
+          path="/k8s/ns/:ns/virtualmachineinstances/:name/standaloneconsole"
+          render={(componentProps) => <AsyncComponent loader={consoleLoader} {...componentProps} />}
+        />
         <Route path="/terminal" component={CloudShellTab} />
         <Route path="/" component={App} />
       </Switch>


### PR DESCRIPTION
design: openshift/openshift-origin-design#425
JIRA: https://issues.redhat.com/browse/CNV-5111

This enables opening an **independent** new window for a VM/VMI console.

* Opening a new window disables the main window's console as they can cause disconnects between each other. closing the new window returns the console to the main window.
**closing the main window doesn't affect the new window :)**

* If the new window fails to open due to some Adblocker, an alert is shown.

* We're introducing a new route `/vm-console` with 3 URL Parameters:
`name`, `namespace`, `console`

* if `console=SerialConsole` it will open the serial console, for every other string or missing parameter it will open `VncConsole`
* If `name` or `namespace` or both are missing or misspelled, an error is shown
<img width="481" alt="Screen Shot 2020-05-26 at 23 08 24" src="https://user-images.githubusercontent.com/24938324/82999433-a452cf00-a011-11ea-8b58-05bb1a5bd882.png">

* If Kubevirt is not installed the following error is shown:
<img width="494" alt="Screen Shot 2020-05-26 at 23 14 18" src="https://user-images.githubusercontent.com/24938324/82999522-c9474200-a011-11ea-9535-86d995762145.png">

Video showing the new feature:
![cloud-console (1)](https://user-images.githubusercontent.com/24938324/83001799-e5001780-a014-11ea-8198-5402f52417c0.gif)
