### PR TITLE
Bug 1840624: fix(CLI-drawer): Add preventdefault to adjust scroll issue

### DIFF
--- a/frontend/packages/console-shared/src/components/drawer/Drawer.tsx
+++ b/frontend/packages/console-shared/src/components/drawer/Drawer.tsx
@@ -98,6 +98,7 @@ const Drawer: React.FC<DrawerProps> = ({
   };
 
   const handleResizeStart = (e: DraggableEvent) => {
+    e.preventDefault();
     lastObservedHeightRef.current = currentHeight;
     // always start with actual drawer height
     const drawerHeight = drawerRef.current?.offsetHeight || currentHeight;

--- a/frontend/packages/console-shared/src/components/drawer/__tests__/Drawer.spec.tsx
+++ b/frontend/packages/console-shared/src/components/drawer/__tests__/Drawer.spec.tsx
@@ -85,13 +85,14 @@ describe('DrawerComponent', () => {
   });
 
   it('should handle resizing', () => {
+    const preventDefault = jest.fn();
     const data = {} as DraggableData;
     const onChange = jest.fn();
     const wrapper = shallow(<Drawer resizable defaultHeight={100} onChange={onChange} />);
     wrapper
       .find(DraggableCoreIFrameFix)
       .props()
-      .onStart({ pageY: 500 } as any, data);
+      .onStart({ pageY: 500, preventDefault } as any, data);
     expect(wrapper.find('.ocs-drawer').prop('style').height).toBe(100);
     wrapper
       .find(DraggableCoreIFrameFix)


### PR DESCRIPTION
## Fixes:
Addresses https://issues.redhat.com/browse/ODC-3740
https://bugzilla.redhat.com/show_bug.cgi?id=1840624

## Analysis / Root cause:
Autoscrolling when using Terminal drawer

## Solution Description:
Adds prevent default to the `function` passed over to the `onStart` action

## Screenshot
![Terminal__scroll](https://user-images.githubusercontent.com/24852534/83007938-0d4a3f00-a032-11ea-9c0e-cd03756f0a4e.gif)

## Tests
Alters test in `Drawer.spec.tsx`

## Browser conformation
Chrome 73





