### PR TITLE
Bug 1840620: fixes issue on firefox with fit-content

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.scss
@@ -1,10 +1,9 @@
 .odc-item-selector-field {
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
     flex-flow: wrap;
     background: var(--pf-global--Color--light-200);
     padding: 4px;
-    width: fit-content;
   
     &__success-icon {
       color: var(--pf-global--success-color--200);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3937

**Analysis / Root cause**: 
For the event sources cards selector, the grey background is not limited to the list of cards and goes till the end of the page.

**Solution Description**: 
added styles specific to mozilla

**Screen shots / Gifs for design review**: 
- Chrome
<img width="1734" alt="Screenshot 2020-05-27 at 4 02 50 PM" src="https://user-images.githubusercontent.com/5129024/83008904-8e560600-a033-11ea-83b4-f92df5d469fd.png">

- Firefox
<img width="1648" alt="Screenshot 2020-05-27 at 4 05 59 PM" src="https://user-images.githubusercontent.com/5129024/83009227-07555d80-a034-11ea-9db0-9fa8e521cfe5.png">

- Safari
<img width="1475" alt="Screenshot 2020-05-27 at 4 07 10 PM" src="https://user-images.githubusercontent.com/5129024/83009285-25bb5900-a034-11ea-877f-d99eaa9c3475.png">




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
