### PR TITLE
Bug 1840720: Fix for updates of Helm charts in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/data-transformer.ts
@@ -152,9 +152,18 @@ export const transformTopologyData = (
     topologyGraphAndNodeData.graph.edges = getTrafficConnectors(trafficData, allResourcesList);
   }
 
+  // Copy the resources into a mutable list of resources, we don't want to effect the incoming lists
+  const dataResources: TopologyDataResources = Object.keys(resources).reduce((obj, key) => {
+    obj[key] = {
+      ...resources[key],
+      data: [...resources[key].data],
+    };
+    return obj;
+  }, {} as TopologyDataResources);
+
   // TODO: plugins
   const knativeModel = getKnativeTopologyDataModel(
-    resources,
+    dataResources,
     allResourcesList,
     installedOperators,
     utils,
@@ -162,7 +171,7 @@ export const transformTopologyData = (
   addToTopologyDataModel(knativeModel, topologyGraphAndNodeData);
 
   const operatorsModel = getOperatorTopologyDataModel(
-    resources,
+    dataResources,
     allResourcesList,
     installedOperators,
     utils,
@@ -172,7 +181,7 @@ export const transformTopologyData = (
   addToTopologyDataModel(operatorsModel, topologyGraphAndNodeData);
 
   const helmModel = getHelmTopologyDataModel(
-    resources,
+    dataResources,
     allResourcesList,
     installedOperators,
     utils,
@@ -183,7 +192,7 @@ export const transformTopologyData = (
   addToTopologyDataModel(helmModel, topologyGraphAndNodeData);
 
   const vmsModel = getKubevirtTopologyDataModel(
-    resources,
+    dataResources,
     allResourcesList,
     installedOperators,
     utils,
@@ -193,7 +202,7 @@ export const transformTopologyData = (
   addToTopologyDataModel(vmsModel, topologyGraphAndNodeData);
 
   const baseModel = getBaseTopologyDataModel(
-    resources,
+    dataResources,
     allResourcesList,
     installedOperators,
     utils,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3477

**Analysis / Root cause**: 
Topology removes resources from the retrieved list as they are being consumed by the different types (Helm, Knative, Operator Backed, etc). Since the view is updated when the helm releases are retrieved, the items were removed from the list and hence no longer transformed into viewable nodes.

**Solution Description**: 
Copy the resource data into new mutable arrays so that the original resource lists are not changed during the transforms.

/kind bug