### PR TITLE
Bug 1840760: Hide monitoring tabs when monitoring is disabled

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
@@ -15,6 +15,7 @@ describe('Monitoring Page ', () => {
         isExact: true,
         params: {},
       },
+      canAccess: true,
     };
     const component = shallow(<MonitoringPage {...monPageProps} />);
     expect(component.find(ProjectListPage).exists()).toBe(true);
@@ -32,7 +33,64 @@ describe('Monitoring Page ', () => {
           ns: 'test-proj',
         },
       },
+      canAccess: true,
     };
+
+    window.SERVER_FLAGS.prometheusBaseURL = 'http://some-mock-url.com';
+
+    const component = shallow(<MonitoringPage {...monPageProps} />);
+    expect(component.find(PageHeading).exists()).toBe(true);
+    expect(component.find(PageHeading).prop('title')).toBe('Monitoring');
+    expect(component.find(HorizontalNav).exists()).toBe(true);
+    const actualTabs = component
+      .find(HorizontalNav)
+      .prop('pages')
+      .map((page) => page.name);
+    expect(actualTabs).toEqual(expectedTabs);
+  });
+
+  it('should render only events tab of Monitoring page for selected project when user cannot access namespaces', () => {
+    const expectedTabs: string[] = ['Events'];
+    monPageProps = {
+      match: {
+        path: '/dev-monitoring/ns/:ns',
+        url: '/dev-monitoring/ns/test-proj',
+        isExact: true,
+        params: {
+          ns: 'test-proj',
+        },
+      },
+      canAccess: false,
+    };
+
+    window.SERVER_FLAGS.prometheusBaseURL = 'http://some-mock-url.com';
+
+    const component = shallow(<MonitoringPage {...monPageProps} />);
+    expect(component.find(PageHeading).exists()).toBe(true);
+    expect(component.find(PageHeading).prop('title')).toBe('Monitoring');
+    expect(component.find(HorizontalNav).exists()).toBe(true);
+    const actualTabs = component
+      .find(HorizontalNav)
+      .prop('pages')
+      .map((page) => page.name);
+    expect(actualTabs).toEqual(expectedTabs);
+  });
+
+  it('should render only events tab of Monitoring page for selected project when prometheus is disabled', () => {
+    const expectedTabs: string[] = ['Events'];
+    monPageProps = {
+      match: {
+        path: '/dev-monitoring/ns/:ns',
+        url: '/dev-monitoring/ns/test-proj',
+        isExact: true,
+        params: {
+          ns: 'test-proj',
+        },
+      },
+      canAccess: true,
+    };
+
+    window.SERVER_FLAGS.prometheusBaseURL = undefined;
 
     const component = shallow(<MonitoringPage {...monPageProps} />);
     expect(component.find(PageHeading).exists()).toBe(true);


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3561
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Monitoring nav item is shown always even if the moniroting operator is disabled. That results in Dashboard and metrics tab being unusable since monitoring is disabled.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Hides `Dashboard` and `Metrics` tabs on Monitoring page when monitoring operators is disabled.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/6041994/83036602-6fb63600-a058-11ea-95a6-cc2f53eb327b.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/6041994/83064425-612f4500-a07f-11ea-9543-7f2043b1c451.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
