### PR TITLE
Bug 1835170: Allow Edit Application Grouping in topology side panel

### DIFF
--- a/frontend/packages/dev-console/src/components/modals/EditApplicationModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/EditApplicationModal.tsx
@@ -15,6 +15,7 @@ import FormSection from '../import/section/FormSection';
 import ApplicationSelector from '../import/app/ApplicationSelector';
 import { updateResourceApplication } from '../../utils/application-utils';
 import { updateTopologyResourceApplication } from '../topology/topology-utils';
+import { UNASSIGNED_KEY } from '../../const';
 
 type EditApplicationFormProps = {
   resource: K8sResourceKind;
@@ -92,7 +93,7 @@ class EditApplicationModal extends PromiseComponent<
     const initialValues = {
       application: {
         name: application,
-        selectedKey: application,
+        selectedKey: application || UNASSIGNED_KEY,
       },
     };
     return (

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -35,6 +35,8 @@ import {
 } from '@console/internal/components/utils';
 import KnativeComponentFactory from '@console/knative-plugin/src/topology/components/knativeComponentFactory';
 import { KubevirtComponentFactory } from '@console/kubevirt-plugin/src/topology/components/kubevirtComponentFactory';
+import { TYPE_VIRTUAL_MACHINE } from '@console/kubevirt-plugin/src/topology/components/const';
+import TopologyVmPanel from '@console/kubevirt-plugin/src/topology/TopologyVmPanel';
 import { useAddToProjectAccess } from '../../utils/useAddToProjectAccess';
 import TopologySideBar from './TopologySideBar';
 import {
@@ -59,13 +61,12 @@ import {
   FILTER_ACTIVE_CLASS,
 } from './filters';
 import TopologyHelmReleasePanel from './helm/TopologyHelmReleasePanel';
-import { TYPE_HELM_RELEASE } from './helm/components/const';
+import { TYPE_HELM_RELEASE, TYPE_HELM_WORKLOAD } from './helm/components/const';
 import { HelmComponentFactory } from './helm/components/helmComponentFactory';
 import { TYPE_OPERATOR_BACKED_SERVICE } from './operators/components/const';
 import { OperatorsComponentFactory } from './operators/components/operatorsComponentFactory';
 import { getServiceBindingStatus } from './topology-utils';
-import { TYPE_VIRTUAL_MACHINE } from '@console/kubevirt-plugin/src/topology/components/const';
-import TopologyVmPanel from '@console/kubevirt-plugin/src/topology/TopologyVmPanel';
+import TopologyHelmWorkloadPanel from './helm/TopologyHelmWorkloadPanel';
 
 interface StateProps {
   filters: TopologyFilters;
@@ -328,6 +329,9 @@ const Topology: React.FC<ComponentProps> = ({
       // TODO: Use Plugins
       if (selectedEntity.getType() === TYPE_HELM_RELEASE) {
         return <TopologyHelmReleasePanel helmRelease={selectedEntity} />;
+      }
+      if (selectedEntity.getType() === TYPE_HELM_WORKLOAD) {
+        return <TopologyHelmWorkloadPanel item={selectedEntity.getData() as TopologyDataObject} />;
       }
       if (selectedEntity.getType() === TYPE_OPERATOR_BACKED_SERVICE) {
         return null;

--- a/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
 import * as _ from 'lodash';
 import KnativeResourceOverviewPage from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
+import { KebabAction } from '@console/internal/components/utils';
 import { TopologyDataObject } from './topology-types';
+import { ModifyApplication } from '../../actions/modify-application';
 
 export type TopologyResourcePanelProps = {
   item: TopologyDataObject;
@@ -15,11 +17,18 @@ const TopologyResourcePanel: React.FC<TopologyResourcePanelProps> = ({ item }) =
   if (_.get(item, 'data.isKnativeResource', false) && itemKind && itemKind !== 'Deployment') {
     return <KnativeResourceOverviewPage item={item.resources} />;
   }
+
+  let customActions: KebabAction[] = null;
+  if (!item.operatorBackedService) {
+    customActions = [ModifyApplication];
+  }
+
   return (
     resourceItemToShowOnSideBar && (
       <ResourceOverviewPage
         item={resourceItemToShowOnSideBar}
         kind={resourceItemToShowOnSideBar.obj.kind}
+        customActions={customActions}
       />
     )
   );

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmWorkloadPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmWorkloadPanel.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
+import { TopologyDataObject } from '../topology-types';
+
+export type TopologyResourcePanelProps = {
+  item: TopologyDataObject;
+};
+
+const TopologyHelmWorkloadPanel: React.FC<TopologyResourcePanelProps> = ({ item }) => {
+  const resourceItemToShowOnSideBar = item && item.resources;
+
+  return (
+    resourceItemToShowOnSideBar && (
+      <ResourceOverviewPage
+        item={resourceItemToShowOnSideBar}
+        kind={resourceItemToShowOnSideBar.obj.kind}
+      />
+    )
+  );
+};
+
+export default TopologyHelmWorkloadPanel;

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -7,7 +7,7 @@ import { RootState } from '@console/internal/redux';
 import { OverviewItem } from '@console/shared';
 import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
 import { KNATIVE_SERVING_APIGROUP } from '../../const';
-import { RevisionModel, ServiceModel } from '../../models';
+import { RevisionModel } from '../../models';
 import { getRevisionActions } from '../../actions/getRevisionActions';
 import { isDynamicEventResourceKind } from '../../utils/fetch-dynamic-eventsources-utils';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
@@ -50,13 +50,14 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
   );
 
   const actions = [];
-  if (resourceModel.kind === ServiceModel.kind) {
-    actions.push(ModifyApplication);
-  }
   if (resourceModel.kind === RevisionModel.kind) {
     actions.push(...getRevisionActions());
   } else {
-    actions.push(...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common);
+    actions.push(
+      ModifyApplication,
+      ...Kebab.getExtensionsActionsForKind(resourceModel),
+      ...Kebab.factory.common,
+    );
   }
 
   return (

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -52,7 +52,11 @@ export const knativeContextMenu = (element: Node) => {
   if (model.kind === RevisionModel.kind) {
     actions.push(...getRevisionActions());
   } else {
-    actions.push(...Kebab.getExtensionsActionsForKind(model), ...Kebab.factory.common);
+    actions.push(
+      ModifyApplication,
+      ...Kebab.getExtensionsActionsForKind(model),
+      ...Kebab.factory.common,
+    );
   }
 
   const kebabOptions = actions.map((action) => {

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -208,6 +208,7 @@ export const menuActionDeleteVMI = (kindObj: K8sKind, vmi: VMIKind): KebabOption
 });
 
 export const vmMenuActions = [
+  ModifyApplication,
   menuActionStart,
   menuActionStop,
   menuActionRestart,
@@ -218,7 +219,6 @@ export const vmMenuActions = [
   menuActionCdEdit,
   Kebab.factory.ModifyLabels,
   Kebab.factory.ModifyAnnotations,
-  ModifyApplication,
   menuActionDeleteVM,
 ];
 

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { OverviewItem, PodRing } from '@console/shared';
 import { DaemonSetModel } from '../../models';
-import { ResourceSummary } from '../utils';
+import { KebabAction, ResourceSummary } from '../utils';
 import { menuActions, DaemonSetDetailsList } from '../daemon-set';
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
 import { ResourceOverviewDetails } from './resource-overview-details';
@@ -33,11 +33,11 @@ const tabs = [
   },
 ];
 
-export const DaemonSetOverview: React.SFC<DaemonSetOverviewProps> = ({ item }) => (
+export const DaemonSetOverview: React.SFC<DaemonSetOverviewProps> = ({ item, customActions }) => (
   <ResourceOverviewDetails
     item={item}
     kindObj={DaemonSetModel}
-    menuActions={menuActions}
+    menuActions={customActions ? [...customActions, ...menuActions] : menuActions}
     tabs={tabs}
   />
 );
@@ -48,4 +48,5 @@ type DaemonSetOverviewDetailsProps = {
 
 type DaemonSetOverviewProps = {
   item: OverviewItem;
+  customActions?: KebabAction[];
 };

--- a/frontend/public/components/overview/deployment-config-overview.tsx
+++ b/frontend/public/components/overview/deployment-config-overview.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { DeploymentConfigModel } from '../../models';
 import { DeploymentConfigDetailsList, menuActions } from '../deployment-config';
-import { LoadingInline, ResourceSummary, WorkloadPausedAlert } from '../utils';
+import { KebabAction, LoadingInline, ResourceSummary, WorkloadPausedAlert } from '../utils';
 
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
 import { ResourceOverviewDetails } from './resource-overview-details';
@@ -66,11 +66,12 @@ const tabs = [
 
 export const DeploymentConfigOverviewPage: React.SFC<DeploymentConfigOverviewProps> = ({
   item,
+  customActions,
 }) => (
   <ResourceOverviewDetails
     item={item}
     kindObj={DeploymentConfigModel}
-    menuActions={menuActions}
+    menuActions={customActions ? [...customActions, ...menuActions] : menuActions}
     tabs={tabs}
   />
 );
@@ -81,4 +82,5 @@ type DeploymentConfigOverviewDetailsProps = {
 
 type DeploymentConfigOverviewProps = {
   item: OverviewItem;
+  customActions?: KebabAction[];
 };

--- a/frontend/public/components/overview/deployment-overview.tsx
+++ b/frontend/public/components/overview/deployment-overview.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { DeploymentModel } from '../../models';
 import { DeploymentKind } from '../../module/k8s';
 import { DeploymentDetailsList, menuActions } from '../deployment';
-import { LoadingInline, ResourceSummary, WorkloadPausedAlert } from '../utils';
+import { KebabAction, LoadingInline, ResourceSummary, WorkloadPausedAlert } from '../utils';
 
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
 import { ResourceOverviewDetails } from './resource-overview-details';
@@ -65,11 +65,14 @@ const tabs = [
   },
 ];
 
-export const DeploymentOverviewPage: React.SFC<DeploymentOverviewProps> = ({ item }) => (
+export const DeploymentOverviewPage: React.SFC<DeploymentOverviewProps> = ({
+  item,
+  customActions,
+}) => (
   <ResourceOverviewDetails
     item={item}
     kindObj={DeploymentModel}
-    menuActions={menuActions}
+    menuActions={customActions ? [...customActions, ...menuActions] : menuActions}
     tabs={tabs}
   />
 );
@@ -80,4 +83,5 @@ type DeploymentOverviewDetailsProps = {
 
 type DeploymentOverviewProps = {
   item: OverviewItem<DeploymentKind>;
+  customActions?: KebabAction[];
 };

--- a/frontend/public/components/overview/pod-overview.tsx
+++ b/frontend/public/components/overview/pod-overview.tsx
@@ -4,6 +4,7 @@ import { PodResourceSummary, PodDetailsList, menuActions } from '../pod';
 import { PodModel } from '../../models';
 import { ResourceOverviewDetails } from './resource-overview-details';
 import { NetworkingOverview } from './networking-overview';
+import { KebabAction } from '../utils';
 
 const PodOverviewDetails: React.SFC<PodOverviewDetailsProps> = ({ item: { obj: pod } }) => {
   return (
@@ -35,8 +36,13 @@ const tabs = [
   },
 ];
 
-export const PodOverviewPage: React.SFC<PodOverviewPageProps> = ({ item }) => (
-  <ResourceOverviewDetails item={item} kindObj={PodModel} menuActions={menuActions} tabs={tabs} />
+export const PodOverviewPage: React.SFC<PodOverviewPageProps> = ({ item, customActions }) => (
+  <ResourceOverviewDetails
+    item={item}
+    kindObj={PodModel}
+    menuActions={customActions ? [...customActions, ...menuActions] : menuActions}
+    tabs={tabs}
+  />
 );
 
 type PodOverviewDetailsProps = {
@@ -49,4 +55,5 @@ type PodResourcesTabProps = {
 
 type PodOverviewPageProps = {
   item: PodOverviewItem;
+  customActions?: KebabAction[];
 };

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -35,25 +35,33 @@ export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabP
   );
 };
 
-export const DefaultOverviewPage = connectToModel(({ kindObj: kindObject, item }) => (
-  <div className="overview__sidebar-pane resource-overview">
-    <ResourceOverviewHeading
-      actions={[...Kebab.getExtensionsActionsForKind(kindObject), ...common]}
-      kindObj={kindObject}
-      resource={item.obj}
-    />
-    <div className="overview__sidebar-pane-body resource-overview__body">
-      <div className="resource-overview__summary">
-        <ResourceSummary resource={item.obj} />
+export const DefaultOverviewPage = connectToModel(
+  ({ kindObj: kindObject, item, customActions }) => (
+    <div className="overview__sidebar-pane resource-overview">
+      <ResourceOverviewHeading
+        actions={[
+          ...(customActions ? customActions : []),
+          ...Kebab.getExtensionsActionsForKind(kindObject),
+          ...common,
+        ]}
+        kindObj={kindObject}
+        resource={item.obj}
+      />
+      <div className="overview__sidebar-pane-body resource-overview__body">
+        <div className="resource-overview__summary">
+          <ResourceSummary resource={item.obj} />
+        </div>
       </div>
     </div>
-  </div>
-));
+  ),
+);
 
-export const ResourceOverviewPage = connectToModel(({ kindObj, item }) => {
+export const ResourceOverviewPage = connectToModel(({ kindObj, item, customActions }) => {
   const ref = referenceForModel(kindObj);
   const loader = resourceOverviewPages.get(ref, () => Promise.resolve(DefaultOverviewPage));
-  return <AsyncComponent loader={loader} kindObj={kindObj} item={item} />;
+  return (
+    <AsyncComponent loader={loader} kindObj={kindObj} item={item} customActions={customActions} />
+  );
 });
 
 export type OverviewDetailsResourcesTabProps = {

--- a/frontend/public/components/overview/stateful-set-overview.tsx
+++ b/frontend/public/components/overview/stateful-set-overview.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { StatefulSetModel } from '../../models';
 import { menuActions } from '../stateful-set';
-import { ResourceSummary } from '../utils';
+import { KebabAction, ResourceSummary } from '../utils';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
@@ -42,11 +42,14 @@ const tabs = [
   },
 ];
 
-export const StatefulSetOverview: React.SFC<StatefulSetOverviewProps> = ({ item }) => (
+export const StatefulSetOverview: React.SFC<StatefulSetOverviewProps> = ({
+  item,
+  customActions,
+}) => (
   <ResourceOverviewDetails
     item={item}
     kindObj={StatefulSetModel}
-    menuActions={menuActions}
+    menuActions={customActions ? [...customActions, ...menuActions] : menuActions}
     tabs={tabs}
   />
 );
@@ -57,4 +60,5 @@ type StatefulSetOverviewDetailsProps = {
 
 type StatefulSetOverviewProps = {
   item: OverviewItem;
+  customActions?: KebabAction[];
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3929

**Analysis / Root cause**: 
Edit Application Grouping kebab menu option was removed from the extensions actions since they are not available for some workloads of some types.

**Solution Description**: 
Add the ability to add custom actions to the sidebar resource overview pages and add the Edit Application Grouping custom action to those resources which can be grouped.

/kind bug