### PR TITLE
Bug 1840839: Check for www when adding from git repo

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -35,7 +35,11 @@ export const validationSchema = yup.object().shape({
 });
 
 const hasDomain = (url: string, domain: string): boolean => {
-  return url.includes(`https://${domain}/`) || url.includes(`@${domain}:`);
+  return (
+    url.startsWith(`https://${domain}/`) ||
+    url.startsWith(`https://www.${domain}/`) ||
+    url.includes(`@${domain}:`)
+  );
 };
 
 export const detectGitType = (url: string): string => {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1840839
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The `www` in a git repo URL causes the URL verification check to fail even though the API supports it.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Check for presence of `www` at the start of a URL.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![upload_temp](https://user-images.githubusercontent.com/20013884/83051735-09d3a980-a06c-11ea-8248-b29599798e65.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
