### PR TITLE
Bug 1840903: Fix context menu not appearing in helm group even with edit access

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmRelease.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmRelease.tsx
@@ -21,7 +21,7 @@ export type HelmReleaseProps = {
   WithDndDropProps;
 
 const HelmRelease: React.FC<HelmReleaseProps> = (props) => {
-  const secretObj = getTopologyResourceObject(props.element.getData().resources.obj);
+  const secretObj = getTopologyResourceObject(props.element.getData());
   const resourceModel = secretObj ? modelFor(referenceFor(secretObj)) : null;
   const editAccess = useAccessReview({
     group: resourceModel?.apiGroup,


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-3948

Problem:
Users with edit access are not able to open the context menu on right clicking the helm group in topology.

Solution:
Passing correct object as an argument to the `getTopologyResourceObject` function fixes the issues

Screenshots:
![helm-node-context-menu-fix](https://user-images.githubusercontent.com/9964343/83067369-31cf0700-a084-11ea-8944-4e3ab0fcb814.gif)
