### PR TITLE
Bug 1792693: add withStartGuide to dev-console pages

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
@@ -2,35 +2,40 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router';
 import Helmet from 'react-helmet';
 import { PageHeading } from '@console/internal/components/utils';
+import { withStartGuide } from '@console/internal/components/start-guide';
 import ProjectListPage from '../projects/ProjectListPage';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import HelmReleaseList from './list/HelmReleaseList';
 
 type HelmReleaseListPageProps = RouteComponentProps<{ ns: string }>;
 
-export const HelmReleaseListPage: React.FC<HelmReleaseListPageProps> = (props) => {
+const PageContents: React.FC<HelmReleaseListPageProps> = (props) => {
   const {
     match: {
       params: { ns: namespace },
     },
   } = props;
-  return (
-    <NamespacedPage variant={NamespacedPageVariants.light} hideApplications>
-      <Helmet>
-        <title>Helm Releases</title>
-      </Helmet>
-      {namespace ? (
-        <div>
-          <PageHeading title="Helm Releases" />
-          <HelmReleaseList namespace={namespace} />
-        </div>
-      ) : (
-        <ProjectListPage title="Helm Releases">
-          Select a project to view the list of Helm Releases
-        </ProjectListPage>
-      )}
-    </NamespacedPage>
+  return namespace ? (
+    <div>
+      <PageHeading title="Helm Releases" />
+      <HelmReleaseList namespace={namespace} />
+    </div>
+  ) : (
+    <ProjectListPage title="Helm Releases">
+      Select a project to view the list of Helm Releases
+    </ProjectListPage>
   );
 };
+
+const PageContentsWithStartGuide = withStartGuide(PageContents);
+
+export const HelmReleaseListPage: React.FC<HelmReleaseListPageProps> = (props) => (
+  <NamespacedPage variant={NamespacedPageVariants.light} hideApplications>
+    <Helmet>
+      <title>Helm Releases</title>
+    </Helmet>
+    <PageContentsWithStartGuide {...props} />
+  </NamespacedPage>
+);
 
 export default HelmReleaseListPage;

--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { HorizontalNav, PageHeading, history } from '@console/internal/components/utils';
 import { featureReducerName } from '@console/internal/reducers/features';
 import { TechPreviewBadge, ALL_NAMESPACES_KEY, FLAGS } from '@console/shared';
+import { withStartGuide } from '@console/internal/components/start-guide';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import ProjectListPage from '../projects/ProjectListPage';
 import ConnectedMonitoringDashboard from './dashboard/MonitoringDashboard';
@@ -31,7 +32,7 @@ const handleNamespaceChange = (newNamespace: string): void => {
   }
 };
 
-export const MonitoringPage: React.FC<Props> = ({ match, canAccess }) => {
+export const PageContents: React.FC<Props> = ({ match, canAccess }) => {
   const activeNamespace = match.params.ns;
   const canAccessPrometheus = canAccess && !!window.SERVER_FLAGS.prometheusBaseURL;
 
@@ -60,30 +61,34 @@ export const MonitoringPage: React.FC<Props> = ({ match, canAccess }) => {
     [canAccessPrometheus],
   );
 
-  return (
+  return activeNamespace ? (
     <>
-      <Helmet>
-        <title>Monitoring</title>
-      </Helmet>
-      <NamespacedPage
-        hideApplications
-        variant={NamespacedPageVariants.light}
-        onNamespaceChange={handleNamespaceChange}
-      >
-        {activeNamespace ? (
-          <>
-            <PageHeading badge={<TechPreviewBadge />} title="Monitoring" />
-            <HorizontalNav pages={pages} match={match} noStatusBox />
-          </>
-        ) : (
-          <ProjectListPage badge={<TechPreviewBadge />} title="Monitoring">
-            Select a project to view monitoring metrics
-          </ProjectListPage>
-        )}
-      </NamespacedPage>
+      <PageHeading badge={<TechPreviewBadge />} title="Monitoring" />
+      <HorizontalNav pages={pages} match={match} noStatusBox />
     </>
+  ) : (
+    <ProjectListPage badge={<TechPreviewBadge />} title="Monitoring">
+      Select a project to view monitoring metrics
+    </ProjectListPage>
   );
 };
+
+const PageContentsWithStartGuide = withStartGuide(PageContents);
+
+export const MonitoringPage: React.FC<Props> = (props) => (
+  <>
+    <Helmet>
+      <title>Monitoring</title>
+    </Helmet>
+    <NamespacedPage
+      hideApplications
+      variant={NamespacedPageVariants.light}
+      onNamespaceChange={handleNamespaceChange}
+    >
+      <PageContentsWithStartGuide {...props} />
+    </NamespacedPage>
+  </>
+);
 
 const stateToProps = (state) => ({
   canAccess: !!state[featureReducerName].get(FLAGS.CAN_GET_NS),

--- a/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { HorizontalNav, PageHeading } from '@console/internal/components/utils';
-import { MonitoringPage } from '../MonitoringPage';
+import { PageContents } from '../MonitoringPage';
 import ProjectListPage from '../../projects/ProjectListPage';
 
 describe('Monitoring Page ', () => {
-  let monPageProps: React.ComponentProps<typeof MonitoringPage>;
+  let monPageProps: React.ComponentProps<typeof PageContents>;
 
   it('should render ProjectList page when in all-projects namespace', () => {
     monPageProps = {
@@ -17,7 +17,7 @@ describe('Monitoring Page ', () => {
       },
       canAccess: true,
     };
-    const component = shallow(<MonitoringPage {...monPageProps} />);
+    const component = shallow(<PageContents {...monPageProps} />);
     expect(component.find(ProjectListPage).exists()).toBe(true);
     expect(component.find(ProjectListPage).prop('title')).toBe('Monitoring');
   });
@@ -38,7 +38,7 @@ describe('Monitoring Page ', () => {
 
     window.SERVER_FLAGS.prometheusBaseURL = 'http://some-mock-url.com';
 
-    const component = shallow(<MonitoringPage {...monPageProps} />);
+    const component = shallow(<PageContents {...monPageProps} />);
     expect(component.find(PageHeading).exists()).toBe(true);
     expect(component.find(PageHeading).prop('title')).toBe('Monitoring');
     expect(component.find(HorizontalNav).exists()).toBe(true);
@@ -65,7 +65,7 @@ describe('Monitoring Page ', () => {
 
     window.SERVER_FLAGS.prometheusBaseURL = 'http://some-mock-url.com';
 
-    const component = shallow(<MonitoringPage {...monPageProps} />);
+    const component = shallow(<PageContents {...monPageProps} />);
     expect(component.find(PageHeading).exists()).toBe(true);
     expect(component.find(PageHeading).prop('title')).toBe('Monitoring');
     expect(component.find(HorizontalNav).exists()).toBe(true);
@@ -92,7 +92,7 @@ describe('Monitoring Page ', () => {
 
     window.SERVER_FLAGS.prometheusBaseURL = undefined;
 
-    const component = shallow(<MonitoringPage {...monPageProps} />);
+    const component = shallow(<PageContents {...monPageProps} />);
     expect(component.find(PageHeading).exists()).toBe(true);
     expect(component.find(PageHeading).prop('title')).toBe('Monitoring');
     expect(component.find(HorizontalNav).exists()).toBe(true);

--- a/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router';
 import { getBadgeFromType } from '@console/shared';
+import { withStartGuide } from '@console/internal/components/start-guide';
 import { PipelineModel } from '../../models';
 import ProjectListPage from '../projects/ProjectListPage';
 import PipelinesResourceList from './PipelinesResourceList';
@@ -32,4 +33,4 @@ export const PipelinesPage: React.FC<PipelinesPageProps> = (props) => {
   );
 };
 
-export default PipelinesPage;
+export default withStartGuide(PipelinesPage);

--- a/frontend/packages/dev-console/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelinesResourceList.tsx
@@ -34,6 +34,7 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
           ? `/k8s/ns/${namespace}/${referenceForModel(PipelineModel)}/~new/builder`
           : `/k8s/cluster/${referenceForModel(PipelineModel)}/~new`,
       }}
+      createAccessReview={{ model: PipelineModel, namespace }}
       filterLabel="by name"
       textFilter="name"
       resources={resources}

--- a/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
@@ -18,6 +18,7 @@ interface MonitoringPageProps {
   match: RMatch<{
     ns?: string;
   }>;
+  noProjectsAvailable?: boolean;
 }
 
 const handleNamespaceChange = (newNamespace: string): void => {
@@ -26,7 +27,11 @@ const handleNamespaceChange = (newNamespace: string): void => {
   }
 };
 
-export const ProjectDetailsPage: React.FC<MonitoringPageProps> = ({ match, ...props }) => {
+export const PageContents: React.FC<MonitoringPageProps> = ({
+  noProjectsAvailable,
+  match,
+  ...props
+}) => {
   const activeNamespace = match.params.ns;
 
   const canListRoleBindings = useAccessReview({
@@ -43,53 +48,55 @@ export const ProjectDetailsPage: React.FC<MonitoringPageProps> = ({ match, ...pr
     namespace: activeNamespace,
   });
 
-  return (
-    <>
-      <Helmet>
-        <title>Project Details</title>
-      </Helmet>
-      <NamespacedPage
-        hideApplications
-        variant={NamespacedPageVariants.light}
-        onNamespaceChange={handleNamespaceChange}
-      >
-        {activeNamespace ? (
-          <DetailsPage
-            {...props}
-            match={match}
-            breadcrumbsFor={() => []}
-            name={activeNamespace}
-            kind={ProjectModel.kind}
-            kindObj={ProjectModel}
-            menuActions={projectMenuActions}
-            customData={{ activeNamespace, hideHeading: true }}
-            pages={[
-              {
-                href: '',
-                name: 'Overview',
-                component: ProjectDashboard,
-              },
-              {
-                href: 'details',
-                name: 'Details',
-                component: NamespaceDetails,
-              },
-              canListRoleBindings &&
-                canCreateRoleBindings && {
-                  href: 'access',
-                  name: 'Project Access',
-                  component: ProjectAccessPage,
-                },
-            ]}
-          />
-        ) : (
-          <ProjectListPage title="Project Details">
-            Select a project to view its details
-          </ProjectListPage>
-        )}
-      </NamespacedPage>
-    </>
+  return !noProjectsAvailable && activeNamespace ? (
+    <DetailsPage
+      {...props}
+      match={match}
+      breadcrumbsFor={() => []}
+      name={activeNamespace}
+      kind={ProjectModel.kind}
+      kindObj={ProjectModel}
+      menuActions={projectMenuActions}
+      customData={{ activeNamespace, hideHeading: true }}
+      pages={[
+        {
+          href: '',
+          name: 'Overview',
+          component: ProjectDashboard,
+        },
+        {
+          href: 'details',
+          name: 'Details',
+          component: NamespaceDetails,
+        },
+        canListRoleBindings &&
+          canCreateRoleBindings && {
+            href: 'access',
+            name: 'Project Access',
+            component: ProjectAccessPage,
+          },
+      ]}
+    />
+  ) : (
+    <ProjectListPage title="Project Details">Select a project to view its details</ProjectListPage>
   );
 };
 
-export default withStartGuide(ProjectDetailsPage);
+const PageContentsWithStartGuide = withStartGuide(PageContents);
+
+export const ProjectDetailsPage: React.FC<MonitoringPageProps> = (props) => (
+  <>
+    <Helmet>
+      <title>Project Details</title>
+    </Helmet>
+    <NamespacedPage
+      hideApplications
+      variant={NamespacedPageVariants.light}
+      onNamespaceChange={handleNamespaceChange}
+    >
+      <PageContentsWithStartGuide {...props} />
+    </NamespacedPage>
+  </>
+);
+
+export default ProjectDetailsPage;

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as _ from 'lodash';
 import * as utils from '@console/internal/components/utils';
-import { ProjectDetailsPage } from '../ProjectDetailsPage';
+import { ProjectDetailsPage, PageContents } from '../ProjectDetailsPage';
 import ProjectListPage from '../../ProjectListPage';
-import NamespacedPage from '../../../NamespacedPage';
 import { DetailsPage } from '@console/internal/components/factory';
 
 const testProjectMatch = { url: '', params: { ns: 'test-project' }, isExact: true, path: '' };
@@ -12,15 +11,13 @@ const allNamespaceMatch = { url: '', params: {}, isExact: true, path: '' };
 
 describe('ProjectDetailsPage', () => {
   it('expect ProjectDetailsPage to render the project list page when in the all-projects namespace', () => {
-    const component = shallow(<ProjectDetailsPage match={allNamespaceMatch} />);
+    const component = shallow(<PageContents match={allNamespaceMatch} />);
 
     expect(component.find(ProjectListPage).exists()).toBe(true);
   });
 
   it('expect ProjectDetailsPage to show a namespaced details page for a namespace', () => {
-    const component = shallow(<ProjectDetailsPage match={testProjectMatch} />);
-
-    expect(component.find(NamespacedPage).exists()).toBe(true);
+    const component = shallow(<PageContents match={testProjectMatch} />);
     expect(component.find(DetailsPage).exists()).toBe(true);
   });
 
@@ -34,7 +31,7 @@ describe('ProjectDetailsPage', () => {
   it('should not render the Project Access tab if user has no access to role bindings', () => {
     const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
     spyUseAccessReview.mockReturnValue(false);
-    const component = shallow(<ProjectDetailsPage match={testProjectMatch} />);
+    const component = shallow(<PageContents match={testProjectMatch} />);
     const pages = component.find(DetailsPage).prop('pages');
     expect(_.find(pages, { name: 'Project Access' })).toBe(undefined);
   });

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -568,7 +568,7 @@ const plugin: Plugin<ConsumedExtensions> = [
           await import(
             './components/pipelines/PipelinesPage' /* webpackChunkName: "pipeline-page" */
           )
-        ).PipelinesPage,
+        ).default,
     },
   },
   {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2773

**Analysis / Root cause**: 
Some pages were not wrapped with the HOC `withStartGuide`

**Solution Description**: 
Added `withStartGuide` to monitoring, pipeline, and helm release pages.

**Screen shots / Gifs for design review**: 
Admin console Pipelines:
_note the location difference of the tech preview badges. Raising a new issue for this._
![image](https://user-images.githubusercontent.com/14068621/83075826-7e91ee00-a042-11ea-9bee-f289a6835545.png)

Dev-console Pipelines:
![image](https://user-images.githubusercontent.com/14068621/83075957-b436d700-a042-11ea-8242-e7b2aea5d692.png)

Dev-console Helm Releases:
![image](https://user-images.githubusercontent.com/14068621/83177748-9ecab700-a0ed-11ea-90f5-2f39917e78fe.png)

Dev-console Monitoring:
![image](https://user-images.githubusercontent.com/14068621/83177770-a722f200-a0ed-11ea-88ec-f50dbf53f1a7.png)

@openshift/team-devconsole-ux 

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Login with a user who has no projects.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
