### PR TITLE
Bug 1841003: fix git url validation

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -1,4 +1,3 @@
-import { ValidatedOptions } from '@patternfly/react-core';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ServiceModel } from '@console/knative-plugin';
 import { UNASSIGNED_KEY } from '../../../const';
@@ -421,7 +420,6 @@ export const gitImportInitialValues: GitImportFormData = {
     dir: '/',
     showGitType: false,
     secret: '',
-    urlValidation: ValidatedOptions.default,
     isUrlValidating: false,
   },
   docker: { dockerfilePath: 'Dockerfile', containerPort: 8080 },

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import { ValidatedOptions } from '@patternfly/react-core';
 import {
   K8sResourceKind,
   referenceFor,
@@ -68,7 +67,6 @@ export const getGitData = (buildConfig: K8sResourceKind) => {
     dir: _.get(buildConfig, 'spec.source.contextDir', ''),
     showGitType: false,
     secret: _.get(buildConfig, 'spec.source.sourceSecret.name', ''),
-    urlValidation: ValidatedOptions.default,
     isUrlValidating: false,
   };
   return gitData;

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Formik } from 'formik';
 import * as _ from 'lodash';
-import { ValidatedOptions } from '@patternfly/react-core';
 import { history, AsyncComponent } from '@console/internal/components/utils';
 import { getActivePerspective, getActiveApplication } from '@console/internal/reducers/ui';
 import { RootState } from '@console/internal/redux';
@@ -63,7 +62,6 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       dir: '/',
       showGitType: false,
       secret: '',
-      urlValidation: ValidatedOptions.default,
       isUrlValidating: false,
     },
     docker: {

--- a/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
@@ -1,4 +1,3 @@
-import { ValidatedOptions } from '@patternfly/react-core';
 import { GitImportFormData, Resources } from '../import-types';
 import { healthChecksProbeInitialData } from '../../health-checks/health-checks-probe-utils';
 
@@ -21,7 +20,6 @@ export const mockFormData: GitImportFormData = {
     dir: '',
     showGitType: false,
     secret: '',
-    urlValidation: ValidatedOptions.default,
     isUrlValidating: false,
   },
   docker: {

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
@@ -1,4 +1,3 @@
-import { ValidatedOptions } from '@patternfly/react-core';
 import { GitImportFormData, Resources } from '../import-types';
 import { healthChecksProbeInitialData } from '../../health-checks/health-checks-probe-utils';
 
@@ -166,7 +165,6 @@ export const defaultData: GitImportFormData = {
     dir: '/',
     showGitType: false,
     secret: '',
-    urlValidation: ValidatedOptions.default,
     isUrlValidating: false,
   },
   docker: {

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -142,7 +142,6 @@ export interface GitData {
   dir: string;
   showGitType: boolean;
   secret: string;
-  urlValidation: ValidatedOptions;
   isUrlValidating: boolean;
 }
 


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-2451

Analysis / Root cause:
git url is only validated onBLur

Solution Description:
validate git url as user types

Screens:
![gitSection](https://user-images.githubusercontent.com/38663217/83106034-61f4c500-a0d9-11ea-990c-1f108ff56fb0.gif)

Test Coverage:
![Screenshot from 2020-05-28 11-51-43](https://user-images.githubusercontent.com/38663217/83106175-a5e7ca00-a0d9-11ea-9b94-4b96a54926b2.png)

Browser Conformance:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge