### PR TITLE
Bug 1840766: Autogenerate data volume names

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
@@ -26,6 +26,7 @@ import {
   NetworkInterfaceModel,
   VolumeType,
 } from '../../../../constants/vm';
+import { DUMMY_VM_NAME } from '../../../../constants/vm/constants';
 import {
   DEFAULT_CPU,
   getCPU,
@@ -58,11 +59,10 @@ import { CloudInitDataHelper } from '../../../../k8s/wrapper/vm/cloud-init-data-
 import { getStorages } from '../../selectors/selectors';
 import { DataVolumeWrapper } from '../../../../k8s/wrapper/vm/data-volume-wrapper';
 import { V1alpha1DataVolume } from '../../../../types/vm/disk/V1alpha1DataVolume';
-import { joinIDs } from '../../../../utils';
-import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import { selectVM } from '../../../../selectors/vm-template/basic';
 import { convertToHighestUnitFromUnknown } from '../../../form/size-unit-utils';
-import { toUIFlavor, isCustomFlavor } from '../../../../selectors/vm-like/flavor';
+import { isCustomFlavor, toUIFlavor } from '../../../../selectors/vm-like/flavor';
+import { generateDataVolumeName } from '../../../../utils';
 
 export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptions) => {
   const state = getState();
@@ -200,7 +200,7 @@ export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptio
           isCloudInitForm = false;
         }
       } else if (volumeWrapper.getType() === VolumeType.DATA_VOLUME && !dataVolume) {
-        const newDataVolumeName = joinIDs(VM_TEMPLATE_NAME_PARAMETER, diskWrapper.getName());
+        const newDataVolumeName = generateDataVolumeName(DUMMY_VM_NAME, diskWrapper.getName());
 
         dataVolume = new DataVolumeWrapper(
           standaloneDataVolumeLookup[volumeWrapper.getDataVolumeName()],

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -16,13 +16,13 @@ import { DiskWrapper } from '../../../../k8s/wrapper/vm/disk-wrapper';
 import { VolumeWrapper } from '../../../../k8s/wrapper/vm/volume-wrapper';
 import { DataVolumeWrapper } from '../../../../k8s/wrapper/vm/data-volume-wrapper';
 import { DiskModal } from '../../../modals/disk-modal';
-import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import { PersistentVolumeClaimWrapper } from '../../../../k8s/wrapper/vm/persistent-volume-claim-wrapper';
 import { TemplateValidations } from '../../../../utils/validations/template/template-validations';
 import { getTemplateValidation } from '../../selectors/template';
 import { ConfigMapKind } from '@console/internal/module/k8s';
 import { toShallowJS } from '../../../../utils/immutable';
 import { getStorages } from '../../selectors/selectors';
+import { DUMMY_VM_NAME } from '../../../../constants/vm';
 
 const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
   const {
@@ -84,7 +84,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
       <DiskModal
         {...restProps}
         storageClassConfigMap={storageClassConfigMap}
-        vmName={VM_TEMPLATE_NAME_PARAMETER}
+        vmName={DUMMY_VM_NAME}
         vmNamespace={vmNamespace}
         namespace={namespace}
         onNamespaceChanged={(n) => setNamespace(n)}
@@ -97,7 +97,8 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
         persistentVolumeClaim={
           persistentVolumeClaim && new PersistentVolumeClaimWrapper(persistentVolumeClaim, true)
         }
-        isCreateTemplate={isCreateTemplate}
+        isTemplate={isCreateTemplate}
+        isInWizard
         editConfig={editConfig}
         onSubmit={(
           resultDiskWrapper,

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
@@ -24,6 +24,7 @@ import { V1Disk } from '../../../types/vm/disk/V1Disk';
 import { V1Volume } from '../../../types/vm/disk/V1Volume';
 import { V1alpha1DataVolume } from '../../../types/vm/disk/V1alpha1DataVolume';
 import { useStorageClassConfigMapWrapped } from '../../../hooks/storage-class-config-map';
+import { isTemplate } from '../../../selectors/check-type';
 
 const DiskModalFirehoseComponent: React.FC<DiskModalFirehoseComponentProps> = (props) => {
   const { disk, volume, dataVolume, vmLikeEntity, vmLikeEntityLoading, ...restProps } = props;
@@ -123,6 +124,7 @@ const DiskModalFirehose: React.FC<DiskModalFirehoseProps> = (props) => {
         vmLikeEntity={vmLikeEntity}
         namespace={namespace}
         onNamespaceChanged={(n) => setNamespace(n)}
+        isTemplate={isTemplate(vmLikeEntity)}
         {...restProps}
       />
     </Firehose>
@@ -137,6 +139,7 @@ type DiskModalFirehoseProps = ModalComponentProps & {
   isEditing?: boolean;
   useProjects: boolean;
   templateValidations?: TemplateValidations;
+  isTemplate?: boolean;
 };
 
 const diskModalStateToProps = ({ k8s }) => {

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -52,3 +52,5 @@ export const PAUSED_VM_MODAL_MESSAGE =
 export const VIRTUAL_MACHINE_IS_NOT_RUNNING = 'Virtual Machine is not running';
 export const NO_GUEST_AGENT_MESSAGE =
   'This VM does not have guest agent installed. Some metrics and management features will not be available';
+
+export const DUMMY_VM_NAME = 'vm';

--- a/frontend/packages/kubevirt-plugin/src/k8s/helpers/vm-clone.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/helpers/vm-clone.ts
@@ -1,7 +1,7 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { createBasicLookup, getName, getNamespace } from '@console/shared';
 import { VMKind } from '../../types/vm';
-import { getBasicID, joinIDs } from '../../utils';
+import { generateDataVolumeName, getBasicID } from '../../utils';
 import {
   getPvcAccessModes,
   getPvcStorageClassName,
@@ -103,7 +103,7 @@ export class VMClone {
 
         if (pvc) {
           const clonedDVTemplate = new DataVolumeTemplate({
-            name: joinIDs(name, pvcName, 'clone'),
+            name: generateDataVolumeName(name, volume.name),
             pvcSourceName: pvcName,
             pvcSourceNamespace: this.oldVMNamespace,
             accessModes: getPvcAccessModes(pvc),
@@ -135,7 +135,7 @@ export class VMClone {
 
         if (dataVolume) {
           const clonedDVTemplate = new DataVolumeTemplate({
-            name: joinIDs(name, dvName, 'clone'),
+            name: generateDataVolumeName(name, volume.name),
             pvcSourceName: dvName,
             pvcSourceNamespace: this.oldVMNamespace,
             accessModes: getDataVolumeAccessModes(dataVolume),

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/default-template.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/default-template.ts
@@ -1,7 +1,6 @@
 import { DefaultVMLikeEntityParams } from './types';
 import { TemplateKind } from '@console/internal/module/k8s';
 import { VMTemplateWrapper } from '../../../wrapper/vm/vm-template-wrapper';
-import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import {
   DiskBus,
   DiskType,
@@ -20,6 +19,7 @@ import { getFlavor, getWorkloadProfile } from '../../../../selectors/vm';
 import { DiskWrapper } from '../../../wrapper/vm/disk-wrapper';
 import { VolumeWrapper } from '../../../wrapper/vm/volume-wrapper';
 import { NetworkInterfaceWrapper } from '../../../wrapper/vm/network-interface-wrapper';
+import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates/constants';
 
 export const resolveDefaultVMTemplate = (params: DefaultVMLikeEntityParams): TemplateKind => {
   const { commonTemplate, name, namespace, containerImage, baseOSName } = params;

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
@@ -1,7 +1,5 @@
-import * as _ from 'lodash';
 import { getOwnerReferences } from '@console/shared/src';
 import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
-import { apiVersionForModel } from '@console/internal/module/k8s';
 import { V1alpha1DataVolume } from '../../../types/vm/disk/V1alpha1DataVolume';
 import { AccessMode, DataVolumeSourceType, VolumeMode } from '../../../constants/vm/storage';
 import {
@@ -31,58 +29,6 @@ export class DataVolumeWrapper extends K8sResourceObjectWithTypePropertyWrapper<
   CombinedTypeData,
   DataVolumeWrapper
 > {
-  /**
-   * @deprecated FIXME deprecate initializeFromSimpleData in favor of init
-   */
-  static initializeFromSimpleData = ({
-    name,
-    namespace,
-    type,
-    typeData,
-    accessModes,
-    volumeMode,
-    size,
-    unit,
-    storageClassName,
-  }: {
-    name?: string;
-    namespace?: string;
-    type?: DataVolumeSourceType;
-    typeData?: CombinedTypeData;
-    accessModes?: object[] | string[];
-    volumeMode?: object | string;
-    size?: string | number;
-    unit?: string;
-    storageClassName?: string;
-  }) => {
-    const resources =
-      size == null
-        ? undefined
-        : {
-            requests: {
-              storage: size && unit ? `${size}${unit}` : size,
-            },
-          };
-
-    return new DataVolumeWrapper({
-      apiVersion: apiVersionForModel(DataVolumeModel),
-      kind: DataVolumeModel.kind,
-      metadata: {
-        name,
-        namespace,
-      },
-      spec: {
-        pvc: {
-          accessModes: _.cloneDeep(accessModes),
-          volumeMode: _.cloneDeep(volumeMode),
-          resources,
-          storageClassName,
-        },
-        source: {},
-      },
-    }).setType(type, typeData);
-  };
-
   constructor(dataVolumeTemplate?: V1alpha1DataVolume | DataVolumeWrapper, copy = false) {
     super(DataVolumeModel, dataVolumeTemplate, copy, DataVolumeSourceType, ['spec', 'source']);
   }

--- a/frontend/packages/kubevirt-plugin/src/utils/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/index.ts
@@ -14,7 +14,7 @@ import {
   getKind,
   getUID,
 } from '@console/shared/src/selectors';
-import { VM_TEMPLATE_NAME_PARAMETER } from '../constants/vm-templates';
+import { getRandomChars } from '@console/shared/src/utils/utils';
 import { pluralize } from './strings';
 
 export const getBasicID = <A extends K8sResourceKind = K8sResourceKind>(entity: A) =>
@@ -24,6 +24,25 @@ export const prefixedID = (idPrefix: string, id: string) =>
   idPrefix && id ? `${idPrefix}-${id}` : null;
 
 export const joinIDs = (...ids: string[]) => ids.join('-');
+
+export const generateDataVolumeName = (vmName: string, volumeName: string): string =>
+  joinIDs(vmName, volumeName, getRandomChars(5));
+
+export const resolveDataVolumeName = ({
+  diskName,
+  vmLikeEntityName,
+  isTemplate,
+  isPlainDataVolume,
+}: {
+  diskName: string;
+  vmLikeEntityName: string;
+  isTemplate: boolean;
+  isPlainDataVolume: boolean;
+}) => {
+  return isTemplate && !isPlainDataVolume
+    ? joinIDs(vmLikeEntityName, diskName)
+    : generateDataVolumeName(vmLikeEntityName, diskName);
+};
 
 export const isLoaded = (result: FirehoseResult<K8sResourceKind | K8sResourceKind[]>) =>
   result && result.loaded;
@@ -62,13 +81,6 @@ export const getLoadError = (
   }
 
   return null;
-};
-
-export const insertName = (value: string, name) => {
-  if (value.indexOf(VM_TEMPLATE_NAME_PARAMETER) > -1) {
-    return value.replace(VM_TEMPLATE_NAME_PARAMETER, name);
-  }
-  return joinIDs(name, value);
 };
 
 export const parseNumber = (value, defaultValue = null) => {


### PR DESCRIPTION
This PR autogenerates data volume names to prevent a clash when a VM is deleted, but its disks are left and a new VM is created with the same name.