### PR TITLE
Bug 1841317: Fix kubevirt consoles integration-tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
@@ -158,12 +158,12 @@ describe('Test network type presets and options', () => {
     await click(wizardView.addNICButton);
     expect((await getSelectOptions(nicType)).sort()).toEqual(bindingMethods);
     await click(wizardView.modalCancelButton);
-
     await wizard.addNIC(multusNetworkInterface);
-
     await wizardView.clickKebabAction(multusNetworkInterface.name, 'Edit');
     // expect masquerade is not available option
     expect((await getSelectOptions(nicType)).sort()).toEqual(nonPodNetworkBindingMethods);
+    await click(wizardView.modalCancelButton);
+    await wizard.closeWizard();
   });
 
   xit('BZ(1828739) ID(CNV-4038) Test NIC default type in example VM', async () => {
@@ -185,6 +185,7 @@ describe('Test network type presets and options', () => {
       await click(createNICButton);
       await NICDialog.selectNetwork(multusNAD.metadata.name);
       expect((await getSelectOptions(nicType)).sort()).toEqual(nonPodNetworkBindingMethods);
+      await vm.navigateToListView();
     });
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
@@ -103,7 +103,7 @@ describe('Kubevirt create VM using wizard', () => {
       testVMConfig.networkResources = [];
       testVMConfig.operatingSystem = OperatingSystem.WINDOWS_10;
       testVMConfig.flavorConfig.flavor = Flavor.MEDIUM;
-      testVMConfig.workloadProfile = WorkloadProfile.SERVER;
+      testVMConfig.workloadProfile = WorkloadProfile.DESKTOP;
       testVMConfig.startOnCreation = false; // do not check as there is only medium/large profile present and we would get insufficient memory.
       const osID = OSIDLookup[testVMConfig.operatingSystem];
 
@@ -122,11 +122,8 @@ describe('Kubevirt create VM using wizard', () => {
 
         const requiredLabels = {
           [`workload.template.kubevirt.io/${testVMConfig.workloadProfile}`]: 'true',
-          [`flavor.template.kubevirt.io/${testVMConfig.flavorConfig.flavor}`]: 'true',
           [`os.template.kubevirt.io/${osID}`]: 'true',
-          'vm.kubevirt.io/template': `windows-${testVMConfig.workloadProfile}-${
-            testVMConfig.flavorConfig.flavor
-          }-${commonTemplateVersion()}`,
+          'vm.kubevirt.io/template': `windows10-${testVMConfig.workloadProfile.toLowerCase()}-${testVMConfig.flavorConfig.flavor.toLowerCase()}-${commonTemplateVersion()}`,
           'vm.kubevirt.io/template.revision': COMMON_TEMPLATES_REVISION,
           'vm.kubevirt.io/template.version': INNER_TEMPLATE_VERSION,
         };

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/dialogs/cloneVirtualMachineDialog.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/dialogs/cloneVirtualMachineDialog.view.ts
@@ -2,7 +2,7 @@ import { $, element, by } from 'protractor';
 
 export const modalDialog = $('.ReactModal__Content');
 
-export const warningMessage = $('.kubevirt-clone-vm-modal__error-group--end');
+export const warningMessage = $('[aria-label="Warning Alert"]');
 
 export const nameHelperMessage = $('#clone-dialog-vm-name-helper');
 


### PR DESCRIPTION
Fix issues with RDP and consoles tests - align with new common template validations and use `jq` instead of grepping IP and nodePort
Fix Clone dialog warning selector
Fix windows 10 expected metadata 