### PR TITLE
Bug 1840809: set default namespace to ALL_NAMESPACES_KEY

### DIFF
--- a/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
+++ b/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
@@ -59,6 +59,7 @@ describe('<PrometheusGraphLink />', () => {
     let wrapper;
 
     store.dispatch(setFlag(FLAGS.CAN_GET_NS, false));
+    store.dispatch(UIActions.setActiveNamespace('default'));
     store.dispatch(UIActions.setActivePerspective('dev'));
     wrapper = getWrapper('');
     expect(wrapper.find(Link).exists()).toBe(false);

--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -7,6 +7,7 @@ import { useExtensions } from '@console/plugin-sdk';
 import { RootState } from '@console/internal/redux';
 import { isAddAction, AddAction } from '../extensions/add-actions';
 import './EmptyState.scss';
+import { ALL_NAMESPACES_KEY } from '@console/shared';
 
 const navigateTo = (e: React.SyntheticEvent, url: string) => {
   history.push(url);
@@ -29,6 +30,10 @@ const Item: React.FC<ItemProps> = ({
     // Defined extensions are immutable. This check will be consistent.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     accessReview.map((descriptor) => useAccessReview({ namespace, ...descriptor })).every((x) => x);
+  if (namespace === ALL_NAMESPACES_KEY && url.match(/:namespace\b/)) {
+    // URL expects namespace scope
+    return null;
+  }
   const resolvedUrl = url.replace(/:namespace\b/g, namespace);
   return access ? (
     <GalleryItem>

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -909,7 +909,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'AddAction',
     properties: {
       id: 'operator-backed',
-      url: '/catalog/ns/:namespace?kind=%5B"ClusterServiceVersion"%5D',
+      url: '/catalog?kind=%5B"ClusterServiceVersion"%5D',
       label: 'Operator Backed',
       description: 'Browse the catalog to discover and deploy operator managed services',
       icon: <BoltIcon />,
@@ -936,6 +936,13 @@ const plugin: Plugin<ConsumedExtensions> = [
       label: 'Pipeline',
       description: 'Create a Tekton Pipeline to automate delivery of your application',
       icon: pipelineIcon,
+      accessReview: [
+        {
+          group: PipelineModel.apiGroup,
+          resource: PipelineModel.plural,
+          verb: 'create',
+        },
+      ],
     },
   },
 ];

--- a/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.spec.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
 import { Table, TableRow } from '@console/internal/components/factory';
+import * as UIActions from '@console/internal/actions/ui';
 import { testPackageManifest, testCatalogSource, testSubscription } from '../../mocks';
 import { PackageManifestKind } from '../types';
 import {
@@ -33,6 +34,7 @@ describe(PackageManifestTableRow.displayName, () => {
   let wrapper: ShallowWrapper<PackageManifestTableRowProps>;
 
   beforeEach(() => {
+    jest.spyOn(UIActions, 'getActiveNamespace').mockReturnValue('default');
     wrapper = shallow(
       <PackageManifestTableRow
         index={0}

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -87,7 +87,7 @@ export default (state: UIState, action: UIAction): UIState => {
     return ImmutableMap({
       activeNavSectionId: 'workloads',
       location: pathname,
-      activeNamespace: activeNamespace || 'default',
+      activeNamespace: activeNamespace || ALL_NAMESPACES_KEY,
       activeApplication: ALL_APPLICATIONS_KEY,
       activePerspective: getDefaultPerspective(),
       createProjectMessage: '',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4029

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Default namespace is always set to `default` for new users regardless whether they have access or not.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Change the default namespace to the `ALL_NAMESPACES_KEY`.
A new user entering the dev perspective is now redirected to: http://localhost:9000/topology/all-namespaces/graph

Updated the Add page cards to omit those whose links require a namespace. In the future we will need to revisit the Add page flows.

Other pages are covered by the start guide along with this pr for dev console: https://github.com/openshift/console/pull/5610

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/14068621/83175012-42659880-a0e9-11ea-81d2-c5dd2d681c2c.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Login with a user who has zero projects as well as one with some projects but not access to the `default` project.
Test using incognito mode as to not load the previous namespace from local storage.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge


cc @spadgett @benjaminapetersen @invincibleJai 