### PR TITLE
Bug 1840543:  fix bug where quota gauge chart does not appear

### DIFF
--- a/frontend/public/components/graphs/gauge.tsx
+++ b/frontend/public/components/graphs/gauge.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
 import { usePrometheusPoll } from './prometheus-poll-hook';
 import { PrometheusEndpoint } from './helpers';
-import { useRefWidth, humanizePercentage, Humanize } from '../utils';
+import { humanizePercentage, Humanize } from '../utils';
 import { getInstantVectorStats } from './utils';
 import { DataPoint } from '.';
 
@@ -32,24 +32,13 @@ export const GaugeChart: React.FC<GaugeChartProps> = ({
   secondaryTitle = usedLabel,
   className,
 }) => {
-  const [ref, width] = useRefWidth();
   const ready = !error && !loading;
   const status = loading ? 'Loading' : error;
   const labels = ({ datum: { x, y } }) => (x ? `${x} ${usedLabel}` : `${y} ${remainderLabel}`);
   return (
-    <PrometheusGraph
-      className={classNames('graph-wrapper--title-center graph-wrapper--gauge', className)}
-      ref={ref}
-      title={title}
-    >
+    <PrometheusGraph className={classNames('graph-wrapper--title-center', className)} title={title}>
       <PrometheusGraphLink query={query}>
-        <ChartDonutThreshold
-          data={thresholds}
-          height={width} // Changes the scale of the graph, not actual width and height
-          padding={0}
-          width={width}
-          y="value"
-        >
+        <ChartDonutThreshold data={thresholds} height={160} padding={0} width={160} y="value">
           <ChartDonutUtilization
             labels={labels}
             data={ready ? data : { y: 0 }}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1840543

It appears [`useRefWidth`](https://github.com/openshift/console/blob/master/frontend/public/components/utils/ref-width-hook.ts#L3-L24) requires a second render of the component utilizing it in order to work correctly [1].  In the case of this bug, a second render may not occur (the bug is easily reproduced when creating a new quota resource).  Since the size of `<GaugeChart>` does not change with the layout, the simplest fix is to simply remove the use of `useRefWidth` and hard code the size of the chart.

After:
![Or9VSipZKB](https://user-images.githubusercontent.com/895728/83184162-05a09e00-a0f7-11ea-9deb-5dba2f8a629a.gif)

[1] We probably want to explore fixing this issue as it has caused other bugs (see #5515).
