### PR TITLE
Bug 1841302: Remove custom ClusterTriggerBinding details page

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -65,7 +65,6 @@ const {
   EventListenerModel,
   TriggerTemplateModel,
   TriggerBindingModel,
-  ClusterTriggerBindingModel,
 } = models;
 
 type ConsumedExtensions =
@@ -404,18 +403,6 @@ const plugin: Plugin<ConsumedExtensions> = [
         (
           await import(
             './components/pipelines/TriggerBindingPage' /* webpackChunkName: "trigger-binding-details" */
-          )
-        ).default,
-    },
-  },
-  {
-    type: 'Page/Resource/Details',
-    properties: {
-      model: ClusterTriggerBindingModel,
-      loader: async () =>
-        (
-          await import(
-            './components/pipelines/TriggerBindingPage' /* webpackChunkName: "cluster-trigger-binding-details" */
           )
         ).default,
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4033

**Analysis / Root cause**: 
Listing namespaced Event Listener resources on Cluster Trigger Binding pages does not work.

**Solution Description**: 
Remove the custom Cluster Trigger Binding page, let it has the default k8s page.

**Screen shots / Gifs for design review**: 

Before:
![Screen Shot 2020-05-28 at 3 27 38 PM](https://user-images.githubusercontent.com/8126518/83185164-8dd37300-a0f8-11ea-8e66-59eb29fc2930.png)
![Screen Shot 2020-05-28 at 3 27 52 PM](https://user-images.githubusercontent.com/8126518/83185169-8f04a000-a0f8-11ea-9bb6-fa543f83bd28.png)

After:
![Screen Shot 2020-05-28 at 3 26 24 PM](https://user-images.githubusercontent.com/8126518/83185185-962bae00-a0f8-11ea-8291-622433d29603.png)

Unaffected namespaced Trigger Bindings:
![Screen Shot 2020-05-28 at 3 26 14 PM](https://user-images.githubusercontent.com/8126518/83185225-a479ca00-a0f8-11ea-9172-132c119fb1cc.png)

**Test setup:**

* Pipeline Operator 1.0.x installed
* Create a new project
* `oc apply -f https://raw.githubusercontent.com/andrewballantyne/pipeline-scratch-pad/master/examples/triggers/ui/resources.yaml`
* Add a Cluster Trigger Binding and a Trigger Binding trigger to the pipeline added to the project you're in
    * Go to the Pipelines page, "Add Trigger" on the pipeline from the actions
    * In the first drop down select `github`, other values do not matter - just fill them in with garbage
    * Repeat and do it again for `github-push`

Viewing the Cluster Trigger Binding (`github-push`) resource should show no links.
Viewing the namespaced Trigger Binding (`github`) resource should show the Event Listener link.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge