### PR TITLE
Bug 1840355: fix useCloudShellWorkspace effect re-entry when searching projects

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -78,18 +78,18 @@ const useCloudShellWorkspace = (
   const workspace = findWorkspace(data);
 
   const searchNamespaces =
-    // wait for access review to return
-    !loadingAccessReview &&
-    // user cannot list workspaces at the cluster scope
-    !canListWorkspaces &&
-    // fetching the workspace succeeded or failed
-    (loaded || loadError) &&
-    // was a workspace was found
-    !workspace &&
-    // did a previous search result in no namespace found
-    !noNamespaceFound &&
     // are we currently searching
-    !searching;
+    searching ||
+    // wait for access review to return
+    (!loadingAccessReview &&
+      // user cannot list workspaces at the cluster scope
+      !canListWorkspaces &&
+      // fetching the workspace succeeded or failed
+      (loaded || loadError) &&
+      // was a workspace was found
+      !workspace &&
+      // did a previous search result in no namespace found
+      !noNamespaceFound);
 
   // FIXME need to use a service account on the backend to find the workspace instead of inefficiently looping through namespaces
   React.useEffect(() => {


### PR DESCRIPTION
**Fixes**: 
Issue related to https://github.com/openshift/console/pull/5554

**Analysis / Root cause**: 
The effect to search for a valid namespace for the terminal was re-entering causing the previous search to abort early.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Ensure that the dependencies to the effect, in this case the `searchNamespaces` variable, does not change while the search is in progress. When the search begins, `setSearching(true)` is called. While this state is `true` we must always assign `searchNamespace` to `true`. If one of the other dependencies change, the search will stop and then `setSearching(false)` will be called in the finally clause as the effect tears down.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
No UI change

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Need to build console and deploy it to a cluster

Tested using cluster-bot.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

cc @rohitkrai03 
