### PR TITLE
Bug 1841032: Fix DynamicForm component logic for hiding schemas that do not produce form fields

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
@@ -15,7 +15,7 @@ import { Switch } from '@patternfly/react-core';
 import SchemaField, {
   SchemaFieldProps,
 } from 'react-jsonschema-form/lib/components/fields/SchemaField';
-import { getSchemaErrors } from './utils';
+import { hasNoFields } from './utils';
 
 export const DescriptionField: React.FC<FieldProps> = ({ id, description }) =>
   description ? (
@@ -201,13 +201,10 @@ export const DropdownField: React.FC<FieldProps> = ({
 };
 
 export const CustomSchemaField: React.FC<SchemaFieldProps> = (props) => {
-  const errors = getSchemaErrors(props.schema ?? {});
-  if (errors.length) {
-    // eslint-disable-next-line no-console
-    console.warn('DynamicForm component does not support the provided JSON schema: ', errors);
+  // If a the provided schema will not generate any form field elements, return null.
+  if (hasNoFields(props.schema, props.uiSchema)) {
     return null;
   }
-
   return <SchemaField {...props} />;
 };
 

--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.spec.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.spec.ts
@@ -1,0 +1,84 @@
+import { JSONSchema6 } from 'json-schema';
+import { hasNoFields } from './utils';
+import { SchemaType } from './types';
+
+const OBJECT: JSONSchema6 = {
+  type: SchemaType.object,
+  properties: {
+    test: { type: SchemaType.string },
+  },
+};
+
+const ARRAY: JSONSchema6 = {
+  type: SchemaType.array,
+  items: {
+    type: SchemaType.string,
+  },
+};
+
+const ADDITIONAL_PROPERTIES_OBJECT: JSONSchema6 = {
+  type: SchemaType.object,
+  additionalProperties: { type: SchemaType.string },
+};
+
+const NESTED: JSONSchema6 = {
+  type: SchemaType.object,
+  properties: {
+    emptyArray: {
+      type: SchemaType.array,
+      items: {
+        type: SchemaType.object,
+        properties: {
+          empty: { type: SchemaType.object },
+        },
+      },
+    },
+    emptyObject: { type: SchemaType.object },
+  },
+};
+
+describe('hasNoFields', () => {
+  it('Returns true if schema is empty', () => {
+    expect(hasNoFields({})).toBeTruthy();
+  });
+
+  it('Returns true if schema type is null', () => {
+    expect(hasNoFields({ type: 'null' })).toBeTruthy();
+  });
+
+  it('Returns true if schema has unsupported properties', () => {
+    expect(hasNoFields({ anyOf: [] })).toBeTruthy();
+    expect(hasNoFields({ allOf: [] })).toBeTruthy();
+    expect(hasNoFields({ oneOf: [] })).toBeTruthy();
+  });
+
+  it('Returns true when only additionalItems are provided for object schema type', () => {
+    expect(hasNoFields(ADDITIONAL_PROPERTIES_OBJECT)).toBeTruthy();
+  });
+
+  it('Returns true when all descendants in nested structure return true', () => {
+    expect(hasNoFields(NESTED)).toBeTruthy();
+  });
+
+  it('Returns false when a field is defined in the ui schema', () => {
+    expect(hasNoFields(ADDITIONAL_PROPERTIES_OBJECT, { 'ui:field': 'Field' })).toBeFalsy();
+    expect(hasNoFields(NESTED, { emptyObject: { 'ui:field': 'Field' } })).toBeFalsy();
+  });
+
+  it('Returns false when a widget is defined in the ui schema', () => {
+    expect(hasNoFields(ADDITIONAL_PROPERTIES_OBJECT, { 'ui:widget': 'Widget' })).toBeFalsy();
+    expect(hasNoFields(NESTED, { emptyObject: { 'ui:widget': 'Widget' } })).toBeFalsy();
+  });
+
+  it('Returns false for primitive schema type', () => {
+    expect(hasNoFields({ type: SchemaType.string })).toBeFalsy();
+  });
+
+  it('Returns false for object schema type with properly defined properties', () => {
+    expect(hasNoFields(OBJECT)).toBeFalsy();
+  });
+
+  it('Returns false for array schema type with properly defined items', () => {
+    expect(hasNoFields(ARRAY)).toBeFalsy();
+  });
+});

--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
@@ -1,5 +1,8 @@
 import * as _ from 'lodash';
 import { JSONSchema6 } from 'json-schema';
+import { getSchemaType } from 'react-jsonschema-form/lib/utils';
+import { SchemaType } from './types';
+import { UiSchema } from 'react-jsonschema-form';
 
 const UNSUPPORTED_SCHEMA_PROPERTIES = ['allOf', 'anyOf', 'oneOf'];
 
@@ -21,6 +24,35 @@ export const getSchemaErrors = (schema: JSONSchema6): SchemaError[] => {
       }),
     ),
   ];
+};
+
+// Determine if a schema will produce no form fields.
+export const hasNoFields = (jsonSchema: JSONSchema6 = {}, uiSchema: UiSchema = {}): boolean => {
+  // If schema is empty or has unsupported properties, it will not render any fields on the form
+  if (getSchemaErrors(jsonSchema).length > 0) {
+    return true;
+  }
+
+  const type = getSchemaType(jsonSchema) ?? '';
+  const noUIFieldOrWidget = !uiSchema?.['ui:field'] && !uiSchema?.['ui:widget'];
+  switch (type) {
+    case SchemaType.array:
+      return noUIFieldOrWidget && hasNoFields(jsonSchema.items as JSONSchema6, uiSchema?.items);
+    case SchemaType.object:
+      return (
+        noUIFieldOrWidget &&
+        _.every(jsonSchema?.properties, (property, propertyName) =>
+          hasNoFields(property as JSONSchema6, uiSchema?.[propertyName]),
+        )
+      );
+    case SchemaType.boolean:
+    case SchemaType.integer:
+    case SchemaType.number:
+    case SchemaType.string:
+      return false;
+    default:
+      return noUIFieldOrWidget;
+  }
 };
 
 type SchemaError = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -32,8 +32,8 @@ import { OperandForm } from './operand-form';
 import { OperandYAML } from './operand-yaml';
 import { exampleForModel, providedAPIForModel } from '..';
 import { FORM_HELP_TEXT, YAML_HELP_TEXT, DEFAULT_K8S_SCHEMA } from './const';
-import { getSchemaErrors } from '@console/shared/src/components/dynamic-form/utils';
-import { hasNoFields } from './utils';
+import { getSchemaErrors, hasNoFields } from '@console/shared/src/components/dynamic-form/utils';
+
 // eslint-disable-next-line @typescript-eslint/camelcase
 import { DEPRECATED_CreateOperandForm } from './DEPRECATED_operand-form';
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
@@ -1,15 +1,7 @@
 import { testCRD } from '../../../integration-tests/mocks';
-import {
-  getJSONSchemaOrder,
-  capabilitiesToUISchema,
-  getDefaultUISchema,
-  hasNoFields,
-} from './utils';
+import { getJSONSchemaOrder, capabilitiesToUISchema } from './utils';
 import { ServiceAccountModel } from '@console/internal/models';
 import { SpecCapability } from '../descriptors/types';
-import { JSONSchema6 } from 'json-schema';
-import { SchemaType } from '@console/shared/src/components/dynamic-form';
-import { HIDDEN_UI_SCHEMA } from './const';
 
 describe('getJSONSchemaOrder', () => {
   it('Accurately converts descriptors to a uiSchema with correct "ui:order" properties:', () => {
@@ -67,50 +59,5 @@ describe('capabilitiesToUISchema', () => {
       FATAL: 'FATAL',
     });
     expect(uiSchema['ui:field']).toEqual('DropdownField');
-  });
-});
-
-describe('hasNoFields', () => {
-  it('Applies hidden widget and label properties to empty schemas', () => {
-    const schema: JSONSchema6 = {
-      type: SchemaType.object,
-      properties: {
-        shown: {
-          type: SchemaType.object,
-          properties: {
-            test: { type: SchemaType.string },
-          },
-        },
-        alsoShown: {
-          type: SchemaType.object,
-          additionalProperties: { type: SchemaType.string },
-        },
-        hidden: {
-          type: SchemaType.object,
-          properties: {
-            emptyArray: {
-              type: SchemaType.array,
-              items: {
-                type: SchemaType.object,
-                properties: {
-                  empty: { type: SchemaType.object },
-                },
-              },
-            },
-            emptyObject: { type: SchemaType.object },
-          },
-        },
-      },
-    };
-    expect(hasNoFields(schema.properties.shown as JSONSchema6)).toBeFalsy();
-    expect(hasNoFields(schema.properties.alsoShown as JSONSchema6)).toBeFalsy();
-    expect(hasNoFields(schema.properties.hidden as JSONSchema6)).toBeTruthy();
-  });
-});
-
-describe('getDefaultUISchema', () => {
-  it('Creates correct ui schema for empty schema property', () => {
-    const uiSchema = getDefaultUISchema(testCRD.spec.validation.openAPIV3Schema as JSONSchema6);
-    expect(uiSchema.spec.hiddenFieldGroup).toEqual(HIDDEN_UI_SCHEMA);
   });
 });


### PR DESCRIPTION
Move logic for detecting and hiding empty or unsupported schemas into the scope of the dynamic form component. Prior to this update, we traversed the schema ahead of time, and used the uiSchema API to recursively hide schemas that did not produce form fields. In some cases, this would override the logic that provides custom widgets and fields from descriptors. That meant that a schema might end up hidden even when it had a descriptor-defined widget. This update waits until render time to check if a schema will actually produce form fields. A schema is considered to have no form fields and will not appear on the form in the following cases:

```
1. The schema is empty
2. The schema uses unsupported properties (allOf, anyOf, oneOf)
3. No widget or field is provided via descriptors AND:
  a. The schema is of object type and:
    - does not define any properties
    - all descendant properties recursively have no fields
  b. The schema is of array type and the items property recursively has no fields
  c. The schema type is 'null', undefined, or cannot be guessed based on other schema properties
```