### PR TITLE
Bug 1840706: Prevent OLM tab component unmounting every render

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -980,16 +980,12 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
                   name: ['Details', 'YAML', 'Subscription', 'Events'].includes(desc.displayName)
                     ? `${desc.displayName} Operand`
                     : desc.displayName,
-                  component: React.memo(
-                    () => (
-                      <ProvidedAPIPage
-                        csv={obj}
-                        kind={referenceForProvidedAPI(desc)}
-                        namespace={obj.metadata.namespace}
-                      />
-                    ),
-                    _.isEqual,
-                  ),
+                  component: ProvidedAPIPage,
+                  pageData: {
+                    csv: obj,
+                    kind: referenceForProvidedAPI(desc),
+                    namespace: obj.metadata.namespace,
+                  },
                 },
               ]
             : acc,

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -53,6 +53,7 @@ export type Page = {
   path?: string;
   name: string;
   component?: React.ComponentType<PageComponentProps>;
+  pageData?: any;
 };
 
 type NavFactory = { [name: string]: (c?: React.ComponentType<any>) => Page };
@@ -238,6 +239,7 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
         <p.component
           {...componentProps}
           {...extraResources}
+          {...p.pageData}
           params={params}
           customData={props.customData}
         />


### PR DESCRIPTION
The ProvidedAPIPage component was declared anonymously inside the
ClusterClusterServiceVersionsDetailsPage component, which caused it to
unmount/remount every time the CSV rendered.