### PR TITLE
CNV-5024: Inform for pending changes in VM details view

### DIFF
--- a/frontend/packages/console-shared/src/components/status/GenericStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/GenericStatus.tsx
@@ -4,18 +4,23 @@ import PopoverStatus from './PopoverStatus';
 import StatusIconAndText from './StatusIconAndText';
 
 const GenericStatus: React.FC<GenericStatusProps> = (props) => {
-  const { Icon, children, ...restProps } = props;
+  const { Icon, children, popoverTitle, title, ...restProps } = props;
   return React.Children.toArray(children).length ? (
-    <PopoverStatus {...restProps} statusBody={<StatusIconAndText {...restProps} icon={<Icon />} />}>
+    <PopoverStatus
+      title={popoverTitle || title}
+      {...restProps}
+      statusBody={<StatusIconAndText {...restProps} title={title} icon={<Icon />} />}
+    >
       {children}
     </PopoverStatus>
   ) : (
-    <StatusIconAndText {...restProps} icon={<Icon />} />
+    <StatusIconAndText {...restProps} title={title} icon={<Icon />} />
   );
 };
 
 type GenericStatusProps = StatusComponentProps & {
   Icon: React.ComponentType<{}>;
+  popoverTitle?: string;
 };
 
 export default GenericStatus;

--- a/frontend/packages/kubevirt-plugin/src/components/Alerts/PendingChangesAlert.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/Alerts/PendingChangesAlert.scss
@@ -1,0 +1,3 @@
+.kv__pending_changes-alert {
+    margin-bottom: var(--pf-global--spacer--sm);
+}

--- a/frontend/packages/kubevirt-plugin/src/components/Alerts/PendingChangesAlert.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/Alerts/PendingChangesAlert.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Alert, AlertVariant } from '@patternfly/react-core';
+
+import './PendingChangesAlert.scss';
+
+type PendingChangesAlertProps = {
+  warningMsg?: string;
+  isWarning?: boolean;
+};
+
+export const PendingChangesAlert: React.FC<PendingChangesAlertProps> = ({
+  warningMsg,
+  isWarning,
+  children,
+}) => (
+  <Alert
+    title="Pending Changes"
+    isInline
+    variant={isWarning ? AlertVariant.warning : AlertVariant.info}
+    className="kv__pending_changes-alert"
+  >
+    {warningMsg || children}
+  </Alert>
+);

--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.scss
@@ -1,3 +1,0 @@
-.kubevirt-boot-order-modal__footer {
-    padding: 0;
-}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
@@ -1,170 +1,197 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Modal, Button, ButtonVariant } from '@patternfly/react-core';
-import { createBasicLookup } from '@console/shared/src';
-import { withHandlePromise, HandlePromiseProps } from '@console/internal/components/utils';
-import { ModalComponentProps } from '@console/internal/components/factory';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { getNamespace, createBasicLookup, getName } from '@console/shared';
+import {
+  withHandlePromise,
+  HandlePromiseProps,
+  Firehose,
+  FirehoseResult,
+} from '@console/internal/components/utils';
+import {
+  ModalComponentProps,
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+} from '@console/internal/components/factory';
 import { k8sPatch } from '@console/internal/module/k8s';
 import { PatchBuilder } from '@console/shared/src/k8s';
-import { BootableDeviceType } from '../../../types';
+import { BootableDeviceType, VMIKind } from '../../../types';
 import { VMLikeEntityKind } from '../../../types/vmLike';
-import { getVMLikeModel, getDevices, getBootableDevices } from '../../../selectors/vm';
+import {
+  getVMLikeModel,
+  getDevices,
+  getBootableDevices,
+  asVM,
+  isVMRunningOrExpectedRunning,
+} from '../../../selectors/vm';
 import { getVMLikePatches } from '../../../k8s/patches/vm-template';
 import { BootOrder, deviceKey } from '../../boot-order';
 import { DeviceType } from '../../../constants';
 import { ModalFooter } from '../modal/modal-footer';
+import { PendingChangesAlert } from '../../Alerts/PendingChangesAlert';
+import { VirtualMachineInstanceModel } from '../../../models';
+import { getLoadedData } from '../../../utils';
+import { MODAL_RESTART_IS_REQUIRED } from '../../../strings/vm/status';
+import { saveAndRestartModal } from '../save-and-restart-modal/save-and-restart-modal';
 
-import './boot-order-modal.scss';
+const BootOrderModalComponent = withHandlePromise(
+  ({
+    vmLikeEntity,
+    cancel,
+    close,
+    handlePromise,
+    inProgress,
+    errorMessage,
+    vmi: vmiProp,
+  }: BootOrderModalProps) => {
+    const [devices, setDevices] = React.useState<BootableDeviceType[]>(
+      getBootableDevices(vmLikeEntity),
+    );
+    const [initialDeviceList, setInitialDeviceList] = React.useState<BootableDeviceType[]>(
+      getBootableDevices(vmLikeEntity),
+    );
+    const [showUpdatedAlert, setUpdatedAlert] = React.useState<boolean>(false);
+    const [showPatchError, setPatchError] = React.useState<boolean>(false);
+    const vm = asVM(vmLikeEntity);
+    const isVMRunning = isVMRunningOrExpectedRunning(vm);
+    const vmi = getLoadedData(vmiProp);
 
-const modalTitle = 'Virtual machine boot order';
+    const onReload = React.useCallback(() => {
+      const updatedDevices = getBootableDevices(vmLikeEntity);
 
-const BootOrderModalComponent = ({
-  vmLikeEntity,
-  isOpen,
-  setOpen,
-  title = modalTitle,
-  handlePromise,
-  inProgress,
-  errorMessage,
-}: BootOrderModalProps) => {
-  const [devices, setDevices] = React.useState<BootableDeviceType[]>(
-    getBootableDevices(vmLikeEntity),
-  );
-  const [initialDeviceList, setInitialDeviceList] = React.useState<BootableDeviceType[]>(
-    getBootableDevices(vmLikeEntity),
-  );
-  const [showUpdatedAlert, setUpdatedAlert] = React.useState<boolean>(false);
-  const [showPatchError, setPatchError] = React.useState<boolean>(false);
+      setInitialDeviceList(updatedDevices);
+      setDevices(updatedDevices);
+      setUpdatedAlert(false);
+      setPatchError(false);
+    }, [vmLikeEntity]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const onReload = React.useCallback(() => {
-    const updatedDevices = getBootableDevices(vmLikeEntity);
+    // Inform user on vmLikeEntity.
+    React.useEffect(() => {
+      // Compare only bootOrder from initialDeviceList to current device list.
+      const devicesMap = createBasicLookup(getBootableDevices(vmLikeEntity), deviceKey);
+      const updated =
+        initialDeviceList.length &&
+        initialDeviceList.some((d) => {
+          // Find the initial device in the updated list.
+          const device = devicesMap[deviceKey(d)];
 
-    setInitialDeviceList(updatedDevices);
-    setDevices(updatedDevices);
-    setUpdatedAlert(false);
-    setPatchError(false);
-  }, [vmLikeEntity]); // eslint-disable-line react-hooks/exhaustive-deps
+          // If a device bootOrder changed, or it was deleted, set alert.
+          return !device || device.value.bootOrder !== d.value.bootOrder;
+        });
 
-  // Inform user on vmLikeEntity.
-  React.useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
+      setUpdatedAlert(updated);
+    }, [vmLikeEntity]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    // Compare only bootOrder from initialDeviceList to current device list.
-    const devicesMap = createBasicLookup(getBootableDevices(vmLikeEntity), deviceKey);
-    const updated =
-      initialDeviceList.length &&
-      initialDeviceList.some((d) => {
-        // Find the initial device in the updated list.
+    const saveChanges = () => {
+      // Copy only bootOrder from devices to current device list.
+      const currentDevices = _.cloneDeep(getDevices(vmLikeEntity));
+      const devicesMap = createBasicLookup(currentDevices, deviceKey);
+      devices.forEach((d) => {
+        // Find the device to update.
         const device = devicesMap[deviceKey(d)];
 
-        // If a device bootOrder changed, or it was deleted, set alert.
-        return !device || device.value.bootOrder !== d.value.bootOrder;
+        // Update device bootOrder.
+        if (device && d.value.bootOrder) {
+          device.value.bootOrder = d.value.bootOrder;
+        }
+        if (device && device.value.bootOrder && !d.value.bootOrder) {
+          delete device.value.bootOrder;
+        }
       });
 
-    setUpdatedAlert(updated);
-  }, [vmLikeEntity]); // eslint-disable-line react-hooks/exhaustive-deps
+      // Filter disks and interfaces from devices list.
+      const disks = [
+        ...currentDevices
+          .filter((source) => source.type === DeviceType.DISK)
+          .map((source) => source.value),
+      ];
 
-  // Re-set device list on isOpen change to true.
-  React.useEffect(() => {
-    if (isOpen) {
-      onReload();
-    }
-  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+      const interfaces = [
+        ...currentDevices
+          .filter((source) => source.type === DeviceType.NIC)
+          .map((source) => source.value),
+      ];
 
-  // Send new bootOrder to k8s.
-  const onSubmit = async (event) => {
-    event.preventDefault();
+      // Patch k8s.
+      const patches = [
+        new PatchBuilder('/spec/template/spec/domain/devices/disks').replace(disks).build(),
+        new PatchBuilder('/spec/template/spec/domain/devices/interfaces')
+          .replace(interfaces)
+          .build(),
+      ];
+      const promise = k8sPatch(
+        getVMLikeModel(vmLikeEntity),
+        vmLikeEntity,
+        getVMLikePatches(vmLikeEntity, () => patches),
+      );
 
-    // Copy only bootOrder from devices to current device list.
-    const currentDevices = _.cloneDeep(getDevices(vmLikeEntity));
-    const devicesMap = createBasicLookup(currentDevices, deviceKey);
-    devices.forEach((d) => {
-      // Find the device to update.
-      const device = devicesMap[deviceKey(d)];
+      handlePromise(promise)
+        .then(() => close())
+        .catch(() => setPatchError(true));
+    };
 
-      // Update device bootOrder.
-      if (device && d.value.bootOrder) {
-        device.value.bootOrder = d.value.bootOrder;
-      }
-      if (device && device.value.bootOrder && !d.value.bootOrder) {
-        delete device.value.bootOrder;
-      }
-    });
+    // Send new bootOrder to k8s.
+    const onSubmit = async (event) => {
+      event.preventDefault();
+      saveChanges();
+    };
 
-    // Filter disks and interfaces from devices list.
-    const disks = [
-      ...currentDevices
-        .filter((source) => source.type === DeviceType.DISK)
-        .map((source) => source.value),
-    ];
-
-    const interfaces = [
-      ...currentDevices
-        .filter((source) => source.type === DeviceType.NIC)
-        .map((source) => source.value),
-    ];
-
-    // Patch k8s.
-    const patches = [
-      new PatchBuilder('/spec/template/spec/domain/devices/disks').replace(disks).build(),
-      new PatchBuilder('/spec/template/spec/domain/devices/interfaces').replace(interfaces).build(),
-    ];
-    const promise = k8sPatch(
-      getVMLikeModel(vmLikeEntity),
-      vmLikeEntity,
-      getVMLikePatches(vmLikeEntity, () => patches),
+    return (
+      <div className="modal-content">
+        <ModalTitle>Virtual machine boot order</ModalTitle>
+        <ModalBody>
+          {isVMRunning && <PendingChangesAlert warningMsg={MODAL_RESTART_IS_REQUIRED} />}
+          <BootOrder devices={devices} setDevices={setDevices} />
+        </ModalBody>
+        <ModalFooter
+          errorMessage={showPatchError && errorMessage}
+          inProgress={inProgress}
+          isSaveAndRestart={isVMRunningOrExpectedRunning(vm)}
+          onSubmit={onSubmit}
+          onCancel={() => cancel()}
+          submitButtonText="Save"
+          infoTitle={showUpdatedAlert && 'Boot order has been updated outside this flow.'}
+          infoMessage={
+            <>
+              Saving these changes will override any boot order previously saved.
+              <br />
+              To see the updated order{' '}
+              <Button variant={ButtonVariant.link} isInline onClick={onReload}>
+                reload the content
+              </Button>
+              .
+            </>
+          }
+          onSaveAndRestart={() => saveAndRestartModal(vm, vmi, saveChanges)}
+        />
+      </div>
     );
-
-    handlePromise(promise)
-      .then(() => setOpen(false))
-      .catch(() => setPatchError(true));
-  };
-
-  const footer = (
-    <ModalFooter
-      errorMessage={showPatchError && errorMessage}
-      inProgress={inProgress}
-      onSubmit={onSubmit}
-      onCancel={() => setOpen(false)}
-      submitButtonText="Save"
-      infoTitle={showUpdatedAlert && 'Boot order has been updated outside this flow.'}
-      infoMessage={
-        <>
-          Saving these changes will override any boot order previously saved.
-          <br />
-          To see the updated order{' '}
-          <Button variant={ButtonVariant.link} isInline onClick={onReload}>
-            reload the content
-          </Button>
-          .
-        </>
-      }
-      className={'kubevirt-boot-order-modal__footer'}
-    />
-  );
-
-  return (
-    <Modal
-      title={title}
-      isOpen={isOpen}
-      variant="small"
-      onClose={() => setOpen(false)}
-      footer={footer}
-      showClose={false}
-    >
-      <BootOrder devices={devices} setDevices={setDevices} />
-    </Modal>
-  );
-};
+  },
+);
 
 export type BootOrderModalProps = HandlePromiseProps &
   ModalComponentProps & {
     vmLikeEntity: VMLikeEntityKind;
-    title?: string;
-    isOpen: boolean;
-    setOpen: (isOpen: boolean) => void;
+    vmi?: FirehoseResult<VMIKind>;
   };
 
-export const BootOrderModal = withHandlePromise(BootOrderModalComponent);
+const BootOrderModalFirehost = (props) => {
+  const { vmLikeEntity } = props;
+  const resources = [];
+
+  resources.push({
+    kind: VirtualMachineInstanceModel.kind,
+    namespace: getNamespace(vmLikeEntity),
+    name: getName(vmLikeEntity),
+    prop: 'vmi',
+  });
+
+  return (
+    <Firehose resources={resources}>
+      <BootOrderModalComponent {...props} />
+    </Firehose>
+  );
+};
+
+export const BootOrderModal = createModalLauncher(BootOrderModalFirehost);

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/vm-cdrom-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/vm-cdrom-modal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNamespace } from '@console/shared';
+import { getNamespace, getName } from '@console/shared';
 import { Firehose } from '@console/internal/components/utils';
 import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
 import { PersistentVolumeClaimModel, StorageClassModel } from '@console/internal/models';
@@ -8,6 +8,7 @@ import { asVM } from '../../../selectors/vm';
 import { V1alpha1DataVolume } from '../../../types/vm/disk/V1alpha1DataVolume';
 import { CDRomModal } from './cdrom-modal';
 import { WINTOOLS_CONTAINER_NAMES } from './constants';
+import { VirtualMachineInstanceModel } from '../../../models';
 
 const CDRomModalFirehose: React.FC<CDRomModalFirehoseProps> = (props) => {
   const { vmLikeEntity } = props;
@@ -26,6 +27,12 @@ const CDRomModalFirehose: React.FC<CDRomModalFirehoseProps> = (props) => {
       isList: true,
       namespace: getNamespace(asVM(vmLikeEntity)),
       prop: 'persistentVolumeClaims',
+    },
+    {
+      kind: VirtualMachineInstanceModel.kind,
+      namespace: getNamespace(asVM(vmLikeEntity)),
+      name: getName(asVM(vmLikeEntity)),
+      prop: 'vmi',
     },
   ];
 

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
@@ -27,7 +27,15 @@ import { useStorageClassConfigMapWrapped } from '../../../hooks/storage-class-co
 import { isTemplate } from '../../../selectors/check-type';
 
 const DiskModalFirehoseComponent: React.FC<DiskModalFirehoseComponentProps> = (props) => {
-  const { disk, volume, dataVolume, vmLikeEntity, vmLikeEntityLoading, ...restProps } = props;
+  const {
+    disk,
+    volume,
+    dataVolume,
+    vmLikeEntity,
+    vmLikeEntityLoading,
+    isVMRunning,
+    ...restProps
+  } = props;
 
   const vmLikeFinal = getLoadedData(vmLikeEntityLoading, vmLikeEntity); // default old snapshot before loading a new one
 
@@ -67,6 +75,7 @@ const DiskModalFirehoseComponent: React.FC<DiskModalFirehoseComponentProps> = (p
       volume={new VolumeWrapper(volumeWrapper, true)}
       dataVolume={new DataVolumeWrapper(dataVolumeWrapper, true)}
       onSubmit={onSubmit}
+      isVMRunning={isVMRunning}
     />
   );
 };
@@ -83,6 +92,7 @@ type DiskModalFirehoseComponentProps = ModalComponentProps & {
   vmLikeEntityLoading?: FirehoseResult<VMLikeEntityKind>;
   vmLikeEntity: VMLikeEntityKind;
   templateValidations?: TemplateValidations;
+  isVMRunning?: boolean;
 };
 
 const DiskModalFirehose: React.FC<DiskModalFirehoseProps> = (props) => {
@@ -140,6 +150,7 @@ type DiskModalFirehoseProps = ModalComponentProps & {
   useProjects: boolean;
   templateValidations?: TemplateValidations;
   isTemplate?: boolean;
+  isVMRunning?: boolean;
 };
 
 const diskModalStateToProps = ({ k8s }) => {

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -57,6 +57,8 @@ import { TemplateValidations } from '../../../utils/validations/template/templat
 import { ConfigMapKind } from '@console/internal/module/k8s';
 import { UIStorageEditConfig } from '../../../types/ui/storage';
 import { isFieldDisabled } from '../../../utils/ui/edit-config';
+import { PendingChangesAlert } from '../../Alerts/PendingChangesAlert';
+import { MODAL_RESTART_IS_REQUIRED } from '../../../strings/vm/status';
 
 import './disk-modal.scss';
 
@@ -84,6 +86,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     templateValidations,
     storageClassConfigMap: _storageClassConfigMap,
     editConfig,
+    isVMRunning,
   } = props;
   const inProgress = _inProgress || !isLoaded(_storageClassConfigMap);
   const isDisabled = (fieldName: string, disabled?: boolean) =>
@@ -317,6 +320,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
         {isEditing ? EDIT : ADD} {type.toString()}
       </ModalTitle>
       <ModalBody>
+        {isVMRunning && <PendingChangesAlert warningMsg={MODAL_RESTART_IS_REQUIRED} />}
         <Form>
           <FormRow title="Source" fieldId={asId('source')} isRequired>
             <FormSelect
@@ -614,5 +618,6 @@ export type DiskModalProps = {
   usedDiskNames: Set<string>;
   usedPVCNames: Set<string>;
   editConfig?: UIStorageEditConfig;
+  isVMRunning?: boolean;
 } & ModalComponentProps &
   HandlePromiseProps;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { Alert, Button, ButtonVariant, AlertProps, ActionGroup } from '@patternfly/react-core';
-import { LoadingInline } from '@console/internal/components/utils';
+import {
+  Alert,
+  Button,
+  ButtonVariant,
+  AlertProps,
+  ActionGroup,
+  Spinner,
+} from '@patternfly/react-core';
 
 import './modal-footer.scss';
 
@@ -49,10 +55,13 @@ type ModalFooterProps = {
   isSimpleError?: boolean;
   onSubmit: (e) => void;
   onCancel: (e) => void;
+  onSaveAndRestart?: (e) => void;
   isDisabled?: boolean;
   inProgress?: boolean;
+  isSaveAndRestart?: boolean;
   submitButtonText?: string;
   cancelButtonText?: string;
+  saveAndRestartText?: string;
   infoTitle?: string;
   infoMessage?: React.ReactNode;
 };
@@ -63,11 +72,14 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
   warningMessage = null,
   isDisabled = false,
   inProgress = false,
+  isSaveAndRestart = false,
   isSimpleError = false,
   onSubmit,
   onCancel,
+  onSaveAndRestart,
   submitButtonText = 'Add',
   cancelButtonText = 'Cancel',
+  saveAndRestartText = 'Save and Restart',
   infoMessage = null,
   infoTitle = null,
 }) => (
@@ -90,6 +102,16 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
       >
         {cancelButtonText}
       </Button>
+      {isSaveAndRestart && (
+        <Button
+          type="button"
+          variant={ButtonVariant.secondary}
+          id="save-and-restart"
+          onClick={onSaveAndRestart}
+        >
+          {saveAndRestartText}
+        </Button>
+      )}
       <Button
         variant={ButtonVariant.primary}
         isDisabled={isDisabled}
@@ -100,6 +122,6 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
       </Button>
     </ActionGroup>
 
-    {inProgress && <LoadingInline />}
+    {inProgress && <Spinner />}
   </footer>
 );

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal-enhanced.tsx
@@ -15,7 +15,7 @@ import { NetworkWrapper } from '../../../k8s/wrapper/vm/network-wrapper';
 import { NICModal } from './nic-modal';
 
 const NICModalFirehoseComponent: React.FC<NICModalFirehoseComponentProps> = (props) => {
-  const { nic, network, vmLikeEntity, vmLikeEntityLoading, ...restProps } = props;
+  const { nic, network, vmLikeEntity, vmLikeEntityLoading, isVMRunning, ...restProps } = props;
 
   const vmLikeFinal = getLoadedData(vmLikeEntityLoading, vmLikeEntity); // default old snapshot before loading a new one
   const vm = asVM(vmLikeFinal);
@@ -62,6 +62,7 @@ const NICModalFirehoseComponent: React.FC<NICModalFirehoseComponentProps> = (pro
       nic={new NetworkInterfaceWrapper(nicWrapper, true)}
       network={new NetworkWrapper(networkWrapper, true)}
       onSubmit={onSubmit}
+      isVMRunning={isVMRunning}
     />
   );
 };
@@ -73,10 +74,11 @@ type NICModalFirehoseComponentProps = ModalComponentProps & {
   nads?: FirehoseResult;
   vmLikeEntityLoading?: FirehoseResult<VMLikeEntityKind>;
   vmLikeEntity: VMLikeEntityKind;
+  isVMRunning?: boolean;
 };
 
 const NICModalFirehose: React.FC<NICModalFirehoseProps> = (props) => {
-  const { hasNADs, vmLikeEntity, ...restProps } = props;
+  const { hasNADs, vmLikeEntity, isVMRunning, ...restProps } = props;
 
   const namespace = getNamespace(vmLikeEntity);
   const name = getName(vmLikeEntity);
@@ -103,7 +105,11 @@ const NICModalFirehose: React.FC<NICModalFirehoseProps> = (props) => {
 
   return (
     <Firehose resources={resources}>
-      <NICModalFirehoseComponent vmLikeEntity={vmLikeEntity} {...restProps} />
+      <NICModalFirehoseComponent
+        vmLikeEntity={vmLikeEntity}
+        isVMRunning={isVMRunning}
+        {...restProps}
+      />
     </Firehose>
   );
 };
@@ -114,6 +120,7 @@ type NICModalFirehoseProps = ModalComponentProps & {
   network?: any;
   isEditing?: boolean;
   hasNADs: boolean;
+  isVMRunning?: boolean;
 };
 
 const nicModalStateToProps = ({ k8s }) => {

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -37,6 +37,8 @@ import { useShowErrorToggler } from '../../../hooks/use-show-error-toggler';
 import { UINetworkEditConfig } from '../../../types/ui/nic';
 import { isFieldDisabled } from '../../../utils/ui/edit-config';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { PendingChangesAlert } from '../../Alerts/PendingChangesAlert';
+import { MODAL_RESTART_IS_REQUIRED } from '../../../strings/vm/status';
 
 const getNetworkChoices = (nads: K8sResourceKind[], allowPodNetwork): NetworkWrapper[] => {
   const networkChoices = nads.map((nad) => {
@@ -138,6 +140,7 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
     close,
     cancel,
     editConfig,
+    isVMRunning,
   } = props;
   const isDisabled = (fieldName: string, disabled?: boolean) =>
     inProgress || disabled || isFieldDisabled(editConfig, fieldName);
@@ -216,6 +219,7 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
     <div className="modal-content">
       <ModalTitle>{isEditing ? EDIT : ADD} Network Interface</ModalTitle>
       <ModalBody>
+        {isVMRunning && <PendingChangesAlert warningMsg={MODAL_RESTART_IS_REQUIRED} />}
         <Form>
           {editConfig?.warning && (
             <Alert variant={AlertVariant.warning} isInline title={editConfig?.warning} />
@@ -333,5 +337,6 @@ export type NICModalProps = {
   usedInterfacesNames: Set<string>;
   allowPodNetwork: boolean;
   editConfig?: UINetworkEditConfig;
+  isVMRunning?: boolean;
 } & ModalComponentProps &
   HandlePromiseProps;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/save-and-restart-modal/save-and-restart-modal.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/save-and-restart-modal/save-and-restart-modal.ts
@@ -1,0 +1,19 @@
+import { VMKind, VMIKind } from '../../../types';
+import { confirmVMIModal } from '../menu-actions-modals/confirm-vmi-modal';
+import { getActionMessage } from '../../vms/constants';
+import { VMActionType, restartVM } from '../../../k8s/requests/vm';
+import * as _ from 'lodash';
+
+export const saveAndRestartModal = (vm: VMKind, vmi: VMIKind, saveChanges?: () => void) =>
+  confirmVMIModal({
+    vmi,
+    title: 'Restart Virtual Machine',
+    alertTitle: 'Restart Virtual Machine alert',
+    message: getActionMessage(vm, VMActionType.Restart),
+    btnText: _.capitalize(VMActionType.Restart),
+    executeFn: () => {
+      saveChanges && saveChanges();
+      return restartVM(vm);
+    },
+    cancel: () => saveChanges && saveChanges(),
+  });

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -25,11 +25,12 @@ import {
   getTemplateValidationsFromTemplate,
 } from '../../selectors/vm-template/selectors';
 import { diskSourceFilter } from './table-filters';
-import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
 import { VMLikeEntityTabProps, VMTabProps } from '../vms/types';
 import { getVMStatus } from '../../statuses/vm/vm-status';
 import { FileSystemsList } from './guest-agent-file-systems';
 import { VM_DISKS_DESCRIPTION } from '../../strings/vm/messages';
+import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
+import { asVM } from '../../selectors/vm';
 
 const getStoragesData = ({
   vmLikeEntity,
@@ -148,6 +149,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, vmTemplate }) =>
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
   const templateValidations = getTemplateValidationsFromTemplate(getLoadedData(vmTemplate));
+  const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
 
   const resources = [
     getResource(PersistentVolumeClaimModel, {
@@ -175,6 +177,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, vmTemplate }) =>
         blocking: true,
         vmLikeEntity: !isVMI(vmLikeEntity) && vmLikeEntity,
         templateValidations,
+        isVMRunning,
       }).result,
     );
 
@@ -186,7 +189,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, vmTemplate }) =>
       createButtonText={ADD_DISK}
       canCreate={!isVMI(vmLikeEntity)}
       createProps={{
-        isDisabled: isLocked || isVMRunningOrExpectedRunning(asVM(vmLikeEntity)),
+        isDisabled: isLocked,
         onClick: createFn,
         id: 'add-disk',
       }}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -6,7 +6,7 @@ import { createBasicLookup, dimensifyHeader } from '@console/shared';
 import { EmptyBox } from '@console/internal/components/utils';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { VMGenericLikeEntityKind } from '../../types/vmLike';
-import { isVMI } from '../../selectors/check-type';
+import { isVMI, isVM } from '../../selectors/check-type';
 import { VMLikeEntityTabProps } from '../vms/types';
 import { NetworkInterfaceWrapper } from '../../k8s/wrapper/vm/network-interface-wrapper';
 import { nicModalEnhanced } from '../modals/nic-modal/nic-modal-enhanced';
@@ -18,7 +18,8 @@ import { NetworkBundle } from './types';
 import { nicTableColumnClasses } from './utils';
 import { asVMILikeWrapper } from '../../k8s/wrapper/utils/convert';
 import { ADD_NETWORK_INTERFACE } from '../../utils/strings';
-import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
+import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
+import { asVM } from '../../selectors/vm';
 
 const getNicsData = (vmLikeEntity: VMGenericLikeEntityKind): NetworkBundle[] => {
   const vmiLikeWrapper = asVMILikeWrapper(vmLikeEntity);
@@ -111,6 +112,8 @@ export const VMNicsTable: React.FC<VMNicsTableProps> = ({
 export const VMNics: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEntity }) => {
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
+  const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
+
   return (
     <div className="co-m-list">
       {!isVMI(vmLikeEntity) && (
@@ -124,10 +127,11 @@ export const VMNics: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEntity }) =>
                   nicModalEnhanced({
                     blocking: true,
                     vmLikeEntity,
+                    isVMRunning,
                   }).result,
                 )
               }
-              isDisabled={isLocked || isVMRunningOrExpectedRunning(asVM(vmLikeEntity))}
+              isDisabled={isLocked}
             >
               {ADD_NETWORK_INTERFACE}
             </Button>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -96,8 +96,6 @@ export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
   dataVolumeLookup,
   canUpdateTemplate,
 }) => {
-  const [isBootOrderModalOpen, setBootOrderModalOpen] = React.useState<boolean>(false);
-
   const vm = asVM(template);
   const id = getBasicID(template);
   const devices = getDevices(template);
@@ -109,14 +107,9 @@ export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
         title="Boot Order"
         canEdit
         editButtonId={prefixedID(id, 'boot-order-edit')}
-        onEditClick={() => setBootOrderModalOpen(true)}
+        onEditClick={() => BootOrderModal({ vmLikeEntity: template, modalClassName: 'modal-lg' })}
         idValue={prefixedID(id, 'boot-order')}
       >
-        <BootOrderModal
-          isOpen={isBootOrderModalOpen}
-          setOpen={setBootOrderModalOpen}
-          vmLikeEntity={template}
-        />
         <BootOrderSummary devices={devices} />
       </VMDetailsItem>
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/constants.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/constants.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { K8sResourceCommon } from '@console/internal/module/k8s/types';
+import { VMActionType } from '../../k8s/requests/vm/actions';
+import { VMIActionType } from '../../k8s/requests/vmi/actions';
+import { getName, getNamespace } from '@console/shared';
+
+export const getActionMessage = (obj: K8sResourceCommon, action: VMActionType | VMIActionType) => (
+  <>
+    Are you sure you want to {action} <strong>{getName(obj)}</strong> in namespace{' '}
+    <strong>{getNamespace(obj)}</strong>?
+  </>
+);

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import { asAccessReview, Kebab, KebabOption } from '@console/internal/components/utils';
-import { K8sKind, K8sResourceCommon, K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { K8sKind, K8sResourceKind, PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, YellowExclamationTriangleIcon } from '@console/shared';
 import { confirmModal } from '@console/internal/components/modals';
 import { VMIKind, VMKind } from '../../types/vm';
@@ -29,18 +29,12 @@ import { deleteVMIModal } from '../modals/menu-actions-modals/delete-vmi-modal';
 import { VMImportWrappper } from '../../k8s/wrapper/vm-import/vm-import-wrapper';
 import { StatusGroup } from '../../constants/status-group';
 import { cancelVMImport } from '../../k8s/requests/vmimport';
+import { getActionMessage } from './constants';
 
 type ActionArgs = {
   vmi?: VMIKind;
   vmStatusBundle?: VMStatusBundle;
 };
-
-const getActionMessage = (obj: K8sResourceCommon, action: VMActionType | VMIActionType) => (
-  <>
-    Are you sure you want to {action} <strong>{getName(obj)}</strong> in namespace{' '}
-    <strong>{getNamespace(obj)}</strong>?
-  </>
-);
 
 export const menuActionDeleteVMImport = (
   kindObj: K8sKind,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/pending-changes-warning.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/pending-changes-warning.scss
@@ -1,0 +1,19 @@
+.kv-warning--pf-c-list {
+    --pf-c-list--li--MarginTop: 0;
+    --pf-c-list--nested--MarginLeft: 0;
+}
+
+.kv-warning--pf-c-breadcrumb {
+    padding-bottom: 0;
+    padding-top: 0;
+}
+
+.kv-warning--comma-margin {
+    margin-right: 8px;
+    padding-top: 4px;
+}
+
+.kv-warning-changed-attrs {
+    display: flex;
+    flex-direction: row;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/pending-changes-warning.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/pending-changes-warning.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { PendingChanges } from './types';
+import { FirehoseResult, Firehose } from '@console/internal/components/utils';
+import { VMIKind, VMKind } from '../../types';
+import { VMLikeEntityKind } from '../../types/vmLike';
+import { getLoadedData } from '../../utils';
+import { VMWrapper } from '../../k8s/wrapper/vm/vm-wrapper';
+import { VMIWrapper } from '../../k8s/wrapper/vm/vmi-wrapper';
+import { PendingChangesAlert } from '../Alerts/PendingChangesAlert';
+import {
+  List,
+  ListItem,
+  Button,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbHeading,
+  ButtonVariant,
+} from '@patternfly/react-core';
+import { asVM } from '../../selectors/vm';
+import { VirtualMachineModel, VirtualMachineInstanceModel } from '../../models';
+import { PENDING_CHANGES_WARNING_MESSAGE } from '../../strings/vm/status';
+import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
+import { getPendingChanges, hasPendingChanges } from '../../utils/pending-changes';
+
+import './pending-changes-warning.scss';
+
+type PendingChangesWarningProps = {
+  vmi?: FirehoseResult<VMIKind>;
+  vmLikeEntity?: FirehoseResult<VMLikeEntityKind>;
+};
+
+const getPendingChangesByTab = (pendingChanges: PendingChanges) =>
+  Object.keys(pendingChanges)
+    .filter((key) => pendingChanges[key].isPendingChange)
+    .reduce((acc, key) => {
+      const pc = pendingChanges[key];
+      return {
+        ...acc,
+        [pc.vmTab]: acc[pc.vmTab] ? [...acc[pc.vmTab], key] : [key],
+      };
+    }, {});
+
+type WarningTabRowProps = {
+  tabName: string;
+  tabProps: string[];
+  pendingChanges: PendingChanges;
+};
+
+const WarningTabRow: React.FC<WarningTabRowProps> = ({ tabName, tabProps, pendingChanges }) => (
+  <Breadcrumb className="kv-warning--pf-c-breadcrumb">
+    <BreadcrumbHeading key={`${tabName}-header-${tabProps.join('-')}`}>{tabName}</BreadcrumbHeading>
+    <BreadcrumbItem key={`${tabName}-${tabProps.join('-')}`}>
+      {tabProps.map((key, idx) => (
+        <div key={`${tabName}-${key}`} className="kv-warning-changed-attrs">
+          <Button isInline onClick={pendingChanges[key].execAction} variant={ButtonVariant.link}>
+            {key}
+          </Button>
+          <div className="kv-warning--comma-margin">{idx === tabProps.length - 1 ? '' : ','}</div>
+        </div>
+      ))}
+    </BreadcrumbItem>
+  </Breadcrumb>
+);
+
+export const PendingChangesWarning: React.FC<PendingChangesWarningProps> = ({
+  vmLikeEntity,
+  vmi: vmiProp,
+}) => {
+  const vm: VMKind = asVM(getLoadedData(vmLikeEntity));
+  if (!isVMRunningOrExpectedRunning(vm)) {
+    return <></>;
+  }
+
+  const vmi = getLoadedData(vmiProp);
+
+  const vmWrapper = new VMWrapper(vm);
+  const vmiWrapper = new VMIWrapper(vmi);
+
+  const pendingChanges = getPendingChanges(vmWrapper, vmiWrapper);
+  const arePendingChanges = hasPendingChanges(vm, vmi, pendingChanges);
+
+  if (_.isEmpty(pendingChanges) || !arePendingChanges) {
+    return <></>;
+  }
+
+  const pendingChangesByTab = getPendingChangesByTab(pendingChanges);
+
+  return (
+    <PendingChangesAlert isWarning>
+      {PENDING_CHANGES_WARNING_MESSAGE}
+      <List className="kv-warning--pf-c-list">
+        {Object.keys(pendingChangesByTab).map(
+          (tabName) =>
+            pendingChangesByTab[tabName].length > 0 && (
+              <ListItem key={tabName}>
+                <WarningTabRow
+                  tabName={tabName}
+                  tabProps={pendingChangesByTab[tabName]}
+                  pendingChanges={pendingChanges}
+                />
+              </ListItem>
+            ),
+        )}
+      </List>
+    </PendingChangesAlert>
+  );
+};
+
+type PendingChangeWarningFirehoseProps = {
+  name: string;
+  namespace: string;
+};
+
+export const PendingChangesWarningFirehose: React.FC<PendingChangeWarningFirehoseProps> = ({
+  name,
+  namespace,
+}) => {
+  const resources = [
+    {
+      kind: VirtualMachineInstanceModel.kind,
+      name,
+      namespace,
+      prop: 'vmi',
+    },
+    {
+      kind: VirtualMachineModel.kind,
+      name,
+      namespace,
+      prop: 'vmLikeEntity',
+    },
+  ];
+  return (
+    <Firehose resources={resources}>
+      <PendingChangesWarning />
+    </Firehose>
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
@@ -4,6 +4,16 @@ import { VMGenericLikeEntityKind, VMILikeEntityKind } from '../../types/vmLike';
 import { VMImportKind } from '../../types/vm-import/ovirt/vm-import';
 import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 
+type PendingChange = {
+  isPendingChange: boolean;
+  execAction: () => void;
+  vmTab?: VMTabEnum;
+};
+
+export type PendingChanges = {
+  [key: string]: PendingChange;
+};
+
 export type VMTabProps = {
   obj?: VMILikeEntityKind;
   vm?: VMKind;
@@ -22,3 +32,26 @@ export type VMTabProps = {
 export type VMLikeEntityTabProps = {
   obj?: VMGenericLikeEntityKind;
 };
+
+export enum IsPendingChange {
+  flavor = 'Flavor',
+  cdroms = 'CD-ROMs',
+  bootOrder = 'Boot Order',
+  env = 'Environment',
+  nics = 'Network Interfaces',
+  disks = 'Disks',
+}
+
+export enum VMTabURLEnum {
+  details = 'details',
+  env = 'environment',
+  nics = 'nics',
+  disks = 'disks',
+}
+
+export enum VMTabEnum {
+  details = 'Details',
+  env = 'Environment',
+  nics = 'Network Interfaces',
+  disks = 'Disks',
+}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -3,7 +3,6 @@ import { navFactory } from '@console/internal/components/utils';
 import { DetailsPage } from '@console/internal/components/factory';
 import { PodModel, TemplateModel } from '@console/internal/models';
 import { VMDisksAndFileSystemsPage } from '../vm-disks/vm-disks';
-import { VMNics } from '../vm-nics';
 import {
   DataVolumeModel,
   VirtualMachineImportModel,
@@ -27,6 +26,8 @@ import { VMDashboard } from './vm-dashboard';
 import { TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM, VM_DETAIL_ENVIRONMENT } from '../../constants/vm';
 import { VMEnvironmentFirehose } from './vm-environment/vm-environment-page';
 import { VMSnapshotsPage } from '../vm-snapshots/vm-snapshots';
+import { VMNics } from '../vm-nics';
+import { PendingChangesWarningFirehose } from './pending-changes-warning';
 
 export const breadcrumbsForVMPage = (match: any) => () => [
   {
@@ -140,7 +141,9 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
       resources={resources}
       breadcrumbsFor={breadcrumbsForVMPage(props.match)}
       customData={{ kindObj: VirtualMachineModel }}
-    />
+    >
+      <PendingChangesWarningFirehose name={name} namespace={namespace} />
+    </DetailsPage>
   );
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Alert } from '@patternfly/react-core';
 import {
   Firehose,
   StatusBox,
@@ -19,14 +18,15 @@ import { VirtualMachineInstanceModel, VirtualMachineModel } from '../../models';
 import { getServicesForVmi } from '../../selectors/service';
 import { VMResourceSummary, VMDetailsList, VMSchedulingList } from './vm-resource';
 import { VMUsersList } from './vm-users';
-import { VMTabProps } from './types';
 import { useGuestAgentInfo } from '../../hooks/use-guest-agent-info';
 import { GuestAgentInfoWrapper } from '../../k8s/wrapper/vm/guest-agent-info/guest-agent-info-wrapper';
+import { VMTabProps } from './types';
 import { getVMStatus } from '../../statuses/vm/vm-status';
 import { VMStatusBundle } from '../../statuses/vm/types';
 import { isWindows } from '../../selectors/vm/combined';
 import { isVM, isVMI } from '../../selectors/check-type';
 import { HashAnchor } from '../hash-anchor/hash-anchor';
+import { Alert } from '@patternfly/react-core';
 
 export const VMDetailsFirehose: React.FC<VMTabProps> = ({
   obj: objProp,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/selectors.ts
@@ -17,7 +17,9 @@ import {
   SecretKind,
   ServiceAccountKind,
 } from '@console/internal/module/k8s';
-import { V1Disk } from 'packages/kubevirt-plugin/src/types/vm/disk/V1Disk';
+import { V1Disk } from '../../../types/vm/disk/V1Disk';
+import { VMWrapper } from '../../../k8s/wrapper/vm/vm-wrapper';
+import { VolumeWrapper } from '../../../k8s/wrapper/vm/volume-wrapper';
 
 export const getSerial = (ed: EnvDisk): string => ed[0];
 export const getEnvVarSource = (ed: EnvDisk): EnvVarSource => ed[1];
@@ -27,6 +29,24 @@ export const getSourceName = (ed: EnvDisk): string => {
   return (
     source?.configMapRef?.name || source?.secretRef?.name || source?.serviceAccountRef?.name || ''
   );
+};
+
+const getVolumeBySource = (sourceName: string, vmWrapper: VMWrapper) => {
+  return vmWrapper.getVolumes().find((vol) => {
+    const volWrapper = new VolumeWrapper(vol);
+    const volType = volWrapper.getType();
+
+    if (!volType?.isEnvType()) {
+      return false;
+    }
+
+    return volWrapper.getReferencedObject()?.name === sourceName;
+  });
+};
+
+export const getDiskNameBySource = (sourceName: string, vmWrapper: VMWrapper): string => {
+  const volume = getVolumeBySource(sourceName, vmWrapper);
+  return volume ? volume.name : null;
 };
 
 export const getEnvDiskRefKind = (envDisk: EnvDisk) =>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-footer.tsx
@@ -8,7 +8,7 @@ export const VMEnvironmentFooter: React.FC<VMEnvironmentFooterProps> = ({
   errorMsg,
   isSuccess,
   isSaveBtnDisabled,
-  isReloadBtnDisabled,
+  isReloadBtnDisabled = false,
 }) => {
   return (
     <footer className="co-m-btn-bar">
@@ -32,5 +32,5 @@ type VMEnvironmentFooterProps = {
   errorMsg: string;
   isSuccess: boolean;
   isSaveBtnDisabled: boolean;
-  isReloadBtnDisabled: boolean;
+  isReloadBtnDisabled?: boolean;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.scss
@@ -1,1 +1,0 @@
-@import "./resource-summary-description";

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -21,11 +21,7 @@ import { EditButton } from '../edit-button';
 import { VMStatus } from '../vm-status/vm-status';
 import { DiskSummary } from '../vm-disks/disk-summary';
 import { BootOrderSummary } from '../boot-order';
-import {
-  getOperatingSystemName,
-  getOperatingSystem,
-  isVMRunningOrExpectedRunning,
-} from '../../selectors/vm';
+import { getOperatingSystemName, getOperatingSystem } from '../../selectors/vm';
 import { getVmiIpAddresses } from '../../selectors/vmi/ip-address';
 import { findVMIPod } from '../../selectors/pod/selectors';
 import { isVMIPaused, getVMINodeName } from '../../selectors/vmi';
@@ -46,9 +42,16 @@ import { GuestAgentInfoWrapper } from '../../k8s/wrapper/vm/guest-agent-info/gue
 import { VMStatusBundle } from '../../statuses/vm/types';
 import { NOT_AVAILABLE_MESSAGE } from '../../strings/vm/messages';
 import { isGuestAgentInstalled } from '../dashboards-page/vm-dashboard/vm-alerts';
-
-import './vm-resource.scss';
 import { getGuestAgentFieldNotAvailMsg } from '../../utils/guest-agent-strings';
+import { Button } from '@patternfly/react-core';
+import {
+  isFlavorChanged,
+  isCDROMChanged,
+  isBootOrderChanged,
+} from '../../selectors/vm-like/next-run-changes';
+import { VMWrapper } from '../../k8s/wrapper/vm/vm-wrapper';
+import { VMIWrapper } from '../../k8s/wrapper/vm/vmi-wrapper';
+import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
 
 export const VMDetailsItem: React.FC<VMDetailsItemProps> = ({
   title,
@@ -59,12 +62,25 @@ export const VMDetailsItem: React.FC<VMDetailsItemProps> = ({
   isNotAvail = false,
   isNotAvailMessage = NOT_AVAILABLE_MESSAGE,
   valueClassName,
+  arePendingChanges,
   children,
 }) => {
   return (
     <>
       <dt>
-        {title} <EditButton id={editButtonId} canEdit={canEdit} onClick={onEditClick} />
+        <span>
+          {title} <EditButton id={editButtonId} canEdit={canEdit} onClick={onEditClick} />
+          {arePendingChanges && (
+            <Button
+              className="co-modal-btn-link--inline"
+              variant="link"
+              isInline
+              onClick={onEditClick}
+            >
+              View Pending Changes
+            </Button>
+          )}
+        </span>
       </dt>
       <dd id={idValue} className={valueClassName}>
         {isNotAvail ? <span className="text-secondary">{isNotAvailMessage}</span> : children}
@@ -140,7 +156,6 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   const hostname = guestAgentInfo.getHostname();
   const timeZone = guestAgentInfo.getTimezoneName();
 
-  const [isBootOrderModalOpen, setBootOrderModalOpen] = React.useState<boolean>(false);
   const isVM = kindObj === VirtualMachineModel;
   const vmiLike = isVM ? vm : vmi;
   const vmiLikeWrapper = asVMILikeWrapper(vmiLike);
@@ -150,11 +165,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
     status,
   );
 
-  const canEdit =
-    vmiLike &&
-    canUpdateVM &&
-    kindObj !== VirtualMachineInstanceModel &&
-    !isVMRunningOrExpectedRunning(vm);
+  const canEditWhileVMRunning = vmiLike && canUpdateVM && kindObj !== VirtualMachineInstanceModel;
 
   const [isStatusModalOpen, setStatusModalOpen] = React.useState<boolean>(false);
 
@@ -191,26 +202,31 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
 
       <VMDetailsItem
         title="Boot Order"
-        canEdit={canEdit}
+        canEdit={canEditWhileVMRunning}
         editButtonId={prefixedID(id, 'boot-order-edit')}
-        onEditClick={() => setBootOrderModalOpen(true)}
+        onEditClick={() => BootOrderModal({ vmLikeEntity: vm, modalClassName: 'modal-lg' })}
         idValue={prefixedID(id, 'boot-order')}
+        arePendingChanges={
+          isVM &&
+          isVMRunningOrExpectedRunning(vm) &&
+          isBootOrderChanged(new VMWrapper(vm), new VMIWrapper(vmi))
+        }
       >
-        <BootOrderModal
-          isOpen={isBootOrderModalOpen}
-          setOpen={setBootOrderModalOpen}
-          vmLikeEntity={vm}
-        />
         <BootOrderSummary devices={devices} />
       </VMDetailsItem>
 
       <VMDetailsItem
         title="CD-ROMs"
-        canEdit={canEdit}
+        canEdit={canEditWhileVMRunning}
         editButtonId={prefixedID(id, 'cdrom-edit')}
         onEditClick={() => VMCDRomModal({ vmLikeEntity: vm, modalClassName: 'modal-lg' })}
         idValue={prefixedID(id, 'cdrom')}
         isNotAvail={cds.length === 0}
+        arePendingChanges={
+          isVM &&
+          isVMRunningOrExpectedRunning(vm) &&
+          isCDROMChanged(new VMWrapper(vm), new VMIWrapper(vmi))
+        }
       >
         <DiskSummary disks={cds} vm={vm} />
       </VMDetailsItem>
@@ -269,6 +285,7 @@ export const VMSchedulingList: React.FC<VMSchedulingListProps> = ({
   const isVM = kindObj === VirtualMachineModel;
   const vmiLike = isVM ? vm : vmi;
   const vmiLikeWrapper = asVMILikeWrapper(vmiLike);
+  const canEditWhileVMRunning = vmiLike && canUpdateVM && kindObj !== VirtualMachineInstanceModel;
   const canEdit =
     vmiLike &&
     canUpdateVM &&
@@ -343,10 +360,15 @@ export const VMSchedulingList: React.FC<VMSchedulingListProps> = ({
           <VMDetailsItem
             title="Flavor"
             idValue={prefixedID(id, 'flavor')}
-            canEdit={canEdit}
+            canEdit={canEditWhileVMRunning}
             onEditClick={() => vmFlavorModal({ vmLike: vm, blocking: true })}
             editButtonId={prefixedID(id, 'flavor-edit')}
             isNotAvail={!flavorText}
+            arePendingChanges={
+              isVM &&
+              isVMRunningOrExpectedRunning(vm) &&
+              isFlavorChanged(new VMWrapper(vm), new VMIWrapper(vmi))
+            }
           >
             {flavorText}
           </VMDetailsItem>
@@ -375,6 +397,7 @@ type VMDetailsItemProps = {
   isNotAvail?: boolean;
   isNotAvailMessage?: string;
   valueClassName?: string;
+  arePendingChanges?: boolean;
   children: React.ReactNode;
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -56,6 +56,7 @@ import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 import { VMImportWrappper } from '../../k8s/wrapper/vm-import/vm-import-wrapper';
 import { getVMImportStatusAsVMStatus } from '../../statuses/vm-import/vm-import-status';
 import { V2VVMImportStatus } from '../../constants/v2v-import/ovirt/v2v-vm-import-status';
+import { hasPendingChanges } from '../../utils/pending-changes';
 
 import './vm.scss';
 
@@ -131,6 +132,8 @@ const VMRow: RowFunction<VMRowObjType> = ({ obj, index, key, style }) => {
     options = vmiMenuActions.map((action) => action(model, vmi));
   }
 
+  const arePendingChanges = hasPendingChanges(vm, vmi);
+
   return (
     <TableRow key={`${key}${name}`} id={uid} index={index} trKey={key} style={style}>
       <TableData className={dimensify()}>
@@ -140,7 +143,13 @@ const VMRow: RowFunction<VMRowObjType> = ({ obj, index, key, style }) => {
         <ResourceLink kind={NamespaceModel.kind} name={namespace} title={namespace} />
       </TableData>
       <TableData className={dimensify()}>
-        <VMStatus vm={vm} vmi={vmi} vmStatusBundle={vmStatusBundle} />
+        <VMStatus
+          vm={vm}
+          vmi={vmi}
+          vmStatusBundle={vmStatusBundle}
+          arePendingChanges={arePendingChanges}
+        />
+        {arePendingChanges && <div>Pending changes</div>}
       </TableData>
       <TableData className={dimensify()}>
         <Timestamp timestamp={creationTimestamp} />

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
@@ -71,4 +71,31 @@ export class DiskWrapper extends ObjectWithTypePropertyWrapper<
         };
     }
   }
+
+  isDiskEqual = (otherDisk: V1Disk, omitRuntimeData?: boolean): boolean => {
+    if (!otherDisk) {
+      return false;
+    }
+
+    if (!omitRuntimeData) {
+      return _.isEqual(this.data, otherDisk);
+    }
+
+    const diskWrapper = new DiskWrapper(otherDisk);
+    const thisDiskType = this.getType();
+
+    if (diskWrapper.getType() !== thisDiskType) {
+      return false;
+    }
+
+    switch (thisDiskType) {
+      case DiskType.CDROM:
+        return _.isEqual(
+          _.omit(this.data, 'cdrom.readonly', 'cdrom.tray'),
+          _.omit(otherDisk, 'cdrom.readonly', 'cdrom.tray'),
+        );
+      default:
+        return _.isEqual(this.data, otherDisk);
+    }
+  };
 }

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vmi-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vmi-wrapper.ts
@@ -11,7 +11,6 @@ import {
   getVMIAffinity,
 } from '../../../selectors/vmi';
 import { VMILikeMethods } from './types';
-import { transformDevices } from '../../../selectors/vm';
 import { findKeySuffixValue } from '../../../selectors/utils';
 import {
   TEMPLATE_FLAVOR_LABEL,
@@ -19,6 +18,9 @@ import {
   TEMPLATE_WORKLOAD_LABEL,
 } from '../../../constants/vm';
 import { VirtualMachineInstanceModel } from '../../../models';
+import { transformDevices } from '../../../selectors/vm/devices';
+import { V1Disk } from '../../../types/vm/disk/V1Disk';
+import { V1Volume } from '../../../types/vm/disk/V1Volume';
 
 export class VMIWrapper extends K8sResourceWrapper<VMIKind, VMIWrapper> implements VMILikeMethods {
   constructor(vmi?: VMIKind | VMIWrapper | any, copy = false) {
@@ -40,6 +42,11 @@ export class VMIWrapper extends K8sResourceWrapper<VMIKind, VMIWrapper> implemen
   getNetworks = (defaultValue = []) => getVMINetworks(this.data, defaultValue);
 
   getVolumes = (defaultValue = []) => getVMIVolumes(this.data, defaultValue);
+
+  getVolumesOfDisks = (disks: V1Disk[]): V1Volume[] => {
+    const diskNames = disks.map((disk) => disk?.name);
+    return this.getVolumes().filter((vol) => diskNames.includes(vol.name));
+  };
 
   getLabeledDevices = () => transformDevices(this.getDisks(), this.getNetworkInterfaces());
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/volume-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/volume-wrapper.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../selectors/vm/volume';
 import { DataVolumeModel } from '../../../models';
 import { V1LocalObjectReference } from '../../../types/vm/disk/V1LocalObjectReference';
+import * as _ from 'lodash';
 
 export type VolumeReferencedObject = {
   name: string;
@@ -143,4 +144,31 @@ export class VolumeWrapper extends ObjectWithTypePropertyWrapper<
         return null;
     }
   }
+
+  isVolumeEqual = (otherVolume: V1Volume, omitRuntimeData?: boolean) => {
+    if (!otherVolume) {
+      return false;
+    }
+
+    if (!omitRuntimeData) {
+      return _.isEqual(this.data, otherVolume);
+    }
+
+    const volWrapper = new VolumeWrapper(otherVolume);
+    const thisType = this.getType();
+
+    if (thisType !== volWrapper.getType()) {
+      return false;
+    }
+
+    switch (thisType) {
+      case VolumeType.CONTAINER_DISK:
+        return _.isEqual(
+          _.omit(this.data, 'containerDisk.imagePullPolicy'),
+          _.omit(otherVolume, 'containerDisk.imagePullPolicy'),
+        );
+      default:
+        return _.isEqual(this.data, otherVolume);
+    }
+  };
 }

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-like/next-run-changes.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-like/next-run-changes.ts
@@ -1,0 +1,151 @@
+import { VMWrapper } from '../../k8s/wrapper/vm/vm-wrapper';
+import { VMIWrapper } from '../../k8s/wrapper/vm/vmi-wrapper';
+import * as _ from 'lodash';
+import { BootableDeviceType } from '../../types/types';
+import { getBootableDevicesInOrder, getDevices } from '../vm/devices';
+import { getVMIBootableDevicesInOrder, getVMIDevices } from '../vmi/devices';
+import { createBasicLookup } from '@console/shared';
+import { getSimpleName } from '../utils';
+import { V1Disk } from '../../types/vm/disk/V1Disk';
+import { VolumeWrapper } from '../../k8s/wrapper/vm/volume-wrapper';
+import { DiskWrapper } from '../../k8s/wrapper/vm/disk-wrapper';
+
+const cpuOmitPaths = ['dedicatedCpuPlacement', 'features', 'isolateEmulatorThread', 'model'];
+
+export const isFlavorChanged = (vm: VMWrapper, vmi: VMIWrapper): boolean => {
+  if (vm.isEmpty() || vmi.isEmpty()) {
+    return false;
+  }
+
+  const vmCPU = _.omit(vm.getCPU(), cpuOmitPaths);
+  const vmiCPU = _.omit(vmi.getCPU(), cpuOmitPaths);
+
+  return (
+    vm.getFlavor() !== vmi.getFlavor() ||
+    !_.isEqual(vm.getMemory(), vmi.getMemory()) ||
+    !_.isEqual(vmCPU, vmiCPU)
+  );
+};
+
+export const isDisksChanged = (
+  vm: VMWrapper,
+  vmi: VMIWrapper,
+  vmDsks?: V1Disk[],
+  vmiDsks?: V1Disk[],
+): boolean => {
+  if (vm.isEmpty() || vmi.isEmpty()) {
+    return false;
+  }
+
+  const vmDisks = vmDsks || vm.getDisks();
+  const vmiDisks = vmiDsks || vmi.getDisks();
+
+  if (vmDisks.length !== vmiDisks.length) {
+    return true;
+  }
+
+  const vmVolumes = vm.getVolumesOfDisks(vmDisks);
+  const vmiVolumes = vmi.getVolumesOfDisks(vmiDisks);
+
+  if (vmVolumes.length !== vmiVolumes.length) {
+    return true;
+  }
+
+  const vmiVolLookup = createBasicLookup(vmiVolumes, getSimpleName);
+  const vmDiskLookup = createBasicLookup(vmDisks, getSimpleName);
+  const vmiDiskLookup = createBasicLookup(vmiDisks, getSimpleName);
+
+  return !vmVolumes.every((vol) => {
+    const diskWrapper = new DiskWrapper(vmDiskLookup[vol.name]);
+    const diskEquality = diskWrapper.isDiskEqual(vmiDiskLookup[vol.name], true);
+
+    if (diskEquality) {
+      const volWrapper = new VolumeWrapper(vol);
+      return volWrapper.isVolumeEqual(vmiVolLookup[vol.name], true);
+    }
+
+    return false;
+  });
+};
+
+export const isCDROMChanged = (vm: VMWrapper, vmi: VMIWrapper): boolean => {
+  if (vm.isEmpty() || vmi.isEmpty()) {
+    return false;
+  }
+  return isDisksChanged(vm, vmi, vm.getCDROMs(), vmi.getCDROMs());
+};
+
+export const isBootOrderChanged = (vm: VMWrapper, vmi: VMIWrapper): boolean => {
+  if (vm.isEmpty() || vmi.isEmpty()) {
+    return false;
+  }
+
+  const vmBootOrder: BootableDeviceType[] = getBootableDevicesInOrder(vm.asResource(true));
+  const vmiBootOrder: BootableDeviceType[] = getVMIBootableDevicesInOrder(vmi.asResource(true));
+
+  if (vmBootOrder.length !== vmiBootOrder.length) {
+    return true;
+  }
+
+  // Implicit boot order - no boot order is configured
+  // Check whether the order of the disks in the YAML has changed
+  if (vmBootOrder.length === 0) {
+    const vmDevices = getDevices(vm.asResource());
+    const vmiDevices = getVMIDevices(vmi.asResource());
+
+    return vmDevices.every((bootableDevice, index) => _.isEqual(bootableDevice, vmiDevices[index]));
+  }
+
+  return !vmBootOrder.every(
+    (device, index) =>
+      device.type === vmiBootOrder[index].type &&
+      device.typeLabel === vmiBootOrder[index].typeLabel &&
+      device.value.bootOrder === vmiBootOrder[index].value.bootOrder &&
+      device.value.name === vmiBootOrder[index].value.name,
+  );
+};
+
+export const isNicsChanged = (vm: VMWrapper, vmi: VMIWrapper): boolean => {
+  if (vm.isEmpty() || vmi.isEmpty()) {
+    return false;
+  }
+
+  const vmNics = vm.getNetworkInterfaces();
+  const vmiNics = vmi.getNetworkInterfaces();
+
+  if (vmNics.length !== vmiNics.length) {
+    return true;
+  }
+
+  const vmNicsLookup = createBasicLookup(vmNics, getSimpleName);
+  const vmiNicsLookup = createBasicLookup(vmiNics, getSimpleName);
+
+  return !Object.keys(vmNicsLookup).every(
+    (vmNicName) =>
+      !!vmiNicsLookup[vmNicName] && _.isEqual(vmiNicsLookup[vmNicName], vmNicsLookup[vmNicName]),
+  );
+};
+
+export const isEnvDisksChanged = (vm: VMWrapper, vmi: VMIWrapper): boolean => {
+  if (vm.isEmpty() || vmi.isEmpty()) {
+    return false;
+  }
+
+  const vmEnvDiskVolumeNames = vm
+    .getVolumes()
+    .filter((vol) => new VolumeWrapper(vol).getType().isEnvType())
+    .map((vol) => vol.name);
+
+  const vmiEnvDiskVolumeNames = vmi
+    .getVolumes()
+    .filter((vol) => new VolumeWrapper(vol).getType().isEnvType())
+    .map((vol) => vol.name);
+
+  if (vmEnvDiskVolumeNames.length !== vmiEnvDiskVolumeNames.length) {
+    return true;
+  }
+  const vmEnvDisks = vm.getDisks().filter((dsk) => vmEnvDiskVolumeNames.includes(dsk.name));
+  const vmiEnvDisks = vmi.getDisks().filter((dsk) => vmiEnvDiskVolumeNames.includes(dsk.name));
+
+  return isDisksChanged(vm, vmi, vmEnvDisks, vmiEnvDisks);
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -55,9 +55,9 @@ export const getVolumes = (vm: VMKind, defaultValue: V1Volume[] = []): V1Volume[
 export const getDataVolumeTemplates = (vm: VMKind, defaultValue = []) =>
   _.get(vm, 'spec.dataVolumeTemplates') == null ? defaultValue : vm.spec.dataVolumeTemplates;
 
-export const getBootableDisks = (vm: VMKind, defaultValue: V1Disk[] = []): V1Disk[] => {
-  const volumeLookup = createBasicLookup(getVolumes(vm), getSimpleName);
-  return getDisks(vm, defaultValue).filter((disk) => {
+export const getBootableDisks = (vm: VMKind, disks?: V1Disk[], volumes?: V1Volume[]): V1Disk[] => {
+  const volumeLookup = createBasicLookup(volumes || getVolumes(vm), getSimpleName);
+  return (disks || getDisks(vm)).filter((disk) => {
     const volWrapper = new VolumeWrapper(volumeLookup[disk.name]);
     return !volWrapper.isEmpty() && volWrapper.getType() && !volWrapper.getType().isEnvType();
   });

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/devices.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/devices.ts
@@ -1,0 +1,17 @@
+import * as _ from 'lodash';
+import { transformDevices } from '../vm/devices';
+import { getVMIInterfaces, getVMIDisks } from './basic';
+import { VMIKind } from '../../types/vm';
+import { BootableDeviceType } from '../../types/types';
+
+export const getVMIDevices = (vmi: VMIKind): BootableDeviceType[] => {
+  return transformDevices(getVMIDisks(vmi), getVMIInterfaces(vmi));
+};
+
+const getVMISelectedBootableDevices = (vmi: VMIKind): BootableDeviceType[] => {
+  const devices = getVMIDevices(vmi).filter((device) => device.value.bootOrder);
+  return [...devices];
+};
+
+export const getVMIBootableDevicesInOrder = (vmi: VMIKind): BootableDeviceType[] =>
+  _.sortBy(getVMISelectedBootableDevices(vmi), 'value.bootOrder');

--- a/frontend/packages/kubevirt-plugin/src/strings/vm/status.ts
+++ b/frontend/packages/kubevirt-plugin/src/strings/vm/status.ts
@@ -10,3 +10,9 @@ export const STARTING_MESSAGE =
   'This virtual machine will start shortly. Preparing storage, networking, and compute resources.';
 export const IMPORT_CDI_PENDING_MESSAGE =
   'The importer pod is waiting for resources to become available.';
+export const MODAL_RESTART_IS_REQUIRED =
+  'The changes you are making require this virtual machine to be updated. Restart this VM to apply these changes.';
+export const PENDING_CHANGES_WARNING_MESSAGE =
+  'The following areas have pending changes that will be applied when this virtual machine is restarted.';
+export const PENDING_CHANGES_POPOVER_MSG =
+  'This virtual machine has some pending changes that will apply after it is restarted.';

--- a/frontend/packages/kubevirt-plugin/src/utils/pending-changes.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/pending-changes.ts
@@ -1,0 +1,70 @@
+import { VMWrapper } from '../k8s/wrapper/vm/vm-wrapper';
+import { VMIWrapper } from '../k8s/wrapper/vm/vmi-wrapper';
+import { PendingChanges, IsPendingChange, VMTabURLEnum, VMTabEnum } from '../components/vms/types';
+import {
+  isFlavorChanged,
+  isCDROMChanged,
+  isBootOrderChanged,
+  isEnvDisksChanged,
+  isNicsChanged,
+  isDisksChanged,
+} from '../selectors/vm-like/next-run-changes';
+import { vmFlavorModal } from '../components/modals';
+import { VMCDRomModal } from '../components/modals/cdrom-vm-modal/vm-cdrom-modal';
+import { BootOrderModal } from '../components/modals/boot-order-modal';
+import { history } from '@console/internal/components/utils/router';
+import { VMKind, VMIKind } from '../types';
+import { getVMTabURL } from './url';
+
+export const getPendingChanges = (vmWrapper: VMWrapper, vmiWrapper: VMIWrapper): PendingChanges => {
+  const vm = vmWrapper.asResource();
+  return {
+    [IsPendingChange.flavor]: {
+      isPendingChange: isFlavorChanged(vmWrapper, vmiWrapper),
+      execAction: () => {
+        history.push(getVMTabURL(vm, VMTabURLEnum.details));
+        vmFlavorModal({ vmLike: vm, blocking: true });
+      },
+      vmTab: VMTabEnum.details,
+    },
+    [IsPendingChange.cdroms]: {
+      isPendingChange: isCDROMChanged(vmWrapper, vmiWrapper),
+      execAction: () => {
+        history.push(getVMTabURL(vm, VMTabURLEnum.details));
+        VMCDRomModal({ vmLikeEntity: vm, modalClassName: 'modal-lg' });
+      },
+      vmTab: VMTabEnum.details,
+    },
+    [IsPendingChange.bootOrder]: {
+      isPendingChange: isBootOrderChanged(vmWrapper, vmiWrapper),
+      execAction: () => {
+        history.push(getVMTabURL(vm, VMTabURLEnum.details));
+        BootOrderModal({ vmLikeEntity: vm, modalClassName: 'modal-lg' });
+      },
+      vmTab: VMTabEnum.details,
+    },
+    [IsPendingChange.env]: {
+      isPendingChange: isEnvDisksChanged(vmWrapper, vmiWrapper),
+      execAction: () => history.push(getVMTabURL(vm, VMTabURLEnum.env)),
+      vmTab: VMTabEnum.env,
+    },
+    [IsPendingChange.nics]: {
+      isPendingChange: isNicsChanged(vmWrapper, vmiWrapper),
+      execAction: () => history.push(getVMTabURL(vm, VMTabURLEnum.nics)),
+      vmTab: VMTabEnum.nics,
+    },
+    [IsPendingChange.disks]: {
+      isPendingChange: isDisksChanged(vmWrapper, vmiWrapper),
+      execAction: () => history.push(getVMTabURL(vm, VMTabURLEnum.disks)),
+      vmTab: VMTabEnum.disks,
+    },
+  };
+};
+
+export const hasPendingChanges = (vm: VMKind, vmi: VMIKind, pc?: PendingChanges): boolean => {
+  const pendingChanges = pc || (!!vmi && getPendingChanges(new VMWrapper(vm), new VMIWrapper(vmi)));
+  return Object.keys(pendingChanges || {}).reduce(
+    (boolVal, k) => boolVal || pendingChanges[k].isPendingChange,
+    false,
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/utils/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/url.ts
@@ -1,9 +1,15 @@
 import { k8sBasePath } from '@console/internal/module/k8s';
 import { VMWizardMode, VMWizardName, VMWizardView } from '../constants/vm';
+import { VMKind } from '../types';
+import { VMTabURLEnum } from '../components/vms/types';
+import { getName, getNamespace } from '@console/shared';
 
 const ELLIPSIS = '…';
 
 const ellipsizeLeft = (word) => `${ELLIPSIS}${word}`;
+
+export const getVMTabURL = (vm: VMKind, tabName: VMTabURLEnum) =>
+  `/ns/${getNamespace(vm)}/virtualmachines/${getName(vm)}/${tabName}`;
 
 export const getConsoleAPIBase = () => {
   // avoid the extra slash when compose the URL by VncConsole


### PR DESCRIPTION
Add alerts when the user make changes in the VM details view
while the VM is running informing to restart the VM for
the changes to apply.

Additionally, the changes aren't reflected immediately on the screen
while the VM is running, like they used to be, but change after the
VM restarts. This way the screen represents the current configuration
rather than the 'future' configuration.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>

CNV-5024# Please enter the commit message for your changes. Lines starting