### PR TITLE
Bug 1842351: Network definitions to nad

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -95,8 +95,8 @@ export const Network: React.FC<NetworkProps> = ({
           isDisabled={!acceptEmptyValues}
           placeholder={
             networkChoices.length === 0
-              ? '--- Network Definitions not available ---'
-              : '--- Select Network Definition ---'
+              ? '--- Network Attachment Definitions not available ---'
+              : '--- Select Attachment Network Definition ---'
           }
         />
         {ignoreCaseSort(networkChoices, undefined, (n) => n.getReadableName()).map(


### PR DESCRIPTION
Typo fix:

After:
![screenshot-localhost_9000-2020 06 01-13_57_09](https://user-images.githubusercontent.com/2181522/83402900-51618900-a410-11ea-90db-e6b7661c1d3a.png)
![screenshot-localhost_9000-2020 06 01-13_57_38](https://user-images.githubusercontent.com/2181522/83402902-51fa1f80-a410-11ea-94c9-c45637a86099.png)

Before:
![screenshot-localhost_9000-2020 06 01-13_55_39](https://user-images.githubusercontent.com/2181522/83402916-59b9c400-a410-11ea-8275-5aa5e07de85a.png)
![screenshot-localhost_9000-2020 06 01-13_56_30](https://user-images.githubusercontent.com/2181522/83402917-5a525a80-a410-11ea-82d3-a8602c945890.png)
