### PR TITLE
Apply Patternfly fix to hide the badge in the Display dropdown in Topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
@@ -44,6 +44,7 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({ filters, onChange }) =>
       onSelect={onSelect}
       placeholderText="Display Options"
       isGrouped
+      isCheckboxSelectionBadgeHidden
     >
       {showOptions}
       {expandOptions}

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
@@ -9,9 +9,4 @@
   &__info-icon {
     margin-left: var(--pf-global--spacer--sm);
   }
-
-  // TODO: Remove when https://github.com/patternfly/patternfly-react/pull/3976 is available
-  .pf-c-select__toggle-badge {
-    display: none;
-  }
 }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3994

**Analysis / Root cause**: 
Custom CSS has been used to hide the badge in the Display dropdown in topology. As there was no way to hide the badge in the Patterfly component.

**Solution Description**: 
Patternfly ```Select``` component has been updated and no we have a prop to hide the badge. So, this PR removed the custom CSS for hiding the badge and use the prop to hide the badge.

**Screen shots / Gifs for design review**: 
<img width="1511" alt="Screenshot 2020-06-01 at 5 22 34 PM" src="https://user-images.githubusercontent.com/2561818/83406548-7fed5d00-a42c-11ea-87c9-fa2d18358b51.png">

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge