### PR TITLE
Remove options other than masquerade for default networks

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-type.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-type.ts
@@ -9,8 +9,6 @@ export class NetworkType extends ObjectEnum<string> {
   ]);
   static readonly POD = new NetworkType('pod', NetworkInterfaceType.MASQUERADE, [
     NetworkInterfaceType.MASQUERADE,
-    NetworkInterfaceType.BRIDGE,
-    NetworkInterfaceType.SRIOV,
   ]);
   static readonly GENIE = new NetworkType(
     'genie',


### PR DESCRIPTION
> You can use the default Pod network with container-native virtualization. To do so, you must use the masquerade binding method.

