### PR TITLE
fix delete application error if ImageStream is not present for a resource

### DIFF
--- a/frontend/packages/dev-console/src/utils/__tests__/application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/application-utils.spec.ts
@@ -44,11 +44,14 @@ const getTopologyData = (
 describe('ApplicationUtils ', () => {
   let spy;
   let checkAccessSpy;
+  let spyK8sGet;
   beforeEach(() => {
     spy = spyOn(k8s, 'k8sKill');
     checkAccessSpy = spyOn(utils, 'checkAccess');
+    spyK8sGet = spyOn(k8s, 'k8sGet');
     spyAndReturn(spy)(Promise.resolve({}));
     spyAndReturn(checkAccessSpy)(Promise.resolve({ status: { allowed: true } }));
+    spyAndReturn(spyK8sGet)(Promise.resolve(true));
   });
 
   it('Should delete all the specific models related to deployment config', (done) => {


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-3731

Analysis/root cause: For resources created through the internal image registry. ImageStream is not created which cause the error while deleting an application

Solution: Add a check for ImageStream before deleting all the related resources in an application

Screenshot:
![Peek 2020-06-01 18-14](https://user-images.githubusercontent.com/9278015/83411386-c1363a80-a435-11ea-944a-86b7609e8c5a.gif)