### PR TITLE
Add edit labels and annotations action in the kebab actions

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
@@ -3,7 +3,7 @@ import { merge } from 'lodash';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useSelector } from 'react-redux';
-import { KebabAction } from '@console/internal/components/utils';
+import { KebabAction, Kebab } from '@console/internal/components/utils';
 import { K8sResourceCommon } from '@console/internal/module/k8s';
 import { PipelineRun } from '../../../utils/pipeline-augment';
 import { StartedByLabel } from '../../pipelines/const';
@@ -33,6 +33,9 @@ export const useMenuActionsWithUserLabel = (menuActions: KebabAction[]): KebabAc
   const labels = useUserLabelForManualStart();
 
   return menuActions.map((kebabAction) => {
+    if (Object.values(Kebab.factory).includes(kebabAction)) {
+      return kebabAction;
+    }
     return (kind, resource, ...rest) =>
       kebabAction(kind, mergeLabelsWithResource(labels, resource), ...rest);
   });

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -88,26 +88,26 @@ describe('PipelineAction testing stopPipelineRun create correct labels and callb
 describe('getPipelineKebabActions', () => {
   it('expect Remove Trigger option is present', () => {
     const pipelineKebabActions = getPipelineKebabActions(actionPipelineRuns[0], true);
-    expect(pipelineKebabActions.length).toBe(6);
+    expect(pipelineKebabActions.length).toBe(8);
     expect(pipelineKebabActions[3](PipelineModel, actionPipelines[0]).label).toBe('Remove Trigger');
   });
   it('expect Remove Trigger option is not present', () => {
     const pipelineKebabActions = getPipelineKebabActions(actionPipelineRuns[0], false);
-    expect(pipelineKebabActions.length).toBe(5);
+    expect(pipelineKebabActions.length).toBe(7);
     expect(pipelineKebabActions[3](PipelineModel, actionPipelines[0]).label).not.toBe(
       'Remove Trigger',
     );
   });
   it('expect Start Last Run option is present', () => {
     const pipelineKebabActions = getPipelineKebabActions(actionPipelineRuns[0], false);
-    expect(pipelineKebabActions.length).toBe(5);
+    expect(pipelineKebabActions.length).toBe(7);
     expect(pipelineKebabActions[1](PipelineRunModel, actionPipelineRuns[0]).label).toBe(
       'Start Last Run',
     );
   });
   it('expect Start Last Run option is not present', () => {
     const pipelineKebabActions = getPipelineKebabActions(undefined, false);
-    expect(pipelineKebabActions.length).toBe(4);
+    expect(pipelineKebabActions.length).toBe(6);
     expect(pipelineKebabActions[1](PipelineRunModel, actionPipelineRuns[0]).label).not.toBe(
       'Start Last Run',
     );

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -236,6 +236,8 @@ export const getPipelineKebabActions = (
   ...(pipelineRun ? [() => rerunPipelineAndRedirect(PipelineRunModel, pipelineRun)] : []),
   (model, pipeline) => addTrigger(EventListenerModel, pipeline),
   ...(isTriggerPresent ? [(model, pipeline) => removeTrigger(EventListenerModel, pipeline)] : []),
+  Kebab.factory.ModifyLabels,
+  Kebab.factory.ModifyAnnotations,
   editPipeline,
   Kebab.factory.Delete,
 ];


### PR DESCRIPTION
**Story :** https://issues.redhat.com/browse/ODC-2434

**Problem:**
Users are not able to modify the labels and annotations of a pipeline from the kebab actions, the only way to change it is via yaml editor.

**Solution:**
Add common kebab menu options such as Edit Label and Edit Annotation actions to the kebab menu.

**Screenshot:**
![kebab-actions](https://user-images.githubusercontent.com/9964343/83435886-94484e80-a45a-11ea-8916-6590522e2f15.gif)
**Menu with Edit Labels and Edit Annotations:** 
![image](https://user-images.githubusercontent.com/9964343/83482820-ce4b3c00-a4be-11ea-9ba0-a2476a0c41cf.png)

**Updated Test cases**
![image](https://user-images.githubusercontent.com/9964343/83436068-dec9cb00-a45a-11ea-9586-0dc9ef7dbaf4.png)

cc: @openshift/team-devconsole-ux @beaumorley 