### PR TITLE
Bug 1840543: Use undefined as default value for width hook

### DIFF
--- a/frontend/public/components/graphs/gauge.tsx
+++ b/frontend/public/components/graphs/gauge.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
 import { usePrometheusPoll } from './prometheus-poll-hook';
 import { PrometheusEndpoint } from './helpers';
-import { humanizePercentage, Humanize } from '../utils';
+import { useRefWidth, humanizePercentage, Humanize } from '../utils';
 import { getInstantVectorStats } from './utils';
 import { DataPoint } from '.';
 
@@ -32,13 +32,24 @@ export const GaugeChart: React.FC<GaugeChartProps> = ({
   secondaryTitle = usedLabel,
   className,
 }) => {
+  const [ref, width] = useRefWidth();
   const ready = !error && !loading;
   const status = loading ? 'Loading' : error;
   const labels = ({ datum: { x, y } }) => (x ? `${x} ${usedLabel}` : `${y} ${remainderLabel}`);
   return (
-    <PrometheusGraph className={classNames('graph-wrapper--title-center', className)} title={title}>
+    <PrometheusGraph
+      className={classNames('graph-wrapper--title-center graph-wrapper--gauge', className)}
+      ref={ref}
+      title={title}
+    >
       <PrometheusGraphLink query={query}>
-        <ChartDonutThreshold data={thresholds} height={160} padding={0} width={160} y="value">
+        <ChartDonutThreshold
+          data={thresholds}
+          height={width} // Changes the scale of the graph, not actual width and height
+          padding={0}
+          width={width}
+          y="value"
+        >
           <ChartDonutUtilization
             labels={labels}
             data={ready ? data : { y: 0 }}

--- a/frontend/public/components/utils/ref-width-hook.ts
+++ b/frontend/public/components/utils/ref-width-hook.ts
@@ -2,12 +2,12 @@ import { useEffect, useRef, useState } from 'react';
 
 export const useRefWidth = () => {
   const ref = useRef<HTMLDivElement>(null);
-  const [width, setWidth] = useState(0);
+  const [width, setWidth] = useState<number>();
 
-  const clientWidth = ref?.current?.clientWidth ?? 0;
+  const clientWidth = ref?.current?.clientWidth;
 
   useEffect(() => {
-    const handleResize = () => setWidth(ref?.current?.clientWidth ?? 0);
+    const handleResize = () => setWidth(ref?.current?.clientWidth);
     window.addEventListener('resize', handleResize);
     window.addEventListener('sidebar_toggle', handleResize);
     return () => {


### PR DESCRIPTION
Originally the width hook started with 0 as width, then `null` and after that we got the actual value. My intention was to remove one render cycle by using 0 always. I see that it wasnt the best choice, so now I changed it to `undefined`
See also https://github.com/openshift/console/pull/5622#pullrequestreview-422044218

@spadgett @TheRealJon @rhamilto 