### PR TITLE
Add optional rootWindow option to route plugin

### DIFF
--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -188,6 +188,16 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'NavItem/Href',
+    properties: {
+      perspective: 'test',
+      componentProps: {
+        name: 'Test Root Window Page',
+        href: '/test-root',
+      },
+    },
+  },
+  {
     type: 'NavItem/ResourceCluster',
     properties: {
       perspective: 'test',
@@ -204,6 +214,15 @@ const plugin: Plugin<ConsumedExtensions> = [
       exact: true,
       path: '/test',
       render: () => <h1>Test Page</h1>,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: '/test-root',
+      rootWindow: true,
+      render: () => <h1>Test Root Window Page</h1>,
     },
   },
   {

--- a/frontend/packages/console-plugin-sdk/src/typings/pages.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/pages.ts
@@ -63,6 +63,8 @@ namespace ExtensionProperties {
     path: string | string[];
     /** Perspective id to which this page belongs to. */
     perspective?: string;
+    /** rootWindow indicate rendering as root window instead of layout content. */
+    rootWindow?: boolean;
     /** Feature flags required for this extension to be effective. */
     required?: string | string[];
   };

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -91,6 +91,7 @@ const getPluginPageRoutes = (activePerspective: string, flags: FlagsObject) =>
   plugins.registry
     .getRoutePages()
     .filter((e) => plugins.registry.isExtensionInUse(e, flags))
+    .filter((r) => !r.properties?.rootWindow)
     .map((r) => {
       if (r.properties.perspective && r.properties.perspective !== activePerspective) {
         return null;
@@ -98,6 +99,15 @@ const getPluginPageRoutes = (activePerspective: string, flags: FlagsObject) =>
       const Component = r.properties.loader ? LazyRoute : Route;
       return <Component {...r.properties} key={Array.from(r.properties.path).join(',')} />;
     });
+
+const getPluginRootWindowRoutes = () =>
+  plugins.registry.getRoutePages().map((r) => {
+    if (!r.properties.rootWindow) {
+      return null;
+    }
+    const Component = r.properties.loader ? LazyRoute : Route;
+    return <Component {...r.properties} key={Array.from(r.properties.path).join(',')} />;
+  });
 
 type AppContentsProps = {
   activePerspective: string;
@@ -651,4 +661,4 @@ const AppContents = connect((state: RootState) => ({
   activePerspective: getActivePerspective(state),
 }))(connectToFlags(...plugins.registry.getGatingFlagNames([plugins.isRoutePage]))(AppContents_));
 
-export default AppContents;
+export { AppContents, getPluginRootWindowRoutes };

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -8,7 +8,7 @@ import { Route, Router, Switch } from 'react-router-dom';
 import 'abort-controller/polyfill';
 import store from '../redux';
 import { detectFeatures } from '../actions/features';
-import AppContents from './app-contents';
+import { AppContents, getPluginRootWindowRoutes } from './app-contents';
 import { getBrandingDetails, Masthead } from './masthead';
 import { ConsoleNotifier } from './console-notifier';
 import { ConnectedNotificationDrawer } from './notification-drawer';
@@ -215,6 +215,7 @@ render(
   <Provider store={store}>
     <Router history={history} basename={window.SERVER_FLAGS.basePath}>
       <Switch>
+        {getPluginRootWindowRoutes()}
         <Route path="/terminal" component={CloudShellTab} />
         <Route path="/" component={App} />
       </Switch>


### PR DESCRIPTION
**Description**
Add an optional option to render routes in root window instead of inside the layout.

Rational
Some plugin _and currently internal_ views can benefit from "full screen" views.

**Current use cases**
  - For the `kubevirt-plugin` we want to render the VNC terminal using a detached window [[1]](https://bugzilla.redhat.com/show_bug.cgi?id=1837677)  [[2]](https://github.com/openshift/console/pull/5593) , having the possibility to add a "full screen" route in the plugin. will give us the option to maintaine the VNC console without the need to mange the hard coded route in the common app. 
 
  - We currently have a `/terminal` path hard-coded to the app root paths, this approach can give developers the option to move the terminal view into a plugin structure if they will want to.

IMHO `oc terminal view` and `VNC console view` are just examples for a common need,  maybe other users can think of other use cases like a "full screen" topology or monitoring views ?

**Example**
Route with `rootWindow: true`
``` js
  {
    type: 'Page/Route',
    properties: {
      exact: true,
      path: '/test-root',
      rootWindow: true,
      render: () => <h1>Test Root Window Page</h1>,
    },
  },
```

**Screenshot**
![Peek 2020-06-03 00-22](https://user-images.githubusercontent.com/2181522/83571442-6f260f80-a530-11ea-8e57-b5fcbe58ab48.gif)

[1] RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1837677
[2] https://github.com/openshift/console/pull/5593