### PR TITLE
Bug 1842965: - Operand's tab for Operand list view is missing 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -980,7 +980,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
                   href: referenceForProvidedAPI(desc),
                   name: ['Details', 'YAML', 'Subscription', 'Events'].includes(desc.displayName)
                     ? `${desc.displayName} Operand`
-                    : desc.displayName,
+                    : desc.displayName || desc.kind,
                   component: ProvidedAPIPage,
                   pageData: {
                     csv: obj,


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett

This PR is a follow on to PR- [https://github.com/openshift/console/pull/5491](url) to address - Operand's tab for Operand list view is missing

![Screen Shot 2020-06-02 at 10 14 57 AM](https://user-images.githubusercontent.com/15249132/83530623-f4baa880-a4b9-11ea-9799-1c9a46e6be50.png)
