### PR TITLE
fix(plr-viz): Remove log links fr Idle/cancelled tasks

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
@@ -4,6 +4,7 @@ $border-color: var(--pf-global--BorderColor--light-100);
 .odc-pipeline-vis-task {
   position: relative;
   width: 10em;
+  cursor: default;
 
   &__content {
     width: inherit;
@@ -48,14 +49,14 @@ $border-color: var(--pf-global--BorderColor--light-100);
     display: flex;
     flex-direction: column;
     min-width: 0;
-    &:hover {
-      cursor: pointer;
-    }
     &.is-text-center {
       text-align: center;
       margin: 0 auto;
       flex: 0 0 100px;
     }
+  }
+  &.is-linked {
+    cursor: pointer;
   }
 
   &__title {

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -58,11 +58,7 @@ export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> 
     reason: runStatus.Idle,
   };
   if (pipelineRunStatus === runStatus.Failed || pipelineRunStatus === runStatus.Cancelled) {
-    if (
-      task.status &&
-      task.status.reason !== runStatus.Succeeded &&
-      task.status.reason !== runStatus.Failed
-    ) {
+    if (task?.status?.reason === runStatus.Idle || task?.status?.reason === runStatus.Pending) {
       taskStatus.reason = runStatus.Cancelled;
     }
   }
@@ -121,6 +117,11 @@ const TaskComponent: React.FC<TaskProps> = ({
   const path = pipelineRunName
     ? `${resourcePathFromModel(PipelineRunModel, pipelineRunName, namespace)}/logs/${name}`
     : undefined;
+  const enableLogLink =
+    status?.reason !== runStatus.Idle &&
+    status?.reason !== runStatus.Pending &&
+    status?.reason !== runStatus.Cancelled &&
+    !!path;
 
   let taskPill = (
     <div className={cx('odc-pipeline-vis-task__content', { 'is-selected': selected })}>
@@ -164,6 +165,8 @@ const TaskComponent: React.FC<TaskProps> = ({
     </>
   );
   return (
-    <div className="odc-pipeline-vis-task">{path ? <Link to={path}>{visTask}</Link> : visTask}</div>
+    <div className={cx('odc-pipeline-vis-task', { 'is-linked': enableLogLink })}>
+      {enableLogLink ? <Link to={path}>{visTask}</Link> : visTask}
+    </div>
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -58,7 +58,7 @@ export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> 
     reason: runStatus.Idle,
   };
   if (pipelineRunStatus === runStatus.Failed || pipelineRunStatus === runStatus.Cancelled) {
-    if (task?.status?.reason === runStatus.Idle || task?.status?.reason === runStatus.Pending) {
+    if (task.status?.reason === runStatus.Idle || task.status?.reason === runStatus.Pending) {
       taskStatus.reason = runStatus.Cancelled;
     }
   }


### PR DESCRIPTION
## Fixes:
https://issues.redhat.com/browse/ODC-2415
Additionally will fix issue mentioned in
https://issues.redhat.com/browse/ODC-2509

## Analysis / Root cause:
Clicking on a pending task bubble in the PLR brings you to a Log page with an odd message

## Solution Description:
Changed cusor to default for Task Bubbles(as it shows a selection cursor earlier) as per UX feedback
Changed cursor to pointer for Logs with Links.
Removed linking logic and only Tasks is Completed, Running and failed status would have a link now.

Changed negation logic and instead doing positive check such that visualization issue 
https://issues.redhat.com/browse/ODC-2509 will be fixed.

## Screenshot
![remove log link](https://user-images.githubusercontent.com/24852534/83531894-2d36a280-a50b-11ea-90d9-b241d191bab3.gif)
![continue parallel task when failed](https://user-images.githubusercontent.com/24852534/83531923-3293ed00-a50b-11ea-9dc1-77a5dba19e8d.gif)


## Browser conformation
Chrome 73





