### PR TITLE
Bug 1843599: cloudshell: fix loading loop for user with multiple projects

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
@@ -44,7 +44,6 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps> = ({ user, onCancel 
     if (loaded && !loadError) {
       // workspace may be undefined which is ok
       setCloudShellNamespace(workspaceNamespace);
-      setNamespace(workspaceNamespace);
     }
   }, [loaded, loadError, workspaceNamespace]);
 

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -30,7 +30,7 @@ const findWorkspace = (data?: CloudShellResource[]): CloudShellResource | undefi
 
 const useCloudShellWorkspace = (
   user: UserKind,
-  defaultNamespace?: string,
+  defaultNamespace: string = null,
 ): WatchK8sResult<CloudShellResource> => {
   const [namespace, setNamespace] = useSafetyFirst(defaultNamespace);
   const [searching, setSearching] = useSafetyFirst<boolean>(false);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4080

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
If a user has multiple projects and they do not have cluster scope access to list projects, the command line terminal drawer shows a loading indicator.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
The issue is caused by a 2 things:
- we were resetting the default namespace used in the search which caused the `useCloudShellWorkspace` hook to rerun with a new namespace whose value was `undefined`. This is not avoided by removing the unnecessary call to `setNamespace`
- Getting a value from localStorage that doesn't exist returns `null`. Since the default namespace began as `undefined` this caused a hook dependency to change in `useCloudShellWorkspace`. Avoided this by assigning a default value of `null` in order to normalize `null` and `undefined`.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![cli-loading](https://user-images.githubusercontent.com/14068621/83565777-f5206700-a4ec-11ea-80e4-2cae4021c77f.gif)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

```
git clone https://github.com/che-incubator/che-workspace-operator
export WEBHOOK_ENABLED=true
export REGISTRY_ENABLED=false
make deploy
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
