### PR TITLE
[release-4.5.z] Bug 1842968: - Operand's tab for Operand list view is missing

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -979,7 +979,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
                   href: referenceForProvidedAPI(desc),
                   name: ['Details', 'YAML', 'Subscription', 'Events'].includes(desc.displayName)
                     ? `${desc.displayName} Operand`
-                    : desc.displayName,
+                    : desc.displayName || desc.kind,
                   component: React.memo(
                     () => (
                       <ProvidedAPIPage


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett

This backport PR (release-4.5) is a follow on to PR #5491 to address - Operand's tab for Operand list view is missing