### PR TITLE
Bug 1842857: Only show Edit Grouping action for VMs in topology view

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -4,7 +4,6 @@ import { asAccessReview, Kebab, KebabOption } from '@console/internal/components
 import { K8sKind, K8sResourceCommon, K8sResourceKind, PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace } from '@console/shared';
 import { confirmModal, deleteModal } from '@console/internal/components/modals';
-import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
 import { VMIKind, VMKind } from '../../types/vm';
 import {
   isVMCreated,
@@ -214,7 +213,6 @@ export const menuActionDeleteVMI = (kindObj: K8sKind, vmi: VMIKind): KebabOption
 });
 
 export const vmMenuActions = [
-  ModifyApplication,
   menuActionStart,
   menuActionStop,
   menuActionRestart,

--- a/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
@@ -20,6 +20,7 @@ import {
   TopologyDataObject,
   getTopologyResourceObject,
 } from '@console/dev-console/src/components/topology';
+import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
 import { vmMenuActions } from '../../components/vms/menu-actions';
 import { VmNode } from './nodes/VmNode';
 import { TYPE_VIRTUAL_MACHINE } from './const';
@@ -36,6 +37,7 @@ export const vmActions = (vm: TopologyDataObject<VMNodeData>): KebabOption[] => 
 
   const model = modelFor(referenceFor(contextMenuResource));
   return [
+    ModifyApplication(model, contextMenuResource),
     ...vmMenuActions.map((action) => {
       return action(model, contextMenuResource, {
         vmi,

--- a/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
@@ -30,8 +30,8 @@ import { VMNodeData } from './types';
 export const kubevirtAllowedResources = ['virtualmachines'];
 
 export const getOperatingSystemImage = (vm: VMKind, templates: K8sResourceKind[]): string => {
-  const templateName = vm.metadata.labels['vm.kubevirt.io/template'];
-  const template = templates.find((t) => t.metadata.name === templateName);
+  const templateName = vm.metadata?.labels?.['vm.kubevirt.io/template'];
+  const template = templateName && templates.find((t) => t.metadata.name === templateName);
   if (!template) {
     return '';
   }


### PR DESCRIPTION
**Analysis / Root cause**: 
The `Edit Application Grouping` kebab action was added to the list of vm-actions used for all VM kebabs.

**Solution Description**: 
Remove the action from the list of vm-actions. Add the action to the VM actions used in the side panel and context menu in topology.

/kind bug