### PR TITLE
[WIP] Bug 1831274: Switch modal to PF4 modal

### DIFF
--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -62,6 +62,32 @@ export const createModalLauncher: CreateModalLauncher = (Component) => (props) =
   return createModal(getModalContainer);
 };
 
+export const createPF4ModalLauncher: CreateModalLauncher = (Component) => (props) => {
+  const getModalContainer: GetModalContainer = (onClose) => {
+    const _handleClose = (e: React.SyntheticEvent) => {
+      onClose && onClose(e);
+      props.close && props.close();
+    };
+    const _handleCancel = (e: React.SyntheticEvent) => {
+      props.cancel && props.cancel();
+      _handleClose(e);
+    };
+
+    return (
+      <Provider store={store}>
+        <Router {...{ history, basename: window.SERVER_FLAGS.basePath }}>
+          <Component
+            {...(_.omit(props, 'blocking', 'modalClassName') as any)}
+            cancel={_handleCancel}
+            close={_handleClose}
+          />
+        </Router>
+      </Provider>
+    );
+  };
+  return createModal(getModalContainer);
+};
+
 export const ModalTitle: React.SFC<ModalTitleProps> = ({
   children,
   className = 'modal-header',
@@ -86,16 +112,79 @@ export const ModalFooter: React.SFC<ModalFooterProps> = ({
   errorMessage,
   inProgress,
   children,
+  noClassName,
 }) => {
   return (
     <ButtonBar
-      className="modal-footer"
+      className={noClassName ? null : 'modal-footer'}
       errorMessage={errorMessage}
       infoMessage={message}
       inProgress={inProgress}
     >
       {children}
     </ButtonBar>
+  );
+};
+
+export const PF4ModalSubmitFooter: React.SFC<ModalSubmitFooterProps> = ({
+  message,
+  errorMessage,
+  inProgress,
+  cancel,
+  submit,
+  submitText,
+  cancelText,
+  submitDisabled,
+  submitDanger,
+  form,
+}) => {
+  const onCancelClick = (e) => {
+    e.stopPropagation();
+    cancel(e);
+  };
+
+  const onSubmitClick = (e) => {
+    e.stopPropagation();
+    submit(e);
+  };
+
+  return (
+    <ModalFooter noClassName inProgress={inProgress} errorMessage={errorMessage} message={message}>
+      <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
+        {submitDanger ? (
+          <Button
+            form={form}
+            onClick={onSubmitClick}
+            type="submit"
+            variant="danger"
+            isDisabled={submitDisabled}
+            id="confirm-action"
+          >
+            {submitText}
+          </Button>
+        ) : (
+          <Button
+            form={form}
+            onClick={onSubmitClick}
+            type="submit"
+            variant="primary"
+            isDisabled={submitDisabled}
+            id="confirm-action"
+          >
+            {submitText}
+          </Button>
+        )}
+        <Button
+          form={form}
+          type="button"
+          variant="secondary"
+          data-test-id="modal-cancel-action"
+          onClick={onCancelClick}
+        >
+          {cancelText || 'Cancel'}
+        </Button>
+      </ActionGroup>
+    </ModalFooter>
   );
 };
 
@@ -165,17 +254,20 @@ export type ModalFooterProps = {
   message?: string;
   errorMessage?: string;
   inProgress: boolean;
+  noClassName?: boolean;
 };
 
 export type ModalSubmitFooterProps = {
   message?: string;
   errorMessage?: string;
   inProgress: boolean;
+  submit?: (e: React.SyntheticEvent<any, Event>) => void;
   cancel: (e: React.SyntheticEvent<any, Event>) => void;
   cancelText?: React.ReactNode;
   submitText: React.ReactNode;
   submitDisabled?: boolean;
   submitDanger?: boolean;
+  form?: string;
 };
 
 export type CreateModalLauncher = <P extends ModalComponentProps>(

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -53,6 +53,10 @@
   }
 }
 
+.modal-body-inner-shadow-covers-no-padding {
+  padding: 0;
+}
+
 .modal-content {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
POC for modal switchover. Will work on additional modals once issues are ironed out with this one.

Will eventually fix https://bugzilla.redhat.com/show_bug.cgi?id=1831274.

We're currently blocked by PF4's lack of support for dropdowns in modals: https://github.com/patternfly/patternfly-react/issues/2790

Will return to this after PatternFly addresses the issue (may be as soon as June).

---

PatternFly added support for dropdowns here: https://github.com/patternfly/patternfly-react/pull/4348. We need select support for the namespace modal, which hasn't been added yet (https://github.com/patternfly/patternfly-react/issues/4364).

Also waiting for Dave's PR moving us to 4.0 so the switch will be easier (cherry-picked some commits from his PR, but there's still stuff being worked out): https://github.com/openshift/console/pull/5081/