### PR TITLE
stop inline secret creation on pipeline start modal

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/SecretsList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/SecretsList.scss
@@ -1,3 +1,6 @@
 .odc-secrets-list {
   margin-bottom: var(--pf-global--spacer--md);
+  &__name {
+    padding-left: var(--pf-global--spacer--xs);
+  }
 }

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/hooks.ts
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import {
+  useK8sWatchResource,
+  WatchK8sResult,
+  WatchK8sResource,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import { SecretModel, ServiceAccountModel } from '@console/internal/models';
+import { SecretKind } from '@console/internal/module/k8s';
+import { ServiceAccountType } from '../../../../utils/pipeline-utils';
+import { PIPELINE_SERVICE_ACCOUNT } from '../../const';
+
+export const useFetchSecrets = (namespace: string): SecretKind[] => {
+  const secretResource = React.useMemo(
+    () => ({
+      isList: true,
+      namespace,
+      kind: SecretModel.kind,
+      prop: SecretModel.plural,
+    }),
+    [namespace],
+  );
+  const [secrets, secretsLoaded]: WatchK8sResult<SecretKind[]> = useK8sWatchResource<SecretKind[]>(
+    secretResource,
+  );
+
+  return secretsLoaded ? secrets : null;
+};
+
+export const useFetchServiceAccount = (namespace: string): ServiceAccountType => {
+  const serviceAccountResource: WatchK8sResource = React.useMemo(
+    () => ({
+      isList: false,
+      namespace,
+      kind: ServiceAccountModel.kind,
+      prop: ServiceAccountModel.plural,
+      name: PIPELINE_SERVICE_ACCOUNT,
+    }),
+    [namespace],
+  );
+  const [
+    serviceAccount,
+    serviceAccountLoaded,
+  ]: WatchK8sResult<ServiceAccountType> = useK8sWatchResource<ServiceAccountType>(
+    serviceAccountResource,
+  );
+
+  return serviceAccountLoaded ? serviceAccount : null;
+};

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
@@ -1,5 +1,7 @@
 import * as _ from 'lodash';
 import { getRandomChars } from '@console/shared';
+import { SecretKind } from '@console/internal/module/k8s';
+import { SecretType } from '@console/internal/components/secrets/create-secret';
 import {
   Pipeline,
   PipelineResource,
@@ -11,6 +13,7 @@ import {
 } from '../../../../utils/pipeline-augment';
 import { PipelineRunModel } from '../../../../models';
 import { getPipelineRunParams, getPipelineRunWorkspaces } from '../../../../utils/pipeline-utils';
+import { SecretAnnotationId } from '../../const';
 import { CREATE_PIPELINE_RESOURCE, initialResourceFormValues } from './const';
 import { CommonPipelineModalFormikValues, PipelineModalFormResource } from './types';
 
@@ -154,4 +157,15 @@ export const getPipelineRunFromForm = (
     },
   };
   return getPipelineRunData(pipeline, pipelineRunData);
+};
+
+export const secretFormDefaultValues = {
+  secretName: '',
+  annotations: { key: SecretAnnotationId.Image, value: '' },
+  type: SecretType.dockerconfigjson,
+  formData: {},
+};
+
+export const isDuplicate = (secrets: SecretKind[], newSecretName: string): boolean => {
+  return !!_.find(secrets, (obj) => obj.metadata.name === newSecretName);
 };

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/validation-utils.ts
@@ -121,6 +121,17 @@ export const startPipelineSchema = commonPipelineSchema.shape({
     }),
   ),
   secretOpen: yup.boolean().equals([false]),
+  secretForm: yup.object().when('secretOpen', {
+    is: true,
+    then: yup.object().shape({
+      secretName: yup.string().required('Required'),
+      type: yup.string().required('Required'),
+      annotations: yup.object({
+        key: yup.string().required('Required'),
+        value: yup.string().required('Required'),
+      }),
+    }),
+  }),
 });
 
 export const addTriggerSchema = commonPipelineSchema.shape({
@@ -134,14 +145,5 @@ export const addTriggerSchema = commonPipelineSchema.shape({
         }),
       })
       .required('Required'),
-  }),
-});
-
-export const advancedSectionValidationSchema = yup.object().shape({
-  secretName: yup.string().required('Required'),
-  type: yup.string().required('Required'),
-  annotations: yup.object().shape({
-    key: yup.string().required('Required'),
-    value: yup.string().required('Required'),
   }),
 });

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -4,11 +4,10 @@ import {
   createModalLauncher,
   ModalComponentProps,
 } from '@console/internal/components/factory/modal';
-import { errorModal } from '@console/internal/components/modals';
 import { Pipeline, PipelineRun, PipelineWorkspace } from '../../../../utils/pipeline-augment';
 import { useUserLabelForManualStart } from '../../../pipelineruns/triggered-by';
 import ModalStructure from '../common/ModalStructure';
-import { convertPipelineToModalData } from '../common/utils';
+import { convertPipelineToModalData, secretFormDefaultValues } from '../common/utils';
 import { startPipelineSchema } from '../common/validation-utils';
 import StartPipelineForm from './StartPipelineForm';
 import { submitStartPipeline } from './submit-utils';
@@ -31,7 +30,9 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
       ...workspace,
       type: 'EmptyDirectory',
     })),
+    newSecrets: [],
     secretOpen: false,
+    secretForm: secretFormDefaultValues,
   };
 
   const handleSubmit = (values: StartPipelineFormValues, actions): void => {
@@ -46,8 +47,6 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
       .catch((err) => {
         actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
-        errorModal({ error: err.message });
-        close();
       });
   };
 

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/types.ts
@@ -1,7 +1,20 @@
+import { SecretKind } from '@console/internal/module/k8s';
+import { SecretType } from '@console/internal/components/secrets/create-secret';
 import { CommonPipelineModalFormikValues } from '../common/types';
+import { SecretAnnotationId } from '../../const';
 import { PipelineWorkspace } from '../../../../utils/pipeline-augment';
 
 export type StartPipelineFormValues = CommonPipelineModalFormikValues & {
   workspaces: PipelineWorkspace[];
+  newSecrets: SecretKind[];
   secretOpen: boolean;
+  secretForm: {
+    secretName: string;
+    annotations: {
+      key: SecretAnnotationId;
+      value: string;
+    };
+    type: SecretType;
+    formData: {};
+  };
 };

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -920,7 +920,7 @@ export type GroupVersionKind = string;
 export type K8sResourceKindReference = GroupVersionKind | string;
 
 export type SecretKind = {
-  data: { [key: string]: string };
+  data?: { [key: string]: string };
   stringData?: { [key: string]: string };
   type: string;
 } & K8sResourceCommon;


### PR DESCRIPTION
**JIRA story:**
https://issues.redhat.com/browse/ODC-3664

**Solution Description:**
- removed the nested formik form, now the Secret form is under the formik context of the start pipeline form
- added a new property `newSecrets` to the `StartPipelineFormValues` for storing all the secrets that the user wants to create 
- secret resources are not created on the secret form submission, now they are simply displayed to the user in the secret lists before the existing secrets in the modal form, with `Pending` text next to them
- these new secrets will wait for the user to submit the start pipeline form, once the form is submitted the secret(s) will be created and will be linked to the Service Account

**GIF:**
![pipeline-secret](https://user-images.githubusercontent.com/22490998/83875172-44b49c00-a754-11ea-9034-a5805d7699ea.gif)
