### PR TITLE
fix(pipeline-bars): Pipeline cancelled show cancelled tasks as pending

### DIFF
--- a/frontend/packages/dev-console/src/test/pipeline-data.ts
+++ b/frontend/packages/dev-console/src/test/pipeline-data.ts
@@ -6,7 +6,10 @@ export enum DataState {
   CANCELLED1 = 'Cancelled at stage1',
   CANCELLED2 = 'Cancelled at stage2 paralell task',
   CANCELLED3 = 'Cancelled at stage3 single task',
-  FAILED = 'Completed But Failed',
+  FAILED1 = 'Failed at stage1',
+  FAILED2 = 'Failed at stage 2',
+  FAILED3 = 'Failed at stage 3',
+  FAILED_BUT_COMPLETE = 'Completed But Failed',
 }
 
 export enum PipelineExampleNames {
@@ -156,7 +159,7 @@ export const pipelineTestData: PipelineTestData = {
       },
     },
     pipelineRuns: {
-      [DataState.FAILED]: {
+      [DataState.FAILED_BUT_COMPLETE]: {
         apiVersion: 'tekton.dev/v1alpha1',
         kind: 'PipelineRun',
         metadata: {
@@ -239,6 +242,39 @@ export const pipelineTestData: PipelineTestData = {
         status: {
           conditions: [
             {
+              reason: 'PipelineRunCancelled',
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+          taskRuns: {
+            'complex-pipeline-fm4hax-build-app-gpq78': {
+              pipelineTaskName: 'build-app',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+          },
+        },
+      },
+      [DataState.FAILED1]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'complex-pipeline-fm4hax',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          params: [{ name: 'APP_NAME', value: '' }],
+          pipelineRef: { name: 'complex-pipeline' },
+          resources: [
+            { name: 'app-git', resourceRef: { name: 'mapit-git' } },
+            { name: 'app-image', resourceRef: { name: 'mapit-image' } },
+          ],
+        },
+        status: {
+          conditions: [
+            {
               status: 'False',
               type: 'Succeeded',
             },
@@ -284,8 +320,7 @@ export const pipelineTestData: PipelineTestData = {
               status: {
                 conditions: [
                   {
-                    reason: 'TaskRunCancelled',
-                    status: 'False',
+                    status: 'True',
                     type: 'Succeeded',
                   },
                 ],
@@ -296,8 +331,7 @@ export const pipelineTestData: PipelineTestData = {
               status: {
                 conditions: [
                   {
-                    reason: 'TaskRunCancelled',
-                    status: 'False',
+                    status: 'True',
                     type: 'Succeeded',
                   },
                 ],
@@ -311,6 +345,143 @@ export const pipelineTestData: PipelineTestData = {
                   {
                     reason: 'Succeeded',
                     status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      [DataState.FAILED2]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'complex-pipeline-fm4hax',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          params: [{ name: 'APP_NAME', value: '' }],
+          pipelineRef: { name: 'complex-pipeline' },
+          resources: [
+            { name: 'app-git', resourceRef: { name: 'mapit-git' } },
+            { name: 'app-image', resourceRef: { name: 'mapit-image' } },
+          ],
+        },
+        status: {
+          conditions: [
+            {
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+          startTime: '2019-12-09T08:59:05Z',
+          taskRuns: {
+            'simple-pipeline-7ergyh-build-1-cht9h': {
+              pipelineTaskName: 'build-1',
+              status: {
+                conditions: [
+                  {
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+              },
+            },
+            'simple-pipeline-7ergyh-build-2-x8jq2': {
+              pipelineTaskName: 'build-2',
+              status: {
+                conditions: [
+                  {
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+              },
+            },
+            'simple-pipeline-7ergyh-push-n2r2q': {
+              pipelineTaskName: 'push',
+              status: {
+                completionTime: '2019-12-09T08:59:26Z',
+                conditions: [
+                  {
+                    status: 'False',
+                    type: 'Succeeded',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      [DataState.FAILED3]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'complex-pipeline-fm4hax',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          params: [{ name: 'APP_NAME', value: '' }],
+          pipelineRef: { name: 'complex-pipeline' },
+          resources: [
+            { name: 'app-git', resourceRef: { name: 'mapit-git' } },
+            { name: 'app-image', resourceRef: { name: 'mapit-image' } },
+          ],
+        },
+        status: {
+          conditions: [
+            {
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+          startTime: '2019-12-10T11:18:38Z',
+          taskRuns: {
+            'simple-pipeline-haeml4-build-1-fddrb': {
+              pipelineTaskName: 'build-1',
+              status: {
+                completionTime: '2019-12-10T11:19:18Z',
+                conditions: [
+                  {
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+              },
+            },
+            'simple-pipeline-haeml4-build-2-l5scg': {
+              pipelineTaskName: 'build-2',
+              status: {
+                completionTime: '2019-12-10T11:19:19Z',
+                conditions: [
+                  {
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                startTime: '2019-12-10T11:18:58Z',
+              },
+            },
+            'simple-pipeline-haeml4-deploy-qtpnz': {
+              pipelineTaskName: 'deploy',
+              status: {
+                conditions: [
+                  {
+                    status: 'False',
+                    type: 'Succeeded',
+                  },
+                ],
+              },
+            },
+            'simple-pipeline-haeml4-push-4gj8n': {
+              pipelineTaskName: 'push',
+              status: {
+                completionTime: '2019-12-10T11:18:58Z',
+                conditions: [
+                  {
+                    status: 'False',
                     type: 'Succeeded',
                   },
                 ],
@@ -377,8 +548,7 @@ export const pipelineTestData: PipelineTestData = {
               status: {
                 conditions: [
                   {
-                    reason: 'TaskRunCancelled',
-                    status: 'False',
+                    status: 'True',
                     type: 'Succeeded',
                   },
                 ],
@@ -390,7 +560,6 @@ export const pipelineTestData: PipelineTestData = {
                 completionTime: '2019-12-10T11:18:58Z',
                 conditions: [
                   {
-                    reason: 'Succeeded',
                     status: 'True',
                     type: 'Succeeded',
                   },

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
@@ -199,7 +199,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
 
       const taskCount = getExpectedTaskCount(partialTestData.pipeline);
       const taskStatus = getTaskStatus(
-        partialTestData.pipelineRuns[DataState.FAILED],
+        partialTestData.pipelineRuns[DataState.FAILED_BUT_COMPLETE],
         partialTestData.pipeline,
       );
 
@@ -208,24 +208,34 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
     });
 
-    it(`expect correct task status for PipelineRun Failed at beginning`, () => {
-      const expected = { succeeded: 0, failed: 1 };
+    it(`expect correct task status for PipelineRun cancelled at beginning`, () => {
+      const expected = { succeeded: 1, failed: 0, cancelled: 12 };
       const taskCount = getExpectedTaskCount(complexTestData.pipeline);
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.CANCELLED1],
         complexTestData.pipeline,
       );
-
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
-      expect(sumCancelledTaskStatus(taskStatus)).toEqual(
-        taskCount - (expected.failed + expected.succeeded),
-      );
+      expect(sumCancelledTaskStatus(taskStatus)).toEqual(expected.cancelled);
       expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
     });
 
-    it(`expect correct task status for PLR failed at stage 2 parallel`, () => {
-      const expected = { succeeded: 1, failed: 0 };
+    it(`expect correct task status for PipelineRun failed at beginning`, () => {
+      const expected = { succeeded: 0, failed: 1, cancelled: 12 };
+      const taskCount = getExpectedTaskCount(complexTestData.pipeline);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.FAILED1],
+        complexTestData.pipeline,
+      );
+      expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
+      expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
+      expect(sumCancelledTaskStatus(taskStatus)).toEqual(expected.cancelled);
+      expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
+    });
+
+    it(`expect correct task status for PLR cancelled at stage 2 parallel`, () => {
+      const expected = { succeeded: 3, failed: 0, cancelled: 10 };
       const taskCount = getExpectedTaskCount(complexTestData.pipeline);
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.CANCELLED2],
@@ -233,14 +243,25 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       );
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
-      expect(sumCancelledTaskStatus(taskStatus)).toEqual(
-        taskCount - (expected.failed + expected.succeeded),
-      );
+      expect(sumCancelledTaskStatus(taskStatus)).toEqual(expected.cancelled);
       expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
     });
 
-    it(`expect correct task status for PLR failed at stage 3`, () => {
-      const expected = { succeeded: 3, failed: 0 };
+    it(`expect correct task status for PLR failed at stage 2 parallel`, () => {
+      const expected = { succeeded: 2, failed: 1, cancelled: 10 };
+      const taskCount = getExpectedTaskCount(complexTestData.pipeline);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.FAILED2],
+        complexTestData.pipeline,
+      );
+      expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
+      expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
+      expect(sumCancelledTaskStatus(taskStatus)).toEqual(expected.cancelled);
+      expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
+    });
+
+    it(`expect correct task status for PLR cancelled at stage 3`, () => {
+      const expected = { succeeded: 4, failed: 0, cancelled: 9 };
       const taskCount = getExpectedTaskCount(complexTestData.pipeline);
       const taskStatus = getTaskStatus(
         complexTestData.pipelineRuns[DataState.CANCELLED3],
@@ -248,9 +269,20 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       );
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
-      expect(sumCancelledTaskStatus(taskStatus)).toEqual(
-        taskCount - (expected.succeeded + expected.failed),
+      expect(sumCancelledTaskStatus(taskStatus)).toEqual(expected.cancelled);
+      expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
+    });
+
+    it(`expect correct task status for PLR failed at stage 3`, () => {
+      const expected = { succeeded: 2, failed: 2, cancelled: 9 };
+      const taskCount = getExpectedTaskCount(complexTestData.pipeline);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.FAILED3],
+        complexTestData.pipeline,
       );
+      expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
+      expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
+      expect(sumCancelledTaskStatus(taskStatus)).toEqual(expected.cancelled);
       expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
     });
   });

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -368,11 +368,16 @@ export const getTaskStatus = (pipelinerun: PipelineRun, pipeline: Pipeline): Tas
         taskStatus[runStatus.Pending]++;
       }
     });
-    taskStatus[runStatus.Failed] > 0 || taskStatus[runStatus.Cancelled] > 0
-      ? (taskStatus[runStatus.Cancelled] +=
-          totalTasks >= plrTaskLength ? totalTasks - plrTaskLength : totalTasks)
-      : (taskStatus[runStatus.Pending] +=
-          totalTasks >= plrTaskLength ? totalTasks - plrTaskLength : totalTasks);
+
+    const pipelineRunHasFailure = taskStatus[runStatus.Failed] > 0;
+    const pipelineRunIsCancelled = pipelineRunFilterReducer(pipelinerun) === runStatus.Cancelled;
+    const unhandledTasks = totalTasks >= plrTaskLength ? totalTasks - plrTaskLength : totalTasks;
+
+    if (pipelineRunHasFailure || pipelineRunIsCancelled) {
+      taskStatus[runStatus.Cancelled] += unhandledTasks;
+    } else {
+      taskStatus[runStatus.Pending] += unhandledTasks;
+    }
   } else if (
     pipelinerun &&
     pipelinerun.status &&


### PR DESCRIPTION
## Fixes:
https://issues.redhat.com/browse/ODC-4081

## Analysis / Root cause:
Pipeline bars show Pending tasks for cancelled pipelines

## Solution Description:
Pipeline bars updated with PipelineRun status check for showing cancelled

## Screenshot
![Screenshot from 2020-06-03 17-02-16](https://user-images.githubusercontent.com/24852534/83638224-7ac41580-a5c6-11ea-9c73-f44c4914f3d8.png)


## Browser conformation
Chrome 73





