### PR TITLE
Bug 1834701: Fix overflowing tooltip on statusDescriptor PodStatusChart

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.tsx
@@ -32,6 +32,7 @@ export const PodStatusChart: React.SFC<PodStatusChartProps> = ({ statuses, statu
     <div ref={ref} className="graph-wrapper--gauge">
       <ChartDonut
         colorScale={colorScale}
+        constrainToVisibleArea
         data={data}
         height={width}
         title={total.toString()}


### PR DESCRIPTION
Add `constrainToVisibleArea` prop to coerce tooltip to fit into the visible area of the chart.
https://formidable.com/open-source/victory/docs/victory-tooltip#constraintovisiblearea