### PR TITLE
[WIP] CONSOLE-2152: - Improve upgrade messaging on the cluster settings page

### DIFF
--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -45,7 +45,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
           variant="info"
           title={
             <>
-              Update available.{' '}
+              Restore your cluster operators.{' '}
               <Link to="/settings/cluster" onClick={closeAboutModal}>
                 View cluster settings
               </Link>

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -21,6 +21,7 @@ import {
   OperandVersion,
   OperatorStatus,
   referenceForModel,
+  hasNotUpgradeable,
 } from '../../module/k8s';
 import {
   navFactory,
@@ -29,6 +30,7 @@ import {
   ResourceLink,
   ResourceSummary,
   SectionHeading,
+  NotUpgradeableAlert,
 } from '../utils';
 import { GreenCheckCircleIcon, YellowExclamationTriangleIcon } from '@console/shared';
 
@@ -41,6 +43,7 @@ const getIcon = (status: OperatorStatus) => {
     [OperatorStatus.Available]: <GreenCheckCircleIcon />,
     [OperatorStatus.Updating]: <SyncAltIcon />,
     [OperatorStatus.Degraded]: <YellowExclamationTriangleIcon />,
+    [OperatorStatus.Upgradeable]: <YellowExclamationTriangleIcon />,
     [OperatorStatus.Unknown]: <UnknownIcon />,
   }[status];
 };
@@ -128,6 +131,7 @@ const allStatuses = [
   OperatorStatus.Available,
   OperatorStatus.Updating,
   OperatorStatus.Degraded,
+  OperatorStatus.Upgradeable,
   OperatorStatus.Unknown,
 ];
 
@@ -165,6 +169,11 @@ const UpdateInProgressAlert: React.SFC<UpdateInProgressAlertProps> = ({ cv }) =>
 export const ClusterOperatorPage: React.SFC<ClusterOperatorPageProps> = (props) => (
   <>
     <UpdateInProgressAlert cv={props.cv} />
+    <NotUpgradeableAlert
+      linkText="View Operators"
+      linkPath="/settings/cluster/clusteroperators"
+      linkSearch="?rowFilter-cluster-operator-status=Not+upgradeable"
+    />
     <ListPage
       {...props}
       title="Cluster Operators"
@@ -211,6 +220,13 @@ const ClusterOperatorDetails: React.SFC<ClusterOperatorDetailsProps> = ({ obj })
   return (
     <>
       <div className="co-m-pane__body">
+        {hasNotUpgradeable(obj) && (
+          <NotUpgradeableAlert
+            linkText="Upgrade to latest patch"
+            linkPath="/settings/cluster/clusteroperators"
+            linkSearch="?rowFilter-cluster-operator-status=Not+upgradeable"
+          />
+        )}
         <SectionHeading text="Cluster Operator Details" />
         <div className="row">
           <div className="col-sm-6">

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -43,6 +43,7 @@ import {
   SectionHeading,
   Timestamp,
   truncateMiddle,
+  NotUpgradeableAlert,
 } from '../utils';
 import {
   GreenCheckCircleIcon,
@@ -88,7 +89,7 @@ const InvalidMessage: React.SFC<CVStatusMessageProps> = ({ cv }) => (
 const UpdatesAvailableMessage: React.SFC<CVStatusMessageProps> = ({ cv }) => (
   <>
     <div className="co-update-status">
-      <ArrowCircleUpIcon className="update-pending" /> Update available
+      <ArrowCircleUpIcon className="update-pending" /> Patch available {/** added Minor */}
     </div>
     <div>
       <Button onClick={() => clusterUpdateModal({ cv })} variant="primary">
@@ -240,6 +241,11 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
 
   return (
     <>
+      <NotUpgradeableAlert
+        linkText="View Operators"
+        linkPath="/settings/cluster/clusteroperators"
+        linkSearch="?rowFilter-cluster-operator-status=Not+upgradeable"
+      />
       <div className="co-m-pane__body">
         <div className="co-m-pane__body-group">
           <div className="co-detail-table co-detail-table--lg">

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -228,7 +228,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     !_.isEmpty(nameFilter) && applyFilter(nameFilter, FilterType.NAME);
     !_.isEmpty(selectedRowFilters) && applyRowFilter(selectedRowFilters);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [!_.isEmpty(selectedRowFilters)]);
 
   const switchFilter = (type: FilterType) => {
     setFilterType(FilterType[type]);

--- a/frontend/public/components/modals/cluster-update-modal.tsx
+++ b/frontend/public/components/modals/cluster-update-modal.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as semver from 'semver';
 
 import { ClusterVersionModel } from '../../models';
-import { Dropdown, PromiseComponent } from '../utils';
+import { Dropdown, PromiseComponent, NotUpgradeableAlert } from '../utils';
 import {
   ClusterUpdate,
   ClusterVersionKind,
@@ -92,6 +92,12 @@ class ClusterUpdateModal extends PromiseComponent<
         className="modal-content modal-content--no-inner-scroll"
       >
         <ModalTitle>Update Cluster</ModalTitle>
+        <NotUpgradeableAlert
+          closeModal={this._cancel}
+          linkText="View Operators"
+          linkPath="/settings/cluster/clusteroperators"
+          linkSearch="?rowFilter-cluster-operator-status=Not+upgradeable"
+        />
         <ModalBody>
           {/* <p>
           // TODO: Determine what content goes here.

--- a/frontend/public/components/utils/cluster-operators-alert.tsx
+++ b/frontend/public/components/utils/cluster-operators-alert.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Alert } from '@patternfly/react-core';
+
+export const NotUpgradeableAlert: React.SFC<NotUpgradeableAlertProps> = (props) => {
+  const { closeModal, linkText, linkPath, linkSearch } = props;
+
+  return (
+    <div className="co-m-pane__body co-m-pane__body--section-heading">
+      <Alert isInline className="co-alert" variant="info" title="Restore your cluster operators">
+        <div>
+          To upgrade to the next release, restore your affected operator(s). You can still upgrade
+          to patch releases.{' '}
+          <Link
+            to={{
+              pathname: linkPath,
+              search: linkSearch,
+            }}
+            onClick={closeModal}
+          >
+            {linkText}
+          </Link>
+        </div>
+      </Alert>
+    </div>
+  );
+};
+
+type NotUpgradeableAlertProps = {
+  closeModal?: () => void;
+  linkPath: string;
+  linkSearch?: string;
+  linkText: string;
+};

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -59,3 +59,4 @@ export { default } from './operator-backed-owner-references';
 export * from './field-level-help';
 export * from './details-item';
 export * from './types';
+export * from './cluster-operators-alert';

--- a/frontend/public/module/k8s/cluster-operator.ts
+++ b/frontend/public/module/k8s/cluster-operator.ts
@@ -5,6 +5,7 @@ export enum OperatorStatus {
   Available = 'Available',
   Updating = 'Updating',
   Degraded = 'Degraded',
+  Upgradeable = 'Not upgradeable',
   Unknown = 'Unknown',
 }
 
@@ -20,12 +21,23 @@ export const getStatusAndMessage = (operator: ClusterOperator) => {
     return { status: OperatorStatus.Updating, message: progressing.message };
   }
 
+  const upgradeable: any = _.find(conditions, { type: 'Upgradeable', status: 'False' });
+  if (upgradeable) {
+    return { status: OperatorStatus.Upgradeable, message: upgradeable.message };
+  }
+
   const available: any = _.find(conditions, { type: 'Available', status: 'True' });
   if (available) {
     return { status: OperatorStatus.Available, message: available.message };
   }
 
   return { status: OperatorStatus.Unknown, message: '' };
+};
+
+export const hasNotUpgradeable = (operator: ClusterOperator) => {
+  const conditions = _.get(operator, 'status.conditions');
+  const upgradeable: any = _.find(conditions, { type: 'Upgradeable', status: 'False' });
+  return upgradeable;
 };
 
 export const getClusterOperatorStatus = (operator: ClusterOperator) => {

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -58,6 +58,18 @@ export const getClusterVersionCondition = (
   return _.find(conditions, { type });
 };
 
+export const getClusterStatusCondition = (
+  cv: ClusterVersionKind,
+  type,
+  status = undefined,
+): ClusterVersionCondition => {
+  const conditions: ClusterVersionCondition[] = _.get(cv, 'status.conditions');
+  if (status) {
+    return _.find(conditions, { type, status });
+  }
+  return _.find(conditions, { type });
+};
+
 export const isProgressing = (cv: ClusterVersionKind): boolean => {
   return !_.isEmpty(
     getClusterVersionCondition(


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett

NB: I started a new conversation with Brie and Ben to find out if we want to show the Not upgradeable alert modal always in cluster setting and cluster operator pages because that was my previously understanding from the conversation I had with Brie. However I was concerned because this behavior is different from what is implemented in About modal. Based on the communication I had with Brie today , It seems we want to show the alert model when both a z-stream update AND non-upgradeable operators are available. Waiting on Ben take on this.

Although I don't know  how to get z-stream update property yet. 

<img width="914" alt="Screen Shot 2020-06-03 at 8 44 06 AM" src="https://user-images.githubusercontent.com/15249132/83686975-21091e80-a5b9-11ea-9a09-15917d42d458.png">
