### PR TITLE
[release-4.4] Bug 1838420: Fix payload for PVCPool BackingStore Creation

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
@@ -409,7 +409,7 @@ const initialState: ProviderDataState = {
   target: '',
   endpoint: '',
   numVolumes: 1,
-  volumeSize: '',
+  volumeSize: '50Gi',
   storageClass: '',
 };
 

--- a/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
@@ -191,6 +191,12 @@ const PVCType: React.FC<PVCTypeProps> = ({ state, dispatch }) => {
     TiB: 'TiB',
   };
 
+  // Noobaa expected Ti console standrad is to show TiB
+  const unitConverter = {
+    GiB: 'Gi',
+    TiB: 'Ti',
+  };
+
   // Fix for updating the storage class by force rerender
   const forceUpdate = React.useCallback(() => updateState({}), []);
 
@@ -200,7 +206,7 @@ const PVCType: React.FC<PVCTypeProps> = ({ state, dispatch }) => {
 
   const onChange = (event) => {
     const { value, unit } = event;
-    const input = `${value} ${unit}`;
+    const input = `${value}${unitConverter[unit]}`;
     setSize(value);
     dispatch({ type: 'setVolumeSize', value: input });
   };
@@ -533,6 +539,11 @@ const CreateBackingStoreForm: React.FC<CreateBackingStoreFormProps> = withHandle
       bsPayload.spec['pvPool'] = {
         numVolumes: providerDataState.numVolumes,
         storageClass: providerDataState.storageClass,
+        resources: {
+          requests: {
+            storage: providerDataState.volumeSize,
+          },
+        },
       };
     } else if (externalProviders.includes(provider)) {
       bsPayload.spec = {


### PR DESCRIPTION
Payload did not contain the field resources.request.storage.

As the bug fix required two commits hence performing a manual backport. The commits have been picked up untouched.
cc71b94d01d65d3699f6d77be255b1d4b5c6e0c6
6bc42b39838a26a10a17b248cf2965e4e203dae6

