### PR TITLE
Bug 1844347: Align kubevirt tests with ux changes, fix teardown in environment tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/diskDialog.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/diskDialog.ts
@@ -52,9 +52,26 @@ export class DiskDialog {
     }
   }
 
+  async selectAdvancedOptions(advancedOptions) {
+    if (advancedOptions) {
+      await this.openAdvancedSettingsDrawer();
+
+      if (advancedOptions.accessMode) {
+        await this.selectAccessMode(advancedOptions.accessMode);
+      }
+
+      if (advancedOptions.volumeMode) {
+        await this.selectVolumeMode(advancedOptions.volumeMode);
+      }
+    }
+  }
+
   async openAdvancedSettingsDrawer() {
     if (await view.advancedDrawerToggle.isPresent()) {
-      await click(view.advancedDrawerToggle);
+      if ((await view.advancedDrawerToggle.getAttribute('aria-expanded')) === 'false') {
+        // Only click the Advanced button if it isn't already expanded
+        await click(view.advancedDrawerToggle);
+      }
     }
   }
 
@@ -104,19 +121,7 @@ export class DiskDialog {
     if (disk.size) {
       await this.fillSize(disk.size);
     }
-
-    if (disk.accessMode || disk.volumeMode) {
-      await this.openAdvancedSettingsDrawer();
-
-      if (disk.accessMode) {
-        await this.selectAccessMode(disk.accessMode);
-      }
-
-      if (disk.volumeMode) {
-        await this.selectVolumeMode(disk.volumeMode);
-      }
-    }
-
+    await this.selectAdvancedOptions(disk.advanced);
     await click(saveButton);
     await waitForNoLoaders();
   }

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/consts.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/consts.ts
@@ -60,7 +60,7 @@ export const KUBEVIRT_STORAGE_CLASS_DEFAULTS = 'kubevirt-storage-class-defaults'
 export const KUBEVIRT_PROJECT_NAME = 'openshift-cnv';
 
 export const commonTemplateVersion = () => rhelTinyCommonTemplateName.match(/v\d+\.\d+\.\d+/)[0];
-export const INNER_TEMPLATE_VERSION = 'v0.9.1';
+export const INNER_TEMPLATE_VERSION = 'v0.11.0';
 
 export const COMMON_TEMPLATES_NAMESPACE = 'openshift';
 export const COMMON_TEMPLATES_REVISION = '1';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-vm-env-readable.sh
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-vm-env-readable.sh
@@ -11,20 +11,21 @@ set password_prompt "Password: "
 set prompt "$"
 
 set response_delay 3
-set timeout 10
 set send_human {.1 .3 1 .05 2}
 
 set source_path1 "/home/fedora/source1"
 set source_path2 "/home/fedora/source2"
 set source_path3 "/home/fedora/source3"
 
-spawn virtctl console $vm_name -n $vm_namespace
+spawn virtctl console $vm_name -n $vm_namespace --timeout 7
 
 send -h "\n"
 
-sleep 1
+sleep 3
 
 send -h \004
+
+set timeout 300
 
 # Enter username
 expect $login_prompt {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/types.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/types.ts
@@ -27,8 +27,10 @@ export type StorageResource = {
   size?: string;
   storageClass: string;
   interface: string;
-  volumeMode?: string;
-  accessMode?: string;
+  advanced?: {
+    volumeMode?: string;
+    accessMode?: string;
+  };
   sourceConfig?: DiskSourceConfig;
   source?: DISK_SOURCE;
 };

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.consoles.rdp.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.consoles.rdp.scenario.ts
@@ -2,7 +2,6 @@ import { execSync } from 'child_process';
 import { browser, ExpectedConditions as until } from 'protractor';
 import { testName } from '@console/internal-integration-tests/protractor.conf';
 import {
-  withResource,
   click,
   deleteResource,
   waitForStringInElement,
@@ -10,7 +9,6 @@ import {
   selectDropdownOption,
   selectDropdownOptionById,
   createResource,
-  removeLeakedResources,
 } from '@console/shared/src/test-utils/utils';
 import {
   consoleTypeSelector,
@@ -31,115 +29,99 @@ import {
   VM_CREATE_AND_EDIT_AND_CLOUDINIT_TIMEOUT_SECS,
 } from './utils/consts';
 import { VirtualMachine } from './models/virtualMachine';
-import { vmConfig, getProvisionConfigs } from './vm.wizard.configs';
-import { ProvisionConfigName, Flavor } from './utils/constants/wizard';
-import { windowsVMConfig, multusNAD } from './utils/mocks';
 import { getWindowsVM } from './utils/templates/windowsVMForRDPL2';
-import { Wizard } from './models/wizard';
+import { multusNAD } from './utils/mocks';
 
 const VM_IP = '123.123.123.123';
 
 describe('KubeVirt VM console - RDP', () => {
-  const wizard = new Wizard();
+  let vm: VirtualMachine;
+
   beforeAll(async () => {
     createResource(multusNAD);
+    const vmName = 'windows-rdp';
+
     // for cmd-line scripts only
     execSync(`kubectl config set-context --current --namespace=${testName}`, { stdio: 'inherit' });
+    execSync('kubectl create -f -', {
+      input: getWindowsVM({
+        name: vmName,
+        networkName: multusNAD.metadata.name,
+        vmIP: VM_IP,
+      }),
+    });
+    vm = new VirtualMachine({ name: vmName, namespace: testName });
   });
 
   afterAll(async () => {
     deleteResource(multusNAD);
+    deleteResource(vm.asResource());
     execSync(`kubectl config set-context --current --namespace=default`, { stdio: 'inherit' });
-  });
-
-  const leakedResources = new Set<string>();
-  const provisionConfigs = getProvisionConfigs();
-
-  const configName = ProvisionConfigName.CONTAINER;
-  const provisionConfig = provisionConfigs.get(configName);
-
-  provisionConfig.networkResources = [];
-  provisionConfig.storageResources = [];
-
-  afterEach(() => {
-    removeLeakedResources(leakedResources);
   });
 
   it(
     'ID(CNV-1721) connects via exposed service',
     async () => {
-      const windowsConfig = vmConfig(
-        configName.toLowerCase(),
-        testName,
-        provisionConfig,
-        windowsVMConfig,
-        true, // startOnCreation
+      await vm.navigateToConsoles();
+      await browser.wait(until.presenceOf(consoleTypeSelector));
+      await click(consoleTypeSelector);
+      await browser.wait(
+        waitForStringInElement(consoleTypeSelector, 'VNC Console'),
+        PAGE_LOAD_TIMEOUT_SECS,
       );
-      windowsConfig.flavorConfig = { flavor: Flavor.CUSTOM, cpu: '1', memory: '2' };
-      const vm = await wizard.createVirtualMachine(windowsConfig);
-      await withResource(leakedResources, vm.asResource(), async () => {
-        await vm.navigateToConsoles();
 
-        await browser.wait(until.presenceOf(consoleTypeSelector));
-        await click(consoleTypeSelector);
-        await browser.wait(
-          waitForStringInElement(consoleTypeSelector, 'VNC Console'),
-          PAGE_LOAD_TIMEOUT_SECS,
-        );
+      const items = await getDropdownOptions(consoleTypeSelectorId);
+      expect(items[0]).toBe('VNC Console');
+      expect(items[1]).toBe('Serial Console');
+      expect(items[2]).toBe('Desktop Viewer');
 
-        const items = await getDropdownOptions(consoleTypeSelectorId);
-        expect(items[0]).toBe('VNC Console');
-        expect(items[1]).toBe('Serial Console');
-        expect(items[2]).toBe('Desktop Viewer');
+      await click(consoleTypeSelector); // close before re-opening
+      await selectDropdownOption(consoleTypeSelectorId, 'Desktop Viewer');
 
-        await click(consoleTypeSelector); // close before re-opening
-        await selectDropdownOption(consoleTypeSelectorId, 'Desktop Viewer');
+      // no service is exposed atm, informative text should be rendered
+      await browser.wait(until.presenceOf(rdpServiceNotConfiguredElem));
 
-        // no service is exposed atm, informative text should be rendered
-        await browser.wait(until.presenceOf(rdpServiceNotConfiguredElem));
+      // the next command follows recommendation by documentation
+      execSync(
+        `virtctl expose virtualmachine ${vm.name} --name ${vm.name}-rdp --port 4567 --target-port 3389 --type NodePort`,
+        { stdio: 'inherit' },
+      );
 
-        // the next command follows recommendation by documentation
-        execSync(
-          `virtctl expose virtualmachine ${vm.name} --name ${vm.name}-rdp --port 4567 --target-port 3389 --type NodePort`,
-          { stdio: 'inherit' },
-        );
+      await browser.wait(until.presenceOf(desktopClientTitle));
+      await browser.wait(
+        waitForStringInElement(desktopClientTitle, 'Desktop Client'),
+        PAGE_LOAD_TIMEOUT_SECS,
+      );
 
-        await browser.wait(until.presenceOf(desktopClientTitle));
-        await browser.wait(
-          waitForStringInElement(desktopClientTitle, 'Desktop Client'),
-          PAGE_LOAD_TIMEOUT_SECS,
-        );
+      expect(launchRemoteViewerButton.isEnabled()).toBe(false);
+      expect(launchRemoteDesktopButton.isEnabled()).toBe(true);
 
-        expect(launchRemoteViewerButton.isEnabled()).toBe(false);
-        expect(launchRemoteDesktopButton.isEnabled()).toBe(true);
+      // there should be just the single laucher-pod
+      const hostIP = execSync("kubectl get pod -o json | jq '.items[0].status.hostIP' -r")
+        .toString()
+        .trim();
+      const port = execSync(
+        `kubectl get service ${vm.name}-rdp -o json | jq '.spec.ports[0].nodePort' -r`,
+      )
+        .toString()
+        .trim();
+      expect(hostIP.length).toBeGreaterThan(0);
+      expect(port.length).toBeGreaterThan(0);
 
-        // there should be just the single laucher-pod
-        const hostIP = execSync("kubectl get pod -o json | jq '.items[0].status.hostIP' -r")
-          .toString()
-          .trim();
-        const port = execSync(
-          `kubectl get service ${vm.name}-rdp -o json | jq '.spec.ports[0].nodePort' -r`,
-        )
-          .toString()
-          .trim();
-        expect(hostIP.length).toBeGreaterThan(0);
-        expect(port.length).toBeGreaterThan(0);
+      await browser.wait(
+        until.textToBePresentInElement(manualConnectionTitle, 'Manual Connection'),
+      );
+      const titles = rdpManualConnectionTitles();
+      expect(titles.first().getText()).toBe('RDP Address:');
+      expect(titles.last().getText()).toBe('RDP Port:');
 
-        await browser.wait(
-          until.textToBePresentInElement(manualConnectionTitle, 'Manual Connection'),
-        );
-        const titles = rdpManualConnectionTitles();
-        expect(titles.first().getText()).toBe('RDP Address:');
-        expect(titles.last().getText()).toBe('RDP Port:');
+      const values = rdpManualConnectionValues();
+      expect(values.count()).toBe(2);
+      expect(values.first().getText()).toBe(hostIP);
+      expect(values.last().getText()).toBe(port);
 
-        const values = rdpManualConnectionValues();
-        expect(values.count()).toBe(2);
-        expect(values.first().getText()).toBe(hostIP);
-        expect(values.last().getText()).toBe(port);
-
-        // TODO: download the .rdp file and verify content
-        // will require protractor configuration change: https://stackoverflow.com/questions/21935696/protractor-e2e-test-case-for-downloading-pdf-file/26127745#26127745
-      });
+      // TODO: download the .rdp file and verify content
+      // will require protractor configuration change: https://stackoverflow.com/questions/21935696/protractor-e2e-test-case-for-downloading-pdf-file/26127745#26127745
     },
     VM_CREATE_AND_EDIT_TIMEOUT_SECS,
   );
@@ -147,69 +129,57 @@ describe('KubeVirt VM console - RDP', () => {
   it(
     'ID(CNV-1726) connects via L2 network',
     async () => {
-      // created just for reusing the later navigation
-      const windowsConfig = vmConfig(`${configName.toLowerCase()}-l2`, testName, provisionConfig);
-      const vm = new VirtualMachine(windowsConfig);
-      await withResource(leakedResources, vm.asResource(), async () => {
-        /* Pre-requisite:
-         * - L2 network is configured on the cluster/node
-         * - the Windows-VM has guest-agent installed
-         * and so the Windows VM gets IP which is reported back to the VMI object among VMI.status.interfaces[].
-         *
-         * We mimmic this "final" state here.
-         */
-        execSync('kubectl create -f -', {
-          input: getWindowsVM({
-            name: windowsConfig.name,
-            networkName: multusNAD.metadata.name,
-            vmIP: VM_IP,
-          }),
-        });
+      /* Pre-requisite:
+       * - L2 network is configured on the cluster/node
+       * - the Windows-VM has guest-agent installed
+       * and so the Windows VM gets IP which is reported back to the VMI object among VMI.status.interfaces[].
+       *
+       * We mimmic this "final" state here.
+       */
 
-        await vm.navigateToDetail();
-        // eslint-disable-next-line no-console
-        console.log(
-          'Waiting for static IP to be reported by the guest-agent (can take up to several minutes ...)',
-        );
-        // Waiting for instllation & start of the guest-agent and reporting the static IP back
-        await browser.wait(
-          waitForStringInElement(vmDetailIP(vm.namespace, vm.name), VM_IP),
-          VM_CREATE_AND_EDIT_AND_CLOUDINIT_TIMEOUT_SECS,
-        );
+      await vm.navigateToDetail();
+      // eslint-disable-next-line no-console
+      console.log(
+        'Waiting for static IP to be reported by the guest-agent (can take up to several minutes ...)',
+      );
+      // Waiting for instllation & start of the guest-agent and reporting the static IP back
+      await browser.wait(
+        waitForStringInElement(vmDetailIP(vm.namespace, vm.name), VM_IP),
+        VM_CREATE_AND_EDIT_AND_CLOUDINIT_TIMEOUT_SECS,
+      );
 
-        await vm.navigateToConsoles();
+      await vm.navigateToConsoles();
 
-        await browser.wait(until.presenceOf(consoleTypeSelector));
-        await click(consoleTypeSelector);
-        await browser.wait(
-          waitForStringInElement(consoleTypeSelector, 'VNC Console'),
-          PAGE_LOAD_TIMEOUT_SECS,
-        );
+      await browser.wait(until.presenceOf(consoleTypeSelector));
+      await click(consoleTypeSelector);
+      await browser.wait(
+        waitForStringInElement(consoleTypeSelector, 'VNC Console'),
+        PAGE_LOAD_TIMEOUT_SECS,
+      );
 
-        const items = await getDropdownOptions(consoleTypeSelectorId);
-        expect(items[0]).toBe('VNC Console');
-        expect(items[1]).toBe('Serial Console');
-        expect(items[2]).toBe('Desktop Viewer');
+      const items = await getDropdownOptions(consoleTypeSelectorId);
+      expect(items[0]).toBe('VNC Console');
+      expect(items[1]).toBe('Serial Console');
+      expect(items[2]).toBe('Desktop Viewer');
 
-        await click(consoleTypeSelector); // close before re-opening
-        await selectDropdownOption(consoleTypeSelectorId, 'Desktop Viewer');
+      await click(consoleTypeSelector); // close before re-opening
+      await selectDropdownOption(consoleTypeSelectorId, 'Desktop Viewer');
 
-        await selectDropdownOptionById(networkSelectorId, 'nic-1-link');
-        await browser.wait(
-          until.textToBePresentInElement(manualConnectionTitle, 'Manual Connection'),
-        );
-        const titles = rdpManualConnectionTitles();
-        expect(titles.first().getText()).toBe('RDP Address:');
-        expect(titles.last().getText()).toBe('RDP Port:');
+      await selectDropdownOptionById(networkSelectorId, 'nic-1-link');
+      await browser.wait(
+        until.textToBePresentInElement(manualConnectionTitle, 'Manual Connection'),
+      );
+      const titles = rdpManualConnectionTitles();
+      expect(titles.first().getText()).toBe('RDP Address:');
+      expect(titles.last().getText()).toBe('RDP Port:');
 
-        const values = rdpManualConnectionValues();
-        expect(values.count()).toBe(2);
-        expect(values.first().getText()).toBe(VM_IP);
-        expect(values.last().getText()).toBe('3389');
+      const values = rdpManualConnectionValues();
+      expect(values.count()).toBe(2);
+      expect(values.first().getText()).toBe(VM_IP);
+      expect(values.last().getText()).toBe('3389');
 
-        // TODO: download the .rdp file and verify content
-        // will require protractor configuration change: https://stackoverflow.com/questions/21935696/protractor-e2e-test-case-for-downloading-pdf-file/26127745#26127745
-      });
+      // TODO: download the .rdp file and verify content
+      // will require protractor configuration change: https://stackoverflow.com/questions/21935696/protractor-e2e-test-case-for-downloading-pdf-file/26127745#26127745
     },
     VM_CREATE_AND_EDIT_AND_CLOUDINIT_TIMEOUT_SECS,
   );

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
@@ -36,9 +36,7 @@ describe('KubeVirt VM detail - edit flavor', () => {
       const vm1Config = vmConfig(configName.toLowerCase(), testName, provisionConfig);
       vm1Config.startOnCreation = false;
 
-      const vm = await wizard.createVirtualMachine(
-        vmConfig(configName.toLowerCase(), testName, provisionConfig),
-      );
+      const vm = await wizard.createVirtualMachine(vm1Config);
       await withResource(leakedResources, vm.asResource(), async () => {
         await vm.navigateToDetail();
         await vm.modalEditFlavor();

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.environment.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.environment.scenario.ts
@@ -1,5 +1,5 @@
 import { getSecret, getConfigMap, getServiceAccount } from './utils/mocks';
-import { createResource, deleteResource, click } from '@console/shared/src/test-utils/utils';
+import { click, createResources, deleteResources } from '@console/shared/src/test-utils/utils';
 import { browser, ExpectedConditions as until, Key } from 'protractor';
 import { createExampleVMViaYAML } from './utils/utils';
 import { testName } from '@console/internal-integration-tests/protractor.conf';
@@ -15,30 +15,25 @@ import {
 import { execSync } from 'child_process';
 import { VirtualMachine } from './models/virtualMachine';
 
-const expecScriptPath = `${KUBEVIRT_SCRIPTS_PATH}/expect-vm-env-readable.sh`;
-const vmName = 'vm-example';
+const environmentExpecScriptPath = `${KUBEVIRT_SCRIPTS_PATH}/expect-vm-env-readable.sh`;
 const configmapName = 'configmap-mock';
 const secretName = 'secret-mock';
 const serviceAccountName = 'service-account-mock';
 
 describe('Test VM enviromnet tab', () => {
   const secret = getSecret(testName, secretName);
-  const configmap = getConfigMap(testName, configmapName);
+  const configMap = getConfigMap(testName, configmapName);
   const serviceAccount = getServiceAccount(testName, serviceAccountName);
   let vm: VirtualMachine;
 
   beforeAll(async () => {
-    createResource(secret);
-    createResource(configmap);
-    createResource(serviceAccount);
+    createResources([secret, configMap, serviceAccount]);
     const vmObj = await createExampleVMViaYAML(true);
     vm = new VirtualMachine(vmObj.metadata);
   });
 
   afterAll(() => {
-    deleteResource(secret);
-    deleteResource(configmap);
-    deleteResource(serviceAccount);
+    deleteResources([secret, configMap, serviceAccount, vm.asResource()]);
   });
 
   beforeEach(async () => {
@@ -67,9 +62,12 @@ describe('Test VM enviromnet tab', () => {
     'ID(CNV-4185) Verify all sources are readable inside the VM',
     async () => {
       await vm.action(VM_ACTION.Start);
-      const out = execSync(`expect ${expecScriptPath} ${vmName} ${testName}`).toString();
+      const out = execSync(
+        `expect ${environmentExpecScriptPath} ${vm.name} ${vm.namespace}`,
+      ).toString();
       const isFailedTest = out.split('\n').find((line) => line === 'FAILED');
       expect(!isFailedTest).toBeTruthy();
+      await vm.action(VM_ACTION.Stop);
     },
     VM_BOOTUP_TIMEOUT_SECS * 2, // VM boot time + test sources time
   );

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.non-admin.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.non-admin.scenario.ts
@@ -14,7 +14,7 @@ import {
   textFilter,
   resourceRows,
 } from '@console/internal-integration-tests/views/crud.view';
-import { restrictedAccessBlock, hintBlockTitle } from '../views/vms.list.view';
+import { restrictedAccessBlock } from '../views/vms.list.view';
 import { createProject } from './utils/utils';
 import { vmConfig, getProvisionConfigs } from './vm.wizard.configs';
 import { ProvisionConfigName } from './utils/constants/wizard';
@@ -50,6 +50,7 @@ describe('Kubevirt non-admin Flow', () => {
   beforeAll(async () => {
     await loginView.logout();
     await loginView.login(BRIDGE_HTPASSWD_IDP, BRIDGE_HTPASSWD_USERNAME, BRIDGE_HTPASSWD_PASSWORD);
+    await createProject(testNonAdminNamespace);
   });
 
   afterAll(async () => {
@@ -60,15 +61,8 @@ describe('Kubevirt non-admin Flow', () => {
   });
 
   it(
-    'ID(CNV-1718) non-admin create project and create/remove vm',
+    'ID(CNV-1718) non-admin create and remove a vm',
     async () => {
-      // Navigate to Virtual Machines page
-      await browser.get(`${appHost}/k8s/ns/${testNonAdminNamespace}/virtualmachines`);
-
-      // Check to make sure Access is Restricted.
-      await browser.wait(until.textToBePresentInElement(hintBlockTitle, 'Getting Started'));
-
-      await createProject(testNonAdminNamespace);
       const vm = await wizard.createVirtualMachine(vm1Config);
       await withResource(
         leakedResources,

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
@@ -22,7 +22,6 @@ import {
   VM_STATUS,
   commonTemplateVersion,
   COMMON_TEMPLATES_REVISION,
-  INNER_TEMPLATE_VERSION,
   DISK_INTERFACE,
   STORAGE_CLASS,
 } from './utils/consts';
@@ -125,7 +124,6 @@ describe('Kubevirt create VM using wizard', () => {
           [`os.template.kubevirt.io/${osID}`]: 'true',
           'vm.kubevirt.io/template': `windows10-${testVMConfig.workloadProfile.toLowerCase()}-${testVMConfig.flavorConfig.flavor.toLowerCase()}-${commonTemplateVersion()}`,
           'vm.kubevirt.io/template.revision': COMMON_TEMPLATES_REVISION,
-          'vm.kubevirt.io/template.version': INNER_TEMPLATE_VERSION,
         };
 
         expect(_.pick(annotations, Object.keys(requiredAnnotations))).toEqual(requiredAnnotations);
@@ -172,8 +170,10 @@ describe('Kubevirt create VM using wizard', () => {
         size: '1',
         interface: DISK_INTERFACE.VirtIO,
         storageClass: `${STORAGE_CLASS}`,
-        accessMode: expectedAccessMode,
-        volumeMode: expectedVolumeMode,
+        advanced: {
+          accessMode: expectedAccessMode,
+          volumeMode: expectedVolumeMode,
+        },
       };
       const testVMConfig = vmConfig('test-dv', testName, {
         provision: {

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/dialogs/diskDialog.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/dialogs/diskDialog.view.ts
@@ -1,4 +1,4 @@
-import { $, element, by } from 'protractor';
+import { $, by } from 'protractor';
 
 export const diskSource = $('#disk-source');
 export const diskURL = $('#disk-url');
@@ -9,7 +9,7 @@ export const diskName = $('#disk-name');
 export const diskSize = $('#disk-size-row-size');
 export const diskInterface = $('#disk-interface');
 export const diskStorageClass = $('#disk-storage-class');
-export const advancedDrawerToggle = element(by.buttonText('Advanced'));
+export const advancedDrawerToggle = $('.modal-body').element(by.buttonText('Advanced'));
 export const diskVolumeMode = $('#disk-volume-mode');
 export const diskAccessMode = $('#disk-access-mode');
 


### PR DESCRIPTION
- in disk modal, selection of SC that allows RWM automatically opens Advanced options, so we need to make sure we don't close it when selecting these
- increasing timeouts for flaking vm environment expect script
- simplified rdp console scenario, reduced the memory size to 1Gi so small clusters can run the test