### PR TITLE
Bug 1844525: Mark name field in git import as touched when autofilling form

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -33,7 +33,10 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
 
     setFieldValue('git.type', gitType);
     setFieldValue('git.showGitType', showGitType);
-    gitRepoName && !values.name && setFieldValue('name', gitRepoName);
+    if (gitRepoName && !values.name) {
+      setFieldValue('name', gitRepoName);
+      setFieldTouched('name', true);
+    }
     gitRepoName &&
       !values.application.name &&
       values.application.selectedKey !== UNASSIGNED_KEY &&


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3161
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
When autofilling an import form for git, if the sample name field violates naming conventions, there is no error shown.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Mark the name field as touched so that it gets considered during validation.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![upload](https://user-images.githubusercontent.com/20013884/83895721-b8fd3880-a770-11ea-9bad-08621f08d902.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
