### PR TITLE
Bug 1844938: Migrate to DevWorkspace CR for the terminal

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-utils.spec.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-utils.spec.ts
@@ -1,20 +1,20 @@
 import {
   newCloudShellWorkSpace,
   CLOUD_SHELL_LABEL,
-  CLOUD_SHELL_IMMUTABLE_ANNOTATION,
+  CLOUD_SHELL_RESTRICTED_ANNOTATION,
 } from '../cloud-shell-utils';
 
 describe('CloudShell Utils', () => {
   it('should create a new workspace resource', () => {
     const name = 'cloudshell';
     const namespace = 'default';
-    const kind = 'Workspace';
+    const kind = 'DevWorkspace';
 
     const newResource = newCloudShellWorkSpace(name, namespace);
     expect(newResource.kind).toEqual(kind);
     expect(newResource.metadata.name).toEqual(name);
     expect(newResource.metadata.namespace).toEqual(namespace);
     expect(newResource.metadata.labels[CLOUD_SHELL_LABEL]).toEqual('true');
-    expect(newResource.metadata.annotations[CLOUD_SHELL_IMMUTABLE_ANNOTATION]).toEqual('true');
+    expect(newResource.metadata.annotations[CLOUD_SHELL_RESTRICTED_ANNOTATION]).toEqual('true');
   });
 });

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -9,7 +9,7 @@ import {
   CLOUD_SHELL_LABEL,
   CLOUD_SHELL_CREATOR_LABEL,
   CloudShellResource,
-  CLOUD_SHELL_IMMUTABLE_ANNOTATION,
+  CLOUD_SHELL_RESTRICTED_ANNOTATION,
   startWorkspace,
 } from './cloud-shell-utils';
 import { useAccessReview2 } from '@console/internal/components/utils';
@@ -21,7 +21,7 @@ const findWorkspace = (data?: CloudShellResource[]): CloudShellResource | undefi
   if (Array.isArray(data)) {
     return data.find(
       (d) =>
-        d?.metadata?.annotations?.[CLOUD_SHELL_IMMUTABLE_ANNOTATION] === 'true' &&
+        d?.metadata?.annotations?.[CLOUD_SHELL_RESTRICTED_ANNOTATION] === 'true' &&
         !d?.metadata?.deletionTimestamp,
     );
   }

--- a/frontend/packages/console-app/src/models/index.ts
+++ b/frontend/packages/console-app/src/models/index.ts
@@ -1,27 +1,14 @@
 import { K8sKind } from '@console/internal/module/k8s';
 
 export const WorkspaceModel: K8sKind = {
-  kind: 'Workspace',
-  label: 'Workspace',
-  labelPlural: 'workspaces',
-  apiGroup: 'workspace.che.eclipse.org',
-  apiVersion: 'v1alpha1',
-  abbr: 'WS',
-  namespaced: true,
-  crd: true,
-  plural: 'workspaces',
-  propagationPolicy: 'Foreground',
-};
-
-export const DevWorkspaceModel: K8sKind = {
   kind: 'DevWorkspace',
-  label: 'Devworkspace',
-  labelPlural: 'workspaces',
-  apiGroup: 'apiextensions.k8s.io',
+  label: 'DevWorkspace',
+  labelPlural: 'devworkspaces',
+  apiGroup: 'workspace.devfile.io',
   apiVersion: 'v1alpha1',
   abbr: 'DW',
   namespaced: true,
   crd: true,
   plural: 'devworkspaces',
-  propagationPolicy: 'Foreground',
+  propagationPolicy: 'Background',
 };

--- a/pkg/terminal/auth.go
+++ b/pkg/terminal/auth.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"context"
+
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/terminal/operator.go
+++ b/pkg/terminal/operator.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -9,7 +10,7 @@ import (
 )
 
 const (
-	webhookName = "workspace.che.eclipse.org"
+	webhookName = "controller.devfile.io"
 )
 
 // workspaceOperatorIsRunning checks if the workspace operator is running and webhooks are enabled,


### PR DESCRIPTION
Update the custom resource used for providing the OpenShift Web terminal to the DevWorkspace API to be more compatible going forward. This PR moves the GVK and spec used for terminals from
```
workspace.che.eclipse.org/v1alpha1/Workspaces
```
to
```
devfile.io/v1alpha1/DevWorkspaces
```
as is reflected in operator PR https://github.com/che-incubator/che-workspace-operator/pull/92

There are additional compatibility changes included as well (e.g. required webhooks are renamed)

### How to test
1. Build image and deploy to cluster
    - You may need to add 'view webhooks' cluster role to the console as in PR https://github.com/openshift/console-operator/pull/432
2. Deploy Workspace operator from changes in https://github.com/che-incubator/che-workspace-operator/pull/92 (using built image)
    ```
    # In che-workspace-controller repo
    export WEBHOOK_ENABLED=true
    make deploy
    ```
3. Start a terminal using a non-cluster-admin user

I've built the changes in this PR as image `docker.io/amisevsk/console:devworkspace-api` to simplify testing.