### PR TITLE
Query Browser: Add additional operators to autocomplete suggestions

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -61,6 +61,19 @@ import {
 import { setAllQueryArguments } from '../utils/router';
 import { colors, Error, QueryObj, QueryBrowser } from './query-browser';
 
+const operators = [
+  'and',
+  'by()',
+  'group_left()',
+  'group_right()',
+  'ignoring()',
+  'offset',
+  'on()',
+  'or',
+  'unless',
+  'without()',
+];
+
 const aggregationOperators = [
   'avg()',
   'bottomk()',
@@ -448,6 +461,7 @@ const QueryInput_: React.FC<QueryInputProps> = ({
       ? {}
       : _.omitBy(
           {
+            ['Operators']: filterSuggestions(operators),
             ['Aggregation Operators']: filterSuggestions(aggregationOperators),
             ['Functions']: filterSuggestions(prometheusFunctions),
             ['Metrics']: filterSuggestions(metrics),


### PR DESCRIPTION
Autocomplete already included aggregation operators, but not other
operators.
![screenshot](https://user-images.githubusercontent.com/460802/83998715-25a84b00-a99c-11ea-82bc-8dca7b2ad135.png)

FYI @cshinn 