### PR TITLE
Bug 1845189: Fix NPE in combinedDisk

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
@@ -330,7 +330,7 @@ export class CombinedDiskFactory {
 
           if (dataVolume && this.pvcs) {
             pvc = this.pvcs.find((p) =>
-              getOwnerReferences(p).some((ownerReference) =>
+              (getOwnerReferences(p) || []).some((ownerReference) =>
                 compareOwnerReference(ownerReference, {
                   name: dataVolumeName,
                   kind: DataVolumeModel.kind,


### PR DESCRIPTION
This PR fixes a null pointer exception that causes the VM templates page to display an error if a PVC created through the PVC wizard is in the same namespace as the template.