### PR TITLE
Bug 1826740: supports insecure image registry in create and edit flow

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/ToggleableFieldBase.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ToggleableFieldBase.tsx
@@ -15,6 +15,7 @@ const ToggleableFieldBase: React.FC<ToggleableFieldBaseProps> = ({
   required,
   children,
   value,
+  onChange,
   name,
   ...props
 }) => {
@@ -40,7 +41,10 @@ const ToggleableFieldBase: React.FC<ToggleableFieldBaseProps> = ({
         isChecked: field.checked,
         isValid,
         'aria-describedby': `${fieldId}-helper`,
-        onChange: (val, event) => field.onChange(event),
+        onChange: (val, event) => {
+          field.onChange(event);
+          onChange && onChange(val);
+        },
       })}
     </FormGroup>
   );

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -43,6 +43,7 @@ export enum GroupTextType {
 export interface CheckboxFieldProps extends FieldProps {
   formLabel?: string;
   value?: string;
+  onChange?: (val: boolean) => void;
 }
 
 export interface SearchInputFieldProps extends BaseInputFieldProps {

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -497,6 +497,7 @@ export const externalImageValues: DeployImageFormData = {
   },
   searchTerm: undefined,
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: { image: '', tag: '', namespace: '', grantAccess: true },
   isi: {
     name: '',
@@ -572,6 +573,7 @@ export const internalImageValues: DeployImageFormData = {
   },
   searchTerm: '',
   registry: 'internal',
+  allowInsecureRegistry: false,
   imageStream: { image: 'python', tag: '3.6', namespace: 'div' },
   isi: {
     name: '',
@@ -667,6 +669,7 @@ export const knExternalImageValues: DeployImageFormData = {
     unknownTargetPort: '',
   },
   searchTerm: 'openshift/hello-openshift',
+  allowInsecureRegistry: false,
   serverless: { scaling: { concurrencylimit: '', concurrencytarget: '', maxpods: '', minpods: 0 } },
   healthChecks: healthChecksProbeInitialData,
 };

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -316,6 +316,7 @@ export const getGitAndDockerfileInitialValues = (
 const deployImageInitialValues = {
   searchTerm: '',
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: {
     image: '',
     tag: '',
@@ -349,11 +350,14 @@ export const getExternalImageInitialValues = (appResources: AppResources) => {
     return {};
   }
   const imageStream = _.orderBy(imageStreamList, ['metadata.resourceVersion'], ['desc']);
-  const name = imageStream.length && imageStream[0]?.spec?.tags?.[0]?.from?.name;
+  const imageStreamData = imageStream?.[0]?.spec?.tags?.[0];
+  const name = imageStreamData?.from?.name;
+  const isAllowInsecureRegistry = imageStreamData?.importPolicy?.insecure || false;
   return {
     ...deployImageInitialValues,
     searchTerm: name,
     registry: 'external',
+    allowInsecureRegistry: isAllowInsecureRegistry,
     imageStream: {
       ...deployImageInitialValues.imageStream,
       grantAccess: true,

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -48,6 +48,7 @@ const DeployImage: React.FC<Props> = ({
     name: '',
     searchTerm: '',
     registry: 'external',
+    allowInsecureRegistry: false,
     imageStream: {
       image: '',
       tag: '',
@@ -175,8 +176,9 @@ const DeployImage: React.FC<Props> = ({
       onSubmit={handleSubmit}
       onReset={history.goBack}
       validationSchema={deployValidationSchema}
-      render={(props) => <DeployImageForm {...props} projects={projects} />}
-    />
+    >
+      {(props) => <DeployImageForm {...props} projects={projects} />}
+    </Formik>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
@@ -15,6 +15,7 @@ export const mockDeployImageFormData: DeployImageFormData = {
   name: 'test-app',
   searchTerm: 'test-app',
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: {
     image: '',
     tag: '',

--- a/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils-data.ts
@@ -15,6 +15,7 @@ export const defaultData: DeployImageFormData = {
   name: '',
   searchTerm: '',
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: {
     image: '',
     tag: '',
@@ -107,6 +108,7 @@ export const dataWithTargetPort: DeployImageFormData = {
   name: 'helloworld-go',
   searchTerm: 'docker.io/mgencur/helloworld-go',
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: {
     image: '',
     tag: '',
@@ -221,6 +223,7 @@ export const dataWithPorts: DeployImageFormData = {
   name: 'test-admin-console',
   searchTerm: 'rohitkrai03/test-admin-console',
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: {
     image: '',
     tag: '',
@@ -443,6 +446,7 @@ export const dataWithoutPorts: DeployImageFormData = {
   name: 'helloworld-go',
   searchTerm: 'docker.io/mgencur/helloworld-go',
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: {
     image: '',
     tag: '',
@@ -565,6 +569,7 @@ export const internalImageData: DeployImageFormData = {
   name: 'react-web-app',
   searchTerm: '',
   registry: 'internal',
+  allowInsecureRegistry: false,
   imageStream: {
     image: 'react-web-app',
     tag: 'latest',

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -63,6 +63,7 @@ export const createOrUpdateImageStream = (
     project: { name: namespace },
     application: { name: application },
     name,
+    allowInsecureRegistry,
     isi: { name: isiName, tag },
     labels: userLabels,
   } = formData;
@@ -87,7 +88,7 @@ export const createOrUpdateImageStream = (
             kind: 'DockerImage',
             name: `${isiName}`,
           },
-          importPolicy: {},
+          importPolicy: { insecure: allowInsecureRegistry },
         },
       ],
     },

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -11,7 +11,7 @@ import {
   ValidatedOptions,
 } from '@patternfly/react-core';
 import { SecretTypeAbstraction } from '@console/internal/components/secrets/create-secret';
-import { InputField, useDebounceCallback } from '@console/shared';
+import { InputField, useDebounceCallback, CheckboxField } from '@console/shared';
 import { getSuggestedName, getPorts, makePortName } from '../../../utils/imagestream-utils';
 import { secretModalLauncher } from '../CreateSecretModal';
 import { UNASSIGNED_KEY, CREATE_APPLICATION_KEY } from '../../../const';
@@ -26,7 +26,7 @@ const ImageSearch: React.FC = () => {
   const { name: applicationNameTouched } = application as FormikTouched<{ name: boolean }>;
 
   const handleSearch = React.useCallback(
-    (searchTermImage: string) => {
+    (searchTermImage: string, isAllowInsecureRegistry = values.allowInsecureRegistry) => {
       setFieldValue('isSearchingForImage', true);
       setValidated(ValidatedOptions.default);
       const importImage = {
@@ -44,6 +44,7 @@ const ImageSearch: React.FC = () => {
                 kind: 'DockerImage',
                 name: _.trim(searchTermImage),
               },
+              importPolicy: { insecure: isAllowInsecureRegistry },
             },
           ],
         },
@@ -98,6 +99,7 @@ const ImageSearch: React.FC = () => {
       values.application.selectedKey,
       values.name,
       values.project.name,
+      values.allowInsecureRegistry,
       initialValues.route.targetPort,
     ],
   );
@@ -201,6 +203,13 @@ const ImageSearch: React.FC = () => {
           action={<AlertActionCloseButton onClose={() => shouldHideAlert(false)} />}
         />
       )}
+      <CheckboxField
+        name="allowInsecureRegistry"
+        label="Allow images from insecure registries"
+        onChange={(val: boolean) => {
+          values.searchTerm && handleSearch(values.searchTerm, val);
+        }}
+      />
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -62,6 +62,7 @@ export interface DeployImageFormData {
   application: ApplicationData;
   name: string;
   searchTerm: string;
+  allowInsecureRegistry: boolean;
   registry: string;
   imageStream: {
     image: string;

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -21,6 +21,7 @@ export const defaultData: DeployImageFormData = {
   name: '',
   searchTerm: '',
   registry: 'external',
+  allowInsecureRegistry: false,
   imageStream: {
     image: '',
     tag: '',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3785

- Create flow for ConatinerImage
- Edit flow for ConatinerImage

**Analysis / Root cause**: 
Insecure external registry was not working as expected in DevConsole

**Solution Description**: 
Add support for insecure registry for `ImageStreamImports` and `imageStream`

`importPolicy: { insecure: ture },`

**Screen shots / Gifs for design review**: 
- Gif
![depInsecureImageRegistry](https://user-images.githubusercontent.com/5129024/84132496-949ca700-aa63-11ea-8a04-4cf04e69978b.gif)

- In case of error
<img width="885" alt="Screenshot 2020-06-09 at 3 13 59 PM" src="https://user-images.githubusercontent.com/5129024/84132895-0bd23b00-aa64-11ea-9067-76d33bed17ca.png">

- In case of secrets creation
<img width="951" alt="Screenshot 2020-06-09 at 3 17 56 PM" src="https://user-images.githubusercontent.com/5129024/84133238-8dc26400-aa64-11ea-9bc2-53ea0b8d6853.png">


- in case of validation
<img width="840" alt="Screenshot 2020-06-09 at 3 14 10 PM" src="https://user-images.githubusercontent.com/5129024/84132950-1f7da180-aa64-11ea-9135-30b2f6707758.png">

cc @openshift/team-devconsole-ux @beaumorley 

**Test setup:**
- Use any external insecure registry to test.
- To expose internal registry in OpenShift cluster as insecure external/public registry

1. `oc login` Login to cluster
2. `oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge`
Follow https://docs.openshift.com/container-platform/4.1/registry/securing-exposing-registry.html
3.  now imageStreams would be exposed as external registry i.e `default-route-openshift-image-registry.apps.XXXXX.devcluster.openshift.com`
4. To know host `oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}'`
5. To know token `oc whoami -t` this would be needed to create secret


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
