### PR TITLE
Bug 1845279: set tileName to desc.kind if displayName not supplied

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
@@ -54,7 +54,7 @@ export const normalizeClusterServiceVersions = (
         ...desc,
       },
       kind: 'InstalledOperator',
-      tileName: desc.displayName,
+      tileName: desc.displayName || desc.kind,
       tileIconClass: null,
       capabilityLevel: _.get(desc, ['csv', 'metadata', 'annotations', 'capabilities'], '')
         .toLowerCase()


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-4147

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
v1.18.0 of the jaeger operator no longer sets the `displayName`: https://github.com/jaegertracing/jaeger-operator/issues/1085

Looks like the CSV no longer marks `displayName` as a required field:
https://github.com/operator-framework/operator-lifecycle-manager/blob/921a71087cf2a0ebf3089d97ee69774680948597/manifests/0000_50_olm_00-clusterserviceversions.crd.yaml#L333-L342

The dev-catalog throws an exception as it expected the `tileName` to always be set and the `tileName` was assigned the value of `desc.displayName`

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Since `kind` is still a required field, assign `kind` as the `tileName` if the `displayName` is not supplied.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Install the jaeger operator v1.18.0
Visit the dev-catalog

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
