### PR TITLE
Add tests for Independent Mode Installation Flow

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests/mocks/independent-external-cluster-data.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests/mocks/independent-external-cluster-data.ts
@@ -1,0 +1,57 @@
+export const ClusterMetadata = [
+  {
+    kind: 'ConfigMap',
+    data: { maxMonId: '0', data: 'a=10.97.47.226:6789', mapping: {} },
+    name: 'rook-ceph-mon-endpoints',
+  },
+  {
+    kind: 'Secret',
+    data: {
+      'mon-secret': 'mon-secret',
+      fsid: 'b99e887c-9f73-47e7-96cc-33c6f3f39aa9',
+      'cluster-name': 'openshift-storage',
+      'admin-secret': 'admin-secret',
+    },
+    name: 'rook-ceph-mon',
+  },
+  {
+    kind: 'Secret',
+    data: {
+      userKey: 'AQAwA85ezIXyORAA8YDlVMoyo5+tByxcCZigoQ==',
+      userID: 'client.healthchecker',
+    },
+    name: 'rook-ceph-operator-creds',
+  },
+  {
+    kind: 'Secret',
+    data: { userKey: 'AQDtAc5e/S7JJBAAhh2k1cjM5KszMObC0Wugyg==', userID: 'csi-rbd-node' },
+    name: 'rook-csi-rbd-node',
+  },
+  {
+    kind: 'Secret',
+    data: {
+      userKey: 'AQDtAc5ebRXHFBAAAGwy0lHtt3gYt9Q/9jhzXg==',
+      userID: 'csi-rbd-provisioner',
+    },
+    name: 'rook-csi-rbd-provisioner',
+  },
+  {
+    kind: 'Secret',
+    data: {
+      adminID: 'csi-cephfs-node',
+      adminKey: 'AQDuAc5esOp8DRAAi2cI3nGVBWH++9cOoE9b9g==',
+    },
+    name: 'rook-csi-cephfs-node',
+  },
+  {
+    kind: 'Secret',
+    data: {
+      adminID: 'csi-cephfs-provisioner',
+      adminKey: 'AQDtAc5eHe3DNRAAIe6HHnQRPSABuhj3GzEeoA==',
+    },
+    name: 'rook-csi-cephfs-provisioner',
+  },
+  { kind: 'StorageClass', data: { pool: 'myfs-data0' }, name: 'ceph-rbd' },
+  { kind: 'StorageClass', data: { pool: 'myfs-data0', fsName: 'myfs' }, name: 'cephfs' },
+  { kind: 'StorageClass', data: { endpoint: '10.10.212.122:9000' }, name: 'ceph-rgw' },
+];

--- a/frontend/packages/ceph-storage-plugin/integration-tests/mocks/testFile.json
+++ b/frontend/packages/ceph-storage-plugin/integration-tests/mocks/testFile.json
@@ -1,0 +1,57 @@
+[
+  {
+    "kind": "ConfigMap",
+    "data": { "maxMonId": "0", "data": "a=10.97.47.226:6789", "mapping": {} },
+    "name": "rook-ceph-mon-endpoints"
+  },
+  {
+    "kind": "Secret",
+    "data": {
+      "mon-secret": "mon-secret",
+      "fsid": "b99e887c-9f73-47e7-96cc-33c6f3f39aa9",
+      "cluster-name": "openshift-storage",
+      "admin-secret": "admin-secret"
+    },
+    "name": "rook-ceph-mon"
+  },
+  {
+    "kind": "Secret",
+    "data": {
+      "userKey": "AQAwA85ezIXyORAA8YDlVMoyo5+tByxcCZigoQ==",
+      "userID": "client.healthchecker"
+    },
+    "name": "rook-ceph-operator-creds"
+  },
+  {
+    "kind": "Secret",
+    "data": { "userKey": "AQDtAc5e/S7JJBAAhh2k1cjM5KszMObC0Wugyg==", "userID": "csi-rbd-node" },
+    "name": "rook-csi-rbd-node"
+  },
+  {
+    "kind": "Secret",
+    "data": {
+      "userKey": "AQDtAc5ebRXHFBAAAGwy0lHtt3gYt9Q/9jhzXg==",
+      "userID": "csi-rbd-provisioner"
+    },
+    "name": "rook-csi-rbd-provisioner"
+  },
+  {
+    "kind": "Secret",
+    "data": {
+      "adminID": "csi-cephfs-node",
+      "adminKey": "AQDuAc5esOp8DRAAi2cI3nGVBWH++9cOoE9b9g=="
+    },
+    "name": "rook-csi-cephfs-node"
+  },
+  {
+    "kind": "Secret",
+    "data": {
+      "adminID": "csi-cephfs-provisioner",
+      "adminKey": "AQDtAc5eHe3DNRAAIe6HHnQRPSABuhj3GzEeoA=="
+    },
+    "name": "rook-csi-cephfs-provisioner"
+  },
+  { "kind": "StorageClass", "data": { "pool": "myfs-data0" }, "name": "ceph-rbd" },
+  { "kind": "StorageClass", "data": { "pool": "myfs-data0", "fsName": "myfs" }, "name": "cephfs" },
+  { "kind": "StorageClass", "data": { "endpoint": "10.10.212.122:9000" }, "name": "ceph-rgw" }
+]


### PR DESCRIPTION
Adds dummy files required to test the independent mode storage cluster.
Adds environment variable to support the selection of Mode for OCS CI.
![Screenshot from 2020-06-10 02-07-39](https://user-images.githubusercontent.com/54092533/84198022-8cbf2000-aac0-11ea-8b76-467bf2712099.png)
/assign @cloudbehl @umangachapagain @gnehapk 