### PR TITLE
Add guest agent info to vm resource summary

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -41,6 +41,7 @@ import {
   TOLERATIONS_MODAL_TITLE,
   AFFINITY_MODAL_TITLE,
 } from '../modals/scheduling-modals/shared/consts';
+import { useGuestAgentInfo } from '../../hooks/use-guest-agent-info';
 import { VMStatusBundle } from '../../statuses/vm/types';
 
 import './vm-resource.scss';
@@ -82,6 +83,8 @@ export const VMResourceSummary: React.FC<VMResourceSummaryProps> = ({
   const description = getDescription(vmiLike);
   const os = getOperatingSystemName(vmiLike) || getOperatingSystem(vmiLike);
 
+  const [guestAgentInfo] = useGuestAgentInfo({ vmi });
+
   return (
     <ResourceSummary resource={vmiLike}>
       <VMDetailsItem
@@ -98,8 +101,12 @@ export const VMResourceSummary: React.FC<VMResourceSummaryProps> = ({
         </EditButton>
       </VMDetailsItem>
 
-      <VMDetailsItem title="Operating System" idValue={prefixedID(id, 'os')} isNotAvail={!os}>
-        {os}
+      <VMDetailsItem
+        title="Operating System"
+        idValue={prefixedID(id, 'os')}
+        isNotAvail={!(guestAgentInfo?.os?.prettyName || os)}
+      >
+        {guestAgentInfo?.os?.prettyName || os}
       </VMDetailsItem>
 
       {isVM && (
@@ -121,6 +128,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   canUpdateVM,
   kindObj,
 }) => {
+  const [guestAgentInfo] = useGuestAgentInfo({ vmi });
   const [isBootOrderModalOpen, setBootOrderModalOpen] = React.useState<boolean>(false);
   const isVM = kindObj === VirtualMachineModel;
   const vmiLike = isVM ? vm : vmi;
@@ -197,6 +205,22 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         isNotAvail={!launcherPod || !ipAddrs}
       >
         {launcherPod && ipAddrs}
+      </VMDetailsItem>
+
+      <VMDetailsItem
+        title="Hostname"
+        idValue={prefixedID(id, 'hostname')}
+        isNotAvail={!guestAgentInfo?.hostname}
+      >
+        {guestAgentInfo?.hostname}
+      </VMDetailsItem>
+
+      <VMDetailsItem
+        title="Time Zone"
+        idValue={prefixedID(id, 'timezone')}
+        isNotAvail={!guestAgentInfo?.timezone}
+      >
+        {guestAgentInfo?.timezone}
       </VMDetailsItem>
 
       <VMDetailsItem

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-users.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-users.tsx
@@ -4,10 +4,6 @@ import { sortable } from '@patternfly/react-table';
 import { fromNow } from '@console/internal/components/utils/datetime';
 import { Table, TableRow, TableData } from '@console/internal/components/factory';
 import { Timestamp } from '@console/internal/components/utils/timestamp';
-import {
-  useURLPoll,
-  URL_POLL_DEFAULT_DELAY,
-} from '@console/internal/components/utils/url-poll-hook';
 import { StatusItem } from '@console/shared/src/components/dashboard/status-card/AlertItem';
 import { BlueInfoCircleIcon } from '@console/shared/src/components/status';
 import {
@@ -16,14 +12,9 @@ import {
 } from '../../constants/vm/constants';
 import { VMStatus } from '../../constants/vm/vm-status';
 import { isGuestAgentInstalled } from '../dashboards-page/vm-dashboard/vm-alerts';
+import { useGuestAgentInfo } from '../../hooks/use-guest-agent-info';
 import { VMStatusBundle } from '../../statuses/vm/types';
 import { VMIKind } from '../../types';
-import { getVMIApiPath, getVMISubresourcePath } from '../../selectors/vmi/selectors';
-
-const guestAgentURL = (vmi: VMIKind) =>
-  vmi &&
-  isGuestAgentInstalled(vmi) &&
-  `/${getVMISubresourcePath()}/${getVMIApiPath(vmi)}/guestosinfo`;
 
 const tableColumnClasses = [
   classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
@@ -75,15 +66,8 @@ const UsersTableRow = ({ obj: user, index, key, style }) => {
   );
 };
 
-export const VMUsersList: React.FC<VMUsersListProps> = ({
-  vmi,
-  vmStatusBundle,
-  delay = URL_POLL_DEFAULT_DELAY,
-}) => {
-  const [response, error, loading] = useURLPoll<VirtualMachineInstanceGuestAgentInfo>(
-    guestAgentURL(vmi),
-    delay,
-  );
+export const VMUsersList: React.FC<VMUsersListProps> = ({ vmi, vmStatusBundle, delay }) => {
+  const [response, error, loading] = useGuestAgentInfo({ vmi, delay });
 
   if (vmStatusBundle.status !== VMStatus.RUNNING) {
     return <div className="text-center">{VIRTUAL_MACHINE_IS_NOT_RUNNING}</div>;
@@ -117,16 +101,6 @@ export const VMUsersList: React.FC<VMUsersListProps> = ({
       virtualize
     />
   );
-};
-
-type VirtualMachineInstanceGuestOSUser = {
-  userName: string;
-  domain?: string;
-  loginTime?: number;
-};
-
-type VirtualMachineInstanceGuestAgentInfo = {
-  userList?: VirtualMachineInstanceGuestOSUser[];
 };
 
 type VMUsersListProps = {

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-guest-agent-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-guest-agent-info.ts
@@ -1,0 +1,64 @@
+import { VMIKind } from '../types';
+import { useURLPoll } from '@console/internal/components/utils/url-poll-hook';
+import { getVMIApiPath, getVMISubresourcePath } from '../selectors/vmi/selectors';
+import { isGuestAgentInstalled } from '../components/dashboards-page/vm-dashboard/vm-alerts';
+
+const getGuestAgentURL = (vmi: VMIKind) =>
+  vmi &&
+  isGuestAgentInstalled(vmi) &&
+  `/${getVMISubresourcePath()}/${getVMIApiPath(vmi)}/guestosinfo`;
+
+const useGuestAgentInfo = ({ vmi, delay }: GuestAgentInfoProps) =>
+  useURLPoll<VirtualMachineInstanceGuestAgentInfo>(getGuestAgentURL(vmi), delay);
+
+type GuestAgentInfoProps = {
+  vmi: VMIKind;
+  delay?: number;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesystem
+type VirtualMachineInstanceFileSystem = {
+  diskName: string;
+  fileSystemType: string;
+  mountPoint: string;
+  totalBytes: number;
+  usedBytes: number;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesysteminfo
+type VirtualMachineInstanceFileSystemInfo = {
+  disks: VirtualMachineInstanceFileSystem[];
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestagentinfo
+type VirtualMachineInstanceGuestOSInfo = {
+  id?: string;
+  kernelRelease?: string;
+  kernelVersion?: string;
+  machine?: string;
+  name?: string;
+  prettyName?: string;
+  version?: string;
+  versionId?: string;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestosuser
+type VirtualMachineInstanceGuestOSUser = {
+  userName: string;
+  domain?: string;
+  loginTime?: number;
+};
+
+// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesysteminfo
+type VirtualMachineInstanceGuestAgentInfo = {
+  apiVersion?: string;
+  fsInfo?: VirtualMachineInstanceFileSystemInfo;
+  guestAgentVersion?: string;
+  hostname?: string;
+  kind?: string;
+  os?: VirtualMachineInstanceGuestOSInfo;
+  timezone?: string;
+  userList?: VirtualMachineInstanceGuestOSUser[];
+};
+
+export { useGuestAgentInfo, GuestAgentInfoProps };

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
@@ -2,12 +2,11 @@ import { getName, getNamespace, getOwnerReferences } from '@console/shared/src/s
 import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { PodKind } from '@console/internal/module/k8s';
 import { buildOwnerReference } from '../../utils';
-import { VMKind } from '../../types/vm';
 import { OS_WINDOWS_PREFIX } from '../../constants';
 import { getOperatingSystem } from './selectors';
-import { VMILikeEntityKind } from '../../types/vmLike';
+import { VMILikeEntityKind, VMGenericLikeEntityKind } from '../../types/vmLike';
 
-export const isWindows = (vm: VMKind): boolean =>
+export const isWindows = (vm: VMGenericLikeEntityKind): boolean =>
   (getOperatingSystem(vm) || '').startsWith(OS_WINDOWS_PREFIX);
 
 export const findConversionPod = (vm: VMILikeEntityKind, pods: PodKind[]) => {


### PR DESCRIPTION
Add guest agent info to vm resource summary

Design: http://openshift.github.io/openshift-origin-design/designs/virtualization/4.x/expose-guest-data/expose%20guest%20data.html

  - [x] add os pretty name
  - [x] add timezone
  - [x] add hostname
  - [x] alert on user-os / guest-agent-os missmatch

Notes:
supported os types - https://github.com/kubevirt/common-templates#templates
downstream struct - https://www.qemu.org/docs/master/qemu-ga-ref.html#index-GuestOSInfo

Screenshot:
Add hostname, timezone and os name:
![screenshot-localhost_9000-2020 06 10-14_31_10](https://user-images.githubusercontent.com/2181522/84262930-32a57580-ab27-11ea-9a5c-b8bedc939046.png)

Add alert on OS mismatch:
![screenshot-localhost_9000-2020 06 11-17_39_13](https://user-images.githubusercontent.com/2181522/84400330-8f2d9100-ac0a-11ea-9181-85aa140aad7b.png)

OS name from GA and from YAML:
![Peek 2020-06-11 18-55](https://user-images.githubusercontent.com/2181522/84408780-3adbde80-ac15-11ea-9755-7c1439e430f9.gif)
