### PR TITLE
Bug 1846319: Fix link for code decorators in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
@@ -92,7 +92,7 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
                   x={cx + radius - decoratorRadius * 0.7}
                   y={cy + radius - decoratorRadius * 0.7}
                   radius={decoratorRadius}
-                  href={workloadData.editUrl}
+                  href={editUrl}
                   external
                 >
                   <g transform={`translate(-${decoratorRadius / 2}, -${decoratorRadius / 2})`}>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4163

**Analysis / Root cause**: 
Correct URL was not being set on the decorator

**Solution Description**: 
Set the correct computed URL on the decorator

/kind bug