### PR TITLE
Add "View release notes" link for version

### DIFF
--- a/frontend/__tests__/components/cluster-settings.spec.tsx
+++ b/frontend/__tests__/components/cluster-settings.spec.tsx
@@ -238,7 +238,9 @@ describe('Current Version', () => {
   });
 
   it('should render the Current Version value', () => {
-    expect(wrapper.text()).toBe('4.2.0-0.ci-2019-07-22-025130');
+    expect(wrapper.find('[data-test-id="cluster-version"]').text()).toBe(
+      '4.2.0-0.ci-2019-07-22-025130',
+    );
   });
 });
 describe('Current Version Header', () => {

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -100,6 +100,7 @@ const testSuites = {
     'tests/dashboards/cluster-dashboard.scenario.ts',
     'tests/dashboards/project-dashboard.scenario.ts',
     'tests/event.scenario.ts',
+    'tests/cluster-settings.scenario.ts',
   ]),
   release: suite([
     'tests/crud.scenario.ts',
@@ -136,6 +137,7 @@ const testSuites = {
     'tests/dashboards/cluster-dashboard.scenario.ts',
     'tests/dashboards/project-dashboard.scenario.ts',
     'tests/event.scenario.ts',
+    'tests/cluster-settings.scenario.ts',
   ]),
   clusterSettings: suite(['tests/cluster-settings.scenario.ts']),
   alertmanager: suite(['tests/alertmanager.scenario.ts']),

--- a/frontend/integration-tests/tests/cluster-settings.scenario.ts
+++ b/frontend/integration-tests/tests/cluster-settings.scenario.ts
@@ -1,13 +1,13 @@
 import { browser } from 'protractor';
 
-import { appHost, checkLogs, checkErrors, testName } from '../protractor.conf';
+import { appHost, checkLogs, checkErrors } from '../protractor.conf';
 import * as crudView from '../views/crud.view';
 import * as clusterSettingsView from '../views/cluster-settings.view';
 import * as horizontalnavView from '../views/horizontal-nav.view';
 
 describe('Cluster Settings', () => {
   beforeEach(async () => {
-    await browser.get(`${appHost}/settings/cluster/${testName}`);
+    await browser.get(`${appHost}/settings/cluster`);
     await crudView.isLoaded();
   });
 
@@ -18,7 +18,7 @@ describe('Cluster Settings', () => {
 
   it('display page title, horizontal navigation tab headings and pages', async () => {
     expect(clusterSettingsView.heading.isPresent()).toBe(true);
-    await horizontalnavView.clickHorizontalTab('Overview');
+    await horizontalnavView.clickHorizontalTab('Details');
     await crudView.isLoaded();
     await horizontalnavView.clickHorizontalTab('Cluster Operators');
     await crudView.isLoaded();
@@ -26,7 +26,7 @@ describe('Cluster Settings', () => {
     await crudView.isLoaded();
   });
   it('display overview channel update modal, select value and click cancel', async () => {
-    await horizontalnavView.clickHorizontalTab('Overview');
+    await horizontalnavView.clickHorizontalTab('Details');
     await crudView.isLoaded();
     expect(clusterSettingsView.channelUpdateLink.isDisplayed()).toBe(true);
     await clusterSettingsView.channelUpdateLink.click();

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -242,9 +242,9 @@ describe('Alertmanager: YAML', () => {
     await crudView.isLoaded();
     await horizontalnavView.clickHorizontalTab('Global Configuration');
     await crudView.isLoaded();
-    await monitoringView.wait(until.elementToBeClickable(firstElementByTestID('alertmanager')));
-    expect(firstElementByTestID('alertmanager').getText()).toContain('Alertmanager');
-    await firstElementByTestID('alertmanager').click();
+    await monitoringView.wait(until.elementToBeClickable(firstElementByTestID('Alertmanager')));
+    expect(firstElementByTestID('Alertmanager').getText()).toContain('Alertmanager');
+    await firstElementByTestID('Alertmanager').click();
     await crudView.isLoaded();
     await horizontalnavView.clickHorizontalTab('YAML');
     await yamlView.isLoaded();

--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -159,28 +159,32 @@ $co-channel-height: 60px;
 }
 
 .co-channel-version-dot {
-  background: $pf-global--primary-color--100;
-  border-radius: 16px;
-  content: '';
-  height: 16px;
+  background: $pf-global--primary-color--100 !important;
+  border-radius: 16px !important;
+  height: 16px !important;
+  padding: 0 !important;
   position: absolute;
-  width: 16px;
+  width: 16px !important;
   z-index: 2;
+
+  &::after {
+    background: var(--pf-c-drawer__content--BackgroundColor) !important;
+    border: 2px solid var(--pf-c-drawer__content--BackgroundColor) !important;
+    border-radius: 12px !important;
+    bottom: 2px !important;
+    content: '';
+    left: 2px !important;
+    position: absolute;
+    right: 2px !important;
+    top: 2px !important;
+  }
 
   &--current::after {
     background: transparent !important;
-  }
 
-  &::after {
-    background: var(--pf-c-drawer__content--BackgroundColor);
-    border: 2px solid var(--pf-c-drawer__content--BackgroundColor);
-    border-radius: 12px;
-    content: '';
-    height: 12px;
-    left: 2px;
-    position: absolute;
-    top: 2px;
-    width: 12px;
+  }
+  &:focus {
+    outline: 0 !important;
   }
 }
 

--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -35,7 +35,7 @@ const ItemRow = ({ item }) => {
   return (
     <div className="row co-resource-list__item" data-test-action={item.label}>
       <div className="col-xs-10 col-sm-4">
-        <Link to={item.path} data-test-id={item.id}>
+        <Link to={item.path} data-test-id={item.label}>
           {item.label}
         </Link>
       </div>

--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { ActionGroup, Button } from '@patternfly/react-core';
 
-import { ClusterVersionKind, getSortedUpdates } from '../../module/k8s';
+import {
+  ClusterVersionKind,
+  getClusterVersionChannel,
+  getSortedUpdates,
+  showReleaseNotes,
+} from '../../module/k8s';
 import {
   ModalBody,
   ModalComponentProps,
@@ -9,10 +14,13 @@ import {
   ModalTitle,
   createModalLauncher,
 } from '../factory/modal';
+import { ReleaseNotesLink } from '../cluster-settings/cluster-settings';
 
 export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = ({ cancel, cv }) => {
   const availableUpdates = getSortedUpdates(cv);
   const moreAvailableUpdates = availableUpdates.slice(1).reverse();
+  const channel = getClusterVersionChannel(cv);
+  const releaseNotes = showReleaseNotes(channel);
 
   return (
     <div className="modal-content">
@@ -22,6 +30,7 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
           <thead>
             <tr>
               <th>Version</th>
+              {releaseNotes && <th>Release Notes</th>}
             </tr>
           </thead>
           <tbody>
@@ -29,6 +38,11 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
               return (
                 <tr key={update.version}>
                   <td>{update.version}</td>
+                  {releaseNotes && (
+                    <td>
+                      <ReleaseNotesLink channel={channel} version={update.version} />
+                    </td>
+                  )}
                 </tr>
               );
             })}


### PR DESCRIPTION
But only when branding is `ocp` and the channel begins with `fast-` or `stable-`.

Branding is `ocp` and channel starts with `fast-` or `stable-`:

<img width="867" alt="Screen Shot 2020-06-24 at 2 37 32 PM" src="https://user-images.githubusercontent.com/895728/85614156-9c924480-b628-11ea-8b61-9164230ae19b.png">
<img width="852" alt="Screen Shot 2020-06-24 at 2 37 39 PM" src="https://user-images.githubusercontent.com/895728/85614159-9dc37180-b628-11ea-8a01-5a634f8395b9.png">
<img width="655" alt="Screen Shot 2020-06-24 at 2 37 45 PM" src="https://user-images.githubusercontent.com/895728/85614161-9e5c0800-b628-11ea-91ec-71f65dc7a696.png">
<img width="869" alt="Screen Shot 2020-06-24 at 2 37 52 PM" src="https://user-images.githubusercontent.com/895728/85614163-9e5c0800-b628-11ea-9b3c-b55e125b5d26.png">

Branding is not `ocp` or channel starts with `candidate-`:

<img width="883" alt="Screen Shot 2020-06-24 at 2 38 46 PM" src="https://user-images.githubusercontent.com/895728/85614166-9ef49e80-b628-11ea-9a76-408e8d75c811.png">
<img width="663" alt="Screen Shot 2020-06-24 at 2 40 31 PM" src="https://user-images.githubusercontent.com/895728/85614215-ad42ba80-b628-11ea-9b92-83af1f500d90.png">


Branding is `ocp` and channels starts with `fast-`, but `Last Completed Version` is from channel that starts with `candidate-`, so we get a link with an invalid anchor (e.g., https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-24):
<img width="841" alt="Screen Shot 2020-06-24 at 3 36 16 PM" src="https://user-images.githubusercontent.com/895728/85619845-e41cce80-b630-11ea-9a80-79c84c01cb13.png">
