### PR TITLE
Add filter by workload in monitoring dashboard

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
@@ -29,7 +29,12 @@ $no-wrap-breakpoint: 915px;
       }
     }
   }
-  &__resource-link {
+  &__resource-toolbar {
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--xl);
+  }
+  &__workload-filter {
+    li[role='presentation'] {
+      list-style: none;
+    }
   }
 }

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringWorkloadFilter.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringWorkloadFilter.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import * as fuzzy from 'fuzzysearch';
+import { DeploymentModel, StatefulSetModel, DaemonSetModel } from '@console/internal/models';
+import { Firehose } from '@console/internal/components/utils';
+import { ResourceDropdown } from '@console/shared';
+
+export enum OptionTypes {
+  selectAll = '#SELECT_ALL_WORKLOADS#',
+}
+export const OptionValues = {
+  [OptionTypes.selectAll]: 'All Workloads',
+};
+type MonitoringWorkloadFilterProps = {
+  namespace: string;
+  name: string;
+  onChange: (key: string, type: string) => void;
+};
+export const MonitoringWorkloadFilter: React.FC<MonitoringWorkloadFilterProps> = React.memo(
+  ({ namespace, name, onChange }) => {
+    const selectedTaskRef = React.useRef<string>(name);
+    selectedTaskRef.current = name;
+
+    const resourcesDefs = [
+      { isList: true, namespace, kind: DeploymentModel.kind, prop: DeploymentModel.id },
+      { isList: true, namespace, kind: DaemonSetModel.kind, prop: DaemonSetModel.id },
+      { isList: true, namespace, kind: StatefulSetModel.kind, prop: StatefulSetModel.id },
+    ];
+    const onSelect = (key: string, ele: React.ReactElement) => {
+      if (selectedTaskRef.current !== key) {
+        selectedTaskRef.current = key;
+        onChange && onChange(key, ele?.props.model.id);
+      }
+    };
+    return (
+      <Firehose resources={resourcesDefs}>
+        <ResourceDropdown
+          id="odc-monitoring-dashboard-workload-filter"
+          dataSelector={['metadata', 'name']}
+          selectedKey={selectedTaskRef.current}
+          placeholder="Filter by workload"
+          dropDownClassName={'odc-monitoring-dashboard__workload-filter dropdown--full-width'}
+          onChange={onSelect}
+          showBadge
+          autoSelect
+          autocompleteFilter={(strText, item: React.ReactElement): boolean =>
+            fuzzy(strText, item?.props?.name)
+          }
+          actionItems={[
+            {
+              actionTitle: OptionValues[OptionTypes.selectAll],
+              actionKey: OptionTypes.selectAll,
+            },
+          ]}
+        />
+      </Firehose>
+    );
+  },
+);

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
@@ -5,7 +5,10 @@ import {
   TimespanDropdown,
   PollIntervalDropdown,
 } from '@console/internal/components/monitoring/dashboards';
+import { ResourceDropdown } from '@console/shared';
+import { Firehose } from '@console/internal/components/utils/firehose';
 import { MonitoringDashboard } from '../MonitoringDashboard';
+import { OptionTypes, MonitoringWorkloadFilter } from '../MonitoringWorkloadFilter';
 import ConnectedMonitoringDashboardGraph from '../MonitoringDashboardGraph';
 import { monitoringDashboardQueries, topWorkloadMetricsQueries } from '../../queries';
 
@@ -68,20 +71,42 @@ describe('Monitoring Dashboard Tab', () => {
     expect(wrapper.find(PollIntervalDropdown).exists()).toBe(true);
   });
 
-  it('should render ResourceLink for workload queries dashboard', () => {
+  it('should render workload filter dropdown with preselected workload in dashboard', () => {
     const spygetURLSearchParams = jest.spyOn(link, 'getURLSearchParams');
     spygetURLSearchParams.mockReturnValue({
       workloadName: 'calculator-react',
       workloadType: 'Deployment',
     });
     const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
-    expect(wrapper.find(link.ResourceLink).exists()).toBe(true);
+    const filterDropdown = wrapper.find(MonitoringWorkloadFilter);
+    expect(filterDropdown.exists()).toBe(true);
+    expect(filterDropdown.props().name).toBe('calculator-react');
   });
 
-  it('should not render ResourceLink for namespace queries dashboard', () => {
+  it('should render filter dropdown with no selection for namespace queries dashboard', () => {
     const spygetURLSearchParams = jest.spyOn(link, 'getURLSearchParams');
     spygetURLSearchParams.mockReturnValue({});
     const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
-    expect(wrapper.find(link.ResourceLink).exists()).toBe(false);
+    const filterDropdown = wrapper.find(MonitoringWorkloadFilter);
+    expect(filterDropdown.exists()).toBe(true);
+    expect(filterDropdown.props().name).toBe(OptionTypes.selectAll);
+  });
+
+  it('should render filter dropdown with correct resources and select all option', () => {
+    const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
+    const filterDropdown = wrapper.find(MonitoringWorkloadFilter);
+    const FirehoseResources = filterDropdown.dive().find(Firehose);
+    expect(FirehoseResources.props().resources).toHaveLength(3);
+  });
+
+  it('should render filter dropdown with badge', () => {
+    const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
+    const filterDropdown = wrapper.find(MonitoringWorkloadFilter);
+    expect(
+      filterDropdown
+        .dive()
+        .find(ResourceDropdown)
+        .props().showBadge,
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-4118

Problem: Currently there is no way to filter the metric charts by workloads.

Solution: Added a filter dropdown to list the supported workloads in monitoring dashboard, from which user can pick a workload to see the a specific workload graph.

Screenshots:
![monitoring_filter](https://user-images.githubusercontent.com/9964343/84943228-b0f2b080-b101-11ea-8d65-aa1647801bb5.gif)

Unit test cases:

![image](https://user-images.githubusercontent.com/9964343/84652994-2d329b80-af2a-11ea-8fc1-cb849fa9499b.png)

cc: @openshift/team-devconsole-ux @cshinn @invincibleJai 