### PR TITLE
Bug 1847581: Fixed inconsistency in breakdown and utilization card wrt capacities

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/__mocks__/breakdown-data.ts
+++ b/frontend/packages/ceph-storage-plugin/src/__mocks__/breakdown-data.ts
@@ -33,7 +33,7 @@ export const breakdownData = {
       metric: { namespace: 'default' },
     },
   ],
-  capacityTotal: '10000000',
+  capacityAvailable: '10000000',
   metricTotal: '10000000',
   capacityUsed: '150000',
   humanize: humanizeBinaryBytes,

--- a/frontend/packages/ceph-storage-plugin/src/__tests__/breakdown-body.spec.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/__tests__/breakdown-body.spec.tsx
@@ -21,7 +21,7 @@ describe('<BreakdownCardBody>', () => {
         hasLoadError={false}
         metricTotal={breakdownData.metricTotal}
         capacityUsed={breakdownData.capacityUsed}
-        capacityTotal={breakdownData.capacityTotal}
+        capacityAvailable={breakdownData.capacityAvailable}
         humanize={breakdownData.humanize}
         metricModel={null}
         top5MetricsStats={top5MetricsStats}
@@ -33,7 +33,7 @@ describe('<BreakdownCardBody>', () => {
     const breakdownChart = wrapper.find(BreakdownChart);
     expect(breakdownChart.exists()).toBe(true);
     expect(breakdownChart.props().data.length).toBe(7);
-    // Last is popped if capacityTotal is available(7 - 1)
+    // Last is popped if capacityAvailable is available(7 - 1)
     expect(breakdownChart.props().legends.length).toBe(6);
     expect(breakdownChart.props().ocsVersion).toBeFalsy();
   });
@@ -44,7 +44,7 @@ describe('<BreakdownCardBody>', () => {
   });
 
   it('Hides available capacity text, legend, stack', () => {
-    wrapper.setProps({ capacityTotal: null });
+    wrapper.setProps({ capacityAvailable: null });
     expect(wrapper.find(TotalCapacityBody).exists()).toBe(true);
     expect(wrapper.find('.capacity-breakdown-card__available-body').exists()).toBe(false);
     const breakdownChart = wrapper.find(BreakdownChart);
@@ -57,7 +57,7 @@ describe('<BreakdownCardBody>', () => {
   it('Hides others capacity text, legend, stack', () => {
     wrapper.setProps({
       top5MetricsStats: getStackChartStats(breakdownData.top5.slice(0, 4), breakdownData.humanize),
-      capacityTotal: null,
+      capacityAvailable: null,
     });
     const breakdownChart = wrapper.find(BreakdownChart);
     expect(breakdownChart.exists()).toBe(true);

--- a/frontend/packages/ceph-storage-plugin/src/__tests__/breakdown-chart.spec.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/__tests__/breakdown-chart.spec.tsx
@@ -20,8 +20,7 @@ const stackData = getStackChartStats(breakdownData.top5, breakdownData.humanize)
 
 const chartData = addAvailable(
   stackData,
-  breakdownData.capacityTotal,
-  breakdownData.capacityUsed,
+  breakdownData.capacityAvailable,
   breakdownData.metricTotal,
   breakdownData.humanize,
 );

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-body.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-body.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { Humanize } from '@console/internal/components/utils';
 import { K8sKind } from '@console/internal/module/k8s';
-import { addAvailable, getCapacityValue, StackDataPoint, getLegends } from './utils';
+import { addAvailable, StackDataPoint, getLegends } from './utils';
 import { BreakdownChart } from './breakdown-chart';
 import { BreakdownChartLoading } from './breakdown-loading';
 import { TotalCapacityBody } from './breakdown-capacity';
@@ -11,7 +11,7 @@ export const BreakdownCardBody: React.FC<BreakdownBodyProps> = ({
   top5MetricsStats,
   metricTotal,
   capacityUsed,
-  capacityTotal,
+  capacityAvailable,
   metricModel,
   humanize,
   isLoading,
@@ -28,24 +28,15 @@ export const BreakdownCardBody: React.FC<BreakdownBodyProps> = ({
     return <div className="text-secondary">Not enough usage data</div>;
   }
 
-  const available = getCapacityValue(capacityUsed, capacityTotal, humanize);
-  const usedCapacity = `${humanize(capacityUsed, null, 'GiB').string} used${
-    capacityTotal ? ` of ${humanize(capacityTotal).string}` : ''
-  }`;
-  const availableCapacity = `${available.string} available`;
+  const usedCapacity = `${humanize(capacityUsed).string} used`;
+  const availableCapacity = `${humanize(capacityAvailable).string} available`;
 
-  const chartData = addAvailable(
-    top5MetricsStats,
-    capacityTotal,
-    capacityUsed,
-    metricTotal,
-    humanize,
-  );
+  const chartData = addAvailable(top5MetricsStats, capacityAvailable, metricTotal, humanize);
 
   const legends = getLegends(chartData);
 
   // Removes Legend for available
-  if (capacityTotal) {
+  if (capacityAvailable) {
     legends.pop();
   }
 
@@ -56,7 +47,7 @@ export const BreakdownCardBody: React.FC<BreakdownBodyProps> = ({
       </GridItem>
       <GridItem span={4} />
       <GridItem span={4}>
-        {capacityTotal && (
+        {capacityAvailable && (
           <TotalCapacityBody
             value={availableCapacity}
             className="capacity-breakdown-card__available-body text-secondary"
@@ -81,7 +72,7 @@ export type BreakdownBodyProps = {
   metricTotal: string;
   top5MetricsStats: StackDataPoint[];
   capacityUsed: string;
-  capacityTotal?: string;
+  capacityAvailable?: string;
   metricModel: K8sKind;
   humanize: Humanize;
   ocsVersion?: string;

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/utils.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/utils.tsx
@@ -29,8 +29,7 @@ const addOthers = (
 
 export const addAvailable = (
   stats: StackDataPoint[],
-  capacityTotal: string,
-  capacityUsed: string,
+  capacityAvailable: string,
   metricTotal: string,
   humanize: Humanize,
 ) => {
@@ -41,8 +40,8 @@ export const addAvailable = (
     othersData = addOthers(stats, metricTotal, humanize);
     newChartData = [...stats, othersData] as StackDataPoint[];
   }
-  if (capacityTotal) {
-    const availableInBytes = Number(capacityTotal) - Number(capacityUsed);
+  if (capacityAvailable) {
+    const availableInBytes = Number(capacityAvailable);
     availableData = {
       x: '0',
       y: availableInBytes,

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.tsx
@@ -46,7 +46,7 @@ const BreakdownCard: React.FC<DashboardItemProps> = ({
   const top5SortedMetricsData = sortInstantVectorStats(top6MetricsData);
   const top5MetricsStats = getStackChartStats(top5SortedMetricsData, humanize);
   const metricTotal = _.get(results[1], 'data.result[0].value[1]');
-  const cephTotal = _.get(results[2], 'data.result[0].value[1]');
+  const cephAvailable = _.get(results[2], 'data.result[0].value[1]');
   const cephUsed = _.get(results[3], 'data.result[0].value[1]');
   const link = `topk(20, (${CAPACITY_BREAKDOWN_QUERIES[queryKeys[0]]}))`;
 
@@ -70,7 +70,7 @@ const BreakdownCard: React.FC<DashboardItemProps> = ({
           hasLoadError={queriesLoadError}
           metricTotal={metricTotal}
           top5MetricsStats={top5MetricsStats}
-          capacityTotal={cephTotal}
+          capacityAvailable={cephAvailable}
           capacityUsed={cephUsed}
           metricModel={model}
           humanize={humanize}

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
@@ -19,7 +19,6 @@ import {
   StorageDashboardQuery,
   UTILIZATION_QUERY,
   utilizationPopoverQueryMap,
-  TOTAL_QUERY,
 } from '../../../../constants/queries';
 import { humanizeIOPS, humanizeLatency } from './utils';
 
@@ -49,7 +48,6 @@ const UtilizationCard: React.FC = () => {
         <PrometheusUtilizationItem
           title="Used Capacity"
           utilizationQuery={UTILIZATION_QUERY[StorageDashboardQuery.CEPH_CAPACITY_USED]}
-          totalQuery={TOTAL_QUERY[StorageDashboardQuery.CEPH_CAPACITY_TOTAL]}
           duration={duration}
           humanizeValue={humanizeBinaryBytes}
           byteDataType={ByteDataTypes.BinaryBytes}

--- a/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
@@ -23,6 +23,7 @@ export enum StorageDashboardQuery {
   NODES_BY_USED = 'NODES_BY_USED',
   USED_CAPACITY = 'USED_CAPACITY',
   REQUESTED_CAPACITY = 'REQUESTED_CAPACITY',
+  CEPH_CAPACITY_AVAILABLE = 'CEPH_CAPACITY_AVAILABLE',
 }
 
 export const INDEPENDENT_UTILIZATION_QUERIES = {
@@ -41,7 +42,8 @@ export const DATA_RESILIENCY_QUERY = {
 };
 
 export const UTILIZATION_QUERY = {
-  [StorageDashboardQuery.CEPH_CAPACITY_USED]: 'ceph_cluster_total_used_bytes',
+  [StorageDashboardQuery.CEPH_CAPACITY_USED]:
+    'sum(kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"}))',
   [StorageDashboardQuery.UTILIZATION_IOPS_QUERY]:
     '(sum(rate(ceph_pool_wr[1m])) + sum(rate(ceph_pool_rd[1m])))',
   [StorageDashboardQuery.UTILIZATION_LATENCY_QUERY]:
@@ -79,7 +81,10 @@ export const CAPACITY_BREAKDOWN_QUERIES = {
   [StorageDashboardQuery.PODS_BY_USED]:
     'sum((kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_right() kube_pod_spec_volumes_persistentvolumeclaims_info) * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"})) by (pod,namespace)',
   [StorageDashboardQuery.CEPH_CAPACITY_TOTAL]: 'ceph_cluster_total_bytes',
-  [StorageDashboardQuery.CEPH_CAPACITY_USED]: 'ceph_cluster_total_used_bytes',
+  [StorageDashboardQuery.CEPH_CAPACITY_USED]:
+    'sum(kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"}))',
+  [StorageDashboardQuery.CEPH_CAPACITY_AVAILABLE]:
+    'max(ceph_pool_max_avail * on (pool_id) group_left(name)ceph_pool_metadata{name=~"(.*file.*)|(.*block.*)"})',
 };
 
 export const breakdownQueryMap = {
@@ -92,8 +97,8 @@ export const breakdownQueryMap = {
       })))`,
       [StorageDashboardQuery.PROJECTS_TOTAL_USED]:
         CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.PROJECTS_TOTAL_USED],
-      [StorageDashboardQuery.CEPH_CAPACITY_TOTAL]:
-        CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_TOTAL],
+      [StorageDashboardQuery.CEPH_CAPACITY_AVAILABLE]:
+        CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_AVAILABLE],
       [StorageDashboardQuery.CEPH_CAPACITY_USED]:
         CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_USED],
     },
@@ -107,8 +112,8 @@ export const breakdownQueryMap = {
       })))`,
       [StorageDashboardQuery.STORAGE_CLASSES_TOTAL_USED]:
         CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.STORAGE_CLASSES_TOTAL_USED],
-      [StorageDashboardQuery.CEPH_CAPACITY_TOTAL]:
-        CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_TOTAL],
+      [StorageDashboardQuery.CEPH_CAPACITY_AVAILABLE]:
+        CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_AVAILABLE],
       [StorageDashboardQuery.CEPH_CAPACITY_USED]:
         CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_USED],
     },
@@ -122,8 +127,8 @@ export const breakdownQueryMap = {
       })))`,
       [StorageDashboardQuery.PODS_TOTAL_USED]:
         CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.PODS_TOTAL_USED],
-      [StorageDashboardQuery.CEPH_CAPACITY_TOTAL]:
-        CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_TOTAL],
+      [StorageDashboardQuery.CEPH_CAPACITY_AVAILABLE]:
+        CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_AVAILABLE],
       [StorageDashboardQuery.CEPH_CAPACITY_USED]:
         CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_USED],
     },


### PR DESCRIPTION

![Screenshot from 2020-06-16 20-14-06](https://user-images.githubusercontent.com/25664409/84872257-4a3cab00-b09f-11ea-80d4-d33d8a1996eb.png)
**Bug:**
We had the inconsistency in capacities:
- _Used/available on card:_ showing replicated capacity and  accounting all block/file/object. It shows actual storage usage.
- _The legends of card that exist below the bar show and the colored bars:_ showing non-replicated capacity and accounting only block/file. It shows provisioned storage.

**Fix:**
 - Showing only non replicated capacity and storage provisioned for use (in used and available over bar)
 - Showing only block and file storage capacities and storage provisioned for use (in used and available over bar)
 - Omitting the total used capacity from utilization card and breakdown card.

https://issues.redhat.com/browse/RHSTOR-1111

Signed-off-by: Afreen Rahman <afrahman@redhat.com>
Co-authored-by: Anmol Sachan <asachan@redhat.com>