### PR TITLE
Alert when stopping a vm with logged in users

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/confirm-vmi-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/confirm-vmi-modal.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { HandlePromiseProps, withHandlePromise } from '@console/internal/components/utils';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+  ModalComponentProps,
+} from '@console/internal/components/factory';
+import { VMIKind } from '../../../types';
+import { VMIUsersAlert } from './vmi-users-alert';
+import { redirectToList } from './utils';
+
+export const ConfirmVMIModal = withHandlePromise((props: ConfirmVMIModalProps) => {
+  const {
+    inProgress,
+    errorMessage,
+    handlePromise,
+    close,
+    cancel,
+    vmi,
+    title,
+    message,
+    executeFn,
+    btnText,
+    cancelText,
+    alertTitle,
+    submitDanger,
+  } = props;
+
+  const submit = (e) => {
+    e.preventDefault();
+
+    return handlePromise(executeFn())
+      .then(close)
+      .then(() => redirectToList(vmi));
+  };
+
+  return (
+    <form onSubmit={submit} className="modal-content">
+      <ModalTitle>{title}</ModalTitle>
+      <ModalBody>{message}</ModalBody>
+      <VMIUsersAlert vmi={vmi} cancel={cancel} alertTitle={alertTitle} />
+      <ModalSubmitFooter
+        errorMessage={errorMessage}
+        submitDisabled={inProgress}
+        inProgress={inProgress}
+        submitText={btnText || 'Confirm'}
+        submitDanger={submitDanger}
+        cancel={cancel}
+        cancelText={cancelText || 'Cancel'}
+      />
+    </form>
+  );
+});
+
+export type ConfirmVMIModalProps = {
+  vmi: VMIKind;
+  message: React.ReactNode | string;
+  title: React.ReactNode | string;
+  executeFn: () => Promise<any>;
+  btnText?: React.ReactNode | string;
+  cancelText?: React.ReactNode | string;
+  alertTitle?: string;
+  submitDanger?: boolean;
+} & ModalComponentProps &
+  HandlePromiseProps;
+
+export const confirmVMIModal = createModalLauncher(ConfirmVMIModal);

--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vm-template-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vm-template-modal.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { HandlePromiseProps, withHandlePromise } from '@console/internal/components/utils';
+import { YellowExclamationTriangleIcon } from '@console/shared/src/components/status/icons';
+import { getName, getNamespace } from '@console/shared/src/selectors/common';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+  ModalComponentProps,
+} from '@console/internal/components/factory';
+import { TemplateModel } from '@console/internal/models';
+import { apiVersionForModel, TemplateKind } from '@console/internal/module/k8s';
+import { asVM, getVolumes } from '../../../selectors/vm';
+import { useOwnedVolumeReferencedResources } from '../../../hooks/use-owned-volume-referenced-resources';
+import { useUpToDateVMLikeEntity } from '../../../hooks/use-vm-like-entity';
+import { deleteVMTemplate } from '../../../k8s/requests/vmtemplate/actions';
+import { redirectToList } from './utils';
+
+export const DeleteVMTemplateModal = withHandlePromise((props: DeleteVMTemplateModalProps) => {
+  const { inProgress, errorMessage, handlePromise, close, cancel, vmTemplate } = props;
+  const vmTemplateUpToDate = useUpToDateVMLikeEntity<TemplateKind>(vmTemplate);
+  const [deleteDisks, setDeleteDisks] = React.useState<boolean>(true);
+
+  const namespace = getNamespace(vmTemplateUpToDate);
+  const name = getName(vmTemplateUpToDate);
+
+  const vmTemplateReference = {
+    name,
+    kind: TemplateModel.kind,
+    apiVersion: apiVersionForModel(TemplateModel),
+  } as any;
+
+  const [ownedVolumeResources, isOwnedVolumeResourcesLoaded] = useOwnedVolumeReferencedResources(
+    vmTemplateReference,
+    namespace,
+    getVolumes(asVM(vmTemplateUpToDate), null),
+  );
+  const isInProgress = inProgress || !isOwnedVolumeResourcesLoaded;
+  const numOfAllResources = ownedVolumeResources.length;
+
+  const submit = (e) => {
+    e.preventDefault();
+
+    const promise = deleteVMTemplate(vmTemplateUpToDate, {
+      ownedVolumeResources,
+      deleteOwnedVolumeResources: deleteDisks,
+    });
+
+    return handlePromise(promise)
+      .then(close)
+      .then(() => redirectToList(vmTemplateUpToDate, 'templates'));
+  };
+
+  return (
+    <form onSubmit={submit} className="modal-content">
+      <ModalTitle>
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete Virtual Machine
+        Template?
+      </ModalTitle>
+      <ModalBody>
+        Are you sure you want to delete <strong className="co-break-word">{name}</strong> in
+        namespace <strong>{namespace}</strong>?
+        {numOfAllResources > 0 && (
+          <p>
+            The following resources will be deleted along with this virtual machine template.
+            Unchecked items will not be deleted.
+          </p>
+        )}
+        {ownedVolumeResources.length > 0 && (
+          <div className="checkbox">
+            <label className="control-label">
+              <input
+                type="checkbox"
+                onChange={() => setDeleteDisks(!deleteDisks)}
+                checked={deleteDisks}
+              />
+              Delete Disks ({ownedVolumeResources.length}x)
+            </label>
+          </div>
+        )}
+      </ModalBody>
+      <ModalSubmitFooter
+        errorMessage={errorMessage}
+        submitDisabled={isInProgress}
+        inProgress={isInProgress}
+        submitText="Delete"
+        submitDanger
+        cancel={cancel}
+      />
+    </form>
+  );
+});
+
+export type DeleteVMTemplateModalProps = {
+  vmTemplate: TemplateKind;
+} & ModalComponentProps &
+  HandlePromiseProps;
+
+export const deleteVMTemplateModal = createModalLauncher(DeleteVMTemplateModal);

--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vmi-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/delete-vmi-modal.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { apiVersionForModel } from '@console/internal/module/k8s';
+import { HandlePromiseProps, withHandlePromise } from '@console/internal/components/utils';
+import { YellowExclamationTriangleIcon } from '@console/shared/src/components/status/icons';
+import { getName, getNamespace } from '@console/shared/src/selectors/common';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+  ModalComponentProps,
+} from '@console/internal/components/factory';
+import { getVMIVolumes } from '../../../selectors/vmi';
+import { VMIKind } from '../../../types';
+import { deleteVMI } from '../../../k8s/requests/vmi/actions';
+import { useOwnedVolumeReferencedResources } from '../../../hooks/use-owned-volume-referenced-resources';
+import { useUpToDateVMLikeEntity } from '../../../hooks/use-vm-like-entity';
+import { VirtualMachineInstanceModel } from '../../../models';
+import { redirectToList } from './utils';
+import { VMIUsersAlert } from './vmi-users-alert';
+
+export const DeleteVMIModal = withHandlePromise((props: DeleteVMIProps) => {
+  const { inProgress, errorMessage, handlePromise, close, cancel, vmi } = props;
+
+  const vmiUpToDate = useUpToDateVMLikeEntity<VMIKind>(vmi);
+  const [deleteDisks, setDeleteDisks] = React.useState<boolean>(true);
+
+  const namespace = getNamespace(vmiUpToDate);
+  const name = getName(vmiUpToDate);
+
+  const vmiReference = {
+    name,
+    kind: VirtualMachineInstanceModel.kind,
+    apiVersion: apiVersionForModel(VirtualMachineInstanceModel),
+  } as any;
+
+  const [ownedVolumeResources, isOwnedVolumeResourcesLoaded] = useOwnedVolumeReferencedResources(
+    vmiReference,
+    namespace,
+    getVMIVolumes(vmiUpToDate, null),
+  );
+  const isInProgress = inProgress || !isOwnedVolumeResourcesLoaded;
+  const numOfAllResources = ownedVolumeResources.length;
+
+  const submit = (e) => {
+    e.preventDefault();
+
+    const promise = deleteVMI(vmiUpToDate, {
+      ownedVolumeResources,
+      deleteOwnedVolumeResources: deleteDisks,
+    });
+
+    return handlePromise(promise)
+      .then(close)
+      .then(() => redirectToList(vmiUpToDate));
+  };
+
+  const alertHref = `/k8s/ns/${namespace}/virtualmachineinstances/${name}/details#logged-in-users`;
+
+  return (
+    <form onSubmit={submit} className="modal-content">
+      <ModalTitle>
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete Virtual Machine
+        Instance?
+      </ModalTitle>
+      <ModalBody>
+        Are you sure you want to delete <strong className="co-break-word">{name}</strong> in
+        namespace <strong>{namespace}</strong>?
+        {numOfAllResources > 0 && (
+          <p>
+            The following resources will be deleted along with this virtual machine instance.
+            Unchecked items will not be deleted.
+          </p>
+        )}
+        {ownedVolumeResources.length > 0 && (
+          <div className="checkbox">
+            <label className="control-label">
+              <input
+                type="checkbox"
+                onChange={() => setDeleteDisks(!deleteDisks)}
+                checked={deleteDisks}
+              />
+              Delete Disks ({ownedVolumeResources.length}x)
+            </label>
+          </div>
+        )}
+      </ModalBody>
+      <VMIUsersAlert
+        vmi={vmiUpToDate}
+        cancel={cancel}
+        alertTitle="Delete Virtual Machine Instance alert"
+        alertHref={alertHref}
+      />
+      <ModalSubmitFooter
+        errorMessage={errorMessage}
+        submitDisabled={isInProgress}
+        inProgress={isInProgress}
+        submitText="Delete"
+        submitDanger
+        cancel={cancel}
+      />
+    </form>
+  );
+});
+
+export type DeleteVMIProps = {
+  vmi: VMIKind;
+} & ModalComponentProps &
+  HandlePromiseProps;
+
+export const deleteVMIModal = createModalLauncher(DeleteVMIModal);

--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/utils.ts
@@ -1,0 +1,11 @@
+import { history } from '@console/internal/components/utils';
+import { getName, getNamespace } from '@console/shared/src/selectors/common';
+import { VMGenericLikeEntityKind } from 'packages/kubevirt-plugin/src/types/vmLike';
+
+export const redirectToList = (vmi: VMGenericLikeEntityKind, tab?: 'templates' | '' | null) => {
+  // If we are currently on the deleted resource's page, redirect to the resource list page
+  const re = new RegExp(`/${getName(vmi)}(/|$)`);
+  if (re.test(window.location.pathname)) {
+    history.push(`/k8s/ns/${getNamespace(vmi)}/virtualization/${tab || ''}`);
+  }
+};

--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/vmi-users-alert.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/vmi-users-alert.scss
@@ -1,0 +1,3 @@
+.kubevirt-confirm-vmi-model__alert {
+    padding: 0 var(--pf-global--spacer--xl) 0;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/vmi-users-alert.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/menu-actions-modals/vmi-users-alert.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Alert, Button, pluralize } from '@patternfly/react-core';
+import { history } from '@console/internal/components/utils';
+import { getName, getNamespace } from '@console/shared/src/selectors/common';
+import { useGuestAgentInfo } from '../../../hooks/use-guest-agent-info';
+import { GuestAgentInfoWrapper } from '../../../k8s/wrapper/vm/guest-agent-info/guest-agent-info-wrapper';
+import { VMIKind } from '../../../types';
+
+import './vmi-users-alert.scss';
+
+type VMIUsersAlertProps = {
+  vmi: VMIKind;
+  alertTitle?: string;
+  cancel: () => void;
+  alertHref?: string;
+};
+
+export const VMIUsersAlert: React.FC<VMIUsersAlertProps> = ({
+  vmi,
+  cancel,
+  alertTitle,
+  alertHref,
+}) => {
+  const [guestAgentInfoRaw] = useGuestAgentInfo({ vmi });
+  const guestAgentInfo = new GuestAgentInfoWrapper(guestAgentInfoRaw);
+  const userListLength = guestAgentInfo.getNumLoggedInUsers();
+
+  const name = getName(vmi);
+  const namespace = getNamespace(vmi);
+  const defaultAlertHref = `/k8s/ns/${namespace}/virtualmachines/${name}/details#logged-in-users`;
+  const onLinkClick = () => {
+    cancel();
+    history.push(alertHref || defaultAlertHref);
+  };
+
+  const alertBody = (
+    <>
+      <Button variant="link" isInline onClick={onLinkClick}>
+        {pluralize(userListLength, 'User')}
+      </Button>{' '}
+      currently logged in to this VM. Proceeding with this operation may cause logged in users data
+      loss.
+    </>
+  );
+
+  return (
+    userListLength > 0 && (
+      <div className="kubevirt-confirm-vmi-model__alert">
+        <Alert isInline variant="warning" title={alertTitle || 'Alert'}>
+          {alertBody}
+        </Alert>
+      </div>
+    )
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -4,7 +4,7 @@ import { asAccessReview, Kebab, KebabOption } from '@console/internal/components
 import { VMWizardName, VMWizardMode } from '../../constants/vm';
 import { VirtualMachineModel } from '../../models';
 import { getVMWizardCreateLink } from '../../utils/url';
-import { deleteVMLikeEntityModal } from '../modals/delete-vm-like-entity-modal/delete-vm-like-entity-modal';
+import { deleteVMTemplateModal } from '../modals/menu-actions-modals/delete-vm-template-modal';
 
 const vmTemplateEditAction = (kind: K8sKind, obj: TemplateKind) => ({
   label: `Edit Virtual Machine Template`,
@@ -29,8 +29,8 @@ export const menuActionDeleteVMTemplate = (
 ): KebabOption => ({
   label: `Delete Virtual Machine Template`,
   callback: () =>
-    deleteVMLikeEntityModal({
-      vmLikeEntity: vmTemplate,
+    deleteVMTemplateModal({
+      vmTemplate,
     }),
   accessReview: asAccessReview(kindObj, vmTemplate, 'delete'),
 });

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-vm-like-entity.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-vm-like-entity.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { getName, getNamespace } from '@console/shared/src/selectors/common';
-import { VMLikeEntityKind } from '../types/vmLike';
+import { VMGenericLikeEntityKind } from '../types/vmLike';
 import { getVMLikeModel } from '../selectors/vm';
 
-export const useUpToDateVMLikeEntity = (vmLikeEntity: VMLikeEntityKind): VMLikeEntityKind => {
+export const useUpToDateVMLikeEntity = <P extends VMGenericLikeEntityKind>(vmLikeEntity: P): P => {
   const vmName = getName(vmLikeEntity);
   const namespace = getNamespace(vmLikeEntity);
   const model = getVMLikeModel(vmLikeEntity);
@@ -26,5 +26,5 @@ export const useUpToDateVMLikeEntity = (vmLikeEntity: VMLikeEntityKind): VMLikeE
   if (!loaded) {
     return vmLikeEntity;
   }
-  return data as VMLikeEntityKind;
+  return data as P;
 };

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vmi/actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vmi/actions.ts
@@ -1,8 +1,10 @@
 import { coFetch } from '@console/internal/co-fetch';
-import { resourceURL } from '@console/internal/module/k8s';
+import { resourceURL, k8sKill, apiVersionForModel } from '@console/internal/module/k8s';
 import { getName, getNamespace } from '@console/shared';
 import { VirtualMachineInstanceModel } from '../../../models';
+import { K8sResourceWithModel } from '../../../types/k8s-resource-with-model';
 import { VMIKind } from '../../../types/vm';
+import { freeOwnedResources } from '../free-owned-resources';
 
 export enum VMIActionType {
   Unpause = 'unpause',
@@ -30,3 +32,28 @@ const VMIActionRequest = async (vmi: VMIKind, action: VMIActionType) => {
 };
 
 export const unpauseVMI = async (vmi: VMIKind) => VMIActionRequest(vmi, VMIActionType.Unpause);
+
+export const deleteVMI = async (
+  vmi: VMIKind,
+  {
+    ownedVolumeResources,
+    deleteOwnedVolumeResources,
+  }: {
+    ownedVolumeResources: K8sResourceWithModel[];
+    deleteOwnedVolumeResources: boolean;
+  },
+) => {
+  if (ownedVolumeResources && !deleteOwnedVolumeResources) {
+    await freeOwnedResources(
+      ownedVolumeResources,
+      {
+        name: getName(vmi),
+        kind: VirtualMachineInstanceModel.kind,
+        apiVersion: apiVersionForModel(VirtualMachineInstanceModel),
+      } as any,
+      false,
+    );
+  }
+
+  await k8sKill(VirtualMachineInstanceModel, vmi);
+};


### PR DESCRIPTION
Alert when stoping a vm with logged in users

Desing: http://openshift.github.io/openshift-origin-design/designs/virtualization/4.x/expose-guest-data/expose%20guest%20data.html#details-tab

  - [x] separate different vm delete modals
  - [x] add a special delete modal for vmi
  - [x] add special modals for stop / restart
  - [x] add users logged in warning to delete/stop/restart modals

Screenshot:
![screenshot-localhost_9000-2020 06 17-15_23_30](https://user-images.githubusercontent.com/2181522/84898154-78c28200-b0af-11ea-98a2-932e31211a14.png)
![screenshot-localhost_9000-2020 06 17-15_29_14](https://user-images.githubusercontent.com/2181522/84898156-79f3af00-b0af-11ea-9235-0c134381434b.png)
![screenshot-localhost_9000-2020 06 17-15_29_51(1)](https://user-images.githubusercontent.com/2181522/84898158-79f3af00-b0af-11ea-8d74-2aabc9f1a80c.png)
