### PR TITLE
Updated approvers list for dev-console/integration-tests folder

### DIFF
--- a/frontend/packages/dev-console/integration-tests/OWNERS
+++ b/frontend/packages/dev-console/integration-tests/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - gajanan-more
+  - sanketpathak
+approvers:
+  - makambalaji

--- a/frontend/packages/knative-plugin/integration-tests/OWNERS
+++ b/frontend/packages/knative-plugin/integration-tests/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - gajanan-more
+  - sanketpathak
+approvers:
+  - makambalaji


### PR DESCRIPTION
As per the today's discussion in UI sync meeting,  updated OWNERS doc in integration-tests folder by including "makambalaji" in approvers list