### PR TITLE
Add tasks and triggers pages in console

### DIFF
--- a/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesListPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesListPage.tsx
@@ -4,6 +4,49 @@ import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import PipelineResourcesList from './PipelineResourcesList';
 import { PipelineResourceModel } from '../../../models';
+import {
+  pipelineResourceFilterReducer,
+  pipelineResourceTypeFilter,
+} from '../../../utils/pipeline-filter-reducer';
+import {
+  PipelineResourceListFilterId,
+  PipelineResourceListFilterLabels,
+} from '../../../utils/pipeline-utils';
+
+const pipelineResourceFilters = [
+  {
+    filterGroupName: 'Type',
+    type: 'pipelineresource-type',
+    reducer: pipelineResourceFilterReducer,
+    items: [
+      {
+        id: PipelineResourceListFilterId.Git,
+        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Git],
+      },
+      {
+        id: PipelineResourceListFilterId.PullRequest,
+        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.PullRequest],
+      },
+      {
+        id: PipelineResourceListFilterId.Image,
+        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Image],
+      },
+      {
+        id: PipelineResourceListFilterId.Cluster,
+        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Cluster],
+      },
+      {
+        id: PipelineResourceListFilterId.Storage,
+        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.Storage],
+      },
+      {
+        id: PipelineResourceListFilterId.CloudEvent,
+        title: PipelineResourceListFilterLabels[PipelineResourceListFilterId.CloudEvent],
+      },
+    ],
+    filter: pipelineResourceTypeFilter,
+  },
+];
 
 interface PipelineResourcesListPageProps {
   hideBadge?: boolean;
@@ -20,6 +63,7 @@ const PipelineResourcesListPage: React.FC<Omit<
       canCreate={false}
       kind={referenceForModel(PipelineResourceModel)}
       ListComponent={PipelineResourcesList}
+      rowFilters={pipelineResourceFilters}
       badge={props.hideBadge ? null : getBadgeFromType(PipelineResourceModel.badge)}
     />
   );

--- a/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
@@ -5,6 +5,8 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineResourceKind } from '../../../utils/pipeline-augment';
 import { PipelineResourceModel } from '../../../models';
 import { tableColumnClasses } from './pipeline-resources-table';
+import { PipelineResourceListFilterLabels } from '../../../utils/pipeline-utils';
+import { pipelineResourceFilterReducer } from '../../../utils/pipeline-filter-reducer';
 
 const PipelineResourcesRow: RowFunction<PipelineResourceKind> = ({ obj, index, key, style }) => {
   const pipelineResourcesReference = referenceForModel(PipelineResourceModel);
@@ -22,7 +24,9 @@ const PipelineResourcesRow: RowFunction<PipelineResourceKind> = ({ obj, index, k
       <TableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
-      <TableData className={tableColumnClasses[2]}>{obj.spec.type}</TableData>
+      <TableData className={tableColumnClasses[2]}>
+        {PipelineResourceListFilterLabels[pipelineResourceFilterReducer(obj)]}
+      </TableData>
       <TableData className={tableColumnClasses[3]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
       </TableData>

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
@@ -11,6 +11,7 @@ import { PipelineRunModel } from '../../../models';
 
 export const runFilters = [
   {
+    filterGroupName: 'Status',
     type: 'pipelinerun-status',
     selected: [
       ListFilterId.Succeeded,

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsHeader.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsHeader.tsx
@@ -1,0 +1,43 @@
+import { sortable } from '@patternfly/react-table';
+import { tableColumnClasses } from './taskruns-table';
+
+const TaskRunsHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortField: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Status',
+      sortField: 'status.conditions[0].reason',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Started',
+      sortField: 'status.startTime',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Duration',
+      sortField: 'status.completionTime',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[5] },
+    },
+  ];
+};
+
+export default TaskRunsHeader;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsList.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsList.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Table } from '@console/internal/components/factory';
+import { TaskRunModel } from '../../../models';
+import TaskRunsHeader from './TaskRunsHeader';
+import TaskRunsRow from './TaskRunsRow';
+
+const TaskRunsList: React.FC = (props) => (
+  <Table
+    {...props}
+    aria-label={TaskRunModel.labelPlural}
+    Header={TaskRunsHeader}
+    Row={TaskRunsRow}
+    virtualize
+  />
+);
+
+export default TaskRunsList;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -11,9 +11,10 @@ interface TaskRunsListPageProps {
 }
 
 const TaskRunsListPage: React.FC<Omit<
-  React.ComponentProps<typeof ListPage> & TaskRunsListPageProps,
+  React.ComponentProps<typeof ListPage>,
   'canCreate' | 'kind' | 'ListComponent' | 'rowFilters'
->> = (props) => {
+> &
+  TaskRunsListPageProps> = (props) => {
   return (
     <ListPage
       {...props}

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { getBadgeFromType } from '@console/shared';
+import { ListPage } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import TaskRunsList from './TaskRunsList';
+import { TaskRunModel } from '../../../models';
+import { runFilters as taskRunFilters } from '../../pipelines/detail-page-tabs/PipelineRuns';
+
+interface TaskRunsListPageProps {
+  hideBadge?: boolean;
+}
+
+const TaskRunsListPage: React.FC<Omit<
+  React.ComponentProps<typeof ListPage> & TaskRunsListPageProps,
+  'canCreate' | 'kind' | 'ListComponent' | 'rowFilters'
+>> = (props) => {
+  return (
+    <ListPage
+      {...props}
+      canCreate={false}
+      kind={referenceForModel(TaskRunModel)}
+      ListComponent={TaskRunsList}
+      rowFilters={taskRunFilters}
+      badge={props.hideBadge ? null : getBadgeFromType(TaskRunModel.badge)}
+    />
+  );
+};
+
+export default TaskRunsListPage;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
+import { ResourceLink, Timestamp, Kebab, ResourceKebab } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { TaskRunKind } from '../../../utils/pipeline-augment';
+import { TaskRunModel } from '../../../models';
+import { tableColumnClasses } from './taskruns-table';
+import { Status } from '@console/shared';
+import { pipelineRunFilterReducer as taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { pipelineRunDuration as taskRunDuration } from '../../../utils/pipeline-utils';
+
+const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style }) => {
+  const taskRunsReference = referenceForModel(TaskRunModel);
+  return (
+    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink
+          kind={taskRunsReference}
+          name={obj.metadata.name}
+          namespace={obj.metadata.namespace}
+          title={obj.metadata.name}
+          data-test-id={obj.metadata.name}
+        />
+      </TableData>
+      <TableData className={tableColumnClasses[1]}>
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <Status status={taskRunFilterReducer(obj)} />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <Timestamp timestamp={obj?.status?.startTime} />
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>{taskRunDuration(obj)}</TableData>
+      <TableData className={tableColumnClasses[5]}>
+        <ResourceKebab actions={Kebab.factory.common} kind={taskRunsReference} resource={obj} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+export default TaskRunsRow;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/taskruns-table.ts
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/taskruns-table.ts
@@ -1,0 +1,10 @@
+import { Kebab } from '@console/internal/components/utils';
+
+export const tableColumnClasses = [
+  '', // name
+  '', // namespace
+  'pf-m-hidden pf-m-visible-on-sm', // status
+  'pf-m-hidden pf-m-visible-on-sm', // started
+  'pf-m-hidden pf-m-visible-on-sm', // duration
+  Kebab.columnClass,
+];

--- a/frontend/packages/dev-console/src/components/tasks-lists/TasksListsPage.tsx
+++ b/frontend/packages/dev-console/src/components/tasks-lists/TasksListsPage.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { match as Rmatch } from 'react-router-dom';
+import MultiTabListPage from '../multi-tab-list/MultiTabListPage';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { TaskModel, ClusterTaskModel, TaskRunModel } from '../../models';
+import { Page } from '@console/internal/components/utils';
+import { TechPreviewBadge } from '@console/shared';
+import { DefaultPage } from '@console/internal/components/default-resource';
+import TaskRunsListPage from '../taskruns/list-page/TaskRunsListPage';
+import { MenuActions } from '../multi-tab-list/multi-tab-list-page-types';
+
+interface TasksListsPageProps {
+  match: Rmatch<any>;
+}
+
+const TasksListsPage: React.FC<TasksListsPageProps> = ({ match }) => {
+  const {
+    params: { ns: namespace },
+  } = match;
+  const [showTitle, canCreate, hideBadge] = [false, false, true];
+  const menuActions: MenuActions = {
+    tasks: { model: TaskModel },
+    taskRun: { model: TaskRunModel },
+    clusterTask: { model: ClusterTaskModel },
+  };
+  const pages: Page[] = [
+    {
+      href: '',
+      name: TaskModel.labelPlural,
+      component: DefaultPage,
+      pageData: {
+        kind: referenceForModel(TaskModel),
+        canCreate,
+        namespace,
+        showTitle,
+      },
+    },
+    {
+      href: 'task-runs',
+      name: TaskRunModel.labelPlural,
+      component: TaskRunsListPage,
+      pageData: {
+        hideBadge,
+        showTitle,
+      },
+    },
+    {
+      href: 'cluster-tasks',
+      name: ClusterTaskModel.labelPlural,
+      component: DefaultPage,
+      pageData: {
+        kind: referenceForModel(ClusterTaskModel),
+        canCreate,
+        showTitle,
+      },
+    },
+  ];
+
+  return (
+    <MultiTabListPage
+      pages={pages}
+      match={match}
+      title="Tasks"
+      badge={<TechPreviewBadge />}
+      menuActions={menuActions}
+    />
+  );
+};
+
+export default TasksListsPage;

--- a/frontend/packages/dev-console/src/components/triggers-lists/TriggersPage.tsx
+++ b/frontend/packages/dev-console/src/components/triggers-lists/TriggersPage.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { match as Rmatch } from 'react-router-dom';
+import MultiTabListPage from '../multi-tab-list/MultiTabListPage';
+import { referenceForModel } from '@console/internal/module/k8s';
+import {
+  EventListenerModel,
+  TriggerTemplateModel,
+  TriggerBindingModel,
+  ClusterTriggerBindingModel,
+} from '../../models';
+import { Page } from '@console/internal/components/utils';
+import { TechPreviewBadge } from '@console/shared';
+import { DefaultPage } from '@console/internal/components/default-resource';
+
+interface TriggersPageProps {
+  match: Rmatch<any>;
+}
+
+const TriggersPage: React.FC<TriggersPageProps> = ({ match }) => {
+  const {
+    params: { ns: namespace },
+  } = match;
+  const [showTitle, canCreate] = [false, false];
+  const menuActions = {
+    eventListener: { model: EventListenerModel },
+    triggerTemplate: { model: TriggerTemplateModel },
+    triggerBinding: { model: TriggerBindingModel },
+    culsterTriggerBinding: { model: ClusterTriggerBindingModel },
+  };
+  const pages: Page[] = [
+    {
+      href: '',
+      name: EventListenerModel.labelPlural,
+      component: DefaultPage,
+      pageData: {
+        kind: referenceForModel(EventListenerModel),
+        canCreate,
+        namespace,
+        showTitle,
+      },
+    },
+    {
+      href: 'trigger-templates',
+      name: TriggerTemplateModel.labelPlural,
+      component: DefaultPage,
+      pageData: {
+        kind: referenceForModel(TriggerTemplateModel),
+        canCreate,
+        namespace,
+        showTitle,
+      },
+    },
+    {
+      href: 'trigger-bindings',
+      name: TriggerBindingModel.labelPlural,
+      component: DefaultPage,
+      pageData: {
+        kind: referenceForModel(TriggerBindingModel),
+        canCreate,
+        namespace,
+        showTitle,
+      },
+    },
+    {
+      href: 'cluster-trigger-bindings',
+      name: ClusterTriggerBindingModel.labelPlural,
+      component: DefaultPage,
+      pageData: {
+        kind: referenceForModel(ClusterTriggerBindingModel),
+        canCreate,
+        showTitle,
+      },
+    },
+  ];
+
+  return (
+    <MultiTabListPage
+      pages={pages}
+      match={match}
+      title="Triggers"
+      badge={<TechPreviewBadge />}
+      menuActions={menuActions}
+    />
+  );
+};
+
+export default TriggersPage;

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -247,13 +247,13 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'NavItem/ResourceNS',
+    type: 'NavItem/Href',
     properties: {
       perspective: 'admin',
       section: 'Pipelines',
       componentProps: {
         name: TaskModel.labelPlural,
-        resource: referenceForModel(TaskModel),
+        href: '/tasks',
       },
     },
     flags: {
@@ -261,27 +261,13 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'NavItem/ResourceNS',
+    type: 'NavItem/Href',
     properties: {
       perspective: 'admin',
       section: 'Pipelines',
       componentProps: {
-        name: TaskRunModel.labelPlural,
-        resource: referenceForModel(TaskRunModel),
-      },
-    },
-    flags: {
-      required: [FLAG_OPENSHIFT_PIPELINE],
-    },
-  },
-  {
-    type: 'NavItem/ResourceCluster',
-    properties: {
-      perspective: 'admin',
-      section: 'Pipelines',
-      componentProps: {
-        name: ClusterTaskModel.labelPlural,
-        resource: referenceForModel(ClusterTaskModel),
+        name: 'Triggers',
+        href: '/triggers',
       },
     },
     flags: {
@@ -430,6 +416,8 @@ const plugin: Plugin<ConsumedExtensions> = [
         '/dev-monitoring',
         '/helm-releases',
         '/pipelines',
+        '/tasks',
+        '/triggers',
       ],
       component: NamespaceRedirect,
     },
@@ -525,6 +513,32 @@ const plugin: Plugin<ConsumedExtensions> = [
         (
           await import(
             './components/pipelines-lists/PipelinesListsPage' /* webpackChunkName: "admin-pipeline" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: false,
+      path: ['/tasks/all-namespaces', '/tasks/ns/:ns'],
+      loader: async () =>
+        (
+          await import(
+            './components/tasks-lists/TasksListsPage' /* webpackChunkName: "admin-tasks`" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: false,
+      path: ['/triggers/all-namespaces', '/triggers/ns/:ns'],
+      loader: async () =>
+        (
+          await import(
+            './components/triggers-lists/TriggersPage' /* webpackChunkName: "admin-triggers" */
           )
         ).default,
     },

--- a/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
@@ -46,3 +46,15 @@ export const pipelineRunStatusFilter = (phases, pipeline) => {
   const status = pipelineRunFilterReducer(pipeline);
   return phases.selected.has(status) || !_.includes(phases.all, status);
 };
+
+export const pipelineResourceFilterReducer = (pipelineResource): string => {
+  return pipelineResource.spec.type;
+};
+
+export const pipelineResourceTypeFilter = (filters, pipelineResource): boolean => {
+  if (!filters || !filters.selected || !filters.selected.size) {
+    return true;
+  }
+  const type = pipelineResourceFilterReducer(pipelineResource);
+  return filters.selected.has(type) || !_.includes(filters.all, type);
+};

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -85,6 +85,24 @@ export const ListFilterLabels = {
   [ListFilterId.Other]: 'Other',
 };
 
+export enum PipelineResourceListFilterId {
+  Git = 'git',
+  PullRequest = 'pullRequest',
+  Image = 'image',
+  Cluster = 'cluster',
+  Storage = 'storage',
+  CloudEvent = 'cloudEvent',
+}
+
+export const PipelineResourceListFilterLabels = {
+  [PipelineResourceListFilterId.Git]: 'Git',
+  [PipelineResourceListFilterId.PullRequest]: 'Pull Request',
+  [PipelineResourceListFilterId.Image]: 'Image',
+  [PipelineResourceListFilterId.Cluster]: 'Cluster',
+  [PipelineResourceListFilterId.Storage]: 'Storage',
+  [PipelineResourceListFilterId.CloudEvent]: 'Cloud Event',
+};
+
 // to be used by both Pipeline and Pipelinerun visualisation
 const sortTasksByRunAfterAndFrom = (
   tasks: PipelineVisualizationTaskItem[],

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -27,6 +27,7 @@ import {
   PipelineTaskRef,
   PipelineWorkspace,
   PipelineRunWorkspace,
+  TaskRunKind,
 } from './pipeline-augment';
 import { pipelineFilterReducer, pipelineRunStatus } from './pipeline-filter-reducer';
 
@@ -356,11 +357,11 @@ export const calculateRelativeTime = (startTime: string, completionTime?: string
   return 'a few seconds';
 };
 
-export const pipelineRunDuration = (run: PipelineRun): string => {
+export const pipelineRunDuration = (run: PipelineRun | TaskRunKind): string => {
   const startTime = _.get(run, ['status', 'startTime'], null);
   const completionTime = _.get(run, ['status', 'completionTime'], null);
 
-  // Duration cannot be computed if start time is missing or a completed/failed pipeline has no end time
+  // Duration cannot be computed if start time is missing or a completed/failed pipeline/task has no end time
   if (!startTime || (!completionTime && pipelineRunStatus(run) !== 'Running')) {
     return '-';
   }


### PR DESCRIPTION
Jira Story - https://issues.redhat.com/browse/ODC-4007

In this PR I have added tasks and triggers pages to pipelines nav in console, created custom task-runs list page and added filters to pipeline-resources list page.

Screenshot:
![image](https://user-images.githubusercontent.com/20724543/85031930-df719980-b19c-11ea-96f3-555f9ff17bc6.png)

![image](https://user-images.githubusercontent.com/20724543/85032554-99690580-b19d-11ea-9a0f-31bc0e0f69c3.png)


Note -
This PR has a dependency on https://github.com/openshift/console/pull/5700