### PR TITLE
Bug 1795387: Query Browser: Remove single column table layout

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -398,7 +398,18 @@ $monitoring-line-height: 18px;
 
 .query-browser__table-cell {
   @include co-break-word;
-  padding-right: 0 !important;
+  min-width: 120px;
+  --pf-c-table-cell--PaddingRight: 0;
+  --pf-c-table__sort-indicator--MarginLeft: 4px;
+}
+
+.query-browser__table-wrapper {
+  overflow-x: scroll;
+  width: 100%;
+
+  table {
+    table-layout: auto;
+  }
 }
 
 .query-browser__table-message {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -753,38 +753,26 @@ const QueryTable_: React.FC<QueryTableProps> = ({
     }
   }
 
-  // Set the result table's break point based on the number of columns
-  let breakPoint: keyof typeof TableGridBreakpoint = 'grid';
-  if (columns.length <= 2) {
-    breakPoint = 'none';
-  } else if (columns.length <= 5) {
-    breakPoint = 'gridMd';
-  } else if (columns.length <= 8) {
-    breakPoint = 'gridLg';
-  } else if (columns.length <= 11) {
-    breakPoint = 'gridXl';
-  } else if (columns.length <= 14) {
-    breakPoint = 'grid2xl';
-  }
-
   const onSort = (e, i, direction) => setSortBy({ index: i, direction });
 
   const tableRows = rows.slice((page - 1) * perPage, page * perPage).map((cells) => ({ cells }));
 
   return (
     <>
-      <Table
-        aria-label="query results table"
-        cells={columns}
-        gridBreakPoint={TableGridBreakpoint[breakPoint]}
-        onSort={onSort}
-        rows={tableRows}
-        sortBy={sortBy}
-        variant={TableVariant.compact}
-      >
-        <TableHeader />
-        <TableBody />
-      </Table>
+      <div className="query-browser__table-wrapper">
+        <Table
+          aria-label="query results table"
+          cells={columns}
+          gridBreakPoint={TableGridBreakpoint.none}
+          onSort={onSort}
+          rows={tableRows}
+          sortBy={sortBy}
+          variant={TableVariant.compact}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+      </div>
       <TablePagination
         itemCount={rows.length}
         page={page}


### PR DESCRIPTION
When there are many columns, always use the grid layout instead of
switching to the single column layout.

This significantly improves performances for queries that return many
labels.

![screenshot](https://user-images.githubusercontent.com/460802/84758736-d21fa800-b000-11ea-9467-ac70a5735307.png)

FYI @cshinn, @sichvoge 