### PR TITLE
Add Context Provider extension API

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -15,3 +15,4 @@ export * from './clusterserviceversions';
 export * from './dev-catalog';
 export * from './reducers';
 export * from './horizontal-nav';
+export * from './providers';

--- a/frontend/packages/console-plugin-sdk/src/typings/providers.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/providers.ts
@@ -1,0 +1,20 @@
+import { Provider } from 'react';
+import { Extension } from './base';
+
+namespace ExtensionProperties {
+  export interface ContextProvider<T> {
+    /** Context Provider Exotic Component. */
+    Provider: Provider<T>;
+    /** Hook for the Context value. */
+    useValueHook: () => T;
+  }
+}
+
+export interface ContextProvider<R = any>
+  extends Extension<ExtensionProperties.ContextProvider<R>> {
+  type: 'ContextProvider';
+}
+
+export const isContextProvider = (e: Extension): e is ContextProvider => {
+  return e.type === 'ContextProvider';
+};

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -25,6 +25,8 @@ import {
   Perspective,
   RoutePage,
   isRoutePage,
+  ContextProvider,
+  isContextProvider,
 } from '@console/plugin-sdk';
 
 const RedirectComponent = (props) => {
@@ -94,18 +96,24 @@ const getPluginPageRoutes = (activePerspective: string, routePages: RoutePage[])
     return <Component {...r.properties} key={Array.from(r.properties.path).join(',')} />;
   });
 
+const EnhancedProvider = ({ Provider, useValueHook, children }) => {
+  const value = useValueHook();
+  return <Provider value={value}>{children}</Provider>;
+};
+
 type AppContentsProps = {
   activePerspective: string;
 };
 
 const AppContents_: React.FC<AppContentsProps> = ({ activePerspective }) => {
+  const contextProviderExtensions = useExtensions<ContextProvider>(isContextProvider);
   const routePageExtensions = useExtensions<RoutePage>(isRoutePage);
   const pluginPageRoutes = React.useMemo(
     () => getPluginPageRoutes(activePerspective, routePageExtensions),
     [activePerspective, routePageExtensions],
   );
 
-  return (
+  const content = (
     <PageSection variant={PageSectionVariants.light}>
       <div id="content">
         <GlobalNotifications />
@@ -646,6 +654,13 @@ const AppContents_: React.FC<AppContentsProps> = ({ activePerspective }) => {
         </div>
       </div>
     </PageSection>
+  );
+
+  return contextProviderExtensions.reduce(
+    (children, provider) => (
+      <EnhancedProvider {...provider.properties}>{children}</EnhancedProvider>
+    ),
+    content,
   );
 };
 

--- a/frontend/public/components/utils/async.tsx
+++ b/frontend/public/components/utils/async.tsx
@@ -20,6 +20,7 @@ export class AsyncComponent extends React.Component<AsyncComponentProps, AsyncCo
 
   private retryCount: number = 0;
   private maxRetries: number = 25;
+  private isAsyncMounted: boolean = false;
 
   static getDerivedStateFromProps(props, state) {
     if (!sameLoader(props.loader)(state.loader)) {
@@ -35,9 +36,14 @@ export class AsyncComponent extends React.Component<AsyncComponentProps, AsyncCo
   }
 
   componentDidMount() {
+    this.isAsyncMounted = true;
     if (this.state.Component === null) {
       this.loadComponent();
     }
+  }
+
+  componentWillUnmount() {
+    this.isAsyncMounted = false;
   }
 
   private loadComponent() {
@@ -47,7 +53,7 @@ export class AsyncComponent extends React.Component<AsyncComponentProps, AsyncCo
         if (!Component) {
           return Promise.reject(AsyncComponentError.ComponentNotFound);
         }
-        this.setState({ Component });
+        this.isAsyncMounted && this.setState({ Component });
       })
       .catch((error) => {
         if (error === AsyncComponentError.ComponentNotFound) {


### PR DESCRIPTION
Allow plugins to add Context Providers, this is for cases where Redux is not suitable, But you wish to preserve state across the app.
This approach adds 0 elements to the DOM, and is providing state only

the component used inside `import()` has to have a `default export`
```js
// usage example:
  {
    type: 'ContextProvider',
    properties: {
      provider: () =>
        import(
          './components/cdi-upload-provider/cdi-upload-provider' /* webpackChunkName: "kubevirt" */
        ),
      required: FLAG_KUBEVIRT,
    },
  },
```

Multiple Providers will be nested
```js
const providers = [A,B,C]

// will return
return (
<A>
   <B>
      <C>
        {App}
      </C>
   </B>
</A>
)
```