### PR TITLE
Bug 1847494: Move try sample button below git url field

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -136,6 +136,7 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
         data-test-id="git-form-input-url"
         required
       />
+      {sampleRepo && <SampleRepo onClick={fillSample} />}
       {values.git.showGitType && (
         <>
           <DropdownField
@@ -153,7 +154,6 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
           )}
         </>
       )}
-      {sampleRepo && <SampleRepo onClick={fillSample} />}
       <AdvancedGitOptions />
     </FormSection>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3149
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
If the Git Type is not auto-detected, the `Try Sample` button shifts below the `Git Type` dropdown.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Move the `try sample` component to below the git URL field
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![temp](https://user-images.githubusercontent.com/20013884/84782782-106b9600-b006-11ea-97a9-f86dd6aabca0.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
