### PR TITLE
[WIP] Hide namespace when all projects not selected pods page example

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import * as classNames from 'classnames';
 import {
   ALL_NAMESPACES_KEY,
   getNodeRoles,
@@ -74,12 +75,17 @@ const globalColumnFilter = {
 };
 
 const isColumnFiltered = (columnTitle) => {
-  return columnTitle !== globalColumnFilter.title;
+  return columnTitle === globalColumnFilter.title;
 };
 
 const getFilteredHeader = (Header, componentProps) => {
   if (UIActions.getActiveNamespace() !== ALL_NAMESPACES_KEY) {
-    return Header(componentProps).filter((column) => isColumnFiltered(column.title));
+    return Header(componentProps).map((column) => {
+      if (isColumnFiltered(column.title)) {
+        column.props.className = classNames('pf-m-hidden');
+      }
+      return column;
+    });
   }
   return Header(componentProps);
 };
@@ -351,7 +357,14 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
   return (
     <VirtualTableBody
       autoHeight
-      className="pf-c-table pf-m-compact pf-m-border-rows pf-c-virtualized pf-c-window-scroller"
+      className={classNames(
+        'pf-c-table',
+        'pf-m-compact',
+        'pf-m-border-rows',
+        'pf-c-virtualized',
+        'pf-c-window-scroller',
+        { 'co-hide-no-active-namespace': UIActions.getActiveNamespace() !== ALL_NAMESPACES_KEY },
+      )}
       deferredMeasurementCache={cellMeasurementCache}
       rowHeight={cellMeasurementCache.rowHeight}
       height={height || 0}

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import {
+  ALL_NAMESPACES_KEY,
   getNodeRoles,
   getMachinePhase,
   nodeMemory,
@@ -67,6 +68,21 @@ const getAllTableFilters = (rowFilters) => ({
   ...tableFilters,
   ...rowFiltersToFilterFuncs(rowFilters),
 });
+
+const globalColumnFilter = {
+  title: 'Namespace',
+};
+
+const isColumnFiltered = (columnTitle) => {
+  return columnTitle !== globalColumnFilter.title;
+};
+
+const getFilteredHeader = (Header, componentProps) => {
+  if (UIActions.getActiveNamespace() !== ALL_NAMESPACES_KEY) {
+    return Header(componentProps).filter((column) => isColumnFiltered(column.title));
+  }
+  return Header(componentProps);
+};
 
 const getFilteredRows = (_filters, rowFilters, objects) => {
   if (_.isEmpty(_filters)) {
@@ -468,7 +484,7 @@ export const Table = connect<
         'match',
         'kindObj',
       ]);
-      const columns = props.Header(componentProps);
+      const columns = getFilteredHeader(props.Header, componentProps);
       const { currentSortField, currentSortFunc, currentSortOrder } = props;
 
       this._columnShift = props.onSelect ? 1 : 0; //shift indexes by 1 if select provided
@@ -499,7 +515,7 @@ export const Table = connect<
         'match',
         'kindObj',
       ]);
-      const columns = this.props.Header(componentProps);
+      const columns = getFilteredHeader(this.props.Header, componentProps);
       const sp = new URLSearchParams(window.location.search);
       const columnIndex = _.findIndex(columns, { title: sp.get('sortBy') });
 
@@ -542,7 +558,7 @@ export const Table = connect<
         'match',
         'kindObj',
       ]);
-      const columns = this.props.Header(componentProps);
+      const columns = getFilteredHeader(this.props.Header, componentProps);
       const sortColumn = columns[index - this._columnShift];
       this._applySort(sortColumn.sortField, sortColumn.sortFunc, direction, sortColumn.title);
       this.setState({
@@ -577,7 +593,7 @@ export const Table = connect<
         'match',
         'kindObj',
       ]);
-      const columns = Header(componentProps);
+      const columns = getFilteredHeader(Header, componentProps);
       const ariaRowCount = componentProps.data && componentProps.data.length;
       const scrollNode = typeof scrollElement === 'function' ? scrollElement() : scrollElement;
       const renderVirtualizedTable = (scrollContainer) => (

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -251,12 +251,17 @@ export type TableRowProps = {
   className?: string;
 };
 
-export const TableData: React.SFC<TableDataProps> = ({ className, ...props }) => {
-  return <td {...props} className={className} role="gridcell" />;
+export const TableData: React.SFC<TableDataProps> = ({
+  className,
+  isFiltered = false,
+  ...props
+}) => {
+  return !isFiltered && <td {...props} className={className} role="gridcell" />;
 };
 TableData.displayName = 'TableData';
 export type TableDataProps = {
   id?: string;
+  isFiltered?: boolean;
   className?: string;
 };
 

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { ALL_NAMESPACES_KEY, Status } from '@console/shared';
+import { Status } from '@console/shared';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
 import * as UIActions from '../actions/ui';
@@ -115,6 +115,7 @@ const podRowStateToProps = ({ UI }) => ({
 
 const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(podRowStateToProps)(
   ({
+    columns,
     obj: pod,
     index,
     rowKey,
@@ -135,7 +136,7 @@ const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(p
         </TableData>
         <TableData
           className={classNames(tableColumnClasses[1], 'co-break-word')}
-          isFiltered={UIActions.getActiveNamespace() !== ALL_NAMESPACES_KEY}
+          isFiltered={_.findIndex(columns, { title: 'Namespace' }) < 0}
         >
           <ResourceLink kind="Namespace" name={namespace} />
         </TableData>
@@ -190,7 +191,6 @@ const getHeader = (showNodes) => {
         sortField: 'metadata.namespace',
         transforms: [sortable],
         props: { className: tableColumnClasses[1] },
-        isFiltered: UIActions.getActiveNamespace() !== ALL_NAMESPACES_KEY,
       },
       {
         title: 'Status',
@@ -238,7 +238,7 @@ const getHeader = (showNodes) => {
         title: '',
         props: { className: tableColumnClasses[9] },
       },
-    ].filter((column) => !column.isFiltered);
+    ];
   };
 };
 
@@ -522,6 +522,7 @@ const getRow = (showNodes) => {
       rowKey={rowArgs.key}
       style={rowArgs.style}
       showNodes={showNodes}
+      columns={rowArgs.columns}
     />
   );
 };
@@ -639,6 +640,7 @@ type PodDetailsProps = {
 };
 
 type PodTableRowProps = {
+  columns: any;
   obj: PodKind;
   index: number;
   rowKey: string;

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -115,7 +115,6 @@ const podRowStateToProps = ({ UI }) => ({
 
 const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(podRowStateToProps)(
   ({
-    columns,
     obj: pod,
     index,
     rowKey,
@@ -134,10 +133,7 @@ const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(p
         <TableData className={tableColumnClasses[0]}>
           <ResourceLink kind={kind} name={name} namespace={namespace} />
         </TableData>
-        <TableData
-          className={classNames(tableColumnClasses[1], 'co-break-word')}
-          isFiltered={_.findIndex(columns, { title: 'Namespace' }) < 0}
-        >
+        <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
           <ResourceLink kind="Namespace" name={namespace} />
         </TableData>
         <TableData className={tableColumnClasses[2]}>
@@ -522,7 +518,6 @@ const getRow = (showNodes) => {
       rowKey={rowArgs.key}
       style={rowArgs.style}
       showNodes={showNodes}
-      columns={rowArgs.columns}
     />
   );
 };
@@ -640,7 +635,6 @@ type PodDetailsProps = {
 };
 
 type PodTableRowProps = {
-  columns: any;
   obj: PodKind;
   index: number;
   rowKey: string;

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { Status } from '@console/shared';
+import { ALL_NAMESPACES_KEY, Status } from '@console/shared';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
 import * as UIActions from '../actions/ui';
@@ -133,7 +133,10 @@ const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(p
         <TableData className={tableColumnClasses[0]}>
           <ResourceLink kind={kind} name={name} namespace={namespace} />
         </TableData>
-        <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+        <TableData
+          className={classNames(tableColumnClasses[1], 'co-break-word')}
+          isFiltered={UIActions.getActiveNamespace() !== ALL_NAMESPACES_KEY}
+        >
           <ResourceLink kind="Namespace" name={namespace} />
         </TableData>
         <TableData className={tableColumnClasses[2]}>
@@ -187,6 +190,7 @@ const getHeader = (showNodes) => {
         sortField: 'metadata.namespace',
         transforms: [sortable],
         props: { className: tableColumnClasses[1] },
+        isFiltered: UIActions.getActiveNamespace() !== ALL_NAMESPACES_KEY,
       },
       {
         title: 'Status',
@@ -234,7 +238,7 @@ const getHeader = (showNodes) => {
         title: '',
         props: { className: tableColumnClasses[9] },
       },
-    ];
+    ].filter((column) => !column.isFiltered);
   };
 };
 

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -457,6 +457,10 @@ $co-external-link-padding-right: 15px;
   padding: 0 0 30px 0;
 }
 
+.co-hide-no-active-namespace > tbody > tr > :nth-child(2) {
+  display: none;
+}
+
 .co-m-table-grid {
   &__body {
     min-height: 50px;


### PR DESCRIPTION
This is a wip on hiding namespace in the pods table when project selector is not All Projects. This provides column filtering as a first step for column management pr which will use this mechanism to filter columns.