### PR TITLE
add Readme to install/upgrade page for current chart version

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReadmeModal.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReadmeModal.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import {
+  ModalTitle,
+  ModalBody,
+  createModalLauncher,
+  ModalComponentProps,
+} from '@console/internal/components/factory';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+
+type HelmReadmeModalProps = {
+  readme: string;
+};
+type Props = HelmReadmeModalProps & ModalComponentProps;
+
+const HelmReadmeModal: React.FunctionComponent<Props> = ({ readme, close }) => (
+  <div className="modal-content">
+    <ModalTitle close={close}>README</ModalTitle>
+    <ModalBody>
+      <SyncMarkdownView content={readme} />
+    </ModalBody>
+  </div>
+);
+
+export const helmReadmeModalLauncher = createModalLauncher<Props>(HelmReadmeModal);
+export default HelmReadmeModal;

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
@@ -57,7 +57,7 @@ export const mockHelmReleases: HelmRelease[] = [
       templates: [],
       values: {},
       schema: '',
-      files: [],
+      files: [{ name: 'README.md', data: btoa('example readme content') }],
     },
     manifest: '',
     hooks: [],

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getChartURL,
   getChartVersions,
   flattenReleaseResources,
+  getHelmChartReadme,
 } from '../helm-utils';
 import { HelmReleaseStatus } from '../helm-types';
 import {
@@ -108,5 +109,9 @@ describe('Helm Releases Utils', () => {
     mockHelmChartData[2].kubeVersion = '>= 1.13.0 < 1.14.0 || >= 1.14.1 < 1.15.0';
     chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
     expect(chartVersions).toEqual(_.omit(expectedChartVersions, '1.0.1'));
+  });
+
+  it('should return the readme for the chart provided', () => {
+    expect(getHelmChartReadme(mockHelmReleases[0].chart)).toEqual('example readme content');
   });
 });

--- a/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
@@ -15,6 +15,7 @@ export type HelmChartVersionDropdownProps = {
   chartVersion: string;
   chartName: string;
   helmAction: string;
+  onVersionChange: (chart: HelmChart) => void;
 };
 type ModalCallback = () => void;
 
@@ -22,6 +23,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   chartVersion,
   chartName,
   helmAction,
+  onVersionChange,
 }) => {
   const {
     setFieldValue,
@@ -104,6 +106,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
 
     coFetchJSON(`/api/helm/chart?url=${chartURL}`)
       .then((res: HelmChart) => {
+        onVersionChange(res);
         const chartValues = getChartValuesYAML(res);
         setFieldValue('chartValuesYAML', chartValues);
         setInitialChartYAMLValues(chartValues);

--- a/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
@@ -4,12 +4,13 @@ import { FormikProps, FormikValues } from 'formik';
 import { TextInputTypes, Grid, GridItem } from '@patternfly/react-core';
 import { InputField, FormFooter, FlexForm, YAMLEditorField } from '@console/shared';
 import FormSection from '../../import/section/FormSection';
-import { HelmActionType } from '../helm-types';
+import { HelmActionType, HelmChart } from '../helm-types';
 import HelmChartVersionDropdown from './HelmChartVersionDropdown';
 
 export interface HelmInstallUpgradeFormProps {
   chartHasValues: boolean;
   helmAction: string;
+  onVersionChange: (chart: HelmChart) => void;
 }
 
 const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUpgradeFormProps> = ({
@@ -22,6 +23,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
   helmAction,
   values,
   dirty,
+  onVersionChange,
 }) => {
   const { chartName, chartVersion } = values;
   const isSubmitDisabled =
@@ -44,6 +46,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
             chartName={chartName}
             chartVersion={chartVersion}
             helmAction={helmAction}
+            onVersionChange={onVersionChange}
           />
         </Grid>
       </FormSection>

--- a/frontend/packages/dev-console/src/components/helm/form/__tests__/HelmInstallUpgradeForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/__tests__/HelmInstallUpgradeForm.spec.tsx
@@ -9,6 +9,7 @@ describe('HelmInstallUpgradeForm', () => {
   helmInstallUpgradeFormProps = {
     chartHasValues: true,
     helmAction: 'Install',
+    onVersionChange: jest.fn(),
     values: {
       helmReleaseName: 'helm-release',
       chartName: 'helm-release',

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -174,3 +174,8 @@ export const getChartValuesYAML = (chart: HelmChart): string => {
 
   return !_.isEmpty(chart?.values) ? safeDump(chart?.values) : '';
 };
+
+export const getHelmChartReadme = (chart: HelmChart): string => {
+  const readmeFile = chart?.files?.find((file) => file.name === 'README.md');
+  return (readmeFile?.data && atob(readmeFile?.data)) ?? '';
+};

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -10,6 +10,7 @@ import { ActionGroup, Button } from '@patternfly/react-core';
 import store from '../../redux';
 import { ButtonBar } from '../utils/button-bar';
 import { history } from '../utils/router';
+import { CloseButton } from '../utils/close-button';
 
 export const createModal: CreateModal = (getModalContainer) => {
   const modalContainer = document.getElementById('modal-container');
@@ -65,10 +66,19 @@ export const createModalLauncher: CreateModalLauncher = (Component) => (props) =
 export const ModalTitle: React.SFC<ModalTitleProps> = ({
   children,
   className = 'modal-header',
+  close,
 }) => (
   <div className={className}>
     <h1 className="pf-c-title pf-m-2xl" data-test-id="modal-title">
       {children}
+      {close && (
+        <CloseButton
+          onClick={(e) => {
+            e.stopPropagation();
+            close(e);
+          }}
+        />
+      )}
     </h1>
   </div>
 );
@@ -155,6 +165,7 @@ export type ModalComponentProps = {
 
 export type ModalTitleProps = {
   className?: string;
+  close?: (e: React.SyntheticEvent<any, Event>) => void;
 };
 
 export type ModalBodyProps = {


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-4087

Solution Description:
- add a link to Readme next to the subtitle in HelmInstall and HelmUpgrade page
- clicking on the link opens a modal with the readme for the current helm chart version

Screens:
![readmeModalUpdated](https://user-images.githubusercontent.com/38663217/85639093-50391a00-b6a5-11ea-82b7-e61c78a79a47.gif)
![Screenshot from 2020-06-19 17-48-17](https://user-images.githubusercontent.com/38663217/85131793-21f6ad00-b255-11ea-8e55-d9c5e5045dcd.png)

Test Coverage:
![Screenshot from 2020-06-19 17-54-04](https://user-images.githubusercontent.com/38663217/85132208-ead4cb80-b255-11ea-9101-0d8bf3044c64.png)

Browser Conformance:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge 