### PR TITLE
Query Browser: Fix sort in example query

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -907,7 +907,7 @@ const QueryBrowserWrapper_: React.FC<QueryBrowserWrapperProps> = ({
     // Pick a suitable example query based on whether we are limiting results to a single namespace
     const text = namespace
       ? 'sum(rate(container_cpu_usage_seconds_total{image!="", container!="POD"}[5m])) by (pod)'
-      : 'sum(sort_desc(sum_over_time(ALERTS{alertstate="firing"}[24h]))) by (alertname)';
+      : 'sort_desc(sum(sum_over_time(ALERTS{alertstate="firing"}[24h])) by (alertname))';
 
     patchQuery(index, { isEnabled: true, query: text, text });
   };


### PR DESCRIPTION
For the admin perspective, fix the the example query so that its
`sort_desc` correctly sorts the results by value.

FYI @cshinn 