### PR TITLE
Bug 1847480: VM's boot order modal will not remove non-bootable disks

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
@@ -8,7 +8,7 @@ import { k8sPatch } from '@console/internal/module/k8s';
 import { PatchBuilder } from '@console/shared/src/k8s';
 import { BootableDeviceType } from '../../../types';
 import { VMLikeEntityKind } from '../../../types/vmLike';
-import { getVMLikeModel, getDevices } from '../../../selectors/vm';
+import { getVMLikeModel, getDevices, getBootableDevices } from '../../../selectors/vm';
 import { getVMLikePatches } from '../../../k8s/patches/vm-template';
 import { BootOrder, deviceKey } from '../../boot-order';
 import { DeviceType } from '../../../constants';
@@ -27,15 +27,17 @@ const BootOrderModalComponent = ({
   inProgress,
   errorMessage,
 }: BootOrderModalProps) => {
-  const [devices, setDevices] = React.useState<BootableDeviceType[]>(getDevices(vmLikeEntity));
+  const [devices, setDevices] = React.useState<BootableDeviceType[]>(
+    getBootableDevices(vmLikeEntity),
+  );
   const [initialDeviceList, setInitialDeviceList] = React.useState<BootableDeviceType[]>(
-    getDevices(vmLikeEntity),
+    getBootableDevices(vmLikeEntity),
   );
   const [showUpdatedAlert, setUpdatedAlert] = React.useState<boolean>(false);
   const [showPatchError, setPatchError] = React.useState<boolean>(false);
 
   const onReload = React.useCallback(() => {
-    const updatedDevices = getDevices(vmLikeEntity);
+    const updatedDevices = getBootableDevices(vmLikeEntity);
 
     setInitialDeviceList(updatedDevices);
     setDevices(updatedDevices);
@@ -50,7 +52,7 @@ const BootOrderModalComponent = ({
     }
 
     // Compare only bootOrder from initialDeviceList to current device list.
-    const devicesMap = createBasicLookup(getDevices(vmLikeEntity), deviceKey);
+    const devicesMap = createBasicLookup(getBootableDevices(vmLikeEntity), deviceKey);
     const updated =
       initialDeviceList.length &&
       initialDeviceList.some((d) => {
@@ -97,6 +99,7 @@ const BootOrderModalComponent = ({
         .filter((source) => source.type === DeviceType.DISK)
         .map((source) => source.value),
     ];
+
     const interfaces = [
       ...currentDevices
         .filter((source) => source.type === DeviceType.NIC)

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { BootableDeviceType, V1NetworkInterface } from '../../types';
 import { DiskWrapper } from '../../k8s/wrapper/vm/disk-wrapper';
 import { DeviceType } from '../../constants';
-import { getBootableDisks, getInterfaces } from './selectors';
+import { getBootableDisks, getInterfaces, getDisks } from './selectors';
 import { asVM } from './vmlike';
 import { VMLikeEntityKind } from '../../types/vmLike';
 import { V1Disk } from '../../types/vm/disk/V1Disk';
@@ -33,18 +33,23 @@ export const transformDevices = (
 
 export const getDevices = (vmLikeEntity: VMLikeEntityKind): BootableDeviceType[] => {
   const vm = asVM(vmLikeEntity);
+  return transformDevices(getDisks(vm), getInterfaces(vm));
+};
+
+export const getBootableDevices = (vmLikeEntity: VMLikeEntityKind): BootableDeviceType[] => {
+  const vm = asVM(vmLikeEntity);
   return transformDevices(getBootableDisks(vm), getInterfaces(vm));
 };
 
-export const getBootableDevices = (vm: VMLikeEntityKind): BootableDeviceType[] => {
-  const devices = getDevices(vm).filter((device) => device.value.bootOrder);
+export const getSelectedBootableDevices = (vm: VMLikeEntityKind): BootableDeviceType[] => {
+  const devices = getBootableDevices(vm).filter((device) => device.value.bootOrder);
   return [...devices];
 };
 
 export const getBootableDevicesInOrder = (vm: VMLikeEntityKind): BootableDeviceType[] =>
-  _.sortBy(getBootableDevices(vm), 'value.bootOrder');
+  _.sortBy(getSelectedBootableDevices(vm), 'value.bootOrder');
 
 export const getNonBootableDevices = (vm: VMLikeEntityKind): BootableDeviceType[] => {
-  const devices = getDevices(vm).filter((device) => !device.value.bootOrder);
+  const devices = getBootableDevices(vm).filter((device) => !device.value.bootOrder);
   return [...devices];
 };


### PR DESCRIPTION
Saving changes on VM's boot-order modal will not remove non-bootable disks

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>