### PR TITLE
Add additional metrics to PVC Page

### DIFF
--- a/frontend/packages/console-shared/src/sorts/index.ts
+++ b/frontend/packages/console-shared/src/sorts/index.ts
@@ -1,1 +1,2 @@
 export * from './nodes';
+export * from './pvc';

--- a/frontend/packages/console-shared/src/sorts/pvc.ts
+++ b/frontend/packages/console-shared/src/sorts/pvc.ts
@@ -1,0 +1,5 @@
+import * as UIActions from '@console/internal/actions/ui';
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+
+export const pvcUsed = (pvc: K8sResourceCommon): number =>
+  UIActions.getPVCMetric(pvc, 'usedCapacity');

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -63,6 +63,7 @@ export enum ActionType {
   SetPodMetrics = 'setPodMetrics',
   SetNamespaceMetrics = 'setNamespaceMetrics',
   SetNodeMetrics = 'setNodeMetrics',
+  SetPVCMetrics = 'setPVCMetrics',
   SetPinnedResources = 'setPinnedResources',
 }
 
@@ -91,6 +92,10 @@ export type NodeMetrics = {
   totalMemory: MetricValuesByName;
   usedStorage: MetricValuesByName;
   totalStorage: MetricValuesByName;
+};
+
+export type PVCMetrics = {
+  usedCapacity: MetricValuesByName;
 };
 
 // URL routes that can be namespaced
@@ -123,6 +128,11 @@ export const getPodMetric = (pod: PodKind, metric: string): number => {
 export const getNodeMetric = (node: NodeKind, metric: string): number => {
   const metrics = store.getState().UI.getIn(['metrics', 'node']);
   return metrics?.[metric]?.[node.metadata.name] ?? 0;
+};
+
+export const getPVCMetric = (pvc: K8sResourceKind, metric: string): number => {
+  const metrics = store.getState().UI.getIn(['metrics', 'pvc']);
+  return metrics?.[metric]?.[pvc.metadata.namespace]?.[pvc.metadata.name] ?? 0;
 };
 
 export const formatNamespaceRoute = (activeNamespace, originalPath, location?) => {
@@ -348,6 +358,8 @@ export const setNamespaceMetrics = (namespaceMetrics: NamespaceMetrics) =>
   action(ActionType.SetNamespaceMetrics, { namespaceMetrics });
 export const setNodeMetrics = (nodeMetrics: NodeMetrics) =>
   action(ActionType.SetNodeMetrics, { nodeMetrics });
+export const setPVCMetrics = (pvcMetrics: PVCMetrics) =>
+  action(ActionType.SetPVCMetrics, { pvcMetrics });
 
 // TODO(alecmerdler): Implement all actions using `typesafe-actions` and add them to this export
 const uiActions = {
@@ -396,6 +408,7 @@ const uiActions = {
   setPodMetrics,
   setNamespaceMetrics,
   setNodeMetrics,
+  setPVCMetrics,
   notificationDrawerToggleExpanded,
   notificationDrawerToggleRead,
   setPinnedResources,

--- a/frontend/public/components/_persistent-volume-claim.scss
+++ b/frontend/public/components/_persistent-volume-claim.scss
@@ -1,0 +1,5 @@
+.co-pvc-donut {
+  max-width: 130px;
+  max-height: 130px;
+  margin-bottom: 20px;
+}

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -9,6 +9,7 @@ import {
   nodeCPU,
   nodeFS,
   nodePods,
+  pvcUsed,
 } from '@console/shared';
 import * as UIActions from '../../actions/ui';
 import {
@@ -143,6 +144,7 @@ const sorts = {
   nodeFS: (node: NodeKind): number => nodeFS(node),
   machinePhase: (machine: MachineKind): string => getMachinePhase(machine),
   nodePods: (node: NodeKind): number => nodePods(node),
+  pvcUsed: (pvc: K8sResourceKind): number => pvcUsed(pvc),
 };
 
 const stateToProps = (

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -360,6 +360,8 @@ export default (state: UIState, action: UIAction): UIState => {
       return state.setIn(['metrics', 'namespace'], action.payload.namespaceMetrics);
     case ActionType.SetNodeMetrics:
       return state.setIn(['metrics', 'node'], action.payload.nodeMetrics);
+    case ActionType.SetPVCMetrics:
+      return state.setIn(['metrics', 'pvc'], action.payload.pvcMetrics);
 
     case ActionType.SetPinnedResources: {
       const pinnedResources = { ...state.get('pinnedResources') };

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -98,6 +98,7 @@
 @import 'components/filter-toolbar';
 @import 'components/autocomplete';
 @import 'components/conditions';
+@import 'components/persistent-volume-claim';
 
 @import 'components/dashboard/dashboards-page/cluster-dashboard/activity-card';
 @import 'components/dashboard/dashboards-page/cluster-dashboard/status-card';


### PR DESCRIPTION
Introduces Donut Chart in Details Page
Introduces Used Capacity in List Page
Moving PVC Metrics from `Mi/Gi/Ti` to `MiB/GiB/TiB`
![Screenshot from 2020-07-01 16-37-04](https://user-images.githubusercontent.com/54092533/86237331-345bd980-bbb9-11ea-91ce-d238e08c1764.png)
![Screenshot from 2020-06-17 20-09-28](https://user-images.githubusercontent.com/54092533/84911921-77588000-b0d6-11ea-8fc9-d1b9b2f7f762.png)
Adding missing items from https://issues.redhat.com/browse/KNIP-638