### PR TITLE
Add guided tour catlog page

### DIFF
--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.scss
@@ -1,4 +1,4 @@
-.odc-guided-tour-catalog {
+.oc-guided-tour-catalog {
   background: var(--pf-global--palette--black-150);
   padding: var(--pf-global--spacer--lg);
   height: 100%;

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.scss
@@ -1,0 +1,5 @@
+.odc-guided-tour-catalog {
+  background: var(--pf-global--palette--black-150);
+  padding: var(--pf-global--spacer--lg);
+  height: 100%;
+}

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { EmptyBox } from '@console/internal/components/utils';
+import { GuidedTourItem as TourItem, TourStatus } from './utils/guided-tour-typings';
+import GuidedTourItem from './GuidedTourItem';
+import './GuidedTourCatalog.scss';
+
+type GuidedTourCatalogItem = TourItem & TourStatus;
+type GuidedTourCatalogProps = {
+  tours: GuidedTourCatalogItem[];
+};
+
+const GuidedTourCatalog: React.FC<GuidedTourCatalogProps> = ({ tours }) => (
+  <div className="odc-guided-tour-catalog">
+    {!tours || tours.length === 0 ? (
+      <EmptyBox label="Guided Tours" />
+    ) : (
+      <Gallery gutter="sm">
+        {tours.map((tour) => (
+          <GalleryItem>
+            <GuidedTourItem key={`tour-${tour.name}`} {...tour} />
+          </GalleryItem>
+        ))}
+      </Gallery>
+    )}
+  </div>
+);
+
+export default GuidedTourCatalog;

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.tsx
@@ -1,24 +1,23 @@
 import * as React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 import { EmptyBox } from '@console/internal/components/utils';
-import { GuidedTourItem as TourItem, TourStatus } from './utils/guided-tour-typings';
+import { GuidedTourCatalogItem } from './utils/guided-tour-typings';
 import GuidedTourItem from './GuidedTourItem';
 import './GuidedTourCatalog.scss';
 
-type GuidedTourCatalogItem = TourItem & TourStatus;
 type GuidedTourCatalogProps = {
   tours: GuidedTourCatalogItem[];
 };
 
 const GuidedTourCatalog: React.FC<GuidedTourCatalogProps> = ({ tours }) => (
-  <div className="odc-guided-tour-catalog">
+  <div className="oc-guided-tour-catalog">
     {!tours || tours.length === 0 ? (
       <EmptyBox label="Guided Tours" />
     ) : (
       <Gallery gutter="sm">
         {tours.map((tour) => (
-          <GalleryItem>
-            <GuidedTourItem key={`tour-${tour.name}`} {...tour} />
+          <GalleryItem key={tour.name}>
+            <GuidedTourItem {...tour} />
           </GalleryItem>
         ))}
       </Gallery>

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.scss
@@ -1,0 +1,3 @@
+.odc-guided-tour-item {
+  height: 100%;
+}

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.scss
@@ -1,3 +1,7 @@
-.odc-guided-tour-item {
+.oc-guided-tour-item {
   height: 100%;
+  & .catalog-tile-pf-description .has-footer {
+    display: block;
+    -webkit-line-clamp: unset;
+  }
 }

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { CatalogTile } from '@patternfly/react-catalog-view-extension';
-import { GuidedTourItem, TourStatus } from './utils/guided-tour-typings';
+import { GuidedTourItem, GuidedTourCatalogItem } from './utils/guided-tour-typings';
 import TourItemHeader from './TourItemHeader';
 import TourItemDescription from './TourItemDescription';
 import TourItemFooter from './TourItemFooter';
 import './GuidedTourItem.scss';
 
-type GuidedTourItemProps = GuidedTourItem & TourStatus;
+type GuidedTourItemProps = GuidedTourCatalogItem;
 
 const GuidedTourItem: React.FC<GuidedTourItemProps> = ({
   iconURL,
@@ -17,21 +17,22 @@ const GuidedTourItem: React.FC<GuidedTourItemProps> = ({
   active,
   duration,
   prerequisites,
+  unmetPrerequisite,
 }) => (
   <CatalogTile
-    className="odc-guided-tour-item"
+    iconImg={iconURL}
+    iconAlt={altIcon}
+    className="oc-guided-tour-item"
     featured={active}
-    title={
-      <TourItemHeader
-        iconURL={iconURL}
-        altIcon={altIcon}
-        name={name}
-        status={status}
-        duration={duration}
+    title={<TourItemHeader name={name} status={status} duration={duration} />}
+    description={
+      <TourItemDescription
+        description={description}
+        prerequisites={prerequisites}
+        unmetPrerequisite={unmetPrerequisite}
       />
     }
-    description={<TourItemDescription description={description} prerequisites={prerequisites} />}
-    footer={<TourItemFooter status={status} />}
+    footer={<TourItemFooter unmetPrerequisite={unmetPrerequisite} status={status} />}
   />
 );
 

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { CatalogTile } from '@patternfly/react-catalog-view-extension';
+import { GuidedTourItem, TourStatus } from './utils/guided-tour-typings';
+import TourItemHeader from './TourItemHeader';
+import TourItemDescription from './TourItemDescription';
+import TourItemFooter from './TourItemFooter';
+import './GuidedTourItem.scss';
+
+type GuidedTourItemProps = GuidedTourItem & TourStatus;
+
+const GuidedTourItem: React.FC<GuidedTourItemProps> = ({
+  iconURL,
+  altIcon,
+  name,
+  description,
+  status,
+  active,
+  duration,
+  prerequisites,
+}) => (
+  <CatalogTile
+    className="odc-guided-tour-item"
+    featured={active}
+    title={
+      <TourItemHeader
+        iconURL={iconURL}
+        altIcon={altIcon}
+        name={name}
+        status={status}
+        duration={duration}
+      />
+    }
+    description={<TourItemDescription description={description} prerequisites={prerequisites} />}
+    footer={<TourItemFooter status={status} />}
+  />
+);
+
+export default GuidedTourItem;

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTours.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTours.tsx
@@ -10,9 +10,7 @@ const GuidedTours: React.FC = () => {
       <Helmet>
         <title>Guided Tours</title>
       </Helmet>
-      <div className="odc-empty-state__title">
-        <PageHeading title="Guided Tours" />
-      </div>
+      <PageHeading title="Guided Tours" />
       <GuidedTourCatalog tours={getGuidedToursWithStatus()} />
     </>
   );

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTours.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTours.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { PageHeading } from '@console/internal/components/utils';
+import { getGuidedToursWithStatus } from './utils/guided-tour-utils';
+import GuidedTourCatalog from './GuidedTourCatalog';
+
+const GuidedTours: React.FC = () => {
+  return (
+    <>
+      <Helmet>
+        <title>Guided Tours</title>
+      </Helmet>
+      <div className="odc-empty-state__title">
+        <PageHeading title="Guided Tours" />
+      </div>
+      <GuidedTourCatalog tours={getGuidedToursWithStatus()} />
+    </>
+  );
+};
+
+export default GuidedTours;

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.scss
@@ -1,6 +1,8 @@
-.odc-tour-item-description {
-  &--section {
+.oc-tour-item-description {
+  &__section {
     margin: 0 0 var(--pf-global--spacer--md) 0;
-    height: 100%;
+  }
+  &__unmetprerequisites {
+    color: var(--pf-global--Color--200);
   }
 }

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.scss
@@ -1,0 +1,6 @@
+.odc-tour-item-description {
+  &--section {
+    margin: 0 0 var(--pf-global--spacer--md) 0;
+    height: 100%;
+  }
+}

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.tsx
@@ -1,22 +1,34 @@
 import * as React from 'react';
+import cx from 'classnames';
+import { Text, TextVariants } from '@patternfly/react-core';
 import './TourItemDescription.scss';
 
 type TourItemDescriptionProps = {
   description: string;
-  prerequisites: string[];
+  prerequisites?: string[];
+  unmetPrerequisite?: boolean;
 };
 const TourItemDescription: React.FC<TourItemDescriptionProps> = ({
   description,
   prerequisites,
+  unmetPrerequisite = false,
 }) => (
   <>
-    <div className="odc-tour-item-description--section">{description}</div>
-    <div className="odc-tour-item-description--section">
-      <h5>Prerequisites</h5>
-      {prerequisites.map((prerequisite) => (
-        <div>{prerequisite}</div>
-      ))}
-    </div>
+    <Text component={TextVariants.p} className="oc-tour-item-description__section">
+      {description}
+    </Text>
+    {Array.isArray(prerequisites) && prerequisites?.length > 0 && (
+      <div
+        className={cx('oc-tour-item-description__section', {
+          'oc-tour-item-description__unmetprerequisites': unmetPrerequisite,
+        })}
+      >
+        <Text component={TextVariants.h5}>Prerequisites</Text>
+        {prerequisites.map((prerequisite) => (
+          <Text component={TextVariants.small}>{prerequisite}</Text>
+        ))}
+      </div>
+    )}
   </>
 );
 export default TourItemDescription;

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemDescription.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import './TourItemDescription.scss';
+
+type TourItemDescriptionProps = {
+  description: string;
+  prerequisites: string[];
+};
+const TourItemDescription: React.FC<TourItemDescriptionProps> = ({
+  description,
+  prerequisites,
+}) => (
+  <>
+    <div className="odc-tour-item-description--section">{description}</div>
+    <div className="odc-tour-item-description--section">
+      <h5>Prerequisites</h5>
+      {prerequisites.map((prerequisite) => (
+        <div>{prerequisite}</div>
+      ))}
+    </div>
+  </>
+);
+export default TourItemDescription;

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemFooter.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemFooter.tsx
@@ -4,39 +4,38 @@ import { GuidedTourStatus } from './utils/guided-tour-status';
 
 type TourItemFooterProps = {
   status: string;
+  unmetPrerequisite?: boolean;
 };
-const TourItemFooter: React.FC<TourItemFooterProps> = ({ status }) => (
-  <div className="odc-guided-tour__footer">
-    <Flex breakpointMods={[{ modifier: FlexModifiers['justify-content-space-between'] }]}>
-      {status === GuidedTourStatus.NOT_STARTED && (
-        <FlexItem>
-          <Button variant="link" isInline>
-            Start the Tour
-          </Button>
-        </FlexItem>
-      )}
-      {status === GuidedTourStatus.IN_PROGRESS && (
-        <FlexItem>
-          <Button variant="link" isInline>
-            Resume the Tour
-          </Button>
-        </FlexItem>
-      )}
-      {status === GuidedTourStatus.COMPLETE && (
-        <FlexItem>
-          <Button variant="link" isInline>
-            Review the Tour
-          </Button>
-        </FlexItem>
-      )}
-      {(status === GuidedTourStatus.COMPLETE || status === GuidedTourStatus.IN_PROGRESS) && (
-        <FlexItem>
-          <Button variant="link" isInline>
-            Restart the Tour
-          </Button>
-        </FlexItem>
-      )}
-    </Flex>
-  </div>
+const TourItemFooter: React.FC<TourItemFooterProps> = ({ status, unmetPrerequisite = false }) => (
+  <Flex breakpointMods={[{ modifier: FlexModifiers['justify-content-space-between'] }]}>
+    {status === GuidedTourStatus.NOT_STARTED && (
+      <FlexItem>
+        <Button variant="link" isInline isDisabled={unmetPrerequisite}>
+          Start the tour
+        </Button>
+      </FlexItem>
+    )}
+    {status === GuidedTourStatus.IN_PROGRESS && (
+      <FlexItem>
+        <Button variant="link" isInline>
+          Resume the tour
+        </Button>
+      </FlexItem>
+    )}
+    {status === GuidedTourStatus.COMPLETE && (
+      <FlexItem>
+        <Button variant="link" isInline>
+          Review the tour
+        </Button>
+      </FlexItem>
+    )}
+    {status === GuidedTourStatus.IN_PROGRESS && (
+      <FlexItem>
+        <Button variant="link" isInline>
+          Restart the tour
+        </Button>
+      </FlexItem>
+    )}
+  </Flex>
 );
 export default TourItemFooter;

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemFooter.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemFooter.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Flex, FlexItem, Button, FlexModifiers } from '@patternfly/react-core';
+import { GuidedTourStatus } from './utils/guided-tour-status';
+
+type TourItemFooterProps = {
+  status: string;
+};
+const TourItemFooter: React.FC<TourItemFooterProps> = ({ status }) => (
+  <div className="odc-guided-tour__footer">
+    <Flex breakpointMods={[{ modifier: FlexModifiers['justify-content-space-between'] }]}>
+      {status === GuidedTourStatus.NOT_STARTED && (
+        <FlexItem>
+          <Button variant="link" isInline>
+            Start the Tour
+          </Button>
+        </FlexItem>
+      )}
+      {status === GuidedTourStatus.IN_PROGRESS && (
+        <FlexItem>
+          <Button variant="link" isInline>
+            Resume the Tour
+          </Button>
+        </FlexItem>
+      )}
+      {status === GuidedTourStatus.COMPLETE && (
+        <FlexItem>
+          <Button variant="link" isInline>
+            Review the Tour
+          </Button>
+        </FlexItem>
+      )}
+      {(status === GuidedTourStatus.COMPLETE || status === GuidedTourStatus.IN_PROGRESS) && (
+        <FlexItem>
+          <Button variant="link" isInline>
+            Restart the Tour
+          </Button>
+        </FlexItem>
+      )}
+    </Flex>
+  </div>
+);
+export default TourItemFooter;

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.scss
@@ -1,10 +1,11 @@
-.odc-tour-item-header {
+.oc-tour-item-header {
   &__status {
     margin: var(--pf-global--spacer--sm) 0;
   }
-  &__icon {
-    width: var(--pf-global--spacer--lg);
-    height: var(--pf-global--spacer--lg);
-    margin: 0 var(--pf-global--spacer--sm) 0 0;
+  &--rightmargin {
+    margin-right: var(--pf-global--spacer--sm);
+  }
+  & .pf-c-badge:not(:last-of-type) {
+    margin-right: var(--pf-global--spacer--sm);
   }
 }

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.scss
@@ -1,0 +1,10 @@
+.odc-tour-item-header {
+  &__status {
+    margin: var(--pf-global--spacer--sm) 0;
+  }
+  &__icon {
+    width: var(--pf-global--spacer--lg);
+    height: var(--pf-global--spacer--lg);
+    margin: 0 var(--pf-global--spacer--sm) 0 0;
+  }
+}

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Status } from '@console/shared';
+import { Badge } from '@patternfly/react-core';
+import { GuidedTourStatus } from './utils/guided-tour-status';
+import './TourItemHeader.scss';
+
+type TourItemHeaderProps = {
+  status: string;
+  duration: number;
+  iconURL: string;
+  altIcon: string;
+  name: string;
+};
+const TourItemHeader: React.FC<TourItemHeaderProps> = ({
+  status,
+  duration,
+  name,
+  iconURL,
+  altIcon,
+}) => (
+  <div className="odc-tour-item-header">
+    <img className="odc-tour-item-header__icon" src={iconURL} alt={altIcon} />
+    {name}
+    <div className="odc-tour-item-header__status">
+      {status !== GuidedTourStatus.NOT_STARTED && (
+        <Badge key={1} isRead>
+          <Status status={status} />
+        </Badge>
+      )}
+      <Badge key={2} isRead>{`${duration} m`}</Badge>
+    </div>
+  </div>
+);
+
+// there could be various statuses in future
+export default TourItemHeader;

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.tsx
@@ -1,33 +1,29 @@
 import * as React from 'react';
 import { Status } from '@console/shared';
 import { Badge } from '@patternfly/react-core';
+import { OutlinedClockIcon } from '@patternfly/react-icons';
 import { GuidedTourStatus } from './utils/guided-tour-status';
 import './TourItemHeader.scss';
 
 type TourItemHeaderProps = {
   status: string;
   duration: number;
-  iconURL: string;
-  altIcon: string;
   name: string;
 };
-const TourItemHeader: React.FC<TourItemHeaderProps> = ({
-  status,
-  duration,
-  name,
-  iconURL,
-  altIcon,
-}) => (
-  <div className="odc-tour-item-header">
-    <img className="odc-tour-item-header__icon" src={iconURL} alt={altIcon} />
+const TourItemHeader: React.FC<TourItemHeaderProps> = ({ status, duration, name }) => (
+  <div className="oc-tour-item-header">
     {name}
-    <div className="odc-tour-item-header__status">
+    <div className="oc-tour-item-header__status">
+      {/* fix me - change badges to labels once migrated to PF4 - */}
       {status !== GuidedTourStatus.NOT_STARTED && (
-        <Badge key={1} isRead>
+        <Badge isRead>
           <Status status={status} />
         </Badge>
       )}
-      <Badge key={2} isRead>{`${duration} m`}</Badge>
+      <Badge isRead>
+        <OutlinedClockIcon className="oc-tour-item-header--rightmargin" />
+        <span className="oc-tour-item-header--rightmargin">{duration}</span>minutes
+      </Badge>
     </div>
   </div>
 );

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourCatalog.spec.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourCatalog.spec.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { EmptyBox } from '@console/internal/components/utils';
+import GuidedTourCatalog from '../GuidedTourCatalog';
+import { getGuidedToursWithStatus } from '../utils/guided-tour-utils';
+
+describe('GuidedTourCatalog', () => {
+  it('should load an emptybox if no tours exist', () => {
+    const guidedTourCatalogProps = { tours: [] };
+    const guidedTourCatalogWrapper = shallow(<GuidedTourCatalog {...guidedTourCatalogProps} />);
+    expect(guidedTourCatalogWrapper.find(EmptyBox).exists()).toBeTruthy();
+  });
+  it('should load a gallery if tours exist', () => {
+    const guidedTourCatalogProps = { tours: getGuidedToursWithStatus() };
+    const guidedTourCatalogWrapper = shallow(<GuidedTourCatalog {...guidedTourCatalogProps} />);
+    expect(guidedTourCatalogWrapper.find(Gallery).exists()).toBeTruthy();
+  });
+  it('should load galleryItems equal to the number of tours', () => {
+    const guidedTourCatalogProps = { tours: getGuidedToursWithStatus() };
+    const guidedTourCatalogWrapper = shallow(<GuidedTourCatalog {...guidedTourCatalogProps} />);
+    const galleryItems = guidedTourCatalogWrapper.find(GalleryItem);
+    expect(galleryItems.exists()).toBeTruthy();
+    expect(galleryItems.length).toEqual(3);
+  });
+});

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourItem.spec.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourItem.spec.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { CatalogTile } from '@patternfly/react-catalog-view-extension';
+import GuidedTourItem from '../GuidedTourItem';
+import { getGuidedToursWithStatus } from '../utils/guided-tour-utils';
+
+describe('GuidedTourItem', () => {
+  const tourItems = getGuidedToursWithStatus();
+
+  it('should load proper catalog tile without featured property', () => {
+    const guidedTourItemWrapper = shallow(<GuidedTourItem {...tourItems[0]} />);
+    const catalogTile = guidedTourItemWrapper.find(CatalogTile);
+    expect(catalogTile.exists()).toBeTruthy();
+    expect(catalogTile.prop('featured')).toBe(false);
+  });
+  it('should load proper catalog tile with featured property', () => {
+    const guidedTourItemWrapper = shallow(<GuidedTourItem {...tourItems[1]} />);
+    const catalogTile = guidedTourItemWrapper.find(CatalogTile);
+    expect(catalogTile.exists()).toBeTruthy();
+    expect(catalogTile.prop('featured')).toBe(true);
+  });
+});

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTours.spec.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTours.spec.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { PageHeading } from '@console/internal/components/utils';
+import GuidedTourCatalog from '../GuidedTourCatalog';
+import GuidedTours from '../GuidedTours';
+
+describe('GuidedTours', () => {
+  const guidedTousWrapper = shallow(<GuidedTours />);
+  it('should load desired page heading', () => {
+    expect(guidedTousWrapper.find(PageHeading).exists()).toBeTruthy();
+    expect(guidedTousWrapper.find(PageHeading).prop('title')).toBe('Guided Tours');
+  });
+  it('should load a GuidedTourCatalog', () => {
+    expect(guidedTousWrapper.find(GuidedTourCatalog).exists()).toBeTruthy();
+  });
+});

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/TourItemFooter.spec.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/TourItemFooter.spec.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { GuidedTourStatus } from '../utils/guided-tour-status';
+import { Button } from '@patternfly/react-core';
+import TourItemFooter from '../TourItemFooter';
+
+describe('TourItemFooter', () => {
+  it('should load proper footer links for completed tours', () => {
+    const TourItemFooterWrapper = shallow(<TourItemFooter status={GuidedTourStatus.COMPLETE} />);
+    const footerButtons = TourItemFooterWrapper.find(Button);
+    expect(footerButtons.exists()).toBeTruthy();
+    expect(footerButtons.length).toEqual(2);
+    expect(footerButtons.at(0).find('Review the Tour')).toBeTruthy();
+    expect(footerButtons.at(1).find('Restart the Tour')).toBeTruthy();
+  });
+  it('should load proper footer links for in progress tours', () => {
+    const TourItemFooterWrapper = shallow(<TourItemFooter status={GuidedTourStatus.IN_PROGRESS} />);
+    const footerButtons = TourItemFooterWrapper.find(Button);
+    expect(footerButtons.exists()).toBeTruthy();
+    expect(footerButtons.length).toEqual(2);
+    expect(footerButtons.at(0).find('Restart the Tour')).toBeTruthy();
+    expect(footerButtons.at(1).find('Resume the Tour')).toBeTruthy();
+  });
+  it('should load proper footer links for not started tours', () => {
+    const TourItemFooterWrapper = shallow(<TourItemFooter status={GuidedTourStatus.NOT_STARTED} />);
+    const footerButtons = TourItemFooterWrapper.find(Button);
+    expect(footerButtons.exists()).toBeTruthy();
+    expect(footerButtons.length).toEqual(1);
+    expect(footerButtons.at(0).find('Start the Tour')).toBeTruthy();
+  });
+});

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/TourItemFooter.spec.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/TourItemFooter.spec.tsx
@@ -9,9 +9,8 @@ describe('TourItemFooter', () => {
     const TourItemFooterWrapper = shallow(<TourItemFooter status={GuidedTourStatus.COMPLETE} />);
     const footerButtons = TourItemFooterWrapper.find(Button);
     expect(footerButtons.exists()).toBeTruthy();
-    expect(footerButtons.length).toEqual(2);
+    expect(footerButtons.length).toEqual(1);
     expect(footerButtons.at(0).find('Review the Tour')).toBeTruthy();
-    expect(footerButtons.at(1).find('Restart the Tour')).toBeTruthy();
   });
   it('should load proper footer links for in progress tours', () => {
     const TourItemFooterWrapper = shallow(<TourItemFooter status={GuidedTourStatus.IN_PROGRESS} />);

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-mocks.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-mocks.ts
@@ -37,3 +37,9 @@ export const mockStatus: Record<string, TourStatus> = {
   'Serverless Aplications': { status: GuidedTourStatus.IN_PROGRESS, active: true },
   'Build Pipelines': { status: GuidedTourStatus.NOT_STARTED },
 };
+
+export const mockPrerequisiteStatus: Record<string, boolean> = {
+  'Explore Serverless': false,
+  'Serverless Aplications': false,
+  'Build Pipelines': true,
+};

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-mocks.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-mocks.ts
@@ -1,0 +1,39 @@
+import { GuidedTourItem, TourStatus } from './guided-tour-typings';
+import { GuidedTourStatus } from './guided-tour-status';
+
+export const mockGuidedTours: GuidedTourItem[] = [
+  {
+    iconURL:
+      '/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-marketplace/packagemanifests/3scale-community-operator/icon?resourceVersion=3scale-community-operator.threescale-2.8.3scale-community-operator.v0.5.1',
+    altIcon: 'KNative',
+    name: 'Explore Serverless',
+    duration: 5,
+    description:
+      'Install the Serverless Operator to enable the containers, microservices and functions to run "serverless"',
+    prerequisites: ['Release requirement if any', 'installs x number of resources'],
+  },
+  {
+    iconURL:
+      '/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-marketplace/packagemanifests/serverless-operator/icon?resourceVersion=serverless-operator.4.3.serverless-operator.v1.7.1',
+    altIcon: 'KNative',
+    name: 'Serverless Aplications',
+    duration: 10,
+    description: 'Learn how to create a serverless application',
+    prerequisites: ['Complete "Explore Serverless" tour'],
+  },
+  {
+    iconURL:
+      '/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-marketplace/packagemanifests/serverless-operator/icon?resourceVersion=serverless-operator.4.3.serverless-operator.v1.7.1',
+    altIcon: 'TKN',
+    name: 'Build Pipelines',
+    duration: 15,
+    description: 'Release requirement if any installs x number of resources',
+    prerequisites: ['Release requirement if any', 'installs x number of resources'],
+  },
+];
+
+export const mockStatus: Record<string, TourStatus> = {
+  'Explore Serverless': { status: GuidedTourStatus.COMPLETE },
+  'Serverless Aplications': { status: GuidedTourStatus.IN_PROGRESS, active: true },
+  'Build Pipelines': { status: GuidedTourStatus.NOT_STARTED },
+};

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-status.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-status.ts
@@ -1,5 +1,5 @@
 export enum GuidedTourStatus {
   COMPLETE = 'Complete',
-  IN_PROGRESS = 'In progress',
+  IN_PROGRESS = 'In Progress',
   NOT_STARTED = 'Not started',
 }

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-status.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-status.ts
@@ -1,0 +1,5 @@
+export enum GuidedTourStatus {
+  COMPLETE = 'Complete',
+  IN_PROGRESS = 'In progress',
+  NOT_STARTED = 'Not started',
+}

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-typings.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-typings.ts
@@ -1,0 +1,13 @@
+export type GuidedTourItem = {
+  iconURL: string;
+  altIcon?: string;
+  name: string;
+  duration: number;
+  description: string;
+  prerequisites?: string[];
+};
+
+export type TourStatus = {
+  active?: boolean;
+  status: string;
+};

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-typings.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-typings.ts
@@ -11,3 +11,8 @@ export type TourStatus = {
   active?: boolean;
   status: string;
 };
+
+export type GuidedTourCatalogItem = GuidedTourItem &
+  TourStatus & {
+    unmetPrerequisite?: boolean;
+  };

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-utils.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-utils.ts
@@ -1,7 +1,6 @@
-import { mockGuidedTours, mockStatus } from './guided-tour-mocks';
-import { TourStatus, GuidedTourItem } from './guided-tour-typings';
+import { mockGuidedTours, mockStatus, mockPrerequisiteStatus } from './guided-tour-mocks';
+import { GuidedTourCatalogItem, GuidedTourItem } from './guided-tour-typings';
 
-type GuidedTourCatalogItem = GuidedTourItem & TourStatus;
 const getGuidedTours = (): GuidedTourItem[] => {
   return mockGuidedTours;
 };
@@ -9,6 +8,10 @@ const getGuidedTours = (): GuidedTourItem[] => {
 export const getGuidedToursWithStatus = (): GuidedTourCatalogItem[] => {
   const items = getGuidedTours();
   return items.map((item) => {
-    return { ...item, ...mockStatus[item.name] };
+    return {
+      ...item,
+      ...mockStatus[item.name],
+      unmetPrerequisite: mockPrerequisiteStatus[item.name],
+    };
   });
 };

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-utils.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-utils.ts
@@ -1,0 +1,14 @@
+import { mockGuidedTours, mockStatus } from './guided-tour-mocks';
+import { TourStatus, GuidedTourItem } from './guided-tour-typings';
+
+type GuidedTourCatalogItem = GuidedTourItem & TourStatus;
+const getGuidedTours = (): GuidedTourItem[] => {
+  return mockGuidedTours;
+};
+
+export const getGuidedToursWithStatus = (): GuidedTourCatalogItem[] => {
+  const items = getGuidedTours();
+  return items.map((item) => {
+    return { ...item, ...mockStatus[item.name] };
+  });
+};

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -8,6 +8,7 @@ import {
   Perspective,
   ModelFeatureFlag,
   ModelDefinition,
+  RoutePage,
   DashboardsOverviewResourceActivity,
   DashboardsOverviewHealthURLSubsystem,
   DashboardsOverviewHealthPrometheusSubsystem,
@@ -52,6 +53,7 @@ type ConsumedExtensions =
   | Perspective
   | ModelDefinition
   | ModelFeatureFlag
+  | RoutePage
   | DashboardsOverviewResourceActivity
   | DashboardsOverviewHealthURLSubsystem<any>
   | DashboardsOverviewHealthPrometheusSubsystem
@@ -186,6 +188,19 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [FLAGS.CLUSTER_VERSION],
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/tours/'],
+      loader: async () =>
+        (
+          await import(
+            './components/guided-tours/GuidedTours' /* webpackChunkName: "co-guided-tour" */
+          )
+        ).default,
     },
   },
   {

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -268,6 +268,10 @@ class MastheadToolbarContents_ extends React.Component {
       isSection: true,
       actions: [
         {
+          label: 'Guided Tours',
+          href: '/tours/',
+        },
+        {
           label: 'Documentation',
           externalLink: true,
           href: openshiftHelpBase,

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -268,8 +268,7 @@ class MastheadToolbarContents_ extends React.Component {
       isSection: true,
       actions: [
         {
-          label: 'Guided Tours',
-          href: '/tours/',
+          component: <Link to="/tours">Guided Tours</Link>,
         },
         {
           label: 'Documentation',


### PR DESCRIPTION
## Fixes:
https://issues.redhat.com/browse/ODC-4130

## Analysis / Root cause:
Create Guided Tour Catalog

## Solution Description:
Added components, utils & tests in console-app/ package. Added route in console app plugin and added link in MastheadHelper icon.

## Screenshot
Icon change for consistency
![GT1](https://user-images.githubusercontent.com/24852534/85529691-f3991900-b62a-11ea-9895-94897da27a66.gif)


## Test
Added testfiles
TourItemFooter.spec.scss, GuidedTours.spec.scss, GuidedTourCatalg.scss, GuidedTourItem.scss

## Browser conformation
Chrome 73


