### PR TITLE
Add visualization of upgrade path

### DIFF
--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -1,9 +1,187 @@
+$co-channel-height: 60px;
+
 .cluster-channel-modal__dropdown .pf-c-dropdown {
   width: 100%;
 }
 
 .cluster-update-modal__dropdown .pf-c-dropdown {
   width: 100%;
+}
+
+.co-channel {
+  align-items: center;
+  display: flex;
+  font-size: ($font-size-small - 1);
+}
+
+.co-channel-line {
+  align-items: center;
+  display: flex;
+  height: $co-channel-height;
+  justify-content: center;
+  position: relative;
+  min-width: 50px;
+  width: 100%;
+
+  &:before {
+    background-color: $pf-global--BorderColor--100;
+    content: '';
+    height: 4px;
+    position: absolute;
+    width: 100%;
+
+    .co-channel-path--current & {
+      background-color: $pf-global--primary-color--100;
+    }
+  }
+
+  &:last-child::after {
+    background: transparent;
+    border: 8px solid transparent;
+    border-left-color: $pf-global--BorderColor--100;
+    border-width: 8px 12px;
+    content: '';
+    position: absolute;
+    right: -15px;
+
+    .co-channel-path--current & {
+      border-left-color: $pf-global--primary-color--100;
+    }
+
+    .co-channel--end-of-life & {
+      background-color: $pf-global--primary-color--100;
+      border: 0;
+      height: 16px;
+      right: 0px;
+      width: 3px;
+    }
+  }
+}
+
+.co-channel-more-versions {
+  background: var(--pf-c-drawer__content--BackgroundColor) !important;
+  border: 1px solid !important;
+  border-radius: 15px !important;
+  display: inline-block !important;
+  font-size: ($font-size-small - 1) !important;
+  font-weight: bold !important;
+  justify-content: center;
+  padding: 0 8px !important;
+  position: absolute !important;
+
+  &::after {
+    display: none;
+  }
+
+  &:hover,
+  &:focus {
+    background: $pf-global--primary-color--100 !important;
+    border-color: $pf-global--primary-color--100 !important;
+    color: var(--pf-c-drawer__content--BackgroundColor) !important;
+  }
+
+  &:focus {
+    outline: 0 !important;
+  }
+}
+
+.co-channel-name {
+  color: $pf-global--BorderColor--200;
+  padding: 0 10px 0 20px;
+  min-width: 150px;
+  white-space: nowrap;
+
+  &--current {
+    color: inherit;
+    padding-top: 20px;
+  }
+}
+
+.co-channel-path {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  width: 100%;
+
+  &--current {
+    margin-top: 20px;
+  }
+}
+
+.co-channel-start::before {
+  position: absolute;
+  right: 0;
+  width: 25%;
+}
+
+.co-channel-switch {
+  position: absolute;
+  top: -28px;
+  width: 100%;
+  height: $co-channel-height;
+  z-index: 1;
+
+  &::after,
+  &::before {
+    background: linear-gradient(to left bottom, transparent 50%, $pf-global--BorderColor--100 50%);
+    content: '';
+    display: block;
+    height: $co-channel-height;
+    position: absolute;
+    right: 0;
+    top: -3px;
+    width: 50%;
+  }
+
+  &::after {
+    background: linear-gradient(to left bottom, transparent 50%, var(--pf-c-drawer__content--BackgroundColor) 50%);
+    right: 3px;
+    top: 0;
+  }
+}
+
+.co-channel-version {
+  color: initial;
+  display: flex;
+  flex-direction: column;
+  height: 35px;
+  justify-content: flex-end;
+  line-height: 1;
+  position: absolute;
+  text-align: center;
+  top: -20px;
+
+  &--current {
+    font-weight: var(--pf-global--FontWeight--bold);
+  }
+}
+
+.co-channel-version-dot {
+  background: $pf-global--primary-color--100;
+  border-radius: 16px;
+  content: '';
+  height: 16px;
+  position: absolute;
+  width: 16px;
+  z-index: 2;
+
+  &--current::after {
+    background: transparent !important;
+  }
+
+  &::after {
+    background: var(--pf-c-drawer__content--BackgroundColor);
+    border: 2px solid var(--pf-c-drawer__content--BackgroundColor);
+    border-radius: 12px;
+    content: '';
+    height: 12px;
+    left: 2px;
+    position: absolute;
+    top: 2px;
+    width: 12px;
+  }
 }
 
 .co-cluster-settings {
@@ -30,7 +208,7 @@
     display: flex;
     justify-content: space-between;
 
-    @media(max-width: $grid-float-breakpoint) {
+    @media(max-width: $screen-md) {
       flex-wrap: wrap;
     }
   }
@@ -45,6 +223,13 @@
 
     &--current {
       flex-grow: 0;
+    }
+  }
+
+  &__updates-graph {
+    padding: 0 var(--pf-global--spacer--lg) 0 0;
+    @media(max-width: 400px) {
+      display: none;
     }
   }
 }

--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { ActionGroup, Button } from '@patternfly/react-core';
+
+import { ClusterVersionKind, getSortedUpdates } from '../../module/k8s';
+import {
+  ModalBody,
+  ModalComponentProps,
+  ModalFooter,
+  ModalTitle,
+  createModalLauncher,
+} from '../factory/modal';
+
+export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = ({ cancel, cv }) => {
+  const availableUpdates = getSortedUpdates(cv);
+  const moreAvailableUpdates = availableUpdates.slice(1).reverse();
+
+  return (
+    <div className="modal-content">
+      <ModalTitle>Other Available Paths</ModalTitle>
+      <ModalBody>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Version</th>
+            </tr>
+          </thead>
+          <tbody>
+            {moreAvailableUpdates.map((update) => {
+              return (
+                <tr key={update.version}>
+                  <td>{update.version}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </ModalBody>
+      <ModalFooter inProgress={false}>
+        <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
+          <Button type="button" variant="primary" onClick={cancel}>
+            Done
+          </Button>
+        </ActionGroup>
+      </ModalFooter>
+    </div>
+  );
+};
+
+export const clusterMoreUpdatesModal = createModalLauncher(ClusterMoreUpdatesModal);
+
+export type ClusterMoreUpdatesModalProps = {
+  cv: ClusterVersionKind;
+} & ModalComponentProps;

--- a/frontend/public/components/modals/cluster-update-modal.tsx
+++ b/frontend/public/components/modals/cluster-update-modal.tsx
@@ -1,14 +1,13 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as semver from 'semver';
 
 import { ClusterVersionModel } from '../../models';
 import { Dropdown, PromiseComponent } from '../utils';
 import {
-  ClusterUpdate,
   ClusterVersionKind,
   getAvailableClusterUpdates,
   getDesiredClusterVersion,
+  getSortedUpdates,
   k8sPatch,
 } from '../../module/k8s';
 import {
@@ -18,17 +17,6 @@ import {
   ModalSubmitFooter,
   ModalTitle,
 } from '../factory/modal';
-
-export const getSortedUpdates = (cv: ClusterVersionKind): ClusterUpdate[] => {
-  const available = getAvailableClusterUpdates(cv) || [];
-  try {
-    return available.sort(({ version: left }, { version: right }) => semver.rcompare(left, right));
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('error sorting cluster updates', e);
-    return available;
-  }
-};
 
 class ClusterUpdateModal extends PromiseComponent<
   ClusterUpdateModalProps,

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -71,6 +71,11 @@ export const clusterChannelModal = (props) =>
     m.clusterChannelModal(props),
   );
 
+export const clusterMoreUpdatesModal = (props) =>
+  import(
+    './cluster-more-updates-modal' /* webpackChunkName: "cluster-more-updates-modal" */
+  ).then((m) => m.clusterMoreUpdatesModal(props));
+
 export const clusterUpdateModal = (props) =>
   import('./cluster-update-modal' /* webpackChunkName: "cluster-update-modal" */).then((m) =>
     m.clusterUpdateModal(props),

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -31,9 +31,13 @@ import {
 } from '@patternfly/react-core';
 
 import { coFetchJSON } from '../co-fetch';
-import { ClusterUpdate, ClusterVersionKind, referenceForModel } from '../module/k8s';
+import {
+  ClusterUpdate,
+  ClusterVersionKind,
+  getSortedUpdates,
+  referenceForModel,
+} from '../module/k8s';
 import { ClusterVersionModel } from '../models';
-import { getSortedUpdates } from './modals/cluster-update-modal';
 import { usePrevious } from '@console/metal3-plugin/src/hooks';
 import { useK8sWatchResource, WatchK8sResource } from './utils/k8s-watch-hook';
 

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -27,6 +27,17 @@ export const getAvailableClusterUpdates = (cv: ClusterVersionKind): ClusterUpdat
   return _.get(cv, 'status.availableUpdates', []);
 };
 
+export const getSortedUpdates = (cv: ClusterVersionKind): ClusterUpdate[] => {
+  const available = getAvailableClusterUpdates(cv) || [];
+  try {
+    return available.sort(({ version: left }, { version: right }) => semver.rcompare(left, right));
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('error sorting cluster updates', e);
+    return available;
+  }
+};
+
 export const getAvailableClusterChannels = () => ({
   'stable-4.5': 'stable-4.5',
   'fast-4.5': 'fast-4.5',


### PR DESCRIPTION
Note:  I am unable to find a way to have the 45 degree angle on the second line and have the up to date line be a shorter length.  As a compromise, all lines always have the same length.

<img width="908" alt="Screen Shot 2020-06-19 at 1 02 33 PM" src="https://user-images.githubusercontent.com/895728/85162047-b26dc700-b22e-11ea-8fad-8cfdc24acd7e.png">
<img width="896" alt="Screen Shot 2020-06-19 at 1 02 45 PM" src="https://user-images.githubusercontent.com/895728/85162049-b3065d80-b22e-11ea-854c-aacee1bec9ec.png">
<img width="690" alt="Screen Shot 2020-06-19 at 1 02 52 PM" src="https://user-images.githubusercontent.com/895728/85162050-b3065d80-b22e-11ea-9700-6ff1847ec176.png">
<img width="903" alt="Screen Shot 2020-06-19 at 1 03 04 PM" src="https://user-images.githubusercontent.com/895728/85162051-b3065d80-b22e-11ea-817b-17d47b97cc8b.png">
<img width="679" alt="Screen Shot 2020-06-19 at 1 03 09 PM" src="https://user-images.githubusercontent.com/895728/85162052-b3065d80-b22e-11ea-9203-b3e90ca4c973.png">
<img width="921" alt="Screen Shot 2020-06-19 at 1 10 56 PM" src="https://user-images.githubusercontent.com/895728/85162053-b39ef400-b22e-11ea-8dd6-c44b4b7244e9.png">


Known issues:

* Release note links will be part of #5723
