### PR TITLE
filter incompatible helm charts from dev catalog

### DIFF
--- a/frontend/__mocks__/catalogItemsMocks.ts
+++ b/frontend/__mocks__/catalogItemsMocks.ts
@@ -1,5 +1,6 @@
 export const catalogListPageProps = {
   namespace: 'default',
+  kubernetesVersion: 'v1.18.0+ui896hui',
   helmCharts: {
     data: [
       {

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
@@ -146,6 +146,7 @@ export const mockHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.2.tgz',
     ],
     version: '1.0.2',
+    kubeVersion: '>=1.10.0',
   },
   {
     appVersion: '3.10.5',
@@ -156,6 +157,7 @@ export const mockHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.1.tgz',
     ],
     version: '1.0.1',
+    kubeVersion: '>=1.11.0',
   },
 ];
 

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -40,7 +40,12 @@ export interface HelmChartMetaData {
   dependencies?: object[];
   type?: string;
   urls: string[];
+  kubeVersion?: string;
 }
+
+export type HelmChartEntries = {
+  [name: string]: HelmChartMetaData[];
+};
 
 export interface HelmReleaseResourcesData {
   releaseName: string;

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,6 +1,7 @@
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
 import { safeDump } from 'js-yaml';
+import * as semver from 'semver';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
@@ -82,10 +83,17 @@ export const getChartURL = (helmChartData: HelmChartMetaData[], chartVersion: st
   return chartData?.urls[0];
 };
 
-export const getChartVersions = (chartEntries: HelmChartMetaData[]) => {
+export const getChartVersions = (chartEntries: HelmChartMetaData[], kubernetesVersion: string) => {
   const chartVersions = _.reduce(
     chartEntries,
     (obj, chart) => {
+      if (
+        chart?.kubeVersion &&
+        semver.valid(kubernetesVersion) &&
+        !semver.satisfies(kubernetesVersion, chart?.kubeVersion)
+      ) {
+        return obj;
+      }
       obj[chart.version] = `${chart.version} / App Version ${chart.appVersion}`;
       return obj;
     },


### PR DESCRIPTION
**JIRA Story:**
https://issues.redhat.com/browse/ODC-4062

**Solution Description:**
- filters the helm charts in the dev-catalog that are incompatible with the Kubernetes Version
- filters helm chart versions in the Chart Version dropdown that are incompatible with the Kubernetes Version
- Fixed the type of `HelmChart` (Referred the Helm docs: https://helm.sh/docs/topics/charts/ , section : `The Chart.yaml File` )
- Added tests
![test](https://user-images.githubusercontent.com/22490998/85122861-e358f680-b244-11ea-81cf-d32beeda924e.png)
