### PR TITLE
Bug 1782818: Added requested storage in textbox by default.

### DIFF
--- a/frontend/packages/console-shared/src/selectors/index.ts
+++ b/frontend/packages/console-shared/src/selectors/index.ts
@@ -4,3 +4,4 @@ export * from './pod';
 export * from './machine';
 export * from './namespace';
 export * from './node';
+export * from './storage';

--- a/frontend/packages/console-shared/src/selectors/storage.ts
+++ b/frontend/packages/console-shared/src/selectors/storage.ts
@@ -1,0 +1,4 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const getRequestedPVCSize = (pvc: K8sResourceKind): string =>
+  pvc?.spec?.resources?.requests?.storage;

--- a/frontend/public/components/modals/expand-pvc-modal.jsx
+++ b/frontend/public/components/modals/expand-pvc-modal.jsx
@@ -1,18 +1,20 @@
 import * as React from 'react';
 
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
-import { PromiseComponent, RequestSizeInput, resourceObjPath, history } from '../utils';
+import { PromiseComponent, RequestSizeInput, resourceObjPath, history, validate } from '../utils';
 import { k8sPatch, referenceFor } from '../../module/k8s/';
+import { getRequestedPVCSize } from '@console/shared';
 
 // Modal for expanding persistent volume claims
 class ExpandPVCModal extends PromiseComponent {
   constructor(props) {
     super(props);
+    const defaultSize = validate.split(getRequestedPVCSize(props.resource));
     this.state = {
       inProgress: false,
       errorMessage: '',
-      requestSizeValue: '',
-      requestSizeUnit: 'Gi',
+      requestSizeValue: defaultSize[0] || '',
+      requestSizeUnit: defaultSize[1] || 'Gi',
     };
     this._handleRequestSizeInputChange = this._handleRequestSizeInputChange.bind(this);
     this._cancel = this.props.cancel.bind(this);


### PR DESCRIPTION
Earlier If the PVC was created for 1Mi/Ti and you open the expansion model the value used to be empty in text & dropdown used to be Gi by default. Which was getting a bit confusing for the user. With the default set to the requested storage now, it makes a bit easy for the user to expand.

Signed-off-by: Ankush Behl <cloudbehl@gmail.com>

**Before**

<img width="1236" alt="Screenshot 2020-06-17 at 11 15 18 PM" src="https://user-images.githubusercontent.com/6695156/84931545-8cdaa380-b0f0-11ea-9cde-396c00c2737b.png">


**After**
<img width="1198" alt="Screenshot 2020-06-17 at 11 11 47 PM" src="https://user-images.githubusercontent.com/6695156/84931580-995efc00-b0f0-11ea-97de-7c43e040404f.png">

<img width="1198" alt="Screenshot 2020-06-17 at 11 12 05 PM" src="https://user-images.githubusercontent.com/6695156/84931588-9bc15600-b0f0-11ea-9587-2f7da9ae95fe.png">


<img width="1186" alt="Screenshot 2020-06-17 at 11 12 31 PM" src="https://user-images.githubusercontent.com/6695156/84931592-9cf28300-b0f0-11ea-8cfa-9e9f987f8885.png">

<img width="1186" alt="Screenshot 2020-06-17 at 11 12 45 PM" src="https://user-images.githubusercontent.com/6695156/84931596-9e23b000-b0f0-11ea-8abd-2f319061cbdc.png">







