### PR TITLE
Query Browser: Stop table data poller when the table is hidden

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -626,7 +626,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   const tick = () => {
-    if (query) {
+    if (isEnabled && isExpanded && query) {
       safeFetch(getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, namespace, query }))
         .then((response) => {
           setData(_.get(response, 'data'));


### PR DESCRIPTION
Don't poll unless the query is both enabled and expanded.

Actually, the poller was already stopping when the query was disabled
because `query` is cleared in that case. However, we should not rely on
that, so also check `isEnabled` in the poller.