### PR TITLE
Bug 1848448: Fix for duplicate  'Edit Application Grouping' in knative services

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -21,7 +21,7 @@ import {
 import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
 import { Kebab, kebabOptionsToMenu } from '@console/internal/components/utils';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
-import { RevisionModel, ServiceModel } from '../../models';
+import { RevisionModel } from '../../models';
 import { getRevisionActions } from '../../actions/getRevisionActions';
 import {
   TYPE_EVENT_SOURCE,
@@ -46,9 +46,6 @@ export const knativeContextMenu = (element: Node) => {
   const model = modelFor(referenceFor(item));
 
   const actions = [];
-  if (model.kind === ServiceModel.kind) {
-    actions.push(ModifyApplication);
-  }
   if (model.kind === RevisionModel.kind) {
     actions.push(...getRevisionActions());
   } else {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4197

**Analysis / Root cause**: 
The modify application grouping action was added to the context menu twice for knative service items.

**Solution Description**: 
Remove the code that added the duplicate entry for knative service context menus.

/kind bug