### PR TITLE
Bug 1848244:  Fix bug where pending pod log tab throws error

### DIFF
--- a/frontend/public/components/pod-logs.jsx
+++ b/frontend/public/components/pod-logs.jsx
@@ -73,7 +73,6 @@ export class PodLogs extends React.Component {
     if (!currentKey) {
       const firstContainer = _.find(newState.containers, { order: 0 });
       newState.currentKey = firstContainer ? firstContainer.name : '';
-      setQueryArgument('container', newState.currentKey);
     }
     return newState;
   }


### PR DESCRIPTION
Only set the container query string param when the user interacts with the containers dropdown to fix the case where a pending pod doesn't have containers, so the page errors.