### PR TITLE
concat App Version with the helm chart Version only when it's present

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
@@ -161,6 +161,26 @@ export const mockHelmChartData: HelmChartMetaData[] = [
   },
 ];
 
+export const mockHelmChartData2: HelmChartMetaData[] = [
+  {
+    appVersion: '3.12',
+    apiVersion: 'v1',
+    name: 'hazelcast-enterprise',
+    urls: [
+      'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.3.tgz',
+    ],
+    version: '1.0.3',
+  },
+  {
+    apiVersion: 'v1',
+    name: 'hazelcast-enterprise',
+    urls: [
+      'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.2.tgz',
+    ],
+    version: '1.0.2',
+  },
+];
+
 export const mockReleaseResources: {
   [key: string]: { data: K8sResourceKind };
 } = {

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
@@ -12,6 +12,7 @@ import { HelmReleaseStatus } from '../helm-types';
 import {
   mockHelmReleases,
   mockHelmChartData,
+  mockHelmChartData2,
   mockReleaseResources,
   flattenedMockReleaseResources,
 } from './helm-release-mock-data';
@@ -60,6 +61,14 @@ describe('Helm Releases Utils', () => {
     expect(chartVersions).toEqual({
       '1.0.1': '1.0.1 / App Version 3.10.5',
       '1.0.2': '1.0.2 / App Version 3.12',
+      '1.0.3': '1.0.3 / App Version 3.12',
+    });
+  });
+
+  it('should concatenate App Version with the Chart Version only when it is available', () => {
+    const chartVersions = getChartVersions(mockHelmChartData2, 'v1.18.2');
+    expect(chartVersions).toEqual({
+      '1.0.2': '1.0.2',
       '1.0.3': '1.0.3 / App Version 3.12',
     });
   });

--- a/frontend/packages/dev-console/src/components/helm/details/overview/HelmChartSummary.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/overview/HelmChartSummary.tsx
@@ -31,7 +31,7 @@ const HelmChartSummary: React.FC<HelmChartSummaryProps> = ({ obj, helmRelease })
       <dt>Chart Version</dt>
       <dd>{chartVersion}</dd>
       <dt>App Version</dt>
-      <dd>{appVersion}</dd>
+      <dd>{appVersion || '-'}</dd>
       <dt>Revision</dt>
       <dd>{revision}</dd>
       <dt>Updated</dt>

--- a/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
@@ -9,7 +9,7 @@ import { confirmModal } from '@console/internal/components/modals/confirm-modal'
 import { k8sVersion } from '@console/internal/module/status';
 import { getK8sGitVersion } from '@console/internal/module/k8s';
 import { HelmChartMetaData, HelmChart, HelmActionType, HelmChartEntries } from '../helm-types';
-import { getChartURL, getChartVersions, getChartValuesYAML } from '../helm-utils';
+import { getChartURL, getChartVersions, getChartValuesYAML, concatVersions } from '../helm-utils';
 
 export type HelmChartVersionDropdownProps = {
   chartVersion: string;
@@ -138,7 +138,7 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
         items={helmChartVersions}
         helpText={helpText}
         disabled={_.isEmpty(helmChartVersions) || _.keys(helmChartVersions).length === 1}
-        title={helmChartVersions[chartVersion] || `${chartVersion} / App Version ${appVersion}`}
+        title={helmChartVersions[chartVersion] || concatVersions(chartVersion, appVersion)}
         onChange={handleChartVersionChange}
         required
         fullWidth

--- a/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListRow.tsx
@@ -23,7 +23,7 @@ const RevisionListRow: RowFunction = ({ obj, index, key, style }) => {
         {obj.chart.metadata.version}
       </TableData>
       <TableData className={tableColumnClasses.appVersion}>
-        {obj.chart.metadata.appVersion}
+        {obj.chart.metadata.appVersion || '-'}
       </TableData>
       <TableData className={tableColumnClasses.description}>{obj.info.description}</TableData>
     </TableRow>

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -29,14 +29,14 @@ export interface HelmChart {
 export interface HelmChartMetaData {
   name: string;
   version: string;
-  description: string;
+  description?: string;
   apiVersion: string;
-  appVersion: string;
+  appVersion?: string;
   keywords?: string[];
   home?: string;
   icon?: string;
   sources?: string[];
-  maintainers?: object[];
+  maintainers?: { name: string; email?: string; url?: string }[];
   dependencies?: object[];
   type?: string;
   urls: string[];

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -83,6 +83,10 @@ export const getChartURL = (helmChartData: HelmChartMetaData[], chartVersion: st
   return chartData?.urls[0];
 };
 
+export const concatVersions = (chartVersion: string, appVersion: string): string => {
+  return appVersion ? `${chartVersion} / App Version ${appVersion}` : chartVersion;
+};
+
 export const getChartVersions = (chartEntries: HelmChartMetaData[], kubernetesVersion: string) => {
   const chartVersions = _.reduce(
     chartEntries,
@@ -94,7 +98,7 @@ export const getChartVersions = (chartEntries: HelmChartMetaData[], kubernetesVe
       ) {
         return obj;
       }
-      obj[chart.version] = `${chart.version} / App Version ${chart.appVersion}`;
+      obj[chart.version] = concatVersions(chart.version, chart.appVersion);
       return obj;
     },
     {},

--- a/frontend/packages/dev-console/src/components/helm/list/HelmReleaseListRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/list/HelmReleaseListRow.tsx
@@ -42,7 +42,7 @@ const HelmReleaseListRow: RowFunction<HelmRelease> = ({ obj, index, key, style }
         {obj.chart.metadata.version}
       </TableData>
       <TableData className={tableColumnClasses.appVersion}>
-        {obj.chart.metadata.appVersion}
+        {obj.chart.metadata.appVersion || '-'}
       </TableData>
       <TableData className={tableColumnClasses.kebab}>
         <Kebab options={menuActions} />

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -216,6 +216,7 @@ export const CatalogListPage = withExtensions<CatalogListPageExtensionProps>({
 
     normalizeHelmCharts(chartEntries: HelmChartEntries): Item[] {
       const { namespace: currentNamespace = '', kubernetesVersion } = this.props;
+      const notAvailable = <span className="properties-side-panel-pf-property-label">N/A</span>;
 
       return _.reduce(
         chartEntries,
@@ -272,9 +273,9 @@ export const CatalogListPage = withExtensions<CatalogListPageExtensionProps>({
             const customProperties = (
               <>
                 <PropertyItem label="Chart Version" value={chartVersion} />
-                <PropertyItem label="App Version" value={appVersion} />
+                <PropertyItem label="App Version" value={appVersion || notAvailable} />
                 {homePage && <PropertyItem label="Home Page" value={homePage} />}
-                {maintainers && <PropertyItem label="Maintainers" value={maintainers} />}
+                <PropertyItem label="Maintainers" value={maintainers || notAvailable} />
               </>
             );
 


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-4193

**Root analysis:**
appVersion field in the chart.yaml is optional. So, for charts with no appVersion available would show up as `undefined` in the chart version dropdown 

**Solution Description:**
- showing App Version as `N/A` in the dev-catalog Sidebar, when helm chart is clicked, for charts with no App Version present
- the chart version dropdown in the Helm install & upgrade form will show the app version only when it's available for that chart
- added tests
- helm chart summary, revision list & release list will show `-` in the App Version column if it's not available

**Screenshot:**
![Screenshot from 2020-06-19 00-47-54](https://user-images.githubusercontent.com/22490998/85062692-8cacd780-b1c6-11ea-888f-11292c45e418.png)
![Screenshot from 2020-06-19 00-48-22](https://user-images.githubusercontent.com/22490998/85062717-98989980-b1c6-11ea-81a2-90bbc42c6994.png)
![Screenshot from 2020-06-19 00-51-22](https://user-images.githubusercontent.com/22490998/85062955-0644c580-b1c7-11ea-86b3-50afb3dc59c1.png)
