### PR TITLE
Label resources owned by operators

### DIFF
--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -21,6 +21,7 @@ import {
   referenceForModel,
 } from '../../module/k8s';
 import { ResourceItemDeleting } from '../overview/project-overview';
+import { ManagedByOperatorLink } from './managed-by';
 
 export const BreadCrumbs: React.SFC<BreadCrumbsProps> = ({ breadcrumbs }) => (
   <Breadcrumb>
@@ -129,6 +130,9 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
               {kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" />}{' '}
               <span data-test-id="resource-title" className="co-resource-item__resource-name">
                 {resourceTitle}
+                {data?.metadata?.namespace && data?.metadata?.ownerReferences?.length && (
+                  <ManagedByOperatorLink obj={data} />
+                )}
               </span>
               {resourceStatus && (
                 <ResourceStatus additionalClassNames="hidden-xs">

--- a/frontend/public/components/utils/managed-by.tsx
+++ b/frontend/public/components/utils/managed-by.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { Link } from 'react-router-dom';
+
+import { ResourceIcon } from './resource-icon';
+import {
+  groupVersionFor,
+  K8sResourceCommon,
+  K8sResourceKind,
+  referenceForGroupVersionKind,
+  referenceForModel,
+  referenceForOwnerRef,
+  OwnerReference,
+} from '../../module/k8s';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
+import { k8sList } from '../../module/k8s/resource';
+
+const isOwnedByOperator = (csv: K8sResourceKind, owner: OwnerReference) => {
+  const { group } = groupVersionFor(owner.apiVersion);
+  return csv.spec?.customresourcedefinitions?.owned?.some((owned) => {
+    const ownedGroup = owned.name.substring(owned.name.indexOf('.') + 1);
+    return owned.kind === owner.kind && ownedGroup === group;
+  });
+};
+
+const matchOwnerAndCSV = (owner: OwnerReference, csvs: K8sResourceCommon[] = []) => {
+  return csvs.find((csv) => isOwnedByOperator(csv, owner));
+};
+
+const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = (props) => {
+  const { csvName, namespace, owner } = props;
+  const name = owner.name;
+  const { group, version } = groupVersionFor(owner.apiVersion);
+  const kind = owner.kind;
+
+  const reference = referenceForGroupVersionKind(group)(version)(kind);
+
+  const link = `/k8s/ns/${namespace}/${referenceForModel(
+    ClusterServiceVersionModel,
+  )}/${csvName}/${reference}/${name}`;
+
+  return (
+    <span className="co-resource-item">
+      <ResourceIcon kind={referenceForOwnerRef(owner)} />
+      <Link to={link} className="co-resource-item__resource-name" data-test-operand-link={name}>
+        {name}
+      </Link>
+    </span>
+  );
+};
+
+export const ManagedByOperatorLink: React.SFC<ManagedByLinkProps> = (props) => {
+  const { obj, className } = props;
+  const [data, setData] = React.useState<ClusterServiceVersionKind[] | undefined>();
+  const namespace = obj.metadata.namespace;
+  React.useEffect(() => {
+    if (!namespace) {
+      return;
+    }
+    k8sList(ClusterServiceVersionModel, { ns: namespace })
+      .then(setData)
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error('Could not fetch CSVs', e);
+      });
+  }, [namespace]);
+  const ownerReferences = obj.metadata.ownerReferences || [];
+  const owner = data
+    ? ownerReferences.find((o) => data.some((csv) => isOwnedByOperator(csv, o)))
+    : undefined;
+  const csv = data && owner ? matchOwnerAndCSV(owner, data) : undefined;
+
+  if (owner && csv) {
+    return (
+      <div className={classNames('co-m-pane__heading-owner', className)}>
+        Managed by{' '}
+        <ManagedByOperatorResourceLink
+          namespace={namespace}
+          csvName={csv.metadata.name}
+          owner={owner}
+        />
+      </div>
+    );
+  }
+  return null;
+};
+
+type ManagedByLinkProps = {
+  className?: string;
+  obj: K8sResourceCommon;
+};
+
+type ManagerLinkProps = {
+  csvName: string;
+  namespace: string;
+  owner: OwnerReference;
+};

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -112,6 +112,16 @@ $co-external-link-padding-right: 15px;
   }
 }
 
+.co-m-pane__heading-owner {
+  display: block;
+  font-size: $font-size-base;
+  line-height: var(--pf-global--LineHeight--md);
+  padding-top: var(--pf-global--spacer--sm);
+  span {
+    display: inline;
+  }
+}
+
 .co-m-pane__heading-link {
   font-size: $font-size-base;
 }


### PR DESCRIPTION
Added web socket for keeping track of CSVs and resource label described in design document. I moved some logic in the ResourceLink component so that URLs are consistently generated for the owner of a given resource. Per @tlwu2013, the Owner link should match the label link. The link in the Owner section of the details page (if present) will now always have a link that matches the label. This should also affect anything using the OwnerReferences component (list views, etc.).

Desktop:
<img width="976" alt="Screen Shot 2020-07-15 at 2 24 40 PM" src="https://user-images.githubusercontent.com/7014965/87581466-ff668100-c6a6-11ea-99a7-98443db6495f.png">

Mobile:
<img width="480" alt="Screen Shot 2020-07-15 at 2 24 49 PM" src="https://user-images.githubusercontent.com/7014965/87581480-04c3cb80-c6a7-11ea-8b2f-7e945e890783.png">

Fixes https://issues.redhat.com/browse/CONSOLE-2288.

Heads up @itsptk and @openshift/team-ux-review.