### PR TITLE
Bug 1848930: Move URL from EventListener details page to it's own section

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
 import { TriggerBindingModel, TriggerTemplateModel } from '../../../models';
 import { EventListenerKind } from '../resource-types';
+import EventListenerURL from './EventListenerURL';
 import DynamicResourceLinkList, {
   ResourceModelLink,
 } from '../resource-overview/DynamicResourceLinkList';
-import TriggerTemplateResourceLink from '../resource-overview/TriggerTemplateResourceLink';
 import {
-  RouteTemplate,
-  useEventListenerTriggerTemplateNames,
+  getEventListenerTriggerTemplateNames,
   getEventListenerTriggerBindingNames,
 } from '../utils/triggers';
 
@@ -17,7 +16,7 @@ export interface EventListenerDetailsProps {
 }
 
 const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventListener }) => {
-  const routeTemplates: RouteTemplate[] = useEventListenerTriggerTemplateNames(eventListener) || [];
+  const templates: ResourceModelLink[] = getEventListenerTriggerTemplateNames(eventListener);
   const bindings: ResourceModelLink[] = getEventListenerTriggerBindingNames(eventListener);
   return (
     <div className="co-m-pane__body">
@@ -27,10 +26,14 @@ const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventL
           <ResourceSummary resource={eventListener} />
         </div>
         <div className="col-sm-6">
-          <TriggerTemplateResourceLink
+          <EventListenerURL
+            eventListener={eventListener}
             namespace={eventListener.metadata.namespace}
-            model={TriggerTemplateModel}
-            links={routeTemplates}
+          />
+          <DynamicResourceLinkList
+            links={templates}
+            namespace={eventListener.metadata.namespace}
+            title={TriggerTemplateModel.labelPlural}
           />
           <DynamicResourceLinkList
             links={bindings}

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerURL.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerURL.scss
@@ -1,0 +1,3 @@
+.odc-event-listener-url {
+  margin-bottom: var(--pf-global--spacer--lg);
+}

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerURL.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerURL.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { ExternalLink } from '@console/internal/components/utils';
+import { EventListenerKind } from '../resource-types';
+import { useEventListenerURL } from '../utils/triggers';
+
+import './EventListenerURL.scss';
+
+type EventListenerURLProps = {
+  eventListener: EventListenerKind;
+  namespace: string;
+};
+
+const EventListenerURL: React.FC<EventListenerURLProps> = ({ eventListener, namespace }) => {
+  const routeURL = useEventListenerURL(eventListener, namespace);
+  return (
+    routeURL && (
+      <div className="odc-event-listener-url">
+        <dl>
+          <dt>URL</dt>
+          <dd>
+            <ExternalLink href={routeURL} text={routeURL} />
+          </dd>
+        </dl>
+      </div>
+    )
+  );
+};
+
+export default EventListenerURL;

--- a/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
@@ -149,29 +149,26 @@ export const usePipelineTriggerTemplateNames = (
   }, []);
 };
 
-export const useEventListenerTriggerTemplateNames = (
+export const useEventListenerURL = (
   eventListener: EventListenerKind,
-): RouteTemplate[] | null => {
-  const {
-    metadata: { namespace },
-  } = eventListener;
-
+  namespace: string,
+): string | null => {
   const [route, routeLoaded] = useK8sGet<RouteKind>(
     RouteModel,
     getEventListenerGeneratedName(eventListener),
     namespace,
   );
-  return eventListener.spec.triggers.reduce(
-    (acc, trigger) => [
-      ...acc,
-      {
-        routeURL: route && routeLoaded ? getRouteWebURL(route) : null,
-        triggerTemplateName: trigger.template.name,
-      },
-    ],
-    [],
-  );
+
+  return routeLoaded ? getRouteWebURL(route) : null;
 };
+
+export const getEventListenerTriggerTemplateNames = (
+  eventListener: EventListenerKind,
+): ResourceModelLink[] =>
+  eventListener.spec.triggers.map((trigger) => ({
+    model: TriggerTemplateModel,
+    name: trigger.template.name,
+  }));
 
 export const getEventListenerTriggerBindingNames = (
   eventListener: EventListenerKind,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3654
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The URL in the EventListener Details page is misleading since it is not originated form the TriggerTemplate.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Move URL to it's own section.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
Before:
![before](https://user-images.githubusercontent.com/20013884/85120707-4052ad80-b241-11ea-9ba7-ee6893ee2038.png)

After:
![after](https://user-images.githubusercontent.com/20013884/85120728-4779bb80-b241-11ea-8138-3e0dbf701a26.png)

cc: @openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
