### PR TITLE
Add custom fields to support dynamic forms in formik

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/const.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/const.ts
@@ -27,3 +27,8 @@ export const K8S_UI_SCHEMA = {
 
 export const JSON_SCHEMA_GROUP_TYPES: string[] = ['object', 'array'];
 export const JSON_SCHEMA_NUMBER_TYPES: string[] = ['number', 'integer'];
+
+const SORT_WEIGHT_BASE = 10;
+export const SORT_WEIGHT_SCALE_1 = SORT_WEIGHT_BASE ** 1;
+export const SORT_WEIGHT_SCALE_2 = SORT_WEIGHT_BASE ** 2;
+export const SORT_WEIGHT_SCALE_3 = SORT_WEIGHT_BASE ** 3;

--- a/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
@@ -31,6 +31,9 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
   schema,
   uiSchema = {},
   widgets = {},
+  customUISchema,
+  noActions,
+  ...restProps
 }) => {
   const schemaErrors = getSchemaErrors(schema);
   // IF the top level schema is unsupported, don't render a form at all.
@@ -58,6 +61,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
       />
       <Accordion asDefinitionList={false} className="co-dynamic-form__accordion">
         <Form
+          {...restProps}
           className="co-dynamic-form"
           noValidate={noValidate}
           ArrayFieldTemplate={ArrayFieldTemplate}
@@ -73,20 +77,22 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
           schema={schema}
           // Don't show the react-jsonschema-form error list at top
           showErrorList={false}
-          uiSchema={_.defaultsDeep({}, K8S_UI_SCHEMA, uiSchema)}
+          uiSchema={customUISchema ? uiSchema : _.defaultsDeep({}, K8S_UI_SCHEMA, uiSchema)}
           widgets={{ ...defaultWidgets, ...widgets }}
         >
           {errors.length > 0 && <ErrorTemplate errors={errors} />}
-          <div style={{ paddingBottom: '30px' }}>
-            <ActionGroup className="pf-c-form">
-              <Button type="submit" variant="primary">
-                Create
-              </Button>
-              <Button onClick={history.goBack} variant="secondary">
-                Cancel
-              </Button>
-            </ActionGroup>
-          </div>
+          {!noActions && (
+            <div style={{ paddingBottom: '30px' }}>
+              <ActionGroup className="pf-c-form">
+                <Button type="submit" variant="primary">
+                  Create
+                </Button>
+                <Button onClick={history.goBack} variant="secondary">
+                  Cancel
+                </Button>
+              </ActionGroup>
+            </div>
+          )}
         </Form>
       </Accordion>
     </>
@@ -96,6 +102,8 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
 type DynamicFormProps = FormProps<any> & {
   errors?: string[];
   ErrorTemplate?: React.FC<{ errors: string[] }>;
+  noActions?: boolean;
+  customUISchema?: boolean;
 };
 
 export * from './types';

--- a/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
@@ -13,6 +13,7 @@ import {
   AccordionContent,
   Button,
   Alert,
+  FormHelperText,
 } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { JSON_SCHEMA_GROUP_TYPES } from './const';
@@ -61,11 +62,13 @@ export const AtomicFieldTemplate: React.FC<FieldTemplateProps> = ({
         {children}
         {description}
         {!_.isEmpty(rawErrors) && (
-          <ul className="co-error">
+          <>
             {_.map(rawErrors, (error) => (
-              <li className="co-error">{error}</li>
+              <FormHelperText key={error} isHidden={false} isError>
+                {_.capitalize(error)}
+              </FormHelperText>
             ))}
-          </ul>
+          </>
         )}
       </>
     </FormField>

--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
@@ -1,8 +1,10 @@
 import * as _ from 'lodash';
+import * as Immutable from 'immutable';
 import { JSONSchema6 } from 'json-schema';
+import { UiSchema } from 'react-jsonschema-form';
 import { getSchemaType } from 'react-jsonschema-form/lib/utils';
 import { SchemaType } from './types';
-import { UiSchema } from 'react-jsonschema-form';
+import { SORT_WEIGHT_SCALE_1, SORT_WEIGHT_SCALE_2, SORT_WEIGHT_SCALE_3 } from './const';
 
 const UNSUPPORTED_SCHEMA_PROPERTIES = ['allOf', 'anyOf', 'oneOf'];
 
@@ -52,6 +54,127 @@ export const hasNoFields = (jsonSchema: JSONSchema6 = {}, uiSchema: UiSchema = {
       return false;
     default:
       return noUIFieldOrWidget;
+  }
+};
+
+// Given a JSONSchema and associated uiSchema, create the appropriat ui schema order property for the jsonSchema.
+// Orders properties according to the following rules:
+//  - required properties with an associated ui schema come first,
+//  - required properties without an associated ui schema next,
+//  - optional fields with an associated ui schema next,
+//  - all other properties
+export const getJSONSchemaOrder = (jsonSchema, uiSchema) => {
+  const type = getSchemaType(jsonSchema ?? {});
+  const handleArray = () => {
+    const descendantOrder = getJSONSchemaOrder(jsonSchema?.items as JSONSchema6, uiSchema?.items);
+    return !_.isEmpty(descendantOrder) ? { items: descendantOrder } : {};
+  };
+
+  const handleObject = () => {
+    const propertyNames = _.keys(jsonSchema?.properties ?? {});
+    if (_.isEmpty(propertyNames)) {
+      return {};
+    }
+
+    // Map control fields to an array so that  an index can be used to apply a modifier to sort weigths of dependent fields
+    const controlProperties = _.reduce(
+      uiSchema,
+      (controlPropertyAccumulator, { 'ui:dependency': dependency }) => {
+        const control = _.last(dependency?.path ?? []);
+        return !control ? controlPropertyAccumulator : [...controlPropertyAccumulator, control];
+      },
+      [],
+    );
+
+    /**
+     * Give a property name a sort wieght based on whether it has a descriptor (uiSchema has property), is required, or is a control
+     * field for a property with a field dependency. A lower weight means higher sort order. Fields are weighted according to the following criteria:
+     *  - Required fields with descriptor - 0 to 999
+     *  - Required fields without descriptor 1000 to 1999
+     *  - Optional fields with descriptor 2000 to 2999
+     *  - Control fields that don't fit any above - 3000 to 3999
+     *  - All other fields - Infinity
+     *
+     * Within each of the above criteria, fields are further weighted based on field dependency:
+     *   - Fields without dependency - base weight
+     *   - Control field - base weight  + (nth control field) * 100
+     *   - Dependent field - corresponding control field weight + 10
+     *
+     * These weight numbers are arbitrary, but spaced far enough apart to leave room for multiple levels of sorting.
+     */
+    const getSortWeight = (property: string): number => {
+      // This property's control field, if it exists
+      const control = _.last<string>(uiSchema?.[property]?.['ui:dependency']?.path ?? []);
+
+      // A small offset that is added to the base weight so that control fields get sorted last within
+      // their appropriate group
+      const controlOffset = (controlProperties.indexOf(property) + 1) * SORT_WEIGHT_SCALE_2;
+
+      // If this property is a dependent, it's weight is based on it's control property
+      if (control) {
+        return getSortWeight(control) + controlOffset + SORT_WEIGHT_SCALE_1;
+      }
+
+      const isRequired = (jsonSchema?.required ?? []).includes(property);
+      const hasDescriptor = uiSchema?.[property];
+
+      // Required fields with a desriptor are sorted first (lowest weight).
+      if (isRequired && hasDescriptor) {
+        return SORT_WEIGHT_SCALE_3 + controlOffset;
+      }
+
+      // Fields that are required, but have no descriptors get sorted next
+      if (isRequired) {
+        // Add requiredIndex to sort required properties based on there index in required array
+        const requiredIndex = (jsonSchema?.required ?? []).indexOf(property);
+        return SORT_WEIGHT_SCALE_3 * 2 + requiredIndex + controlOffset;
+      }
+
+      // Optional fields with descriptors get sorted next
+      if (hasDescriptor) {
+        return SORT_WEIGHT_SCALE_3 * 3 + controlOffset;
+      }
+
+      // Control fields that don't fit into any of the above criteria come next
+      if (controlOffset > 0) {
+        return SORT_WEIGHT_SCALE_3 * 4 + controlOffset;
+      }
+
+      // All other fields are sorted in the order in which they are encountered
+      // in the schema
+      return Infinity;
+    };
+
+    const uiOrder = Immutable.Set(propertyNames)
+      .sortBy(getSortWeight)
+      .toJS();
+
+    return {
+      ...(uiOrder.length > 1 && { 'ui:order': uiOrder }),
+      ..._.reduce(
+        jsonSchema?.properties ?? {},
+        (orderAccumulator, property, propertyName) => {
+          const descendantOrder = getJSONSchemaOrder(property, uiSchema?.[propertyName]);
+          if (_.isEmpty(descendantOrder)) {
+            return orderAccumulator;
+          }
+          return {
+            ...orderAccumulator,
+            [propertyName]: descendantOrder,
+          };
+        },
+        {},
+      ),
+    };
+  };
+
+  switch (type) {
+    case SchemaType.array:
+      return handleArray();
+    case SchemaType.object:
+      return handleObject();
+    default:
+      return {};
   }
 };
 

--- a/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FormProps } from 'react-jsonschema-form';
 import { useField, useFormikContext, FormikValues } from 'formik';
+import { Grid, GridItem } from '@patternfly/react-core';
 import { AsyncComponent } from '@console/internal/components/utils';
 
 type DynamicFormFieldProps = FormProps<any> & {
@@ -21,9 +22,8 @@ const DynamicFormField: React.FC<DynamicFormFieldProps> = ({
   const { setFieldValue } = useFormikContext<FormikValues>();
 
   return (
-    <div className="row" style={{ marginTop: `16px` }}>
-      <div className="col-md-6 col-md-push-6 col-lg-6 col-lg-push-6">{formDescription}</div>
-      <div className="col-md-6 col-md-pull-6 col-lg-6 col-lg-pull-6">
+    <Grid gutter="md">
+      <GridItem span={6}>
         <AsyncComponent
           loader={() => import('../dynamic-form').then((c) => c.DynamicForm)}
           errors={errors}
@@ -37,8 +37,9 @@ const DynamicFormField: React.FC<DynamicFormFieldProps> = ({
           noActions
           liveValidate
         />
-      </div>
-    </div>
+      </GridItem>
+      <GridItem span={6}>{formDescription}</GridItem>
+    </Grid>
   );
 };
 

--- a/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { FormProps } from 'react-jsonschema-form';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import { AsyncComponent } from '@console/internal/components/utils';
+
+type DynamicFormFieldProps = FormProps<any> & {
+  name: string;
+  errors?: string[];
+  formDescription?: React.ReactNode;
+};
+
+const DynamicFormField: React.FC<DynamicFormFieldProps> = ({
+  name,
+  schema,
+  uiSchema,
+  errors,
+  formDescription,
+  formContext,
+}) => {
+  const [field] = useField(name);
+  const { setFieldValue } = useFormikContext<FormikValues>();
+
+  return (
+    <div className="row" style={{ marginTop: `16px` }}>
+      <div className="col-md-6 col-md-push-6 col-lg-6 col-lg-push-6">{formDescription}</div>
+      <div className="col-md-6 col-md-pull-6 col-lg-6 col-lg-pull-6">
+        <AsyncComponent
+          loader={() => import('../dynamic-form').then((c) => c.DynamicForm)}
+          errors={errors}
+          formContext={formContext}
+          uiSchema={uiSchema}
+          formData={field.value}
+          onChange={(data) => setFieldValue(name, data)}
+          schema={schema}
+          tagName="div"
+          customUISchema
+          noActions
+          liveValidate
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DynamicFormField;

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioButtonField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioButtonField.tsx
@@ -4,9 +4,15 @@ import { Radio } from '@patternfly/react-core';
 import { RadioButtonFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
 
-const RadioButtonField: React.FC<RadioButtonFieldProps> = ({ name, label, value, ...props }) => {
+const RadioButtonField: React.FC<RadioButtonFieldProps> = ({
+  name,
+  label,
+  value,
+  onChange,
+  ...props
+}) => {
   const [field, { touched, error }] = useField(name);
-  const { setFieldValue } = useFormikContext<FormikValues>();
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const fieldId = getFieldId(`${name}-${value}`, 'radiobutton');
   const isValid = !(touched && error);
   return (
@@ -20,7 +26,14 @@ const RadioButtonField: React.FC<RadioButtonFieldProps> = ({ name, label, value,
       isValid={isValid}
       isDisabled={props.isDisabled}
       aria-label={`${fieldId}-${label}`}
-      onChange={() => setFieldValue(name, value)}
+      onChange={() => {
+        if (onChange) {
+          onChange(value);
+        } else {
+          setFieldValue(name, value);
+        }
+        setFieldTouched(name, true);
+      }}
     />
   );
 };

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
@@ -8,4 +8,14 @@
   &__children {
     padding: var(--pf-global--spacer--md) 0;
   }
+
+  &--inline {
+    display: flex;
+    align-items: flex-start;
+
+    > .pf-c-form__label, .pf-c-radio {
+      margin-right: var(--pf-global--spacer--md);
+    }
+
+  }
 }

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { useField } from 'formik';
 import { FormGroup } from '@patternfly/react-core';
 import { RadioGroupFieldProps } from './field-types';
@@ -11,6 +12,8 @@ const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
   options,
   helpText,
   required,
+  inline,
+  onChange,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
@@ -19,7 +22,7 @@ const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
   const errorMessage = !isValid ? error : '';
   return (
     <FormGroup
-      className="ocs-radio-group-field"
+      className={classNames('ocs-radio-group-field', { 'ocs-radio-group-field--inline': inline })}
       fieldId={fieldId}
       helperText={helpText}
       helperTextInvalid={errorMessage}
@@ -48,6 +51,7 @@ const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
               isDisabled={option.isDisabled}
               aria-describedby={`${fieldId}-helper`}
               description={description}
+              onChange={onChange}
             />
           </React.Fragment>
         );

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
@@ -1,0 +1,14 @@
+@import '../../../../../public/style/vars';
+
+.ocs-synced-editor-field {
+  &__editor-toggle {
+    padding-top: var(--pf-global--spacer--sm);
+    margin: var(--pf-global--spacer--md) 0;
+    border-bottom: 1px solid #ddd;
+    border-top: 1px solid #ddd;
+  }
+
+  &__yaml-warning {
+    margin: $grid-gutter-width $grid-gutter-width 0;
+  }
+}

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import { Alert, Button } from '@patternfly/react-core';
+import { EditorType } from '../synced-editor/editor-toggle';
+import RadioGroupField from './RadioGroupField';
+
+import './SyncedEditorField.scss';
+import { safeYAMLToJS, safeJSToYAML } from '../../utils/yaml';
+
+type EditorContext = {
+  name: string;
+  editor: React.ReactNode;
+  isDisabled?: boolean;
+};
+
+type SyncedEditorFieldProps = {
+  name: string;
+  formContext: EditorContext;
+  yamlContext: EditorContext;
+};
+
+const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
+  name,
+  formContext,
+  yamlContext,
+}) => {
+  const [field] = useField(name);
+  const { values, setFieldValue } = useFormikContext<FormikValues>();
+
+  const formData = _.get(values, formContext.name);
+  const yamlData = _.get(values, yamlContext.name);
+
+  const [yamlWarning, setYAMLWarning] = React.useState<boolean>(false);
+
+  const changeEditorType = (newType: EditorType): void => {
+    setFieldValue(name, newType);
+  };
+
+  const handleToggleToForm = () => {
+    const newFormData = safeYAMLToJS(yamlData);
+    if (!_.isEmpty(newFormData)) {
+      changeEditorType(EditorType.Form);
+      setFieldValue(formContext.name, newFormData);
+    } else {
+      setYAMLWarning(true);
+    }
+  };
+
+  const handleToggleToYAML = () => {
+    const newYAML = safeJSToYAML(formData, yamlData, { skipInvalid: true });
+    setFieldValue(yamlContext.name, newYAML);
+    changeEditorType(EditorType.YAML);
+  };
+
+  const onClickYAMLWarningConfirm = () => {
+    setYAMLWarning(false);
+    changeEditorType(EditorType.Form);
+  };
+
+  const onClickYAMLWarningCancel = () => {
+    setYAMLWarning(false);
+  };
+
+  const onChangeType = (newType) => {
+    switch (newType) {
+      case EditorType.YAML:
+        handleToggleToYAML();
+        break;
+      case EditorType.Form:
+        handleToggleToForm();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <>
+      <div className="ocs-synced-editor-field__editor-toggle">
+        <RadioGroupField
+          label="Configure via:"
+          name={name}
+          options={[
+            {
+              label: 'Form View',
+              value: EditorType.Form,
+              isDisabled: formContext.isDisabled,
+            },
+            {
+              label: 'YAML View',
+              value: EditorType.YAML,
+              isDisabled: yamlContext.isDisabled,
+            },
+          ]}
+          onChange={(val) => onChangeType(val as EditorType)}
+          inline
+        />
+      </div>
+      {yamlWarning && (
+        <Alert
+          className="co-synced-editor__yaml-warning"
+          variant="danger"
+          isInline
+          title="Invalid YAML cannot be persisted"
+        >
+          <p>Switching to Form View will delete any invalid YAML.</p>
+          <Button variant="danger" onClick={onClickYAMLWarningConfirm}>
+            Switch and Delete
+          </Button>
+          &nbsp;
+          <Button variant="secondary" onClick={onClickYAMLWarningCancel}>
+            Cancel
+          </Button>
+        </Alert>
+      )}
+      {formContext.isDisabled && (
+        <Alert
+          variant="default"
+          title="Form view is disabled for this chart because the schema is not available"
+          isInline
+        />
+      )}
+      {field.value === EditorType.Form ? formContext.editor : yamlContext.editor}
+    </>
+  );
+};
+
+export default SyncedEditorField;

--- a/frontend/packages/console-shared/src/components/formik-fields/__tests__/SyncedEditorField.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/__tests__/SyncedEditorField.spec.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { shallow } from 'enzyme';
+import { useField } from 'formik';
+import { Alert } from '@patternfly/react-core';
+import SyncedEditorField from '../SyncedEditorField';
+import RadioGroupField from '../RadioGroupField';
+import DynamicFormField from '../DynamicFormField';
+import YAMLEditorField from '../YAMLEditorField';
+
+jest.mock('formik', () => ({
+  useField: jest.fn(() => [{ value: 'form' }, {}]),
+  useFormikContext: jest.fn(() => ({
+    values: {},
+    setFieldValue: jest.fn(),
+  })),
+}));
+
+const mockEditors = {
+  form: <DynamicFormField name="formData" schema={{}} />,
+  yaml: <YAMLEditorField name="yamlData" />,
+};
+
+const props = {
+  name: 'editorType',
+  formContext: {
+    name: 'formData',
+    editor: mockEditors.form,
+    isDisabled: false,
+  },
+  yamlContext: {
+    name: 'yamlData',
+    editor: mockEditors.yaml,
+    isDisabled: false,
+  },
+};
+describe('DropdownField', () => {
+  it('should render radio group field inline', () => {
+    const wrapper = shallow(<SyncedEditorField {...props} />);
+    expect(wrapper.find(RadioGroupField).exists()).toBe(true);
+    expect(
+      wrapper
+        .find(RadioGroupField)
+        .first()
+        .props().inline,
+    ).toBe(true);
+  });
+
+  it('should render dynamic form field if initial editor type is form', () => {
+    const wrapper = shallow(<SyncedEditorField {...props} />);
+    expect(wrapper.find(DynamicFormField).exists()).toBe(true);
+  });
+
+  it('should render dynamic form field if initial editor type is form', () => {
+    (useField as any).mockImplementation(() => [{ value: 'yaml' }, {}]);
+    const wrapper = shallow(<SyncedEditorField {...props} />);
+    expect(wrapper.find(YAMLEditorField).exists()).toBe(true);
+  });
+
+  it('should disable corresponding radio button if any editor context is disaled', () => {
+    const newProps = _.cloneDeep(props);
+    newProps.yamlContext.isDisabled = true;
+    const wrapper = shallow(<SyncedEditorField {...newProps} />);
+    expect(
+      wrapper
+        .find(RadioGroupField)
+        .first()
+        .props().options[1].isDisabled,
+    ).toBe(true);
+  });
+
+  it('should show an alert if form context is disaled', () => {
+    const newProps = _.cloneDeep(props);
+    newProps.formContext.isDisabled = true;
+    const wrapper = shallow(<SyncedEditorField {...newProps} />);
+    expect(wrapper.find(Alert).exists()).toBe(true);
+    expect(
+      wrapper
+        .find(Alert)
+        .first()
+        .props().title,
+    ).toBe('Form view is disabled for this chart because the schema is not available');
+  });
+});

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -113,16 +113,19 @@ export interface SecretKeyRef {
 }
 
 export interface RadioButtonFieldProps extends FieldProps {
-  value: string | number;
+  value: React.ReactText;
   description?: React.ReactNode;
+  onChange?: (value: React.ReactText) => void;
 }
 
 export interface RadioGroupFieldProps extends FieldProps {
+  inline?: boolean;
   options: RadioGroupOption[];
+  onChange?: (value: React.ReactText) => void;
 }
 
 export interface RadioGroupOption {
-  value: string | number;
+  value: React.ReactText;
   label: React.ReactNode;
   isDisabled?: boolean;
   children?: React.ReactNode;

--- a/frontend/packages/console-shared/src/components/formik-fields/index.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/index.ts
@@ -16,5 +16,7 @@ export { default as YAMLEditorField } from './YAMLEditorField';
 export { default as ItemSelectorField } from './item-selector-field/ItemSelectorField';
 export { default as InputGroupField } from './InputGroupField';
 export { default as TextColumnField } from './TextColumnField';
+export { default as DynamicFormField } from './DynamicFormField';
+export { default as SyncedEditorField } from './SyncedEditorField';
 export * from './field-utils';
 export * from './field-types';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/const.ts
@@ -34,8 +34,3 @@ export const HIDDEN_UI_SCHEMA = {
   'ui:widget': 'hidden',
   'ui:options': { label: false },
 };
-
-const SORT_WEIGHT_BASE = 10;
-export const SORT_WEIGHT_SCALE_1 = SORT_WEIGHT_BASE ** 1;
-export const SORT_WEIGHT_SCALE_2 = SORT_WEIGHT_BASE ** 2;
-export const SORT_WEIGHT_SCALE_3 = SORT_WEIGHT_BASE ** 3;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
@@ -1,6 +1,7 @@
 import { testCRD } from '../../../integration-tests/mocks';
-import { getJSONSchemaOrder, capabilitiesToUISchema } from './utils';
+import { getJSONSchemaOrder } from '@console/shared/src/components/dynamic-form/utils';
 import { ServiceAccountModel } from '@console/internal/models';
+import { capabilitiesToUISchema } from './utils';
 import { SpecCapability } from '../descriptors/types';
 
 describe('getJSONSchemaOrder', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
@@ -1,18 +1,12 @@
 import * as _ from 'lodash';
 import * as Immutable from 'immutable';
 import { JSONSchema6 } from 'json-schema';
-import { SpecCapability, Descriptor } from '../descriptors/types';
-import { modelFor } from '@console/internal/module/k8s';
-import { capabilityFieldMap, capabilityWidgetMap } from '../descriptors/spec/spec-descriptor-input';
-import {
-  HIDDEN_UI_SCHEMA,
-  SORT_WEIGHT_SCALE_1,
-  SORT_WEIGHT_SCALE_2,
-  SORT_WEIGHT_SCALE_3,
-} from './const';
 import { UiSchema } from 'react-jsonschema-form';
-import { SchemaType } from '@console/shared/src/components/dynamic-form';
-import { getSchemaType } from 'react-jsonschema-form/lib/utils';
+import { modelFor } from '@console/internal/module/k8s';
+import { getJSONSchemaOrder } from '@console/shared/src/components/dynamic-form/utils';
+import { SpecCapability, Descriptor } from '../descriptors/types';
+import { capabilityFieldMap, capabilityWidgetMap } from '../descriptors/spec/spec-descriptor-input';
+import { HIDDEN_UI_SCHEMA } from './const';
 import {
   REGEXP_K8S_RESOURCE_SUFFIX,
   REGEXP_FIELD_DEPENDENCY_PATH_VALUE,
@@ -135,125 +129,6 @@ export const capabilitiesToUISchema = (capabilities: SpecCapability[] = []) => {
     ...(field && { 'ui:field': field }),
     ...(widget && { 'ui:widget': widget }),
   };
-};
-
-// Given a JSONSchema and associated uiSchema, create the appropriat ui schema order property for the jsonSchema.
-// Orders properties according to the following rules:
-//  - required properties with an associated ui schema come first,
-//  - required properties without an associated ui schema next,
-//  - optional fields with an associated ui schema next,
-//  - all other properties
-export const getJSONSchemaOrder = (jsonSchema, uiSchema) => {
-  const type = getSchemaType(jsonSchema ?? {});
-  const handleArray = () => {
-    const descendantOrder = getJSONSchemaOrder(jsonSchema?.items as JSONSchema6, uiSchema?.items);
-    return !_.isEmpty(descendantOrder) ? { items: descendantOrder } : {};
-  };
-
-  const handleObject = () => {
-    const propertyNames = _.keys(jsonSchema?.properties ?? {});
-    if (_.isEmpty(propertyNames)) {
-      return {};
-    }
-
-    // Map control fields to an array so that  an index can be used to apply a modifier to sort weigths of dependent fields
-    const controlProperties = _.reduce(
-      uiSchema,
-      (controlPropertyAccumulator, { 'ui:dependency': dependency }) => {
-        const control = _.last(dependency?.path ?? []);
-        return !control ? controlPropertyAccumulator : [...controlPropertyAccumulator, control];
-      },
-      [],
-    );
-
-    /**
-     * Give a property name a sort wieght based on whether it has a descriptor (uiSchema has property), is required, or is a control
-     * field for a property with a field dependency. A lower weight means higher sort order. Fields are weighted according to the following criteria:
-     *  - Required fields with descriptor - 0 to 999
-     *  - Required fields without descriptor 1000 to 1999
-     *  - Optional fields with descriptor 2000 to 2999
-     *  - Control fields that don't fit any above - 3000 to 3999
-     *  - All other fields - Infinity
-     *
-     * Within each of the above criteria, fields are further weighted based on field dependency:
-     *   - Fields without dependency - base weight
-     *   - Control field - base weight  + (nth control field) * 100
-     *   - Dependent field - corresponding control field weight + 10
-     *
-     * These weight numbers are arbitrary, but spaced far enough apart to leave room for multiple levels of sorting.
-     */
-    const getSortWeight = (property: string): number => {
-      // This property's control field, if it exists
-      const control = _.last<string>(uiSchema?.[property]?.['ui:dependency']?.path ?? []);
-
-      // A small offset that is added to the base weight so that control fields get sorted last within
-      // their appropriate group
-      const controlOffset = (controlProperties.indexOf(property) + 1) * SORT_WEIGHT_SCALE_2;
-
-      // If this property is a dependent, it's weight is based on it's control property
-      if (control) {
-        return getSortWeight(control) + controlOffset + SORT_WEIGHT_SCALE_1;
-      }
-
-      const isRequired = (jsonSchema?.required ?? []).includes(property);
-      const hasDescriptor = uiSchema?.[property];
-
-      // Required fields with a desriptor are sorted first (lowest weight).
-      if (isRequired && hasDescriptor) {
-        return SORT_WEIGHT_SCALE_3 + controlOffset;
-      }
-
-      // Fields that are required, but have no descriptors get sorted next
-      if (isRequired) {
-        return SORT_WEIGHT_SCALE_3 * 2 + controlOffset;
-      }
-
-      // Optional fields with descriptors get sorted next
-      if (hasDescriptor) {
-        return SORT_WEIGHT_SCALE_3 * 3 + controlOffset;
-      }
-
-      // Control fields that don't fit into any of the above criteria come next
-      if (controlOffset > 0) {
-        return SORT_WEIGHT_SCALE_3 * 4 + controlOffset;
-      }
-
-      // All other fields are sorted in the order in which they are encountered
-      // in the schema
-      return Infinity;
-    };
-
-    const uiOrder = Immutable.Set(propertyNames)
-      .sortBy(getSortWeight)
-      .toJS();
-
-    return {
-      ...(uiOrder.length > 1 && { 'ui:order': uiOrder }),
-      ..._.reduce(
-        jsonSchema?.properties ?? {},
-        (orderAccumulator, property, propertyName) => {
-          const descendantOrder = getJSONSchemaOrder(property, uiSchema?.[propertyName]);
-          if (_.isEmpty(descendantOrder)) {
-            return orderAccumulator;
-          }
-          return {
-            ...orderAccumulator,
-            [propertyName]: descendantOrder,
-          };
-        },
-        {},
-      ),
-    };
-  };
-
-  switch (type) {
-    case SchemaType.array:
-      return handleArray();
-    case SchemaType.object:
-      return handleObject();
-    default:
-      return {};
-  }
 };
 
 // Map a set of spec descriptors to a ui schema


### PR DESCRIPTION
**Fixes**:  https://issues.redhat.com/browse/ODC-4084

**Analysis / Root cause**: Right now we use formik for all of our forms in dev console. Dynamic forms uses a separate framework called `json-schema-form` and it created based on kube resources and there actions. This wouldn't work for use because of formik forms and Helm resources not  being kube native resources.

**Solution Description**: In order to make use of dynamic forms in the formik context, we needed to customize the already present dynamic form components and utils to support our use case for Helm install and upgrade forms. We also needed to create bridge components which bridges formik state to dynamic form state. This PR adds support for these custom components and also customizes already present components and utils.

**Screen shots / Gifs for design review**: 
Helm Install - 
![Dynamic Forms Helm Install](https://user-images.githubusercontent.com/6041994/85137942-96364e00-b25f-11ea-8b50-107547cd2d94.gif)

Helm Upgrade - 
![Dynamic Forms Helm Upgrade](https://user-images.githubusercontent.com/6041994/85137964-9fbfb600-b25f-11ea-85c1-7a46cb5ffbd3.gif)

**Unit Tests Added**
![image](https://user-images.githubusercontent.com/6041994/85751606-58866900-b728-11ea-9dcd-a8af2dbb0ac0.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge