### PR TITLE
Fix guest agent fields messaging in Overview & Details tabs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -22,18 +22,25 @@ import { VM_DETAIL_DETAILS_HREF } from '../../../constants';
 import { findVMIPod } from '../../../selectors/pod/selectors';
 import { useGuestAgentInfo } from '../../../hooks/use-guest-agent-info';
 import { GuestAgentInfoWrapper } from '../../../k8s/wrapper/vm/guest-agent-info/guest-agent-info-wrapper';
-import { getNumLoggedInUsersMessage, getGuestAgentFieldNotAvailMsg } from '../../../utils/strings';
 import { isGuestAgentInstalled } from './vm-alerts';
 import { getOperatingSystemName, getOperatingSystem } from '../../../selectors/vm';
+import {
+  getNumLoggedInUsersMessage,
+  getGuestAgentFieldNotAvailMsg,
+} from '../../../utils/guest-agent-strings';
 
 export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
   const vmDashboardContext = React.useContext(VMDashboardContext);
-  const { vm, vmi, pods } = vmDashboardContext;
+  const { vm, vmi, pods, vmStatusBundle } = vmDashboardContext;
   const vmiLike = vm || vmi;
+  const { status } = vmStatusBundle;
 
   const [guestAgentInfoRaw] = useGuestAgentInfo({ vmi });
   const guestAgentInfo = new GuestAgentInfoWrapper(guestAgentInfoRaw);
-  const guestAgentFieldNotAvailMsg = getGuestAgentFieldNotAvailMsg(isGuestAgentInstalled(vmi));
+  const guestAgentFieldNotAvailMsg = getGuestAgentFieldNotAvailMsg(
+    isGuestAgentInstalled(vmi),
+    status,
+  );
 
   const launcherPod = findVMIPod(vmi, pods);
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -48,7 +48,7 @@ import { NOT_AVAILABLE_MESSAGE } from '../../strings/vm/messages';
 import { isGuestAgentInstalled } from '../dashboards-page/vm-dashboard/vm-alerts';
 
 import './vm-resource.scss';
-import { getGuestAgentFieldNotAvailMsg } from '../../utils/strings';
+import { getGuestAgentFieldNotAvailMsg } from '../../utils/guest-agent-strings';
 
 export const VMDetailsItem: React.FC<VMDetailsItemProps> = ({
   title,
@@ -144,7 +144,11 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   const isVM = kindObj === VirtualMachineModel;
   const vmiLike = isVM ? vm : vmi;
   const vmiLikeWrapper = asVMILikeWrapper(vmiLike);
-  const guestAgentFieldNotAvailMsg = getGuestAgentFieldNotAvailMsg(isGuestAgentInstalled(vmi));
+  const { status } = vmStatusBundle;
+  const guestAgentFieldNotAvailMsg = getGuestAgentFieldNotAvailMsg(
+    isGuestAgentInstalled(vmi),
+    status,
+  );
 
   const canEdit =
     vmiLike &&

--- a/frontend/packages/kubevirt-plugin/src/strings/vm/messages.ts
+++ b/frontend/packages/kubevirt-plugin/src/strings/vm/messages.ts
@@ -5,3 +5,5 @@ export const NO_GUEST_AGENT_MESSAGE =
   'A guest agent has not been found for this VM. This could be because the VM has not finished booting or a guest agent is not installed. Without a guest agent installed, some management features will not be available and some metrics may be inaccurate.';
 export const GUEST_AGENT_REQUIRED_MESSAGE = 'Guest agent required';
 export const NOT_AVAILABLE_MESSAGE = 'Not available';
+export const VM_NOT_RUNNING_MESSAGE = 'VM not running';
+export const NO_LOGGED_IN_USERS_MSG = 'No users logged in';

--- a/frontend/packages/kubevirt-plugin/src/utils/guest-agent-strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/guest-agent-strings.ts
@@ -1,0 +1,31 @@
+import {
+  GUEST_AGENT_REQUIRED_MESSAGE,
+  NOT_AVAILABLE_MESSAGE,
+  NO_LOGGED_IN_USERS_MSG,
+  VM_NOT_RUNNING_MESSAGE,
+} from '../strings/vm/messages';
+import { pluralize } from './strings';
+import { VMStatus } from '../constants/vm/vm-status';
+
+export const getNumLoggedInUsersMessage = (numLoggedInUsers: number | null) => {
+  if (numLoggedInUsers == null) {
+    return NOT_AVAILABLE_MESSAGE;
+  }
+
+  if (numLoggedInUsers === 0) {
+    return NO_LOGGED_IN_USERS_MSG;
+  }
+
+  return `${numLoggedInUsers} ${pluralize(numLoggedInUsers, 'user')}`;
+};
+
+export const getGuestAgentFieldNotAvailMsg = (
+  isGuestAgentInstalled: boolean,
+  vmStatus: VMStatus,
+): string => {
+  if (vmStatus !== VMStatus.RUNNING) {
+    return VM_NOT_RUNNING_MESSAGE;
+  }
+
+  return isGuestAgentInstalled ? NOT_AVAILABLE_MESSAGE : GUEST_AGENT_REQUIRED_MESSAGE;
+};

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -1,5 +1,3 @@
-import { NOT_AVAILABLE_MESSAGE, GUEST_AGENT_REQUIRED_MESSAGE } from '../strings/vm/messages';
-
 export const COULD_NOT_LOAD_DATA = 'Could not load data';
 
 export const CREATED = 'created';
@@ -15,8 +13,6 @@ export const ADD = 'Add';
 
 export const ADD_DISK = 'Add Disk';
 export const ADD_NETWORK_INTERFACE = 'Add Network Interface';
-
-export const NO_LOGGED_IN_USERS_MSG = 'No users logged in';
 
 export const getDialogUIError = (hasAllRequiredFilled) =>
   hasAllRequiredFilled
@@ -78,18 +74,3 @@ export const createUniqueNameResolver = (data: { name: string }[]) => {
     return `${name}-${nameCounts[name].next - 1}`;
   };
 };
-
-export const getNumLoggedInUsersMessage = (numLoggedInUsers: number | null) => {
-  if (numLoggedInUsers == null) {
-    return NOT_AVAILABLE_MESSAGE;
-  }
-
-  if (numLoggedInUsers === 0) {
-    return NO_LOGGED_IN_USERS_MSG;
-  }
-
-  return `${numLoggedInUsers} ${pluralize(numLoggedInUsers, 'user')}`;
-};
-
-export const getGuestAgentFieldNotAvailMsg = (isGuestAgentInstalled: boolean): string =>
-  isGuestAgentInstalled ? NOT_AVAILABLE_MESSAGE : GUEST_AGENT_REQUIRED_MESSAGE;


### PR DESCRIPTION
This PR fixes the message displayed in guest agent fields in the Overview and Details tabs to the following:

VM is not running: 'VM not running'
VM is running, but no guest agent is detected: 'Guest agent required'
VM is running, but guest agent data isn't yet available: 'Not available'