### PR TITLE
Bug 1849556: console hit runtime error when all receivers are deleted

### DIFF
--- a/frontend/public/components/monitoring/alert-manager-config.tsx
+++ b/frontend/public/components/monitoring/alert-manager-config.tsx
@@ -189,14 +189,19 @@ const numberOfIncompleteReceivers = (): number => {
   const { route, receivers } = config;
   const { receiver: defaultReceiverName } = route;
 
+  // if no receivers or default receiver, then no longer initial setup, hide info alerts
+  if (!receivers || !defaultReceiverName) {
+    return 0;
+  }
   const defaultReceiver = receivers.filter((receiver) => receiver.name === defaultReceiverName);
   const criticalReceiver = receivers.filter(
     (receiver) => receiver.name === InitialReceivers.Critical,
   );
 
-  const numIncompleteReceivers: number = _.isEmpty(getIntegrationTypes(defaultReceiver[0])) ? 1 : 0;
+  const numIncompleteReceivers =
+    !_.isEmpty(defaultReceiver) && _.isEmpty(getIntegrationTypes(defaultReceiver[0])) ? 1 : 0;
 
-  return _.isEmpty(getIntegrationTypes(criticalReceiver[0]))
+  return !_.isEmpty(criticalReceiver) && _.isEmpty(getIntegrationTypes(criticalReceiver[0]))
     ? numIncompleteReceivers + 1
     : numIncompleteReceivers;
 };

--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -219,7 +219,10 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
   }
 
   const doesReceiverNameAlreadyExist = (receiverName: string): boolean => {
-    const receiverNames = config?.receivers
+    if (!config?.receivers) {
+      return false;
+    }
+    const receiverNames = config.receivers
       .filter((receiver) => receiver.name !== editReceiverNamed)
       .map((receiver) => receiver.name);
     return receiverNames.includes(receiverName);
@@ -274,8 +277,11 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
   }
 
   const { receiver: defaultReceiver } = route || {}; // top level route.receiver is the default receiver for all alarms
-  // if no default receiver defined or editing the default receiver
-  const isDefaultReceiver = defaultReceiver === undefined || defaultReceiver === editReceiverNamed;
+  // if default receiver name defined but no receiver exists with that name, or editing the default receiver,
+  const isDefaultReceiver = defaultReceiver
+    ? _.isEmpty(config?.receivers?.filter((receiver) => receiver.name === defaultReceiver)) ||
+      defaultReceiver === editReceiverNamed
+    : true; // defaultReceiver (the name stored in config.routes.receiver) is not defined, so this should be the default receiver
 
   INITIAL_STATE.routeLabels = getRouteLabelsForEditor(
     isDefaultReceiver,


### PR DESCRIPTION
Info alerts were introduced to help users configure the initial/greenfield receivers:
![image](https://user-images.githubusercontent.com/12733153/85316600-feb54300-b48a-11ea-8a17-885a3f68df7f.png)

The GUI prevents one from removing the default receiver
![image](https://user-images.githubusercontent.com/12733153/85316648-142a6d00-b48b-11ea-8781-aabb2f4d2133.png)

But one can edit the yaml and remove all receivers, so null and empty logic tests was added to handle this scenerio and correctly display the empty state screen:
![image](https://user-images.githubusercontent.com/12733153/85316704-2d331e00-b48b-11ea-92a7-16e0f1c41c41.png)

Clicking on [Create Receiver] from the empty state does correctly default to creating a Default Receiver:
![image](https://user-images.githubusercontent.com/12733153/85316967-9ca90d80-b48b-11ea-95a8-6d5ab7d46c3b.png)
