### PR TITLE
Bug 1849148:  disable addOnPaste in <SelectorInput>

### DIFF
--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -48,6 +48,13 @@ export class SelectorInput extends React.Component {
     // We track the input field value in state so we can retain the input value when an invalid tag is entered.
     // Otherwise, the default behaviour of TagsInput is to clear the input field.
     const inputValue = e.target.value;
+
+    // If the user deletes an existing inputValue, set isInputValid back to true
+    if (inputValue === '') {
+      this.setState({ inputValue, isInputValid: true });
+      return;
+    }
+
     this.setState({ inputValue, isInputValid: this.isTagValid(inputValue) });
   }
 
@@ -120,7 +127,6 @@ export class SelectorInput extends React.Component {
             inputProps={inputProps}
             renderTag={renderTag}
             onChange={this.handleChange.bind(this)}
-            addOnPaste
             addOnBlur
           />
         </tags-input>


### PR DESCRIPTION
Fix bug where pasted values such as `openshift.io/run-level: '1'` do not appear.  Note this fix disables the ability to paste multiple values at the same time; however, [*the existing code assumes only one value is being added at a time*](https://github.com/openshift/console/pull/5801/files#diff-a32f482ea68288d5f3a51d2a8623864fL55), and if one of the values contains an invalid character, the entire paste fails (which is the underlying cause of the issue with a value like `openshift.io/run-level: '1'` since the space indicates more than more value).

Bonus fix:  if the entered text was invalid, set the cursor back to black if the user deletes all the entered text (was staying red).

Strings copied/pasted in the screenshots below:
1.  `openshift.io/run-level: '1'`
1.  `foo bar=bam baz=bam`
1.  `foo bar=bam baz=bam bam: bop`

Before:
![s74DbvULEJ](https://user-images.githubusercontent.com/895728/85334527-6a0e0d80-b4a9-11ea-9c3b-3e7157b82570.gif)
1.  Text is not pasted, but cursor turns red.
1.  Text is split on " " and converted to separate values.
1.  Text is not pasted, but cursor turns red.

After:
![MuNcEx011z](https://user-images.githubusercontent.com/895728/85334540-71cdb200-b4a9-11ea-8440-84c18ca77f63.gif)
1. Text is pasted and turns red indicating there is a problem with the format.
1. Text is pasted and turns red indicating there is a problem with the format.
1. Text is pasted and turns red indicating there is a problem with the format.


