### PR TITLE
Allow Tekton Event Listeners to render without a full route

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
@@ -159,7 +159,7 @@ export const useEventListenerURL = (
     namespace,
   );
 
-  return routeLoaded ? getRouteWebURL(route) : null;
+  return routeLoaded && route?.status?.ingress ? getRouteWebURL(route) : null;
 };
 
 export const getEventListenerTriggerTemplateNames = (


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4202

**Analysis / Root cause**: 
Tried to use the partial Route object to craft a route and it failed to do so.

**Solution Description**: 
Make sure we have a valid structured route before trying to get a URL out of it.

**Test setup:**

- OpenShift Pipelines Operator
- Go to Event Listener Create YAML and add this:
```
apiVersion: triggers.tekton.dev/v1alpha1
kind: EventListener
metadata:
  name: event-listener
spec:
  serviceAccountName: pipeline
  triggers:
    - bindings:
        - name: generic-git
      template:
        name: pipeline-template
```
- Before this fix, on completion of the YAML it would throw the error as it had a non-exposed route object

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge