### PR TITLE
adds datamodel for channel and update visualisation

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -38,6 +38,8 @@ import { RootState } from '@console/internal/redux';
 import { getActiveApplication } from '@console/internal/reducers/ui';
 import { selectOverviewDetailsTab } from '@console/internal/actions/ui';
 import { getEventSourceStatus } from '@console/knative-plugin/src/topology/knative-topology-utils';
+import { TYPE_EVENT_PUB_SUB_LINK } from '@console/knative-plugin/src/topology/const';
+import KnativeResourceOverviewPage from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
 import {
   getQueryArgument,
   setQueryArgument,
@@ -447,6 +449,10 @@ const Topology: React.FC<ComponentProps> = ({
     }
 
     if (isEdge(selectedEntity)) {
+      if (selectedEntity.getType() === TYPE_EVENT_PUB_SUB_LINK) {
+        const itemResources = selectedEntity.getData();
+        return <KnativeResourceOverviewPage item={itemResources.data.resources} />;
+      }
       return <ConnectedTopologyEdgePanel edge={selectedEntity as BaseEdge} model={filteredModel} />;
     }
     return null;

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -451,7 +451,7 @@ const Topology: React.FC<ComponentProps> = ({
     if (isEdge(selectedEntity)) {
       if (selectedEntity.getType() === TYPE_EVENT_PUB_SUB_LINK) {
         const itemResources = selectedEntity.getData();
-        return <KnativeResourceOverviewPage item={itemResources.data.resources} />;
+        return <KnativeResourceOverviewPage item={itemResources.resources} />;
       }
       return <ConnectedTopologyEdgePanel edge={selectedEntity as BaseEdge} model={filteredModel} />;
     }

--- a/frontend/packages/dev-console/src/components/topology/actions/edgeActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/edgeActions.ts
@@ -7,6 +7,7 @@ import {
   TYPE_EVENT_SOURCE_LINK,
   TYPE_KNATIVE_REVISION,
   TYPE_KNATIVE_SERVICE,
+  TYPE_EVENT_PUB_SUB,
   TYPE_REVISION_TRAFFIC,
 } from '@console/knative-plugin/src/topology/const';
 import { getTopologyResourceObject } from '../topology-utils';
@@ -68,7 +69,7 @@ export const edgeActions = (edge: Edge, nodes: Node[]): KebabOption[] => {
         case TYPE_SERVICE_BINDING:
           return false;
         case TYPE_EVENT_SOURCE_LINK:
-          return n.getType() === TYPE_KNATIVE_SERVICE;
+          return n.getType() === TYPE_KNATIVE_SERVICE || n.getType() === TYPE_EVENT_PUB_SUB;
         case TYPE_REVISION_TRAFFIC:
           return false;
         case TYPE_TRAFFIC_CONNECTOR:

--- a/frontend/packages/knative-plugin/src/actions/sink-source.ts
+++ b/frontend/packages/knative-plugin/src/actions/sink-source.ts
@@ -1,10 +1,12 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { setSinkSourceModal } from '../components/modals';
+import { EventingSubscriptionModel } from '../models';
 
 export const setSinkSource = (model: K8sKind, source: K8sResourceKind): KebabOption => {
+  const label = model.kind === EventingSubscriptionModel.kind ? `Move ${model.kind}` : 'Move Sink';
   return {
-    label: 'Move Sink',
+    label,
     callback: () =>
       setSinkSourceModal({
         source,

--- a/frontend/packages/knative-plugin/src/components/overview/EventPubSubResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventPubSubResources.tsx
@@ -11,10 +11,14 @@ type PubSubResourceOverviewListProps = {
 };
 
 type EventPubSubResourcesProps = {
-  item: OverviewItem;
+  item: OverviewItem & {
+    eventSources?: K8sResourceKind[];
+    eventingsubscription?: K8sResourceKind[];
+    connections?: K8sResourceKind[];
+  };
 };
 
-const PubSubResourceOverviewList: React.FC<PubSubResourceOverviewListProps> = ({
+export const PubSubResourceOverviewList: React.FC<PubSubResourceOverviewListProps> = ({
   items,
   title,
 }) => (
@@ -39,20 +43,23 @@ const PubSubResourceOverviewList: React.FC<PubSubResourceOverviewListProps> = ({
 );
 
 const EventPubSubResources: React.FC<EventPubSubResourcesProps> = ({ item }) => {
-  const { obj } = item;
-  const sinkServices = _.get(item, 'ksservices', []);
-  const sinkSources = _.get(item, 'eventSources', []);
-  const sinkSubscription = _.get(item, 'eventingsubscription', []);
-  const sinkConnections = _.get(item, 'connections', []);
+  const {
+    obj,
+    ksservices = [],
+    eventSources = [],
+    eventingsubscription = [],
+    connections = [],
+  } = item;
+
   switch (obj.kind) {
     case EventingSubscriptionModel.kind:
-      return <PubSubResourceOverviewList items={sinkConnections} title="Connections" />;
+      return <PubSubResourceOverviewList items={connections} title="Connections" />;
     default:
       return (
         <>
-          <PubSubResourceOverviewList items={sinkServices} title="Knative Service" />
-          <PubSubResourceOverviewList items={sinkSources} title="Event Source" />
-          <PubSubResourceOverviewList items={sinkSubscription} title="Subscription" />
+          <PubSubResourceOverviewList items={ksservices} title="Knative Service" />
+          <PubSubResourceOverviewList items={eventSources} title="Event Source" />
+          <PubSubResourceOverviewList items={eventingsubscription} title="Subscription" />
         </>
       );
   }

--- a/frontend/packages/knative-plugin/src/components/overview/EventPubSubResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventPubSubResources.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { OverviewItem } from '@console/shared';
+import { referenceFor, K8sResourceKind } from '@console/internal/module/k8s';
+import { ResourceLink, SidebarSectionHeading } from '@console/internal/components/utils';
+import { EventingSubscriptionModel } from '../../models';
+
+type PubSubResourceOverviewListProps = {
+  items: K8sResourceKind[];
+  title: string;
+};
+
+type EventPubSubResourcesProps = {
+  item: OverviewItem;
+};
+
+const PubSubResourceOverviewList: React.FC<PubSubResourceOverviewListProps> = ({
+  items,
+  title,
+}) => (
+  <>
+    <SidebarSectionHeading text={title} />
+    {items?.length > 0 ? (
+      <ul className="list-group">
+        {_.map(items, (itemData) => (
+          <li className="list-group-item" key={itemData.metadata.uid}>
+            <ResourceLink
+              kind={referenceFor(itemData)}
+              name={itemData.metadata?.name}
+              namespace={itemData.metadata?.namespace}
+            />
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <span className="text-muted">No {title} found for this resource.</span>
+    )}
+  </>
+);
+
+const EventPubSubResources: React.FC<EventPubSubResourcesProps> = ({ item }) => {
+  const { obj } = item;
+  const sinkServices = _.get(item, 'ksservices', []);
+  const sinkSources = _.get(item, 'eventSources', []);
+  const sinkSubscription = _.get(item, 'eventingsubscription', []);
+  const sinkConnections = _.get(item, 'connections', []);
+  switch (obj.kind) {
+    case EventingSubscriptionModel.kind:
+      return <PubSubResourceOverviewList items={sinkConnections} title="Connections" />;
+    default:
+      return (
+        <>
+          <PubSubResourceOverviewList items={sinkServices} title="Knative Service" />
+          <PubSubResourceOverviewList items={sinkSources} title="Event Source" />
+          <PubSubResourceOverviewList items={sinkSubscription} title="Subscription" />
+        </>
+      );
+  }
+};
+
+export default EventPubSubResources;

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -6,10 +6,13 @@ import { groupVersionFor, K8sKind, referenceForModel } from '@console/internal/m
 import { RootState } from '@console/internal/redux';
 import { OverviewItem } from '@console/shared';
 import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
-import { KNATIVE_SERVING_APIGROUP } from '../../const';
-import { RevisionModel } from '../../models';
+import { KNATIVE_SERVING_APIGROUP, KNATIVE_EVENT_MESSAGE_APIGROUP } from '../../const';
+import { RevisionModel, EventingSubscriptionModel } from '../../models';
 import { getRevisionActions } from '../../actions/getRevisionActions';
-import { isDynamicEventResourceKind } from '../../utils/fetch-dynamic-eventsources-utils';
+import {
+  isDynamicEventResourceKind,
+  isEventingChannelResourceKind,
+} from '../../utils/fetch-dynamic-eventsources-utils';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
 import KnativeOverview from './KnativeOverview';
 
@@ -52,6 +55,8 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
   const actions = [];
   if (resourceModel.kind === RevisionModel.kind) {
     actions.push(...getRevisionActions());
+  } else if (resourceModel.kind === EventingSubscriptionModel.kind) {
+    actions.push(...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common);
   } else {
     actions.push(
       ModifyApplication,
@@ -78,7 +83,9 @@ const mapStateToProps = (state: RootState): StateProps => {
       .filter(
         (model: K8sKind) =>
           model.apiGroup === KNATIVE_SERVING_APIGROUP ||
-          isDynamicEventResourceKind(referenceForModel(model)),
+          model.apiGroup === KNATIVE_EVENT_MESSAGE_APIGROUP ||
+          isDynamicEventResourceKind(referenceForModel(model)) ||
+          isEventingChannelResourceKind(referenceForModel(model)),
       ),
   };
 };

--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -2,14 +2,18 @@ import * as React from 'react';
 import { OverviewItem } from '@console/shared';
 import OperatorBackedOwnerReferences from '@console/internal/components/utils';
 import { referenceFor } from '@console/internal/module/k8s';
-import { RevisionModel, ServiceModel } from '../../models';
+import { RevisionModel, ServiceModel, EventingSubscriptionModel } from '../../models';
 import KnativeServiceResources from './KnativeServiceResources';
 import KnativeRevisionResources from './KnativeRevisionResources';
 import RevisionsOverviewList from './RevisionsOverviewList';
 import KSRoutesOverviewList from './RoutesOverviewList';
 import ConfigurationsOverviewList from './ConfigurationsOverviewList';
 import EventSinkServicesOverviewList from './EventSinkServicesOverviewList';
-import { isDynamicEventResourceKind } from '../../utils/fetch-dynamic-eventsources-utils';
+import {
+  isDynamicEventResourceKind,
+  isEventingChannelResourceKind,
+} from '../../utils/fetch-dynamic-eventsources-utils';
+import EventPubSubResources from './EventPubSubResources';
 
 type OverviewDetailsResourcesTabProps = {
   item: OverviewItem;
@@ -19,6 +23,9 @@ const getSidebarResources = (item: OverviewItem) => {
   const { obj, ksroutes, revisions, configurations, pods, current } = item;
   if (isDynamicEventResourceKind(referenceFor(obj))) {
     return <EventSinkServicesOverviewList obj={obj} pods={pods} current={current} />;
+  }
+  if (isEventingChannelResourceKind(referenceFor(obj))) {
+    return <EventPubSubResources item={item} />;
   }
   switch (obj.kind) {
     case RevisionModel.kind:
@@ -33,6 +40,8 @@ const getSidebarResources = (item: OverviewItem) => {
       );
     case ServiceModel.kind:
       return <KnativeServiceResources item={item} />;
+    case EventingSubscriptionModel.kind:
+      return <EventPubSubResources item={item} />;
     default:
       return (
         <>

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { OverviewItem } from '@console/shared';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ResourceLink, SidebarSectionHeading } from '@console/internal/components/utils';
+import {
+  EventSubscriptionObj,
+  EventIMCObj,
+  knativeServiceObj,
+} from '../../../topology/__tests__/topology-knative-test-data';
+import EventPubSubResources, { PubSubResourceOverviewList } from '../EventPubSubResources';
+
+type EventPubSubResourcesProps = React.ComponentProps<typeof EventPubSubResources>;
+type PubSubResourceOverviewListProps = React.ComponentProps<typeof PubSubResourceOverviewList>;
+let itemData: OverviewItem & {
+  eventSources?: K8sResourceKind[];
+  eventingsubscription?: K8sResourceKind[];
+  connections?: K8sResourceKind[];
+};
+
+describe('EventPubSubResources', () => {
+  let wrapper: ShallowWrapper<EventPubSubResourcesProps>;
+  itemData = {
+    obj: EventSubscriptionObj,
+    buildConfigs: [],
+    eventSources: [],
+    routes: [],
+    services: [],
+    connections: [EventIMCObj, knativeServiceObj],
+  };
+
+  it('should render PubSubResourceOverviewList once if obj of kind Subscription', () => {
+    wrapper = shallow(<EventPubSubResources item={itemData} />);
+    const findPubSubList = wrapper.find(PubSubResourceOverviewList);
+    expect(findPubSubList).toHaveLength(1);
+    expect(findPubSubList.at(0).props().title).toEqual('Connections');
+  });
+
+  it('should render PubSubResourceOverviewList thrice if obj not of kind Subscription', () => {
+    const channelItemData = {
+      ...itemData,
+      obj: EventIMCObj,
+      ksservices: [knativeServiceObj],
+      eventingsubscription: [EventSubscriptionObj],
+    };
+    wrapper = shallow(<EventPubSubResources item={channelItemData} />);
+    const findPubSubList = wrapper.find(PubSubResourceOverviewList);
+    expect(findPubSubList).toHaveLength(3);
+    expect(findPubSubList.at(0).props().title).toEqual('Knative Service');
+    expect(findPubSubList.at(1).props().title).toEqual('Event Source');
+    expect(findPubSubList.at(2).props().title).toEqual('Subscription');
+  });
+});
+
+describe('PubSubResourceOverviewList', () => {
+  let wrapper: ShallowWrapper<PubSubResourceOverviewListProps>;
+  const itemsData: K8sResourceKind[] = [EventIMCObj, knativeServiceObj];
+
+  it('should render ResourceLink respective for each resources, SidebarSectionHeading and no span', () => {
+    wrapper = shallow(<PubSubResourceOverviewList items={itemsData} title="Connections" />);
+    const findPubSubList = wrapper.find(ResourceLink);
+    expect(findPubSubList).toHaveLength(2);
+    expect(findPubSubList.at(0).props().name).toEqual('testchannel');
+    expect(wrapper.find(SidebarSectionHeading)).toHaveLength(1);
+    expect(wrapper.find('.text-muted').exists()).toBe(false);
+  });
+
+  it('should render SidebarSectionHeading, text-muted and not ResourceLink if no resources exists', () => {
+    wrapper = shallow(<PubSubResourceOverviewList items={[]} title="Connections" />);
+    const findTextMutedList = wrapper.find('.text-muted');
+    expect(wrapper.find(ResourceLink).exists()).toBe(false);
+    expect(wrapper.find(SidebarSectionHeading)).toHaveLength(1);
+    expect(findTextMutedList.exists()).toBe(true);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
@@ -10,7 +10,12 @@ import {
   SidebarSectionHeading,
 } from '@console/internal/components/utils';
 import { getEventSourceResponse } from '../../../topology/__tests__/topology-knative-test-data';
-import { ServiceModel, EventSourceApiServerModel, EventSourceCamelModel } from '../../../models';
+import {
+  ServiceModel,
+  EventSourceApiServerModel,
+  EventSourceCamelModel,
+  EventingIMCModel,
+} from '../../../models';
 import EventSinkServicesOverviewList from '../EventSinkServicesOverviewList';
 
 describe('EventSinkServicesOverviewList', () => {
@@ -71,7 +76,7 @@ describe('EventSinkServicesOverviewList', () => {
     expect(wrapper.find('span').text()).toBe('No sink found for this resource.');
   });
 
-  it('should have ResourceLink with proper kind', () => {
+  it('should have ResourceLink with proper kind for sink to knSvc', () => {
     const wrapper = shallow(
       <EventSinkServicesOverviewList
         obj={getEventSourceResponse(EventSourceApiServerModel).data[0]}
@@ -80,6 +85,24 @@ describe('EventSinkServicesOverviewList', () => {
     const findResourceLink = wrapper.find(ResourceLink);
     expect(findResourceLink).toHaveLength(1);
     expect(findResourceLink.at(0).props().kind).toEqual(referenceForModel(ServiceModel));
+  });
+
+  it('should have ResourceLink with proper kind for sink to channel', () => {
+    const sinkData = {
+      sink: {
+        apiVersion: `${EventingIMCModel.apiGroup}/${EventingIMCModel.apiVersion}`,
+        kind: EventingIMCModel.kind,
+        name: 'testchannel',
+      },
+    };
+    const sinkChannelData = {
+      ...getEventSourceResponse(EventSourceApiServerModel).data[0],
+      ...{ spec: sinkData },
+    };
+    const wrapper = shallow(<EventSinkServicesOverviewList obj={sinkChannelData} />);
+    const findResourceLink = wrapper.find(ResourceLink);
+    expect(findResourceLink).toHaveLength(1);
+    expect(findResourceLink.at(0).props().kind).toEqual(referenceForModel(EventingIMCModel));
   });
 
   it('should have ExternaLink when sinkUri is present', () => {

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
@@ -68,7 +68,7 @@ describe('EventSinkServicesOverviewList', () => {
       'spec',
     );
     const wrapper = shallow(<EventSinkServicesOverviewList obj={mockData} />);
-    expect(wrapper.find('span').text()).toBe('No services found for this resource.');
+    expect(wrapper.find('span').text()).toBe('No sink found for this resource.');
   });
 
   it('should have ResourceLink with proper kind', () => {

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
@@ -3,8 +3,11 @@ import { shallow } from 'enzyme';
 import { OverviewItem } from '@console/shared';
 import { LoadingBox } from '@console/internal/components/utils';
 import { ResourceOverviewDetails } from '@console/internal/components/overview/resource-overview-details';
-import { revisionObj } from '../../../topology/__tests__/topology-knative-test-data';
-import { RevisionModel } from '../../../models';
+import {
+  revisionObj,
+  EventSubscriptionObj,
+} from '../../../topology/__tests__/topology-knative-test-data';
+import { RevisionModel, EventingSubscriptionModel } from '../../../models';
 import { KnativeResourceOverviewPage } from '../KnativeResourceOverviewPage';
 
 describe('KnativeResourceOverviewPage', () => {
@@ -37,5 +40,19 @@ describe('KnativeResourceOverviewPage', () => {
       />,
     );
     expect(wrapper.find(ResourceOverviewDetails)).toHaveLength(1);
+  });
+  it('should render ResourceOverviewDetails for subscription with proper action menu', () => {
+    const itemData = { ...item, ...{ obj: EventSubscriptionObj } };
+    const wrapper = shallow(
+      <KnativeResourceOverviewPage
+        item={itemData}
+        knativeModels={[EventingSubscriptionModel]}
+        kindsInFlight={false}
+      />,
+    );
+    const resourceOverviewDetails = wrapper.find(ResourceOverviewDetails);
+    expect(resourceOverviewDetails).toHaveLength(1);
+    expect(resourceOverviewDetails.at(0).props().menuActions).toHaveLength(4);
+    expect(resourceOverviewDetails.at(0).props().kindObj).toEqual(EventingSubscriptionModel);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -9,10 +9,13 @@ import RevisionsOverviewList from '../RevisionsOverviewList';
 import KSRoutesOverviewList from '../RoutesOverviewList';
 import ConfigurationsOverviewList from '../ConfigurationsOverviewList';
 import EventSinkServicesOverviewList from '../EventSinkServicesOverviewList';
+import EventPubSubResources from '../EventPubSubResources';
 import {
   MockKnativeResources,
   getEventSourceResponse,
   sampleEventSourceSinkbinding,
+  EventIMCObj,
+  EventSubscriptionObj,
 } from '../../../topology/__tests__/topology-knative-test-data';
 import { EventSourceCronJobModel } from '../../../models';
 
@@ -92,5 +95,26 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
     expect(wrapper.find(RevisionsOverviewList)).toHaveLength(1);
     expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
     expect(wrapper.find(ConfigurationsOverviewList)).toHaveLength(1);
+  });
+
+  it('should render EventPubSubResources on sidebar for Subscription', () => {
+    knItem.item = {
+      ...knItem.item,
+      ...{ obj: EventSubscriptionObj },
+    };
+    const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
+    expect(wrapper.find(EventPubSubResources)).toHaveLength(1);
+  });
+
+  it('should render EventPubSubResources on sidebar for channel', () => {
+    jest
+      .spyOn(fetchDynamicEventSources, 'isEventingChannelResourceKind')
+      .mockImplementationOnce(() => true);
+    knItem.item = {
+      ...knItem.item,
+      ...{ obj: EventIMCObj },
+    };
+    const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
+    expect(wrapper.find(EventPubSubResources)).toHaveLength(1);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
@@ -7,21 +7,22 @@ import {
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
 import { ResourceDropdownField } from '@console/shared';
+import { FirehoseResource } from '@console/internal/components/utils';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
-import { knativeServingResourcesServices } from '../../utils/get-knative-resources';
-import { getDynamicChannelResourceList } from '../../utils/fetch-dynamic-eventsources-utils';
 
 export interface SinkSourceModalProps {
-  namespace: string;
   resourceName: string;
+  resourceDropdown: FirehoseResource[];
+  labelTitle: string;
   cancel?: () => void;
 }
 
 type Props = FormikProps<FormikValues> & SinkSourceModalProps;
 
 const SinkSourceModal: React.FC<Props> = ({
-  namespace,
   resourceName,
+  resourceDropdown,
+  labelTitle,
   handleSubmit,
   cancel,
   isSubmitting,
@@ -37,37 +38,33 @@ const SinkSourceModal: React.FC<Props> = ({
     (selectedValue, target) => {
       const modelResource = target?.props?.model;
       if (selectedValue) {
-        setFieldTouched('sink.ref.name', true);
-        setFieldValue('sink.ref.name', selectedValue);
+        setFieldTouched('ref.name', true);
+        setFieldValue('ref.name', selectedValue);
         if (modelResource) {
           const { apiGroup, apiVersion, kind } = modelResource;
           const sinkApiversion = `${apiGroup}/${apiVersion}`;
-          setFieldValue('sink.ref.apiVersion', sinkApiversion);
-          setFieldTouched('sink.ref.apiVersion', true);
-          setFieldValue('sink.ref.kind', kind);
-          setFieldTouched('sink.ref.kind', true);
+          setFieldValue('ref.apiVersion', sinkApiversion);
+          setFieldTouched('ref.apiVersion', true);
+          setFieldValue('ref.kind', kind);
+          setFieldTouched('ref.kind', true);
         }
         validateForm();
       }
     },
     [setFieldValue, setFieldTouched, validateForm],
   );
-  const dirty = values?.sink?.ref?.name !== initialValues.sink.ref.name;
-  const resourcesDropdownField = [
-    ...knativeServingResourcesServices(namespace),
-    ...getDynamicChannelResourceList(namespace),
-  ];
+  const dirty = values?.ref?.name !== initialValues.ref.name;
   return (
     <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
-      <ModalTitle>Move Sink</ModalTitle>
+      <ModalTitle>{labelTitle}</ModalTitle>
       <ModalBody>
         <p>
-          Select a sink to move the event source <strong>{resourceName}</strong> to
+          Connects <strong>{resourceName}</strong> to
         </p>
         <FormSection fullWidth>
           <ResourceDropdownField
-            name="sink.ref.name"
-            resources={resourcesDropdownField}
+            name="ref.name"
+            resources={resourceDropdown}
             dataSelector={['metadata', 'name']}
             fullWidth
             required
@@ -76,7 +73,7 @@ const SinkSourceModal: React.FC<Props> = ({
             autocompleteFilter={autocompleteFilter}
             onChange={onSinkChange}
             autoSelect
-            selectedKey={values?.sink?.ref?.name}
+            selectedKey={values?.ref?.name}
           />
         </FormSection>
       </ModalBody>

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
@@ -9,6 +9,7 @@ import {
 import { ResourceDropdownField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { knativeServingResourcesServices } from '../../utils/get-knative-resources';
+import { getDynamicChannelResourceList } from '../../utils/fetch-dynamic-eventsources-utils';
 
 export interface SinkSourceModalProps {
   namespace: string;
@@ -52,6 +53,10 @@ const SinkSourceModal: React.FC<Props> = ({
     [setFieldValue, setFieldTouched, validateForm],
   );
   const dirty = values?.sink?.ref?.name !== initialValues.sink.ref.name;
+  const resourcesDropdownField = [
+    ...knativeServingResourcesServices(namespace),
+    ...getDynamicChannelResourceList(namespace),
+  ];
   return (
     <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
       <ModalTitle>Move Sink</ModalTitle>
@@ -62,7 +67,7 @@ const SinkSourceModal: React.FC<Props> = ({
         <FormSection fullWidth>
           <ResourceDropdownField
             name="sink.ref.name"
-            resources={knativeServingResourcesServices(namespace)}
+            resources={resourcesDropdownField}
             dataSelector={['metadata', 'name']}
             fullWidth
             required

--- a/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSource.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSource.spec.tsx
@@ -2,29 +2,42 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import SinkSource from '../SinkSource';
-import { sampleEventSourceSinkbinding } from '../../../topology/__tests__/topology-knative-test-data';
+import {
+  sampleEventSourceSinkbinding,
+  EventSubscriptionObj,
+} from '../../../topology/__tests__/topology-knative-test-data';
 
 type SinkSourceProps = React.ComponentProps<typeof SinkSource>;
 
 describe('SinkSource', () => {
-  let formProps: SinkSourceProps;
   let eventSourceForm: ShallowWrapper<SinkSourceProps>;
-  beforeEach(() => {
-    formProps = {
-      source: sampleEventSourceSinkbinding.data[0],
-    };
-    eventSourceForm = shallow(<SinkSource {...formProps} />);
-  });
+  const formProps: SinkSourceProps = {
+    source: sampleEventSourceSinkbinding.data[0],
+  };
+  eventSourceForm = shallow(<SinkSource {...formProps} />);
   it('should render Formik with proper initial values', () => {
     const formikForm = eventSourceForm.find(Formik);
     expect(formikForm).toHaveLength(1);
-    expect(formikForm.get(0).props.initialValues.sink.ref.name).toBe('wss-event-display');
+    expect(formikForm.get(0).props.initialValues.ref.name).toBe('wss-event-display');
   });
 
   it('should render Formik child with proper props', () => {
     const formikFormRender = eventSourceForm.find(Formik).get(0).props;
     expect(formikFormRender.children).toHaveLength(1);
-    expect(formikFormRender.children().props.namespace).toBe('testproject3');
     expect(formikFormRender.children().props.resourceName).toBe('bind-wss');
+  });
+
+  it('should render Formik child with label move sink for EventSource', () => {
+    const formikFormRender = eventSourceForm.find(Formik).get(0).props;
+    expect(formikFormRender.children).toHaveLength(1);
+    expect(formikFormRender.children().props.labelTitle).toBe('Move Sink');
+  });
+
+  it('should render Formik child with label move Subscription for EventSource', () => {
+    const formPropsData = { source: EventSubscriptionObj };
+    eventSourceForm = shallow(<SinkSource {...formPropsData} />);
+    const formikFormRender = eventSourceForm.find(Formik).get(0).props;
+    expect(formikFormRender.children).toHaveLength(1);
+    expect(formikFormRender.children().props.labelTitle).toBe('Move Subscription');
   });
 });

--- a/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSourceModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSourceModal.spec.tsx
@@ -16,21 +16,20 @@ describe('SinkSourceModal Form', () => {
   let formProps: SinkSourceModalProps;
   let sinkSourceModalWrapper: ShallowWrapper<SinkSourceModalProps>;
   const formValues = {
-    sink: {
-      ref: {
-        apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
-        kind: ServiceModel.kind,
-        name: 'event-greeter',
-      },
+    ref: {
+      apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+      kind: ServiceModel.kind,
+      name: 'event-greeter',
     },
   };
   beforeEach(() => {
     formProps = {
       ...formikFormProps,
       values: formValues,
-      namespace: 'myapp',
       resourceName: 'myappes',
       initialValues: formValues,
+      resourceDropdown: [],
+      labelTitle: 'Move Sink',
     };
     sinkSourceModalWrapper = shallow(<SinkSourceModal {...formProps} />);
   });
@@ -43,7 +42,7 @@ describe('SinkSourceModal Form', () => {
   it('should render ResourceDropdownField for service', () => {
     const serviceDropDown = sinkSourceModalWrapper.find(ResourceDropdownField);
     expect(serviceDropDown).toHaveLength(1);
-    expect(serviceDropDown.get(0).props.name).toBe('sink.ref.name');
+    expect(serviceDropDown.get(0).props.name).toBe('ref.name');
     expect(serviceDropDown.get(0).props.selectedKey).toBe('event-greeter');
   });
 
@@ -67,12 +66,10 @@ describe('SinkSourceModal Form', () => {
 
   it('Save should be enabled if value is  changed', () => {
     const sinkValues = {
-      sink: {
-        ref: {
-          apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
-          kind: ServiceModel.kind,
-          name: 'event-greeter-new',
-        },
+      ref: {
+        apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+        kind: ServiceModel.kind,
+        name: 'event-greeter-new',
       },
     };
     formProps = {
@@ -81,6 +78,8 @@ describe('SinkSourceModal Form', () => {
         ...formProps.values,
         ...sinkValues,
       },
+      resourceDropdown: [],
+      labelTitle: 'Move Sink',
     };
     sinkSourceModalWrapper = shallow(<SinkSourceModal {...formProps} />);
     const modalSubmitFooter = sinkSourceModalWrapper.find(ModalSubmitFooter);

--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -6,5 +6,6 @@ export const FLAG_KNATIVE_SERVING_ROUTE = 'KNATIVE_SERVING_ROUTE';
 export const FLAG_KNATIVE_SERVING_SERVICE = 'KNATIVE_SERVING_SERVICE';
 export const KNATIVE_SERVING_LABEL = 'serving.knative.dev/service';
 export const KNATIVE_SERVING_APIGROUP = 'serving.knative.dev';
+export const KNATIVE_EVENT_MESSAGE_APIGROUP = 'messaging.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP_DEP = 'sources.eventing.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP = 'sources.knative.dev';

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -209,3 +209,31 @@ export const EventingSubscriptionModel: K8sKind = {
   crd: true,
   color: knativeEventingColor.value,
 };
+
+export const EventingIMCModel: K8sKind = {
+  apiGroup: KNATIVE_EVENT_MESSAGE_APIGROUP,
+  apiVersion: 'v1beta1',
+  kind: 'InMemoryChannel',
+  label: 'InMemoryChannel',
+  labelPlural: 'inmemorychannels',
+  plural: 'inmemorychannels',
+  id: 'inmemorychannel',
+  abbr: 'IMC',
+  namespaced: true,
+  crd: true,
+  color: knativeEventingColor.value,
+};
+
+export const EventingChannelModel: K8sKind = {
+  apiGroup: KNATIVE_EVENT_MESSAGE_APIGROUP,
+  apiVersion: 'v1beta1',
+  kind: 'Channel',
+  label: 'Channel',
+  labelPlural: 'channels',
+  plural: 'channels',
+  id: 'channel',
+  abbr: 'C',
+  namespaced: true,
+  crd: true,
+  color: knativeEventingColor.value,
+};

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -8,6 +8,7 @@ import {
   KNATIVE_EVENT_SOURCE_APIGROUP,
   KNATIVE_EVENT_SOURCE_APIGROUP_DEP,
   KNATIVE_SERVING_APIGROUP,
+  KNATIVE_EVENT_MESSAGE_APIGROUP,
 } from './const';
 
 const apiVersion = 'v1';
@@ -190,6 +191,20 @@ export const EventSourceSinkBindingModel: K8sKind = {
   plural: 'sinkbindings',
   id: 'sinkbindingsource',
   abbr: 'SBS',
+  namespaced: true,
+  crd: true,
+  color: knativeEventingColor.value,
+};
+
+export const EventingSubscriptionModel: K8sKind = {
+  apiGroup: KNATIVE_EVENT_MESSAGE_APIGROUP,
+  apiVersion: 'v1beta1',
+  kind: 'Subscription',
+  label: 'Subscription',
+  labelPlural: 'Subscriptions',
+  plural: 'subscriptions',
+  id: 'subscriptioneventing',
+  abbr: 'S',
   namespaced: true,
   crd: true,
   color: knativeEventingColor.value,

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -36,11 +36,14 @@ import {
   getKnativeServingConfigurations,
   getKnativeServingRoutes,
   getKnativeServingServices,
+  knativeEventingResourcesSubscription,
 } from './utils/get-knative-resources';
 import { getKebabActionsForKind } from './utils/kebab-actions';
 import {
   fetchEventSourcesCrd,
+  fetchChannelsCrd,
   getDynamicEventSourcesResourceList,
+  getDynamicChannelResourceList,
   hideDynamicEventSourceCard,
 } from './utils/fetch-dynamic-eventsources-utils';
 import { TopologyConsumedExtensions, topologyPlugin } from './topology/topology-plugin';
@@ -64,7 +67,7 @@ type ConsumedExtensions =
 
 // Added it to perform discovery of Dynamic event sources on cluster on app load as kebab option needed models upfront
 fetchEventSourcesCrd();
-
+fetchChannelsCrd();
 const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'ModelDefinition',
@@ -217,6 +220,24 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Overview/CRD',
     properties: {
       resources: getDynamicEventSourcesResourceList,
+    },
+    flags: {
+      required: [FLAG_KNATIVE_EVENTING],
+    },
+  },
+  {
+    type: 'Overview/CRD',
+    properties: {
+      resources: knativeEventingResourcesSubscription,
+    },
+    flags: {
+      required: [FLAG_KNATIVE_EVENTING],
+    },
+  },
+  {
+    type: 'Overview/CRD',
+    properties: {
+      resources: getDynamicChannelResourceList,
     },
     flags: {
       required: [FLAG_KNATIVE_EVENTING],

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -413,7 +413,7 @@ export const getEventSourceResponse = (eventSourceModel: K8sKind): FirehoseResul
         },
         spec: {
           sink: {
-            apiVersion: 'serving.knative.dev/v1alpha1',
+            apiVersion: 'serving.knative.dev/v1',
             kind: 'Service',
             name: 'overlayimage',
           },

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -19,12 +19,16 @@ import {
   EventSourcePingModel,
   EventSourceSinkBindingModel,
   EventSourceApiServerModel,
+  EventingSubscriptionModel,
+  EventingIMCModel,
 } from '../../models';
 import {
   RevisionKind,
   ConditionTypes,
   RouteKind,
   ServiceKind as knativeServiceKind,
+  EventSubscriptionKind,
+  EventChannelKind,
 } from '../../types';
 
 export const sampleKnativeDeployments: FirehoseResult<DeploymentKind[]> = {
@@ -664,6 +668,63 @@ export const sampleEventSourceDeployments: FirehoseResult<DeploymentKind[]> = {
       status: {},
     },
   ],
+};
+
+export const EventSubscriptionObj: EventSubscriptionKind = {
+  apiVersion: `${EventingSubscriptionModel.apiGroup}/${EventingSubscriptionModel.apiVersion}`,
+  kind: EventingSubscriptionModel.kind,
+  metadata: {
+    name: 'sub1',
+    namespace: 'testproject3',
+    selfLink: '/apis/messaging.knative.dev/v1beta1/namespaces/testproject3/subscriptions/sub2',
+    uid: '4de9aba5-432c-46d8-8492-a5bedb10c89a',
+    resourceVersion: '235775100',
+    generation: 1,
+  },
+  spec: {
+    channel: {
+      apiVersion: `${EventingIMCModel.apiGroup}/${EventingIMCModel.apiVersion}`,
+      kind: EventingIMCModel.kind,
+      name: 'testchannel',
+    },
+    subscriber: {
+      ref: { apiVersion: 'serving.knative.dev/v1', kind: 'Service', name: 'overlayimage' },
+    },
+  },
+  status: {
+    observedGeneration: 1,
+    physicalSubscription: {
+      subscriberURI: 'http://channel-display1.testproject3.svc.cluster.local',
+    },
+  },
+};
+
+export const EventIMCObj: EventChannelKind = {
+  apiVersion: `${EventingIMCModel.apiGroup}/${EventingIMCModel.apiVersion}`,
+  kind: EventingIMCModel.kind,
+  metadata: {
+    name: 'testchannel',
+    namespace: 'testproject3',
+    selfLink:
+      '/apis/messaging.knative.dev/v1beta1/namespaces/testproject3/inmemorychannels/testchannel',
+    uid: 'a35e6244-3233-473d-9120-ed274c7ae811',
+    resourceVersion: '235628221',
+    generation: 1,
+  },
+  spec: {
+    subscriber: [
+      {
+        subscriberUri: 'http://channel-display0.testproject3.svc.cluster.local',
+        uid: 'ae670cb1-cb66-4444-aead-c366552e7cef',
+      },
+    ],
+  },
+  status: {
+    observedGeneration: 1,
+    address: {
+      url: 'http://channel-display1.testproject3.svc.cluster.local',
+    },
+  },
 };
 
 export const MockKnativeResources: TopologyDataResources = {

--- a/frontend/packages/knative-plugin/src/topology/components/edges/EventSourceLink.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/edges/EventSourceLink.scss
@@ -3,4 +3,3 @@
     --edge__arrow--cursor: pointer;
   }
 }
-

--- a/frontend/packages/knative-plugin/src/topology/components/edges/EventingPubSubLink.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/edges/EventingPubSubLink.scss
@@ -1,0 +1,5 @@
+.odc-base-edge.odc-eventing-pubsub-link {
+    &.odc-m-editable {
+      --edge__arrow--cursor: pointer;
+    }
+  }

--- a/frontend/packages/knative-plugin/src/topology/components/edges/EventingPubSubLink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/edges/EventingPubSubLink.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { useAccessReview } from '@console/internal/components/utils';
+import { Edge, observer, WithSourceDragProps, WithTargetDragProps } from '@console/topology';
+import { getTopologyResourceObject, BaseEdge } from '@console/dev-console/src/components/topology';
+
+import './EventingPubSubLink.scss';
+
+type EventingPubSubLinkProps = {
+  element: Edge;
+  dragging: boolean;
+} & WithSourceDragProps &
+  WithTargetDragProps;
+
+const EventingPubSubLink: React.FC<EventingPubSubLinkProps> = ({
+  element,
+  targetDragRef,
+  children,
+  ...others
+}) => {
+  const resourceObj = getTopologyResourceObject(element.getSource().getData());
+  const resourceModel = modelFor(referenceFor(resourceObj));
+  const editAccess = useAccessReview({
+    group: resourceModel.apiGroup,
+    verb: 'update',
+    resource: resourceModel.plural,
+    name: resourceObj.metadata.name,
+    namespace: resourceObj.metadata.namespace,
+  });
+  const markerPoint = element.getEndPoint();
+  const edgeClasses = classNames('odc-eventing-pubsub-link', { 'odc-m-editable': editAccess });
+  return (
+    <BaseEdge className={edgeClasses} element={element} {...others}>
+      <circle
+        className="topology-connector-arrow"
+        ref={editAccess ? targetDragRef : null}
+        cx={markerPoint.x}
+        cy={markerPoint.y}
+        r={6}
+      />
+    </BaseEdge>
+  );
+};
+
+export default observer(EventingPubSubLink);

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -104,18 +104,17 @@ export const getKnativeComponentFactory = (): ComponentFactory => {
           ),
         );
       case TYPE_EVENT_PUB_SUB:
-        return withCreateConnector(
-          createConnectorCallback(),
-          CreateConnector,
-        )(
-          withDndDrop<
-            any,
-            any,
-            { droppable?: boolean; hover?: boolean; canDrop?: boolean; dropTarget?: boolean },
-            NodeComponentProps
-          >(pubSubDropTargetSpec)(
-            withEditReviewAccess('update')(
-              withSelection(false, true)(withContextMenu(knativeContextMenu)(EventingPubSubNode)),
+        return withEditReviewAccess('update')(
+          withDragNode(nodeDragSourceSpec(type))(
+            withSelection(
+              false,
+              true,
+            )(
+              withContextMenu(knativeContextMenu)(
+                withDndDrop<any, any, {}, NodeComponentProps>(pubSubDropTargetSpec)(
+                  EventingPubSubNode,
+                ),
+              ),
             ),
           ),
         );

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -31,16 +31,22 @@ import {
   TYPE_KNATIVE_REVISION,
   TYPE_KNATIVE_SERVICE,
   TYPE_REVISION_TRAFFIC,
+  TYPE_EVENT_PUB_SUB,
+  TYPE_EVENT_PUB_SUB_LINK,
 } from '../const';
 import KnativeService from './groups/KnativeService';
 import RevisionNode from './nodes/RevisionNode';
 import TrafficLink from './edges/TrafficLink';
 import EventSourceLink from './edges/EventSourceLink';
+import EventingPubSubLink from './edges/EventingPubSubLink';
 import EventSource from './nodes/EventSource';
+import EventingPubSubNode from './nodes/EventingPubSubNode';
 import {
   eventSourceLinkDragSourceSpec,
+  eventingPubSubLinkDragSourceSpec,
   eventSourceTargetSpec,
-  knativeServiceDropTargetSpec,
+  eventSourceSinkDropTargetSpec,
+  pubSubDropTargetSpec,
 } from './knativeComponentUtils';
 
 export const knativeContextMenu = (element: Node) => {
@@ -78,7 +84,7 @@ export const getKnativeComponentFactory = (): ComponentFactory => {
             any,
             { droppable?: boolean; hover?: boolean; canDrop?: boolean; dropTarget?: boolean },
             NodeComponentProps
-          >(knativeServiceDropTargetSpec)(
+          >(eventSourceSinkDropTargetSpec)(
             withEditReviewAccess('update')(
               withSelection(false, true)(withContextMenu(knativeContextMenu)(KnativeService)),
             ),
@@ -97,6 +103,22 @@ export const getKnativeComponentFactory = (): ComponentFactory => {
             ),
           ),
         );
+      case TYPE_EVENT_PUB_SUB:
+        return withCreateConnector(
+          createConnectorCallback(),
+          CreateConnector,
+        )(
+          withDndDrop<
+            any,
+            any,
+            { droppable?: boolean; hover?: boolean; canDrop?: boolean; dropTarget?: boolean },
+            NodeComponentProps
+          >(pubSubDropTargetSpec)(
+            withEditReviewAccess('update')(
+              withSelection(false, true)(withContextMenu(knativeContextMenu)(EventingPubSubNode)),
+            ),
+          ),
+        );
       case TYPE_KNATIVE_REVISION:
         return withDragNode(nodeDragSourceSpec(type, false))(
           withSelection(
@@ -108,6 +130,8 @@ export const getKnativeComponentFactory = (): ComponentFactory => {
         return TrafficLink;
       case TYPE_EVENT_SOURCE_LINK:
         return withTargetDrag(eventSourceLinkDragSourceSpec())(EventSourceLink);
+      case TYPE_EVENT_PUB_SUB_LINK:
+        return withTargetDrag(eventingPubSubLinkDragSourceSpec())(EventingPubSubLink);
       default:
         return undefined;
     }

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
@@ -143,11 +143,7 @@ export const eventingPubSubLinkDragSourceSpec = (): DragSourceSpec<
       dropResult &&
       canDropPubSubSinkOnNode(monitor.getOperation().type, props.element, dropResult)
     ) {
-      createSinkPubSubConnection(
-        props.element.getData(),
-        props.element.getSource(),
-        dropResult,
-      ).catch((error) => {
+      createSinkPubSubConnection(props.element, dropResult).catch((error) => {
         errorModal({
           title: 'Error while sink',
           error: error.message,

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
@@ -17,10 +17,16 @@ import {
   EdgeComponentProps,
   EditableDragOperationType,
 } from '@console/dev-console/src/components/topology';
-import { TYPE_EVENT_SOURCE_LINK, TYPE_KNATIVE_SERVICE } from '../const';
-import { createSinkConnection } from '../knative-topology-utils';
+import {
+  TYPE_EVENT_SOURCE_LINK,
+  TYPE_EVENT_PUB_SUB_LINK,
+  TYPE_KNATIVE_SERVICE,
+  TYPE_EVENT_PUB_SUB,
+} from '../const';
+import { createSinkConnection, createSinkPubSubConnection } from '../knative-topology-utils';
 
 export const MOVE_EV_SRC_CONNECTOR_OPERATION = 'moveeventsourceconnector';
+export const MOVE_PUB_SUB_CONNECTOR_OPERATION = 'movepubsubconnector';
 
 export const nodesEdgeIsDragging = (monitor, props) =>
   monitor.isDragging() &&
@@ -30,11 +36,37 @@ export const nodesEdgeIsDragging = (monitor, props) =>
 
 export const canDropEventSourceSinkOnNode = (operation: string, edge: Edge, node: Node): boolean =>
   edge.getSource() !== node &&
-  node.getType() === TYPE_KNATIVE_SERVICE &&
+  (node.getType() === TYPE_KNATIVE_SERVICE || node.getType() === TYPE_EVENT_PUB_SUB) &&
   operation === MOVE_EV_SRC_CONNECTOR_OPERATION &&
   !node.getTargetEdges().find((e) => e.getSource() === edge.getSource());
 
-export const knativeServiceDropTargetSpec: DropTargetSpec<
+export const canDropPubSubSinkOnNode = (operation: string, edge: Edge, node: Node): boolean =>
+  edge.getSource() !== node &&
+  node.getType() === TYPE_KNATIVE_SERVICE &&
+  operation === MOVE_PUB_SUB_CONNECTOR_OPERATION &&
+  !node.getTargetEdges().find((e) => e.getSource() === edge.getSource());
+
+export const eventSourceSinkDropTargetSpec: DropTargetSpec<
+  Edge,
+  any,
+  { canDrop: boolean; dropTarget: boolean; edgeDragging: boolean },
+  NodeComponentProps
+> = {
+  accept: [EDGE_DRAG_TYPE],
+  canDrop: (item, monitor, props) =>
+    (item.getType() === TYPE_EVENT_SOURCE_LINK || item.getType() === TYPE_EVENT_PUB_SUB_LINK) &&
+    item.getSource() !== props.element,
+  collect: (monitor, props) => ({
+    canDrop:
+      monitor.isDragging() &&
+      (monitor.getOperation()?.type === MOVE_EV_SRC_CONNECTOR_OPERATION ||
+        monitor.getOperation()?.type === MOVE_PUB_SUB_CONNECTOR_OPERATION),
+    dropTarget: monitor.isOver({ shallow: true }),
+    edgeDragging: nodesEdgeIsDragging(monitor, props),
+  }),
+};
+
+export const pubSubDropTargetSpec: DropTargetSpec<
   Edge,
   any,
   { canDrop: boolean; dropTarget: boolean; edgeDragging: boolean },
@@ -77,6 +109,47 @@ export const eventSourceLinkDragSourceSpec = (): DragSourceSpec<
       createSinkConnection(props.element.getSource(), dropResult).catch((error) => {
         errorModal({
           title: 'Error moving event source sink',
+          error: error.message,
+          showIcon: true,
+        });
+      });
+    }
+  },
+  collect: (monitor) => ({
+    dragging: monitor.isDragging(),
+  }),
+});
+
+export const eventingPubSubLinkDragSourceSpec = (): DragSourceSpec<
+  DragObjectWithType,
+  DragSpecOperationType<EditableDragOperationType>,
+  Node,
+  { dragging: boolean },
+  EdgeComponentProps
+> => ({
+  item: { type: EDGE_DRAG_TYPE },
+  operation: { type: MOVE_PUB_SUB_CONNECTOR_OPERATION, edit: true },
+  begin: (monitor, props) => {
+    props.element.raise();
+    return props.element;
+  },
+  drag: (event, monitor, props) => {
+    props.element.setEndPoint(event.x, event.y);
+  },
+  end: (dropResult, monitor, props) => {
+    props.element.setEndPoint();
+    if (
+      monitor.didDrop() &&
+      dropResult &&
+      canDropPubSubSinkOnNode(monitor.getOperation().type, props.element, dropResult)
+    ) {
+      createSinkPubSubConnection(
+        props.element.getData(),
+        props.element.getSource(),
+        dropResult,
+      ).catch((error) => {
+        errorModal({
+          title: 'Error while sink',
           error: error.message,
           showIcon: true,
         });

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.scss
@@ -20,11 +20,19 @@
     stroke-width: 2px;
     stroke: $selected-stroke-color;
   }
+  &.is-highlight &__bg {
+    fill: $group-node-fill-color;
+    stroke: $interactive-stroke-color;
+  }
+  &.is-dropTarget &__bg {
+    fill: $interactive-fill-color;
+    stroke: $interactive-stroke-color;
+  }
 }
 
 .odc-m-drag-active,
 .odc-m-filter-active {
-  .odc-event-source {
+  .odc-eventing-pubsub {
     opacity: $de-emphasize-opacity;
     &.is-dragging {
       opacity: 1;
@@ -33,7 +41,7 @@
 }
 
 .odc-m-filter-active:not(.odc-m-drag-active) {
-  .odc-event-source {
+  .odc-eventing-pubsub {
     &.is-filtered {
       opacity: 1;
     }

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.scss
@@ -1,0 +1,41 @@
+@import '../../../../../dev-console/src/components/topology/topology-utils';
+
+.odc-eventing-pubsub {
+  outline: none;
+  cursor: pointer;
+
+  .odc-m-drag-active & {
+    pointer-events: none;
+  }
+
+  &__bg {
+    fill: var(--pf-global--BackgroundColor--light-100);
+  }
+
+  &.is-filtered &__bg {
+    stroke-width: 2px;
+    stroke: $filtered-stroke-color;
+  }
+  &.is-selected &__bg {
+    stroke-width: 2px;
+    stroke: $selected-stroke-color;
+  }
+}
+
+.odc-m-drag-active,
+.odc-m-filter-active {
+  .odc-event-source {
+    opacity: $de-emphasize-opacity;
+    &.is-dragging {
+      opacity: 1;
+    }
+  }
+}
+
+.odc-m-filter-active:not(.odc-m-drag-active) {
+  .odc-event-source {
+    &.is-filtered {
+      opacity: 1;
+    }
+  }
+}

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { Tooltip } from '@patternfly/react-core';
+import { useAccessReview } from '@console/internal/components/utils';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import {
+  Node,
+  observer,
+  useHover,
+  WithSelectionProps,
+  WithDndDropProps,
+  WithContextMenuProps,
+  useSvgAnchor,
+  useDragNode,
+  useCombineRefs,
+  WithCreateConnectorProps,
+  createSvgIdUrl,
+} from '@console/topology';
+import SvgBoxedText from '@console/dev-console/src/components/svg/SvgBoxedText';
+import {
+  NodeShadows,
+  NODE_SHADOW_FILTER_ID_HOVER,
+  NODE_SHADOW_FILTER_ID,
+  useSearchFilter,
+  useDisplayFilters,
+  nodeDragSourceSpec,
+  getTopologyResourceObject,
+} from '@console/dev-console/src/components/topology';
+import { TYPE_EVENT_PUB_SUB } from '../../const';
+
+import './EventingPubSubNode.scss';
+
+export type EventingPubSubNodeProps = {
+  element: Node;
+  canDrop?: boolean;
+  dropTarget?: boolean;
+  edgeDragging?: boolean;
+} & WithSelectionProps &
+  WithDndDropProps &
+  WithContextMenuProps &
+  WithCreateConnectorProps;
+
+const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
+  element,
+  canDrop,
+  dropTarget,
+  selected,
+  onSelect,
+  onContextMenu,
+  contextMenuOpen,
+  dndDropRef,
+  edgeDragging,
+  onHideCreateConnector,
+  onShowCreateConnector,
+}) => {
+  const svgAnchorRef = useSvgAnchor();
+  const [hover, hoverRef] = useHover();
+
+  const resourceObj = getTopologyResourceObject(element.getData());
+  const resourceModel = modelFor(referenceFor(resourceObj));
+  const editAccess = useAccessReview({
+    group: resourceModel.apiGroup,
+    verb: 'patch',
+    resource: resourceModel.plural,
+    name: resourceObj.metadata.name,
+    namespace: resourceObj.metadata.namespace,
+  });
+  const [{ dragging }, dragNodeRef] = useDragNode(
+    nodeDragSourceSpec(TYPE_EVENT_PUB_SUB, true, editAccess),
+    {
+      element,
+    },
+  );
+
+  const groupRefs = useCombineRefs(dragNodeRef, dndDropRef, hoverRef);
+  const [filtered] = useSearchFilter(element.getLabel());
+  const displayFilters = useDisplayFilters();
+  const showLabels = displayFilters.showLabels || hover;
+  const { width, height } = element.getBounds();
+  const { data } = element.getData();
+
+  React.useLayoutEffect(() => {
+    if (editAccess) {
+      if (hover) {
+        onShowCreateConnector && onShowCreateConnector();
+      } else {
+        onHideCreateConnector && onHideCreateConnector();
+      }
+    }
+  }, [editAccess, hover, onShowCreateConnector, onHideCreateConnector]);
+
+  return (
+    <Tooltip
+      content="Move sink to Channel"
+      trigger="manual"
+      isVisible={dropTarget && canDrop}
+      tippyProps={{ duration: 0, delay: 0 }}
+    >
+      <g
+        className={classNames('odc-eventing-pubsub', {
+          'is-filtered': filtered,
+          'is-dragging': dragging || edgeDragging,
+          'is-selected': selected,
+        })}
+        onClick={onSelect}
+        onContextMenu={onContextMenu}
+        ref={groupRefs}
+      >
+        <NodeShadows />
+        <rect
+          ref={svgAnchorRef}
+          className="odc-eventing-pubsub__bg"
+          x={0}
+          y={0}
+          width={width}
+          height={height / 2}
+          rx="15"
+          ry="15"
+          filter={createSvgIdUrl(
+            hover || dragging || contextMenuOpen
+              ? NODE_SHADOW_FILTER_ID_HOVER
+              : NODE_SHADOW_FILTER_ID,
+          )}
+        />
+        {showLabels && (data.kind || element.getLabel()) && (
+          <SvgBoxedText
+            className="odc-eventing-pubsub__label odc-base-node__label"
+            x={width / 2}
+            y={height - 30}
+            paddingX={8}
+            paddingY={4}
+            kind={data.kind}
+            typeIconClass="icon-knative"
+          >
+            {element.getLabel()}
+          </SvgBoxedText>
+        )}
+      </g>
+    </Tooltip>
+  );
+};
+
+export default observer(EventingPubSubNode);

--- a/frontend/packages/knative-plugin/src/topology/const.ts
+++ b/frontend/packages/knative-plugin/src/topology/const.ts
@@ -5,6 +5,8 @@ import {
 
 export const TYPE_EVENT_SOURCE = 'event-source';
 export const TYPE_EVENT_SOURCE_LINK = 'event-source-link';
+export const TYPE_EVENT_PUB_SUB = 'event-pubsub';
+export const TYPE_EVENT_PUB_SUB_LINK = 'event-pubsub-link';
 export const TYPE_KNATIVE_SERVICE = 'knative-service';
 export const TYPE_REVISION_TRAFFIC = 'revision-traffic';
 export const TYPE_KNATIVE_REVISION = 'knative-revision';

--- a/frontend/packages/knative-plugin/src/topology/data-transformer.ts
+++ b/frontend/packages/knative-plugin/src/topology/data-transformer.ts
@@ -4,14 +4,12 @@ import {
   TopologyDataResources,
   addToTopologyDataModel,
 } from '@console/dev-console/src/components/topology';
-import { getDynamicEventSourcesModelRefs } from '../utils/fetch-dynamic-eventsources-utils';
 import {
   getRevisionsData,
   KnativeUtil,
   NodeType,
   transformKnNodeData,
-  getKnativeEventSources,
-  getKnativeChannelResources,
+  getKnativeDynamicResources,
 } from './knative-topology-utils';
 import {
   getKnativeServingConfigurations,
@@ -19,24 +17,10 @@ import {
   getKnativeServingRoutes,
   getKnativeServingServices,
 } from '../utils/get-knative-resources';
-
-/**
- * Filter out deployments not created via revisions/eventsources
- */
-// export const filterNonKnativeDeployments = (
-//   resources: DeploymentKind[],
-//   eventSources?: K8sResourceKind[],
-// ): DeploymentKind[] => {
-//   const KNATIVE_CONFIGURATION = 'serving.knative.dev/configuration';
-//   const isEventSourceKind = (uid: string): boolean =>
-//     uid && !!eventSources?.find((eventSource) => eventSource.metadata?.uid === uid);
-//   return _.filter(resources, (d) => {
-//     return (
-//       !_.get(d, ['metadata', 'labels', KNATIVE_CONFIGURATION], false) &&
-//       !isEventSourceKind(d.metadata?.ownerReferences?.[0].uid)
-//     );
-//   });
-// };
+import {
+  getDynamicEventSourcesModelRefs,
+  getDynamicChannelModelRefs,
+} from '../utils/fetch-dynamic-eventsources-utils';
 
 const addKnativeTopologyData = (
   graphModel: Model,
@@ -64,11 +48,16 @@ export const getKnativeTopologyDataModel = (
     getKnativeServingRoutes,
     getKnativeServingServices,
   ];
+  const eventSourceProps = getDynamicEventSourcesModelRefs();
+  const channelResourceProps = getDynamicChannelModelRefs();
   const knativeTopologyGraphModel: Model = { nodes: [], edges: [] };
   const knSvcResources: K8sResourceKind[] = resources?.ksservices?.data ?? [];
-  const knEventSources: K8sResourceKind[] = getKnativeEventSources(resources);
+  const knEventSources: K8sResourceKind[] = getKnativeDynamicResources(resources, eventSourceProps);
   const knRevResources: K8sResourceKind[] = resources?.revisions?.data ?? [];
-  const knChannelResources: K8sResourceKind[] = getKnativeChannelResources(resources);
+  const knChannelResources: K8sResourceKind[] = getKnativeDynamicResources(
+    resources,
+    channelResourceProps,
+  );
 
   addKnativeTopologyData(
     knativeTopologyGraphModel,

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -36,7 +36,6 @@ import { getImageForIconClass } from '@console/internal/components/catalog/catal
 import { DeploymentModel } from '@console/internal/models';
 import { RootState } from '@console/internal/redux';
 import { FLAG_KNATIVE_EVENTING } from '../const';
-import { ServiceModel as knServiceModel } from '../models';
 import { KnativeItem } from '../utils/get-knative-resources';
 import { Traffic as TrafficData } from '../types';
 import {
@@ -44,16 +43,22 @@ import {
   KNATIVE_GROUP_NODE_PADDING,
   KNATIVE_GROUP_NODE_WIDTH,
 } from './const';
+import {
+  getDynamicEventSourcesModelRefs,
+  getDynamicChannelModelRefs,
+} from '../utils/fetch-dynamic-eventsources-utils';
 
 export enum NodeType {
   EventSource = 'event-source',
   KnService = 'knative-service',
   Revision = 'knative-revision',
+  PubSub = 'event-pubsub',
 }
 
 export enum EdgeType {
   Traffic = 'revision-traffic',
   EventSource = 'event-source-link',
+  EventPubSubLink = 'event-pubsub-link',
 }
 
 type RevK8sResourceKind = K8sResourceKind & {
@@ -269,6 +274,74 @@ const createKnativeDeploymentItems = (
   };
 };
 
+export const getKnativeEventSources = (resources: TopologyDataResources): K8sResourceKind[] => {
+  const evenSourceProps = getDynamicEventSourcesModelRefs();
+  return evenSourceProps.reduce((acc, currProp) => {
+    const currPropResource = resources[currProp]?.data ?? [];
+    return [...acc, ...currPropResource];
+  }, []);
+};
+
+export const getKnativeChannelResources = (resources: TopologyDataResources): K8sResourceKind[] => {
+  const evenSourceProps = getDynamicChannelModelRefs();
+  return evenSourceProps.reduce((acc, currProp) => {
+    const currPropResource = resources[currProp]?.data ?? [];
+    return [...acc, ...currPropResource];
+  }, []);
+};
+
+export const createPubSubDataItems = (
+  resource: K8sResourceKind,
+  resources: TopologyDataResources,
+) => {
+  const {
+    kind: resKind,
+    metadata: { name },
+    spec,
+  } = resource;
+  const subscriptionData = _.get(resources, 'eventingsubscription.data', []);
+  const eventSources = _.reduce(
+    getKnativeEventSources(resources),
+    (acc, evSrc) => {
+      const sinkRes = _.get(evSrc, 'spec.sink.ref', {});
+      if (resKind === sinkRes.kind && name === sinkRes.name) {
+        acc.push(evSrc);
+      }
+      return acc;
+    },
+    [],
+  );
+  const channelSubsData = _.reduce(
+    subscriptionData,
+    (acc, subs) => {
+      const subUid = subs.metadata?.uid;
+      const subscribers = spec?.subscribable?.subscribers || spec?.subscribers;
+      const isSubscribableData = _.findIndex(subscribers, function({ uid }) {
+        return uid === subUid;
+      });
+      if (isSubscribableData !== -1) {
+        acc.eventingsubscription.push(subs);
+        const subscriptionSvc = _.get(subs, 'spec.subscriber.ref', null);
+        _.forEach(resources?.ksservices?.data, (svc) => {
+          if (svc.kind === subscriptionSvc?.kind && svc.metadata.name === subscriptionSvc?.name) {
+            acc.ksservices.push(svc);
+          }
+        });
+      }
+      return acc;
+    },
+    { eventingsubscription: [], ksservices: [] },
+  );
+  return {
+    obj: resource,
+    buildConfigs: [],
+    routes: [],
+    services: [],
+    eventSources,
+    ...channelSubsData,
+  };
+};
+
 /**
  * only get revision which are included in traffic data
  */
@@ -318,14 +391,15 @@ export const getKnativeTopologyNodeItems = (
  * Form Edge data for event sources
  */
 export const getEventTopologyEdgeItems = (resource: K8sResourceKind, { data }): EdgeModel[] => {
-  const uid = _.get(resource, ['metadata', 'uid']);
-  const sinkSvc = _.get(resource, 'spec.sink.ref', null) || _.get(resource, 'spec.sink', null);
+  const uid = resource?.metadata?.uid;
+  const sinkTarget = _.get(resource, 'spec.sink.ref', null) || _.get(resource, 'spec.sink', null);
   const edges = [];
-  if (sinkSvc && sinkSvc.kind === knServiceModel.kind) {
+  if (sinkTarget) {
     _.forEach(data, (res) => {
-      const resname = _.get(res, ['metadata', 'name']);
-      const resUid = _.get(res, ['metadata', 'uid']);
-      if (resname === sinkSvc.name) {
+      const {
+        metadata: { uid: resUid, name: resname },
+      } = res;
+      if (resname === sinkTarget.name) {
         edges.push({
           id: `${uid}_${resUid}`,
           type: EdgeType.EventSource,
@@ -335,6 +409,41 @@ export const getEventTopologyEdgeItems = (resource: K8sResourceKind, { data }): 
       }
     });
   }
+  return edges;
+};
+
+export const getSubscriptionTopologyEdgeItems = (resource: K8sResourceKind, resources): Edge[] => {
+  const {
+    metadata: { uid, name },
+  } = resource;
+  // const subscriptionData = resources?.eventingsubscription;
+  const { eventingsubscription, ksservices } = resources;
+  const edges = [];
+  _.forEach(eventingsubscription?.data, (subRes) => {
+    const channelData = _.get(subRes, ['spec', 'channel']);
+    if (name === channelData?.name && ksservices) {
+      const svcData = _.get(subRes, ['spec', 'subscriber', 'ref']);
+      _.forEach(ksservices?.data, (res) => {
+        const {
+          metadata: { uid: resUid, name: resname },
+        } = res;
+        if (resname === svcData.name) {
+          edges.push({
+            id: `${uid}_${resUid}`,
+            type: EdgeType.EventPubSubLink,
+            source: uid,
+            target: resUid,
+            data: {
+              resources: {
+                obj: subRes,
+                connections: [resource, res],
+              },
+            },
+          });
+        }
+      });
+    }
+  });
   return edges;
 };
 
@@ -403,6 +512,27 @@ export const createTopologyServiceNodeData = (
   };
 };
 
+export const createTopologyPubSubNodeData = (
+  res: TopologyOverviewItem,
+  type: string,
+): TopologyDataObject => {
+  const {
+    obj: {
+      metadata: { name, uid, labels },
+    },
+  } = res;
+  return {
+    id: uid,
+    name: name || labels?.['app.kubernetes.io/instance'],
+    type,
+    resources: { ...res },
+    data: {
+      kind: referenceFor(res.obj),
+      isKnativeResource: true,
+    },
+  };
+};
+
 export const transformKnNodeData = (
   knResourcesData: K8sResourceKind[],
   type: string,
@@ -418,6 +548,11 @@ export const transformKnNodeData = (
         const data = createTopologyNodeData(item, type, getImageForIconClass(`icon-openshift`));
         knDataModel.nodes.push(...getKnativeTopologyNodeItems(res, type, data, resources));
         knDataModel.edges.push(...getEventTopologyEdgeItems(res, resources.ksservices));
+        // form connections for channels
+        const eventingChannels = getDynamicChannelModelRefs();
+        _.forEach(eventingChannels, (currentProp) => {
+          knDataModel.graph.edges.push(...getEventTopologyEdgeItems(res, resources[currentProp]));
+        });
         const newGroup = getTopologyGroupItems(res);
         mergeGroup(newGroup, knDataModel.nodes);
         break;
@@ -428,6 +563,15 @@ export const transformKnNodeData = (
         knDataModel.edges.push(...getTrafficTopologyEdgeItems(res, resources.revisions));
         const newGroup = getTopologyGroupItems(res);
         mergeGroup(newGroup, knDataModel.nodes);
+        break;
+      }
+      case NodeType.PubSub: {
+        const itemData = createPubSubDataItems(res, resources);
+        const data = createTopologyPubSubNodeData(itemData, type);
+        knDataModel.nodes.push(...getKnativeTopologyNodeItems(res, type, data, resources));
+        knDataModel.edges.push(...getSubscriptionTopologyEdgeItems(res, resources));
+        const newGroup = getTopologyGroupItems(res);
+        mergeGroup(newGroup, knDataModel.graph.groups);
         break;
       }
       default:
@@ -504,4 +648,52 @@ export const createSinkConnection = (
   targetNode: Node,
 ): Promise<K8sResourceKind> => {
   return createTopologySinkConnection(sourceNode.getData(), targetNode.getData());
+};
+
+export const createEventingPubSubSink = (
+  subObj,
+  source: K8sResourceKind,
+  target: K8sResourceKind,
+) => {
+  if (!subObj || !source || !target || source === target) {
+    return Promise.reject();
+  }
+  const subscriptionObj = _.omit(subObj, 'status');
+  const sink = {
+    channel: {
+      apiVersion: source.apiVersion,
+      kind: source.kind,
+      name: source.metadata?.name,
+    },
+    subscriber: {
+      ref: {
+        apiVersion: target.apiVersion,
+        kind: target.kind,
+        name: target.metadata?.name,
+      },
+    },
+  };
+  const updatePayload = {
+    ...subscriptionObj,
+    spec: { ...subscriptionObj.spec, ...sink },
+  };
+  return k8sUpdate(modelFor(referenceFor(subscriptionObj)), updatePayload);
+};
+
+export const createSinkPubSubConnection = (
+  connector: any,
+  sourceNode: Node,
+  targetNode: Node,
+): Promise<K8sResourceKind> => {
+  const { resources } = connector.data;
+  const source = sourceNode.getData();
+  const target = targetNode.getData();
+  if (!source || !target || source === target || !resources?.obj) {
+    return Promise.reject();
+  }
+
+  const sourceObj = getTopologyResourceObject(source);
+  const targetObj = getTopologyResourceObject(target);
+
+  return createEventingPubSubSink(resources?.obj, sourceObj, targetObj);
 };

--- a/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
@@ -25,8 +25,12 @@ import {
   knativeServingResourcesRevisionWatchers,
   knativeServingResourcesRoutesWatchers,
   knativeServingResourcesServicesWatchers,
+  knativeEventingResourcesSubscriptionWatchers,
 } from '../utils/get-knative-resources';
-import { getDynamicEventSourcesWatchers } from '../utils/fetch-dynamic-eventsources-utils';
+import {
+  getDynamicEventSourcesWatchers,
+  getDynamicEventingChannelWatchers,
+} from '../utils/fetch-dynamic-eventsources-utils';
 
 export const getKnativeResources = (namespace: string) => {
   return {
@@ -34,7 +38,9 @@ export const getKnativeResources = (namespace: string) => {
     ...knativeServingResourcesConfigurationsWatchers(namespace),
     ...knativeServingResourcesRoutesWatchers(namespace),
     ...knativeServingResourcesServicesWatchers(namespace),
+    ...knativeEventingResourcesSubscriptionWatchers(namespace),
     ...getDynamicEventSourcesWatchers(namespace),
+    ...getDynamicEventingChannelWatchers(namespace),
   };
 };
 

--- a/frontend/packages/knative-plugin/src/types.ts
+++ b/frontend/packages/knative-plugin/src/types.ts
@@ -51,3 +51,25 @@ export type RoutesOverviewListItem = {
   name: string;
   namespace: string;
 };
+
+export type EventSubscriptionKind = {
+  metadata?: {
+    generation?: number;
+  };
+  status: {
+    physicalSubscription: {
+      subscriberURI: string;
+    };
+  };
+} & K8sResourceKind;
+
+export type EventChannelKind = {
+  metadata?: {
+    generation?: number;
+  };
+  status: {
+    address: {
+      url: string;
+    };
+  };
+} & K8sResourceKind;

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -227,6 +227,18 @@ export const getDynamicChannelResourceList = (namespace: string) => {
   });
 };
 
+export const getDynamicEventingChannelWatchers = (namespace: string) => {
+  return eventSourceData.eventSourceChannels.reduce((acc, model) => {
+    acc[referenceForModel(model)] = {
+      isList: true,
+      kind: referenceForModel(model),
+      namespace,
+      optional: true,
+    };
+    return acc;
+  }, {});
+};
+
 export const getDynamicChannelModelRefs = (): string[] => {
   return eventSourceData.eventSourceChannels.map((model: K8sKind) => referenceForModel(model));
 };

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -2,8 +2,14 @@ import * as _ from 'lodash';
 import { K8sResourceKind, PodKind, referenceForModel } from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { KNATIVE_SERVING_LABEL } from '../const';
-import { ServiceModel, RevisionModel, ConfigurationModel, RouteModel } from '../models';
 import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
+import {
+  ServiceModel,
+  RevisionModel,
+  ConfigurationModel,
+  RouteModel,
+  EventingSubscriptionModel,
+} from '../models';
 
 export type KnativeItem = {
   revisions?: K8sResourceKind[];
@@ -118,6 +124,19 @@ export const knativeServingResourcesServices = (namespace: string): FirehoseReso
   return knativeResource;
 };
 
+export const knativeEventingResourcesSubscription = (namespace: string): FirehoseResource[] => {
+  const knativeResource = [
+    {
+      isList: true,
+      kind: referenceForModel(EventingSubscriptionModel),
+      namespace,
+      prop: 'eventingsubscription',
+      optional: true,
+    },
+  ];
+  return knativeResource;
+};
+
 export const knativeServingResourcesRevisionWatchers = (
   namespace: string,
 ): WatchK8sResources<any> => {
@@ -167,6 +186,20 @@ export const knativeServingResourcesServicesWatchers = (
     ksservices: {
       isList: true,
       kind: referenceForModel(ServiceModel),
+      namespace,
+      optional: true,
+    },
+  };
+  return knativeResource;
+};
+
+export const knativeEventingResourcesSubscriptionWatchers = (
+  namespace: string,
+): WatchK8sResources<any> => {
+  const knativeResource = {
+    eventingsubscription: {
+      isList: true,
+      kind: referenceForModel(EventingSubscriptionModel),
       namespace,
       optional: true,
     },

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -5,7 +5,7 @@ import { EditApplication } from '@console/dev-console/src/actions/modify-applica
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { setTrafficDistribution } from '../actions/traffic-splitting';
 import { setSinkSource } from '../actions/sink-source';
-import { ServiceModel } from '../models';
+import { ServiceModel, EventingSubscriptionModel } from '../models';
 import { getDynamicEventSourcesModelRefs } from './fetch-dynamic-eventsources-utils';
 
 export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => {
@@ -16,6 +16,9 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
       menuActions.push(setTrafficDistribution, AddHealthChecks, EditApplication, EditHealthChecks);
     }
     if (_.includes(eventSourceModelrefs, referenceForModel(resourceKind))) {
+      menuActions.push(setSinkSource);
+    }
+    if (referenceForModel(resourceKind) === referenceForModel(EventingSubscriptionModel)) {
       menuActions.push(setSinkSource);
     }
   }


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/ODC-4164
- https://issues.redhat.com/browse/ODC-4165
- https://issues.redhat.com/browse/ODC-4169

**Analysis / Root cause**: 
In topology we don't visualise Channels / Subscription associated relation with Sources and kn service

**Solution Description**: 
- Fetch Channels CRDs based on label and and form Datamodel required for visualising Channel  / Subscription associated relation
- Extending Shape for Channel
- Extending connector for Subscription
- Show sidebar for channel  
- Show sidebar for Subscription connector
- Update sidebar for EventSources
- Action menus for Channel Node/Subscription Edge - Move Subscription apart from custom one's
- Gestures for for eventSource Connector can be dropped to Channel as well
- Gestures for for Subscription  Connector can be dropped to Other kn Svc as well

**Screen shots / Gifs for design review**: 

- Sidebar for Channel
![image](https://user-images.githubusercontent.com/5129024/85819366-12b1bb00-b791-11ea-9f0f-0d1f842887d8.png)

- Sidebar for Subscription connector
![image](https://user-images.githubusercontent.com/5129024/85819422-3ecd3c00-b791-11ea-9ccd-d92b81d6bf14.png)

- Sidebar for eventSource while sinking to channel
![image](https://user-images.githubusercontent.com/5129024/85819471-67edcc80-b791-11ea-817f-76b1ed337c28.png)

- gif showing some of gestures and action menu

![Jun-26-2020 09-46-13](https://user-images.githubusercontent.com/5129024/85819692-18f46700-b792-11ea-9820-10f90d687f75.gif)


@openshift/team-devconsole-ux

**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/85846761-f418e780-b7c3-11ea-9feb-a524e1e0be2f.png)

**Test setup:**
- Create channel/sources/subscription and kn svc, can follow https://github.com/matzew/knative-eventing-samples/tree/master/02-source_channel

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
