### PR TITLE
kubevirt: Short the guest agent poll delay

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-users.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-users.tsx
@@ -64,8 +64,8 @@ const UsersTableRow = ({ obj: user, index, key, style }) => {
   );
 };
 
-export const VMUsersList: React.FC<VMUsersListProps> = ({ vmi, vmStatusBundle, delay }) => {
-  const [guestAgentInfoRaw, error, loading] = useGuestAgentInfo({ vmi, delay });
+export const VMUsersList: React.FC<VMUsersListProps> = ({ vmi, vmStatusBundle }) => {
+  const [guestAgentInfoRaw, error, loading] = useGuestAgentInfo({ vmi });
   const guestAgentInfo = new GuestAgentInfoWrapper(guestAgentInfoRaw);
   const userList = guestAgentInfo.getUserList();
 
@@ -106,5 +106,4 @@ export const VMUsersList: React.FC<VMUsersListProps> = ({ vmi, vmStatusBundle, d
 type VMUsersListProps = {
   vmi?: VMIKind;
   vmStatusBundle?: VMStatusBundle;
-  delay?: number;
 };

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-guest-agent-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-guest-agent-info.ts
@@ -4,12 +4,14 @@ import { isGuestAgentInstalled } from '../components/dashboards-page/vm-dashboar
 import { getVMIApiPath, getVMISubresourcePath } from '../selectors/vmi/selectors';
 import { V1VirtualMachineInstanceGuestAgentInfo } from '../types/vmi-guest-data-info/vmi-guest-agent-info';
 
+export const GUEST_AGENT_POLL_DEFAULT_DELAY = 5000; // 5 seconds
+
 const getGuestAgentURL = (vmi: VMIKind) =>
   vmi &&
   isGuestAgentInstalled(vmi) &&
   `/${getVMISubresourcePath()}/${getVMIApiPath(vmi)}/guestosinfo`;
 
-const useGuestAgentInfo = ({ vmi, delay }: GuestAgentInfoProps) =>
+const useGuestAgentInfo = ({ vmi, delay = GUEST_AGENT_POLL_DEFAULT_DELAY }: GuestAgentInfoProps) =>
   useURLPoll<V1VirtualMachineInstanceGuestAgentInfo>(getGuestAgentURL(vmi), delay);
 
 type GuestAgentInfoProps = {


### PR DESCRIPTION
Make the details, overview and alert messages update quicker.