### PR TITLE
Bug 1843301: Update vmi details page information message

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
@@ -107,9 +107,8 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
         title={`Virtual Machine Instance ${name}`}
       >
         <p>
-          This is a VirtualMachineInstance overview page. Please consider using a VirtualMachine
-          that will provide additional management capabilities to a VirtualMachineInstance inside
-          the cluster.
+          Consider using a Virtual Machine that will provide additional management capabilities to a
+          VirtualMachineInstance inside the cluster.
         </p>
         <ExternalLink
           href="https://kubevirt.io/user-guide/#/architecture?id=virtualmachine"


### PR DESCRIPTION
Create a VMI and navigate to VMI tabs, it always say "This is a VirtualMachineInstance overview page" no matter what tab it's on.
This PR remove this sentence.

Screenshot:
After:
![screenshot-localhost_9000-2020 06 23-15_56_17](https://user-images.githubusercontent.com/2181522/85406229-2929fd80-b56a-11ea-98cc-4732742666fa.png)

Before:
![screenshot-console-openshift-console apps ostest test metalkube org-2020 06 23-15_50_50](https://user-images.githubusercontent.com/2181522/85406226-28916700-b56a-11ea-98be-506dc73cbe1e.png)

