### PR TITLE
Bug 1843311: Kubevirt vm wizard create to confirm

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
@@ -30,7 +30,7 @@ import { iGetCommonData } from './selectors/immutable/selectors';
 import { setActiveNamespace, getActiveNamespace } from '@console/internal/actions/ui';
 import {
   getCreateVMLikeEntityLabel,
-  getReviewAndCreateVMLikeEntityLabel,
+  REVIEW_AND_CONFIRM,
   WIZARD_CLOSE_PROMPT,
 } from './strings/strings';
 import { vmWizardActions } from './redux/actions';
@@ -191,7 +191,7 @@ const CreateVMWizardFooterComponent: React.FC<CreateVMWizardFooterComponentProps
                   }
                 }}
               >
-                {getReviewAndCreateVMLikeEntityLabel(isProviderImport)}
+                {REVIEW_AND_CONFIRM}
               </Button>
             )}
             {areMainTabsHidden && canNavigateEverywhere && (

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
@@ -4,8 +4,7 @@ export const CREATE_VM = 'Create Virtual Machine';
 export const CREATE_VM_TEMPLATE = `${CREATE_VM} Template`;
 export const IMPORT = `Import`;
 export const IMPORT_VM = 'Import Virtual Machine';
-export const REVIEW_AND_CREATE = 'Review and create';
-export const REVIEW_AND_IMPORT = 'Review and import';
+export const REVIEW_AND_CONFIRM = 'Review and confirm';
 export const NO_TEMPLATE = 'None';
 export const SELECT_TEMPLATE = '--- Select Template ---';
 export const NO_TEMPLATE_AVAILABLE = 'No template available';
@@ -15,9 +14,6 @@ export const WIZARD_CLOSE_PROMPT =
 
 export const getCreateVMLikeEntityLabel = (isTemplate: boolean, isProviderImport: boolean) =>
   isProviderImport ? IMPORT : isTemplate ? CREATE_VM_TEMPLATE : CREATE_VM;
-
-export const getReviewAndCreateVMLikeEntityLabel = (isProviderImport: boolean) =>
-  isProviderImport ? REVIEW_AND_IMPORT : REVIEW_AND_CREATE;
 
 export const TabTitleResolver = {
   [VMWizardTab.IMPORT_PROVIDERS]: 'Connect to Provider',


### PR DESCRIPTION
On VM wizard, click button "Review and create" jumps to "Review and confirm your settings" page and the create button "Create Virtual Machine" is on that page, so it's reasonable to lable "Review and create" to "Review and confirm". 

Screeshots:
Before:
![screenshot-console-openshift-console apps ostest test metalkube org-2020 06 24-09_41_05](https://user-images.githubusercontent.com/2181522/85509879-5eccf600-b5ff-11ea-89ad-347a80689862.png)

After:
![screenshot-localhost_9000-2020 06 24-09_42_30](https://user-images.githubusercontent.com/2181522/85509886-5ffe2300-b5ff-11ea-9161-94aaf0e9ff51.png)