### PR TITLE
Bug 1850438: Check for empty multidata list

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -81,7 +81,7 @@ export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> =
         <div className="co-utilization-card__item-description">
           <div className="co-utilization-card__item-section-multiline">
             <h4 className="pf-c-title pf-m-md">{title}</h4>
-            {error || (!isLoading && !data.every((datum) => datum.length)) ? (
+            {error || (!isLoading && !(data.length && data.every((datum) => datum.length))) ? (
               <div className="text-secondary">Not available</div>
             ) : (
               <div className="co-utilization-card__item-description">{currentValue}</div>


### PR DESCRIPTION
If we create a VM and visit VM overview page, there are "Not available" for other metrics but not for network, start the VM and "Not available" displayed for network immediately.

Screenshot:
After:
![screenshot-localhost_9000-2020 06 24-15_26_15](https://user-images.githubusercontent.com/2181522/85556239-52f92800-b62f-11ea-8f8f-66fa97164833.png)

Before:
![screenshot-localhost_9000-2020 06 24-15_29_23](https://user-images.githubusercontent.com/2181522/85556460-889e1100-b62f-11ea-866c-9c3102162790.png)
