### PR TITLE
Add Jobs, CronJobs, and standalone Pods to topology view

### DIFF
--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind, PodKind, RouteKind } from '@console/internal/module/k8s';
+import { JobKind, K8sResourceKind, PodKind, RouteKind } from '@console/internal/module/k8s';
 import { DEPLOYMENT_STRATEGY } from '../constants';
 import { OverviewItemAlerts, PodControllerOverviewItem } from './pod';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
@@ -28,6 +28,7 @@ export type OverviewItem<T = K8sResourceKind> = {
   previous?: PodControllerOverviewItem;
   routes: RouteKind[];
   services: K8sResourceKind[];
+  jobs?: JobKind[];
   status?: React.ReactNode;
   ksroutes?: K8sResourceKind[];
   configurations?: K8sResourceKind[];

--- a/frontend/packages/dev-console/src/components/svg/SvgResourceIcon.scss
+++ b/frontend/packages/dev-console/src/components/svg/SvgResourceIcon.scss
@@ -12,10 +12,15 @@
 }
 .odc-resource-icon-deployment,
 .odc-resource-icon-daemonset,
-.odc-resource-icon-deploymentconfig {
+.odc-resource-icon-deploymentconfig,
+.odc-resource-icon-job
+{
   fill: $color-pod-overlord;
 }
 .odc-resource-icon-application {
   fill: $color-application-dark;
+}
+.odc-resource-icon-pod {
+  fill: $color-pod-dark;
 }
 

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -458,6 +458,411 @@ export const samplePods: FirehoseResult<PodKind[]> = {
   loadError: '',
   data: [
     {
+      metadata: {
+        generateName: 'py-cron-1593000600-',
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.50"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.50"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/scc': 'restricted',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/py-cron-1593000600-pq8jn',
+        resourceVersion: '104969',
+        name: 'py-cron-1593000600-pq8jn',
+        uid: 'd09c22d8-4d12-465c-b178-fbd76db43ed8',
+        creationTimestamp: '2020-06-24T12:10:43Z',
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            name: 'py-cron-1593000600',
+            uid: 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+          'job-name': 'py-cron-1593000600',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Failed',
+      },
+    },
+    {
+      metadata: {
+        generateName: 'py-cron-1593000600-',
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.48"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.48"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/scc': 'restricted',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/py-cron-1593000600-9v5lq',
+        resourceVersion: '104275',
+        name: 'py-cron-1593000600-9v5lq',
+        uid: 'f680a75a-9bd5-4b72-a5da-62477f0a4573',
+        creationTimestamp: '2020-06-24T12:10:13Z',
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            name: 'py-cron-1593000600',
+            uid: 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+          'job-name': 'py-cron-1593000600',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Failed',
+      },
+    },
+    {
+      metadata: {
+        generateName: 'py-cron-1593002400-',
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.96"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.96"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/scc': 'restricted',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/py-cron-1593002400-bzzmm',
+        resourceVersion: '132152',
+        name: 'py-cron-1593002400-bzzmm',
+        uid: 'c5f81e7f-a373-41f7-912a-55940642cc4e',
+        creationTimestamp: '2020-06-24T12:42:40Z',
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            name: 'py-cron-1593002400',
+            uid: '3410e32d-309d-453e-889a-065c116eada5',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': '3410e32d-309d-453e-889a-065c116eada5',
+          'job-name': 'py-cron-1593002400',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Failed',
+      },
+    },
+    {
+      metadata: {
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.131.0.15"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.131.0.15"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/build.name': 'py-cron-1',
+          'openshift.io/scc': 'privileged',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/py-cron-1-build',
+        resourceVersion: '60137',
+        name: 'py-cron-1-build',
+        uid: '67120da8-0c67-4158-892e-d7278d62795d',
+        creationTimestamp: '2020-06-24T11:17:41Z',
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'build.openshift.io/v1',
+            kind: 'Build',
+            name: 'py-cron-1',
+            uid: '7b599334-c53b-4559-acfe-532db362106c',
+            controller: true,
+          },
+        ],
+        labels: {
+          'openshift.io/build.name': 'py-cron-1',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Succeeded',
+      },
+    },
+    {
+      metadata: {
+        generateName: 'py-cron-1593002400-',
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.91"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.91"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/scc': 'restricted',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/py-cron-1593002400-hcnrb',
+        resourceVersion: '129932',
+        name: 'py-cron-1593002400-hcnrb',
+        uid: '1bb8b0f1-be63-4e41-b37c-88778fea1722',
+        creationTimestamp: '2020-06-24T12:40:06Z',
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            name: 'py-cron-1593002400',
+            uid: '3410e32d-309d-453e-889a-065c116eada5',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': '3410e32d-309d-453e-889a-065c116eada5',
+          'job-name': 'py-cron-1593002400',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Failed',
+      },
+    },
+    {
+      metadata: {
+        generateName: 'py-cron-1593002400-',
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.94"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.94"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/scc': 'restricted',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/py-cron-1593002400-pvcgm',
+        resourceVersion: '130695',
+        name: 'py-cron-1593002400-pvcgm',
+        uid: '7f65e6ef-26a2-4c55-9665-cc57a6ba7ebe',
+        creationTimestamp: '2020-06-24T12:40:40Z',
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            name: 'py-cron-1593002400',
+            uid: '3410e32d-309d-453e-889a-065c116eada5',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': '3410e32d-309d-453e-889a-065c116eada5',
+          'job-name': 'py-cron-1593002400',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Failed',
+      },
+    },
+    {
+      metadata: {
+        generateName: 'standalone-job-',
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.129.2.16"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.129.2.16"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/scc': 'restricted',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/standalone-job-jchzw',
+        resourceVersion: '59798',
+        name: 'standalone-job-jchzw',
+        uid: '100afa1b-58fd-40cc-b428-6c9c939c4e15',
+        creationTimestamp: '2020-06-24T11:17:41Z',
+        managedFields: [
+          {
+            manager: 'kube-controller-manager',
+            operation: 'Update',
+            apiVersion: 'v1',
+            time: '2020-06-24T11:17:41Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:metadata': {
+                'f:generateName': {},
+                'f:labels': {
+                  '.': {},
+                  'f:controller-uid': {},
+                  'f:job-name': {},
+                },
+                'f:ownerReferences': {
+                  '.': {},
+                  'k:{"uid":"c1a988ed-3fd6-4a10-a4a5-7612a28eb48e"}': {
+                    '.': {},
+                    'f:apiVersion': {},
+                    'f:blockOwnerDeletion': {},
+                    'f:controller': {},
+                    'f:kind': {},
+                    'f:name': {},
+                    'f:uid': {},
+                  },
+                },
+              },
+              'f:spec': {
+                'f:containers': {
+                  'k:{"name":"pi"}': {
+                    '.': {},
+                    'f:command': {},
+                    'f:image': {},
+                    'f:imagePullPolicy': {},
+                    'f:name': {},
+                    'f:resources': {},
+                    'f:terminationMessagePath': {},
+                    'f:terminationMessagePolicy': {},
+                  },
+                },
+                'f:dnsPolicy': {},
+                'f:enableServiceLinks': {},
+                'f:restartPolicy': {},
+                'f:schedulerName': {},
+                'f:securityContext': {},
+                'f:terminationGracePeriodSeconds': {},
+              },
+            },
+          },
+          {
+            manager: 'multus',
+            operation: 'Update',
+            apiVersion: 'v1',
+            time: '2020-06-24T11:17:44Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:metadata': {
+                'f:annotations': {
+                  'f:k8s.v1.cni.cncf.io/network-status': {},
+                  'f:k8s.v1.cni.cncf.io/networks-status': {},
+                },
+              },
+            },
+          },
+          {
+            manager: 'kubelet',
+            operation: 'Update',
+            apiVersion: 'v1',
+            time: '2020-06-24T11:18:42Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:status': {
+                'f:conditions': {
+                  'k:{"type":"ContainersReady"}': {
+                    '.': {},
+                    'f:lastProbeTime': {},
+                    'f:lastTransitionTime': {},
+                    'f:reason': {},
+                    'f:status': {},
+                    'f:type': {},
+                  },
+                  'k:{"type":"Initialized"}': {
+                    '.': {},
+                    'f:lastProbeTime': {},
+                    'f:lastTransitionTime': {},
+                    'f:reason': {},
+                    'f:status': {},
+                    'f:type': {},
+                  },
+                  'k:{"type":"Ready"}': {
+                    '.': {},
+                    'f:lastProbeTime': {},
+                    'f:lastTransitionTime': {},
+                    'f:reason': {},
+                    'f:status': {},
+                    'f:type': {},
+                  },
+                },
+                'f:containerStatuses': {},
+                'f:hostIP': {},
+                'f:phase': {},
+                'f:podIP': {},
+                'f:podIPs': {
+                  '.': {},
+                  'k:{"ip":"10.129.2.16"}': {
+                    '.': {},
+                    'f:ip': {},
+                  },
+                },
+                'f:startTime': {},
+              },
+            },
+          },
+        ],
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1',
+            kind: 'Job',
+            name: 'standalone-job',
+            uid: 'c1a988ed-3fd6-4a10-a4a5-7612a28eb48e',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': 'c1a988ed-3fd6-4a10-a4a5-7612a28eb48e',
+          'job-name': 'standalone-job',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Succeeded',
+      },
+    },
+    {
+      metadata: {
+        annotations: {
+          'k8s.v1.cni.cncf.io/network-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.20"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'k8s.v1.cni.cncf.io/networks-status':
+            '[{\n    "name": "openshift-sdn",\n    "interface": "eth0",\n    "ips": [\n        "10.128.2.20"\n    ],\n    "default": true,\n    "dns": {}\n}]',
+          'openshift.io/scc': 'anyuid',
+        },
+        selfLink: '/api/v1/namespaces/jeff-project/pods/standalone-pod',
+        resourceVersion: '59106',
+        name: 'standalone-pod',
+        uid: 'ef598095-c5d7-413f-8f41-e2b1da622dee',
+        creationTimestamp: '2020-06-24T11:17:41Z',
+        namespace: 'jeff-project',
+        labels: {
+          app: 'hello-openshift',
+        },
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Running',
+      },
+    },
+    {
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: {
@@ -1195,6 +1600,53 @@ export const sampleBuildConfigs: FirehoseResult = {
   loadError: '',
   data: [
     {
+      metadata: {
+        name: 'py-cron',
+        namespace: 'jeff-project',
+        selfLink: '/apis/build.openshift.io/v1/namespaces/jeff-project/buildconfigs/py-cron',
+        uid: '73d2d812-29aa-4b6a-87e0-d69fcf3ed0cd',
+        resourceVersion: '58983',
+        creationTimestamp: '2020-06-24T11:17:40Z',
+        labels: {
+          app: 'py-cron',
+        },
+      },
+      spec: {
+        nodeSelector: null,
+        output: {
+          to: {
+            kind: 'ImageStreamTag',
+            name: 'py-cron:1.0',
+          },
+        },
+        resources: {},
+        successfulBuildsHistoryLimit: 5,
+        failedBuildsHistoryLimit: 5,
+        strategy: {
+          type: 'Source',
+          sourceStrategy: {
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'openshift',
+              name: 'python:3.6',
+            },
+          },
+        },
+        postCommit: {},
+        source: {
+          type: 'Git',
+          git: {
+            uri: 'https://github.com/clcollins/openshift-cronjob-example.git',
+            ref: 'master',
+          },
+        },
+        runPolicy: 'Serial',
+      },
+      status: {
+        lastVersion: 1,
+      },
+    },
+    {
       kind: 'BuildConfig',
       metadata: {
         name: 'analytics-build',
@@ -1600,6 +2052,665 @@ export const sampleStatefulSets: FirehoseResult = {
       kind: 'StatefulSet',
     },
   ],
+};
+
+export const sampleJobs: FirehoseResult = {
+  data: [
+    {
+      metadata: {
+        annotations: {
+          'alpha.image.policy.openshift.io/resolve-names': '*',
+        },
+        selfLink: '/apis/batch/v1/namespaces/jeff-project/jobs/py-cron-1593000600',
+        resourceVersion: '108691',
+        name: 'py-cron-1593000600',
+        uid: 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+        creationTimestamp: '2020-06-24T12:10:09Z',
+        managedFields: [
+          {
+            manager: 'kube-controller-manager',
+            operation: 'Update',
+            apiVersion: 'batch/v1',
+            time: '2020-06-24T12:14:43Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:metadata': {
+                'f:annotations': {
+                  '.': {},
+                  'f:alpha.image.policy.openshift.io/resolve-names': {},
+                },
+                'f:ownerReferences': {
+                  '.': {},
+                  'k:{"uid":"be644703-be4b-4ee5-9d86-fdeb9495569c"}': {
+                    '.': {},
+                    'f:apiVersion': {},
+                    'f:blockOwnerDeletion': {},
+                    'f:controller': {},
+                    'f:kind': {},
+                    'f:name': {},
+                    'f:uid': {},
+                  },
+                },
+              },
+              'f:spec': {
+                'f:backoffLimit': {},
+                'f:completions': {},
+                'f:parallelism': {},
+                'f:template': {
+                  'f:spec': {
+                    'f:containers': {
+                      'k:{"name":"py-cron"}': {
+                        '.': {},
+                        'f:env': {
+                          '.': {},
+                          'k:{"name":"HOST"}': {
+                            '.': {},
+                            'f:name': {},
+                            'f:value': {},
+                          },
+                          'k:{"name":"NAMESPACE"}': {
+                            '.': {},
+                            'f:name': {},
+                            'f:valueFrom': {
+                              '.': {},
+                              'f:fieldRef': {
+                                '.': {},
+                                'f:apiVersion': {},
+                                'f:fieldPath': {},
+                              },
+                            },
+                          },
+                        },
+                        'f:image': {},
+                        'f:imagePullPolicy': {},
+                        'f:name': {},
+                        'f:resources': {},
+                        'f:terminationMessagePath': {},
+                        'f:terminationMessagePolicy': {},
+                      },
+                    },
+                    'f:dnsPolicy': {},
+                    'f:restartPolicy': {},
+                    'f:schedulerName': {},
+                    'f:securityContext': {},
+                    'f:terminationGracePeriodSeconds': {},
+                  },
+                },
+              },
+              'f:status': {
+                'f:conditions': {
+                  '.': {},
+                  'k:{"type":"Failed"}': {
+                    '.': {},
+                    'f:lastProbeTime': {},
+                    'f:lastTransitionTime': {},
+                    'f:message': {},
+                    'f:reason': {},
+                    'f:status': {},
+                    'f:type': {},
+                  },
+                },
+                'f:failed': {},
+                'f:startTime': {},
+              },
+            },
+          },
+        ],
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1beta1',
+            kind: 'CronJob',
+            name: 'py-cron',
+            uid: 'be644703-be4b-4ee5-9d86-fdeb9495569c',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+          'job-name': 'py-cron-1593000600',
+        },
+      },
+      spec: {
+        parallelism: 1,
+        completions: 1,
+        backoffLimit: 6,
+        selector: {
+          matchLabels: {
+            'controller-uid': 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+          },
+        },
+        template: {
+          metadata: {
+            creationTimestamp: null,
+            labels: {
+              'controller-uid': 'c9a27ca7-d258-4acf-a915-a146cacd6924',
+              'job-name': 'py-cron-1593000600',
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: 'py-cron',
+                image:
+                  'image-registry.openshift-image-registry.svc:5000/jeff-project/py-cron@sha256:47c25f041c18c19f65b609df38a49a095ca0358dcfd11db77a21a0380905ecac',
+                env: [
+                  {
+                    name: 'NAMESPACE',
+                    valueFrom: {
+                      fieldRef: {
+                        apiVersion: 'v1',
+                        fieldPath: 'metadata.namespace',
+                      },
+                    },
+                  },
+                  {
+                    name: 'HOST',
+                    value: 'https://okd.host:port',
+                  },
+                ],
+                resources: {},
+                terminationMessagePath: '/dev/termination-log',
+                terminationMessagePolicy: 'File',
+                imagePullPolicy: 'Always',
+              },
+            ],
+            restartPolicy: 'Never',
+            terminationGracePeriodSeconds: 30,
+            dnsPolicy: 'ClusterFirst',
+            securityContext: {},
+            schedulerName: 'default-scheduler',
+          },
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Failed',
+            status: 'True',
+            lastProbeTime: '2020-06-24T12:14:43Z',
+            lastTransitionTime: '2020-06-24T12:14:43Z',
+            reason: 'BackoffLimitExceeded',
+            message: 'Job has reached the specified backoff limit',
+          },
+        ],
+        startTime: '2020-06-24T12:10:09Z',
+        failed: 6,
+      },
+    },
+    {
+      metadata: {
+        name: 'standalone-job',
+        namespace: 'jeff-project',
+        selfLink: '/apis/batch/v1/namespaces/jeff-project/jobs/standalone-job',
+        uid: 'c1a988ed-3fd6-4a10-a4a5-7612a28eb48e',
+        resourceVersion: '59800',
+        creationTimestamp: '2020-06-24T11:17:41Z',
+        labels: {
+          'controller-uid': 'c1a988ed-3fd6-4a10-a4a5-7612a28eb48e',
+          'job-name': 'standalone-job',
+        },
+        managedFields: [
+          {
+            manager: 'oc',
+            operation: 'Update',
+            apiVersion: 'batch/v1',
+            time: '2020-06-24T11:17:41Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:spec': {
+                'f:backoffLimit': {},
+                'f:completions': {},
+                'f:parallelism': {},
+                'f:selector': {},
+                'f:template': {
+                  'f:metadata': {
+                    'f:name': {},
+                  },
+                  'f:spec': {
+                    'f:containers': {
+                      'k:{"name":"pi"}': {
+                        '.': {},
+                        'f:command': {},
+                        'f:image': {},
+                        'f:imagePullPolicy': {},
+                        'f:name': {},
+                        'f:resources': {},
+                        'f:terminationMessagePath': {},
+                        'f:terminationMessagePolicy': {},
+                      },
+                    },
+                    'f:dnsPolicy': {},
+                    'f:restartPolicy': {},
+                    'f:schedulerName': {},
+                    'f:securityContext': {},
+                    'f:terminationGracePeriodSeconds': {},
+                  },
+                },
+              },
+            },
+          },
+          {
+            manager: 'kube-controller-manager',
+            operation: 'Update',
+            apiVersion: 'batch/v1',
+            time: '2020-06-24T11:18:42Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:status': {
+                'f:completionTime': {},
+                'f:conditions': {
+                  '.': {},
+                  'k:{"type":"Complete"}': {
+                    '.': {},
+                    'f:lastProbeTime': {},
+                    'f:lastTransitionTime': {},
+                    'f:status': {},
+                    'f:type': {},
+                  },
+                },
+                'f:startTime': {},
+                'f:succeeded': {},
+              },
+            },
+          },
+        ],
+      },
+      spec: {
+        parallelism: 1,
+        completions: 1,
+        backoffLimit: 6,
+        selector: {
+          matchLabels: {
+            'controller-uid': 'c1a988ed-3fd6-4a10-a4a5-7612a28eb48e',
+          },
+        },
+        template: {
+          metadata: {
+            name: 'pi',
+            creationTimestamp: null,
+            labels: {
+              'controller-uid': 'c1a988ed-3fd6-4a10-a4a5-7612a28eb48e',
+              'job-name': 'standalone-job',
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: 'pi',
+                image: 'perl',
+                command: ['perl', '-Mbignum=bpi', '-wle', 'print bpi(2000)'],
+                resources: {},
+                terminationMessagePath: '/dev/termination-log',
+                terminationMessagePolicy: 'File',
+                imagePullPolicy: 'Always',
+              },
+            ],
+            restartPolicy: 'Never',
+            terminationGracePeriodSeconds: 30,
+            dnsPolicy: 'ClusterFirst',
+            securityContext: {},
+            schedulerName: 'default-scheduler',
+          },
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Complete',
+            status: 'True',
+            lastProbeTime: '2020-06-24T11:18:42Z',
+            lastTransitionTime: '2020-06-24T11:18:42Z',
+          },
+        ],
+        startTime: '2020-06-24T11:17:41Z',
+        completionTime: '2020-06-24T11:18:42Z',
+        succeeded: 1,
+      },
+    },
+    {
+      kind: 'Job',
+      apiVersion: 'batch/v1',
+      metadata: {
+        annotations: {
+          'alpha.image.policy.openshift.io/resolve-names': '*',
+        },
+        selfLink: '/apis/batch/v1/namespaces/jeff-project/jobs/py-cron-1593002100',
+        resourceVersion: '125142',
+        name: 'py-cron-1593002100',
+        uid: '39d16c87-00b8-4423-a66a-ac712cda7701',
+        creationTimestamp: '2020-06-24T12:35:05Z',
+        managedFields: [
+          {
+            manager: 'kube-controller-manager',
+            operation: 'Update',
+            apiVersion: 'batch/v1',
+            time: '2020-06-24T12:35:05Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:metadata': {
+                'f:annotations': {
+                  '.': {},
+                  'f:alpha.image.policy.openshift.io/resolve-names': {},
+                },
+                'f:ownerReferences': {
+                  '.': {},
+                  'k:{"uid":"be644703-be4b-4ee5-9d86-fdeb9495569c"}': {
+                    '.': {},
+                    'f:apiVersion': {},
+                    'f:blockOwnerDeletion': {},
+                    'f:controller': {},
+                    'f:kind': {},
+                    'f:name': {},
+                    'f:uid': {},
+                  },
+                },
+              },
+              'f:spec': {
+                'f:backoffLimit': {},
+                'f:completions': {},
+                'f:parallelism': {},
+                'f:template': {
+                  'f:spec': {
+                    'f:containers': {
+                      'k:{"name":"py-cron"}': {
+                        '.': {},
+                        'f:env': {
+                          '.': {},
+                          'k:{"name":"HOST"}': {
+                            '.': {},
+                            'f:name': {},
+                            'f:value': {},
+                          },
+                          'k:{"name":"NAMESPACE"}': {
+                            '.': {},
+                            'f:name': {},
+                            'f:valueFrom': {
+                              '.': {},
+                              'f:fieldRef': {
+                                '.': {},
+                                'f:apiVersion': {},
+                                'f:fieldPath': {},
+                              },
+                            },
+                          },
+                        },
+                        'f:image': {},
+                        'f:imagePullPolicy': {},
+                        'f:name': {},
+                        'f:resources': {},
+                        'f:terminationMessagePath': {},
+                        'f:terminationMessagePolicy': {},
+                      },
+                    },
+                    'f:dnsPolicy': {},
+                    'f:restartPolicy': {},
+                    'f:schedulerName': {},
+                    'f:securityContext': {},
+                    'f:terminationGracePeriodSeconds': {},
+                  },
+                },
+              },
+              'f:status': {
+                'f:active': {},
+                'f:startTime': {},
+              },
+            },
+          },
+        ],
+        namespace: 'jeff-project',
+        ownerReferences: [
+          {
+            apiVersion: 'batch/v1beta1',
+            kind: 'CronJob',
+            name: 'py-cron',
+            uid: 'be644703-be4b-4ee5-9d86-fdeb9495569c',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'controller-uid': '39d16c87-00b8-4423-a66a-ac712cda7701',
+          'job-name': 'py-cron-1593002100',
+        },
+      },
+      spec: {
+        parallelism: 1,
+        completions: 1,
+        backoffLimit: 6,
+        selector: {
+          matchLabels: {
+            'controller-uid': '39d16c87-00b8-4423-a66a-ac712cda7701',
+          },
+        },
+        template: {
+          metadata: {
+            creationTimestamp: null,
+            labels: {
+              'controller-uid': '39d16c87-00b8-4423-a66a-ac712cda7701',
+              'job-name': 'py-cron-1593002100',
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: 'py-cron',
+                image:
+                  'image-registry.openshift-image-registry.svc:5000/jeff-project/py-cron@sha256:47c25f041c18c19f65b609df38a49a095ca0358dcfd11db77a21a0380905ecac',
+                env: [
+                  {
+                    name: 'NAMESPACE',
+                    valueFrom: {
+                      fieldRef: {
+                        apiVersion: 'v1',
+                        fieldPath: 'metadata.namespace',
+                      },
+                    },
+                  },
+                  {
+                    name: 'HOST',
+                    value: 'https://okd.host:port',
+                  },
+                ],
+                resources: {},
+                terminationMessagePath: '/dev/termination-log',
+                terminationMessagePolicy: 'File',
+                imagePullPolicy: 'Always',
+              },
+            ],
+            restartPolicy: 'Never',
+            terminationGracePeriodSeconds: 30,
+            dnsPolicy: 'ClusterFirst',
+            securityContext: {},
+            schedulerName: 'default-scheduler',
+          },
+        },
+      },
+      status: {
+        startTime: '2020-06-24T12:35:05Z',
+        active: 1,
+      },
+    },
+  ],
+  loaded: true,
+  loadError: '',
+};
+
+export const sampleCronJobs: FirehoseResult = {
+  data: [
+    {
+      metadata: {
+        name: 'py-cron',
+        namespace: 'jeff-project',
+        selfLink: '/apis/batch/v1beta1/namespaces/jeff-project/cronjobs/py-cron',
+        uid: 'be644703-be4b-4ee5-9d86-fdeb9495569c',
+        resourceVersion: '125137',
+        creationTimestamp: '2020-06-24T11:17:41Z',
+        labels: {
+          app: 'py-cron',
+        },
+        managedFields: [
+          {
+            manager: 'oc',
+            operation: 'Update',
+            apiVersion: 'batch/v1beta1',
+            time: '2020-06-24T11:17:41Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:metadata': {
+                'f:labels': {
+                  '.': {},
+                  'f:app': {},
+                },
+              },
+              'f:spec': {
+                'f:concurrencyPolicy': {},
+                'f:failedJobsHistoryLimit': {},
+                'f:jobTemplate': {
+                  'f:metadata': {
+                    'f:annotations': {
+                      '.': {},
+                      'f:alpha.image.policy.openshift.io/resolve-names': {},
+                    },
+                  },
+                  'f:spec': {
+                    'f:template': {
+                      'f:spec': {
+                        'f:containers': {
+                          'k:{"name":"py-cron"}': {
+                            '.': {},
+                            'f:env': {
+                              '.': {},
+                              'k:{"name":"HOST"}': {
+                                '.': {},
+                                'f:name': {},
+                                'f:value': {},
+                              },
+                              'k:{"name":"NAMESPACE"}': {
+                                '.': {},
+                                'f:name': {},
+                                'f:valueFrom': {
+                                  '.': {},
+                                  'f:fieldRef': {
+                                    '.': {},
+                                    'f:apiVersion': {},
+                                    'f:fieldPath': {},
+                                  },
+                                },
+                              },
+                            },
+                            'f:image': {},
+                            'f:imagePullPolicy': {},
+                            'f:name': {},
+                            'f:resources': {},
+                            'f:terminationMessagePath': {},
+                            'f:terminationMessagePolicy': {},
+                          },
+                        },
+                        'f:dnsPolicy': {},
+                        'f:restartPolicy': {},
+                        'f:schedulerName': {},
+                        'f:securityContext': {},
+                        'f:terminationGracePeriodSeconds': {},
+                      },
+                    },
+                  },
+                },
+                'f:schedule': {},
+                'f:startingDeadlineSeconds': {},
+                'f:successfulJobsHistoryLimit': {},
+                'f:suspend': {},
+              },
+            },
+          },
+          {
+            manager: 'kube-controller-manager',
+            operation: 'Update',
+            apiVersion: 'batch/v1beta1',
+            time: '2020-06-24T12:35:05Z',
+            fieldsType: 'FieldsV1',
+            fieldsV1: {
+              'f:status': {
+                'f:active': {},
+                'f:lastScheduleTime': {},
+              },
+            },
+          },
+        ],
+      },
+      spec: {
+        schedule: '*/5 * * * *',
+        startingDeadlineSeconds: 600,
+        concurrencyPolicy: 'Replace',
+        suspend: false,
+        jobTemplate: {
+          metadata: {
+            creationTimestamp: null,
+            annotations: {
+              'alpha.image.policy.openshift.io/resolve-names': '*',
+            },
+          },
+          spec: {
+            template: {
+              metadata: {
+                creationTimestamp: null,
+              },
+              spec: {
+                containers: [
+                  {
+                    name: 'py-cron',
+                    image: 'py-cron/py-cron:1.0',
+                    env: [
+                      {
+                        name: 'NAMESPACE',
+                        valueFrom: {
+                          fieldRef: {
+                            apiVersion: 'v1',
+                            fieldPath: 'metadata.namespace',
+                          },
+                        },
+                      },
+                      {
+                        name: 'HOST',
+                        value: 'https://okd.host:port',
+                      },
+                    ],
+                    resources: {},
+                    terminationMessagePath: '/dev/termination-log',
+                    terminationMessagePolicy: 'File',
+                    imagePullPolicy: 'Always',
+                  },
+                ],
+                restartPolicy: 'Never',
+                terminationGracePeriodSeconds: 30,
+                dnsPolicy: 'ClusterFirst',
+                securityContext: {},
+                schedulerName: 'default-scheduler',
+              },
+            },
+          },
+        },
+        successfulJobsHistoryLimit: 3,
+        failedJobsHistoryLimit: 1,
+      },
+      status: {
+        active: [
+          {
+            kind: 'Job',
+            namespace: 'jeff-project',
+            name: 'py-cron-1593002100',
+            uid: '39d16c87-00b8-4423-a66a-ac712cda7701',
+            apiVersion: 'batch/v1',
+            resourceVersion: '125136',
+          },
+        ],
+        lastScheduleTime: '2020-06-24T12:35:00Z',
+      },
+    },
+  ],
+  loaded: true,
+  loadError: '',
 };
 
 export const samplePipeline: FirehoseResult = {
@@ -2386,6 +3497,8 @@ export const MockResources: TopologyDataResources = {
   replicationControllers: sampleReplicationControllers,
   replicaSets: sampleReplicaSets,
   pods: samplePods,
+  jobs: sampleJobs,
+  cronJobs: sampleCronJobs,
   services: sampleServices,
   routes: sampleRoutes,
   buildConfigs: sampleBuildConfigs,
@@ -2404,6 +3517,8 @@ export const MockBaseResources: TopologyDataResources = {
   replicationControllers: sampleReplicationControllers,
   replicaSets: sampleReplicaSets,
   pods: samplePods,
+  jobs: sampleJobs,
+  cronJobs: sampleCronJobs,
   services: sampleServices,
   routes: sampleRoutes,
   buildConfigs: sampleBuildConfigs,

--- a/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
@@ -1,10 +1,6 @@
 import * as _ from 'lodash';
-import { KebabAction, KebabOption } from '@console/internal/components/utils';
+import { Kebab, KebabAction, KebabOption } from '@console/internal/components/utils';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
-import { menuActions as deploymentConfigMenuActions } from '@console/internal/components/deployment-config';
-import { menuActions as deploymentMenuActions } from '@console/internal/components/deployment';
-import { menuActions as statefulSetMenuActions } from '@console/internal/components/stateful-set';
-import { menuActions as daemonSetMenuActions } from '@console/internal/components/daemon-set';
 import { ModifyApplication } from '../../../actions/modify-application';
 import { TopologyDataObject } from '../topology-types';
 import { getTopologyResourceObject } from '../topology-utils';
@@ -22,22 +18,11 @@ export const workloadActions = (
   if (allowRegroup) {
     menuActions.push(ModifyApplication);
   }
-  switch (contextMenuResource.kind) {
-    case 'DeploymentConfig':
-      menuActions.push(...deploymentConfigMenuActions);
-      break;
-    case 'Deployment':
-      menuActions.push(...deploymentMenuActions);
-      break;
-    case 'StatefulSet':
-      menuActions.push(...statefulSetMenuActions);
-      break;
-    case 'DaemonSet':
-      menuActions.push(...daemonSetMenuActions);
-      break;
-    default:
-      break;
-  }
+
+  const kindObject = modelFor(contextMenuResource.kind);
+  const { common } = Kebab.factory;
+  menuActions.push(...Kebab.getExtensionsActionsForKind(kindObject));
+  menuActions.push(...common);
 
   return _.map(menuActions, (a) =>
     a(modelFor(referenceFor(contextMenuResource)), contextMenuResource),

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/data-transformer.spec.ts
@@ -103,6 +103,7 @@ describe('data transformer ', () => {
     const graphData = getTransformedTopologyData(mockResources, [
       'deploymentConfigs',
       'deployments',
+      'pods',
     ]);
     const node = getNodeForName('nodejs', graphData);
     const status = getPodStatus((node.data.data as WorkloadData).donutStatus.pods[0]);
@@ -143,14 +144,16 @@ describe('data transformer ', () => {
   });
 
   it('should return a valid daemon set', () => {
-    const graphData = getTransformedTopologyData(mockResources, ['daemonSets']);
-    expect(graphData.nodes).toHaveLength(1);
+    const graphData = getTransformedTopologyData(mockResources, ['daemonSets', 'pods']);
+    expect(graphData.nodes).toHaveLength(2);
     expect(graphData.nodes[0].data.resources.obj.kind).toEqual('DaemonSet');
   });
+
   it('should return a daemon set pod ', () => {
-    const graphData = getTransformedTopologyData(mockResources, ['daemonSets']);
-    expect(graphData.nodes).toHaveLength(1);
-    expect((graphData.nodes[0].data.data as WorkloadData).donutStatus.pods).toHaveLength(1);
+    const graphData = getTransformedTopologyData(mockResources, ['daemonSets', 'pods']);
+    expect(graphData.nodes).toHaveLength(2);
+    const daemonSets = graphData.nodes.filter((n) => n.data.resources.obj.kind === 'DaemonSet');
+    expect((daemonSets[0].data.data as WorkloadData).donutStatus.pods).toHaveLength(1);
   });
 
   it('should return a valid stateful set', () => {
@@ -158,10 +161,51 @@ describe('data transformer ', () => {
     expect(graphData.nodes).toHaveLength(1);
     expect(graphData.nodes[0].data.resources.obj.kind).toEqual('StatefulSet');
   });
+
   it('should return a stateful set pod ', () => {
-    const graphData = getTransformedTopologyData(mockResources, ['statefulSets']);
+    const graphData = getTransformedTopologyData(mockResources, ['statefulSets', 'pods']);
+    expect(graphData.nodes).toHaveLength(2);
+    const statefulSets = graphData.nodes.filter((n) => n.data.resources.obj.kind === 'StatefulSet');
+    expect((statefulSets[0].data.data as WorkloadData).donutStatus.pods).toHaveLength(1);
+  });
+
+  it('should return a valid standalone pod', () => {
+    const graphData = getTransformedTopologyData(mockResources, ['pods']);
+    expect(graphData.nodes).toHaveLength(1);
+    expect(graphData.nodes[0].data.resources.obj.kind).toEqual('Pod');
+  });
+
+  it('should return a standalone pod pod ', () => {
+    const graphData = getTransformedTopologyData(mockResources, ['pods']);
     expect(graphData.nodes).toHaveLength(1);
     expect((graphData.nodes[0].data.data as WorkloadData).donutStatus.pods).toHaveLength(1);
+  });
+
+  it('should return a valid standalone job', () => {
+    const graphData = getTransformedTopologyData(mockResources, ['jobs']);
+    expect(graphData.nodes).toHaveLength(1);
+    expect(graphData.nodes[0].data.resources.obj.kind).toEqual('Job');
+  });
+
+  it('should return a standalone job pod ', () => {
+    const graphData = getTransformedTopologyData(mockResources, ['jobs', 'pods']);
+    expect(graphData.nodes).toHaveLength(2);
+    const jobs = graphData.nodes.filter((n) => n.data.resources.obj.kind === 'Job');
+    expect((jobs[0].data.data as WorkloadData).donutStatus.pods).toHaveLength(1);
+  });
+
+  it('should return a valid cronjobs', () => {
+    const graphData = getTransformedTopologyData(mockResources, ['cronJobs']);
+    expect(graphData.nodes).toHaveLength(1);
+    expect(graphData.nodes[0].data.resources.obj.kind).toEqual('CronJob');
+  });
+
+  it('should return a CronJob pod ', () => {
+    const graphData = getTransformedTopologyData(mockResources, ['cronJobs', 'jobs', 'pods']);
+    expect(graphData.nodes).toHaveLength(3);
+    const cronJobs = graphData.nodes.filter((n) => n.data.resources.obj.kind === 'CronJob');
+    expect(cronJobs[0].data.resources.jobs).toHaveLength(2);
+    expect((cronJobs[0].data.data as WorkloadData).donutStatus.pods).toHaveLength(2);
   });
 
   it('should return a valid che workspace factory URL if cheURL is there', () => {

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/updateModelFromFilters.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/updateModelFromFilters.spec.ts
@@ -44,7 +44,7 @@ describe('topology model ', () => {
 
   it('should have the correct nodes, groups, and edges when no filters', () => {
     const topologyTransformedData = getTransformedTopologyData();
-    expect(topologyTransformedData.nodes.filter((n) => !n.group)).toHaveLength(7);
+    expect(topologyTransformedData.nodes.filter((n) => !n.group)).toHaveLength(10);
     expect(topologyTransformedData.nodes.filter((n) => n.group)).toHaveLength(2);
     expect(topologyTransformedData.edges).toHaveLength(1);
   });
@@ -57,7 +57,7 @@ describe('topology model ', () => {
       'application-1',
       filterers,
     );
-    expect(newModel.nodes.filter((n) => !n.group).length).toBe(7);
+    expect(newModel.nodes.filter((n) => !n.group).length).toBe(10);
     expect(newModel.nodes.filter((n) => !n.group && n.visible).length).toBe(2);
     expect(newModel.nodes.filter((n) => n.group).length).toBe(2);
     expect(newModel.nodes.filter((n) => n.group && n.visible).length).toBe(1);

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -365,6 +365,18 @@ export const getBaseWatchedResources = (namespace: string): WatchK8sResources<an
       namespace,
       optional: true,
     },
+    jobs: {
+      isList: true,
+      kind: 'Job',
+      namespace,
+      optional: true,
+    },
+    cronJobs: {
+      isList: true,
+      kind: 'CronJob',
+      namespace,
+      optional: true,
+    },
     buildConfigs: {
       isList: true,
       kind: 'BuildConfig',

--- a/frontend/packages/dev-console/src/components/topology/operators/__tests__/operator-data-transformer.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/__tests__/operator-data-transformer.spec.ts
@@ -52,7 +52,7 @@ describe('operator data transformer ', () => {
     expect(getNodeById(operatorBackedServices[0].id, graphData).type).toBe(
       TYPE_OPERATOR_BACKED_SERVICE,
     );
-    expect(graphData.nodes.filter((n) => !n.group)).toHaveLength(7);
+    expect(graphData.nodes.filter((n) => !n.group)).toHaveLength(10);
     expect(graphData.nodes.filter((n) => n.group)).toHaveLength(3);
     expect(graphData.edges).toHaveLength(1);
   });

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -14,7 +14,15 @@ import { TYPE_OPERATOR_BACKED_SERVICE } from './operators/components/const';
 import { HelmReleaseResourcesMap } from '../helm/helm-types';
 import { ALLOW_SERVICE_BINDING } from '../../const';
 
-export const WORKLOAD_TYPES = ['deployments', 'deploymentConfigs', 'daemonSets', 'statefulSets'];
+export const WORKLOAD_TYPES = [
+  'deployments',
+  'deploymentConfigs',
+  'daemonSets',
+  'statefulSets',
+  'jobs',
+  'cronJobs',
+  'pods',
+];
 
 export const getServiceBindingStatus = ({ FLAGS }: RootState): boolean =>
   FLAGS.get(ALLOW_SERVICE_BINDING);

--- a/frontend/public/components/cron-job.tsx
+++ b/frontend/public/components/cron-job.tsx
@@ -33,7 +33,7 @@ import { PodList, filters as PodFilters } from './pod';
 import { JobsList } from './job';
 
 const { common } = Kebab.factory;
-const menuActions = [...Kebab.getExtensionsActionsForKind(CronJobModel), ...common];
+export const menuActions = [...Kebab.getExtensionsActionsForKind(CronJobModel), ...common];
 
 const kind = 'CronJob';
 

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -42,7 +42,7 @@ const ModifyJobParallelism: KebabAction = (kind: K8sKind, obj: JobKind) => ({
     verb: 'patch',
   },
 });
-const menuActions: KebabAction[] = [
+export const menuActions: KebabAction[] = [
   ModifyJobParallelism,
   ...Kebab.getExtensionsActionsForKind(JobModel),
   ...Kebab.factory.common,
@@ -138,7 +138,7 @@ const jobStatus = (job: JobKind): string => {
   return job && job.status ? _.get(job, 'status.conditions[0].type', 'In Progress') : null;
 };
 
-const JobDetails: React.FC<JobsDetailsProps> = ({ obj: job }) => (
+export const JobDetails: React.FC<JobsDetailsProps> = ({ obj: job }) => (
   <>
     <div className="co-m-pane__body">
       <div className="row">

--- a/frontend/public/components/overview/_job-overview.scss
+++ b/frontend/public/components/overview/_job-overview.scss
@@ -1,0 +1,5 @@
+.job-overview__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -54,6 +54,7 @@ $overview-sidebar-width: 550px;
 
 .overview__sidebar-pane-body {
   padding: 0 20px;
+  min-height: 200px;
 }
 
 .overview__sidebar-pane-head {
@@ -67,6 +68,10 @@ $overview-sidebar-width: 550px;
   .co-actions-menu {
     margin-top: -3px;
   }
+}
+
+.overview__pod-donut-sm {
+  width: var(--pf-global--icon--FontSize--lg);
 }
 
 .resource-overview {

--- a/frontend/public/components/overview/cron-job-overview.tsx
+++ b/frontend/public/components/overview/cron-job-overview.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
+import { OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
+import { CronJobModel } from '../../models';
+import { CronJobKind } from '../../module/k8s';
+import { menuActions } from '../cron-job';
+import { DetailsItem, KebabAction, pluralize, ResourceSummary, Timestamp } from '../utils';
+import { ResourceOverviewDetails } from './resource-overview-details';
+import { PodsOverview } from './pods-overview';
+import { BuildOverview } from './build-overview';
+import { JobsOverview } from './jobs-overview';
+
+const CronJobOverviewDetails: React.SFC<CronJobOverviewDetailsProps> = ({
+  item: { obj: cronjob, pods: pods },
+}) => (
+  <div className="overview__sidebar-pane-body resource-overview__body">
+    <div className="resource-overview__pod-counts">
+      <PodRingSet
+        key={cronjob.metadata.uid}
+        podData={{
+          pods,
+          current: undefined,
+          previous: undefined,
+          isRollingOut: true,
+        }}
+        obj={cronjob}
+        resourceKind={CronJobModel}
+        path=""
+      />
+    </div>
+    <ResourceSummary resource={cronjob} showPodSelector>
+      <DetailsItem label="Schedule" obj={cronjob} path="spec.schedule" />
+      <DetailsItem label="Concurrency Policy" obj={cronjob} path="spec.concurrencyPolicy" />
+      <DetailsItem
+        label="Starting Deadline Seconds"
+        obj={cronjob}
+        path="spec.startingDeadlineSeconds"
+      >
+        {cronjob.spec.startingDeadlineSeconds
+          ? pluralize(cronjob.spec.startingDeadlineSeconds, 'second')
+          : 'Not Configured'}
+      </DetailsItem>
+      <DetailsItem label="Last Schedule Time" obj={cronjob} path="status.lastScheduleTime">
+        <Timestamp timestamp={cronjob.status.lastScheduleTime} />
+      </DetailsItem>
+    </ResourceSummary>
+  </div>
+);
+
+const CronJobResourcesTab: React.SFC<CronJobResourcesTabProps> = ({ item }) => {
+  const { buildConfigs, pods, jobs, obj } = item;
+  const pluginComponents = usePluginsOverviewTabSection(item);
+  return (
+    <div className="overview__sidebar-pane-body">
+      <PodsOverview pods={pods} obj={obj} />
+      <JobsOverview jobs={jobs} pods={pods} obj={obj} />
+      <BuildOverview buildConfigs={buildConfigs} />
+      {pluginComponents.map(({ Component, key }) => (
+        <Component key={key} item={item} />
+      ))}
+    </div>
+  );
+};
+
+const tabs = [
+  {
+    name: 'Details',
+    component: CronJobOverviewDetails,
+  },
+  {
+    name: 'Resources',
+    component: CronJobResourcesTab,
+  },
+];
+
+export const CronJobOverview: React.SFC<CronJobOverviewProps> = ({ item, customActions }) => (
+  <ResourceOverviewDetails
+    item={item}
+    kindObj={CronJobModel}
+    menuActions={customActions ? [...customActions, ...menuActions] : menuActions}
+    tabs={tabs}
+  />
+);
+
+type CronJobOverviewDetailsProps = {
+  item: OverviewItem<CronJobKind>;
+};
+
+type CronJobResourcesTabProps = {
+  item: OverviewItem;
+};
+
+type CronJobOverviewProps = {
+  item: OverviewItem;
+  customActions?: KebabAction[];
+};

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -10,11 +10,10 @@ import {
   METRICS_POLL_INTERVAL,
   OverviewItem,
   getResourceList,
-  createDaemonSetItems,
   createDeploymentConfigItems,
   createDeploymentItems,
+  createWorkloadItems,
   createPodItems,
-  createStatefulSetItems,
   formatNamespacedRouteForResource,
 } from '@console/shared';
 import {
@@ -33,6 +32,7 @@ import { CloseButton, Dropdown, Firehose, StatusBox, FirehoseResult, MsgBox } fr
 import { ProjectOverview } from './project-overview';
 import { ResourceOverviewPage } from './resource-overview-page';
 import { OverviewSpecialGroup } from './constants';
+import { DaemonSetModel, StatefulSetModel } from '../../models';
 
 const asOverviewGroups = (keyedItems: { [name: string]: OverviewItem[] }): OverviewGroup[] => {
   const compareGroups = (a: OverviewGroup, b: OverviewGroup) => {
@@ -328,14 +328,24 @@ class OverviewMainContent_ extends React.Component<
     }
 
     const items = [
-      ...createDaemonSetItems(this.props.daemonSets.data, this.props, this.props.utils),
+      ...createWorkloadItems(
+        DaemonSetModel,
+        this.props.daemonSets.data,
+        this.props,
+        this.props.utils,
+      ),
       ...createDeploymentItems(this.props.deployments.data, this.props, this.props.utils),
       ...createDeploymentConfigItems(
         this.props.deploymentConfigs.data,
         this.props,
         this.props.utils,
       ),
-      ...createStatefulSetItems(this.props.statefulSets.data, this.props, this.props.utils),
+      ...createWorkloadItems(
+        StatefulSetModel,
+        this.props.statefulSets.data,
+        this.props,
+        this.props.utils,
+      ),
       ...createPodItems(this.props),
     ];
 

--- a/frontend/public/components/overview/job-overview.tsx
+++ b/frontend/public/components/overview/job-overview.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
+import { JobModel } from '../../models';
+import { JobKind } from '../../module/k8s';
+import { menuActions } from '../job';
+import { DetailsItem, KebabAction, pluralize, ResourceSummary } from '../utils';
+import { ResourceOverviewDetails } from './resource-overview-details';
+import { PodsOverview } from './pods-overview';
+
+const JobOverviewDetails: React.FC<JobOverviewDetailsProps> = ({
+  item: { obj: job, pods: pods },
+}) => (
+  <div className="overview__sidebar-pane-body resource-overview__body">
+    <div className="resource-overview__pod-counts">
+      <PodRingSet
+        key={job.metadata.uid}
+        podData={{
+          pods,
+          current: undefined,
+          previous: undefined,
+          isRollingOut: true,
+        }}
+        obj={job}
+        resourceKind={JobModel}
+        path=""
+      />
+    </div>
+    <ResourceSummary resource={job} showPodSelector>
+      <DetailsItem label="Desired Completions" obj={job} path="spec.completions" />
+      <DetailsItem label="Parallelism" obj={job} path="spec.parallelism" />
+      <DetailsItem label="Active Deadline Seconds" obj={job} path="spec.activeDeadlineSeconds">
+        {job.spec?.activeDeadlineSeconds
+          ? pluralize(job.spec.activeDeadlineSeconds, 'second')
+          : 'Not Configured'}
+      </DetailsItem>
+    </ResourceSummary>
+  </div>
+);
+
+export const JobResourcesTab: React.SFC<JobResourcesTabProps> = ({ item }) => {
+  const { obj, pods } = item;
+  const pluginComponents = usePluginsOverviewTabSection(item);
+  return (
+    <div className="overview__sidebar-pane-body">
+      <PodsOverview pods={pods} obj={obj} />
+      {pluginComponents.map(({ Component, key }) => (
+        <Component key={key} item={item} />
+      ))}
+    </div>
+  );
+};
+
+const tabs = [
+  {
+    name: 'Details',
+    component: JobOverviewDetails,
+  },
+  {
+    name: 'Resources',
+    component: JobResourcesTab,
+  },
+];
+
+export const JobOverview: React.SFC<JobOverviewProps> = ({ item, customActions }) => (
+  <ResourceOverviewDetails
+    item={item}
+    kindObj={JobModel}
+    menuActions={customActions ? [...customActions, ...menuActions] : menuActions}
+    tabs={tabs}
+  />
+);
+
+type JobOverviewDetailsProps = {
+  item: OverviewItem<JobKind>;
+};
+
+export type JobResourcesTabProps = {
+  item: OverviewItem;
+};
+
+type JobOverviewProps = {
+  item: OverviewItem;
+  customActions?: KebabAction[];
+};

--- a/frontend/public/components/overview/jobs-overview.tsx
+++ b/frontend/public/components/overview/jobs-overview.tsx
@@ -1,0 +1,99 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { getOwnedResources, PodStatus } from '@console/shared';
+import { ResourceLink, resourcePath, SidebarSectionHeading } from '../utils';
+import { K8sResourceKind, referenceFor, JobKind, PodKind } from '../../module/k8s';
+import { ChartLabel } from '@patternfly/react-charts';
+
+const kind: string = 'Job';
+const MAX_JOBS: number = 3;
+
+const JobOverviewItem: React.FC<JobOverviewItemProps> = ({ job, pods }) => {
+  const {
+    metadata: { name, namespace },
+  } = job;
+  const podsLink = `${resourcePath(referenceFor(job), name, namespace)}/pods`;
+
+  const jobPods = getOwnedResources(job, pods) as PodKind[];
+  return (
+    <li className="list-group-item container-fluid">
+      <div className="job-overview__item">
+        <ResourceLink kind={kind} name={name} namespace={namespace} />
+        <Link to={podsLink} className="overview__pod-donut-sm">
+          <PodStatus
+            standalone
+            data={jobPods}
+            size={25}
+            innerRadius={8}
+            outerRadius={12}
+            title={`${jobPods.length}`}
+            titleComponent={<ChartLabel style={{ fontSize: '10px' }} />}
+            showTooltip={false}
+          />
+        </Link>
+      </div>
+    </li>
+  );
+};
+
+JobOverviewItem.displayName = 'JobOverviewItem';
+
+type JobOverviewItemProps = {
+  job: JobKind;
+  pods: PodKind[];
+};
+
+const JobsOverviewList: React.SFC<JobsOverviewListProps> = ({ jobs, pods }) => (
+  <ul className="list-group">
+    {_.map(jobs, (job) => (
+      <JobOverviewItem key={job.metadata.uid} job={job} pods={pods} />
+    ))}
+  </ul>
+);
+
+JobsOverviewList.displayName = 'JobsOverviewList';
+
+export const JobsOverview: React.SFC<JobsOverviewProps> = ({
+  jobs,
+  pods,
+  obj,
+  allJobsLink,
+  emptyText,
+}) => {
+  const {
+    metadata: { name, namespace },
+  } = obj;
+  const linkTo = allJobsLink || `${resourcePath(referenceFor(obj), name, namespace)}/jobs`;
+  const emptyMessage = emptyText || 'No Jobs found for this resource.';
+
+  return (
+    <>
+      <SidebarSectionHeading text="Jobs">
+        {_.size(jobs) > MAX_JOBS && (
+          <Link className="sidebar__section-view-all" to={linkTo}>
+            {`View all (${_.size(jobs)})`}
+          </Link>
+        )}
+      </SidebarSectionHeading>
+      {_.isEmpty(jobs) ? (
+        <span className="text-muted">{emptyMessage}</span>
+      ) : (
+        <JobsOverviewList jobs={_.take(jobs, MAX_JOBS)} pods={pods} />
+      )}
+    </>
+  );
+};
+
+type JobsOverviewListProps = {
+  jobs: JobKind[];
+  pods: PodKind[];
+};
+
+type JobsOverviewProps = {
+  jobs: JobKind[];
+  pods: PodKind[];
+  obj: K8sResourceKind;
+  allJobsLink?: string;
+  emptyText?: string;
+};

--- a/frontend/public/components/overview/pod-overview.tsx
+++ b/frontend/public/components/overview/pod-overview.tsx
@@ -1,14 +1,30 @@
 import * as React from 'react';
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { PodOverviewItem } from '.';
 import { PodResourceSummary, PodDetailsList, menuActions } from '../pod';
 import { PodModel } from '../../models';
 import { ResourceOverviewDetails } from './resource-overview-details';
 import { NetworkingOverview } from './networking-overview';
 import { KebabAction } from '../utils';
+import { PodsOverview } from './pods-overview';
 
 const PodOverviewDetails: React.SFC<PodOverviewDetailsProps> = ({ item: { obj: pod } }) => {
   return (
     <div className="overview__sidebar-pane-body resource-overview__body">
+      <div className="resource-overview__pod-counts">
+        <PodRingSet
+          key={pod.metadata.uid}
+          podData={{
+            pods: [pod],
+            current: undefined,
+            previous: undefined,
+            isRollingOut: true,
+          }}
+          obj={pod}
+          resourceKind={PodModel}
+          path=""
+        />
+      </div>
       <div className="resource-overview__summary">
         <PodResourceSummary pod={pod} />
       </div>
@@ -19,8 +35,9 @@ const PodOverviewDetails: React.SFC<PodOverviewDetailsProps> = ({ item: { obj: p
   );
 };
 
-const PodResourcesTab: React.SFC<PodResourcesTabProps> = ({ item: { routes, services } }) => (
+const PodResourcesTab: React.SFC<PodResourcesTabProps> = ({ item: { obj, routes, services } }) => (
   <div className="overview__sidebar-pane-body">
+    <PodsOverview pods={[obj]} obj={obj} />
     <NetworkingOverview services={services} routes={routes} />
   </div>
 );

--- a/frontend/public/components/overview/resource-overview-pages.tsx
+++ b/frontend/public/components/overview/resource-overview-pages.tsx
@@ -7,6 +7,8 @@ import {
   DeploymentConfigModel,
   StatefulSetModel,
   PodModel,
+  JobModel,
+  CronJobModel,
 } from '../../models';
 
 export const resourceOverviewPages = ImmutableMap<
@@ -35,4 +37,10 @@ export const resourceOverviewPages = ImmutableMap<
     import('./stateful-set-overview' /* webpackChunkName: "stateful-set"*/).then(
       (m) => m.StatefulSetOverview,
     ),
+  )
+  .set(referenceForModel(CronJobModel), () =>
+    import('./cron-job-overview' /* webpackChunkName: "cron-job"*/).then((m) => m.CronJobOverview),
+  )
+  .set(referenceForModel(JobModel), () =>
+    import('./job-overview' /* webpackChunkName: "job"*/).then((m) => m.JobOverview),
   );

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -83,6 +83,7 @@
 @import 'components/catalog/catalog';
 @import 'components/cluster-service-instance';
 @import 'components/overview/build-overview';
+@import 'components/overview/job-overview';
 @import 'components/overview/overview';
 @import 'components/overview/list-view/list-view';
 @import 'components/overview/project-overview';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4045
https://issues.redhat.com/browse/ODC-4047
https://issues.redhat.com/browse/ODC-4048
https://issues.redhat.com/browse/ODC-4051
https://issues.redhat.com/browse/ODC-4052

**Description**: 
As a Developer, I want to be able to see any workload type in the topology/list view so I can better get a view of all of the computing resources being used. This adds Jobs, CronJobs, Pods.

**Screen shots / Gifs for design review**:

Topology View:

![image](https://user-images.githubusercontent.com/11633780/85581217-63e37280-b60a-11ea-9618-66b824eaed6e.png)



Job Side Panel:

![image](https://user-images.githubusercontent.com/11633780/85581280-72ca2500-b60a-11ea-8bed-72b037b4a0e2.png)

![image](https://user-images.githubusercontent.com/11633780/85581320-7bbaf680-b60a-11ea-8051-9ab1d6a2e8c8.png)


CronJob Side Panel:

![image](https://user-images.githubusercontent.com/11633780/85581366-85dcf500-b60a-11ea-912c-123c8c95a571.png)

![image](https://user-images.githubusercontent.com/11633780/85581416-91302080-b60a-11ea-8ac8-93c0b4dca790.png)



Pod Side Panel:

![image](https://user-images.githubusercontent.com/11633780/85581484-a016d300-b60a-11ea-89f2-e16ff0b76715.png)

![image](https://user-images.githubusercontent.com/11633780/85581523-a7d67780-b60a-11ea-8b60-6ffba05a9f83.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @bgliwa01

/kind feature