### PR TITLE
Bug 1852743: Update node list metrics

### DIFF
--- a/frontend/packages/console-shared/src/sorts/nodes.ts
+++ b/frontend/packages/console-shared/src/sorts/nodes.ts
@@ -1,15 +1,20 @@
 import * as UIActions from '@console/internal/actions/ui';
 import { NodeKind } from '@console/internal/module/k8s';
+import { convertToBaseValue } from '@console/internal/components/utils';
 
 export const nodeMemory = (node: NodeKind): number => {
   const used = UIActions.getNodeMetric(node, 'usedMemory');
-  const total = UIActions.getNodeMetric(node, 'totalMemory');
-  return total === 0 ? 0 : used / total;
+  const total = convertToBaseValue(node?.status?.allocatable?.memory);
+  return used && total ? used / total : 0;
 };
 export const nodeFS = (node: NodeKind): number => {
   const used = UIActions.getNodeMetric(node, 'usedStorage');
   const total = UIActions.getNodeMetric(node, 'totalStorage');
-  return total === 0 ? 0 : used / total;
+  return used && total ? used / total : 0;
 };
-export const nodeCPU = (node: NodeKind): number => Number(UIActions.getNodeMetric(node, 'cpu'));
+export const nodeCPU = (node: NodeKind): number => {
+  const used = Number(UIActions.getNodeMetric(node, 'cpu'));
+  const total = convertToBaseValue(node?.status?.allocatable?.cpu);
+  return used && total ? used / total : 0;
+};
 export const nodePods = (node: NodeKind): number => Number(UIActions.getNodeMetric(node, 'pods'));

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -379,6 +379,9 @@ export type NodeKind = {
     unschedulable?: boolean;
   };
   status?: {
+    allocatable?: {
+      [key: string]: string;
+    };
     capacity?: {
       [key: string]: string;
     };


### PR DESCRIPTION
Based on feedback from @smarterclayton. @andybraren What do you think?

* Show usage as a percentage of allocatable
* Use `status.allocatable.memory` for total memory value. (The previous value from Prometheus is not correct.)
* Show total allocatable CPU

/assign @rhamilto @bipuladh 

Before:

<img width="1343" alt="Screen Shot 2020-06-24 at 3 01 02 PM" src="https://user-images.githubusercontent.com/1167259/85616354-8f2a8980-b62b-11ea-8b43-e41250033bb7.png">

After:

<img width="1366" alt="Screen Shot 2020-06-24 at 3 18 23 PM" src="https://user-images.githubusercontent.com/1167259/85617894-f77a6a80-b62d-11ea-9e9e-2874ceeb9aa1.png">

