### PR TITLE
Add Jobs and Pods sections to cronjob details page

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -536,7 +536,7 @@ export const PodList: React.FC<PodListProps> = (props) => {
 };
 PodList.displayName = 'PodList';
 
-const filters = [
+export const filters = [
   {
     filterGroupName: 'Status',
     type: 'pod-status',

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -83,6 +83,11 @@ export const navFactory: NavFactory = {
     name: 'Pods',
     component: component || PodsComponent,
   }),
+  jobs: (component) => ({
+    href: 'jobs',
+    name: 'Jobs',
+    component,
+  }),
   roles: (component) => ({
     href: 'roles',
     name: 'Role Bindings',


### PR DESCRIPTION
**Addresses**: 
https://issues.redhat.com/browse/ODC-4050 (addresses a portion of the story)

**Description**: 
As a user I want to see pods and jobs related to a specific CronJob.

**Screen shots / Gifs for design review**:

![image](https://user-images.githubusercontent.com/11633780/85717078-1e32b280-b6bb-11ea-819b-950cd0093367.png)


![image](https://user-images.githubusercontent.com/11633780/85717112-27238400-b6bb-11ea-9306-bf29c8d17d27.png)


**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @bgliwa01

/kind feature