### PR TITLE
kubevirt: Shorten the guest agent poll delay

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/hooks/use-guest-agent-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-guest-agent-info.ts
@@ -4,7 +4,7 @@ import { isGuestAgentInstalled } from '../components/dashboards-page/vm-dashboar
 import { getVMIApiPath, getVMISubresourcePath } from '../selectors/vmi/selectors';
 import { V1VirtualMachineInstanceGuestAgentInfo } from '../types/vmi-guest-data-info/vmi-guest-agent-info';
 
-export const GUEST_AGENT_POLL_DEFAULT_DELAY = 5000; // 5 seconds
+export const GUEST_AGENT_POLL_DEFAULT_DELAY = 3000; // 3 seconds
 
 const getGuestAgentURL = (vmi: VMIKind) =>
   vmi &&


### PR DESCRIPTION
poll every 3sec instead of 5sec