### PR TITLE
Show alert details page on click of alert under alert rules in dev-perspective

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.scss
@@ -7,9 +7,6 @@
   &--kebab {
     text-align: right;
   }
-  &--alert-title {
-    color: var(--pf-global--link--Color);
-  }
   .pf-c-table {
     table-layout: auto;
   }

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
@@ -70,7 +70,7 @@ export const MonitoringAlerts: React.FC<props> = ({ match, rules, filters, listS
       alertingRuleStateOrder(rule),
     );
     dispatch(monitoringSetRules('devRules', sortThanosRules));
-    dispatch(monitoringLoaded('devAlerts', thanosAlertsAndRules.alerts));
+    dispatch(monitoringLoaded('devAlerts', thanosAlertsAndRules.alerts, 'dev'));
   }, [dispatch, thanosAlertsAndRules]);
 
   const filteredRules = React.useMemo(() => {

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.tsx
@@ -9,7 +9,7 @@ import { match as RMatch } from 'react-router-dom';
 import { Table, TableHeader, TableBody, SortByDirection } from '@patternfly/react-table';
 import { FilterToolbar } from '@console/internal/components/filter-toolbar';
 import { getAlertsAndRules } from '@console/internal/components/monitoring/utils';
-import { monitoringSetRules, sortList } from '@console/internal/actions/ui';
+import { monitoringSetRules, monitoringLoaded, sortList } from '@console/internal/actions/ui';
 import { useURLPoll } from '@console/internal/components/utils/url-poll-hook';
 import { PrometheusRulesResponse, Rules } from '@console/internal/components/monitoring/types';
 import { PROMETHEUS_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
@@ -60,15 +60,18 @@ export const MonitoringAlerts: React.FC<props> = ({ match, rules, filters, listS
     POLL_DELAY,
     namespace,
   );
-  const thanosRules = React.useMemo(
-    () => (!loading && !loadError ? getAlertsAndRules(response?.data).rules : []),
+  const thanosAlertsAndRules = React.useMemo(
+    () => (!loading && !loadError ? getAlertsAndRules(response?.data) : { rules: [], alerts: [] }),
     [response, loadError, loading],
   );
 
   React.useEffect(() => {
-    const sortThanosRules = _.sortBy(thanosRules, (rule) => alertingRuleStateOrder(rule));
+    const sortThanosRules = _.sortBy(thanosAlertsAndRules.rules, (rule) =>
+      alertingRuleStateOrder(rule),
+    );
     dispatch(monitoringSetRules('devRules', sortThanosRules));
-  }, [dispatch, thanosRules]);
+    dispatch(monitoringLoaded('devAlerts', thanosAlertsAndRules.alerts));
+  }, [dispatch, thanosAlertsAndRules]);
 
   const filteredRules = React.useMemo(() => {
     const filtersObj = filters?.toJS();
@@ -86,9 +89,9 @@ export const MonitoringAlerts: React.FC<props> = ({ match, rules, filters, listS
   }, [filters, listSorts, columnIndex, rules, listOrderBy, sortOrder]);
 
   React.useEffect(() => {
-    const tableRows = monitoringAlertRows(filteredRules, collapsedRowsIds);
+    const tableRows = monitoringAlertRows(filteredRules, collapsedRowsIds, namespace);
     setRows(tableRows);
-  }, [collapsedRowsIds, filteredRules]);
+  }, [collapsedRowsIds, filteredRules, namespace]);
 
   const onCollapse = (event: React.MouseEvent, rowKey: number, isOpen: boolean) => {
     rows[rowKey].isOpen = isOpen;

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsDetailsPage.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router';
+import * as _ from 'lodash';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch } from 'react-redux';
+import { history, StatusBox, LoadingBox } from '@console/internal/components/utils';
+import { ALL_NAMESPACES_KEY } from '@console/shared';
+import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
+import { AlertsDetailsPage } from '@console/internal/components/monitoring/alerting';
+import { PrometheusRulesResponse } from '@console/internal/components/monitoring/types';
+import { useURLPoll } from '@console/internal/components/utils/url-poll-hook';
+import { PROMETHEUS_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
+import { getAlertsAndRules } from '@console/internal/components/monitoring/utils';
+import { alertingRuleStateOrder } from '@console/internal/reducers/monitoring';
+import { monitoringSetRules, monitoringLoaded } from '@console/internal/actions/ui';
+
+interface MonitoringAlertsDetailsPageProps {
+  match: RMatch<{
+    ns?: string;
+    name?: string;
+  }>;
+}
+
+const POLL_DELAY = 15 * 1000;
+
+const handleNamespaceChange = (newNamespace: string): void => {
+  if (newNamespace === ALL_NAMESPACES_KEY) {
+    history.push('/dev-monitoring/all-namespaces');
+  } else {
+    history.push('/dev-monitoring/ns/:ns/alerts');
+  }
+};
+
+const MonitoringAlertsDetailsPage: React.FC<MonitoringAlertsDetailsPageProps> = ({ match }) => {
+  const namespace = match.params.ns;
+  const dispatch = useDispatch();
+  const [response, loadError, loading] = useURLPoll<PrometheusRulesResponse>(
+    `${PROMETHEUS_TENANCY_BASE_PATH}/api/v1/rules?namespace=${namespace}`,
+    POLL_DELAY,
+    namespace,
+  );
+  const thanosAlertsAndRules = React.useMemo(
+    () => (!loading && !loadError ? getAlertsAndRules(response?.data) : { rules: [], alerts: [] }),
+    [response, loadError, loading],
+  );
+
+  React.useEffect(() => {
+    const sortThanosRules = _.sortBy(thanosAlertsAndRules.rules, (rule) =>
+      alertingRuleStateOrder(rule),
+    );
+    dispatch(monitoringSetRules('devRules', sortThanosRules));
+    dispatch(monitoringLoaded('devAlerts', thanosAlertsAndRules.alerts));
+  }, [dispatch, thanosAlertsAndRules]);
+
+  if (loading && _.isEmpty(loadError)) {
+    return <LoadingBox />;
+  }
+
+  if (!_.isEmpty(loadError)) {
+    return <StatusBox loaded={!loading} loadError={loadError} />;
+  }
+
+  return (
+    <NamespacedPage
+      variant={NamespacedPageVariants.light}
+      hideApplications
+      onNamespaceChange={handleNamespaceChange}
+    >
+      <AlertsDetailsPage match={match} />
+    </NamespacedPage>
+  );
+};
+
+export default MonitoringAlertsDetailsPage;

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertsDetailsPage.tsx
@@ -50,7 +50,7 @@ const MonitoringAlertsDetailsPage: React.FC<MonitoringAlertsDetailsPageProps> = 
       alertingRuleStateOrder(rule),
     );
     dispatch(monitoringSetRules('devRules', sortThanosRules));
-    dispatch(monitoringLoaded('devAlerts', thanosAlertsAndRules.alerts));
+    dispatch(monitoringLoaded('devAlerts', thanosAlertsAndRules.alerts, 'dev'));
   }, [dispatch, thanosAlertsAndRules]);
 
   if (loading && _.isEmpty(loadError)) {

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/__tests__/monitoring-alerts-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/__tests__/monitoring-alerts-utils.spec.tsx
@@ -6,18 +6,18 @@ import { RuleStates } from '@console/internal/reducers/monitoring';
 describe('monitoring-alerts-utils', () => {
   it('row should be expanded if rule state is FIRING', () => {
     const alertRules = getAlertsAndRules(rules?.data).rules;
-    const rows = monitoringAlertRows(alertRules, ['KubeNodeReadinessFlapping']);
+    const rows = monitoringAlertRows(alertRules, ['KubeNodeReadinessFlapping'], 'ns');
     expect(rows[0].isOpen).toBe(true);
   });
   it('row should be collapsed if rule state is FIRING but collapsed by user', () => {
     const alertRules = getAlertsAndRules(rules?.data).rules;
-    const rows = monitoringAlertRows(alertRules, ['KubeNodeNotReady']);
+    const rows = monitoringAlertRows(alertRules, ['KubeNodeNotReady'], 'ns');
     expect(rows[0].isOpen).toBe(false);
   });
   it('row should be collapse if rule state is not FIRING', () => {
     const alertRules = getAlertsAndRules(rules?.data).rules;
     alertRules[0].state = RuleStates.Inactive;
-    const rows = monitoringAlertRows(alertRules, ['']);
+    const rows = monitoringAlertRows(alertRules, [''], 'ns');
     expect(rows[0].isOpen).toBe(undefined);
   });
 });

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { Link } from 'react-router-dom';
 import {
   expandable,
   sortable,
@@ -25,6 +26,7 @@ import {
 } from '@console/internal/reducers/monitoring';
 import { Alert, Rule } from '@console/internal/components/monitoring/types';
 import { YellowExclamationTriangleIcon } from '@console/shared';
+import { labelsToParams } from '@console/internal/components/monitoring/utils';
 
 const viewAlertRule = {
   label: 'View Alerting Rule',
@@ -61,7 +63,11 @@ export const monitoringAlertColumn: MonitoringAlertColumn[] = [
   { title: '' },
 ];
 
-export const monitoringAlertRows = (alertrules: Rule[], collapsedRowsIds: string[]) => {
+export const monitoringAlertRows = (
+  alertrules: Rule[],
+  collapsedRowsIds: string[],
+  namespace: string,
+) => {
   const rows = [];
   _.forEach(alertrules, (rls) => {
     rows.push({
@@ -102,7 +108,13 @@ export const monitoringAlertRows = (alertrules: Rule[], collapsedRowsIds: string
         cells: [
           {
             title: (
-              <div className="odc-monitoring-alerts--alert-title">{alertDescription(alert)}</div>
+              <Link
+                to={`/dev-monitoring/ns/${namespace}/alerts/${rls.id}?${labelsToParams(
+                  alert.labels,
+                )}`}
+              >
+                {alertDescription(alert)}
+              </Link>
             ),
             props: { colSpan: 3 },
           },

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -754,6 +754,19 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: false,
+      path: ['/dev-monitoring/ns/:ns/alerts/:ruleID'],
+      loader: async () =>
+        (
+          await import(
+            './components/monitoring/alerts/MonitoringAlertsDetailsPage' /* webpackChunkName: "dev-console-monitoring-alerts" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: false,
       path: ['/dev-monitoring/all-namespaces', '/dev-monitoring/ns/:ns'],
       loader: async () =>
         (

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -315,8 +315,14 @@ export const monitoringLoading = (key: 'alerts' | 'silences' | 'notificationAler
     key,
     data: { loaded: false, loadError: null, data: null },
   });
-export const monitoringLoaded = (key: 'alerts' | 'silences' | 'notificationAlerts', data: any) =>
-  action(ActionType.SetMonitoringData, { key, data: { loaded: true, loadError: null, data } });
+export const monitoringLoaded = (
+  key: 'alerts' | 'silences' | 'notificationAlerts' | 'devAlerts',
+  alerts: any,
+) =>
+  action(ActionType.SetMonitoringData, {
+    key,
+    data: { loaded: true, loadError: null, data: alerts },
+  });
 export const monitoringErrored = (
   key: 'alerts' | 'silences' | 'notificationAlerts',
   loadError: any,

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -310,23 +310,32 @@ export const monitoringDashboardsSetTimespan = (timespan: number) =>
   action(ActionType.MonitoringDashboardsSetTimespan, { timespan });
 export const monitoringDashboardsVariableOptionsLoaded = (key: string, newOptions: string[]) =>
   action(ActionType.MonitoringDashboardsVariableOptionsLoaded, { key, newOptions });
-export const monitoringLoading = (key: 'alerts' | 'silences' | 'notificationAlerts') =>
+export const monitoringLoading = (
+  key: 'alerts' | 'silences' | 'notificationAlerts',
+  perspective = 'admin',
+) =>
   action(ActionType.SetMonitoringData, {
     key,
-    data: { loaded: false, loadError: null, data: null },
+    data: { loaded: false, loadError: null, data: null, perspective },
   });
 export const monitoringLoaded = (
   key: 'alerts' | 'silences' | 'notificationAlerts' | 'devAlerts',
   alerts: any,
+  perspective = 'admin',
 ) =>
   action(ActionType.SetMonitoringData, {
     key,
-    data: { loaded: true, loadError: null, data: alerts },
+    data: { loaded: true, loadError: null, data: alerts, perspective },
   });
 export const monitoringErrored = (
   key: 'alerts' | 'silences' | 'notificationAlerts',
   loadError: any,
-) => action(ActionType.SetMonitoringData, { key, data: { loaded: true, loadError, data: null } });
+  perspective = 'admin',
+) =>
+  action(ActionType.SetMonitoringData, {
+    key,
+    data: { loaded: true, loadError, data: null, perspective },
+  });
 export const monitoringSetRules = (key: 'rules' | 'devRules', rules: Rule[]) =>
   action(ActionType.MonitoringSetRules, { key, data: rules });
 export const monitoringToggleGraphs = () => action(ActionType.ToggleMonitoringGraphs);

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -21,7 +21,6 @@ import {
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
-import { getActivePerspective, getActiveNamespace } from '../../reducers/ui';
 import * as UIActions from '../../actions/ui';
 import { coFetchJSON } from '../../co-fetch';
 import {
@@ -494,17 +493,26 @@ const HeaderAlertMessage: React.FC<{ alert: Alert; rule: Rule }> = ({ alert, rul
 };
 
 const alertStateToProps = (state: RootState, { match }): AlertsDetailsPageProps => {
-  const { data, loaded, loadError }: Alerts = alertsToProps(state);
+  const perspective = _.has(match.params, 'ns') ? 'dev' : 'admin';
+  const namespace = match.params?.ns;
+  const { data, loaded, loadError }: Alerts = alertsToProps(state, perspective);
   const { loaded: silencesLoaded }: Silences = silencesToProps(state);
-  const ruleID = _.get(match, 'params.ruleID');
+  const ruleID = match?.params?.ruleID;
   const labels = getURLSearchParams();
   const alerts = _.filter(data, (a) => a.rule.id === ruleID);
-  const rule = _.get(alerts, '[0].rule');
+  const rule = alerts?.[0]?.rule;
   const alert = _.find(alerts, (a) => _.isEqual(a.labels, labels));
-  const activePerspective = getActivePerspective(state);
-  const namespace = getActiveNamespace(state);
   const url = match.url;
-  return { alert, loaded, loadError, rule, silencesLoaded, activePerspective, namespace, url };
+  return {
+    alert,
+    loaded,
+    loadError,
+    rule,
+    silencesLoaded,
+    activePerspective: perspective,
+    namespace,
+    url,
+  };
 };
 
 export const AlertsDetailsPage = withFallback(

--- a/frontend/public/components/monitoring/utils.ts
+++ b/frontend/public/components/monitoring/utils.ts
@@ -68,7 +68,9 @@ export const getAlertsAndRules = (
   return { alerts, rules };
 };
 
-export const alertsToProps = ({ UI }) => UI.getIn(['monitoring', 'alerts']) || {};
+export const alertsToProps = ({ UI }) =>
+  UI.getIn(['monitoring', UI.getIn(['activePerspective']) === 'admin' ? 'alerts' : 'devAlerts']) ||
+  {};
 
 export const rulesToProps = (state: RootState) => {
   const data = state.UI.getIn(['monitoring', 'rules']);

--- a/frontend/public/components/monitoring/utils.ts
+++ b/frontend/public/components/monitoring/utils.ts
@@ -68,9 +68,8 @@ export const getAlertsAndRules = (
   return { alerts, rules };
 };
 
-export const alertsToProps = ({ UI }) =>
-  UI.getIn(['monitoring', UI.getIn(['activePerspective']) === 'admin' ? 'alerts' : 'devAlerts']) ||
-  {};
+export const alertsToProps = ({ UI }, perspective?: string) =>
+  UI.getIn(['monitoring', perspective === 'dev' ? 'devAlerts' : 'alerts']) || {};
 
 export const rulesToProps = (state: RootState) => {
   const data = state.UI.getIn(['monitoring', 'rules']);

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -199,7 +199,7 @@ export default (state: UIState, action: UIAction): UIState => {
       return state.setIn(['monitoring', action.payload.key], action.payload.data);
 
     case ActionType.SetMonitoringData: {
-      const alertKey = state.get('activePerspective') === 'admin' ? 'alerts' : 'devAlerts';
+      const alertKey = action.payload.data.perspective === 'admin' ? 'alerts' : 'devAlerts';
       const alerts =
         action.payload.key === alertKey
           ? action.payload.data

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -199,11 +199,11 @@ export default (state: UIState, action: UIAction): UIState => {
       return state.setIn(['monitoring', action.payload.key], action.payload.data);
 
     case ActionType.SetMonitoringData: {
-      // alerts used by monitoring -> alerting pages
+      const alertKey = state.get('activePerspective') === 'admin' ? 'alerts' : 'devAlerts';
       const alerts =
-        action.payload.key === 'alerts'
+        action.payload.key === alertKey
           ? action.payload.data
-          : state.getIn(['monitoring', 'alerts']);
+          : state.getIn(['monitoring', alertKey]);
       // notificationAlerts used by notification drawer and certain dashboards
       const notificationAlerts: NotificationAlerts =
         action.payload.key === 'notificationAlerts'
@@ -221,7 +221,7 @@ export default (state: UIState, action: UIAction): UIState => {
       silenceFiringAlerts(_.filter(notificationAlerts?.data, isAlertFiring), silences);
       // filter out silenced alerts from notificationAlerts
       notificationAlerts.data = _.reject(notificationAlerts.data, { state: AlertStates.Silenced });
-      state = state.setIn(['monitoring', 'alerts'], alerts);
+      state = state.setIn(['monitoring', alertKey], alerts);
       state = state.setIn(['monitoring', 'notificationAlerts'], notificationAlerts);
 
       // For each Silence, store a list of the Alerts it is silencing


### PR DESCRIPTION
**JIRA story:**
https://issues.redhat.com/browse/ODC-4120

**Solution Description:**
- added link to alerts under alert rules
- reused the `AlertsDetailsPage` component
- added breadcrumbs in the alert details page
- added Namespace bar in `AlertsDetailsPage` when in Dev perspective

**GIF/Screenshot:**
![alert details](https://user-images.githubusercontent.com/22490998/87676392-310a4580-c796-11ea-94e0-5b56e8ce6d45.gif)


screenshot of the alert details page in the admin side
![Screenshot from 2020-07-16 18-57-10](https://user-images.githubusercontent.com/22490998/87676441-3f586180-c796-11ea-8346-65d476cf243c.png)
