### PR TITLE
Bug 1825137: Monitoring: Fix alert details graph when externalLabels are defined

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -51,12 +51,6 @@ import {
   twentyFourHourTimeWithSeconds,
 } from '../utils/datetime';
 
-// Prometheus internal labels start with "__"
-const isInternalLabel = (key: string): boolean => _.startsWith(key, '__');
-
-// External labels added by Prometheus (included in Thanos Querier responses)
-const isExternalLabel = (key: string): boolean => key === 'prometheus';
-
 const spans = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2w'];
 const dropdownItems = _.zipObject(spans, spans);
 const chartTheme = getCustomTheme(
@@ -587,11 +581,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
               const newGraphData = _.map(newResults, (result: PrometheusResult[]) => {
                 return _.map(result, ({ metric, values }) => {
                   // If filterLabels is specified, ignore all series that don't match
-                  return filterLabels &&
-                    _.some(
-                      metric,
-                      (v, k) => filterLabels[k] !== v && !isInternalLabel(k) && !isExternalLabel(k),
-                    )
+                  return _.some(filterLabels, (v, k) => _.has(metric, k) && metric[k] !== v)
                     ? []
                     : [metric, formatSeriesValues(values, samples, span)];
                 });


### PR DESCRIPTION
The `filterLabels` logic did not account for the case where Prometheus
`externalLabels` have been added. Only the single external label
`prometheus` was accounted for (because it is added by default).

This bug resulted in the graph on the alert details page failing to
display any data when `externalLabels` were defined. (The alerting rule
page graph and Metrics page graph were not affected.)

The fix is to ignore any labels not found in `metric`. This also
naturally handles the `isInternalLabel` case.