### PR TITLE
Add no power management status and alert for BMH

### DIFF
--- a/frontend/packages/console-shared/src/components/status/GenericStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/GenericStatus.tsx
@@ -5,8 +5,8 @@ import StatusIconAndText from './StatusIconAndText';
 
 const GenericStatus: React.FC<GenericStatusProps> = (props) => {
   const { Icon, children, ...restProps } = props;
-  return children ? (
-    <PopoverStatus {...restProps} icon={<Icon />}>
+  return React.Children.toArray(children).length ? (
+    <PopoverStatus {...restProps} statusBody={<StatusIconAndText {...restProps} icon={<Icon />} />}>
       {children}
     </PopoverStatus>
   ) : (

--- a/frontend/packages/console-shared/src/components/status/PopoverStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/PopoverStatus.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import { Instance as TippyInstance } from 'tippy.js';
-import StatusIconAndText from './StatusIconAndText';
 
 const PopoverStatus: React.FC<PopoverStatusProps> = ({
-  title,
   hideHeader,
-  icon,
-  activeIcon,
   children,
   isVisible = null,
   shouldClose = null,
-  ...other
+  statusBody,
+  title,
+  onHide,
+  onShow,
 }) => {
-  const [isActive, setActive] = React.useState(false);
-  const onHide = React.useCallback(() => setActive(false), [setActive]);
-  const onShow = React.useCallback(() => setActive(true), [setActive]);
-
   return (
     <Popover
       position={PopoverPosition.right}
@@ -29,18 +24,17 @@ const PopoverStatus: React.FC<PopoverStatusProps> = ({
       shouldClose={shouldClose}
     >
       <Button variant="link" isInline>
-        <StatusIconAndText
-          {...other}
-          title={title}
-          icon={isActive && activeIcon ? activeIcon : icon}
-        />
+        {statusBody}
       </Button>
     </Popover>
   );
 };
 
-type PopoverStatusProps = React.ComponentProps<typeof StatusIconAndText> & {
-  activeIcon?: React.ReactElement;
+type PopoverStatusProps = {
+  statusBody: React.ReactNode;
+  onHide?: () => void;
+  onShow?: () => void;
+  title?: string;
   hideHeader?: boolean;
   isVisible?: boolean;
   shouldClose?: (tip: TippyInstance) => void;

--- a/frontend/packages/console-shared/src/components/status/statuses.tsx
+++ b/frontend/packages/console-shared/src/components/status/statuses.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { InfoCircleIcon, HourglassHalfIcon, InProgressIcon } from '@patternfly/react-icons';
+import { HourglassHalfIcon, InProgressIcon } from '@patternfly/react-icons';
 import {
   RedExclamationCircleIcon,
   GreenCheckCircleIcon,
   YellowExclamationTriangleIcon,
+  BlueInfoCircleIcon,
 } from './icons';
 import GenericStatus from './GenericStatus';
 import { StatusComponentProps } from './types';
@@ -14,7 +15,7 @@ export const ErrorStatus: React.FC<StatusComponentProps> = (props) => (
 ErrorStatus.displayName = 'ErrorStatus';
 
 export const InfoStatus: React.FC<StatusComponentProps> = (props) => (
-  <GenericStatus {...props} Icon={InfoCircleIcon} />
+  <GenericStatus {...props} Icon={BlueInfoCircleIcon} />
 );
 InfoStatus.displayName = 'InfoStatus';
 

--- a/frontend/packages/kubevirt-plugin/src/components/form/form-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/form-row.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { FormGroup } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
+import * as classnames from 'classnames';
 import { LoadingInline } from '@console/internal/components/utils';
-import { PopoverStatus, ValidationErrorType } from '@console/shared';
+import { PopoverStatus, ValidationErrorType, StatusIconAndText } from '@console/shared';
 import './form-row.scss';
 
 export const FormRow: React.FC<FormRowProps> = ({
@@ -18,6 +19,9 @@ export const FormRow: React.FC<FormRowProps> = ({
   children,
   className,
 }) => {
+  const [isActive, setActive] = React.useState(false);
+  const onHide = React.useCallback(() => setActive(false), [setActive]);
+  const onShow = React.useCallback(() => setActive(true), [setActive]);
   if (isHidden) {
     return null;
   }
@@ -39,11 +43,21 @@ export const FormRow: React.FC<FormRowProps> = ({
       {help && (
         <span className="kubevirt-form-row__icon-status-container">
           <PopoverStatus
-            icon={<HelpIcon className="kubevirt-form-row__help-icon--hidden" />}
-            activeIcon={<HelpIcon />}
             title={`${fieldId} help`}
-            iconOnly
             hideHeader
+            onHide={onHide}
+            onShow={onShow}
+            statusBody={
+              <StatusIconAndText
+                title={`${fieldId} help`}
+                iconOnly
+                icon={
+                  <HelpIcon
+                    className={classnames({ 'kubevirt-form-row__help-icon--hidden': !isActive })}
+                  />
+                }
+              />
+            }
           >
             {help}
           </PopoverStatus>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
@@ -23,6 +23,7 @@ import {
   StatusIconAndText,
   DetailPropertyList,
   DetailPropertyListItem,
+  SecondaryStatus,
 } from '@console/shared';
 import { getHostStatus } from '../../status/host-status';
 import {
@@ -41,13 +42,14 @@ import {
   getHostProvisioningState,
   getHostBootMACAddress,
   isHostScheduledForRestart,
+  hasPowerManagement,
 } from '../../selectors';
 import { BareMetalHostKind } from '../../types';
 import { HOST_REGISTERING_STATES } from '../../constants/bare-metal-host';
 import MachineLink from './MachineLink';
 import BareMetalHostPowerStatusIcon from './BareMetalHostPowerStatusIcon';
 import BareMetalHostStatus from './BareMetalHostStatus';
-import { HOST_SCHEDULED_FOR_RESTART } from './BareMetalHostSecondaryStatus';
+import { HOST_SCHEDULED_FOR_RESTART, HOST_NO_POWER_MGMT } from './BareMetalHostSecondaryStatus';
 
 type BareMetalHostDetailsProps = {
   obj: BareMetalHostKind;
@@ -147,15 +149,21 @@ const BareMetalHostDetails: React.FC<BareMetalHostDetailsProps> = ({
               <>
                 <dt>Power Status</dt>
                 <dd>
-                  <StatusIconAndText
-                    title={powerStatus}
-                    icon={<BareMetalHostPowerStatusIcon powerStatus={powerStatus} />}
-                  />
-                  {isHostScheduledForRestart(host) && (
-                    <StatusIconAndText
-                      title={HOST_SCHEDULED_FOR_RESTART}
-                      icon={<RebootingIcon />}
-                    />
+                  {!hasPowerManagement(host) ? (
+                    <SecondaryStatus status={HOST_NO_POWER_MGMT} />
+                  ) : (
+                    <>
+                      <StatusIconAndText
+                        title={powerStatus}
+                        icon={<BareMetalHostPowerStatusIcon powerStatus={powerStatus} />}
+                      />
+                      {isHostScheduledForRestart(host) && (
+                        <StatusIconAndText
+                          title={HOST_SCHEDULED_FOR_RESTART}
+                          icon={<RebootingIcon />}
+                        />
+                      )}
+                    </>
                   )}
                 </dd>
               </>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
@@ -5,6 +5,7 @@ import {
   getHostPowerStatus,
   getHostProvisioningState,
   isHostScheduledForRestart,
+  hasPowerManagement,
 } from '../../selectors';
 import { HOST_POWER_STATUS_POWERED_ON, HOST_REGISTERING_STATES } from '../../constants';
 
@@ -13,14 +14,17 @@ type BareMetalHostSecondaryStatusProps = {
 };
 
 export const HOST_SCHEDULED_FOR_RESTART = 'Restart pending';
+export const HOST_NO_POWER_MGMT = 'No power management';
 
 const BareMetalHostSecondaryStatus: React.FC<BareMetalHostSecondaryStatusProps> = ({ host }) => {
   const powerStatus = getHostPowerStatus(host);
   const provisioningState = getHostProvisioningState(host);
   const status = [];
 
-  // don't show power status when host registration/inspection hasn't finished
-  if (!HOST_REGISTERING_STATES.includes(provisioningState)) {
+  if (!hasPowerManagement(host)) {
+    status.push(HOST_NO_POWER_MGMT);
+    // don't show power status when host registration/inspection hasn't finished
+  } else if (!HOST_REGISTERING_STATES.includes(provisioningState)) {
     if (isHostScheduledForRestart(host)) {
       status.push(HOST_SCHEDULED_FOR_RESTART);
     }

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
@@ -1,45 +1,45 @@
 import * as React from 'react';
-import { Button } from 'patternfly-react';
-import { AddCircleOIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+import { resourcePathFromModel } from '@console/internal/components/utils';
 import {
   ProgressStatus,
   SuccessStatus,
   ErrorStatus,
   Status,
-  StatusIconAndText,
-  getNamespace,
+  PopoverStatus,
+  InfoStatus,
 } from '@console/shared';
-import { RequireCreatePermission } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
-  HOST_STATUS_DISCOVERED,
   HOST_PROGRESS_STATES,
   HOST_ERROR_STATES,
   HOST_SUCCESS_STATES,
   NODE_STATUS_UNDER_MAINTENANCE,
   NODE_STATUS_STARTING_MAINTENANCE,
   NODE_STATUS_STOPPING_MAINTENANCE,
+  HOST_STATUS_UNMANAGED,
+  HOST_INFO_STATES,
 } from '../../constants';
-import { BareMetalHostModel } from '../../models';
 import { getHostErrorMessage } from '../../selectors';
 import { StatusProps } from '../types';
 import MaintenancePopover from '../maintenance/MaintenancePopover';
 import { BareMetalHostKind } from '../../types';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { BareMetalHostModel } from '../../models';
 
-// TODO(jtomasek): Update this with onClick handler once add discovered host functionality
-// is available
-export const AddDiscoveredHostButton: React.FC<{ host: BareMetalHostKind }> = (
-  { host }, // eslint-disable-line @typescript-eslint/no-unused-vars
-) => {
-  const namespace = getNamespace(host);
-
-  return (
-    <RequireCreatePermission model={BareMetalHostModel} namespace={namespace}>
-      <Button bsStyle="link">
-        <StatusIconAndText icon={<AddCircleOIcon />} title="Add host" />
-      </Button>
-    </RequireCreatePermission>
-  );
+export const HOST_STATUS_ACTIONS = {
+  [HOST_STATUS_UNMANAGED]: (host: BareMetalHostKind) => (
+    <p>
+      <Link
+        to={`${resourcePathFromModel(
+          BareMetalHostModel,
+          host.metadata.name,
+          host.metadata.namespace,
+        )}/edit`}
+      >
+        Add credentials
+      </Link>
+    </p>
+  ),
 };
 
 const BareMetalHostStatus: React.FC<BareMetalHostStatusProps> = ({
@@ -50,24 +50,51 @@ const BareMetalHostStatus: React.FC<BareMetalHostStatusProps> = ({
   nodeMaintenance,
 }) => {
   const statusTitle = title || status;
+  const action = HOST_STATUS_ACTIONS[status]?.(host);
   switch (true) {
-    case status === HOST_STATUS_DISCOVERED:
-      return <AddDiscoveredHostButton host={host} />;
     case [NODE_STATUS_STARTING_MAINTENANCE, NODE_STATUS_UNDER_MAINTENANCE].includes(status):
       return <MaintenancePopover title={statusTitle} nodeMaintenance={nodeMaintenance} />;
     case [NODE_STATUS_STOPPING_MAINTENANCE, ...HOST_PROGRESS_STATES].includes(status):
-      return <ProgressStatus title={statusTitle}>{description}</ProgressStatus>;
+      return (
+        <ProgressStatus title={statusTitle}>
+          {description}
+          {action}
+        </ProgressStatus>
+      );
     case HOST_ERROR_STATES.includes(status):
       return (
         <ErrorStatus title={statusTitle}>
           <p>{description}</p>
           <p>{getHostErrorMessage(host)}</p>
+          {action}
         </ErrorStatus>
       );
     case HOST_SUCCESS_STATES.includes(status):
-      return <SuccessStatus title={statusTitle}>{description}</SuccessStatus>;
-    default:
-      return <Status status={status} title={statusTitle} />;
+      return (
+        <SuccessStatus title={statusTitle}>
+          {description}
+          {action}
+        </SuccessStatus>
+      );
+    case HOST_INFO_STATES.includes(status):
+      return (
+        <InfoStatus title={statusTitle}>
+          {description}
+          {action}
+        </InfoStatus>
+      );
+    default: {
+      const statusBody = <Status status={status} title={statusTitle} />;
+
+      return description || action ? (
+        <PopoverStatus title={statusTitle} statusBody={statusBody}>
+          {description}
+          {action}
+        </PopoverStatus>
+      ) : (
+        statusBody
+      );
+    }
   }
 };
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/DetailsCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/DetailsCard.tsx
@@ -6,10 +6,6 @@ import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboa
 import DetailsBody from '@console/shared/src/components/dashboard/details-card/DetailsBody';
 import DetailItem from '@console/shared/src/components/dashboard/details-card/DetailItem';
 import DashboardCardLink from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardLink';
-import {
-  DashboardItemProps,
-  withDashboardResources,
-} from '@console/internal/components/dashboard/with-dashboard-resources';
 import { getName, getNamespace } from '@console/shared';
 import { MachineKind, NodeKind } from '@console/internal/module/k8s';
 import { resourcePathFromModel } from '@console/internal/components/utils';
@@ -56,9 +52,9 @@ const DetailsCard: React.FC<DetailsCardProps> = () => {
   );
 };
 
-export default withDashboardResources(DetailsCard);
+export default DetailsCard;
 
-type DetailsCardProps = DashboardItemProps & {
+type DetailsCardProps = {
   obj: BareMetalHostKind;
   machines: MachineKind[];
   nodes: NodeKind[];

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import {
   DashboardItemProps,
   withDashboardResources,
@@ -13,18 +14,26 @@ import HealthBody from '@console/shared/src/components/dashboard/status-card/Hea
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
 import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
-import AlertItem from '@console/shared/src/components/dashboard/status-card/AlertItem';
 import { Alert } from '@console/internal/components/monitoring/types';
 import { alertURL } from '@console/internal/components/monitoring/utils';
+import { BlueInfoCircleIcon } from '@console/shared';
+import AlertItem, {
+  StatusItem,
+} from '@console/shared/src/components/dashboard/status-card/AlertItem';
+import { resourcePathFromModel } from '@console/internal/components/utils';
 import { getBareMetalHostStatus } from '../../../status/host-status';
 import {
+  HOST_STATUS_DESCRIPTIONS,
   HOST_SUCCESS_STATES,
   HOST_ERROR_STATES,
   HOST_PROGRESS_STATES,
   HOST_HARDWARE_ERROR_STATES,
+  HOST_STATUS_UNMANAGED,
 } from '../../../constants';
 import { BareMetalHostKind } from '../../../types';
 import { BareMetalHostDashboardContext } from './BareMetalHostDashboardContext';
+import { BareMetalHostModel } from '../../../models';
+import { hasPowerManagement } from '../../../selectors';
 
 const getHostHealthState = (obj: BareMetalHostKind): HostHealthState => {
   const { status, title } = getBareMetalHostStatus(obj);
@@ -92,7 +101,7 @@ const HealthCard: React.FC<HealthCardProps> = ({
         <HealthBody>
           <Gallery className="co-overview-status__health" hasGutter>
             <GalleryItem>
-              <HealthItem title="Status" state={health.state} details={health.title} />
+              <HealthItem title={health.title} state={health.state} />
             </GalleryItem>
             <GalleryItem>
               <HealthItem title="Hardware" state={hwHealth.state} details={hwHealth.title} />
@@ -100,6 +109,22 @@ const HealthCard: React.FC<HealthCardProps> = ({
           </Gallery>
         </HealthBody>
         <AlertsBody error={!_.isEmpty(loadError)}>
+          {!hasPowerManagement(obj) && (
+            <StatusItem
+              Icon={BlueInfoCircleIcon}
+              message={HOST_STATUS_DESCRIPTIONS[HOST_STATUS_UNMANAGED]}
+            >
+              <Link
+                to={`${resourcePathFromModel(
+                  BareMetalHostModel,
+                  obj.metadata.name,
+                  obj.metadata.namespace,
+                )}/edit`}
+              >
+                Add credentials
+              </Link>
+            </StatusItem>
+          )}
           {loaded && alerts.length !== 0
             ? alerts.map((alert) => (
                 <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
@@ -10,6 +10,7 @@ import {
   HOST_STATUS_EXTERNALLY_PROVISIONED,
   NODE_STATUS_TITLES,
   HOST_STATUS_AVAILABLE,
+  HOST_STATUS_UNMANAGED,
 } from '../../constants';
 import { BareMetalHostBundle } from '../types';
 
@@ -37,6 +38,10 @@ const hostStatesToFilterMap = Object.freeze({
   maintenance: {
     title: 'Maintenance',
     states: Object.keys(NODE_STATUS_TITLES),
+  },
+  unmanaged: {
+    title: 'Unmanaged',
+    states: [HOST_STATUS_UNMANAGED],
   },
   other: {
     title: 'Other',

--- a/frontend/packages/metal3-plugin/src/components/maintenance/MaintenancePopover.tsx
+++ b/frontend/packages/metal3-plugin/src/components/maintenance/MaintenancePopover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { PopoverStatus } from '@console/shared';
+import { PopoverStatus, StatusIconAndText } from '@console/shared';
 import { InProgressIcon, MaintenanceIcon } from '@patternfly/react-icons';
 import { getNodeMaintenancePhase } from '../../selectors';
 import UnderMaintenancePopoverContent from './UnderMaintenancePopoverContent';
@@ -16,20 +16,27 @@ const MaintenancePopover: React.FC<MaintenancePopoverProps> = ({
   title,
   nodeMaintenance,
   className,
+  children,
 }) => {
   const phase = getNodeMaintenancePhase(nodeMaintenance);
 
   return (
     <PopoverStatus
-      icon={phase === 'Succeeded' ? <MaintenanceIcon /> : <InProgressIcon />}
       title={title}
-      className={className}
+      statusBody={
+        <StatusIconAndText
+          title={title}
+          icon={phase === 'Succeeded' ? <MaintenanceIcon /> : <InProgressIcon />}
+          className={className}
+        />
+      }
     >
       {phase === 'Succeeded' ? (
         <UnderMaintenancePopoverContent nodeMaintenance={nodeMaintenance} />
       ) : (
         <StartingMaintenancePopoverContent nodeMaintenance={nodeMaintenance} />
       )}
+      {children}
     </PopoverStatus>
   );
 };

--- a/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
+++ b/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
@@ -2,7 +2,7 @@
 // once 'ready' status is replaced with 'available' in BMO
 export const HOST_STATUS_READY = 'ready';
 export const HOST_STATUS_AVAILABLE = 'available';
-export const HOST_STATUS_DISCOVERED = 'discovered';
+export const HOST_STATUS_UNMANAGED = 'unmanaged';
 export const HOST_STATUS_OK = 'OK';
 export const HOST_STATUS_ERROR = 'error';
 export const HOST_STATUS_UNKNOWN = 'Unknown';
@@ -28,7 +28,6 @@ export const HOST_POWER_STATUS_POWERING_ON = 'Powering on';
 export const HOST_STATUS_TITLES = {
   [HOST_STATUS_READY]: 'Available',
   [HOST_STATUS_AVAILABLE]: 'Available',
-  [HOST_STATUS_DISCOVERED]: 'Discovered',
   [HOST_STATUS_OK]: 'OK',
   [HOST_STATUS_ERROR]: 'Error',
   [HOST_STATUS_PROVISIONED]: 'Provisioned',
@@ -45,6 +44,7 @@ export const HOST_STATUS_TITLES = {
   [HOST_STATUS_MATCH_PROFILE]: 'Matching profile',
   [HOST_STATUS_DELETING]: 'Deleting',
   [HOST_STATUS_UNKNOWN]: 'Unknown',
+  [HOST_STATUS_UNMANAGED]: 'Unmanaged',
 };
 
 export const HOST_STATUS_DESCRIPTIONS = {
@@ -62,6 +62,10 @@ export const HOST_STATUS_DESCRIPTIONS = {
   [HOST_STATUS_PROVISIONING_ERROR]: 'The image could not be written to the host.',
   [HOST_STATUS_POWER_MANAGEMENT_ERROR]:
     'An error was found while trying to power the host either on or off.',
+  [HOST_STATUS_EXTERNALLY_PROVISIONED]:
+    'This host was provisioned outside of this cluster and added manually.',
+  [HOST_STATUS_UNMANAGED]:
+    'Power operations cannot be performed on this host until Baseboard Management Controller (BMC) credentials are provided.',
 };
 
 export const HOST_REGISTERING_STATES = [
@@ -94,12 +98,13 @@ export const HOST_PROGRESS_STATES = [
 export const HOST_SUCCESS_STATES = [
   HOST_STATUS_READY,
   HOST_STATUS_AVAILABLE,
-  HOST_STATUS_DISCOVERED,
   HOST_STATUS_OK,
   HOST_STATUS_PROVISIONED,
   HOST_STATUS_EXTERNALLY_PROVISIONED,
   HOST_STATUS_DEPROVISIONED,
 ];
+
+export const HOST_INFO_STATES = [HOST_STATUS_UNMANAGED];
 
 export const HOST_HARDWARE_ERROR_STATES = [HOST_STATUS_POWER_MANAGEMENT_ERROR];
 

--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -24,7 +24,7 @@ import { formatNamespacedRouteForResource } from '@console/shared/src/utils/name
 import { BareMetalHostModel, NodeMaintenanceModel } from './models';
 import { getBMHStatusGroups } from './components/baremetal-hosts/dashboard/utils';
 import { getBMNStatusGroups } from './components/baremetal-nodes/dashboard/utils';
-import { getHostPowerStatus } from './selectors';
+import { getHostPowerStatus, hasPowerManagement } from './selectors';
 import { HOST_POWER_STATUS_POWERING_OFF, HOST_POWER_STATUS_POWERING_ON } from './constants';
 import { BareMetalHostKind } from './types';
 import { detectBaremetalPlatform, BAREMETAL_FLAG, NODE_MAINTENANCE_FLAG } from './features';
@@ -243,7 +243,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       isActivity: (resource: BareMetalHostKind) =>
         [HOST_POWER_STATUS_POWERING_OFF, HOST_POWER_STATUS_POWERING_ON].includes(
           getHostPowerStatus(resource),
-        ),
+        ) && hasPowerManagement(resource),
       loader: () =>
         import(
           './components/baremetal-hosts/dashboard/BareMetalStatusActivity' /* webpackChunkName: "metal3-powering" */

--- a/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
@@ -14,6 +14,7 @@ import {
   HOST_POWER_STATUS_POWERING_OFF,
   HOST_POWER_STATUS_POWERING_ON,
   HOST_POWER_STATUS_POWERED_OFF,
+  HOST_STATUS_UNMANAGED,
 } from '../constants';
 
 const ANNOTATION_HOST_RESTART = 'reboot.metal3.io';
@@ -76,3 +77,6 @@ export const getHostMachine = (
   machines: MachineKind[] = [],
 ): MachineKind =>
   machines.find((machine: MachineKind) => getHostMachineName(host) === getName(machine));
+
+export const hasPowerManagement = (host: BareMetalHostKind): boolean =>
+  getHostProvisioningState(host) !== HOST_STATUS_UNMANAGED;

--- a/frontend/packages/metal3-plugin/src/status/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/host-status.ts
@@ -4,7 +4,6 @@ import {
   HOST_STATUS_TITLES,
   HOST_STATUS_DESCRIPTIONS,
   HOST_STATUS_ERROR,
-  HOST_STATUS_DISCOVERED,
   HOST_PROGRESS_STATES,
   HOST_STATUS_DEPROVISIONING,
   HOST_STATUS_UNKNOWN,
@@ -18,7 +17,7 @@ export const getBareMetalHostStatus = (host: BareMetalHostKind): StatusProps => 
   const provisioningState = getHostProvisioningState(host);
   const errorType = getHostErrorType(host);
 
-  let hostStatus;
+  let hostStatus: string;
 
   if (operationalStatus === HOST_STATUS_ERROR) {
     if (errorType) {
@@ -26,8 +25,6 @@ export const getBareMetalHostStatus = (host: BareMetalHostKind): StatusProps => 
     } else {
       hostStatus = HOST_STATUS_ERROR;
     }
-  } else if (operationalStatus === HOST_STATUS_DISCOVERED) {
-    hostStatus = HOST_STATUS_DISCOVERED;
   } else if (provisioningState) {
     hostStatus = provisioningState;
   } else {

--- a/frontend/packages/metal3-plugin/src/types/host.ts
+++ b/frontend/packages/metal3-plugin/src/types/host.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceCommon } from '@console/internal/module/k8s';
 
 export type BareMetalHostNIC = {
   ip: string;
@@ -59,6 +59,8 @@ export type BareMetalHostKind = {
       url: string;
     };
     online: boolean;
+    externallyProvisioned?: boolean;
+    description?: string;
   };
   status?: {
     hardwareProfile: string;
@@ -86,4 +88,4 @@ export type BareMetalHostKind = {
     errorType?: string;
     errorMessage: string;
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;

--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
@@ -35,7 +35,7 @@ import {
   RowFunction,
 } from '@console/internal/components/factory';
 import { ConfigMapModel } from '@console/internal/models';
-import { PopoverStatus } from '@console/shared';
+import { PopoverStatus, StatusIconAndText } from '@console/shared';
 import {
   SubscriptionModel,
   CatalogSourceModel,
@@ -394,10 +394,15 @@ const DisabledPopover: React.FC<DisabledPopoverProps> = ({ operatorHub, sourceNa
     [close, operatorHub, sourceName],
   );
   return (
-    <PopoverStatus title="Disabled" isVisible={visible} shouldClose={close}>
+    <PopoverStatus
+      title="Disabled"
+      isVisible={visible}
+      shouldClose={close}
+      statusBody={<StatusIconAndText title="Disabled" />}
+    >
       <p>
         Operators provided by this source will not appear in OperatorHub and any operators installed
-        from this source will not receive updates unitl this source is re-enabled.
+        from this source will not receive updates until this source is re-enabled.
       </p>
       <Button isInline variant="link" onClick={onClickEnable}>
         Enable source


### PR DESCRIPTION
List view
![Screenshot from 2020-06-25 15-41-15](https://user-images.githubusercontent.com/2078045/85840958-b012ec00-b79d-11ea-9429-97574aa51b44.png)
Overview (message in Status)
![Screenshot from 2020-06-30 17-08-44](https://user-images.githubusercontent.com/2078045/86143286-8850ba80-baf4-11ea-806c-beebd575e8b4.png)

Details - maybe in this case the message does not have to be alert ?
![Screenshot from 2020-06-30 17-08-56](https://user-images.githubusercontent.com/2078045/86143302-8be44180-baf4-11ea-9ecb-b08ea37f7227.png)


I've also disabled power actions if there's no power management.
Improved the BMH activities on overview page - wont be shown anymore if there's no power mgmt.

Now I wonder what should we do about the New/Edit BMH dialog - BMC address/pass/username is required right now but I guess we should remove that. But if user fills in one of these values he has to fill in all - its all or nothing - how to visualize that ? - tracking in https://issues.redhat.com/browse/MGMT-1352
