### PR TITLE
Replace Errata links with View release notes

### DIFF
--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -12,17 +12,18 @@ import { Link } from 'react-router-dom';
 import { FLAGS } from '@console/shared';
 import { connectToFlags, FlagsObject } from '../reducers/features';
 import { getBrandingDetails } from './masthead';
-import { ExternalLink, Firehose } from './utils';
+import { Firehose } from './utils';
 import { ClusterVersionModel } from '../models';
 import { ClusterVersionKind, referenceForModel } from '../module/k8s';
 import { k8sVersion } from '../module/status';
 import {
-  hasAvailableUpdates,
+  getClusterID,
+  getCurrentVersion,
   getK8sGitVersion,
   getOpenShiftVersion,
-  getClusterID,
-  getErrataLink,
+  hasAvailableUpdates,
 } from '../module/k8s/cluster-settings';
+import { ReleaseNotesLink } from './cluster-settings/cluster-settings';
 
 const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }) => {
   const [kubernetesVersion, setKubernetesVersion] = React.useState('');
@@ -36,7 +37,6 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
   const clusterID = getClusterID(clusterVersion);
   const channel: string = _.get(cv, 'data.spec.channel');
   const openshiftVersion = getOpenShiftVersion(clusterVersion);
-  const errataLink = getErrataLink(clusterVersion);
   return (
     <>
       {clusterVersion && hasAvailableUpdates(clusterVersion) && (
@@ -60,11 +60,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
               <TextListItem component="dt">OpenShift Version</TextListItem>
               <TextListItem component="dd">
                 <div className="co-select-to-copy">{openshiftVersion}</div>
-                {errataLink && (
-                  <div>
-                    <ExternalLink text="View errata" href={errataLink} />
-                  </div>
-                )}
+                <ReleaseNotesLink channel={channel} version={getCurrentVersion(clusterVersion)} />
               </TextListItem>
             </>
           )}

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -35,7 +35,6 @@ import {
   getClusterVersionCondition,
   getCurrentVersion,
   getDesiredClusterVersion,
-  getErrataLink,
   getLastCompletedUpdate,
   getOCMLink,
   getReleaseNotesLink,
@@ -44,6 +43,7 @@ import {
   K8sResourceConditionStatus,
   K8sResourceKind,
   referenceForModel,
+  showReleaseNotes,
 } from '../../module/k8s';
 import {
   EmptyBox,
@@ -446,10 +446,11 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
 }) => {
   const { history = [] } = cv.status;
   const clusterID = getClusterID(cv);
-  const errataLink = getErrataLink(cv);
   const desiredImage: string = _.get(cv, 'status.desired.image') || '';
   // Split image on `@` to emphasize the digest.
   const imageParts = desiredImage.split('@');
+  const channel = getClusterVersionChannel(cv);
+  const releaseNotes = showReleaseNotes(channel);
 
   return (
     <>
@@ -545,13 +546,7 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
         </div>
       </div>
       <div className="co-m-pane__body">
-        <SectionHeading text="Update History">
-          {errataLink && (
-            <small>
-              <ExternalLink text="View errata" href={errataLink} />
-            </small>
-          )}
-        </SectionHeading>
+        <SectionHeading text="Update History" />
         {_.isEmpty(history) ? (
           <EmptyBox label="History" />
         ) : (
@@ -563,6 +558,7 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
                   <th>State</th>
                   <th>Started</th>
                   <th>Completed</th>
+                  {releaseNotes && <th className="hidden-xs hidden-sm">Release Notes</th>}
                 </tr>
               </thead>
               <tbody>
@@ -585,6 +581,11 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
                         '-'
                       )}
                     </td>
+                    {releaseNotes && (
+                      <td className="hidden-xs hidden-sm">
+                        <ReleaseNotesLink channel={channel} version={update.version} />
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -181,23 +181,6 @@ Browser: ${window.navigator.userAgent}
       };
 };
 
-// example link: https://access.redhat.com/downloads/content/290/ver=4.1/rhel---7/4.1.13/x86_64/product-errata
-export const getErrataLink = (cv: ClusterVersionKind): string => {
-  const version: string = getCurrentVersion(cv);
-  const parsed: ParsedVersion = semver.parse(version);
-  if (!parsed) {
-    return null;
-  }
-
-  const { major, minor, patch, prerelease } = parsed;
-  if (major !== 4 || !_.isEmpty(prerelease)) {
-    return null;
-  }
-
-  // TODO: Determine architecture instead of assuming x86_64.
-  return `https://access.redhat.com/downloads/content/290/ver=${major}.${minor}/rhel---7/${major}.${minor}.${patch}/x86_64/product-errata`;
-};
-
 export const showReleaseNotes = (channel: string): boolean => {
   return (
     window.SERVER_FLAGS.branding === 'ocp' &&


### PR DESCRIPTION
Note that unlike the `Errata` links they replace, `View release notes` links only appear when branding is `ocp` and the channel begins with `fast-` or `stable-`.

Follow on to https://github.com/openshift/console/pull/5723

<img width="542" alt="Screen Shot 2020-06-26 at 10 02 17 AM" src="https://user-images.githubusercontent.com/895728/85870859-9f617680-b79b-11ea-9ee4-199ffb361f95.png">
<img width="1288" alt="Screen Shot 2020-06-26 at 10 49 59 AM" src="https://user-images.githubusercontent.com/895728/85870862-9ffa0d00-b79b-11ea-813f-041228752c23.png">

cc: @megan-hall, @ncameronbritt 