### PR TITLE
Bug 1845624: Use `match.path` to build tab paths

### DIFF
--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -37,19 +37,23 @@ const reportPages = [
 const { common } = Kebab.factory;
 const menuActions = [...Kebab.getExtensionsActionsForKind(ChargebackReportModel), ...common];
 
-const dataURL = (obj, format = 'json') => {
+const dataURL = (obj: K8sResourceKind, format = 'json') => {
   return `${window.SERVER_FLAGS.meteringBaseURL}/api/v2/reports/${obj.metadata.namespace}/${obj.metadata.name}/table?format=${format}`;
 };
 
-const ChargebackNavBar: React.SFC<{ match: { url: string } }> = (props) => (
+const removeLastPathElement = (path: string) =>
+  path
+    .split('/')
+    .slice(0, -1)
+    .join('/');
+
+const ChargebackNavBar: React.SFC<{ match: { url: string; path: string } }> = (props) => (
   <div>
     <PageHeading title="Chargeback Reporting" style={{ paddingBottom: 15 }} />
     <NavBar
       pages={reportPages}
-      basePath={props.match.url
-        .split('/')
-        .slice(0, -1)
-        .join('/')}
+      basePath={removeLastPathElement(props.match.path)}
+      baseURL={removeLastPathElement(props.match.url)}
     />
   </div>
 );
@@ -650,7 +654,10 @@ export type DataTableRowsProps = {
 export type ReportsPageProps = {
   filterLabel: string;
   flags: { [_: string]: boolean };
-  match: { url: string };
+  match: {
+    url: string;
+    path: string;
+  };
 };
 
 export type ReportsDetailsPageProps = {
@@ -667,7 +674,10 @@ export type ReportGenerationQueriesDetailsProps = {
 
 export type ReportGenerationQueriesPageProps = {
   filterLabel: string;
-  match: { url: string };
+  match: {
+    url: string;
+    path: string;
+  };
 };
 
 export type ReportGenerationQueriesDetailsPageProps = {

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -140,22 +140,25 @@ export const navFactory: NavFactory = {
   }),
 };
 
-export const NavBar = withRouter<NavBarProps>(({ pages, basePath }) => {
+export const NavBar = withRouter<NavBarProps>(({ pages, baseURL, basePath }) => {
   basePath = basePath.replace(/\/$/, '');
 
   const tabs = (
     <>
       {pages.map(({ name, href, path }) => {
-        const matchUrl = matchPath(location.pathname, {
+        const matchURL = matchPath(location.pathname, {
           path: `${basePath}/${path || href}`,
           exact: true,
         });
         const klass = classNames('co-m-horizontal-nav__menu-item', {
-          'co-m-horizontal-nav-item--active': matchUrl && matchUrl.isExact,
+          'co-m-horizontal-nav-item--active': matchURL?.isExact,
         });
         return (
           <li className={klass} key={name}>
-            <Link to={`${basePath}/${href}`} data-test-id={`horizontal-link-${name}`}>
+            <Link
+              to={`${baseURL.replace(/\/$/, '')}/${href}`}
+              data-test-id={`horizontal-link-${name}`}
+            >
               {name}
             </Link>
           </li>
@@ -233,7 +236,7 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
   const pages = (props.pages || props.pagesFor(props.obj?.data)).concat(pluginPages);
 
   const routes = pages.map((p) => {
-    const path = `${props.match.url}/${p.path || p.href}`;
+    const path = `${props.match.path}/${p.path || p.href}`;
     const render = (params) => {
       return (
         <p.component
@@ -251,7 +254,9 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
   return (
     <div className={classNames('co-m-page__body', props.className)}>
       <div className="co-m-horizontal-nav">
-        {!props.hideNav && <NavBar pages={pages} basePath={props.match.url} />}
+        {!props.hideNav && (
+          <NavBar pages={pages} baseURL={props.match.url} basePath={props.match.path} />
+        )}
       </div>
       {renderContent(routes)}
     </div>
@@ -265,6 +270,7 @@ export type PodsComponentProps = {
 
 export type NavBarProps = {
   pages: Page[];
+  baseURL: string;
   basePath: string;
   history: History;
   location: Location<any>;


### PR DESCRIPTION
Use `match.path` instead of `match.url` to build `Route` paths for `HorizontalNav` tabs. This avoids problems where parameters in the path could have special characters like `User` and `Group` names.

/assign @rhamilto 

Before:

![Screenshot_2020-06-26 (example) · Details · OKD(1)](https://user-images.githubusercontent.com/1167259/85874232-4f38e300-b7a0-11ea-950a-e6876c711652.png)

After:

![Screenshot_2020-06-26 (example) · Details · OKD](https://user-images.githubusercontent.com/1167259/85874244-54962d80-b7a0-11ea-947f-e1aa447bcd4a.png)
