### PR TITLE
Update upgrade icon color to new standard

### DIFF
--- a/frontend/packages/console-shared/src/components/status/icons.tsx
+++ b/frontend/packages/console-shared/src/components/status/icons.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  ArrowCircleUpIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
@@ -47,6 +48,10 @@ export const RedResourcesFullIcon: React.FC<ColoredIconProps> = ({ className, al
 
 export const YellowResourcesAlmostFullIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
   <ResourcesAlmostFullIcon color={warningColor.value} className={className} alt={alt} />
+);
+
+export const BlueArrowCircleUpIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
+  <ArrowCircleUpIcon color={blueInfoColor.value} className={className} alt={alt} />
 );
 
 export type ColoredIconProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -4,7 +4,7 @@ import { match, Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import { Alert, Button } from '@patternfly/react-core';
-import { ArrowCircleUpIcon, InProgressIcon, PencilAltIcon } from '@patternfly/react-icons';
+import { InProgressIcon, PencilAltIcon } from '@patternfly/react-icons';
 import {
   DetailsPage,
   MultiListPage,
@@ -33,11 +33,12 @@ import {
   k8sUpdate,
 } from '@console/internal/module/k8s';
 import {
-  YellowExclamationTriangleIcon,
-  GreenCheckCircleIcon,
-  getNamespace,
+  BlueArrowCircleUpIcon,
   getName,
+  getNamespace,
+  GreenCheckCircleIcon,
   WarningStatus,
+  YellowExclamationTriangleIcon,
 } from '@console/shared';
 import {
   SubscriptionModel,
@@ -169,7 +170,7 @@ export const UpgradeApprovalLink: React.FC<{ subscription: SubscriptionKind }> =
   return (
     <span className="co-icon-and-text">
       <Link to={to}>
-        <ArrowCircleUpIcon className="update-pending" /> Upgrade available
+        <BlueArrowCircleUpIcon /> Upgrade available
       </Link>
     </span>
   );

--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
@@ -3,13 +3,12 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
-  YellowExclamationTriangleIcon,
-  GreenCheckCircleIcon,
+  BlueArrowCircleUpIcon,
   BlueInfoCircleIcon,
+  GreenCheckCircleIcon,
   RedExclamationCircleIcon,
+  YellowExclamationTriangleIcon,
 } from '@console/shared';
-import { ArrowCircleUpIcon } from '@patternfly/react-icons';
-import { global_info_color_100 as blueInfoColor } from '@patternfly/react-tokens';
 import { history, Timestamp } from '@console/internal/components/utils';
 
 export enum NotificationTypes {
@@ -23,7 +22,7 @@ export enum NotificationTypes {
 const NotificationIcon: React.FC<NotificationIconTypes> = ({ type }) => {
   switch (type) {
     case NotificationTypes.update:
-      return <ArrowCircleUpIcon color={blueInfoColor.value} />;
+      return <BlueArrowCircleUpIcon />;
     case NotificationTypes.success:
       return <GreenCheckCircleIcon />;
     case NotificationTypes.critical:

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -6,12 +6,7 @@ import { Helmet } from 'react-helmet';
 import { Button, Popover, Tooltip } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
-import {
-  AddCircleOIcon,
-  ArrowCircleUpIcon,
-  SyncAltIcon,
-  PencilAltIcon,
-} from '@patternfly/react-icons';
+import { AddCircleOIcon, SyncAltIcon, PencilAltIcon } from '@patternfly/react-icons';
 
 import { ClusterOperatorPage } from './cluster-operator';
 import {
@@ -57,6 +52,7 @@ import {
   truncateMiddle,
 } from '../utils';
 import {
+  BlueArrowCircleUpIcon,
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,
   YellowExclamationTriangleIcon,
@@ -99,7 +95,7 @@ const InvalidMessage: React.SFC<CVStatusMessageProps> = ({ cv }) => (
 
 const UpdatesAvailableMessage: React.SFC<CVStatusMessageProps> = () => (
   <div className="co-update-status">
-    <ArrowCircleUpIcon className="update-pending" /> Available Updates
+    <BlueArrowCircleUpIcon /> Available Updates
   </div>
 );
 

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Button } from '@patternfly/react-core';
-import { ArrowCircleUpIcon, InProgressIcon } from '@patternfly/react-icons';
-import { FLAGS, getInfrastructureAPIURL, getInfrastructurePlatform } from '@console/shared';
+import { InProgressIcon } from '@patternfly/react-icons';
+import {
+  BlueArrowCircleUpIcon,
+  FLAGS,
+  getInfrastructureAPIURL,
+  getInfrastructurePlatform,
+} from '@console/shared';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
@@ -60,7 +65,7 @@ const ClusterVersion: React.FC<ClusterVersionProps> = ({ cv }) => {
               variant="link"
               className="btn-link--no-btn-default-values"
               onClick={() => clusterUpdateModal({ cv })}
-              icon={<ArrowCircleUpIcon />}
+              icon={<BlueArrowCircleUpIcon />}
               isInline
             >
               Update

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -13,9 +13,8 @@ import {
   isDashboardsOverviewHealthResourceSubsystem,
   isDashboardsOverviewHealthOperator,
 } from '@console/plugin-sdk';
-import { ArrowCircleUpIcon } from '@patternfly/react-icons';
 import { Gallery, GalleryItem, Button } from '@patternfly/react-core';
-import { FLAGS, getInfrastructurePlatform } from '@console/shared';
+import { BlueArrowCircleUpIcon, FLAGS, getInfrastructurePlatform } from '@console/shared';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
@@ -88,10 +87,7 @@ const ClusterAlerts = withDashboardResources(
     const { data: alerts, loaded: alertsLoaded, loadError: alertsResponseError } =
       notificationAlerts || {};
 
-    const UpdateIcon = React.useCallback(
-      () => <ArrowCircleUpIcon className="update-pending" />,
-      [],
-    );
+    const UpdateIcon = React.useCallback(() => <BlueArrowCircleUpIcon />, []);
 
     const items: React.ReactNode[] = [];
 

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -10,7 +10,3 @@
   padding-right: 6px;
   width: 16px;
 }
-
-.update-pending {
-  color: $color-pf-blue-400;
-}


### PR DESCRIPTION
<img width="696" alt="Screen Shot 2020-06-26 at 11 36 01 AM" src="https://user-images.githubusercontent.com/895728/85875940-ff0f5000-b7a2-11ea-9619-1775775e69c6.png">
<img width="362" alt="Screen Shot 2020-06-26 at 11 36 18 AM" src="https://user-images.githubusercontent.com/895728/85875946-00407d00-b7a3-11ea-945a-2e08473cca43.png">
<img width="482" alt="Screen Shot 2020-06-26 at 11 41 34 AM" src="https://user-images.githubusercontent.com/895728/85875947-00407d00-b7a3-11ea-9ff5-bcbc145752bd.png">
<img width="402" alt="Screen Shot 2020-06-26 at 11 45 19 AM" src="https://user-images.githubusercontent.com/895728/85875949-00407d00-b7a3-11ea-83af-f57e006a4ea3.png">

cc: @megan-hall 