### PR TITLE
Correct color of update icon

### DIFF
--- a/frontend/packages/console-shared/src/components/status/icons.tsx
+++ b/frontend/packages/console-shared/src/components/status/icons.tsx
@@ -11,11 +11,12 @@ import {
   ResourcesFullIcon,
 } from '@patternfly/react-icons';
 import {
-  global_warning_color_100 as warningColor,
   global_danger_color_100 as dangerColor,
-  global_success_color_200 as okColor,
-  global_info_color_100 as blueInfoColor,
+  global_default_color_200 as blueDefaultColor,
   global_disabled_color_100 as disabledColor,
+  global_info_color_100 as blueInfoColor,
+  global_success_color_200 as okColor,
+  global_warning_color_100 as warningColor,
 } from '@patternfly/react-tokens';
 
 export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
@@ -51,7 +52,7 @@ export const YellowResourcesAlmostFullIcon: React.FC<ColoredIconProps> = ({ clas
 );
 
 export const BlueArrowCircleUpIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <ArrowCircleUpIcon color={blueInfoColor.value} className={className} alt={alt} />
+  <ArrowCircleUpIcon color={blueDefaultColor.value} className={className} alt={alt} />
 );
 
 export type ColoredIconProps = {


### PR DESCRIPTION
Follow on to #5834 to correct the icon color.

<img width="1256" alt="Screen Shot 2020-06-26 at 1 17 58 PM" src="https://user-images.githubusercontent.com/895728/85884052-fe30eb00-b7af-11ea-8552-c832053938b3.png">
