### PR TITLE
Remove channel check from <ReleaseNotesLink>

### DIFF
--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -60,7 +60,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
               <TextListItem component="dt">OpenShift Version</TextListItem>
               <TextListItem component="dd">
                 <div className="co-select-to-copy">{openshiftVersion}</div>
-                <ReleaseNotesLink channel={channel} version={getCurrentVersion(clusterVersion)} />
+                <ReleaseNotesLink version={getCurrentVersion(clusterVersion)} />
               </TextListItem>
             </>
           )}

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -26,7 +26,6 @@ import {
   getAvailableClusterUpdates,
   getClusterID,
   getClusterUpdateStatus,
-  getClusterVersionChannel,
   getClusterVersionCondition,
   getCurrentVersion,
   getDesiredClusterVersion,
@@ -182,8 +181,8 @@ export const UpdateStatus: React.SFC<UpdateStatusProps> = ({ cv }) => {
   }
 };
 
-export const ReleaseNotesLink: React.FC<ReleaseNotesLinkProps> = ({ channel, version }) => {
-  const releaseNotesLink = getReleaseNotesLink(channel, version);
+export const ReleaseNotesLink: React.FC<ReleaseNotesLinkProps> = ({ version }) => {
+  const releaseNotesLink = getReleaseNotesLink(version);
   return releaseNotesLink && <ExternalLink text="View release notes" href={releaseNotesLink} />;
 };
 
@@ -191,7 +190,6 @@ export const CurrentVersion: React.SFC<CurrentVersionProps> = ({ cv }) => {
   const desiredVersion = getDesiredClusterVersion(cv);
   const lastVersion = getLastCompletedUpdate(cv);
   const status = getClusterUpdateStatus(cv);
-  const channel = getClusterVersionChannel(cv);
 
   if (status === ClusterUpdateStatus.UpToDate || status === ClusterUpdateStatus.UpdatesAvailable) {
     return desiredVersion ? (
@@ -201,7 +199,7 @@ export const CurrentVersion: React.SFC<CurrentVersionProps> = ({ cv }) => {
             {desiredVersion}
           </span>
         </div>
-        <ReleaseNotesLink channel={channel} version={getCurrentVersion(cv)} />
+        <ReleaseNotesLink version={getCurrentVersion(cv)} />
       </>
     ) : (
       <>
@@ -218,7 +216,7 @@ export const CurrentVersion: React.SFC<CurrentVersionProps> = ({ cv }) => {
           {lastVersion}
         </span>
       </div>
-      <ReleaseNotesLink channel={channel} version={getLastCompletedUpdate(cv)} />
+      <ReleaseNotesLink version={getLastCompletedUpdate(cv)} />
     </>
   ) : (
     <>None</>
@@ -333,13 +331,13 @@ const ChannelVersion: React.FC<ChannelVersionProps> = ({ children, current }) =>
   );
 };
 
-const ChannelVersionDot: React.FC<ChannelVersionDotProps> = ({ channel, current, version }) => {
-  const releaseNotesLink = getReleaseNotesLink(channel, version);
+const ChannelVersionDot: React.FC<ChannelVersionDotProps> = ({ current, version }) => {
+  const releaseNotesLink = getReleaseNotesLink(version);
 
   return releaseNotesLink ? (
     <Popover
       headerContent={<>Version {version}</>}
-      bodyContent={<ReleaseNotesLink channel={channel} version={version} />}
+      bodyContent={<ReleaseNotesLink version={version} />}
     >
       <Button
         variant="secondary"
@@ -445,8 +443,7 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
   const desiredImage: string = _.get(cv, 'status.desired.image') || '';
   // Split image on `@` to emphasize the digest.
   const imageParts = desiredImage.split('@');
-  const channel = getClusterVersionChannel(cv);
-  const releaseNotes = showReleaseNotes(channel);
+  const releaseNotes = showReleaseNotes();
 
   return (
     <>
@@ -579,7 +576,7 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
                     </td>
                     {releaseNotes && (
                       <td className="hidden-xs hidden-sm">
-                        <ReleaseNotesLink channel={channel} version={update.version} />
+                        <ReleaseNotesLink version={update.version} />
                       </td>
                     )}
                   </tr>
@@ -644,7 +641,6 @@ type UpdateStatusProps = {
 };
 
 type ReleaseNotesLinkProps = {
-  channel: string;
   version: string;
 };
 

--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import { ActionGroup, Button } from '@patternfly/react-core';
 
-import {
-  ClusterVersionKind,
-  getClusterVersionChannel,
-  getSortedUpdates,
-  showReleaseNotes,
-} from '../../module/k8s';
+import { ClusterVersionKind, getSortedUpdates, showReleaseNotes } from '../../module/k8s';
 import {
   ModalBody,
   ModalComponentProps,
@@ -19,8 +14,7 @@ import { ReleaseNotesLink } from '../cluster-settings/cluster-settings';
 export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = ({ cancel, cv }) => {
   const availableUpdates = getSortedUpdates(cv);
   const moreAvailableUpdates = availableUpdates.slice(1).reverse();
-  const channel = getClusterVersionChannel(cv);
-  const releaseNotes = showReleaseNotes(channel);
+  const releaseNotes = showReleaseNotes();
 
   return (
     <div className="modal-content">
@@ -40,7 +34,7 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
                   <td>{update.version}</td>
                   {releaseNotes && (
                     <td>
-                      <ReleaseNotesLink channel={channel} version={update.version} />
+                      <ReleaseNotesLink version={update.version} />
                     </td>
                   )}
                 </tr>

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -181,16 +181,13 @@ Browser: ${window.navigator.userAgent}
       };
 };
 
-export const showReleaseNotes = (channel: string): boolean => {
-  return (
-    window.SERVER_FLAGS.branding === 'ocp' &&
-    (channel?.startsWith('fast-') || channel?.startsWith('stable-'))
-  );
+export const showReleaseNotes = (): boolean => {
+  return window.SERVER_FLAGS.branding === 'ocp';
 };
 
 // example link: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-4
-export const getReleaseNotesLink = (channel: string, version: string): string => {
-  if (!showReleaseNotes(channel)) {
+export const getReleaseNotesLink = (version: string): string => {
+  if (!showReleaseNotes()) {
     return null;
   }
 


### PR DESCRIPTION
Note this change means releases to the `candidate` channel that have not or will not make it to the `fast` or `stable` channels will have links with invalid link anchors (e.g., https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-24).  The link will still go to the correct release notes page, it just won't jump to the correct anchor if it doesn't exist.