### PR TITLE
Extension for customized components for provisioner

### DIFF
--- a/frontend/__tests__/components/storage-class-form.spec.tsx
+++ b/frontend/__tests__/components/storage-class-form.spec.tsx
@@ -3,24 +3,41 @@ import { ShallowWrapper, shallow } from 'enzyme';
 import Spy = jasmine.Spy;
 
 import {
+  StorageClassProvisioner,
+  ExtensionSCProvisionerProp,
+} from '@console/plugin-sdk/src/typings/storage-class-params';
+
+import {
   ConnectedStorageClassForm,
   StorageClassFormProps,
   StorageClassFormState,
+  StorageClassParamsExtensions,
 } from '../../public/components/storage-class-form';
 
 describe(ConnectedStorageClassForm.displayName, () => {
-  const Component: React.ComponentType<StorageClassFormProps> = ConnectedStorageClassForm.WrappedComponent as any;
+  const Component: React.ComponentType<StorageClassFormProps &
+    StorageClassParamsExtensions> = ConnectedStorageClassForm.WrappedComponent as any;
   let wrapper: ShallowWrapper<StorageClassFormProps, StorageClassFormState>;
   let onClose: Spy;
   let watchK8sList: Spy;
   let stopK8sWatch: Spy;
   let k8s: Spy;
+  let params: StorageClassProvisioner[];
+  let extensionFunction: ExtensionSCProvisionerProp;
 
   beforeEach(() => {
     onClose = jasmine.createSpy('onClose');
     watchK8sList = jasmine.createSpy('watchK8sList');
     stopK8sWatch = jasmine.createSpy('stopK8sWatch');
     k8s = jasmine.createSpy('k8s');
+    params = [
+      {
+        type: 'StorageClass/Provisioner',
+        properties: {
+          getStorageClassProvisioner: extensionFunction,
+        },
+      },
+    ];
 
     wrapper = shallow(
       <Component
@@ -28,6 +45,7 @@ describe(ConnectedStorageClassForm.displayName, () => {
         watchK8sList={watchK8sList}
         stopK8sWatch={stopK8sWatch}
         k8s={k8s}
+        params={params}
       />,
     );
   });

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Dropdown, DropdownItem, DropdownToggle, Alert } from '@patternfly/react-core';
+import { CaretDownIcon } from '@patternfly/react-icons';
+
+import { ProvisionerProps } from '@console/plugin-sdk';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+
+import { cephBlockPoolResource } from '../constants/resources';
+
+export const PoolResourceComponent: React.FC<ProvisionerProps> = ({ onParamChange }) => {
+  const [poolData, poolDataLoaded, poolDataLoadError] = useK8sWatchResource<K8sResourceKind[]>(
+    cephBlockPoolResource,
+  );
+  const [isOpen, setOpen] = React.useState<boolean>(false);
+  const [poolName, setPoolName] = React.useState<string>(null);
+
+  const handleDropdownChange = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const name = e.currentTarget.id;
+    setPoolName(name);
+    onParamChange(name);
+  };
+
+  const poolDropdownItems = poolData?.map((pool) => (
+    <DropdownItem
+      key={pool.metadata.uid}
+      component="button"
+      id={pool?.metadata?.name}
+      onClick={handleDropdownChange}
+    >
+      {pool?.metadata?.name}
+    </DropdownItem>
+  ));
+
+  return (
+    <>
+      {!poolDataLoadError && (
+        <div className="form-group">
+          <label className="co-required" htmlFor="ocs-storage-pool">
+            Pool
+          </label>
+          <Dropdown
+            title="Select Pool"
+            className="dropdown dropdown--full-width"
+            toggle={
+              <DropdownToggle
+                id="toggle-id"
+                onToggle={() => setOpen(!isOpen)}
+                toggleIndicator={CaretDownIcon}
+              >
+                {poolName || 'Select a Pool'}
+              </DropdownToggle>
+            }
+            isOpen={isOpen}
+            dropdownItems={poolDropdownItems}
+            onSelect={() => setOpen(false)}
+            id="ocs-storage-pool"
+          />
+          <span className="help-block">Ceph pool into which volume data shall be stored</span>
+        </div>
+      )}
+      {poolDataLoaded && poolDataLoadError && (
+        <Alert className="co-alert" variant="danger" title="Error retrieving Pools" isInline />
+      )}
+    </>
+  );
+};

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -5,7 +5,7 @@ import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-h
 import { SubscriptionModel } from '@console/operator-lifecycle-manager';
 import { LocalVolumeSetModel } from '@console/local-storage-operator-plugin/src/models';
 import { LSO_NAMESPACE } from '@console/local-storage-operator-plugin/src/constants';
-import { CephClusterModel } from '../models';
+import { CephClusterModel, CephBlockPoolModel } from '../models';
 
 export const cephClusterResource: FirehoseResource = {
   kind: referenceForModel(CephClusterModel),
@@ -37,4 +37,10 @@ export const LSOSubscriptionResource: WatchK8sResource = {
   namespace: LSO_NAMESPACE,
   isList: false,
   name: 'local-storage-operator',
+};
+
+export const cephBlockPoolResource: WatchK8sResource = {
+  kind: referenceForModel(CephBlockPoolModel),
+  namespaced: true,
+  isList: true,
 };

--- a/frontend/packages/ceph-storage-plugin/src/models.ts
+++ b/frontend/packages/ceph-storage-plugin/src/models.ts
@@ -38,3 +38,16 @@ export const VolumeSnapshotModel: K8sKind = {
   labelPlural: 'Volume Snapshots',
   crd: true,
 };
+
+export const CephBlockPoolModel: K8sKind = {
+  label: 'Ceph Block Pool',
+  labelPlural: 'Ceph Block Pools',
+  apiVersion: 'v1',
+  apiGroup: 'ceph.rook.io',
+  plural: 'cephblockpools',
+  abbr: 'CBP',
+  namespaced: true,
+  kind: 'CephBlockPool',
+  id: 'cephblockpools',
+  crd: true,
+};

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -31,6 +31,8 @@ import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { getCephHealthState } from './components/dashboard-page/storage-dashboard/status-card/utils';
 import { isClusterExpandActivity } from './components/dashboard-page/storage-dashboard/activity-card/cluster-expand-activity';
 import { WatchCephResource } from './types';
+import { StorageClassProvisioner } from '@console/plugin-sdk/src/typings/storage-class-params';
+import { StorageClassFormProvisoners } from './utils/storage-class-params';
 
 type ConsumedExtensions =
   | ModelFeatureFlag
@@ -47,7 +49,8 @@ type ConsumedExtensions =
   | ResourceTabPage
   | ClusterServiceVersionAction
   | KebabActions
-  | DashboardsOverviewResourceActivity;
+  | DashboardsOverviewResourceActivity
+  | StorageClassProvisioner;
 
 const apiObjectRef = referenceForModel(models.OCSServiceModel);
 
@@ -75,6 +78,12 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'FeatureFlag/Custom',
     properties: {
       detect: detectOCS,
+    },
+  },
+  {
+    type: 'StorageClass/Provisioner',
+    properties: {
+      getStorageClassProvisioner: StorageClassFormProvisoners,
     },
   },
   {

--- a/frontend/packages/ceph-storage-plugin/src/utils/storage-class-params.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/storage-class-params.tsx
@@ -1,0 +1,109 @@
+import { ExtensionSCProvisionerProp } from '@console/plugin-sdk';
+import { PoolResourceComponent } from '../components/ocs-storage-class-form';
+import { CEPH_STORAGE_NAMESPACE } from '../constants';
+
+export const StorageClassFormProvisoners: ExtensionSCProvisionerProp = Object.freeze({
+  csi: {
+    'openshift-storage.rbd.csi.ceph.com': {
+      title: 'Ceph RBD',
+      provisioner: 'rbd.csi.ceph.com',
+      parameters: {
+        clusterID: {
+          name: 'Cluster ID',
+          hintText: 'The namespace where Ceph is deployed',
+          value: CEPH_STORAGE_NAMESPACE,
+          visible: () => false,
+        },
+        pool: {
+          name: 'Pool',
+          hintText: 'Ceph pool into which volume data shall be stored',
+          required: true,
+          Component: PoolResourceComponent,
+        },
+        imageFormat: {
+          name: 'Image Format',
+          hintText: 'RBD image format. Defaults to "2"',
+          value: '2',
+          visible: () => false,
+        },
+        imageFeatures: {
+          name: 'Image Features',
+          hintText: 'Ceph RBD image features',
+          value: 'layering',
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/provisioner-secret-name': {
+          name: 'Provisioner Secret Name',
+          hintText: 'The name of provisioner secret',
+          value: 'rook-csi-rbd-provisioner',
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/provisioner-secret-namespace': {
+          name: 'Provisioner Secret Namespace',
+          hintText: 'The namespace where provisioner secret is created',
+          value: CEPH_STORAGE_NAMESPACE,
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/node-stage-secret-name': {
+          name: 'Node Stage Secret Name',
+          hintText: 'The name of Node Stage secret',
+          value: 'rook-csi-rbd-node',
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/node-stage-secret-namespace': {
+          name: 'Node Stage Secret Namespace',
+          hintText: 'The namespace where provisioner secret is created',
+          value: CEPH_STORAGE_NAMESPACE,
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/fstype': {
+          name: 'Filesystem Type',
+          hintText: 'Ceph RBD filesystem type. Default set to ext4',
+          value: 'ext4',
+          visible: () => false,
+        },
+      },
+    },
+    'openshift-storage.cephfs.csi.ceph.com': {
+      title: 'Ceph FS',
+      provisioner: 'cephfs.csi.ceph.com',
+      parameters: {
+        clusterID: {
+          name: 'Cluster ID',
+          hintText: 'The namespace where Ceph is deployed',
+          value: CEPH_STORAGE_NAMESPACE,
+          visible: () => false,
+        },
+        fsName: {
+          name: 'Filesystem Name',
+          hintText: 'CephFS filesystem name into which the volume shall be created',
+          required: true,
+        },
+        'csi.storage.k8s.io/provisioner-secret-name': {
+          name: 'Provisioner Secret Name',
+          hintText: 'The name of provisioner secret',
+          value: 'rook-csi-cephfs-provisioner',
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/provisioner-secret-namespace': {
+          name: 'Provisioner Secret Namespace',
+          hintText: 'The namespace where provisioner secret is created',
+          value: CEPH_STORAGE_NAMESPACE,
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/node-stage-secret-name': {
+          name: 'Node Stage Secret Name',
+          hintText: 'The name of Node Stage secret',
+          value: 'rook-csi-cephfs-node',
+          visible: () => false,
+        },
+        'csi.storage.k8s.io/node-stage-secret-namespace': {
+          name: 'Node Stage Secret Namespace',
+          hintText: 'The namespace where provisioner secret is created',
+          value: CEPH_STORAGE_NAMESPACE,
+          visible: () => false,
+        },
+      },
+    },
+  },
+});

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -17,3 +17,4 @@ export * from './reducers';
 export * from './horizontal-nav';
 export * from './providers';
 export * from './pvc';
+export * from './storage-class-params';

--- a/frontend/packages/console-plugin-sdk/src/typings/storage-class-params.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/storage-class-params.ts
@@ -1,0 +1,39 @@
+import { Extension } from '@console/plugin-sdk';
+
+namespace ExtensionProperties {
+  export interface StorageClassProvisioner {
+    getStorageClassProvisioner: ExtensionSCProvisionerProp;
+  }
+}
+
+export interface StorageClassProvisioner
+  extends Extension<ExtensionProperties.StorageClassProvisioner> {
+  type: 'StorageClass/Provisioner';
+}
+
+export const isStorageClassProvisioner = (e: Extension): e is StorageClassProvisioner => {
+  return e.type === 'StorageClass/Provisioner';
+};
+
+export type ProvisionerProps = {
+  onParamChange: (id: string) => void;
+};
+
+export type ExtensionSCProvisionerProp = {
+  [key: string]: {
+    [key: string]: {
+      title: string;
+      provisioner: string;
+      parameters: {
+        [key: string]: {
+          name: string;
+          hintText: string;
+          value?: string;
+          visible?: () => boolean;
+          required?: boolean;
+          Component?: React.ComponentType<ProvisionerProps>;
+        };
+      };
+    };
+  };
+};


### PR DESCRIPTION
Helps to add customized components for provisoners in storage class creation form.

- Adds extension `getStorageClassProvisioner` to fetch provisioners defined in different operators
- Provides a way to add custom components for Provisioners
- Introduces an attribute `value` for parameters, which help to take default values of provisioner's parameter

![Screenshot from 2020-07-01 02-59-27](https://user-images.githubusercontent.com/12200504/86178938-ef975a80-bb46-11ea-8103-44c2de892ea0.png)

Thanks @rawagner 
cc @rawagner @cloudbehl @bipuladh 