### PR TITLE
Output `-` in empty release notes table cells

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -576,7 +576,11 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
                     </td>
                     {releaseNotes && (
                       <td className="hidden-xs hidden-sm">
-                        <ReleaseNotesLink version={update.version} />
+                        {getReleaseNotesLink(update.version) ? (
+                          <ReleaseNotesLink version={update.version} />
+                        ) : (
+                          '-'
+                        )}
                       </td>
                     )}
                   </tr>

--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { ActionGroup, Button } from '@patternfly/react-core';
 
-import { ClusterVersionKind, getSortedUpdates, showReleaseNotes } from '../../module/k8s';
+import {
+  ClusterVersionKind,
+  getReleaseNotesLink,
+  getSortedUpdates,
+  showReleaseNotes,
+} from '../../module/k8s';
 import {
   ModalBody,
   ModalComponentProps,
@@ -34,7 +39,11 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
                   <td>{update.version}</td>
                   {releaseNotes && (
                     <td>
-                      <ReleaseNotesLink version={update.version} />
+                      {getReleaseNotesLink(update.version) ? (
+                        <ReleaseNotesLink version={update.version} />
+                      ) : (
+                        '-'
+                      )}
                     </td>
                   )}
                 </tr>


### PR DESCRIPTION
...so that they are consistent with other empty table cells.

Before:
<img width="1399" alt="Screen Shot 2020-06-29 at 11 32 00 AM" src="https://user-images.githubusercontent.com/895728/86026375-514bad80-b9fd-11ea-8365-d03168dec91e.png">

After:
<img width="1407" alt="Screen Shot 2020-06-29 at 11 35 22 AM" src="https://user-images.githubusercontent.com/895728/86026383-56106180-b9fd-11ea-9399-e03111b51a18.png">
