### PR TITLE
adds capability for sources to sink to channel and broker along with ksvc

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
@@ -7,7 +7,7 @@ import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
 import { QUERY_PROPERTIES } from '@console/dev-console/src/const';
-import EventSource from './EventSource';
+import ConnectedEventSource from './EventSource';
 import { KnativeEventingModel } from '../../models';
 import EventSourceAlert from './EventSourceAlert';
 import { useEventSourceList } from '../../utils/create-eventsources-utils';
@@ -28,7 +28,7 @@ const EventSourcePage: React.FC<EventSourcePageProps> = ({ match, location }) =>
       </PageHeading>
       <PageBody flexLayout>
         <EventSourceAlert namespace={namespace} eventSourceStatus={eventSourceStatus} />
-        <EventSource
+        <ConnectedEventSource
           namespace={namespace}
           eventSourceStatus={eventSourceStatus}
           selectedApplication={searchParams.get(QUERY_PROPERTIES.APPLICATION)}

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Formik } from 'formik';
+import { EventSource } from '../EventSource';
+
+type EventSourceProps = React.ComponentProps<typeof EventSource>;
+describe('EventSourceSpec', () => {
+  let wrapper: ShallowWrapper<EventSourceProps>;
+  const namespaceName = 'myApp';
+  const activeApplicationName = 'appGroup';
+  const eventSourceStatusData = null;
+
+  it('should render form with proper initialvalues if contextSource is not passed', () => {
+    wrapper = shallow(
+      <EventSource
+        namespace={namespaceName}
+        eventSourceStatus={eventSourceStatusData}
+        activeApplication={activeApplicationName}
+      />,
+    );
+    const FormikField = wrapper.find(Formik);
+    expect(FormikField.exists()).toBe(true);
+    expect(FormikField.get(0).props.initialValues.project.name).toBe('myApp');
+    expect(FormikField.get(0).props.initialValues.sink).toEqual({
+      apiVersion: '',
+      kind: '',
+      name: '',
+    });
+  });
+
+  it('should render form with proper initialvalues for sink if contextSource is passed', () => {
+    const contextSourceData = 'serving.knative.dev~v1~Service/svc-display';
+    wrapper = shallow(
+      <EventSource
+        namespace={namespaceName}
+        eventSourceStatus={eventSourceStatusData}
+        contextSource={contextSourceData}
+        activeApplication={activeApplicationName}
+      />,
+    );
+    const FormikField = wrapper.find(Formik);
+    expect(FormikField.exists()).toBe(true);
+    expect(FormikField.get(0).props.initialValues.project.name).toBe('myApp');
+    expect(FormikField.get(0).props.initialValues.sink).toEqual({
+      apiVersion: 'serving.knative.dev/v1',
+      kind: 'Service',
+      name: 'svc-display',
+    });
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Alert } from '@patternfly/react-core';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import EventSourceAlert from '../EventSourceAlert';
 import { knativeServiceObj } from '../../../topology/__tests__/topology-knative-test-data';
 import { getKnativeEventSourceIcon } from '../../../utils/get-knative-icon';
 import { EventSourceContainerModel } from '../../../models';
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
-  useK8sWatchResource: jest.fn(),
+  useK8sWatchResources: jest.fn(),
 }));
 
 describe('EventSourceAlert', () => {
@@ -26,7 +26,9 @@ describe('EventSourceAlert', () => {
     },
   };
   it('should not display alert if service data not loaded and eventSources are there', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, false]);
+    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
+      ksservices: { loaded: false, data: [] },
+    });
     const wrapper = shallow(
       <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatusData} />,
     );
@@ -34,7 +36,9 @@ describe('EventSourceAlert', () => {
   });
 
   it('should display alert if service loaded with empty data and eventSources are there', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
+      ksservices: { loaded: true, data: [] },
+    });
     const wrapper = shallow(
       <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatusData} />,
     );
@@ -43,7 +47,9 @@ describe('EventSourceAlert', () => {
   });
 
   it('should not alert if service loaded with data and eventSources are there', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[knativeServiceObj], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
+      ksservices: { loaded: true, data: [knativeServiceObj] },
+    });
     const wrapper = shallow(
       <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatusData} />,
     );
@@ -51,7 +57,9 @@ describe('EventSourceAlert', () => {
   });
 
   it('should show alert if service loaded with data and eventSources is null', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[knativeServiceObj], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
+      ksservices: { loaded: true, data: [knativeServiceObj] },
+    });
     const wrapper = shallow(
       <EventSourceAlert namespace={namespaceName} eventSourceStatus={null} />,
     );
@@ -59,7 +67,9 @@ describe('EventSourceAlert', () => {
   });
 
   it('should show alert if service loaded with data and eventSources has loaded with no data', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[knativeServiceObj], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
+      ksservices: { loaded: true, data: [knativeServiceObj] },
+    });
     const eventSourceStatus = { loaded: true, eventSourceList: {} };
     const wrapper = shallow(
       <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatus} />,
@@ -68,7 +78,9 @@ describe('EventSourceAlert', () => {
   });
 
   it('should not alert if service loaded with data and eventSources has not loaded', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[knativeServiceObj], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
+      ksservices: { loaded: true, data: [knativeServiceObj] },
+    });
     const eventSourceStatus = { loaded: false, eventSourceList: {} };
     const wrapper = shallow(
       <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatus} />,

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
@@ -17,7 +17,11 @@ describe('Event Source ValidationUtils', () => {
     it('should throw an error for required fields if empty', async () => {
       const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
       const mockData = _.cloneDeep(defaultEventingData);
-      mockData.sink.knativeService = '';
+      mockData.sink = {
+        apiVersion: '',
+        name: '',
+        kind: '',
+      };
       await eventSourceValidationSchema
         .resolve({ value: mockData })
         .isValid(mockData)
@@ -42,7 +46,11 @@ describe('Event Source ValidationUtils', () => {
     it('should throw an error for required fields if empty', async () => {
       const defaultEventingData = getDefaultEventingData(EventSources.ApiServerSource);
       const mockData = _.cloneDeep(defaultEventingData);
-      mockData.sink.knativeService = '';
+      mockData.sink = {
+        apiVersion: '',
+        name: '',
+        kind: '',
+      };
       mockData.data.apiserversource.resources[0] = { apiVersion: '', kind: '' };
       await eventSourceValidationSchema
         .resolve({ value: mockData })

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
@@ -3,8 +3,14 @@ import * as fuzzy from 'fuzzysearch';
 import { useFormikContext, FormikValues } from 'formik';
 import { FormGroup } from '@patternfly/react-core';
 import { getFieldId, ResourceDropdownField } from '@console/shared';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
-import { knativeServingResourcesServices } from '../../../utils/get-knative-resources';
+import { EventingBrokerModel } from '../../../models';
+import {
+  knativeServingResourcesServices,
+  knativeEventingResourcesBroker,
+} from '../../../utils/get-knative-resources';
+import { getDynamicChannelResourceList } from '../../../utils/fetch-dynamic-eventsources-utils';
 
 interface SinkSectionProps {
   namespace: string;
@@ -17,36 +23,60 @@ const SinkSection: React.FC<SinkSectionProps> = ({ namespace }) => {
   const autocompleteFilter = (strText, item): boolean => fuzzy(strText, item?.props?.name);
   const fieldId = getFieldId('sink-name', 'dropdown');
   const onChange = React.useCallback(
-    (selectedValue) => {
-      if (selectedValue) {
-        setFieldTouched('sink.knativeService', true);
-        setFieldValue('sink.knativeService', selectedValue);
+    (selectedValue, valueObj) => {
+      const modelData = valueObj?.props?.model;
+      if (selectedValue && modelData) {
+        const { apiGroup, apiVersion, kind } = modelData;
+        setFieldValue('sink.name', selectedValue);
+        setFieldTouched('sink.name', true);
+        setFieldValue('sink.apiVersion', `${apiGroup}/${apiVersion}`);
+        setFieldTouched('sink.apiVersion', true);
+        setFieldValue('sink.kind', kind);
+        setFieldTouched('sink.kind', true);
         validateForm();
       }
     },
     [setFieldValue, setFieldTouched, validateForm],
   );
-  const contextAvailable = !!initialValues.sink.knativeService;
+  const contextAvailable = !!initialValues.sink.name;
+  const resourcesData = [
+    ...knativeServingResourcesServices(namespace),
+    ...getDynamicChannelResourceList(namespace),
+    ...knativeEventingResourcesBroker(namespace),
+  ];
+
+  // filter out channels backing brokers
+  const resourceFilter = (resource: K8sResourceKind) => {
+    const {
+      metadata: { ownerReferences },
+    } = resource;
+    return !ownerReferences?.length || ownerReferences[0].kind !== EventingBrokerModel.kind;
+  };
   return (
-    <FormSection title="Sink" extraMargin>
+    <FormSection
+      title="Sink"
+      subTitle="Add a sink to route this event source to a Channel, Broker or Knative service."
+      extraMargin
+    >
       <FormGroup
         fieldId={fieldId}
-        helperText={!contextAvailable ? 'Select a Service to sink to.' : ''}
+        helperText={!contextAvailable ? 'This resource will be the sink for the event source.' : ''}
         isRequired
       >
         <ResourceDropdownField
-          name="sink.knativeService"
-          label="Knative Service"
-          resources={knativeServingResourcesServices(namespace)}
+          name="sink.name"
+          label="Resource"
+          resources={resourcesData}
           dataSelector={['metadata', 'name']}
           fullWidth
           required
-          placeholder="Select Knative Service"
+          placeholder="Select resource"
           showBadge
           disabled={contextAvailable}
           onChange={onChange}
           autocompleteFilter={autocompleteFilter}
           autoSelect
+          resourceFilter={resourceFilter}
         />
       </FormGroup>
     </FormSection>

--- a/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
@@ -8,7 +8,7 @@ import { EventSources } from './import-types';
 import { isKnownEventSource } from '../../utils/create-eventsources-utils';
 
 const sinkServiceSchema = yup.object().shape({
-  knativeService: yup.string().required('Required'),
+  name: yup.string().required('Required'),
 });
 
 export const sourceDataSpecSchema = yup

--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -33,8 +33,10 @@ export interface EventSourceData {
   [x: string]: any;
 }
 
-export interface KnativeServiceName {
-  knativeService: string;
+export interface SinkResourceData {
+  apiVersion: string;
+  name: string;
+  kind: string;
 }
 
 export interface EventSourceFormData {
@@ -43,7 +45,7 @@ export interface EventSourceFormData {
   name: string;
   apiVersion: string;
   type: string;
-  sink: KnativeServiceName;
+  sink: SinkResourceData;
   limits: LimitsData;
   data?: EventSourceData;
   yamlData?: string;

--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -7,5 +7,6 @@ export const FLAG_KNATIVE_SERVING_SERVICE = 'KNATIVE_SERVING_SERVICE';
 export const KNATIVE_SERVING_LABEL = 'serving.knative.dev/service';
 export const KNATIVE_SERVING_APIGROUP = 'serving.knative.dev';
 export const KNATIVE_EVENT_MESSAGE_APIGROUP = 'messaging.knative.dev';
+export const KNATIVE_EVENT_EVENTING_APIGROUP = 'eventing.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP_DEP = 'sources.eventing.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP = 'sources.knative.dev';

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -9,6 +9,7 @@ import {
   KNATIVE_EVENT_SOURCE_APIGROUP_DEP,
   KNATIVE_SERVING_APIGROUP,
   KNATIVE_EVENT_MESSAGE_APIGROUP,
+  KNATIVE_EVENT_EVENTING_APIGROUP,
 } from './const';
 
 const apiVersion = 'v1';
@@ -233,6 +234,20 @@ export const EventingChannelModel: K8sKind = {
   plural: 'channels',
   id: 'channel',
   abbr: 'C',
+  namespaced: true,
+  crd: true,
+  color: knativeEventingColor.value,
+};
+
+export const EventingBrokerModel: K8sKind = {
+  apiGroup: KNATIVE_EVENT_EVENTING_APIGROUP,
+  apiVersion: 'v1beta1',
+  kind: 'Broker',
+  label: 'Broker',
+  labelPlural: 'brokers',
+  plural: 'brokers',
+  id: 'broker',
+  abbr: 'B',
   namespaced: true,
   crd: true,
   color: knativeEventingColor.value,

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -423,28 +423,29 @@ export const getSubscriptionTopologyEdgeItems = (
   const { eventingsubscription, ksservices } = resources;
   const edges = [];
   _.forEach(eventingsubscription?.data, (subRes) => {
-    const channelData = _.get(subRes, ['spec', 'channel']);
+    const channelData = subRes.spec?.channel;
     if (name === channelData?.name && ksservices) {
-      const svcData = _.get(subRes, ['spec', 'subscriber', 'ref']);
-      _.forEach(ksservices?.data, (res) => {
-        const {
-          metadata: { uid: resUid, name: resName },
-        } = res;
-        if (resName === svcData.name) {
-          edges.push({
-            id: `${uid}_${resUid}`,
-            type: EdgeType.EventPubSubLink,
-            source: uid,
-            target: resUid,
-            data: {
-              resources: {
-                obj: subRes,
-                connections: [resource, res],
+      const svcData = subRes.spec?.subscriber?.ref;
+      svcData &&
+        _.forEach(ksservices?.data, (res) => {
+          const {
+            metadata: { uid: resUid, name: resName },
+          } = res;
+          if (resName === svcData.name) {
+            edges.push({
+              id: `${uid}_${resUid}`,
+              type: EdgeType.EventPubSubLink,
+              source: uid,
+              target: resUid,
+              data: {
+                resources: {
+                  obj: subRes,
+                  connections: [resource, res],
+                },
               },
-            },
-          });
-        }
-      });
+            });
+          }
+        });
     }
   });
   return edges;

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -4,7 +4,7 @@ import {
   Resources,
 } from '@console/dev-console/src/components/import/import-types';
 import { EventSourceFormData } from '../../components/add/import-types';
-import { RevisionModel } from '../../models';
+import { RevisionModel, ServiceModel } from '../../models';
 import { healthChecksProbeInitialData } from '@console/dev-console/src/components/health-checks/health-checks-probe-utils';
 
 export const defaultData: DeployImageFormData = {
@@ -334,7 +334,9 @@ export const getDefaultEventingData = (typeEventSource: string): EventSourceForm
     },
     name: 'esmyapp',
     sink: {
-      knativeService: 'event-display',
+      apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+      name: 'event-display',
+      kind: ServiceModel.kind,
     },
     limits: {
       cpu: {

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -13,7 +13,6 @@ import {
   EventSourceFormData,
   EventSourceListData,
 } from '../components/add/import-types';
-import { ServiceModel } from '../models';
 import { getKnativeEventSourceIcon } from './get-knative-icon';
 import { useEventSourceModels } from './fetch-dynamic-eventsources-utils';
 
@@ -28,11 +27,12 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
     application: { name: applicationName },
     project: { name: namespace },
     data,
-    sink: { knativeService },
+    sink,
   } = formData;
 
   const defaultLabel = getAppLabels(name, applicationName);
   const eventSrcData = data[type.toLowerCase()];
+  const { name: sinkName, kind: sinkKind, apiVersion: sinkApiVersion } = sink;
   const eventSourceResource: K8sResourceKind = {
     kind: type,
     apiVersion,
@@ -45,13 +45,17 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
       annotations: getCommonAnnotations(),
     },
     spec: {
-      sink: {
-        ref: {
-          apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
-          kind: ServiceModel.kind,
-          name: knativeService,
-        },
-      },
+      ...(sinkName &&
+        sinkApiVersion &&
+        sinkKind && {
+          sink: {
+            ref: {
+              apiVersion: sinkApiVersion,
+              kind: sinkKind,
+              name: sinkName,
+            },
+          },
+        }),
       ...(eventSrcData && eventSrcData),
     },
   };

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -9,6 +9,7 @@ import {
   ConfigurationModel,
   RouteModel,
   EventingSubscriptionModel,
+  EventingBrokerModel,
 } from '../models';
 
 export type KnativeItem = {
@@ -137,6 +138,19 @@ export const knativeEventingResourcesSubscription = (namespace: string): Firehos
   return knativeResource;
 };
 
+export const knativeEventingResourcesBroker = (namespace: string): FirehoseResource[] => {
+  const knativeResource = [
+    {
+      isList: true,
+      kind: referenceForModel(EventingBrokerModel),
+      namespace,
+      prop: 'eventingbroker',
+      optional: true,
+    },
+  ];
+  return knativeResource;
+};
+
 export const knativeServingResourcesRevisionWatchers = (
   namespace: string,
 ): WatchK8sResources<any> => {
@@ -200,6 +214,20 @@ export const knativeEventingResourcesSubscriptionWatchers = (
     eventingsubscription: {
       isList: true,
       kind: referenceForModel(EventingSubscriptionModel),
+      namespace,
+      optional: true,
+    },
+  };
+  return knativeResource;
+};
+
+export const knativeEventingResourcesBrokerWatchers = (
+  namespace: string,
+): WatchK8sResources<any> => {
+  const knativeResource = {
+    eventingbroker: {
+      isList: true,
+      kind: referenceForModel(EventingBrokerModel),
       namespace,
       optional: true,
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4166

**Analysis / Root cause**: 
User is unable to sink a source to broker and channels along with ksvc

**Solution Description**: 
- Show Brokers / Channels as part of resource dropdown along with ksvc for sink
- Creation of source with sink to any of above
- Handle error state for user if in `ns` none of the above resources is present
- Filter out channels backing broker

**Screen shots / Gifs for design review**: 
- Ability to sink to Channel/Broker/ksvc
![image](https://user-images.githubusercontent.com/5129024/86032359-dc0bc700-ba54-11ea-928f-ff79ecf96bc1.png)

- Visualisation post sink to channel
![image](https://user-images.githubusercontent.com/5129024/86205148-cbf40480-bb86-11ea-843b-0ab6bc2ca44b.png)


- Error message if none of Channel/Broker/ksvc exists in a namespace
![image](https://user-images.githubusercontent.com/5129024/86204953-66a01380-bb86-11ea-98b0-18e7a7046656.png)

**Note**: Discuss with UXD as IMO this specific error message will not be needed once sink uri support comes in

@openshift/team-devconsole-ux @rachael-phillips 


**Test Coverage**
![image](https://user-images.githubusercontent.com/5129024/86218925-16817b00-bb9f-11ea-82ea-b10336cc91d9.png)


**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
