### PR TITLE
 Add FormHeader and update helm form title to be reactive

### DIFF
--- a/frontend/packages/console-shared/src/components/form-utils/FormHeader.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormHeader.tsx
@@ -1,21 +1,31 @@
 import * as React from 'react';
 import { Title, FormHelperText } from '@patternfly/react-core';
 
+type SpacerSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
+
 type FormHeaderProps = {
   title: React.ReactNode;
   helpText?: React.ReactNode;
-  flexLayout?: boolean;
+  marginTop?: SpacerSize;
+  marginBottom?: SpacerSize;
 };
 
-const FormHeader: React.FC<FormHeaderProps> = ({ title, helpText, flexLayout }) => (
-  <div style={flexLayout ? { marginBottom: 'var(--pf-global--spacer--lg)' } : {}}>
-    <Title headingLevel="h1" size="2xl">
-      {title}
-    </Title>
-    <FormHelperText isHidden={false} style={{ marginTop: 'var(--pf-global--spacer--xs)' }}>
-      {helpText}
-    </FormHelperText>
-  </div>
-);
+const FormHeader: React.FC<FormHeaderProps> = ({ title, helpText, marginTop, marginBottom }) => {
+  const marginStyles = {
+    ...(marginTop ? { marginTop: `var(--pf-global--spacer--${marginTop})` } : {}),
+    ...(marginBottom ? { marginBottom: `var(--pf-global--spacer--${marginBottom})` } : {}),
+  };
+
+  return (
+    <div style={marginStyles}>
+      <Title headingLevel="h1" size="2xl">
+        {title}
+      </Title>
+      <FormHelperText isHidden={false} style={{ marginTop: 'var(--pf-global--spacer--xs)' }}>
+        {helpText}
+      </FormHelperText>
+    </div>
+  );
+};
 
 export default FormHeader;

--- a/frontend/packages/console-shared/src/components/form-utils/FormHeader.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormHeader.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { Title, FormHelperText } from '@patternfly/react-core';
+
+type FormHeaderProps = {
+  title: React.ReactNode;
+  helpText?: React.ReactNode;
+  flexLayout?: boolean;
+};
+
+const FormHeader: React.FC<FormHeaderProps> = ({ title, helpText, flexLayout }) => (
+  <div style={flexLayout ? { marginBottom: 'var(--pf-global--spacer--lg)' } : {}}>
+    <Title headingLevel="h1" size="2xl">
+      {title}
+    </Title>
+    <FormHelperText isHidden={false} style={{ marginTop: 'var(--pf-global--spacer--xs)' }}>
+      {helpText}
+    </FormHelperText>
+  </div>
+);
+
+export default FormHeader;

--- a/frontend/packages/console-shared/src/components/form-utils/index.ts
+++ b/frontend/packages/console-shared/src/components/form-utils/index.ts
@@ -1,4 +1,5 @@
 export { default as FormFooter } from './FormFooter';
+export { default as FormHeader } from './FormHeader';
 export { default as PageBody } from './PageBody';
 export { default as FlexForm } from './FlexForm';
 export { default as ActionGroupWithIcons } from './ActionGroupWithIcons';

--- a/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { FormProps } from 'react-jsonschema-form';
 import { useField, useFormikContext, FormikValues } from 'formik';
-import { Grid, GridItem } from '@patternfly/react-core';
 import { AsyncComponent } from '@console/internal/components/utils';
 
 type DynamicFormFieldProps = FormProps<any> & {
@@ -22,8 +21,11 @@ const DynamicFormField: React.FC<DynamicFormFieldProps> = ({
   const { setFieldValue } = useFormikContext<FormikValues>();
 
   return (
-    <Grid gutter="md">
-      <GridItem xl={6} lg={6} md={12} sm={12}>
+    <div className="row">
+      <div className="col-sm-12 col-md-4 col-md-push-8 col-lg-5 col-lg-push-7">
+        {formDescription}
+      </div>
+      <div className="col-sm-12 col-md-8 col-md-pull-4 col-lg-7 col-lg-pull-5">
         <AsyncComponent
           loader={() => import('../dynamic-form').then((c) => c.DynamicForm)}
           errors={errors}
@@ -37,11 +39,8 @@ const DynamicFormField: React.FC<DynamicFormFieldProps> = ({
           noActions
           liveValidate
         />
-      </GridItem>
-      <GridItem xl={6} lg={6} md={12} sm={12}>
-        {formDescription}
-      </GridItem>
-    </Grid>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useField, useFormikContext, FormikValues } from 'formik';
-import { Alert, Button } from '@patternfly/react-core';
+import { Alert, Button, AlertActionCloseButton } from '@patternfly/react-core';
 import { EditorType } from '../synced-editor/editor-toggle';
 import RadioGroupField from './RadioGroupField';
 
@@ -32,6 +32,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
   const yamlData = _.get(values, yamlContext.name);
 
   const [yamlWarning, setYAMLWarning] = React.useState<boolean>(false);
+  const [disabledFormAlert, setDisabledFormAlert] = React.useState<boolean>(formContext.isDisabled);
 
   const changeEditorType = (newType: EditorType): void => {
     setFieldValue(name, newType);
@@ -75,6 +76,10 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
     }
   };
 
+  React.useEffect(() => {
+    setDisabledFormAlert(formContext.isDisabled);
+  }, [formContext.isDisabled]);
+
   return (
     <>
       <div className="ocs-synced-editor-field__editor-toggle">
@@ -114,10 +119,11 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
           </Button>
         </Alert>
       )}
-      {formContext.isDisabled && (
+      {disabledFormAlert && (
         <Alert
           variant="default"
           title="Form view is disabled for this chart because the schema is not available"
+          action={<AlertActionCloseButton onClose={() => setDisabledFormAlert(false)} />}
           isInline
         />
       )}

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
@@ -4,7 +4,7 @@ import { Formik } from 'formik';
 import { RouteComponentProps } from 'react-router';
 import { PageBody } from '@console/shared';
 import { coFetchJSON } from '@console/internal/co-fetch';
-import { PageHeading, history, getQueryArgument } from '@console/internal/components/utils';
+import { history, getQueryArgument } from '@console/internal/components/utils';
 
 import { HelmRelease, HelmActionType, HelmActionOrigins } from './helm-types';
 import { getHelmActionConfig } from './helm-utils';
@@ -79,12 +79,16 @@ const HelmReleaseRollbackPage: React.FC<HelmReleaseRollbackPageProps> = ({ match
       <Helmet>
         <title>{config.title}</title>
       </Helmet>
-      <PageHeading title={config.title}>
-        Select the version to rollback <strong>{releaseName}</strong> to, from the table below:
-      </PageHeading>
       <PageBody>
         <Formik initialValues={initialValues} onSubmit={handleSubmit} onReset={history.goBack}>
-          {(props) => <HelmReleaseRollbackForm {...props} releaseHistory={releaseHistory} />}
+          {(props) => (
+            <HelmReleaseRollbackForm
+              {...props}
+              releaseName={releaseName}
+              releaseHistory={releaseHistory}
+              helmActionConfig={config}
+            />
+          )}
         </Formik>
       </PageBody>
     </NamespacedPage>

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
@@ -7,7 +7,7 @@ import {
   getChartURL,
   getChartVersions,
   flattenReleaseResources,
-  getHelmChartReadme,
+  getChartReadme,
 } from '../helm-utils';
 import { HelmReleaseStatus } from '../helm-types';
 import {
@@ -121,6 +121,6 @@ describe('Helm Releases Utils', () => {
   });
 
   it('should return the readme for the chart provided', () => {
-    expect(getHelmChartReadme(mockHelmReleases[0].chart)).toEqual('example readme content');
+    expect(getChartReadme(mockHelmReleases[0].chart)).toEqual('example readme content');
   });
 });

--- a/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { safeLoad } from 'js-yaml';
 import { FormikValues, useFormikContext } from 'formik';
 import { GridItem } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { coFetchJSON, coFetch } from '@console/internal/co-fetch';
 import { DropdownField } from '@console/shared';
 import { confirmModal } from '@console/internal/components/modals/confirm-modal';
@@ -46,15 +47,19 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
       title: 'Change Chart Version?',
       message: (
         <>
-          Are you sure you want to change the chart version from <strong>{currentVersion}</strong>{' '}
-          to <strong>{newVersion}</strong>? <br />
-          You have data entered for version <strong>{currentVersion}</strong> in the YAML editor.
-          All data entered will be lost when changed to <strong>{newVersion}</strong>.
+          <p>
+            Are you sure you want to change the chart version from <strong>{currentVersion}</strong>{' '}
+            to <strong>{newVersion}</strong>?{' '}
+          </p>
+          <p>
+            <InfoCircleIcon color="var(--pf-global--info-color--100)" /> All data entered for
+            version <strong>{currentVersion}</strong> will be reset.
+          </p>
         </>
       ),
-      submitDanger: true,
-      btnText: 'Yes',
-      cancelText: 'No',
+      submitDanger: false,
+      btnText: 'Proceed',
+      cancelText: 'Cancel',
       executeFn: () => {
         onAccept();
         return Promise.resolve();

--- a/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
@@ -11,7 +11,13 @@ import { k8sVersion } from '@console/internal/module/status';
 import { getK8sGitVersion } from '@console/internal/module/k8s';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { HelmChartMetaData, HelmChart, HelmActionType, HelmChartEntries } from '../helm-types';
-import { getChartURL, getChartVersions, getChartValuesYAML, concatVersions } from '../helm-utils';
+import {
+  getChartURL,
+  getChartVersions,
+  getChartValuesYAML,
+  getChartReadme,
+  concatVersions,
+} from '../helm-utils';
 
 export type HelmChartVersionDropdownProps = {
   chartVersion: string;
@@ -116,15 +122,16 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
       .then((res: HelmChart) => {
         onVersionChange(res);
 
+        const chartReadme = getChartReadme(res);
         const valuesYAML = getChartValuesYAML(res);
         const valuesJSON = res?.values;
         const valuesSchema = res?.schema && JSON.parse(atob(res?.schema));
         const editorType = valuesSchema ? EditorType.Form : EditorType.YAML;
         setFieldValue('editorType', editorType);
         setFieldValue('formSchema', valuesSchema);
-
         setFieldValue('yamlData', valuesYAML);
         setFieldValue('formData', valuesJSON);
+        setFieldValue('chartReadme', chartReadme);
         setInitialYamlData(valuesYAML);
         setInitialFormData(valuesJSON);
       })

--- a/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
-import { TextInputTypes, Grid, GridItem } from '@patternfly/react-core';
+import { TextInputTypes, Grid, GridItem, Button } from '@patternfly/react-core';
 import {
   InputField,
   FormFooter,
@@ -9,15 +9,17 @@ import {
   YAMLEditorField,
   DynamicFormField,
   SyncedEditorField,
+  FormHeader,
 } from '@console/shared';
 import { getJSONSchemaOrder } from '@console/shared/src/components/dynamic-form/utils';
 import FormSection from '../../import/section/FormSection';
-import { HelmActionType, HelmChart } from '../helm-types';
+import { helmReadmeModalLauncher } from '../HelmReadmeModal';
+import { HelmActionType, HelmChart, HelmActionConfigType } from '../helm-types';
 import HelmChartVersionDropdown from './HelmChartVersionDropdown';
 
 export interface HelmInstallUpgradeFormProps {
   chartHasValues: boolean;
-  helmAction: string;
+  helmActionConfig: HelmActionConfigType;
   chartMetaDescription: React.ReactNode;
   onVersionChange: (chart: HelmChart) => void;
 }
@@ -29,13 +31,14 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
   handleReset,
   status,
   isSubmitting,
-  helmAction,
+  helmActionConfig,
   values,
   dirty,
   chartMetaDescription,
   onVersionChange,
 }) => {
-  const { chartName, chartVersion, formData, formSchema } = values;
+  const { chartName, chartVersion, chartReadme, formData, formSchema, editorType } = values;
+  const { type: helmAction, title, subTitle } = helmActionConfig;
 
   const isSubmitDisabled =
     (helmAction === HelmActionType.Upgrade && !dirty) || status?.isSubmitting || !_.isEmpty(errors);
@@ -50,10 +53,41 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
       formDescription={chartMetaDescription}
     />
   );
+
   const yamlEditor = chartHasValues && <YAMLEditorField name="yamlData" onSave={handleSubmit} />;
+
+  const formSubTitle = _.isString(subTitle) ? subTitle : subTitle?.[editorType];
+
+  const readmeText = chartReadme && (
+    <>
+      For more information on the chart, refer to this{' '}
+      <Button
+        type="button"
+        variant="link"
+        data-test-id="helm-readme-modal"
+        onClick={() =>
+          helmReadmeModalLauncher({
+            readme: chartReadme,
+            modalClassName: 'modal-lg',
+          })
+        }
+        isInline
+      >
+        README
+      </Button>
+    </>
+  );
+
+  const formHelpText = (
+    <>
+      {formSubTitle}
+      {readmeText}
+    </>
+  );
 
   return (
     <FlexForm onSubmit={handleSubmit}>
+      <FormHeader title={title} helpText={formHelpText} flexLayout />
       <FormSection fullWidth>
         <Grid gutter={'md'}>
           <GridItem xl={6} lg={6} md={12} sm={12}>

--- a/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
@@ -80,17 +80,17 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
 
   const formHelpText = (
     <>
-      {formSubTitle}
+      {chartHasValues && <>{formSubTitle} &nbsp;</>}
       {readmeText}
     </>
   );
 
   return (
     <FlexForm onSubmit={handleSubmit}>
-      <FormHeader title={title} helpText={formHelpText} flexLayout />
+      <FormHeader title={title} helpText={formHelpText} marginBottom="lg" />
       <FormSection fullWidth>
         <Grid gutter={'md'}>
-          <GridItem xl={6} lg={6} md={12} sm={12}>
+          <GridItem xl={7} lg={8} md={12}>
             <InputField
               type={TextInputTypes.text}
               name="releaseName"
@@ -100,7 +100,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
               isDisabled={helmAction === HelmActionType.Upgrade}
             />
           </GridItem>
-          <GridItem xl={6} lg={6} md={12} sm={12}>
+          <GridItem xl={5} lg={4} md={12}>
             <HelmChartVersionDropdown
               chartName={chartName}
               chartVersion={chartVersion}

--- a/frontend/packages/dev-console/src/components/helm/form/HelmReleaseRollbackForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmReleaseRollbackForm.tsx
@@ -2,16 +2,18 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
 import { Form, FormGroup } from '@patternfly/react-core';
-import { FormFooter } from '@console/shared';
+import { FormFooter, FormHeader } from '@console/shared';
 import { SortByDirection } from '@patternfly/react-table';
 import { Table } from '@console/internal/components/factory';
-import { HelmRelease } from '../helm-types';
+import { HelmRelease, HelmActionConfigType } from '../helm-types';
 
 import RevisionListHeader from './rollback/RevisionListHeader';
 import RevisionListRow from './rollback/RevisionListRow';
 
 interface HelmReleaseRollbackFormProps {
+  releaseName: string;
   releaseHistory: HelmRelease[];
+  helmActionConfig: HelmActionConfigType;
 }
 
 type Props = FormikProps<FormikValues> & HelmReleaseRollbackFormProps;
@@ -24,9 +26,21 @@ const HelmReleaseRollbackForm: React.FC<Props> = ({
   isSubmitting,
   dirty,
   releaseHistory,
+  releaseName,
+  helmActionConfig,
 }) => {
+  const { type: helmAction, title } = helmActionConfig;
+
+  const formHelpText = (
+    <>
+      Select the version to rollback <strong style={{ color: '#000' }}>{releaseName}</strong> to,
+      from the table below:
+    </>
+  );
+
   return (
     <Form onSubmit={handleSubmit}>
+      <FormHeader title={title} helpText={formHelpText} />
       <FormGroup fieldId="revision-list-field" label="Revision History" isRequired>
         <Table
           data={releaseHistory}
@@ -43,7 +57,7 @@ const HelmReleaseRollbackForm: React.FC<Props> = ({
         handleReset={handleReset}
         errorMessage={status?.submitError}
         isSubmitting={status?.isSubmitting || isSubmitting}
-        submitLabel="Rollback"
+        submitLabel={helmAction}
         disableSubmit={status?.isSubmitting || !dirty || !_.isEmpty(errors)}
         resetLabel="Cancel"
         sticky

--- a/frontend/packages/dev-console/src/components/helm/form/__tests__/HelmInstallUpgradeForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/__tests__/HelmInstallUpgradeForm.spec.tsx
@@ -1,104 +1,126 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { shallow } from 'enzyme';
-import { InputField, SyncedEditorField } from '@console/shared';
+import { InputField, SyncedEditorField, FormHeader } from '@console/shared';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import HelmInstallUpgradeForm from '../HelmInstallUpgradeForm';
+import { HelmActionType } from '../../helm-types';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 
-let helmInstallUpgradeFormProps: React.ComponentProps<typeof HelmInstallUpgradeForm>;
+const formValues = {
+  releaseName: 'helm-release',
+  chartName: 'helm-release',
+  chartVersion: '0.3',
+  chartReadme: 'some-readme',
+  yamlData: 'chart-yaml-values',
+  formData: {
+    test: 'data',
+  },
+  formSchema: {
+    type: 'object',
+    required: ['test'],
+    properties: {
+      test: {
+        type: 'string',
+      },
+    },
+  },
+  editorType: EditorType.Form,
+};
+
+const helmConfig = {
+  type: HelmActionType.Install,
+  title: 'Install Helm Chart',
+  subTitle: {
+    form: 'Mock form help text',
+    yaml: 'Mock yaml help text',
+  },
+  helmReleaseApi: `/api/helm/chart?url=mock-chart-url`,
+  fetch: coFetchJSON.post,
+  redirectURL: 'mock-redirect-url',
+};
+
+const componentProps = {
+  chartHasValues: true,
+  helmActionConfig: helmConfig,
+  onVersionChange: jest.fn(),
+  chartMetaDescription: <p>Some chart meta</p>,
+};
+
+const props: React.ComponentProps<typeof HelmInstallUpgradeForm> = {
+  ...componentProps,
+  ...formikFormProps,
+  values: formValues,
+};
 
 describe('HelmInstallUpgradeForm', () => {
-  helmInstallUpgradeFormProps = {
-    chartHasValues: true,
-    helmAction: 'Install',
-    onVersionChange: jest.fn(),
-    chartMetaDescription: <p>Some chart meta</p>,
-    values: {
-      releaseName: 'helm-release',
-      chartName: 'helm-release',
-      chartVersion: '',
-      yamlData: 'chart-yaml-values',
-      formData: {
-        test: 'data',
-      },
-      formSchema: {
-        type: 'object',
-        required: ['test'],
-        properties: {
-          test: {
-            type: 'string',
-          },
-        },
-      },
-      editorType: EditorType.Form,
-    },
-    errors: {},
-    touched: {},
-    isValid: true,
-    initialValues: {
-      releaseName: 'helm-release',
-      chartName: 'helm-release',
-      chartVersion: '0.3',
-      yamlData: 'chart-yaml-values',
-      formData: {
-        test: 'data',
-      },
-      formSchema: {
-        type: 'object',
-        required: ['test'],
-        properties: {
-          test: {
-            type: 'string',
-          },
-        },
-      },
-      editorType: EditorType.Form,
-    },
-    isSubmitting: true,
-    isValidating: true,
-    status: {},
-    submitCount: 0,
-    dirty: false,
-    getFieldProps: jest.fn(),
-    handleBlur: jest.fn(),
-    handleChange: jest.fn(),
-    handleReset: jest.fn(),
-    handleSubmit: jest.fn(),
-    initialErrors: {},
-    initialStatus: {},
-    initialTouched: {},
-    registerField: jest.fn(),
-    resetForm: jest.fn(),
-    setErrors: jest.fn(),
-    setFieldError: jest.fn(),
-    setFieldTouched: jest.fn(),
-    setFieldValue: jest.fn(),
-    setFormikState: jest.fn(),
-    setStatus: jest.fn(),
-    setSubmitting: jest.fn(),
-    setTouched: jest.fn(),
-    setValues: jest.fn(),
-    submitForm: jest.fn(),
-    unregisterField: jest.fn(),
-    validateField: jest.fn(),
-    validateForm: jest.fn(),
-    getFieldMeta: jest.fn(),
-    validateOnBlur: true,
-    validateOnChange: true,
-  };
-
   it('should render the SyncedEditorField  component', () => {
-    const helmInstallUpgradeForm = shallow(
-      <HelmInstallUpgradeForm {...helmInstallUpgradeFormProps} />,
-    );
-    expect(helmInstallUpgradeForm.find(SyncedEditorField).exists()).toBe(true);
+    const wrapper = shallow(<HelmInstallUpgradeForm {...props} />);
+    expect(wrapper.find(SyncedEditorField).exists()).toBe(true);
+  });
+
+  it('should render FormHeader with correct title for the form', () => {
+    const wrapper = shallow(<HelmInstallUpgradeForm {...props} />);
+    const header = wrapper.find(FormHeader);
+    expect(header.exists()).toBe(true);
+    expect(header.props().title).toBe(helmConfig.title);
+  });
+
+  it('should render FormHeader with form help text', () => {
+    const wrapper = shallow(<HelmInstallUpgradeForm {...props} />);
+    const header = wrapper.find(FormHeader);
+    const helpText = header.props().helpText as any;
+    expect(header.exists()).toBe(true);
+    expect(helpText.props.children[0].props.children).toContain(helmConfig.subTitle.form);
+  });
+
+  it('should render FormHeader with yaml help text', () => {
+    const newProps = _.cloneDeep(props);
+    newProps.values.editorType = EditorType.YAML;
+    const wrapper = shallow(<HelmInstallUpgradeForm {...newProps} />);
+    const header = wrapper.find(FormHeader);
+    const helpText = header.props().helpText as any;
+    expect(header.exists()).toBe(true);
+    expect(helpText.props.children[0].props.children).toContain(helmConfig.subTitle.yaml);
+  });
+
+  it('should not render form helm text if there are no chart values', () => {
+    const newProps = _.cloneDeep(props);
+    newProps.chartHasValues = false;
+    const wrapper = shallow(<HelmInstallUpgradeForm {...newProps} />);
+    const header = wrapper.find(FormHeader);
+    const helpText = header.props().helpText as any;
+    expect(header.exists()).toBe(true);
+    expect(helpText.props.children[0]).toBeFalsy();
+    expect(helpText.props.children[1]).toBeTruthy();
+  });
+
+  it('should not render readme button in help text if there is no readme', () => {
+    const newProps = _.cloneDeep(props);
+    newProps.values.chartReadme = null;
+    const wrapper = shallow(<HelmInstallUpgradeForm {...newProps} />);
+    const header = wrapper.find(FormHeader);
+    const helpText = header.props().helpText as any;
+    expect(header.exists()).toBe(true);
+    expect(helpText.props.children[0]).toBeTruthy();
+    expect(helpText.props.children[1]).toBeFalsy();
+  });
+
+  it('should disable form editor if there is no formSchema', () => {
+    const newProps = _.cloneDeep(props);
+    newProps.values.formSchema = null;
+    const wrapper = shallow(<HelmInstallUpgradeForm {...newProps} />);
+    const editor = wrapper.find(SyncedEditorField);
+    expect(editor.exists()).toBe(true);
+    expect(editor.props().formContext.isDisabled).toBe(true);
   });
 
   it('should have the Release Name field disabled in the Helm Upgrade Form', () => {
-    helmInstallUpgradeFormProps.helmAction = 'Upgrade';
-    const helmInstallUpgradeForm = shallow(
-      <HelmInstallUpgradeForm {...helmInstallUpgradeFormProps} />,
-    );
-    expect(helmInstallUpgradeForm.find(InputField).props().label).toBe('Release Name');
-    expect(helmInstallUpgradeForm.find(InputField).props().isDisabled).toBe(true);
+    const newProps = _.cloneDeep(props);
+    newProps.helmActionConfig.type = HelmActionType.Upgrade;
+    const wrapper = shallow(<HelmInstallUpgradeForm {...newProps} />);
+    expect(wrapper.find(InputField).props().label).toBe('Release Name');
+    expect(wrapper.find(InputField).props().isDisabled).toBe(true);
   });
 });

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -72,8 +72,9 @@ export enum HelmActionType {
 }
 
 export interface HelmActionConfigType {
+  type: HelmActionType;
   title: string;
-  subTitle: string;
+  subTitle: string | { form: string; yaml: string };
   helmReleaseApi: string;
   fetch: (url: string, json: any, options?: {}, timeout?: number) => Promise<any>;
   redirectURL: string;

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -133,17 +133,24 @@ export const getHelmActionConfig = (
   switch (helmAction) {
     case HelmActionType.Install:
       return {
+        type: HelmActionType.Install,
         title: 'Install Helm Chart',
-        subTitle: 'The helm chart will be installed using the YAML shown in the editor below.',
+        subTitle: {
+          form:
+            'The Helm chart can be installed by completing the form. Default values may be provided by the Helm chart authors. ',
+          yaml:
+            'The Helm chart can be installed by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor. ',
+        },
         helmReleaseApi: `/api/helm/chart?url=${chartURL}`,
         fetch: coFetchJSON.post,
         redirectURL: getOriginRedirectURL(HelmActionOrigins.topology, namespace, releaseName),
       };
     case HelmActionType.Upgrade:
       return {
+        type: HelmActionType.Upgrade,
         title: 'Upgrade Helm Release',
         subTitle:
-          'Upgrade by selecting a new chart version or manually changing the YAML shown in the editor below.',
+          'Upgrade by selecting a new chart version or manually changing the YAML shown in the editor below. ',
         helmReleaseApi: `/api/helm/release?ns=${namespace}&name=${releaseName}`,
         fetch: coFetchJSON.put,
         redirectURL: getOriginRedirectURL(actionOrigin, namespace, releaseName),
@@ -151,6 +158,7 @@ export const getHelmActionConfig = (
 
     case HelmActionType.Rollback:
       return {
+        type: HelmActionType.Rollback,
         title: 'Rollback Helm Release',
         subTitle: ``,
         helmReleaseApi: `/api/helm/release/history?ns=${namespace}&name=${releaseName}`,
@@ -179,7 +187,7 @@ export const getChartValuesYAML = (chart: HelmChart): string => {
   return !_.isEmpty(chart?.values) ? safeDump(chart?.values) : '';
 };
 
-export const getHelmChartReadme = (chart: HelmChart): string => {
+export const getChartReadme = (chart: HelmChart): string => {
   const readmeFile = chart?.files?.find((file) => file.name === 'README.md');
   return (readmeFile?.data && atob(readmeFile?.data)) ?? '';
 };

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -137,9 +137,9 @@ export const getHelmActionConfig = (
         title: 'Install Helm Chart',
         subTitle: {
           form:
-            'The Helm chart can be installed by completing the form. Default values may be provided by the Helm chart authors. ',
+            'The Helm chart can be installed by completing the form. Default values may be provided by the Helm chart authors.',
           yaml:
-            'The Helm chart can be installed by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor. ',
+            'The Helm chart can be installed by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor.',
         },
         helmReleaseApi: `/api/helm/chart?url=${chartURL}`,
         fetch: coFetchJSON.post,
@@ -149,8 +149,10 @@ export const getHelmActionConfig = (
       return {
         type: HelmActionType.Upgrade,
         title: 'Upgrade Helm Release',
-        subTitle:
-          'Upgrade by selecting a new chart version or manually changing the YAML shown in the editor below. ',
+        subTitle: {
+          form: 'Upgrade by selecting a new chart version or manually changing the form values.',
+          yaml: 'Upgrade by selecting a new chart version or manually changing YAML.',
+        },
         helmReleaseApi: `/api/helm/release?ns=${namespace}&name=${releaseName}`,
         fetch: coFetchJSON.put,
         redirectURL: getOriginRedirectURL(actionOrigin, namespace, releaseName),


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4229

**Analysis / Root cause**: Latest changes to helm install/upgrade form needed the subtitle for the form to change when user toggle between form view and yaml view. but the page title for the form was at page level and had no idea of the form context. 

**Solution Description**: 
- Created a new reusable `FormHeader` component that abstracts the page title logic and implements the current design properly.
- Brought the header at form level to make it reactive to the form context, 
- Added new unit tests for the form component.

**Screen shots / Gifs for design review**: 
cc: @openshift/team-devconsole-ux @parvathyvr 

![Peek 2020-06-29 23-55](https://user-images.githubusercontent.com/6041994/86042490-dddd8680-ba64-11ea-8a5d-1a3adf93c762.gif)


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/6041994/86265323-4487af00-bbe1-11ea-80ab-7ab5974deaa9.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge