### PR TITLE
Bug 1842756: Monitoring: Persist timespan when graph is hidden

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -53,7 +53,7 @@ import store, { RootState } from '../redux';
 import { RowFunction, Table, TableData, TableRow, TextFilter } from './factory';
 import { confirmModal } from './modals';
 import MonitoringDashboardsPage from './monitoring/dashboards';
-import { graphStateToProps, QueryBrowserPage, ToggleGraph } from './monitoring/metrics';
+import { QueryBrowserPage, ToggleGraph } from './monitoring/metrics';
 import { PrometheusLabels } from './graphs';
 import { QueryBrowser, QueryObj } from './monitoring/query-browser';
 import { CheckBoxes } from './row-filter';
@@ -315,7 +315,6 @@ const queryBrowserURL = (query: string) =>
 const Graph_: React.FC<GraphProps> = ({
   deleteAll,
   filterLabels = undefined,
-  hideGraphs,
   patchQuery,
   rule,
 }) => {
@@ -331,10 +330,6 @@ const Graph_: React.FC<GraphProps> = ({
 
   const queries = React.useMemo(() => [query], [query]);
 
-  if (hideGraphs) {
-    return null;
-  }
-
   // 3 times the rule's duration, but not less than 30 minutes
   const timespan = Math.max(3 * duration, 30 * 60) * 1000;
 
@@ -349,7 +344,7 @@ const Graph_: React.FC<GraphProps> = ({
     />
   );
 };
-const Graph = connect(graphStateToProps, {
+const Graph = connect(null, {
   deleteAll: UIActions.queryBrowserDeleteAllQueries,
   patchQuery: UIActions.queryBrowserPatchQuery,
 })(Graph_);
@@ -1941,7 +1936,6 @@ type AlertingPageProps = {
 type GraphProps = {
   deleteAll: () => never;
   filterLabels?: PrometheusLabels;
-  hideGraphs: boolean;
   patchQuery: (index: number, patch: QueryObj) => any;
   rule: Rule;
 };

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -205,7 +205,7 @@ const HeaderPrometheusLink_ = ({ url }) => {
 };
 const HeaderPrometheusLink = connect(headerPrometheusLinkStateToProps)(HeaderPrometheusLink_);
 
-export const graphStateToProps = ({ UI }: RootState) => ({
+const graphStateToProps = ({ UI }: RootState) => ({
   hideGraphs: !!UI.getIn(['monitoring', 'hideGraphs']),
 });
 


### PR DESCRIPTION
Fixes a bug where the graph timespan on the alert details page and
alerting rule details page was lost when the graph was hidden.

The `hideGraphs` prop was actually unnecessary because we also track
that flag in Redux and removing the prop fixes the bug.