### PR TITLE
Add VSCode file exclusions

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -30,6 +30,24 @@
     "**/.cache-loader": true,
     "**/public/dist": true
   },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/.cache-loader": true,
+    "**/public/dist": true
+  },
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/node_modules/**": true,
+    "**/.hg/store/**": true,
+    "**/bower_components": true,
+    "**/.cache-loader": true,
+    "**/public/dist": true
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   }


### PR DESCRIPTION
I have an issue in my macOS env where the VSCode IntelliSense would just stop working after some time, I believe it happens because of too much load overtime:

`Webpack recompile => public/dist changes => VSCode re-index`

this process happens 100s of times a day, and could cause the issue.
This change removes unnecessary files from the watcher and from the explorer.

Removed from watcher:
```
    "**/bower_components": true,
    "**/node_modules/**": true,
    "**/.cache-loader": true,
    "**/public/dist": true
```

Removed from files (They won't show on VSCode):
```
    "**/.cache-loader": true,
    "**/public/dist": true
```