### PR TITLE
Change button label 'Done' to 'Close' in cluster more updates modal

### DIFF
--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -55,7 +55,7 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
       <ModalFooter inProgress={false}>
         <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
           <Button type="button" variant="primary" onClick={cancel}>
-            Done
+            Close
           </Button>
         </ActionGroup>
       </ModalFooter>


### PR DESCRIPTION
After:
<img width="634" alt="Screen Shot 2020-06-30 at 10 58 26 AM" src="https://user-images.githubusercontent.com/895728/86142362-1c089380-bac1-11ea-997b-63831d8197ba.png">

cc: @megan-hall 