### PR TITLE
Rename PipelineRun filter label

### DIFF
--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -81,7 +81,7 @@ export enum ListFilterId {
 export const ListFilterLabels = {
   [ListFilterId.Running]: 'Running',
   [ListFilterId.Failed]: 'Failed',
-  [ListFilterId.Succeeded]: 'Complete',
+  [ListFilterId.Succeeded]: 'Succeeded',
   [ListFilterId.Cancelled]: 'Cancelled',
   [ListFilterId.Other]: 'Other',
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3580
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Filter label (`Complete`) is not the same as it's corresponding list item field for last run status(`Succeeded`).
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Rename filter label to `Succeeded`.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![upload](https://user-images.githubusercontent.com/20013884/86160615-a258c000-bb29-11ea-9e37-078b88826997.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
