### PR TITLE
Add support for edit action in DetailsItem component

### DIFF
--- a/frontend/public/components/utils/_details-item.scss
+++ b/frontend/public/components/utils/_details-item.scss
@@ -1,0 +1,45 @@
+.details-item {
+  display: inline-block;
+  margin-bottom: var(--pf-global--spacer--lg);
+}
+
+.details-item__label {
+  font-weight: bold;
+}
+
+.details-item__popover-button {
+  // Use `background-image: linear-gradient` to draw a dotted underline. This gives us more control over the styling.
+  background-image: linear-gradient(
+    to right,
+    var(--pf-c-button--m-plain--Color) 33%,
+    rgba(255, 255, 255, 0) 0%
+  );
+  background-position: bottom;
+  background-size: 3px 1px;
+  background-repeat: repeat-x;
+  color: inherit !important;
+  font-weight: inherit !important;
+  margin-bottom: 3px;
+  padding: 0 !important;
+  &:focus,
+  &:hover {
+    background-image: linear-gradient(
+      to right,
+      var(--pf-c-button--m-tertiary--Color) 33%,
+      rgba(255, 255, 255, 0) 0%
+    );
+  }
+}
+
+.details-item__value--editable {
+  border: 1px solid var(--pf-global--BorderColor--100);
+  padding: var(--pf-global--spacer--md);
+  margin-top: var(--pf-global--spacer--xs);
+}
+
+.details-item__value--labels.details-item__value--editable {
+  padding: var(--pf-global--spacer--xs);
+  .co-m-label {
+    margin: 2px;
+  }
+}

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { Breadcrumb, BreadcrumbItem, Button, Popover } from '@patternfly/react-core';
+import * as classnames from 'classnames';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Popover,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
 
 import {
   getPropertyDescription,
@@ -29,13 +38,24 @@ const PropertyPath: React.FC<{ kind: string; path: string | string[] }> = ({ kin
   );
 };
 
+const EditButton = (props) => (
+  <Button variant="link" isInline onClick={props.onClick}>
+    {props.children}
+    <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+  </Button>
+);
+
 export const DetailsItem: React.FC<DetailsItemProps> = ({
-  label,
-  obj,
-  path,
-  defaultValue = '-',
-  hideEmpty,
   children,
+  defaultValue = '-',
+  editAsGroup,
+  hideEmpty,
+  label,
+  labelClassName,
+  obj,
+  onEdit,
+  path,
+  valueClassName,
 }) => {
   if (hideEmpty && _.isEmpty(_.get(obj, path))) {
     return null;
@@ -47,36 +67,57 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
   const value: React.ReactNode = children || _.get(obj, path, defaultValue);
   return (
     <>
-      <dt>
-        {description ? (
-          <Popover
-            headerContent={<div>{label}</div>}
-            bodyContent={
-              <LinkifyExternal>
-                <div className="co-pre-line">{description}</div>
-              </LinkifyExternal>
-            }
-            footerContent={<PropertyPath kind={model.kind} path={path} />}
-            maxWidth="30rem"
-          >
-            <Button variant="plain" className="co-m-pane__details-popover-button">
-              {label}
-            </Button>
-          </Popover>
-        ) : (
-          label
-        )}
+      <dt className={classnames('details-item__label', labelClassName)}>
+        <Split>
+          <SplitItem className="details-item__label">
+            {description ? (
+              <Popover
+                headerContent={<div>{label}</div>}
+                bodyContent={
+                  <LinkifyExternal>
+                    <div className="co-pre-line">{description}</div>
+                  </LinkifyExternal>
+                }
+                footerContent={<PropertyPath kind={model.kind} path={path} />}
+                maxWidth="30rem"
+              >
+                <Button variant="plain" className="details-item__popover-button">
+                  {label}
+                </Button>
+              </Popover>
+            ) : (
+              label
+            )}
+          </SplitItem>
+          {onEdit && editAsGroup && (
+            <>
+              <SplitItem isFilled />
+              <SplitItem>
+                <EditButton onClick={onEdit}>Edit</EditButton>
+              </SplitItem>
+            </>
+          )}
+        </Split>
       </dt>
-      <dd>{value}</dd>
+      <dd
+        className={classnames('details-item__value', valueClassName, {
+          'details-item__value--editable': onEdit,
+        })}
+      >
+        {onEdit && !editAsGroup ? <EditButton onClick={onEdit}>{value}</EditButton> : value}
+      </dd>
     </>
   );
 };
 
 export type DetailsItemProps = {
-  label: string;
-  obj: K8sResourceKind;
-  path: string | string[];
   defaultValue?: React.ReactNode;
+  editAsGroup?: boolean;
   hideEmpty?: boolean;
-  children?: React.ReactNode;
+  label: string;
+  labelClassName?: string;
+  obj: K8sResourceKind;
+  onEdit?: (e: Event) => void;
+  path: string | string[];
+  valueClassName?: string;
 };

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -12,6 +12,12 @@ import { Selector } from './selector';
 import { Timestamp } from './timestamp';
 import { useAccessReview } from './rbac';
 import { K8sResourceKind, modelFor, referenceFor, Toleration } from '../../module/k8s';
+import { labelsModal } from '../modals';
+
+const editLabelsModal = (e, props) => {
+  e.preventDefault();
+  labelsModal(props);
+};
 
 export const pluralize = (
   i: number,
@@ -72,7 +78,14 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
       )}
       {type ? <dt>Type</dt> : null}
       {type ? <dd>{type}</dd> : null}
-      <DetailsItem label="Labels" obj={resource} path="metadata.labels">
+      <DetailsItem
+        label="Labels"
+        obj={resource}
+        path="metadata.labels"
+        valueClassName="details-item__value--labels"
+        onEdit={(e) => editLabelsModal(e, { resource, kind: model })}
+        editAsGroup
+      >
         <LabelList kind={reference} labels={metadata.labels} />
       </DetailsItem>
       {showPodSelector && (

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -99,6 +99,7 @@
 @import 'components/autocomplete';
 @import 'components/conditions';
 @import 'components/persistent-volume-claim';
+@import 'components/utils/details-item';
 
 @import 'components/dashboard/dashboards-page/cluster-dashboard/activity-card';
 @import 'components/dashboard/dashboards-page/cluster-dashboard/status-card';

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -74,7 +74,7 @@ $co-external-link-padding-right: 15px;
 
 .co-m-pane__filter-bar-group--badge,
 .co-m-pane__filter-bar-group--filter {
-  @media(min-width: $screen-xs-min) {
+  @media (min-width: $screen-xs-min) {
     flex: 1 0 auto;
     justify-content: flex-end;
   }
@@ -171,22 +171,6 @@ $co-external-link-padding-right: 15px;
   }
 }
 
-.co-m-pane__details-popover-button {
-  // Use `background-image: linear-gradient` to draw a dotted underline. This gives us more control over the styling.
-  background-image: linear-gradient(to right, var(--pf-c-button--m-plain--Color) 33%, rgba(255,255,255,0) 0%);
-  background-position: bottom;
-  background-size: 3px 1px;
-  background-repeat: repeat-x;
-  color: inherit !important;
-  font-weight: inherit !important;
-  margin-bottom: 3px;
-  padding: 0 !important;
-  &:focus,
-  &:hover {
-    background-image: linear-gradient(to right, var(--pf-c-button--m-tertiary--Color) 33%, rgba(255,255,255,0) 0%);
-  }
-}
-
 .co-m-pane__dropdown {
   margin-bottom: 20px;
 }
@@ -218,8 +202,10 @@ $co-external-link-padding-right: 15px;
 }
 
 // Prevent iOS phones from zooming on form inputs
-@supports (-webkit-overflow-scrolling: touch) { // Target mobile Safari
-  @media (max-width: $grid-float-breakpoint-max) { // Target phones
+@supports (-webkit-overflow-scrolling: touch) {
+  // Target mobile Safari
+  @media (max-width: $grid-float-breakpoint-max) {
+    // Target phones
     input,
     select,
     .tag-item,
@@ -237,7 +223,7 @@ $co-external-link-padding-right: 15px;
 .error-message {
   color: #fff;
   padding: 2px 12px;
-  background-color: #D64456;
+  background-color: #d64456;
 }
 
 .co-action-divider {
@@ -302,11 +288,12 @@ $co-external-link-padding-right: 15px;
   .close {
     font-size: 16px;
     // adjustments to increase click target and default color contrast because it's on a grey background
-    opacity: .3;
+    opacity: 0.3;
     padding: 10px 15px;
 
-    &:hover, &:focus {
-      opacity: .6;
+    &:hover,
+    &:focus {
+      opacity: 0.6;
     }
   }
 }
@@ -375,7 +362,7 @@ $co-external-link-padding-right: 15px;
   margin-bottom: 5px;
 
   + .radio {
-    margin-top :0;
+    margin-top: 0;
   }
 }
 
@@ -401,8 +388,30 @@ $co-external-link-padding-right: 15px;
 
 .co-an-fade-in-out {
   transition-duration: compact(0.2s, false, false, false, false, false, false, false, false, false);
-  transition-property: compact(opacity, false, false, false, false, false, false, false, false, false);
-  transition-timing-function: compact(linear, false, false, false, false, false, false, false, false, false);
+  transition-property: compact(
+    opacity,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false
+  );
+  transition-timing-function: compact(
+    linear,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false
+  );
 }
 
 .co-m-radio-desc {
@@ -463,7 +472,7 @@ $co-external-link-padding-right: 15px;
     position: relative;
     width: 100%;
     .row {
-      padding: 10px 20px 10px 0;  // right padding creates space for .co-resource-kebab
+      padding: 10px 20px 10px 0; // right padding creates space for .co-resource-kebab
     }
   }
   &__head {


### PR DESCRIPTION
- Add `editModal` prop to `DetailsItem` component, which accepts a callback to trigger an edit modal. If defined, a left-justified edit button will appear next to the detail label,  and the detail value will be surrounded by a light gray border.
- Use the new editModal prop to make 'Labels' field on details pages editable.

![screenshot-localhost_9000-2020 06 30-14_49_28](https://user-images.githubusercontent.com/22625502/86165426-3f433b00-bae1-11ea-95fe-4b462ce412c0.gif)
