### PR TITLE
added service to fetch knative channel crds

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -574,6 +574,24 @@ func main() {
 		knative.EventSourceFilter,
 	)
 
+	srv.KnativeChannelCRDLister = server.NewResourceLister(
+		resourceListerToken,
+		&url.URL{
+			Scheme: k8sEndpoint.Scheme,
+			Host:   k8sEndpoint.Host,
+			Path:   "/apis/apiextensions.k8s.io/v1/customresourcedefinitions",
+			RawQuery: url.Values{
+				"labelSelector": {"duck.knative.dev/addressable=true,messaging.knative.dev/subscribable=true"},
+			}.Encode(),
+		},
+		&http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: srv.K8sProxyConfig.TLSClientConfig,
+			},
+		},
+		knative.ChannelFilter,
+	)
+
 	listenURL := bridge.ValidateFlagIsURL("listen", *fListen)
 	switch listenURL.Scheme {
 	case "http":

--- a/pkg/knative/types.go
+++ b/pkg/knative/types.go
@@ -40,3 +40,6 @@ type EventSourceList struct {
 	// items list individual EventSourceDefinition objects
 	Items []EventSourceDefinition `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
+
+// ChannelList is a list of CRD per Channel
+type ChannelList = EventSourceList

--- a/pkg/knative/utils.go
+++ b/pkg/knative/utils.go
@@ -26,3 +26,18 @@ func EventSourceFilter(w http.ResponseWriter, r *http.Response) {
 		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
 	}
 }
+
+// ChannelFilter shall filter partial metadata from knative channel CRDs before propagating
+func ChannelFilter(w http.ResponseWriter, r *http.Response) {
+	var channelList ChannelList
+
+	if err := json.NewDecoder(r.Body).Decode(&channelList); err != nil {
+		plog.Errorf("Channel CRD response deserialization failed: %s", err)
+		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+	}
+
+	if err := json.NewEncoder(w).Encode(channelList); err != nil {
+		plog.Errorf("Channel CRD response serialization failed: %s", err)
+		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -113,6 +113,7 @@ type Server struct {
 	// A lister for resource listing of a particular kind
 	MonitoringDashboardConfigMapLister ResourceLister
 	KnativeEventSourceCRDLister        ResourceLister
+	KnativeChannelCRDLister            ResourceLister
 	HelmChartRepoProxyConfig           *proxy.Config
 	GOARCH                             string
 	GOOS                               string
@@ -352,6 +353,7 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	handle("/api/console/monitoring-dashboard-config", authHandler(s.handleMonitoringDashboardConfigmaps))
 	handle("/api/console/knative-event-sources", authHandler(s.handleKnativeEventSourceCRDs))
+	handle("/api/console/knative-channels", authHandler(s.handleKnativeChannelCRDs))
 	handle("/api/console/version", authHandler(s.versionHandler))
 
 	// Helm Endpoints
@@ -397,6 +399,10 @@ func (s *Server) handleMonitoringDashboardConfigmaps(w http.ResponseWriter, r *h
 
 func (s *Server) handleKnativeEventSourceCRDs(w http.ResponseWriter, r *http.Request) {
 	s.KnativeEventSourceCRDLister.HandleResources(w, r)
+}
+
+func (s *Server) handleKnativeChannelCRDs(w http.ResponseWriter, r *http.Request) {
+	s.KnativeChannelCRDLister.HandleResources(w, r)
 }
 
 func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4171

**Analysis / Root cause**: 
Presently `knative/operator` doesn't have discovery API to list available `channels` in cluster. And this API should be accessible to non-admin users as well. 

**Solution Description**: 
[Dependant API](https://issues.redhat.com/browse/SRVKE-465) doesn't seem to be available in 4.6 timeline so a backend service in console is added as workaround. API `/api/console/knative-channels` has been added to list channel CRDs for any non-admin users based on `labelSelector` `duck.knative.dev/addressable` & `messaging.knative.dev/subscribable`.
P.S: Have reused resource lister infrastructure created for listing knative event source crds.

**Screen shots / Gifs for design review**:  n/a

**Unit test coverage report**: n/a

**Test setup:**
1. Install Serverless & Knative Apache Kafka operators
2. Create Knative Serving & Knative Eventing 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
