### PR TITLE
kubevirt: don't show GA help info inside the wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -106,8 +106,12 @@ export const VMDisksTable: React.FC<React.ComponentProps<typeof Table> | VMDisks
 ) => {
   return (
     <div>
-      <h3>Disks</h3>
-      The following information is provided by the OpenShift Virtualization operator.
+      {props?.customData?.showGuestAgentHelp && (
+        <>
+          <h3>Disks</h3>
+          The following information is provided by the OpenShift Virtualization operator.
+        </>
+      )}
       <Table
         {...props}
         aria-label="VM Disks List"
@@ -181,6 +185,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, vmTemplate }) =>
         isDisabled: isLocked,
         templateValidations,
         columnClasses: diskTableColumnClasses,
+        showGuestAgentHelp: true,
       }}
       hideLabelFilter
     />


### PR DESCRIPTION
Don't show GA help message and sub title when in wizard mode.
 
Screenshot:
Before:
![screenshot-localhost_9000-2020 07 01-11_16_17](https://user-images.githubusercontent.com/2181522/86220592-7b7fa580-bb8c-11ea-8482-20753da1023b.png)

After:
![screenshot-localhost_9000-2020 07 01-11_58_18](https://user-images.githubusercontent.com/2181522/86225001-4d9d5f80-bb92-11ea-8004-dd4f446d9e38.png)


Overvew disks view after:
![screenshot-localhost_9000-2020 07 01-11_57_22](https://user-images.githubusercontent.com/2181522/86224965-3cece980-bb92-11ea-8ae8-034273175d29.png)
