### PR TITLE
Bug 1852689: When node disk is under pressure NodeTerminalError should show pod's status message

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeTerminal.tsx
@@ -115,7 +115,8 @@ const NodeTerminalInner: React.FC<NodeTerminalInnerProps> = ({ obj }) => {
           error={
             <>
               The debug pod failed.{' '}
-              {obj?.data?.status?.containerStatuses[0]?.state?.terminated?.message}
+              {obj?.data?.status?.containerStatuses?.[0]?.state?.terminated?.message ||
+                obj?.data?.status?.message}
             </>
           }
         />


### PR DESCRIPTION
In case the node disk is under pressure its pods terminal wont be reachable and the `Pod` itself won't contain `status.containerStatuses` field. In that case show directly the `status.message`

Screen:
<img width="383" alt="Screenshot 2020-07-01 at 12 08 51" src="https://user-images.githubusercontent.com/1668218/86233552-dd90d880-bb95-11ea-9623-76f3520c6ba0.png">

/assign @rhamilto 