### PR TITLE
Bug 1852473: kubevirt: fix importing VMs with same vnicIDs for ovirt provider

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -282,6 +282,7 @@ export type VMWizardNetwork = {
   importData?: {
     id?: string;
     vnicID?: string;
+    networksWithSameVnicID?: [];
   };
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Form, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Form,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+} from '@patternfly/react-core';
 import {
   FirehoseResult,
   HandlePromiseProps,
@@ -210,6 +217,9 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
       <ModalTitle>{isEditing ? EDIT : ADD} Network Interface</ModalTitle>
       <ModalBody>
         <Form>
+          {editConfig?.warning && (
+            <Alert variant={AlertVariant.warning} isInline title={editConfig?.warning} />
+          )}
           <FormRow
             title="Name"
             fieldId={asId('name')}
@@ -253,7 +263,11 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
             network={resultNetwork}
             onChange={onNetworkChoiceChange}
             nads={nads}
-            allowPodNetwork={allowPodNetwork}
+            allowPodNetwork={
+              editConfig?.allowPodNetworkOverride != null
+                ? editConfig?.allowPodNetworkOverride
+                : allowPodNetwork
+            }
             acceptEmptyValues={editConfig?.acceptEmptyValuesOverride?.network}
           />
           <FormRow title="Type" fieldId={asId('type')} isRequired>

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-ovirt.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-ovirt.ts
@@ -66,7 +66,7 @@ const getNetworkMappings = (networks: VMWizardNetwork[]) => {
       ({ network, importData }) =>
         SUPPORTED_NETWORK_TYPES.has(new NetworkWrapper(network).getType()) && importData?.vnicID,
     ),
-    (wizardNetwork) => wizardNetwork.importData?.vnicID, // should be mapped 1 to 1
+    (wizardNetwork) => wizardNetwork.importData?.vnicID, // should be mapped 1 to 1 - UI makes sure it duplicates contain the same network (type and data)
   );
 
   return networksToMap.map(({ network, importData: { vnicID } }) => {

--- a/frontend/packages/kubevirt-plugin/src/types/ui/nic.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/ui/nic.ts
@@ -22,4 +22,6 @@ export type UINetworkEditConfig = {
   acceptEmptyValuesOverride?: {
     network?: boolean;
   };
+  allowPodNetworkOverride?: boolean;
+  warning?: string;
 };


### PR DESCRIPTION
- don't allow Pod networks for such nics
- allow only same network values for nics with same vnicID