### PR TITLE
Add capability for selecting multiple bootstrapServers and topics

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.scss
@@ -1,0 +1,3 @@
+.pf-c-select__menu {
+  list-style-type: none;
+}

--- a/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.scss
@@ -1,3 +1,0 @@
-.pf-c-select__menu {
-  list-style-type: none;
-}

--- a/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.tsx
@@ -5,7 +5,6 @@ import { FormGroup, Select, SelectVariant, SelectOption } from '@patternfly/reac
 import { getFieldId } from './field-utils';
 import { SelectInputFieldProps, SelectInputOption } from './field-types';
 import { useFormikValidationFix } from '../../hooks';
-import './SelectInputField.scss';
 
 const SelectInputField: React.FC<SelectInputFieldProps> = ({
   name,
@@ -19,7 +18,7 @@ const SelectInputField: React.FC<SelectInputFieldProps> = ({
 }) => {
   const [field, { touched, error }] = useField<string[]>(name);
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
-  const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [newOptions, setNewOptions] = React.useState<SelectInputOption[]>([]);
   const fieldId = getFieldId(name, 'select-input');
   const isValid = !(touched && error);
@@ -28,7 +27,7 @@ const SelectInputField: React.FC<SelectInputFieldProps> = ({
   useFormikValidationFix(field.value);
 
   const onToggle = () => {
-    setIsExpanded(!isExpanded);
+    setIsOpen(!isOpen);
   };
 
   const onSelect = (event, selection: string) => {
@@ -53,7 +52,7 @@ const SelectInputField: React.FC<SelectInputFieldProps> = ({
   return (
     <FormGroup
       fieldId={fieldId}
-      isValid={isValid}
+      validated={isValid ? 'default' : 'error'}
       label={label}
       helperText={helpText}
       helperTextInvalid={errorMessage}
@@ -64,7 +63,7 @@ const SelectInputField: React.FC<SelectInputFieldProps> = ({
         onToggle={onToggle}
         onSelect={onSelect}
         onClear={onClearSelection}
-        isExpanded={isExpanded}
+        isOpen={isOpen}
         selections={field.value}
         placeholderText={placeholderText}
         isCreatable={isCreatable}

--- a/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SelectInputField.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import * as _ from 'lodash';
+import { FormGroup, Select, SelectVariant, SelectOption } from '@patternfly/react-core';
+import { getFieldId } from './field-utils';
+import { FieldProps } from './field-types';
+
+interface SelectInputFieldProps extends FieldProps {
+  options: { value: string; disabled: boolean }[];
+  placeholderText?: React.ReactNode;
+  isCreatable?: boolean;
+  hasOnCreateOption?: boolean;
+}
+
+const SelectInputField: React.FC<SelectInputFieldProps> = ({
+  name,
+  label,
+  options,
+  placeholderText,
+  isCreatable,
+  hasOnCreateOption,
+  helpText,
+  required,
+}) => {
+  const [field, { touched, error }] = useField<string[]>(name);
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const fieldId = getFieldId(name, 'select-input');
+  const isValid = !(touched && error);
+
+  const onToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const onSelect = (event, selection) => {
+    const selections = field.value;
+    if (_.includes(selections, selection)) {
+      setFieldValue(name, _.pull(selections, selection));
+    } else {
+      setFieldValue(name, [...selections, selection]);
+    }
+    setFieldTouched(name);
+  };
+
+  const onCreateOption = (newVal) => {
+    const selections = field.value;
+    setFieldValue(name, [...selections, newVal]);
+    setFieldTouched(name);
+  };
+
+  const onClearSelection = () => {
+    setFieldValue(name, []);
+    setFieldTouched(name);
+  };
+
+  return (
+    <FormGroup
+      fieldId={fieldId}
+      isValid={isValid}
+      label={label}
+      helperText={helpText}
+      isRequired={required}
+    >
+      <Select
+        variant={SelectVariant.typeaheadMulti}
+        onToggle={onToggle}
+        onSelect={onSelect}
+        onClear={onClearSelection}
+        isExpanded={isExpanded}
+        selections={field.value}
+        placeholderText={placeholderText}
+        isCreatable={isCreatable}
+        onCreateOption={(hasOnCreateOption && onCreateOption) || undefined}
+      >
+        {_.map(options, (op) => (
+          <SelectOption value={op.value} isDisabled={op.disabled} key={op.value} />
+        ))}
+      </Select>
+    </FormGroup>
+  );
+};
+
+export default SelectInputField;

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -131,3 +131,15 @@ export interface RadioGroupOption {
   children?: React.ReactNode;
   activeChildren?: React.ReactElement;
 }
+
+export interface SelectInputOption {
+  value: string;
+  disabled: boolean;
+}
+
+export interface SelectInputFieldProps extends FieldProps {
+  options: SelectInputOption[];
+  placeholderText?: React.ReactNode;
+  isCreatable?: boolean;
+  hasOnCreateOption?: boolean;
+}

--- a/frontend/packages/console-shared/src/components/formik-fields/index.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/index.ts
@@ -18,5 +18,6 @@ export { default as InputGroupField } from './InputGroupField';
 export { default as TextColumnField } from './TextColumnField';
 export { default as DynamicFormField } from './DynamicFormField';
 export { default as SyncedEditorField } from './SyncedEditorField';
+export { default as SelectInputField } from './SelectInputField';
 export * from './field-utils';
 export * from './field-types';

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
@@ -76,14 +76,14 @@ describe('Event Source ValidationUtils', () => {
     it('should throw an error for required fields if empty', async () => {
       const defaultEventingData = getDefaultEventingData(EventSources.KafkaSource);
       const mockData = _.cloneDeep(defaultEventingData);
-      mockData.data.kafkasource.bootstrapServers = [''];
+      mockData.data.kafkasource.bootstrapServers = [];
       await eventSourceValidationSchema
         .resolve({ value: mockData })
         .isValid(mockData)
         .then((valid) => expect(valid).toEqual(false));
       await eventSourceValidationSchema.validate(mockData).catch((err) => {
         expect(err.message).toBe('Required');
-        expect(err.type).toBe('required');
+        expect(err.type).toBe('min');
       });
     });
   });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -1,37 +1,117 @@
 import * as React from 'react';
-import { useFormikContext, FormikValues } from 'formik';
+import * as _ from 'lodash';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
-import { InputField, TextColumnField } from '@console/shared';
+import { InputField, SelectInputField, SelectInputOption } from '@console/shared';
 import { TextInputTypes } from '@patternfly/react-core';
 import KafkaSourceNetSection from './KafkaSourceNetSection';
 import ServiceAccountDropdown from '../../dropdowns/ServiceAccountDropdown';
+import { KafkaModel, KafkaTopicModel } from '../../../models';
+import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { getBootstrapServers } from '../../../utils/create-eventsources-utils';
 
 const KafkaSourceSection: React.FC = () => {
-  const { values } = useFormikContext<FormikValues>();
-  const {
-    data: {
-      kafkasource: { bootstrapServers, topics },
-    },
-  } = values;
+  const [bootstrapServers, setBootstrapServers] = React.useState<SelectInputOption[]>([]);
+  const [bsPlaceholder, setBsPlaceholder] = React.useState<React.ReactNode>('');
+  const [kafkaTopics, setKafkaTopics] = React.useState<SelectInputOption[]>([]);
+  const [ktPlaceholder, setKtPlaceholder] = React.useState<React.ReactNode>('');
+
+  const memoResources = React.useMemo(
+    () => ({
+      kafka: {
+        isList: true,
+        kind: referenceForModel(KafkaModel),
+        optional: true,
+      },
+      kafkaTopic: {
+        isList: true,
+        kind: referenceForModel(KafkaTopicModel),
+        optional: true,
+      },
+    }),
+    [],
+  );
+  const { kafka, kafkaTopic } = useK8sWatchResources<{
+    [key: string]: K8sResourceKind[];
+  }>(memoResources);
+
+  React.useEffect(() => {
+    let bootstrapServersOptions: SelectInputOption[] = [];
+    let placeholder: React.ReactNode = '';
+    if (kafka.loaded && !kafka.loadError) {
+      bootstrapServersOptions = !_.isEmpty(kafka.data)
+        ? _.map(getBootstrapServers(kafka.data), (bs) => ({
+            value: bs,
+            disabled: false,
+          }))
+        : [
+            {
+              value: 'No Bootstrapservers found',
+              disabled: true,
+            },
+          ];
+      placeholder = 'Add Bootstrapservers';
+    } else if (kafka.loadError) {
+      bootstrapServersOptions = [{ value: kafka.loadError?.message, disabled: true }];
+      placeholder = 'Error loading Bootstrapservers';
+    } else {
+      bootstrapServersOptions = [{ value: 'Loading Bootstrapservers...', disabled: true }];
+      placeholder = '...';
+    }
+    setBootstrapServers(bootstrapServersOptions);
+    setBsPlaceholder(placeholder);
+  }, [kafka.data, kafka.loaded, kafka.loadError]);
+
+  React.useEffect(() => {
+    let topicsOptions: SelectInputOption[] = [];
+    let placeholder: React.ReactNode = '';
+    if (kafkaTopic.loaded && !kafkaTopic.loadError) {
+      topicsOptions = !_.isEmpty(kafkaTopic.data)
+        ? _.map(kafkaTopic.data, (kt) => ({
+            value: kt?.metadata.name,
+            disabled: false,
+          }))
+        : [
+            {
+              value: 'No Topics found',
+              disabled: true,
+            },
+          ];
+      placeholder = 'Add Topics';
+    } else if (kafkaTopic.loadError) {
+      topicsOptions = [{ value: kafkaTopic.loadError?.message, disabled: true }];
+      placeholder = 'Error loading Topics';
+    } else {
+      topicsOptions = [{ value: 'Loading Topics...', disabled: true }];
+      placeholder = '...';
+    }
+    setKafkaTopics(topicsOptions);
+    setKtPlaceholder(placeholder);
+  }, [kafkaTopic.data, kafkaTopic.loaded, kafkaTopic.loadError]);
+
   return (
     <FormSection title="KafkaSource" extraMargin>
-      <TextColumnField
+      <SelectInputField
         data-test-id="kafkasource-bootstrapservers-field"
         name="data.kafkasource.bootstrapServers"
-        label="BootstrapServers"
-        addLabel="Add Bootstrapservers"
+        label="Bootstrapservers"
+        options={bootstrapServers}
+        placeholderText={bsPlaceholder}
         helpText="The address of the Kafka broker"
+        isCreatable
+        hasOnCreateOption
         required
-        disableDeleteRow={bootstrapServers?.length === 1}
       />
-      <TextColumnField
+      <SelectInputField
         data-test-id="kafkasource-topics-field"
         name="data.kafkasource.topics"
         label="Topics"
-        addLabel="Add Topics"
+        options={kafkaTopics}
+        placeholderText={ktPlaceholder}
         helpText="Virtual groups across Kafka brokers"
+        isCreatable
+        hasOnCreateOption
         required
-        disableDeleteRow={topics?.length === 1}
       />
       <InputField
         data-test-id="kafkasource-consumergroup-field"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import KafkaSourceSection from '../KafkaSourceSection';
 import { EventSources } from '../../import-types';
 import KafkaSourceNetSection from '../KafkaSourceNetSection';
@@ -10,22 +10,26 @@ import ServiceAccountDropdown from '../../../dropdowns/ServiceAccountDropdown';
 type KafkaSourceSectionProps = React.ComponentProps<typeof KafkaSourceSection>;
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
-  useK8sWatchResource: jest.fn(),
+  useK8sWatchResources: jest.fn(),
 }));
 describe('KafkaSourceSection', () => {
   let wrapper: ShallowWrapper<KafkaSourceSectionProps>;
 
   it('should render KafkaSource FormSection with proper title', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      kafkas: { data: [], loaded: true },
+      kafkatopics: { data: [], loaded: true },
+    });
     wrapper = shallow(<KafkaSourceSection />);
     expect(wrapper.find(FormSection)).toHaveLength(1);
     expect(wrapper.find(FormSection).props().title).toBe(EventSources.KafkaSource);
   });
 
   it('should render BootstrapServers and Topics fields with ', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      kafkas: { data: [], loaded: true },
+      kafkatopics: { data: [], loaded: true },
+    });
     wrapper = shallow(<KafkaSourceSection />);
     const bootstrapServersField = wrapper.find(
       '[data-test-id="kafkasource-bootstrapservers-field"]',
@@ -39,8 +43,10 @@ describe('KafkaSourceSection', () => {
   });
 
   it('should render consumergroup, netsection and service dropdown', () => {
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
-    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      kafkas: { data: [], loaded: true },
+      kafkatopics: { data: [], loaded: true },
+    });
     wrapper = shallow(<KafkaSourceSection />);
     const consumerGroupField = wrapper.find('[data-test-id="kafkasource-consumergroup-field"]');
     expect(consumerGroupField).toHaveLength(1);

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import KafkaSourceSection from '../KafkaSourceSection';
 import { EventSources } from '../../import-types';
 import KafkaSourceNetSection from '../KafkaSourceNetSection';
@@ -8,35 +9,24 @@ import ServiceAccountDropdown from '../../../dropdowns/ServiceAccountDropdown';
 
 type KafkaSourceSectionProps = React.ComponentProps<typeof KafkaSourceSection>;
 
-jest.mock('formik', () => ({
-  useField: jest.fn(() => [{}, {}]),
-  useFormikContext: jest.fn(() => ({
-    setFieldValue: jest.fn(),
-    setFieldTouched: jest.fn(),
-    validateForm: jest.fn(),
-    values: {
-      type: 'KafkaSource',
-      data: {
-        kafkasource: {
-          bootstrapServers: [''],
-          topics: [''],
-        },
-      },
-    },
-  })),
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResource: jest.fn(),
 }));
 describe('KafkaSourceSection', () => {
   let wrapper: ShallowWrapper<KafkaSourceSectionProps>;
-  beforeEach(() => {
-    wrapper = shallow(<KafkaSourceSection />);
-  });
 
   it('should render KafkaSource FormSection with proper title', () => {
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    wrapper = shallow(<KafkaSourceSection />);
     expect(wrapper.find(FormSection)).toHaveLength(1);
     expect(wrapper.find(FormSection).props().title).toBe(EventSources.KafkaSource);
   });
 
-  it('should render BootstrapServers and Topics fields', () => {
+  it('should render BootstrapServers and Topics fields with ', () => {
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    wrapper = shallow(<KafkaSourceSection />);
     const bootstrapServersField = wrapper.find(
       '[data-test-id="kafkasource-bootstrapservers-field"]',
     );
@@ -49,6 +39,9 @@ describe('KafkaSourceSection', () => {
   });
 
   it('should render consumergroup, netsection and service dropdown', () => {
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
+    wrapper = shallow(<KafkaSourceSection />);
     const consumerGroupField = wrapper.find('[data-test-id="kafkasource-consumergroup-field"]');
     expect(consumerGroupField).toHaveLength(1);
     expect(consumerGroupField.props().required).toBeTruthy();

--- a/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
@@ -77,9 +77,15 @@ export const sourceDataSpecSchema = yup
     is: EventSources.KafkaSource,
     then: yup.object().shape({
       kafkasource: yup.object().shape({
-        bootstrapServers: yup.array().of(yup.string().required('Required')),
+        bootstrapServers: yup
+          .array()
+          .of(yup.string())
+          .min(1, 'Required'),
         consumerGroup: yup.string().required('Required'),
-        topics: yup.array().of(yup.string().required('Required')),
+        topics: yup
+          .array()
+          .of(yup.string())
+          .min(1, 'Required'),
         net: yup.object().shape({
           sasl: yup.object().shape({
             enable: yup.boolean(),

--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -10,3 +10,4 @@ export const KNATIVE_EVENTING_APIGROUP = 'eventing.knative.dev';
 export const KNATIVE_EVENT_MESSAGE_APIGROUP = 'messaging.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP_DEP = 'sources.eventing.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP = 'sources.knative.dev';
+export const STRIMZI_KAFKA_APIGROUP = 'kafka.strimzi.io';

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -279,6 +279,7 @@ export const KafkaModel: K8sKind = {
   abbr: 'K',
   namespaced: true,
   crd: true,
+  color: knativeEventingColor.value,
 };
 
 export const KafkaTopicModel: K8sKind = {
@@ -292,4 +293,5 @@ export const KafkaTopicModel: K8sKind = {
   abbr: 'KT',
   namespaced: true,
   crd: true,
+  color: knativeEventingColor.value,
 };

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -10,6 +10,7 @@ import {
   KNATIVE_SERVING_APIGROUP,
   KNATIVE_EVENT_MESSAGE_APIGROUP,
   KNATIVE_EVENTING_APIGROUP,
+  STRIMZI_KAFKA_APIGROUP,
 } from './const';
 
 const apiVersion = 'v1';
@@ -265,4 +266,30 @@ export const EventingTriggerModel: K8sKind = {
   namespaced: true,
   crd: true,
   color: knativeEventingColor.value,
+};
+
+export const KafkaModel: K8sKind = {
+  apiGroup: STRIMZI_KAFKA_APIGROUP,
+  apiVersion: 'v1beta1',
+  kind: 'Kafka',
+  label: 'Kafka',
+  labelPlural: 'Kafkas',
+  plural: 'kafkas',
+  id: 'kafka',
+  abbr: 'K',
+  namespaced: true,
+  crd: true,
+};
+
+export const KafkaTopicModel: K8sKind = {
+  apiGroup: STRIMZI_KAFKA_APIGROUP,
+  apiVersion: 'v1beta1',
+  kind: 'KafkaTopic',
+  label: 'KafkaTopic',
+  labelPlural: 'KafkaTopics',
+  plural: 'kafkatopics',
+  id: 'kafkatopic',
+  abbr: 'KT',
+  namespaced: true,
+  crd: true,
 };

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -6,8 +6,8 @@ import {
   EventSourceSinkBindingModel,
   EventSourceKafkaModel,
 } from '../../models';
-import { getEventSourceResource } from '../create-eventsources-utils';
-import { getDefaultEventingData } from './knative-serving-data';
+import { getEventSourceResource, getBootstrapServers } from '../create-eventsources-utils';
+import { getDefaultEventingData, Kafkas } from './knative-serving-data';
 import { EventSources } from '../../components/add/import-types';
 
 describe('Create knative Utils', () => {
@@ -63,5 +63,14 @@ describe('Create knative Utils', () => {
     );
     expect(knEventingResource.spec?.resources?.limits?.cpu).toBe('200m');
     expect(knEventingResource.spec?.resources?.requests?.cpu).toBe('100m');
+  });
+
+  it('should return bootstrapServers', () => {
+    expect(getBootstrapServers(Kafkas)).toEqual([
+      'my-cluster-kafka-bootstrap.div.svc:9092',
+      'my-cluster-kafka-bootstrap.div.svc:9093',
+      'my-cluster2-kafka-bootstrap.div.svc:9092',
+      'my-cluster2-kafka-bootstrap.div.svc:9093',
+    ]);
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -1,10 +1,10 @@
-import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, K8sKind, apiVersionForModel } from '@console/internal/module/k8s';
 import {
   DeployImageFormData,
   Resources,
 } from '@console/dev-console/src/components/import/import-types';
 import { EventSourceFormData } from '../../components/add/import-types';
-import { RevisionModel, ServiceModel } from '../../models';
+import { RevisionModel, ServiceModel, KafkaModel } from '../../models';
 import { healthChecksProbeInitialData } from '@console/dev-console/src/components/health-checks/health-checks-probe-utils';
 
 export const defaultData: DeployImageFormData = {
@@ -416,3 +416,152 @@ export const getEventSourceDeploymentData = (EventSourceModel: K8sKind): K8sReso
     },
   };
 };
+
+export const Kafkas: K8sResourceKind[] = [
+  {
+    apiVersion: apiVersionForModel(KafkaModel),
+    kind: KafkaModel.kind,
+    metadata: {
+      creationTimestamp: '2020-07-06T16:43:44Z',
+      generation: 1,
+      name: 'my-cluster',
+      namespace: 'div',
+      resourceVersion: '142204',
+      selfLink: '/apis/kafka.strimzi.io/v1beta1/namespaces/div/kafkas/my-cluster',
+      uid: '56c871cf-e649-4c7e-8ac6-8fafc933c96f',
+    },
+    spec: {
+      kafka: {
+        config: {
+          'log.message.format.version': '2.5',
+          'offsets.topic.replication.factor': 3,
+          'transaction.state.log.min.isr': 2,
+          'transaction.state.log.replication.factor': 3,
+        },
+        listeners: {
+          plain: {},
+          tls: {},
+        },
+        replicas: 3,
+        storage: {
+          type: 'ephemeral',
+        },
+        version: '2.5.0',
+      },
+      zookeeper: {
+        replicas: 3,
+        storage: {
+          type: 'ephemeral',
+        },
+      },
+    },
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: '2020-07-06T16:45:13+0000',
+          status: 'True',
+          type: 'Ready',
+        },
+      ],
+      listeners: [
+        {
+          addresses: [
+            {
+              host: 'my-cluster-kafka-bootstrap.div.svc',
+              port: 9092,
+            },
+          ],
+          bootstrapServers: 'my-cluster-kafka-bootstrap.div.svc:9092',
+          type: 'plain',
+        },
+        {
+          addresses: [
+            {
+              host: 'my-cluster-kafka-bootstrap.div.svc',
+              port: 9093,
+            },
+          ],
+          bootstrapServers: 'my-cluster-kafka-bootstrap.div.svc:9093',
+          certificates: [
+            '-----BEGIN CERTIFICATE-----\nMIIDLTCCAhWgAwIBAgIJAKdAmIkaXSmiMA0GCSqGSIb3DQEBCwUAMC0xEzARBgNV\nBAoMCmlvLnN0cmltemkxFjAUBgNVBAMMDWNsdXN0ZXItY2EgdjAwHhcNMjAwNzA2\nMTY0MzQ0WhcNMjEwNzA2MTY0MzQ0WjAtMRMwEQYDVQQKDAppby5zdHJpbXppMRYw\nFAYDVQQDDA1jbHVzdGVyLWNhIHYwMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAp0yDYlEHNPChuaNVBqZMTpYGfNe+FvHoyp3oB6bsErsl5SjCTTs5rkfK\nMT/vfEI7vmuaAvtSktJKKrZrDY/L4tJkf7IaJGAf5Jfgr2UEAmfzZHR2JTx+kODF\n1Q5PI3pH/ENjof6i686UE9VCovCifLiWuZaLaaYFoadVKnDJMPUyQvSr6zBbwCKO\n4jUM2MRMKabAhvlUricmTXX/1y4+26UIzmad2jG2bLZr+vrHDtc+HfkuJXl/4lD/\nm9TMN/Ab08aNFvF9dorg9hgxoL/tE4J8TRJp9wB5oF0BfU0B9JZ5ML+nvWMTF8no\nEYlejBHvmnUaBEecEZ0C3GKm4CFABwIDAQABo1AwTjAdBgNVHQ4EFgQUGign3S8T\n+p2ABHBE+ASURZZ0GsQwHwYDVR0jBBgwFoAUGign3S8T+p2ABHBE+ASURZZ0GsQw\nDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAJpkcJO5y9h5zRGkQ1+Pr\n8Y9+qPZnQeFCYIFmtT7eX+1/64anDnK8i3ZPy2GyQvxFazGPLRzaUpFr/fRDcw05\ntNRAIhet6cKQYgZBGJo4QPCE6XTZrPI9tf7xG/otJczQtsDNxkxfxJ3AGVdKkbw7\nst1gAFJncoDWyie5I9LiR8rr7OjAgbECKRePbjxbYmb3rIkaecARPiOiOOfEdwB+\nWOPSSTc5L1Wtf00pQ1jtnpnFgh9s5xHoATWjm0kr2uKSEd7Jwikf1HNLEjNlOdpD\njSavbHxKaQXxbs2e+z5RNqsGi6LgZs6tEni3j9zadX2KoXgrlxn9ZrK90e8E1Pdg\ndw==\n-----END CERTIFICATE-----\n',
+          ],
+          type: 'tls',
+        },
+      ],
+      observedGeneration: 1,
+    },
+  },
+  {
+    apiVersion: apiVersionForModel(KafkaModel),
+    kind: KafkaModel.kind,
+    metadata: {
+      creationTimestamp: '2020-07-06T16:56:39Z',
+      generation: 1,
+      name: 'my-cluster2',
+      namespace: 'div',
+      resourceVersion: '152566',
+      selfLink: '/apis/kafka.strimzi.io/v1beta1/namespaces/div/kafkas/my-cluster2',
+      uid: '219842be-00df-4e30-9c15-fce4b7438244',
+    },
+    spec: {
+      kafka: {
+        config: {
+          'log.message.format.version': '2.5',
+          'offsets.topic.replication.factor': 3,
+          'transaction.state.log.min.isr': 2,
+          'transaction.state.log.replication.factor': 3,
+        },
+        listeners: {
+          plain: {},
+          tls: {},
+        },
+        replicas: 3,
+        storage: {
+          type: 'ephemeral',
+        },
+        version: '2.5.0',
+      },
+      zookeeper: {
+        replicas: 3,
+        storage: {
+          type: 'ephemeral',
+        },
+      },
+    },
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: '2020-07-06T16:57:34+0000',
+          status: 'True',
+          type: 'Ready',
+        },
+      ],
+      listeners: [
+        {
+          addresses: [
+            {
+              host: 'my-cluster2-kafka-bootstrap.div.svc',
+              port: 9092,
+            },
+          ],
+          bootstrapServers: 'my-cluster2-kafka-bootstrap.div.svc:9092',
+          type: 'plain',
+        },
+        {
+          addresses: [
+            {
+              host: 'my-cluster2-kafka-bootstrap.div.svc',
+              port: 9093,
+            },
+          ],
+          bootstrapServers: 'my-cluster2-kafka-bootstrap.div.svc:9093',
+          certificates: [
+            '-----BEGIN CERTIFICATE-----\nMIIDLTCCAhWgAwIBAgIJAM5D3NjoJTpcMA0GCSqGSIb3DQEBCwUAMC0xEzARBgNV\nBAoMCmlvLnN0cmltemkxFjAUBgNVBAMMDWNsdXN0ZXItY2EgdjAwHhcNMjAwNzA2\nMTY1NjQwWhcNMjEwNzA2MTY1NjQwWjAtMRMwEQYDVQQKDAppby5zdHJpbXppMRYw\nFAYDVQQDDA1jbHVzdGVyLWNhIHYwMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEA4VPNI9879XEQ6ZNRVLOtP9FeUfkbdvxfSYqat1mT/BIV+gO/UlYbVpuq\nr19D3hBLja2q0skJAP0id0alX48f2UErXHumLZwz+4rpuZWToKqaTPp/0RTFv0d8\nDdDGweyysIyj5+MY2sRDQISXVg/3sUe5IIuJTWlAibgStcKq8wQYsbijLRx+2/GP\nUIALGJBU6vazyMo7do90AJoZ1YzG/n7mX3UYqpVy8qbJ47HkfQO8I/swS6+gEgp0\nyE+zKo41eUpX/ZMXLFIpry+I8xwBaTN7/Oc1kmTvODSvEKjmjtK0B9jhAwbrZk9u\nyLEqw9VTz1c1/70qpRg399RF8mFV4wIDAQABo1AwTjAdBgNVHQ4EFgQUUVDhyMRG\nbkUeL9+XddzQwUq5cr4wHwYDVR0jBBgwFoAUUVDhyMRGbkUeL9+XddzQwUq5cr4w\nDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAh7lwMOXzocBKx9HfdHou\neyL26gsF/bUpn01X0kmkEMpdj0a+FfeEXlPiH8AUQlbPjAaOIICHj8IeSM4T8/4c\n/qT0q4BZU81A4X05jHUijEEPQ5fRvmjdY2qkDUT5hOeHOQRfVXgwnBzNDykzNq4K\n6MIEwyz7PhvKUgsJ/f6j/KpHyxN2dJLTx+PaxWorRY5eiajnqZ+4WmnVPcPID8ax\nd3lChMhC3eGZiBv8/OtXZKeBF4ChTOdbfYS3jx8fElc0GkbLk56SyHMVtjRkGsON\n34tNqjz8rHQ0AGineJ72YtGR5DJzWvll09cVtXFBTL+6LYVCQYqSB9/gzXyAtUjb\nHw==\n-----END CERTIFICATE-----\n',
+          ],
+          type: 'tls',
+        },
+      ],
+      observedGeneration: 1,
+    },
+  },
+];

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -140,8 +140,8 @@ export const getEventSourceData = (source: string) => {
       ],
     },
     kafkasource: {
-      bootstrapServers: [''],
-      topics: [''],
+      bootstrapServers: [],
+      topics: [],
       consumerGroup: '',
       net: {
         sasl: {
@@ -214,4 +214,15 @@ export const useEventSourceList = (namespace: string): EventSourceListData | nul
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modelLoaded]);
   return eventSourceModels.length === 0 && modelLoaded ? null : accessData;
+};
+
+export const getBootstrapServers = (kafkaResources: K8sResourceKind[]) => {
+  const servers = [];
+  _.forEach(kafkaResources, (kafka) => {
+    const listeners = kafka?.status?.listeners;
+    _.map(listeners, (l) => {
+      servers.push(..._.split(l?.bootstrapServers, ','));
+    });
+  });
+  return servers;
 };

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -11,6 +11,8 @@ import {
   EventingSubscriptionModel,
   EventingBrokerModel,
   EventingTriggerModel,
+  KafkaModel,
+  KafkaTopicModel,
 } from '../models';
 
 export type KnativeItem = {
@@ -242,4 +244,20 @@ export const knativeEventingTriggerResourceWatchers = (namespace: string) => {
       optional: true,
     },
   };
+};
+
+export const strimziResourcesWatcher = (): WatchK8sResources<any> => {
+  const strimziResources = {
+    [KafkaModel.plural]: {
+      isList: true,
+      kind: referenceForModel(KafkaModel),
+      optional: true,
+    },
+    [KafkaTopicModel.plural]: {
+      isList: true,
+      kind: referenceForModel(KafkaTopicModel),
+      optional: true,
+    },
+  };
+  return strimziResources;
 };

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -474,3 +474,7 @@ button.pf-c-dropdown__menu-item.pf-m-disabled {
   // enables tooltips for disabled menu items
   pointer-events: auto;
 }
+
+.pf-c-select__menu {
+  list-style-type: none;
+}


### PR DESCRIPTION
Jira - https://issues.redhat.com/browse/ODC-4160

This PR adds a new formik-field component SelectInputField that can be used for selecting multiple options and also creating and adding an option if not present in the list. In this PR I have also refactored KafkaSourceSection and now SelectInputField is being used for displaying and selecting multiple bootsrapServers and topics.

![Screenshot from 2020-07-02 23-44-02](https://user-images.githubusercontent.com/20724543/86395417-d95fda80-bcbd-11ea-8433-a7a80b47090f.png)
![Screenshot from 2020-07-02 23-44-35](https://user-images.githubusercontent.com/20724543/86395422-da910780-bcbd-11ea-825f-3cff387a8e8f.png)
![Screenshot from 2020-07-02 23-45-04](https://user-images.githubusercontent.com/20724543/86395424-da910780-bcbd-11ea-8202-633cc7e87ee6.png)
![Screenshot from 2020-07-02 23-45-28](https://user-images.githubusercontent.com/20724543/86395426-db299e00-bcbd-11ea-94a0-47dc1ed81a62.png)

Updated labels:
![image](https://user-images.githubusercontent.com/20724543/87145415-e5075e80-c2c6-11ea-97cd-0991976e5ac2.png)


@openshift/team-devconsole-ux 

Note - There is some issue with pf Select placeholder, it doesn't render JSX elements correctly even though placeholder prop type is ReactNode. Bug - https://github.com/patternfly/patternfly-react/issues/4511




