### PR TITLE
Added bare metal views for OCS install

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
@@ -35,10 +35,10 @@ import { OCSServiceModel } from '../../models';
 import FileUpload from './fileUpload';
 import { isValidJSON, checkError, prettifyJSON } from './utils';
 import { OCS_INDEPENDENT_FLAG, OCS_FLAG } from '../../features';
-import { OCS_INDEPENDENT_CR_NAME } from '../../constants';
+import { OCS_EXTERNAL_CR_NAME } from '../../constants';
 import './install.scss';
 
-const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterProps) => {
+const CreateExternalCluster = withHandlePromise((props: CreateExternalClusterProps) => {
   const {
     inProgress,
     errorMessage,
@@ -94,7 +94,7 @@ const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterP
       apiVersion: apiVersionForModel(OCSServiceModel),
       kind: OCSServiceModel.kind,
       metadata: {
-        name: OCS_INDEPENDENT_CR_NAME,
+        name: OCS_EXTERNAL_CR_NAME,
         namespace: ns,
       },
       spec: {
@@ -137,7 +137,7 @@ const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterP
 
   return (
     <>
-      <div className="im-install-page">
+      <div className="im-install-page co-m-pane__body co-m-pane__form">
         <div className="im-install-page__sub-header">
           <Title size="lg" headingLevel="h5" className="nb-bs-page-title__main">
             <div className="im-install-page-sub-header__title">Connect to external cluster</div>
@@ -212,10 +212,10 @@ const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterP
   );
 });
 
-type InstallExternalClusterProps = HandlePromiseProps & {
+type CreateExternalClusterProps = HandlePromiseProps & {
   match: match<{ ns?: string; appName?: string }>;
   minRequiredKeys?: { [key: string]: string[] };
   downloadFile: string;
 };
 
-export default InstallExternalCluster;
+export default CreateExternalCluster;

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
@@ -30,7 +30,7 @@ const StorageClassDropdown = (props: any) => {
 };
 
 export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (props) => {
-  const { onChange, defaultClass } = props;
+  const { onChange, defaultClass, filter } = props;
 
   return (
     <>
@@ -40,6 +40,7 @@ export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (
           name="storageClass"
           defaultClass={defaultClass}
           hideClassName="ceph-sc-dropdown__hide-default"
+          filter={filter}
           required
         />
       </Firehose>
@@ -50,4 +51,5 @@ export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (
 type OCSStorageClassDropdownProps = {
   onChange: (sc: StorageClassResourceKind) => void;
   defaultClass?: string;
+  filter?: (sc: StorageClassResourceKind) => boolean;
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/attached-devices.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/attached-devices.scss
@@ -1,0 +1,7 @@
+.ceph-ocs-install__lso-alert__button {
+  margin-top: var(--pf-global--spacer--md);
+}
+
+.ceph-ocs-install__no-nodes-text--large {
+  font-size: var(--pf-global--FontSize--lg);
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import { match } from 'react-router';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch } from 'react-redux';
+import { ActionGroup, Button, Form } from '@patternfly/react-core';
+import {
+  NodeKind,
+  StorageClassResourceKind,
+  referenceForModel,
+  k8sCreate,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
+import {
+  withHandlePromise,
+  HandlePromiseProps,
+  history,
+  ButtonBar,
+} from '@console/internal/components/utils';
+import { setFlag } from '@console/internal/actions/features';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { getName } from '@console/shared';
+import { minSelectedNode, defaultRequestSize, NO_PROVISIONER } from '../../../constants';
+import { OCSServiceModel } from '../../../models';
+import AttachedDevicesNodeTable from './sc-node-list';
+import { PVsAvailableCapacity } from '../pvs-available-capacity';
+import { OCS_CONVERGED_FLAG, OCS_FLAG } from '../../../features';
+import { makeLabelNodesRequest } from '../create-form';
+import { LVSResource } from '../../../constants/resources';
+import { getOCSRequestData } from '../ocs-request-data';
+import {
+  OCSAlert,
+  SelectNodesSection,
+  StorageClassSection,
+} from '../../../utils/common-ocs-install-el';
+import { filterSCWithNoProv } from '../../../utils/install';
+import '../ocs-install.scss';
+import './attached-devices.scss';
+
+const makeOCSRequest = (
+  selectedData: NodeKind[],
+  storageClass: StorageClassResourceKind,
+): Promise<any> => {
+  const promises = makeLabelNodesRequest(selectedData);
+  const scName = getName(storageClass);
+  const ocsObj = getOCSRequestData(scName, defaultRequestSize.BAREMETAL, NO_PROVISIONER);
+
+  return Promise.all(promises).then(() => k8sCreate(OCSServiceModel, ocsObj));
+};
+
+export const CreateOCS = withHandlePromise<CreateOCSProps & HandlePromiseProps>((props) => {
+  const {
+    handlePromise,
+    errorMessage,
+    inProgress,
+    match: {
+      params: { appName, ns },
+    },
+  } = props;
+  const [filteredNodes, setFilteredNodes] = React.useState<string[]>([]);
+  const [storageClass, setStorageClass] = React.useState<StorageClassResourceKind>(null);
+  const [nodes, setNodes] = React.useState<NodeKind[]>([]);
+  // LVS: Local Volume Set
+  const dispatch = useDispatch();
+  const [LVSData, LVSLoaded, LVSLoadError] = useK8sWatchResource<K8sResourceKind[]>(LVSResource);
+
+  const handleStorageClass = (sc: StorageClassResourceKind) => {
+    setStorageClass(sc);
+
+    if (sc) {
+      const [volumeSet] =
+        LVSLoaded &&
+        !LVSLoadError &&
+        LVSData.filter((l) => l?.spec?.storageClassName === sc?.metadata?.name);
+      setFilteredNodes(
+        volumeSet?.spec?.nodeSelector?.nodeSelectorTerms?.[0]?.matchExpressions?.[0]?.values,
+      );
+    } else {
+      setFilteredNodes([]);
+    }
+  };
+
+  React.useEffect(() => {
+    if ((LVSLoadError || LVSData.length === 0) && LVSLoaded) {
+      setFilteredNodes([]);
+    }
+  }, [LVSData, LVSLoaded, LVSLoadError]);
+
+  const submit = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    // eslint-disable-next-line promise/catch-or-return
+    handlePromise(makeOCSRequest(nodes, storageClass)).then(() => {
+      dispatch(setFlag(OCS_CONVERGED_FLAG, true));
+      dispatch(setFlag(OCS_FLAG, true));
+      history.push(
+        `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(
+          OCSServiceModel,
+        )}/${getName(getOCSRequestData())}`,
+      );
+    });
+  };
+
+  const onlyNoProvSC = React.useCallback(filterSCWithNoProv, []);
+
+  return (
+    <div className="co-m-pane__form">
+      <OCSAlert />
+      <Form className="co-m-pane__body-group">
+        <StorageClassSection handleStorageClass={handleStorageClass} filterSC={onlyNoProvSC}>
+          <PVsAvailableCapacity
+            replica={getOCSRequestData().spec.storageDeviceSets[0].replica}
+            data-test-id="ceph-ocs-install-pvs-available-capacity"
+            sc={storageClass}
+          />
+        </StorageClassSection>
+        <h3 className="co-m-pane__heading co-m-pane__heading--baseline ceph-ocs-install__pane--margin">
+          <div className="co-m-pane__name">Nodes</div>
+        </h3>
+        {storageClass && filteredNodes.length ? (
+          <SelectNodesSection
+            table={AttachedDevicesNodeTable}
+            customData={{ filteredNodes, nodes, setNodes }}
+          />
+        ) : (
+          <div className="ceph-ocs-install__no-nodes-text--large">No nodes available to show</div>
+        )}
+        <ButtonBar errorMessage={errorMessage} inProgress={inProgress}>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="button"
+              variant="primary"
+              onClick={submit}
+              isDisabled={(filteredNodes?.length ?? 0) < minSelectedNode}
+            >
+              Create
+            </Button>
+            <Button type="button" variant="secondary" onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
+        </ButtonBar>
+      </Form>
+    </div>
+  );
+});
+
+type CreateOCSProps = {
+  match: match<{ appName: string; ns: string }>;
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { match as RouterMatch } from 'react-router';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { Alert, Button } from '@patternfly/react-core';
+import { StorageClassResourceKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { history } from '@console/internal/components/utils';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { fetchK8s } from '@console/internal/graphql/client';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
+import { LSO_NAMESPACE } from '@console/local-storage-operator-plugin/src/constants';
+import { CreateOCS } from './install-lso-sc';
+import { scResource, LSOSubscriptionResource } from '../../../constants/resources';
+import { filterSCWithNoProv } from '../../../utils/install';
+import './attached-devices.scss';
+
+export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesClusterProps> = ({
+  match,
+}) => {
+  const [hasNoProvSC, setHasNoProvSC] = React.useState(false);
+  // LSO stands for local-storage-operator
+  const [LSOEnabled, setLSOEnabled] = React.useState(false);
+  const [scData, scLoaded, scLoadError] = useK8sWatchResource<StorageClassResourceKind[]>(
+    scResource,
+  );
+  const [LSOData, LSOLoaded, LSOLoadError] = useK8sWatchResource<K8sResourceKind>(
+    LSOSubscriptionResource,
+  );
+
+  React.useEffect(() => {
+    if ((LSOLoadError || !LSOData) && LSOLoaded) {
+      setLSOEnabled(false);
+    } else if (LSOLoaded) {
+      // checking for availability of LSO CSV
+      fetchK8s(ClusterServiceVersionModel, LSOData?.status?.currentCSV, LSO_NAMESPACE)
+        .then(() => {
+          setLSOEnabled(true);
+        })
+        .catch(() => {
+          setLSOEnabled(false);
+        });
+    }
+  }, [LSOData, LSOLoaded, LSOLoadError]);
+
+  React.useEffect(() => {
+    if ((scLoadError || scData.length === 0) && scLoaded) {
+      setHasNoProvSC(false);
+    } else if (scLoaded) {
+      const filteredSCData = scData.filter(filterSCWithNoProv);
+      if (filteredSCData.length) {
+        setHasNoProvSC(true);
+      }
+    }
+  }, [scData, scLoaded, scLoadError]);
+
+  const goToLSOInstallationPage = () => {
+    history.push(
+      '/operatorhub/all-namespaces?details-item=local-storage-operator-redhat-operators-openshift-marketplace',
+    );
+  };
+
+  return (
+    <div className="co-m-pane__body">
+      {!LSOEnabled && (
+        <Alert
+          className="co-alert"
+          variant="info"
+          title="Local Storage Operator Not Installed"
+          isInline
+        >
+          <div>
+            Before we can create a storage cluster, the local storage operator needs to be
+            installed. When installation is finished come back to OpenShift Container Storage to
+            create a storage cluster.
+            <div className="ceph-ocs-install__lso-alert__button">
+              <Button type="button" variant="primary" onClick={goToLSOInstallationPage}>
+                Install
+              </Button>
+            </div>
+          </div>
+        </Alert>
+      )}
+      {hasNoProvSC && LSOEnabled && <CreateOCS match={match} />}
+    </div>
+  );
+};
+
+type CreateAttachedDevicesClusterProps = {
+  match: RouterMatch<{ appName: string; ns: string }>;
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/sc-node-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/sc-node-list.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {
+  getName,
+  getNodeRoles,
+  getNodeCPUCapacity,
+  getNodeAllocatableMemory,
+} from '@console/shared';
+import { humanizeCpuCores, ResourceLink } from '@console/internal/components/utils/';
+import { Table } from '@console/internal/components/factory';
+import { IRow } from '@patternfly/react-table';
+import { getConvertedUnits } from '../../../utils/install';
+import { getColumns } from '../node-list';
+import { GetRows, NodeTableProps } from '../types';
+import '../ocs-install.scss';
+
+const getRows: GetRows = ({ componentProps, customData }) => {
+  const { data } = componentProps;
+  const { nodes, setNodes, filteredNodes } = customData;
+
+  const nodeList = filteredNodes?.length ? filteredNodes : data.map(getName);
+  const filteredData = data.filter((node) => nodeList.includes(getName(node)));
+
+  const rows = filteredData.map((node) => {
+    const roles = getNodeRoles(node).sort();
+    const cpuSpec: string = getNodeCPUCapacity(node);
+    const memSpec: string = getNodeAllocatableMemory(node);
+    const cells: IRow['cells'] = [
+      {
+        title: <ResourceLink kind="Node" name={getName(node)} title={node.metadata.uid} />,
+      },
+      {
+        title: roles.join(', ') || '-',
+      },
+      {
+        title: node.metadata.labels?.['failure-domain.beta.kubernetes.io/zone'] || '-',
+      },
+      {
+        title: `${humanizeCpuCores(cpuSpec).string || '-'}`,
+      },
+      {
+        title: `${getConvertedUnits(memSpec)}`,
+      },
+    ];
+    return {
+      cells,
+      props: {
+        id: node.metadata.uid,
+      },
+    };
+  });
+
+  if (!_.isEqual(filteredData, nodes)) {
+    setNodes(filteredData);
+  }
+
+  return rows;
+};
+
+const AttachedDevicesNodeTable: React.FC<NodeTableProps> = (props) => (
+  <div className="ceph-node-list__max-height">
+    <Table
+      aria-label="Node Table"
+      data-test-id="attached-devices-nodes-table"
+      {...props}
+      Rows={getRows}
+      Header={getColumns}
+      virtualize={false}
+    />
+  </div>
+);
+
+export default AttachedDevicesNodeTable;

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.scss
@@ -13,3 +13,9 @@
 .ceph-install--no-margin > input {
   margin: auto;
 }
+
+.ceph-install__mode-toggle {
+  // no pf class for 0.3rem
+  padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--xl) 0.3rem var(--pf-global--spacer--xl);
+  border-bottom: var(--pf-global--BorderWidth--sm) solid #ddd;
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -4,17 +4,19 @@ import { k8sGet } from '@console/internal/module/k8s';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { BreadCrumbs } from '@console/internal/components/utils';
 import { getAnnotations } from '@console/shared/src/selectors/common';
-import { Radio, Title } from '@patternfly/react-core';
+import { RadioGroup } from '@console/internal/components/radio';
 import { getRequiredKeys, createDownloadFile } from '../independent-mode/utils';
 import { OCSServiceModel } from '../../models';
-import InstallExternalCluster from '../independent-mode/install';
-import { CreateOCSServiceForm } from './create-form';
+import CreateExternalCluster from '../independent-mode/install';
+import { CreateInternalCluster } from './create-form';
 import { OCS_SUPPORT_ANNOTATION } from '../../constants';
+import { CreateAttachedDevicesCluster } from './attached-devices/install';
 import './install-page.scss';
 
 enum MODES {
-  CONVERGED = 'Converged',
-  INDEPENDENT = 'Independent',
+  INTERNAL = 'Internal',
+  EXTERNAL = 'External',
+  ATTACHED_DEVICES = 'Attached Devices',
 }
 
 // eslint-disable-next-line no-shadow
@@ -29,10 +31,10 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
     null,
   );
   const [downloadFile, setDownloadFile] = React.useState(null);
-  const [mode, setMode] = React.useState(MODES.CONVERGED);
+  const [mode, setMode] = React.useState(MODES.INTERNAL);
   const [clusterServiceVersion, setClusterServiceVersion] = React.useState(null);
 
-  const handleModeChange = (_checked: boolean, event: React.FormEvent<HTMLInputElement>) => {
+  const handleModeChange = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;
     setMode(value as MODES);
   };
@@ -89,47 +91,39 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
           storage, and handles the scenes such as provisioning and management.
         </p>
       </div>
-
-      <div className="co-m-pane__body co-m-pane__form">
-        {isIndependent && (
-          <div className="ceph-install__select-mode">
-            <Title headingLevel="h5" size="lg" className="ceph-install-select-mode__title">
-              Select Mode
-            </Title>
-            <div className="ceph-install-select-mode">
-              <Radio
-                value={MODES.CONVERGED}
-                isChecked={mode === MODES.CONVERGED}
-                onChange={handleModeChange}
-                id="radio-1"
-                className="ceph-install--no-margin"
-                label="Internal"
-                name="converged-mode"
-              />
-            </div>
-            <div className="ceph-install-select-mode">
-              <Radio
-                value={MODES.INDEPENDENT}
-                isChecked={mode === MODES.INDEPENDENT}
-                onChange={handleModeChange}
-                id="radio-2"
-                label="External"
-                name="independent-mode"
-                className="ceph-install--no-margin"
-              />
-            </div>
-          </div>
-        )}
-        {(isIndependent === false || mode === MODES.CONVERGED) && (
-          <CreateOCSServiceForm match={match} />
-        )}
-        {mode === MODES.INDEPENDENT && (
-          <InstallExternalCluster
+      <div className="ceph-install__mode-toggle">
+        <RadioGroup
+          label="Select Mode:"
+          currentValue={mode}
+          inline
+          items={[
+            {
+              value: MODES.INTERNAL,
+              title: MODES.INTERNAL,
+            },
+            {
+              value: MODES.EXTERNAL,
+              title: MODES.EXTERNAL,
+              disabled: !isIndependent,
+            },
+            {
+              value: MODES.ATTACHED_DEVICES,
+              title: MODES.ATTACHED_DEVICES,
+            },
+          ]}
+          onChange={handleModeChange}
+        />
+      </div>
+      <div>
+        {mode === MODES.INTERNAL && <CreateInternalCluster match={match} />}
+        {mode === MODES.EXTERNAL && (
+          <CreateExternalCluster
             match={match}
             minRequiredKeys={independentReqdKeys}
             downloadFile={downloadFile}
           />
         )}
+        {mode === MODES.ATTACHED_DEVICES && <CreateAttachedDevicesCluster match={match} />}
       </div>
     </>
   );

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
@@ -15,6 +15,7 @@ import { Table } from '@console/internal/components/factory';
 import { IRow } from '@patternfly/react-table';
 import { hasOCSTaint, hasTaints, getConvertedUnits } from '../../utils/install';
 import { cephStorageLabel } from '../../selectors';
+import { GetRows, NodeTableProps } from './types';
 
 import './ocs-install.scss';
 
@@ -27,7 +28,7 @@ const tableColumnClasses = [
   classNames('col-md-2', 'hidden-sm', 'hidden-xs'),
 ];
 
-const getColumns = () => {
+export const getColumns = () => {
   return [
     {
       title: 'Name',
@@ -51,20 +52,6 @@ const getColumns = () => {
     },
   ];
 };
-
-const isSelected = (selected: Set<string>, nodeUID: string): boolean => selected.has(nodeUID);
-
-type GetRows = (
-  {
-    componentProps,
-  }: {
-    componentProps: { data: NodeKind[] };
-  },
-  visibleRows: Set<string>,
-  setVisibleRows: React.Dispatch<React.SetStateAction<Set<string>>>,
-  selectedNodes: Set<string>,
-  setSelectedNodes: (nodes: NodeKind[]) => void,
-) => NodeTableRow[];
 
 const getRows: GetRows = (
   { componentProps },
@@ -101,7 +88,7 @@ const getRows: GetRows = (
     return {
       cells,
       selected: selectedNodes
-        ? isSelected(selectedNodes, node.metadata.uid)
+        ? selectedNodes.has(node.metadata.uid)
         : hasLabel(node, cephStorageLabel),
       props: {
         id: node.metadata.uid,
@@ -154,19 +141,3 @@ const NodeTable: React.FC<NodeTableProps> = (props) => {
 };
 
 export default NodeTable;
-
-type NodeTableProps = {
-  data: NodeKind[];
-  customData: {
-    onRowSelected: (nodes: NodeKind[]) => void;
-  };
-  filters: { name: string; label: { all: string[] } };
-};
-
-type NodeTableRow = {
-  cells: IRow['cells'];
-  props: {
-    id: string;
-  };
-  selected: boolean;
-};

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-install.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-install.scss
@@ -29,3 +29,7 @@
 .ceph-install-select-mode {
   padding: var(--pf-global--spacer--sm) 0;
 }
+
+.ceph-ocs-install__pane--margin {
+  margin-bottom: 0;
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
@@ -1,0 +1,49 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { NO_PROVISIONER, OCS_INTERNAL_CR_NAME, CEPH_STORAGE_NAMESPACE } from '../../constants';
+
+export const getOCSRequestData = (
+  scName?: string,
+  storage?: string,
+  infra?: string,
+): K8sResourceKind => {
+  const requestData = {
+    apiVersion: 'ocs.openshift.io/v1',
+    kind: 'StorageCluster',
+    metadata: {
+      name: OCS_INTERNAL_CR_NAME,
+      namespace: CEPH_STORAGE_NAMESPACE,
+    },
+    spec: {
+      manageNodes: false,
+      storageDeviceSets: [
+        {
+          name: 'ocs-deviceset',
+          count: 1,
+          replica: 3,
+          resources: {},
+          placement: {},
+          portable: true,
+          dataPVCTemplate: {
+            spec: {
+              storageClassName: scName,
+              accessModes: ['ReadWriteOnce'],
+              volumeMode: 'Block',
+              resources: {
+                requests: {
+                  storage,
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  } as K8sResourceKind;
+
+  if (infra === NO_PROVISIONER) {
+    requestData.spec.monDataDirHostPath = '/var/lib/rook';
+    requestData.spec.storageDeviceSets[0].portable = false;
+  }
+
+  return requestData;
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
@@ -12,16 +12,16 @@ export const PVsAvailableCapacity: React.FC<PVAvaialbleCapacityProps> = ({ repli
   const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>(pvResource);
   let availableCapacity: string = '';
 
-  let availableStatusEl = (
+  let availableStatusElement = (
     <div className="skeleton-text ceph-pvs-available-capacity__current-capacity--loading" />
   );
 
-  if ((loadError || data.length === 0) && loaded) {
-    availableStatusEl = <div className="text-muted">Not Available</div>;
+  if ((loadError || data.length === 0 || !sc) && loaded) {
+    availableStatusElement = <div className="text-muted">Not Available</div>;
   } else if (loaded) {
     const pvs = getSCAvailablePVs(data, getName(sc));
     availableCapacity = humanizeBinaryBytes(calcPVsCapacity(pvs)).string;
-    availableStatusEl = <div>{`${availableCapacity} / ${replica} replicas`}</div>;
+    availableStatusElement = <div>{`${availableCapacity} / ${replica} replicas`}</div>;
   }
 
   return (
@@ -29,7 +29,7 @@ export const PVsAvailableCapacity: React.FC<PVAvaialbleCapacityProps> = ({ repli
       <div className="text-secondary ceph-add-capacity__current-capacity--text">
         <strong>Available capacity:</strong>
       </div>
-      {availableStatusEl}
+      {availableStatusElement}
     </div>
   );
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/types.ts
@@ -1,0 +1,36 @@
+import { NodeKind } from '@console/internal/module/k8s';
+import { IRow } from '@patternfly/react-table';
+
+type NodeTableRow = {
+  cells: IRow['cells'];
+  props: {
+    id: string;
+  };
+  selected?: boolean;
+};
+
+export type GetRows = (
+  {
+    componentProps,
+    customData,
+  }: {
+    componentProps: { data: NodeKind[] };
+    customData?: {
+      filteredNodes: string[];
+      setNodes: React.Dispatch<React.SetStateAction<NodeKind[]>>;
+      nodes: NodeKind[];
+    };
+  },
+  visibleRows?: Set<string>,
+  setVisibleRows?: React.Dispatch<React.SetStateAction<Set<string>>>,
+  selectedNodes?: Set<string>,
+  setSelectedNodes?: (nodes: NodeKind[]) => void,
+) => NodeTableRow[];
+
+export type NodeTableProps = {
+  data: NodeKind[];
+  customData?: {
+    onRowSelected: (nodes: NodeKind[]) => void;
+  };
+  filters: { name: string; label: { all: string[] } };
+};

--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './ocs-install';
 export const CEPH_HEALTHY = 'is healthy';
 export const CEPH_DEGRADED = 'health is degraded';
 export const CEPH_ERROR = 'health is in error state';
@@ -9,7 +10,7 @@ export const PODS = 'Pods';
 export const BY_USED = 'By Used Capacity';
 export const BY_REQUESTED = 'By Requested Capacity';
 export const OCS_OPERATOR = 'ocs-operator';
-export const OCS_INDEPENDENT_CR_NAME = 'ocs-external-storagecluster';
-export const OCS_CONVERGED_CR_NAME = 'ocs-storagecluster';
+export const OCS_EXTERNAL_CR_NAME = 'ocs-external-storagecluster';
+export const OCS_INTERNAL_CR_NAME = 'ocs-storagecluster';
 export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';
 export const OCS_SUPPORT_ANNOTATION = 'features.ocs.openshift.io/enabled';

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind, Taint } from '@console/internal/module/k8s';
+import { Taint } from '@console/internal/module/k8s';
 
 export const minSelectedNode = 3;
 export const ocsTaint: Taint = {
@@ -12,45 +12,6 @@ export const storageClassTooltip =
   'The Storage Class will be used to request storage from the underlying infrastructure to create the backing persistent volumes that will be used to provide the OpenShift Container Storage (OCS) service.';
 export const labelTooltip =
   'The backing storage requested will be higher as it will factor in the requested capacity, replica factor, and fault tolerant costs associated with the requested capacity.';
-
-export const ocsRequestData: K8sResourceKind = {
-  apiVersion: 'ocs.openshift.io/v1',
-  kind: 'StorageCluster',
-  metadata: {
-    name: 'ocs-storagecluster',
-    namespace: 'openshift-storage',
-  },
-  spec: {
-    manageNodes: false,
-    storageDeviceSets: [
-      {
-        name: 'ocs-deviceset',
-        count: 1,
-        replica: 3,
-        resources: {},
-        placement: {},
-        portable: true,
-        dataPVCTemplate: {
-          spec: {
-            storageClassName: '',
-            accessModes: ['ReadWriteOnce'],
-            volumeMode: 'Block',
-            resources: {
-              requests: {
-                storage: '',
-              },
-            },
-          },
-        },
-      },
-    ],
-  },
-};
-
-export const infraProvisionerMap = {
-  aws: 'kubernetes.io/aws-ebs',
-  vsphere: 'kubernetes.io/vsphere-volume',
-};
 
 export enum defaultRequestSize {
   BAREMETAL = '1',

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -1,7 +1,10 @@
 import { FirehoseResource } from '@console/internal/components/utils/index';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
-import { PersistentVolumeModel } from '@console/internal/models';
+import { PersistentVolumeModel, StorageClassModel } from '@console/internal/models';
 import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { SubscriptionModel } from '@console/operator-lifecycle-manager';
+import { LocalVolumeSetModel } from '@console/local-storage-operator-plugin/src/models';
+import { LSO_NAMESPACE } from '@console/local-storage-operator-plugin/src/constants';
 import { CephClusterModel } from '../models';
 
 export const cephClusterResource: FirehoseResource = {
@@ -15,4 +18,23 @@ export const pvResource: WatchK8sResource = {
   kind: PersistentVolumeModel.kind,
   namespaced: false,
   isList: true,
+};
+
+export const scResource: WatchK8sResource = {
+  kind: StorageClassModel.kind,
+  namespaced: false,
+  isList: true,
+};
+
+export const LVSResource: WatchK8sResource = {
+  kind: referenceForModel(LocalVolumeSetModel),
+  namespace: LSO_NAMESPACE,
+  isList: true,
+};
+
+export const LSOSubscriptionResource: WatchK8sResource = {
+  kind: referenceForModel(SubscriptionModel),
+  namespace: LSO_NAMESPACE,
+  isList: false,
+  name: 'local-storage-operator',
 };

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -8,10 +8,10 @@ import { getAnnotations } from '@console/shared/src/selectors/common';
 import { fetchK8s } from '@console/internal/graphql/client';
 import { OCSServiceModel } from './models';
 import {
-  OCS_INDEPENDENT_CR_NAME,
+  OCS_EXTERNAL_CR_NAME,
   CEPH_STORAGE_NAMESPACE,
   OCS_SUPPORT_ANNOTATION,
-  OCS_CONVERGED_CR_NAME,
+  OCS_INTERNAL_CR_NAME,
 } from './constants';
 
 export const OCS_INDEPENDENT_FLAG = 'OCS_INDEPENDENT';
@@ -41,7 +41,7 @@ const handleError = (res: any, flags: string[], dispatch: Dispatch, cb: FeatureD
 
 export const detectOCS: FeatureDetector = async (dispatch) => {
   try {
-    await fetchK8s(OCSServiceModel, OCS_CONVERGED_CR_NAME, CEPH_STORAGE_NAMESPACE);
+    await fetchK8s(OCSServiceModel, OCS_INTERNAL_CR_NAME, CEPH_STORAGE_NAMESPACE);
     dispatch(setFlag(OCS_FLAG, true));
     dispatch(setFlag(OCS_CONVERGED_FLAG, true));
     dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
@@ -50,7 +50,7 @@ export const detectOCS: FeatureDetector = async (dispatch) => {
       ? handleError(e, [OCS_CONVERGED_FLAG], dispatch, detectOCS)
       : dispatch(setFlag(OCS_CONVERGED_FLAG, false));
     try {
-      await fetchK8s(OCSServiceModel, OCS_INDEPENDENT_CR_NAME, CEPH_STORAGE_NAMESPACE);
+      await fetchK8s(OCSServiceModel, OCS_EXTERNAL_CR_NAME, CEPH_STORAGE_NAMESPACE);
       dispatch(setFlag(OCS_FLAG, true));
       dispatch(setFlag(OCS_INDEPENDENT_FLAG, true));
       dispatch(setFlag(OCS_CONVERGED_FLAG, false));

--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { Alert, FormGroup } from '@patternfly/react-core';
+import { ListPage } from '@console/internal/components/factory';
+import { NodeModel } from '@console/internal/models';
+import { FieldLevelHelp } from '@console/internal/components/utils';
+import { StorageClassResourceKind } from '@console/internal/module/k8s';
+import { OCSStorageClassDropdown } from '../components/modals/storage-class-dropdown';
+import { storageClassTooltip } from '../constants/ocs-install';
+import '../components/ocs-install/ocs-install.scss';
+
+export const OCSAlert = () => (
+  <Alert
+    className="co-alert"
+    variant="info"
+    title="A bucket will be created to provide the OCS Service."
+    isInline
+  />
+);
+
+export const SelectNodesSection: React.FC<SelectNodesSectionProps> = ({ table, customData }) => (
+  <>
+    <FormGroup fieldId="select-nodes">
+      <p>
+        Selected nodes will be labeled with{' '}
+        <code>cluster.ocs.openshift.io/openshift-storage=&quot;&quot;</code> to create the OCS
+        Service.
+      </p>
+      <p className="co-legend" data-test-id="warning">
+        Select at least 3 nodes in different failure domains with minimum requirements of 16 CPUs
+        and 64 GiB of RAM per node.
+      </p>
+      <p>
+        3 selected nodes are used for initial deployment. The remaining selected nodes will be used
+        by OpenShift as scheduling targets for OCS scaling.
+      </p>
+      <ListPage
+        kind={NodeModel.kind}
+        showTitle={false}
+        ListComponent={table}
+        customData={customData}
+      />
+    </FormGroup>
+  </>
+);
+
+export const StorageClassSection: React.FC<StorageClassSectionProps> = ({
+  handleStorageClass,
+  filterSC,
+  children,
+}) => (
+  <>
+    <h3 className="co-m-pane__heading co-m-pane__heading--baseline ceph-ocs-install__pane--margin">
+      <div className="co-m-pane__name">Capacity</div>
+    </h3>
+    <FormGroup
+      fieldId="select-sc"
+      label={
+        <>
+          Storage Class
+          <FieldLevelHelp>{storageClassTooltip}</FieldLevelHelp>
+        </>
+      }
+    >
+      <div className="ceph-ocs-install__ocs-service-capacity--dropdown">
+        <OCSStorageClassDropdown
+          onChange={handleStorageClass}
+          data-test-id="ocs-dropdown"
+          filter={filterSC}
+        />
+      </div>
+      {children}
+    </FormGroup>
+  </>
+);
+
+type SelectNodesSectionProps = {
+  table: React.ComponentType<any>;
+  customData?: any;
+};
+
+type StorageClassSectionProps = {
+  handleStorageClass: (sc: StorageClassResourceKind) => void;
+  filterSC: (sc: StorageClassResourceKind) => boolean;
+  children?: React.ReactElement;
+};

--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
-import { NodeKind, Taint } from '@console/internal/module/k8s';
-import { ocsTaint } from '../constants/ocs-install';
+import { NodeKind, Taint, StorageClassResourceKind } from '@console/internal/module/k8s';
+import { ocsTaint, NO_PROVISIONER } from '../constants';
 import { humanizeBinaryBytes, convertToBaseValue } from '@console/internal/components/utils';
 
 export const hasTaints = (node: NodeKind) => {
@@ -15,3 +15,9 @@ export const hasOCSTaint = (node: NodeKind) => {
 export const getConvertedUnits = (value: string) => {
   return humanizeBinaryBytes(convertToBaseValue(value)).string ?? '-';
 };
+
+export const filterSCWithNoProv = (sc: StorageClassResourceKind) =>
+  sc?.provisioner === NO_PROVISIONER;
+
+export const filterSCWithoutNoProv = (sc: StorageClassResourceKind) =>
+  sc?.provisioner !== NO_PROVISIONER;

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
@@ -6,7 +6,7 @@
   margin: 0;
 }
 
-.lso-create-lvs__max-volume-limit-help-text--margin {
+.lso-create-lvs__max-disk-limit-help-text--margin {
   margin-top: 0;
 }
 
@@ -14,6 +14,26 @@
   margin-top: 0;
 }
 
-.lso-create-lvs__volume-mode-dropdown--margin {
+.lso-create-lvs__disk-mode-dropdown--margin {
   margin-bottom: var(--pf-global--spacer--md);
+}
+
+.lso-create-lvs__disk-size-form-group--margin {
+  margin: var(--pf-global--spacer--lg) 0;
+}
+
+.lso-create-lvs__disk-size-form-group-div {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  width: 22em;
+}
+
+.lso-create-lvs__disk-size-form-group-max-min-input {
+  display: flex;
+  flex-direction: column;
+}
+
+.lso-create-lvs__disk-size-form-group-max-input {
+  max-width: 100px;
 }

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -1,0 +1,213 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  TextInput,
+  Radio,
+  ExpandableSection,
+  TextInputTypes,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
+import { Dropdown } from '@console/internal/components/utils';
+import { ListPage } from '@console/internal/components/factory';
+import { NodeKind } from '@console/internal/module/k8s';
+import { getName } from '@console/shared';
+import { NodeModel } from '@console/internal/models';
+import { NodesSelectionList } from './nodes-selection-list';
+import { State, Action } from './state';
+import {
+  MAX_DISK_SIZE,
+  diskModeDropdownItems,
+  diskTypeDropdownItems,
+  diskSizeUnitOptions,
+} from '../../constants';
+import './create-local-volume-set.scss';
+
+export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = (props) => {
+  const { dispatch, state } = props;
+
+  React.useEffect(() => {
+    if (!state.showNodesList) {
+      dispatch({ type: 'setNodeNames', value: state.allNodeNames });
+    }
+  }, [dispatch, state.allNodeNames, state.showNodesList]);
+
+  const toggleShowNodesList = () => {
+    dispatch({ type: 'setShowNodesList', value: !state.showNodesList });
+  };
+
+  const onMaxSizeChange = (size: string) => {
+    if (
+      size !== MAX_DISK_SIZE &&
+      (Number.isNaN(Number(size)) || Number(size) < state.minDiskSize)
+    ) {
+      dispatch({ type: 'setIsValidMaxSize', value: false });
+    } else {
+      dispatch({ type: 'setIsValidMaxSize', value: true });
+    }
+    dispatch({ type: 'setMaxDiskSize', value: size });
+  };
+
+  return (
+    <>
+      <FormGroup label="Volume Set Name" isRequired fieldId="create-lvs--volume-set-name">
+        <TextInput
+          type={TextInputTypes.text}
+          id="create-lvs--volume-set-name"
+          value={state.volumeSetName}
+          onChange={(name: string) => dispatch({ type: 'setVolumeSetName', name })}
+          isRequired
+        />
+      </FormGroup>
+      <FormGroup label="Storage Class Name" fieldId="create-lvs--storage-class-name">
+        <TextInput
+          type={TextInputTypes.text}
+          id="create-lvs--storage-class-name"
+          value={state.storageClassName}
+          onChange={(name: string) => dispatch({ type: 'setStorageClassName', name })}
+        />
+      </FormGroup>
+      <Text component={TextVariants.h3} className="lso-create-lvs__filter-volumes-text--margin">
+        Filter Disks
+      </Text>
+      <FormGroup label="Node Selector" fieldId="create-lvs--radio-group-node-selector">
+        <div id="create-lvs--radio-group-node-selector">
+          <Radio
+            label="All nodes"
+            name="nodes-selection"
+            id="create-lvs--radio-all-nodes"
+            className="lso-create-lvs__all-nodes-radio--padding"
+            value="allNodes"
+            onChange={toggleShowNodesList}
+            description="Selecting all nodes will search for available disks storage on all nodes."
+            defaultChecked
+          />
+          <Radio
+            label="Select nodes"
+            name="nodes-selection"
+            id="create-lvs--radio-select-nodes"
+            value="selectedNodes"
+            onChange={toggleShowNodesList}
+            description="Selecting nodes allow you to limit the search for available disks to specific nodes."
+          />
+        </div>
+      </FormGroup>
+      {state.showNodesList && (
+        <ListPage
+          showTitle={false}
+          kind={NodeModel.kind}
+          ListComponent={NodesSelectionList}
+          customData={{
+            onRowSelected: (selectedNodes: NodeKind[]) => {
+              const nodes = selectedNodes.map(getName);
+              dispatch({ type: 'setNodeNames', value: nodes });
+            },
+          }}
+        />
+      )}
+      <FormGroup label="Disk Type" fieldId="create-lvs--disk-type-dropdown">
+        <Dropdown
+          id="create-lvs--disk-type-dropdown"
+          dropDownClassName="dropdown--full-width"
+          items={diskTypeDropdownItems}
+          title={state.diskType}
+          selectedKey={state.diskType}
+          onChange={(type: string) =>
+            dispatch({ type: 'setDiskType', value: diskTypeDropdownItems[type] })
+          }
+        />
+      </FormGroup>
+      <ExpandableSection toggleText="Advanced" data-test-id="create-lvs-form-advanced">
+        <FormGroup
+          label="Disk Mode"
+          fieldId="create-lso--disk-mode-dropdown"
+          className="lso-create-lvs__disk-mode-dropdown--margin"
+        >
+          <Dropdown
+            id="create-lso--disk-mode-dropdown"
+            dropDownClassName="dropdown--full-width"
+            items={diskModeDropdownItems}
+            title={state.diskMode}
+            selectedKey={state.diskMode}
+            onChange={(mode: string) => {
+              dispatch({ type: 'setDiskMode', value: diskModeDropdownItems[mode] });
+            }}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Disk Size"
+          fieldId="create-lvs--disk-size"
+          className="lso-create-lvs__disk-size-form-group--margin"
+        >
+          <div id="create-lvs--disk-size" className="lso-create-lvs__disk-size-form-group-div">
+            <FormGroup
+              label="Min"
+              fieldId="create-lvs--min-disk-size"
+              className="lso-create-lvs__disk-size-form-group-max-min-input"
+            >
+              <TextInput
+                type={TextInputTypes.number}
+                id="create-lvs--min-disk-size"
+                value={state.minDiskSize}
+                onChange={(size: string) => {
+                  dispatch({ type: 'setMinDiskSize', value: size });
+                }}
+              />
+            </FormGroup>
+            <div>-</div>
+            <FormGroup
+              label="Max"
+              fieldId="create-lvs--max-disk-size"
+              className="lso-create-lvs__disk-size-form-group-max-min-input"
+            >
+              <TextInput
+                type={TextInputTypes.text}
+                id="create-lvs--max-disk-size"
+                value={state.maxDiskSize}
+                validated={state.isValidMaxSize ? 'default' : 'error'}
+                className="lso-create-lvs__disk-size-form-group-max-input"
+                onChange={onMaxSizeChange}
+              />
+            </FormGroup>
+            <Dropdown
+              id="create-lvs--disk-size-unit-dropdown"
+              items={diskSizeUnitOptions}
+              title={state.diskSizeUnit}
+              selectedKey={state.diskSizeUnit}
+              onChange={(unit: string) => {
+                dispatch({ type: 'setDiskSizeUnit', value: unit });
+              }}
+            />
+          </div>
+        </FormGroup>
+        <FormGroup label="Max Disk Limit" fieldId="create-lvs--max-disk-limit">
+          <p className="help-block lso-create-lvs__max-disk-limit-help-text--margin">
+            Disk limit will set the maximum number of PVs to create on a node. If the field is
+            empty, will create PVs for all available disks on the matching nodes.
+          </p>
+          <TextInput
+            type={TextInputTypes.number}
+            id="create-lvs--max-disk-limit"
+            value={state.maxDiskLimit}
+            onChange={(maxLimit) => dispatch({ type: 'setMaxDiskLimit', value: maxLimit })}
+          />
+        </FormGroup>
+      </ExpandableSection>
+    </>
+  );
+};
+
+type LocalVolumeSetInnerProps = {
+  state: State;
+  dispatch: React.Dispatch<Action>;
+};
+
+export const LocalVolumeSetHeader = () => (
+  <>
+    <h1 className="co-create-operand__header-text">Local Volume Set</h1>
+    <p className="help-block">
+      A Local Volume Set allows you to filter a set of storage volumes, group them and create a
+      dedicated storage class to consume storage for them.
+    </p>
+  </>
+);

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -1,0 +1,42 @@
+import { apiVersionForModel } from '@console/internal/module/k8s';
+import { LocalVolumeSetModel } from '../../models';
+import { LocalVolumeSetKind, DiskType, DiskMechanicalProperty } from './types';
+import { State } from './state';
+import { MAX_DISK_SIZE } from '../../constants';
+
+export const getLocalVolumeSetRequestData = (state: State): LocalVolumeSetKind => {
+  const requestData = {
+    apiVersion: apiVersionForModel(LocalVolumeSetModel),
+    kind: LocalVolumeSetModel.kind,
+    metadata: { name: state.volumeSetName, namespace: 'local-storage' },
+    spec: {
+      storageClassName: state.storageClassName || state.volumeSetName,
+      volumeMode: state.diskMode,
+      deviceInclusionSpec: {
+        // Only Raw disk supported for 4.6
+        deviceTypes: [DiskType.RawDisk],
+        deviceMechanicalProperty:
+          state.diskType === 'HDD'
+            ? [DiskMechanicalProperty[state.diskType]]
+            : [DiskMechanicalProperty.SSD],
+      },
+      nodeSelector: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              { key: 'kubernetes.io/hostname', operator: 'In', values: state.nodeNames },
+            ],
+          },
+        ],
+      },
+    },
+  } as LocalVolumeSetKind;
+
+  if (state.maxDiskLimit) requestData.spec.maxDeviceCount = +state.maxDiskLimit;
+  if (state.minDiskSize)
+    requestData.spec.deviceInclusionSpec.minSize = state.minDiskSize.toString();
+  if (state.maxDiskSize && state.maxDiskSize !== MAX_DISK_SIZE)
+    requestData.spec.deviceInclusionSpec.maxSize = state.maxDiskSize.toString();
+
+  return requestData;
+};

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -1,0 +1,76 @@
+import { MAX_DISK_SIZE, diskTypeDropdownItems, diskModeDropdownItems } from '../../constants';
+
+export const initialState = {
+  volumeSetName: '',
+  storageClassName: '',
+  showNodesList: false,
+  diskType: diskTypeDropdownItems.SSD,
+  diskMode: diskModeDropdownItems.BLOCK,
+  maxDiskLimit: '',
+  nodeNames: [],
+  minDiskSize: 0,
+  maxDiskSize: MAX_DISK_SIZE,
+  diskSizeUnit: 'TiB',
+  isValidMaxSize: true,
+  allNodeNames: [],
+};
+
+export type State = {
+  volumeSetName: string;
+  storageClassName: string;
+  showNodesList: boolean;
+  diskType: string;
+  diskMode: string;
+  maxDiskLimit: string;
+  nodeNames: string[];
+  minDiskSize: number | string;
+  maxDiskSize: number | string;
+  diskSizeUnit: string;
+  isValidMaxSize: boolean;
+  allNodeNames: string[];
+};
+
+export type Action =
+  | { type: 'setVolumeSetName'; name: string }
+  | { type: 'setStorageClassName'; name: string }
+  | { type: 'setShowNodesList'; value: boolean }
+  | { type: 'setDiskType'; value: string }
+  | { type: 'setDiskMode'; value: string }
+  | { type: 'setMaxDiskLimit'; value: string }
+  | { type: 'setNodeNames'; value: string[] }
+  | { type: 'setMinDiskSize'; value: number | string }
+  | { type: 'setMaxDiskSize'; value: number | string }
+  | { type: 'setDiskSizeUnit'; value: string }
+  | { type: 'setIsValidMaxSize'; value: boolean }
+  | { type: 'setAllNodeNames'; value: string[] };
+
+export const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'setVolumeSetName':
+      return Object.assign({}, state, { volumeSetName: action.name });
+    case 'setStorageClassName':
+      return Object.assign({}, state, { storageClassName: action.name });
+    case 'setShowNodesList':
+      return Object.assign({}, state, { showNodesList: action.value });
+    case 'setDiskType':
+      return Object.assign({}, state, { diskType: action.value });
+    case 'setDiskMode':
+      return Object.assign({}, state, { diskMode: action.value });
+    case 'setMaxDiskLimit':
+      return Object.assign({}, state, { maxDiskLimit: action.value });
+    case 'setNodeNames':
+      return Object.assign({}, state, { nodeNames: action.value });
+    case 'setMinDiskSize':
+      return Object.assign({}, state, { minDiskSize: action.value });
+    case 'setMaxDiskSize':
+      return Object.assign({}, state, { maxDiskSize: action.value });
+    case 'setDiskSizeUnit':
+      return Object.assign({}, state, { diskSizeUnit: action.value });
+    case 'setIsValidMaxSize':
+      return Object.assign({}, state, { isValidMaxSize: action.value });
+    case 'setAllNodeNames':
+      return Object.assign({}, state, { allNodeNames: action.value });
+    default:
+      return initialState;
+  }
+};

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
@@ -10,16 +10,11 @@ export type NodeTableRow = {
 };
 
 export enum DiskType {
-  SSD = 'SSD',
-  HDD = 'HDD',
-}
-
-export enum DeviceType {
-  RawDisk = 'RawDisk',
+  RawDisk = 'disk',
   Partition = 'Partition',
 }
 
-export enum DeviceMechanicalProperty {
+export enum DiskMechanicalProperty {
   SSD = 'Rotational',
   HDD = 'NonRotational',
 }
@@ -29,17 +24,15 @@ export type LocalVolumeSetKind = K8sResourceCommon & {
     storageClassName: string;
     volumeMode: string;
     deviceInclusionSpec: {
-      deviceTypes: DeviceType[];
-      deviceMechanicalProperty: DeviceMechanicalProperty[];
-      minSize?: number;
-      maxSize?: number;
+      deviceTypes: DiskType[];
+      deviceMechanicalProperty: DiskMechanicalProperty[];
+      minSize?: string;
+      maxSize?: string;
     };
     nodeSelector?: {
-      nodeSelectorTerms: [
-        {
-          matchExpressions: [{ key: string; operator: string; values: string[] }];
-        },
-      ];
+      nodeSelectorTerms: {
+        matchExpressions: { key: string; operator: string; values: string[] }[];
+      }[];
     };
     maxDeviceCount?: number;
   };

--- a/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
@@ -1,0 +1,17 @@
+export const LSO_NAMESPACE = 'local-storage';
+export const MAX_DISK_SIZE = 'All';
+
+export const diskModeDropdownItems = {
+  BLOCK: 'Block',
+  FILESYSTEM: 'Filesystem',
+};
+
+export const diskTypeDropdownItems = {
+  SSD: 'SSD / NVMe',
+  HDD: 'HDD',
+};
+
+export const diskSizeUnitOptions = {
+  TiB: 'TiB',
+  GiB: 'GiB',
+};

--- a/frontend/packages/local-storage-operator-plugin/src/constants/resources.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/resources.ts
@@ -1,0 +1,8 @@
+import { NodeModel } from '@console/internal/models';
+import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-hook';
+
+export const nodeResource: WatchK8sResource = {
+  kind: NodeModel.kind,
+  namespaced: false,
+  isList: true,
+};

--- a/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
@@ -1,0 +1,6 @@
+import * as _ from 'lodash';
+import { NodeKind } from '@console/internal/module/k8s';
+
+export const hasTaints = (node: NodeKind): boolean => {
+  return !_.isEmpty(node.spec?.taints);
+};


### PR DESCRIPTION
What is implemented?

- Create Local Volume Set view(except disk list and donut chart)
- Bare Metal Views
   - When LSO and SC present
   - When LSO is not present

What not covered? Will be sent as a follow up PR
 -  Minimum nodes validation for bare metal(UXD not yet present)
 -  Unit tests 
 -  Bare Metal View when LSO is present but SC is not present i.e. Integrated Wizard
 -  LSO view - Auto Discovery
 -  Donut chart with Disk List

![lvs](https://user-images.githubusercontent.com/5517376/86375156-4e341400-bcc0-11ea-8fc3-1c7a01225e1f.png)
![bare-metal](https://user-images.githubusercontent.com/5517376/86375165-4f654100-bcc0-11ea-98a6-e93667909d3a.png)


