### PR TITLE
Don't download geckodriver when CHROME_VERSION is defined

### DIFF
--- a/test-gui.sh
+++ b/test-gui.sh
@@ -5,10 +5,14 @@ set -exuo pipefail
 cd frontend
 
 yarn install
-if [ -z "${CHROME_VERSION-}" ]; then
+if [ "${BRIDGE_E2E_BROWSER_NAME-}" == 'firefox' ]; then
  yarn run webdriver-update
 else
- yarn run webdriver-update --versions.chrome="$CHROME_VERSION"
+ if [ -n "${CHROME_VERSION-}" ]; then
+  yarn run webdriver-update --versions.chrome="$CHROME_VERSION" --gecko=false
+ else
+  yarn run webdriver-update --gecko=false
+ fi
 fi
 
 if [ $# -gt 0 ] && [ -n "$1" ]; then


### PR DESCRIPTION
In CNV Jenkins CI we're too often hitting problem with webdriver-update failing to download geckodriver because of exceeding allowed number of unauthenticated requests to github API.

webdriver-managed will support authentication only in version 13 according to https://github.com/angular/webdriver-manager/issues/216#issuecomment-476087741 

I think it would make sense to set `--gecko=false` in case CHROME_VERSION is explicitly defined, as Firefox is presumably not being used.

