### PR TITLE
Support sink to URI for sources creation

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
@@ -18,4 +18,10 @@
     }
 
   }
+  .pf-c-radio {
+    &__description {
+      width: 100%;
+    }
+  }
 }
+

--- a/frontend/packages/console-shared/src/utils/icon-utils.ts
+++ b/frontend/packages/console-shared/src/utils/icon-utils.ts
@@ -6,14 +6,4 @@ export const getImageForCSVIcon = (icon: CSVIcon | undefined) => {
   return icon ? `data:${icon.mediatype};base64,${icon.base64data}` : operatorLogo;
 };
 
-export const isIconUrl = (url: string): boolean => {
-  try {
-    // eslint-disable-next-line no-new
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 export const getDefaultOperatorIcon = () => operatorLogo;

--- a/frontend/packages/console-shared/src/utils/utils.ts
+++ b/frontend/packages/console-shared/src/utils/utils.ts
@@ -33,3 +33,13 @@ export const getRandomChars = (len = 6): string => {
     .replace(/[^a-z0-9]+/g, '')
     .substr(1, len);
 };
+
+export const isValidUrl = (url: string): boolean => {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/frontend/packages/dev-console/src/components/svg/SvgCircledIcon.tsx
+++ b/frontend/packages/dev-console/src/components/svg/SvgCircledIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useSize, createSvgIdUrl } from '@patternfly/react-topology';
-import { isIconUrl } from '@console/shared/';
+import { isValidUrl } from '@console/shared';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import SvgDropShadowFilter from './SvgDropShadowFilter';
 
@@ -45,7 +45,7 @@ export const CircledIcon: React.FC<SvgTypedIconProps> = (
           y={y}
           width={width}
           height={height}
-          xlinkHref={isIconUrl(iconClass) ? iconClass : getImageForIconClass(iconClass)}
+          xlinkHref={isValidUrl(iconClass) ? iconClass : getImageForIconClass(iconClass)}
           filter={createSvgIdUrl(FILTER_ID)}
         />
       </g>

--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -16,7 +16,7 @@ import { sanitizeApplicationValue } from '@console/dev-console/src/utils/applica
 import { eventSourceValidationSchema } from './eventSource-validation-utils';
 import EventSourceForm from './EventSourceForm';
 import { getEventSourceResource } from '../../utils/create-eventsources-utils';
-import { EventSourceFormData, EventSourceListData } from './import-types';
+import { EventSourceFormData, EventSourceListData, SinkType } from './import-types';
 
 interface EventSourceProps {
   namespace: string;
@@ -54,10 +54,12 @@ export const EventSource: React.FC<Props> = ({
     },
     name: '',
     apiVersion: '',
+    sinkType: SinkType.Resource,
     sink: {
       apiVersion: sinkApiVersion,
       kind: sinkKind,
       name: sinkName,
+      uri: '',
     },
     limits: {
       cpu: {

--- a/frontend/packages/knative-plugin/src/components/add/EventSourceAlert.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourceAlert.tsx
@@ -1,64 +1,22 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Alert } from '@patternfly/react-core';
-import {
-  useK8sWatchResources,
-  WatchK8sResults,
-} from '@console/internal/components/utils/k8s-watch-hook';
-import { K8sResourceKind } from '@console/internal/module/k8s';
-import {
-  knativeServingResourcesServicesWatchers,
-  knativeEventingBrokerResourceWatchers,
-} from '../../utils/get-knative-resources';
-import { getDynamicEventingChannelWatchers } from '../../utils/fetch-dynamic-eventsources-utils';
 import { EventSourceListData } from './import-types';
 
 interface EventSourceAlertProps {
-  namespace: string;
   eventSourceStatus: EventSourceListData | null;
 }
 
-type ResourcesObject = { [key: string]: K8sResourceKind[] };
-
-const EventSourceAlert: React.FC<EventSourceAlertProps> = ({ namespace, eventSourceStatus }) => {
-  const getKnResources = React.useMemo(
-    () => ({
-      ...knativeServingResourcesServicesWatchers(namespace),
-      ...knativeEventingBrokerResourceWatchers(namespace),
-      ...getDynamicEventingChannelWatchers(namespace),
-    }),
-    [namespace],
-  );
-  const resourcesData: WatchK8sResults<ResourcesObject> = useK8sWatchResources<ResourcesObject>(
-    getKnResources,
-  );
-  const resourcesDataList = Object.values(resourcesData);
-  const { loaded, data } = _.reduce(
-    resourcesDataList,
-    (acm, resData) => {
-      if (resData.loaded) {
-        acm.loaded = true;
-        acm.data = [...acm.data, ...resData.data];
-      }
-      return acm;
-    },
-    { loaded: false, data: [] },
-  );
-
+const EventSourceAlert: React.FC<EventSourceAlertProps> = ({ eventSourceStatus }) => {
   const noEventSources = eventSourceStatus === null;
   const noEventSourceAccess =
     !noEventSources && eventSourceStatus.loaded && _.isEmpty(eventSourceStatus.eventSourceList);
-  const noKnativeResources = loaded && _.isEmpty(data);
-  const showAlert = noKnativeResources || noEventSources || noEventSourceAccess;
+  const showAlert = noEventSources || noEventSourceAccess;
 
   return showAlert ? (
     <Alert variant="default" title="Event Source cannot be created" isInline>
       {noEventSourceAccess && 'You do not have write access in this project.'}
       {noEventSources && 'Creation of event sources are not currently supported on this cluster.'}
-      {noKnativeResources &&
-        !noEventSourceAccess &&
-        !noEventSources &&
-        'Event Sources can only sink to Channel, Broker or Knative services. No Channels, Brokers or Knative services exist in this project.'}
     </Alert>
   ) : null;
 };

--- a/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
@@ -27,7 +27,7 @@ const EventSourcePage: React.FC<EventSourcePageProps> = ({ match, location }) =>
         Create an event source to register interest in a class of events from a particular system
       </PageHeading>
       <PageBody flexLayout>
-        <EventSourceAlert namespace={namespace} eventSourceStatus={eventSourceStatus} />
+        <EventSourceAlert eventSourceStatus={eventSourceStatus} />
         <ConnectedEventSource
           namespace={namespace}
           eventSourceStatus={eventSourceStatus}

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSource.spec.tsx
@@ -21,11 +21,9 @@ describe('EventSourceSpec', () => {
     const FormikField = wrapper.find(Formik);
     expect(FormikField.exists()).toBe(true);
     expect(FormikField.get(0).props.initialValues.project.name).toBe('myApp');
-    expect(FormikField.get(0).props.initialValues.sink).toEqual({
-      apiVersion: '',
-      kind: '',
-      name: '',
-    });
+    expect(FormikField.get(0).props.initialValues.sink.apiVersion).toEqual('');
+    expect(FormikField.get(0).props.initialValues.sink.kind).toEqual('');
+    expect(FormikField.get(0).props.initialValues.sink.name).toEqual('');
   });
 
   it('should render form with proper initialvalues for sink if contextSource is passed', () => {
@@ -41,10 +39,10 @@ describe('EventSourceSpec', () => {
     const FormikField = wrapper.find(Formik);
     expect(FormikField.exists()).toBe(true);
     expect(FormikField.get(0).props.initialValues.project.name).toBe('myApp');
-    expect(FormikField.get(0).props.initialValues.sink).toEqual({
-      apiVersion: 'serving.knative.dev/v1',
-      kind: 'Service',
-      name: 'svc-display',
-    });
+    expect(FormikField.get(0).props.initialValues.sink.apiVersion).toEqual(
+      'serving.knative.dev/v1',
+    );
+    expect(FormikField.get(0).props.initialValues.sink.kind).toEqual('Service');
+    expect(FormikField.get(0).props.initialValues.sink.name).toEqual('svc-display');
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
@@ -2,18 +2,11 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Alert } from '@patternfly/react-core';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import EventSourceAlert from '../EventSourceAlert';
-import { knativeServiceObj } from '../../../topology/__tests__/topology-knative-test-data';
 import { getKnativeEventSourceIcon } from '../../../utils/get-knative-icon';
 import { EventSourceContainerModel } from '../../../models';
 
-jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
-  useK8sWatchResources: jest.fn(),
-}));
-
 describe('EventSourceAlert', () => {
-  const namespaceName = 'myApp';
   const eventSourceStatusData = {
     loaded: true,
     eventSourceList: {
@@ -25,66 +18,26 @@ describe('EventSourceAlert', () => {
       },
     },
   };
-  it('should not display alert if service data not loaded and eventSources are there', () => {
-    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
-      ksservices: { loaded: false, data: [] },
-    });
-    const wrapper = shallow(
-      <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatusData} />,
-    );
+
+  it('should not alert if eventSources are there', () => {
+    const wrapper = shallow(<EventSourceAlert eventSourceStatus={eventSourceStatusData} />);
     expect(wrapper.find(Alert).exists()).toBe(false);
   });
 
-  it('should display alert if service loaded with empty data and eventSources are there', () => {
-    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
-      ksservices: { loaded: true, data: [] },
-    });
-    const wrapper = shallow(
-      <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatusData} />,
-    );
-    expect(wrapper.find(Alert).exists()).toBe(true);
-    expect(wrapper.find(Alert)).toHaveLength(1);
-  });
-
-  it('should not alert if service loaded with data and eventSources are there', () => {
-    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
-      ksservices: { loaded: true, data: [knativeServiceObj] },
-    });
-    const wrapper = shallow(
-      <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatusData} />,
-    );
-    expect(wrapper.find(Alert).exists()).toBe(false);
-  });
-
-  it('should show alert if service loaded with data and eventSources is null', () => {
-    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
-      ksservices: { loaded: true, data: [knativeServiceObj] },
-    });
-    const wrapper = shallow(
-      <EventSourceAlert namespace={namespaceName} eventSourceStatus={null} />,
-    );
+  it('should show alert if eventSources is null', () => {
+    const wrapper = shallow(<EventSourceAlert eventSourceStatus={null} />);
     expect(wrapper.find(Alert).exists()).toBe(true);
   });
 
-  it('should show alert if service loaded with data and eventSources has loaded with no data', () => {
-    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
-      ksservices: { loaded: true, data: [knativeServiceObj] },
-    });
+  it('should show alert if eventSources has loaded with no data', () => {
     const eventSourceStatus = { loaded: true, eventSourceList: {} };
-    const wrapper = shallow(
-      <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatus} />,
-    );
+    const wrapper = shallow(<EventSourceAlert eventSourceStatus={eventSourceStatus} />);
     expect(wrapper.find(Alert).exists()).toBe(true);
   });
 
-  it('should not alert if service loaded with data and eventSources has not loaded', () => {
-    (useK8sWatchResources as jest.Mock).mockReturnValueOnce({
-      ksservices: { loaded: true, data: [knativeServiceObj] },
-    });
+  it('should not alert if  eventSources has not loaded', () => {
     const eventSourceStatus = { loaded: false, eventSourceList: {} };
-    const wrapper = shallow(
-      <EventSourceAlert namespace={namespaceName} eventSourceStatus={eventSourceStatus} />,
-    );
+    const wrapper = shallow(<EventSourceAlert eventSourceStatus={eventSourceStatus} />);
     expect(wrapper.find(Alert).exists()).toBe(false);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import * as fuzzy from 'fuzzysearch';
 import { useFormikContext, FormikValues } from 'formik';
-import { FormGroup } from '@patternfly/react-core';
-import { getFieldId, ResourceDropdownField } from '@console/shared';
+import { FormGroup, TextInputTypes, Alert } from '@patternfly/react-core';
+import { InputField, getFieldId, ResourceDropdownField, RadioGroupField } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { EventingBrokerModel } from '../../../models';
@@ -11,12 +12,34 @@ import {
   knativeEventingResourcesBroker,
 } from '../../../utils/get-knative-resources';
 import { getDynamicChannelResourceList } from '../../../utils/fetch-dynamic-eventsources-utils';
+import { sourceSinkType } from '../import-types';
 
 interface SinkSectionProps {
   namespace: string;
 }
 
-const SinkSection: React.FC<SinkSectionProps> = ({ namespace }) => {
+interface SinkResourcesProps {
+  namespace: string;
+}
+
+const SinkUri: React.FC = () => (
+  <>
+    <InputField
+      type={TextInputTypes.text}
+      name="sink.uri"
+      placeholder="Enter URI"
+      data-test-id="sink-section-uri"
+      required
+    />
+    <div className="help-block">
+      A Universal Resource Indicator where events are going to be delivered. Ex.
+      &quot;http://cluster.example.com/svc&quot;
+    </div>
+  </>
+);
+
+const SinkResources: React.FC<SinkResourcesProps> = ({ namespace }) => {
+  const [resourceAlert, setResourceAlert] = React.useState(false);
   const { setFieldValue, setFieldTouched, validateForm, initialValues } = useFormikContext<
     FormikValues
   >();
@@ -45,6 +68,9 @@ const SinkSection: React.FC<SinkSectionProps> = ({ namespace }) => {
     ...knativeEventingResourcesBroker(namespace),
   ];
 
+  const handleOnLoad = (resourceList: { [key: string]: string }) =>
+    _.isEmpty(resourceList) ? setResourceAlert(true) : setResourceAlert(false);
+
   // filter out channels backing brokers
   const resourceFilter = (resource: K8sResourceKind) => {
     const {
@@ -53,32 +79,60 @@ const SinkSection: React.FC<SinkSectionProps> = ({ namespace }) => {
     return !ownerReferences?.length || ownerReferences[0].kind !== EventingBrokerModel.kind;
   };
   return (
+    <FormGroup
+      fieldId={fieldId}
+      helperText={!contextAvailable ? 'This resource will be the Sink for the Event Source.' : ''}
+      isRequired
+    >
+      {resourceAlert && (
+        <>
+          <Alert variant="default" title="No resources available" isInline>
+            Select the URI option, or exit this form and create a Knative Service, Broker, or
+            Channel first.
+          </Alert>
+          &nbsp;
+        </>
+      )}
+      <ResourceDropdownField
+        name="sink.name"
+        resources={resourcesData}
+        dataSelector={['metadata', 'name']}
+        fullWidth
+        placeholder="Select resource"
+        showBadge
+        disabled={contextAvailable || resourceAlert}
+        onChange={onChange}
+        autocompleteFilter={autocompleteFilter}
+        autoSelect
+        resourceFilter={resourceFilter}
+        onLoad={handleOnLoad}
+      />
+    </FormGroup>
+  );
+};
+
+const SinkSection: React.FC<SinkSectionProps> = ({ namespace }) => {
+  return (
     <FormSection
       title="Sink"
-      subTitle="Add a sink to route this event source to a Channel, Broker or Knative service."
+      subTitle="Add a Sink to route this Event Source to a Channel, Broker, Knative Service or another route."
       extraMargin
     >
-      <FormGroup
-        fieldId={fieldId}
-        helperText={!contextAvailable ? 'This resource will be the sink for the event source.' : ''}
-        isRequired
-      >
-        <ResourceDropdownField
-          name="sink.name"
-          label="Resource"
-          resources={resourcesData}
-          dataSelector={['metadata', 'name']}
-          fullWidth
-          required
-          placeholder="Select resource"
-          showBadge
-          disabled={contextAvailable}
-          onChange={onChange}
-          autocompleteFilter={autocompleteFilter}
-          autoSelect
-          resourceFilter={resourceFilter}
-        />
-      </FormGroup>
+      <RadioGroupField
+        name="sinkType"
+        options={[
+          {
+            label: sourceSinkType.Resource.label,
+            value: sourceSinkType.Resource.value,
+            activeChildren: <SinkResources namespace={namespace} />,
+          },
+          {
+            label: sourceSinkType.Uri.label,
+            value: sourceSinkType.Uri.value,
+            activeChildren: <SinkUri />,
+          },
+        ]}
+      />
     </FormSection>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
@@ -1,15 +1,33 @@
 import * as yup from 'yup';
+import { isValidUrl } from '@console/shared';
 import {
   nameValidationSchema,
   projectNameValidationSchema,
   applicationNameValidationSchema,
 } from '@console/dev-console/src/components/import/validation-schema';
-import { EventSources } from './import-types';
+import { EventSources, SinkType } from './import-types';
 import { isKnownEventSource } from '../../utils/create-eventsources-utils';
 
-const sinkServiceSchema = yup.object().shape({
-  name: yup.string().required('Required'),
-});
+const sinkServiceSchema = yup
+  .object()
+  .when('sinkType', {
+    is: SinkType.Resource,
+    then: yup.object().shape({
+      name: yup.string().required('Required'),
+    }),
+  })
+  .when('sinkType', {
+    is: SinkType.Uri,
+    then: yup.object().shape({
+      uri: yup
+        .string()
+        .max(2000, 'Please enter a URI that is less then 2000 characters.')
+        .test('validate-uri', 'Invalid URI.', function(value) {
+          return isValidUrl(value);
+        })
+        .required('Required'),
+    }),
+  });
 
 export const sourceDataSpecSchema = yup
   .object()

--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -37,6 +37,7 @@ export interface SinkResourceData {
   apiVersion: string;
   name: string;
   kind: string;
+  uri?: string;
 }
 
 export interface EventSourceFormData {
@@ -45,6 +46,7 @@ export interface EventSourceFormData {
   name: string;
   apiVersion: string;
   type: string;
+  sinkType: string;
   sink: SinkResourceData;
   limits: LimitsData;
   data?: EventSourceData;
@@ -67,3 +69,19 @@ export interface EventSourceListData {
   loaded: boolean;
   eventSourceList: NormalizedEventSources;
 }
+
+export enum SinkType {
+  Resource = 'resource',
+  Uri = 'uri',
+}
+
+export const sourceSinkType = {
+  Resource: {
+    value: SinkType.Resource,
+    label: 'Resource',
+  },
+  Uri: {
+    value: SinkType.Uri,
+    label: 'URI',
+  },
+};

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -3,7 +3,7 @@ import {
   DeployImageFormData,
   Resources,
 } from '@console/dev-console/src/components/import/import-types';
-import { EventSourceFormData } from '../../components/add/import-types';
+import { EventSourceFormData, SinkType } from '../../components/add/import-types';
 import { RevisionModel, ServiceModel, KafkaModel } from '../../models';
 import { healthChecksProbeInitialData } from '@console/dev-console/src/components/health-checks/health-checks-probe-utils';
 
@@ -333,6 +333,7 @@ export const getDefaultEventingData = (typeEventSource: string): EventSourceForm
       selectedKey: 'mock-app',
     },
     name: 'esmyapp',
+    sinkType: SinkType.Resource,
     sink: {
       apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
       name: 'event-display',

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -12,6 +12,7 @@ import {
   EventSources,
   EventSourceFormData,
   EventSourceListData,
+  SinkType,
 } from '../components/add/import-types';
 import { getKnativeEventSourceIcon } from './get-knative-icon';
 import { useEventSourceModels } from './fetch-dynamic-eventsources-utils';
@@ -27,12 +28,13 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
     application: { name: applicationName },
     project: { name: namespace },
     data,
+    sinkType,
     sink,
   } = formData;
 
   const defaultLabel = getAppLabels(name, applicationName);
   const eventSrcData = data[type.toLowerCase()];
-  const { name: sinkName, kind: sinkKind, apiVersion: sinkApiVersion } = sink;
+  const { name: sinkName, kind: sinkKind, apiVersion: sinkApiVersion, uri: sinkUri } = sink;
   const eventSourceResource: K8sResourceKind = {
     apiVersion,
     kind: type,
@@ -45,17 +47,21 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
       annotations: getCommonAnnotations(),
     },
     spec: {
-      ...(sinkName &&
-        sinkApiVersion &&
-        sinkKind && {
-          sink: {
-            ref: {
-              apiVersion: sinkApiVersion,
-              kind: sinkKind,
-              name: sinkName,
+      ...(sinkType === SinkType.Resource && sinkName && sinkApiVersion && sinkKind
+        ? {
+            sink: {
+              ref: {
+                apiVersion: sinkApiVersion,
+                kind: sinkKind,
+                name: sinkName,
+              },
             },
-          },
-        }),
+          }
+        : {
+            sink: {
+              uri: sinkUri,
+            },
+          }),
       ...(eventSrcData && eventSrcData),
     },
   };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4241

**Analysis / Root cause**: 
User is unable to sink a source to URI along with ksvc/Channel/Broker

**Solution Description**: 
- Show URI as sink option under radio group along with Resources
- Resources will be pre-selected
- Should be able to create Source with Sink to URI
- Added yup validations
- Remove error state shown in case of no resources (KSVC/Channel/Broker) present as no more needed)

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
- Resource preselected
![image](https://user-images.githubusercontent.com/5129024/87169350-77baf400-c2ed-11ea-829f-be7a8cdcf57a.png)


- Sink URI
![image](https://user-images.githubusercontent.com/5129024/87169425-9a4d0d00-c2ed-11ea-9788-02f9bd72dda8.png)



- Error State (Invalid URI)
![image](https://user-images.githubusercontent.com/5129024/87169528-c072ad00-c2ed-11ea-9502-e69a343f052c.png)


- Inline Alert if no resources(KSVC, Channel, Broker) exists 
![image](https://user-images.githubusercontent.com/5129024/87171576-7b03af00-c2f0-11ea-8e9b-327a5cd1658d.png)




cc @openshift/team-devconsole-ux @rachael-phillips 

**Unit test coverage report**: 

![image](https://user-images.githubusercontent.com/5129024/86444560-883bff00-bd2e-11ea-9e86-847800da09d2.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


