### PR TITLE
Guard against missing user info

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
@@ -17,6 +17,10 @@ const mergeLabelsWithResource = (labels: LabelMap, resource: K8sResourceCommon) 
 export const useUserLabelForManualStart = (): LabelMap => {
   const user = useSelector((state) => state.UI.get('user'));
 
+  if (!user?.metadata?.name) {
+    return {};
+  }
+
   return {
     // kube:admin is an invalid k8s label value
     [StartedByLabel.user]: user.metadata.name.replace(/:/, ''),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4252

**Analysis / Root cause**: 
Seems that there are some cases where the user data is not available and causes the app to whitescreen due to a NPE.

**Solution Description**: 
Guard against missing data.

**Test setup:**
See bug for steps.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge