### PR TITLE
Add option to create snapshot for PVC

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/_create-volume-snapshot.scss
+++ b/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/_create-volume-snapshot.scss
@@ -1,0 +1,42 @@
+@import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
+@import '../../../../../console-shared/src/styles/skeleton-screen.scss';
+
+.co-volume-snapshot__body {
+    display: inline-flex;
+}
+
+.co-volume-snapshot__form {
+    margin: var(--pf-global--spacer--md) 0;
+}
+
+.co-volume-snapshot__details-body {
+    margin-bottom: var(--pf-global--spacer--md);
+}
+
+.co-volume-snapshot__alert-body {
+    margin-top: var(--pf-global--spacer--md);
+}
+
+.co-volume-snapshot__info {
+    max-width: 50%;
+    margin-right: 0;
+    @media(max-width: $screen-sm-max) {
+        display: none;
+      }
+}
+
+.skeleton-activity {
+  animation: $skeleton-animation;
+  background: $skeleton-color;
+  opacity: 0;
+  border-radius: 6px;
+  margin: 0.5rem 0.7em 0.5rem 0.7em;
+  height: 30px;
+  &::after {
+    background-repeat: no-repeat;
+    content: "";
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
@@ -1,0 +1,334 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { match } from 'react-router';
+
+import { Grid, GridItem, ActionGroup, Button, Alert } from '@patternfly/react-core';
+
+import {
+  LoadingBox,
+  ListDropdown,
+  ButtonBar,
+  history,
+  ResourceIcon,
+  resourceObjPath,
+  HandlePromiseProps,
+  withHandlePromise,
+  convertToBaseValue,
+  humanizeBinaryBytes,
+} from '@console/internal/components/utils';
+import {
+  K8sKind,
+  referenceForModel,
+  k8sCreate,
+  referenceFor,
+  VolumeSnapshotClassKind,
+  StorageClassResourceKind,
+  PersistentVolumeClaimKind,
+  k8sGet,
+  VolumeSnapshotKind,
+  apiVersionForModel,
+} from '@console/internal/module/k8s';
+import { connectToPlural } from '@console/internal/kinds';
+import {
+  PersistentVolumeClaimModel,
+  VolumeSnapshotModel,
+  VolumeSnapshotClassModel,
+  StorageClassModel,
+  NamespaceModel,
+  PersistentVolumeModel,
+} from '@console/internal/models';
+import { accessModeRadios } from '@console/internal/components/storage/shared';
+import { PVCDropdown } from '@console/internal/components/utils/pvc-dropdown';
+import { getName, getNamespace } from '@console/shared';
+import { PVCStatus } from '@console/internal/components/persistent-volume-claim';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+
+import './_create-volume-snapshot.scss';
+
+const LoadingComponent: React.FC = () => (
+  <Grid className="skeleton-box">
+    <GridItem span={12} className="skeleton-activity" />
+    <GridItem span={12} className="skeleton-activity" />
+    <GridItem span={12} className="skeleton-activity" />
+    <GridItem span={12} className="skeleton-activity" />
+    <GridItem span={12} className="skeleton-activity" />
+    <GridItem span={12} className="skeleton-activity" />
+    <GridItem span={12} className="skeleton-activity" />
+    <GridItem span={12} className="skeleton-activity" />
+  </Grid>
+);
+
+const SnapshotClassDropdown: React.FC<SnapshotClassDropdownProps> = (props) => {
+  const { selectedKey, pvcSC } = props;
+  const kind = referenceForModel(VolumeSnapshotClassModel);
+  const resources = [{ kind }];
+  const [scObj, setSCObj] = React.useState<StorageClassResourceKind>(null);
+  const [scError, setError] = React.useState('');
+
+  React.useEffect(() => {
+    k8sGet(StorageClassModel, pvcSC)
+      .then(setSCObj)
+      .catch((error) => setError(error));
+  }, [pvcSC]);
+
+  const filter = (snapshotClass: VolumeSnapshotClassKind) =>
+    !scObj || !scObj.provisioner ? false : scObj?.provisioner.includes(snapshotClass?.driver);
+
+  if (scError) {
+    return (
+      <Alert
+        className="co-alert co-volume-snapshot__alert-body"
+        variant="danger"
+        title="Error fetching info on claim's provisioner"
+        isInline
+      />
+    );
+  }
+
+  return (
+    <ListDropdown
+      {...props}
+      desc="Volume Snapshot Class with same provisioner as claim"
+      dataFilter={filter}
+      resources={resources}
+      selectedKeyKind={kind}
+      placeholder="Select snapshot class"
+      selectedKey={selectedKey}
+    />
+  );
+};
+
+const PVCSummary: React.FC<PVCSummaryProps> = ({ persistentVolumeClaim }) => {
+  const storageClass = persistentVolumeClaim?.spec?.storageClassName;
+  const requestedCapacity = persistentVolumeClaim?.spec?.resources?.requests?.storage;
+  const sizeBase = convertToBaseValue(requestedCapacity);
+  const sizeMetrics = requestedCapacity ? humanizeBinaryBytes(sizeBase).string : '-';
+  const accessModes = accessModeRadios.find(
+    (accessMode) => accessMode.value === persistentVolumeClaim?.spec?.accessModes?.[0],
+  );
+  const volumeMode = persistentVolumeClaim?.spec?.volumeMode;
+  return (
+    <dl>
+      <dt className="co-volume-snapshot__details-body">
+        {PersistentVolumeClaimModel.label} Details
+      </dt>
+      <dt>Name</dt>
+      <dd>
+        <ResourceIcon kind={PersistentVolumeClaimModel.kind} />
+        {getName(persistentVolumeClaim)}
+      </dd>
+      <dt>Namespace</dt>
+      <dd>
+        <ResourceIcon kind={NamespaceModel.kind} />
+        {getNamespace(persistentVolumeClaim)}
+      </dd>
+      <dt>Status</dt>
+      <dd>
+        <PVCStatus pvc={persistentVolumeClaim} />
+      </dd>
+      <dt>Storage Class</dt>
+      <dd>
+        <ResourceIcon kind={StorageClassModel.kind} />
+        {storageClass}
+      </dd>
+      <dt>Requested Capacity</dt>
+      <dd>{sizeMetrics}</dd>
+      <dt>Access Mode</dt>
+      <dd>{accessModes.title}</dd>
+      <dt>Volume Mode</dt>
+      <dd>{volumeMode}</dd>
+    </dl>
+  );
+};
+
+const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
+  const { resourceName, namespace, kindObj, handlePromise, inProgress, errorMessage } = props;
+
+  const [pvcName, setPVCName] = React.useState(resourceName);
+  const [pvcObj, setPVCObj] = React.useState<PersistentVolumeClaimKind>(null);
+  const [snapshotName, setSnapshotName] = React.useState(`${pvcName || 'pvc'}-snapshot`);
+  const [snapshotClassName, setSnapshotClassName] = React.useState('');
+  const title = 'Create VolumeSnapshot';
+
+  const resourceWatch = React.useMemo(() => {
+    return Object.assign(
+      {
+        kind: PersistentVolumeClaimModel.kind,
+        namespace,
+        isList: true,
+      },
+      pvcName ? { name: pvcName } : null,
+    );
+  }, [namespace, pvcName]);
+
+  const [data, loaded, loadError] = useK8sWatchResource<PersistentVolumeClaimKind[]>(resourceWatch);
+
+  React.useEffect(() => {
+    const currentPVC = data.find((pvc) => pvc.metadata.name === pvcName);
+    setPVCObj(currentPVC);
+  }, [data, pvcName, namespace, loadError]);
+
+  const handleSnapshotName: React.ReactEventHandler<HTMLInputElement> = (event) =>
+    setSnapshotName(event.currentTarget.value);
+
+  const handlePVCName = (name: string) => {
+    const currentPVC = data.find((pvc) => pvc.metadata.name === name);
+    setPVCObj(currentPVC);
+    setSnapshotName(`${name}-snapshot`);
+    setPVCName(name);
+  };
+
+  const create = (event: React.FormEvent<EventTarget>) => {
+    event.preventDefault();
+    const snapshotTemplate: VolumeSnapshotKind = {
+      apiVersion: apiVersionForModel(VolumeSnapshotModel),
+      kind: VolumeSnapshotModel.kind,
+      metadata: {
+        name: snapshotName,
+        namespace: getNamespace(pvcObj),
+      },
+      spec: {
+        volumeSnapshotClassName: snapshotClassName,
+        source: {
+          persistentVolumeClaimName: pvcName,
+        },
+      },
+    };
+
+    // eslint-disable-next-line promise/catch-or-return
+    handlePromise(k8sCreate(VolumeSnapshotModel, snapshotTemplate)).then((resource) => {
+      history.push(resourceObjPath(resource, referenceFor(resource)));
+    });
+  };
+
+  return (
+    <div className="co-m-pane__body co-volume-snapshot__body">
+      <Helmet>
+        <title>{title}</title>
+      </Helmet>
+      <form className="co-m-pane__body-group co-m-pane__form" onSubmit={create}>
+        <h1 className="co-m-pane__heading">{title}</h1>
+        {kindObj.kind === PersistentVolumeClaimModel.kind && (
+          <p>
+            Creating snapshot for claim <strong>{resourceName}</strong>
+          </p>
+        )}
+        {pvcName && pvcObj && pvcObj?.status?.phase !== 'Bound' && (
+          <Alert
+            className="co-alert co-volume-snapshot__alert-body"
+            variant="warning"
+            title="Snapshot creation for unbound claim is not recommended."
+            isInline
+          />
+        )}
+        {kindObj.kind === VolumeSnapshotModel.kind && (
+          /* eslint-disable jsx-a11y/label-has-associated-control */
+          <>
+            <label className="control-label co-required" html-for="claimName">
+              {PersistentVolumeModel.label}
+            </label>
+            <PVCDropdown
+              namespace={namespace}
+              onChange={handlePVCName}
+              id="claimName"
+              selectedKey={pvcName}
+              desc={`Persistent Volume Claim in ${namespace} namespace`}
+            />
+          </>
+        )}
+        <div className="form-group co-volume-snapshot__form">
+          <label className="control-label co-required" htmlFor="snapshot-name">
+            Name
+          </label>
+          <input
+            className="pf-c-form-control"
+            type="text"
+            onChange={handleSnapshotName}
+            name="snapshotName"
+            id="snapshot-name"
+            value={snapshotName}
+            required
+          />
+        </div>
+        {pvcObj && (
+          <div className="form-group co-volume-snapshot__form">
+            <label className="control-label co-required" htmlFor="snapshot-class">
+              Snapshot Class
+            </label>
+            <SnapshotClassDropdown
+              onChange={setSnapshotClassName}
+              id="claimName"
+              selectedKey={snapshotClassName}
+              pvcSC={pvcObj?.spec?.storageClassName}
+            />
+          </div>
+        )}
+
+        <ButtonBar errorMessage={errorMessage || loadError} inProgress={inProgress}>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary"
+              id="save-changes"
+              isDisabled={
+                !snapshotClassName || !snapshotName || !pvcName || pvcObj?.status?.phase !== 'Bound'
+              }
+            >
+              Create
+            </Button>
+            <Button type="button" variant="secondary" onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
+        </ButtonBar>
+      </form>
+      <div className="co-volume-snapshot__info">
+        <Grid hasGutter>
+          <GridItem span={1} />
+          <GridItem span={10}>
+            {pvcName && pvcObj && loaded && <PVCSummary persistentVolumeClaim={pvcObj} />}
+            {!loaded && <LoadingComponent />}
+          </GridItem>
+          <GridItem span={1} />
+        </Grid>
+      </div>
+    </div>
+  );
+});
+
+const VolumeSnapshotComponent: React.FC<VolumeSnapshotComponentProps> = (props) => {
+  const {
+    kindObj,
+    kindsInFlight,
+    match: { params },
+  } = props;
+  if (!kindObj && kindsInFlight) {
+    return <LoadingBox />;
+  }
+  return <CreateSnapshotForm namespace={params.ns} resourceName={params.name} kindObj={kindObj} />;
+};
+
+export const VolumeSnapshot = connectToPlural(VolumeSnapshotComponent);
+
+type SnapshotClassDropdownProps = {
+  selectedKey: string;
+  onChange: (string) => void;
+  id: string;
+  pvcSC: string;
+};
+
+type SnapshotResourceProps = HandlePromiseProps & {
+  namespace: string;
+  resourceName: string;
+  kindObj: K8sKind;
+};
+
+type PVCSummaryProps = {
+  persistentVolumeClaim: PersistentVolumeClaimKind;
+};
+
+type VolumeSnapshotComponentProps = {
+  kindObj: K8sKind;
+  kindsInFlight: boolean;
+  match: match<{ ns?: string; plural?: string; name?: string }>;
+};

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-class.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-class.tsx
@@ -11,6 +11,7 @@ import {
   RowFunction,
 } from '@console/internal/components/factory';
 import { VolumeSnapshotClassModel } from '@console/internal/models';
+import { getBadgeFromType, BadgeType } from '@console/shared';
 
 const tableColumnClasses = [
   '', // name
@@ -75,6 +76,7 @@ const VolumeSnapshotClassPage: React.FC = (props) => (
     ListComponent={VolumeSnapshotClassTable}
     kind={referenceForModel(VolumeSnapshotClassModel)}
     canCreate
+    badge={getBadgeFromType(BadgeType.TECH)}
   />
 );
 

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content.tsx
@@ -21,7 +21,7 @@ import {
   VolumeSnapshotClassModel,
   VolumeSnapshotContentModel,
 } from '@console/internal/models';
-import { Status } from '@console/shared';
+import { Status, getBadgeFromType, BadgeType } from '@console/shared';
 import { snapshotStatusFilters, volumeSnapshotStatus } from '../../status';
 
 const tableColumnClasses = [
@@ -136,6 +136,7 @@ const VolumeSnapshotContentPage: React.FC = (props) => {
       ListComponent={VolumeSnapshotContentTable}
       rowFilters={snapshotStatusFilters}
       canCreate
+      badge={getBadgeFromType(BadgeType.TECH)}
     />
   );
 };

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { match } from 'react-router';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { referenceForModel, VolumeSnapshotKind } from '@console/internal/module/k8s';
@@ -24,7 +25,7 @@ import {
   VolumeSnapshotClassModel,
   VolumeSnapshotContentModel,
 } from '@console/internal/models';
-import { Status } from '@console/shared';
+import { Status, getBadgeFromType, BadgeType } from '@console/shared';
 import { snapshotStatusFilters, volumeSnapshotStatus } from '../../status';
 
 const tableColumnClasses = [
@@ -154,15 +155,29 @@ const VolumeSnapshotTable: React.FC = (props) => (
   <Table {...props} aria-label="Volume Snapshot Table" Header={Header} Row={Row} virtualize />
 );
 
-const VolumeSnapshotPage: React.FC = (props) => {
+const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = (props) => {
+  const namespace = props.namespace || props.match?.params?.ns || 'all-namespaces';
+  const createProps = {
+    to: `/k8s/${namespace === 'all-namespaces' ? namespace : `ns/${namespace}`}/${
+      props.match?.params?.plural
+    }/~new/form`,
+  };
   return (
     <ListPage
       {...props}
       kind={referenceForModel(VolumeSnapshotModel)}
       ListComponent={VolumeSnapshotTable}
       rowFilters={snapshotStatusFilters}
+      canCreate
+      createProps={createProps}
+      badge={getBadgeFromType(BadgeType.TECH)}
     />
   );
+};
+
+type VolumeSnapshotPageProps = {
+  namespace?: string;
+  match: match<{ ns?: string; plural?: string }>;
 };
 
 export default VolumeSnapshotPage;

--- a/frontend/packages/console-app/src/status/snapshot.ts
+++ b/frontend/packages/console-app/src/status/snapshot.ts
@@ -1,6 +1,6 @@
 import { VolumeSnapshotStatus } from '@console/internal/module/k8s';
 
-export const volumeSnapshotStatus = ({ status }: { status: VolumeSnapshotStatus }) => {
+export const volumeSnapshotStatus = ({ status }: { status?: VolumeSnapshotStatus }) => {
   const readyToUse = status?.readyToUse;
   const isError = !!status?.error?.message;
   return readyToUse ? 'Ready' : isError ? 'Error' : 'Pending';

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -11,7 +11,7 @@ import { SearchPage } from './search';
 import { ResourceDetailsPage, ResourceListPage } from './resource-list';
 import { AsyncComponent, LoadingBox } from './utils';
 import { namespacedPrefixes } from './utils/link';
-import { AlertmanagerModel } from '../models';
+import { AlertmanagerModel, VolumeSnapshotModel } from '../models';
 import { referenceForModel } from '../module/k8s';
 import { NamespaceRedirect } from './utils/namespace-redirect';
 import { getActivePerspective } from '../reducers/ui';
@@ -431,6 +431,36 @@ const AppContents_: React.FC<AppContentsProps> = ({ activePerspective }) => {
                 import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
                   (m) => m.CreatePVC,
                 )
+              }
+            />
+
+            <LazyRoute
+              path={`/k8s/ns/:ns/:plural/:name/${VolumeSnapshotModel.plural}/~new/form`}
+              exact
+              loader={() =>
+                import(
+                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                ).then((m) => m.VolumeSnapshot)
+              }
+            />
+
+            <LazyRoute
+              path="/k8s/ns/:ns/:plural/~new/form"
+              exact
+              loader={() =>
+                import(
+                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                ).then((m) => m.VolumeSnapshot)
+              }
+            />
+
+            <LazyRoute
+              path="/k8s/all-namespaces/:plural/~new/form"
+              exact
+              loader={() =>
+                import(
+                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                ).then((m) => m.VolumeSnapshot)
               }
             />
 

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -29,14 +29,15 @@ import { setPVCMetrics } from '../actions/ui';
 import { PrometheusEndpoint } from './graphs/helpers';
 import { usePrometheusPoll } from './graphs/prometheus-poll-hook';
 
-const { common, ExpandPVC } = Kebab.factory;
+const { common, ExpandPVC, PVCSnapshot } = Kebab.factory;
 const menuActions = [
   ...Kebab.getExtensionsActionsForKind(PersistentVolumeClaimModel),
   ExpandPVC,
+  PVCSnapshot,
   ...common,
 ];
 
-const PVCStatus = ({ pvc }) => {
+export const PVCStatus = ({ pvc }) => {
   const pvcStatusExtensions = useExtensions(isPVCStatus);
   if (pvcStatusExtensions.length > 0) {
     const sortedByPriority = pvcStatusExtensions.sort(

--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -12,35 +12,13 @@ import {
   k8sPatch,
   referenceFor,
 } from '../../module/k8s';
-import {
-  ButtonBar,
-  history,
-  ListDropdown,
-  LoadingBox,
-  ResourceLink,
-  resourceObjPath,
-} from '../utils';
+import { ButtonBar, history, LoadingBox, ResourceLink, resourceObjPath } from '../utils';
 import { Checkbox } from '../checkbox';
 import { RadioInput } from '../radio';
 import { CreatePVCForm } from './create-pvc';
 import { PersistentVolumeClaimModel } from '../../models';
 import { ContainerSelector } from '../container-selector';
-
-const PVCDropdown: React.FC<PVCDropdownProps> = (props) => {
-  const kind = 'PersistentVolumeClaim';
-  const { namespace, selectedKey } = props;
-  const resources = [{ kind, namespace }];
-  return (
-    <ListDropdown
-      {...props}
-      desc="Persistent Volume Claim"
-      resources={resources}
-      selectedKeyKind={kind}
-      placeholder="Select claim"
-      selectedKey={selectedKey}
-    />
-  );
-};
+import { PVCDropdown } from '../utils/pvc-dropdown';
 
 export const AttachStorageForm: React.FC<AttachStorageFormProps> = (props) => {
   const [obj, setObj] = React.useState(null);
@@ -370,13 +348,6 @@ const AttachStorage_ = ({ kindObj, kindsInFlight, match: { params } }) => {
   return <AttachStorageForm namespace={params.ns} resourceName={params.name} kindObj={kindObj} />;
 };
 export const AttachStorage = connectToPlural(AttachStorage_);
-
-export type PVCDropdownProps = {
-  namespace: string;
-  selectedKey: string;
-  onChange: (string) => void;
-  id: string;
-};
 
 export type AttachStorageFormProps = {
   kindObj: K8sKind;

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -27,6 +27,7 @@ import {
 import { impersonateStateToProps } from '../../reducers/ui';
 import { connectToModel } from '../../kinds';
 import * as plugins from '../../plugins';
+import { VolumeSnapshotModel } from '../../models';
 
 export const kebabOptionsToMenu = (options: KebabOption[]): KebabMenuOption[] => {
   const subs: { [key: string]: KebabSubMenu } = {};
@@ -328,6 +329,13 @@ const kebabFactory: KebabFactory = {
         resource: obj,
       }),
     accessReview: asAccessReview(kind, obj, 'patch'),
+  }),
+  PVCSnapshot: (kind, obj) => ({
+    label: 'Create Snapshot',
+    href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/${
+      VolumeSnapshotModel.plural
+    }/~new/form`,
+    accessReview: asAccessReview(kind, obj, 'create'),
   }),
 };
 

--- a/frontend/public/components/utils/pvc-dropdown.tsx
+++ b/frontend/public/components/utils/pvc-dropdown.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { ListDropdown } from './list-dropdown';
+import { PersistentVolumeClaimModel } from '../../models';
+
+export const PVCDropdown: React.FC<PVCDropdownProps> = (props) => {
+  const kind = PersistentVolumeClaimModel.kind;
+  const { namespace, selectedKey, desc } = props;
+  const resources = [{ kind, namespace }];
+  return (
+    <ListDropdown
+      {...props}
+      desc={desc}
+      resources={resources}
+      selectedKeyKind={kind}
+      placeholder="Select claim"
+      selectedKey={selectedKey}
+    />
+  );
+};
+
+export type PVCDropdownProps = {
+  namespace: string;
+  selectedKey: string;
+  onChange: (string) => void;
+  id: string;
+  desc?: string;
+};

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -970,7 +970,7 @@ export type MachineHealthCheckKind = K8sResourceCommon & {
 };
 
 export type VolumeSnapshotKind = K8sResourceCommon & {
-  status: VolumeSnapshotStatus & {
+  status?: VolumeSnapshotStatus & {
     boundVolumeSnapshotContentName?: string;
   };
   spec: {
@@ -1013,4 +1013,20 @@ export type VolumeSnapshotStatus = {
 export type VolumeSnapshotClassKind = K8sResourceCommon & {
   deletionPolicy: string;
   driver: string;
+};
+
+export type PersistentVolumeClaimKind = K8sResourceCommon & {
+  spec: {
+    accessModes: string;
+    resources: {
+      requests: {
+        storage: string;
+      };
+    };
+    storageClassName: string;
+    volumeMode: string;
+  };
+  status: {
+    phase: string;
+  };
 };


### PR DESCRIPTION
'Create Snapshot` action in kebab menu for PVC will allow
user to create in-time images of snapshot.

![Screenshot from 2020-07-08 02-20-20](https://user-images.githubusercontent.com/12200504/86843669-84103880-c0c4-11ea-8fd8-4f63784c5ab3.png)



@bipuladh @cloudbehl 
Signed-off-by: Kanika <kmurarka@redhat.com>