### PR TITLE
sidebar for guided tours

### DIFF
--- a/frontend/packages/console-app/src/components/guided-tours/DrawerComponent.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/DrawerComponent.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContentBody,
+  Title,
+} from '@patternfly/react-core';
+import { GuidedTourItem, GuidedTourState } from './utils/guided-tour-typings';
+import './GuidedTourDrawer.scss';
+
+type DrawerComponentProps = {
+  guidedTour: GuidedTourItem;
+  guidedTourState?: GuidedTourState;
+  expanded: boolean;
+  onClose: () => void;
+  children?: React.ReactNode;
+  additionalHeaderContent?: React.ReactElement;
+};
+
+const DrawerComponent: React.FC<DrawerComponentProps> = ({
+  expanded,
+  guidedTour,
+  onClose,
+  children,
+  additionalHeaderContent,
+}) => {
+  const { name, duration } = guidedTour ?? {};
+  const panelContent = (
+    <DrawerPanelContent>
+      <DrawerHead>
+        <div>
+          <Title headingLevel="h1" size="xl" className="co-guided-tour-drawer__title">
+            {name}
+          </Title>
+          <Title
+            headingLevel="h6"
+            size="md"
+            className="text-secondary "
+            style={{ display: 'inline-block' }}
+          >
+            {`${duration} minutes`}
+          </Title>
+        </div>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+        {additionalHeaderContent}
+      </DrawerHead>
+      <DrawerPanelBody>Test Sidebar</DrawerPanelBody>
+    </DrawerPanelContent>
+  );
+
+  return (
+    <Drawer isExpanded={expanded} isInline>
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody style={{ zIndex: 0 }}>{children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default DrawerComponent;

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourCatalog.tsx
@@ -1,15 +1,39 @@
 import * as React from 'react';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 import { EmptyBox } from '@console/internal/components/utils';
 import { GuidedTourCatalogItem } from './utils/guided-tour-typings';
 import GuidedTourItem from './GuidedTourItem';
+import { setActiveGuidedTour } from '../../redux/actions/guided-tour-actions';
 import './GuidedTourCatalog.scss';
+import { RootState } from '@console/internal/redux';
+import {
+  getActiveTourID,
+  isGuidedTourDrawerExpanded,
+} from '../../redux/reducers/guided-tour-reducer';
 
-type GuidedTourCatalogProps = {
+type StateProps = {
+  isExpanded?: boolean;
+  activeTourID?: string;
+};
+
+type DispatchProps = {
+  onClick?: (tourId: string) => void;
+};
+
+type OwnProps = {
   tours: GuidedTourCatalogItem[];
 };
 
-const GuidedTourCatalog: React.FC<GuidedTourCatalogProps> = ({ tours }) => (
+type GuidedTourCatalogProps = OwnProps & DispatchProps & StateProps;
+
+const GuidedTourCatalog: React.FC<GuidedTourCatalogProps> = ({
+  tours,
+  isExpanded,
+  activeTourID,
+  onClick,
+}) => (
   <div className="oc-guided-tour-catalog">
     {!tours || tours.length === 0 ? (
       <EmptyBox label="Guided Tours" />
@@ -17,7 +41,10 @@ const GuidedTourCatalog: React.FC<GuidedTourCatalogProps> = ({ tours }) => (
       <Gallery hasGutter>
         {tours.map((tour) => (
           <GalleryItem key={tour.name}>
-            <GuidedTourItem {...tour} />
+            <GuidedTourItem
+              {...tour}
+              onClick={() => onClick(!isExpanded || tour.id !== activeTourID ? tour.id : '')}
+            />
           </GalleryItem>
         ))}
       </Gallery>
@@ -25,4 +52,19 @@ const GuidedTourCatalog: React.FC<GuidedTourCatalogProps> = ({ tours }) => (
   </div>
 );
 
-export default GuidedTourCatalog;
+const mapStateToProps = (state: RootState): StateProps => ({
+  isExpanded: isGuidedTourDrawerExpanded(state),
+  activeTourID: getActiveTourID(state),
+});
+
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+  onClick: (tourId: string) => dispatch(setActiveGuidedTour(tourId)),
+});
+
+// exposed for testing
+export const InternalGuidedTourCatalog = GuidedTourCatalog;
+
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(GuidedTourCatalog);

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourDrawer.scss
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourDrawer.scss
@@ -1,0 +1,6 @@
+.co-guided-tour-drawer {
+  &__title {
+    display: inline-block;
+    padding-right: var(--pf-global--spacer--md) !important;
+  }
+}

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourDrawer.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourDrawer.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
+import { RootState } from '@console/internal/redux';
+import DrawerComponent from './DrawerComponent';
+import {
+  getActiveTourID,
+  isGuidedTourDrawerExpanded,
+} from '../../redux/reducers/guided-tour-reducer';
+import { setActiveGuidedTour } from '../../redux/actions/guided-tour-actions';
+import { getGuidedTour } from './utils/guided-tour-utils';
+
+type StateProps = {
+  isExpanded: boolean;
+  activeTourID: string;
+};
+
+type DispatchProps = {
+  onClose: () => void;
+};
+
+type GuidedTourDrawerProps = StateProps & DispatchProps;
+
+const GuidedTourDrawer: React.FC<GuidedTourDrawerProps> = ({
+  isExpanded,
+  activeTourID,
+  onClose,
+  children,
+}) => {
+  const guidedTour = getGuidedTour(activeTourID);
+  // TODO: Add check for tour completed status and send complete alert based on that
+  // const tourCompleteAlert = (
+  //   <Alert variant="success" isInline title="This tour has already been completed" />
+  // );
+
+  return (
+    <DrawerComponent expanded={isExpanded} guidedTour={guidedTour} onClose={onClose}>
+      {children}
+    </DrawerComponent>
+  );
+};
+
+const mapStateToProps = (state: RootState): StateProps => ({
+  isExpanded: isGuidedTourDrawerExpanded(state),
+  activeTourID: getActiveTourID(state),
+});
+
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+  onClose: () => dispatch(setActiveGuidedTour('')),
+});
+
+export default connect<StateProps, DispatchProps>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(GuidedTourDrawer);

--- a/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/GuidedTourItem.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CatalogTile } from '@patternfly/react-catalog-view-extension';
-import { GuidedTourItem, GuidedTourCatalogItem } from './utils/guided-tour-typings';
+import { GuidedTourCatalogItem } from './utils/guided-tour-typings';
 import TourItemHeader from './TourItemHeader';
 import TourItemDescription from './TourItemDescription';
 import TourItemFooter from './TourItemFooter';
 import './GuidedTourItem.scss';
 
-type GuidedTourItemProps = GuidedTourCatalogItem;
+type GuidedTourItemProps = {
+  onClick: () => void;
+} & GuidedTourCatalogItem;
 
 const GuidedTourItem: React.FC<GuidedTourItemProps> = ({
   iconURL,
@@ -18,6 +20,7 @@ const GuidedTourItem: React.FC<GuidedTourItemProps> = ({
   duration,
   prerequisites,
   unmetPrerequisite,
+  onClick,
 }) => (
   <CatalogTile
     iconImg={iconURL}
@@ -25,6 +28,7 @@ const GuidedTourItem: React.FC<GuidedTourItemProps> = ({
     className="oc-guided-tour-item"
     featured={active}
     title={<TourItemHeader name={name} status={status} duration={duration} />}
+    onClick={onClick}
     description={
       <TourItemDescription
         description={description}

--- a/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/TourItemHeader.tsx
@@ -6,7 +6,7 @@ import { GuidedTourStatus } from './utils/guided-tour-status';
 import './TourItemHeader.scss';
 
 type TourItemHeaderProps = {
-  status: string;
+  status: GuidedTourStatus;
   duration: number;
   name: string;
 };

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourCatalog.spec.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourCatalog.spec.tsx
@@ -2,23 +2,29 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 import { EmptyBox } from '@console/internal/components/utils';
-import GuidedTourCatalog from '../GuidedTourCatalog';
+import { InternalGuidedTourCatalog } from '../GuidedTourCatalog';
 import { getGuidedToursWithStatus } from '../utils/guided-tour-utils';
 
 describe('GuidedTourCatalog', () => {
   it('should load an emptybox if no tours exist', () => {
-    const guidedTourCatalogProps = { tours: [] };
-    const guidedTourCatalogWrapper = shallow(<GuidedTourCatalog {...guidedTourCatalogProps} />);
+    const guidedTourCatalogProps = { tours: [], onClick: jest.fn() };
+    const guidedTourCatalogWrapper = shallow(
+      <InternalGuidedTourCatalog {...guidedTourCatalogProps} />,
+    );
     expect(guidedTourCatalogWrapper.find(EmptyBox).exists()).toBeTruthy();
   });
   it('should load a gallery if tours exist', () => {
-    const guidedTourCatalogProps = { tours: getGuidedToursWithStatus() };
-    const guidedTourCatalogWrapper = shallow(<GuidedTourCatalog {...guidedTourCatalogProps} />);
+    const guidedTourCatalogProps = { tours: getGuidedToursWithStatus(), onClick: jest.fn() };
+    const guidedTourCatalogWrapper = shallow(
+      <InternalGuidedTourCatalog {...guidedTourCatalogProps} />,
+    );
     expect(guidedTourCatalogWrapper.find(Gallery).exists()).toBeTruthy();
   });
   it('should load galleryItems equal to the number of tours', () => {
-    const guidedTourCatalogProps = { tours: getGuidedToursWithStatus() };
-    const guidedTourCatalogWrapper = shallow(<GuidedTourCatalog {...guidedTourCatalogProps} />);
+    const guidedTourCatalogProps = { tours: getGuidedToursWithStatus(), onClick: jest.fn() };
+    const guidedTourCatalogWrapper = shallow(
+      <InternalGuidedTourCatalog {...guidedTourCatalogProps} />,
+    );
     const galleryItems = guidedTourCatalogWrapper.find(GalleryItem);
     expect(galleryItems.exists()).toBeTruthy();
     expect(galleryItems.length).toEqual(3);

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourItem.spec.tsx
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/GuidedTourItem.spec.tsx
@@ -8,13 +8,13 @@ describe('GuidedTourItem', () => {
   const tourItems = getGuidedToursWithStatus();
 
   it('should load proper catalog tile without featured property', () => {
-    const guidedTourItemWrapper = shallow(<GuidedTourItem {...tourItems[0]} />);
+    const guidedTourItemWrapper = shallow(<GuidedTourItem {...tourItems[0]} onClick={jest.fn()} />);
     const catalogTile = guidedTourItemWrapper.find(CatalogTile);
     expect(catalogTile.exists()).toBeTruthy();
     expect(catalogTile.prop('featured')).toBe(false);
   });
   it('should load proper catalog tile with featured property', () => {
-    const guidedTourItemWrapper = shallow(<GuidedTourItem {...tourItems[1]} />);
+    const guidedTourItemWrapper = shallow(<GuidedTourItem {...tourItems[1]} onClick={jest.fn()} />);
     const catalogTile = guidedTourItemWrapper.find(CatalogTile);
     expect(catalogTile.exists()).toBeTruthy();
     expect(catalogTile.prop('featured')).toBe(true);

--- a/frontend/packages/console-app/src/components/guided-tours/__tests__/guided-tour-utils.spec.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/__tests__/guided-tour-utils.spec.ts
@@ -1,0 +1,9 @@
+import { mockGuidedTours } from '../utils/guided-tour-mocks';
+import { getGuidedTour } from '../utils/guided-tour-utils';
+
+describe('guided-tour-utils', () => {
+  it('should return the guided tour corresponding to the id', () => {
+    const mockID = mockGuidedTours[0].id;
+    expect(getGuidedTour(mockID).id === mockID).toBe(true);
+  });
+});

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-mocks.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-mocks.ts
@@ -6,6 +6,7 @@ export const mockGuidedTours: GuidedTourItem[] = [
     iconURL:
       '/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-marketplace/packagemanifests/3scale-community-operator/icon?resourceVersion=3scale-community-operator.threescale-2.8.3scale-community-operator.v0.5.1',
     altIcon: 'KNative',
+    id: 'serverless-explore',
     name: 'Explore Serverless',
     duration: 5,
     description:
@@ -16,6 +17,7 @@ export const mockGuidedTours: GuidedTourItem[] = [
     iconURL:
       '/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-marketplace/packagemanifests/serverless-operator/icon?resourceVersion=serverless-operator.4.3.serverless-operator.v1.7.1',
     altIcon: 'KNative',
+    id: 'serverless-applications',
     name: 'Serverless Aplications',
     duration: 10,
     description: 'Learn how to create a serverless application',
@@ -25,6 +27,7 @@ export const mockGuidedTours: GuidedTourItem[] = [
     iconURL:
       '/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-marketplace/packagemanifests/serverless-operator/icon?resourceVersion=serverless-operator.4.3.serverless-operator.v1.7.1',
     altIcon: 'TKN',
+    id: 'pipelines-build',
     name: 'Build Pipelines',
     duration: 15,
     description: 'Release requirement if any installs x number of resources',

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-typings.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-typings.ts
@@ -1,6 +1,9 @@
+import { GuidedTourStatus } from './guided-tour-status';
+
 export type GuidedTourItem = {
   iconURL: string;
   altIcon?: string;
+  id: string;
   name: string;
   duration: number;
   description: string;
@@ -9,10 +12,12 @@ export type GuidedTourItem = {
 
 export type TourStatus = {
   active?: boolean;
-  status: string;
+  status: GuidedTourStatus;
 };
 
 export type GuidedTourCatalogItem = GuidedTourItem &
   TourStatus & {
     unmetPrerequisite?: boolean;
   };
+
+export type GuidedTourState = {};

--- a/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-utils.ts
+++ b/frontend/packages/console-app/src/components/guided-tours/utils/guided-tour-utils.ts
@@ -15,3 +15,7 @@ export const getGuidedToursWithStatus = (): GuidedTourCatalogItem[] => {
     };
   });
 };
+
+export const getGuidedTour = (tourID: string): GuidedTourItem => {
+  return mockGuidedTours.find((tour) => tour.id === tourID);
+};

--- a/frontend/packages/console-app/src/redux/actions/guided-tour-actions.ts
+++ b/frontend/packages/console-app/src/redux/actions/guided-tour-actions.ts
@@ -1,0 +1,14 @@
+import { action, ActionType } from 'typesafe-actions';
+
+export enum Actions {
+  SetActiveGuidedTour = 'setActiveGuidedTour',
+}
+
+export const setActiveGuidedTour = (activeTourID: string) =>
+  action(Actions.SetActiveGuidedTour, { activeTourID });
+
+const actions = {
+  setActiveGuidedTour,
+};
+
+export type GuidedTourSidebarActions = ActionType<typeof actions>;

--- a/frontend/packages/console-app/src/redux/reducer.ts
+++ b/frontend/packages/console-app/src/redux/reducer.ts
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
 import cloudShellReducer, { cloudShellReducerName } from './reducers/cloud-shell-reducer';
+import guidedTourReducer, { guidedTourReducerName } from './reducers/guided-tour-reducer';
 
 export default combineReducers({
   [cloudShellReducerName]: cloudShellReducer,
+  [guidedTourReducerName]: guidedTourReducer,
 });

--- a/frontend/packages/console-app/src/redux/reducers/guided-tour-reducer.ts
+++ b/frontend/packages/console-app/src/redux/reducers/guided-tour-reducer.ts
@@ -1,0 +1,31 @@
+import { GuidedTourSidebarActions, Actions } from '../actions/guided-tour-actions';
+import { RootState } from '@console/internal/redux';
+
+export const guidedTourReducerName = 'guidedTour';
+
+type State = {
+  isExpanded: boolean;
+  activeTourID: string;
+};
+
+const initialState: State = {
+  isExpanded: false,
+  activeTourID: '',
+};
+
+export default (state = initialState, action: GuidedTourSidebarActions) => {
+  if (action.type === Actions.SetActiveGuidedTour) {
+    return {
+      isExpanded: !!action.payload.activeTourID,
+      activeTourID: action.payload.activeTourID || state.activeTourID,
+    };
+  }
+
+  return state;
+};
+
+export const isGuidedTourDrawerExpanded = (state: RootState): boolean =>
+  !!state.plugins?.console?.[guidedTourReducerName]?.isExpanded;
+
+export const getActiveTourID = (state: RootState): string =>
+  state.plugins?.console?.[guidedTourReducerName]?.activeTourID;

--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-drawer.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-drawer.tsx
@@ -10,7 +10,8 @@ const NotificationDrawer: React.FC<NotificationDrawerProps> = ({
   notificationEntries,
   className,
 }) => {
-  const panelContent = (
+  // Added check for `isExpanded` due to flaw in patternfly drawer. Remove the check on patternfly version upgrade
+  const panelContent = isExpanded && (
     <DrawerPanelContent className={className}>
       <NotificationDrawerHeading>{notificationEntries}</NotificationDrawerHeading>
       <DrawerPanelBody hasNoPadding />

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -26,6 +26,7 @@ const consoleLoader = () =>
   import(
     '@console/kubevirt-plugin/src/components/connected-vm-console/vm-console-page' /* webpackChunkName: "kubevirt" */
   ).then((m) => m.VMConsolePage);
+import GuidedTourDrawer from '@console/app/src/components/guided-tours/GuidedTourDrawer';
 import '../vendor.scss';
 import '../style.scss';
 
@@ -134,26 +135,28 @@ class App extends React.PureComponent {
     return (
       <DetectPerspective>
         <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
-        <ConsoleNotifier location="BannerTop" />
-        <Page
-          header={<Masthead onNavToggle={this._onNavToggle} />}
-          sidebar={
-            <Navigation
-              isNavOpen={isNavOpen}
-              onNavSelect={this._onNavSelect}
-              onPerspectiveSelected={this._onNavSelect}
-            />
-          }
-        >
-          <ConnectedNotificationDrawer
-            isDesktop={isDrawerInline}
-            onDrawerChange={this._onNotificationDrawerToggle}
+        <GuidedTourDrawer>
+          <ConsoleNotifier location="BannerTop" />
+          <Page
+            header={<Masthead onNavToggle={this._onNavToggle} />}
+            sidebar={
+              <Navigation
+                isNavOpen={isNavOpen}
+                onNavSelect={this._onNavSelect}
+                onPerspectiveSelected={this._onNavSelect}
+              />
+            }
           >
-            <AppContents />
-          </ConnectedNotificationDrawer>
-        </Page>
-        <CloudShell />
-        <ConsoleNotifier location="BannerBottom" />
+            <ConnectedNotificationDrawer
+              isDesktop={isDrawerInline}
+              onDrawerChange={this._onNotificationDrawerToggle}
+            >
+              <AppContents />
+            </ConnectedNotificationDrawer>
+          </Page>
+          <CloudShell />
+          <ConsoleNotifier location="BannerBottom" />
+        </GuidedTourDrawer>
       </DetectPerspective>
     );
   }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -352,6 +352,11 @@ h6 {
   }
 }
 
+// TODO remove this override once https://github.com/patternfly/patternfly/pull/3268 is adopted
+.pf-c-drawer .pf-c-page__main {
+  min-height: auto !important;
+}
+
 // pf table overrides
 
 .pf-c-table tr > th {


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-4129

Solution Description:
- Add a sidebar for guided tours
- add redux to manage sidebar toggle

Screens:
![guidedtourdrawer](https://user-images.githubusercontent.com/38663217/86559001-79488d00-bf78-11ea-9eb5-7a3514cf6acd.gif)
![Screenshot from 2020-07-06 10-01-02](https://user-images.githubusercontent.com/38663217/86559007-806f9b00-bf78-11ea-90cf-1dd447915f04.png)

Test Coverage:
![Screenshot from 2020-07-06 11-09-02](https://user-images.githubusercontent.com/38663217/86559262-28856400-bf79-11ea-842f-8e90c5e1ecf9.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge