### PR TITLE
Adjustments for alignment and spacing on the following search elements

### DIFF
--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -19,7 +19,8 @@
 }
 
 .co-m-nav-title {
-  padding: $grid-gutter-width ($grid-gutter-width / 2) 0;
+  margin-top: $grid-gutter-width;
+  padding: 0 ($grid-gutter-width / 2) 0;
   @media (min-width: $grid-float-breakpoint) {
     padding-left: $grid-gutter-width;
     padding-right: $grid-gutter-width;
@@ -40,6 +41,6 @@
   }
   // Positioned after --detail to take precedence, since they will be a siblings
   &--breadcrumbs {
-    padding-top: 0;
+    margin-top: 0;
   }
 }

--- a/frontend/public/components/_search.scss
+++ b/frontend/public/components/_search.scss
@@ -1,5 +1,12 @@
 .co-search__accordion {
   padding-top: 0 !important;
+  // Align with search results
+  @media (min-width: $screen-sm-min) {
+    .co-search-group__accordion-toggle {
+      padding-left: $grid-gutter-width;
+      padding-right: $grid-gutter-width;
+    }
+  }
   .co-m-pane__filter-bar {
     // Reduce the margin between the accordion toggle and the create button
     // so that the space is equal above and below the button.

--- a/frontend/public/components/utils/_status-box.scss
+++ b/frontend/public/components/utils/_status-box.scss
@@ -1,5 +1,5 @@
 .cos-status-box {
-  padding: 20px;
+  padding: 40px 20px;
 
   &__title {
     color: #333;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -236,6 +236,7 @@ h6 {
     --pf-c-toolbar--PaddingTop: 0;
     --pf-c-toolbar__content--PaddingLeft: 0;
     --pf-c-toolbar__content--PaddingRight: 0;
+    --pf-c-toolbar--RowGap: var(--pf-global--spacer--md);
   }
 
   .pf-c-page__main-section {


### PR DESCRIPTION
- accordion toggle left and right padding
- empty results help message Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1851488
- spacing between pf-c-toolbar and filters to match events filter

<img width="866" alt="Screen Shot 2020-07-06 at 5 14 27 PM" src="https://user-images.githubusercontent.com/1874151/86647693-43260000-bfae-11ea-85bf-27707c0f84c6.png">

**Corrected version**

<img width="928" alt="Screen Shot 2020-07-06 at 4 57 14 PM" src="https://user-images.githubusercontent.com/1874151/86647801-5769fd00-bfae-11ea-8c4e-2e11b47d3cd1.png">

<img width="868" alt="Screen Shot 2020-07-06 at 5 18 23 PM" src="https://user-images.githubusercontent.com/1874151/86647822-5b961a80-bfae-11ea-8a9a-27aef5a541be.png">
