### PR TITLE
Bug 1854131: Machine's 'Provisioned as node' phase should use SuccessStatus component with GreenCheckCircleIcon icon

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -44,7 +44,6 @@ export const Status: React.FC<StatusProps> = ({
     case 'Running':
     case 'Updating':
     case 'Upgrading':
-    case 'Provisioned as node':
       return <StatusIconAndText {...statusProps} icon={<SyncAltIcon />} />;
 
     case 'Cancelled':
@@ -83,6 +82,7 @@ export const Status: React.FC<StatusProps> = ({
     case 'Succeeded':
     case 'Ready':
     case 'Up to date':
+    case 'Provisioned as node':
       return <SuccessStatus {...statusProps} />;
 
     case 'Info':


### PR DESCRIPTION
/assign @spadgett 