### PR TITLE
Monitoring: Add Refresh Interval dropdown to Metrics page

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -46,6 +46,7 @@ export enum ActionType {
   QueryBrowserRunQueries = 'queryBrowserRunQueries',
   QueryBrowserSetAllExpanded = 'queryBrowserSetAllExpanded',
   QueryBrowserSetMetrics = 'queryBrowserSetMetrics',
+  QueryBrowserSetPollInterval = 'queryBrowserSetPollInterval',
   QueryBrowserToggleIsEnabled = 'queryBrowserToggleIsEnabled',
   QueryBrowserToggleSeries = 'queryBrowserToggleSeries',
   SetClusterID = 'setClusterID',
@@ -347,6 +348,8 @@ export const queryBrowserSetAllExpanded = (isExpanded: boolean) => {
 };
 export const queryBrowserSetMetrics = (metrics: string[]) =>
   action(ActionType.QueryBrowserSetMetrics, { metrics });
+export const queryBrowserSetPollInterval = (pollInterval: number) =>
+  action(ActionType.QueryBrowserSetPollInterval, { pollInterval });
 export const queryBrowserToggleIsEnabled = (index: number) =>
   action(ActionType.QueryBrowserToggleIsEnabled, { index });
 export const queryBrowserToggleSeries = (index: number, labels: { [key: string]: unknown }) => {
@@ -402,6 +405,7 @@ const uiActions = {
   queryBrowserRunQueries,
   queryBrowserSetAllExpanded,
   queryBrowserSetMetrics,
+  queryBrowserSetPollInterval,
   queryBrowserToggleIsEnabled,
   queryBrowserToggleSeries,
   setConsoleLinks,

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -20,6 +20,7 @@ import { RootState } from '../../../redux';
 import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';
 import { ExternalLink, history, LoadingInline, useSafeFetch } from '../../utils';
 import { formatPrometheusDuration, parsePrometheusDuration } from '../../utils/datetime';
+import IntervalDropdown from '../poll-interval-dropdown';
 import BarChart from './bar-chart';
 import Graph from './graph';
 import SingleStat from './single-stat';
@@ -238,47 +239,14 @@ export const TimespanDropdown = connect(
   },
 )(TimespanDropdown_);
 
-const pollOffText = 'Off';
-const pollIntervalOptions = {
-  [pollOffText]: pollOffText,
-  '15s': '15 seconds',
-  '30s': '30 seconds',
-  '1m': '1 minute',
-  '5m': '5 minutes',
-  '15m': '15 minutes',
-  '30m': '30 minutes',
-  '1h': '1 hour',
-  '2h': '2 hours',
-  '1d': '1 day',
-};
-
-const PollIntervalDropdown_: React.FC<PollIntervalDropdownProps> = ({
-  pollInterval,
-  setPollInterval,
-}) => {
-  const onChange = React.useCallback(
-    (v: string) => setPollInterval(v === pollOffText ? null : parsePrometheusDuration(v)),
-    [setPollInterval],
-  );
-
-  return (
-    <VariableDropdown
-      items={pollIntervalOptions}
-      label="Refresh Interval"
-      onChange={onChange}
-      selectedKey={pollInterval === null ? pollOffText : formatPrometheusDuration(pollInterval)}
-    />
-  );
-};
-
 export const PollIntervalDropdown = connect(
   ({ UI }: RootState) => ({
-    pollInterval: UI.getIn(['monitoringDashboards', 'pollInterval']),
+    interval: UI.getIn(['monitoringDashboards', 'pollInterval']),
   }),
   {
-    setPollInterval: UIActions.monitoringDashboardsSetPollInterval,
+    setInterval: UIActions.monitoringDashboardsSetPollInterval,
   },
-)(PollIntervalDropdown_);
+)(IntervalDropdown);
 
 // Matches Prometheus labels surrounded by {{ }} in the graph legend label templates
 const legendTemplateOptions = { interpolate: /{{([a-zA-Z_][a-zA-Z0-9_]*)}}/g };
@@ -523,7 +491,10 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
           </h1>
           <div className="monitoring-dashboards__options">
             <TimespanDropdown />
-            <PollIntervalDropdown />
+            <div className="form-group monitoring-dashboards__dropdown-wrap">
+              <label className="monitoring-dashboards__dropdown-title">Refresh Interval</label>
+              <PollIntervalDropdown />
+            </div>
           </div>
         </div>
         <div className="monitoring-dashboards__variables">
@@ -611,11 +582,6 @@ type AllVariableDropdownsProps = {
 type TimespanDropdownProps = {
   timespan: number;
   setTimespan: (v: number) => never;
-};
-
-type PollIntervalDropdownProps = {
-  pollInterval: number;
-  setPollInterval: (v: number) => never;
 };
 
 type CardBodyProps = {

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -59,6 +59,7 @@ import {
   useSafeFetch,
 } from '../utils';
 import { setAllQueryArguments } from '../utils/router';
+import IntervalDropdown from './poll-interval-dropdown';
 import { colors, Error, QueryObj, QueryBrowser } from './query-browser';
 
 const operators = [
@@ -571,6 +572,7 @@ const QueryKebab = connect(
 const queryTableStateToProps = ({ UI }: RootState, { index }) => ({
   isEnabled: UI.getIn(['queryBrowser', 'queries', index, 'isEnabled']),
   isExpanded: UI.getIn(['queryBrowser', 'queries', index, 'isExpanded']),
+  pollInterval: UI.getIn(['queryBrowser', 'pollInterval']),
   query: UI.getIn(['queryBrowser', 'queries', index, 'query']),
   series: UI.getIn(['queryBrowser', 'queries', index, 'series']),
 });
@@ -614,6 +616,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
   isEnabled,
   isExpanded,
   namespace,
+  pollInterval = 15 * 1000,
   query,
   series,
 }) => {
@@ -641,7 +644,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
     }
   };
 
-  usePoll(tick, 15 * 1000, namespace, query);
+  usePoll(tick, pollInterval, namespace, query);
 
   React.useEffect(() => {
     setData(undefined);
@@ -967,6 +970,15 @@ const TechPreview = () => (
   </span>
 );
 
+const PollIntervalDropdown = connect(
+  ({ UI }: RootState) => ({
+    interval: UI.getIn(['queryBrowser', 'pollInterval']),
+  }),
+  {
+    setInterval: UIActions.queryBrowserSetPollInterval,
+  },
+)(IntervalDropdown);
+
 const QueryBrowserPage_: React.FC<QueryBrowserPageProps> = ({ deleteAll, namespace }) => {
   // Clear queries on unmount
   React.useEffect(() => deleteAll, [deleteAll]);
@@ -983,6 +995,7 @@ const QueryBrowserPage_: React.FC<QueryBrowserPageProps> = ({ deleteAll, namespa
             {namespace ? <TechPreview /> : <HeaderPrometheusLink />}
           </span>
           <div className="co-actions">
+            <PollIntervalDropdown />
             <MetricsActionsMenu />
           </div>
         </h1>
@@ -1079,6 +1092,7 @@ type QueryTableProps = {
   isEnabled: boolean;
   isExpanded: boolean;
   namespace?: string;
+  pollInterval: number;
   query: string;
   series: PrometheusLabels[];
 };

--- a/frontend/public/components/monitoring/poll-interval-dropdown.tsx
+++ b/frontend/public/components/monitoring/poll-interval-dropdown.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { Dropdown } from '../utils/dropdown';
+import { formatPrometheusDuration, parsePrometheusDuration } from '../utils/datetime';
+
+const OFF_KEY = 'OFF_KEY';
+const intervalOptions = {
+  [OFF_KEY]: 'Refresh Off',
+  '15s': '15 seconds',
+  '30s': '30 seconds',
+  '1m': '1 minute',
+  '5m': '5 minutes',
+  '15m': '15 minutes',
+  '30m': '30 minutes',
+  '1h': '1 hour',
+  '2h': '2 hours',
+  '1d': '1 day',
+};
+
+type Props = {
+  interval: number;
+  setInterval: (v: number) => never;
+};
+
+const IntervalDropdown: React.FC<Props> = ({ interval, setInterval }) => {
+  const onChange = React.useCallback(
+    (v: string) => setInterval(v === OFF_KEY ? null : parsePrometheusDuration(v)),
+    [setInterval],
+  );
+
+  return (
+    <Dropdown
+      items={intervalOptions}
+      onChange={onChange}
+      selectedKey={interval === null ? OFF_KEY : formatPrometheusDuration(interval)}
+    />
+  );
+};
+
+export default IntervalDropdown;

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -111,6 +111,7 @@ export default (state: UIState, action: UIAction): UIState => {
       }),
       queryBrowser: ImmutableMap({
         metrics: [],
+        pollInterval: null,
         queries: ImmutableList([newQueryBrowserQuery()]),
       }),
       pinnedResources,
@@ -300,6 +301,9 @@ export default (state: UIState, action: UIAction): UIState => {
     }
     case ActionType.QueryBrowserSetMetrics:
       return state.setIn(['queryBrowser', 'metrics'], action.payload.metrics);
+
+    case ActionType.QueryBrowserSetPollInterval:
+      return state.setIn(['queryBrowser', 'pollInterval'], action.payload.pollInterval);
 
     case ActionType.QueryBrowserToggleIsEnabled: {
       const query = state.getIn(['queryBrowser', 'queries', action.payload.index]);


### PR DESCRIPTION
Defaults to "Refresh Off".
Only applies to the admin perspective for now.

![screenshot](https://user-images.githubusercontent.com/460802/86782774-734acd00-c09a-11ea-9333-f4c59008b816.png)
