### PR TITLE
Add support for perspective detection using extensions

### DIFF
--- a/frontend/__tests__/reducers/ui.spec.ts
+++ b/frontend/__tests__/reducers/ui.spec.ts
@@ -17,20 +17,6 @@ describe('getDefaultPerspective', () => {
     expect(getDefaultPerspective()).toBeUndefined();
   });
 
-  it('should default to perspective extension marked default', () => {
-    // return Perspectives extension with one marked as the default
-    spyOn(pluginStore, 'getAllExtensions').and.returnValue([
-      {
-        type: 'Perspective',
-        properties: {
-          id: 'admin',
-          default: true,
-        },
-      } as Perspective,
-    ]);
-    expect(getDefaultPerspective()).toBe('admin');
-  });
-
   it('should default to localStorage if perspective is a valid extension', () => {
     // return Perspectives extension whose id matches that in the localStorage
     spyOn(pluginStore, 'getAllExtensions').and.returnValue([

--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -19,6 +19,8 @@ const {
 describe('Auth test', () => {
   beforeAll(async () => {
     await browser.get(appHost);
+    // Stop the perspective detection from running by setting last perspective in localStorage
+    await browser.executeScript('window.localStorage.setItem("bridge/last-perspective", "admin")');
     await browser.sleep(3000); // Wait long enough for the login redirect to complete
   });
 

--- a/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { connect, Dispatch } from 'react-redux';
+import { getActivePerspective } from '@console/internal/reducers/ui';
+import { RootState } from '@console/internal/redux';
+import * as UIActions from '@console/internal/actions/ui';
+import PerspectiveDetector from './PerspectiveDetector';
+
+type OwnProps = {
+  children: React.ReactNode;
+};
+
+type StateProps = {
+  activePerspective: string;
+};
+
+type DispatchProps = {
+  setActivePerspective: (string) => void;
+};
+
+type DetectPerspectiveProps = OwnProps & StateProps & DispatchProps;
+
+const DetectPerspective: React.FC<DetectPerspectiveProps> = ({
+  activePerspective,
+  children,
+  setActivePerspective,
+}) =>
+  activePerspective ? (
+    <>{children}</>
+  ) : (
+    <PerspectiveDetector setActivePerspective={setActivePerspective} />
+  );
+
+const mapStateToProps = (state: RootState) => ({
+  activePerspective: getActivePerspective(state),
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  setActivePerspective: (perspective) => dispatch(UIActions.setActivePerspective(perspective)),
+});
+
+// For testing
+export const InternalDetectPerspective = DetectPerspective;
+
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DetectPerspective);

--- a/frontend/packages/console-app/src/components/detect-perspective/PerspectiveDetector.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/PerspectiveDetector.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { useExtensions, isPerspective } from '@console/plugin-sdk';
+
+type PerspectiveDetectorProps = {
+  setActivePerspective: (string) => void;
+};
+
+const PerspectiveDetector: React.FC<PerspectiveDetectorProps> = ({ setActivePerspective }) => {
+  let detectedPerspective: string;
+  const perspectiveExtensions = useExtensions(isPerspective);
+  const defaultPerspective = perspectiveExtensions.find((p) => p.properties.default);
+  const detectors = perspectiveExtensions.filter((p) => p.properties.usePerspectiveDetection);
+  const detectionResults = detectors.map((p) => p.properties.usePerspectiveDetection());
+
+  const detectionComplete = detectionResults.every((result, index) => {
+    const [enablePerspective, loading] = result;
+    if (!detectedPerspective && !loading && enablePerspective) {
+      detectedPerspective = detectors[index].properties.id;
+    }
+    return loading === false;
+  });
+
+  React.useEffect(() => {
+    if (detectedPerspective) {
+      setActivePerspective(detectedPerspective);
+    } else if (detectors.length < 1 || detectionComplete) {
+      setActivePerspective(defaultPerspective.properties.id); // set default perspective if there are no detectors or none of the detections were successfull
+    }
+  }, [
+    defaultPerspective,
+    detectedPerspective,
+    detectionComplete,
+    detectors.length,
+    setActivePerspective,
+  ]);
+
+  return null;
+};
+
+export default PerspectiveDetector;

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { InternalDetectPerspective } from '../DetectPerspective';
+import PerspectiveDetector from '../PerspectiveDetector';
+
+const MockApp = () => <h1>App</h1>;
+
+describe('DetectPerspective', () => {
+  it('should render children if there is an activePerspective', () => {
+    const wrapper = shallow(
+      <InternalDetectPerspective activePerspective="dev" setActivePerspective={() => {}}>
+        <MockApp />
+      </InternalDetectPerspective>,
+    );
+    expect(wrapper.find(MockApp).exists()).toBe(true);
+  });
+
+  it('should render PerspectiveDetector if there is no activePerspective', () => {
+    const wrapper = shallow(
+      <InternalDetectPerspective activePerspective={undefined} setActivePerspective={() => {}}>
+        <MockApp />
+      </InternalDetectPerspective>,
+    );
+    expect(wrapper.find(PerspectiveDetector).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/PerspectiveDetector.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/PerspectiveDetector.spec.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { Perspective, useExtensions } from '@console/plugin-sdk';
+import PerspectiveDetector from '../PerspectiveDetector';
+
+jest.mock('@console/plugin-sdk', () => ({
+  useExtensions: jest.fn(),
+}));
+
+const mockPerspectives = [
+  {
+    type: 'Perspective',
+    properties: {
+      id: 'admin',
+      name: 'Admin Perspective',
+      default: true,
+    },
+  },
+  {
+    type: 'Perspective',
+    properties: {
+      id: 'dev',
+      name: 'Dev Perspective',
+      usePerspectiveDetection: undefined,
+    },
+  },
+] as Perspective[];
+
+const setActivePerspective = jest.fn();
+
+describe('PerspectiveDetector', () => {
+  it('should set default perspective if there are no perspective detectors available', () => {
+    (useExtensions as jest.Mock).mockImplementation(() => mockPerspectives);
+
+    const wrapper = mount(<PerspectiveDetector setActivePerspective={setActivePerspective} />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+    expect(setActivePerspective).toHaveBeenCalledWith('admin');
+  });
+
+  it('should set detected perspective if detection is successful', () => {
+    mockPerspectives[1].properties.usePerspectiveDetection = () => [true, false];
+    (useExtensions as jest.Mock).mockImplementation(() => mockPerspectives);
+
+    const wrapper = mount(<PerspectiveDetector setActivePerspective={setActivePerspective} />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+    expect(setActivePerspective).toHaveBeenCalledWith('dev');
+  });
+
+  it('should set default perspective if detection fails', () => {
+    mockPerspectives[1].properties.usePerspectiveDetection = () => [false, false];
+    (useExtensions as jest.Mock).mockImplementation(() => mockPerspectives);
+
+    const wrapper = mount(<PerspectiveDetector setActivePerspective={setActivePerspective} />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+    expect(setActivePerspective).toHaveBeenCalledWith('admin');
+  });
+});

--- a/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
@@ -20,6 +20,8 @@ namespace ExtensionProperties {
     getK8sLandingPageURL: GetLandingPage;
     /** The function to get redirect URL for import flow. */
     getImportRedirectURL: (project: string) => string;
+    /** The hook to detect default perspective */
+    usePerspectiveDetection?: () => [boolean, boolean]; // [enablePerspective: boolean, loading: boolean]
   }
 }
 

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -64,6 +64,7 @@ import {
   OperatorsTopologyConsumedExtensions,
   operatorsTopologyPlugin,
 } from './components/topology/operators/operatorsTopologyPlugin';
+import { usePerspectiveDetection } from './utils/usePerspectiveDetection';
 
 const {
   ClusterTaskModel,
@@ -422,6 +423,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       getLandingPageURL: () => '/topology',
       getK8sLandingPageURL: () => '/add',
       getImportRedirectURL: (project) => `/topology/ns/${project}`,
+      usePerspectiveDetection,
     },
   },
   {

--- a/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
@@ -1,0 +1,37 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+import { testHook } from '@console/shared/src/test-utils/hooks-utils';
+import { usePerspectiveDetection } from '../usePerspectiveDetection';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+describe('usePerspectiveDetection', () => {
+  it('should return loading as true if CAN_GET_NS flag is pending', () => {
+    (useSelector as jest.Mock).mockImplementation(() => ({
+      CAN_GET_NS: undefined,
+    }));
+
+    testHook(() => {
+      const [enablePerspective, loading] = usePerspectiveDetection();
+
+      expect(enablePerspective).toBe(true);
+      expect(loading).toBe(true);
+    });
+  });
+
+  it('should return loading as false if CAN_GET_NS flag is loaded', () => {
+    (useSelector as jest.Mock).mockImplementation(() => ({
+      CAN_GET_NS: false,
+    }));
+
+    testHook(() => {
+      const [enablePerspective, loading] = usePerspectiveDetection();
+
+      expect(enablePerspective).toBe(true);
+      expect(loading).toBe(false);
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/utils/usePerspectiveDetection.ts
+++ b/frontend/packages/dev-console/src/utils/usePerspectiveDetection.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+import { RootState } from '@console/internal/redux';
+import { getFlagsObject, flagPending } from '@console/internal/reducers/features';
+
+export const usePerspectiveDetection = () => {
+  const flags = useSelector((state: RootState) => getFlagsObject(state));
+  const canGetNS = flags.CAN_GET_NS;
+  const loadingFlag = flagPending(canGetNS);
+  const enablePerspective = !canGetNS;
+
+  return [enablePerspective, loadingFlag] as [boolean, boolean];
+};

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -20,6 +20,8 @@ import { receivedResources, watchAPIServices } from '../actions/k8s';
 // cloud shell imports must come later than features
 import CloudShell from '@console/app/src/components/cloud-shell/CloudShell';
 import CloudShellTab from '@console/app/src/components/cloud-shell/CloudShellTab';
+import DetectPerspective from '@console/app/src/components/detect-perspective/DetectPerspective';
+
 const consoleLoader = () =>
   import(
     '@console/kubevirt-plugin/src/components/connected-vm-console/vm-console-page' /* webpackChunkName: "kubevirt" */
@@ -130,7 +132,7 @@ class App extends React.PureComponent {
     const { productName } = getBrandingDetails();
 
     return (
-      <>
+      <DetectPerspective>
         <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
         <ConsoleNotifier location="BannerTop" />
         <Page
@@ -152,7 +154,7 @@ class App extends React.PureComponent {
         </Page>
         <CloudShell />
         <ConsoleNotifier location="BannerBottom" />
-      </>
+      </DetectPerspective>
     );
   }
 }

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -30,13 +30,6 @@ export function getDefaultPerspective() {
     // invalid saved perspective
     activePerspective = undefined;
   }
-  if (!activePerspective) {
-    // assign default perspective
-    const defaultPerspective = perspectiveExtensions.find((p) => p.properties.default);
-    if (defaultPerspective) {
-      activePerspective = defaultPerspective.properties.id;
-    }
-  }
   return activePerspective || undefined;
 }
 


### PR DESCRIPTION
**Fixes**:  https://issues.redhat.com/browse/ODC-4022

**Analysis / Root cause**: We want a developer to be directly taken to developer perspective.

**Solution Description**: 
- Added a new perspective extension property `usePerspectiveDetection` which runs the perspective detection.
- Created `DetectPerspective` component that wraps top level `App` component and runs perspective detection using the extension mechanism.

**Screen shots / Gifs for design review**: 
![perpsectives](https://user-images.githubusercontent.com/6041994/86832286-99ca3180-c0b5-11ea-8134-39dfe4085c91.gif)

![perpsectives - 2](https://user-images.githubusercontent.com/6041994/86832315-a2bb0300-c0b5-11ea-9cb9-20ad3c2884d7.gif)

**Unit test coverage report**: 
![Screenshot from 2020-07-10 00-56-43](https://user-images.githubusercontent.com/6041994/87082419-a16e0f80-c248-11ea-9259-8efed5f4f852.png)

![Screenshot from 2020-07-10 00-57-33](https://user-images.githubusercontent.com/6041994/87082425-a5019680-c248-11ea-9f92-cec3712ea98d.png)

![Screenshot from 2020-07-10 01-01-52](https://user-images.githubusercontent.com/6041994/87082651-fd389880-c248-11ea-974a-86371b492f52.png)


**Test setup:**
- Remove `last-perspective` from local storage.
- Login as basic user into the console.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge