### PR TITLE
Remove overflow:hidden so that yaml help tool tips aren't clipped.

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/YAMLEditor.scss
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditor.scss
@@ -1,13 +1,11 @@
 .ocs-yaml-editor {
   &__root {
     flex: 1;
-    overflow: hidden;
     position: relative;
   }
 
   &__wrapper {
     position: absolute;
-    overflow: hidden;
     top: 0;
     right: 0;
     left: 0;


### PR DESCRIPTION
Fix Bug https://bugzilla.redhat.com/show_bug.cgi?id=1854214

<img width="804" alt="Screen Shot 2020-07-07 at 7 24 50 PM" src="https://user-images.githubusercontent.com/1874151/86855291-0b8b8680-c088-11ea-85f4-704539d42da2.png">
