### PR TITLE
Fix crash (white screen) when cancel Pipeline Create with open sidebar

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -80,6 +80,12 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
     highlightedIds: selectedIds,
   };
 
+  const closeSidebarAndHandleReset = React.useCallback(() => {
+    setSelectedTask(null);
+    selectedTaskRef.current = null;
+    handleReset();
+  }, [handleReset]);
+
   return (
     <>
       <Stack className="odc-pipeline-builder-form">
@@ -126,7 +132,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
               <PipelineResources addLabel="Add Resources" fieldName="resources" />
             </div>
             <FormFooter
-              handleReset={handleReset}
+              handleReset={closeSidebarAndHandleReset}
               errorMessage={status?.submitError}
               isSubmitting={isSubmitting}
               submitLabel={existingPipeline ? 'Save' : 'Create'}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4275

**Analysis / Root cause**: 
When creating a pipeline, open a sidebar and press cancel the Console "crashes" and shows just a white screen.

Cause is that the state was resetted and the pipeline was rendered without the required formik data.

**Solution Description**: 
Deselected the task for the sidebar so that the sidebar content was not rerendered with missing informations.

**Screen shots / Gifs for design review**: 
Before:
![Screencast_08 07 2020_12:03:59 webm](https://user-images.githubusercontent.com/139310/86907589-91094800-c115-11ea-97a3-af25b8463915.gif)

After:
![Screencast_08 07 2020_12:06:26 webm](https://user-images.githubusercontent.com/139310/86907652-ae3e1680-c115-11ea-8430-0008f92947a7.gif)

**Unit test coverage report**: 
No new tests, no test changed

**Test setup:**
When creating a pipeline, open a sidebar and press cancel the Console "crashes" and shows just a white screen.

1. Install OpenShift Pipelines operator (tested with 1.0.1)
2. Open the Developer perspective and select Pipeline from the navigation.
3. Select "Create Pipeline"
4. Select task "git-clone" from the task list
5. Click on task "git-clone" to open the config sidebar on the right side
6. Press cancel (on the bottom left) while the sidebar is open!


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge