### PR TITLE
adds support for sink uri visualisation in topology

### DIFF
--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -33,6 +33,7 @@ export type OverviewItem<T = K8sResourceKind> = {
   ksroutes?: K8sResourceKind[];
   configurations?: K8sResourceKind[];
   ksservices?: K8sResourceKind[];
+  eventSources?: K8sResourceKind[];
   revisions?: K8sResourceKind[];
   isOperatorBackedService?: boolean;
   isMonitorable?: boolean;

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -37,7 +37,11 @@ import { RootState } from '@console/internal/redux';
 import { getActiveApplication } from '@console/internal/reducers/ui';
 import { selectOverviewDetailsTab } from '@console/internal/actions/ui';
 import { getEventSourceStatus } from '@console/knative-plugin/src/topology/knative-topology-utils';
-import { TYPE_EVENT_PUB_SUB_LINK } from '@console/knative-plugin/src/topology/const';
+import {
+  TYPE_EVENT_PUB_SUB_LINK,
+  TYPE_REVISION_TRAFFIC,
+  TYPE_EVENT_SOURCE_LINK,
+} from '@console/knative-plugin/src/topology/const';
 import KnativeResourceOverviewPage from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
 import {
   getQueryArgument,
@@ -76,6 +80,7 @@ import TopologyHelmWorkloadPanel from './helm/TopologyHelmWorkloadPanel';
 import { updateModelFromFilters } from './data-transforms';
 import { setSupportedTopologyFilters, setTopologyFilters } from './redux/action';
 import { odcElementFactory } from './elements';
+import KnativeTopologyEdgePanel from '@console/knative-plugin/src/components/overview/KnativeTopologyEdgePanel';
 
 export const FILTER_ACTIVE_CLASS = 'odc-m-filter-active';
 
@@ -451,6 +456,9 @@ const Topology: React.FC<ComponentProps> = ({
       if (selectedEntity.getType() === TYPE_EVENT_PUB_SUB_LINK) {
         const itemResources = selectedEntity.getData();
         return <KnativeResourceOverviewPage item={itemResources.resources} />;
+      }
+      if ([TYPE_REVISION_TRAFFIC, TYPE_EVENT_SOURCE_LINK].includes(selectedEntity.getType())) {
+        return <KnativeTopologyEdgePanel edge={selectedEntity as BaseEdge} model={model} />;
       }
       return <ConnectedTopologyEdgePanel edge={selectedEntity as BaseEdge} model={filteredModel} />;
     }

--- a/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
@@ -31,10 +31,11 @@ const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps
     apiVersion,
     metadata: { name, namespace },
     spec,
+    status,
   } = obj;
   const { name: sinkName, kind: sinkKind, apiVersion: sinkApiversion } =
     spec?.sink?.ref || spec?.sink || {};
-  const sinkUri = obj?.status?.sinkUri;
+  const sinkUri = status?.sinkUri;
   const deploymentData = current?.obj?.metadata?.ownerReferences?.[0];
   const apiGroup = apiVersion.split('/')[0];
   const linkUrl = `/search/ns/${namespace}?kind=${PodModel.kind}&q=${encodeURIComponent(
@@ -45,14 +46,16 @@ const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps
   return (
     <>
       <SidebarSectionHeading text="Sink" />
-      {isSinkReference ? (
+      {isSinkReference || sinkUri ? (
         <ul className="list-group">
           <li className="list-group-item">
-            <ResourceLink
-              kind={referenceForGroupVersionKind(group)(version)(sinkKind)}
-              name={sinkName}
-              namespace={namespace}
-            />
+            {isSinkReference && (
+              <ResourceLink
+                kind={referenceForGroupVersionKind(group)(version)(sinkKind)}
+                name={sinkName}
+                namespace={namespace}
+              />
+            )}
             {sinkUri && (
               <>
                 <span className="text-muted">Sink URI: </span>

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -19,6 +19,8 @@ import {
 } from '../../utils/fetch-dynamic-eventsources-utils';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
 import KnativeOverview from './KnativeOverview';
+import SinkUriResourcesTab from './SinkUriResourcesTab';
+import { NodeType } from '../../topology/knative-topology-utils';
 
 interface StateProps {
   kindsInFlight?: boolean;
@@ -45,6 +47,9 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
   knativeModels,
   kindsInFlight,
 }: KnativeResourceOverviewPageProps) => {
+  if (NodeType.SinkUri === item?.obj?.type?.nodeType) {
+    return <SinkUriResourcesTab itemData={item} />;
+  }
   if (kindsInFlight) {
     return !knativeModels ? null : <LoadingBox />;
   }

--- a/frontend/packages/knative-plugin/src/components/overview/SinkUriResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/SinkUriResourcesTab.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import * as _ from 'lodash';
+import { OverviewItem } from '@console/shared';
+import { referenceFor } from '@console/internal/module/k8s';
+import {
+  ActionsMenu,
+  ResourceLink,
+  SidebarSectionHeading,
+  ExternalLink,
+} from '@console/internal/components/utils';
+
+export type SinkUriResourcesTabProps = {
+  itemData: OverviewItem;
+};
+
+const SinkUriResourcesTab: React.FC<SinkUriResourcesTabProps> = ({ itemData }) => {
+  const { obj, eventSources } = itemData;
+  const sinkUri = obj?.spec?.sinkUri;
+
+  return (
+    <div className="overview__sidebar-pane resource-overview">
+      <div className="overview__sidebar-pane-head resource-overview__heading">
+        <h1 className="co-m-pane__heading">
+          <div className="co-m-pane__name co-resource-item">URI</div>
+          <div className="co-actions">
+            <ActionsMenu actions={[]} />
+          </div>
+        </h1>
+      </div>
+      <ul
+        className={classNames(
+          'co-m-horizontal-nav__menu',
+          'co-m-horizontal-nav__menu--within-sidebar',
+          'co-m-horizontal-nav__menu--within-overview-sidebar',
+          'odc-application-resource-tab',
+        )}
+      >
+        <li className="co-m-horizontal-nav__menu-item">
+          <button type="button">Resources</button>
+        </li>
+      </ul>
+      <div className="overview__sidebar-pane-body">
+        <SidebarSectionHeading text="URI" />
+        <ul className="list-group">
+          {sinkUri && (
+            <li className="list-group-item  container-fluid">
+              <ExternalLink
+                href={sinkUri}
+                additionalClassName="co-external-link--block"
+                text={sinkUri}
+              />
+            </li>
+          )}
+        </ul>
+
+        <SidebarSectionHeading text="Event Sources" />
+        <ul className="list-group">
+          {_.map(eventSources, (resource) => {
+            if (!resource) {
+              return null;
+            }
+            const {
+              metadata: { name, uid, namespace },
+            } = resource;
+            return (
+              <li className="list-group-item  container-fluid" key={uid}>
+                <ResourceLink kind={referenceFor(resource)} name={name} namespace={namespace} />
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default SinkUriResourcesTab;

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
@@ -68,10 +68,10 @@ describe('EventSinkServicesOverviewList', () => {
   ];
 
   it('should show error info if no sink present or sink,kind is incorrect', () => {
-    const mockData = _.omit(
-      _.cloneDeep(getEventSourceResponse(EventSourceCamelModel).data[0]),
+    const mockData = _.omit(_.cloneDeep(getEventSourceResponse(EventSourceCamelModel).data[0]), [
       'spec',
-    );
+      'status',
+    ]);
     const wrapper = shallow(<EventSinkServicesOverviewList obj={mockData} />);
     expect(wrapper.find('span').text()).toBe('No sink found for this resource.');
   });
@@ -103,6 +103,18 @@ describe('EventSinkServicesOverviewList', () => {
     const findResourceLink = wrapper.find(ResourceLink);
     expect(findResourceLink).toHaveLength(1);
     expect(findResourceLink.at(0).props().kind).toEqual(referenceForModel(EventingIMCModel));
+  });
+
+  it('should have only external link and not ResourceLink for sink to uri', () => {
+    const mockData = {
+      ...getEventSourceResponse(EventSourceCamelModel).data[0],
+      spec: {
+        uri: 'http://overlayimage.testproject3.svc.cluster.local',
+      },
+    };
+    const wrapper = shallow(<EventSinkServicesOverviewList obj={mockData} />);
+    expect(wrapper.find(ExternalLink)).toHaveLength(1);
+    expect(wrapper.find(ResourceLink)).toHaveLength(0);
   });
 
   it('should have ExternaLink when sinkUri is present', () => {

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
@@ -9,6 +9,8 @@ import {
 } from '../../../topology/__tests__/topology-knative-test-data';
 import { RevisionModel, EventingSubscriptionModel } from '../../../models';
 import { KnativeResourceOverviewPage } from '../KnativeResourceOverviewPage';
+import SinkUriResourcesTab from '../SinkUriResourcesTab';
+import { NodeType } from '../../../topology/knative-topology-utils';
 
 describe('KnativeResourceOverviewPage', () => {
   let item: OverviewItem;
@@ -54,5 +56,22 @@ describe('KnativeResourceOverviewPage', () => {
     expect(resourceOverviewDetails).toHaveLength(1);
     expect(resourceOverviewDetails.at(0).props().menuActions).toHaveLength(4);
     expect(resourceOverviewDetails.at(0).props().kindObj).toEqual(EventingSubscriptionModel);
+  });
+
+  it('should render SinkUriResourcesTab if NodeType is sink-uri', () => {
+    const itemData = {
+      ...item,
+      obj: {
+        metadata: {
+          uid: '02c34a0e-9638-11e9-b134-06a61d886b62_nodesinkuri',
+        },
+        spec: { sinkUri: 'http://overlayimage.testproject3.svc.cluster.local' },
+        type: { nodeType: NodeType.SinkUri },
+      },
+    };
+    const wrapper = shallow(
+      <KnativeResourceOverviewPage item={itemData} knativeModels={[RevisionModel]} kindsInFlight />,
+    );
+    expect(wrapper.find(SinkUriResourcesTab)).toHaveLength(1);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSource.tsx
@@ -18,14 +18,17 @@ const SinkSource: React.FC<SinkSourceProps> = ({ source, cancel, close }) => {
     spec,
   } = source;
   const isPubSubSink = !!spec?.subscriber;
-  const { name: sinkName, apiVersion, kind } = isPubSubSink
+  const isSinkRef = !!spec?.sink?.ref;
+  const { name: sinkName = '', apiVersion = '', kind = '' } = isPubSubSink
     ? spec?.subscriber?.ref
-    : spec?.sink?.ref;
+    : isSinkRef
+    ? spec?.sink?.ref
+    : {};
   const initialValues = {
     ref: {
-      apiVersion: apiVersion || '',
-      kind: kind || '',
-      name: sinkName || '',
+      apiVersion,
+      kind,
+      name: sinkName,
     },
   };
   const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -34,6 +34,7 @@ import {
   TYPE_REVISION_TRAFFIC,
   TYPE_EVENT_PUB_SUB,
   TYPE_EVENT_PUB_SUB_LINK,
+  TYPE_SINK_URI,
 } from '../const';
 import KnativeService from './groups/KnativeService';
 import RevisionNode from './nodes/RevisionNode';
@@ -42,11 +43,13 @@ import EventSourceLink from './edges/EventSourceLink';
 import EventingPubSubLink from './edges/EventingPubSubLink';
 import EventSource from './nodes/EventSource';
 import EventingPubSubNode from './nodes/EventingPubSubNode';
+import SinkUriNode from './nodes/SinkUriNode';
 import {
   eventSourceLinkDragSourceSpec,
   eventingPubSubLinkDragSourceSpec,
   eventSourceTargetSpec,
   eventSourceSinkDropTargetSpec,
+  sinkUriDropTargetSpec,
   pubSubDropTargetSpec,
   CREATE_PUB_SUB_CONNECTOR_OPERATION,
 } from './knativeComponentUtils';
@@ -123,6 +126,12 @@ export const getKnativeComponentFactory = (): ComponentFactory => {
                 ),
               ),
             ),
+          ),
+        );
+      case TYPE_SINK_URI:
+        return withDragNode(nodeDragSourceSpec(type))(
+          withSelection({ controlled: true })(
+            withDndDrop<any, any, {}, NodeComponentProps>(sinkUriDropTargetSpec)(SinkUriNode),
           ),
         );
       case TYPE_KNATIVE_REVISION:

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
@@ -17,7 +17,12 @@ import {
   EdgeComponentProps,
   EditableDragOperationType,
 } from '@console/dev-console/src/components/topology';
-import { TYPE_EVENT_SOURCE_LINK, TYPE_KNATIVE_SERVICE, TYPE_EVENT_PUB_SUB } from '../const';
+import {
+  TYPE_EVENT_SOURCE_LINK,
+  TYPE_KNATIVE_SERVICE,
+  TYPE_EVENT_PUB_SUB,
+  TYPE_SINK_URI,
+} from '../const';
 import { createSinkConnection, createSinkPubSubConnection } from '../knative-topology-utils';
 import { EventingBrokerModel } from '../../models';
 
@@ -35,7 +40,7 @@ export const nodesEdgeIsDragging = (monitor, props) =>
 
 export const canDropEventSourceSinkOnNode = (operation: string, edge: Edge, node: Node): boolean =>
   edge.getSource() !== node &&
-  (node.getType() === TYPE_KNATIVE_SERVICE || node.getType() === TYPE_EVENT_PUB_SUB) &&
+  [TYPE_KNATIVE_SERVICE, TYPE_EVENT_PUB_SUB, TYPE_SINK_URI].includes(node.getType()) &&
   operation === MOVE_EV_SRC_CONNECTOR_OPERATION &&
   !node.getTargetEdges().find((e) => e.getSource() === edge.getSource());
 
@@ -94,6 +99,23 @@ export const eventSourceSinkDropTargetSpec: DropTargetSpec<
 };
 
 export const pubSubDropTargetSpec: DropTargetSpec<
+  Edge,
+  any,
+  { canDrop: boolean; dropTarget: boolean; edgeDragging: boolean },
+  NodeComponentProps
+> = {
+  accept: [EDGE_DRAG_TYPE],
+  canDrop: (item, monitor, props) =>
+    item.getType() === TYPE_EVENT_SOURCE_LINK && item.getSource() !== props.element,
+  collect: (monitor, props) => ({
+    canDrop:
+      monitor.isDragging() && monitor.getOperation()?.type === MOVE_EV_SRC_CONNECTOR_OPERATION,
+    dropTarget: monitor.isOver({ shallow: true }),
+    edgeDragging: nodesEdgeIsDragging(monitor, props),
+  }),
+};
+
+export const sinkUriDropTargetSpec: DropTargetSpec<
   Edge,
   any,
   { canDrop: boolean; dropTarget: boolean; edgeDragging: boolean },

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.scss
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.scss
@@ -1,0 +1,50 @@
+@import '../../../../../dev-console/src/components/topology/topology-utils';
+
+.odc-sink-uri {
+  outline: none;
+  cursor: pointer;
+
+  .odc-m-drag-active & {
+    pointer-events: none;
+  }
+
+  &__bg {
+    fill: var(--pf-global--BackgroundColor--light-100);
+  }
+
+  &.is-filtered &__bg {
+    stroke-width: 2px;
+    stroke: $filtered-stroke-color;
+  }
+  &.is-selected &__bg {
+    stroke-width: 2px;
+    stroke: $selected-stroke-color;
+  }
+  &.is-highlight &__bg {
+    stroke: $interactive-stroke-color;
+  }
+  &.is-dropTarget &__bg {
+    fill: $interactive-fill-color;
+    stroke: $interactive-stroke-color;
+  }
+}
+
+.odc-m-drag-active,
+.odc-m-filter-active {
+  .odc-sink-uri {
+    opacity: $de-emphasize-opacity;
+    &.is-dragging,
+    &.is-highlight {
+      opacity: 1;
+    }
+  }
+}
+
+
+.odc-m-filter-active:not(.odc-m-drag-active) {
+  .odc-sink-uri {
+    &.is-filtered {
+      opacity: 1;
+    }
+  }
+}

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { calculateRadius } from '@console/shared';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { ExternalLinkAltIcon, LinkIcon } from '@patternfly/react-icons';
+import {
+  Node,
+  observer,
+  WithDragNodeProps,
+  WithSelectionProps,
+  WithDndDropProps,
+  WithContextMenuProps,
+  useHover,
+  useCombineRefs,
+  useAnchor,
+  createSvgIdUrl,
+  EllipseAnchor,
+} from '@patternfly/react-topology';
+import {
+  NodeShadows,
+  NODE_SHADOW_FILTER_ID_HOVER,
+  NODE_SHADOW_FILTER_ID,
+} from '@console/dev-console/src/components/topology';
+import { Decorator } from '@console/dev-console/src/components/topology/components/nodes/Decorator';
+import { EVENT_MARKER_RADIUS } from '../../const';
+
+import './SinkUriNode.scss';
+
+export type SinkUriNodeProps = {
+  element: Node;
+  dragging?: boolean;
+  edgeDragging?: boolean;
+  canDrop?: boolean;
+  dropTarget?: boolean;
+} & WithSelectionProps &
+  WithDragNodeProps &
+  WithDndDropProps &
+  WithContextMenuProps;
+
+const DECORATOR_RADIUS = 13;
+const SinkUriNode: React.FC<SinkUriNodeProps> = ({
+  element,
+  selected,
+  onSelect,
+  onContextMenu,
+  contextMenuOpen,
+  dragNodeRef,
+  dndDropRef,
+  dragging,
+  edgeDragging,
+  canDrop,
+  dropTarget,
+}) => {
+  useAnchor(React.useCallback((node: Node) => new EllipseAnchor(node, EVENT_MARKER_RADIUS), []));
+  const [hover, hoverRef] = useHover();
+  const groupRefs = useCombineRefs<SVGCircleElement>(hoverRef, dragNodeRef);
+  const { width, height } = element.getDimensions();
+  const sinkData = element.getData().data;
+  const size = Math.min(width, height);
+  const { radius } = calculateRadius(size);
+  const cx = width / 2;
+  const cy = height / 2;
+  return (
+    <Tooltip
+      content="Move sink to URI"
+      trigger="manual"
+      isVisible={dropTarget && canDrop}
+      animationDuration={0}
+    >
+      <g
+        className={classNames('odc-sink-uri', {
+          'is-dragging': dragging,
+          'is-highlight': canDrop || edgeDragging,
+        })}
+        onClick={onSelect}
+        onContextMenu={onContextMenu}
+        ref={hoverRef}
+      >
+        <NodeShadows />
+        <g
+          className={classNames('odc-sink-uri', {
+            'is-dragging': dragging,
+            'is-highlight': canDrop || edgeDragging,
+            'is-selected': selected,
+            'is-dropTarget': canDrop && dropTarget,
+          })}
+          ref={groupRefs}
+        >
+          <circle
+            className="odc-sink-uri__bg"
+            ref={dndDropRef}
+            cx={cx}
+            cy={cy}
+            r={radius}
+            filter={createSvgIdUrl(
+              hover || dragging || contextMenuOpen
+                ? NODE_SHADOW_FILTER_ID_HOVER
+                : NODE_SHADOW_FILTER_ID,
+            )}
+          />
+          <g transform={`translate(${cx / 2}, ${cy / 2})`}>
+            <LinkIcon style={{ fontSize: radius }} />
+          </g>
+        </g>
+        {sinkData.sinkUri && (
+          <Tooltip key="URI" content="Open URI" position={TooltipPosition.right}>
+            <Decorator
+              x={cx + radius - DECORATOR_RADIUS * 0.7}
+              y={cy - radius + DECORATOR_RADIUS * 0.7}
+              radius={DECORATOR_RADIUS}
+              href={sinkData.sinkUri}
+              external
+            >
+              <g transform={`translate(-${DECORATOR_RADIUS / 2}, -${DECORATOR_RADIUS / 2})`}>
+                <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} alt="Open URL" />
+              </g>
+            </Decorator>
+          </Tooltip>
+        )}
+      </g>
+    </Tooltip>
+  );
+};
+
+export default observer(SinkUriNode);

--- a/frontend/packages/knative-plugin/src/topology/const.ts
+++ b/frontend/packages/knative-plugin/src/topology/const.ts
@@ -10,6 +10,7 @@ export const TYPE_EVENT_PUB_SUB_LINK = 'event-pubsub-link';
 export const TYPE_KNATIVE_SERVICE = 'knative-service';
 export const TYPE_REVISION_TRAFFIC = 'revision-traffic';
 export const TYPE_KNATIVE_REVISION = 'knative-revision';
+export const TYPE_SINK_URI = 'sink-uri';
 
 export const KNATIVE_GROUP_NODE_WIDTH = GROUP_WIDTH;
 export const KNATIVE_GROUP_NODE_HEIGHT = 100;

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
@@ -14,6 +14,9 @@ import {
   getParentResource,
   filterRevisionsByActiveApplication,
   createKnativeEventSourceSink,
+  getSinkUriTopologyNodeItems,
+  getSinkUriTopologyEdgeItems,
+  EdgeType,
 } from '../../topology/knative-topology-utils';
 import { mockServiceData, mockRevisions } from '../__mocks__/traffic-splitting-utils-mock';
 import { EventSourceCronJobModel } from '../../models';
@@ -161,5 +164,50 @@ describe('Knative Topology Utils', () => {
       .catch(() => {
         done();
       });
+  });
+});
+
+describe('SinkURI knative topology utils', () => {
+  const sinkUid = '1317f615-9636-11e9-b134-06a61d886b689_1_nodesinkuri';
+  const sinkUri = 'http://overlayimage.testproject3.svc.cluster.local';
+  const resData = {
+    ...getEventSourceResponse(EventSourceCronJobModel).data[0],
+    spec: { sink: { uri: sinkUri } },
+  };
+  const sinkUriObj = {
+    metadata: {
+      uid: sinkUid,
+    },
+    spec: { sinkUri },
+    type: { nodeType: NodeType.SinkUri },
+  };
+  const sinkData = {
+    id: sinkUid,
+    name: 'URI',
+    type: NodeType.SinkUri,
+    resources: {
+      buildConfigs: [],
+      routes: [],
+      services: [],
+      obj: sinkUriObj,
+      eventSources: [resData],
+    },
+    resource: sinkUriObj,
+    data: { sinkUri },
+  };
+
+  it('expect getSinkUriTopologyNodeItems to return node data for sinkUri', () => {
+    const knSinkUriNode = getSinkUriTopologyNodeItems(NodeType.SinkUri, sinkUid, sinkData);
+    expect(knSinkUriNode).toBeDefined();
+    expect(knSinkUriNode).toHaveLength(1);
+  });
+
+  it('expect getSinkUriTopologyEdgeItems to return edge data for eventSource and sinkuri', () => {
+    const knEventSrcEdge = getSinkUriTopologyEdgeItems(resData, sinkUid);
+    expect(knEventSrcEdge).toBeDefined();
+    expect(knEventSrcEdge).toHaveLength(1);
+    expect(knEventSrcEdge[0].source).toBe('1317f615-9636-11e9-b134-06a61d886b689_1');
+    expect(knEventSrcEdge[0].target).toBe('1317f615-9636-11e9-b134-06a61d886b689_1_nodesinkuri');
+    expect(knEventSrcEdge[0].type).toBe(EdgeType.EventSource);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4015

**Analysis / Root cause**: 
User is unable to sink a source to URI and visualise it in topology

**Solution Description**: 
- Show associated sink uri in topology as a node and support gestures i.e user should be able to drag and drop sink from ksvc to sinkUriNode and vice versa
- Sidebar on click of eventSources should show sinkUri in resources tab
- Sidebar on click on sinkUri node should have just resources tab and show associated resources (uri/EventSources)
- Sidebar on click on connector between eventSource and sinkUri node should have just resources tab and show connected resources (uri/EventSource)

Note: Edit URI and updating Move Connector are part of separate story
 
**Screen shots / Gifs for design review**: 
- SinkUriNode with sidebar
![image](https://user-images.githubusercontent.com/5129024/87787014-93c41580-c858-11ea-9309-c07f9988b8f9.png)


- EventSource connector with sidebar
![image](https://user-images.githubusercontent.com/5129024/87787087-b3f3d480-c858-11ea-83e0-1709a14d245e.png)


- EventSource with sidebar
![image](https://user-images.githubusercontent.com/5129024/87787193-db4aa180-c858-11ea-94a9-44fb43e68291.png)


- Gif (showing gestures)
![Jul-17-2020 18-15-28](https://user-images.githubusercontent.com/5129024/87787649-9d9a4880-c859-11ea-9466-345903a8b7fc.gif)




cc @openshift/team-devconsole-ux @bgilwa01


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/87069733-5a2a5380-c235-11ea-825d-a245f096c68e.png)


**Test Setup**

`oc apply` below yaml

```
apiVersion: sources.knative.dev/v1alpha2
kind: PingSource
metadata:
  name: test-ping-source
spec:
  schedule: "*/2 * * * *"
  jsonData: '{"message": "Hello world!"}'
  sink:
    uri: 'http://hello-openshift.jai-test.svc.cluster.local'

```


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
