### PR TITLE
Add proxy for GitOps backend service

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -53,6 +53,9 @@ const (
 
 	// Well-known location of metering service for OpenShift. This is only accessible in-cluster.
 	openshiftMeteringHost = "reporting-operator.openshift-metering.svc:8080"
+
+	// Well-known location of the GitOps service. This is only accessible in-cluster
+	openshiftGitOpsHost = "cluster.openshift-pipelines-app-delivery.svc:8080"
 )
 
 func main() {
@@ -88,6 +91,8 @@ func main() {
 
 	fK8sAuth := fs.String("k8s-auth", "service-account", "service-account | bearer-token | oidc | openshift")
 	fK8sAuthBearerToken := fs.String("k8s-auth-bearer-token", "", "Authorization token to send with proxied Kubernetes API requests.")
+
+	fK8sModeOffClusterGitOps := fs.String("k8s-mode-off-cluster-gitops", "", "DEV ONLY. URL of the GitOps backend service")
 
 	fRedirectPort := fs.Int("redirect-port", 0, "Port number under which the console should listen for custom hostname redirect.")
 	fLogLevel := fs.String("log-level", "", "level of logging information by package (pkg=level).")
@@ -357,6 +362,12 @@ func main() {
 				Endpoint:        &url.URL{Scheme: "https", Host: openshiftMeteringHost, Path: "/api"},
 			}
 			srv.TerminalProxyTLSConfig = serviceProxyTLSConfig
+
+			srv.GitOpsProxyConfig = &proxy.Config{
+				TLSClientConfig: serviceProxyTLSConfig,
+				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+				Endpoint:        &url.URL{Scheme: "https", Host: openshiftGitOpsHost},
+			}
 		}
 
 	case "off-cluster":
@@ -412,6 +423,15 @@ func main() {
 		}
 
 		srv.TerminalProxyTLSConfig = serviceProxyTLSConfig
+
+		if *fK8sModeOffClusterGitOps != "" {
+			offClusterGitOpsURL := bridge.ValidateFlagIsURL("k8s-mode-off-cluster-gitops", *fK8sModeOffClusterGitOps)
+			srv.GitOpsProxyConfig = &proxy.Config{
+				TLSClientConfig: serviceProxyTLSConfig,
+				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+				Endpoint:        offClusterGitOpsURL,
+			}
+		}
 
 	default:
 		bridge.FlagFatalf("k8s-mode", "must be one of: in-cluster, off-cluster")

--- a/contrib/oc-environment.sh
+++ b/contrib/oc-environment.sh
@@ -31,6 +31,12 @@ export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS
 BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
 export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER
 
+GITOPS_HOSTNAME=$(oc -n openshift-pipelines-app-delivery get route cluster -o jsonpath='{.spec.host}' 2> /dev/null)
+if [ -n "$GITOPS_HOSTNAME" ]; then
+    BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS="https://$GITOPS_HOSTNAME"
+    export BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS
+fi
+
 BRIDGE_K8S_AUTH="bearer-token"
 export BRIDGE_K8S_AUTH
 


### PR DESCRIPTION
The GitOps operator will deploy the backend service in a known namespace. The UI can use this proxy to fetch the GitOps dashboard information from the service. In this PR the proxy exposes the `/api/gitops` endpoint 

Epic: https://issues.redhat.com/browse/ODC-3067

API patterns:
1. API to fetch initial applications details   
GET   /api/gitops/pipelines?secretNS=foo&secretName=bar&url=https:/<i></i>/example.com/gitops.git

2. API to fetch dashboard details
GET /api/gitops/environments/prod/application/bus-app?secretNS=foo&secretName=bar&url=https:/<i></i>/example.com/gitops.git

`secretName` : Your GitHub secret name
`secretNS`      :  Namespace of GitHub secret
`url`                 : URL of your GitOps repository

**How to Test:**

1. Install the GitOps operator from https://github.com/redhat-developer/gitops-operator
Note: Use OCP >= v4.5

2. Add your GitHub token as a secret

```
kubectl create secret generic SECRET_NAME --from-literal=token=${GITHUB_TOKEN} -n SECRET_NS
```
3. Build and run the proxy

```
source ./contrib/oc-environment.sh
./build-backend.sh 
./bin/bridge
```
4. Test the proxy
API 1:
```
curl "http://localhost:9000/api/gitops/pipelines?secretNS=SECRET_NS&secretName=SECRET_NAME&url=https://github.com/rhd-gitops-example/gitops.git"
``` 
Response:
```
{
  "applications": [
    {
      "name": "latest-demo",
      "repo_url": "https://github.com/bigkevmcd/gitops.git",
      "environments": [ "dev" ]
    }
  ]
}

```
API 2:
```
curl "http://localhost:9000/api/gitops/environments/prod/application/bus-app?secretNS=SECRET_NS&secretName=SECRET_NAME&url=https://github.com/rhd-gitops-example/gitops.git"
``` 
Response:
````
{
    "cluster": "",
    "environment": "dev",
        {
            "name": "taxi",
            "source": {
                "url": "https://github.com/chetan-rns/taxi.git",
                "type": "github.com"
            },
            "resources": [
                ......,
            ]
        }
    ]
}
````


CC: @sbose78 @bigkevmcd 