### PR TITLE
Add filter and scroll for EventSource selector

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/__tests__/ItemSelectorField.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/__tests__/ItemSelectorField.spec.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import ItemSelectorField from '../item-selector-field/ItemSelectorField';
+import { EmptyState } from '@patternfly/react-core';
+
+jest.mock('formik', () => ({
+  useField: jest.fn(() => [{}, {}]),
+  useFormikContext: jest.fn(() => ({
+    setFieldValue: jest.fn(),
+    setFieldTouched: jest.fn(),
+    validateForm: jest.fn(),
+  })),
+}));
+describe('ItemSelectorField', () => {
+  it('Should not render if showIfSingle is false and list contains single item', () => {
+    const list = { ListItem: { name: 'ItemName', title: 'ItemName', iconUrl: 'DisplayIcon' } };
+    const wrapper = shallow(<ItemSelectorField name="test" itemList={list} />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('Should display empty state if list is empty and filter is shown', () => {
+    const list = {};
+    const wrapper = shallow(<ItemSelectorField name="test" itemList={list} showFilter />);
+    expect(wrapper.find(EmptyState)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.scss
@@ -1,9 +1,28 @@
+.odc-item-selector-filter {
+    display: flex;
+    padding-bottom: var(--pf-global--spacer--md);
+
+    &__input {
+      max-width: 20em;
+    }
+
+    &__count {
+      color: var(--pf-global--Color--200);
+      margin-left: auto;
+    }
+  }
+
 .odc-item-selector-field {
     display: inline-flex;
     flex-direction: column;
     flex-flow: wrap;
     background: var(--pf-global--Color--light-200);
     padding: 4px;
+
+    &__scrollbar {
+      max-height: 260px;
+      overflow-y: auto;
+    }
 
     &__success-icon {
       color: var(--pf-global--palette--green-700);

--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import * as fuzzy from 'fuzzysearch';
 import { useField, useFormikContext, FormikValues } from 'formik';
 import { LoadingInline } from '@console/internal/components/utils';
-import { FormGroup } from '@patternfly/react-core';
-import { getFieldId } from '@console/shared';
+import {
+  FormGroup,
+  EmptyState,
+  Title,
+  EmptyStatePrimary,
+  Button,
+  TextInput,
+  EmptyStateBody,
+  pluralize,
+} from '@patternfly/react-core';
+import { getFieldId, useDebounceCallback } from '@console/shared';
 import SelectorCard from './SelectorCard';
 import './ItemSelectorField.scss';
 
@@ -26,6 +36,9 @@ interface ItemSelectorFieldProps {
   label?: string;
   autoSelect?: boolean;
   onSelect?: (name: string) => void;
+  showIfSingle?: boolean;
+  showFilter?: boolean;
+  showCount?: boolean;
 }
 
 const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
@@ -36,10 +49,15 @@ const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
   onSelect,
   label,
   autoSelect,
+  showIfSingle = false,
+  showFilter = false,
+  showCount = false,
 }) => {
   const [selected, { error: selectedError, touched: selectedTouched }] = useField(name);
   const { setFieldValue, setFieldTouched, validateForm } = useFormikContext<FormikValues>();
-  const itemCount = _.keys(itemList).length;
+  const [filteredList, setFilteredList] = React.useState(itemList);
+  const [filterText, setFilterText] = React.useState('');
+  const itemCount = _.keys(filteredList).length;
 
   const handleItemChange = React.useCallback(
     (item: string) => {
@@ -52,22 +70,22 @@ const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
   );
 
   React.useEffect(() => {
-    if (!selected.value && itemCount === 1) {
-      const image = _.find(itemList);
+    if (!selected.value && _.keys(itemList).length === 1) {
+      const image = _.find(filteredList);
       handleItemChange(image.name);
     }
     if (!selected.value && recommended) {
       handleItemChange(recommended);
       setFieldTouched(name, false);
     }
-    if (!selected.value && autoSelect && !_.isEmpty(itemList)) {
-      const image = _.get(_.keys(itemList), 0);
-      handleItemChange(itemList[image]?.name);
+    if (!selected.value && autoSelect && !_.isEmpty(filteredList)) {
+      const image = _.get(_.keys(filteredList), 0);
+      handleItemChange(filteredList[image]?.name);
     }
   }, [
     autoSelect,
-    itemCount,
     itemList,
+    filteredList,
     handleItemChange,
     selected.value,
     recommended,
@@ -75,7 +93,34 @@ const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
     setFieldTouched,
   ]);
 
-  if (itemCount === 1) {
+  const filterSources = React.useCallback(
+    (text: string) => {
+      const subList = _.pickBy(itemList, (val) =>
+        fuzzy(text.toLowerCase(), val.title.toLowerCase()),
+      );
+      if (selected.value) {
+        subList[selected.value] = itemList[selected.value];
+      }
+      setFilteredList(subList);
+    },
+    [itemList, selected.value],
+  );
+
+  const debounceFilterText = useDebounceCallback<(text: string) => void>(filterSources, [
+    filterSources,
+  ]);
+
+  const handleFilterChange = (text: string) => {
+    setFilterText(text);
+    debounceFilterText(text);
+  };
+
+  const handleClearFilter = () => {
+    setFilterText('');
+    filterSources('');
+  };
+
+  if (!showIfSingle && itemCount === 1) {
     return null;
   }
 
@@ -94,20 +139,59 @@ const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
       {loadingItems ? (
         <LoadingInline />
       ) : (
-        <div id="item-selector-field" className="odc-item-selector-field">
-          {_.values(itemList).map((item) => (
-            <SelectorCard
-              key={item.name}
-              title={item.title}
-              iconUrl={item.iconUrl}
-              name={item.name}
-              displayName={item.displayName}
-              selected={selected.value === item.name}
-              recommended={recommended === item.name}
-              onChange={handleItemChange}
-            />
-          ))}
-        </div>
+        <>
+          {showFilter && (
+            <div className="odc-item-selector-filter">
+              <TextInput
+                className="odc-item-selector-filter__input"
+                onChange={handleFilterChange}
+                value={filterText}
+                placeholder="Filter by type..."
+                aria-label="Filter by type"
+              />
+              {showCount && (
+                <span className="odc-item-selector-filter__count">
+                  {pluralize(itemCount, 'item')}
+                </span>
+              )}
+            </div>
+          )}
+          {showFilter && itemCount === 0 ? (
+            <EmptyState>
+              <Title headingLevel="h2" size="lg">
+                No results match the filter criteria
+              </Title>
+              <EmptyStateBody>
+                No Event Source types are being shown due to the filters being applied.
+              </EmptyStateBody>
+              <EmptyStatePrimary>
+                <Button variant="link" onClick={handleClearFilter}>
+                  Clear filter
+                </Button>
+              </EmptyStatePrimary>
+            </EmptyState>
+          ) : (
+            <div
+              id="item-selector-field"
+              className={`odc-item-selector-field ${
+                showFilter ? 'odc-item-selector-field__scrollbar' : ''
+              }`}
+            >
+              {_.values(filteredList).map((item) => (
+                <SelectorCard
+                  key={item.name}
+                  title={item.title}
+                  iconUrl={item.iconUrl}
+                  name={item.name}
+                  displayName={item.displayName}
+                  selected={selected.value === item.name}
+                  recommended={recommended === item.name}
+                  onChange={handleItemChange}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </FormGroup>
   );

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -62,22 +62,18 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
     ],
   );
 
-  const itemSelectorField = (
-    <ItemSelectorField
-      itemList={eventSourceList}
-      loadingItems={!eventSourceItems}
-      name="type"
-      onSelect={handleItemChange}
-      autoSelect
-    />
-  );
-
-  return eventSourceItems > 1 ? (
+  return (
     <FormSection title="Type" fullWidth extraMargin>
-      {itemSelectorField}
+      <ItemSelectorField
+        itemList={eventSourceList}
+        loadingItems={!eventSourceItems}
+        name="type"
+        onSelect={handleItemChange}
+        showIfSingle
+        showFilter
+        showCount
+      />
     </FormSection>
-  ) : (
-    itemSelectorField
   );
 };
 

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
@@ -31,19 +31,6 @@ describe('EventSourcesSelector', () => {
     wrapper = shallow(<EventSourcesSelector eventSourceList={eventSourceList} />);
   });
 
-  it('should not render FormSection if no more than one eventSource present', () => {
-    const eventSourceList = {
-      SinkBinding: {
-        title: 'sinkBinding',
-        iconUrl: 'sinkBindingIcon',
-        name: 'SinkBinding',
-        displayName: 'Sink Binding',
-      },
-    };
-    wrapper = shallow(<EventSourcesSelector eventSourceList={eventSourceList} />);
-    expect(wrapper.find(FormSection).exists()).toBe(false);
-  });
-
   it('should render FormSection if more than one eventSource present', () => {
     const eventSourceList = {
       SinkBinding: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4244
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
As a user, i would like the ability to filter eventSources by name and scroll through list if goes more than two rows.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
This PR adds the following changes:
- Add a fuzzy text filter to event sources list
- Add an item counter on the top right
- Disable default selection on page load
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![ev1](https://user-images.githubusercontent.com/20013884/87025180-aeaede00-c1f7-11ea-8521-c58774a5f8b1.png)
![ev2](https://user-images.githubusercontent.com/20013884/87025226-bec6bd80-c1f7-11ea-9c24-5fd9970a89b1.png)
![ev3](https://user-images.githubusercontent.com/20013884/87025239-c1c1ae00-c1f7-11ea-9602-43cf9ae29ab2.png)

cc: @openshift/team-devconsole-ux @invincibleJai 

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
