### PR TITLE
Fixes deletion of node connected to a split node

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -72,13 +72,14 @@ const mapStitchReplaceInOthers = <TaskType extends PipelineBuilderTaskBase>(
   }
 
   const updatedIterationTask = mapRemoveRelatedInOthers(removalTask.name, iterationTask);
+  let newRunAfter: string[] = removalTask.runAfter;
   if (updatedIterationTask.runAfter.length > 0) {
-    return updatedIterationTask;
+    newRunAfter = [...updatedIterationTask.runAfter, ...newRunAfter];
   }
 
   return {
     ...updatedIterationTask,
-    runAfter: removalTask.runAfter,
+    runAfter: newRunAfter,
   };
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3931

**Analysis / Root cause**: 
When the original logic of Pipeline Builder was written, the code failed to properly handle a deletion of a node that had a runAfter (single or more) and was part of a runAfter that had multiple references. Essentially it just failed to carry over the removal node's runAfters to the the node that was connected to it... thus causing the break.

**Solution Description**: 
Merge the runAfters together so it keeps all the data needed to hold the graph together.

**Screen shots / Gifs for design review**: 

Error:
![pb-task-removal-error](https://user-images.githubusercontent.com/8126518/87067715-6f29c700-c1e2-11ea-8a45-a07f982c86ff.gif)

Fix:
![pb-task-removal-fix](https://user-images.githubusercontent.com/8126518/87067721-705af400-c1e2-11ea-9492-9923f4a59a6c.gif)

**Unit test coverage report**: 

Will be part of #4805 

**Test setup:**

* OpenShift Pipeline Operator installed
* Create a pattern of "A - B" and then add a parallel task to "A", say "C", and then one more task to the left of "C".
* Delete "C"

Crude diagram: 
```
    A - B
      /
D - C 
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge