### PR TITLE
Add GitOps to dev-console nav

### DIFF
--- a/frontend/packages/dev-console/src/components/gitops/GitOpsDashboard.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/GitOpsDashboard.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import Helmet from 'react-helmet';
+import { PageHeading } from '@console/internal/components/utils';
+
+const GitOpsDashboard: React.FC = () => (
+  <>
+    <Helmet>
+      <title>GitOps</title>
+    </Helmet>
+    <PageHeading title="GitOps" />;
+  </>
+);
+
+export default GitOpsDashboard;

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -1,6 +1,7 @@
 export const ALLOW_SERVICE_BINDING = 'ALLOW_SERVICE_BINDING';
 export const FLAG_OPENSHIFT_PIPELINE = 'OPENSHIFT_PIPELINE';
 export const CLUSTER_PIPELINE_NS = 'openshift';
+export const FLAG_OPENSHIFT_GITOPS = 'OPENSHIFT_GITOPS';
 
 /** URL query params that adjust scope / purpose of the page */
 export enum QUERY_PROPERTIES {

--- a/frontend/packages/dev-console/src/models/gitops.ts
+++ b/frontend/packages/dev-console/src/models/gitops.ts
@@ -1,0 +1,14 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+export const GitOpsServiceModel: K8sKind = {
+  apiGroup: 'pipelines.openshift.io',
+  apiVersion: 'v1alpha1',
+  kind: 'GitopsService',
+  id: 'gitopsservice',
+  plural: 'gitopsservices',
+  label: 'Gitops Service',
+  labelPlural: 'Gitops Services',
+  abbr: 'GS',
+  namespaced: true,
+  crd: true,
+};

--- a/frontend/packages/dev-console/src/models/index.ts
+++ b/frontend/packages/dev-console/src/models/index.ts
@@ -1,3 +1,4 @@
 export * from './applications';
 export * from './pipelines';
 export * from './service-binding';
+export * from './gitops';

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -41,7 +41,7 @@ import {
   getPipelinesAndPipelineRunsForResource,
   tknPipelineAndPipelineRunsResources,
 } from './utils/pipeline-plugin-utils';
-import { FLAG_OPENSHIFT_PIPELINE, ALLOW_SERVICE_BINDING } from './const';
+import { FLAG_OPENSHIFT_PIPELINE, ALLOW_SERVICE_BINDING, FLAG_OPENSHIFT_GITOPS } from './const';
 import {
   newPipelineTemplate,
   newTaskTemplate,
@@ -121,6 +121,13 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'FeatureFlag/Model',
+    properties: {
+      model: models.GitOpsServiceModel,
+      flag: FLAG_OPENSHIFT_GITOPS,
+    },
+  },
+  {
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
@@ -143,6 +150,20 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [FLAGS.OPENSHIFT],
+    },
+  },
+  {
+    type: 'NavItem/Href',
+    properties: {
+      perspective: 'dev',
+      componentProps: {
+        name: 'GitOps',
+        href: '/gitops',
+        testID: 'gitops-header',
+      },
+    },
+    flags: {
+      required: [FLAG_OPENSHIFT_GITOPS],
     },
   },
   {
@@ -468,6 +489,19 @@ const plugin: Plugin<ConsumedExtensions> = [
         (
           await import(
             './components/topology/TopologyPage' /* webpackChunkName: "dev-console-topology" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: '/gitops',
+      loader: async () =>
+        (
+          await import(
+            './components/gitops/GitOpsDashboard' /* webpackChunkName: "dev-console-gitops" */
           )
         ).default,
     },


### PR DESCRIPTION
Jira - https://issues.redhat.com/browse/ODC-4287

This PR adds GitOps nav-item to devconsole nav which takes the user to the GitOps Dashboard. It is feature-flagged based on availability of `GitopsService` CRD.

![Screenshot from 2020-07-09 22-21-09](https://user-images.githubusercontent.com/20724543/87067807-2d287180-c232-11ea-89e0-d049df56b248.png)

