### PR TITLE
Side navigation correction of font-size to match PF4

### DIFF
--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -54,8 +54,8 @@ $table-border-color: $color-pf-black-200;
 $co-m-label-line-height: 20px;
 $pf-header-icon-fontsize: 16px; // Patternfly 4 default
 // Manually set because our default font size is different than PF 4
-$co-side-nav-font-size: 15.75px; // Matches PF 4 --pf-c-nav__subnav__link--FontSize
-$co-side-nav-section-font-size: 18px; // Matches PF 4 --pf-c-nav__link--FontSize
+$co-side-nav-font-size: $font-size-base; // Matches PF 4 --pf-c-nav__subnav__link--FontSize
+$co-side-nav-section-font-size: ($font-size-base + 2); // Matches PF 4 --pf-c-nav__link--FontSize
 $co-m-catalog-tile-height: 100%;
 $co-m-catalog-tile-width: 260px;
 


### PR DESCRIPTION
Primary nav section = 16px
Sub nav = 14px

<img width="494" alt="Screen Shot 2020-07-09 at 2 57 12 PM" src="https://user-images.githubusercontent.com/1874151/87079855-b0c36d80-c1f4-11ea-8c54-c46052caa9c9.png">
