### PR TITLE
Editable TT, EL, CTB, TB

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/EventListenerPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/EventListenerPage.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
-import { Kebab, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import { Kebab, navFactory } from '@console/internal/components/utils';
 import EventListenerDetails from './detail-page-tabs/EventListenerDetails';
 
 const EventListenerPage: React.FC<DetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
     menuActions={Kebab.factory.common}
-    pages={[navFactory.details(EventListenerDetails), navFactory.editYaml(viewYamlComponent)]}
+    pages={[navFactory.details(EventListenerDetails), navFactory.editYaml()]}
   />
 );
 

--- a/frontend/packages/dev-console/src/components/pipelines/TriggerBindingPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/TriggerBindingPage.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
-import { Kebab, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import { Kebab, navFactory } from '@console/internal/components/utils';
 import TriggerBindingDetails from './detail-page-tabs/TriggerBindingDetails';
 
 const TriggerBindingPage: React.FC<DetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
     menuActions={Kebab.factory.common}
-    pages={[navFactory.details(TriggerBindingDetails), navFactory.editYaml(viewYamlComponent)]}
+    pages={[navFactory.details(TriggerBindingDetails), navFactory.editYaml()]}
   />
 );
 

--- a/frontend/packages/dev-console/src/components/pipelines/TriggerTemplatePage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/TriggerTemplatePage.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
-import { Kebab, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import { Kebab, navFactory } from '@console/internal/components/utils';
 import TriggerTemplateDetails from './detail-page-tabs/TriggerTemplateDetails';
 
 const TriggerTemplatePage: React.FC<DetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
     menuActions={Kebab.factory.common}
-    pages={[navFactory.details(TriggerTemplateDetails), navFactory.editYaml(viewYamlComponent)]}
+    pages={[navFactory.details(TriggerTemplateDetails), navFactory.editYaml()]}
   />
 );
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4239

**Analysis / Root cause**: 
For the trigger resources, the UI Says "Edit ..." on kebab actions for each resource and there is no reason for them not to be editable.

**Solution Description**: 
Make them editable.

**Screen shots / Gifs for design review**: 
![Screen Shot 2020-07-09 at 3 18 52 PM](https://user-images.githubusercontent.com/8126518/87081697-cf773380-c1f7-11ea-9c5b-992793ff62ca.png)
![Screen Shot 2020-07-09 at 3 19 02 PM](https://user-images.githubusercontent.com/8126518/87081701-d0a86080-c1f7-11ea-9ae5-dafe79a90e8b.png)
![Screen Shot 2020-07-09 at 3 19 11 PM](https://user-images.githubusercontent.com/8126518/87081703-d140f700-c1f7-11ea-9756-5a213538beef.png)
![Screen Shot 2020-07-09 at 3 19 21 PM](https://user-images.githubusercontent.com/8126518/87081705-d1d98d80-c1f7-11ea-922b-3429c2330f24.png)

**Test setup:**

* OpenShift Pipelines Operator
* Navigate to each resource and create one or add a trigger to a Pipeline to get resources
** namespaced `TriggerBindings` can be created easily with the `.spec` value from one of the provided `ClusterTriggerBindings`

**Browser conformance**: 

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge