### PR TITLE
Move disk explanations to popovers

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/guest-agent-file-systems.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/guest-agent-file-systems.scss
@@ -1,5 +1,5 @@
 .kubevirt-vm-details__file-systems {
-  padding-left: 30px;
-  padding-right: 30px;
-  margin-top: 20px;
+  padding-left: var(--pf-global--spacer--xl);
+  padding-right: var(--pf-global--spacer--xl);
+  margin-top: var(--pf-global--spacer--lg);
 }

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/guest-agent-file-systems.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/guest-agent-file-systems.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
+import { Button, Popover } from '@patternfly/react-core';
+import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { TableRow, TableData, Table } from '@console/internal/components/factory';
 import { humanizeBinaryBytes } from '@console/internal/components/utils';
 import { useGuestAgentInfo } from '../../hooks/use-guest-agent-info';
@@ -8,9 +10,10 @@ import { GuestAgentInfoWrapper } from '../../k8s/wrapper/vm/guest-agent-info/gue
 import { isGuestAgentInstalled } from '../dashboards-page/vm-dashboard/vm-alerts';
 import { VMIKind } from '../../types/vm';
 import { VMStatusBundle } from '../../statuses/vm/types';
+import { getGuestAgentFieldNotAvailMsg } from '../../utils/guest-agent-strings';
+import { GUEST_AGENT_FILE_SYSTEMS_DESCRIPTION } from '../../strings/vm/messages';
 
 import './guest-agent-file-systems.scss';
-import { getGuestAgentFieldNotAvailMsg } from '../../utils/guest-agent-strings';
 
 const tableColumnClasses = [
   classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
@@ -110,9 +113,18 @@ export const FileSystemsList: React.FC<FileSystemsListProps> = ({ vmi, vmStatusB
 
   return (
     <div className="kubevirt-vm-details__file-systems">
-      <h3>File Systems</h3>
-      The following information regarding how the disks are partitioned is provided by the guest
-      agent.
+      <h3>
+        File Systems
+        <Popover
+          aria-label="File systems description"
+          position="top"
+          bodyContent={<>{GUEST_AGENT_FILE_SYSTEMS_DESCRIPTION}</>}
+        >
+          <Button variant="plain">
+            <QuestionCircleIcon />
+          </Button>
+        </Popover>
+      </h3>
       {body()}
     </div>
   );

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
+import { Button, Popover } from '@patternfly/react-core';
+import { sortable } from '@patternfly/react-table';
+import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { RowFunction, Table, MultiListPage } from '@console/internal/components/factory';
 import { PersistentVolumeClaimModel, TemplateModel } from '@console/internal/models';
 import { Firehose, FirehoseResult, EmptyBox } from '@console/internal/components/utils';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { K8sResourceKind, TemplateKind } from '@console/internal/module/k8s';
 import { dimensifyHeader, getNamespace } from '@console/shared';
-import { sortable } from '@patternfly/react-table';
 import { DataVolumeModel, VirtualMachineModel, VirtualMachineInstanceModel } from '../../models';
 import { VMGenericLikeEntityKind } from '../../types/vmLike';
 import { getResource, getLoadedData } from '../../utils';
@@ -27,6 +29,7 @@ import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
 import { VMLikeEntityTabProps, VMTabProps } from '../vms/types';
 import { getVMStatus } from '../../statuses/vm/vm-status';
 import { FileSystemsList } from './guest-agent-file-systems';
+import { VM_DISKS_DESCRIPTION } from '../../strings/vm/messages';
 
 const getStoragesData = ({
   vmLikeEntity,
@@ -107,8 +110,18 @@ export const VMDisksTable: React.FC<React.ComponentProps<typeof Table> | VMDisks
     <div>
       {props?.customData?.showGuestAgentHelp && (
         <>
-          <h3>Disks</h3>
-          The following information is provided by the OpenShift Virtualization operator.
+          <h3>
+            Disks
+            <Popover
+              aria-label="Disks description"
+              position="top"
+              bodyContent={<>{VM_DISKS_DESCRIPTION}</>}
+            >
+              <Button variant="plain">
+                <QuestionCircleIcon />
+              </Button>
+            </Popover>
+          </h3>
         </>
       )}
       <Table

--- a/frontend/packages/kubevirt-plugin/src/strings/vm/messages.ts
+++ b/frontend/packages/kubevirt-plugin/src/strings/vm/messages.ts
@@ -7,3 +7,8 @@ export const GUEST_AGENT_REQUIRED_MESSAGE = 'Guest agent required';
 export const NOT_AVAILABLE_MESSAGE = 'Not available';
 export const VM_NOT_RUNNING_MESSAGE = 'VM not running';
 export const NO_LOGGED_IN_USERS_MSG = 'No users logged in';
+
+export const GUEST_AGENT_FILE_SYSTEMS_DESCRIPTION =
+  'The following information regarding how the disks are partitioned is provided by the guest agent.';
+export const VM_DISKS_DESCRIPTION =
+  'The following information is provided by the OpenShift Virtualization operator.';


### PR DESCRIPTION
This PR moves the explanations for Disk and File Systems in the Disks tab to popovers to remove the visual clutter from the page.

Popover not activated:
![Selection_670](https://user-images.githubusercontent.com/8544299/87085518-02bcc100-c1fe-11ea-805a-537a041b9023.png)

Popover activated:
![Selection_671](https://user-images.githubusercontent.com/8544299/87085542-09e3cf00-c1fe-11ea-9366-68dd3bf171f7.png)