### PR TITLE
pkg/server: get rules/alerts from thanos

### DIFF
--- a/contrib/oc-environment.sh
+++ b/contrib/oc-environment.sh
@@ -29,9 +29,6 @@ export BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS
 BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
 export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS
 
-BRIDGE_K8S_MODE_OFF_CLUSTER_PROMETHEUS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.prometheusPublicURL}')
-export BRIDGE_K8S_MODE_OFF_CLUSTER_PROMETHEUS
-
 BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
 export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER
 

--- a/examples/run-bridge.sh
+++ b/examples/run-bridge.sh
@@ -15,6 +15,5 @@ set -exuo pipefail
     --user-auth-oidc-client-id=console-oauth-client \
     --user-auth-oidc-client-secret-file=examples/console-client-secret \
     --user-auth-oidc-ca-file=examples/ca.crt \
-    --k8s-mode-off-cluster-prometheus="$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.prometheusPublicURL}')"  \
     --k8s-mode-off-cluster-alertmanager="$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')" \
     --k8s-mode-off-cluster-thanos="$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -275,7 +275,6 @@ func (s *Server) HTTPHandler() http.Handler {
 			tenancyRulesSourcePath      = prometheusTenancyProxyEndpoint + "/api/v1/rules"
 			tenancyTargetAPIPath        = prometheusTenancyProxyEndpoint + "/api/"
 
-			prometheusProxy            = proxy.NewProxy(s.PrometheusProxyConfig)
 			thanosProxy                = proxy.NewProxy(s.ThanosProxyConfig)
 			thanosTenancyProxy         = proxy.NewProxy(s.ThanosTenancyProxyConfig)
 			thanosTenancyForRulesProxy = proxy.NewProxy(s.ThanosTenancyProxyForRulesConfig)
@@ -304,12 +303,13 @@ func (s *Server) HTTPHandler() http.Handler {
 			})),
 		)
 
-		// alerting (rules) have to be proxied via cluster monitoring prometheus
+		// alerting (rules) are being proxied via thanos querier
+		// such that both in-cluster and user workload alerts appear in console.
 		handle(rulesSourcePath, http.StripPrefix(
 			proxy.SingleJoiningSlash(s.BaseURL.Path, targetAPIPath),
 			authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
 				r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.Token))
-				prometheusProxy.ServeHTTP(w, r)
+				thanosProxy.ServeHTTP(w, r)
 			})),
 		)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -104,7 +104,6 @@ type Server struct {
 	DexClient            api.DexClient
 	// A client with the correct TLS setup for communicating with the API server.
 	K8sClient                        *http.Client
-	PrometheusProxyConfig            *proxy.Config
 	ThanosProxyConfig                *proxy.Config
 	ThanosTenancyProxyConfig         *proxy.Config
 	ThanosTenancyProxyForRulesConfig *proxy.Config
@@ -130,7 +129,7 @@ func (s *Server) authDisabled() bool {
 }
 
 func (s *Server) prometheusProxyEnabled() bool {
-	return s.PrometheusProxyConfig != nil && s.ThanosTenancyProxyConfig != nil && s.ThanosTenancyProxyForRulesConfig != nil
+	return s.ThanosTenancyProxyConfig != nil && s.ThanosTenancyProxyForRulesConfig != nil
 }
 
 func (s *Server) alertManagerProxyEnabled() bool {


### PR DESCRIPTION
It's a rebase of #5881 on top of master because the previous PR had conflicts. Since @s-urbaniak isn't available, I'm taking over the change.

This enables user workload alerting rules to be shown in the admin perspective.
As discussed in the arch call it is favorable to implement some filtering knobs first in the UI.
~~Additionally this requires thanos-io/thanos#2834 to be pulled in downstream first.~~

/cc @openshift/openshift-team-monitoring