### PR TITLE
Bug 1815189: Fix race watching APIServices

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/bridge"
+	"github.com/openshift/console/pkg/crd"
 	"github.com/openshift/console/pkg/helm/chartproxy"
 	"github.com/openshift/console/pkg/knative"
 	"github.com/openshift/console/pkg/proxy"
@@ -563,6 +564,21 @@ func main() {
 	default:
 		bridge.FlagFatalf("k8s-mode", "must be one of: service-account, bearer-token, oidc, openshift")
 	}
+
+	srv.CRDLister = server.NewResourceLister(
+		resourceListerToken,
+		&url.URL{
+			Scheme: k8sEndpoint.Scheme,
+			Host:   k8sEndpoint.Host,
+			Path:   "/apis/apiextensions.k8s.io/v1/customresourcedefinitions",
+		},
+		&http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: srv.K8sProxyConfig.TLSClientConfig,
+			},
+		},
+		crd.CRDFilter,
+	)
 
 	srv.MonitoringDashboardConfigMapLister = server.NewResourceLister(
 		resourceListerToken,

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -17,7 +17,7 @@ import { Navigation } from './nav';
 import { history, AsyncComponent } from './utils';
 import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources } from '../module/k8s';
-import { receivedResources, watchAPIServices } from '../actions/k8s';
+import { receivedResources, watchCRDs } from '../actions/k8s';
 // cloud shell imports must come later than features
 import CloudShell from '@console/app/src/components/cloud-shell/CloudShell';
 import CloudShellTab from '@console/app/src/components/cloud-shell/CloudShellTab';
@@ -191,7 +191,7 @@ class App_ extends React.PureComponent {
 
 const App = withExtensions({ contextProviderExtensions: isContextProvider })(App_);
 
-const startDiscovery = () => store.dispatch(watchAPIServices());
+const startDiscovery = () => store.dispatch(watchCRDs());
 
 // Load cached API resources from localStorage to speed up page load.
 getCachedResources()

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -680,19 +680,6 @@ export const LimitRangeModel: K8sKind = {
   labelPlural: 'Limit Ranges',
 };
 
-export const APIServiceModel: K8sKind = {
-  label: 'API Service',
-  labelPlural: 'API Services',
-  apiVersion: 'v1',
-  apiGroup: 'apiregistration.k8s.io',
-  plural: 'apiservices',
-  abbr: 'APIS',
-  namespaced: false,
-  kind: 'APIService',
-  id: 'apiservice',
-  crd: true,
-};
-
 export const UserModel: K8sKind = {
   label: 'User',
   labelPlural: 'Users',

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -86,8 +86,6 @@ export default (state: K8sState, action: K8sAction): K8sState => {
   switch (action.type) {
     case ActionType.GetResourcesInFlight:
       return state.setIn(['RESOURCES', 'inFlight'], true);
-    case ActionType.SetAPIGroups:
-      return state.setIn(['RESOURCES', 'apiGroups'], action.payload.value);
     case ActionType.ReceivedResources:
       return (
         action.payload.resources.models

--- a/pkg/crd/types.go
+++ b/pkg/crd/types.go
@@ -1,0 +1,15 @@
+package crd
+
+type CRDMeta struct {
+	UID string `json:"uid"`
+}
+
+// CRDItem is a minimal CRD response that only returns the UID. This lets the
+// client detect new CRDs without leaking anything about their contents.
+type CRDItem struct {
+	CRDMeta `json:"metadata"`
+}
+
+type CRDList struct {
+	Items []CRDItem `json:"items"`
+}

--- a/pkg/crd/utils.go
+++ b/pkg/crd/utils.go
@@ -1,0 +1,29 @@
+package crd
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/openshift/console/pkg/serverutils"
+)
+
+var (
+	plog = capnslog.NewPackageLogger("github.com/openshift/console", "crd")
+)
+
+// CRDFilter filters all but the CRD UIDs before propagating. This lets the
+// client detect new CRD without leaking any information about the content.
+func CRDFilter(w http.ResponseWriter, r *http.Response) {
+	var crdList CRDList
+
+	if err := json.NewDecoder(r.Body).Decode(&crdList); err != nil {
+		plog.Errorf("CRD response deserialization failed: %s", err)
+		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+	}
+
+	if err := json.NewEncoder(w).Encode(crdList); err != nil {
+		plog.Errorf("CRD response serialization failed: %s", err)
+		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -115,6 +115,7 @@ type Server struct {
 	TerminalProxyTLSConfig           *tls.Config
 	GitOpsProxyConfig                *proxy.Config
 	// A lister for resource listing of a particular kind
+	CRDLister                          ResourceLister
 	MonitoringDashboardConfigMapLister ResourceLister
 	KnativeEventSourceCRDLister        ResourceLister
 	KnativeChannelCRDLister            ResourceLister
@@ -370,6 +371,7 @@ func (s *Server) HTTPHandler() http.Handler {
 		)
 	}
 
+	handle("/api/console/crds", authHandler(s.handleCRDs))
 	handle("/api/console/monitoring-dashboard-config", authHandler(s.handleMonitoringDashboardConfigmaps))
 	handle("/api/console/knative-event-sources", authHandler(s.handleKnativeEventSourceCRDs))
 	handle("/api/console/knative-channels", authHandler(s.handleKnativeChannelCRDs))
@@ -416,6 +418,10 @@ func (s *Server) HTTPHandler() http.Handler {
 	mux.HandleFunc(s.BaseURL.Path, s.indexHandler)
 
 	return securityHeadersMiddleware(http.Handler(mux))
+}
+
+func (s *Server) handleCRDs(w http.ResponseWriter, r *http.Request) {
+	s.CRDLister.HandleResources(w, r)
 }
 
 func (s *Server) handleMonitoringDashboardConfigmaps(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
* Watch CRDs instead of APIServices for users with access. This allows us
  to detect CRDs added to existing API groups, which we missed before.
* Add a backend endpoint for detecting when CRDs change (but don't
  return CRD data to users who don't have authority).