### PR TITLE
Add knative event source, channels and brokers to topology application dropdown

### DIFF
--- a/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
@@ -3,7 +3,13 @@ import { Firehose } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ServiceModel } from '@console/knative-plugin';
 import { VirtualMachineModel } from '@console/kubevirt-plugin/src/models';
+import { PodModel, JobModel, CronJobModel } from '@console/internal/models';
 import { ResourceDropdown } from '@console/shared';
+import {
+  getDynamicChannelResourceList,
+  getDynamicEventSourcesResourceList,
+} from '@console/knative-plugin/src/utils/fetch-dynamic-eventsources-utils';
+import { knativeEventingResourcesBroker } from '@console/knative-plugin/src/utils/get-knative-resources';
 
 interface ApplicationDropdownProps {
   id?: string;
@@ -77,6 +83,30 @@ const ApplicationDropdown: React.FC<ApplicationDropdownProps> = ({ namespace, ..
       prop: 'virtualMachines',
       optional: true,
     },
+    {
+      isList: true,
+      kind: CronJobModel.kind,
+      namespace,
+      prop: 'cronjobs',
+      optional: true,
+    },
+    {
+      isList: true,
+      kind: JobModel.kind,
+      namespace,
+      prop: 'jobs',
+      optional: true,
+    },
+    {
+      isList: true,
+      kind: PodModel.kind,
+      namespace,
+      prop: 'pods',
+      optional: true,
+    },
+    ...getDynamicChannelResourceList(namespace),
+    ...getDynamicEventSourcesResourceList(namespace),
+    ...knativeEventingResourcesBroker(namespace),
   ];
   return (
     <Firehose resources={resources}>


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-4268

Analysis / Root cause:
Topology application dropdown doesn't support the knative event brokers, channels and event sources.

Solution:
Add all dynamic event sources, channels and brokers resource objects to the application dropdown's watcher list.

Screenshot:
![knative-app-grouping](https://user-images.githubusercontent.com/9964343/87187827-6c76c100-c30b-11ea-9c77-ab7363438702.gif)

Browser Conformance:
1. chrome
2. firefox

