### PR TITLE
Add Snapshots to VM Details

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/snapshot-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/snapshot-modal.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Alert, AlertVariant, Form, TextInput } from '@patternfly/react-core';
+import { prefixedID } from '../../../utils';
+import { HandlePromiseProps, withHandlePromise } from '@console/internal/components/utils';
+import { getName, getNamespace } from '@console/shared';
+import {
+  createModalLauncher,
+  ModalBody,
+  ModalComponentProps,
+  ModalTitle,
+} from '@console/internal/components/factory';
+import { k8sCreate } from '@console/internal/module/k8s';
+import { VMLikeEntityKind } from '../../../types/vmLike';
+import { FormRow } from '../../form/form-row';
+import { ADD_SNAPSHOT, SAVE } from '../../../utils/strings';
+import { ModalFooter } from '../modal/modal-footer';
+import { VMSnapshotWrapper } from '../../../k8s/wrapper/vm/vm-snapshot-wrapper';
+
+const getSnapshotName = (vmName: string) => {
+  const date = new Date();
+  return [vmName, date.getFullYear(), date.getUTCMonth() + 1, date.getDate()].join('-');
+};
+
+const SnapshotsModal = withHandlePromise((props: SnapshotsModalProps) => {
+  const { vmLikeEntity, inProgress, errorMessage, handlePromise, close, cancel } = props;
+  const vmName = getName(vmLikeEntity);
+  const [name, setName] = React.useState<string>(getSnapshotName(vmName));
+  const asId = prefixedID.bind(null, 'snapshot');
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const snapshotWrapper = new VMSnapshotWrapper().init({
+      name,
+      namespace: getNamespace(vmLikeEntity),
+      vmName,
+    });
+
+    handlePromise(k8sCreate(snapshotWrapper.getModel(), snapshotWrapper.asResource()))
+      .then(close)
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      });
+  };
+
+  return (
+    <div className="modal-content">
+      <ModalTitle>{ADD_SNAPSHOT}</ModalTitle>
+      <ModalBody>
+        <Alert
+          title="Snapshot only includes disks backed by a snapshot supported storage class"
+          isInline
+          variant={AlertVariant.info}
+          className="co-m-form-row"
+        />
+        <Form onSubmit={submit}>
+          <FormRow title="Snapshot Name" fieldId={asId('name')} isRequired>
+            <TextInput
+              autoFocus
+              isRequired
+              id={asId('name')}
+              value={name}
+              onChange={(v) => setName(v)}
+            />
+          </FormRow>
+        </Form>
+      </ModalBody>
+      <ModalFooter
+        id="snapshot"
+        submitButtonText={SAVE}
+        errorMessage={errorMessage}
+        isDisabled={inProgress}
+        inProgress={inProgress}
+        onSubmit={submit}
+        onCancel={(e) => {
+          e.stopPropagation();
+          cancel();
+        }}
+      />
+    </div>
+  );
+});
+
+export default createModalLauncher(SnapshotsModal);
+
+export type SnapshotsModalProps = {
+  vmLikeEntity: VMLikeEntityKind;
+} & ModalComponentProps &
+  HandlePromiseProps;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-restore-modal/snapshot-restore-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-restore-modal/snapshot-restore-modal.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import {
+  HandlePromiseProps,
+  withHandlePromise,
+  history,
+  resourcePath,
+} from '@console/internal/components/utils';
+import { getName, getNamespace, getRandomChars } from '@console/shared';
+import {
+  createModalLauncher,
+  ModalBody,
+  ModalComponentProps,
+  ModalTitle,
+} from '@console/internal/components/factory';
+import { k8sCreate } from '@console/internal/module/k8s';
+import { RESTORE_SNAPSHOT, RESTORE } from '../../../utils/strings';
+import { ModalFooter } from '../modal/modal-footer';
+import { VMRestoreWrapper } from '../../../k8s/wrapper/vm/vm-restore-wrapper';
+import { VMSnapshot } from '../../../types';
+import { getVmSnapshotVmName } from '../../../selectors/snapshot/snapshot';
+
+const SnapshotRestoreModal = withHandlePromise((props: SnapshotRestoreModalProps) => {
+  const { snapshot, inProgress, errorMessage, handlePromise, close, cancel } = props;
+  const snapshotName = getName(snapshot);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const restoreName = `${snapshotName}-restore-${getRandomChars()}`;
+    const namespace = getNamespace(snapshot);
+    const snapshotRestoreWrapper = new VMRestoreWrapper().init({
+      name: restoreName,
+      namespace,
+      snapshotName,
+      vmName: getVmSnapshotVmName(snapshot),
+    });
+
+    handlePromise(k8sCreate(snapshotRestoreWrapper.getModel(), snapshotRestoreWrapper.asResource()))
+      .then(() => {
+        close();
+        history.push(resourcePath(snapshotRestoreWrapper.getModel().kind, restoreName, namespace));
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      });
+  };
+
+  return (
+    <div className="modal-content">
+      <ModalTitle>{RESTORE_SNAPSHOT}</ModalTitle>
+      <ModalBody>
+        Are you sure you want to restore <strong className="co-break-word">{snapshotName}</strong>{' '}
+        snapshot?
+      </ModalBody>
+      <ModalFooter
+        id="snapshot"
+        submitButtonText={RESTORE}
+        errorMessage={errorMessage}
+        isDisabled={inProgress}
+        inProgress={inProgress}
+        onSubmit={submit}
+        onCancel={(e) => {
+          e.stopPropagation();
+          cancel();
+        }}
+      />
+    </div>
+  );
+});
+
+export default createModalLauncher(SnapshotRestoreModal);
+
+export type SnapshotRestoreModalProps = {
+  snapshot: VMSnapshot;
+} & ModalComponentProps &
+  HandlePromiseProps;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/snapshot-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/snapshot-row.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { TableData, TableRow, RowFunction } from '@console/internal/components/factory';
+import {
+  asAccessReview,
+  Kebab,
+  KebabOption,
+  ResourceLink,
+  Timestamp,
+} from '@console/internal/components/utils';
+import { deleteModal } from '@console/internal/components/modals';
+import {
+  getName,
+  getNamespace,
+  dimensifyRow,
+  getCreationTimestamp,
+  Status,
+  ErrorStatus,
+} from '@console/shared';
+import { referenceFor } from '@console/internal/module/k8s';
+import { VirtualMachineSnapshotModel } from '../../models';
+import { isVMI } from '../../selectors/check-type';
+import { VMLikeEntityKind } from '../../types/vmLike';
+import { VMSnapshotRowActionOpts, VMSnapshotRowCustomData } from './types';
+import { VMSnapshot } from '../../types';
+import { getVMSnapshotError, isVMSnapshotReady } from '../../selectors/snapshot/snapshot';
+import snapshotRestoreModal from '../modals/snapshot-restore-modal/snapshot-restore-modal';
+import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
+
+const menuActionRestore = (
+  snapshot: VMSnapshot,
+  vmLikeEntity: VMLikeEntityKind,
+  { withProgress }: { withProgress: (promise: Promise<any>) => void },
+): KebabOption => ({
+  label: 'Restore',
+  isDisabled: isVMRunningOrExpectedRunning(asVM(vmLikeEntity)),
+  callback: () =>
+    withProgress(
+      snapshotRestoreModal({
+        snapshot,
+      }).result,
+    ),
+});
+
+const menuActionDelete = (
+  snapshot: VMSnapshot,
+  vmLikeEntity: VMLikeEntityKind,
+  { withProgress }: { withProgress: (promise: Promise<any>) => void },
+): KebabOption => ({
+  label: 'Delete',
+  callback: () =>
+    withProgress(
+      deleteModal({
+        kind: VirtualMachineSnapshotModel,
+        resource: snapshot,
+      }),
+    ),
+  accessReview: asAccessReview(VirtualMachineSnapshotModel, snapshot, 'delete'),
+});
+
+const getActions = (
+  snapshot: VMSnapshot,
+  vmLikeEntity: VMLikeEntityKind,
+  opts: VMSnapshotRowActionOpts,
+) => {
+  if (isVMI(vmLikeEntity)) {
+    return [];
+  }
+
+  const actions = [menuActionRestore, menuActionDelete];
+  return actions.map((a) => a(snapshot, vmLikeEntity, opts));
+};
+
+export type VMSnapshotSimpleRowProps = {
+  data: VMSnapshot;
+  columnClasses: string[];
+  actionsComponent: React.ReactNode;
+  index: number;
+  style: object;
+};
+
+export type VMSnapshotStatusProps = {
+  error: any;
+  readyToUse: boolean;
+};
+
+export const VMSnapshotStatus: React.FC<VMSnapshotStatusProps> = ({ error, readyToUse }) =>
+  error ? (
+    <ErrorStatus>{error?.message}</ErrorStatus>
+  ) : (
+    <Status status={readyToUse ? 'Ready' : 'Not Ready'} />
+  );
+
+export const SnapshotSimpleRow: React.FC<VMSnapshotSimpleRowProps> = ({
+  data: snapshot,
+  columnClasses,
+  actionsComponent,
+  index,
+  style,
+}) => {
+  const dimensify = dimensifyRow(columnClasses);
+  const name = getName(snapshot);
+  const namespace = getNamespace(snapshot);
+  const error = getVMSnapshotError(snapshot);
+  const readyToUse = isVMSnapshotReady(snapshot);
+
+  return (
+    <TableRow id={snapshot?.metadata?.uid} index={index} trKey={name} style={style}>
+      <TableData className={dimensify()}>
+        <ResourceLink
+          kind={referenceFor(VirtualMachineSnapshotModel)}
+          namespace={namespace}
+          name={name}
+        />
+      </TableData>
+      <TableData className={dimensify()}>
+        <Timestamp timestamp={getCreationTimestamp(snapshot)} />
+      </TableData>
+      <TableData className={dimensify()}>
+        <VMSnapshotStatus error={error} readyToUse={readyToUse} />
+      </TableData>
+      <TableData className={dimensify(true)}>{actionsComponent}</TableData>
+    </TableRow>
+  );
+};
+
+export const SnapshotRow: RowFunction<VMSnapshot, VMSnapshotRowCustomData> = ({
+  obj: snapshot,
+  customData: { withProgress, vmLikeEntity, columnClasses },
+  index,
+  style,
+}) => (
+  <SnapshotSimpleRow
+    data={snapshot}
+    columnClasses={columnClasses}
+    index={index}
+    style={style}
+    actionsComponent={
+      <Kebab
+        options={getActions(snapshot, vmLikeEntity, { withProgress })}
+        id={`kebab-for-${getName(snapshot)}`}
+      />
+    }
+  />
+);

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/types.ts
@@ -1,0 +1,9 @@
+import { VMLikeEntityKind } from '../../types/vmLike';
+
+export type VMSnapshotRowActionOpts = { withProgress: (promise: Promise<any>) => void };
+
+export type VMSnapshotRowCustomData = {
+  vmLikeEntity: VMLikeEntityKind;
+  columnClasses: string[];
+  isDisabled: boolean;
+} & VMSnapshotRowActionOpts;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/utils.ts
@@ -1,0 +1,9 @@
+import * as classNames from 'classnames';
+import { Kebab } from '@console/internal/components/utils';
+
+export const snapshotsTableColumnClasses = [
+  classNames('col-lg-2'),
+  classNames('col-lg-2'),
+  classNames('col-lg-2'),
+  Kebab.columnClass,
+];

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { Table, RowFunction } from '@console/internal/components/factory';
+import { sortable } from '@patternfly/react-table';
+import { getName, getNamespace, dimensifyHeader } from '@console/shared';
+import { useSafetyFirst } from '@console/internal/components/safety-first';
+import { Button } from '@patternfly/react-core';
+import { EmptyBox } from '@console/internal/components/utils';
+import {
+  WatchK8sResource,
+  useK8sWatchResource,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import { getVmSnapshotVmName } from '../../selectors/snapshot/snapshot';
+import { VMSnapshot } from '../../types';
+import { isVMI } from '../../selectors/check-type';
+import { wrapWithProgress } from '../../utils/utils';
+import { VMLikeEntityTabProps } from '../vms/types';
+import { snapshotsTableColumnClasses } from './utils';
+import { ADD_SNAPSHOT } from '../../utils/strings';
+import { VirtualMachineSnapshotModel } from '../../models';
+import { SnapshotRow } from './snapshot-row';
+import SnapshotModal from '../modals/snapshot-modal/snapshot-modal';
+import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
+
+export type VMSnapshotsTableProps = {
+  data?: any[];
+  customData?: object;
+  row: RowFunction;
+  columnClasses: string[];
+  loadError: any;
+  loaded: boolean;
+};
+
+const NoDataEmptyMsg = () => <EmptyBox label="Snapshots" />;
+
+export const VMSnapshotsTable: React.FC<VMSnapshotsTableProps> = ({
+  data,
+  customData,
+  row: Row,
+  columnClasses,
+  loaded,
+  loadError,
+}) => (
+  <Table
+    aria-label="VM Snapshots List"
+    loaded={loaded}
+    loadError={loadError}
+    data={data}
+    NoDataEmptyMsg={NoDataEmptyMsg}
+    Header={() =>
+      dimensifyHeader(
+        [
+          {
+            title: 'Name',
+            sortField: 'metadata.name',
+            transforms: [sortable],
+          },
+          {
+            title: 'Created',
+            sortField: 'metadata.creationTimestamp',
+            transforms: [sortable],
+          },
+          {
+            title: 'Status',
+            sortField: 'status.readyToUse',
+            transforms: [sortable],
+          },
+          {
+            title: '',
+          },
+        ],
+        columnClasses,
+      )
+    }
+    Row={Row}
+    customData={{ ...customData, columnClasses }}
+    virtualize
+  />
+);
+
+export const VMSnapshotsPage: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEntity }) => {
+  const vmName = getName(vmLikeEntity);
+  const namespace = getNamespace(vmLikeEntity);
+
+  const resource: WatchK8sResource = React.useMemo(
+    () => ({
+      isList: true,
+      kind: VirtualMachineSnapshotModel.kind,
+      namespaced: true,
+      namespace,
+    }),
+    [namespace],
+  );
+
+  const [snapshots, snapshotsLoaded, snapshotsError] = useK8sWatchResource<VMSnapshot[]>(resource);
+  const [isLocked, setIsLocked] = useSafetyFirst(false);
+  const withProgress = wrapWithProgress(setIsLocked);
+  const filteredSnapshots = snapshots.filter((snap) => getVmSnapshotVmName(snap) === vmName);
+  const isDisabled = isLocked || isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
+
+  return (
+    <div className="co-m-list">
+      {!isVMI(vmLikeEntity) && (
+        <div className="co-m-pane__filter-bar">
+          <div className="co-m-pane__filter-bar-group">
+            <Button
+              variant="primary"
+              id="add-snapshot"
+              onClick={() =>
+                withProgress(
+                  SnapshotModal({
+                    blocking: true,
+                    vmLikeEntity,
+                  }).result,
+                )
+              }
+              isDisabled={isDisabled}
+            >
+              {ADD_SNAPSHOT}
+            </Button>
+          </div>
+        </div>
+      )}
+      <div className="co-m-pane__body">
+        <VMSnapshotsTable
+          loaded={snapshotsLoaded}
+          loadError={snapshotsError}
+          data={filteredSnapshots}
+          customData={{
+            vmLikeEntity,
+            withProgress,
+            isDisabled,
+          }}
+          row={SnapshotRow}
+          columnClasses={snapshotsTableColumnClasses}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -17,6 +17,7 @@ import {
   VM_DETAIL_DISKS_HREF,
   VM_DETAIL_NETWORKS_HREF,
   VM_DETAIL_CONSOLES_HREF,
+  VM_DETAIL_SNAPSHOTS,
 } from '../../constants';
 import { VMEvents } from './vm-events';
 import { VMConsoleFirehose } from './vm-console';
@@ -25,6 +26,7 @@ import { vmMenuActionsCreator } from './menu-actions';
 import { VMDashboard } from './vm-dashboard';
 import { TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM, VM_DETAIL_ENVIRONMENT } from '../../constants/vm';
 import { VMEnvironmentFirehose } from './vm-environment/vm-environment-page';
+import { VMSnapshotsPage } from '../vm-snapshots/vm-snapshots';
 
 export const breadcrumbsForVMPage = (match: any) => () => [
   {
@@ -77,6 +79,12 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
     component: VMEnvironmentFirehose,
   };
 
+  const snapshotsPage = {
+    href: VM_DETAIL_SNAPSHOTS,
+    name: 'Snapshots',
+    component: VMSnapshotsPage,
+  };
+
   const pages = [
     dashboardPage,
     overviewPage,
@@ -86,6 +94,7 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
     consolePage,
     nicsPage,
     disksPage,
+    snapshotsPage,
   ];
 
   const resources = [

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -34,6 +34,7 @@ export const VM_DETAIL_DISKS_HREF = 'disks';
 export const VM_DETAIL_NETWORKS_HREF = 'nics';
 export const VM_DETAIL_CONSOLES_HREF = 'consoles';
 export const VM_DETAIL_ENVIRONMENT = 'environment';
+export const VM_DETAIL_SNAPSHOTS = 'snapshots';
 
 export const CLOUDINIT_DISK = 'cloudinitdisk';
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-restore-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-restore-wrapper.ts
@@ -1,0 +1,66 @@
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+import { VMRestore } from '../../../types';
+import { VirtualMachineModel, VirtualMachineRestoreModel } from '../../../models';
+import { K8sInitAddon } from '../common/util/k8s-mixin';
+import { getVmRestoreVmName } from '../../../selectors/snapshot/snapshot';
+import { apiVersionForModel } from '@console/internal/module/k8s';
+
+export class VMRestoreWrapper extends K8sResourceWrapper<VMRestore, VMRestoreWrapper> {
+  constructor(snapshot?: VMRestore | VMRestoreWrapper | any, copy = false) {
+    super(VirtualMachineRestoreModel, snapshot, copy);
+  }
+
+  init(
+    data: K8sInitAddon & {
+      vmName: string;
+      snapshotName: string;
+      excludeVolumes?: string[];
+      includeVolumes?: string[];
+    },
+  ) {
+    super.init(data);
+    if (data?.vmName) {
+      this.setVm(data.vmName);
+    }
+    if (data?.snapshotName) {
+      this.setSnapshotName(data.snapshotName);
+    }
+    if (data?.includeVolumes) {
+      this.setIncludedVolumes(data.includeVolumes);
+    }
+    if (data?.excludeVolumes) {
+      this.setExcludedVolumes(data.excludeVolumes);
+    }
+    return this;
+  }
+
+  setVm = (vmName: string) => {
+    this.ensurePath('spec');
+    this.data.spec.target = {
+      apiGroup: apiVersionForModel(VirtualMachineModel),
+      kind: VirtualMachineModel.kind,
+      name: vmName,
+    };
+    return this;
+  };
+
+  setSnapshotName = (snapshotName: string) => {
+    this.ensurePath('spec');
+    this.data.spec.virtualMachineSnapshotName = snapshotName;
+    return this;
+  };
+
+  setIncludedVolumes = (volumes: string[]) => {
+    this.ensurePath('spec');
+    this.data.spec.includeVolumes = volumes;
+    return this;
+  };
+
+  setExcludedVolumes = (volumes: string[]) => {
+    this.ensurePath('spec');
+    this.data.spec.excludeVolumes = volumes;
+    return this;
+  };
+
+  getVmName = () => getVmRestoreVmName(this.data);
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-snapshot-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-snapshot-wrapper.ts
@@ -1,0 +1,32 @@
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+import { VMSnapshot } from '../../../types';
+import { VirtualMachineModel, VirtualMachineSnapshotModel } from '../../../models';
+import { K8sInitAddon } from '../common/util/k8s-mixin';
+import { getVmSnapshotVmName } from '../../../selectors/snapshot/snapshot';
+import { apiVersionForModel } from '@console/internal/module/k8s';
+
+export class VMSnapshotWrapper extends K8sResourceWrapper<VMSnapshot, VMSnapshotWrapper> {
+  constructor(snapshot?: VMSnapshot | VMSnapshotWrapper | any, copy = false) {
+    super(VirtualMachineSnapshotModel, snapshot, copy);
+  }
+
+  init(data: K8sInitAddon & { vmName: string }) {
+    super.init(data);
+    if (data?.vmName) {
+      this.setVm(data.vmName);
+    }
+    return this;
+  }
+
+  setVm = (vmName: string) => {
+    this.ensurePath('spec');
+    this.data.spec.source = {
+      apiGroup: apiVersionForModel(VirtualMachineModel),
+      kind: VirtualMachineModel.kind,
+      name: vmName,
+    };
+    return this;
+  };
+
+  getVmName = () => getVmSnapshotVmName(this.data);
+}

--- a/frontend/packages/kubevirt-plugin/src/models/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/index.ts
@@ -132,3 +132,27 @@ export const CDIConfigModel: K8sKind = {
   kind: 'CDIConfig',
   id: 'cdiconfig',
 };
+
+export const VirtualMachineSnapshotModel: K8sKind = {
+  label: 'Virtual Machine Snapshot',
+  labelPlural: 'Virtual Machine Snapshots',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'snapshot.kubevirt.io',
+  plural: 'virtualmachinesnapshots',
+  abbr: 'VMS',
+  namespaced: true,
+  kind: 'VirtualMachineSnapshot',
+  id: 'virtualmachinesnapshot',
+};
+
+export const VirtualMachineRestoreModel: K8sKind = {
+  label: 'Virtual Machine Restore',
+  labelPlural: 'Virtual Machine Restores',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'snapshot.kubevirt.io',
+  plural: 'virtualmachinerestores',
+  abbr: 'VMR',
+  namespaced: true,
+  kind: 'VirtualMachineRestore',
+  id: 'virtualmachinerestore',
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/snapshot/snapshot.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/snapshot/snapshot.ts
@@ -1,0 +1,10 @@
+import { VMSnapshot, VMRestore } from '../../types';
+
+export const getVmSnapshotVmName = (snapshot: VMSnapshot) => snapshot?.spec?.source?.name;
+
+export const getVMSnapshotError = (snapshot: VMSnapshot) => snapshot?.status?.error;
+
+export const isVMSnapshotReady = (snapshot: VMSnapshot) => snapshot?.status?.readyToUse;
+
+// restore
+export const getVmRestoreVmName = (snapshot: VMRestore) => snapshot?.spec?.target?.name;

--- a/frontend/packages/kubevirt-plugin/src/types/vm/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vm/index.ts
@@ -102,3 +102,26 @@ export type V1Network = {
 export type NodeSelector = {
   [key: string]: string;
 };
+
+export type VMSnapshot = {
+  spec: {
+    source: {
+      apiGroup: string;
+      kind: string;
+      name: string;
+    };
+  };
+} & K8sResourceKind;
+
+export type VMRestore = {
+  spec: {
+    target: {
+      apiGroup: string;
+      kind: string;
+      name: string;
+    };
+    virtualMachineSnapshotName: string;
+    includeVolumes: string[];
+    excludeVolumes: string[];
+  };
+} & K8sResourceKind;

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -9,10 +9,14 @@ export const DYNAMIC = 'Dynamic';
 
 export const EDIT = 'Edit';
 export const SAVE = 'Save';
+export const RESTORE = 'Restore';
 export const ADD = 'Add';
+export const READY = 'Ready';
 
 export const ADD_DISK = 'Add Disk';
 export const ADD_NETWORK_INTERFACE = 'Add Network Interface';
+export const ADD_SNAPSHOT = 'Take Snapshot';
+export const RESTORE_SNAPSHOT = 'Restore Snapshot';
 
 export const getDialogUIError = (hasAllRequiredFilled) =>
   hasAllRequiredFilled


### PR DESCRIPTION
Minimal Implementation of VM Snapshots.
There was no way to filter snapshots with the current DefaultPage because `fieldSelector` doesn't support `spec.source.name`, so I added a filter function prop.

<img width="1028" alt="Screen Shot 2020-07-12 at 21 58 22" src="https://user-images.githubusercontent.com/24938324/87254436-4e37cf00-c48b-11ea-8bbb-61b5eb5182be.png">
