### PR TITLE
Bug 1856583: Monitoring: Fix table sort order for alert state and severity

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -14,6 +14,7 @@ import {
 } from '@console/shared';
 import * as UIActions from '../../actions/ui';
 import {
+  alertingRuleStateOrder,
   alertSeverityOrder,
   alertStateOrder,
   silenceFiringAlertsOrder,
@@ -106,6 +107,7 @@ const filterPropType = (props, propName, componentName) => {
 };
 
 const sorts = {
+  alertingRuleStateOrder,
   alertSeverityOrder,
   alertStateOrder,
   daemonsetNumScheduled: (daemonset) =>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1149,7 +1149,7 @@ const ruleTableHeader = () => [
   },
   {
     title: 'Alert State',
-    sortFunc: 'alertStateOrder',
+    sortFunc: 'alertingRuleStateOrder',
     transforms: [sortable],
     props: { className: tableRuleClasses[2] },
   },

--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -61,11 +61,18 @@ export const alertStateOrder = (alert: Alert): ListOrder => [
     : _.get(alert, 'activeAt'),
 ];
 
+export const alertingRuleStateOrder = (rule: Rule): ListOrder => {
+  const counts = _.countBy(rule.alerts, 'state');
+  return [AlertStates.Firing, AlertStates.Pending, AlertStates.Silenced].map(
+    (state) => Number.MAX_SAFE_INTEGER - (counts[state] ?? 0),
+  );
+};
+
 export const silenceFiringAlertsOrder = (silence: Silence): ListOrder => {
-  const severityCounts = _.countBy(silence.firingAlerts, 'labels.severity');
+  const counts = _.countBy(silence.firingAlerts, 'labels.severity');
   return [
-    severityCounts[AlertSeverity.Critical],
-    severityCounts[AlertSeverity.Warning],
+    Number.MAX_SAFE_INTEGER - (counts[AlertSeverity.Critical] ?? 0),
+    Number.MAX_SAFE_INTEGER - (counts[AlertSeverity.Warning] ?? 0),
     silence.firingAlerts.length,
   ];
 };


### PR DESCRIPTION
Fixes the Alert State column sort order for the alerting rules list.
Reverses the alert severity sort order to be consistent with other
columns.