### PR TITLE
Bug 1849503: Pin Minimist dependency package to 1.2.5 version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -145,5 +145,8 @@
   },
   "engines": {
     "node": ">=8.x <=10.x"
+  },
+  "resolutions": {
+    "minimist": "1.2.5"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6948,21 +6948,9 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
-
-minimist@0.0.8, minimist@~0.0.1:
-  version "0.0.8"
-  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-minimist@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
-
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+minimist@0.0.5, minimist@0.0.8, minimist@1.2.5, minimist@^0.1.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@~0.0.1, minimist@~1.2.0:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
 
 minipass@^2.2.1, minipass@^2.2.4:
   version "2.3.1"
@@ -11410,7 +11398,6 @@ xtend@~2.1.1:
 xterm@~3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.8.1.tgz#0beabaccdc23bd3ab2397c5129ed9b06b0abb167"
-  integrity sha512-M8bKuibUOr07zReT+2XWQgwoHvBZpi8rkuiYMY+xstmMjfxtb3BgCTQMesmi2WEtmXQu6vIw6rg0v736KkLtQQ==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Ran the `yarn install` locally, without any errors, but for some reason the `vendor/` has not changed. Not sure if thats expectable.

/assign @spadgett 