### PR TITLE
Bug 1856251: fix test env expect script timeout

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-vm-env-readable.sh
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-vm-env-readable.sh
@@ -21,8 +21,9 @@ spawn virtctl console $vm_name -n $vm_namespace --timeout 7
 
 send -h "\n"
 
-sleep 3
+sleep 60
 
+# Send ctrl + D preventively to make sure user is logged out
 send -h \004
 
 set timeout 300


### PR DESCRIPTION
For some reason, the executor VM in cnv-qe-jenkins cluster doesn't seem wait for the full duration of the `set timeout 300`.
Even when @irosenzw tried setting the timeout to 4000, the script failed sooner that that.
We decided for adding a minute sleep
