### PR TITLE
Bug 1853706: Add tooltip to name value editor delete button

### DIFF
--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import { DragSource, DropTarget } from 'react-dnd';
 import { DRAGGABLE_TYPE } from './draggable-item-types';
-import { Button } from '@patternfly/react-core';
+import { Button, Tooltip } from '@patternfly/react-core';
 import { PficonDragdropIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import { NameValueEditorPair, EnvFromPair, EnvType } from './index';
@@ -475,6 +475,7 @@ const PairElement = DragSource(
               tabIndex="-1"
               isDisabled={disableReorder}
               variant="plain"
+              aria-label="Drag to reorder"
             >
               <PficonDragdropIcon className="pairs-list__action-icon--reorder" />
             </Button>
@@ -529,18 +530,20 @@ const PairElement = DragSource(
               )}
               {!readOnly && (
                 <div className="col-xs-1 pairs-list__action">
-                  <Button
-                    type="button"
-                    data-test-id="pairs-list__delete-btn"
-                    className={classNames({
-                      'pairs-list__span-btns': allowSorting,
-                    })}
-                    onClick={this._onRemove}
-                    isDisabled={isEmpty}
-                    variant="plain"
-                  >
-                    {deleteIcon}
-                  </Button>
+                  <Tooltip content={<>Delete</>}>
+                    <Button
+                      type="button"
+                      data-test-id="pairs-list__delete-btn"
+                      className={classNames({
+                        'pairs-list__span-btns': allowSorting,
+                      })}
+                      onClick={this._onRemove}
+                      isDisabled={isEmpty}
+                      variant="plain"
+                    >
+                      {deleteIcon}
+                    </Button>
+                  </Tooltip>
                 </div>
               )}
             </div>,
@@ -642,6 +645,7 @@ const EnvFromPairElement = DragSource(
                       className="pairs-list__action-icon"
                       tabIndex="-1"
                       variant="plain"
+                      aria-label="Drag to reorder"
                     >
                       <PficonDragdropIcon className="pairs-list__action-icon--reorder" />
                     </Button>
@@ -670,15 +674,17 @@ const EnvFromPairElement = DragSource(
               </div>
               {readOnly ? null : (
                 <div className="col-xs-1 pairs-list__action">
-                  <Button
-                    type="button"
-                    data-test-id="pairs-list__delete-from-btn"
-                    className="pairs-list__span-btns"
-                    onClick={this._onRemove}
-                    variant="plain"
-                  >
-                    {deleteButton}
-                  </Button>
+                  <Tooltip content={<>Delete</>}>
+                    <Button
+                      type="button"
+                      data-test-id="pairs-list__delete-from-btn"
+                      className="pairs-list__span-btns"
+                      onClick={this._onRemove}
+                      variant="plain"
+                    >
+                      {deleteButton}
+                    </Button>
+                  </Tooltip>
                 </div>
               )}
             </div>,


### PR DESCRIPTION
After:
<img width="1370" alt="Screen Shot 2020-07-13 at 9 52 28 AM" src="https://user-images.githubusercontent.com/895728/87313057-66413a00-c4ef-11ea-888a-99dfb1b3c46b.png">
<img width="1378" alt="Screen Shot 2020-07-13 at 9 45 01 AM" src="https://user-images.githubusercontent.com/895728/87313059-66d9d080-c4ef-11ea-9767-5617ec58b54e.png">

I intentionally did not add a tooltip to the reorder icon as the tooltip creates a wonky interaction when reordering the rows; however, I did add an `aria-label` to the reorder icon to improve accessibility.