### PR TITLE
Revert 'tab key opens drawer fix' in console since css added upstream for PFv4

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -300,19 +300,6 @@ h6 {
   }
 }
 
-// Fix for the notification drawer appearing due to tabbing through components
-// Remove this when the pf4 breaking changes dependency is contributed
-@keyframes pf-c-drawer-hide-panel {
-  to {
-    visibility: hidden;
-  }
-}
-.pf-c-drawer__panel[hidden] {
-  animation-name: pf-c-drawer-hide-panel;
-  animation-delay: var(--pf-c-drawer__panel--TransitionDuration);
-  animation-fill-mode: forwards;
-}
-
 .pf-c-page__sidebar {
   --pf-c-page__sidebar-body--PaddingTop: 0;
   bottom: 0;


### PR DESCRIPTION
Reversion of https://github.com/openshift/console/pull/5577

Tabbing thru masthead icons does not open notification drawer.

JIRA: https://issues.redhat.com/browse/CONSOLE-2289