### PR TITLE
Fix inline radio group after PF4 upgrade

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
@@ -13,7 +13,7 @@
     display: flex;
     align-items: flex-start;
 
-    > .pf-c-form__label, .pf-c-radio {
+    > .pf-c-form__group-label {
       margin-right: var(--pf-global--spacer--md);
     }
 

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
@@ -12,7 +12,7 @@ const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
   options,
   helpText,
   required,
-  inline,
+  isInline,
   onChange,
   ...props
 }) => {
@@ -22,13 +22,14 @@ const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
   const errorMessage = !isValid ? error : '';
   return (
     <FormGroup
-      className={classNames('ocs-radio-group-field', { 'ocs-radio-group-field--inline': inline })}
+      className={classNames('ocs-radio-group-field', { 'ocs-radio-group-field--inline': isInline })}
       fieldId={fieldId}
       helperText={helpText}
       helperTextInvalid={errorMessage}
       validated={isValid ? 'default' : 'error'}
       isRequired={required}
       label={label}
+      isInline={isInline}
     >
       {options.map((option) => {
         const activeChild = field.value === option.value && option.activeChildren;

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -99,7 +99,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
             },
           ]}
           onChange={(val) => onChangeType(val as EditorType)}
-          inline
+          isInline
         />
       </div>
       {yamlWarning && (

--- a/frontend/packages/console-shared/src/components/formik-fields/__tests__/SyncedEditorField.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/__tests__/SyncedEditorField.spec.tsx
@@ -42,7 +42,7 @@ describe('DropdownField', () => {
       wrapper
         .find(RadioGroupField)
         .first()
-        .props().inline,
+        .props().isInline,
     ).toBe(true);
   });
 

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -119,7 +119,7 @@ export interface RadioButtonFieldProps extends FieldProps {
 }
 
 export interface RadioGroupFieldProps extends FieldProps {
-  inline?: boolean;
+  isInline?: boolean;
   options: RadioGroupOption[];
   onChange?: (value: React.ReactText) => void;
 }


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4310

**Analysis / Root cause**: After the PF4 upgrade, inline radio group is broken due to changes in PF classes.

**Solution Description**: Update the styles and use `isInline` prop for `FormGroup` component.

**Screen shots / Gifs for design review**: 

Before - 

![Screenshot from 2020-07-13 23-33-27](https://user-images.githubusercontent.com/6041994/87337733-87427300-c561-11ea-90bc-98f0812cc337.png)

After -

![Screenshot from 2020-07-13 23-25-41](https://user-images.githubusercontent.com/6041994/87337757-8f9aae00-c561-11ea-8438-e345a8680a51.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge