### PR TITLE
Fix for dev perspective nav items with double separators

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
@@ -12,6 +12,8 @@ namespace ExtensionProperties {
     perspective?: string;
     /** Nav section to which this item belongs to. If not specified, render item as top-level link. */
     section?: string;
+    /** Nav group to which this item belongs to. Add items to a grouping with a separator above */
+    group?: string;
     /** Props to pass to the corresponding `NavLink` component. */
     componentProps: Pick<NavLinkProps, 'name' | 'startsWith' | 'testID'>;
     /** Nav item before which this item should be placed. */

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -7,7 +7,6 @@ import {
   ModelFeatureFlag,
   KebabActions,
   HrefNavItem,
-  SeparatorNavItem,
   ResourceNSNavItem,
   ResourceClusterNavItem,
   ResourceListPage,
@@ -83,7 +82,6 @@ type ConsumedExtensions =
   | ModelFeatureFlag
   | HrefNavItem
   | ResourceClusterNavItem
-  | SeparatorNavItem
   | ResourceNSNavItem
   | ResourceListPage
   | ResourceDetailsPage
@@ -132,6 +130,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
+      group: 'top',
       componentProps: {
         name: '+Add',
         href: '/add',
@@ -143,6 +142,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
+      group: 'top',
       componentProps: {
         name: 'Topology',
         href: '/topology',
@@ -157,6 +157,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
+      group: 'top',
       componentProps: {
         name: 'GitOps',
         href: '/gitops',
@@ -171,6 +172,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
+      group: 'top',
       componentProps: {
         name: 'Monitoring',
         href: '/dev-monitoring',
@@ -185,6 +187,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
+      group: 'top',
       componentProps: {
         name: 'Search',
         href: '/search',
@@ -193,18 +196,10 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'NavItem/Separator',
-    properties: {
-      perspective: 'dev',
-      componentProps: {
-        testID: 'dev-separator',
-      },
-    },
-  },
-  {
     type: 'NavItem/ResourceNS',
     properties: {
       perspective: 'dev',
+      group: 'resources',
       componentProps: {
         name: 'Builds',
         resource: 'buildconfigs',
@@ -219,6 +214,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       perspective: 'dev',
+      group: 'resources',
       componentProps: {
         name: PipelineModel.labelPlural,
         resource: referenceForModel(PipelineModel),
@@ -233,6 +229,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
+      group: 'resources',
       componentProps: {
         name: 'Helm',
         href: '/helm-releases',
@@ -247,6 +244,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       perspective: 'dev',
+      group: 'resources',
       componentProps: {
         name: 'Project',
         href: '/project-details',

--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -1,3 +1,19 @@
+.oc-nav-group.pf-c-nav__section {
+  margin-top: 0;
+  .pf-c-nav__section-title {
+    padding-bottom: 0;
+  }
+  &:first-of-type {
+    .pf-c-nav__section-title {
+      padding-top: 0;
+      border: none;
+    }
+  }
+  > ul {
+    padding-left: 0;
+  }
+}
+
 .oc-nav-pinned-item.pf-c-nav__item {
   display: flex;
 

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import * as _ from 'lodash-es';
-import { NavItemSeparator, Button } from '@patternfly/react-core';
+import { NavItemSeparator, NavGroup, Button } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import {
   useExtensions,
@@ -117,20 +117,28 @@ const PerspectiveNav: React.FC<StateProps & DispatchProps> = ({
       })
       .filter((p) => p !== null);
 
-  // track sections so that we do not create duplicates
+  // track sections and groups so that we do not create duplicates
   const renderedSections: string[] = [];
+  const renderedGroups: string[] = [];
 
   return (
     <>
       {_.compact(
         matchingNavItems.map((item, index) => {
-          const { section } = item.properties;
+          const { section, group } = item.properties;
           if (section) {
             if (renderedSections.includes(section)) {
               return;
             }
             renderedSections.push(section);
             return <NavSection title={section} key={section} />;
+          }
+          if (group) {
+            if (renderedGroups.includes(group)) {
+              return;
+            }
+            renderedGroups.push(group);
+            return <NavSection title={group} key={group} isGrouped />;
           }
           if (isSeparatorNavItem(item)) {
             return <NavItemSeparator key={`separator-${index}`} />;
@@ -139,10 +147,9 @@ const PerspectiveNav: React.FC<StateProps & DispatchProps> = ({
         }),
       )}
       {pinnedResources?.length ? (
-        <>
-          <NavItemSeparator />
+        <NavGroup className="oc-nav-group" title="" key={`group-pins`}>
           {getPinnedItems(true)}
-        </>
+        </NavGroup>
       ) : null}
     </>
   );

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
-import { NavExpandable } from '@patternfly/react-core';
+import { NavExpandable, NavGroup } from '@patternfly/react-core';
 
 import {
   withExtensions,
@@ -121,7 +121,7 @@ export const NavSection = connect(navSectionStateToProps)(
         this.setState({ isOpen: expandState });
       };
 
-      getNavItemExtensions = (perspective: string, section: string) => {
+      getNavItemExtensions = (perspective: string, title: string) => {
         const { navItemExtensions, perspectiveExtensions } = this.props;
 
         const defaultPerspective = _.find(perspectiveExtensions, (p) => p.properties.default);
@@ -134,7 +134,7 @@ export const NavSection = connect(navSectionStateToProps)(
             // or if no perspective specified, are we in the default perspective
             (item.properties.perspective === perspective ||
               (!item.properties.perspective && isDefaultPerspective)) &&
-            item.properties.section === section,
+            (item.properties.section === title || item.properties.group === title),
         );
       };
 
@@ -186,12 +186,24 @@ export const NavSection = connect(navSectionStateToProps)(
           return null;
         }
 
-        const { title } = this.props;
+        const { title, isGrouped } = this.props;
         const { isOpen, activeChild } = this.state;
         const isActive = !!activeChild;
         const children = this.getChildren();
 
-        return children.length > 0 ? (
+        if (!children.length) {
+          return null;
+        }
+
+        if (isGrouped) {
+          return (
+            <NavGroup className="oc-nav-group" title="">
+              {children}
+            </NavGroup>
+          );
+        }
+
+        return (
           <NavExpandable
             title={title}
             isActive={isActive}
@@ -200,7 +212,7 @@ export const NavSection = connect(navSectionStateToProps)(
           >
             {children}
           </NavExpandable>
-        ) : null;
+        );
       }
     },
   ),
@@ -234,6 +246,7 @@ type NavSectionExtensionProps = {
 
 type NavSectionProps = {
   title: NavSectionTitle | string;
+  isGrouped?: boolean;
   required?: string;
 };
 


### PR DESCRIPTION
This change fixes an issue with the developer perspective navigation visuals. It removes the borders from the navigation items and adds groupings for separator between the sections.

**Screen Shot**

![image](https://user-images.githubusercontent.com/11633780/87345101-8687ed80-c51d-11ea-9089-c114e3db718f.png)

/kind bug

/cc @beaumorley @serenamarie125 