### PR TITLE
Add Jobs and CronJobs to list views

### DIFF
--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -85,6 +85,20 @@ export const getResourceList = (namespace: string, resList?: any): FirehoseResou
     },
     {
       isList: true,
+      kind: 'Job',
+      namespace,
+      prop: 'jobs',
+      optional: true,
+    },
+    {
+      isList: true,
+      kind: 'CronJob',
+      namespace,
+      prop: 'cronJobs',
+      optional: true,
+    },
+    {
+      isList: true,
       kind: 'ReplicationController',
       namespace,
       prop: 'replicationControllers',
@@ -959,6 +973,7 @@ export const createPodItems = (resources: any): OverviewItem[] => {
           services,
           status,
           pods: [obj],
+          isMonitorable: isKindMonitorable(PodModel),
         },
       ];
     },

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -14,6 +14,8 @@ import {
   createDeploymentItems,
   createWorkloadItems,
   createPodItems,
+  createCronJobItems,
+  getStandaloneJobs,
   formatNamespacedRouteForResource,
 } from '@console/shared';
 import {
@@ -27,12 +29,19 @@ import { coFetchJSON } from '../../co-fetch';
 import { PROMETHEUS_TENANCY_BASE_PATH } from '../graphs';
 import { TextFilter } from '../factory';
 import * as UIActions from '../../actions/ui';
-import { DeploymentKind, K8sResourceKind, PodKind, RouteKind } from '../../module/k8s';
+import {
+  CronJobKind,
+  DeploymentKind,
+  JobKind,
+  K8sResourceKind,
+  PodKind,
+  RouteKind,
+} from '../../module/k8s';
 import { CloseButton, Dropdown, Firehose, StatusBox, FirehoseResult, MsgBox } from '../utils';
 import { ProjectOverview } from './project-overview';
 import { ResourceOverviewPage } from './resource-overview-page';
 import { OverviewSpecialGroup } from './constants';
-import { DaemonSetModel, StatefulSetModel } from '../../models';
+import { DaemonSetModel, JobModel, StatefulSetModel } from '../../models';
 
 const asOverviewGroups = (keyedItems: { [name: string]: OverviewItem[] }): OverviewGroup[] => {
   const compareGroups = (a: OverviewGroup, b: OverviewGroup) => {
@@ -197,6 +206,8 @@ class OverviewMainContent_ extends React.Component<
       loaded,
       namespace,
       pods,
+      jobs,
+      cronJobs,
       replicaSets,
       replicationControllers,
       routes,
@@ -214,6 +225,8 @@ class OverviewMainContent_ extends React.Component<
       !_.isEqual(deploymentConfigs, prevProps.deploymentConfigs) ||
       !_.isEqual(deployments, prevProps.deployments) ||
       !_.isEqual(pods, prevProps.pods) ||
+      !_.isEqual(jobs, prevProps.jobs) ||
+      !_.isEqual(cronJobs, prevProps.cronJobs) ||
       !_.isEqual(replicaSets, prevProps.replicaSets) ||
       !_.isEqual(replicationControllers, prevProps.replicationControllers) ||
       !_.isEqual(routes, prevProps.routes) ||
@@ -347,6 +360,13 @@ class OverviewMainContent_ extends React.Component<
         this.props.utils,
       ),
       ...createPodItems(this.props),
+      ...createCronJobItems(this.props.cronJobs.data, this.props, this.props.utils),
+      ...createWorkloadItems(
+        JobModel,
+        getStandaloneJobs(this.props.jobs.data),
+        this.props,
+        this.props.utils,
+      ),
     ];
 
     updateResources(items);
@@ -581,6 +601,8 @@ type OverviewMainContentOwnProps = {
   loadError?: any;
   namespace: string;
   pods?: FirehoseResult<PodKind[]>;
+  jobs?: FirehoseResult<JobKind[]>;
+  cronJobs?: FirehoseResult<CronJobKind[]>;
   project?: FirehoseResult<K8sResourceKind>;
   replicationControllers?: FirehoseResult;
   replicaSets?: FirehoseResult;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4049
https://issues.redhat.com/browse/ODC-4050

**Description**: 
As a Developer, I want to be able to see any workload type in the list views so I can better get a view of all of the computing resources being used. This adds Jobs, CronJobs, Pods.

**Screen shots / Gifs for design review**:

Project Workloads Tab:

![image](https://user-images.githubusercontent.com/11633780/87348977-9efb0680-c523-11ea-943e-a4d619c04cf5.png)

![image](https://user-images.githubusercontent.com/11633780/87349039-b803b780-c523-11ea-8e93-4446647c1c0d.png)


Topology List View:

![image](https://user-images.githubusercontent.com/11633780/87349094-cb168780-c523-11ea-9519-f31c3f19938a.png)

![image](https://user-images.githubusercontent.com/11633780/87349130-d4075900-c523-11ea-891f-58f06cd0f612.png)


**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @bgliwa01

/kind feature