### PR TITLE
Apply break-word mixin so that long strings don't cause horiztonal scroll within notifications bar.

### DIFF
--- a/frontend/public/components/_notification-drawer.scss
+++ b/frontend/public/components/_notification-drawer.scss
@@ -1,6 +1,7 @@
 .co-notification-drawer {
   overflow-y: hidden !important;
   z-index: 10;
+  @include co-break-word;
 }
 
 .pf-c-drawer.pf-m-inline .pf-c-notification-drawer__header {


### PR DESCRIPTION
…
**After**
<img width="476" alt="Screen Shot 2020-07-13 at 3 50 59 PM" src="https://user-images.githubusercontent.com/1874151/87350211-8ab80900-c525-11ea-91ea-9381c1cba4dd.png">

![horz-scroll](https://user-images.githubusercontent.com/1874151/87350166-783dcf80-c525-11ea-96d6-f77245f6e82e.png)
