### PR TITLE
component to render guided tour in sidebar

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartConclusion.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartConclusion.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+import { QuickStartTaskItem } from './utils/quick-start-typings';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import TaskHeader from './QuickStartTaskHeader';
+import { TaskStatus } from './utils/quick-start-status';
+
+type QuickStartConclusionProps = {
+  tasks: QuickStartTaskItem[];
+  taskStatus: TaskStatus[];
+  conclusion: string;
+  nextQuickStart?: string;
+  launchNextQuickStart?: () => void;
+  onTaskSelect: (index) => void;
+};
+
+const QuickStartConclusion: React.FC<QuickStartConclusionProps> = ({
+  tasks,
+  taskStatus,
+  conclusion,
+  nextQuickStart,
+  launchNextQuickStart,
+  onTaskSelect,
+}) => {
+  return (
+    <>
+      {tasks.map((task, index) => (
+        <TaskHeader
+          key={task.title}
+          title={task.title}
+          taskIndex={index + 1}
+          size="md"
+          taskStatus={taskStatus[index]}
+          onTaskSelect={onTaskSelect}
+        />
+      ))}
+      <SyncMarkdownView content={conclusion} styles="div {overflow-y: visible !important}" />
+      {nextQuickStart && (
+        <Button variant="link" onClick={launchNextQuickStart}>
+          {`Start ${nextQuickStart} quick start`}
+          <ArrowRightIcon />
+        </Button>
+      )}
+    </>
+  );
+};
+export default QuickStartConclusion;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartIntroduction.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartIntroduction.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { QuickStartTaskItem } from './utils/quick-start-typings';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import TaskHeader from './QuickStartTaskHeader';
+
+type QuickStartIntroductionProps = {
+  tasks: QuickStartTaskItem[];
+  introduction: string;
+  onTaskSelect: (index) => void;
+};
+
+const QuickStartIntroduction: React.FC<QuickStartIntroductionProps> = ({
+  tasks,
+  introduction,
+  onTaskSelect,
+}) => {
+  return (
+    <>
+      <SyncMarkdownView styles="div {overflow-y: visible !important}" content={introduction} />
+      <p style={{ marginBottom: 'var(--pf-global--spacer--md)' }}>
+        In this tour, you will complete {tasks.length} tasks:
+      </p>
+      {tasks.map((task, index) => (
+        <TaskHeader
+          key={task.title}
+          title={task.title}
+          taskIndex={index + 1}
+          size="md"
+          onTaskSelect={onTaskSelect}
+        />
+      ))}
+    </>
+  );
+};
+export default QuickStartIntroduction;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartSection.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartSection.scss
@@ -1,0 +1,13 @@
+@import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
+
+.co-quick-start-section {
+    &__task-content {
+        @media(min-width: $screen-lg-min) {
+            min-height: calc(100vh - (var(--pf-global--spacer--4xl) + var(--pf-global--spacer--3xl)));
+        }
+    }
+    &__footer {
+        margin-top: var(--pf-global--spacer--md);
+        background-color: var(--pf-global--Color--light-100);
+    }
+}

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartSection.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartSection.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@patternfly/react-core';
+import { QuickStartTaskItem } from './utils/quick-start-typings';
+import { QuickStartStatus, TaskStatus } from './utils/quick-start-status';
+import QuickStartIntroduction from './QuickStartIntroduction';
+import QuickStartTasks from './QuickStartTasks';
+import QuickStartConclusion from './QuickStartConclusion';
+import './QuickStartSection.scss';
+
+type QuickStartSectionProps = {
+  quickStartStatus: QuickStartStatus;
+  introduction: string;
+  tasks: QuickStartTaskItem[];
+  taskStatus: TaskStatus[];
+  activeTaskIndex: number;
+  conclusion: string;
+  nextQuickStart?: string;
+  nextCallback?: () => void;
+  reviewCallback?: (reviewState: boolean) => void;
+  prevCallback?: () => void;
+  launchNextQuickStart?: () => void;
+  onTaskSelect: (index) => void;
+};
+
+enum PrimaryButtonText {
+  START = 'Start Tour',
+  NEXT = 'Next',
+  CLOSE = 'Close',
+}
+
+const QuickStartSection: React.FC<QuickStartSectionProps> = ({
+  quickStartStatus,
+  introduction,
+  tasks,
+  taskStatus,
+  activeTaskIndex,
+  conclusion,
+  nextQuickStart,
+  nextCallback,
+  prevCallback,
+  reviewCallback,
+  launchNextQuickStart,
+  onTaskSelect,
+}) => {
+  const getPrimaryButtonText = (): PrimaryButtonText => {
+    if (quickStartStatus === QuickStartStatus.COMPLETE) {
+      return PrimaryButtonText.CLOSE;
+    }
+    if (quickStartStatus === QuickStartStatus.IN_PROGRESS) {
+      return PrimaryButtonText.NEXT;
+    }
+    return PrimaryButtonText.START;
+  };
+
+  return (
+    <>
+      <div className="co-quick-start-section__task-content">
+        {quickStartStatus === QuickStartStatus.NOT_STARTED && (
+          <QuickStartIntroduction
+            tasks={tasks}
+            introduction={introduction}
+            onTaskSelect={onTaskSelect}
+          />
+        )}
+        {quickStartStatus === QuickStartStatus.IN_PROGRESS && (
+          <QuickStartTasks
+            tasks={tasks}
+            taskStatus={taskStatus}
+            activeTaskIndex={activeTaskIndex}
+            reviewCallback={reviewCallback}
+            onTaskSelect={onTaskSelect}
+          />
+        )}
+        {quickStartStatus === QuickStartStatus.COMPLETE && (
+          <QuickStartConclusion
+            tasks={tasks}
+            taskStatus={taskStatus}
+            conclusion={conclusion}
+            nextQuickStart={nextQuickStart}
+            launchNextQuickStart={launchNextQuickStart}
+            onTaskSelect={onTaskSelect}
+          />
+        )}
+      </div>
+      <div className="co-quick-start-section__footer">
+        <Button
+          style={{
+            marginRight: 'var(--pf-global--spacer--md)',
+          }}
+          type="submit"
+          variant="primary"
+          onClick={nextCallback}
+          isInline
+        >
+          {getPrimaryButtonText()}
+        </Button>
+        {quickStartStatus !== QuickStartStatus.NOT_STARTED && (
+          <Button
+            style={{
+              marginRight: 'var(--pf-global--spacer--md)',
+            }}
+            type="submit"
+            variant="secondary"
+            onClick={prevCallback}
+            isInline
+          >
+            Back
+          </Button>
+        )}
+        {quickStartStatus === QuickStartStatus.COMPLETE && (
+          <Link style={{ display: 'inline-block' }} to="/tours">
+            View all tours
+          </Link>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default QuickStartSection;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartTaskHeader.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartTaskHeader.scss
@@ -1,0 +1,35 @@
+.co-quick-start-task-header {
+    margin-bottom: var(--pf-global--spacer--md);
+    button::before {
+        content: none;
+    }
+    li {
+        list-style-type: none;
+    }
+    &__title {
+        display: inline-block;
+        margin-right: var(--pf-global--spacer--md) !important;
+        color: var(--pf-global--primary-color--100) !important;
+    }
+    &__title-success {
+        color: var(--pf-global--palette--green-500) !important;
+    }
+    &__title-failed {
+        color: var(--pf-chart-global--danger--Color--100) !important;
+    }
+    &__task-icon {
+        &-init {
+        border-radius: var(--pf-global--BorderRadius--lg);
+        background-color: var(--pf-global--palette--blue-400);
+        color: var(--pf-global--Color--light-100);
+        display: inline-block;
+        line-height: calc(var(--pf-global--spacer--xl) - var(--pf-global--spacer--sm));
+        min-width: calc(var(--pf-global--spacer--xl) - var(--pf-global--spacer--xs));
+        padding: var(--pf-global--BorderWidth--sm) var(--pf-global--BorderWidth--lg);
+        text-align: center;
+        }
+        &-success, &-failed {
+            vertical-align: middle !important;
+        }
+    }
+}

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartTaskHeader.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartTaskHeader.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import cx from 'classnames';
+import { Title, WizardNavItem } from '@patternfly/react-core';
+import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { TaskStatus } from './utils/quick-start-status';
+import './QuickStartTaskHeader.scss';
+
+type QuickStartTaskHeaderProps = {
+  title: string;
+  taskIndex: number;
+  subtitle?: string;
+  taskStatus?: TaskStatus;
+  size?: 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+  isActiveTask?: boolean;
+  onTaskSelect: (index: number) => void;
+};
+
+const TaskIcon: React.FC<{ taskIndex; taskStatus; isActiveTask }> = ({
+  taskIndex,
+  taskStatus,
+  isActiveTask,
+}) => {
+  if (isActiveTask) {
+    return (
+      <span className="co-icon-and-text__icon co-quick-start-task-header__task-icon-init">
+        {taskIndex}
+      </span>
+    );
+  }
+  switch (taskStatus) {
+    case TaskStatus.SUCCESS:
+      return (
+        <span className="co-icon-and-text__icon">
+          <CheckCircleIcon size="md" className="co-quick-start-task-header__task-icon-success" />
+        </span>
+      );
+    case TaskStatus.FAILED:
+      return (
+        <span className="co-icon-and-text__icon">
+          <TimesCircleIcon size="md" className="co-quick-start-task-header__task-icon-failed" />
+        </span>
+      );
+    default:
+      return (
+        <span className="co-icon-and-text__icon co-quick-start-task-header__task-icon-init">
+          {taskIndex}
+        </span>
+      );
+  }
+};
+
+const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
+  title,
+  taskIndex,
+  subtitle,
+  taskStatus,
+  size,
+  isActiveTask,
+  onTaskSelect,
+}) => (
+  <div className="co-quick-start-task-header">
+    <WizardNavItem
+      content={
+        <>
+          <Title
+            headingLevel="h3"
+            size={size}
+            className={cx('co-quick-start-task-header__title', {
+              'co-quick-start-task-header__title-success':
+                taskStatus === TaskStatus.SUCCESS && !isActiveTask,
+              'co-quick-start-task-header__title-failed':
+                taskStatus === TaskStatus.FAILED && !isActiveTask,
+            })}
+          >
+            <TaskIcon taskIndex={taskIndex} taskStatus={taskStatus} isActiveTask={isActiveTask} />
+            {title}
+          </Title>
+          {isActiveTask && subtitle && (
+            <Title
+              headingLevel="h6"
+              size="md"
+              className="text-secondary "
+              style={{ display: 'inline-block' }}
+            >
+              {subtitle}
+            </Title>
+          )}
+        </>
+      }
+      step={taskIndex}
+      onNavItemClick={onTaskSelect}
+      navItemComponent="Button"
+    />
+  </div>
+);
+
+export default QuickStartTaskHeader;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartTasks.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartTasks.scss
@@ -1,0 +1,24 @@
+.co-quick-start-task {
+    &__radio-button-group {
+        display: flex;
+        align-items: flex-start;
+        input[type='radio'] {
+            margin-top: 0;
+            margin-right: 0;
+          }
+    }
+    &__radio-button-field {
+        margin-right: var(--pf-global--spacer--xl) !important;
+    }
+    &__review-success {
+        color: var(--pf-global--palette--green-500);
+        font-size: var(--pf-global--FontSize--md);
+        line-height: var(--pf-global--FontSize--xl);
+    }
+    &__review-failed {
+        color: var(--pf-chart-global--danger--Color--100);
+        font-size: var(--pf-global--FontSize--md);
+        line-height: var(--pf-global--FontSize--xl);
+    }
+  }
+  

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartTasks.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartTasks.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import cx from 'classnames';
+import { Alert, Radio } from '@patternfly/react-core';
+import { QuickStartTaskItem } from './utils/quick-start-typings';
+import { TaskStatus } from './utils/quick-start-status';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import TaskHeader from './QuickStartTaskHeader';
+import './QuickStartTasks.scss';
+
+type QuickStartTaskProps = {
+  tasks: QuickStartTaskItem[];
+  taskStatus: TaskStatus[];
+  activeTaskIndex: number;
+  reviewCallback: (reviewState: boolean) => void;
+  onTaskSelect: (index) => void;
+};
+
+const QuickStartTasks: React.FC<QuickStartTaskProps> = ({
+  tasks,
+  taskStatus,
+  activeTaskIndex,
+  reviewCallback,
+  onTaskSelect,
+}) => (
+  <>
+    {tasks
+      .filter((_, index) => index <= activeTaskIndex)
+      .map((task, index) => {
+        const { title, description, review, recapitulation, taskHelp } = task;
+        const currTaskStatus = taskStatus[index];
+        const isActiveTask = index === activeTaskIndex;
+        return (
+          <React.Fragment key={task.title}>
+            <TaskHeader
+              taskIndex={index + 1}
+              title={title}
+              subtitle={`${index + 1} of ${tasks.length}`}
+              taskStatus={currTaskStatus}
+              isActiveTask={isActiveTask}
+              onTaskSelect={onTaskSelect}
+            />
+            <SyncMarkdownView
+              styles="div {overflow-y: visible !important}"
+              content={
+                isActiveTask
+                  ? description
+                  : currTaskStatus === TaskStatus.SUCCESS
+                  ? recapitulation.success
+                  : recapitulation.failed
+              }
+            />
+            {isActiveTask && currTaskStatus !== TaskStatus.INIT && review && (
+              <Alert
+                key={`${currTaskStatus}${task.title}`}
+                isInline
+                variant={
+                  currTaskStatus === TaskStatus.SUCCESS
+                    ? 'success'
+                    : currTaskStatus === TaskStatus.FAILED
+                    ? 'danger'
+                    : 'info'
+                }
+                title={
+                  <span
+                    className={cx({
+                      'co-quick-start-task__review-success': currTaskStatus === TaskStatus.SUCCESS,
+                      'co-quick-start-task__review-failed': currTaskStatus === TaskStatus.FAILED,
+                    })}
+                  >
+                    Check your work
+                  </span>
+                }
+              >
+                <SyncMarkdownView content={review} styles="div {overflow-y: visible !important}" />
+                <span className="co-quick-start-task__radio-button-group">
+                  <Radio
+                    name="review-affirmative"
+                    onChange={() => reviewCallback(true)}
+                    label="Yes"
+                    id="review-affirmative"
+                    isChecked={currTaskStatus === TaskStatus.SUCCESS}
+                    className="co-quick-start-task__radio-button-field"
+                  />
+                  <Radio
+                    name="review-negative"
+                    onChange={() => reviewCallback(false)}
+                    label="No"
+                    id="review-negative"
+                    isChecked={currTaskStatus === TaskStatus.FAILED}
+                    className="co-quick-start-task__radio-button-field"
+                  />
+                </span>
+                {currTaskStatus === TaskStatus.FAILED && taskHelp && <h5>{taskHelp}</h5>}
+              </Alert>
+            )}
+          </React.Fragment>
+        );
+      })}
+  </>
+);
+export default QuickStartTasks;

--- a/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartConclusion.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartConclusion.spec.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Button } from '@patternfly/react-core';
+import { getQuickStart } from '../utils/quick-start-utils';
+import { TaskStatus } from '../utils/quick-start-status';
+import QuickStartConclusion from '../QuickStartConclusion';
+
+type QuickStartConclusionProps = React.ComponentProps<typeof QuickStartConclusion>;
+let wrapper: ShallowWrapper<QuickStartConclusionProps>;
+const props: QuickStartConclusionProps = {
+  tasks: getQuickStart('serverless-explore').tasks,
+  taskStatus: [TaskStatus.INIT, TaskStatus.INIT, TaskStatus.INIT],
+  conclusion: 'conclusion',
+  onTaskSelect: jest.fn(),
+};
+
+describe('QuickStartConclusion', () => {
+  beforeEach(() => {
+    wrapper = shallow(<QuickStartConclusion {...props} />);
+  });
+
+  it('should not render link for next quick start if nextQuickStart props is available', () => {
+    expect(wrapper.find(Button).length).toBe(0);
+  });
+
+  it('should render link for next quick start if nextQuickStart props is available', () => {
+    wrapper = shallow(
+      <QuickStartConclusion
+        {...props}
+        nextQuickStart="Serverless Application"
+        launchNextQuickStart={jest.fn()}
+      />,
+    );
+    expect(
+      wrapper
+        .find(Button)
+        .at(0)
+        .props().children[0],
+    ).toEqual('Start Serverless Application quick start');
+  });
+});

--- a/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartSection.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartSection.spec.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Button } from '@patternfly/react-core';
+import { getQuickStart } from '../utils/quick-start-utils';
+import { QuickStartStatus, TaskStatus } from '../utils/quick-start-status';
+import QuickStartSection from '../QuickStartSection';
+import QuickStartIntroduction from '../QuickStartIntroduction';
+import QuickStartTasks from '../QuickStartTasks';
+import QuickStartConclusion from '../QuickStartConclusion';
+
+type QuickStartSectionProps = React.ComponentProps<typeof QuickStartSection>;
+let wrapper: ShallowWrapper<QuickStartSectionProps>;
+const props: QuickStartSectionProps = {
+  quickStartStatus: QuickStartStatus.NOT_STARTED,
+  introduction: 'introduction',
+  tasks: getQuickStart('serverless-explore').tasks,
+  taskStatus: [TaskStatus.INIT, TaskStatus.INIT, TaskStatus.INIT],
+  activeTaskIndex: 0,
+  conclusion: 'conclusion',
+  nextQuickStart: 'nextQuickStart',
+  nextCallback: jest.fn(),
+  prevCallback: jest.fn(),
+  reviewCallback: jest.fn(),
+  launchNextQuickStart: jest.fn(),
+  onTaskSelect: jest.fn(),
+};
+
+describe('QuickStartSection', () => {
+  beforeEach(() => {
+    wrapper = shallow(<QuickStartSection {...props} />);
+  });
+
+  it('should render QuickStartIntroduction and not render secondary button when the tour status is Not Started', () => {
+    expect(wrapper.find(QuickStartIntroduction).length).toBe(1);
+    expect(wrapper.find(QuickStartTasks).length).toBe(0);
+    expect(wrapper.find(QuickStartConclusion).length).toBe(0);
+    expect(wrapper.find(Button).length).toBe(1);
+    expect(
+      wrapper
+        .find(Button)
+        .at(0)
+        .props().children,
+    ).toEqual('Start Tour');
+    expect(wrapper.find(Link).length).toBe(0);
+  });
+
+  it('should render QuickStartTasks and secondary button when the tour status is In Progress', () => {
+    wrapper = shallow(
+      <QuickStartSection {...props} quickStartStatus={QuickStartStatus.IN_PROGRESS} />,
+    );
+    expect(wrapper.find(QuickStartIntroduction).length).toBe(0);
+    expect(wrapper.find(QuickStartTasks).length).toBe(1);
+    expect(wrapper.find(QuickStartConclusion).length).toBe(0);
+    expect(wrapper.find(Button).length).toBe(2);
+    expect(
+      wrapper
+        .find(Button)
+        .at(0)
+        .props().children,
+    ).toEqual('Next');
+    expect(
+      wrapper
+        .find(Button)
+        .at(1)
+        .props().children,
+    ).toEqual('Back');
+    expect(wrapper.find(Link).length).toBe(0);
+  });
+
+  it('should render QuickStartConclusion, secondary button and Link to QuickStartCatalog when the tour status is Complete', () => {
+    wrapper = shallow(
+      <QuickStartSection {...props} quickStartStatus={QuickStartStatus.COMPLETE} />,
+    );
+    expect(wrapper.find(QuickStartIntroduction).length).toBe(0);
+    expect(wrapper.find(QuickStartTasks).length).toBe(0);
+    expect(wrapper.find(QuickStartConclusion).length).toBe(1);
+    expect(wrapper.find(Button).length).toBe(2);
+    expect(
+      wrapper
+        .find(Button)
+        .at(0)
+        .props().children,
+    ).toEqual('Close');
+    expect(
+      wrapper
+        .find(Button)
+        .at(1)
+        .props().children,
+    ).toEqual('Back');
+    expect(wrapper.find(Link).length).toBe(1);
+  });
+});

--- a/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartTask.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartTask.spec.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import { Alert } from '@patternfly/react-core';
+import { getQuickStart } from '../utils/quick-start-utils';
+import { TaskStatus } from '../utils/quick-start-status';
+import QuickStartTask from '../QuickStartTasks';
+import TaskHeader from '../QuickStartTaskHeader';
+
+type QuickStartTaskProps = React.ComponentProps<typeof QuickStartTask>;
+let wrapper: ShallowWrapper<QuickStartTaskProps>;
+const props: QuickStartTaskProps = {
+  tasks: getQuickStart('serverless-explore').tasks,
+  taskStatus: [TaskStatus.SUCCESS, TaskStatus.INIT, TaskStatus.INIT],
+  activeTaskIndex: 1,
+  reviewCallback: jest.fn(),
+  onTaskSelect: jest.fn(),
+};
+
+describe('QuickStartTask', () => {
+  beforeEach(() => {
+    wrapper = shallow(<QuickStartTask {...props} />);
+  });
+  it('should render correct number of tasks based on currentTaskIndex', () => {
+    expect(wrapper.find(TaskHeader).length).toBe(2);
+  });
+
+  it('should render SyncMarkdownView with description or recapitulation according to task status', () => {
+    wrapper = shallow(
+      <QuickStartTask
+        {...props}
+        taskStatus={[TaskStatus.SUCCESS, TaskStatus.FAILED, TaskStatus.INIT]}
+        activeTaskIndex={2}
+      />,
+    );
+
+    expect(
+      wrapper
+        .find(SyncMarkdownView)
+        .at(0)
+        .props().content,
+    ).toEqual(props.tasks[0].recapitulation.success);
+
+    expect(
+      wrapper
+        .find(SyncMarkdownView)
+        .at(1)
+        .props().content,
+    ).toEqual(props.tasks[1].recapitulation.failed);
+
+    expect(
+      wrapper
+        .find(SyncMarkdownView)
+        .at(2)
+        .props().content,
+    ).toEqual(props.tasks[2].description);
+  });
+
+  it('should render review Alert in variant info when task is active and in Review state', () => {
+    wrapper = shallow(
+      <QuickStartTask
+        {...props}
+        taskStatus={[TaskStatus.SUCCESS, TaskStatus.REVIEW, TaskStatus.INIT]}
+      />,
+    );
+    expect(
+      wrapper
+        .find(Alert)
+        .at(0)
+        .props().variant,
+    ).toEqual('info');
+  });
+
+  it('should render review Alert in variant success when task is active and in Success state', () => {
+    wrapper = shallow(
+      <QuickStartTask
+        {...props}
+        taskStatus={[TaskStatus.SUCCESS, TaskStatus.SUCCESS, TaskStatus.INIT]}
+      />,
+    );
+    expect(
+      wrapper
+        .find(Alert)
+        .at(0)
+        .props().variant,
+    ).toEqual('success');
+  });
+
+  it('should render review Alert in variant danger when task is active and in Failed state', () => {
+    wrapper = shallow(
+      <QuickStartTask
+        {...props}
+        taskStatus={[TaskStatus.SUCCESS, TaskStatus.FAILED, TaskStatus.INIT]}
+      />,
+    );
+    expect(
+      wrapper
+        .find(Alert)
+        .at(0)
+        .props().variant,
+    ).toEqual('danger');
+  });
+});

--- a/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartTaskHeader.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/__tests__/QuickStartTaskHeader.spec.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Title, WizardNavItem } from '@patternfly/react-core';
+import QuickStartTaskHeader from '../QuickStartTaskHeader';
+import { TaskStatus } from '../utils/quick-start-status';
+
+type QuickStartTaskHeaderProps = React.ComponentProps<typeof QuickStartTaskHeader>;
+let wrapper: ShallowWrapper<QuickStartTaskHeaderProps>;
+const props: QuickStartTaskHeaderProps = {
+  title: 'title',
+  taskIndex: 1,
+  subtitle: 'subtitle',
+  taskStatus: TaskStatus.INIT,
+  size: 'lg',
+  isActiveTask: true,
+  onTaskSelect: jest.fn(),
+};
+
+describe('QuickStartTaskHeader', () => {
+  beforeEach(() => {
+    wrapper = shallow(<QuickStartTaskHeader {...props} />);
+  });
+
+  it('should render subtitle for active task', () => {
+    expect(
+      wrapper
+        .find(WizardNavItem)
+        .dive()
+        .find(Title).length,
+    ).toBe(2);
+    expect(
+      wrapper
+        .find(WizardNavItem)
+        .dive()
+        .find(Title)
+        .at(1)
+        .props().children,
+    ).toEqual(props.subtitle);
+  });
+
+  it('should not render subtitle if task is not active', () => {
+    wrapper = shallow(<QuickStartTaskHeader {...props} isActiveTask={false} />);
+    expect(
+      wrapper
+        .find(WizardNavItem)
+        .dive()
+        .find(Title).length,
+    ).toBe(1);
+    expect(
+      wrapper
+        .find(WizardNavItem)
+        .dive()
+        .find(Title)
+        .at(0)
+        .props().children[1],
+    ).toEqual(props.title);
+  });
+});

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-mocks.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-mocks.ts
@@ -12,6 +12,84 @@ export const mockQuickStarts: QuickStartItem[] = [
     description:
       'Install the Serverless Operator to enable the containers, microservices and functions to run "serverless"',
     prerequisites: ['Release requirement if any', 'installs x number of resources'],
+    introduction: `The Red Hat® OpenShift® Serverless provides an enterprise-grade serverless platform. Based on the open source Knative project, it provides a solution for efficient application development supporting dynamic scale and providing a reliable and secure event-driven mechanism to connect on-cluster and off-cluster event producers, bringing portability and consistency across hybrid and multi-cloud environments.
+    Run anywhereUse Kubernetes and OpenShift to build, scale, and manage serverless applications in any cloud, on-premise, or hybrid environment.
+    Integrate with legacyBuild modern, serverless applications and support legacy apps by using event sources. Manage all of your applications in one place: Red Hat OpenShift.
+    Focus on businessKnative allows app teams to focus on building products. Knative installs on OpenShift using Operators, simplifying installation and automating updates and management.
+    Operations friendlyKnative uses Kubernetes to achieve greater consistency and more granular scalability across applications and teams.`,
+    tasks: [
+      {
+        title: `Install Serverless Operator`,
+        description: `To install the Serverless Operator:
+            1. Go to the OperatorHub from the Operators section of the navigation.
+            2. Use the filter at the top of the page to search for the OpenShift Serverless Operator.
+            3. Click on the tile to open the Operator details.
+            4. At the top of the side panel, click Install.
+            5. Fill out the Operator Subscription form and click Install. You can leave all of the prefilled options if you&#39;d like.
+            6. After a few minutes, the OpenShift Serverless Operator should appear in your Installed Operators list.
+              1. Wait for the Operator to completely install. When prompted, click View Operator to view the OpenShift Serverless Operator details.
+            7. Click it to see its details.`,
+
+        review: `To verify that the Serverless Operator was successfully installed:
+            1. Go to the Installed Operators page from the Operators section of the navigation.
+            2. Find OpenShift Serverless Operator in the list.
+            3. Find the Status column and check the status of the OpenShift Serverless Operator.
+            
+            Is the status Succeeded?`,
+
+        recapitulation: {
+          success: `You've just installed the Serverless Operator! Next, we'll install the required CR's for this Operator to run.`,
+          failed: `Check your work to make sure that the Serverless Operator is properly installed`,
+        },
+        taskHelp: `Try walking through the steps again to properly install the Serverless Operator`,
+      },
+      {
+        title: `Create knative-serving API`,
+        description: `The first CR you create is Knative Serving.
+            Knative-serving offers a request-driven model that serves containerized workloads. These workloads auto-scale based on demand and can scale to zero.
+            To create the knative-serving API:
+            1. Open the project dropdown in the secondary masthead and click Create Project.
+            2. In the Name field, type &quot;knative-serving&quot;.
+            3. Click Create.
+            4. Make sure you&#39;re still on the Installed Operators page.
+            5. Click OpenShift Serverless Operator.
+            6. Click on the Knative Serving tile to create an instance of the API.
+            7. Click Create.`,
+
+        review: `To verify that the knative-serving API was installed successfully:
+            1. Make sure that you are on the Knative Serving tab of the OpenShift Serverless Operator.
+            
+            Is there a knative-serving resource in the list?`,
+        recapitulation: {
+          success: `You've just created an instance of knative-serving! Next, we'll create an instance of knative-eventing`,
+          failed: `Check your work to make sure that the instance of knative-serving is properly created`,
+        },
+        taskHelp: `Try walking through the steps again to properly create the instance of knative-serving`,
+      },
+      {
+        title: `Create knative-eventing API`,
+        description: `The second CR you create is Knative Eventing.
+            Knative Eventing creates a common infrastructure for consuming and producing events. Serverless uses this infrastructure to do… something. infraststractuire to stimulate applications.
+            To create the knative-eventing API:
+            1. Open the project dropdown in the secondary masthead and click Create Project.
+            2. In the Name field, type &quot;knative-eventing&quot;.
+            3. Click Create.
+            4. Make sure you&#39;re still on the Installed Operators page.
+            5. Click OpenShift Serverless Operator.
+            6. Click on the Knative Eventing tile to create an instance of the API.
+            7. Click Create.`,
+        review: `To verify that the knative-eventing API was installed successfully:
+            1. Make sure that you are on the Knative Eventing tab of the OpenShift Serverless Operator.
+            
+            Is there a knative-eventing resource in the list?`,
+        recapitulation: {
+          success: `You've just created an instance of knative-eventing!`,
+          failed: `Check your work to make sure that the instance of knative-eventing is properly created`,
+        },
+        taskHelp: `Try walking through the steps again to properly create the instance of knative-eventing`,
+      },
+    ],
+    conclusion: `Your Serverless Operator is ready! If you want to learn how to deploy a serverless application, take the Serverless Application tour.`,
   },
   {
     iconURL:

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-status.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-status.ts
@@ -3,3 +3,10 @@ export enum QuickStartStatus {
   IN_PROGRESS = 'In Progress',
   NOT_STARTED = 'Not started',
 }
+
+export enum TaskStatus {
+  INIT = 'Initial',
+  REVIEW = 'Review',
+  SUCCESS = 'Success',
+  FAILED = 'Failed',
+}

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-typings.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-typings.ts
@@ -1,3 +1,5 @@
+import { QuickStartStatus as Status, TaskStatus } from './quick-start-status';
+
 export type QuickStartItem = {
   iconURL: string;
   altIcon?: string;
@@ -6,6 +8,20 @@ export type QuickStartItem = {
   duration: number;
   description: string;
   prerequisites?: string[];
+  introduction?: string;
+  tasks?: QuickStartTaskItem[];
+  conclusion?: string;
+};
+
+export type QuickStartTaskItem = {
+  title?: string;
+  description: string;
+  review?: string;
+  recapitulation?: {
+    success?: string;
+    failed?: string;
+  };
+  taskHelp?: string;
 };
 
 export type QuickStartStatus = {
@@ -18,4 +34,7 @@ export type QuickStartCatalogItem = QuickStartItem &
     unmetPrerequisite?: boolean;
   };
 
-export type QuickStartState = {};
+export type QuickStartState = {
+  tourStatus: Status;
+  taskStatus?: TaskStatus[];
+};


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-4132

Solution Description:
    Add a `QuickStartSectiont` to display the guided tours in the sidebar

Screens:
![Screenshot from 2020-07-20 04-26-25](https://user-images.githubusercontent.com/38663217/87933119-4939d780-caaa-11ea-84dd-5ca12b9de7db.png)
![Screenshot from 2020-07-20 04-33-09](https://user-images.githubusercontent.com/38663217/87933128-4dfe8b80-caaa-11ea-865a-739ab0ec3b77.png)
![Screenshot from 2020-07-20 15-02-10](https://user-images.githubusercontent.com/38663217/87933141-51921280-caaa-11ea-977c-57cced6ffb53.png)
![Screenshot from 2020-07-20 15-56-56](https://user-images.githubusercontent.com/38663217/87933151-55be3000-caaa-11ea-94e6-1853b2293af4.png)
![Screenshot from 2020-07-20 15-57-34](https://user-images.githubusercontent.com/38663217/87933164-5eaf0180-caaa-11ea-9993-ec07974a33d9.png)
![Screenshot from 2020-07-20 16-03-08](https://user-images.githubusercontent.com/38663217/87933176-640c4c00-caaa-11ea-83f5-5fa0ce023fd7.png)
![Screenshot from 2020-07-20 16-36-29](https://user-images.githubusercontent.com/38663217/87933184-68d10000-caaa-11ea-906c-cc47ec0e1181.png)
![Screenshot from 2020-07-20 21-07-36](https://user-images.githubusercontent.com/38663217/87967136-0264d580-cadc-11ea-9f47-665ef428e292.png)

Test Coverage:
![Screenshot from 2020-07-23 07-28-07](https://user-images.githubusercontent.com/38663217/88245815-27ad3b80-ccb6-11ea-8fe8-d1e461cc0742.png)

Browser Conformation:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
