### PR TITLE
Disable error overlay of react-refresh

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -184,9 +184,7 @@ const config: Configuration = {
     ...(IS_WDS
       ? [
           new ReactRefreshWebpackPlugin({
-            overlay: {
-              sockPort: WDS_PORT,
-            },
+            overlay: false,
           }),
         ]
       : []),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24938324/87425038-ae428880-c5e5-11ea-8bff-b42095e7bdb0.png)

----------

Disable react-refresh error overlay, it hurts the developing experience, and requires an extra click to close it