### PR TITLE
Bug 1856803: Fix incorrect monitoring doc link

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -425,7 +425,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
               operators can lead to malicious metrics data overriding existing cluster metrics. For
               more information, see the{' '}
               <ExternalLink
-                href={`${openshiftHelpBase}monitoring/cluster-monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring`}
+                href={`${openshiftHelpBase}monitoring/cluster_monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring`}
                 text="cluster monitoring documentation"
               />{' '}
               .


### PR DESCRIPTION
The doc link in the OperatorHub install page for non-Red Hat operators that request monitoring was incorrect.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1856803

/assign @rhamilto 