### PR TITLE
Use DetailsItem component on operand details page

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useK8sModel.ts
+++ b/frontend/packages/console-shared/src/hooks/useK8sModel.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+import { K8sKind, kindForReference, GroupVersionKind } from '@console/internal/module/k8s';
+import { RootState } from '@console/internal/redux';
+
+// Hook that retrieves the k8s model for provided groupVersionKind reference. Hook version of
+// `connectToModel`.
+export const useK8sModel = (groupVersionKind: GroupVersionKind): [K8sKind, boolean] => [
+  useSelector<RootState, K8sKind>(
+    ({ k8s }) =>
+      k8s.getIn(['RESOURCES', 'models', groupVersionKind]) ??
+      k8s.getIn(['RESOURCES', 'models', kindForReference(groupVersionKind)]) ??
+      {},
+  ),
+  useSelector<RootState, boolean>(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
+];

--- a/frontend/packages/console-shared/src/utils/utils.ts
+++ b/frontend/packages/console-shared/src/utils/utils.ts
@@ -1,6 +1,8 @@
+import { toPath } from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { FirehoseResult } from '@console/internal/components/utils/types';
 import { getUID } from '../selectors/common';
+import { JSONSchema6 } from 'json-schema';
 
 export type EntityMap<A> = { [propertyName: string]: A };
 export type K8sEntityMap<A extends K8sResourceKind> = EntityMap<A>;
@@ -42,4 +44,22 @@ export const isValidUrl = (url: string): boolean => {
   } catch {
     return false;
   }
+};
+
+// Recursive helper for getSchemaAtPath
+const recursiveGetSchemaAtPath = (
+  schema: JSONSchema6,
+  [segment, ...path]: string[] = [],
+): JSONSchema6 => {
+  if (segment) {
+    return /^\d+$/.test(segment)
+      ? recursiveGetSchemaAtPath(schema?.items as JSONSchema6, path)
+      : recursiveGetSchemaAtPath(schema?.properties?.[segment] as JSONSchema6, path);
+  }
+  return schema;
+};
+
+// Get a schema at the provided path string.
+export const getSchemaAtPath = (schema: JSONSchema6, path: string): JSONSchema6 => {
+  return recursiveGetSchemaAtPath(schema, toPath(path));
 };

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator.view.ts
@@ -8,4 +8,4 @@ export const operatorNameLink = (displayName: string) =>
 export const operandLink = (name: string) => $(`[data-test-operand-link="${name}"]`);
 export const operandKind = (kind: string) => $(`[data-test-operand-kind="${kind}"]`);
 export const descriptorLabel = ({ displayName }: Descriptor) =>
-  $(`[data-test-descriptor-label="${displayName}"]`);
+  $(`[data-test-selector="details-item-label__${displayName}"]`);

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.spec.tsx
@@ -1,156 +1,113 @@
 import * as React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
-import { ResourceLink, Selector } from '@console/internal/components/utils';
+import { Button } from '@patternfly/react-core';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router';
+import { mount, ReactWrapper } from 'enzyme';
+import store from '@console/internal/redux';
+import { ResourceLink, Selector, history } from '@console/internal/components/utils';
 import { DescriptorProps, SpecCapability, Descriptor } from '../types';
 import { testResourceInstance, testModel } from '../../../../mocks';
-import { EndpointList, Endpoint } from './endpoint';
+import { EndpointList } from './endpoint';
 import { ResourceRequirementsModalLink } from './resource-requirements';
 import * as configureSize from './configure-size';
 import { SpecDescriptor } from '.';
-import { Button } from '@patternfly/react-core';
+
+const OBJ = {
+  ...testResourceInstance,
+  spec: {
+    ...testResourceInstance.spec,
+    pods: 3,
+    endpoints: [{ targetPort: 80, scheme: 'TCP' }],
+    basicSelector: { matchNames: ['default'] },
+    resourceLink: 'my-service',
+  },
+};
 
 describe(SpecDescriptor.name, () => {
-  let wrapper: ShallowWrapper<DescriptorProps>;
+  let wrapper: ReactWrapper<DescriptorProps>;
   let descriptor: Descriptor;
 
   beforeEach(() => {
     descriptor = {
-      path: '',
+      path: 'test',
       displayName: 'Some Spec Control',
-      description: 'This is a description',
+      description: '',
       'x-descriptors': [],
     };
-    wrapper = shallow(
-      <SpecDescriptor
-        model={testModel}
-        obj={testResourceInstance}
-        namespace="foo"
-        descriptor={descriptor}
-        value={null}
-      />,
-    )
-      .childAt(0)
-      .shallow();
+    wrapper = mount(<SpecDescriptor model={testModel} obj={OBJ} descriptor={descriptor} />, {
+      wrappingComponent: (props) => (
+        <Router history={history}>
+          <Provider store={store} {...props} />
+        </Router>
+      ),
+    });
   });
 
-  it('renders status value as text if no matching capability component', () => {
-    expect(
-      wrapper
-        .find('dt')
-        .render()
-        .text(),
-    ).toEqual(descriptor.displayName);
-    // expect(wrapper.find('.olm-descriptor__title').text()).toEqual(descriptor.displayName);
-    expect(
-      wrapper
-        .find('dd')
-        .render()
-        .text(),
-    ).toEqual('None');
+  it('renders spec value as text if no matching capability component', () => {
+    expect(wrapper.find('dt').text()).toEqual(descriptor.displayName);
+    expect(wrapper.find('dd').text()).toEqual('None');
   });
 
   it('renders a pod count modal link', (done) => {
-    const value = 3;
-    descriptor['x-descriptors'] = [SpecCapability.podCount];
-    wrapper = wrapper.setProps({ descriptor, value });
-
+    descriptor = {
+      ...descriptor,
+      path: 'pods',
+      'x-descriptors': [SpecCapability.podCount],
+    };
+    wrapper.setProps({ descriptor });
     expect(
       wrapper
         .find('dd')
-        .childAt(0)
-        .shallow()
         .find(Button)
-        .render()
         .text(),
-    ).toEqual(`${value} pods`);
+    ).toEqual(`${OBJ.spec.pods} pods`);
 
     spyOn(configureSize, 'configureSizeModal').and.callFake((props) => {
       expect(props).toEqual({
         kindObj: testModel,
-        resource: testResourceInstance,
+        resource: OBJ,
         specDescriptor: descriptor,
-        specValue: value,
+        specValue: OBJ.spec.pods,
       });
       done();
     });
     wrapper
       .find('dd')
-      .childAt(0)
-      .shallow()
       .find(Button)
       .props()
       .onClick(null);
   });
 
   it('renders an endpoints list', () => {
-    const value: Endpoint[] = [{ targetPort: 80, scheme: 'TCP' }];
-    descriptor['x-descriptors'] = [SpecCapability.endpointList];
-    wrapper = wrapper.setProps({ descriptor, value });
-
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(EndpointList)
-        .props().endpoints,
-    ).toEqual(value);
-  });
-
-  it('renders a label', () => {
-    const value = 'app=foo';
-    descriptor['x-descriptors'] = [SpecCapability.label];
-    wrapper = wrapper.setProps({ descriptor, value });
-
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .text(),
-    ).toEqual(value);
+    descriptor = {
+      ...descriptor,
+      path: 'endpoints',
+      'x-descriptors': [SpecCapability.endpointList],
+    };
+    wrapper.setProps({ descriptor });
+    expect(wrapper.find(EndpointList).prop('endpoints')).toEqual(OBJ.spec.endpoints);
   });
 
   it('renders a namespace selector', () => {
-    const value = { matchNames: ['default'] };
-    descriptor['x-descriptors'] = [SpecCapability.namespaceSelector];
-    wrapper = wrapper.setProps({ descriptor, value });
+    descriptor = {
+      ...descriptor,
+      path: 'basicSelector',
+      'x-descriptors': [SpecCapability.namespaceSelector],
+    };
+    wrapper.setProps({ descriptor });
 
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(ResourceLink)
-        .props().kind,
-    ).toEqual('Namespace');
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(ResourceLink)
-        .props().name,
-    ).toEqual('default');
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(ResourceLink)
-        .props().title,
-    ).toEqual('default');
+    expect(wrapper.find(ResourceLink).prop('kind')).toEqual('Namespace');
+    expect(wrapper.find(ResourceLink).prop('name')).toEqual('default');
+    expect(wrapper.find(ResourceLink).prop('title')).toEqual('default');
   });
 
   it('renders a resource requirements control', () => {
     descriptor['x-descriptors'] = [SpecCapability.resourceRequirements];
-    wrapper = wrapper.setProps({ descriptor });
+    wrapper.setProps({ descriptor });
 
     expect(
       wrapper
         .find('dd')
-        .childAt(0)
-        .shallow()
         .find('dt')
         .at(0)
         .text(),
@@ -158,17 +115,13 @@ describe(SpecDescriptor.name, () => {
     expect(
       wrapper
         .find('dd')
-        .childAt(0)
-        .shallow()
         .find(ResourceRequirementsModalLink)
         .at(0)
-        .props().type,
+        .prop('type'),
     ).toEqual('limits');
     expect(
       wrapper
         .find('dd')
-        .childAt(0)
-        .shallow()
         .find('dt')
         .at(1)
         .text(),
@@ -176,67 +129,34 @@ describe(SpecDescriptor.name, () => {
     expect(
       wrapper
         .find('dd')
-        .childAt(0)
-        .shallow()
         .find(ResourceRequirementsModalLink)
         .at(1)
-        .props().type,
+        .prop('type'),
     ).toEqual('requests');
   });
 
   it('renders a resource link to a Kubernetes object', () => {
-    const value = 'my-service';
-    descriptor['x-descriptors'] = [
-      `${SpecCapability.k8sResourcePrefix}core:v1:Service`,
-    ] as SpecCapability[];
-    wrapper = wrapper.setProps({ descriptor, value });
+    descriptor = {
+      ...descriptor,
+      path: 'resourceLink',
+      'x-descriptors': [`${SpecCapability.k8sResourcePrefix}core:v1:Service`],
+    };
+    wrapper.setProps({ descriptor });
 
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(ResourceLink)
-        .props().kind,
-    ).toEqual('Service');
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(ResourceLink)
-        .props().name,
-    ).toEqual(value);
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(ResourceLink)
-        .props().namespace,
-    ).toEqual('foo');
+    expect(wrapper.find(ResourceLink).prop('kind')).toEqual('Service');
+    expect(wrapper.find(ResourceLink).prop('name')).toEqual(OBJ.spec.resourceLink);
+    expect(wrapper.find(ResourceLink).prop('namespace')).toEqual('default');
   });
 
   it('renders a basic selector', () => {
-    const value = { matchNames: ['default'] };
-    descriptor['x-descriptors'] = [`${SpecCapability.selector}core:v1:Service`] as SpecCapability[];
-    wrapper = wrapper.setProps({ descriptor, value });
+    descriptor = {
+      ...descriptor,
+      path: 'basicSelector',
+      'x-descriptors': [`${SpecCapability.selector}core:v1:Service`],
+    };
+    wrapper.setProps({ descriptor });
 
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(Selector)
-        .props().selector,
-    ).toEqual(value);
-    expect(
-      wrapper
-        .find('dd')
-        .childAt(0)
-        .shallow()
-        .find(Selector)
-        .props().kind,
-    ).toEqual('core:v1:Service');
+    expect(wrapper.find(Selector).prop('selector')).toEqual(OBJ.spec.basicSelector);
+    expect(wrapper.find(Selector).prop('kind')).toEqual('core:v1:Service');
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -1,87 +1,182 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Map as ImmutableMap } from 'immutable';
-import { Tooltip } from '@patternfly/react-core';
-import { Status, SuccessStatus, YellowExclamationTriangleIcon } from '@console/shared';
-import { ResourceLink } from '@console/internal/components/utils';
+import {
+  Status,
+  SuccessStatus,
+  YellowExclamationTriangleIcon,
+  getSchemaAtPath,
+} from '@console/shared';
+import { ResourceLink, DetailsItem } from '@console/internal/components/utils';
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
 import { Conditions } from '@console/internal/components/conditions';
-import { StatusCapability, CapabilityProps, DescriptorProps } from '../types';
+import {
+  CapabilityProps,
+  DescriptorProps,
+  StatusCapability,
+  StatusDescriptor as StatusDescriptorType,
+} from '../types';
 import { Phase } from './phase';
 import { PodStatusChart } from './pods';
 
-const Invalid: React.SFC<StatusCapabilityProps> = (props) => (
+const Invalid: React.SFC<{ path: string }> = ({ path }) => (
   <span className="text-muted">
     <YellowExclamationTriangleIcon />
-    &nbsp;&nbsp;The field <code>status.{props.descriptor.path}</code> is invalid
+    &nbsp;&nbsp;The field <code>status.{path}</code> is invalid
   </span>
 );
 
-const Default: React.SFC<StatusCapabilityProps> = ({ value }) => {
-  if (_.isEmpty(value) && !_.isNumber(value) && !_.isBoolean(value)) {
-    return <span className="text-muted">None</span>;
-  }
-  if (_.isObject(value)) {
+const Default: React.SFC<StatusCapabilityProps> = ({
+  description,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => {
+  const detail = React.useMemo(() => {
+    if (_.isEmpty(value) && !_.isNumber(value) && !_.isBoolean(value)) {
+      return <span className="text-muted">None</span>;
+    }
+    if (_.isObject(value)) {
+      return (
+        <div className="row">
+          {_.map(value, (v, k) => (
+            <span key={k}>
+              {k}: {v}
+            </span>
+          ))}
+        </div>
+      );
+    }
+    return _.toString(value);
+  }, [value]);
+  return (
+    <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+      {detail}
+    </DetailsItem>
+  );
+};
+
+const PodStatuses: React.SFC<StatusCapabilityProps> = ({
+  description,
+  descriptor,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => {
+  const detail = React.useMemo(() => {
+    if (!_.isObject(value) || _.some(value, (v) => !_.isArray(v))) {
+      return <Invalid path={descriptor.path} />;
+    }
+    if (_.every(value, (v) => _.isArray(v) && v.length === 0)) {
+      return <span className="text-muted">No members</span>;
+    }
+    return <PodStatusChart statuses={value} subTitle={descriptor.path} />;
+  }, [descriptor.path, value]);
+  return (
+    <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+      {detail}
+    </DetailsItem>
+  );
+};
+
+const StatusConditions: React.SFC<StatusCapabilityProps> = ({
+  description,
+  descriptor,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => {
+  const detail = React.useMemo(() => {
     return (
-      <div className="row">
-        {_.map(value, (v, k) => (
-          <span key={k}>
-            {k}: {v}
-          </span>
-        ))}
-      </div>
+      (!_.isArray(value) && <Invalid path={descriptor.path} />) ||
+      (value.length === 0 && <span className="text-muted">No conditions present</span>) || (
+        <Conditions conditions={value} />
+      )
     );
-  }
-  return <span>{_.toString(value)}</span>;
-};
-
-const PodStatuses: React.SFC<StatusCapabilityProps> = (props) => {
+  }, [descriptor.path, value]);
   return (
-    ((!_.isObject(props.value) || _.some(props.value, (v) => !_.isArray(v))) && (
-      <Invalid {...props} />
-    )) ||
-    (_.every(props.value, (v) => _.isArray(v) && v.length === 0) && (
-      <span className="text-muted">No members</span>
-    )) || <PodStatusChart statuses={props.value} statusDescriptor={props.descriptor} />
+    <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+      {detail}
+    </DetailsItem>
   );
 };
 
-const StatusConditions: React.SFC<StatusCapabilityProps> = (props) => {
+const Link: React.SFC<StatusCapabilityProps> = ({ description, fullPath, label, obj, value }) => (
+  <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+    {!_.isNil(value) ? (
+      <a href={value}>{value.replace(/https?:\/\//, '')}</a>
+    ) : (
+      <span className="text-muted">None</span>
+    )}
+  </DetailsItem>
+);
+
+const K8sPhase: React.SFC<StatusCapabilityProps> = ({
+  description,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => (
+  <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+    <Phase status={value} />
+  </DetailsItem>
+);
+
+const K8sPhaseReason: React.SFC<StatusCapabilityProps> = ({
+  description,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => (
+  <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+    {_.isEmpty(value) ? (
+      <span className="text-muted">None</span>
+    ) : (
+      <pre style={{ width: 'max-content' }}>{value}</pre>
+    )}
+  </DetailsItem>
+);
+
+const K8sResourceLink: React.SFC<StatusCapabilityProps> = ({
+  capability,
+  description,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => (
+  <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+    {_.isEmpty(value) ? (
+      <span className="text-muted">None</span>
+    ) : (
+      <ResourceLink
+        kind={capability.substr(StatusCapability.k8sResourcePrefix.length)}
+        name={value}
+        namespace={obj.metadata.namespace}
+        title={value}
+      />
+    )}
+  </DetailsItem>
+);
+
+const MainStatus: React.SFC<StatusCapabilityProps> = ({
+  description,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => {
   return (
-    (!_.isArray(props.value) && <Invalid {...props} />) ||
-    (props.value.length === 0 && <span className="text-muted">No conditions present</span>) || (
-      <Conditions conditions={props.value} />
-    )
+    <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+      {value === 'Running' ? <SuccessStatus title={value} /> : <Status status={value} />}
+    </DetailsItem>
   );
 };
-
-const Link: React.SFC<StatusCapabilityProps> = ({ value }) =>
-  !_.isNil(value) ? (
-    <a href={value}>{value.replace(/https?:\/\//, '')}</a>
-  ) : (
-    <span className="text-muted">None</span>
-  );
-
-const K8sPhase: React.SFC<StatusCapabilityProps> = ({ value }) => <Phase status={value} />;
-
-const K8sPhaseReason: React.SFC<StatusCapabilityProps> = ({ value }) =>
-  _.isEmpty(value) ? (
-    <span className="text-muted">None</span>
-  ) : (
-    <pre style={{ width: 'max-content' }}>{value}</pre>
-  );
-
-const K8sResourceLink: React.SFC<StatusCapabilityProps> = ({ capability, namespace, value }) =>
-  _.isEmpty(value) ? (
-    <span className="text-muted">None</span>
-  ) : (
-    <ResourceLink
-      kind={capability.substr(StatusCapability.k8sResourcePrefix.length)}
-      name={value}
-      namespace={namespace}
-      title={value}
-    />
-  );
 
 const capabilityComponents = ImmutableMap<
   StatusCapability,
@@ -95,7 +190,10 @@ const capabilityComponents = ImmutableMap<
   .set(StatusCapability.k8sResourcePrefix, K8sResourceLink)
   .set(StatusCapability.hidden, null);
 
-const capabilityFor = (statusCapability: StatusCapability) => {
+const capabilityFor = (statusCapability: StatusCapability, descriptor: StatusDescriptorType) => {
+  if (descriptor.displayName === 'Status') {
+    return MainStatus;
+  }
   if (_.isEmpty(statusCapability)) {
     return Default;
   }
@@ -109,35 +207,26 @@ const capabilityFor = (statusCapability: StatusCapability) => {
  * Main entrypoint component for rendering custom UI for a given status descriptor. This should be used instead of importing
  * individual components from this module.
  */
-export const StatusDescriptor = withFallback((props: DescriptorProps) => {
-  const { descriptor, value, namespace } = props;
+export const StatusDescriptor = withFallback(({ descriptor, obj, schema }: DescriptorProps) => {
   // Only using first capability instead of dealing with combimations/permutations
-  const capability = _.get(descriptor, ['x-descriptors', 0], null) as StatusCapability;
-  const Capability = capabilityFor(capability);
-
-  return Capability ? (
+  const statusCapability = _.get(descriptor, ['x-descriptors', 0], null) as StatusCapability;
+  const CapabilityComponent = capabilityFor(statusCapability, descriptor);
+  const fullPath = ['status', ..._.toPath(descriptor.path)];
+  const value = _.get(obj.status, _.toPath(descriptor.path), descriptor.value);
+  const propertySchema = getSchemaAtPath(schema, descriptor.path);
+  const description = descriptor?.description || propertySchema?.description;
+  const label = descriptor?.displayName || propertySchema?.title;
+  return CapabilityComponent ? (
     <dl className="olm-descriptor">
-      <Tooltip content={descriptor.description}>
-        <dt className="olm-descriptor__title" data-test-descriptor-label={descriptor.displayName}>
-          {descriptor.displayName}
-        </dt>
-      </Tooltip>
-      <dd className="olm-descriptor__value">
-        {descriptor.displayName === 'Status' ? (
-          value === 'Running' ? (
-            <SuccessStatus title={value} />
-          ) : (
-            <Status status={value} />
-          )
-        ) : (
-          <Capability
-            descriptor={descriptor}
-            capability={capability}
-            value={value}
-            namespace={namespace}
-          />
-        )}
-      </dd>
+      <CapabilityComponent
+        capability={statusCapability}
+        description={description}
+        descriptor={descriptor}
+        fullPath={fullPath}
+        label={label}
+        obj={obj}
+        value={value}
+      />
     </dl>
   ) : null;
 });
@@ -146,3 +235,12 @@ type StatusCapabilityProps = CapabilityProps<StatusCapability>;
 
 StatusDescriptor.displayName = 'StatusDescriptor';
 Phase.displayName = 'Phase';
+Invalid.displayName = 'Invalid';
+Default.displayName = 'Default';
+PodStatuses.displayName = 'PodStatuses';
+StatusConditions.displayName = 'StatusConditions';
+Link.displayName = 'Link';
+K8sPhase.displayName = 'K8sPhase';
+K8sPhaseReason.displayName = 'K8sPhaseReason';
+K8sResourceLink.displayName = 'K8sResourceLink';
+MainStatus.displayName = 'MainStatus';

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.spec.tsx
@@ -15,7 +15,7 @@ describe(PodStatusChart.displayName, () => {
       description: 'The desired number of member Pods for the etcd cluster.',
       'x-descriptors': [SpecCapability.podCount],
     };
-    wrapper = shallow(<PodStatusChart statusDescriptor={descriptor} statuses={{}} />);
+    wrapper = shallow(<PodStatusChart subTitle={descriptor.path} statuses={{}} />);
   });
 
   it('renders a donut chart component with correct props', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.tsx
@@ -9,12 +9,11 @@ import {
   /* eslint-enable camelcase */
 } from '@patternfly/react-tokens';
 import { useRefWidth } from '@console/internal/components/utils';
-import { Descriptor } from '../types';
 import { calculateRadius } from '@console/shared/';
 
 const colorScale = [blue300.value, blue200.value, blue100.value];
 
-export const PodStatusChart: React.SFC<PodStatusChartProps> = ({ statuses, statusDescriptor }) => {
+export const PodStatusChart: React.SFC<PodStatusChartProps> = ({ statuses, subTitle }) => {
   const [ref, width] = useRefWidth();
   const data = _.map(statuses, (podList, status) => {
     const x = status;
@@ -42,14 +41,14 @@ export const PodStatusChart: React.SFC<PodStatusChartProps> = ({ statuses, statu
       />
       {/* Use instead of `subTitle` on <ChartDonut> so long paths do not clip  */}
       <div className="graph-donut-subtitle" data-test-id="chart-donut-subtitle">
-        {statusDescriptor.path}
+        {subTitle}
       </div>
     </div>
   );
 };
 
 export type PodStatusChartProps = {
-  statusDescriptor: Descriptor;
+  subTitle: string;
   statuses: { [key: string]: string[] };
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
@@ -1,3 +1,4 @@
+import { JSONSchema6 } from 'json-schema';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 
 export enum SpecCapability {
@@ -54,21 +55,23 @@ export type StatusDescriptor = Descriptor<StatusCapability>;
 
 export type DescriptorProps = {
   descriptor: Descriptor;
-  value: any;
-  obj: K8sResourceKind;
   model: K8sKind;
-  namespace?: string;
-  onHandleError?: (message: string) => void;
+  obj: K8sResourceKind;
+  onError?: (error: Error) => void;
+  schema?: JSONSchema6;
 };
 
 export type CapabilityProps<C extends SpecCapability | StatusCapability> = {
-  descriptor: Descriptor;
   capability: C;
-  value: any;
-  obj?: K8sResourceKind;
+  descriptor: Descriptor;
+  description?: string;
+  fullPath?: string[];
+  label?: string;
   model?: K8sKind;
   namespace?: string;
-  onHandleError?: (message: string) => void;
+  obj?: K8sResourceKind;
+  onError?: (error: Error) => void;
+  value: any;
 };
 
 export type Error = { message: string };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -146,7 +146,7 @@ describe(OperandDetails.displayName, () => {
     };
     wrapper = shallow(
       <OperandDetails.WrappedComponent
-        clusterServiceVersion={testClusterServiceVersion}
+        csv={testClusterServiceVersion}
         obj={testResourceInstance}
         kindObj={resourceDefinition}
         appName={testClusterServiceVersion.metadata.name}
@@ -178,9 +178,9 @@ describe(OperandDetails.displayName, () => {
   });
 
   it('does not render any spec descriptor fields if there are none defined on the `ClusterServiceVersion`', () => {
-    const clusterServiceVersion = _.cloneDeep(testClusterServiceVersion);
-    clusterServiceVersion.spec.customresourcedefinitions.owned = [];
-    wrapper = wrapper.setProps({ clusterServiceVersion });
+    const csv = _.cloneDeep(testClusterServiceVersion);
+    csv.spec.customresourcedefinitions.owned = [];
+    wrapper = wrapper.setProps({ csv });
 
     expect(wrapper.find(SpecDescriptor).length).toEqual(0);
   });
@@ -192,15 +192,15 @@ describe(OperandDetails.displayName, () => {
   });
 
   it('renders spec descriptor fields if the custom resource is `required`', () => {
-    const clusterServiceVersion = _.cloneDeep(testClusterServiceVersion);
-    clusterServiceVersion.spec.customresourcedefinitions.required = _.cloneDeep(
-      clusterServiceVersion.spec.customresourcedefinitions.owned,
+    const csv = _.cloneDeep(testClusterServiceVersion);
+    csv.spec.customresourcedefinitions.required = _.cloneDeep(
+      csv.spec.customresourcedefinitions.owned,
     );
-    clusterServiceVersion.spec.customresourcedefinitions.owned = [];
-    wrapper = wrapper.setProps({ clusterServiceVersion });
+    csv.spec.customresourcedefinitions.owned = [];
+    wrapper = wrapper.setProps({ csv });
 
     expect(wrapper.find(SpecDescriptor).length).toEqual(
-      clusterServiceVersion.spec.customresourcedefinitions.required[0].specDescriptors.length,
+      csv.spec.customresourcedefinitions.required[0].specDescriptors.length,
     );
   });
 });
@@ -252,21 +252,20 @@ describe(OperandDetailsPage.displayName, () => {
 
   beforeEach(() => {
     match = {
-      params: { appName: 'etcd', plural: 'etcdclusters', name: 'my-etcd', ns: 'default' },
+      params: {
+        appName: 'testapp',
+        plural: 'testapp.coreos.com~v1alpha1~TestResource',
+        name: 'my-test-resource',
+        ns: 'default',
+      },
       isExact: false,
-      url: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/etcd/etcdclusters/my-etcd`,
+      url: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1alpha1~TestResource/my-test-resource`,
       path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`,
     };
 
-    wrapper = mount(
-      <OperandDetailsPage.WrappedComponent
-        modelRef={k8sModels.referenceFor(testResourceInstance)}
-        match={match}
-      />,
-      {
-        wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,
-      },
-    );
+    wrapper = mount(<OperandDetailsPage match={match} />, {
+      wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
   });
 
   it('renders a `DetailsPage` with the correct subpages', () => {
@@ -281,15 +280,13 @@ describe(OperandDetailsPage.displayName, () => {
   });
 
   it('renders a `DetailsPage` which also watches the parent CSV', () => {
-    expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {
-        kind: k8sModels.referenceForModel(ClusterServiceVersionModel),
-        name: match.params.appName,
-        namespace: match.params.ns,
-        isList: false,
-        prop: 'csv',
-      },
-    ]);
+    expect(wrapper.find(DetailsPage).prop('resources')[0]).toEqual({
+      kind: k8sModels.referenceForModel(ClusterServiceVersionModel),
+      name: match.params.appName,
+      namespace: match.params.ns,
+      isList: false,
+      prop: 'csv',
+    });
   });
 
   it('menu actions to `DetailsPage`', () => {
@@ -316,12 +313,12 @@ describe(OperandDetailsPage.displayName, () => {
     ).toEqual([
       { name: 'Installed Operators', path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}` },
       {
-        name: 'etcd',
-        path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/etcd/etcdclusters`,
+        name: 'testapp',
+        path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1alpha1~TestResource`,
       },
       {
         name: `${testResourceInstance.kind} Details`,
-        path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/etcd/etcdclusters/my-etcd`,
+        path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1alpha1~TestResource/my-test-resource`,
       },
     ]);
   });
@@ -343,7 +340,7 @@ describe(OperandDetailsPage.displayName, () => {
       { name: 'Installed Operators', path: `/k8s/ns/example/${ClusterServiceVersionModel.plural}` },
       { name: 'example', path: `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example` },
       {
-        name: `${testResourceInstance.kind} Details`,
+        name: `example Details`,
         path: `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example/example`,
       },
     ]);

--- a/frontend/public/components/utils/_details-item.scss
+++ b/frontend/public/components/utils/_details-item.scss
@@ -32,7 +32,7 @@
 }
 
 .details-item__value--editable {
-  border: 1px solid var(--pf-global--BorderColor--100);
+  border: 1px solid var(--pf-global--BorderColor--300);
   padding: var(--pf-global--spacer--md);
   margin-top: var(--pf-global--spacer--xs);
 }

--- a/frontend/public/kinds.ts
+++ b/frontend/public/kinds.ts
@@ -50,7 +50,7 @@ export const connectToPlural: ConnectToPlural = connect(
       match: match<{ plural: GroupVersionKind | string }>;
     },
   ) => {
-    const plural = props.plural || _.get(props, 'match.params.plural');
+    const plural = props.plural ?? props.match?.params?.plural;
 
     const groupVersionKind = getGroupVersionKind(plural);
 


### PR DESCRIPTION
- Convert SpecDescriptor and StatusDescriptor components to use DetailsItem. 
- Provide JSONSchema to details items so that description can be displayed in the popover. 
- DetailsItem now shows the popover interaction if either a description or a path is provided. If no description is present, the popover will still be shown with just the heading and path.

Story https://issues.redhat.com/browse/CONSOLE-2283
Sub-task https://issues.redhat.com/browse/CONSOLE-2311

**Details Item With Description**
![details item w description](https://user-images.githubusercontent.com/22625502/88184248-74ced600-cc00-11ea-9c9a-2142418cae4a.png)

**Details Item Without Description**
![details item wo description](https://user-images.githubusercontent.com/22625502/88184259-7a2c2080-cc00-11ea-8182-788e6a8bc2d2.png)
