### PR TITLE
Fix label alignment on Namespace details 'Memory Usage' bar charts.

### DIFF
--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -62,7 +62,9 @@ export const BarChart: React.FC<BarChartProps> = ({
                   barWidth={barWidth}
                   data={[datum]}
                   horizontal
-                  labelComponent={<ChartLabel x={width} />}
+                  labelComponent={
+                    <ChartLabel x={width} textAnchor={theme.bar?.style?.labels?.textAnchor} />
+                  }
                   theme={theme}
                   height={barWidth + padding.bottom}
                   width={width}


### PR DESCRIPTION
When using PFv4's `ChartLabel` component, which is a wrapper for new `VictoryLabel` component; must pass in `textAnchor` to it rather than the chart's `theme`.

### Before
![image](https://user-images.githubusercontent.com/12733153/87467756-712ac600-c5e6-11ea-8429-cac21152e093.png)

### After
![image](https://user-images.githubusercontent.com/12733153/87467771-7851d400-c5e6-11ea-83e9-2e3fcb4dcca0.png)

