### PR TITLE
Fix critical alerts not able to close in notification drawer

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -231,7 +231,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
     true,
   );
   const [isClusterUpdateExpanded, toggleClusterUpdateExpanded] = React.useState<boolean>(true);
-  const prevDrawerToggleState = usePrevious(isDrawerExpanded);
+  const prevDrawerToggleState = usePrevious(isDrawerExpanded, [isAlertExpanded]);
 
   const hasCriticalAlerts = criticalAlertList.length > 0;
   const hasNonCriticalAlerts = otherAlertList.length > 0;


### PR DESCRIPTION
The usePrevious hook has changed in the last week to add dependency. adding a dependency to the use of usePrevious in the notification drawer code allowed the state to update correctly and open and close the critical alerts category