### PR TITLE
update namespace for sources created through yaml if edited

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -1,12 +1,19 @@
 import * as _ from 'lodash';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { safeDump } from 'js-yaml';
+import * as k8sModels from '@console/internal/module/k8s';
 import {
   ServiceModel,
   EventSourceCronJobModel,
   EventSourceSinkBindingModel,
   EventSourceKafkaModel,
+  EventSourceCamelModel,
 } from '../../models';
-import { getEventSourceResource, getBootstrapServers } from '../create-eventsources-utils';
+import {
+  getEventSourceResource,
+  getBootstrapServers,
+  loadYamlData,
+  getEventSourcesDepResource,
+} from '../create-eventsources-utils';
 import { getDefaultEventingData, Kafkas } from './knative-serving-data';
 import { EventSources } from '../../components/add/import-types';
 
@@ -15,7 +22,7 @@ describe('Create knative Utils', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
     const mockData = _.cloneDeep(defaultEventingData);
     mockData.apiVersion = 'sources.eventing.knative.dev/v1alpha1';
-    const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
+    const knEventingResource: k8sModels.K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.kind).toBe(EventSourceCronJobModel.kind);
     expect(knEventingResource.apiVersion).toBe(
       `${EventSourceCronJobModel.apiGroup}/${EventSourceCronJobModel.apiVersion}`,
@@ -25,14 +32,14 @@ describe('Create knative Utils', () => {
   it('expect response to schedule in spec for CronJobSource', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
     const mockData = _.cloneDeep(defaultEventingData);
-    const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
+    const knEventingResource: k8sModels.K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.spec.schedule).toBe('* * * * *');
   });
 
   it('expect response for sink to be of kind knative service', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
     const mockData = _.cloneDeep(defaultEventingData);
-    const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
+    const knEventingResource: k8sModels.K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.spec.sink.ref.kind).toBe(ServiceModel.kind);
     expect(knEventingResource.spec.sink.ref.apiVersion).toBe(
       `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
@@ -43,7 +50,7 @@ describe('Create knative Utils', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
     const mockData = _.cloneDeep(defaultEventingData);
     mockData.type = 'SinkBinding';
-    const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
+    const knEventingResource: k8sModels.K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.kind).toBe(EventSourceSinkBindingModel.kind);
     expect(knEventingResource.apiVersion).toBe(
       `${EventSourceSinkBindingModel.apiGroup}/${EventSourceSinkBindingModel.apiVersion}`,
@@ -56,7 +63,7 @@ describe('Create knative Utils', () => {
     mockData.type = 'KafkaSource';
     mockData.limits.cpu.limit = '200';
     mockData.limits.cpu.request = '100';
-    const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
+    const knEventingResource: k8sModels.K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.kind).toBe(EventSourceKafkaModel.kind);
     expect(knEventingResource.apiVersion).toBe(
       `${EventSourceKafkaModel.apiGroup}/${EventSourceKafkaModel.apiVersion}`,
@@ -72,5 +79,36 @@ describe('Create knative Utils', () => {
       'my-cluster2-kafka-bootstrap.div.svc:9092',
       'my-cluster2-kafka-bootstrap.div.svc:9093',
     ]);
+  });
+
+  it('expect response of loadYamlData to have namespace as passed in yamlEditor', () => {
+    jest.spyOn(k8sModels, 'modelFor').mockImplementation(() => EventSourceCamelModel);
+    const defaultEventingData = getDefaultEventingData(EventSourceCamelModel.kind);
+    const mockData = {
+      ...defaultEventingData,
+      yamlData: safeDump(getEventSourcesDepResource(defaultEventingData)),
+    };
+    const knEventingResource: k8sModels.K8sResourceKind = loadYamlData(mockData);
+    expect(knEventingResource.kind).toBe(EventSourceCamelModel.kind);
+    expect(knEventingResource.apiVersion).toBe(
+      `${EventSourceCamelModel.apiGroup}/${EventSourceCamelModel.apiVersion}`,
+    );
+    expect(knEventingResource.metadata?.namespace).toEqual('mock-project');
+  });
+
+  it('expect response of loadYamlData to update namespace if not there yamlEditor', () => {
+    jest.spyOn(k8sModels, 'modelFor').mockImplementation(() => EventSourceCamelModel);
+    const defaultEventingData = getDefaultEventingData(EventSourceCamelModel.kind);
+    defaultEventingData.project.name = '';
+    const mockData = {
+      ...getDefaultEventingData(EventSourceCamelModel.kind),
+      yamlData: safeDump(getEventSourcesDepResource(defaultEventingData)),
+    };
+    const knEventingResource: k8sModels.K8sResourceKind = loadYamlData(mockData);
+    expect(knEventingResource.kind).toBe(EventSourceCamelModel.kind);
+    expect(knEventingResource.apiVersion).toBe(
+      `${EventSourceCamelModel.apiGroup}/${EventSourceCamelModel.apiVersion}`,
+    );
+    expect(knEventingResource.metadata?.namespace).toEqual('mock-project');
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4227

**Analysis / Root cause**: 
If user omits namespace from yaml and tries to create it gives 404 as these sources are namespaced

**Solution Description**: 
Update namespace if not present with current namespace user is in


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/87517788-038da100-c69d-11ea-8c8b-95fb55c922b7.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
