### PR TITLE
adds support for camel K connector in ES create and  visualisation

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceAlert.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { Alert } from '@patternfly/react-core';
 import { referenceForModel } from '@console/internal/module/k8s';
 import EventSourceAlert from '../EventSourceAlert';
-import { getKnativeEventSourceIcon } from '../../../utils/get-knative-icon';
+import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 import { EventSourceContainerModel } from '../../../models';
 
 describe('EventSourceAlert', () => {
@@ -13,7 +13,7 @@ describe('EventSourceAlert', () => {
       [EventSourceContainerModel.kind]: {
         name: EventSourceContainerModel.kind,
         title: EventSourceContainerModel.kind,
-        iconUrl: getKnativeEventSourceIcon(referenceForModel(EventSourceContainerModel)),
+        iconUrl: getEventSourceIcon(referenceForModel(EventSourceContainerModel)),
         displayName: EventSourceContainerModel.kind,
       },
     },

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceForm.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceForm.spec.tsx
@@ -8,7 +8,7 @@ import EventSourcesSelector from '../event-sources/EventSourcesSelector';
 import { getDefaultEventingData } from '../../../utils/__tests__/knative-serving-data';
 import { EventSources } from '../import-types';
 import EventSourceSection from '../event-sources/EventSourceSection';
-import { getKnativeEventSourceIcon } from '../../../utils/get-knative-icon';
+import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 import { EventSourceContainerModel } from '../../../models';
 
 type EventSourceFormProps = React.ComponentProps<typeof EventSourceForm>;
@@ -22,7 +22,7 @@ describe('EventSource Form', () => {
       [EventSourceContainerModel.kind]: {
         name: EventSourceContainerModel.kind,
         title: EventSourceContainerModel.kind,
-        iconUrl: getKnativeEventSourceIcon(referenceForModel(EventSourceContainerModel)),
+        iconUrl: getEventSourceIcon(referenceForModel(EventSourceContainerModel)),
         displayName: EventSourceContainerModel.kind,
       },
     },

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
@@ -7,7 +7,11 @@ import { DropdownField, getFieldId } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import ServiceAccountDropdown from '../../dropdowns/ServiceAccountDropdown';
 
-const ApiServerSection: React.FC = () => {
+interface ApiServerSectionProps {
+  title: string;
+}
+
+const ApiServerSection: React.FC<ApiServerSectionProps> = ({ title }) => {
   const { values, setFieldValue } = useFormikContext<FormikValues>();
   const initVal = values?.data?.apiserversource?.resources || [];
   const initialValueResources = !_.isEmpty(initVal)
@@ -35,7 +39,7 @@ const ApiServerSection: React.FC = () => {
   };
   const fieldId = getFieldId(values.type, 'res-input');
   return (
-    <FormSection title="ApiServerSource" extraMargin>
+    <FormSection title={title} extraMargin>
       <FormGroup
         fieldId={fieldId}
         label="Resource"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/ContainerSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/ContainerSourceSection.tsx
@@ -14,7 +14,11 @@ const containerPaths = {
   Args: 'data.containersource.template.spec.containers[0].args',
 };
 
-const ContainerSourceSection: React.FC = () => {
+interface ContainerSourceSectionProps {
+  title: string;
+}
+
+const ContainerSourceSection: React.FC<ContainerSourceSectionProps> = ({ title }) => {
   const { values, setFieldValue } = useFormikContext<FormikValues>();
   const {
     data: {
@@ -40,7 +44,7 @@ const ContainerSourceSection: React.FC = () => {
     [setFieldValue],
   );
   return (
-    <FormSection title="ContainerSource" extraMargin>
+    <FormSection title={title} extraMargin>
       <h3 className="co-section-heading-tertiary">Container</h3>
       <InputField
         data-test-id="container-image-field"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/CronJobSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/CronJobSection.tsx
@@ -3,8 +3,12 @@ import { TextInputTypes } from '@patternfly/react-core';
 import { InputField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 
-const CronJobSection: React.FC = () => (
-  <FormSection title="CronJobSource" extraMargin>
+interface CronJobSectionProps {
+  title: string;
+}
+
+const CronJobSection: React.FC<CronJobSectionProps> = ({ title }) => (
+  <FormSection title={title} extraMargin>
     <InputField
       type={TextInputTypes.text}
       name="data.cronjobsource.data"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
@@ -31,27 +31,28 @@ const EventSourceSection: React.FC<EventSourceSectionProps> = ({ namespace }) =>
     return null;
   }
   let EventSource: React.ReactElement;
+  const sectionTitle = values.data?.itemData?.title ?? values.type;
   switch (values.type) {
     case EventSources.CronJobSource:
-      EventSource = <CronJobSection />;
+      EventSource = <CronJobSection title={sectionTitle} />;
       break;
     case EventSources.SinkBinding:
-      EventSource = <SinkBindingSection />;
+      EventSource = <SinkBindingSection title={sectionTitle} />;
       break;
     case EventSources.ApiServerSource:
-      EventSource = <ApiServerSection />;
+      EventSource = <ApiServerSection title={sectionTitle} />;
       break;
     case EventSources.KafkaSource:
-      EventSource = <KafkaSourceSection />;
+      EventSource = <KafkaSourceSection title={sectionTitle} />;
       break;
     case EventSources.ContainerSource:
-      EventSource = <ContainerSourceSection />;
+      EventSource = <ContainerSourceSection title={sectionTitle} />;
       break;
     case EventSources.PingSource:
-      EventSource = <PingSourceSection />;
+      EventSource = <PingSourceSection title={sectionTitle} />;
       break;
     default:
-      EventSource = <YAMLEditorSection />;
+      EventSource = <YAMLEditorSection title={sectionTitle} />;
   }
   return (
     <>

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -35,6 +35,7 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
         setFieldValue(nameData, sourceData);
         setFieldTouched(nameData, true);
       }
+      setFieldValue('data.itemData', eventSourceList[item]);
       const selDataModel = _.find(getEventSourceModels(), { kind: item });
       const selApiVersion = selDataModel
         ? `${selDataModel?.apiGroup}/${selDataModel?.apiVersion}`
@@ -50,7 +51,15 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
       setFieldTouched('apiVersion', true);
       validateForm();
     },
-    [setErrors, setStatus, setFieldValue, setFieldTouched, selectedKey, validateForm],
+    [
+      setErrors,
+      setStatus,
+      setFieldValue,
+      setFieldTouched,
+      selectedKey,
+      validateForm,
+      eventSourceList,
+    ],
   );
 
   const itemSelectorField = (

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -10,7 +10,11 @@ import { useK8sWatchResources } from '@console/internal/components/utils/k8s-wat
 import { getBootstrapServers } from '../../../utils/create-eventsources-utils';
 import { strimziResourcesWatcher } from '../../../utils/get-knative-resources';
 
-const KafkaSourceSection: React.FC = () => {
+interface KafkaSourceSectionProps {
+  title: string;
+}
+
+const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title }) => {
   const memoResources = React.useMemo(() => strimziResourcesWatcher(), []);
   const { kafkas, kafkatopics } = useK8sWatchResources<{
     [key: string]: K8sResourceKind[];
@@ -69,7 +73,7 @@ const KafkaSourceSection: React.FC = () => {
   }, [kafkatopics.data, kafkatopics.loaded, kafkatopics.loadError]);
 
   return (
-    <FormSection title="KafkaSource" extraMargin>
+    <FormSection title={title} extraMargin>
       <SelectInputField
         data-test-id="kafkasource-bootstrapservers-field"
         name="data.kafkasource.bootstrapServers"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
@@ -3,8 +3,12 @@ import { TextInputTypes } from '@patternfly/react-core';
 import { InputField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 
-const PingSourceSection: React.FC = () => (
-  <FormSection title="PingSource" extraMargin>
+interface PingSourceSectionProps {
+  title: string;
+}
+
+const PingSourceSection: React.FC<PingSourceSectionProps> = ({ title }) => (
+  <FormSection title={title} extraMargin>
     <InputField
       type={TextInputTypes.text}
       name="data.pingsource.data"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkBindingSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkBindingSection.tsx
@@ -6,7 +6,11 @@ import { InputField, getFieldId } from '@console/shared';
 import { AsyncComponent } from '@console/internal/components/utils/async';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 
-const SinkBindingSection: React.FC = () => {
+interface SinkBindingSectionProps {
+  title: string;
+}
+
+const SinkBindingSection: React.FC<SinkBindingSectionProps> = ({ title }) => {
   const { values, setFieldValue } = useFormikContext<FormikValues>();
   const initVal = values?.data?.sinkbinding?.subject?.selector?.matchLabels || {};
   const initialValueResources = !_.isEmpty(initVal)
@@ -30,7 +34,7 @@ const SinkBindingSection: React.FC = () => {
   );
   const fieldId = getFieldId(values.type, 'subject-matchLabels');
   return (
-    <FormSection title="SinkBinding" extraMargin>
+    <FormSection title={title} extraMargin>
       <h3 className="co-section-heading-tertiary">Subject</h3>
       <InputField
         data-test-id="sinkbinding-apiversion-field"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ApiServerSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ApiServerSection.spec.tsx
@@ -18,21 +18,22 @@ jest.mock('formik', () => ({
   getFieldId: jest.fn(),
 }));
 describe('ApiServerSection', () => {
+  const title = 'Api Server Source';
   it('should render FormSection', () => {
-    const wrapper = shallow(<ApiServerSection />);
+    const wrapper = shallow(<ApiServerSection title={title} />);
     expect(wrapper.find(FormSection)).toHaveLength(1);
-    expect(wrapper.find(FormSection).props().title).toBe('ApiServerSource');
+    expect(wrapper.find(FormSection).props().title).toBe('Api Server Source');
   });
 
   it('should render NameValueEditor', () => {
-    const wrapper = shallow(<ApiServerSection />);
+    const wrapper = shallow(<ApiServerSection title={title} />);
     const nameValueEditorField = wrapper.find(AsyncComponent);
     expect(nameValueEditorField).toHaveLength(1);
     expect(nameValueEditorField.props().nameString).toBe('apiVersion');
     expect(nameValueEditorField.props().valueString).toBe('kind');
   });
   it('should render ServiceAccountDropdown', () => {
-    const wrapper = shallow(<ApiServerSection />);
+    const wrapper = shallow(<ApiServerSection title={title} />);
     expect(wrapper.find(ServiceAccountDropdown)).toHaveLength(1);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ContainerSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/ContainerSourceSection.spec.tsx
@@ -4,7 +4,6 @@ import { TextColumnField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { AsyncComponent } from '@console/internal/components/utils/async';
 import ContainerSourceSection from '../ContainerSourceSection';
-import { EventSources } from '../../import-types';
 
 type ContainerSourceSectionProps = React.ComponentProps<typeof ContainerSourceSection>;
 
@@ -33,14 +32,15 @@ jest.mock('formik', () => ({
   })),
 }));
 describe('ContainerSourceSection', () => {
+  const title = 'Container Source';
   let wrapper: ShallowWrapper<ContainerSourceSectionProps>;
   beforeEach(() => {
-    wrapper = shallow(<ContainerSourceSection />);
+    wrapper = shallow(<ContainerSourceSection title={title} />);
   });
 
   it('should render ContainerSource FormSection', () => {
     expect(wrapper.find(FormSection)).toHaveLength(1);
-    expect(wrapper.find(FormSection).props().title).toBe(EventSources.ContainerSource);
+    expect(wrapper.find(FormSection).props().title).toBe('Container Source');
   });
 
   it('should render Container image and name input fields', () => {

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
@@ -3,7 +3,6 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import KafkaSourceSection from '../KafkaSourceSection';
-import { EventSources } from '../../import-types';
 import KafkaSourceNetSection from '../KafkaSourceNetSection';
 import ServiceAccountDropdown from '../../../dropdowns/ServiceAccountDropdown';
 
@@ -13,6 +12,7 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
   useK8sWatchResources: jest.fn(),
 }));
 describe('KafkaSourceSection', () => {
+  const title = 'Kafka Source';
   let wrapper: ShallowWrapper<KafkaSourceSectionProps>;
 
   it('should render KafkaSource FormSection with proper title', () => {
@@ -20,9 +20,9 @@ describe('KafkaSourceSection', () => {
       kafkas: { data: [], loaded: true },
       kafkatopics: { data: [], loaded: true },
     });
-    wrapper = shallow(<KafkaSourceSection />);
+    wrapper = shallow(<KafkaSourceSection title={title} />);
     expect(wrapper.find(FormSection)).toHaveLength(1);
-    expect(wrapper.find(FormSection).props().title).toBe(EventSources.KafkaSource);
+    expect(wrapper.find(FormSection).props().title).toBe('Kafka Source');
   });
 
   it('should render BootstrapServers and Topics fields with ', () => {
@@ -30,7 +30,7 @@ describe('KafkaSourceSection', () => {
       kafkas: { data: [], loaded: true },
       kafkatopics: { data: [], loaded: true },
     });
-    wrapper = shallow(<KafkaSourceSection />);
+    wrapper = shallow(<KafkaSourceSection title={title} />);
     const bootstrapServersField = wrapper.find(
       '[data-test-id="kafkasource-bootstrapservers-field"]',
     );
@@ -47,7 +47,7 @@ describe('KafkaSourceSection', () => {
       kafkas: { data: [], loaded: true },
       kafkatopics: { data: [], loaded: true },
     });
-    wrapper = shallow(<KafkaSourceSection />);
+    wrapper = shallow(<KafkaSourceSection title={title} />);
     const consumerGroupField = wrapper.find('[data-test-id="kafkasource-consumergroup-field"]');
     expect(consumerGroupField).toHaveLength(1);
     expect(consumerGroupField.props().required).toBeTruthy();

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/SinkBindingSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/SinkBindingSection.spec.tsx
@@ -20,13 +20,14 @@ jest.mock('formik', () => ({
   getFieldId: jest.fn(),
 }));
 describe('SinkBindingSection', () => {
+  const title = 'Sink Binding';
   let wrapper: ShallowWrapper<SinkBindingSectionProps>;
   beforeEach(() => {
-    wrapper = shallow(<SinkBindingSection />);
+    wrapper = shallow(<SinkBindingSection title={title} />);
   });
   it('should render FormSection', () => {
     expect(wrapper.find(FormSection)).toHaveLength(1);
-    expect(wrapper.find(FormSection).props().title).toBe('SinkBinding');
+    expect(wrapper.find(FormSection).props().title).toBe('Sink Binding');
   });
 
   it('should render NameValueEditor', () => {

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/YAMLEditorSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/YAMLEditorSection.spec.tsx
@@ -13,10 +13,11 @@ jest.mock('formik', () => ({
 }));
 
 describe('YAMLEditorSection', () => {
-  const wrapper = shallow(<YAMLEditorSection />);
+  const title = 'Jira';
+  const wrapper = shallow(<YAMLEditorSection title={title} />);
   it('should render FormSection with proper props', () => {
     expect(wrapper.find(FormSection)).toHaveLength(1);
-    expect(wrapper.find(FormSection).props().title).toEqual('CamelSource');
+    expect(wrapper.find(FormSection).props().title).toEqual('Jira');
     expect(wrapper.find(FormSection).props().fullWidth).toBe(true);
     expect(wrapper.find(FormSection).props().flexLayout).toBe(true);
   });

--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -11,3 +11,5 @@ export const KNATIVE_EVENT_MESSAGE_APIGROUP = 'messaging.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP_DEP = 'sources.eventing.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP = 'sources.knative.dev';
 export const STRIMZI_KAFKA_APIGROUP = 'kafka.strimzi.io';
+export const EVENT_SOURCE_LABEL = 'console.openshift.io/event-source';
+export const EVENT_SOURCE_ICON = 'console.openshift.io/icon';

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -268,6 +268,20 @@ export const EventingTriggerModel: K8sKind = {
   color: knativeEventingColor.value,
 };
 
+export const CamelIntegrationModel: K8sKind = {
+  apiGroup: 'camel.apache.org',
+  apiVersion: 'v1',
+  kind: 'Integration',
+  label: 'Integration',
+  labelPlural: 'Integrations',
+  plural: 'integrations',
+  id: 'integration',
+  abbr: 'I',
+  namespaced: true,
+  crd: true,
+  color: knativeEventingColor.value,
+};
+
 export const KafkaModel: K8sKind = {
   apiGroup: STRIMZI_KAFKA_APIGROUP,
   apiVersion: 'v1beta1',

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
@@ -22,7 +22,7 @@ import {
   getFilterById,
   SHOW_LABELS_FILTER_ID,
 } from '@console/dev-console/src/components/topology';
-import { getKnativeEventSourceIcon } from '../../../utils/get-knative-icon';
+import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 
 import './EventSource.scss';
 
@@ -55,7 +55,7 @@ const EventSource: React.FC<EventSourceProps> = ({
   const showLabels = showLabelsFilter?.value || hover;
   const { width, height } = element.getBounds();
   const size = Math.min(width, height);
-  const { data } = element.getData();
+  const { data, resources } = element.getData();
 
   return (
     <g
@@ -85,7 +85,7 @@ const EventSource: React.FC<EventSourceProps> = ({
         y={height * 0.25}
         width={size * 0.5}
         height={size * 0.5}
-        xlinkHref={getKnativeEventSourceIcon(data.kind)}
+        xlinkHref={getEventSourceIcon(data.kind, resources.obj)}
       />
       {showLabels && (data.kind || element.getLabel()) && (
         <SvgBoxedText

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -61,6 +61,7 @@ import {
   ServiceModel,
   EventingTriggerModel,
   EventingSubscriptionModel,
+  EventSourceCamelModel,
 } from '../models';
 import { addEventSource } from '../actions/add-event-source';
 import { addTrigger, addSubscription } from '../actions/add-pubsub-actions';
@@ -250,7 +251,16 @@ const createKnativeDeploymentItems = (
   resources: TopologyDataResources,
   utils?: KnativeUtil[],
 ): TopologyOverviewItem => {
-  const associatedDeployment = getOwnedResources(resource, resources.deployments.data);
+  let associatedDeployment = getOwnedResources(resource, resources.deployments.data);
+  // form Deployments for camelSource as they are owned by integrations
+  if (resource.kind === EventSourceCamelModel.kind) {
+    const intgrationsOwnData = getOwnedResources(resource, resources.integrations.data);
+    const integrationsOwnedDeployment =
+      intgrationsOwnData?.length > 0
+        ? getOwnedResources(intgrationsOwnData[0], resources.deployments.data)
+        : [];
+    associatedDeployment = [...associatedDeployment, ...integrationsOwnedDeployment];
+  }
   if (!_.isEmpty(associatedDeployment)) {
     const depObj: K8sResourceKind = {
       ...associatedDeployment[0],

--- a/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
@@ -30,6 +30,7 @@ import {
   knativeEventingResourcesSubscriptionWatchers,
   knativeEventingBrokerResourceWatchers,
   knativeEventingTriggerResourceWatchers,
+  knativeCamelIntegrationsResourceWatchers,
 } from '../utils/get-knative-resources';
 import {
   getDynamicEventSourcesWatchers,
@@ -47,6 +48,7 @@ export const getKnativeResources = (namespace: string) => {
     ...getDynamicEventingChannelWatchers(namespace),
     ...knativeEventingBrokerResourceWatchers(namespace),
     ...knativeEventingTriggerResourceWatchers(namespace),
+    ...knativeCamelIntegrationsResourceWatchers(namespace),
   };
 };
 

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -3,7 +3,12 @@ import {
   DeployImageFormData,
   Resources,
 } from '@console/dev-console/src/components/import/import-types';
-import { EventSourceFormData, SinkType } from '../../components/add/import-types';
+import {
+  EventSourceFormData,
+  SinkType,
+  NormalizedEventSources,
+} from '../../components/add/import-types';
+import { ClusterServiceVersionKind, InstallModeType } from '@console/operator-lifecycle-manager';
 import { RevisionModel, ServiceModel, KafkaModel } from '../../models';
 import { healthChecksProbeInitialData } from '@console/dev-console/src/components/health-checks/health-checks-probe-utils';
 
@@ -563,6 +568,137 @@ export const Kafkas: K8sResourceKind[] = [
         },
       ],
       observedGeneration: 1,
+    },
+  },
+];
+
+export const eventSourcesObj: NormalizedEventSources = {
+  CamelSource: {
+    name: 'CamelSource',
+    iconUrl: 'static/assets/camelsource.svg',
+    displayName: 'Camel Source',
+    title: 'Camel Source',
+  },
+  PingSource: {
+    name: 'PingSource',
+    iconUrl: 'static/assets/pingsource.png',
+    displayName: 'Ping Source',
+    title: 'Ping Source',
+  },
+  ApiServerSource: {
+    name: 'ApiServerSource',
+    iconUrl: 'static/assets/apiserversource.png',
+    displayName: 'Api Server Source',
+    title: 'Api Server Source',
+  },
+  GitHubSource: {
+    name: 'GitHubSource',
+    iconUrl: 'static/assets/github.png',
+    displayName: 'Api Server Source',
+    title: 'Api Server Source',
+  },
+  jira: {
+    name: 'jira',
+    iconUrl: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbm',
+    displayName: 'Camel Source',
+    title: 'Camel Source',
+    data: {
+      almdata: {
+        apiVersion: 'sources.knative.dev/v1alpha1',
+        kind: 'CamelSource',
+        metadata: { name: 'jira' },
+        spec: {},
+      },
+    },
+  },
+};
+
+export const camelCsvData: ClusterServiceVersionKind[] = [
+  {
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'ClusterServiceVersion',
+    metadata: {
+      annotations: {
+        certified: 'false',
+        repository: 'https://github.com/knative/eventing-sources',
+        support: 'Camel',
+        'alm-examples':
+          '[\n  {\n    "apiVersion": "sources.knative.dev/v1alpha1",\n    "kind": "CamelSource",\n    "metadata": {\n      "name": "camel-timer-source"\n    },\n    "spec": {\n      "source": {\n        "flow": {\n          "from": {\n            "uri": "timer:tick?period=3000",\n            "steps": [\n              {\n                "set-body": {\n                  "constant": "Hello World!"\n                }\n              }\n            ]\n          }\n        }\n      },\n      "sink": {\n        "ref": {\n          "apiVersion": "messaging.knative.dev/v1beta1",\n          "kind": "InMemoryChannel",\n          "name": "camel-test"\n        }\n      }\n    }\n  },\n  {"apiVersion": "sources.knative.dev/v1alpha1", "kind": "CamelSource", "metadata": {"name": "telegram", "labels": {"console.openshift.io/event-source": "true"}, "annotations": {"console.openshift.io/icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNDAgMjQwIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImEiIHgxPSIuNjY3IiB4Mj0iLjQxNyIgeTE9Ii4xNjciIHkyPSIuNzUiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzM3YWVlMiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzFlOTZjOCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJiIiB4MT0iLjY2IiB4Mj0iLjg1MSIgeTE9Ii40MzciIHkyPSIuODAyIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNlZmY3ZmMiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNmZmYiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48Y2lyY2xlIGN4PSIxMjAiIGN5PSIxMjAiIHI9IjEyMCIgZmlsbD0idXJsKCNhKSIvPjxwYXRoIGZpbGw9IiNjOGRhZWEiIGQ9Ik05OCAxNzVjLTMuODg4IDAtMy4yMjctMS40NjgtNC41NjgtNS4xN0w4MiAxMzIuMjA3IDE3MCA4MCIvPjxwYXRoIGZpbGw9IiNhOWM5ZGQiIGQ9Ik05OCAxNzVjMyAwIDQuMzI1LTEuMzcyIDYtM2wxNi0xNS41NTgtMTkuOTU4LTEyLjAzNSIvPjxwYXRoIGZpbGw9InVybCgjYikiIGQ9Ik0xMDAuMDQgMTQ0LjQxbDQ4LjM2IDM1LjcyOWM1LjUxOSAzLjA0NSA5LjUwMSAxLjQ2OCAxMC44NzYtNS4xMjNsMTkuNjg1LTkyLjc2M2MyLjAxNS04LjA4LTMuMDgtMTEuNzQ2LTguMzYtOS4zNDlsLTExNS41OSA0NC41NzFjLTcuODkgMy4xNjUtNy44NDMgNy41NjctMS40MzggOS41MjhsMjkuNjYzIDkuMjU5IDY4LjY3My00My4zMjVjMy4yNDItMS45NjYgNi4yMTgtLjkxIDMuNzc2IDEuMjU4Ii8+PC9zdmc+"}}, "spec": {"source": {"flow": {"from": {"uri": "telegram:bots", "parameters": {"authorizationToken": "<put-here-the-token-from-the-bot-father>"}, "steps": [{"marshal": {"json": {}}}, {"to": "log:info"}]}}, "integration": {"dependencies": ["camel:jackson"]}}, "sink": {"ref": {"apiVersion": "messaging.knative.dev/v1beta1", "kind": "InMemoryChannel", "name": "messages"}}}},\n  {"apiVersion": "sources.knative.dev/v1alpha1", "kind": "CamelSource", "metadata": {"name": "salesforce", "labels": {"console.openshift.io/event-source": "true"}, "annotations": {"console.openshift.io/icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZpZXdCb3g9IjAgMCA0OCA0OCIgdmVyc2lvbj0iMS4xIj48ZyBpZD0ic3VyZmFjZTEiPjxwYXRoIGQ9Ik0zNi41IDEyYy0xLjMyNCAwLTIuNTkuMjU4LTMuNzU4LjcwM0E3Ljk5NCA3Ljk5NCAwIDAgMCAyNiA5Yy0yLjEwNSAwLTQuMDIuODItNS40NDUgMi4xNTJBOS40NjggOS40NjggMCAwIDAgMTMuNSA4QzguMjU0IDggNCAxMi4yNTQgNCAxNy41YzAgLjc5My4xMSAxLjU1OS4yOSAyLjI5M0E4LjQ3MiA4LjQ3MiAwIDAgMCAxIDI2LjVDMSAzMS4xOTUgNC44MDUgMzUgOS41IDM1Yy40MTQgMCAuODE2LS4wNCAxLjIxNS0uMDk4IDEuMzEyIDMgNC4zIDUuMDk4IDcuNzg1IDUuMDk4IDMuMTYgMCA1LjkxNC0xLjczIDcuMzc5LTQuMjkzQTcuOTIzIDcuOTIzIDAgMCAwIDI4IDM2YzIuNjIxIDAgNC45MzgtMS4yNjYgNi4zOTgtMy4yMS42OC4xMzYgMS4zODMuMjEgMi4xMDIuMjFDNDIuMyAzMyA0NyAyOC4zIDQ3IDIyLjVTNDIuMyAxMiAzNi41IDEyeiIgZmlsbD0iIzAzOUJFNSIvPjxwYXRoIGQ9Ik0xNS44MjQgMjVjLjA0MyAwIC4wNzQtLjAzNS4wNzQtLjA4MiAwIC4wNDctLjAzLjA4Mi0uMDc0LjA4MnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMjEuNTA0IDIzLjkzNHoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNNy4xMzcgMjMuOTNhLjExNi4xMTYgMCAwIDEgLjAwNCAwaC0uMDA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yNC4xMjUgMjEuOTFjLS4wMTYuMDQtLjA0Ny4wNDMtLjA3LjA0M2guMDA4Yy4wMjMgMCAuMDUtLjAwOC4wNjItLjA0M3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTUuODI0IDE5Yy4wNDMgMCAuMDc0LjAzNS4wNzQuMDgyIDAtLjA0Ny0uMDMtLjA4Mi0uMDc0LS4wODJ6IiBmaWxsPSIjRkZGIi8+PHBhdGggZD0iTTIxLjM2IDIyLjE4NGMwIC40MS4yMS42NjQuNTAzLjgzNi0uMjkzLS4xNzItLjUwNC0uNDI2LS41MDQtLjgzNnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzguMTI1IDI0LjczYy4wMjcuMDYtLjAzMS4wODYtLjAzMS4wODZzLjA1OC0uMDI3LjAzMS0uMDg2eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik04LjU1OSAyMXoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNOS43NjYgMjEuOTFjLS4wMi4wNC0uMDQ3LjA0My0uMDc1LjA0M0g5LjdjLjAyOCAwIC4wNTEtLjAwOC4wNjctLjA0M3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzUuMTk1IDI0LjE2NHoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzcuODI4IDIxLjc5N2gtLjAyM3MuMDA4LjAwNC4wMjMuMDA0di0uMDA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0zNy44MzIgMjQuMTg4cy4wMTYgMCAuMDM1LS4wMDRoLS4wMDRjLS4wMTUgMC0uMDMxLjAwMy0uMDMxLjAwM3oiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNNi44ODcgMjQuNDZjLS4wMzIuMDcxLjAwOC4wODcuMDIuMDk5LjA4NS4wNTguMTcxLjA5Ny4yNjEuMTQ0LjQ2OS4yMy45MS4yOTcgMS4zNzUuMjk3Ljk0NSAwIDEuNTMxLS40NiAxLjUzMS0xLjIwN3YtLjAxNmMwLS42ODctLjY2NC0uOTM3LTEuMjg1LTEuMTE3bC0uMDc4LS4wMjNjLS40NjktLjE0LS44NzEtLjI2Mi0uODcxLS41NDd2LS4wMTZjMC0uMjQyLjIzNC0uNDIyLjYwMS0uNDIyLjQwNyAwIC44ODcuMTI1IDEuMi4yODUgMCAwIC4wOS4wNTUuMTI1LS4wMjcuMDE1LS4wNDMuMTc1LS40MzMuMTkxLS40NzYuMDItLjA0My0uMDE2LS4wNzktLjA0Ny0uMDk4QTIuODQ1IDIuODQ1IDAgMCAwIDguNTYgMjFoLS4wOTRjLS44NjMgMC0xLjQ2OS40OC0xLjQ2OSAxLjE3MnYuMDEyYzAgLjcyNi42NjQuOTY0IDEuMjkgMS4xMjhsLjEuMDI4Yy40NTQuMTI5Ljg0NC4yMzguODQ0LjUzMXYuMDE2YzAgLjI3LS4yNTMuNDcyLS42NjQuNDcyLS4xNiAwLS42NjgtLjAwNC0xLjIxNC0uMzI0YTIuNDUgMi40NSAwIDAgMS0uMTU3LS4wOWMtLjAyNy0uMDE1LS4wOTMtLjA0My0uMTI1LjA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yMS4yNDYgMjQuNDZjLS4wMjcuMDcxLjAxMi4wODcuMDIuMDk5LjA5LjA1OC4xNzUuMDk3LjI2MS4xNDQuNDcuMjMuOTE0LjI5NyAxLjM4LjI5Ny45NCAwIDEuNTI3LS40NiAxLjUyNy0xLjIwN3YtLjAxNmMwLS42ODctLjY2LS45MzctMS4yODItMS4xMTdsLS4wODItLjAyM2MtLjQ2NS0uMTQtLjg3LS4yNjItLjg3LS41NDd2LS4wMTZjMC0uMjQyLjIzOC0uNDIyLjYwNS0uNDIyLjQwNiAwIC44ODYuMTI1IDEuMTk5LjI4NSAwIDAgLjA5LjA1NS4xMjUtLjAyNy4wMTYtLjA0My4xNzItLjQzMy4xOTEtLjQ3Ni4wMTYtLjA0My0uMDE1LS4wNzktLjA0Ny0uMDk4QTIuODU3IDIuODU3IDAgMCAwIDIyLjkyMiAyMWgtLjA5OGMtLjg2MyAwLTEuNDY1LjQ4LTEuNDY1IDEuMTcydi4wMTJjMCAuNzI2LjY2NC45NjQgMS4yOSAxLjEyOGwuMDk3LjAyOGMuNDU3LjEyOS44NDguMjM4Ljg0OC41MzF2LjAxNmMwIC4yNy0uMjU0LjQ3Mi0uNjY0LjQ3Mi0uMTYgMC0uNjY4LS4wMDQtMS4yMTUtLjMyNGEyLjQ1IDIuNDUgMCAwIDEtLjE1Ni0uMDljLS4wMi0uMDA4LS4wOTgtLjAzOS0uMTI1LjA0eiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0zMS40NjUgMjIuMjE5YTEuNzE0IDEuNzE0IDAgMCAwLS4zNi0uNjMzIDEuNzQgMS43NCAwIDAgMC0uNjAxLS40MyAyLjE4NyAyLjE4NyAwIDAgMC0uODQ4LS4xNTZjLS4zMTYgMC0uNjAxLjA1NS0uODQzLjE1NmExLjY3IDEuNjcgMCAwIDAtLjYwMi40M2MtLjE2NC4xNzYtLjI4MS4zOS0uMzYuNjMzYTIuNTQ0IDIuNTQ0IDAgMCAwLS4xMTcuNzg1YzAgLjI3Ny4wNC41NDMuMTE4Ljc4NWExLjY5MSAxLjY5MSAwIDAgMCAuOTYgMS4wNTljLjI0My4wOTcuNTI4LjE1Mi44NDQuMTUyLjMyIDAgLjYwNi0uMDUuODQ4LS4xNTIuMjM4LS4xMDIuNDQxLS4yNDYuNjAxLS40MjIuMTYtLjE4LjI4Mi0uMzk1LjM2LS42MzcuMDc4LS4yNDIuMTE3LS41MDQuMTE3LS43ODVzLS4wMzktLjU0My0uMTE3LS43ODVtLS43OS43ODVjMCAuNDIyLS4wODEuNzU4LS4yNS45OTItLjE2Ny4yMzQtLjQxNy4zNDgtLjc2OS4zNDgtLjM0NyAwLS41OTctLjExNC0uNzYxLS4zNDgtLjE2OC0uMjM0LS4yNS0uNTctLjI1LS45OTIgMC0uNDIyLjA4NS0uNzU4LjI1LS45ODguMTY0LS4yMzUuNDE0LS4zNDQuNzYxLS4zNDQuMzUyIDAgLjYwMi4xMS43Ny4zNDQuMTY4LjIzLjI1LjU2Ni4yNS45ODgiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzcuOTM0IDI0LjIzNGMtLjAyOC0uMDc0LS4xMDItLjA0Ny0uMTAyLS4wNDdhMS43NDMgMS43NDMgMCAwIDEtLjM2Ny4wOTggMi44OCAyLjg4IDAgMCAxLS40My4wMzFjLS4zODMgMC0uNjgzLS4xMDUtLjkwMi0uMzEyLS4yMTUtLjIxMS0uMzM2LS41NDctLjMzNi0xIDAtLjQxNC4xMS0uNzI3LjMtLjk2NS4xOTItLjIzNC40ODUtLjM1NS44NzYtLjM1NS4zMjQgMCAuNTc0LjAzNS44MzIuMTA5IDAgMCAuMDYyLjAyNy4wOS0uMDUuMDctLjE3Ny4xMi0uMzAyLjE5NS0uNDk3LjAyLS4wNTgtLjAzMS0uMDgyLS4wNS0uMDg2YTMuMjQgMy4yNCAwIDAgMC0uNTI0LS4xMjUgNC40MzUgNC40MzUgMCAwIDAtLjU5LS4wMzVjLS4zMzIgMC0uNjI1LjA1NS0uODguMTU2YTEuODQyIDEuODQyIDAgMCAwLS42MzYuNDI2Yy0uMTY4LjE4LS4yOTcuMzk1LS4zODMuNjM3YTIuMzE1IDIuMzE1IDAgMCAwLS4xMjkuNzg1YzAgLjYwNS4xNzYgMS4wOTQuNTI4IDEuNDUzLjM0Ny4zNi44Ny41NDMgMS41NTQuNTQzLjQwMyAwIC44MTctLjA3NCAxLjExNC0uMTg0IDAgMCAuMDU4LS4wMjcuMDM1LS4wODZ6IiBmaWxsPSIjRkZGIi8+PHBhdGggZD0iTTQxLjk2NSAyMi4wODJhMS41MiAxLjUyIDAgMCAwLS4zNDQtLjU3OCAxLjUxNiAxLjUxNiAwIDAgMC0uNTA0LS4zNiAyLjEwNSAyLjEwNSAwIDAgMC0uNzY1LS4xNDRjLS4zMzIgMC0uNjMzLjA1LS44OC4xNi0uMjQ1LjEwNi0uNDUyLjI1LS42MTMuNDM0LS4xNjQuMTgtLjI4NS4zOTgtLjM2My42NGEyLjYwNSAyLjYwNSAwIDAgMC0uMTE3Ljc5YzAgLjI4NS4wNDMuNTUuMTIxLjc5Mi4wODIuMjM5LjIxLjQ1NC4zODcuNjMuMTc1LjE3NS40MDIuMzEyLjY3Mi40MS4yNjUuMDk3LjU5My4xNDguOTY4LjE0NC43NyAwIDEuMTc2LS4xNiAxLjM0LS4yNDYuMDMxLS4wMTYuMDU5LS4wNDMuMDI0LS4xMTdsLS4xNzItLjQ1M2MtLjAyOC0uMDctLjEwMi0uMDQzLS4xMDItLjA0My0uMTkxLjA2Mi0uNDYuMTgzLTEuMDk0LjE4LS40MTQgMC0uNzIyLS4xMS0uOTE0LS4yOS0uMTk1LS4xOC0uMjkzLS40NDUtLjMwOC0uODJoMi42NjRzLjA3IDAgLjA3OC0uMDY2Yy4wMDQtLjAyOC4wOS0uNTA4LS4wNzgtMS4wNjNtLTIuNjUzLjUxNmMuMDM2LS4yMzUuMTA2LS40MzQuMjE1LS41ODIuMTY0LS4yMzUuNDEtLjM2Ljc2Mi0uMzYuMzUyIDAgLjU4Mi4xMjUuNzQ2LjM2LjExLjE1Mi4xNi4zNTUuMTguNTgyeiIgZmlsbD0iI0ZGRiIvPjxwYXRoIGQ9Ik0yMC40NTMgMjIuMDgyYTEuNTE3IDEuNTE3IDAgMCAwLS4zNC0uNTc4IDEuNDkgMS40OSAwIDAgMC0uNTA4LS4zNiAyLjA4MyAyLjA4MyAwIDAgMC0uNzYxLS4xNDRjLS4zMzIgMC0uNjM3LjA1LS44ODMuMTYtLjI0Mi4xMDYtLjQ1LjI1LS42MTMuNDM0YTEuNzggMS43OCAwIDAgMC0uMzYuNjQgMi42MDUgMi42MDUgMCAwIDAtLjExNy43OWMwIC4yODUuMDQuNTUuMTIxLjc5Mi4wNzguMjM5LjIxMS40NTQuMzg3LjYzLjE3Ni4xNzUuMzk4LjMxMi42NjguNDEuMjcuMDk3LjU5NC4xNDguOTY5LjE0NC43NyAwIDEuMTc1LS4xNiAxLjM0My0uMjQ2LjAzMi0uMDE2LjA1NS0uMDQzLjAyNC0uMTE3bC0uMTc2LS40NTNjLS4wMjctLjA3LS4xMDItLjA0My0uMTAyLS4wNDMtLjE5LjA2Mi0uNDYuMTgzLTEuMDkzLjE4LS40MTQgMC0uNzE5LS4xMS0uOTEtLjI5LS4yLS4xOC0uMjk3LS40NDUtLjMxMy0uODJoMi42NjhzLjA3IDAgLjA3OC0uMDY2YzAtLjAyOC4wOS0uNTA4LS4wODItMS4wNjNtLTIuNjUyLjUxNmMuMDM5LS4yMzUuMTEtLjQzNC4yMTUtLjU4Mi4xNjQtLjIzNS40MTQtLjM2Ljc2NS0uMzYuMzQ4IDAgLjU3OC4xMjUuNzQ2LjM2LjExLjE1Mi4xNi4zNTUuMTc2LjU4MnoiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTIuOTMgMjIuNDhjLS4xMS0uMDAzLS4yNDYtLjAwNy0uNDE0LS4wMDctLjIzIDAtLjQ1NC4wMjMtLjY2LjA3OC0uMjA4LjA1LS4zOTUuMTI5LS41NTUuMjM4LS4xNi4xMDYtLjI5My4yNDItLjM4Ny40MDZhMS4xMzUgMS4xMzUgMCAwIDAtLjE0NC41N2MwIC4yMi4wNDMuNDEuMTI1LjU2My4wNzguMTU2LjE5NS4yODUuMzQzLjM4Ny4xNDkuMTAxLjMzMi4xNzYuNTQzLjIxOS4yMTEuMDQzLjQ1LjA2Ni43MTEuMDY2LjI3NCAwIC41NDMtLjAyLjgwOS0uMDYzLjI2MS0uMDQyLjU4Mi0uMTAxLjY3Mi0uMTIuMDktLjAyLjE4Ny0uMDQ0LjE4Ny0uMDQ0LjA2Ny0uMDE1LjA1OS0uMDgyLjA1OS0uMDgydi0yLjI1N2MwLS40OTctLjE0NS0uODY0LS40MjItMS4wOTQtLjI4MS0uMjI3LS42OTUtLjM0LTEuMjI3LS4zNC0uMTk5IDAtLjUyLjAyMy0uNzE1LjA2MyAwIDAtLjU4Mi4xMDEtLjgyLjI3NyAwIDAtLjA1NS4wMzEtLjAyMy4wOThsLjE4Ny40NjhjLjAyNC4wNjMuMDg2LjA0My4wODYuMDQzcy4wMjQtLjAwOC4wNDctLjAyM2MuNTEyLS4yNTggMS4xNi0uMjUgMS4xNi0uMjUuMjkgMCAuNTEyLjA1NC42Ni4xNi4xNDUuMTA1LjIyLjI1OC4yMi41OXYuMTA1Yy0uMjMxLS4wMzEtLjQ0Mi0uMDUtLjQ0Mi0uMDVtLTEuMDYzIDEuNzM4YS41MzguNTM4IDAgMCAxLS4xNTItLjE0OS41Ny41NyAwIDAgMS0uMDc4LS4zMmMwLS4yMTkuMDc4LS4zNzEuMjM4LS40NzctLjAwNCAwIC4yMy0uMTg3Ljc3My0uMTguMzguMDA1LjcyMy4wNTUuNzIzLjA1NXYxLjEyNXMtLjM0LjA2Ny0uNzE5LjA4NmMtLjU0My4wMzItLjc4NS0uMTQtLjc4NS0uMTQiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMzQuNzYyIDIxLjE2OGMuMDItLjA1OS0uMDI0LS4wODItLjA0My0uMDlhMi41MjYgMi41MjYgMCAwIDAtLjQ0Ni0uMDc0Yy0uMzM2LS4wMi0uNTIuMDM1LS42ODcuMTA1LS4xNjguMDctLjM1Mi4xODgtLjQ1LjMybC0uMDAzLS4zMTJjMC0uMDQzLS4wMzEtLjA3OC0uMDc0LS4wNzhoLS42ODRhLjA3Ni4wNzYgMCAwIDAtLjA3OC4wNzh2My44MDVjMCAuMDQzLjAzOS4wNzguMDgyLjA3OGguN2EuMDguMDggMCAwIDAgLjA4MS0uMDc4di0xLjg5OWMwLS4yNTcuMDI4LS41MTEuMDg2LS42NzFhLjk2NC45NjQgMCAwIDEgLjIzNC0uMzc1Ljg2Ljg2IDAgMCAxIC4zMzMtLjE5MiAxLjM1IDEuMzUgMCAwIDEgLjM1NS0uMDQ3Yy4xNCAwIC4yOTMuMDM1LjI5My4wMzUuMDUuMDA0LjA3OC0uMDI3LjA5OC0uMDcuMDQ2LS4xMTMuMTc1LS40NjUuMjAzLS41MzUiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMjguMjAzIDE5LjEwNWExLjk1IDEuOTUgMCAwIDAtLjYyNS0uMDljLS40ODQgMC0uODYzLjEzNy0xLjEyOS40MDctLjI2NS4yNjUtLjQ0NS42NzYtLjUzOSAxLjIxbC0uMDQ3LjM2NGgtLjYwNXMtLjA3NC0uMDA0LS4wOS4wNzhsLS4wOTguNTU1Yy0uMDA4LjA1NS4wMTYuMDg2LjA4Ni4wODZoLjU5bC0uNTk4IDMuMzM2YTQuNDMgNC40MyAwIDAgMS0uMTYuNjYgMS40MjIgMS40MjIgMCAwIDEtLjE4Ny4zNzkuNTA1LjUwNSAwIDAgMS0uMjQyLjE4NyAxIDEgMCAwIDEtLjMxNy4wNDMuOTcuOTcgMCAwIDEtLjIxLS4wMjMuNTguNTggMCAwIDEtLjE0NS0uMDQzcy0uMDctLjAyNy0uMDk4LjA0M2MtLjAyMy4wNTUtLjE4LjQ4OC0uMTk1LjUzOS0uMDIuMDU1LjAwNC4wOTQuMDM5LjEwNS4wNzguMDMyLjEzNy4wNDcuMjQyLjA3NS4xNDguMDM1LjI3My4wMzUuMzkuMDM1LjI0NyAwIC40Ny0uMDM1LjY1Ny0uMTAyLjE4Ny0uMDY2LjM0OC0uMTgzLjQ5Mi0uMzQ0LjE1Ni0uMTcxLjI1NC0uMzUxLjM0OC0uNTkzLjA5LS4yNDYuMTY4LS41NDcuMjM0LS44OTlsLjU5OC0zLjM5OGguODc5cy4wNzQuMDA0LjA5LS4wNzhsLjA5Ny0uNTU1Yy4wMDgtLjA1LS4wMTUtLjA4Ni0uMDg2LS4wODZoLS44NTFjLjAwNC0uMDIuMDU4LS41MDQuMTU2LS43ODVhLjc4OC43ODggMCAwIDEgLjE4Ny0uMjg1LjU2Ni41NjYgMCAwIDEgLjIyMy0uMTQgMS4xNjUgMS4xNjUgMCAwIDEgLjUwNC0uMDJjLjA4Mi4wMi4xMTcuMDI3LjEzNy4wMzUuMDkuMDI3LjA5NyAwIC4xMTctLjA0M2wuMjAzLS41NTljLjAyMy0uMDU4LS4wMjctLjA4Ni0uMDQ3LS4wOTQiIGZpbGw9IiNGRkYiLz48cGF0aCBkPSJNMTUuODk4IDI0LjkxOGMwIC4wNDctLjAzLjA4Mi0uMDc0LjA4MmgtLjcwN2MtLjA0NyAwLS4wNzgtLjAzNS0uMDc4LS4wODJ2LTUuODM2YzAtLjA0Ny4wMzEtLjA4Mi4wNzgtLjA4MmguNzA3Yy4wNDMgMCAuMDc0LjA0LjA3NC4wODJ6IiBmaWxsPSIjRkZGIi8+PC9nPjxtZXRhZGF0YT48cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiIHhtbG5zOnJkZnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDEvcmRmLXNjaGVtYSMiIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyI+PHJkZjpEZXNjcmlwdGlvbiBhYm91dD0iaHR0cHM6Ly9pY29uc2NvdXQuY29tL2xlZ2FsI2xpY2Vuc2VzIiBkYzp0aXRsZT0ic2FsZXNmb3JjZSIgZGM6ZGVzY3JpcHRpb249InNhbGVzZm9yY2UiIGRjOnB1Ymxpc2hlcj0iSWNvbnNjb3V0IiBkYzpkYXRlPSIyMDE3LTEyLTE1IiBkYzpmb3JtYXQ9ImltYWdlL3N2Zyt4bWwiIGRjOmxhbmd1YWdlPSJlbiI+PGRjOmNyZWF0b3I+PHJkZjpCYWc+PHJkZjpsaT5JY29uczg8L3JkZjpsaT48L3JkZjpCYWc+PC9kYzpjcmVhdG9yPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L21ldGFkYXRhPjwvc3ZnPg=="}}, "spec": {"source": {"flow": {"from": {"uri": "salesforce:camelTestTopic", "parameters": {"notifyForFields": "ALL", "updateTopic": "true", "notifyForOperationCreate": "true", "notifyForOperationUpdate": "false", "notifyForOperationDelete": "false", "notifyForOperationUndelete": "false", "sObjectQuery": "SELECT Id, Name, Email, Phone FROM Contact"}, "steps": [{"to": "log:info"}]}}}, "sink": {"ref": {"apiVersion": "messaging.knative.dev/v1beta1", "kind": "InMemoryChannel", "name": "salesforce"}}}},\n  {"apiVersion":"sources.knative.dev/v1alpha1","kind":"CamelSource","metadata":{"name":"slack","labels":{"console.openshift.io/event-source":"true"},"annotations":{"console.openshift.io/icon":"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaWQ9IkxheWVyXzEiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDUxMiA1MTI7IiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMyNUQzNjY7fQoJLnN0MXtmaWxsOiNGRkZGRkY7fQoJLnN0MntmaWxsOiNGRjAwMDA7fQoJLnN0M3tmaWxsOiMzRDVBOTg7fQoJLnN0NHtmaWxsOnVybCgjU1ZHSURfMV8pO30KCS5zdDV7ZmlsbDp1cmwoI1NWR0lEXzJfKTt9Cgkuc3Q2e2ZpbGw6IzU1QURFRTt9Cgkuc3Q3e2ZpbGw6IzFFOTZDODt9Cgkuc3Q4e2ZpbGw6I0E5QzlERDt9Cgkuc3Q5e2ZpbGw6I0M4REFFQTt9Cgkuc3QxMHtmaWxsOm5vbmU7fQoJLnN0MTF7ZmlsbDojNDc4N0YzO30KCS5zdDEye2ZpbGw6I0RDNDgzQzt9Cgkuc3QxM3tmaWxsOiNGRkNFNDM7fQoJLnN0MTR7ZmlsbDojMTQ5RjVDO30KCS5zdDE1e2ZpbGw6I0NFMUU1Qjt9Cgkuc3QxNntmaWxsOiM3MkM1Q0Q7fQoJLnN0MTd7ZmlsbDojREZBMjJGO30KCS5zdDE4e2ZpbGw6IzNDQjE4Nzt9Cgkuc3QxOXtmaWxsOiMyNDhDNzM7fQoJLnN0MjB7ZmlsbDojMzkyNTM4O30KCS5zdDIxe2ZpbGw6I0JCMjQyQTt9Cgkuc3QyMntmaWxsOm5vbmU7c3Ryb2tlOiMzQ0IxODc7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0MjN7ZmlsbDojMDA5QTU3O30KCS5zdDI0e2ZpbGw6I0ZDQ0QzNzt9Cgkuc3QyNXtmaWxsOiMyNzcxRjA7fQo8L3N0eWxlPjxnPjxwYXRoIGNsYXNzPSJzdDE1IiBkPSJNNTAxLjgsMjc0TDUwMS44LDI3NGMtNy42LTIzLjMtMzIuNi0zNi4xLTU2LTI4LjVMOTYuMiwzNTkuMWMtMjMuMyw3LjYtMzYuMSwzMi42LTI4LjUsNTZsMCwwICAgYzcuNiwyMy4zLDMyLjYsMzYuMSw1NiwyOC41bDM0OS42LTExMy42QzQ5Ni42LDMyMi40LDUwOS40LDI5Ny4zLDUwMS44LDI3NHoiLz48cGF0aCBjbGFzcz0ic3QxNiIgZD0iTTQ0My41LDk3LjdsLTAuMi0wLjVjLTcuNi0yMy4zLTMyLjYtMzYuMS01Ni0yOC41TDM4LjcsMTgyLjFjLTIzLjMsNy42LTM2LjEsMzIuNi0yOC41LDU2bDAuMiwwLjUgICBjNy42LDIzLjMsMzIuNiwzNi4xLDU2LDI4LjVsMzQ4LjYtMTEzLjNDNDM4LjMsMTQ2LjEsNDUxLDEyMS4xLDQ0My41LDk3Ljd6Ii8+PHBhdGggY2xhc3M9InN0MTciIGQ9Ik00NDMuNiwzODguM0wzMjkuOSwzOC43Yy03LjYtMjMuMy0zMi42LTM2LjEtNTYtMjguNXYwYy0yMy4zLDcuNi0zNi4xLDMyLjYtMjguNSw1NmwxMTMuNiwzNDkuNiAgIGM3LjYsMjMuMywzMi42LDM2LjEsNTYsMjguNWgwQzQzOC40LDQzNi43LDQ1MS4yLDQxMS42LDQ0My42LDM4OC4zeiIvPjxwYXRoIGNsYXNzPSJzdDE4IiBkPSJNMjY3LDQ0NS43TDE1My43LDk3LjFjLTcuNi0yMy4zLTMyLjYtMzYuMS01Ni0yOC41bC0wLjUsMC4yYy0yMy4zLDcuNi0zNi4xLDMyLjYtMjguNSw1NmwxMTMuMywzNDguNiAgIGM3LjYsMjMuMywzMi42LDM2LjEsNTYsMjguNWwwLjUtMC4yQzI2MS45LDQ5NC4xLDI3NC42LDQ2OSwyNjcsNDQ1Ljd6Ii8+PHJlY3QgY2xhc3M9InN0MTkiIGhlaWdodD0iODkuNCIgdHJhbnNmb3JtPSJtYXRyaXgoLTAuOTUxIDAuMzA5MSAtMC4zMDkxIC0wLjk1MSAzMzEuOTg5NiAzNDAuMjQ1KSIgd2lkdGg9Ijg5LjQiIHg9Ijk0LjQiIHk9IjE1MS43Ii8+PHJlY3QgY2xhc3M9InN0MjAiIGhlaWdodD0iODguOCIgdHJhbnNmb3JtPSJtYXRyaXgoMC45NTEgLTAuMzA5MSAwLjMwOTEgMC45NTEgLTEwNS43NDk4IDc5LjAzMDEpIiB3aWR0aD0iODkuNCIgeD0iMTUxLjgiIHk9IjMyOC44Ii8+PHJlY3QgY2xhc3M9InN0MjEiIGhlaWdodD0iODguOCIgdHJhbnNmb3JtPSJtYXRyaXgoMC45NTEgLTAuMzA5MSAwLjMwOTEgMC45NTEgLTc5LjMyNSAxMzAuODY4OSkiIHdpZHRoPSI4OC44IiB4PSIzMjguOSIgeT0iMjcxLjMiLz48L2c+PC9zdmc+"}},"spec":{"source":{"flow":{"from":{"uri":"slack:general","parameters":{"token":"{{slack.token}}"},"steps":[{"marshal":{"json":{}}},{"to":"log:info"}]}},"integration":{"configuration":[{"type":"secret","value":"slack"}],"dependencies":["camel:jackson"]}},"sink":{"ref":{"apiVersion":"messaging.knative.dev/v1beta1","kind":"InMemoryChannel","name":"slack"}}}},\n  {"apiVersion":"sources.knative.dev/v1alpha1","kind":"CamelSource","metadata":{"name":"aws-kinesis","labels":{"console.openshift.io/event-source":"true"},"annotations":{"console.openshift.io/icon":"data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTYgMzA4LjIzNDAxIj48dGl0bGU+YXdzLWtpbmVzaXM8L3RpdGxlPjxwYXRoIGQ9Ik0wLDE3Mi4wODdsMTI3Ljc1NCw1OC44MSwxMjcuNzUyLTU4LjgxLTEyNy43NTItNS4yOTNaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwIDAuMDAwMDUpIiBmaWxsPSIjZmNiZjkyIi8+PHBhdGggZD0iTTEyOC4xNDcsMCwuMDU5LDYzLjg4MXY5MC4xMzZIMTUzLjY0OFYxMi43NTFaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwIDAuMDAwMDUpIiBmaWxsPSIjOWQ1MDI1Ii8+PHBhdGggZD0iTS4wNTksMjE3LjU1OWwxMjguMTYyLDkwLjY3NUwyNTYsMjE3LjU1OSwxMjcuOTQ1LDE5OC45MjZaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwIDAuMDAwMDUpIiBmaWxsPSIjZmNiZjkyIi8+PHBhdGggZD0iTTEyOC4xNDYsMTU0LjAxN2g2Ny41NzdWNTcuODM2TDE3NS45OSw0OS45NDMsMTI4LjE0Niw2My44OThaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwIDAuMDAwMDUpIiBmaWxsPSIjOWQ1MDI1Ii8+PHBhdGggZD0iTTE3NS45OSwxNTQuMDE3aDUyLjIzM1Y5MS42MzJsLTE0Ljk0LTQuNDgxLTM3LjI5Myw2LjMzWiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAwLjAwMDA1KSIgZmlsbD0iIzlkNTAyNSIvPjxwYXRoIGQ9Ik0yMTMuMjgyLDgyLjI2djcxLjc1N2g0Mi4yMjRMMjU2LDgxLjk0MWwtMTIuODI2LTUuMTI0WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAwLjAwMDA1KSIgZmlsbD0iIzlkNTAyNSIvPjxwYXRoIGQ9Ik0xMjguMTQ3LDBWMTU0LjAxN2gyNS41VjEyLjc1MVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMC4wMDAwNSkiIGZpbGw9IiNmNjg1MzQiLz48cGF0aCBkPSJNMTk1LjcyNCw1Ny44MzZsLTE5LjczMy03Ljg5NFYxNTQuMDE3aDE5LjczMloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMC4wMDAwNSkiIGZpbGw9IiNmNjg1MzQiLz48cGF0aCBkPSJNMjI4LjIyNCw5MS42MzJsLTE0Ljk0MS00LjQ4djY2Ljg2NWgxNC45NFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMC4wMDAwNSkiIGZpbGw9IiNmNjg1MzQiLz48cGF0aCBkPSJNMjQzLjE3NCwxNTQuMDE3SDI1NlY4MS45NDFsLTEyLjgyNi01LjEyNFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMC4wMDAwNSkiIGZpbGw9IiNmNjg1MzQiLz48cGF0aCBkPSJNMTI3Ljc1NCwxODQuODYzdjQ2LjAzM2wxMjcuNzUyLTMxLjg0NFYxNzIuMDg3WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCAwLjAwMDA1KSIgZmlsbD0iI2Y2ODUzNCIvPjxwYXRoIGQ9Ik0xMjcuNzU0LDI2Mi43ODF2NDUuNDUzTDI1NiwyNDQuMTE0VjIxNy41NloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMC4wMDAwNSkiIGZpbGw9IiNmNjg1MzQiLz48cGF0aCBkPSJNLjA1OSwyNDQuMzlsMTI3LjY5NSw2My44NDRWMjYyLjQ0OEwuMDU4LDIxNy41NThaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwIDAuMDAwMDUpIiBmaWxsPSIjOWQ1MDI1Ii8+PHBhdGggZD0iTTAsMTk5LjA1MWwxMjcuNzU0LDMxLjg0NVYxODQuODYyTDAsMTcyLjA4NloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMC4wMDAwNSkiIGZpbGw9IiM5ZDUwMjUiLz48L3N2Zz4="}},"spec":{"source":{"flow":{"from":{"uri":"aws-kinesis:stream","parameters":{"secretKey":"{{aws.kinesis.secretKey}}","accessKey":"{{aws.kinesis.accessKey}}","region":"{{aws.kinesis.region}}"},"steps":[{"marshal":{"json":{}}},{"to":"log:info"}]}},"integration":{"configuration":[{"type":"secret","value":"aws-kinesis"}],"dependencies":["camel:jackson","camel:camel-aws-kinesis","mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.10.4"]}},"sink":{"ref":{"apiVersion":"messaging.knative.dev/v1beta1","kind":"InMemoryChannel","name":"aws-kinesis"}}}},\n  {"apiVersion":"sources.knative.dev/v1alpha1","kind":"CamelSource","metadata":{"name":"jira","labels": {"console.openshift.io/event-source": "true"}, "annotations": {"console.openshift.io/icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjU2cHgiIGhlaWdodD0iMjU2cHgiIHZpZXdCb3g9IjAgMCAyNTYgMjU2IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaWRZTWlkIj4KICAgIDxkZWZzPgogICAgICAgIDxsaW5lYXJHcmFkaWVudCB4MT0iOTguMDMwODY3NSUiIHkxPSIwLjE2MDU5OTU3MiUiIHgyPSI1OC44ODc3MDYyJSIgeTI9IjQwLjc2NTUyNDYlIiBpZD0ibGluZWFyR3JhZGllbnQtMSI+CiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMwMDUyQ0MiIG9mZnNldD0iMTglIj48L3N0b3A+CiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMyNjg0RkYiIG9mZnNldD0iMTAwJSI+PC9zdG9wPgogICAgICAgIDwvbGluZWFyR3JhZGllbnQ+CiAgICAgICAgPGxpbmVhckdyYWRpZW50IHgxPSIxMDAuNjY1MjQ3JSIgeTE9IjAuNDU1MDMyMTIlIiB4Mj0iNTUuNDAxODA5NSUiIHkyPSI0NC43MjY5ODA3JSIgaWQ9ImxpbmVhckdyYWRpZW50LTIiPgogICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjMDA1MkNDIiBvZmZzZXQ9IjE4JSI+PC9zdG9wPgogICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjMjY4NEZGIiBvZmZzZXQ9IjEwMCUiPjwvc3RvcD4KICAgICAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPC9kZWZzPgogICAgPGc+CgkJCQk8cGF0aCBkPSJNMjQ0LjY1Nzc3OCwwIEwxMjEuNzA2NjY3LDAgQzEyMS43MDY2NjcsMTQuNzIwMTA0NiAxMjcuNTU0MjA1LDI4LjgzNzMxMiAxMzcuOTYyODkxLDM5LjI0NTk5NzcgQzE0OC4zNzE1NzcsNDkuNjU0NjgzNSAxNjIuNDg4Nzg0LDU1LjUwMjIyMjIgMTc3LjIwODg4OSw1NS41MDIyMjIyIEwxOTkuODU3Nzc4LDU1LjUwMjIyMjIgTDE5OS44NTc3NzgsNzcuMzY4ODg4OSBDMTk5Ljg3NzM5MSwxMDcuOTk0MTU1IDIyNC42OTkxNzgsMTMyLjgxNTk0MyAyNTUuMzI0NDQ0LDEzMi44MzU1NTYgTDI1NS4zMjQ0NDQsMTAuNjY2NjY2NyBDMjU1LjMyNDQ0NCw0Ljc3NTYyOTM0IDI1MC41NDg4MTUsMy42MDcyMjAwMWUtMTYgMjQ0LjY1Nzc3OCwwIFoiIGZpbGw9IiMyNjg0RkYiPjwvcGF0aD4KCQkJCTxwYXRoIGQ9Ik0xODMuODIyMjIyLDYxLjI2MjIyMjIgTDYwLjg3MTExMTEsNjEuMjYyMjIyMiBDNjAuODkwNzIzOCw5MS44ODc0ODg4IDg1LjcxMjUxMTIsMTE2LjcwOTI3NiAxMTYuMzM3Nzc4LDExNi43Mjg4ODkgTDEzOC45ODY2NjcsMTE2LjcyODg4OSBMMTM4Ljk4NjY2NywxMzguNjY2NjY3IEMxMzkuMDI1OTA1LDE2OS4yOTE5MjMgMTYzLjg2MzYwNywxOTQuMDk3ODAzIDE5NC40ODg4ODksMTk0LjA5Nzc3OCBMMTk0LjQ4ODg4OSw3MS45Mjg4ODg5IEMxOTQuNDg4ODg5LDY2LjAzNzg1MTYgMTg5LjcxMzI2LDYxLjI2MjIyMjIgMTgzLjgyMjIyMiw2MS4yNjIyMjIyIFoiIGZpbGw9InVybCgjbGluZWFyR3JhZGllbnQtMSkiPjwvcGF0aD4KCQkJCTxwYXRoIGQ9Ik0xMjIuOTUxMTExLDEyMi40ODg4ODkgTDAsMTIyLjQ4ODg4OSBDMy43NTM5MTM2MmUtMTUsMTUzLjE0MTkyIDI0Ljg0OTE5MTMsMTc3Ljk5MTExMSA1NS41MDIyMjIyLDE3Ny45OTExMTEgTDc4LjIyMjIyMjIsMTc3Ljk5MTExMSBMNzguMjIyMjIyMiwxOTkuODU3Nzc4IEM3OC4yNDE3NjcsMjMwLjQ1NTMyIDEwMy4wMjAyODUsMjU1LjI2NTY0NyAxMzMuNjE3Nzc4LDI1NS4zMjQ0NDQgTDEzMy42MTc3NzgsMTMzLjE1NTU1NiBDMTMzLjYxNzc3OCwxMjcuMjY0NTE4IDEyOC44NDIxNDgsMTIyLjQ4ODg4OSAxMjIuOTUxMTExLDEyMi40ODg4ODkgWiIgZmlsbD0idXJsKCNsaW5lYXJHcmFkaWVudC0yKSI+PC9wYXRoPgoJCTwvZz4KPC9zdmc+Cg=="}},"spec":{"source":{"integration":{"configuration":[{"type":"secret","value":"jira"}],"dependencies":["camel:jackson","mvn:org.apache.httpcomponents:httpclient:jar:4.5.12","mvn:com.atlassian.jira:jira-rest-java-client-core:jar:5.2.1","mvn:com.atlassian.jira:jira-rest-java-client-api:jar:5.2.1"]},"flow":{"from":{"uri":"jira:newIssues","parameters":{"jiraUrl":"{{jira.url}}","username":"{{jira.username}}","password":"{{jira.password}}","jql":"{{jira.jql}}","delay":"500"},"steps":[{"to":"log:received?showAll=true&multiline=true"},{"marshal":{"json":{"disable-features":"FAIL_ON_EMPTY_BEANS"}}}]}}},"sink":{"ref":{"apiVersion":"messaging.knative.dev/v1alpha1","kind":"InMemoryChannel","name":"jira"}}}}\n]',
+        capabilities: 'Basic Install',
+        'olm.operatorNamespace': 'openshift-operators',
+        containerImage:
+          'quay.io/openshift-knative/knative-eventing-sources-camel-source-controller:v0.15.0',
+        createdAt: '2020-07-16T09:15:43+02:00',
+        categories: 'Integration & Delivery',
+        description:
+          'The Knative Camel addon provides a collection of eventing sources from the popular integration framework Apache Camel.',
+        'olm.operatorGroup': 'global-operators',
+      },
+      selfLink:
+        '/apis/operators.coreos.com/v1alpha1/namespaces/my-app/clusterserviceversions/knative-camel-operator.v0.15.0-20200716091543',
+      resourceVersion: '108547',
+      name: 'knative-camel-operator.v0.15.0-20200716091543',
+      uid: '700a45fe-1ebe-4432-a6a7-2c1ae4391a1d',
+      creationTimestamp: '2020-07-16T15:18:52Z',
+      generation: 1,
+      namespace: 'my-app',
+      labels: {
+        'console.openshift.io/event-source-provider': 'true',
+        'olm.api.c766370cb4da0c0c': 'required',
+        'olm.api.cf25648aa5bc41fd': 'provided',
+        'olm.copiedFrom': 'openshift-operators',
+      },
+    },
+    spec: {
+      install: {
+        strategy: 'Deployment',
+        spec: {
+          permissions: [
+            {
+              serviceAccountName: '',
+              rules: [{ apiGroups: [], resources: [], verbs: [] }],
+            },
+          ],
+          deployments: [{ name: '', spec: {} }],
+        },
+      },
+      installModes: [{ type: InstallModeType.InstallModeTypeAllNamespaces, supported: true }],
+      customresourcedefinitions: {
+        owned: [
+          {
+            description: 'Represents a Knative Source based on Apache Camel',
+            displayName: 'Camel Source',
+            kind: 'CamelSource',
+            name: 'camelsources.sources.knative.dev',
+            version: 'v1alpha1',
+          },
+        ],
+        required: [
+          {
+            description: 'Represents a Camel K Integration',
+            displayName: 'Camel K Integration',
+            kind: 'Integration',
+            name: 'integrations.camel.apache.org',
+            version: 'v1',
+          },
+        ],
+      },
+      apiservicedefinitions: {},
+      keywords: ['serverless', 'eventing', 'apache camel', 'camel k'],
+      displayName: 'Knative Apache Camel Operator',
+      provider: { name: 'Red Hat' },
+      maturity: 'alpha',
+      version: '0.15.0-20200716091543',
+      minKubeVersion: '1.11.0',
+      links: [
+        { name: 'Knative Eventing Contrib', url: 'https://github.com/knative/eventing-contrib' },
+        { name: 'Documentation', url: 'https://www.knative.dev/docs/' },
+      ],
+      maintainers: [{ email: 'knative@redhat.com', name: 'Knative Team' }],
+      description:
+        'The Knative Camel addon provides a collection of eventing sources from the popular integration framework [Apache Camel](http://camel.apache.org/).\nSources are based on [Camel K integrations](https://github.com/apache/camel-k), a subproject of Apache Camel for running integration code in the cloud.\n\nFor documentation on using Knative Camel Sources, see the\n[Camel Source section](https://knative.dev/docs/eventing/samples/apache-camel-source/) of the\n[Knative documentation site](https://www.knative.dev/docs).\n\nThe operator requires Camel K 1.0.0 to be installed in any namespace where you want to run Camel eventing sources. Please, refer to the\n[Camel K documentation](https://github.com/apache/camel-k) for installation instructions.\n\nKnative Serving and Eventing are also required for installing this operator.\n',
+      selector: { matchLabels: { name: 'knative-camel' } },
+      labels: { name: 'knative-camel' },
     },
   },
 ];

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -4,15 +4,6 @@ import { coFetch } from '@console/internal/co-fetch';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { K8sKind, kindToAbbr, referenceForModel } from '@console/internal/module/k8s';
 import { chart_color_red_300 as knativeEventingColor } from '@patternfly/react-tokens';
-import {
-  EventSourceContainerModel,
-  EventSourceApiServerModel,
-  EventSourceSinkBindingModel,
-  EventSourceCamelModel,
-  EventSourcePingModel,
-  EventSourceKafkaModel,
-  EventSourceCronJobModel,
-} from '../models';
 
 interface EventSourcetData {
   loaded: boolean;
@@ -24,29 +15,6 @@ const eventSourceData: EventSourcetData = {
   loaded: false,
   eventSourceModels: [],
   eventSourceChannels: [],
-};
-
-// To order sources with known followed by CamelSource and everything else
-export const orderedEventSourceModelData = (allModels: K8sKind[]): K8sKind[] => {
-  const sortModels = _.orderBy(allModels, ['kind'], ['asc']);
-  const knownSourcesList = [
-    EventSourceApiServerModel.kind,
-    EventSourceContainerModel.kind,
-    EventSourceCronJobModel.kind,
-    EventSourceKafkaModel.kind,
-    EventSourcePingModel.kind,
-    EventSourceSinkBindingModel.kind,
-  ];
-  const knownSourcesCrd = _.filter(sortModels, (model) => knownSourcesList.includes(model.kind));
-  const camelSourcesCrd = _.filter(
-    sortModels,
-    (model) => model?.kind === EventSourceCamelModel.kind,
-  );
-  const dynamicSourcesCrd = _.filter(
-    sortModels,
-    (model) => !knownSourcesList.includes(model.kind) && model.kind !== EventSourceCamelModel.kind,
-  );
-  return [...knownSourcesCrd, ...camelSourcesCrd, ...dynamicSourcesCrd];
 };
 
 export const fetchEventSourcesCrd = async () => {
@@ -93,7 +61,7 @@ export const fetchEventSourcesCrd = async () => {
       [],
     );
 
-    eventSourceData.eventSourceModels = orderedEventSourceModelData(allModels);
+    eventSourceData.eventSourceModels = allModels;
   } catch (err) {
     // show warning if there is an error fetching the CRDs
     // eslint-disable-next-line no-console
@@ -172,8 +140,7 @@ export const hideDynamicEventSourceCard = () =>
   eventSourceData.eventSourceModels && eventSourceData.eventSourceModels.length > 0;
 
 export const fetchChannelsCrd = async () => {
-  const url =
-    '/api/kubernetes/apis/apiextensions.k8s.io/v1/customresourcedefinitions?labelSelector=messaging.knative.dev/subscribable=true';
+  const url = 'api/console/knative-channels';
   try {
     const res = await coFetch(url);
     const resolvedRes = await res.json();

--- a/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
@@ -1,4 +1,5 @@
-import { kindForReference } from '@console/internal/module/k8s';
+import { kindForReference, K8sResourceKind } from '@console/internal/module/k8s';
+import { isValidUrl } from '@console/shared';
 import * as apiServerSourceImg from '../imgs/logos/apiserversource.png';
 import * as camelSourceImg from '../imgs/logos/camelsource.svg';
 import * as containerSourceImg from '../imgs/logos/containersource.png';
@@ -13,8 +14,9 @@ import {
   EventSourceKafkaModel,
   EventSourcePingModel,
 } from '../models';
+import { EVENT_SOURCE_ICON } from '../const';
 
-export const getKnativeEventSourceIcon = (kind: string): string => {
+const getEventSourceIconFromKind = (kind: string): string => {
   switch (kindForReference(kind)) {
     case EventSourceApiServerModel.kind:
       return apiServerSourceImg;
@@ -30,4 +32,10 @@ export const getKnativeEventSourceIcon = (kind: string): string => {
     default:
       return eventSourceImg;
   }
+};
+
+export const getEventSourceIcon = (kind: string, obj?: K8sResourceKind) => {
+  return obj && isValidUrl(obj.metadata?.annotations?.[EVENT_SOURCE_ICON])
+    ? obj.metadata?.annotations?.[EVENT_SOURCE_ICON]
+    : getEventSourceIconFromKind(kind);
 };

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { K8sResourceKind, PodKind, referenceForModel } from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { KNATIVE_SERVING_LABEL } from '../const';
 import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
 import {
@@ -13,6 +14,7 @@ import {
   EventingTriggerModel,
   KafkaModel,
   KafkaTopicModel,
+  CamelIntegrationModel,
 } from '../models';
 
 export type KnativeItem = {
@@ -154,6 +156,23 @@ export const knativeEventingResourcesBroker = (namespace: string): FirehoseResou
   return knativeResource;
 };
 
+const EVENT_SOURCE_PROVIDER_CSV = 'console.openshift.io/event-source-provider';
+
+export const clusterServiceVersionResource = (namespace: string): FirehoseResource => {
+  return {
+    isList: true,
+    kind: referenceForModel(ClusterServiceVersionModel),
+    namespace,
+    prop: ClusterServiceVersionModel.plural,
+    selector: {
+      matchLabels: {
+        [EVENT_SOURCE_PROVIDER_CSV]: 'true',
+      },
+    },
+    optional: true,
+  };
+};
+
 export const knativeServingResourcesRevisionWatchers = (
   namespace: string,
 ): WatchK8sResources<any> => {
@@ -240,6 +259,19 @@ export const knativeEventingTriggerResourceWatchers = (namespace: string) => {
     [EventingTriggerModel.plural]: {
       isList: true,
       kind: referenceForModel(EventingTriggerModel),
+      namespace,
+      optional: true,
+    },
+  };
+};
+
+export const knativeCamelIntegrationsResourceWatchers = (
+  namespace: string,
+): WatchK8sResources<any> => {
+  return {
+    [CamelIntegrationModel.plural]: {
+      isList: true,
+      kind: referenceForModel(CamelIntegrationModel),
       namespace,
       optional: true,
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4245

**Analysis / Root cause**: 
User can't visualise camelK connectors in create EventSource flow and topology

**Solution Description**: 
Enable camel connectors to visualise as selector in eventSource creation view with icons and yaml Editors and visualise it in topology view

**Screen shots / Gifs for design review**: 
- Gif:

![Jul-16-2020 20-50-36](https://user-images.githubusercontent.com/5129024/87689915-69b21b00-c7a6-11ea-80bc-ba8a6765e9b6.gif)


- Creation flow:

![image](https://user-images.githubusercontent.com/5129024/87690025-8cdcca80-c7a6-11ea-9545-2ec7d8a1e4bd.png)

- Topology flow

![image](https://user-images.githubusercontent.com/5129024/87762628-10db9480-c831-11ea-9fe5-5895b332f0a2.png)

cc @openshift/team-devconsole-ux @rachael-phillips

**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/87705522-a3d9e780-c7bb-11ea-9c52-8213ca2fd4ca.png)


**Test Setup**
- oc apply -f  {file:  https://gist.github.com/nicolaferraro/68afc4e07cfa7ef1a10f926967b76063 } on 4.4 Cluster (dependency is on 4.4 cluster for testing now as knative-camel operator in operator Hub doesn't have `alm-examples` for camel connectors and to test here have installed via operator source which works till 4.4)
- Install Serverless/Knative camel (custom) will show up in operator hub post applying above

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


