### PR TITLE
Bug 1857310: Give current line number more contrast in YAML editor

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -6,11 +6,7 @@ import {
 import { getLanguageService, TextDocument } from 'yaml-language-server';
 import { openAPItoJSONSchema } from '@console/internal/module/k8s/openapi-to-json-schema';
 import { getStoredSwagger } from '@console/internal/module/k8s/swagger';
-import {
-  global_BackgroundColor_100 as lineNumberActiveForeground,
-  global_BackgroundColor_200 as lineNumberForeground,
-  global_BackgroundColor_dark_100 as editorBackground,
-} from '@patternfly/react-tokens';
+import { global_BackgroundColor_dark_100 as editorBackground } from '@patternfly/react-tokens';
 
 window.monaco.editor.defineTheme('console', {
   base: 'vs-dark',
@@ -25,8 +21,8 @@ window.monaco.editor.defineTheme('console', {
   colors: {
     'editor.background': editorBackground.value,
     'editorGutter.background': '#292e34', // no pf token defined
-    'editorLineNumber.activeForeground': lineNumberActiveForeground.value,
-    'editorLineNumber.foreground': lineNumberForeground.value,
+    'editorLineNumber.activeForeground': '#fff',
+    'editorLineNumber.foreground': '#f0f0f0',
   },
 });
 


### PR DESCRIPTION
Didn't wanted to give the same white as background.
/assign @spadgett 

Screen:
<img width="410" alt="Screenshot 2020-07-15 at 18 46 53" src="https://user-images.githubusercontent.com/1668218/87572704-3ac77680-c6cc-11ea-9125-e0a141f88f30.png">
