### PR TITLE
Adds Pipelines back to Topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/data-transformer.ts
@@ -2,6 +2,7 @@ import { createOverviewItemsForType } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { Model, EdgeModel } from '@patternfly/react-topology';
+import { getPipelinesAndPipelineRunsForResource } from '../../../utils/pipeline-plugin-utils';
 import {
   TopologyDataResources,
   TrafficData,
@@ -71,8 +72,11 @@ const getBaseTopologyDataModel = (resources: TopologyDataResources): Model => {
 
       createOverviewItemsForType(key, resources).forEach((item) => {
         const { obj: deploymentConfig } = item;
+
+        const pipelineData = getPipelinesAndPipelineRunsForResource(deploymentConfig, resources);
+
         const data = createTopologyNodeData(
-          item,
+          { ...item, ...pipelineData },
           TYPE_WORKLOAD,
           getImageForIconClass(`icon-openshift`),
         );

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -17,6 +17,7 @@ import {
   TYPE_KNATIVE_REVISION,
 } from '@console/knative-plugin/src/topology/const';
 import { edgesFromAnnotations } from '../../../utils/application-utils';
+import { tknPipelineAndPipelineRunsWatchResources } from '../../../utils/pipeline-plugin-utils';
 import {
   TopologyDataObject,
   TopologyOverviewItem,
@@ -407,5 +408,6 @@ export const getBaseWatchedResources = (namespace: string): WatchK8sResources<an
       namespace,
       optional: true,
     },
+    ...tknPipelineAndPipelineRunsWatchResources(namespace),
   };
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4294

**Analysis / Root cause**: 
The work done in #5647 appears to have broken off Pipeline fetching data from the core resources.

**Solution Description**: 
Bring back in the data to the flow of things, it seems to plug in nicely. We'll need to see if this is the best way to augment the workload object.

**Screen shots / Gifs for design review**: 
![Screen Shot 2020-07-15 at 3 08 32 PM](https://user-images.githubusercontent.com/8126518/87587013-861f5c00-c6af-11ea-934a-b14fc14e2af6.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge