### PR TITLE
add andrewballantyne to console-shared/OWNERS

### DIFF
--- a/frontend/packages/console-shared/OWNERS
+++ b/frontend/packages/console-shared/OWNERS
@@ -1,2 +1,4 @@
+approvers:
+  - andrewballantyne
 labels:
   - component/shared


### PR DESCRIPTION
Adds @andrewballantyne to console-shared/OWNERS as dev-console needs another approver for shared code.