### PR TITLE
Add capability to collapse all grouping in topology view

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/updateModelFromFilters.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/updateModelFromFilters.spec.ts
@@ -6,7 +6,7 @@ import {
   TEST_KINDS_MAP,
 } from '../../__tests__/topology-test-data';
 import { updateModelFromFilters } from '../updateModelFromFilters';
-import { getFilterById } from '../../filters';
+import { EXPAND_GROUPS_FILTER_ID, getFilterById } from '../../filters';
 import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_APPLICATION_GROUPS_FILTER_ID } from '../../filters/const';
 import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
 import { baseDataModelGetter } from '../data-transformer';
@@ -66,6 +66,20 @@ describe('topology model ', () => {
   it('should flag application groups as collapsed when display filter is set', () => {
     const topologyTransformedData = getTransformedTopologyData();
     getFilterById(EXPAND_APPLICATION_GROUPS_FILTER_ID, filters).value = false;
+    const newModel = updateModelFromFilters(
+      topologyTransformedData,
+      filters,
+      ALL_APPLICATIONS_KEY,
+      filterers,
+    );
+    expect(newModel.nodes.filter((n) => n.group).length).toBe(2);
+    expect(newModel.nodes.filter((n) => n.group && n.collapsed).length).toBe(2);
+  });
+
+  it('should flag application groups as collapsed when expand groups is false', () => {
+    const topologyTransformedData = getTransformedTopologyData();
+    getFilterById(EXPAND_APPLICATION_GROUPS_FILTER_ID, filters).value = true;
+    getFilterById(EXPAND_GROUPS_FILTER_ID, filters).value = false;
     const newModel = updateModelFromFilters(
       topologyTransformedData,
       filters,

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
@@ -1,9 +1,9 @@
 import { Model, NodeModel, createAggregateEdges } from '@patternfly/react-topology';
 import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
 import {
-  getFilterById,
   EXPAND_APPLICATION_GROUPS_FILTER_ID,
   DEFAULT_SUPPORTED_FILTER_IDS,
+  isExpanded,
 } from '../filters';
 import { TYPE_APPLICATION_GROUP, TYPE_AGGREGATE_EDGE } from '../components/const';
 import { TopologyApplyDisplayOptions, DisplayFilters } from '../topology-types';
@@ -34,8 +34,8 @@ export const updateModelFromFilters = (
     edges: [...model.edges],
   };
   const supportedFilters = [...DEFAULT_SUPPORTED_FILTER_IDS];
-  const expandGroups = getFilterById(EXPAND_APPLICATION_GROUPS_FILTER_ID, filters)?.value ?? true;
   let appGroupFound = false;
+  const expanded = isExpanded(EXPAND_APPLICATION_GROUPS_FILTER_ID, filters);
   dataModel.nodes.forEach((d) => {
     d.visible = true;
     if (displayFilterers) {
@@ -49,7 +49,7 @@ export const updateModelFromFilters = (
         appGroupFound = true;
         supportedFilters.push(EXPAND_APPLICATION_GROUPS_FILTER_ID);
       }
-      d.collapsed = !expandGroups;
+      d.collapsed = !expanded;
     }
   });
 

--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.scss
@@ -1,0 +1,32 @@
+@import '../../../../../../public/style/vars';
+
+.odc-topology-filter-dropdown {
+  &__expand-groups-switcher {
+    display: flex;
+    align-items: center;
+
+    .pf-c-select__menu-group-title {
+      flex: 1;
+    }
+
+    .pf-c-switch {
+      margin-right: var(--pf-global--spacer--sm);
+    }
+
+    .pf-m-disabled {
+      color: var(--pf-c-check__label--disabled--Color);
+    }
+  }
+
+  &__group {
+    &:not(:first-of-type) {
+      margin-top: var(--pf-global--spacer--sm);
+      border-top: 1px solid var(--pf-global--BorderColor--300);
+    }
+  }
+
+  &__expand-groups-label .pf-c-select__menu-group-title {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
@@ -1,16 +1,25 @@
 import * as React from 'react';
-import { Select, SelectGroup, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectGroup, SelectOption, SelectVariant, Switch } from '@patternfly/react-core';
 import { TopologyDisplayFilterType, DisplayFilters } from '../topology-types';
+import { EXPAND_GROUPS_FILTER_ID } from './const';
+
+import './FilterDropdown.scss';
 
 type FilterDropdownProps = {
   filters: DisplayFilters;
   supportedFilters: string[];
   onChange: (filter: DisplayFilters) => void;
+  opened?: boolean; // Use only for testing
 };
 
-const FilterDropdown: React.FC<FilterDropdownProps> = ({ filters, supportedFilters, onChange }) => {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const selected = filters.filter((f) => f.value).map((f) => f.id);
+const FilterDropdown: React.FC<FilterDropdownProps> = ({
+  filters,
+  supportedFilters,
+  onChange,
+  opened = false,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(opened);
+  const groupsExpanded = filters?.find((f) => f.id === EXPAND_GROUPS_FILTER_ID)?.value ?? true;
 
   const onToggle = (open: boolean): void => setIsOpen(open);
   const onSelect = (e: React.MouseEvent, key: string) => {
@@ -19,58 +28,83 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({ filters, supportedFilte
     onChange([...filters.slice(0, index), filter, ...filters.slice(index + 1)]);
   };
 
-  const ShowFiltersKeyValue = filters
+  const onGroupsExpandedChange = (value: boolean) => {
+    const index = filters?.findIndex((f) => f.id === EXPAND_GROUPS_FILTER_ID) ?? -1;
+    if (index === -1) {
+      return;
+    }
+    const filter = {
+      ...filters[index],
+      value,
+    };
+    onChange([...filters.slice(0, index), filter, ...filters.slice(index + 1)]);
+  };
+
+  const expandFilters = filters
+    .filter(
+      (f) =>
+        f.type === TopologyDisplayFilterType.expand &&
+        f.id !== EXPAND_GROUPS_FILTER_ID &&
+        supportedFilters.includes(f.id),
+    )
+    .sort((a, b) => a.priority - b.priority);
+
+  const showFilters = filters
     .filter((f) => f.type === TopologyDisplayFilterType.show && supportedFilters.includes(f.id))
-    .sort((a, b) => a.priority - b.priority)
-    .reduce((acc, f) => {
-      acc[f.id] = f.label;
-      return acc;
-    }, {});
-  const ExpandFiltersKeyValue = filters
-    .filter((f) => f.type === TopologyDisplayFilterType.expand && supportedFilters.includes(f.id))
-    .sort((a, b) => a.priority - b.priority)
-    .reduce((acc, f) => {
-      acc[f.id] = f.label;
-      return acc;
-    }, {});
-  const options = [];
-  if (Object.keys(ShowFiltersKeyValue).length) {
-    options.push(
-      <SelectGroup key="show" label="Show">
-        {Object.keys(ShowFiltersKeyValue).map((key) => (
-          <SelectOption key={key} value={key}>
-            {ShowFiltersKeyValue[key]}
-          </SelectOption>
-        ))}
-      </SelectGroup>,
-    );
-  }
-  if (Object.keys(ExpandFiltersKeyValue).length) {
-    options.push(
-      <SelectGroup key="expand" label="Expand">
-        {Object.keys(ExpandFiltersKeyValue).map((key) => (
-          <SelectOption key={key} value={key}>
-            {ExpandFiltersKeyValue[key]}
-          </SelectOption>
-        ))}
-      </SelectGroup>,
-    );
-  }
+    .sort((a, b) => a.priority - b.priority);
+
+  const selectContent = (
+    <div className="odc-topology-filter-dropdown">
+      {expandFilters.length && (
+        <div className="odc-topology-filter-dropdown__group">
+          <span className="odc-topology-filter-dropdown__expand-groups-switcher">
+            <span className="pf-c-select__menu-group-title">Expand</span>
+            <Switch
+              aria-label="Collapse Groups"
+              isChecked={groupsExpanded}
+              onChange={onGroupsExpandedChange}
+            />
+          </span>
+          <SelectGroup className="odc-topology-filter-dropdown__expand-groups-label">
+            {expandFilters.map((filter) => (
+              <SelectOption
+                key={filter.id}
+                value={filter.id}
+                isDisabled={!groupsExpanded}
+                isChecked={filter.value}
+              >
+                {filter.label}
+              </SelectOption>
+            ))}
+          </SelectGroup>
+        </div>
+      )}
+      {showFilters.length && (
+        <div className="odc-topology-filter-dropdown__group">
+          <SelectGroup label="Show">
+            {showFilters.map((filter) => (
+              <SelectOption key={filter.id} value={filter.id} isChecked={filter.value}>
+                {filter.label}
+              </SelectOption>
+            ))}
+          </SelectGroup>
+        </div>
+      )}
+    </div>
+  );
 
   return (
     <Select
-      className="odc-filter-dropdown__select"
+      className="odc-topology-filter-dropdown__select"
       variant={SelectVariant.checkbox}
+      customContent={selectContent}
       onToggle={onToggle}
-      selections={selected}
       isOpen={isOpen}
       onSelect={onSelect}
       placeholderText="Display Options"
       isGrouped
       isCheckboxSelectionBadgeHidden
-    >
-      {...options}
-    </Select>
+    />
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
-import { SelectOption } from '@patternfly/react-core';
+import { mount, shallow } from 'enzyme';
+import { SelectOption, Switch } from '@patternfly/react-core';
 import FilterDropdown from '../FilterDropdown';
 import { DisplayFilters } from '../../topology-types';
-import { DEFAULT_TOPOLOGY_FILTERS } from '../const';
+import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_APPLICATION_GROUPS_FILTER_ID } from '../const';
 
 describe(FilterDropdown.displayName, () => {
   let dropdownFilter: DisplayFilters;
@@ -25,24 +25,40 @@ describe(FilterDropdown.displayName, () => {
   });
 
   it('should have the correct number of filters', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
+        opened
       />,
     );
-    expect(wrapper.find(SelectOption)).toHaveLength(Object.keys(DEFAULT_TOPOLOGY_FILTERS).length);
+    expect(wrapper.find(SelectOption)).toHaveLength(
+      Object.keys(DEFAULT_TOPOLOGY_FILTERS).length - 1,
+    );
   });
 
   it('should hide unsupported filters', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        supportedFilters={[dropdownFilter[0].id]}
+        supportedFilters={[EXPAND_APPLICATION_GROUPS_FILTER_ID]}
         onChange={onChange}
+        opened
       />,
     );
     expect(wrapper.find(SelectOption)).toHaveLength(1);
+  });
+
+  it('should contain the show expand groups switch', () => {
+    const wrapper = mount(
+      <FilterDropdown
+        filters={dropdownFilter}
+        supportedFilters={dropdownFilter.map((f) => f.id)}
+        onChange={onChange}
+        opened
+      />,
+    );
+    expect(wrapper.find(Switch)).toHaveLength(1);
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/filters/const.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/const.ts
@@ -3,7 +3,16 @@ import { TopologyDisplayFilterType } from '../topology-types';
 export const SHOW_POD_COUNT_FILTER_ID = 'show-pod-count';
 export const SHOW_LABELS_FILTER_ID = 'show-labels';
 export const EXPAND_APPLICATION_GROUPS_FILTER_ID = 'expand-app-groups';
+export const EXPAND_GROUPS_FILTER_ID = 'expand-groups';
+
 export const DEFAULT_TOPOLOGY_FILTERS = [
+  {
+    type: TopologyDisplayFilterType.expand,
+    id: EXPAND_GROUPS_FILTER_ID,
+    label: 'Expand Groups',
+    priority: 1,
+    value: true,
+  },
   {
     type: TopologyDisplayFilterType.show,
     id: SHOW_POD_COUNT_FILTER_ID,

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
@@ -1,9 +1,13 @@
 import { RootState } from '@console/internal/redux';
 import { getQueryArgument } from '@console/internal/components/utils';
 import { getDefaultTopologyFilters } from '../redux/reducer';
-import { TopologyDisplayOption, DisplayFilters } from '../topology-types';
-import { DEFAULT_TOPOLOGY_FILTERS } from './const';
 import { getAppliedFilters } from '../redux/action';
+import {
+  TopologyDisplayOption,
+  DisplayFilters,
+  TopologyDisplayFilterType,
+} from '../topology-types';
+import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_GROUPS_FILTER_ID } from './const';
 
 export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
 
@@ -29,4 +33,30 @@ export const getFilterById = (id: string, filters: DisplayFilters): TopologyDisp
     return null;
   }
   return filters.find((f) => f.id === id);
+};
+
+export const isExpanded = (id: string, filters: DisplayFilters): boolean => {
+  if (!filters) {
+    return true;
+  }
+  const groupsExpanded = getFilterById(EXPAND_GROUPS_FILTER_ID, filters);
+  if (!groupsExpanded.value) {
+    return false;
+  }
+  const filter = getFilterById(id, filters);
+  if (filter && filter.type === TopologyDisplayFilterType.expand) {
+    return filter.value;
+  }
+  return true;
+};
+
+export const isShown = (id: string, filters: DisplayFilters): boolean => {
+  if (!filters) {
+    return true;
+  }
+  const filter = getFilterById(id, filters);
+  if (filter && filter.type === TopologyDisplayFilterType.show) {
+    return filter.value;
+  }
+  return true;
 };

--- a/frontend/packages/dev-console/src/components/topology/helm/__tests__/helm-data-transformer.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/__tests__/helm-data-transformer.spec.ts
@@ -13,7 +13,7 @@ import {
   TEST_KINDS_MAP,
 } from '../../__tests__/topology-test-data';
 import { TYPE_HELM_RELEASE } from '../components/const';
-import { DEFAULT_TOPOLOGY_FILTERS } from '../../filters/const';
+import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_GROUPS_FILTER_ID } from '../../filters/const';
 import {
   baseDataModelGetter,
   getWorkloadResources,
@@ -83,5 +83,18 @@ describe('HELM data transformer ', () => {
     const newModel = updateModelFromFilters(graphData, filters, ALL_APPLICATIONS_KEY, filterers);
     expect(newModel.nodes.filter((n) => n.group)).toHaveLength(4);
     expect(newModel.nodes.filter((n) => n.group && n.collapsed)).toHaveLength(1);
+  });
+
+  it('should flag helm groups as collapsed when all groups are collapsed', async () => {
+    const filters = [...DEFAULT_TOPOLOGY_FILTERS];
+    filters.push(...getTopologyFilters());
+    const graphData = await getTransformedTopologyData(mockResources);
+    getFilterById(EXPAND_HELM_RELEASE_FILTER, filters).value = true;
+    getFilterById(EXPAND_GROUPS_FILTER_ID, filters).value = false;
+    const newModel = updateModelFromFilters(graphData, filters, ALL_APPLICATIONS_KEY, filterers);
+    expect(newModel.nodes.filter((n) => n.group)).toHaveLength(4);
+    expect(newModel.nodes.filter((n) => n.type === TYPE_HELM_RELEASE && n.collapsed)).toHaveLength(
+      1,
+    );
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/helm/helmFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/helmFilters.ts
@@ -1,7 +1,7 @@
 import { Model } from '@patternfly/react-topology';
 import { TYPE_HELM_RELEASE } from './components/const';
 import { TopologyDisplayFilterType, DisplayFilters } from '../topology-types';
-import { getFilterById } from '../filters';
+import { isExpanded } from '../filters';
 
 export const EXPAND_HELM_RELEASE_FILTER = 'helmGrouping';
 
@@ -18,9 +18,9 @@ export const getTopologyFilters = () => {
 };
 
 export const applyHelmDisplayOptions = (model: Model, filters: DisplayFilters): string[] => {
-  const expanded = getFilterById(EXPAND_HELM_RELEASE_FILTER, filters)?.value ?? true;
   let found = false;
   const appliedFilters = [];
+  const expanded = isExpanded(EXPAND_HELM_RELEASE_FILTER, filters);
   model.nodes.forEach((d) => {
     if (d.type === TYPE_HELM_RELEASE) {
       if (!found) {

--- a/frontend/packages/dev-console/src/components/topology/operators/__tests__/operator-data-transformer.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/__tests__/operator-data-transformer.spec.ts
@@ -4,7 +4,7 @@ import { Model, NodeModel } from '@patternfly/react-topology';
 import { WorkloadData, TopologyDataResources } from '../../topology-types';
 import { MockResources, TEST_KINDS_MAP } from '../../__tests__/topology-test-data';
 import { TYPE_OPERATOR_BACKED_SERVICE } from '../components/const';
-import { DEFAULT_TOPOLOGY_FILTERS } from '../../filters/const';
+import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_GROUPS_FILTER_ID } from '../../filters/const';
 import { getOperatorTopologyDataModel } from '../operators-data-transformer';
 import {
   baseDataModelGetter,
@@ -79,5 +79,23 @@ describe('operator data transformer ', () => {
     );
     expect(newModel.nodes.filter((n) => n.group).length).toBe(3);
     expect(newModel.nodes.filter((n) => n.group && n.collapsed).length).toBe(1);
+  });
+
+  it('should flag operator groups as collapsed when all groups are collapsed', async () => {
+    const filters = [...DEFAULT_TOPOLOGY_FILTERS];
+    filters.push(...getTopologyFilters());
+    const topologyTransformedData = await getTransformedTopologyData(mockResources);
+    getFilterById(EXPAND_OPERATORS_RELEASE_FILTER, filters).value = true;
+    getFilterById(EXPAND_GROUPS_FILTER_ID, filters).value = false;
+    const newModel = updateModelFromFilters(
+      topologyTransformedData,
+      filters,
+      ALL_APPLICATIONS_KEY,
+      filterers,
+    );
+    expect(newModel.nodes.filter((n) => n.group).length).toBe(3);
+    expect(
+      newModel.nodes.filter((n) => n.type === TYPE_OPERATOR_BACKED_SERVICE && n.collapsed).length,
+    ).toBe(1);
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/operators/operatorFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operatorFilters.ts
@@ -1,7 +1,7 @@
 import { Model } from '@patternfly/react-topology';
 import { TopologyDisplayFilterType, DisplayFilters } from '../topology-types';
 import { TYPE_OPERATOR_BACKED_SERVICE } from './components/const';
-import { getFilterById } from '../filters';
+import { isExpanded } from '../filters';
 
 export const EXPAND_OPERATORS_RELEASE_FILTER = 'operatorGrouping';
 
@@ -18,9 +18,9 @@ export const getTopologyFilters = () => {
 };
 
 export const applyOperatorDisplayOptions = (model: Model, filters: DisplayFilters): string[] => {
-  const expanded = getFilterById(EXPAND_OPERATORS_RELEASE_FILTER, filters)?.value ?? true;
   let found = false;
   const appliedFilters = [];
+  const expanded = isExpanded(EXPAND_OPERATORS_RELEASE_FILTER, filters);
   model.nodes.forEach((d) => {
     if (d.type === TYPE_OPERATOR_BACKED_SERVICE) {
       if (!found) {

--- a/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
@@ -11,6 +11,7 @@ import {
   WORKLOAD_TYPES,
   WorkloadData,
   DEFAULT_TOPOLOGY_FILTERS,
+  EXPAND_GROUPS_FILTER_ID,
   TopologyDataModelDepicted,
   OdcNodeModel,
 } from '@console/dev-console/src/components/topology';
@@ -32,7 +33,7 @@ import {
   getTopologyFilters,
 } from '../knativeFilters';
 import { isKnativeResource } from '../isKnativeResource';
-import { TYPE_EVENT_PUB_SUB, TYPE_EVENT_PUB_SUB_LINK } from '../const';
+import { TYPE_EVENT_PUB_SUB, TYPE_EVENT_PUB_SUB_LINK, TYPE_KNATIVE_SERVICE } from '../const';
 import * as knativefetchutils from '../../utils/fetch-dynamic-eventsources-utils';
 
 import Spy = jasmine.Spy;
@@ -183,6 +184,19 @@ describe('knative data transformer ', () => {
     const newModel = updateModelFromFilters(graphData, filters, ALL_APPLICATIONS_KEY, filterers);
     expect(newModel.nodes.filter((n) => n.group).length).toBe(2);
     expect(newModel.nodes.filter((n) => n.group && n.collapsed).length).toBe(1);
+  });
+
+  it('should flag knative services as collapsed when all groups are collapsed', async () => {
+    const filters = [...DEFAULT_TOPOLOGY_FILTERS];
+    filters.push(...getTopologyFilters());
+    const graphData = await getTransformedTopologyData(mockResources);
+    getFilterById(EXPAND_KNATIVE_SERVICES_FILTER_ID, filters).value = true;
+    getFilterById(EXPAND_GROUPS_FILTER_ID, filters).value = false;
+    const newModel = updateModelFromFilters(graphData, filters, ALL_APPLICATIONS_KEY, filterers);
+    expect(newModel.nodes.filter((n) => n.group).length).toBe(2);
+    expect(
+      newModel.nodes.filter((n) => n.type === TYPE_KNATIVE_SERVICE && n.collapsed).length,
+    ).toBe(1);
   });
 
   it('should return eventpub nodes and link for event brokers', async () => {

--- a/frontend/packages/knative-plugin/src/topology/knativeFilters.ts
+++ b/frontend/packages/knative-plugin/src/topology/knativeFilters.ts
@@ -1,7 +1,8 @@
 import { Model } from '@patternfly/react-topology';
 import {
   DisplayFilters,
-  getFilterById,
+  isExpanded,
+  isShown,
   TopologyDisplayFilterType,
 } from '@console/dev-console/src/components/topology';
 import { TYPE_EVENT_SOURCE, TYPE_KNATIVE_SERVICE } from './const';
@@ -29,8 +30,8 @@ export const getTopologyFilters = () => {
 };
 
 export const applyKnativeDisplayOptions = (model: Model, filters: DisplayFilters): string[] => {
-  const showEventSources = getFilterById(SHOW_EVENT_SOURCE_FILTER_ID, filters)?.value ?? true;
-  const expandServices = getFilterById(EXPAND_KNATIVE_SERVICES_FILTER_ID, filters)?.value ?? true;
+  const showEventSources = isShown(SHOW_EVENT_SOURCE_FILTER_ID, filters);
+  const expandServices = isExpanded(EXPAND_KNATIVE_SERVICES_FILTER_ID, filters);
   const appliedFilters = [];
   let sourceFound = false;
   let serviceFound = false;

--- a/frontend/packages/kubevirt-plugin/src/topology/kubevirtFilters.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/kubevirtFilters.ts
@@ -1,7 +1,7 @@
 import { Model } from '@patternfly/react-topology';
 import {
   DisplayFilters,
-  getFilterById,
+  isShown,
   TopologyDisplayFilterType,
 } from '@console/dev-console/src/components/topology';
 import { TYPE_VIRTUAL_MACHINE } from './components/const';
@@ -21,7 +21,7 @@ export const getTopologyFilters = () => {
 };
 
 export const applyKubevirtDisplayOptions = (model: Model, filters: DisplayFilters): string[] => {
-  const showVMs = getFilterById(SHOW_VMS_FILTER_ID, filters)?.value ?? true;
+  const showVMs = isShown(SHOW_VMS_FILTER_ID, filters);
   const appliedFilters = [];
   let found = false;
   model.nodes.forEach((d) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4316

**Description**: 
As a developer, I want to view all my “Grouped Resources” (Application Groups, Helm Releases, Knative Services, Operator Backed Services)as collapsed groupings in the Topology Graph View

**Screen shots / Gifs for design review**:

![image](https://user-images.githubusercontent.com/11633780/87679776-959fb300-c74a-11ea-8ed2-10c805574405.png)


![image](https://user-images.githubusercontent.com/11633780/87679816-a3553880-c74a-11ea-9c38-ec07d9501fc1.png)



**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @bgliwa01

/kind feature