### PR TITLE
[feat]:Add disk inventory to Nodes View

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/src/components/disks-list/disks-list-page.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/disks-list/disks-list-page.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import * as cx from 'classnames';
+import {
+  Table,
+  TableProps,
+  TableRow,
+  TableData,
+  RowFunction,
+  MultiListPage,
+} from '@console/internal/components/factory';
+import { sortable } from '@patternfly/react-table';
+import { FirehoseResult, humanizeBinaryBytes } from '@console/internal/components/utils';
+import { referenceForModel, NodeKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { RowFilter } from '@console/internal/components/filter-toolbar';
+import { LocalVolumeDiscoveryResult } from '../../models';
+import { LABEL_SELECTOR } from '../../constants/disks-list';
+
+export const diskFilters: RowFilter[] = [
+  {
+    type: 'disk-state',
+    filterGroupName: 'Disk State',
+    reducer: (disk: DiskMetadata) => {
+      return disk?.status?.state;
+    },
+    items: [
+      { id: 'Available', title: 'Available' },
+      { id: 'NotAvailable', title: 'NotAvailable' },
+      { id: 'Unknown', title: 'Unknown' },
+    ],
+    filter: (states: { all: DiskStates[]; selected: Set<DiskStates> }, disk: DiskMetadata) => {
+      if (!states || !states.selected || _.isEmpty(states.selected)) {
+        return true;
+      }
+      const diskState = disk?.status.state;
+      return states.selected.has(diskState) || !_.includes(states.all, diskState);
+    },
+  },
+];
+
+export const tableColumnClasses = [
+  '',
+  '',
+  cx('pf-m-hidden', 'pf-m-visible-on-xl'),
+  cx('pf-m-hidden', 'pf-m-visible-on-2xl'),
+  cx('pf-m-hidden', 'pf-m-visible-on-lg'),
+  cx('pf-m-hidden', 'pf-m-visible-on-xl'),
+];
+
+const DiskHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'path',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Disk State',
+      sortField: 'status.state',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Type',
+      sortField: 'type',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Model',
+      sortField: 'model',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Capacity',
+      sortField: 'size',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: 'Filesystem',
+      sortField: 'fstype',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[5] },
+    },
+  ];
+};
+
+const DiskRow: RowFunction<DiskMetadata> = ({ obj, index, key, style }) => {
+  return (
+    <TableRow id={obj.deviceID} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>{obj.path}</TableData>
+      <TableData className={tableColumnClasses[1]}>{obj.status.state}</TableData>
+      <TableData className={tableColumnClasses[2]}>{obj.type || '-'}</TableData>
+      <TableData className={cx(tableColumnClasses[3], 'co-break-word')}>
+        {obj.model || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>
+        {humanizeBinaryBytes(obj.size).string || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[5]}>{obj.fstype || '-'}</TableData>
+    </TableRow>
+  );
+};
+
+const DisksList: React.FC<TableProps> = (props) => {
+  return <Table {...props} aria-label="Disks List" Header={DiskHeader} Row={DiskRow} virtualize />;
+};
+
+const DisksListPage: React.FC<{ obj: NodeKind }> = (props) => {
+  const nodeName = props.obj.metadata.name;
+  const propName = `lvdr-${nodeName}`;
+
+  return (
+    <MultiListPage
+      canCreate={false}
+      title="Disks"
+      hideLabelFilter
+      textFilter="node-disk-name"
+      rowFilters={diskFilters}
+      flatten={(resource: FirehoseResult<LocalVolumeDiscoveryResult>) =>
+        resource[propName]?.data[0]?.status?.discoveredDevices ?? {}
+      }
+      ListComponent={DisksList}
+      resources={[
+        {
+          kind: referenceForModel(LocalVolumeDiscoveryResult),
+          prop: propName,
+          selector: { [LABEL_SELECTOR]: nodeName },
+        },
+      ]}
+    />
+  );
+};
+
+export default DisksListPage;
+
+type DiskMetadata = LocalVolumeDiscoveryResult['status']['discoveredDevices'];
+
+type LocalVolumeDiscoveryResult = K8sResourceCommon & {
+  spec: {
+    nodeName: string;
+  };
+  status: {
+    discoveredDevices: {
+      deviceID: string;
+      fstype: string;
+      model: string;
+      path: string;
+      serial: string;
+      size: string;
+      status: {
+        state: DiskStates;
+      };
+      type: string;
+      vendor: string;
+    };
+  };
+};
+
+type DiskStates = 'Available' | 'Unknown' | 'NotAvailable';

--- a/frontend/packages/local-storage-operator-plugin/src/constants/disks-list.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/disks-list.ts
@@ -1,0 +1,1 @@
+export const LABEL_SELECTOR = 'discovery-result-node';

--- a/frontend/packages/local-storage-operator-plugin/src/models.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/models.ts
@@ -1,5 +1,18 @@
 import { K8sKind } from '@console/internal/module/k8s';
 
+export const LocalVolumeDiscoveryResult: K8sKind = {
+  label: 'Local Volume Discovery Result',
+  labelPlural: 'Local Volume Discovery Results',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'local.storage.openshift.io',
+  plural: 'localvolumediscoveryresults',
+  abbr: 'LVDR',
+  namespaced: true,
+  kind: 'LocalVolumeDiscoveryResult',
+  id: 'localvolumediscoveryresults',
+  crd: true,
+};
+
 export const LocalVolumeSetModel: K8sKind = {
   label: 'Local Volume Set',
   labelPlural: 'Local Volume Sets',

--- a/frontend/packages/local-storage-operator-plugin/src/plugin.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/plugin.ts
@@ -1,12 +1,20 @@
 import * as _ from 'lodash';
-import { ModelDefinition, ModelFeatureFlag, Plugin, RoutePage } from '@console/plugin-sdk';
+import {
+  ModelDefinition,
+  ModelFeatureFlag,
+  Plugin,
+  RoutePage,
+  HorizontalNavTab,
+} from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
 import * as models from './models';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
+import { NodeModel } from '@console/internal/models';
 
-type ConsumedExtensions = ModelFeatureFlag | ModelDefinition | RoutePage;
+type ConsumedExtensions = HorizontalNavTab | ModelFeatureFlag | ModelDefinition | RoutePage;
 
 const LSO_FLAG = 'LSO';
+const LSO_DEVICE_DISCOVERY = 'LSO_DEVICE_DISCOVERY';
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -23,6 +31,13 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'FeatureFlag/Model',
+    properties: {
+      model: models.LocalVolumeDiscoveryResult,
+      flag: LSO_DEVICE_DISCOVERY,
+    },
+  },
+  {
     type: 'Page/Route',
     properties: {
       exact: true,
@@ -31,11 +46,28 @@ const plugin: Plugin<ConsumedExtensions> = [
       )}/~new`,
       loader: () =>
         import(
-          './components/local-volume-set/create-local-volume-set' /* webpackChunkName: "create-local-volume-set" */
+          './components/local-volume-set/create-local-volume-set' /* webpackChunkName: "lso-create-local-volume-set" */
         ).then((m) => m.default),
     },
     flags: {
       required: [LSO_FLAG],
+    },
+  },
+  {
+    type: 'HorizontalNavTab',
+    properties: {
+      model: NodeModel,
+      page: {
+        href: 'disks',
+        name: 'Disks',
+      },
+      loader: () =>
+        import(
+          './components/disks-list/disks-list-page' /* webpackChunkName: "lso-disks-list" */
+        ).then((m) => m.default),
+    },
+    flags: {
+      required: [LSO_DEVICE_DISCOVERY],
     },
   },
 ];

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -265,6 +265,7 @@ export const tableFilters: TableFilterMap = {
     const status = volumeSnapshotStatus(snapshot);
     return statuses.selected.has(status) || !_.includes(statuses.all, status);
   },
+  'node-disk-name': (name, disks) => fuzzyCaseInsensitive(name, disks?.path),
 };
 
 export interface TableFilterGroups {


### PR DESCRIPTION
- LSO operator allows discovery of the disks present on the node.
- The discovered devices comes in the result for localvolumediscoveryresult CR
- Adds a Disk nav tab to the exiting nodes view

Implements https://issues.redhat.com/browse/RHSTOR-1195

cc @yuvalgalanti 
![Screenshot from 2020-07-17 05-33-17](https://user-images.githubusercontent.com/25664409/87757538-724b3580-c828-11ea-87d0-8ec8a58c554f.png)
