### PR TITLE
Add Topology sidebar for Operator Backed Services

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -81,6 +81,7 @@ import { updateModelFromFilters } from './data-transforms';
 import { setSupportedTopologyFilters, setTopologyFilters } from './redux/action';
 import { odcElementFactory } from './elements';
 import KnativeTopologyEdgePanel from '@console/knative-plugin/src/components/overview/KnativeTopologyEdgePanel';
+import TopologyOperatorBackedPanel from './operators/TopologyOperatorBackedPanel';
 
 export const FILTER_ACTIVE_CLASS = 'odc-m-filter-active';
 
@@ -444,7 +445,11 @@ const Topology: React.FC<ComponentProps> = ({
         return <TopologyHelmWorkloadPanel item={selectedEntity.getData() as TopologyDataObject} />;
       }
       if (selectedEntity.getType() === TYPE_OPERATOR_BACKED_SERVICE) {
-        return null;
+        return (
+          <TopologyOperatorBackedPanel
+            item={selectedEntity.getData() as TopologyDataObject<string>}
+          />
+        );
       }
       if (selectedEntity.getType() === TYPE_VIRTUAL_MACHINE) {
         return <TopologyVmPanel vmNode={selectedEntity} />;

--- a/frontend/packages/dev-console/src/components/topology/components/TopologyGroupResourceItem.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/TopologyGroupResourceItem.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { ResourceLink } from '@console/internal/components/utils';
 import { K8sResourceKind, referenceFor, modelFor } from '@console/internal/module/k8s';
 
-type TopologyHelmReleaseResourceItemProps = {
+type TopologyGroupResourceItemProps = {
   item: K8sResourceKind;
   releaseNamespace: string;
 };
 
-const TopologyHelmReleaseResourceItem: React.FC<TopologyHelmReleaseResourceItemProps> = ({
+const TopologyGroupResourceItem: React.FC<TopologyGroupResourceItemProps> = ({
   item,
   releaseNamespace,
 }) => {
@@ -29,4 +29,4 @@ const TopologyHelmReleaseResourceItem: React.FC<TopologyHelmReleaseResourceItemP
   );
 };
 
-export default TopologyHelmReleaseResourceItem;
+export default TopologyGroupResourceItem;

--- a/frontend/packages/dev-console/src/components/topology/components/TopologyGroupResourceList.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/TopologyGroupResourceList.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import TopologyHelmReleaseResourceItem from './TopologyHelmReleaseResourceItem';
+import TopologyGroupResourceItem from './TopologyGroupResourceItem';
 
-type TopologyHelmReleaseResourceListProps = {
+type TopologyGroupResourceListProps = {
   resources: K8sResourceKind[];
   releaseNamespace: string;
 };
 
-const TopologyHelmReleaseResourceList: React.FC<TopologyHelmReleaseResourceListProps> = ({
+const TopologyGroupResourceList: React.FC<TopologyGroupResourceListProps> = ({
   resources,
   releaseNamespace,
 }) => {
@@ -16,7 +16,7 @@ const TopologyHelmReleaseResourceList: React.FC<TopologyHelmReleaseResourceListP
       {resources
         .sort((r1, r2) => r1.metadata.name.localeCompare(r2.metadata.name))
         .map((resource) => (
-          <TopologyHelmReleaseResourceItem
+          <TopologyGroupResourceItem
             key={resource.metadata.name}
             item={resource}
             releaseNamespace={releaseNamespace}
@@ -26,4 +26,4 @@ const TopologyHelmReleaseResourceList: React.FC<TopologyHelmReleaseResourceListP
   );
 };
 
-export default TopologyHelmReleaseResourceList;
+export default TopologyGroupResourceList;

--- a/frontend/packages/dev-console/src/components/topology/components/TopologyGroupResourcesPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/TopologyGroupResourcesPanel.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
 import { SidebarSectionHeading } from '@console/internal/components/utils';
-import TopologyHelmReleaseResourceList from './TopologyHelmReleaseResourceList';
+import TopologyGroupResourceList from './TopologyGroupResourceList';
 
-type TopologyHelmReleaseResourcesPanelProps = {
+type TopologyGroupResourcesPanelProps = {
   manifestResources: K8sResourceKind[];
   releaseNamespace: string;
 };
 
-const TopologyHelmReleaseResourcesPanel: React.SFC<TopologyHelmReleaseResourcesPanelProps> = ({
+const TopologyGroupResourcesPanel: React.SFC<TopologyGroupResourcesPanelProps> = ({
   manifestResources,
   releaseNamespace,
 }) => {
@@ -22,24 +22,19 @@ const TopologyHelmReleaseResourcesPanel: React.SFC<TopologyHelmReleaseResourcesP
     }, [])
     .sort((a, b) => a.localeCompare(b));
 
-  const resourceLists = kinds.reduce((lists, kind) => {
+  return kinds.reduce((lists, kind) => {
     const model = modelFor(kind);
     const resources = manifestResources.filter((resource) => resource.kind === model.kind);
     if (resources.length) {
       lists.push(
         <div key={model.kind}>
           <SidebarSectionHeading text={model.labelPlural} />
-          <TopologyHelmReleaseResourceList
-            resources={resources}
-            releaseNamespace={releaseNamespace}
-          />
+          <TopologyGroupResourceList resources={resources} releaseNamespace={releaseNamespace} />
         </div>,
       );
     }
     return lists;
   }, []);
-
-  return <div className="overview__sidebar-pane-body">{resourceLists}</div>;
 };
 
-export default TopologyHelmReleaseResourcesPanel;
+export default TopologyGroupResourcesPanel;

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
@@ -12,7 +12,7 @@ import * as UIActions from '@console/internal/actions/ui';
 import { Node } from '@patternfly/react-topology';
 import HelmReleaseOverview from '../../helm/details/overview/HelmReleaseOverview';
 import { helmReleaseActions } from './actions/helmReleaseActions';
-import TopologyHelmReleaseResourcesPanel from './TopologyHelmReleaseResourcesPanel';
+import TopologyGroupResourcesPanel from '../components/TopologyGroupResourcesPanel';
 import TopologyHelmReleaseNotesPanel from './TopologyHelmReleaseNotesPanel';
 
 type PropsFromState = {
@@ -58,10 +58,12 @@ export const ConnectedTopologyHelmReleasePanel: React.FC<TopologyHelmReleasePane
 
   const resourcesComponent = () =>
     manifestResources ? (
-      <TopologyHelmReleaseResourcesPanel
-        manifestResources={manifestResources}
-        releaseNamespace={namespace}
-      />
+      <div className="overview__sidebar-pane-body">
+        <TopologyGroupResourcesPanel
+          manifestResources={manifestResources}
+          releaseNamespace={namespace}
+        />
+      </div>
     ) : null;
 
   const releaseNotesComponent = () => <TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} />;

--- a/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow, mount } from 'enzyme';
 import { SidebarSectionHeading, StatusBox } from '@console/internal/components/utils';
 import { mockHelmReleaseNode, mockManifest, mockReleaseNotes } from './mockData';
-import TopologyHelmReleaseResourcesPanel from '../TopologyHelmReleaseResourcesPanel';
+import TopologyGroupResourcesPanel from '../../components/TopologyGroupResourcesPanel';
 import TopologyHelmReleaseNotesPanel from '../TopologyHelmReleaseNotesPanel';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 import { ConnectedTopologyHelmReleasePanel } from '../TopologyHelmReleasePanel';
@@ -13,7 +13,7 @@ describe('TopologyHelmReleasePanel', () => {
     const component = mount(
       <ConnectedTopologyHelmReleasePanel helmRelease={mockHelmReleaseNode} />,
     );
-    expect(component.find(TopologyHelmReleaseResourcesPanel)).toHaveLength(1);
+    expect(component.find(TopologyGroupResourcesPanel)).toHaveLength(1);
   });
 
   it('should render the details tab when specified', () => {
@@ -44,7 +44,7 @@ describe('TopologyHelmReleaseResourcesPanel', () => {
 
   it('should render the correct number of resource categories', () => {
     const component = shallow(
-      <TopologyHelmReleaseResourcesPanel
+      <TopologyGroupResourcesPanel
         manifestResources={manifestResources}
         releaseNamespace="mock-ns"
       />,

--- a/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedPanel.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import {
+  ResourceIcon,
+  ResourceLink,
+  SimpleTabNav,
+  ResourceSummary,
+  SectionHeading,
+} from '@console/internal/components/utils';
+import { referenceFor } from '@console/internal/module/k8s';
+import TopologyOperatorBackedResources from './TopologyOperatorBackedResources';
+import { TopologyDataObject } from '../topology-types';
+
+export type TopologyOperatorBackedPanelProps = {
+  item: TopologyDataObject<string>;
+};
+
+const TopologyOperatorBackedPanel: React.FC<TopologyOperatorBackedPanelProps> = ({ item }) => {
+  const {
+    name,
+    resources: { obj },
+  } = item;
+
+  const ResourcesSection = () => <TopologyOperatorBackedResources item={item} />;
+  const DetailsSection = () => (
+    <div className="overview__sidebar-pane-body">
+      <SectionHeading text="Operator Details" />
+      <ResourceSummary resource={obj} />
+    </div>
+  );
+
+  return (
+    <div className="overview__sidebar-pane resource-overview">
+      <div className="overview__sidebar-pane-head resource-overview__heading">
+        <h1 className="co-m-pane__heading">
+          <div className="co-m-pane__name co-resource-item">
+            <ResourceIcon kind="Operator" />
+            <ResourceLink
+              kind={referenceFor(obj)}
+              name={name}
+              namespace={obj.metadata.namespace}
+              hideIcon
+            />
+          </div>
+        </h1>
+      </div>
+      <SimpleTabNav
+        tabs={[
+          { name: 'Details', component: DetailsSection },
+          { name: 'Resources', component: ResourcesSection },
+        ]}
+        tabProps={null}
+        additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
+      />
+    </div>
+  );
+};
+
+export default TopologyOperatorBackedPanel;

--- a/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedResources.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedResources.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import OperatorBackedOwnerReferences from '@console/internal/components/utils';
+import { TopologyDataObject } from '../topology-types';
+import TopologyGroupResourcesPanel from '../components/TopologyGroupResourcesPanel';
+import { OverviewItem } from '@console/shared';
+
+type TopologyOperatorBackedResourcesProps = {
+  item: TopologyDataObject;
+};
+
+const TopologyOperatorBackedResources: React.FC<TopologyOperatorBackedResourcesProps> = ({
+  item,
+}) => {
+  const { groupResources = [] } = item;
+  const finalRes = groupResources.map((val) => val.resources.obj);
+  const ownerReferencedResources = groupResources.reduce(
+    (acc, val) => {
+      acc.obj = { ...val.resources.obj, ...acc.obj };
+      return acc;
+    },
+    { obj: {}, isOperatorBackedService: true },
+  );
+
+  return (
+    <div className="overview__sidebar-pane-body">
+      <OperatorBackedOwnerReferences item={ownerReferencedResources as OverviewItem} />
+      <TopologyGroupResourcesPanel
+        manifestResources={finalRes}
+        releaseNamespace={item.resources.obj.metadata.namespace}
+      />
+    </div>
+  );
+};
+
+export default TopologyOperatorBackedResources;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4024
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
As a user, I want to see more details about operator backed services in Topology.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Add a sidebar that can be opened by clicking an operator backed service from the topology.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review(updated)**: 
![p1](https://user-images.githubusercontent.com/20013884/88057468-c2572e80-cb7f-11ea-839c-8270f73ca4b0.png)
![p2](https://user-images.githubusercontent.com/20013884/88057483-c71be280-cb7f-11ea-98e2-f7a45378f351.png)


cc: @openshift/team-devconsole-ux @rohitkrai03 

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
