### PR TITLE
Added Auto discovery of volumes and create SC wizard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/attached-devices.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/attached-devices.scss
@@ -5,3 +5,38 @@
 .ceph-ocs-install__no-nodes-text--large {
   font-size: var(--pf-global--FontSize--lg);
 }
+
+.ceph-create-sc-wizard {
+  overflow-y: auto;
+}
+
+.ceph-ocs-install__auto-detect-table {
+  width: 80%;
+  margin-top: var(--pf-global--spacer--lg);
+}
+
+.ceph-ocs-install__wizard-alert {
+  width: 90%;
+  margin: var(--pf-c-wizard__main-body--PaddingTop) var(--pf-c-wizard__main-body--PaddingRight) var(--pf-c-wizard__main-body--PaddingBottom) var(--pf-c-wizard__main-body--PaddingLeft);
+}
+
+.ceph-ocs-install__create-sc-form {
+  width: 70%;
+}
+
+.ceph-ocs-install__form-wrapper {
+  display: flex;
+  margin-top: var(--pf-global--spacer--lg);
+  justify-content: space-between;
+}
+
+.ceph-ocs-install__chart-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.ceph-ocs-install__create-new-sc-btn {
+  padding-left: 0;
+  padding-top: var(--pf-global--spacer--lg);
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react';
+import { match as RouterMatch } from 'react-router';
+import {
+  Wizard,
+  WizardFooter,
+  WizardContextConsumer,
+  Button,
+  Alert,
+  WizardStep,
+} from '@patternfly/react-core';
+import { history } from '@console/internal/components/utils/router';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { k8sCreate, k8sPatch, K8sResourceKind } from '@console/internal/module/k8s';
+import { fetchK8s } from '@console/internal/graphql/client';
+import { LocalVolumeDiscovery } from '@console/local-storage-operator-plugin/src/models';
+import { getDiscoveryRequestData } from '@console/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data';
+import {
+  LOCAL_STORAGE_NAMESPACE,
+  DISCOVERY_CR_NAME,
+} from '@console/local-storage-operator-plugin/src/constants';
+import { getNodes } from '@console/local-storage-operator-plugin/src/utils';
+import {
+  DiskMechanicalProperty,
+  DiskType,
+} from '@console/local-storage-operator-plugin/src/components/local-volume-set/types';
+import { initialState, reducer, State, Action, Discoveries, OnNextClick } from './state';
+import { AutoDetectVolume } from './wizard-pages/auto-detect-volume';
+import { CreateLocalVolumeSet } from './wizard-pages/create-local-volume-set';
+import { nodesDiscoveriesResource } from '../../../../constants/resources';
+import { getTotalDeviceCapacity } from '../../../../utils/install';
+import { AVAILABLE, CreateStepsSC, minSelectedNode } from '../../../../constants';
+import { CreateOCS } from '../install-lso-sc';
+import '../attached-devices.scss';
+
+const makeAutoDiscoveryCall = (
+  onNext: OnNextClick,
+  state: State,
+  dispatch: React.Dispatch<Action>,
+) => {
+  dispatch({ type: 'setIsLoading', value: true });
+  const selectedNodes = getNodes(
+    state.showNodesListOnADV,
+    state.allNodeNamesOnADV,
+    state.nodeNamesForLVS,
+  );
+
+  fetchK8s(LocalVolumeDiscovery, DISCOVERY_CR_NAME, LOCAL_STORAGE_NAMESPACE)
+    .then((discoveryRes: K8sResourceKind) => {
+      const nodes = new Set(
+        discoveryRes?.spec?.nodeSelector?.nodeSelectorTerms?.[0]?.matchExpressions?.[0]?.values,
+      );
+      selectedNodes.forEach((name) => nodes.add(name));
+      const patch = [
+        {
+          op: 'replace',
+          path: `/spec/nodeSelector/nodeSelectorTerms/0/matchExpressions/0/values`,
+          value: Array.from(nodes),
+        },
+      ];
+      return k8sPatch(LocalVolumeDiscovery, discoveryRes, patch);
+    })
+    .catch(() => {
+      const requestData = getDiscoveryRequestData(state);
+      return k8sCreate(LocalVolumeDiscovery, requestData);
+    })
+    .then(() => {
+      dispatch({ type: 'setNodeNamesForLVS', value: selectedNodes });
+      onNext();
+      dispatch({ type: 'setIsLoading', value: false });
+    })
+    .catch((err) => {
+      dispatch({ type: 'setError', value: err.message });
+      dispatch({ type: 'setIsLoading', value: false });
+    });
+};
+
+const CreateSC: React.FC<CreateSCProps> = ({ match }) => {
+  const [state, dispatch] = React.useReducer(reducer, initialState);
+  const [discoveriesData, discoveriesLoaded, discoveriesLoadError] = useK8sWatchResource<
+    K8sResourceKind[]
+  >(nodesDiscoveriesResource);
+
+  React.useEffect(() => {
+    if (discoveriesLoaded && !discoveriesLoadError && discoveriesData.length) {
+      const nodesDiscoveries: Discoveries[] = discoveriesData.reduce((res, nodeDiscovery) => {
+        const name = nodeDiscovery?.spec?.nodeName;
+        const selectedNodes = getNodes(
+          state.showNodesListOnADV,
+          state.allNodeNamesOnADV,
+          state.nodeNamesForLVS,
+        );
+
+        let availableDisks: Discoveries[] = [];
+        if (selectedNodes.includes(name)) {
+          const discoveries = nodeDiscovery?.status?.discoveredDevices ?? [];
+          availableDisks = discoveries.filter((discovery) => {
+            // filter out non supported disks
+            if (
+              discovery?.status?.state === AVAILABLE &&
+              discovery.property === DiskMechanicalProperty.SSD &&
+              discovery.type === DiskType.RawDisk
+            ) {
+              discovery.node = name;
+              return true;
+            }
+            return false;
+          });
+        }
+        return [...res, ...availableDisks];
+      }, []);
+
+      dispatch({ type: 'setNodesDiscoveries', value: nodesDiscoveries });
+      const capacity = getTotalDeviceCapacity(nodesDiscoveries);
+      dispatch({ type: 'setChartTotalData', value: capacity?.value });
+      dispatch({ type: 'setChartDataUnit', unit: capacity?.unit });
+    }
+  }, [
+    discoveriesData,
+    discoveriesLoaded,
+    discoveriesLoadError,
+    state.nodeNamesForLVS,
+    state.showNodesListOnADV,
+    state.allNodeNamesOnADV,
+  ]);
+
+  const steps = [
+    {
+      id: CreateStepsSC.DISCOVER,
+      name: 'Discover Disks',
+      component: <AutoDetectVolume state={state} dispatch={dispatch} />,
+    },
+    {
+      id: CreateStepsSC.STORAGECLASS,
+      name: 'Create Storage Class',
+      component: <CreateLocalVolumeSet dispatch={dispatch} state={state} />,
+    },
+    {
+      id: CreateStepsSC.STORAGECLUSTER,
+      name: 'Create Storage Cluster',
+      component: <CreateOCS match={match} />,
+    },
+  ];
+
+  const getDisabledCondition = (activeStep: WizardStep) => {
+    switch (activeStep.id) {
+      case CreateStepsSC.DISCOVER:
+        return (
+          getNodes(state.showNodesListOnADV, state.allNodeNamesOnADV, state.nodeNamesForLVS)
+            .length < 1
+        );
+      case CreateStepsSC.STORAGECLASS:
+        if (!state.volumeSetName.trim().length) return true;
+        if (state.showNodesListOnLVS) return state.nodeNames.length < minSelectedNode;
+        return !state.volumeSetName.trim().length;
+
+      default:
+        return false;
+    }
+  };
+
+  const makeCall = (activeStep: WizardStep, onNext: OnNextClick) => {
+    // TODO: Need to think of a way to remove this
+    dispatch({ type: 'setOnNextClick', value: onNext });
+    if (activeStep.id === CreateStepsSC.DISCOVER) {
+      makeAutoDiscoveryCall(onNext, state, dispatch);
+    } else if (activeStep.id === CreateStepsSC.STORAGECLASS) {
+      dispatch({ type: 'setShowConfirmModal', value: true });
+    }
+  };
+
+  const CustomFooter = (
+    <div>
+      {!state.isLoading && state.error && (
+        <Alert
+          className="co-alert ceph-ocs-install__wizard-alert"
+          variant="danger"
+          title="An error occured"
+          isInline
+        >
+          {state.error}
+        </Alert>
+      )}
+      <WizardFooter>
+        <WizardContextConsumer>
+          {({ activeStep, onNext, onBack, onClose }) => {
+            if (activeStep.id !== CreateStepsSC.STORAGECLUSTER) {
+              return (
+                <>
+                  <Button
+                    variant="primary"
+                    type="submit"
+                    onClick={() => makeCall(activeStep, onNext)}
+                    className={
+                      state.isLoading || getDisabledCondition(activeStep) ? 'pf-m-disabled' : ''
+                    }
+                  >
+                    Next
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={onBack}
+                    className={activeStep.id === CreateStepsSC.STORAGECLASS ? '' : 'pf-m-disabled'}
+                  >
+                    Back
+                  </Button>
+                  <Button variant="link" onClick={onClose}>
+                    Cancel
+                  </Button>
+                </>
+              );
+            }
+            return null;
+          }}
+        </WizardContextConsumer>
+      </WizardFooter>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="ceph-create-sc-wizard">
+        <Wizard steps={steps} onClose={() => history.goBack()} footer={CustomFooter} />
+      </div>
+    </>
+  );
+};
+
+type CreateSCProps = {
+  match: RouterMatch<{ appName: string; ns: string }>;
+};
+
+export default CreateSC;

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
@@ -1,0 +1,163 @@
+export const diskModeDropdownItems = {
+  BLOCK: 'Block',
+  FILESYSTEM: 'Filesystem',
+};
+
+export const diskTypeDropdownItems = {
+  SSD: 'SSD / NVMe',
+  HDD: 'HDD',
+};
+
+export const diskSizeUnitOptions = {
+  TiB: 'TiB',
+  GiB: 'GiB',
+};
+
+export const initialState: State = {
+  // states for step 1
+  showNodesListOnADV: false,
+  nodeNamesForLVS: [], // nodes selected on discovery step, used in LVS step
+  allNodeNamesOnADV: [], // all nodes present in the env
+
+  // states for step 2
+  volumeSetName: '',
+  storageClassName: '',
+  showNodesListOnLVS: false,
+  diskType: diskTypeDropdownItems.SSD,
+  diskMode: diskModeDropdownItems.BLOCK,
+  maxDiskLimit: '',
+  nodeNames: [], // nodes selected on the LVS step
+  minDiskSize: 0,
+  maxDiskSize: 'All',
+  diskSizeUnit: 'TiB',
+  isValidMaxSize: true,
+  // states for chart
+  nodesDiscoveries: [],
+  chartSelectedData: '',
+  chartTotalData: '',
+  chartDataUnit: '',
+  showConfirmModal: false,
+
+  // common states
+  isLoading: false,
+  error: '',
+  onNextClick: null,
+};
+
+export type Discoveries = {
+  size: string;
+  path: string;
+  fstype: string;
+  vendor: string;
+  model: string;
+  status: {
+    state: string;
+  };
+  deviceID: string;
+  type: string;
+  property: string;
+  node: string;
+};
+
+export type OnNextClick = () => void;
+
+export type State = {
+  volumeSetName: string;
+  storageClassName: string;
+  showNodesListOnLVS: boolean;
+  diskType: string;
+  diskMode: string;
+  maxDiskLimit: string;
+  nodeNames: string[];
+  minDiskSize: number | string;
+  maxDiskSize: number | string;
+  diskSizeUnit: string;
+  isValidMaxSize: boolean;
+  chartSelectedData: string;
+  chartTotalData: string;
+  chartDataUnit: string;
+  showNodesListOnADV: boolean;
+  nodeNamesForLVS: string[];
+  isLoading: boolean;
+  error: string;
+  allNodeNamesOnADV: string[];
+  nodesDiscoveries: Discoveries[];
+  showConfirmModal: boolean;
+  onNextClick: () => void;
+};
+
+export type Action =
+  | { type: 'setVolumeSetName'; name: string }
+  | { type: 'setStorageClassName'; name: string }
+  | { type: 'setShowNodesListOnLVS'; value: boolean }
+  | { type: 'setDiskType'; value: string }
+  | { type: 'setDiskMode'; value: string }
+  | { type: 'setMaxDiskLimit'; value: string }
+  | { type: 'setNodeNames'; value: string[] }
+  | { type: 'setMinDiskSize'; value: number | string }
+  | { type: 'setMaxDiskSize'; value: number | string }
+  | { type: 'setDiskSizeUnit'; value: string }
+  | { type: 'setIsValidMaxSize'; value: boolean }
+  | { type: 'setAllNodeNames'; value: string[] }
+  | { type: 'setShowNodesListOnADV'; value: boolean }
+  | { type: 'setNodeNamesForLVS'; value: string[] }
+  | { type: 'setIsLoading'; value: boolean }
+  | { type: 'setError'; value: string }
+  | { type: 'setAllNodeNamesOnADV'; value: string[] }
+  | { type: 'setNodesDiscoveries'; value: Discoveries[] }
+  | { type: 'setChartSelectedData'; value: string }
+  | { type: 'setChartTotalData'; value: string }
+  | { type: 'setChartDataUnit'; unit: string }
+  | { type: 'setShowConfirmModal'; value: boolean }
+  | { type: 'setOnNextClick'; value: OnNextClick };
+
+export const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'setVolumeSetName':
+      return Object.assign({}, state, { volumeSetName: action.name });
+    case 'setStorageClassName':
+      return Object.assign({}, state, { storageClassName: action.name });
+    case 'setShowNodesListOnLVS':
+      return Object.assign({}, state, { showNodesListOnLVS: action.value });
+    case 'setDiskType':
+      return Object.assign({}, state, { diskType: action.value });
+    case 'setDiskMode':
+      return Object.assign({}, state, { diskMode: action.value });
+    case 'setMaxDiskLimit':
+      return Object.assign({}, state, { maxDiskLimit: action.value });
+    case 'setNodeNames':
+      return Object.assign({}, state, { nodeNames: action.value });
+    case 'setMinDiskSize':
+      return Object.assign({}, state, { minDiskSize: action.value });
+    case 'setMaxDiskSize':
+      return Object.assign({}, state, { maxDiskSize: action.value });
+    case 'setDiskSizeUnit':
+      return Object.assign({}, state, { diskSizeUnit: action.value });
+    case 'setIsValidMaxSize':
+      return Object.assign({}, state, { isValidMaxSize: action.value });
+    case 'setShowNodesListOnADV':
+      return Object.assign({}, state, { showNodesListOnADV: action.value });
+    case 'setNodeNamesForLVS':
+      return Object.assign({}, state, { nodeNamesForLVS: action.value });
+    case 'setIsLoading':
+      return Object.assign({}, state, { isLoading: action.value });
+    case 'setError':
+      return Object.assign({}, state, { error: action.value });
+    case 'setAllNodeNamesOnADV':
+      return Object.assign({}, state, { allNodeNamesOnADV: action.value });
+    case 'setNodesDiscoveries':
+      return Object.assign({}, state, { nodesDiscoveries: action.value });
+    case 'setChartSelectedData':
+      return Object.assign({}, state, { chartSelectedData: action.value });
+    case 'setChartTotalData':
+      return Object.assign({}, state, { chartTotalData: action.value });
+    case 'setChartDataUnit':
+      return Object.assign({}, state, { chartDataUnit: action.unit });
+    case 'setShowConfirmModal':
+      return Object.assign({}, state, { showConfirmModal: action.value });
+    case 'setOnNextClick':
+      return Object.assign({}, state, { onNextClick: action.value });
+    default:
+      return initialState;
+  }
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/auto-detect-volume.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/auto-detect-volume.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Form } from '@patternfly/react-core';
+import {
+  AutoDetectVolumeInner,
+  AutoDetectVolumeHeader,
+} from '@console/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume-inner';
+import { State, Action } from '../state';
+import '../../attached-devices.scss';
+
+export const AutoDetectVolume: React.FC<AutoDetectVolumeProps> = ({ state, dispatch }) => (
+  <>
+    <AutoDetectVolumeHeader />
+    <Form noValidate={false} className="ceph-ocs-install__auto-detect-table">
+      <AutoDetectVolumeInner state={state} dispatch={dispatch} />
+    </Form>
+  </>
+);
+
+type AutoDetectVolumeProps = {
+  state: State;
+  dispatch: React.Dispatch<Action>;
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Form, Alert, Modal, Button } from '@patternfly/react-core';
+import { k8sCreate } from '@console/internal/module/k8s';
+import { LocalVolumeSetModel } from '@console/local-storage-operator-plugin/src/models';
+import {
+  LocalVolumeSetInner,
+  LocalVolumeSetHeader,
+} from '@console/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner';
+import { getNodes } from '@console/local-storage-operator-plugin/src/utils';
+import { getLocalVolumeSetRequestData } from '@console/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data';
+import { State, Action } from '../state';
+import { minSelectedNode } from '../../../../../constants';
+import '../../attached-devices.scss';
+
+const makeLocalVolumeSetCall = (state: State, dispatch: React.Dispatch<Action>) => {
+  dispatch({ type: 'setIsLoading', value: true });
+  const requestData = getLocalVolumeSetRequestData(state);
+  k8sCreate(LocalVolumeSetModel, requestData)
+    .then(() => {
+      state.onNextClick();
+      dispatch({ type: 'setIsLoading', value: false });
+    })
+    .catch((err) => {
+      dispatch({ type: 'setError', value: err.message });
+      dispatch({ type: 'setIsLoading', value: false });
+    });
+};
+
+export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({ state, dispatch }) => {
+  const nodesCnt = getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames)
+    .length;
+  return (
+    <>
+      <LocalVolumeSetHeader />
+      <div className="ceph-ocs-install__form-wrapper">
+        <Form noValidate={false} className="ceph-ocs-install__create-sc-form">
+          <LocalVolumeSetInner state={state} dispatch={dispatch} />
+        </Form>
+      </div>
+      <ConfirmationModal state={state} dispatch={dispatch} />
+      {nodesCnt < minSelectedNode && (
+        <Alert
+          className="co-alert ceph-ocs-install__wizard-alert"
+          variant="danger"
+          title="Minimum Node Requirement"
+          isInline
+        >
+          The OCS storage cluster require a minimum of 3 nodes for the intial deployment. Only{' '}
+          {nodesCnt} nodes match to the selected filters. Please adjust the filters to include more
+          nodes.
+        </Alert>
+      )}
+    </>
+  );
+};
+
+type CreateLocalVolumeSetProps = {
+  state: State;
+  dispatch: React.Dispatch<Action>;
+};
+
+const ConfirmationModal = ({ state, dispatch }) => {
+  const makeLVSCall = () => {
+    dispatch({ type: 'setShowConfirmModal', value: false });
+    makeLocalVolumeSetCall(state, dispatch);
+  };
+
+  const cancel = () => {
+    dispatch({ type: 'setCreateLVS', value: false });
+    dispatch({ type: 'setShowConfirmModal', value: false });
+  };
+
+  return (
+    <>
+      <Modal
+        title="Create Storage Class"
+        isOpen={state.showConfirmModal}
+        onClose={cancel}
+        variant="small"
+        actions={[
+          <Button key="confirm" variant="primary" onClick={makeLVSCall}>
+            Yes
+          </Button>,
+          <Button key="cancel" variant="link" onClick={cancel}>
+            Cancel
+          </Button>,
+        ]}
+      >
+        {
+          "After the volume set and storage class are created you won't be able to go back to this step. Are you sure you want to continue?"
+        }
+      </Modal>
+    </>
+  );
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -140,7 +140,12 @@ export const CreateInternalCluster = withHandlePromise<
           customData={{
             onRowSelected: setNodes,
           }}
-        />
+        >
+          <span>
+            Select at least 3 nodes in different zones you wish to use with minimum requirements of
+            16 CPUs and 64 GiB of RAM per node.
+          </span>
+        </SelectNodesSection>
         <ButtonBar errorMessage={errorMessage} inProgress={inProgress}>
           <ActionGroup className="pf-c-form">
             <Button

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -16,7 +16,7 @@ import './install-page.scss';
 enum MODES {
   INTERNAL = 'Internal',
   EXTERNAL = 'External',
-  ATTACHED_DEVICES = 'Attached Devices',
+  ATTACHED_DEVICES = 'Internal - Attached Devices',
 }
 
 // eslint-disable-next-line no-shadow
@@ -31,7 +31,7 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
     null,
   );
   const [downloadFile, setDownloadFile] = React.useState(null);
-  const [mode, setMode] = React.useState(MODES.INTERNAL);
+  const [mode, setMode] = React.useState(MODES.ATTACHED_DEVICES);
   const [clusterServiceVersion, setClusterServiceVersion] = React.useState(null);
 
   const handleModeChange = (event: React.FormEvent<HTMLInputElement>) => {
@@ -102,13 +102,13 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
               title: MODES.INTERNAL,
             },
             {
+              value: MODES.ATTACHED_DEVICES,
+              title: MODES.ATTACHED_DEVICES,
+            },
+            {
               value: MODES.EXTERNAL,
               title: MODES.EXTERNAL,
               disabled: !isIndependent,
-            },
-            {
-              value: MODES.ATTACHED_DEVICES,
-              title: MODES.ATTACHED_DEVICES,
             },
           ]}
           onChange={handleModeChange}

--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -16,3 +16,5 @@ export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';
 export const OCS_SUPPORT_ANNOTATION = 'features.ocs.openshift.io/enabled';
 export const OCS_DEVICE_SET_REPLICA = 3;
 export const ATTACHED_DEVICES_ANNOTATION = 'cluster.ocs.openshift.io/local-devices';
+export const LSO_NAMESPACE = 'local-storage';
+export const AVAILABLE = 'Available';

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -17,3 +17,9 @@ export enum defaultRequestSize {
   BAREMETAL = '1',
   NON_BAREMETAL = '2Ti',
 }
+
+export enum CreateStepsSC {
+  DISCOVER = 'DISCOVER',
+  STORAGECLASS = 'STORAGECLASS',
+  STORAGECLUSTER = 'STORAGECLUSTER',
+}

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -1,10 +1,10 @@
 import { FirehoseResource } from '@console/internal/components/utils/index';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
 import { PrometheusEndpoint } from '@console/internal/components/graphs/helpers';
-import { PersistentVolumeModel, StorageClassModel } from '@console/internal/models';
+import { PersistentVolumeModel, StorageClassModel, NodeModel } from '@console/internal/models';
 import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { SubscriptionModel } from '@console/operator-lifecycle-manager';
-import { LocalVolumeSetModel } from '@console/local-storage-operator-plugin/src/models';
+import { LocalVolumeDiscoveryResult } from '@console/local-storage-operator-plugin/src/models';
 import { LSO_NAMESPACE } from '@console/local-storage-operator-plugin/src/constants';
 import { CephClusterModel, CephBlockPoolModel } from '../models';
 import { CEPH_STORAGE_NAMESPACE } from '.';
@@ -29,12 +29,6 @@ export const scResource: WatchK8sResource = {
   isList: true,
 };
 
-export const LVSResource: WatchK8sResource = {
-  kind: referenceForModel(LocalVolumeSetModel),
-  namespace: LSO_NAMESPACE,
-  isList: true,
-};
-
 export const LSOSubscriptionResource: WatchK8sResource = {
   kind: referenceForModel(SubscriptionModel),
   namespace: LSO_NAMESPACE,
@@ -52,4 +46,16 @@ export const cephCapacityResource = {
   endpoint: PrometheusEndpoint.QUERY,
   namespace: CEPH_STORAGE_NAMESPACE,
   query: CAPACITY_USAGE_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_USED],
+};
+
+export const nodeResource: WatchK8sResource = {
+  kind: NodeModel.kind,
+  namespaced: false,
+  isList: true,
+};
+
+export const nodesDiscoveriesResource: WatchK8sResource = {
+  kind: referenceForModel(LocalVolumeDiscoveryResult),
+  namespaced: false,
+  isList: true,
 };

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -23,6 +23,8 @@ export const OCS_FLAG = 'OCS';
 // Todo(bipuladh): Remove this completely in 4.6
 export const CEPH_FLAG = 'CEPH';
 
+export const LSO_FLAG = 'LSO';
+
 /* Key and Value should be same value received in CSV  */
 export const OCS_SUPPORT_FLAGS = {
   SNAPSHOT: 'SNAPSHOT',

--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -17,22 +17,21 @@ export const OCSAlert = () => (
   />
 );
 
-export const SelectNodesSection: React.FC<SelectNodesSectionProps> = ({ table, customData }) => (
+export const SelectNodesSection: React.FC<SelectNodesSectionProps> = ({
+  table,
+  customData,
+  children,
+}) => (
   <>
     <FormGroup fieldId="select-nodes">
       <p>
-        Selected nodes will be labeled with{' '}
+        {children}
+        The selected nodes will be labeled with{' '}
         <code>cluster.ocs.openshift.io/openshift-storage=&quot;&quot;</code> to create the OCS
-        Service.
+        cluster and 3 of the selected nodes will be used for initial deployment. The other selected
+        nodes will be used by OpenShift as scheduling targets for OCS scaling.
       </p>
-      <p className="co-legend" data-test-id="warning">
-        Select at least 3 nodes in different failure domains with minimum requirements of 16 CPUs
-        and 64 GiB of RAM per node.
-      </p>
-      <p>
-        3 selected nodes are used for initial deployment. The remaining selected nodes will be used
-        by OpenShift as scheduling targets for OCS scaling.
-      </p>
+
       <ListPage
         kind={NodeModel.kind}
         showTitle={false}
@@ -76,6 +75,7 @@ export const StorageClassSection: React.FC<StorageClassSectionProps> = ({
 type SelectNodesSectionProps = {
   table: React.ComponentType<any>;
   customData?: any;
+  children?: React.ReactChild;
 };
 
 type StorageClassSectionProps = {

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume-inner.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { FormGroup, Radio } from '@patternfly/react-core';
+import { ListPage } from '@console/internal/components/factory';
+import { NodeKind } from '@console/internal/module/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { getName } from '@console/shared';
+import { NodeModel } from '@console/internal/models';
+import { NodesSelectionList } from '../local-volume-set/nodes-selection-list';
+import { State, Action } from './state';
+import { hasTaints } from '../../utils';
+import { nodeResource } from '../../constants/resources';
+import './auto-detect-volume.scss';
+
+export const AutoDetectVolumeInner: React.FC<AutoDetectVolumeInnerProps> = ({
+  state,
+  dispatch,
+}) => {
+  const [nodeData, nodeLoaded, nodeLoadError] = useK8sWatchResource<NodeKind[]>(nodeResource);
+
+  React.useEffect(() => {
+    if ((nodeLoadError || nodeData.length === 0) && nodeLoaded) {
+      dispatch({ type: 'setAllNodeNamesOnADV', value: [] });
+    } else if (nodeLoaded) {
+      const names = nodeData.filter((node) => !hasTaints(node)).map((node) => getName(node));
+      dispatch({ type: 'setAllNodeNamesOnADV', value: names });
+    }
+  }, [dispatch, nodeData, nodeLoaded, nodeLoadError]);
+
+  React.useEffect(() => {
+    if (!state.showNodesListOnADV) {
+      // explicitly needs to set this in order to make the validation works
+      dispatch({ type: 'setNodeNamesForLVS', value: [] });
+      dispatch({ type: 'setAllNodeNamesOnADV', value: state.allNodeNamesOnADV });
+    } else {
+      dispatch({ type: 'setNodeNamesForLVS', value: state.nodeNamesForLVS });
+    }
+    // TODO: Neha- Find out a better way
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, state.allNodeNamesOnADV, state.showNodesListOnADV]);
+
+  const toggleShowNodesList = () => {
+    dispatch({ type: 'setShowNodesListOnADV', value: !state.showNodesListOnADV });
+  };
+
+  return (
+    <>
+      <FormGroup label="Node Selector" fieldId="auto-detect-volume--radio-group-node-selector">
+        <div id="auto-detect-volume-radio-group-node-selector">
+          <Radio
+            label="All nodes"
+            name="nodes-selection"
+            id="auto-detect-volume-radio-all-nodes"
+            className="auto-detect-volume__all-nodes-radio--padding"
+            value="allNodes"
+            onChange={toggleShowNodesList}
+            description="Selecting all nodes will discover for available disks storage on all nodes."
+            checked={!state.showNodesListOnADV}
+          />
+          <Radio
+            label="Select nodes"
+            name="nodes-selection"
+            id="auto-detect-volume-radio-select-nodes"
+            value="selectedNodes"
+            onChange={toggleShowNodesList}
+            description="Selecting nodes allow you to limit the discovery for available disks to specific nodes."
+            checked={state.showNodesListOnADV}
+          />
+        </div>
+      </FormGroup>
+      {state.showNodesListOnADV && (
+        <ListPage
+          showTitle={false}
+          kind={NodeModel.kind}
+          ListComponent={NodesSelectionList}
+          customData={{
+            onRowSelected: (selectedNodes: NodeKind[]) => {
+              const nodes = selectedNodes.map(getName);
+              dispatch({ type: 'setNodeNamesForLVS', value: nodes });
+            },
+            preSelected: state.nodeNamesForLVS,
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export const AutoDetectVolumeHeader = () => (
+  <>
+    <h1 className="co-create-operand__header-text">Auto Detect Volume</h1>
+    <p className="help-block">Allows you to discover the available disks on all available nodes</p>
+  </>
+);
+
+type AutoDetectVolumeInnerProps = {
+  state: State;
+  dispatch: React.Dispatch<Action>;
+};

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.scss
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.scss
@@ -1,0 +1,8 @@
+.auto-detect-volume__all-nodes-radio--padding {
+  padding-bottom: var(--pf-global--spacer--sm);
+}
+
+// required to hide the space between radio button and node list
+.co-m-nav-title {
+  margin-top: 0;
+}

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { match as RouterMatch } from 'react-router';
+import { ActionGroup, Button, Form } from '@patternfly/react-core';
+import {
+  resourcePathFromModel,
+  BreadCrumbs,
+  resourceObjPath,
+  withHandlePromise,
+  HandlePromiseProps,
+  ButtonBar,
+} from '@console/internal/components/utils';
+import { history } from '@console/internal/components/utils/router';
+import { k8sCreate, k8sPatch, referenceFor, K8sResourceKind } from '@console/internal/module/k8s';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
+import { getNodes } from '../../utils';
+import { AutoDetectVolumeInner, AutoDetectVolumeHeader } from './auto-detect-volume-inner';
+import { getDiscoveryRequestData } from './discovery-request-data';
+import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
+import { initialState, reducer } from './state';
+import { DISCOVERY_CR_NAME, LOCAL_STORAGE_NAMESPACE } from '../../constants';
+import { fetchK8s } from '@console/internal/graphql/client';
+
+const AutoDetectVolume: React.FC = withHandlePromise<AutoDetectVolumeProps & HandlePromiseProps>(
+  (props) => {
+    const { match, handlePromise, inProgress, errorMessage } = props;
+    const { appName, ns } = match.params;
+    const [state, dispatch] = React.useReducer(reducer, initialState);
+
+    const onSubmit = (event: React.FormEvent<EventTarget>) => {
+      event.preventDefault();
+
+      handlePromise(
+        fetchK8s(AutoDetectVolumeModel, DISCOVERY_CR_NAME, LOCAL_STORAGE_NAMESPACE)
+          .then((discoveryRes: K8sResourceKind) => {
+            const nodes = new Set(
+              discoveryRes?.spec?.nodeSelector?.nodeSelectorTerms?.[0]?.matchExpressions?.[0]?.values,
+            );
+            const selectedNodes = getNodes(
+              state.showNodesListOnADV,
+              state.allNodeNamesOnADV,
+              state.nodeNamesForLVS,
+            );
+            selectedNodes.forEach((name) => nodes.add(name));
+            const patch = [
+              {
+                op: 'replace',
+                path: `/spec/nodeSelector/nodeSelectorTerms/0/matchExpressions/0/values`,
+                value: Array.from(nodes),
+              },
+            ];
+            return k8sPatch(AutoDetectVolumeModel, discoveryRes, patch);
+          })
+          .catch(() => {
+            const requestData = getDiscoveryRequestData(state);
+
+            return k8sCreate(AutoDetectVolumeModel, requestData);
+          })
+          .then((resource) => history.push(resourceObjPath(resource, referenceFor(resource))))
+          .catch(() => null),
+      );
+    };
+
+    return (
+      <>
+        <div className="co-create-operand__header">
+          <div className="co-create-operand__header-buttons">
+            <BreadCrumbs
+              breadcrumbs={[
+                {
+                  name: 'Local Storage',
+                  path: resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
+                },
+                { name: `Auto Detect Volume`, path: '' },
+              ]}
+            />
+          </div>
+
+          <AutoDetectVolumeHeader />
+        </div>
+        <Form noValidate={false} className="co-m-pane__body co-m-pane__form" onSubmit={onSubmit}>
+          <AutoDetectVolumeInner state={state} dispatch={dispatch} />
+          <ButtonBar errorMessage={errorMessage} inProgress={inProgress}>
+            <ActionGroup>
+              <Button
+                type="submit"
+                variant="primary"
+                isDisabled={state.showNodesListOnADV && state.nodeNamesForLVS?.length < 1}
+              >
+                Create
+              </Button>
+              <Button type="button" variant="secondary" onClick={history.goBack}>
+                Cancel
+              </Button>
+            </ActionGroup>
+          </ButtonBar>
+        </Form>
+      </>
+    );
+  },
+);
+
+type AutoDetectVolumeProps = {
+  match: RouterMatch<{ appName: string; ns: string }>;
+} & HandlePromiseProps;
+
+export default AutoDetectVolume;

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
@@ -1,0 +1,50 @@
+import { apiVersionForModel, K8sResourceCommon } from '@console/internal/module/k8s';
+import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
+import {
+  DISCOVERY_CR_NAME,
+  LOCAL_STORAGE_NAMESPACE,
+  HOSTNAME_LABEL_KEY,
+  LABEL_OPERATOR,
+} from '../../constants';
+import { getNodes } from '../../utils';
+
+export const getDiscoveryRequestData = ({
+  nodeNamesForLVS,
+  allNodeNamesOnADV,
+  showNodesListOnADV,
+}: {
+  nodeNamesForLVS: string[];
+  allNodeNamesOnADV: string[];
+  showNodesListOnADV: boolean;
+}): AutoDetectVolumeKind => ({
+  apiVersion: apiVersionForModel(AutoDetectVolumeModel),
+  kind: AutoDetectVolumeModel.kind,
+  metadata: { name: DISCOVERY_CR_NAME, namespace: LOCAL_STORAGE_NAMESPACE },
+  spec: {
+    nodeSelector: {
+      nodeSelectorTerms: [
+        {
+          matchExpressions: [
+            {
+              key: HOSTNAME_LABEL_KEY,
+              operator: LABEL_OPERATOR,
+              values: getNodes(showNodesListOnADV, allNodeNamesOnADV, nodeNamesForLVS),
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+type AutoDetectVolumeKind = K8sResourceCommon & {
+  spec: {
+    nodeSelector?: {
+      nodeSelectorTerms: [
+        {
+          matchExpressions: [{ key: string; operator: string; values: string[] }];
+        },
+      ];
+    };
+  };
+};

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/state.ts
@@ -1,0 +1,29 @@
+export const initialState = {
+  showNodesListOnADV: false,
+  nodeNamesForLVS: [],
+  allNodeNamesOnADV: [],
+};
+
+export type State = {
+  showNodesListOnADV: boolean;
+  nodeNamesForLVS: string[];
+  allNodeNamesOnADV: string[];
+};
+
+export type Action =
+  | { type: 'setShowNodesListOnADV'; value: boolean }
+  | { type: 'setNodeNamesForLVS'; value: string[] }
+  | { type: 'setAllNodeNamesOnADV'; value: string[] };
+
+export const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'setShowNodesListOnADV':
+      return Object.assign({}, state, { showNodesListOnADV: action.value });
+    case 'setNodeNamesForLVS':
+      return Object.assign({}, state, { nodeNamesForLVS: action.value });
+    case 'setAllNodeNamesOnADV':
+      return Object.assign({}, state, { allNodeNamesOnADV: action.value });
+    default:
+      return initialState;
+  }
+};

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
@@ -37,3 +37,8 @@
 .lso-create-lvs__disk-size-form-group-max-input {
   max-width: 100px;
 }
+
+// required to hide the space between radio button and node list
+.co-m-nav-title {
+  margin-top: 0;
+}

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -27,13 +27,19 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = (props) =
   const { dispatch, state } = props;
 
   React.useEffect(() => {
-    if (!state.showNodesList) {
-      dispatch({ type: 'setNodeNames', value: state.allNodeNames });
+    if (!state.showNodesListOnLVS) {
+      // explicitly needs to set this in order to make the validation works
+      dispatch({ type: 'setNodeNames', value: [] });
+      dispatch({ type: 'setNodeNamesForLVS', value: state.nodeNamesForLVS });
+    } else {
+      dispatch({ type: 'setNodeNames', value: state.nodeNames });
     }
-  }, [dispatch, state.allNodeNames, state.showNodesList]);
+    // TODO: Neha- Find out a better way
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, state.nodeNamesForLVS, state.showNodesListOnLVS]);
 
   const toggleShowNodesList = () => {
-    dispatch({ type: 'setShowNodesList', value: !state.showNodesList });
+    dispatch({ type: 'setShowNodesListOnLVS', value: !state.showNodesListOnLVS });
   };
 
   const onMaxSizeChange = (size: string) => {
@@ -64,6 +70,7 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = (props) =
           type={TextInputTypes.text}
           id="create-lvs--storage-class-name"
           value={state.storageClassName}
+          placeholder={state.volumeSetName}
           onChange={(name: string) => dispatch({ type: 'setStorageClassName', name })}
         />
       </FormGroup>
@@ -71,28 +78,29 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = (props) =
         Filter Disks
       </Text>
       <FormGroup label="Node Selector" fieldId="create-lvs--radio-group-node-selector">
-        <div id="create-lvs--radio-group-node-selector">
+        <div id="create-lvs-radio-group-node-selector">
           <Radio
             label="All nodes"
             name="nodes-selection"
-            id="create-lvs--radio-all-nodes"
+            id="create-lvs-radio-all-nodes"
             className="lso-create-lvs__all-nodes-radio--padding"
             value="allNodes"
             onChange={toggleShowNodesList}
-            description="Selecting all nodes will search for available disks storage on all nodes."
-            defaultChecked
+            description="Selecting all nodes will use the available disks that match the selected filters on all nodes."
+            checked={!state.showNodesListOnLVS}
           />
           <Radio
             label="Select nodes"
             name="nodes-selection"
-            id="create-lvs--radio-select-nodes"
+            id="create-lvs-radio-select-nodes"
             value="selectedNodes"
             onChange={toggleShowNodesList}
-            description="Selecting nodes allow you to limit the search for available disks to specific nodes."
+            description="Selecting all nodes will use the available disks that match the selected filters only on selected nodes."
+            checked={state.showNodesListOnLVS}
           />
         </div>
       </FormGroup>
-      {state.showNodesList && (
+      {state.showNodesListOnLVS && (
         <ListPage
           showTitle={false}
           kind={NodeModel.kind}
@@ -102,6 +110,8 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = (props) =
               const nodes = selectedNodes.map(getName);
               dispatch({ type: 'setNodeNames', value: nodes });
             },
+            filteredNodes: state.nodeNamesForLVS,
+            preSelected: state.nodeNames,
           }}
         />
       )}

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -2,13 +2,19 @@ import { apiVersionForModel } from '@console/internal/module/k8s';
 import { LocalVolumeSetModel } from '../../models';
 import { LocalVolumeSetKind, DiskType, DiskMechanicalProperty } from './types';
 import { State } from './state';
-import { MAX_DISK_SIZE } from '../../constants';
+import {
+  MAX_DISK_SIZE,
+  LOCAL_STORAGE_NAMESPACE,
+  HOSTNAME_LABEL_KEY,
+  LABEL_OPERATOR,
+} from '../../constants';
+import { getNodes } from '../../utils';
 
 export const getLocalVolumeSetRequestData = (state: State): LocalVolumeSetKind => {
   const requestData = {
     apiVersion: apiVersionForModel(LocalVolumeSetModel),
     kind: LocalVolumeSetModel.kind,
-    metadata: { name: state.volumeSetName, namespace: 'local-storage' },
+    metadata: { name: state.volumeSetName, namespace: LOCAL_STORAGE_NAMESPACE },
     spec: {
       storageClassName: state.storageClassName || state.volumeSetName,
       volumeMode: state.diskMode,
@@ -24,7 +30,11 @@ export const getLocalVolumeSetRequestData = (state: State): LocalVolumeSetKind =
         nodeSelectorTerms: [
           {
             matchExpressions: [
-              { key: 'kubernetes.io/hostname', operator: 'In', values: state.nodeNames },
+              {
+                key: HOSTNAME_LABEL_KEY,
+                operator: LABEL_OPERATOR,
+                values: getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames),
+              },
             ],
           },
         ],

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -3,7 +3,7 @@ import { MAX_DISK_SIZE, diskTypeDropdownItems, diskModeDropdownItems } from '../
 export const initialState = {
   volumeSetName: '',
   storageClassName: '',
-  showNodesList: false,
+  showNodesListOnLVS: false,
   diskType: diskTypeDropdownItems.SSD,
   diskMode: diskModeDropdownItems.BLOCK,
   maxDiskLimit: '',
@@ -12,13 +12,13 @@ export const initialState = {
   maxDiskSize: MAX_DISK_SIZE,
   diskSizeUnit: 'TiB',
   isValidMaxSize: true,
-  allNodeNames: [],
+  nodeNamesForLVS: [],
 };
 
 export type State = {
   volumeSetName: string;
   storageClassName: string;
-  showNodesList: boolean;
+  showNodesListOnLVS: boolean;
   diskType: string;
   diskMode: string;
   maxDiskLimit: string;
@@ -27,13 +27,13 @@ export type State = {
   maxDiskSize: number | string;
   diskSizeUnit: string;
   isValidMaxSize: boolean;
-  allNodeNames: string[];
+  nodeNamesForLVS: string[];
 };
 
 export type Action =
   | { type: 'setVolumeSetName'; name: string }
   | { type: 'setStorageClassName'; name: string }
-  | { type: 'setShowNodesList'; value: boolean }
+  | { type: 'setShowNodesListOnLVS'; value: boolean }
   | { type: 'setDiskType'; value: string }
   | { type: 'setDiskMode'; value: string }
   | { type: 'setMaxDiskLimit'; value: string }
@@ -42,7 +42,7 @@ export type Action =
   | { type: 'setMaxDiskSize'; value: number | string }
   | { type: 'setDiskSizeUnit'; value: string }
   | { type: 'setIsValidMaxSize'; value: boolean }
-  | { type: 'setAllNodeNames'; value: string[] };
+  | { type: 'setNodeNamesForLVS'; value: string[] };
 
 export const reducer = (state: State, action: Action) => {
   switch (action.type) {
@@ -50,8 +50,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { volumeSetName: action.name });
     case 'setStorageClassName':
       return Object.assign({}, state, { storageClassName: action.name });
-    case 'setShowNodesList':
-      return Object.assign({}, state, { showNodesList: action.value });
+    case 'setShowNodesListOnLVS':
+      return Object.assign({}, state, { showNodesListOnLVS: action.value });
     case 'setDiskType':
       return Object.assign({}, state, { diskType: action.value });
     case 'setDiskMode':
@@ -68,8 +68,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { diskSizeUnit: action.value });
     case 'setIsValidMaxSize':
       return Object.assign({}, state, { isValidMaxSize: action.value });
-    case 'setAllNodeNames':
-      return Object.assign({}, state, { allNodeNames: action.value });
+    case 'setNodeNamesForLVS':
+      return Object.assign({}, state, { nodeNamesForLVS: action.value });
     default:
       return initialState;
   }

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
@@ -41,10 +41,16 @@ export type LocalVolumeSetKind = K8sResourceCommon & {
 export type GetRows = (
   {
     componentProps,
+    customData,
   }: {
     componentProps: { data: NodeKind[] };
+    customData?: {
+      filteredNodes: string[];
+      preSelected?: string[];
+    };
   },
   visibleRows: Set<string>,
   setVisibleRows: React.Dispatch<React.SetStateAction<Set<string>>>,
   selectedNodes: Set<string>,
+  setSelectedNodes?: (nodes: NodeKind[]) => void,
 ) => NodeTableRow[];

--- a/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
@@ -15,3 +15,7 @@ export const diskSizeUnitOptions = {
   TiB: 'TiB',
   GiB: 'GiB',
 };
+export const DISCOVERY_CR_NAME = 'auto-discover-devices';
+export const LOCAL_STORAGE_NAMESPACE = 'local-storage';
+export const HOSTNAME_LABEL_KEY = 'kubernetes.io/hostname';
+export const LABEL_OPERATOR = 'In';

--- a/frontend/packages/local-storage-operator-plugin/src/models.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/models.ts
@@ -38,3 +38,16 @@ export const LocalVolumeModel: K8sKind = {
   id: 'localvolume',
   crd: true,
 };
+
+export const LocalVolumeDiscovery: K8sKind = {
+  label: 'Local Volume Discovery',
+  labelPlural: 'Local Volume Discoveries',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'local.storage.openshift.io',
+  plural: 'localvolumediscoveries',
+  abbr: 'LVD',
+  namespaced: true,
+  kind: 'LocalVolumeDiscovery',
+  id: 'localvolumediscovery',
+  crd: true,
+};

--- a/frontend/packages/local-storage-operator-plugin/src/plugin.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/plugin.ts
@@ -99,6 +99,22 @@ const plugin: Plugin<ConsumedExtensions> = [
       required: [LSO_DEVICE_DISCOVERY],
     },
   },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/${referenceForModel(
+        models.LocalVolumeDiscovery,
+      )}/~new`,
+      loader: () =>
+        import(
+          './components/auto-detect-volume/auto-detect-volume' /* webpackChunkName: "lso-auto-detect-volume" */
+        ).then((m) => m.default),
+    },
+    flags: {
+      required: [LSO_FLAG],
+    },
+  },
 ];
 
 export default plugin;

--- a/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
@@ -4,3 +4,9 @@ import { NodeKind } from '@console/internal/module/k8s';
 export const hasTaints = (node: NodeKind): boolean => {
   return !_.isEmpty(node.spec?.taints);
 };
+
+export const getNodes = (
+  showNodes: boolean,
+  allNodes: string[],
+  selectedNodes: string[],
+): string[] => (showNodes ? selectedNodes : allNodes);

--- a/frontend/packages/noobaa-storage-plugin/src/components/bucket-class/create-bc.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/bucket-class/create-bc.tsx
@@ -153,14 +153,7 @@ const CreateBucketClass: React.FC<CreateBCProps> = ({ match }) => {
         </div>
       </div>
       <div className="nb-create-bc-wizard">
-        <Wizard
-          isOpen
-          title="Create new Bucket Class"
-          description="NooBaa Bucket Class is a CRD representing a class for buckets that defines policies for data placement and more"
-          steps={steps}
-          onSave={finalStep}
-          onClose={() => history.goBack()}
-        />
+        <Wizard steps={steps} onSave={finalStep} onClose={() => history.goBack()} />
       </div>
     </>
   );


### PR DESCRIPTION
Completed -
- Auto Detect Volume Flow for Local Storage Operator View
- Create Storage Cluster Wizard for ocs installation on attached devices
- Total Capacity available on the discovered nodes

![Screenshot from 2020-07-20 13-04-44](https://user-images.githubusercontent.com/5517376/87898846-4af3a300-ca8a-11ea-8a49-9e62f79dbb27.png)
![Screenshot from 2020-07-20 13-05-10](https://user-images.githubusercontent.com/5517376/87898852-4fb85700-ca8a-11ea-948c-65a8581ab09c.png)
![Screenshot from 2020-07-20 13-07-06](https://user-images.githubusercontent.com/5517376/87898854-521ab100-ca8a-11ea-8ac3-0e09a5bc2b6d.png)

Changes to be included in next PR -
- Donut chart using the total capacity calculated
- Update the selected capacity based on filter
- Do changes to incorporate CLI scenario in all UI views
- Hide non OCS specific options from LVS and ADV

