### PR TITLE
Hide internal operators

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -1,3 +1,6 @@
 export enum Flags {
   OPERATOR_LIFECYCLE_MANAGER = 'OPERATOR_LIFECYCLE_MANAGER',
 }
+
+export const operatorTypeAnnotation = 'operators.operatorframework.io/operator-type';
+export const nonStandardAnnotationValue = 'non-standard';


### PR DESCRIPTION
Based on https://issues.redhat.com/browse/CONSOLE-2293

Hiding **non-standalone** operators from the Operator Hub and Installed Operators pages.

For the Operator Hub we should be checking for the `currentCSVDesc` annotations for the `operators.operatorframework.io/operator-type: 'non-standalone'`, which indicates a non-standalone operator.
For the Installed Operators list page we are hiding:
- **CSV** that contain the provided annotation and are in *Failed* phase
- **Subscriptions**, for which are we matching a packageManifest and checking its `currentCSVDesc` annotations, and the Subscription is in the *UpgradeFailed* state.

/assign @spadgett 