### PR TITLE
Bug 1857821: Fix for pod ring exception

### DIFF
--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -76,6 +76,10 @@ const isPendingPods = (
   (!currentPodCount && !!desiredPodCount);
 
 export const getFailedPods = (pods: ExtPodKind[]): number => {
+  if (!pods?.length) {
+    return 0;
+  }
+
   return pods.reduce((acc, currValue) => {
     if ([AllPodStatus.CrashLoopBackOff, AllPodStatus.Failed].includes(getPodStatus(currValue))) {
       return acc + 1;


### PR DESCRIPTION
This a manual backport for a fix used in 4.6 to correct a pod ring exception. This was caused by a lack of handling for a bad pods parameter in getFailedPods.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1857821.