### PR TITLE
Add HPA In-Context

### DIFF
--- a/frontend/packages/console-app/src/actions/modify-hpa.ts
+++ b/frontend/packages/console-app/src/actions/modify-hpa.ts
@@ -1,0 +1,16 @@
+import { history, KebabAction } from '@console/internal/components/utils';
+import { K8sKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+
+export const AddHorizontalPodAutoScaler: KebabAction = (kind: K8sKind, obj: K8sResourceCommon) => ({
+  label: `Add ${HorizontalPodAutoscalerModel.label}`,
+  callback: () => {
+    history.push(`/workload-hpa/ns/${obj.metadata.namespace}/${kind.kind}/${obj.metadata.name}`);
+  },
+  accessReview: {
+    group: HorizontalPodAutoscalerModel.apiGroup,
+    resource: HorizontalPodAutoscalerModel.plural,
+    namespace: obj.metadata.namespace,
+    verb: 'create',
+  },
+});

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -12,6 +12,7 @@ type EditorContext = {
   name: string;
   editor: React.ReactNode;
   isDisabled?: boolean;
+  sanitizeTo?: (preFormData: any) => any;
 };
 
 type SyncedEditorFieldProps = {
@@ -42,7 +43,10 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
     const newFormData = safeYAMLToJS(yamlData);
     if (!_.isEmpty(newFormData)) {
       changeEditorType(EditorType.Form);
-      setFieldValue(formContext.name, newFormData);
+      setFieldValue(
+        formContext.name,
+        formContext.sanitizeTo ? formContext.sanitizeTo(newFormData) : newFormData,
+      );
     } else {
       setYAMLWarning(true);
     }
@@ -50,7 +54,10 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
 
   const handleToggleToYAML = () => {
     const newYAML = safeJSToYAML(formData, yamlData, { skipInvalid: true });
-    setFieldValue(yamlContext.name, newYAML);
+    setFieldValue(
+      yamlContext.name,
+      yamlContext.sanitizeTo ? formContext.sanitizeTo(newYAML) : newYAML,
+    );
     changeEditorType(EditorType.YAML);
   };
 
@@ -63,7 +70,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
     setYAMLWarning(false);
   };
 
-  const onChangeType = (newType) => {
+  const onChangeType = (newType: EditorType) => {
     switch (newType) {
       case EditorType.YAML:
         handleToggleToYAML();
@@ -98,7 +105,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
               isDisabled: yamlContext.isDisabled,
             },
           ]}
-          onChange={(val) => onChangeType(val as EditorType)}
+          onChange={(val: string) => onChangeType(val as EditorType)}
           isInline
         />
       </div>

--- a/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { useField, useFormikContext } from 'formik';
+import { Alert, AlertActionCloseButton, Flex } from '@patternfly/react-core';
+import { InputField, NumberSpinnerField } from '@console/shared';
+import { HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
+import HPAUtilizationField from './HPAUtilizationField';
+import { getMetricByType } from './hpa-utils';
+import { HPAFormValues, SupportedMetricTypes } from './types';
+
+const HPADetailsForm: React.FC = () => {
+  const name = 'formData';
+  const [field] = useField<HorizontalPodAutoscalerKind>(name);
+  const {
+    setFieldValue,
+    values: {
+      disabledFields: { cpuUtilization, memoryUtilization },
+      showCanUseYAMLMessage,
+    },
+  } = useFormikContext<HPAFormValues>();
+
+  const updateField = (type: SupportedMetricTypes) => (value: string) => {
+    const numValue = parseInt(value, 10);
+
+    const hpa: HorizontalPodAutoscalerKind = field.value;
+    const { metric, index } = getMetricByType(hpa, type);
+    const hpaMetrics = hpa.spec.metrics || [];
+
+    const updatedMetrics = [...hpaMetrics];
+    updatedMetrics[index] = {
+      ...metric,
+      resource: {
+        ...metric.resource,
+        target: {
+          ...metric.resource.target,
+          averageUtilization: numValue,
+        },
+      },
+    };
+
+    setFieldValue(name, {
+      ...hpa,
+      spec: {
+        ...hpa.spec,
+        metrics: updatedMetrics,
+      },
+    });
+  };
+
+  return (
+    <>
+      {showCanUseYAMLMessage && (
+        <Alert
+          actionClose={
+            <AlertActionCloseButton onClose={() => setFieldValue('showCanUseYAMLMessage', false)} />
+          }
+          isInline
+          title={
+            'Note: Some fields may not be represented in this form view. Please select "YAML view" for full control.'
+          }
+          variant="info"
+        />
+      )}
+      <div className="row">
+        <div className="col-lg-8">
+          <Flex direction={{ default: 'column' }}>
+            <InputField label="Name" name={`${name}.metadata.name`} />
+            <NumberSpinnerField label="Minimum Pods" name={`${name}.spec.minReplicas`} />
+            <NumberSpinnerField label="Maximum Pods" name={`${name}.spec.maxReplicas`} />
+            <HPAUtilizationField
+              disabled={cpuUtilization}
+              hpa={field.value}
+              label="CPU"
+              onUpdate={updateField('cpu')}
+              type="cpu"
+            />
+            <HPAUtilizationField
+              disabled={memoryUtilization}
+              hpa={field.value}
+              label="Memory"
+              onUpdate={updateField('memory')}
+              type="memory"
+            />
+          </Flex>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default HPADetailsForm;

--- a/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { isEmpty } from 'lodash';
+import { FormikProps } from 'formik';
+import { FlexForm, FormFooter, SyncedEditorField, YAMLEditorField } from '@console/shared';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { HorizontalPodAutoscalerKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import HPADetailsForm from './HPADetailsForm';
+import { sanitizeHPAToForm } from './hpa-utils';
+import { HPAFormValues } from './types';
+
+type HPAFormProps = {
+  targetResource: K8sResourceCommon;
+};
+
+const HPAForm: React.FC<FormikProps<HPAFormValues> & HPAFormProps> = ({
+  errors,
+  handleReset,
+  handleSubmit,
+  status,
+  setStatus,
+  isSubmitting,
+  targetResource,
+  validateForm,
+  values,
+}) => {
+  const isForm = values.editorType === EditorType.Form;
+  const formEditor = <HPADetailsForm />;
+  const yamlEditor = <YAMLEditorField name="yamlData" onSave={handleSubmit} />;
+  const customMetrics = false;
+
+  React.useEffect(() => {
+    setStatus({ submitError: null });
+    if (values.editorType === EditorType.Form) {
+      // Force validation against the new data that was adjusted in the YAML
+      // Formik isn't properly handling the immediate state of the form values during the cycle of the editorType
+      setTimeout(() => validateForm(), 0);
+    }
+  }, [setStatus, values.editorType, validateForm]);
+
+  return (
+    <FlexForm onSubmit={handleSubmit}>
+      <SyncedEditorField
+        name="editorType"
+        formContext={{
+          name: 'formData',
+          editor: formEditor,
+          isDisabled: customMetrics,
+          sanitizeTo: (newFormData: Partial<HorizontalPodAutoscalerKind>) =>
+            sanitizeHPAToForm(newFormData, targetResource),
+        }}
+        yamlContext={{ name: 'yamlData', editor: yamlEditor }}
+      />
+      <FormFooter
+        handleReset={handleReset}
+        errorMessage={status?.submitError}
+        isSubmitting={isSubmitting}
+        submitLabel="Save"
+        disableSubmit={isForm && (!isEmpty(errors) || status?.submitError)}
+        resetLabel="Cancel"
+        sticky
+      />
+    </FlexForm>
+  );
+};
+
+export default HPAForm;

--- a/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Formik, FormikHelpers, FormikProps } from 'formik';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import {
+  HorizontalPodAutoscalerKind,
+  k8sCreate,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
+import { history } from '@console/internal/components/utils';
+import HPAForm from './HPAForm';
+import {
+  getFormData,
+  getInvalidUsageError,
+  getYAMLData,
+  isCpuUtilizationPossible,
+  isMemoryUtilizationPossible,
+  sanityForSubmit,
+} from './hpa-utils';
+import { HPAFormValues } from './types';
+import { hpaValidationSchema } from './validation-utils';
+
+type HPAFormikFormProps = {
+  targetResource: K8sResourceKind;
+};
+
+const HPAFormikForm: React.FC<HPAFormikFormProps> = ({ targetResource }) => {
+  const initialValues: HPAFormValues = {
+    showCanUseYAMLMessage: true,
+    disabledFields: {
+      cpuUtilization: !isCpuUtilizationPossible(targetResource),
+      memoryUtilization: !isMemoryUtilizationPossible(targetResource),
+    },
+    editorType: EditorType.Form,
+    formData: getFormData(targetResource),
+    yamlData: getYAMLData(targetResource),
+  };
+
+  const handleSubmit = (values: HPAFormValues, helpers: FormikHelpers<HPAFormValues>) => {
+    const hpa: HorizontalPodAutoscalerKind = sanityForSubmit(
+      targetResource,
+      values.editorType === EditorType.YAML ? safeYAMLToJS(values.yamlData) : values.formData,
+    );
+
+    const invalidUsageError = getInvalidUsageError(hpa, values);
+    if (invalidUsageError) {
+      helpers.setStatus({ submitError: invalidUsageError });
+      return;
+    }
+
+    helpers.setSubmitting(true);
+    k8sCreate(HorizontalPodAutoscalerModel, hpa)
+      .then(() => {
+        helpers.setSubmitting(false);
+        history.goBack();
+      })
+      .catch((error) => {
+        helpers.setSubmitting(false);
+        helpers.setStatus({ submitError: error?.message || 'Unknown error submitting' });
+      });
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      onReset={history.goBack}
+      validationSchema={hpaValidationSchema}
+    >
+      {(props: FormikProps<HPAFormValues>) => (
+        <HPAForm {...props} targetResource={targetResource} />
+      )}
+    </Formik>
+  );
+};
+
+export default HPAFormikForm;

--- a/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { PageBody } from '@console/shared';
+import { LoadingInline, PageComponentProps } from '@console/internal/components/utils';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
+import HPAFormikForm from './HPAFormikForm';
+import HPAPageHeader from './HPAPageHeader';
+import { getLimitWarning, VALID_HPA_TARGET_KINDS } from './hpa-utils';
+
+const HPAPage: React.FC<PageComponentProps> = (props) => {
+  const {
+    match: {
+      params: { ns, kind, name },
+    },
+  } = props;
+
+  const resource = React.useMemo(
+    () => ({
+      kind,
+      namespace: ns,
+      name,
+    }),
+    [kind, ns, name],
+  );
+  const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind>(resource);
+
+  const validSupportedType = VALID_HPA_TARGET_KINDS.includes(kind);
+  const title = `Add ${HorizontalPodAutoscalerModel.label}`;
+  return (
+    <NamespacedPage disabled variant={NamespacedPageVariants.light} hideApplications>
+      <Helmet>
+        <title>{title}</title>
+      </Helmet>
+      <PageBody flexLayout>
+        <HPAPageHeader
+          kind={kind}
+          limitWarning={loaded && validSupportedType ? getLimitWarning(data) : null}
+          loadError={loadError ? loadError.message : null}
+          name={name}
+          title={title}
+          validSupportedType={validSupportedType}
+        />
+        {!loadError && validSupportedType && (
+          <>{loaded ? <HPAFormikForm targetResource={data} /> : <LoadingInline />}</>
+        )}
+      </PageBody>
+    </NamespacedPage>
+  );
+};
+
+export default HPAPage;

--- a/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Alert, Flex } from '@patternfly/react-core';
+import { ResourceLink } from '@console/internal/components/utils';
+
+type HPAPageHeaderProps = {
+  kind: string;
+  limitWarning?: string;
+  loadError?: string;
+  name: string;
+  title: string;
+  validSupportedType: boolean;
+};
+
+const HPAPageHeader: React.FC<HPAPageHeaderProps> = ({
+  name,
+  title,
+  kind,
+  loadError,
+  limitWarning,
+  validSupportedType,
+}) => {
+  return (
+    <Flex direction={{ default: 'column' }}>
+      <h1 className="pf-c-title pf-m-2xl">{title}</h1>
+      {validSupportedType ? (
+        <>
+          <div>
+            Resource <ResourceLink inline linkTo={false} kind={kind} name={name} />
+          </div>
+          {loadError && (
+            <Alert isInline variant="danger" title="This resource is not available">
+              {loadError}
+            </Alert>
+          )}
+          {limitWarning && <Alert isInline variant="warning" title={limitWarning} />}
+        </>
+      ) : (
+        <Alert isInline variant="danger" title="This is not a supported in-context type" />
+      )}
+    </Flex>
+  );
+};
+
+export default HPAPageHeader;

--- a/frontend/packages/dev-console/src/components/hpa/HPAUtilizationField.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAUtilizationField.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { FormikErrors, useFormikContext } from 'formik';
+import { FormGroup, InputGroup, InputGroupText, TextInput } from '@patternfly/react-core';
+import { PercentIcon } from '@patternfly/react-icons';
+import { HorizontalPodAutoscalerKind, HPAMetric } from '@console/internal/module/k8s';
+import { getMetricByType } from './hpa-utils';
+import { HPAFormValues, SupportedMetricTypes } from './types';
+
+type HPAUtilizationFieldProps = {
+  disabled?: boolean;
+  hpa: HorizontalPodAutoscalerKind;
+  label: string;
+  onUpdate: (stringValue: string) => void;
+  type: SupportedMetricTypes;
+};
+
+const HPAUtilizationField: React.FC<HPAUtilizationFieldProps> = ({
+  disabled,
+  hpa,
+  label,
+  onUpdate,
+  type,
+}) => {
+  const { errors } = useFormikContext<HPAFormValues>();
+  const { metric, index } = getMetricByType(hpa, type);
+  const value: number = metric?.resource?.target?.averageUtilization;
+  const thisErrorMetric = errors.formData?.spec?.metrics?.[index] as FormikErrors<HPAMetric>;
+  const error: string = thisErrorMetric?.resource?.target?.averageUtilization;
+
+  return (
+    <FormGroup
+      fieldId={`${type}-utilization`}
+      label={`${label} Utilization`}
+      helperText={`${label} request and limit must be set before ${label} utilization can be set.`}
+      helperTextInvalid={error}
+      validated={error ? 'error' : null}
+    >
+      <InputGroup>
+        <TextInput
+          id={type}
+          type="text"
+          isDisabled={disabled}
+          onChange={onUpdate}
+          value={Number.isNaN(value) ? '' : value}
+        />
+        <InputGroupText id="percent" aria-label="%">
+          <PercentIcon />
+        </InputGroupText>
+      </InputGroup>
+    </FormGroup>
+  );
+};
+
+export default HPAUtilizationField;

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
@@ -1,0 +1,648 @@
+import {
+  DeploymentKind,
+  HorizontalPodAutoscalerKind,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
+
+export const deploymentExamples: { [key: string]: DeploymentKind } = {
+  hasNoLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http',
+            deploymentconfig: 'nodejs-rest-http',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {},
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+  hasMemoryOnlyLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http-with-memory-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http-with-memory-limits',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-with-memory-limits',
+            deploymentconfig: 'nodejs-rest-http-with-memory-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-with-memory-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-with-memory-limits:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  memory: '2Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+  hasCpuOnlyLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http-with-cpu-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http-with-cpu-limits',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-with-cpu-limits',
+            deploymentconfig: 'nodejs-rest-http-with-cpu-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-with-cpu-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-with-cpu-limits:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+  hasCpuAndMemoryLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http-with-resource-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http-with-resource-limits',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-with-resource-limits',
+            deploymentconfig: 'nodejs-rest-http-with-resource-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-with-resource-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-with-resource-limits:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                  memory: '2Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+};
+
+export const deploymentConfigExamples: { [key: string]: K8sResourceKind } = {
+  hasNoLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud@sha256:461b6963d26b1ca3a618bb51649a417d1de8411c5cb3f5a8998ec14584a0a5ba',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud',
+        deploymentconfig: 'nodejs-rest-http-crud',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud',
+            deploymentconfig: 'nodejs-rest-http-crud',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud@sha256:461b6963d26b1ca3a618bb51649a417d1de8411c5cb3f5a8998ec14584a0a5ba',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {},
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+  hasMemoryOnlyLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud-memory-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud-memory-limits'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud-memory-limits:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-memory-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud-memory-limits',
+        deploymentconfig: 'nodejs-rest-http-crud-memory-limits',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud-memory-limits',
+            deploymentconfig: 'nodejs-rest-http-crud-memory-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud-memory-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-memory-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  memory: '2Mi',
+                },
+                requests: {
+                  memory: '1Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+  hasCpuOnlyLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud-cpu-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud-cpu-limits'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud-cpu-limits:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-cpu-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud-cpu-limits',
+        deploymentconfig: 'nodejs-rest-http-crud-cpu-limits',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud-cpu-limits',
+            deploymentconfig: 'nodejs-rest-http-crud-cpu-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud-cpu-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-cpu-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                },
+                requests: {
+                  cpu: '1m',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+  hasCpuAndMemoryLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud-resource-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud-resource-limits'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud-resource-limits:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-resource-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud-resource-limits',
+        deploymentconfig: 'nodejs-rest-http-crud-resource-limits',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud-resource-limits',
+            deploymentconfig: 'nodejs-rest-http-crud-resource-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud-resource-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-resource-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                  memory: '2Mi',
+                },
+                requests: {
+                  cpu: '1m',
+                  memory: '1Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+};
+
+export const hpaExamples: { [key: string]: HorizontalPodAutoscalerKind } = {
+  noMetrics: {
+    kind: 'HorizontalPodAutoscaler',
+    apiVersion: 'autoscaling/v2beta2',
+    metadata: {
+      name: 'example',
+      namespace: 'test-ns',
+    },
+    spec: {
+      scaleTargetRef: {
+        kind: 'Deployment',
+        name: 'example',
+        apiVersion: 'apps/v1',
+      },
+      minReplicas: 1,
+      maxReplicas: 3,
+    },
+  },
+  cpuScaled: {
+    kind: 'HorizontalPodAutoscaler',
+    apiVersion: 'autoscaling/v2beta2',
+    metadata: {
+      name: 'example',
+      namespace: 'test-ns',
+    },
+    spec: {
+      scaleTargetRef: {
+        kind: 'Deployment',
+        name: 'nodejs-rest-http-crud-resource-limits',
+        apiVersion: 'apps/v1',
+      },
+      minReplicas: 2,
+      maxReplicas: 10,
+      metrics: [
+        {
+          type: 'Resource',
+          resource: {
+            name: 'cpu',
+            target: {
+              type: 'Utilization',
+              averageUtilization: 42,
+            },
+          },
+        },
+      ],
+    },
+  },
+};

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
@@ -1,0 +1,265 @@
+import { cloneDeep } from 'lodash';
+import {
+  getFormData,
+  getInvalidUsageError,
+  getLimitWarning,
+  getMetricByType,
+  getYAMLData,
+  isCpuUtilizationPossible,
+  isMemoryUtilizationPossible,
+  sanitizeHPAToForm,
+  sanityForSubmit,
+} from '../hpa-utils';
+import { deploymentConfigExamples, deploymentExamples, hpaExamples } from './hpa-utils-data';
+import { DeploymentKind, HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
+import { HPAFormValues } from '../types';
+
+describe('isCpuUtilizationPossible provides accurate checks', () => {
+  it('expect an invalid resource to return no', () => {
+    expect(isCpuUtilizationPossible(null)).toBe(false);
+    expect(isCpuUtilizationPossible({})).toBe(false);
+  });
+
+  it('expect a resource with no limits to be not possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasNoLimits)).toBe(false);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasNoLimits)).toBe(false);
+  });
+
+  it('expect a resource with other limits but not CPU limits to be not possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasMemoryOnlyLimits)).toBe(false);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasMemoryOnlyLimits)).toBe(false);
+  });
+
+  it('expect a resource with CPU limits to be possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasCpuOnlyLimits)).toBe(true);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasCpuOnlyLimits)).toBe(true);
+  });
+
+  it('expect a resource with both CPU And Memory limits to be possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasCpuAndMemoryLimits)).toBe(true);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasCpuAndMemoryLimits)).toBe(true);
+  });
+});
+
+describe('isMemoryUtilizationPossible provides accurate checks', () => {
+  it('expect an invalid resource to return no', () => {
+    expect(isMemoryUtilizationPossible(null)).toBe(false);
+    expect(isMemoryUtilizationPossible({})).toBe(false);
+  });
+
+  it('expect a resource with no limits to be not possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasNoLimits)).toBe(false);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasNoLimits)).toBe(false);
+  });
+
+  it('expect a resource with other limits but not CPU limits to be not possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasCpuOnlyLimits)).toBe(false);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasCpuOnlyLimits)).toBe(false);
+  });
+
+  it('expect a resource with CPU limits to be possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasMemoryOnlyLimits)).toBe(true);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasMemoryOnlyLimits)).toBe(true);
+  });
+
+  it('expect a resource with both CPU And Memory limits to be possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasCpuAndMemoryLimits)).toBe(true);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasCpuAndMemoryLimits)).toBe(true);
+  });
+});
+
+describe('getLimitWarning provides a string when limits are lacking', () => {
+  /** Intentionally avoid checking the string value as we don't want to couple our tests to text */
+  const hasWarning = (value: any) => typeof value === 'string';
+
+  it('expect invalid resource to return a value', () => {
+    expect(hasWarning(getLimitWarning(null))).toBe(true);
+    expect(hasWarning(getLimitWarning({}))).toBe(true);
+  });
+
+  it('expect no limit resources to return a value', () => {
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasNoLimits))).toBe(true);
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasNoLimits))).toBe(true);
+  });
+
+  it('expect partial limit resources to return a value', () => {
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasCpuOnlyLimits))).toBe(true);
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasMemoryOnlyLimits))).toBe(true);
+
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasCpuOnlyLimits))).toBe(true);
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasMemoryOnlyLimits))).toBe(true);
+  });
+
+  it('expect full limits to not return a value', () => {
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasCpuAndMemoryLimits))).toBe(false);
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasCpuAndMemoryLimits))).toBe(false);
+  });
+});
+
+describe('getFormData gets back an hpa structured form object', () => {
+  it('expect to be scaled against the resource provided', () => {
+    const deploymentResource: DeploymentKind = deploymentExamples.hasCpuAndMemoryLimits;
+    expect(getFormData(deploymentResource).spec.scaleTargetRef).toEqual({
+      apiVersion: deploymentResource.apiVersion,
+      kind: deploymentResource.kind,
+      name: deploymentResource.metadata.name,
+    });
+  });
+
+  it('expect to be able to build off an existing HPA', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const formData: HorizontalPodAutoscalerKind = getFormData(
+      deploymentExamples.hasCpuAndMemoryLimits,
+      hpaResource,
+    );
+    expect(formData).toBeTruthy();
+    expect(formData.spec.minReplicas).toBe(hpaResource.spec.minReplicas);
+    expect(formData.spec.maxReplicas).toBe(hpaResource.spec.maxReplicas);
+    expect(formData.spec.metrics.length).toBe(1);
+    expect(formData.spec.metrics[0]).toEqual(hpaResource.spec.metrics[0]);
+  });
+});
+
+describe('getYAMLData gets back an hpa structured editor string', () => {
+  it('expect to be scaled against the resource provided', () => {
+    const deploymentResource: DeploymentKind = deploymentExamples.hasCpuAndMemoryLimits;
+    const result = getYAMLData(deploymentResource);
+    expect(new RegExp(`apiVersion: ${deploymentResource.apiVersion}`).test(result)).toBe(true);
+    expect(new RegExp(`kind: ${deploymentResource.kind}`).test(result)).toBe(true);
+    expect(new RegExp(`name: ${deploymentResource.metadata.name}`).test(result)).toBe(true);
+  });
+
+  it('expect to be able to build off an existing HPA', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const yamlData = getYAMLData(deploymentExamples.hasCpuAndMemoryLimits, hpaResource);
+    expect(yamlData).toBeTruthy();
+    expect(new RegExp(`minReplicas: ${hpaResource.spec.minReplicas}`).test(yamlData)).toBe(true);
+    expect(new RegExp(`maxReplicas: ${hpaResource.spec.maxReplicas}`).test(yamlData)).toBe(true);
+    expect(new RegExp(`name: ${hpaResource.spec.metrics[0].resource.name}`).test(yamlData)).toBe(
+      true,
+    );
+  });
+});
+
+describe('getMetricByType returns an appropriate metric and the index it is at', () => {
+  it('expect no metrics to return a default metric as a new metric on the end', () => {
+    const { metric, index } = getMetricByType(hpaExamples.noMetrics, 'memory');
+    expect(metric).toBeTruthy();
+    expect(metric.resource.name).toBe('memory');
+    expect(metric.resource.target.averageUtilization).toBe(0);
+    expect(index).toBe(0);
+  });
+
+  it('expect to get back a default memory metric when only cpu metric is available', () => {
+    const { metric, index } = getMetricByType(hpaExamples.cpuScaled, 'memory');
+    expect(metric).toBeTruthy();
+    expect(metric.resource.name).toBe('memory');
+    expect(metric.resource.target.averageUtilization).toBe(0);
+    expect(index).toBe(1);
+  });
+
+  it('expect to get back the cpu metric when it is available', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const { metric, index } = getMetricByType(hpaResource, 'cpu');
+    expect(metric).toBeTruthy();
+    expect(metric.resource.name).toBe('cpu');
+    expect(metric.resource.target.averageUtilization).toBe(
+      hpaResource.spec.metrics[0].resource.target.averageUtilization,
+    );
+    expect(index).toBe(0);
+  });
+});
+
+describe('sanitizeHPAToForm always returns valid HPA', () => {
+  it('expect an empty form to return a default HPA', () => {
+    const formData: HorizontalPodAutoscalerKind = sanitizeHPAToForm(
+      {},
+      deploymentExamples.hasCpuAndMemoryLimits,
+    );
+    expect(formData).toBeTruthy();
+    expect(formData.kind).toBe('HorizontalPodAutoscaler');
+    expect(formData.spec.metrics).not.toBeTruthy();
+  });
+
+  it('expect it not to remove existing metrics', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const formData: HorizontalPodAutoscalerKind = sanitizeHPAToForm(
+      hpaResource,
+      deploymentExamples.hasCpuOnlyLimits,
+    );
+    expect(formData).toBeTruthy();
+    expect(formData.spec.maxReplicas).toBe(hpaResource.spec.maxReplicas);
+    expect(formData.spec.metrics[0]).toBeTruthy();
+    expect(formData.spec.metrics[0]).toEqual(hpaResource.spec.metrics[0]);
+  });
+});
+
+describe('sanityForSubmit covers some basic field locking and trimming', () => {
+  const deploymentResource: DeploymentKind = deploymentExamples.hasNoLimits;
+  const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+
+  it('expect to always return in the deployment namespace', () => {
+    const overriddenResource: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    overriddenResource.metadata.namespace = 'not-the-deployment-namespace';
+    expect(sanityForSubmit(deploymentResource, overriddenResource).metadata.namespace).toBe(
+      deploymentResource.metadata.namespace,
+    );
+  });
+
+  it('expect to always scale to the same resource despite hpa settings', () => {
+    const scaledTargetRef = {
+      apiVersion: deploymentResource.apiVersion,
+      kind: deploymentResource.kind,
+      name: deploymentResource.metadata.name,
+    };
+
+    const exampleRemoved: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    delete exampleRemoved.spec.scaleTargetRef;
+    expect(sanityForSubmit(deploymentResource, exampleRemoved).spec.scaleTargetRef).toEqual(
+      scaledTargetRef,
+    );
+
+    const exampleChanged: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    exampleChanged.spec.scaleTargetRef.name = 'not-the-deployment';
+    expect(sanityForSubmit(deploymentResource, exampleChanged).spec.scaleTargetRef).toEqual(
+      scaledTargetRef,
+    );
+  });
+
+  it('expect not to have empty cpu or memory metrics', () => {
+    const overriddenResource: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    overriddenResource.spec.metrics[0].resource.target.averageUtilization = 0;
+    expect(sanityForSubmit(deploymentResource, overriddenResource).spec.metrics.length).toBe(0);
+  });
+
+  it('expect not to trim custom resource metrics', () => {
+    const overriddenResource: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    overriddenResource.spec.metrics[0].resource.name = 'custom-resource';
+    overriddenResource.spec.metrics[0].resource.target.averageUtilization = 0;
+    expect(sanityForSubmit(deploymentResource, overriddenResource).spec.metrics.length).toBe(1);
+  });
+});
+
+describe('getInvalidUsageError returns an error string when limits are not set', () => {
+  const formValues: HPAFormValues = {
+    showCanUseYAMLMessage: false,
+    disabledFields: {
+      cpuUtilization: true,
+      memoryUtilization: true,
+    },
+    editorType: null,
+    formData: null,
+    yamlData: null,
+  };
+  const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+
+  it('expect cpu metric not to be allowed while disabled', () => {
+    expect(typeof getInvalidUsageError(hpaResource, formValues)).toBe('string');
+  });
+
+  it('expect memory metric to not be allowed while disabled', () => {
+    const memoryHPA = cloneDeep(hpaResource);
+    memoryHPA.spec.metrics[0].resource.name = 'memory';
+    expect(typeof getInvalidUsageError(memoryHPA, formValues)).toBe('string');
+  });
+});

--- a/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
@@ -1,0 +1,161 @@
+import { omit, merge } from 'lodash';
+import { safeJSToYAML, safeYAMLToJS } from '@console/shared/src/utils/yaml';
+import {
+  HorizontalPodAutoscalerKind,
+  HPAMetric,
+  K8sResourceKind,
+  referenceForModel,
+} from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import { baseTemplates } from '@console/internal/models/yaml-templates';
+import { LimitsData } from '../import/import-types';
+import { HPAFormValues, SupportedMetricTypes } from './types';
+
+export const VALID_HPA_TARGET_KINDS = ['Deployment', 'DeploymentConfig'];
+
+const getResourceLimitsData = (resource: K8sResourceKind): LimitsData => {
+  const container = resource?.spec?.template?.spec?.containers?.find((c) => c.resources.limits);
+
+  return container?.resources?.limits || null;
+};
+const hasCpuLimits = (limits: LimitsData): boolean => !!limits?.cpu;
+export const isCpuUtilizationPossible = (resource: K8sResourceKind): boolean =>
+  hasCpuLimits(getResourceLimitsData(resource));
+const hasMemoryLimits = (limits: LimitsData): boolean => !!limits?.memory;
+export const isMemoryUtilizationPossible = (resource: K8sResourceKind): boolean =>
+  hasMemoryLimits(getResourceLimitsData(resource));
+
+export const getLimitWarning = (resource: K8sResourceKind): string => {
+  const limits = getResourceLimitsData(resource);
+
+  if (!limits) {
+    return `CPU and memory resource limits must be set if you want to use CPU and memory utilization. \
+    The ${HorizontalPodAutoscalerModel.label} will not have CPU or memory metrics until resource limits are set.`;
+  }
+
+  if (!hasCpuLimits(limits)) {
+    return `CPU resource limits must be set if you want to use CPU utilization. \
+    The ${HorizontalPodAutoscalerModel.label} will not have CPU metrics until resource limits are set.`;
+  }
+  if (!hasMemoryLimits(limits)) {
+    return `Memory resource limits must be set if you want to use memory utilization. \
+    The ${HorizontalPodAutoscalerModel.label} will not have memory metrics until resource limits are set.`;
+  }
+
+  return null;
+};
+
+const defaultHPAYAML = baseTemplates
+  .get(referenceForModel(HorizontalPodAutoscalerModel))
+  .get('default');
+
+const getDefaultMetric = (type: SupportedMetricTypes): HPAMetric => ({
+  type: 'Resource',
+  resource: {
+    name: type,
+    target: {
+      averageUtilization: 0,
+      type: 'Utilization',
+    },
+  },
+});
+
+const createScaleTargetRef = (resource: K8sResourceKind) => ({
+  apiVersion: resource.apiVersion,
+  kind: resource.kind,
+  name: resource.metadata.name,
+});
+
+export const getFormData = (
+  resource: K8sResourceKind,
+  existingHPA?: HorizontalPodAutoscalerKind,
+): HorizontalPodAutoscalerKind => {
+  const hpa: HorizontalPodAutoscalerKind = existingHPA || safeYAMLToJS(defaultHPAYAML);
+  if (!existingHPA) {
+    // If we are working off the default, zero out cpu metrics to make it easier to use non-cpu metrics with the default
+    hpa.spec.metrics = [getDefaultMetric('cpu')];
+  }
+
+  return {
+    ...hpa,
+    spec: {
+      ...hpa.spec,
+      scaleTargetRef: createScaleTargetRef(resource),
+    },
+  };
+};
+export const getYAMLData = (
+  resource: K8sResourceKind,
+  existingHPA?: HorizontalPodAutoscalerKind,
+): string => {
+  return safeJSToYAML(getFormData(resource, existingHPA));
+};
+
+export const getMetricByType = (
+  hpa: HorizontalPodAutoscalerKind,
+  type: SupportedMetricTypes,
+): { metric: HPAMetric; index: number } => {
+  const hpaMetrics = hpa.spec.metrics || [];
+  const metricIndex = hpaMetrics.findIndex((m) => m.resource.name?.toLowerCase() === type);
+  const metric: HPAMetric = hpaMetrics[metricIndex] || getDefaultMetric(type);
+
+  return { metric, index: metricIndex === -1 ? hpaMetrics.length : metricIndex };
+};
+
+export const sanitizeHPAToForm = (
+  newFormData: Partial<HorizontalPodAutoscalerKind>,
+  resource: K8sResourceKind,
+): HorizontalPodAutoscalerKind => {
+  // Remove the default metrics as the user may be crafting their own custom ones
+  const defaultHPA: HorizontalPodAutoscalerKind = omit(getFormData(resource), 'spec.metrics');
+  return merge({}, defaultHPA, newFormData);
+};
+
+export const sanityForSubmit = (
+  targetResource: K8sResourceKind,
+  hpa: HorizontalPodAutoscalerKind,
+): HorizontalPodAutoscalerKind => {
+  const validHPA = merge(
+    {},
+    hpa,
+    // Make sure it's against _this_ namespace
+    { metadata: { namespace: targetResource.metadata.namespace } },
+    // Make sure we kept the target we started with
+    { spec: { scaleTargetRef: createScaleTargetRef(targetResource) } },
+  );
+
+  // Remove empty metrics
+  validHPA.spec.metrics = validHPA.spec.metrics.filter(
+    (metric: HPAMetric) =>
+      !['cpu', 'memory'].includes(metric?.resource?.name?.toLowerCase()) ||
+      (metric.resource.target.type === 'Utilization' &&
+        metric.resource.target.averageUtilization > 0),
+  );
+
+  return validHPA;
+};
+
+export const getInvalidUsageError = (
+  hpa: HorizontalPodAutoscalerKind,
+  formValues: HPAFormValues,
+): string => {
+  const lackCPULimits = formValues.disabledFields.cpuUtilization;
+  const lackMemoryLimits = formValues.disabledFields.memoryUtilization;
+  const metricNames = (hpa.spec.metrics || []).map((metric) =>
+    metric.resource?.name?.toLowerCase(),
+  );
+  const invalidCPU = lackCPULimits && metricNames.includes('cpu');
+  const invalidMemory = lackMemoryLimits && metricNames.includes('memory');
+
+  if (invalidCPU && invalidMemory) {
+    return 'CPU and memory utilization cannot be used currently.';
+  }
+  if (invalidCPU) {
+    return 'CPU utilization cannot be used currently.';
+  }
+  if (invalidMemory) {
+    return 'Memory utilization cannot be used currently.';
+  }
+
+  return null;
+};

--- a/frontend/packages/dev-console/src/components/hpa/types.ts
+++ b/frontend/packages/dev-console/src/components/hpa/types.ts
@@ -1,0 +1,15 @@
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
+
+export type SupportedMetricTypes = 'cpu' | 'memory';
+
+export type HPAFormValues = {
+  showCanUseYAMLMessage: boolean;
+  disabledFields: {
+    cpuUtilization: boolean;
+    memoryUtilization: boolean;
+  };
+  editorType: EditorType;
+  formData: HorizontalPodAutoscalerKind;
+  yamlData: string;
+};

--- a/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
@@ -1,0 +1,66 @@
+import * as yup from 'yup';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+
+export const hpaValidationSchema = yup.object({
+  editorType: yup.string(),
+  formData: yup.object().when('editorType', {
+    is: EditorType.Form,
+    then: yup.object({
+      metadata: yup.object({
+        name: yup
+          .string()
+          .matches(/^([a-z]([-a-z0-9]*[a-z0-9])?)*$/, {
+            message:
+              'Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+            excludeEmptyString: true,
+          })
+          .max(253, 'Cannot be longer than 253 characters.')
+          .required('Required'),
+      }),
+      spec: yup.object({
+        minReplicas: yup
+          .number()
+          .integer('Minimum Pods must be an integer.')
+          .min(1, 'Minimum Pods must greater than or equal to 1.')
+          .test(
+            'test-less-than-max',
+            'Minimum Pods should be less than or equal to Maximum Pods.',
+            function(minReplicas) {
+              const { maxReplicas } = this.parent;
+              return minReplicas <= maxReplicas;
+            },
+          ),
+        maxReplicas: yup
+          .number()
+          .integer('Maximum Pods must be an integer.')
+          .test(
+            'test-greater-than-min',
+            'Maximum Pods should be greater than or equal to Minimum Pods.',
+            function(maxReplicas) {
+              const { minReplicas } = this.parent;
+              return minReplicas <= maxReplicas;
+            },
+          )
+          .required('Max Pods must be defined.'),
+        metrics: yup.array(
+          yup.object({
+            resource: yup.object({
+              target: yup.object({
+                averageUtilization: yup
+                  .mixed()
+                  .test(
+                    'test-for-valid-utilization',
+                    'Average Utilization must be a positive number.',
+                    function(avgUtilization) {
+                      if (!avgUtilization) return true;
+                      return /^\d+$/.test(String(avgUtilization));
+                    },
+                  ),
+              }),
+            }),
+          }),
+        ),
+      }),
+    }),
+  }),
+});

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -878,6 +878,16 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/workload-hpa/ns/:ns/:kind/:name'],
+      loader: async () =>
+        (await import('./components/hpa/HPAPage' /* webpackChunkName: "hpa-on-workload`" */))
+          .default,
+    },
+  },
+  {
     type: 'ReduxReducer',
     properties: {
       namespace: 'devconsole',

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash-es';
 import { Status, PodRingController } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { AddHorizontalPodAutoScaler } from '@console/app/src/actions/modify-hpa';
 import { k8sCreate, K8sKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { errorModal } from './modals';
 import { DeploymentConfigModel } from '../models';
@@ -84,6 +85,7 @@ export const menuActions: KebabAction[] = [
   PauseAction,
   ModifyCount,
   AddHealthChecks,
+  AddHorizontalPodAutoScaler,
   AddStorage,
   ...getExtensionsKebabActionsForKind(DeploymentConfigModel),
   EditHealthChecks,

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Status, PodRingController } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { AddHorizontalPodAutoScaler } from '@console/app/src/actions/modify-hpa';
 import { DeploymentModel } from '../models';
 import { DeploymentKind, K8sKind, K8sResourceKindReference } from '../module/k8s';
 import { configureUpdateStrategyModal, errorModal } from './modals';
@@ -58,6 +59,7 @@ export const menuActions = [
   ModifyCount,
   PauseAction,
   AddHealthChecks,
+  AddHorizontalPodAutoScaler,
   AddStorage,
   UpdateStrategy,
   ...Kebab.getExtensionsActionsForKind(DeploymentModel),

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -123,7 +123,7 @@ export const ReplicationControllerModel: K8sKind = {
 export const HorizontalPodAutoscalerModel: K8sKind = {
   label: 'Horizontal Pod Autoscaler',
   plural: 'horizontalpodautoscalers',
-  apiVersion: 'v2beta1',
+  apiVersion: 'v2beta2',
   apiGroup: 'autoscaling',
   abbr: 'HPA',
   namespaced: true,

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -358,7 +358,7 @@ spec:
   .setIn(
     [referenceForModel(k8sModels.HorizontalPodAutoscalerModel), 'default'],
     `
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example
@@ -373,7 +373,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 50
+      target:
+        averageUtilization: 50
+        type: Utilization
 `,
   )
   .setIn(

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -364,6 +364,29 @@ export type DeploymentKind = {
   };
 } & K8sResourceCommon;
 
+export type HPAMetric = {
+  type: 'Object' | 'Pods' | 'Resource';
+  resource: {
+    name: string;
+    target: {
+      averageUtilization?: number;
+      type: string;
+    };
+  };
+};
+export type HorizontalPodAutoscalerKind = K8sResourceCommon & {
+  spec: {
+    scaleTargetRef: {
+      apiVersion: string;
+      kind: string;
+      name: string;
+    };
+    minReplicas?: number;
+    maxReplicas: number;
+    metrics?: HPAMetric[];
+  };
+};
+
 export type StorageClassResourceKind = {
   provisioner: string;
   reclaimPolicy: string;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4269

**Analysis / Root cause**: 
As a user, I'd like to be able to add an HPA to my D or DC node from Topology.

**Solution Description**: 
Add a kebab option to the D/DC nodes that redirects to an 'in-context' add HPA page.

**Screen shots / Gifs for design review**: 

@openshift/team-devconsole-ux 
@lwrigh 

Deployment with no limits (On Form)
![Screen Shot 2020-07-17 at 1 56 13 PM](https://user-images.githubusercontent.com/8126518/87816832-f1933600-c835-11ea-90ff-bc5c421608c4.png)

Deployment with no limits (On YAML)
![Screen Shot 2020-07-17 at 1 56 36 PM](https://user-images.githubusercontent.com/8126518/87816835-f2c46300-c835-11ea-9346-ad2947a96d1a.png)

DeploymentConfig with CPU Limits:
![Screen Shot 2020-07-17 at 1 58 27 PM](https://user-images.githubusercontent.com/8126518/87816841-f3f59000-c835-11ea-9385-923ca36f7652.png)

Can't have less than 1 Min Pod / Can't have more Max than Min Pods:
![Screen Shot 2020-07-24 at 10 55 23 AM](https://user-images.githubusercontent.com/8126518/88404721-44bc3a00-cd9c-11ea-9d15-46f1b00890a3.png)

Modifying the Utilization to be a non-number on YAML and trying to submit on the Form:
![Screen Shot 2020-07-17 at 1 59 00 PM](https://user-images.githubusercontent.com/8126518/87816843-f48e2680-c835-11ea-8e81-d2d051b5f1f8.png)

Modifying a metric for memory (on YAML) without Memory Limits and trying to submit on Form:
![Screen Shot 2020-07-17 at 1 59 52 PM](https://user-images.githubusercontent.com/8126518/87816844-f48e2680-c835-11ea-99d9-2b60043935bd.png)

**Unit test coverage report**: 

```
 PASS  packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
  isCpuUtilizationPossible provides accurate checks
    ✓ expect an invalid resource to return no (2ms)
    ✓ expect a resource with no limits to be not possible
    ✓ expect a resource with other limits but not CPU limits to be not possible
    ✓ expect a resource with CPU limits to be possible
    ✓ expect a resource with both CPU And Memory limits to be possible
  isMemoryUtilizationPossible provides accurate checks
    ✓ expect an invalid resource to return no (1ms)
    ✓ expect a resource with no limits to be not possible
    ✓ expect a resource with other limits but not CPU limits to be not possible
    ✓ expect a resource with CPU limits to be possible
    ✓ expect a resource with both CPU And Memory limits to be possible
  getLimitWarning provides a string when limits are lacking
    ✓ expect invalid resource to return a value
    ✓ expect no limit resources to return a value (1ms)
    ✓ expect partial limit resources to return a value
    ✓ expect full limits to not return a value
  getFormData gets back an hpa structured form object
    ✓ expect to be scaled against the resource provided (4ms)
    ✓ expect to be able to build off an existing HPA (1ms)
  getYAMLData gets back an hpa structured editor string
    ✓ expect to be scaled against the resource provided (2ms)
    ✓ expect to be able to build off an existing HPA
  getMetricByType returns an appropriate metric and the index it is at
    ✓ expect no metrics to return a default metric as a new metric on the end (1ms)
    ✓ expect to get back a default memory metric when only cpu metric is available
    ✓ expect to get back the cpu metric when it is available
  sanitizeHPAToForm always returns valid HPA
    ✓ expect an empty form to return a default HPA (2ms)
    ✓ expect it not to remove existing metrics (1ms)
  sanityForSubmit covers some basic field locking and trimming
    ✓ expect to always return in the deployment namespace
    ✓ expect to always scale to the same resource despite hpa settings (1ms)
    ✓ expect not to have empty cpu or memory metrics
    ✓ expect not to trim custom resource metrics
  getInvalidUsageError returns an error string when limits are not set
    ✓ expect cpu metric not to be allowed while disabled
    ✓ expect memory metric to not be allowed while disabled

Test Suites: 1 passed, 1 total
Tests:       29 passed, 29 total

------------------------------------------------------------|----------|----------|----------|----------|-------------------|
File                                                        |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------------------------------------------------|----------|----------|----------|----------|-------------------|
  src/components/hpa/hpa-utils.ts                           |    96.97 |    90.32 |      100 |    96.49 |            92,100 |
------------------------------------------------------------|----------|----------|----------|----------|-------------------|
```

**Test setup:**

- Have a D or DC
- Add via the Topology Sidebar
- You can set limits on your D/DC by using the Advanced Option "Resource Limits" on the Add/Edit Add forms

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge