### PR TITLE
Add warnings for managed resources

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -107,6 +107,10 @@
   padding: var(--pf-global--spacer--xl) var(--pf-global--spacer--xl) var(--pf-global--spacer--lg);
 }
 
+.modal__inline-resource-link {
+  margin: 0;
+}
+
 .toleration-modal__field, .taint-modal__field  {
   padding-right: 0;
 }

--- a/frontend/public/components/modals/delete-modal.jsx
+++ b/frontend/public/components/modals/delete-modal.jsx
@@ -1,10 +1,15 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { Alert } from '@patternfly/react-core';
 
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
 import { PromiseComponent, history, resourceListPathFromModel } from '../utils';
-import { k8sKill } from '../../module/k8s/';
+import { k8sKill, referenceForOwnerRef } from '../../module/k8s/';
 import { YellowExclamationTriangleIcon } from '@console/shared';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
+import { findOwner } from '../../module/k8s/managed-by';
+import { k8sList } from '../../module/k8s/resource';
+import { ResourceLink } from '../utils/resource-link';
 
 //Modal for resource deletion and allows cascading deletes if propagationPolicy is provided for the enum
 class DeleteModal extends PromiseComponent {
@@ -14,6 +19,7 @@ class DeleteModal extends PromiseComponent {
     this._cancel = this.props.cancel.bind(this);
     this.state = Object.assign(this.state, {
       isChecked: true,
+      owner: null,
     });
   }
 
@@ -45,8 +51,26 @@ class DeleteModal extends PromiseComponent {
     this.checked = !this.checked;
   }
 
+  componentDidMount() {
+    const { resource } = this.props;
+    const namespace = resource?.metadata?.namespace;
+    if (!namespace || !resource?.metadata?.ownerReferences?.length) {
+      return;
+    }
+    k8sList(ClusterServiceVersionModel, { ns: namespace })
+      .then((data) => {
+        const owner = findOwner(this.props.resource, data);
+        this.setState({ owner });
+      })
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error('Could not fetch CSVs', e);
+      });
+  }
+
   render() {
     const { kind, resource, message } = this.props;
+    const { owner } = this.state;
     return (
       <form onSubmit={this._submit} name="form" className="modal-content ">
         <ModalTitle>
@@ -75,6 +99,25 @@ class DeleteModal extends PromiseComponent {
                   Delete dependent objects of this resource
                 </label>
               </div>
+            )}
+            {owner && (
+              <Alert
+                className="co-alert co-alert--margin-top"
+                isInline
+                variant="warning"
+                title="Managed resource"
+              >
+                This resource is managed by{' '}
+                <ResourceLink
+                  className="modal__inline-resource-link"
+                  inline
+                  kind={referenceForOwnerRef(owner)}
+                  name={owner.name}
+                  namespace={resource.metadata.namespace}
+                />{' '}
+                and any modifications may be overwritten. Edit the managing resource to preserve
+                changes.
+              </Alert>
             )}
           </div>
         </ModalBody>

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -128,3 +128,8 @@ export const restorePVCModal = (props) =>
   import(
     '@console/app/src/components/modals/restore-pvc/restore-pvc-modal' /* webpackChunkName: "restore-pvc-modal" */
   ).then((m) => m.default(props));
+
+export const managedResourceSaveModal = (props) =>
+  import(
+    './managed-resource-save-modal' /* webpackChunkName: "managed-resource-save-modal" */
+  ).then((m) => m.managedResourceSaveModal(props));

--- a/frontend/public/components/modals/managed-resource-save-modal.tsx
+++ b/frontend/public/components/modals/managed-resource-save-modal.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
+import { referenceForOwnerRef, K8sResourceCommon, OwnerReference } from '../../module/k8s/';
+import { YellowExclamationTriangleIcon } from '@console/shared';
+
+import { ResourceLink } from '../utils/resource-link';
+
+const ManagedResourceSaveModal: React.SFC<ManagedResourceSaveModalProps> = (props) => {
+  const submit = (event) => {
+    event.preventDefault();
+    props.onSubmit();
+    props.close();
+  };
+
+  const { owner, resource } = props;
+  return (
+    <form onSubmit={submit} name="form" className="modal-content ">
+      <ModalTitle>
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Managed resource
+      </ModalTitle>
+      <ModalBody className="modal-body">
+        This resource is managed by{' '}
+        <ResourceLink
+          className="modal__inline-resource-link"
+          inline
+          kind={referenceForOwnerRef(owner)}
+          name={owner.name}
+          namespace={resource.metadata.namespace}
+        />{' '}
+        and any modifications may be overwritten. Edit the managing resource to preserve changes.
+      </ModalBody>
+      <ModalSubmitFooter submitText="Save" cancel={props.close} inProgress={false} />
+    </form>
+  );
+};
+
+export const managedResourceSaveModal = createModalLauncher(ManagedResourceSaveModal);
+
+type ManagedResourceSaveModalProps = {
+  onSubmit: () => void;
+  close: () => void;
+  resource: K8sResourceCommon;
+  owner: OwnerReference;
+};

--- a/frontend/public/components/utils/_alerts.scss
+++ b/frontend/public/components/utils/_alerts.scss
@@ -8,6 +8,11 @@
   }
 }
 
+.co-alert--margin-top {
+  margin-bottom: 0;
+  margin-top: $grid-gutter-width / 2;
+}
+
 .co-alert--scrollable .pf-c-alert__description {
   max-height: 100px;
   overflow-x: hidden;

--- a/frontend/public/module/k8s/managed-by.ts
+++ b/frontend/public/module/k8s/managed-by.ts
@@ -1,0 +1,20 @@
+import { groupVersionFor, K8sResourceCommon, OwnerReference } from './';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
+
+const isOwnedByOperator = (csv: ClusterServiceVersionKind, owner: OwnerReference) => {
+  const { group } = groupVersionFor(owner.apiVersion);
+  return csv.spec?.customresourcedefinitions?.owned?.some((owned) => {
+    const ownedGroup = owned.name.substring(owned.name.indexOf('.') + 1);
+    return owned.kind === owner.kind && ownedGroup === group;
+  });
+};
+
+export const matchOwnerAndCSV = (owner: OwnerReference, csvs: ClusterServiceVersionKind[] = []) => {
+  return csvs.find((csv) => isOwnedByOperator(csv, owner));
+};
+
+export const findOwner = (obj: K8sResourceCommon, data: ClusterServiceVersionKind[]) => {
+  return obj?.metadata?.ownerReferences?.find((o) =>
+    data?.some((csv) => isOwnedByOperator(csv, o)),
+  );
+};


### PR DESCRIPTION
I added a warning modal for when users save a managed resource. I also edited the delete modal so it has an alert if the resource is managed. I have a separate PR for the managed resources label, but this PR shares code (first commit) in order to get the modals to work. The other PR is https://github.com/openshift/console/pull/5784. I'll drop that commit once the prior PR is merged.

<img width="584" alt="Screen Shot 2020-07-17 at 2 09 56 PM" src="https://user-images.githubusercontent.com/7014965/87818570-c4945280-c838-11ea-97ba-75238010f9da.png">
<img width="581" alt="Screen Shot 2020-07-17 at 2 10 16 PM" src="https://user-images.githubusercontent.com/7014965/87818585-ca8a3380-c838-11ea-8ca6-a5ebca504e5e.png">

Fixes https://issues.redhat.com/projects/CONSOLE/issues/CONSOLE-2163.

Heads up @openshift/team-ux-review and @itsptk.