### PR TITLE
Bug 1856511: Correct alignment of help icons

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/form/form-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/form-row.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { FormGroup } from '@patternfly/react-core';
+import { FormGroup, Popover, PopoverPosition } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
-import * as classnames from 'classnames';
 import { LoadingInline } from '@console/internal/components/utils';
-import { PopoverStatus, ValidationErrorType, StatusIconAndText } from '@console/shared';
+import { ValidationErrorType } from '@console/shared';
+
 import './form-row.scss';
 
 export const FormRow: React.FC<FormRowProps> = ({
@@ -19,9 +19,6 @@ export const FormRow: React.FC<FormRowProps> = ({
   children,
   className,
 }) => {
-  const [isActive, setActive] = React.useState(false);
-  const onHide = React.useCallback(() => setActive(false), [setActive]);
-  const onShow = React.useCallback(() => setActive(true), [setActive]);
   if (isHidden) {
     return null;
   }
@@ -39,30 +36,25 @@ export const FormRow: React.FC<FormRowProps> = ({
         type === ValidationErrorType.Info || type === ValidationErrorType.Warn ? message : undefined
       }
       className={className}
-    >
-      {help && (
-        <span className="kubevirt-form-row__icon-status-container">
-          <PopoverStatus
-            title={`${fieldId} help`}
-            hideHeader
-            onHide={onHide}
-            onShow={onShow}
-            statusBody={
-              <StatusIconAndText
-                title={`${fieldId} help`}
-                iconOnly
-                icon={
-                  <HelpIcon
-                    className={classnames({ 'kubevirt-form-row__help-icon--hidden': !isActive })}
-                  />
-                }
-              />
-            }
+      labelIcon={
+        help && (
+          <Popover
+            position={PopoverPosition.right}
+            aria-label={`${fieldId} help`}
+            bodyContent={help}
           >
-            {help}
-          </PopoverStatus>
-        </span>
-      )}
+            <button
+              type="button"
+              onClick={(e) => e.preventDefault()}
+              className="pf-c-form__group-label-help"
+              aria-label={`${fieldId} help`}
+            >
+              <HelpIcon noVerticalAlign />
+            </button>
+          </Popover>
+        )
+      }
+    >
       {isLoading && (
         <span className="kubevirt-form-row__loading-container">
           <LoadingInline />


### PR DESCRIPTION
This PR corrects help icon styles to comply with PF4 styles and accessibility guidelines.

Before:
![Selection_676](https://user-images.githubusercontent.com/8544299/87936232-79f51f00-ca60-11ea-8b12-3886b4deda19.png)

After:
![Selection_675](https://user-images.githubusercontent.com/8544299/87936252-824d5a00-ca60-11ea-9928-e2a4797228c0.png)
