### PR TITLE
Correct the vertical alignment of operatorhub icons

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -383,7 +383,14 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
     const badges = [COMMUNITY_PROVIDER_TYPE, MARKETPLACE_PROVIDER_TYPE].includes(item.providerType)
       ? [badge(item.providerType)]
       : [];
-    const icon = <img className="catalog-tile-pf-icon" loading="lazy" src={imgUrl} alt="" />;
+    const icon = (
+      <img
+        className="catalog-tile-pf-icon catalog-tile-pf-icon--align-top"
+        loading="lazy"
+        src={imgUrl}
+        alt=""
+      />
+    );
     return (
       <CatalogTile
         className="co-catalog-tile"

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -6,10 +6,6 @@ $catalog-item-icon-size-sm: 24px;
 $co-modal-ignore-warning-icon-width: 30px;
 $catalog-tile-width: $co-m-catalog-tile-width;
 
-// Until Patternfly-React-Extensions is updated: https://github.com/patternfly/patternfly-react/issues/1146
-.catalog-tile-pf-title {
-  @include co-break-word;
-}
 
 // reset font size back to 13px since console h5 font size is 14px
 .catalog-item-header-pf-subtitle {

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -16,6 +16,16 @@ form.pf-c-form {
   background: none;
 }
 
+// Positions the img in OperatorHub that are nested with <span class="catalog-tile-pf-icon"><img ...>
+.catalog-tile-pf-icon--align-top {
+  vertical-align: top;
+}
+
+// Until Patternfly-React-Extensions is updated: https://github.com/patternfly/patternfly-react/issues/1146
+.catalog-tile-pf-title {
+  @include co-break-word;
+}
+
 kbd {
   border-radius: 3px;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
<img width="825" alt="Screen Shot 2020-07-15 at 3 24 47 PM" src="https://user-images.githubusercontent.com/1874151/87944198-158c8c80-ca6d-11ea-914c-a2d282cbdb9a.png">
<img width="829" alt="Screen Shot 2020-07-20 at 9 40 05 AM" src="https://user-images.githubusercontent.com/1874151/87944200-16252300-ca6d-11ea-87b6-ccf3f6c3dbcd.png">
