### PR TITLE
Add kind and apiVersion to resources returned from k8sList

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -460,6 +460,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
   loadError: '',
   data: [
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         generateName: 'py-cron-1593000600-',
         annotations: {
@@ -498,6 +500,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
       },
     },
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         generateName: 'py-cron-1593000600-',
         annotations: {
@@ -536,6 +540,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
       },
     },
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         generateName: 'py-cron-1593002400-',
         annotations: {
@@ -574,6 +580,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
       },
     },
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         annotations: {
           'k8s.v1.cni.cncf.io/network-status':
@@ -610,6 +618,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
       },
     },
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         generateName: 'py-cron-1593002400-',
         annotations: {
@@ -648,6 +658,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
       },
     },
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         generateName: 'py-cron-1593002400-',
         annotations: {
@@ -686,6 +698,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
       },
     },
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         generateName: 'standalone-job-',
         annotations: {
@@ -839,6 +853,8 @@ export const samplePods: FirehoseResult<PodKind[]> = {
       },
     },
     {
+      apiVersion: 'v1',
+      kind: 'Pod',
       metadata: {
         annotations: {
           'k8s.v1.cni.cncf.io/network-status':
@@ -2059,6 +2075,8 @@ export const sampleStatefulSets: FirehoseResult = {
 export const sampleJobs: FirehoseResult = {
   data: [
     {
+      kind: 'Job',
+      apiVersion: 'batch/v1',
       metadata: {
         annotations: {
           'alpha.image.policy.openshift.io/resolve-names': '*',
@@ -2242,6 +2260,8 @@ export const sampleJobs: FirehoseResult = {
       },
     },
     {
+      kind: 'Job',
+      apiVersion: 'batch/v1',
       metadata: {
         name: 'standalone-job',
         namespace: 'jeff-project',
@@ -2542,6 +2562,8 @@ export const sampleJobs: FirehoseResult = {
 export const sampleCronJobs: FirehoseResult = {
   data: [
     {
+      kind: 'CronJob',
+      apiVersion: 'batch/v1beta1',
       metadata: {
         name: 'py-cron',
         namespace: 'jeff-project',

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -129,9 +129,14 @@ export const k8sList = (kind, params = {}, raw = false, options = {}) => {
   }).join('&');
 
   const listURL = resourceURL(kind, { ns: params.ns });
-  return coFetchJSON(`${listURL}?${query}`, 'GET', options).then((result) =>
-    raw ? result : result.items,
-  );
+  return coFetchJSON(`${listURL}?${query}`, 'GET', options).then((result) => {
+    const typedItems = result.items?.map((i) => ({
+      kind: kind.kind,
+      apiVersion: result.apiVersion,
+      ...i,
+    }));
+    return raw ? { ...result, items: typedItems } : typedItems;
+  });
 };
 
 export const k8sListPartialMetadata = (kind, params = {}, raw = false) => {


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4351

**Description**
This PR adds `kind` and `apiVersion` fields to the items returned from `k8sList`. Without those fields, the overview page needed to add them to the resources causing comparisons with newly retrieved items to fail though no data had changed.
It makes sense that these items contain these fields and upon retrieval seems to be the best single place to set them.

/kind bug