### PR TITLE
hides operatorBacked group if deployments in it are backing eventsources in topology view

### DIFF
--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -13,3 +13,4 @@ export const KNATIVE_EVENT_SOURCE_APIGROUP = 'sources.knative.dev';
 export const STRIMZI_KAFKA_APIGROUP = 'kafka.strimzi.io';
 export const EVENT_SOURCE_LABEL = 'console.openshift.io/event-source';
 export const EVENT_SOURCE_ICON = 'console.openshift.io/icon';
+export const CAMEL_SOURCE_INTEGRATION = 'camel.apache.org/integration';

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -34,6 +34,156 @@ import {
   EventTriggerKind,
 } from '../../types';
 
+export const sampleDeploymentsCamelConnector: FirehoseResult<DeploymentKind[]> = {
+  loaded: true,
+  loadError: '',
+  data: [
+    {
+      kind: 'Deployment',
+      apiVersion: 'apps/v1',
+      metadata: {
+        annotations: { 'deployment.kubernetes.io/revision': '1' },
+        selfLink: '/apis/apps/v1/namespaces/testproject1/deployments/overlayimage-f56hh',
+        resourceVersion: '466744',
+        name: 'overlayimage-f56hh',
+        uid: '644ee7d3-83ce-442c-b478-492bc92d8959',
+        creationTimestamp: '2020-07-23T08:00:44Z',
+        generation: 1,
+        namespace: 'testproject1',
+        ownerReferences: [
+          {
+            apiVersion: 'camel.apache.org/v1',
+            kind: 'Integration',
+            name: 'overlayimage-f56hh',
+            uid: 'c1b802c8-42ff-4224-824f-5d454814ab01',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+        labels: {
+          'camel.apache.org/generation': '1',
+          'camel.apache.org/integration': 'overlayimage-f56hh',
+        },
+      },
+      spec: {
+        replicas: 1,
+        selector: {
+          matchLabels: { 'camel.apache.org/integration': 'overlayimage-f56hh' },
+        },
+        template: {
+          metadata: {
+            creationTimestamp: null,
+            labels: { 'camel.apache.org/integration': 'overlayimage-f56hh' },
+          },
+          spec: {
+            volumes: [
+              {
+                name: 'i-source-000',
+                configMap: {
+                  name: 'overlayimage-f56hh-source-000',
+                  items: [{ key: 'content', path: 'flow.yaml' }],
+                  defaultMode: 420,
+                },
+              },
+              {
+                name: 'application-properties',
+                configMap: {
+                  name: 'overlayimage-f56hh-application-properties',
+                  items: [{ key: 'application.properties', path: 'application.properties' }],
+                  defaultMode: 420,
+                },
+              },
+            ],
+            containers: [
+              {
+                resources: {},
+                terminationMessagePath: '/dev/termination-log',
+                name: 'integration',
+                command: ['/bin/sh', '-c'],
+                env: [
+                  { name: 'CAMEL_K_DIGEST', value: 'vUzNeM-0LVeJNAd5q9DNRZ4mRiM5PY7PICcRXFl3EI3Y' },
+                  {
+                    name: 'CAMEL_K_ROUTES',
+                    value:
+                      'file:/etc/camel/sources/i-source-000/flow.yaml?language=yaml&interceptors=knative-source',
+                  },
+                  { name: 'CAMEL_K_CONF', value: '/etc/camel/conf/application.properties' },
+                  { name: 'CAMEL_K_CONF_D', value: '/etc/camel/conf.d' },
+                  {
+                    name: 'CAMEL_KNATIVE_CONFIGURATION',
+                    value:
+                      '{"services":[{"type":"endpoint","name":"sink","host":"messages-kn-channel.testproject1.svc.cluster.local","port":80,"metadata":{"camel.endpoint.kind":"sink","ce.override.ce-source":"camel-source:testproject1/overlayimage","knative.apiVersion":"","knative.kind":""}}]}',
+                  },
+                  { name: 'CAMEL_K_VERSION', value: '1.0.1' },
+                  { name: 'CAMEL_K_INTEGRATION', value: 'overlayimage-f56hh' },
+                  { name: 'CAMEL_K_RUNTIME_VERSION', value: '1.3.0' },
+                  { name: 'CAMEL_K_MOUNT_PATH_CONFIGMAPS', value: '/etc/camel/conf.d/_configmaps' },
+                  { name: 'CAMEL_K_MOUNT_PATH_SECRETS', value: '/etc/camel/conf.d/_secrets' },
+                  {
+                    name: 'NAMESPACE',
+                    valueFrom: { fieldRef: { apiVersion: 'v1', fieldPath: 'metadata.namespace' } },
+                  },
+                  {
+                    name: 'POD_NAME',
+                    valueFrom: { fieldRef: { apiVersion: 'v1', fieldPath: 'metadata.name' } },
+                  },
+                ],
+                volumeMounts: [
+                  { name: 'i-source-000', mountPath: '/etc/camel/sources/i-source-000' },
+                  { name: 'application-properties', mountPath: '/etc/camel/conf' },
+                ],
+                terminationMessagePolicy: 'File',
+                image:
+                  'image-registry.openshift-image-registry.svc:5000/testproject1/camel-k-kit-bsck6ptket36jkvbvt9g@sha256:53eab3d851061862ce86fd64d0ca2fb05562e2a707dd5341cbb8067ba8d27831',
+                workingDir: '/deployments',
+                args: [
+                  'echo exec java -cp ./resources:/etc/camel/conf:/etc/camel/resources:/etc/camel/sources/i-source-000:dependencies/com.fasterxml.jackson.core.jackson-annotations-2.10.4.jar:dependencies/com.fasterxml.jackson.core.jackson-core-2.10.4.jar:dependencies/com.fasterxml.jackson.core.jackson-databind-2.10.4.jar:dependencies/com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.10.4.jar:dependencies/com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.10.4.jar:dependencies/com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.10.4.jar:dependencies/com.sun.activation.javax.activation-1.2.0.jar:dependencies/com.typesafe.netty.netty-reactive-streams-2.0.4.jar:dependencies/io.netty.netty-buffer-4.1.46.Final.jar:dependencies/io.netty.netty-codec-4.1.46.Final.jar:dependencies/io.netty.netty-codec-dns-4.1.48.Final.jar:dependencies/io.netty.netty-codec-http-4.1.46.Final.jar:dependencies/io.netty.netty-codec-http2-4.1.48.Final.jar:dependencies/io.netty.netty-codec-socks-4.1.46.Final.jar:dependencies/io.netty.netty-common-4.1.46.Final.jar:dependencies/io.netty.netty-handler-4.1.46.Final.jar:dependencies/io.netty.netty-handler-proxy-4.1.46.Final.jar:dependencies/io.netty.netty-resolver-4.1.46.Final.jar:dependencies/io.netty.netty-resolver-dns-4.1.48.Final.jar:dependencies/io.netty.netty-transport-4.1.46.Final.jar:dependencies/io.netty.netty-transport-native-epoll-4.1.46.Final-linux-x86_64.jar:dependencies/io.netty.netty-transport-native-kqueue-4.1.46.Final-osx-x86_64.jar:dependencies/io.netty.netty-transport-native-unix-common-4.1.46.Final.jar:dependencies/io.vertx.vertx-auth-common-3.9.0.jar:dependencies/io.vertx.vertx-bridge-common-3.9.0.jar:dependencies/io.vertx.vertx-core-3.9.0.jar:dependencies/io.vertx.vertx-web-3.9.0.jar:dependencies/io.vertx.vertx-web-client-3.9.0.jar:dependencies/io.vertx.vertx-web-common-3.9.0.jar:dependencies/javax.xml.bind.jaxb-api-2.3.0.jar:dependencies/org.apache.camel.camel-api-3.3.0.jar:dependencies/org.apache.camel.camel-base-3.3.0.jar:dependencies/org.apache.camel.camel-bean-3.3.0.jar:dependencies/org.apache.camel.camel-cloud-3.3.0.jar:dependencies/org.apache.camel.camel-core-engine-3.3.0.jar:dependencies/org.apache.camel.camel-core-languages-3.3.0.jar:dependencies/org.apache.camel.camel-jackson-3.3.0.jar:dependencies/org.apache.camel.camel-log-3.3.0.jar:dependencies/org.apache.camel.camel-main-3.3.0.jar:dependencies/org.apache.camel.camel-management-api-3.3.0.jar:dependencies/org.apache.camel.camel-platform-http-3.3.0.jar:dependencies/org.apache.camel.camel-platform-http-vertx-3.3.0.jar:dependencies/org.apache.camel.camel-support-3.3.0.jar:dependencies/org.apache.camel.camel-telegram-3.3.0.jar:dependencies/org.apache.camel.camel-util-3.3.0.jar:dependencies/org.apache.camel.camel-webhook-3.3.0.jar:dependencies/org.apache.camel.k.camel-k-loader-yaml-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-loader-yaml-common-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-core-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-http-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-knative-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-main-1.3.0.jar:dependencies/org.apache.camel.k.camel-knative-1.3.0.jar:dependencies/org.apache.camel.k.camel-knative-api-1.3.0.jar:dependencies/org.apache.camel.k.camel-knative-http-1.3.0.jar:dependencies/org.apache.logging.log4j.log4j-api-2.13.3.jar:dependencies/org.apache.logging.log4j.log4j-core-2.13.3.jar:dependencies/org.apache.logging.log4j.log4j-slf4j-impl-2.13.3.jar:dependencies/org.asynchttpclient.async-http-client-2.11.0.jar:dependencies/org.asynchttpclient.async-http-client-netty-utils-2.11.0.jar:dependencies/org.reactivestreams.reactive-streams-1.0.3.jar:dependencies/org.slf4j.slf4j-api-1.7.30.jar:dependencies/org.yaml.snakeyaml-1.26.jar org.apache.camel.k.main.Application && exec java -cp ./resources:/etc/camel/conf:/etc/camel/resources:/etc/camel/sources/i-source-000:dependencies/com.fasterxml.jackson.core.jackson-annotations-2.10.4.jar:dependencies/com.fasterxml.jackson.core.jackson-core-2.10.4.jar:dependencies/com.fasterxml.jackson.core.jackson-databind-2.10.4.jar:dependencies/com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.10.4.jar:dependencies/com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.10.4.jar:dependencies/com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.10.4.jar:dependencies/com.sun.activation.javax.activation-1.2.0.jar:dependencies/com.typesafe.netty.netty-reactive-streams-2.0.4.jar:dependencies/io.netty.netty-buffer-4.1.46.Final.jar:dependencies/io.netty.netty-codec-4.1.46.Final.jar:dependencies/io.netty.netty-codec-dns-4.1.48.Final.jar:dependencies/io.netty.netty-codec-http-4.1.46.Final.jar:dependencies/io.netty.netty-codec-http2-4.1.48.Final.jar:dependencies/io.netty.netty-codec-socks-4.1.46.Final.jar:dependencies/io.netty.netty-common-4.1.46.Final.jar:dependencies/io.netty.netty-handler-4.1.46.Final.jar:dependencies/io.netty.netty-handler-proxy-4.1.46.Final.jar:dependencies/io.netty.netty-resolver-4.1.46.Final.jar:dependencies/io.netty.netty-resolver-dns-4.1.48.Final.jar:dependencies/io.netty.netty-transport-4.1.46.Final.jar:dependencies/io.netty.netty-transport-native-epoll-4.1.46.Final-linux-x86_64.jar:dependencies/io.netty.netty-transport-native-kqueue-4.1.46.Final-osx-x86_64.jar:dependencies/io.netty.netty-transport-native-unix-common-4.1.46.Final.jar:dependencies/io.vertx.vertx-auth-common-3.9.0.jar:dependencies/io.vertx.vertx-bridge-common-3.9.0.jar:dependencies/io.vertx.vertx-core-3.9.0.jar:dependencies/io.vertx.vertx-web-3.9.0.jar:dependencies/io.vertx.vertx-web-client-3.9.0.jar:dependencies/io.vertx.vertx-web-common-3.9.0.jar:dependencies/javax.xml.bind.jaxb-api-2.3.0.jar:dependencies/org.apache.camel.camel-api-3.3.0.jar:dependencies/org.apache.camel.camel-base-3.3.0.jar:dependencies/org.apache.camel.camel-bean-3.3.0.jar:dependencies/org.apache.camel.camel-cloud-3.3.0.jar:dependencies/org.apache.camel.camel-core-engine-3.3.0.jar:dependencies/org.apache.camel.camel-core-languages-3.3.0.jar:dependencies/org.apache.camel.camel-jackson-3.3.0.jar:dependencies/org.apache.camel.camel-log-3.3.0.jar:dependencies/org.apache.camel.camel-main-3.3.0.jar:dependencies/org.apache.camel.camel-management-api-3.3.0.jar:dependencies/org.apache.camel.camel-platform-http-3.3.0.jar:dependencies/org.apache.camel.camel-platform-http-vertx-3.3.0.jar:dependencies/org.apache.camel.camel-support-3.3.0.jar:dependencies/org.apache.camel.camel-telegram-3.3.0.jar:dependencies/org.apache.camel.camel-util-3.3.0.jar:dependencies/org.apache.camel.camel-webhook-3.3.0.jar:dependencies/org.apache.camel.k.camel-k-loader-yaml-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-loader-yaml-common-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-core-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-http-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-knative-1.3.0.jar:dependencies/org.apache.camel.k.camel-k-runtime-main-1.3.0.jar:dependencies/org.apache.camel.k.camel-knative-1.3.0.jar:dependencies/org.apache.camel.k.camel-knative-api-1.3.0.jar:dependencies/org.apache.camel.k.camel-knative-http-1.3.0.jar:dependencies/org.apache.logging.log4j.log4j-api-2.13.3.jar:dependencies/org.apache.logging.log4j.log4j-core-2.13.3.jar:dependencies/org.apache.logging.log4j.log4j-slf4j-impl-2.13.3.jar:dependencies/org.asynchttpclient.async-http-client-2.11.0.jar:dependencies/org.asynchttpclient.async-http-client-netty-utils-2.11.0.jar:dependencies/org.reactivestreams.reactive-streams-1.0.3.jar:dependencies/org.slf4j.slf4j-api-1.7.30.jar:dependencies/org.yaml.snakeyaml-1.26.jar org.apache.camel.k.main.Application',
+                ],
+              },
+            ],
+            restartPolicy: 'Always',
+            terminationGracePeriodSeconds: 30,
+            dnsPolicy: 'ClusterFirst',
+            securityContext: {},
+            schedulerName: 'default-scheduler',
+          },
+        },
+        strategy: {
+          type: 'RollingUpdate',
+          rollingUpdate: { maxUnavailable: '25%', maxSurge: '25%' },
+        },
+        revisionHistoryLimit: 10,
+        progressDeadlineSeconds: 600,
+      },
+      status: {
+        observedGeneration: 1,
+        replicas: 1,
+        updatedReplicas: 1,
+        readyReplicas: 1,
+        availableReplicas: 1,
+        conditions: [
+          {
+            type: 'Available',
+            status: 'True',
+            lastUpdateTime: '2020-07-23T08:00:59Z',
+            lastTransitionTime: '2020-07-23T08:00:59Z',
+            reason: 'MinimumReplicasAvailable',
+            message: 'Deployment has minimum availability.',
+          },
+          {
+            type: 'Progressing',
+            status: 'True',
+            lastUpdateTime: '2020-07-23T08:00:59Z',
+            lastTransitionTime: '2020-07-23T08:00:44Z',
+            reason: 'NewReplicaSetAvailable',
+            message: 'ReplicaSet "overlayimage-f56hh-76d96fcc86" has successfully progressed.',
+          },
+        ],
+      },
+    },
+  ],
+};
+
 export const sampleKnativeDeployments: FirehoseResult<DeploymentKind[]> = {
   loaded: true,
   loadError: '',

--- a/frontend/packages/knative-plugin/src/topology/isKnativeResource.ts
+++ b/frontend/packages/knative-plugin/src/topology/isKnativeResource.ts
@@ -4,6 +4,7 @@ import { TYPE_EVENT_SOURCE } from './const';
 import { OdcNodeModel } from '@console/dev-console/src/components/topology';
 import { DeploymentModel } from '@console/internal/models';
 import { EventingBrokerModel } from '../models';
+import { CAMEL_SOURCE_INTEGRATION } from '../const';
 
 const KNATIVE_CONFIGURATION = 'serving.knative.dev/configuration';
 
@@ -20,7 +21,14 @@ export const isKnativeResource = (resource: K8sResourceKind, model: Model): bool
     .map((n) => (n as OdcNodeModel).resource);
 
   const isEventSourceKind = (uid: string): boolean =>
-    uid && !!eventSources?.find((eventSource) => eventSource.metadata?.uid === uid);
+    uid &&
+    !!eventSources?.find(
+      (eventSource) =>
+        eventSource.metadata?.uid === uid ||
+        resource.metadata?.labels?.[CAMEL_SOURCE_INTEGRATION]?.startsWith(
+          eventSource.metadata?.name,
+        ),
+    );
 
   if (isEventSourceKind(resource.metadata?.ownerReferences?.[0].uid)) {
     return true;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4245

Issue : https://issues.redhat.com/browse/ODC-4357 

**Analysis / Root cause**: 
Deployment owned by camelConnectors are shown in topology view as operator backed service and should be shown only in eventSources sidebar

**Solution Description**: 
Don't show Deployment owned by camelConnectors  in topology view as operator backed service and show only in eventSources sidebar

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/5129024/88264127-e1250480-cce8-11ea-8d61-6ef6e5fa386a.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/5129024/88272788-e5581e80-ccf6-11ea-8533-94e8834615d6.png)


**Test setup:**
- Install Serverless Operator, create `knativeServing/knativeEventing` CR

**To test one camel Source**
-  Install Knative camel Operator
-  go to DevConsole -> Add -> EventSources
- Create Camel telegram source

**To test various camel Connectors**
- oc apply -f {file: https://gist.github.com/nicolaferraro/68afc4e07cfa7ef1a10f926967b76063 } on 4.4 Cluster (dependency is on 4.4 cluster for testing now as knative-camel operator in operator Hub doesn't have alm-examples for camel connectors and to test here have installed via operator source which works till 4.4)
- Install Serverless/Knative camel (custom) will show up in operator hub post applying above
- go to DevConsole -> Add -> EventSources

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
