### PR TITLE
Bug 1871996: Made create role bindings links consistent

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -288,7 +288,9 @@ export const RoleBindingsPage = ({
   showTitle = true,
   mock = false,
   staticFilters = undefined,
-  createPath = '/k8s/cluster/rolebindings/~new',
+  createPath = `/k8s/${namespace ? `ns/${namespace}` : 'cluster'}/rolebindings/~new${
+    namespace ? `?namespace=${namespace}` : ''
+  }`,
 }) => (
   <MultiListPage
     canCreate={!mock}

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -32,9 +32,10 @@ const menuActions = [
   // }),
   (kind, role) => ({
     label: 'Add Role Binding',
-    href: `/k8s/cluster/rolebindings/~new?rolekind=${roleKind(role)}&rolename=${
-      role.metadata.name
-    }`,
+    href: `/k8s/${
+      role.metadata.namespace ? `ns/${role.metadata.namespace}` : 'cluster'
+    }/rolebindings/~new?rolekind=${roleKind(role)}&rolename=${role.metadata.name}${role.metadata
+      .namespace && `&namespace=${role.metadata.namespace}`}`,
   }),
   Kebab.factory.Edit,
   Kebab.factory.Delete,
@@ -230,7 +231,7 @@ export const BindingsForRolePage = (props) => {
       createProps={{
         to: `/k8s/${
           ns ? `ns/${ns}` : 'cluster'
-        }/rolebindings/~new?rolekind=${kind}&rolename=${name}`,
+        }/rolebindings/~new?rolekind=${kind}&rolename=${name}${ns && `&namespace=${ns}`}`,
       }}
       ListComponent={BindingsListComponent}
       staticFilters={[{ 'role-binding-roleRef-name': name }, { 'role-binding-roleRef-kind': kind }]}


### PR DESCRIPTION
The "Create Binding" button under the Role Bindings tab on the Role details page linked to a namespaced or cluster bindings URL. Meanwhile, other pages only use the cluster URL. I made the URLs consistent.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1871996.