### PR TITLE
Bug 1857843:  add RBAC checks to cluster upgrade notifications

### DIFF
--- a/frontend/__tests__/components/cluster-settings.spec.tsx
+++ b/frontend/__tests__/components/cluster-settings.spec.tsx
@@ -217,7 +217,7 @@ describe('Current Channel component', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(<CurrentChannel cv={clusterVersionProps} />);
+    wrapper = mount(<CurrentChannel cv={clusterVersionProps} clusterVersionIsEditable={true} />);
   });
 
   it('should accept props', () => {

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -12,7 +12,7 @@ import { Link } from 'react-router-dom';
 import { FLAGS } from '@console/shared';
 import { connectToFlags, FlagsObject } from '../reducers/features';
 import { getBrandingDetails } from './masthead';
-import { Firehose } from './utils';
+import { Firehose, useAccessReview } from './utils';
 import { ClusterVersionModel } from '../models';
 import { ClusterVersionKind, referenceForModel } from '../module/k8s';
 import { k8sVersion } from '../module/status';
@@ -37,9 +37,16 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
   const clusterID = getClusterID(clusterVersion);
   const channel: string = _.get(cv, 'data.spec.channel');
   const openshiftVersion = getOpenShiftVersion(clusterVersion);
+  const clusterVersionIsEditable = useAccessReview({
+    group: ClusterVersionModel.apiGroup,
+    resource: ClusterVersionModel.plural,
+    verb: 'patch',
+    name: clusterVersion.metadata.name,
+  });
+
   return (
     <>
-      {clusterVersion && hasAvailableUpdates(clusterVersion) && (
+      {clusterVersion && hasAvailableUpdates(clusterVersion) && clusterVersionIsEditable && (
         <Alert
           className="co-alert co-about-modal__alert"
           variant="info"

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -31,7 +31,7 @@ import {
   getOCMLink,
 } from '../../../../module/k8s';
 import { flagPending, featureReducerName } from '../../../../reducers/features';
-import { ExternalLink } from '../../../utils';
+import { ExternalLink, useAccessReview } from '../../../utils';
 import { RootState } from '../../../../redux';
 import { clusterUpdateModal } from '../../../modals';
 import { Link } from 'react-router-dom';
@@ -42,6 +42,12 @@ const ClusterVersion: React.FC<ClusterVersionProps> = ({ cv }) => {
   const desiredVersion = getDesiredClusterVersion(cv);
   const lastVersion = getLastCompletedUpdate(cv);
   const status = getClusterUpdateStatus(cv);
+  const clusterVersionIsEditable = useAccessReview({
+    group: ClusterVersionModel.apiGroup,
+    resource: ClusterVersionModel.plural,
+    verb: 'patch',
+    name: 'version',
+  });
 
   switch (status) {
     case ClusterUpdateStatus.Updating:
@@ -60,17 +66,19 @@ const ClusterVersion: React.FC<ClusterVersionProps> = ({ cv }) => {
       return (
         <>
           <span className="co-select-to-copy">{desiredVersion}</span>
-          <div>
-            <Button
-              variant="link"
-              className="btn-link--no-btn-default-values"
-              onClick={() => clusterUpdateModal({ cv })}
-              icon={<BlueArrowCircleUpIcon />}
-              isInline
-            >
-              Update
-            </Button>
-          </div>
+          {clusterVersionIsEditable && (
+            <div>
+              <Button
+                variant="link"
+                className="btn-link--no-btn-default-values"
+                onClick={() => clusterUpdateModal({ cv })}
+                icon={<BlueArrowCircleUpIcon />}
+                isInline
+              >
+                Update
+              </Button>
+            </div>
+          )}
         </>
       );
     default:

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -45,6 +45,7 @@ import {
 import { WatchK8sResource, useK8sWatchResource } from '../../../utils/k8s-watch-hook';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { ClusterDashboardContext } from './context';
+import { useAccessReview } from '../../../utils';
 
 const filterSubsystems = (
   subsystems: DashboardsOverviewHealthSubsystem[],
@@ -91,7 +92,14 @@ const ClusterAlerts = withDashboardResources(
 
     const items: React.ReactNode[] = [];
 
-    if (hasCVResource && cvLoaded && hasAvailableUpdates(cv)) {
+    const clusterVersionIsEditable = useAccessReview({
+      group: ClusterVersionModel.apiGroup,
+      resource: ClusterVersionModel.plural,
+      verb: 'patch',
+      name: 'version',
+    });
+
+    if (hasCVResource && cvLoaded && hasAvailableUpdates(cv) && clusterVersionIsEditable) {
       items.push(
         <StatusItem Icon={UpdateIcon} message="A cluster version update is available">
           <Button variant="link" onClick={() => clusterUpdateModal({ cv })} isInline>

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -40,6 +40,7 @@ import {
 } from '../module/k8s';
 import { ClusterVersionModel } from '../models';
 import { useK8sWatchResource, WatchK8sResource } from './utils/k8s-watch-hook';
+import { useAccessReview } from './utils/rbac';
 
 const criticalCompare = (a: Alert): boolean => getAlertSeverity(a) === 'critical';
 const otherAlertCompare = (a: Alert): boolean => getAlertSeverity(a) !== 'critical';
@@ -106,9 +107,10 @@ const getAlertNotificationEntries = (
 const getUpdateNotificationEntries = (
   isLoaded: boolean,
   updateData: ClusterUpdate[],
+  isEditable: boolean,
   toggleNotificationDrawer: () => void,
 ): React.ReactNode[] =>
-  isLoaded && !_.isEmpty(updateData)
+  isLoaded && !_.isEmpty(updateData) && isEditable
     ? [
         <NotificationEntry
           actionPath="/settings/cluster"
@@ -207,9 +209,17 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
   const updateData: ClusterUpdate[] = getSortedUpdates(clusterVersionData);
   const { data, loaded, loadError } = alerts || {};
 
+  const clusterVersionIsEditable = useAccessReview({
+    group: ClusterVersionModel.apiGroup,
+    resource: ClusterVersionModel.plural,
+    verb: 'patch',
+    name: 'version',
+  });
+
   const updateList: React.ReactNode[] = getUpdateNotificationEntries(
     clusterVersionLoaded,
     updateData,
+    clusterVersionIsEditable,
     toggleNotificationDrawer,
   );
   const criticalAlertList: React.ReactNode[] = getAlertNotificationEntries(


### PR DESCRIPTION
Updates are available, but the user cannot edit the ClusterVersion:
<img width="2207" alt="Screen Shot 2020-07-20 at 3 54 49 PM" src="https://user-images.githubusercontent.com/895728/87980656-f3613180-caa1-11ea-9a45-0d9ddde7da0e.png">
<img width="900" alt="Screen Shot 2020-07-20 at 10 22 03 AM" src="https://user-images.githubusercontent.com/895728/87980661-f4925e80-caa1-11ea-9f52-52bc8b1b4364.png">
<img width="1283" alt="Screen Shot 2020-07-20 at 2 04 19 PM" src="https://user-images.githubusercontent.com/895728/87980673-f78d4f00-caa1-11ea-9ebb-e7c0d54664a9.png">
