### PR TITLE
Monitoring: Make alert state ordering consistent

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -151,8 +151,8 @@ const MonitoringResourceIcon: React.FC<MonitoringResourceIconProps> = ({ classNa
 
 const stateIcons = {
   [AlertStates.Firing]: <BellIcon />,
-  [AlertStates.Silenced]: <BellSlashIcon className="text-muted" />,
   [AlertStates.Pending]: <OutlinedBellIcon />,
+  [AlertStates.Silenced]: <BellSlashIcon className="text-muted" />,
 };
 
 export const AlertState: React.FC<AlertStateProps> = ({ state }) => {
@@ -1010,8 +1010,8 @@ export const alertsRowFilters: RowFilter[] = [
     filterGroupName: 'Alert State',
     items: [
       { id: AlertStates.Firing, title: 'Firing' },
-      { id: AlertStates.Silenced, title: 'Silenced' },
       { id: AlertStates.Pending, title: 'Pending' },
+      { id: AlertStates.Silenced, title: 'Silenced' },
     ],
     reducer: alertState,
     type: 'alert-state',

--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -53,7 +53,7 @@ export const alertSeverityOrder = (alert: Alert | Rule): ListOrder => {
 // Sort alerts and silences by their state (sort first by the state itself, then by the timestamp
 // relevant to the state)
 export const alertStateOrder = (alert: Alert): ListOrder => [
-  [AlertStates.Firing, AlertStates.Silenced, AlertStates.Pending].indexOf(alertState(alert)),
+  [AlertStates.Firing, AlertStates.Pending, AlertStates.Silenced].indexOf(alertState(alert)),
   alertState(alert) === AlertStates.Silenced
     ? _.max(_.map(alert.silencedBy, 'endsAt'))
     : _.get(alert, 'activeAt'),


### PR DESCRIPTION
The alerts list page used the order Firing > Silenced > Pending, but the
alerting rules list page used the order Firing > Pending > Silenced.
This removes the inconsistency by using Firing > Pending > Silenced
everywhere.

FYI @cshinn 