### PR TITLE
Update BMH unmanaged state

### DIFF
--- a/frontend/packages/console-shared/src/hooks/previous.ts
+++ b/frontend/packages/console-shared/src/hooks/previous.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react';
 
-export const usePrevious = <P = any>(value: P, deps: any[] = []): P => {
+export const usePrevious = <P = any>(value: P, deps?: any[]): P => {
   const ref = useRef<P>();
   useEffect(() => {
     ref.current = value;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, ...deps]);
+  }, deps || [value]);
   return ref.current;
 };

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
@@ -26,9 +26,11 @@ import MaintenancePopover from '../maintenance/MaintenancePopover';
 import { BareMetalHostKind } from '../../types';
 import { BareMetalHostModel } from '../../models';
 
+import './status.scss';
+
 export const HOST_STATUS_ACTIONS = {
   [HOST_STATUS_UNMANAGED]: (host: BareMetalHostKind) => (
-    <p>
+    <div className="bmh-status-action">
       <Link
         to={`${resourcePathFromModel(
           BareMetalHostModel,
@@ -38,7 +40,7 @@ export const HOST_STATUS_ACTIONS = {
       >
         Add credentials
       </Link>
-    </p>
+    </div>
   ),
 };
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHost.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHost.tsx
@@ -46,7 +46,9 @@ const getInitialValues = (
   bootMACAddress: getHostBootMACAddress(host) || '',
   online: isHostOnline(host) || true,
   description: getHostDescription(host) || '',
-  enablePowerManagement: isEditing ? !!host?.spec?.bmc || enablePowerMgmt : true,
+  enablePowerManagement: isEditing
+    ? !!host?.spec?.bmc?.address || !!host?.spec?.bmc?.credentialsName || enablePowerMgmt
+    : true,
 });
 
 type AddBareMetalHostProps = {
@@ -122,7 +124,7 @@ const AddBareMetalHost: React.FC<AddBareMetalHostProps> = ({
   const initialValues = getInitialValues(host, secret, !!name, enablePowerMgmt);
   const prevInitialValues = getInitialValues(initialHost, initialSecret, !!name, enablePowerMgmt);
 
-  const showUpdated = initialHost && !_.isEqual(prevInitialValues, initialValues);
+  const showUpdated = !_.isEmpty(initialHost) && !_.isEqual(prevInitialValues, initialValues);
 
   const addHostValidationSchema = Yup.lazy(({ enablePowerManagement }) =>
     Yup.object().shape({
@@ -152,7 +154,11 @@ const AddBareMetalHost: React.FC<AddBareMetalHostProps> = ({
   ) => {
     const opts = { ...values, namespace };
     const promise = name
-      ? updateBareMetalHost(initialHost, initialSecret, opts)
+      ? updateBareMetalHost(
+          _.isEmpty(initialHost) ? host : initialHost,
+          _.isEmpty(initialSecret) ? secret : initialSecret,
+          opts,
+        )
       : createBareMetalHost(opts);
 
     promise

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
@@ -29,6 +29,7 @@ import {
   HOST_PROGRESS_STATES,
   HOST_HARDWARE_ERROR_STATES,
   HOST_STATUS_UNMANAGED,
+  HOST_INFO_STATES,
 } from '../../../constants';
 import { BareMetalHostKind } from '../../../types';
 import { BareMetalHostDashboardContext } from './BareMetalHostDashboardContext';
@@ -39,7 +40,7 @@ const getHostHealthState = (obj: BareMetalHostKind): HostHealthState => {
   const { status, title } = getBareMetalHostStatus(obj);
   let state: HealthState = HealthState.UNKNOWN;
 
-  if (HOST_SUCCESS_STATES.includes(status)) {
+  if ([...HOST_SUCCESS_STATES, ...HOST_INFO_STATES].includes(status)) {
     state = HealthState.OK;
   }
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/status.scss
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/status.scss
@@ -1,0 +1,3 @@
+.bmh-status-action {
+  padding: var(--pf-global--spacer--sm) 0;
+}

--- a/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
@@ -3,7 +3,7 @@ import { nodeStatus } from '@console/app/src/status/node';
 import { isNodeUnschedulable } from '@console/shared/src/selectors/node';
 import { StatusProps } from '../components/types';
 import { BareMetalHostKind } from '../types';
-import { isHostPoweredOn } from '../selectors';
+import { isHostPoweredOn, hasPowerManagement } from '../selectors';
 import { getNodeMaintenanceStatus } from './node-maintenance-status';
 
 type BareMetalNodeStatusProps = {
@@ -33,7 +33,7 @@ export const baremetalNodeSecondaryStatus = ({
     states.push('Scheduling disabled');
   }
   // show host power status only if there is actual host associated to node
-  if (host && !isHostPoweredOn(host)) {
+  if (host && hasPowerManagement(host) && !isHostPoweredOn(host)) {
     states.push('Host is powered off');
   }
   return states;


### PR DESCRIPTION
@jtomasek minor tweaks around BMH

1. Some style updates
2. Node list page does not show `Powered On` if BMH has no power management capabilities
3. Show Unmanaged state as OK in Overview page (there's info in alerts section about missing BMC credentials)