### PR TITLE
Add an alert action extension

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -18,3 +18,4 @@ export * from './horizontal-nav';
 export * from './providers';
 export * from './pvc';
 export * from './storage-class-params';
+export * from './notification-alerts';

--- a/frontend/packages/console-plugin-sdk/src/typings/notification-alerts.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/notification-alerts.ts
@@ -1,0 +1,21 @@
+import { Extension } from './base';
+import { Alert } from '@console/internal/components/monitoring/types';
+
+namespace ExtensionProperties {
+  export interface AlertAction {
+    /* Alert name as defined by `alert.rule.name` property */
+    alert: string;
+    /* Action text */
+    text: string;
+    /* Action href link */
+    path: (alert: Alert) => string;
+  }
+}
+
+export interface AlertAction extends Extension<ExtensionProperties.AlertAction> {
+  type: 'AlertAction';
+}
+
+export function isAlertAction(e: Extension): e is AlertAction {
+  return e.type === 'AlertAction';
+}

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
-import { alertActions } from '@console/internal/components/notification-drawer';
+import { isAlertAction, useExtensions, AlertAction } from '@console/plugin-sdk';
+import { getAlertActions } from '@console/internal/components/notification-drawer';
 import { Timestamp } from '@console/internal/components/utils/timestamp';
 import { Alert } from '@console/internal/components/monitoring/types';
 import { alertURL } from '@console/internal/components/monitoring/utils';
@@ -42,7 +44,8 @@ export const StatusItem: React.FC<StatusItemProps> = ({ Icon, timestamp, message
 };
 
 const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
-  const action = alertActions.get(alert.rule.name);
+  const actionsExtensions = useExtensions<AlertAction>(isAlertAction);
+  const action = getAlertActions(actionsExtensions).get(alert.rule.name);
   return (
     <StatusItem
       Icon={getSeverityIcon(getAlertSeverity(alert))}
@@ -50,7 +53,7 @@ const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
       message={getAlertDescription(alert) || getAlertMessage(alert)}
     >
       {action ? (
-        <Link to={action.path}>{action.text}</Link>
+        <Link to={_.isFunction(action.path) ? action.path(alert) : action.path}>{action.text}</Link>
       ) : (
         <Link to={alertURL(alert, alert.rule.id)}>View details</Link>
       )}

--- a/frontend/packages/local-storage-operator-plugin/src/plugin.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/plugin.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import {
+  AlertAction,
   ModelDefinition,
   ModelFeatureFlag,
   Plugin,
@@ -7,11 +8,17 @@ import {
   HorizontalNavTab,
 } from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
-import * as models from './models';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { NodeModel } from '@console/internal/models';
+import { getAlertActionPath } from './utils/alert-actions-path';
+import * as models from './models';
 
-type ConsumedExtensions = HorizontalNavTab | ModelFeatureFlag | ModelDefinition | RoutePage;
+type ConsumedExtensions =
+  | AlertAction
+  | HorizontalNavTab
+  | ModelFeatureFlag
+  | ModelDefinition
+  | RoutePage;
 
 const LSO_FLAG = 'LSO';
 const LSO_DEVICE_DISCOVERY = 'LSO_DEVICE_DISCOVERY';
@@ -65,6 +72,28 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/disks-list/disks-list-page' /* webpackChunkName: "lso-disks-list" */
         ).then((m) => m.default),
+    },
+    flags: {
+      required: [LSO_DEVICE_DISCOVERY],
+    },
+  },
+  {
+    type: 'AlertAction',
+    properties: {
+      alert: 'CephOSDDiskNotResponding',
+      text: 'Troubleshoot',
+      path: getAlertActionPath,
+    },
+    flags: {
+      required: [LSO_DEVICE_DISCOVERY],
+    },
+  },
+  {
+    type: 'AlertAction',
+    properties: {
+      alert: 'CephOSDDiskUnavailable',
+      text: 'Troubleshoot',
+      path: getAlertActionPath,
     },
     flags: {
       required: [LSO_DEVICE_DISCOVERY],

--- a/frontend/packages/local-storage-operator-plugin/src/utils/alert-actions-path.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/utils/alert-actions-path.tsx
@@ -1,0 +1,4 @@
+import { Alert } from '@console/internal/components/monitoring/types';
+
+export const getAlertActionPath = (alertData: Alert) =>
+  `/k8s/cluster/nodes/${alertData.labels.host}/disks/node-disk-name=${alertData.labels.device}`;


### PR DESCRIPTION

- Extension for adding an alert action to the alerts body on status card and notification drawer
- Also adds the consumer for extension in lso-plugin

https://issues.redhat.com/browse/RHSTOR-1204

Persistent Dashboard and Notification Drawer
![Screenshot from 2020-07-21 22-19-43](https://user-images.githubusercontent.com/25664409/88085515-90f05a00-cba3-11ea-8655-086c5d0d092a.png)
Cluster dashboard 
![Screenshot from 2020-07-21 22-15-16](https://user-images.githubusercontent.com/25664409/88085574-a9607480-cba3-11ea-9d9a-b82429d9586c.png)
