### PR TITLE
Align `Update cluster` label and links with the one in notifications

### DIFF
--- a/frontend/public/components/_about-modal.scss
+++ b/frontend/public/components/_about-modal.scss
@@ -16,10 +16,13 @@
 
 .co-about-modal__alert {
   margin-bottom: var(--pf-global--spacer--xl);
-}
-
-// Temp fix until https://github.com/patternfly/patternfly-next/issues/2447 is fixed upstream
-.pf-c-backdrop {
-  backdrop-filter: none !important;
-  -webkit-backdrop-filter: none !important; // so Safari is consistent with Chrome
+  // PatternFly does not have an `update` alert variant
+  // See https://github.com/patternfly/patternfly-react/issues/4594
+  .pf-c-alert__icon {
+    display: none;
+    &--alt {
+      display: inline-flex;
+      vertical-align: -0.25em !important;
+    }
+  }
 }

--- a/frontend/public/components/_notification-drawer.scss
+++ b/frontend/public/components/_notification-drawer.scss
@@ -12,3 +12,9 @@
 .pf-c-drawer__content {
   --pf-c-drawer__content--ZIndex: auto;
 }
+
+// PatternFly does not have an `update` variant
+// See https://github.com/patternfly/patternfly/issues/3312
+.pf-c-notification-drawer__list-item.pf-m-update {
+  --pf-c-notification-drawer__list-item--before--BackgroundColor: var(--pf-global--default-color--200);
+}

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -55,7 +55,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
               See https://github.com/patternfly/patternfly-react/issues/4594 */}
               <BlueArrowCircleUpIcon className="pf-c-alert__icon pf-c-alert__icon--alt" />
               Cluster update available.{' '}
-              <Link to="/settings/cluster" onClick={closeAboutModal}>
+              <Link to="/settings/cluster?showVersions" onClick={closeAboutModal}>
                 Update cluster
               </Link>
             </>

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -9,7 +9,7 @@ import {
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
-import { FLAGS } from '@console/shared';
+import { BlueArrowCircleUpIcon, FLAGS } from '@console/shared';
 import { connectToFlags, FlagsObject } from '../reducers/features';
 import { getBrandingDetails } from './masthead';
 import { Firehose, useAccessReview } from './utils';
@@ -49,12 +49,14 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
       {clusterVersion && hasAvailableUpdates(clusterVersion) && clusterVersionIsEditable && (
         <Alert
           className="co-alert co-about-modal__alert"
-          variant="info"
           title={
             <>
-              Update available.{' '}
+              {/* PatternFly does not have an `update` alert variant
+              See https://github.com/patternfly/patternfly-react/issues/4594 */}
+              <BlueArrowCircleUpIcon className="pf-c-alert__icon pf-c-alert__icon--alt" />
+              Cluster update available.{' '}
               <Link to="/settings/cluster" onClick={closeAboutModal}>
-                View cluster settings
+                Update cluster
               </Link>
             </>
           }

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Button } from '@patternfly/react-core';
 import { InProgressIcon } from '@patternfly/react-icons';
 import {
   BlueArrowCircleUpIcon,
@@ -33,7 +32,6 @@ import {
 import { flagPending, featureReducerName } from '../../../../reducers/features';
 import { ExternalLink, useAccessReview } from '../../../utils';
 import { RootState } from '../../../../redux';
-import { clusterUpdateModal } from '../../../modals';
 import { Link } from 'react-router-dom';
 import { useK8sWatchResource, WatchK8sResource } from '../../../utils/k8s-watch-hook';
 import { ClusterDashboardContext } from './context';
@@ -68,15 +66,10 @@ const ClusterVersion: React.FC<ClusterVersionProps> = ({ cv }) => {
           <span className="co-select-to-copy">{desiredVersion}</span>
           {clusterVersionIsEditable && (
             <div>
-              <Button
-                variant="link"
-                className="btn-link--no-btn-default-values"
-                onClick={() => clusterUpdateModal({ cv })}
-                icon={<BlueArrowCircleUpIcon />}
-                isInline
-              >
-                Update
-              </Button>
+              <Link to="/settings/cluster?showVersions">
+                <BlueArrowCircleUpIcon className="co-icon-space-r" />
+                Update cluster
+              </Link>
             </div>
           )}
         </>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
+import { Link } from 'react-router-dom';
 import {
   useExtensions,
   DashboardsOverviewHealthSubsystem,
@@ -13,7 +14,7 @@ import {
   isDashboardsOverviewHealthResourceSubsystem,
   isDashboardsOverviewHealthOperator,
 } from '@console/plugin-sdk';
-import { Gallery, GalleryItem, Button } from '@patternfly/react-core';
+import { Gallery, GalleryItem } from '@patternfly/react-core';
 import { BlueArrowCircleUpIcon, FLAGS, getInfrastructurePlatform } from '@console/shared';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
@@ -34,7 +35,6 @@ import {
   K8sKind,
 } from '../../../../module/k8s';
 import { ClusterVersionModel } from '../../../../models';
-import { clusterUpdateModal } from '../../../modals/cluster-update-modal';
 import { RootState } from '../../../../redux';
 import {
   OperatorHealthItem,
@@ -102,9 +102,7 @@ const ClusterAlerts = withDashboardResources(
     if (hasCVResource && cvLoaded && hasAvailableUpdates(cv) && clusterVersionIsEditable) {
       items.push(
         <StatusItem Icon={UpdateIcon} message="A cluster version update is available">
-          <Button variant="link" onClick={() => clusterUpdateModal({ cv })} isInline>
-            View details
-          </Button>
+          <Link to="/settings/cluster?showVersions">Update cluster</Link>
         </StatusItem>,
       );
     }

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -51,6 +51,24 @@ export const getDesiredClusterVersion = (cv: ClusterVersionKind): string => {
 
 export const getClusterVersionChannel = (cv: ClusterVersionKind): string => cv?.spec?.channel;
 
+export const splitClusterVersionChannel = (channel: string) => {
+  const parsed = /^(.+)-(\d\.\d+)$/.exec(channel);
+  return parsed ? { prefix: parsed[1], version: parsed[2] } : null;
+};
+
+export const getSimilarClusterVersionChannels = (currentPrefix) => {
+  return _.keys(getAvailableClusterChannels()).filter((channel: string) => {
+    return currentPrefix && splitClusterVersionChannel(channel)?.prefix === currentPrefix;
+  });
+};
+
+export const getNewerClusterVersionChannel = (similarChannels, currentChannel) => {
+  return similarChannels.find(
+    // find the next minor version, which there should never be more than one
+    (channel) => semver.gt(semver.coerce(channel).version, semver.coerce(currentChannel).version),
+  );
+};
+
 export const getLastCompletedUpdate = (cv: ClusterVersionKind): string => {
   const history: UpdateHistory[] = _.get(cv, 'status.history', []);
   const lastCompleted: UpdateHistory = history.find((update) => update.state === 'Completed');


### PR DESCRIPTION
so that the label and action is consistent (goes to Cluster Settings and opens the Update Cluster modal)

Requires #6055

<img width="1218" alt="Screen Shot 2020-07-21 at 4 59 24 PM" src="https://user-images.githubusercontent.com/895728/88107019-6dfa8180-cb74-11ea-8bd2-904a0eac5964.png">
<img width="1259" alt="Screen Shot 2020-07-21 at 5 06 21 PM" src="https://user-images.githubusercontent.com/895728/88107084-85d20580-cb74-11ea-8736-80c44cdc91f5.png">
