### PR TITLE
Add Kiali link to topology and project dashboard

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyEdgePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyEdgePanel.tsx
@@ -13,7 +13,7 @@ import {
 } from '@console/internal/components/utils';
 import { TYPE_CONNECTS_TO, TYPE_SERVICE_BINDING, TYPE_TRAFFIC_CONNECTOR } from './components/const';
 import { edgeActions } from './actions/edgeActions';
-import { getKialiLink, getResource } from './topology-utils';
+import { getNamespaceDashboardKialiLink, getResource } from './topology-utils';
 
 type StateProps = {
   consoleLinks?: K8sResourceKind[];
@@ -91,7 +91,10 @@ const TopologyEdgePanel: React.FC<TopologyEdgePanelProps> = ({ edge, model, cons
         {edge.getType() === TYPE_TRAFFIC_CONNECTOR && (
           <>
             <SidebarSectionHeading text="Kiali Link" />
-            <ExternalLink href={getKialiLink(consoleLinks, namespace)} text="Kiali Graph View" />
+            <ExternalLink
+              href={getNamespaceDashboardKialiLink(consoleLinks, namespace)}
+              text="Kiali Graph View"
+            />
           </>
         )}
       </div>

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
@@ -10,10 +10,10 @@
     padding-right: $grid-gutter-width;
   }
 
-  &__search {
+  &__kiali-link {
     margin-left: auto;
   }
-  &__info-icon {
+  &__text-filter {
     margin-left: var(--pf-global--spacer--sm);
   }
 }

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -47,9 +47,13 @@ export const isHelmReleaseNode = (
   return false;
 };
 
-export const getKialiLink = (consoleLinks: K8sResourceKind[], namespace: string): string => {
-  const kialiLink = _.find(consoleLinks, ['metadata.name', `kiali-namespace-${namespace}`])?.spec
-    ?.href;
+export const getNamespaceDashboardKialiLink = (
+  consoleLinks: K8sResourceKind[],
+  namespace: string,
+): string => {
+  const kialiLink = _.find(consoleLinks, (consoleLink) =>
+    _.includes(consoleLink.spec?.namespaceDashboard?.namespaces, namespace),
+  )?.spec?.href;
   return kialiLink || '';
 };
 

--- a/frontend/public/components/dashboard/project-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/details-card.tsx
@@ -7,7 +7,7 @@ import DashboardCardLink from '@console/shared/src/components/dashboard/dashboar
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import DetailsBody from '@console/shared/src/components/dashboard/details-card/DetailsBody';
 import DetailItem from '@console/shared/src/components/dashboard/details-card/DetailItem';
-import { getName, getRequester } from '@console/shared';
+import { getName, getRequester, GreenCheckCircleIcon } from '@console/shared';
 import { LabelList, resourcePathFromModel } from '../../utils';
 import { ProjectModel } from '../../../models';
 import { ProjectDashboardContext } from './project-dashboard-context';
@@ -18,6 +18,7 @@ export const DetailsCard: React.FC = () => {
   const labelsSubset = _.take(keys, 3);
   const firstThreelabels = _.pick(obj.metadata.labels, labelsSubset);
   const detailsLink = `${resourcePathFromModel(ProjectModel, obj.metadata.name)}/details`;
+  const serviceMeshEnabled = obj.metadata?.labels?.['maistra.io/member-of'];
   return (
     <DashboardCard data-test-id="details-card">
       <DashboardCardHeader>
@@ -38,6 +39,11 @@ export const DetailsCard: React.FC = () => {
               {keys.length > 3 && <DashboardCardLink to={detailsLink}>View all</DashboardCardLink>}
             </div>
           </DetailItem>
+          {serviceMeshEnabled && (
+            <DetailItem isLoading={!obj} title="Service Mesh">
+              <GreenCheckCircleIcon /> Service Mesh Enabled
+            </DetailItem>
+          )}
         </DetailsBody>
       </DashboardCardBody>
     </DashboardCard>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -15,6 +15,7 @@ import {
   KEYBOARD_SHORTCUTS,
   NAMESPACE_LOCAL_STORAGE_KEY,
   FLAGS,
+  GreenCheckCircleIcon,
 } from '@console/shared';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
@@ -518,6 +519,7 @@ const ResourceUsage = requirePrometheus(({ ns }) => (
 export const NamespaceSummary = ({ ns }) => {
   const displayName = getDisplayName(ns);
   const requester = getRequester(ns);
+  const serviceMeshEnabled = ns.metadata?.labels?.['maistra.io/member-of'];
   const canListSecrets = useAccessReview({
     group: SecretModel.apiGroup,
     resource: SecretModel.plural,
@@ -552,6 +554,14 @@ export const NamespaceSummary = ({ ns }) => {
           <dd>
             <Link to={`/k8s/ns/${ns.metadata.name}/networkpolicies`}>Network Policies</Link>
           </dd>
+          {serviceMeshEnabled && (
+            <>
+              <dt>Service Mesh</dt>
+              <dd>
+                <GreenCheckCircleIcon /> Service Mesh Enabled
+              </dd>
+            </>
+          )}
         </dl>
       </div>
     </div>


### PR DESCRIPTION
Story - https://issues.redhat.com/browse/ODC-4103

- Add Kiali link in topology filterbar
<img width="1499" alt="Screenshot 2020-07-27 at 8 41 28 PM" src="https://user-images.githubusercontent.com/2561818/88558751-9806e480-d049-11ea-999f-1bbbb13c84ba.png">



- Service Mesh Enabled status on project dashboard
<img width="1502" alt="Screenshot 2020-07-22 at 4 02 00 PM" src="https://user-images.githubusercontent.com/2561818/88166304-af526600-cc34-11ea-9bfd-ef46ed26b6fe.png">

- Service Mesh Enabled status on project detail page
<img width="1502" alt="Screenshot 2020-07-22 at 4 02 50 PM" src="https://user-images.githubusercontent.com/2561818/88166377-cd1fcb00-cc34-11ea-8f16-6aef1ddac0b9.png">

Test setup:
Follow this doc to setup service mesh
https://docs.openshift.com/container-platform/4.5/service_mesh/service_mesh_install/installing-ossm.html#installing-ossm