### PR TITLE
Add Attached devices flag to ceph plugin

### DIFF
--- a/frontend/packages/ceph-storage-plugin/README.md
+++ b/frontend/packages/ceph-storage-plugin/README.md
@@ -1,21 +1,24 @@
 # OCS UI Features
 
-The OCS UI requires some annotations in the OCS Operator CSV to perform various actions.
+The OCS UI requires some annotations in the OCS Operator CSV and Storage Cluster CR to perform various actions.
 
 Following table maps the annotation to its use case and accepted values:
-|Annotation Name|Purpose|Accepted Values |
-|---------------------------------------|---------------------------|--------|
-| `features.ocs.openshift.io/enabled`| Activate UI Features | "external", "snapshot" |
-| `external.features.ocs.openshift.io/validation`| Mininum required keys to be supplied by the admin to connect to an external cluster | Array of Keys that need to be validated in UI |
+|Annotation Name|Purpose|Accepted Values |CR/CSV
+|---------------------------------------|---------------------------|--------|----------------|
+| `features.ocs.openshift.io/enabled`| Activates Snapshot and External Mode Features | "external", "snapshot" | Operator CSV
+| `cluster.ocs.openshift.io/local-devices`| Activates disk replacement and ocs status column in disk inventory | "true" | Storage Cluster CR
+| `external.features.ocs.openshift.io/validation`| Mininum required keys to be supplied by the admin to connect to an external cluster | Array of Keys that need to be validated in UI | Operator CSV
 ||||
 
 ## Enabling Features in UI
 
-UI features are activated based on the values in `features.ocs.openshift.io/enabled` annotation. The following table maps a feature and the respective annotation required to activate it.
-| Feature |Feature guard|
-|------------------------------|------------|
-| External Cluster Installation| `external` |
-| Volume Snapshots| `snapshot`
+UI features are activated based on the annotations. The following table maps a feature and the respective annotation key-value pair required to activate it.
+| Feature |Annotation Value| Annotation Key
+|------------------------------|--------------------------|---------|
+| External Cluster Installation|`features.ocs.openshift.io/enabled` | `external` |
+| Volume Snapshots|`features.ocs.openshift.io/enabled` | `snapshot`|
+| Disk Replacement Action| `cluster.ocs.openshift.io/local-devices` | `true`|
+| Disk Inventory OCS Status Column | `cluster.ocs.openshift.io/local-devices` | `true`|
 
 #### Example
 

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
@@ -30,7 +30,7 @@ import {
 import { OCSServiceModel } from '../../../models';
 import AttachedDevicesNodeTable from './sc-node-list';
 import { PVsAvailableCapacity } from '../pvs-available-capacity';
-import { OCS_CONVERGED_FLAG, OCS_FLAG } from '../../../features';
+import { OCS_CONVERGED_FLAG, OCS_FLAG, OCS_ATTACHED_DEVICES_FLAG } from '../../../features';
 import { makeLabelNodesRequest } from '../create-form';
 import { LVSResource } from '../../../constants/resources';
 import { getOCSRequestData } from '../ocs-request-data';
@@ -96,6 +96,7 @@ export const CreateOCS = withHandlePromise<CreateOCSProps & HandlePromiseProps>(
     event.preventDefault();
     // eslint-disable-next-line promise/catch-or-return
     handlePromise(makeOCSRequest(nodes, storageClass)).then(() => {
+      dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, true));
       dispatch(setFlag(OCS_CONVERGED_FLAG, true));
       dispatch(setFlag(OCS_FLAG, true));
       history.push(

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
@@ -4,6 +4,7 @@ import {
   OCS_INTERNAL_CR_NAME,
   CEPH_STORAGE_NAMESPACE,
   OCS_DEVICE_SET_REPLICA,
+  ATTACHED_DEVICES_ANNOTATION,
 } from '../../constants';
 
 export const createDeviceSet = (scName: string, osdSize: string, portable: boolean): DeviceSet => ({
@@ -48,6 +49,12 @@ export const getOCSRequestData = (
   if (provisioner === NO_PROVISIONER) {
     requestData.spec.monDataDirHostPath = '/var/lib/rook';
     requestData.spec.storageDeviceSets[0].portable = false;
+    requestData.metadata = {
+      ...requestData.metadata,
+      annotations: {
+        [ATTACHED_DEVICES_ANNOTATION]: 'true',
+      },
+    };
   }
   return requestData;
 };

--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -15,3 +15,4 @@ export const OCS_INTERNAL_CR_NAME = 'ocs-storagecluster';
 export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';
 export const OCS_SUPPORT_ANNOTATION = 'features.ocs.openshift.io/enabled';
 export const OCS_DEVICE_SET_REPLICA = 3;
+export const ATTACHED_DEVICES_ANNOTATION = 'cluster.ocs.openshift.io/local-devices';


### PR DESCRIPTION
- The flag name is OCS_ATTACHED_DEVICES
- The flag will allow to detect ocs installation on baremetal
- The flag will be consumed for disk replacement kebab action in 4.6
- Updated Readme
- https://issues.redhat.com/browse/RHSTOR-1196
