### PR TITLE
Remove .cache-loader directory in clean-frontend script

### DIFF
--- a/clean-frontend.sh
+++ b/clean-frontend.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 find frontend -type d -name 'node_modules' -prune -exec rm -rf {} \;
+rm -rf frontend/.cache-loader
 rm -rf frontend/public/dist


### PR DESCRIPTION
To run a clean build, you also need to remove the webpack cache-loader folder.

https://webpack.js.org/loaders/cache-loader/

/cc @vojtechszocs @christianvogt 