### PR TITLE
HPA in Topology Sidebar

### DIFF
--- a/frontend/packages/console-app/src/actions/modify-hpa.ts
+++ b/frontend/packages/console-app/src/actions/modify-hpa.ts
@@ -3,6 +3,7 @@ import {
   HorizontalPodAutoscalerKind,
   K8sKind,
   K8sResourceCommon,
+  referenceForModel,
 } from '@console/internal/module/k8s';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
 import deleteHPAModal from '@console/dev-console/src/components/hpa/DeleteHPAModal';
@@ -20,13 +21,31 @@ export const AddHorizontalPodAutoScaler: KebabAction = (
   resources: RelatedResources,
 ) => ({
   label: `Add ${HorizontalPodAutoscalerModel.label}`,
-  href: `/workload-hpa/${obj.metadata.namespace}/${kind.kind}/${obj.metadata.name}`,
+  href: `/workload-hpa/${obj.metadata.namespace}/${referenceForModel(kind)}/${obj.metadata.name}`,
   hidden: hasHPAs(resources),
   accessReview: {
     group: HorizontalPodAutoscalerModel.apiGroup,
     resource: HorizontalPodAutoscalerModel.plural,
     namespace: obj.metadata.namespace,
     verb: 'create',
+  },
+});
+
+export const EditHorizontalPodAutoScaler: KebabAction = (
+  kind: K8sKind,
+  obj: K8sResourceCommon,
+  resources: RelatedResources,
+) => ({
+  label: `Edit ${HorizontalPodAutoscalerModel.label}`,
+  href: `/workload-hpa/${obj.metadata.namespace}/${referenceForModel(kind)}/${
+    obj.metadata.name
+  }/edit`,
+  hidden: !hasHPAs(resources),
+  accessReview: {
+    group: HorizontalPodAutoscalerModel.apiGroup,
+    resource: HorizontalPodAutoscalerModel.plural,
+    namespace: obj.metadata.namespace,
+    verb: 'update',
   },
 });
 

--- a/frontend/packages/console-app/src/actions/modify-hpa.ts
+++ b/frontend/packages/console-app/src/actions/modify-hpa.ts
@@ -1,0 +1,16 @@
+import { history, KebabAction } from '@console/internal/components/utils';
+import { K8sKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+
+export const AddHorizontalPodAutoScaler: KebabAction = (kind: K8sKind, obj: K8sResourceCommon) => ({
+  label: `Add ${HorizontalPodAutoscalerModel.label}`,
+  callback: () => {
+    history.push(`/workload-hpa/${obj.metadata.namespace}/${kind.kind}/${obj.metadata.name}`);
+  },
+  accessReview: {
+    group: HorizontalPodAutoscalerModel.apiGroup,
+    resource: HorizontalPodAutoscalerModel.plural,
+    namespace: obj.metadata.namespace,
+    verb: 'create',
+  },
+});

--- a/frontend/packages/console-app/src/actions/modify-hpa.ts
+++ b/frontend/packages/console-app/src/actions/modify-hpa.ts
@@ -69,3 +69,15 @@ export const DeleteHorizontalPodAutoScaler: KebabAction = (
     verb: 'delete',
   },
 });
+
+export const hideActionForHPAs = (action: KebabAction): KebabAction => (
+  kind: K8sKind,
+  obj: K8sResourceCommon,
+  resources: RelatedResources,
+) => {
+  const actionOptions = action(kind, obj);
+  return {
+    ...actionOptions,
+    hidden: hasHPAs(resources) || actionOptions.hidden,
+  };
+};

--- a/frontend/packages/console-app/src/actions/modify-hpa.ts
+++ b/frontend/packages/console-app/src/actions/modify-hpa.ts
@@ -1,16 +1,52 @@
-import { history, KebabAction } from '@console/internal/components/utils';
-import { K8sKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { KebabAction } from '@console/internal/components/utils';
+import {
+  HorizontalPodAutoscalerKind,
+  K8sKind,
+  K8sResourceCommon,
+} from '@console/internal/module/k8s';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import deleteHPAModal from '@console/dev-console/src/components/hpa/DeleteHPAModal';
 
-export const AddHorizontalPodAutoScaler: KebabAction = (kind: K8sKind, obj: K8sResourceCommon) => ({
+type RelatedResources = {
+  hpas?: HorizontalPodAutoscalerKind[];
+};
+
+const hasHPAs = (mapOfResources: RelatedResources) =>
+  Array.isArray(mapOfResources?.hpas) && mapOfResources.hpas.length > 0;
+
+export const AddHorizontalPodAutoScaler: KebabAction = (
+  kind: K8sKind,
+  obj: K8sResourceCommon,
+  resources: RelatedResources,
+) => ({
   label: `Add ${HorizontalPodAutoscalerModel.label}`,
-  callback: () => {
-    history.push(`/workload-hpa/${obj.metadata.namespace}/${kind.kind}/${obj.metadata.name}`);
-  },
+  href: `/workload-hpa/${obj.metadata.namespace}/${kind.kind}/${obj.metadata.name}`,
+  hidden: hasHPAs(resources),
   accessReview: {
     group: HorizontalPodAutoscalerModel.apiGroup,
     resource: HorizontalPodAutoscalerModel.plural,
     namespace: obj.metadata.namespace,
     verb: 'create',
+  },
+});
+
+export const DeleteHorizontalPodAutoScaler: KebabAction = (
+  kind: K8sKind,
+  obj: K8sResourceCommon,
+  resources: RelatedResources,
+) => ({
+  label: `Remove ${HorizontalPodAutoscalerModel.label}`,
+  callback: () => {
+    deleteHPAModal({
+      workload: obj,
+      hpa: resources?.hpas?.[0],
+    });
+  },
+  hidden: !hasHPAs(resources),
+  accessReview: {
+    group: HorizontalPodAutoscalerModel.apiGroup,
+    resource: HorizontalPodAutoscalerModel.plural,
+    namespace: obj.metadata.namespace,
+    verb: 'delete',
   },
 });

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -12,6 +12,7 @@ type EditorContext = {
   name: string;
   editor: React.ReactNode;
   isDisabled?: boolean;
+  sanitizeTo?: (preFormData: any) => any;
 };
 
 type SyncedEditorFieldProps = {
@@ -42,7 +43,10 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
     const newFormData = safeYAMLToJS(yamlData);
     if (!_.isEmpty(newFormData)) {
       changeEditorType(EditorType.Form);
-      setFieldValue(formContext.name, newFormData);
+      setFieldValue(
+        formContext.name,
+        formContext.sanitizeTo ? formContext.sanitizeTo(newFormData) : newFormData,
+      );
     } else {
       setYAMLWarning(true);
     }
@@ -50,7 +54,10 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
 
   const handleToggleToYAML = () => {
     const newYAML = safeJSToYAML(formData, yamlData, { skipInvalid: true });
-    setFieldValue(yamlContext.name, newYAML);
+    setFieldValue(
+      yamlContext.name,
+      yamlContext.sanitizeTo ? formContext.sanitizeTo(newYAML) : newYAML,
+    );
     changeEditorType(EditorType.YAML);
   };
 
@@ -63,7 +70,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
     setYAMLWarning(false);
   };
 
-  const onChangeType = (newType) => {
+  const onChangeType = (newType: EditorType) => {
     switch (newType) {
       case EditorType.YAML:
         handleToggleToYAML();
@@ -98,7 +105,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
               isDisabled: yamlContext.isDisabled,
             },
           ]}
-          onChange={(val) => onChangeType(val as EditorType)}
+          onChange={(val: string) => onChangeType(val as EditorType)}
           isInline
         />
       </div>

--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -1,4 +1,10 @@
-import { JobKind, K8sResourceKind, PodKind, RouteKind } from '@console/internal/module/k8s';
+import {
+  HorizontalPodAutoscalerKind,
+  JobKind,
+  K8sResourceKind,
+  PodKind,
+  RouteKind,
+} from '@console/internal/module/k8s';
 import { DEPLOYMENT_STRATEGY } from '../constants';
 import { OverviewItemAlerts, PodControllerOverviewItem } from './pod';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
@@ -24,6 +30,7 @@ export type OverviewItem<T = K8sResourceKind> = {
   current?: PodControllerOverviewItem;
   isRollingOut?: boolean;
   obj: T;
+  hpas?: HorizontalPodAutoscalerKind[];
   pods?: PodKind[];
   previous?: PodControllerOverviewItem;
   routes: RouteKind[];

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -16,6 +16,7 @@ import {
   K8sResourceKind,
   K8sKind,
   SelfSubjectAccessReviewKind,
+  HorizontalPodAutoscalerKind,
 } from '@console/internal/module/k8s';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { PodRCData, PodRingResources, PodRingData, ExtPodKind } from '../types';
@@ -204,6 +205,23 @@ export const podRingLabel = (
         titleComponent: getTitleComponent(titleData.longSubtitle),
       };
   }
+};
+
+export const hpaPodRingLabel = (
+  obj: K8sResourceKind,
+  hpa: HorizontalPodAutoscalerKind,
+  pods: ExtPodKind[],
+): PodRingLabelType => {
+  const desiredPodCount = obj.spec?.replicas;
+  const desiredPods = hpa.status?.desiredReplicas || desiredPodCount;
+  const currentPods = hpa.status?.currentReplicas;
+  const scaling =
+    (!currentPods && !!desiredPods) || !pods.every((p) => p.status?.phase === 'Running');
+  return {
+    title: scaling ? 'Autoscaling' : 'Autoscaled',
+    subTitle: `to ${desiredPods}`,
+    titleComponent: getTitleComponent(false, true),
+  };
 };
 
 export const usePodScalingAccessStatus = (

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -52,6 +52,7 @@ import {
 } from '../constants';
 import { resourceStatus, podStatus } from './ResourceStatus';
 import { isKnativeServing, isIdled } from './pod-utils';
+import { doesHpaMatch } from '@console/dev-console/src/components/hpa/hpa-utils';
 
 export const getResourceList = (namespace: string, resList?: any): FirehoseResource[] => {
   let resources: FirehoseResource[] = [
@@ -783,10 +784,12 @@ export const getOverviewItemsForResource = (
     ...getBuildAlerts(buildConfigs),
   };
   const status = resourceStatus(obj, current, isRollingOut);
+  const hpas = resources?.hpas?.data?.filter(doesHpaMatch(obj));
   const overviewItems = {
     alerts,
     buildConfigs,
     obj,
+    hpas,
     pods,
     routes,
     services,

--- a/frontend/packages/dev-console/src/components/hpa/DeleteHPAModal.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/DeleteHPAModal.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { Form } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
+import {
+  createModalLauncher,
+  ModalBody,
+  ModalComponentProps,
+  ModalSubmitFooter,
+  ModalTitle,
+} from '@console/internal/components/factory/modal';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import { LoadingInline } from '@console/internal/components/utils';
+import {
+  HorizontalPodAutoscalerKind,
+  k8sKill,
+  K8sResourceCommon,
+} from '@console/internal/module/k8s';
+
+type DeleteHPAModalProps = ModalComponentProps & {
+  hpa: HorizontalPodAutoscalerKind;
+  workload: K8sResourceCommon;
+};
+
+const DeleteHPAModal: React.FC<DeleteHPAModalProps> = ({ close, hpa, workload }) => {
+  const [submitError, setSubmitError] = React.useState<string>(null);
+  const [isSubmitting, setIsSubmitting] = React.useState<boolean>(false);
+  const hpaName = hpa.metadata.name;
+  const workloadName = workload.metadata.name;
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    k8sKill(HorizontalPodAutoscalerModel, hpa)
+      .then(() => {
+        close();
+      })
+      .catch((error) => {
+        setSubmitError(
+          error?.message ||
+            `Unknown error removing ${HorizontalPodAutoscalerModel.label} ${hpaName}.`,
+        );
+      });
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <div className="modal-content">
+        <ModalTitle>
+          <ExclamationTriangleIcon color={warningColor.value} /> Remove{' '}
+          {HorizontalPodAutoscalerModel.label}?
+        </ModalTitle>
+        <ModalBody>
+          {hpaName ? (
+            <>
+              <p>
+                Are you sure you want to remove the {HorizontalPodAutoscalerModel.label}{' '}
+                <b>{hpaName}</b> from <b>{workloadName}</b>?
+              </p>
+              <p>
+                The resources that are attached to the {HorizontalPodAutoscalerModel.label} will be
+                deleted.
+              </p>
+            </>
+          ) : (
+            !submitError && <LoadingInline />
+          )}
+        </ModalBody>
+        <ModalSubmitFooter
+          errorMessage={submitError}
+          inProgress={isSubmitting}
+          submitText="Remove"
+          submitDanger
+          submitDisabled={!!submitError}
+          cancel={close}
+        />
+      </div>
+    </Form>
+  );
+};
+
+export default createModalLauncher(DeleteHPAModal);

--- a/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPADetailsForm.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { useField, useFormikContext } from 'formik';
+import { Alert, AlertActionCloseButton, Flex } from '@patternfly/react-core';
+import { InputField, NumberSpinnerField } from '@console/shared';
+import { HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
+import HPAUtilizationField from './HPAUtilizationField';
+import { getMetricByType } from './hpa-utils';
+import { HPAFormValues, SupportedMetricTypes } from './types';
+
+const HPADetailsForm: React.FC = () => {
+  const name = 'formData';
+  const [field] = useField<HorizontalPodAutoscalerKind>(name);
+  const { setFieldValue, values } = useFormikContext<HPAFormValues>();
+
+  const updateField = (type: SupportedMetricTypes) => (value: string) => {
+    const numValue = parseInt(value, 10);
+
+    const hpa: HorizontalPodAutoscalerKind = field.value;
+    const { metric, index } = getMetricByType(hpa, type);
+    const hpaMetrics = hpa.spec.metrics || [];
+
+    const updatedMetrics = [...hpaMetrics];
+    updatedMetrics[index] = {
+      ...metric,
+      resource: {
+        ...metric.resource,
+        target: {
+          ...metric.resource.target,
+          averageUtilization: numValue,
+        },
+      },
+    };
+
+    setFieldValue(name, {
+      ...hpa,
+      spec: {
+        ...hpa.spec,
+        metrics: updatedMetrics,
+      },
+    });
+  };
+
+  return (
+    <div className="row">
+      <div className="col-lg-8">
+        <Flex direction={{ default: 'column' }}>
+          {values.showCanUseYAMLMessage && (
+            <Alert
+              actionClose={
+                <AlertActionCloseButton
+                  onClose={() => setFieldValue('showCanUseYAMLMessage', false)}
+                />
+              }
+              isInline
+              title={
+                'Note: Some fields may not be represented in this form view. Please select "YAML view" for full control.'
+              }
+              variant="info"
+            />
+          )}
+          <InputField label="Name" name={`${name}.metadata.name`} />
+          <NumberSpinnerField label="Minimum Pods" name={`${name}.spec.minReplicas`} />
+          <NumberSpinnerField label="Maximum Pods" name={`${name}.spec.maxReplicas`} />
+          <HPAUtilizationField
+            disabled={values.disabledFields.cpuUtilization}
+            hpa={field.value}
+            label="CPU"
+            onUpdate={updateField('cpu')}
+            type="cpu"
+          />
+          <HPAUtilizationField
+            disabled={values.disabledFields.memoryUtilization}
+            hpa={field.value}
+            label="Memory"
+            onUpdate={updateField('memory')}
+            type="memory"
+          />
+        </Flex>
+      </div>
+    </div>
+  );
+};
+
+export default HPADetailsForm;

--- a/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { isEmpty } from 'lodash';
+import { FormikProps } from 'formik';
+import { FlexForm, FormFooter, SyncedEditorField, YAMLEditorField } from '@console/shared';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { HorizontalPodAutoscalerKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import HPADetailsForm from './HPADetailsForm';
+import { sanitizeHPAToForm } from './hpa-utils';
+import { HPAFormValues } from './types';
+
+type HPAFormProps = {
+  targetResource: K8sResourceCommon;
+};
+
+const HPAForm: React.FC<FormikProps<HPAFormValues> & HPAFormProps> = ({
+  errors,
+  handleReset,
+  handleSubmit,
+  status,
+  setStatus,
+  isSubmitting,
+  targetResource,
+  values,
+}) => {
+  const isForm = values.editorType === EditorType.Form;
+  const formEditor = <HPADetailsForm />;
+  const yamlEditor = <YAMLEditorField name="yamlData" onSave={handleSubmit} />;
+  const customMetrics = false;
+
+  React.useEffect(() => {
+    setStatus({ submitError: null });
+  }, [setStatus, values.editorType]);
+
+  return (
+    <FlexForm onSubmit={handleSubmit}>
+      <SyncedEditorField
+        name="editorType"
+        formContext={{
+          name: 'formData',
+          editor: formEditor,
+          isDisabled: customMetrics,
+          sanitizeTo: (newFormData: Partial<HorizontalPodAutoscalerKind>) =>
+            sanitizeHPAToForm(newFormData, targetResource),
+        }}
+        yamlContext={{ name: 'yamlData', editor: yamlEditor }}
+      />
+      <FormFooter
+        handleReset={handleReset}
+        errorMessage={status?.submitError}
+        isSubmitting={isSubmitting}
+        submitLabel="Save"
+        disableSubmit={isForm && (!isEmpty(errors) || status?.submitError)}
+        resetLabel="Cancel"
+        sticky
+      />
+    </FlexForm>
+  );
+};
+
+export default HPAForm;

--- a/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Formik, FormikHelpers, FormikProps } from 'formik';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import {
+  HorizontalPodAutoscalerKind,
+  k8sCreate,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
+import { history } from '@console/internal/components/utils';
+import HPAForm from './HPAForm';
+import {
+  getFormData,
+  getInvalidUsageError,
+  getYAMLData,
+  isCpuUtilizationPossible,
+  isMemoryUtilizationPossible,
+  sanityForSubmit,
+} from './hpa-utils';
+import { HPAFormValues } from './types';
+import { hpaValidationSchema } from './validation-utils';
+
+type HPAFormikFormProps = {
+  targetResource: K8sResourceKind;
+};
+
+const HPAFormikForm: React.FC<HPAFormikFormProps> = ({ targetResource }) => {
+  const initialValues: HPAFormValues = {
+    showCanUseYAMLMessage: true,
+    disabledFields: {
+      cpuUtilization: !isCpuUtilizationPossible(targetResource),
+      memoryUtilization: !isMemoryUtilizationPossible(targetResource),
+    },
+    editorType: EditorType.Form,
+    formData: getFormData(targetResource),
+    yamlData: getYAMLData(targetResource),
+  };
+
+  const handleSubmit = (values: HPAFormValues, helpers: FormikHelpers<HPAFormValues>) => {
+    const hpa: HorizontalPodAutoscalerKind = sanityForSubmit(
+      targetResource,
+      values.editorType === EditorType.YAML ? safeYAMLToJS(values.yamlData) : values.formData,
+    );
+
+    const invalidUsageError = getInvalidUsageError(hpa, values);
+    if (invalidUsageError) {
+      helpers.setStatus({ submitError: invalidUsageError });
+      return;
+    }
+
+    helpers.setSubmitting(true);
+    k8sCreate(HorizontalPodAutoscalerModel, hpa)
+      .then(() => {
+        helpers.setSubmitting(false);
+        history.goBack();
+      })
+      .catch((error) => {
+        helpers.setSubmitting(false);
+        helpers.setStatus({ submitError: error?.message || 'Unknown error submitting' });
+      });
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      onReset={history.goBack}
+      validationSchema={hpaValidationSchema}
+    >
+      {(props: FormikProps<HPAFormValues>) => (
+        <HPAForm {...props} targetResource={targetResource} />
+      )}
+    </Formik>
+  );
+};
+
+export default HPAFormikForm;

--- a/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { PageBody } from '@console/shared';
+import { ErrorPage404 } from '@console/internal/components/error';
 import { LoadingInline, PageComponentProps } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { getGroupVersionKind, K8sResourceKind } from '@console/internal/module/k8s';
@@ -19,7 +20,8 @@ const HPAPage: React.FC<PageComponentProps> = (props) => {
     },
   } = props;
   const editHPA = path === '/workload-hpa/:ns/:resourceRef/:name/edit';
-  const [group, version, kind] = getGroupVersionKind(resourceRef);
+  const breakdown = getGroupVersionKind(resourceRef) || [];
+  const [group, version, kind] = breakdown;
   const [hpa, hpaError] = useRelatedHPA(`${group}/${version}`, kind, name, ns);
   const resource = React.useMemo(
     () => ({
@@ -36,6 +38,11 @@ const HPAPage: React.FC<PageComponentProps> = (props) => {
 
   const validSupportedType = VALID_HPA_TARGET_KINDS.includes(kind);
   const title = `${editHPA ? 'Edit' : 'Add'} ${HorizontalPodAutoscalerModel.label}`;
+
+  if (!breakdown) {
+    return <ErrorPage404 />;
+  }
+
   return (
     <NamespacedPage disabled variant={NamespacedPageVariants.light} hideApplications>
       <Helmet>

--- a/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
@@ -3,20 +3,24 @@ import { Helmet } from 'react-helmet';
 import { PageBody } from '@console/shared';
 import { LoadingInline, PageComponentProps } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { getGroupVersionKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import HPAFormikForm from './HPAFormikForm';
 import HPAPageHeader from './HPAPageHeader';
 import { getLimitWarning, VALID_HPA_TARGET_KINDS } from './hpa-utils';
+import { useRelatedHPA } from './hooks';
 
 const HPAPage: React.FC<PageComponentProps> = (props) => {
   const {
     match: {
-      params: { ns, kind, name },
+      params: { ns, resourceRef, name },
+      path,
     },
   } = props;
-
+  const editHPA = path === '/workload-hpa/:ns/:resourceRef/:name/edit';
+  const [group, version, kind] = getGroupVersionKind(resourceRef);
+  const [hpa, hpaError] = useRelatedHPA(`${group}/${version}`, kind, name, ns);
   const resource = React.useMemo(
     () => ({
       kind,
@@ -25,10 +29,13 @@ const HPAPage: React.FC<PageComponentProps> = (props) => {
     }),
     [kind, ns, name],
   );
-  const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind>(resource);
+  const [data, loaded, workloadError] = useK8sWatchResource<K8sResourceKind>(resource);
+
+  const fullyLoaded = editHPA ? !!hpa && !!data : loaded && !!data;
+  const error = (editHPA ? hpaError : null) || workloadError?.message;
 
   const validSupportedType = VALID_HPA_TARGET_KINDS.includes(kind);
-  const title = `Add ${HorizontalPodAutoscalerModel.label}`;
+  const title = `${editHPA ? 'Edit' : 'Add'} ${HorizontalPodAutoscalerModel.label}`;
   return (
     <NamespacedPage disabled variant={NamespacedPageVariants.light} hideApplications>
       <Helmet>
@@ -38,13 +45,19 @@ const HPAPage: React.FC<PageComponentProps> = (props) => {
         <HPAPageHeader
           kind={kind}
           limitWarning={loaded && validSupportedType ? getLimitWarning(data) : null}
-          loadError={loadError ? loadError.message : null}
+          loadError={error}
           name={name}
           title={title}
           validSupportedType={validSupportedType}
         />
-        {!loadError && validSupportedType && (
-          <>{loaded ? <HPAFormikForm targetResource={data} /> : <LoadingInline />}</>
+        {!error && validSupportedType && (
+          <>
+            {fullyLoaded ? (
+              <HPAFormikForm existingHPA={hpa} targetResource={data} />
+            ) : (
+              <LoadingInline />
+            )}
+          </>
         )}
       </PageBody>
     </NamespacedPage>

--- a/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPage.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { PageBody } from '@console/shared';
+import { LoadingInline, PageComponentProps } from '@console/internal/components/utils';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
+import HPAFormikForm from './HPAFormikForm';
+import HPAPageHeader from './HPAPageHeader';
+import { getLimitWarning, VALID_HPA_TARGET_KINDS } from './hpa-utils';
+
+const HPAPage: React.FC<PageComponentProps> = (props) => {
+  const {
+    match: {
+      params: { ns, kind, name },
+    },
+  } = props;
+
+  const resource = React.useMemo(
+    () => ({
+      kind,
+      namespace: ns,
+      name,
+    }),
+    [kind, ns, name],
+  );
+  const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind>(resource);
+
+  const validSupportedType = VALID_HPA_TARGET_KINDS.includes(kind);
+  const title = `Add ${HorizontalPodAutoscalerModel.label}`;
+  return (
+    <NamespacedPage disabled variant={NamespacedPageVariants.light} hideApplications>
+      <Helmet>
+        <title>{title}</title>
+      </Helmet>
+      <PageBody flexLayout>
+        <HPAPageHeader
+          kind={kind}
+          limitWarning={loaded && validSupportedType ? getLimitWarning(data) : null}
+          loadError={loadError ? loadError.message : null}
+          name={name}
+          title={title}
+          validSupportedType={validSupportedType}
+        />
+        {!loadError && validSupportedType && (
+          <>{loaded ? <HPAFormikForm targetResource={data} /> : <LoadingInline />}</>
+        )}
+      </PageBody>
+    </NamespacedPage>
+  );
+};
+
+export default HPAPage;

--- a/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Alert, Flex } from '@patternfly/react-core';
+import { ResourceLink } from '@console/internal/components/utils';
+
+type HPAPageHeaderProps = {
+  kind: string;
+  limitWarning?: string;
+  loadError?: string;
+  name: string;
+  title: string;
+  validSupportedType: boolean;
+};
+
+const HPAPageHeader: React.FC<HPAPageHeaderProps> = ({
+  name,
+  title,
+  kind,
+  loadError,
+  limitWarning,
+  validSupportedType,
+}) => {
+  return (
+    <Flex direction={{ default: 'column' }}>
+      <h1 className="pf-c-title pf-m-2xl">{title}</h1>
+      {validSupportedType ? (
+        <>
+          <div>
+            Resource <ResourceLink inline linkTo={false} kind={kind} name={name} />
+          </div>
+          {loadError && (
+            <Alert isInline variant="danger" title="This resource is not available">
+              {loadError}
+            </Alert>
+          )}
+          {limitWarning && <Alert isInline variant="warning" title={limitWarning} />}
+        </>
+      ) : (
+        <Alert isInline variant="danger" title="This is not a supported in-context type" />
+      )}
+    </Flex>
+  );
+};
+
+export default HPAPageHeader;

--- a/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAPageHeader.tsx
@@ -27,12 +27,13 @@ const HPAPageHeader: React.FC<HPAPageHeaderProps> = ({
           <div>
             Resource <ResourceLink inline linkTo={false} kind={kind} name={name} />
           </div>
-          {loadError && (
+          {loadError ? (
             <Alert isInline variant="danger" title="This resource is not available">
               {loadError}
             </Alert>
+          ) : (
+            limitWarning && <Alert isInline variant="warning" title={limitWarning} />
           )}
-          {limitWarning && <Alert isInline variant="warning" title={limitWarning} />}
         </>
       ) : (
         <Alert isInline variant="danger" title="This is not a supported in-context type" />

--- a/frontend/packages/dev-console/src/components/hpa/HPAUtilizationField.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAUtilizationField.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { FormikErrors, useFormikContext } from 'formik';
+import { FormGroup, InputGroup, InputGroupText, TextInput } from '@patternfly/react-core';
+import { PercentIcon } from '@patternfly/react-icons';
+import { HorizontalPodAutoscalerKind, HPAMetric } from '@console/internal/module/k8s';
+import { getMetricByType } from './hpa-utils';
+import { HPAFormValues, SupportedMetricTypes } from './types';
+
+type HPAUtilizationFieldProps = {
+  disabled?: boolean;
+  hpa: HorizontalPodAutoscalerKind;
+  label: string;
+  onUpdate: (stringValue: string) => void;
+  type: SupportedMetricTypes;
+};
+
+const HPAUtilizationField: React.FC<HPAUtilizationFieldProps> = ({
+  disabled,
+  hpa,
+  label,
+  onUpdate,
+  type,
+}) => {
+  const { errors } = useFormikContext<HPAFormValues>();
+  const { metric, index } = getMetricByType(hpa, type);
+  const value: number = metric?.resource?.target?.averageUtilization;
+  const thisErrorMetric = errors.formData?.spec?.metrics?.[index] as FormikErrors<HPAMetric>;
+  const error: string = thisErrorMetric?.resource?.target?.averageUtilization;
+
+  return (
+    <FormGroup
+      fieldId={`${type}-utilization`}
+      label={`${label} Utilization`}
+      helperText={`${label} request and limit must be set before ${label} utilization can be set.`}
+      helperTextInvalid={error}
+      validated={error ? 'error' : null}
+    >
+      <InputGroup>
+        <TextInput
+          id={type}
+          type="text"
+          isDisabled={disabled}
+          onChange={onUpdate}
+          value={Number.isNaN(value) ? '' : value}
+        />
+        <InputGroupText id="percent" aria-label="%">
+          <PercentIcon />
+        </InputGroupText>
+      </InputGroup>
+    </FormGroup>
+  );
+};
+
+export default HPAUtilizationField;

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
@@ -625,9 +625,9 @@ export const hpaExamples: { [key: string]: HorizontalPodAutoscalerKind } = {
     },
     spec: {
       scaleTargetRef: {
-        kind: 'Deployment',
+        kind: 'DeploymentConfig',
         name: 'nodejs-rest-http-crud-resource-limits',
-        apiVersion: 'apps/v1',
+        apiVersion: 'apps.openshift.io/v1',
       },
       minReplicas: 2,
       maxReplicas: 10,

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils-data.ts
@@ -1,0 +1,648 @@
+import {
+  DeploymentKind,
+  HorizontalPodAutoscalerKind,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
+
+export const deploymentExamples: { [key: string]: DeploymentKind } = {
+  hasNoLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http',
+            deploymentconfig: 'nodejs-rest-http',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {},
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+  hasMemoryOnlyLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http-with-memory-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http-with-memory-limits',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-with-memory-limits',
+            deploymentconfig: 'nodejs-rest-http-with-memory-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-with-memory-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-with-memory-limits:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  memory: '2Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+  hasCpuOnlyLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http-with-cpu-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http-with-cpu-limits',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-with-cpu-limits',
+            deploymentconfig: 'nodejs-rest-http-with-cpu-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-with-cpu-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-with-cpu-limits:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+  hasCpuAndMemoryLimits: {
+    kind: 'Deployment',
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'nodejs-rest-http-with-resource-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'nodejs-rest-http-with-resource-limits',
+        },
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-with-resource-limits',
+            deploymentconfig: 'nodejs-rest-http-with-resource-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-with-resource-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-with-resource-limits:latest',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                  memory: '2Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: {
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+      },
+      revisionHistoryLimit: 10,
+      progressDeadlineSeconds: 600,
+    },
+  },
+};
+
+export const deploymentConfigExamples: { [key: string]: K8sResourceKind } = {
+  hasNoLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud@sha256:461b6963d26b1ca3a618bb51649a417d1de8411c5cb3f5a8998ec14584a0a5ba',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud',
+        deploymentconfig: 'nodejs-rest-http-crud',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud',
+            deploymentconfig: 'nodejs-rest-http-crud',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud@sha256:461b6963d26b1ca3a618bb51649a417d1de8411c5cb3f5a8998ec14584a0a5ba',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {},
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+  hasMemoryOnlyLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud-memory-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud-memory-limits'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud-memory-limits:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-memory-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud-memory-limits',
+        deploymentconfig: 'nodejs-rest-http-crud-memory-limits',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud-memory-limits',
+            deploymentconfig: 'nodejs-rest-http-crud-memory-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud-memory-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-memory-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  memory: '2Mi',
+                },
+                requests: {
+                  memory: '1Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+  hasCpuOnlyLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud-cpu-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud-cpu-limits'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud-cpu-limits:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-cpu-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud-cpu-limits',
+        deploymentconfig: 'nodejs-rest-http-crud-cpu-limits',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud-cpu-limits',
+            deploymentconfig: 'nodejs-rest-http-crud-cpu-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud-cpu-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-cpu-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                },
+                requests: {
+                  cpu: '1m',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+  hasCpuAndMemoryLimits: {
+    kind: 'DeploymentConfig',
+    apiVersion: 'apps.openshift.io/v1',
+    metadata: {
+      name: 'nodejs-rest-http-crud-resource-limits',
+      namespace: 'test-ns',
+    },
+    spec: {
+      strategy: {
+        type: 'Rolling',
+        rollingParams: {
+          updatePeriodSeconds: 1,
+          intervalSeconds: 1,
+          timeoutSeconds: 600,
+          maxUnavailable: '25%',
+          maxSurge: '25%',
+        },
+        resources: {},
+        activeDeadlineSeconds: 21600,
+      },
+      triggers: [
+        {
+          type: 'ImageChange',
+          imageChangeParams: {
+            automatic: true,
+            containerNames: ['nodejs-rest-http-crud-resource-limits'],
+            from: {
+              kind: 'ImageStreamTag',
+              namespace: 'andrew',
+              name: 'nodejs-rest-http-crud-resource-limits:latest',
+            },
+            lastTriggeredImage:
+              'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-resource-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+          },
+        },
+        {
+          type: 'ConfigChange',
+        },
+      ],
+      replicas: 1,
+      revisionHistoryLimit: 10,
+      test: false,
+      selector: {
+        app: 'nodejs-rest-http-crud-resource-limits',
+        deploymentconfig: 'nodejs-rest-http-crud-resource-limits',
+      },
+      template: {
+        metadata: {
+          creationTimestamp: null,
+          labels: {
+            app: 'nodejs-rest-http-crud-resource-limits',
+            deploymentconfig: 'nodejs-rest-http-crud-resource-limits',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nodejs-rest-http-crud-resource-limits',
+              image:
+                'image-registry.openshift-image-registry.svc:5000/test-ns/nodejs-rest-http-crud-resource-limits@sha256:7b2d8948044492b6c719fd7b64bbf51170293fabc93be8b027c075a500a06bc0',
+              ports: [
+                {
+                  containerPort: 8080,
+                  protocol: 'TCP',
+                },
+              ],
+              resources: {
+                limits: {
+                  cpu: '2m',
+                  memory: '2Mi',
+                },
+                requests: {
+                  cpu: '1m',
+                  memory: '1Mi',
+                },
+              },
+              terminationMessagePath: '/dev/termination-log',
+              terminationMessagePolicy: 'File',
+              imagePullPolicy: 'Always',
+            },
+          ],
+          restartPolicy: 'Always',
+          terminationGracePeriodSeconds: 30,
+          dnsPolicy: 'ClusterFirst',
+          securityContext: {},
+          schedulerName: 'default-scheduler',
+        },
+      },
+    },
+  },
+};
+
+export const hpaExamples: { [key: string]: HorizontalPodAutoscalerKind } = {
+  noMetrics: {
+    kind: 'HorizontalPodAutoscaler',
+    apiVersion: 'autoscaling/v2beta2',
+    metadata: {
+      name: 'example',
+      namespace: 'test-ns',
+    },
+    spec: {
+      scaleTargetRef: {
+        kind: 'Deployment',
+        name: 'example',
+        apiVersion: 'apps/v1',
+      },
+      minReplicas: 1,
+      maxReplicas: 3,
+    },
+  },
+  cpuScaled: {
+    kind: 'HorizontalPodAutoscaler',
+    apiVersion: 'autoscaling/v2beta2',
+    metadata: {
+      name: 'example',
+      namespace: 'test-ns',
+    },
+    spec: {
+      scaleTargetRef: {
+        kind: 'Deployment',
+        name: 'nodejs-rest-http-crud-resource-limits',
+        apiVersion: 'apps/v1',
+      },
+      minReplicas: 2,
+      maxReplicas: 10,
+      metrics: [
+        {
+          type: 'Resource',
+          resource: {
+            name: 'cpu',
+            target: {
+              type: 'Utilization',
+              averageUtilization: 42,
+            },
+          },
+        },
+      ],
+    },
+  },
+};

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
@@ -1,0 +1,265 @@
+import { cloneDeep } from 'lodash';
+import {
+  getFormData,
+  getInvalidUsageError,
+  getLimitWarning,
+  getMetricByType,
+  getYAMLData,
+  isCpuUtilizationPossible,
+  isMemoryUtilizationPossible,
+  sanitizeHPAToForm,
+  sanityForSubmit,
+} from '../hpa-utils';
+import { deploymentConfigExamples, deploymentExamples, hpaExamples } from './hpa-utils-data';
+import { DeploymentKind, HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
+import { HPAFormValues } from '../types';
+
+describe('isCpuUtilizationPossible provides accurate checks', () => {
+  it('expect an invalid resource to return no', () => {
+    expect(isCpuUtilizationPossible(null)).toBe(false);
+    expect(isCpuUtilizationPossible({})).toBe(false);
+  });
+
+  it('expect a resource with no limits to be not possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasNoLimits)).toBe(false);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasNoLimits)).toBe(false);
+  });
+
+  it('expect a resource with other limits but not CPU limits to be not possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasMemoryOnlyLimits)).toBe(false);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasMemoryOnlyLimits)).toBe(false);
+  });
+
+  it('expect a resource with CPU limits to be possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasCpuOnlyLimits)).toBe(true);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasCpuOnlyLimits)).toBe(true);
+  });
+
+  it('expect a resource with both CPU And Memory limits to be possible', () => {
+    expect(isCpuUtilizationPossible(deploymentExamples.hasCpuAndMemoryLimits)).toBe(true);
+    expect(isCpuUtilizationPossible(deploymentConfigExamples.hasCpuAndMemoryLimits)).toBe(true);
+  });
+});
+
+describe('isMemoryUtilizationPossible provides accurate checks', () => {
+  it('expect an invalid resource to return no', () => {
+    expect(isMemoryUtilizationPossible(null)).toBe(false);
+    expect(isMemoryUtilizationPossible({})).toBe(false);
+  });
+
+  it('expect a resource with no limits to be not possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasNoLimits)).toBe(false);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasNoLimits)).toBe(false);
+  });
+
+  it('expect a resource with other limits but not CPU limits to be not possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasCpuOnlyLimits)).toBe(false);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasCpuOnlyLimits)).toBe(false);
+  });
+
+  it('expect a resource with CPU limits to be possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasMemoryOnlyLimits)).toBe(true);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasMemoryOnlyLimits)).toBe(true);
+  });
+
+  it('expect a resource with both CPU And Memory limits to be possible', () => {
+    expect(isMemoryUtilizationPossible(deploymentExamples.hasCpuAndMemoryLimits)).toBe(true);
+    expect(isMemoryUtilizationPossible(deploymentConfigExamples.hasCpuAndMemoryLimits)).toBe(true);
+  });
+});
+
+describe('getLimitWarning provides a string when limits are lacking', () => {
+  /** Intentionally avoid checking the string value as we don't want to couple our tests to text */
+  const hasWarning = (value: any) => typeof value === 'string';
+
+  it('expect invalid resource to return a value', () => {
+    expect(hasWarning(getLimitWarning(null))).toBe(true);
+    expect(hasWarning(getLimitWarning({}))).toBe(true);
+  });
+
+  it('expect no limit resources to return a value', () => {
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasNoLimits))).toBe(true);
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasNoLimits))).toBe(true);
+  });
+
+  it('expect partial limit resources to return a value', () => {
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasCpuOnlyLimits))).toBe(true);
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasMemoryOnlyLimits))).toBe(true);
+
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasCpuOnlyLimits))).toBe(true);
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasMemoryOnlyLimits))).toBe(true);
+  });
+
+  it('expect full limits to not return a value', () => {
+    expect(hasWarning(getLimitWarning(deploymentExamples.hasCpuAndMemoryLimits))).toBe(false);
+    expect(hasWarning(getLimitWarning(deploymentConfigExamples.hasCpuAndMemoryLimits))).toBe(false);
+  });
+});
+
+describe('getFormData gets back an hpa structured form object', () => {
+  it('expect to be scaled against the resource provided', () => {
+    const deploymentResource: DeploymentKind = deploymentExamples.hasCpuAndMemoryLimits;
+    expect(getFormData(deploymentResource).spec.scaleTargetRef).toEqual({
+      apiVersion: deploymentResource.apiVersion,
+      kind: deploymentResource.kind,
+      name: deploymentResource.metadata.name,
+    });
+  });
+
+  it('expect to be able to build off an existing HPA', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const formData: HorizontalPodAutoscalerKind = getFormData(
+      deploymentExamples.hasCpuAndMemoryLimits,
+      hpaResource,
+    );
+    expect(formData).toBeTruthy();
+    expect(formData.spec.minReplicas).toBe(hpaResource.spec.minReplicas);
+    expect(formData.spec.maxReplicas).toBe(hpaResource.spec.maxReplicas);
+    expect(formData.spec.metrics.length).toBe(1);
+    expect(formData.spec.metrics[0]).toEqual(hpaResource.spec.metrics[0]);
+  });
+});
+
+describe('getYAMLData gets back an hpa structured editor string', () => {
+  it('expect to be scaled against the resource provided', () => {
+    const deploymentResource: DeploymentKind = deploymentExamples.hasCpuAndMemoryLimits;
+    const result = getYAMLData(deploymentResource);
+    expect(new RegExp(`apiVersion: ${deploymentResource.apiVersion}`).test(result)).toBe(true);
+    expect(new RegExp(`kind: ${deploymentResource.kind}`).test(result)).toBe(true);
+    expect(new RegExp(`name: ${deploymentResource.metadata.name}`).test(result)).toBe(true);
+  });
+
+  it('expect to be able to build off an existing HPA', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const yamlData = getYAMLData(deploymentExamples.hasCpuAndMemoryLimits, hpaResource);
+    expect(yamlData).toBeTruthy();
+    expect(new RegExp(`minReplicas: ${hpaResource.spec.minReplicas}`).test(yamlData)).toBe(true);
+    expect(new RegExp(`maxReplicas: ${hpaResource.spec.maxReplicas}`).test(yamlData)).toBe(true);
+    expect(new RegExp(`name: ${hpaResource.spec.metrics[0].resource.name}`).test(yamlData)).toBe(
+      true,
+    );
+  });
+});
+
+describe('getMetricByType returns an appropriate metric and the index it is at', () => {
+  it('expect no metrics to return a default metric as a new metric on the end', () => {
+    const { metric, index } = getMetricByType(hpaExamples.noMetrics, 'memory');
+    expect(metric).toBeTruthy();
+    expect(metric.resource.name).toBe('memory');
+    expect(metric.resource.target.averageUtilization).toBe(0);
+    expect(index).toBe(0);
+  });
+
+  it('expect to get back a default memory metric when only cpu metric is available', () => {
+    const { metric, index } = getMetricByType(hpaExamples.cpuScaled, 'memory');
+    expect(metric).toBeTruthy();
+    expect(metric.resource.name).toBe('memory');
+    expect(metric.resource.target.averageUtilization).toBe(0);
+    expect(index).toBe(1);
+  });
+
+  it('expect to get back the cpu metric when it is available', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const { metric, index } = getMetricByType(hpaResource, 'cpu');
+    expect(metric).toBeTruthy();
+    expect(metric.resource.name).toBe('cpu');
+    expect(metric.resource.target.averageUtilization).toBe(
+      hpaResource.spec.metrics[0].resource.target.averageUtilization,
+    );
+    expect(index).toBe(0);
+  });
+});
+
+describe('sanitizeHPAToForm always returns valid HPA', () => {
+  it('expect an empty form to return a default HPA', () => {
+    const formData: HorizontalPodAutoscalerKind = sanitizeHPAToForm(
+      {},
+      deploymentExamples.hasCpuAndMemoryLimits,
+    );
+    expect(formData).toBeTruthy();
+    expect(formData.kind).toBe('HorizontalPodAutoscaler');
+    expect(formData.spec.metrics).not.toBeTruthy();
+  });
+
+  it('expect it not to remove existing metrics', () => {
+    const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+    const formData: HorizontalPodAutoscalerKind = sanitizeHPAToForm(
+      hpaResource,
+      deploymentExamples.hasCpuOnlyLimits,
+    );
+    expect(formData).toBeTruthy();
+    expect(formData.spec.maxReplicas).toBe(hpaResource.spec.maxReplicas);
+    expect(formData.spec.metrics[0]).toBeTruthy();
+    expect(formData.spec.metrics[0]).toEqual(hpaResource.spec.metrics[0]);
+  });
+});
+
+describe('sanityForSubmit covers some basic field locking and trimming', () => {
+  const deploymentResource: DeploymentKind = deploymentExamples.hasNoLimits;
+  const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+
+  it('expect to always return in the deployment namespace', () => {
+    const overriddenResource: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    overriddenResource.metadata.namespace = 'not-the-deployment-namespace';
+    expect(sanityForSubmit(deploymentResource, overriddenResource).metadata.namespace).toBe(
+      deploymentResource.metadata.namespace,
+    );
+  });
+
+  it('expect to always scale to the same resource despite hpa settings', () => {
+    const scaledTargetRef = {
+      apiVersion: deploymentResource.apiVersion,
+      kind: deploymentResource.kind,
+      name: deploymentResource.metadata.name,
+    };
+
+    const exampleRemoved: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    delete exampleRemoved.spec.scaleTargetRef;
+    expect(sanityForSubmit(deploymentResource, exampleRemoved).spec.scaleTargetRef).toEqual(
+      scaledTargetRef,
+    );
+
+    const exampleChanged: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    exampleChanged.spec.scaleTargetRef.name = 'not-the-deployment';
+    expect(sanityForSubmit(deploymentResource, exampleChanged).spec.scaleTargetRef).toEqual(
+      scaledTargetRef,
+    );
+  });
+
+  it('expect not to have empty cpu or memory metrics', () => {
+    const overriddenResource: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    overriddenResource.spec.metrics[0].resource.target.averageUtilization = 0;
+    expect(sanityForSubmit(deploymentResource, overriddenResource).spec.metrics.length).toBe(0);
+  });
+
+  it('expect not to trim custom resource metrics', () => {
+    const overriddenResource: HorizontalPodAutoscalerKind = cloneDeep(hpaResource);
+    overriddenResource.spec.metrics[0].resource.name = 'custom-resource';
+    overriddenResource.spec.metrics[0].resource.target.averageUtilization = 0;
+    expect(sanityForSubmit(deploymentResource, overriddenResource).spec.metrics.length).toBe(1);
+  });
+});
+
+describe('getInvalidUsageError returns an error string when limits are not set', () => {
+  const formValues: HPAFormValues = {
+    showCanUseYAMLMessage: false,
+    disabledFields: {
+      cpuUtilization: true,
+      memoryUtilization: true,
+    },
+    editorType: null,
+    formData: null,
+    yamlData: null,
+  };
+  const hpaResource: HorizontalPodAutoscalerKind = hpaExamples.cpuScaled;
+
+  it('expect cpu metric not to be allowed while disabled', () => {
+    expect(typeof getInvalidUsageError(hpaResource, formValues)).toBe('string');
+  });
+
+  it('expect memory metric to not be allowed while disabled', () => {
+    const memoryHPA = cloneDeep(hpaResource);
+    memoryHPA.spec.metrics[0].resource.name = 'memory';
+    expect(typeof getInvalidUsageError(memoryHPA, formValues)).toBe('string');
+  });
+});

--- a/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/hpa/__tests__/hpa-utils.spec.ts
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash';
 import {
+  doesHpaMatch,
   getFormData,
   getInvalidUsageError,
   getLimitWarning,
@@ -261,5 +262,19 @@ describe('getInvalidUsageError returns an error string when limits are not set',
     const memoryHPA = cloneDeep(hpaResource);
     memoryHPA.spec.metrics[0].resource.name = 'memory';
     expect(typeof getInvalidUsageError(memoryHPA, formValues)).toBe('string');
+  });
+});
+
+describe('doesHpaMatch checks if it aligns to a workload', () => {
+  it('expect not to match when hpa does not target workload', () => {
+    expect(doesHpaMatch(deploymentExamples.hasCpuAndMemoryLimits)(hpaExamples.cpuScaled)).toBe(
+      false,
+    );
+  });
+
+  it('expect to match when hpa does target workload', () => {
+    expect(
+      doesHpaMatch(deploymentConfigExamples.hasCpuAndMemoryLimits)(hpaExamples.cpuScaled),
+    ).toBe(true);
   });
 });

--- a/frontend/packages/dev-console/src/components/hpa/hooks.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hooks.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { HorizontalPodAutoscalerKind, k8sList } from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+
+export const useRelatedHPA = (
+  workloadAPI: string,
+  workloadKind: string,
+  workloadName: string,
+  workloadNamespace: string,
+): [HorizontalPodAutoscalerKind, string] => {
+  const [errorMessage, setErrorMessage] = React.useState<string>(null);
+  const [hpa, setHPA] = React.useState<HorizontalPodAutoscalerKind>(null);
+
+  React.useEffect(() => {
+    k8sList(HorizontalPodAutoscalerModel, { ns: workloadNamespace })
+      .then((hpaList: HorizontalPodAutoscalerKind[]) => {
+        const matchingHPA = hpaList.find((thisHPA: HorizontalPodAutoscalerKind) => {
+          const ref = thisHPA.spec.scaleTargetRef;
+          return (
+            ref.apiVersion === workloadAPI && ref.kind === workloadKind && ref.name === workloadName
+          );
+        });
+        if (!matchingHPA) {
+          setErrorMessage(`No matching ${HorizontalPodAutoscalerModel.label} found.`);
+          return;
+        }
+        setHPA({
+          apiVersion: `${HorizontalPodAutoscalerModel.apiGroup}/${HorizontalPodAutoscalerModel.apiVersion}`,
+          kind: HorizontalPodAutoscalerModel.kind,
+          ...matchingHPA,
+        });
+      })
+      .catch((error) => {
+        setErrorMessage(
+          error?.message || `No matching ${HorizontalPodAutoscalerModel.label} found.`,
+        );
+      });
+  }, [workloadAPI, workloadKind, workloadName, workloadNamespace]);
+
+  return [hpa, errorMessage];
+};

--- a/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
@@ -3,6 +3,7 @@ import { safeJSToYAML, safeYAMLToJS } from '@console/shared/src/utils/yaml';
 import {
   HorizontalPodAutoscalerKind,
   HPAMetric,
+  K8sResourceCommon,
   K8sResourceKind,
   referenceForModel,
 } from '@console/internal/module/k8s';
@@ -156,7 +157,7 @@ export const getInvalidUsageError = (
   return null;
 };
 
-export const doesHpaMatch = (workload: K8sResourceKind) => (
+export const doesHpaMatch = (workload: K8sResourceCommon) => (
   thisHPA: HorizontalPodAutoscalerKind,
 ) => {
   const workloadAPI: string = workload.apiVersion;

--- a/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
@@ -155,3 +155,13 @@ export const getInvalidUsageError = (
 
   return null;
 };
+
+export const doesHpaMatch = (workload: K8sResourceKind) => (
+  thisHPA: HorizontalPodAutoscalerKind,
+) => {
+  const workloadAPI: string = workload.apiVersion;
+  const workloadKind: string = workload.kind;
+  const workloadName: string = workload.metadata.name;
+  const ref = thisHPA.spec.scaleTargetRef;
+  return ref.apiVersion === workloadAPI && ref.kind === workloadKind && ref.name === workloadName;
+};

--- a/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
@@ -165,3 +165,12 @@ export const doesHpaMatch = (workload: K8sResourceKind) => (
   const ref = thisHPA.spec.scaleTargetRef;
   return ref.apiVersion === workloadAPI && ref.kind === workloadKind && ref.name === workloadName;
 };
+
+export const hasCustomMetrics = (hpa?: HorizontalPodAutoscalerKind): boolean => {
+  const metrics = hpa?.spec?.metrics;
+  if (!metrics) {
+    return false;
+  }
+
+  return !!metrics.find((metric) => !['cpu', 'memory'].includes(metric?.resource?.name));
+};

--- a/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
@@ -1,0 +1,157 @@
+import { omit, merge } from 'lodash';
+import { safeJSToYAML, safeYAMLToJS } from '@console/shared/src/utils/yaml';
+import {
+  HorizontalPodAutoscalerKind,
+  HPAMetric,
+  K8sResourceKind,
+  referenceForModel,
+} from '@console/internal/module/k8s';
+import { HorizontalPodAutoscalerModel } from '@console/internal/models';
+import { baseTemplates } from '@console/internal/models/yaml-templates';
+import { LimitsData } from '../import/import-types';
+import { HPAFormValues, SupportedMetricTypes } from './types';
+
+export const VALID_HPA_TARGET_KINDS = ['Deployment', 'DeploymentConfig'];
+
+const getResourceLimitsData = (resource: K8sResourceKind): LimitsData => {
+  const container = resource?.spec?.template?.spec?.containers?.find((c) => c.resources.limits);
+
+  return container?.resources?.limits || null;
+};
+const hasCpuLimits = (limits: LimitsData): boolean => !!limits?.cpu;
+export const isCpuUtilizationPossible = (resource: K8sResourceKind): boolean =>
+  hasCpuLimits(getResourceLimitsData(resource));
+const hasMemoryLimits = (limits: LimitsData): boolean => !!limits?.memory;
+export const isMemoryUtilizationPossible = (resource: K8sResourceKind): boolean =>
+  hasMemoryLimits(getResourceLimitsData(resource));
+
+export const getLimitWarning = (resource: K8sResourceKind): string => {
+  const limits = getResourceLimitsData(resource);
+
+  if (!limits) {
+    return `CPU and memory resource limits must be set if you want to use CPU and memory utilization. \
+    The ${HorizontalPodAutoscalerModel.label} will not have CPU or memory metrics until resource limits are set.`;
+  }
+
+  if (!hasCpuLimits(limits)) {
+    return `CPU resource limits must be set if you want to use CPU utilization. \
+    The ${HorizontalPodAutoscalerModel.label} will not have CPU metrics until resource limits are set.`;
+  }
+  if (!hasMemoryLimits(limits)) {
+    return `Memory resource limits must be set if you want to use memory utilization. \
+    The ${HorizontalPodAutoscalerModel.label} will not have memory metrics until resource limits are set.`;
+  }
+
+  return null;
+};
+
+const defaultHPAYAML = baseTemplates
+  .get(referenceForModel(HorizontalPodAutoscalerModel))
+  .get('default');
+
+const createScaleTargetRef = (resource: K8sResourceKind) => ({
+  apiVersion: resource.apiVersion,
+  kind: resource.kind,
+  name: resource.metadata.name,
+});
+
+export const getFormData = (
+  resource: K8sResourceKind,
+  existingHPA?: HorizontalPodAutoscalerKind,
+): HorizontalPodAutoscalerKind => {
+  const hpa: HorizontalPodAutoscalerKind = existingHPA || safeYAMLToJS(defaultHPAYAML);
+
+  return {
+    ...hpa,
+    spec: {
+      ...hpa.spec,
+      scaleTargetRef: createScaleTargetRef(resource),
+    },
+  };
+};
+export const getYAMLData = (
+  resource: K8sResourceKind,
+  existingHPA?: HorizontalPodAutoscalerKind,
+): string => {
+  return safeJSToYAML(getFormData(resource, existingHPA));
+};
+
+const getDefaultMetric = (type: SupportedMetricTypes): HPAMetric => ({
+  type: 'Resource',
+  resource: {
+    name: type,
+    target: {
+      averageUtilization: 0,
+      type: 'Utilization',
+    },
+  },
+});
+
+export const getMetricByType = (
+  hpa: HorizontalPodAutoscalerKind,
+  type: SupportedMetricTypes,
+): { metric: HPAMetric; index: number } => {
+  const hpaMetrics = hpa.spec.metrics || [];
+  const metricIndex = hpaMetrics.findIndex((m) => m.resource.name?.toLowerCase() === type);
+  const metric: HPAMetric = hpaMetrics[metricIndex] || getDefaultMetric(type);
+
+  return { metric, index: metricIndex === -1 ? hpaMetrics.length : metricIndex };
+};
+
+export const sanitizeHPAToForm = (
+  newFormData: Partial<HorizontalPodAutoscalerKind>,
+  resource: K8sResourceKind,
+): HorizontalPodAutoscalerKind => {
+  // Remove the default metrics as the user may be crafting their own custom ones
+  const defaultHPA: HorizontalPodAutoscalerKind = omit(getFormData(resource), 'spec.metrics');
+  return merge({}, defaultHPA, newFormData);
+};
+
+export const sanityForSubmit = (
+  targetResource: K8sResourceKind,
+  hpa: HorizontalPodAutoscalerKind,
+): HorizontalPodAutoscalerKind => {
+  const validHPA = merge(
+    {},
+    hpa,
+    // Make sure it's against _this_ namespace
+    { metadata: { namespace: targetResource.metadata.namespace } },
+    // Make sure we kept the target we started with
+    { spec: { scaleTargetRef: createScaleTargetRef(targetResource) } },
+  );
+
+  // Remove empty metrics
+  validHPA.spec.metrics = validHPA.spec.metrics.filter(
+    (metric: HPAMetric) =>
+      !['cpu', 'memory'].includes(metric?.resource?.name?.toLowerCase()) ||
+      (metric.resource.target.type === 'Utilization' &&
+        metric.resource.target.averageUtilization > 0),
+  );
+
+  return validHPA;
+};
+
+export const getInvalidUsageError = (
+  hpa: HorizontalPodAutoscalerKind,
+  formValues: HPAFormValues,
+): string => {
+  const lackCPULimits = formValues.disabledFields.cpuUtilization;
+  const lackMemoryLimits = formValues.disabledFields.memoryUtilization;
+  const metricNames = (hpa.spec.metrics || []).map((metric) =>
+    metric.resource?.name?.toLowerCase(),
+  );
+  const invalidCPU = lackCPULimits && metricNames.includes('cpu');
+  const invalidMemory = lackMemoryLimits && metricNames.includes('memory');
+
+  if (invalidCPU && invalidMemory) {
+    return 'CPU and memory utilization cannot be used currently.';
+  }
+  if (invalidCPU) {
+    return 'CPU utilization cannot be used currently.';
+  }
+  if (invalidMemory) {
+    return 'Memory utilization cannot be used currently.';
+  }
+
+  return null;
+};

--- a/frontend/packages/dev-console/src/components/hpa/types.ts
+++ b/frontend/packages/dev-console/src/components/hpa/types.ts
@@ -1,0 +1,15 @@
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { HorizontalPodAutoscalerKind } from '@console/internal/module/k8s';
+
+export type SupportedMetricTypes = 'cpu' | 'memory';
+
+export type HPAFormValues = {
+  showCanUseYAMLMessage: boolean;
+  disabledFields: {
+    cpuUtilization: boolean;
+    memoryUtilization: boolean;
+  };
+  editorType: EditorType;
+  formData: HorizontalPodAutoscalerKind;
+  yamlData: string;
+};

--- a/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/validation-utils.ts
@@ -1,0 +1,51 @@
+import * as yup from 'yup';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+
+export const hpaValidationSchema = yup.object({
+  editorType: yup.string(),
+  formData: yup.object().when('editorType', {
+    is: EditorType.Form,
+    then: yup.object({
+      spec: yup.object({
+        minReplicas: yup
+          .number()
+          .integer('Min Pods must be an integer.')
+          .min(1, 'Min Pods must greater than or equal to 1.')
+          .test('test-less-than-max', 'Min Pods should be less than Max Pods.', function(
+            minReplicas,
+          ) {
+            const { maxReplicas } = this.parent;
+            return minReplicas <= maxReplicas;
+          }),
+        maxReplicas: yup
+          .number()
+          .integer('Max Pods must be an integer.')
+          .test('test-greater-than-min', 'Max Pods should be greater than Min Pods.', function(
+            maxReplicas,
+          ) {
+            const { minReplicas } = this.parent;
+            return minReplicas <= maxReplicas;
+          })
+          .required('Max Pods must be defined.'),
+        metrics: yup.array(
+          yup.object({
+            resource: yup.object({
+              target: yup.object({
+                averageUtilization: yup
+                  .mixed()
+                  .test(
+                    'test-for-valid-utilization',
+                    'Average Utilization must be a positive number.',
+                    function(avgUtilization) {
+                      if (!avgUtilization) return true;
+                      return /^\d+$/.test(String(avgUtilization));
+                    },
+                  ),
+              }),
+            }),
+          }),
+        ),
+      }),
+    }),
+  }),
+});

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
@@ -6,8 +6,10 @@ import {
   getPodData,
   podRingLabel,
   podDataInProgress,
+  hpaPodRingLabel,
 } from '@console/shared';
 import { DonutStatusData } from '../../topology-types';
+import { useRelatedHPA } from '../../../hpa/hooks';
 
 interface PodSetProps {
   size: number;
@@ -67,8 +69,18 @@ const PodSet: React.FC<PodSetProps> = ({ size, data, x = 0, y = 0, showPodCount 
     data.isRollingOut,
   );
 
+  const [hpa] = useRelatedHPA(
+    data.dc.apiVersion,
+    data.dc.kind,
+    data.dc.metadata.name,
+    data.dc.metadata.namespace,
+  );
+  const hpaControlledScaling = !!hpa;
+
   const obj = get(data, ['current', 'obj'], null) || data.dc;
-  const { title, subTitle, titleComponent } = podRingLabel(obj, data.dc.kind, data?.pods);
+  const { title, subTitle, titleComponent } = hpaControlledScaling
+    ? hpaPodRingLabel(obj, hpa, data?.pods)
+    : podRingLabel(obj, obj.kind, data?.pods);
   return (
     <>
       <PodStatus

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -402,6 +402,12 @@ export const getBaseWatchedResources = (namespace: string): WatchK8sResources<an
       namespace,
       optional: true,
     },
+    hpas: {
+      isList: true,
+      kind: 'HorizontalPodAutoscaler',
+      namespace,
+      optional: true,
+    },
     clusterServiceVersions: {
       isList: true,
       kind: referenceForModel(ClusterServiceVersionModel),

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -805,6 +805,16 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/workload-hpa/:ns/:kind/:name'],
+      loader: async () =>
+        (await import('./components/hpa/HPAPage' /* webpackChunkName: "hpa-on-workload`" */))
+          .default,
+    },
+  },
+  {
     type: 'ReduxReducer',
     properties: {
       namespace: 'devconsole',

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -808,7 +808,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: ['/workload-hpa/:ns/:kind/:name'],
+      path: ['/workload-hpa/:ns/:resourceRef/:name', '/workload-hpa/:ns/:resourceRef/:name/edit'],
       loader: async () =>
         (await import('./components/hpa/HPAPage' /* webpackChunkName: "hpa-on-workload`" */))
           .default,

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash-es';
 import { Status, PodRingController } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { AddHorizontalPodAutoScaler } from '@console/app/src/actions/modify-hpa';
 import { k8sCreate, K8sKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { errorModal } from './modals';
 import { DeploymentConfigModel } from '../models';
@@ -84,6 +85,7 @@ export const menuActions: KebabAction[] = [
   PauseAction,
   ModifyCount,
   AddHealthChecks,
+  AddHorizontalPodAutoScaler,
   AddStorage,
   ...getExtensionsKebabActionsForKind(DeploymentConfigModel),
   EditHealthChecks,

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -4,7 +4,10 @@ import * as _ from 'lodash-es';
 import { Status, PodRingController } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
-import { AddHorizontalPodAutoScaler } from '@console/app/src/actions/modify-hpa';
+import {
+  AddHorizontalPodAutoScaler,
+  DeleteHorizontalPodAutoScaler,
+} from '@console/app/src/actions/modify-hpa';
 import { k8sCreate, K8sKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { errorModal } from './modals';
 import { DeploymentConfigModel } from '../models';
@@ -87,6 +90,7 @@ export const menuActions: KebabAction[] = [
   AddHealthChecks,
   AddHorizontalPodAutoScaler,
   AddStorage,
+  DeleteHorizontalPodAutoScaler,
   ...getExtensionsKebabActionsForKind(DeploymentConfigModel),
   EditHealthChecks,
   ...common,

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -7,6 +7,7 @@ import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modi
 import {
   AddHorizontalPodAutoScaler,
   DeleteHorizontalPodAutoScaler,
+  EditHorizontalPodAutoScaler,
 } from '@console/app/src/actions/modify-hpa';
 import { k8sCreate, K8sKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { errorModal } from './modals';
@@ -89,6 +90,7 @@ export const menuActions: KebabAction[] = [
   ModifyCount,
   AddHealthChecks,
   AddHorizontalPodAutoScaler,
+  EditHorizontalPodAutoScaler,
   AddStorage,
   DeleteHorizontalPodAutoScaler,
   ...getExtensionsKebabActionsForKind(DeploymentConfigModel),

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -8,6 +8,7 @@ import {
   AddHorizontalPodAutoScaler,
   DeleteHorizontalPodAutoScaler,
   EditHorizontalPodAutoScaler,
+  hideActionForHPAs,
 } from '@console/app/src/actions/modify-hpa';
 import { k8sCreate, K8sKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { errorModal } from './modals';
@@ -87,7 +88,7 @@ const { ModifyCount, AddStorage, common } = Kebab.factory;
 export const menuActions: KebabAction[] = [
   RolloutAction,
   PauseAction,
-  ModifyCount,
+  hideActionForHPAs(ModifyCount),
   AddHealthChecks,
   AddHorizontalPodAutoScaler,
   EditHorizontalPodAutoScaler,

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -3,7 +3,10 @@ import * as React from 'react';
 import { Status, PodRingController } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
-import { AddHorizontalPodAutoScaler } from '@console/app/src/actions/modify-hpa';
+import {
+  AddHorizontalPodAutoScaler,
+  DeleteHorizontalPodAutoScaler,
+} from '@console/app/src/actions/modify-hpa';
 import { DeploymentModel } from '../models';
 import { DeploymentKind, K8sKind, K8sResourceKindReference } from '../module/k8s';
 import { configureUpdateStrategyModal, errorModal } from './modals';
@@ -62,6 +65,7 @@ export const menuActions = [
   AddHorizontalPodAutoScaler,
   AddStorage,
   UpdateStrategy,
+  DeleteHorizontalPodAutoScaler,
   ...Kebab.getExtensionsActionsForKind(DeploymentModel),
   EditHealthChecks,
   ...common,

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Status, PodRingController } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { AddHorizontalPodAutoScaler } from '@console/app/src/actions/modify-hpa';
 import { DeploymentModel } from '../models';
 import { DeploymentKind, K8sKind, K8sResourceKindReference } from '../module/k8s';
 import { configureUpdateStrategyModal, errorModal } from './modals';
@@ -58,6 +59,7 @@ export const menuActions = [
   ModifyCount,
   PauseAction,
   AddHealthChecks,
+  AddHorizontalPodAutoScaler,
   AddStorage,
   UpdateStrategy,
   ...Kebab.getExtensionsActionsForKind(DeploymentModel),

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -6,6 +6,7 @@ import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modi
 import {
   AddHorizontalPodAutoScaler,
   DeleteHorizontalPodAutoScaler,
+  EditHorizontalPodAutoScaler,
 } from '@console/app/src/actions/modify-hpa';
 import { DeploymentModel } from '../models';
 import { DeploymentKind, K8sKind, K8sResourceKindReference } from '../module/k8s';
@@ -63,6 +64,7 @@ export const menuActions = [
   PauseAction,
   AddHealthChecks,
   AddHorizontalPodAutoScaler,
+  EditHorizontalPodAutoScaler,
   AddStorage,
   UpdateStrategy,
   DeleteHorizontalPodAutoScaler,

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -7,6 +7,7 @@ import {
   AddHorizontalPodAutoScaler,
   DeleteHorizontalPodAutoScaler,
   EditHorizontalPodAutoScaler,
+  hideActionForHPAs,
 } from '@console/app/src/actions/modify-hpa';
 import { DeploymentModel } from '../models';
 import { DeploymentKind, K8sKind, K8sResourceKindReference } from '../module/k8s';
@@ -60,7 +61,7 @@ const PauseAction: KebabAction = (kind: K8sKind, obj: DeploymentKind) => ({
 });
 
 export const menuActions = [
-  ModifyCount,
+  hideActionForHPAs(ModifyCount),
   PauseAction,
   AddHealthChecks,
   AddHorizontalPodAutoScaler,

--- a/frontend/public/components/overview/hpa-overview.tsx
+++ b/frontend/public/components/overview/hpa-overview.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { HorizontalPodAutoscalerKind } from '../../module/k8s';
+import { ResourceLink, SidebarSectionHeading } from '../utils';
+import { HorizontalPodAutoscalerModel } from '../../models';
+
+type HPAOverviewProps = {
+  hpas?: HorizontalPodAutoscalerKind[];
+};
+
+export const HPAOverview: React.FC<HPAOverviewProps> = ({ hpas }) => {
+  if (!hpas?.length) {
+    return null;
+  }
+
+  return (
+    <div>
+      <SidebarSectionHeading text={HorizontalPodAutoscalerModel.labelPlural} />
+      <ul className="list-group">
+        {hpas.map((hpa: HorizontalPodAutoscalerKind) => (
+          <li key={hpa.metadata.name} className="list-group-item">
+            <ResourceLink
+              kind={HorizontalPodAutoscalerModel.kind}
+              name={hpa.metadata.name}
+              namespace={hpa.metadata.namespace}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -77,7 +77,7 @@ export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch
     }
     return (
       <div className="overview__sidebar-pane resource-overview">
-        <ResourceOverviewHeading actions={menuActions} kindObj={kindObj} resource={item.obj} />
+        <ResourceOverviewHeading actions={menuActions} kindObj={kindObj} resources={item} />
         <SimpleTabNav
           onClickTab={onClickTab}
           selectedTab={selectedDetailsTab}

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -10,6 +10,7 @@ import OperatorBackedOwnerReferences, {
 } from '../utils';
 
 import { BuildOverview } from './build-overview';
+import { HPAOverview } from './hpa-overview';
 import { NetworkingOverview } from './networking-overview';
 import { PodsOverview } from './pods-overview';
 import { resourceOverviewPages } from './resource-overview-pages';
@@ -20,13 +21,14 @@ const { common } = Kebab.factory;
 export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabProps> = ({
   item,
 }) => {
-  const { buildConfigs, routes, services, pods, obj } = item;
+  const { buildConfigs, hpas, routes, services, pods, obj } = item;
   const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <div className="overview__sidebar-pane-body">
       <OperatorBackedOwnerReferences item={item} />
       <PodsOverview pods={pods} obj={obj} />
       <BuildOverview buildConfigs={buildConfigs} />
+      <HPAOverview hpas={hpas} />
       {pluginComponents.map(({ Component, key }) => (
         <Component key={key} item={item} />
       ))}

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -45,7 +45,7 @@ export const DefaultOverviewPage = connectToModel(
           ...common,
         ]}
         kindObj={kindObject}
-        resource={item.obj}
+        resources={item}
       />
       <div className="overview__sidebar-pane-body resource-overview__body">
         <div className="resource-overview__summary">

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem, Button, SplitItem, Split } from '@patternfly/react-core';
-import { Status, HealthChecksAlert } from '@console/shared';
+import { OverviewItem, Status, HealthChecksAlert } from '@console/shared';
 import {
   ActionsMenu,
   FirehoseResult,
@@ -194,8 +194,9 @@ export const SidebarSectionHeading: React.SFC<SidebarSectionHeadingProps> = ({
 export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = ({
   kindObj,
   actions,
-  resource,
+  resources,
 }) => {
+  const { obj: resource, ...otherResources } = resources;
   const isDeleting = !!resource.metadata.deletionTimestamp;
   return (
     <div className="overview__sidebar-pane-head resource-overview__heading">
@@ -219,7 +220,7 @@ export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = 
         </div>
         {!isDeleting && (
           <div className="co-actions">
-            <ActionsMenu actions={actions.map((a) => a(kindObj, resource))} />
+            <ActionsMenu actions={actions.map((a) => a(kindObj, resource, otherResources))} />
           </div>
         )}
       </h1>
@@ -266,7 +267,7 @@ export type PageHeadingProps = {
 export type ResourceOverviewHeadingProps = {
   actions: KebabAction[];
   kindObj: K8sKind;
-  resource: K8sResourceKind;
+  resources?: OverviewItem;
 };
 
 export type SectionHeadingProps = {

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -123,7 +123,7 @@ export const ReplicationControllerModel: K8sKind = {
 export const HorizontalPodAutoscalerModel: K8sKind = {
   label: 'Horizontal Pod Autoscaler',
   plural: 'horizontalpodautoscalers',
-  apiVersion: 'v2beta1',
+  apiVersion: 'v2beta2',
   apiGroup: 'autoscaling',
   abbr: 'HPA',
   namespaced: true,

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -358,7 +358,7 @@ spec:
   .setIn(
     [referenceForModel(k8sModels.HorizontalPodAutoscalerModel), 'default'],
     `
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example
@@ -373,7 +373,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 50
+      target:
+        averageUtilization: 50
+        type: Utilization
 `,
   )
   .setIn(

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -385,6 +385,12 @@ export type HorizontalPodAutoscalerKind = K8sResourceCommon & {
     maxReplicas: number;
     metrics?: HPAMetric[];
   };
+  status?: {
+    currentReplicas: number;
+    desiredReplicas: number;
+    currentMetrics: any;
+    conditions: NodeCondition[];
+  };
 };
 
 export type StorageClassResourceKind = {

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -364,6 +364,29 @@ export type DeploymentKind = {
   };
 } & K8sResourceCommon;
 
+export type HPAMetric = {
+  type: 'Object' | 'Pods' | 'Resource';
+  resource: {
+    name: string;
+    target: {
+      averageUtilization?: number;
+      type: string;
+    };
+  };
+};
+export type HorizontalPodAutoscalerKind = K8sResourceCommon & {
+  spec: {
+    scaleTargetRef: {
+      apiVersion: string;
+      kind: string;
+      name: string;
+    };
+    minReplicas?: number;
+    maxReplicas: number;
+    metrics?: HPAMetric[];
+  };
+};
+
 export type StorageClassResourceKind = {
   provisioner: string;
   reclaimPolicy: string;


### PR DESCRIPTION
## Built on #6039 - See the 4th Commit

**Fixes**: 
https://issues.redhat.com/browse/ODC-4272

**Analysis / Root cause**: 
As a user, I'd like to be able to see my HPA resource in the sidebar and not be able to change pods as the HPA will fight me

**Solution Description**: 
Update to add a resource section for HPAs and to stop manual scaling of the pods; through kebab and scale arrows on the pod donut that is on the details tab.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux & @lwrigh 

![Screen Shot 2020-07-23 at 1 24 52 PM](https://user-images.githubusercontent.com/8126518/88319858-c2277200-ccea-11ea-96fc-4a071f539c2f.png)
![Screen Shot 2020-07-23 at 1 25 06 PM](https://user-images.githubusercontent.com/8126518/88319864-c3589f00-ccea-11ea-9a3a-027e8db6a215.png)
![Screen Shot 2020-07-23 at 1 42 05 PM](https://user-images.githubusercontent.com/8126518/88319867-c3f13580-ccea-11ea-9d1a-a441d5899863.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge