### PR TITLE
Group multiple KSVC revision URLs under the same Route

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KSRouteSplitListItem.scss
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRouteSplitListItem.scss
@@ -1,0 +1,3 @@
+.odc-ksroute-split-list-item {
+  padding-left: var(--pf-global--spacer--lg);
+}

--- a/frontend/packages/knative-plugin/src/components/overview/KSRouteSplitListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRouteSplitListItem.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { ExternalLink } from '@console/internal/components/utils';
+import { RoutesOverviewListItem } from '../../types';
+import './KSRouteSplitListItem.scss';
+
+type KSRouteSplitListItemProps = {
+  route: RoutesOverviewListItem;
+};
+
+const KSRouteSplitListItem: React.FC<KSRouteSplitListItemProps> = ({ route: { percent, url } }) =>
+  url.length > 0 && percent.length > 0 ? (
+    <li className="list-group-item">
+      <div className="odc-ksroute-split-list-item">
+        <div className="row">
+          <div className="col-xs-10">
+            <span>
+              {`${percent} → `}
+              <ExternalLink href={url} additionalClassName="co-external-link--block" text={url} />
+            </span>
+          </div>
+        </div>
+      </div>
+    </li>
+  ) : null;
+
+export default KSRouteSplitListItem;

--- a/frontend/packages/knative-plugin/src/components/overview/KSRoutes.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRoutes.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { RoutesOverviewListItem } from '../../types';
+import KSRoutesOverviewListItem from './KSRoutesOverviewListItem';
+import KSRouteSplitListItem from './KSRouteSplitListItem';
+
+type KSRoutesProps = {
+  route: K8sResourceKind;
+  routeLinks: RoutesOverviewListItem[];
+};
+
+const KSRoutes: React.FC<KSRoutesProps> = ({ route, routeLinks }) => (
+  <>
+    <KSRoutesOverviewListItem ksroute={route} />
+    {routeLinks.map((splitRoute) => (
+      <KSRouteSplitListItem key={splitRoute.uid} route={splitRoute} />
+    ))}
+  </>
+);
+
+export default KSRoutes;

--- a/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { RouteModel } from '../../models';
+
+type KSRoutesOverviewListItemProps = {
+  ksroute: K8sResourceKind;
+};
+
+const KSRoutesOverviewListItem: React.FC<KSRoutesOverviewListItemProps> = ({ ksroute }) => {
+  const {
+    metadata: { name, namespace },
+    status,
+  } = ksroute;
+  return (
+    status && (
+      <li className="list-group-item">
+        <div className="row">
+          <div className="col-xs-10">
+            <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
+            {status.url?.length > 0 && (
+              <>
+                <span className="text-muted">Location: </span>
+                <ExternalLink
+                  href={status.url}
+                  additionalClassName="co-external-link--block"
+                  text={status.url}
+                />
+              </>
+            )}
+          </div>
+        </div>
+      </li>
+    )
+  );
+};
+
+export default KSRoutesOverviewListItem;

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
@@ -4,6 +4,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 import { SidebarSectionHeading } from '@console/internal/components/utils';
 import { getKnativeRoutesLinks } from '../../utils/resource-overview-utils';
 import RoutesOverviewListItem from './RoutesOverviewListItem';
+import KSRoutes from './KSRoutes';
 
 export type RoutesOverviewListProps = {
   ksroutes: K8sResourceKind[];
@@ -19,9 +20,10 @@ const RoutesOverviewList: React.FC<RoutesOverviewListProps> = ({ ksroutes, resou
       <ul className="list-group">
         {_.map(ksroutes, (route) => {
           const routeLinks = getKnativeRoutesLinks(route, resource);
-          return routeLinks.map((routeLink) => (
-            <RoutesOverviewListItem key={routeLink.uid} routeLink={routeLink} />
-          ));
+          if (routeLinks.length === 1) {
+            return <RoutesOverviewListItem key={route.metadata.uid} routeLink={routeLinks[0]} />;
+          }
+          return <KSRoutes key={route.metadata.uid} route={route} routeLinks={routeLinks} />;
         })}
       </ul>
     )}

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRouteSplitListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRouteSplitListItem.spec.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { ExternalLink } from '@console/internal/components/utils';
+import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
+import KSRouteSplitListItem from '../KSRouteSplitListItem';
+import { getKnativeRoutesLinks } from '../../../utils/resource-overview-utils';
+
+type RoutesOverviewListItemProps = React.ComponentProps<typeof KSRouteSplitListItem>;
+
+describe('KSRouteSplitListItem', () => {
+  let wrapper: ShallowWrapper<RoutesOverviewListItemProps>;
+  beforeEach(() => {
+    const [route] = getKnativeRoutesLinks(
+      MockKnativeResources.ksroutes.data[0],
+      MockKnativeResources.revisions.data[0],
+    );
+    wrapper = shallow(<KSRouteSplitListItem route={route} />);
+  });
+
+  it('should list the Route', () => {
+    expect(wrapper.find('li')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('li')
+        .at(0)
+        .props().className,
+    ).toEqual('list-group-item');
+  });
+
+  it('should have route ExternalLink with proper href', () => {
+    expect(wrapper.find(ExternalLink)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(ExternalLink)
+        .at(0)
+        .props().href,
+    ).toEqual('http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com');
+  });
+
+  it('should not render if url is not available', () => {
+    const mockRouteData = {
+      ...MockKnativeResources.ksroutes.data[0],
+      status: {
+        ...MockKnativeResources.ksroutes.data[0].status,
+        url: undefined,
+        traffic: [
+          {
+            ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+            percent: undefined,
+            url: undefined,
+          },
+        ],
+      },
+    };
+    const [route] = getKnativeRoutesLinks(mockRouteData, MockKnativeResources.revisions.data[0]);
+    wrapper.setProps({ route });
+    expect(wrapper.find(ExternalLink)).toHaveLength(0);
+  });
+
+  it('should not render if percent is not available', () => {
+    const mockRouteData = {
+      ...MockKnativeResources.ksroutes.data[0],
+      status: {
+        ...MockKnativeResources.ksroutes.data[0].status,
+        url: undefined,
+        traffic: [
+          {
+            ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+            percent: undefined,
+            url: undefined,
+          },
+        ],
+      },
+    };
+    const [route] = getKnativeRoutesLinks(mockRouteData, MockKnativeResources.revisions.data[0]);
+    wrapper.setProps({ route });
+    expect(wrapper.find(ExternalLink)).toHaveLength(0);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
+import { RouteModel } from '../../../models';
+import KSRoutesOverviewListItem from '../KSRoutesOverviewListItem';
+
+type KSRoutesOverviewListItemProps = React.ComponentProps<typeof KSRoutesOverviewListItem>;
+
+describe('KSRoutesOverviewListItem', () => {
+  let wrapper: ShallowWrapper<KSRoutesOverviewListItemProps>;
+  beforeEach(() => {
+    const [ksroute] = MockKnativeResources.ksroutes.data;
+    wrapper = shallow(<KSRoutesOverviewListItem ksroute={ksroute} />);
+  });
+
+  it('should list the Route', () => {
+    expect(wrapper.find('li')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('li')
+        .at(0)
+        .props().className,
+    ).toEqual('list-group-item');
+  });
+
+  it('should have ResourceLink with proper kind', () => {
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(ResourceLink)
+        .at(0)
+        .props().kind,
+    ).toEqual(referenceForModel(RouteModel));
+  });
+
+  it('should have route ExternalLink with proper href', () => {
+    expect(wrapper.find(ExternalLink)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(ExternalLink)
+        .at(0)
+        .props().href,
+    ).toEqual('http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com');
+  });
+
+  it('should not show the route url if it is not available', () => {
+    const ksroute = { ...MockKnativeResources.ksroutes.data[0], status: { url: '' } };
+    wrapper.setProps({ ksroute });
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(wrapper.find(ExternalLink)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3827
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
As an user i would like to view associated Routes for selected Revisions/Service along with respective locations.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Group multiple revision URLs under the same route.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
- Sidebar for `KSVC`: 
![p0](https://user-images.githubusercontent.com/20013884/88541761-f07eb780-d032-11ea-8b91-2eb2f07fcc46.png)

- Sidebar for `REV` when there is no traffic split:
![p1](https://user-images.githubusercontent.com/20013884/88541784-f70d2f00-d032-11ea-836f-fbc31aa9cdf1.png)

- Sidebar for `REV` when there is traffic split:
![p2](https://user-images.githubusercontent.com/20013884/88541823-03918780-d033-11ea-86d4-855e825a18b4.png)



cc: @openshift/team-devconsole-ux @invincibleJai @beaumorley 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
