### PR TITLE
WIP Add test for Yamel Editor component #6091

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/__tests__/YAMLEditor.spec.tsx
+++ b/frontend/packages/console-shared/src/components/editor/__tests__/YAMLEditor.spec.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import YAMLEditor from '../YAMLEditor';
+
+describe('YAMLEditorComponent', () => {
+  it('should exist', () => {
+    const wrapper = shallow(<YAMLEditor />);
+    expect(wrapper.isEmptyRender()).toBe(false);
+  });
+});


### PR DESCRIPTION
test failing with:
```
Summary of all failing tests
 FAIL  packages/console-shared/src/components/editor/__tests__/YAMLEditor.spec.tsx
  ● Test suite failed to run

    Cannot find module 'monaco-editor' from 'editor.js'

      at Resolver.resolveModule
(node_modules/jest-resolve/build/index.js:191:17)
      at Object.<anonymous>
(node_modules/react-monaco-editor/lib/editor.js:11:21)
```

why the dependency can be missing??
