### PR TITLE
update moveSink modal to support URI along with resources

### DIFF
--- a/frontend/packages/knative-plugin/src/actions/sink-pubsub.ts
+++ b/frontend/packages/knative-plugin/src/actions/sink-pubsub.ts
@@ -1,12 +1,12 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
-import { setSinkSourceModal } from '../components/modals';
+import { setSinkPubsubModal } from '../components/modals';
 
-export const setSinkSource = (model: K8sKind, source: K8sResourceKind): KebabOption => {
+export const setSinkPubsub = (model: K8sKind, source: K8sResourceKind): KebabOption => {
   return {
-    label: 'Move Sink',
+    label: `Move ${model.kind}`,
     callback: () =>
-      setSinkSourceModal({
+      setSinkPubsubModal({
         source,
       }),
     accessReview: {

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
@@ -20,6 +20,7 @@ interface SinkSectionProps {
 
 interface SinkResourcesProps {
   namespace: string;
+  isMoveSink?: boolean;
 }
 
 const SinkUri: React.FC = () => (
@@ -38,7 +39,7 @@ const SinkUri: React.FC = () => (
   </>
 );
 
-const SinkResources: React.FC<SinkResourcesProps> = ({ namespace }) => {
+const SinkResources: React.FC<SinkResourcesProps> = ({ namespace, isMoveSink }) => {
   const [resourceAlert, setResourceAlert] = React.useState(false);
   const { setFieldValue, setFieldTouched, validateForm, initialValues } = useFormikContext<
     FormikValues
@@ -61,7 +62,7 @@ const SinkResources: React.FC<SinkResourcesProps> = ({ namespace }) => {
     },
     [setFieldValue, setFieldTouched, validateForm],
   );
-  const contextAvailable = !!initialValues.sink.name;
+  const contextAvailable = isMoveSink ? false : !!initialValues.sink.name;
   const resourcesData = [
     ...knativeServingResourcesServices(namespace),
     ...getDynamicChannelResourceList(namespace),
@@ -111,6 +112,24 @@ const SinkResources: React.FC<SinkResourcesProps> = ({ namespace }) => {
   );
 };
 
+export const SinkUriResourcesGroup: React.FC<SinkResourcesProps> = ({ namespace, isMoveSink }) => (
+  <RadioGroupField
+    name="sinkType"
+    options={[
+      {
+        label: sourceSinkType.Resource.label,
+        value: sourceSinkType.Resource.value,
+        activeChildren: <SinkResources namespace={namespace} isMoveSink={isMoveSink} />,
+      },
+      {
+        label: sourceSinkType.Uri.label,
+        value: sourceSinkType.Uri.value,
+        activeChildren: <SinkUri />,
+      },
+    ]}
+  />
+);
+
 const SinkSection: React.FC<SinkSectionProps> = ({ namespace }) => {
   return (
     <FormSection
@@ -118,21 +137,7 @@ const SinkSection: React.FC<SinkSectionProps> = ({ namespace }) => {
       subTitle="Add a Sink to route this Event Source to a Channel, Broker, Knative Service or another route."
       extraMargin
     >
-      <RadioGroupField
-        name="sinkType"
-        options={[
-          {
-            label: sourceSinkType.Resource.label,
-            value: sourceSinkType.Resource.value,
-            activeChildren: <SinkResources namespace={namespace} />,
-          },
-          {
-            label: sourceSinkType.Uri.label,
-            value: sourceSinkType.Uri.value,
-            activeChildren: <SinkUri />,
-          },
-        ]}
-      />
+      <SinkUriResourcesGroup namespace={namespace} />
     </FormSection>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
@@ -9,6 +9,16 @@ import { EventSources, SinkType } from './import-types';
 import { isKnownEventSource } from '../../utils/create-eventsources-utils';
 import { isDefaultChannel, getChannelKind } from '../../utils/create-channel-utils';
 
+export const sinkTypeUriValidatiuon = yup.object().shape({
+  uri: yup
+    .string()
+    .max(2000, 'Please enter a URI that is less then 2000 characters.')
+    .test('validate-uri', 'Invalid URI.', function(value) {
+      return isValidUrl(value);
+    })
+    .required('Required'),
+});
+
 const sinkServiceSchema = yup
   .object()
   .when('sinkType', {
@@ -19,15 +29,7 @@ const sinkServiceSchema = yup
   })
   .when('sinkType', {
     is: SinkType.Uri,
-    then: yup.object().shape({
-      uri: yup
-        .string()
-        .max(2000, 'Please enter a URI that is less then 2000 characters.')
-        .test('validate-uri', 'Invalid URI.', function(value) {
-          return isValidUrl(value);
-        })
-        .required('Required'),
-    }),
+    then: sinkTypeUriValidatiuon,
   });
 
 export const sourceDataSpecSchema = yup

--- a/frontend/packages/knative-plugin/src/components/modals/index.ts
+++ b/frontend/packages/knative-plugin/src/components/modals/index.ts
@@ -8,6 +8,11 @@ export const setSinkSourceModal = (props) =>
     m.sinkModalLauncher(props),
   );
 
+export const setSinkPubsubModal = (props) =>
+  import('../sink-pubsub/SinkPubsubController' /* webpackChunkName: "sink-pubsub" */).then((m) =>
+    m.sinkPubsubModalLauncher(props),
+  );
+
 export const deleteRevisionModal = (props) =>
   import(
     '../revisions/DeleteRevisionModalController' /* webpackChunkName: "delete-revision" */

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsub.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsub.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Formik, FormikValues, FormikHelpers } from 'formik';
+import { K8sResourceKind, k8sUpdate, referenceFor, modelFor } from '@console/internal/module/k8s';
+import SinkPubsubModal from './SinkPubsubModal';
+import { knativeServingResourcesServices } from '../../utils/get-knative-resources';
+
+export interface SinkPubsubProps {
+  source: K8sResourceKind;
+  cancel?: () => void;
+  close?: () => void;
+}
+
+const SinkPubsub: React.FC<SinkPubsubProps> = ({ source, cancel, close }) => {
+  const {
+    kind: sourceKind,
+    metadata: { namespace, name },
+    spec,
+  } = source;
+  const isSinkRef = !!spec?.subscriber?.ref;
+  const { name: sinkName = '', apiVersion = '', kind = '' } = isSinkRef
+    ? spec?.subscriber?.ref
+    : {};
+  const initialValues = {
+    ref: {
+      apiVersion,
+      kind,
+      name: sinkName,
+    },
+  };
+  const resourcesDropdownField = knativeServingResourcesServices(namespace);
+  const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {
+    const updatePayload = {
+      ...source,
+      ...(sinkName !== values?.ref?.name && {
+        spec: { ...source.spec, subscriber: { ...values } },
+      }),
+    };
+    k8sUpdate(modelFor(referenceFor(source)), updatePayload)
+      .then(() => {
+        action.setSubmitting(false);
+        action.setStatus({ error: '' });
+        close();
+      })
+      .catch((err) => {
+        action.setStatus({ error: err.message || 'An error occurred. Please try again' });
+      });
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      onReset={cancel}
+      initialStatus={{ error: '' }}
+    >
+      {(formikProps) => (
+        <SinkPubsubModal
+          {...formikProps}
+          resourceName={name}
+          resourceDropdown={resourcesDropdownField}
+          labelTitle={`Move ${sourceKind}`}
+          cancel={cancel}
+        />
+      )}
+    </Formik>
+  );
+};
+
+export default SinkPubsub;

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubController.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubController.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import SinkPubsub from './SinkPubsub';
+
+type SinkPubsubControllerProps = {
+  source: K8sResourceKind;
+};
+
+const SinkPubsubController: React.FC<SinkPubsubControllerProps> = ({ source, ...props }) => (
+  <SinkPubsub {...props} source={source} />
+);
+
+type Props = SinkPubsubControllerProps & ModalComponentProps;
+
+export const sinkPubsubModalLauncher = createModalLauncher<Props>(SinkPubsubController);
+
+export default SinkPubsubController;

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubModal.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import * as fuzzy from 'fuzzysearch';
+import { FormikProps, FormikValues } from 'formik';
+import {
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import { ResourceDropdownField } from '@console/shared';
+import { FirehoseResource } from '@console/internal/components/utils';
+import FormSection from '@console/dev-console/src/components/import/section/FormSection';
+
+export interface SinkPubsubModalProps {
+  resourceName: string;
+  resourceDropdown: FirehoseResource[];
+  labelTitle: string;
+  cancel?: () => void;
+}
+
+type Props = FormikProps<FormikValues> & SinkPubsubModalProps;
+
+const SinkPubsubModal: React.FC<Props> = ({
+  resourceName,
+  resourceDropdown,
+  labelTitle,
+  handleSubmit,
+  cancel,
+  isSubmitting,
+  status,
+  setFieldValue,
+  setFieldTouched,
+  validateForm,
+  values,
+  initialValues,
+}) => {
+  const autocompleteFilter = (strText, item): boolean => fuzzy(strText, item?.props?.name);
+  const onSinkChange = React.useCallback(
+    (selectedValue, target) => {
+      const modelResource = target?.props?.model;
+      if (selectedValue) {
+        setFieldTouched('ref.name', true);
+        setFieldValue('ref.name', selectedValue);
+        if (modelResource) {
+          const { apiGroup, apiVersion, kind } = modelResource;
+          const sinkApiversion = `${apiGroup}/${apiVersion}`;
+          setFieldValue('ref.apiVersion', sinkApiversion);
+          setFieldTouched('ref.apiVersion', true);
+          setFieldValue('ref.kind', kind);
+          setFieldTouched('ref.kind', true);
+        }
+        validateForm();
+      }
+    },
+    [setFieldValue, setFieldTouched, validateForm],
+  );
+  const dirty = values?.ref?.name !== initialValues.ref.name;
+  return (
+    <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
+      <ModalTitle>{labelTitle}</ModalTitle>
+      <ModalBody>
+        <p>
+          Connects <strong>{resourceName}</strong> to
+        </p>
+        <FormSection fullWidth>
+          <ResourceDropdownField
+            name="ref.name"
+            resources={resourceDropdown}
+            dataSelector={['metadata', 'name']}
+            fullWidth
+            required
+            placeholder="Select a sink"
+            showBadge
+            autocompleteFilter={autocompleteFilter}
+            onChange={onSinkChange}
+            autoSelect
+            selectedKey={values?.ref?.name}
+          />
+        </FormSection>
+      </ModalBody>
+      <ModalSubmitFooter
+        inProgress={isSubmitting}
+        submitText="Save"
+        submitDisabled={!dirty}
+        cancel={cancel}
+        errorMessage={status.error}
+      />
+    </form>
+  );
+};
+
+export default SinkPubsubModal;

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsub.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsub.spec.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Formik } from 'formik';
+import SinkPubsub from '../SinkPubsub';
+import {
+  EventTriggerObj,
+  EventSubscriptionObj,
+} from '../../../topology/__tests__/topology-knative-test-data';
+
+type SinkPubsubProps = React.ComponentProps<typeof SinkPubsub>;
+
+describe('SinkPubsub', () => {
+  let pubsubForm: ShallowWrapper<SinkPubsubProps>;
+  const formProps: SinkPubsubProps = {
+    source: EventSubscriptionObj,
+  };
+  pubsubForm = shallow(<SinkPubsub {...formProps} />);
+  it('should render Formik with proper initial values', () => {
+    const formikForm = pubsubForm.find(Formik);
+    expect(formikForm).toHaveLength(1);
+    expect(formikForm.get(0).props.initialValues.ref.name).toBe('overlayimage');
+  });
+
+  it('should render Formik child with proper props', () => {
+    const formikFormRender = pubsubForm.find(Formik).get(0).props;
+    expect(formikFormRender.children).toHaveLength(1);
+    expect(formikFormRender.children().props.resourceName).toBe('sub1');
+  });
+
+  it('should render Formik child with label move Subscription for Subscription', () => {
+    const formikFormRender = pubsubForm.find(Formik).get(0).props;
+    expect(formikFormRender.children).toHaveLength(1);
+    expect(formikFormRender.children().props.labelTitle).toBe('Move Subscription');
+  });
+
+  it('should render Formik child with label move Trigger for Trigger', () => {
+    const formPropsData = { source: EventTriggerObj };
+    pubsubForm = shallow(<SinkPubsub {...formPropsData} />);
+    const formikFormRender = pubsubForm.find(Formik).get(0).props;
+    expect(formikFormRender.children).toHaveLength(1);
+    expect(formikFormRender.children().props.labelTitle).toBe('Move Trigger');
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsubModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsubModal.spec.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import {
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import { ResourceDropdownField } from '@console/shared';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import SinkPubsubModal from '../SinkPubsubModal';
+import { ServiceModel } from '../../../models';
+
+type SinkPubsubModalProps = React.ComponentProps<typeof SinkPubsubModal>;
+
+describe('SinkPubsubModal Form', () => {
+  let formProps: SinkPubsubModalProps;
+  let sinkPubsubeModalWrapper: ShallowWrapper<SinkPubsubModalProps>;
+  const formValues = {
+    ref: {
+      apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+      kind: ServiceModel.kind,
+      name: 'event-greeter',
+    },
+  };
+  beforeEach(() => {
+    formProps = {
+      ...formikFormProps,
+      values: formValues,
+      resourceName: 'myapps',
+      initialValues: formValues,
+      resourceDropdown: [],
+      labelTitle: 'Move Subscription',
+    };
+    sinkPubsubeModalWrapper = shallow(<SinkPubsubModal {...formProps} />);
+  });
+
+  it('should render ModalTitle, body and footer', () => {
+    expect(sinkPubsubeModalWrapper.find(ModalTitle)).toHaveLength(1);
+    expect(sinkPubsubeModalWrapper.find(ModalBody)).toHaveLength(1);
+    expect(sinkPubsubeModalWrapper.find(ModalSubmitFooter)).toHaveLength(1);
+  });
+  it('should render ResourceDropdownField for service', () => {
+    const serviceDropDown = sinkPubsubeModalWrapper.find(ResourceDropdownField);
+    expect(serviceDropDown).toHaveLength(1);
+    expect(serviceDropDown.get(0).props.name).toBe('ref.name');
+    expect(serviceDropDown.get(0).props.selectedKey).toBe('event-greeter');
+  });
+
+  it('should call validateForm, setFieldValue onChange', () => {
+    const modal = sinkPubsubeModalWrapper.find(ResourceDropdownField);
+    modal.props().onChange('event-greeter');
+    expect(formProps.setFieldTouched).toHaveBeenCalled();
+    expect(formProps.setFieldValue).toHaveBeenCalled();
+    expect(formProps.validateForm).toHaveBeenCalled();
+  });
+
+  it('should call handleSubmit on form submit', () => {
+    sinkPubsubeModalWrapper.simulate('submit');
+    expect(formProps.handleSubmit).toHaveBeenCalled();
+  });
+
+  it('Save should be disabled if value is not changed', () => {
+    const modalSubmitFooter = sinkPubsubeModalWrapper.find(ModalSubmitFooter);
+    expect(modalSubmitFooter.get(0).props.submitDisabled).toBe(true);
+  });
+
+  it('Save should be enabled if value is  changed', () => {
+    const sinkValues = {
+      ref: {
+        apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+        kind: ServiceModel.kind,
+        name: 'event-greeter-new',
+      },
+    };
+    formProps = {
+      ...formProps,
+      values: {
+        ...formProps.values,
+        ...sinkValues,
+      },
+      resourceDropdown: [],
+      labelTitle: 'Move Subscription',
+    };
+    sinkPubsubeModalWrapper = shallow(<SinkPubsubModal {...formProps} />);
+    const modalSubmitFooter = sinkPubsubeModalWrapper.find(ModalSubmitFooter);
+    expect(modalSubmitFooter.get(0).props.submitDisabled).toBe(false);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSourceModal.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react';
-import * as fuzzy from 'fuzzysearch';
+import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
 import {
   ModalTitle,
   ModalBody,
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
-import { ResourceDropdownField } from '@console/shared';
-import { FirehoseResource } from '@console/internal/components/utils';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
+import { SinkUriResourcesGroup } from '../add/event-sources/SinkSection';
 
 export interface SinkSourceModalProps {
   resourceName: string;
-  resourceDropdown: FirehoseResource[];
-  labelTitle: string;
+  namespace: string;
   cancel?: () => void;
 }
 
@@ -21,66 +19,32 @@ type Props = FormikProps<FormikValues> & SinkSourceModalProps;
 
 const SinkSourceModal: React.FC<Props> = ({
   resourceName,
-  resourceDropdown,
-  labelTitle,
+  namespace,
   handleSubmit,
   cancel,
   isSubmitting,
   status,
-  setFieldValue,
-  setFieldTouched,
-  validateForm,
+  errors,
   values,
   initialValues,
 }) => {
-  const autocompleteFilter = (strText, item): boolean => fuzzy(strText, item?.props?.name);
-  const onSinkChange = React.useCallback(
-    (selectedValue, target) => {
-      const modelResource = target?.props?.model;
-      if (selectedValue) {
-        setFieldTouched('ref.name', true);
-        setFieldValue('ref.name', selectedValue);
-        if (modelResource) {
-          const { apiGroup, apiVersion, kind } = modelResource;
-          const sinkApiversion = `${apiGroup}/${apiVersion}`;
-          setFieldValue('ref.apiVersion', sinkApiversion);
-          setFieldTouched('ref.apiVersion', true);
-          setFieldValue('ref.kind', kind);
-          setFieldTouched('ref.kind', true);
-        }
-        validateForm();
-      }
-    },
-    [setFieldValue, setFieldTouched, validateForm],
-  );
-  const dirty = values?.ref?.name !== initialValues.ref.name;
+  const dirty =
+    values?.sink?.name !== initialValues.sink.name || values?.sink?.uri !== initialValues.sink.uri;
   return (
     <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
-      <ModalTitle>{labelTitle}</ModalTitle>
+      <ModalTitle>Move Sink</ModalTitle>
       <ModalBody>
         <p>
           Connects <strong>{resourceName}</strong> to
         </p>
         <FormSection fullWidth>
-          <ResourceDropdownField
-            name="ref.name"
-            resources={resourceDropdown}
-            dataSelector={['metadata', 'name']}
-            fullWidth
-            required
-            placeholder="Select a sink"
-            showBadge
-            autocompleteFilter={autocompleteFilter}
-            onChange={onSinkChange}
-            autoSelect
-            selectedKey={values?.ref?.name}
-          />
+          <SinkUriResourcesGroup namespace={namespace} isMoveSink />
         </FormSection>
       </ModalBody>
       <ModalSubmitFooter
         inProgress={isSubmitting}
         submitText="Save"
-        submitDisabled={!dirty}
+        submitDisabled={!dirty || !_.isEmpty(errors)}
         cancel={cancel}
         errorMessage={status.error}
       />

--- a/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSource.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSource.spec.tsx
@@ -2,42 +2,24 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import SinkSource from '../SinkSource';
-import {
-  sampleEventSourceSinkbinding,
-  EventSubscriptionObj,
-} from '../../../topology/__tests__/topology-knative-test-data';
+import { sampleEventSourceSinkbinding } from '../../../topology/__tests__/topology-knative-test-data';
 
 type SinkSourceProps = React.ComponentProps<typeof SinkSource>;
 
 describe('SinkSource', () => {
-  let eventSourceForm: ShallowWrapper<SinkSourceProps>;
   const formProps: SinkSourceProps = {
     source: sampleEventSourceSinkbinding.data[0],
   };
-  eventSourceForm = shallow(<SinkSource {...formProps} />);
+  const eventSourceForm: ShallowWrapper<SinkSourceProps> = shallow(<SinkSource {...formProps} />);
   it('should render Formik with proper initial values', () => {
     const formikForm = eventSourceForm.find(Formik);
     expect(formikForm).toHaveLength(1);
-    expect(formikForm.get(0).props.initialValues.ref.name).toBe('wss-event-display');
+    expect(formikForm.get(0).props.initialValues.sink.name).toBe('wss-event-display');
   });
 
   it('should render Formik child with proper props', () => {
     const formikFormRender = eventSourceForm.find(Formik).get(0).props;
     expect(formikFormRender.children).toHaveLength(1);
     expect(formikFormRender.children().props.resourceName).toBe('bind-wss');
-  });
-
-  it('should render Formik child with label move sink for EventSource', () => {
-    const formikFormRender = eventSourceForm.find(Formik).get(0).props;
-    expect(formikFormRender.children).toHaveLength(1);
-    expect(formikFormRender.children().props.labelTitle).toBe('Move Sink');
-  });
-
-  it('should render Formik child with label move Subscription for EventSource', () => {
-    const formPropsData = { source: EventSubscriptionObj };
-    eventSourceForm = shallow(<SinkSource {...formPropsData} />);
-    const formikFormRender = eventSourceForm.find(Formik).get(0).props;
-    expect(formikFormRender.children).toHaveLength(1);
-    expect(formikFormRender.children().props.labelTitle).toBe('Move Subscription');
   });
 });

--- a/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSourceModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/__tests__/SinkSourceModal.spec.tsx
@@ -5,10 +5,10 @@ import {
   ModalBody,
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
-import { ResourceDropdownField } from '@console/shared';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 import SinkSourceModal from '../SinkSourceModal';
 import { ServiceModel } from '../../../models';
+import { SinkUriResourcesGroup } from '../../add/event-sources/SinkSection';
 
 type SinkSourceModalProps = React.ComponentProps<typeof SinkSourceModal>;
 
@@ -16,7 +16,7 @@ describe('SinkSourceModal Form', () => {
   let formProps: SinkSourceModalProps;
   let sinkSourceModalWrapper: ShallowWrapper<SinkSourceModalProps>;
   const formValues = {
-    ref: {
+    sink: {
       apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
       kind: ServiceModel.kind,
       name: 'event-greeter',
@@ -26,10 +26,9 @@ describe('SinkSourceModal Form', () => {
     formProps = {
       ...formikFormProps,
       values: formValues,
-      resourceName: 'myappes',
+      resourceName: 'myapps',
+      namespace: 'myapp',
       initialValues: formValues,
-      resourceDropdown: [],
-      labelTitle: 'Move Sink',
     };
     sinkSourceModalWrapper = shallow(<SinkSourceModal {...formProps} />);
   });
@@ -39,19 +38,11 @@ describe('SinkSourceModal Form', () => {
     expect(sinkSourceModalWrapper.find(ModalBody)).toHaveLength(1);
     expect(sinkSourceModalWrapper.find(ModalSubmitFooter)).toHaveLength(1);
   });
-  it('should render ResourceDropdownField for service', () => {
-    const serviceDropDown = sinkSourceModalWrapper.find(ResourceDropdownField);
-    expect(serviceDropDown).toHaveLength(1);
-    expect(serviceDropDown.get(0).props.name).toBe('ref.name');
-    expect(serviceDropDown.get(0).props.selectedKey).toBe('event-greeter');
-  });
 
-  it('should call validateForm, setFieldValue onChange', () => {
-    const modal = sinkSourceModalWrapper.find(ResourceDropdownField);
-    modal.props().onChange('event-greeter');
-    expect(formProps.setFieldTouched).toHaveBeenCalled();
-    expect(formProps.setFieldValue).toHaveBeenCalled();
-    expect(formProps.validateForm).toHaveBeenCalled();
+  it('should render SinkUriResourcesGroup', () => {
+    const serviceDropDown = sinkSourceModalWrapper.find(SinkUriResourcesGroup);
+    expect(serviceDropDown).toHaveLength(1);
+    expect(serviceDropDown.get(0).props.namespace).toBe('myapp');
   });
 
   it('should call handleSubmit on form submit', () => {
@@ -66,7 +57,7 @@ describe('SinkSourceModal Form', () => {
 
   it('Save should be enabled if value is  changed', () => {
     const sinkValues = {
-      ref: {
+      sink: {
         apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
         kind: ServiceModel.kind,
         name: 'event-greeter-new',
@@ -78,8 +69,6 @@ describe('SinkSourceModal Form', () => {
         ...formProps.values,
         ...sinkValues,
       },
-      resourceDropdown: [],
-      labelTitle: 'Move Sink',
     };
     sinkSourceModalWrapper = shallow(<SinkSourceModal {...formProps} />);
     const modalSubmitFooter = sinkSourceModalWrapper.find(ModalSubmitFooter);

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -5,6 +5,7 @@ import { EditApplication } from '@console/dev-console/src/actions/modify-applica
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { setTrafficDistribution } from '../actions/traffic-splitting';
 import { setSinkSource } from '../actions/sink-source';
+import { setSinkPubsub } from '../actions/sink-pubsub';
 import {
   ServiceModel,
   EventingSubscriptionModel,
@@ -31,7 +32,7 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
       referenceForModel(resourceKind) === referenceForModel(EventingSubscriptionModel) ||
       referenceForModel(resourceKind) === referenceForModel(EventingTriggerModel)
     ) {
-      menuActions.push(setSinkSource);
+      menuActions.push(setSinkPubsub);
     }
     if (referenceForModel(resourceKind) === referenceForModel(EventingBrokerModel)) {
       menuActions.push(addTrigger);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4292

Task: https://issues.redhat.com/browse/ODC-4383

**Analysis / Root cause**: 
Move connector/Sink for eventSource and it's connector currently just show dropdown to select ksvc/channel/broker , would need to have URI as well  as we have in Create EventSources

**Solution Description**: 
- Made `Move Connector` to be `Move Sink` as they serve same purpose
- Supports text uri as  well in Move Sink modal along with other resoources
- PreSelection of URI if connected to URI or Resources

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
- Move Sink Resource
![image](https://user-images.githubusercontent.com/5129024/88385246-9def9200-cdcb-11ea-9d47-fc57bd54b3d3.png)

- Move Sink URI
![image](https://user-images.githubusercontent.com/5129024/88385307-b5c71600-cdcb-11ea-97f8-68a2f9791b16.png)

- Move Sink in-context
![image](https://user-images.githubusercontent.com/5129024/88385372-d42d1180-cdcb-11ea-81ab-6011c21138d1.png)

- Error State (In case of no Resources
![image](https://user-images.githubusercontent.com/5129024/88385496-135b6280-cdcc-11ea-8645-0b9bba9a82f7.png)

- Error state (in case of invalid URI)
![image](https://user-images.githubusercontent.com/5129024/88385647-5cabb200-cdcc-11ea-9f4f-5882a3b15b20.png)


@openshift/team-devconsole-ux 

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/5129024/88386147-6eda2000-cdcd-11ea-9372-bd0bbdf5b364.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
