### PR TITLE
fixes issue with ksvc decorator not showing base route

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -45,7 +45,6 @@ import { errorModal } from '@console/internal/components/modals';
 import { KebabAction } from '@console/dev-console/src/utils/add-resources-menu-utils';
 import { FLAG_KNATIVE_EVENTING, CAMEL_SOURCE_INTEGRATION } from '../const';
 import { KnativeItem } from '../utils/get-knative-resources';
-import { Traffic as TrafficData } from '../types';
 import {
   KNATIVE_GROUP_NODE_HEIGHT,
   KNATIVE_GROUP_NODE_PADDING,
@@ -138,17 +137,6 @@ export const getKnNodeModelProps = (type: string) => {
  */
 export const getEventSourceStatus = ({ FLAGS }: RootState): boolean =>
   FLAGS.get(FLAG_KNATIVE_EVENTING);
-
-/**
- * get knative service routes url based on the revision's traffic
- */
-export const getKnativeServiceRoutesURL = (ksvc: K8sResourceKind): string => {
-  if (!ksvc.status) {
-    return '';
-  }
-  const maximumTraffic: TrafficData = _.maxBy(ksvc.status.traffic as TrafficData[], 'percent');
-  return maximumTraffic?.url || ksvc.status.url;
-};
 
 /**
  * fetch the parent resource from a resource
@@ -671,7 +659,7 @@ export const createTopologyServiceNodeData = (
     resource,
     resources: { ...svcRes },
     data: {
-      url: getKnativeServiceRoutesURL(knativeSvc),
+      url: knativeSvc.status?.url || '',
       kind: referenceFor(knativeSvc),
       editURL: annotations['app.openshift.io/edit-url'],
       vcsURI: annotations['app.openshift.io/vcs-uri'],


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4253

**Analysis / Root cause**: 
On OpenShift 4.5 deploying a Knative Service with traffic distribution will show an invalid URL(route of revision) instead of base route for KSVC. The URL should be the same as advised by Knative Service, but now it's the same as one of the revisions of traffic distribution.

**Solution Description**: 
Fixed the route decorator on topology for KSVC to redirect to base URL 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
