### PR TITLE
guard against replacing history URL with same value

### DIFF
--- a/frontend/public/components/utils/router.ts
+++ b/frontend/public/components/utils/router.ts
@@ -36,21 +36,33 @@ export const getQueryArgument = (arg: string) =>
 
 export const setQueryArgument = (k: string, v: string) => {
   const params = new URLSearchParams(window.location.search);
-  params.set(k, v);
-  const url = new URL(window.location.href);
-  history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  if (params.get(k) !== v) {
+    params.set(k, v);
+    const url = new URL(window.location.href);
+    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  }
 };
 
 export const setAllQueryArguments = (newParams: { [k: string]: string }) => {
   const params = new URLSearchParams();
-  _.each(newParams, (v, k) => params.set(k, v));
-  const url = new URL(window.location.href);
-  history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  let update = false;
+  _.each(newParams, (v, k) => {
+    if (params.get(k) !== v) {
+      update = true;
+      params.set(k, v);
+    }
+  });
+  if (update) {
+    const url = new URL(window.location.href);
+    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  }
 };
 
 export const removeQueryArgument = (k: string) => {
   const params = new URLSearchParams(window.location.search);
-  params.delete(k);
-  const url = new URL(window.location.href);
-  history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  if (params.has(k)) {
+    params.delete(k);
+    const url = new URL(window.location.href);
+    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  }
 };


### PR DESCRIPTION
This change compares the new params (or param to be removed) against its current value before calling `history.replace`. If the param value won't change, `history.replace` won't be called. This prevents re-rendering needlessly from `react-router` which notifies of URL changes.

This currently happens in topology where clicking on the open area is supposed to cause a deselection. A deselection results in removing a specific query param. While it's possible to guard against this in topology, updating these utils to perform such checks ensures other areas also benefit.

cc @sahil143 