### PR TITLE
Support Schema in the YAMLEditorField

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
@@ -1,0 +1,16 @@
+.osc-yaml-editor {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: row;
+
+  &__editor {
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
+  }
+  &__sidebar {
+    display: flex;
+    flex: 1 0 0;
+    margin-left: 20px;
+  }
+}

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
@@ -1,21 +1,59 @@
 import * as React from 'react';
+import { isEmpty } from 'lodash';
 import { FormikValues, useField, useFormikContext } from 'formik';
+import { Button } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { AsyncComponent } from '@console/internal/components/utils';
+import { definitionFor } from '@console/internal/module/k8s';
 import { YAMLEditorFieldProps } from './field-types';
 
-const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name, onSave }) => {
+import './YAMLEditorField.scss';
+
+const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name, onSave, schemaModel }) => {
   const [field] = useField(name);
   const { setFieldValue } = useFormikContext<FormikValues>();
 
+  const [sidebarOpen, setSidebarOpen] = React.useState<boolean>(true);
+  const definition = schemaModel ? definitionFor(schemaModel) : { properties: [] };
+  const showSchema = definition && !isEmpty(definition.properties);
+
   return (
-    <AsyncComponent
-      loader={() => import('../editor/YAMLEditor').then((c) => c.default)}
-      value={field.value}
-      minHeight="200px"
-      onChange={(yaml: string) => setFieldValue(name, yaml)}
-      onSave={onSave}
-      showShortcuts
-    />
+    <div className="osc-yaml-editor">
+      <div className="osc-yaml-editor__editor">
+        <AsyncComponent
+          loader={() => import('../editor/YAMLEditor').then((c) => c.default)}
+          value={field.value}
+          minHeight="200px"
+          onChange={(yaml: string) => setFieldValue(name, yaml)}
+          onSave={onSave}
+          showShortcuts
+          toolbarLinks={
+            !sidebarOpen &&
+            showSchema && [
+              <Button isInline variant="link" onClick={() => setSidebarOpen(true)}>
+                <InfoCircleIcon className="co-icon-space-r co-p-has-sidebar__sidebar-link-icon" />
+                View sidebar
+              </Button>,
+            ]
+          }
+        />
+      </div>
+      {sidebarOpen && showSchema && (
+        <div className="osc-yaml-editor__sidebar">
+          <AsyncComponent
+            loader={() =>
+              import('@console/internal/components/sidebars/resource-sidebar').then(
+                (c) => c.ResourceSidebar,
+              )
+            }
+            kindObj={schemaModel}
+            showSidebar={sidebarOpen}
+            toggleSidebar={() => setSidebarOpen(!sidebarOpen)}
+            showSchema={showSchema}
+          />
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -1,5 +1,5 @@
 import { ValidatedOptions, TextInputTypes, gridItemSpanValueShape } from '@patternfly/react-core';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 
 export interface FieldProps {
   name: string;
@@ -86,6 +86,7 @@ export interface MultiColumnFieldProps extends FieldProps {
 export interface YAMLEditorFieldProps extends FieldProps {
   onChange?: (value: string) => void;
   onSave?: () => void;
+  schemaModel?: K8sKind;
 }
 
 export interface NameValuePair {


### PR DESCRIPTION
**Analysis / Root cause**: 
Our Formik YAMLEditorField lacked the ability to show schema. So when used in the new Formik variation of the yaml/form switcher, it wouldn't show the schema for the editing.

**Solution Description**: 
I wrote a separate component that deals with adding a wrapper around it. It's another component to call. There is no usage implementation part of this PR.

/cc @rohitkrai03 