### PR TITLE
Query Browser: Highlight matching strings in autocomplete suggestions

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -255,6 +255,10 @@ $monitoring-line-height: 18px;
   font-size: ($font-size-base - 1);
 }
 
+.query-browser__autocomplete-match {
+  font-weight: var(--pf-global--FontWeight--bold);
+}
+
 .query-browser__clear-icon {
   font-size: 18px !important;
   padding: 4px !important;


### PR DESCRIPTION
This is only for the query text input, not for the metrics dropdown list.

![screenshot](https://user-images.githubusercontent.com/460802/88504818-bc929a80-d010-11ea-8af5-0a68f41b3075.png)
