### PR TITLE
Bug 1860736: Remove duplicate lines from Installed Operators list page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -542,7 +542,7 @@ export const NamespacedClusterServiceVersionList: React.SFC<ClusterServiceVersio
       }
       const csv = source as ClusterServiceVersionKind;
       if (allNamespaceActive) {
-        return !isCopiedCSV(csv, kind) || isStandardCSV(csv);
+        return !isCopiedCSV(csv, kind) && isStandardCSV(csv);
       }
       return isStandardCSV(csv);
     });


### PR DESCRIPTION
The logic is a bit more complex but should be right now. 
Was thinking to make it more readable by having it like:

```js
if (isCopiedCSV(csv, kind)) {
  return false;
}
return isStandardCSV(csv);
```  

/assign @spadgett 