### PR TITLE
Bug 1859518: kubevirt: fix editing of pvc datavolumes from different namespaces

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -58,7 +58,9 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
       .map(({ dataVolumeWrapper: dvw }) => dvw.getName()),
   );
 
-  const [namespace, setNamespace] = React.useState<string>(vmNamespace);
+  const [namespace, setNamespace] = React.useState<string>(
+    new DataVolumeWrapper(dataVolume).getPesistentVolumeClaimNamespace() || vmNamespace,
+  );
 
   const resources = [
     {

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
@@ -91,7 +91,9 @@ const DiskModalFirehose: React.FC<DiskModalFirehoseProps> = (props) => {
   const vmName = getName(vmLikeEntity);
   const vmNamespace = getNamespace(vmLikeEntity);
 
-  const [namespace, setNamespace] = React.useState<string>(vmNamespace);
+  const [namespace, setNamespace] = React.useState<string>(
+    new DataVolumeWrapper(props.dataVolume).getPesistentVolumeClaimNamespace() || vmNamespace,
+  );
 
   const resources = [
     {


### PR DESCRIPTION
@yaacov I noticed this bug when reviewing https://github.com/openshift/console/pull/5977 