### PR TITLE
Fix Size dropdown help text margin in Pvc forms

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -304,11 +304,9 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = (props) => {
               dropdownUnits={dropdownUnits}
               describedBy="request-size-help"
               inputID="request-size-input"
+              helpText="Ensure your PVC size covers the requirements of the uncompressed image and any other
+              space requirements"
             />
-            <p className="help-block" id="request-size-help">
-              Ensure your PVC size covers the requirements of the uncompressed image and any other
-              space requirements
-            </p>
           </SplitItem>
         </Split>
       </div>

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -224,10 +224,8 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
         dropdownUnits={dropdownUnits}
         describedBy="request-size-help"
         inputID="request-size-input"
+        helpText="Desired storage capacity"
       />
-      <p className="help-block" id="request-size-help">
-        Desired storage capacity
-      </p>
       <Checkbox
         label="Use label selectors to request storage"
         onChange={handleUseSelector}

--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -19,7 +19,7 @@ export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
   };
 
   render() {
-    const { describedBy, name, inputID } = this.props;
+    const { describedBy, name, inputID, helpText } = this.props;
     const inputName = `${name}Value`;
     const dropdownName = `${name}Unit`;
     return (
@@ -49,6 +49,11 @@ export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
             ariaLabel={`Number of ${this.props.dropdownUnits[this.props.defaultRequestSizeUnit]}`}
           />
         </div>
+        {helpText && (
+          <p className="help-block" id={describedBy}>
+            {helpText}
+          </p>
+        )}
       </div>
     );
   }
@@ -67,4 +72,5 @@ export type RequestSizeInputProps = {
   minValue?: number;
   inputClassName?: string;
   inputID?: string;
+  helpText?: string;
 };


### PR DESCRIPTION
Margin is too big
<img width="642" alt="Screen Shot 2020-07-27 at 12 59 58" src="https://user-images.githubusercontent.com/24938324/88529843-3888e480-d009-11ea-946b-091da391bf65.png">
