### PR TITLE
Add create CR button on CSV details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -15,7 +15,14 @@ import {
   Popover,
   CardTitle,
 } from '@patternfly/react-core';
-import { ALL_NAMESPACES_KEY, Status, WarningStatus, getNamespace, getUID } from '@console/shared';
+import {
+  ALL_NAMESPACES_KEY,
+  Status,
+  WarningStatus,
+  getNamespace,
+  getUID,
+  StatusIconAndText,
+} from '@console/shared';
 import {
   DetailsPage,
   Table,
@@ -29,11 +36,13 @@ import {
   modelFor,
   referenceForModel,
   referenceFor,
+  groupVersionFor,
   GroupVersionKind,
   K8sKind,
   k8sKill,
   k8sPatch,
   k8sGet,
+  K8sResourceCommon,
 } from '@console/internal/module/k8s';
 import { ResourceEventStream } from '@console/internal/components/events';
 import { Conditions } from '@console/internal/components/conditions';
@@ -46,6 +55,7 @@ import {
   Timestamp,
   SectionHeading,
   ResourceSummary,
+  ResourceStatus,
   ScrollToTopOnMount,
   AsyncComponent,
   ExternalLink,
@@ -58,6 +68,7 @@ import {
   resourceObjPath,
   KebabAction,
 } from '@console/internal/components/utils';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { useAccessReview } from '@console/internal/components/utils/rbac';
 import { RootState } from '@console/internal/redux';
 import {
@@ -90,8 +101,10 @@ import {
   upgradeRequiresApproval,
   UpgradeApprovalLink,
 } from './subscription';
+import { RedExclamationCircleIcon } from '@console/shared/src/components/status/icons';
 import { ClusterServiceVersionLogo, referenceForProvidedAPI, providedAPIsFor } from './index';
 import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumbs';
+import { CreateInitializationResourceButton } from './operator-install-page';
 
 const clusterServiceVersionStateToProps = (state: RootState): ClusterServiceVersionStateProps => {
   return {
@@ -694,20 +707,28 @@ export const MarkdownView = (props: {
 };
 
 export const CRDCard: React.SFC<CRDCardProps> = (props) => {
-  const { csv, crd, canCreate } = props;
+  const { csv, crd, canCreate, required = false } = props;
   const reference = referenceForProvidedAPI(crd);
   const model = modelFor(reference);
   const createRoute = () =>
     `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${reference}/~new`;
+
   return (
     <Card>
       <CardTitle>
-        <ResourceLink
-          kind={referenceForProvidedAPI(crd)}
-          title={crd.name}
-          linkTo={false}
-          displayName={crd.displayName || crd.kind}
-        />
+        <span className="co-resource-item">
+          <ResourceLink
+            kind={referenceForProvidedAPI(crd)}
+            title={crd.name}
+            linkTo={false}
+            displayName={crd.displayName || crd.kind}
+          />
+          {required && (
+            <ResourceStatus badgeAlt>
+              <StatusIconAndText icon={<RedExclamationCircleIcon />} title="Required" />
+            </ResourceStatus>
+          )}
+        </span>
       </CardTitle>
       <CardBody>
         <MarkdownView content={crd.description} truncateContent />
@@ -761,6 +782,53 @@ export const CRDCardRow = connect(crdCardRowStateToProps)((props: CRDCardRowProp
   );
 });
 
+const InitializationResourceAlert: React.SFC<InitializationResourceAlertProps> = (props) => {
+  const { initializationResource, csv } = props;
+
+  const initializationResourceKind = initializationResource?.kind;
+  const { group: initializationResourceGroup } = groupVersionFor(
+    initializationResource?.apiVersion,
+  );
+  const model = modelFor(referenceFor(initializationResource));
+
+  // Check if the CR is already present - only checks for the specific name/ns in the initialization-resource
+  const [customResource, customResourceLoaded] = useK8sGet<K8sResourceCommon>(
+    model,
+    initializationResource?.metadata.name,
+    model?.namespaced ? initializationResource?.metadata.namespace || csv.metadata.namespace : null,
+  );
+  const canCreateCustomResource = useAccessReview({
+    group: initializationResourceGroup,
+    resource: model?.plural,
+    namespace: model?.namespaced
+      ? initializationResource?.metadata.namespace || csv.metadata.namespace
+      : null,
+    verb: 'create',
+  });
+
+  if (!customResource && customResourceLoaded && canCreateCustomResource) {
+    return (
+      <Alert
+        isInline
+        className="co-alert"
+        variant="warning"
+        title={`${initializationResourceKind} Required`}
+      >
+        <p>Create a {initializationResourceKind} instance to use this operator.</p>
+        <CreateInitializationResourceButton
+          obj={props.csv}
+          targetNamespace={
+            model?.namespaced
+              ? initializationResource?.metadata.namespace || csv.metadata?.namespace
+              : null
+          }
+        />
+      </Alert>
+    );
+  }
+  return null;
+};
+
 export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetailsProps> = (
   props,
 ) => {
@@ -768,7 +836,18 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
   const {
     'marketplace.openshift.io/support-workflow': marketplaceSupportWorkflow,
     'olm.targetNamespaces': olmTargetNamespaces = '',
+    'operatorframework.io/initialization-resource': initializationResourceJSON,
   } = metadata.annotations || {};
+
+  let initializationResource = null;
+  if (initializationResourceJSON) {
+    try {
+      initializationResource = JSON.parse(initializationResourceJSON);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error.message);
+    }
+  }
 
   return (
     <>
@@ -784,6 +863,12 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
                   className="co-alert"
                   variant="danger"
                   title={`${status.phase}: ${status.message}`}
+                />
+              )}
+              {initializationResource && (
+                <InitializationResourceAlert
+                  initializationResource={initializationResource}
+                  csv={props.obj}
                 />
               )}
               <SectionHeading text="Provided APIs" />
@@ -1085,6 +1170,7 @@ export type CRDCardProps = {
   crd: CRDDescription | APIServiceDefinition;
   csv: ClusterServiceVersionKind;
   canCreate: boolean;
+  required?: boolean;
 };
 
 export type CRDCardRowProps = {
@@ -1147,6 +1233,11 @@ export type CSVSubscriptionProps = {
 
 type ClusterServiceVersionStateProps = {
   activeNamespace?: string;
+};
+
+type InitializationResourceAlertProps = {
+  csv: ClusterServiceVersionKind;
+  initializationResource: K8sResourceCommon;
 };
 
 type Header = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -24,6 +24,7 @@ import {
   k8sGet,
   k8sListPartialMetadata,
   kindForReference,
+  referenceFor,
   referenceForModel,
 } from '@console/internal/module/k8s';
 import { RadioGroup, RadioInput } from '@console/internal/components/radio';
@@ -97,6 +98,26 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     currentCSVDesc.annotations?.['operatorframework.io/suggested-namespace'];
   const operatorRequestsMonitoring =
     currentCSVDesc.annotations?.['operatorframework.io/cluster-monitoring'] === 'true';
+  const initializationResourceJSON =
+    currentCSVDesc.annotations?.['operatorframework.io/initialization-resource'];
+
+  let initializationResourceReference = null;
+  if (initializationResourceJSON) {
+    let initializationResource = null;
+    try {
+      initializationResource = JSON.parse(initializationResourceJSON);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        err.message || 'Operator Hub Subscribe: Could not get initialization resource.',
+      );
+    }
+
+    initializationResourceReference = initializationResource
+      ? referenceFor(initializationResource)
+      : null;
+  }
+
   const internalObjects = getInternalObjects(currentCSVDesc, 'annotations');
 
   const globalNS =
@@ -665,6 +686,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                     canCreate={false}
                     crd={api}
                     csv={null}
+                    required={referenceForProvidedAPI(api) === initializationResourceReference}
                   />
                 ))
               )}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -18,12 +18,7 @@ import {
   ResourceStatus,
   resourcePathFromModel,
 } from '@console/internal/components/utils';
-import {
-  groupVersionFor,
-  k8sPatch,
-  referenceForModel,
-  referenceForGroupVersionKind,
-} from '@console/internal/module/k8s';
+import { k8sPatch, modelFor, referenceForModel, referenceFor } from '@console/internal/module/k8s';
 import { errorModal } from '@console/internal/components/modals';
 import {
   ClusterServiceVersionModel,
@@ -45,7 +40,9 @@ import {
 } from '@console/shared/src/components/status/icons';
 import { InstallPlanPreview } from './install-plan';
 
-const getCRDFromObject = (obj: ClusterServiceVersionKind | InstallPlanKind | SubscriptionKind) => {
+const getInitializationResourceJSON = (
+  obj: ClusterServiceVersionKind | InstallPlanKind | SubscriptionKind,
+) => {
   return obj?.metadata?.annotations?.['operatorframework.io/initialization-resource'];
 };
 
@@ -68,14 +65,14 @@ const ViewInstalledOperatorsButton: React.FC<ViewOperatorButtonProps> = ({ names
 );
 
 const InstallFailedMessage: React.FC<InstallFailedMessageProps> = ({ namespace, csvName, obj }) => {
-  const crdMessage = getCRDFromObject(obj)
+  const initializationResourceMessage = getInitializationResourceJSON(obj)
     ? "The required custom resource can be created in the Operator's details view."
     : '';
 
   return (
     <>
       <h2 className="co-clusterserviceversion-install__heading">Operator installation failed</h2>
-      <p>The operator did not install successfully. {crdMessage}</p>
+      <p>The operator did not install successfully. {initializationResourceMessage}</p>
       <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
         <Link to={resourcePathFromModel(ClusterServiceVersionModel, csvName, namespace)}>
           <Button variant="primary">View Error</Button>
@@ -118,28 +115,33 @@ const InstallNeedsApprovalMessage: React.FC<InstallNeedsApprovalMessageProps> = 
   </>
 );
 
-const CreateCRDButton: React.FC<CRDButtonProps> = ({ obj, disabled }) => {
-  if (!getCRDFromObject(obj)) {
+export const CreateInitializationResourceButton: React.FC<InitializationResourceButtonProps> = ({
+  obj,
+  disabled,
+  targetNamespace,
+}) => {
+  if (!getInitializationResourceJSON(obj)) {
     return null;
   }
-  let cr = null;
+  let initializationResource = null;
   try {
-    cr = JSON.parse(getCRDFromObject(obj));
+    initializationResource = JSON.parse(getInitializationResourceJSON(obj));
   } catch (error) {
     const errorMsg = error.message;
     errorModal({ errorMsg });
   }
-  const crNamespace = cr?.[0]?.metadata.namespace;
-  const apiVersion = cr?.[0]?.apiVersion;
-  const kind = cr?.[0]?.kind;
-  const { group, version } = groupVersionFor(apiVersion);
-  const reference = referenceForGroupVersionKind(group)(version)(kind);
+  const reference = referenceFor(initializationResource);
+  const model = modelFor(reference);
+  const initializationResourceNamespace = model?.namespaced
+    ? initializationResource?.metadata?.namespace || targetNamespace
+    : null;
+  const kind = initializationResource?.kind;
   return (
     <Link
       to={`${resourcePathFromModel(
         ClusterServiceVersionModel,
         obj.metadata.name,
-        crNamespace,
+        initializationResourceNamespace,
       )}/${reference}/~new`}
     >
       <Button isDisabled={disabled} variant="primary">
@@ -149,24 +151,30 @@ const CreateCRDButton: React.FC<CRDButtonProps> = ({ obj, disabled }) => {
   );
 };
 
-const InstallPageCRDRequiredMessage: React.FC<InstallCRDMessageProps> = ({ obj }) => {
-  if (!getCRDFromObject(obj)) {
+const InitializationResourceRequiredMessage: React.FC<InitializationResourceRequiredMessageProps> = ({
+  obj,
+}) => {
+  if (!getInitializationResourceJSON(obj)) {
     return null;
   }
-  let cr = null;
+  let initializationResource = null;
   try {
-    cr = JSON.parse(getCRDFromObject(obj));
+    initializationResource = JSON.parse(getInitializationResourceJSON(obj));
   } catch (error) {
     const errorMsg = error.message;
     errorModal({ errorMsg });
   }
-  const crdKind = cr?.[0]?.kind;
-  const crNamespace = cr?.[0]?.metadata?.namespace;
+  const initializationResourceKind = initializationResource?.kind;
+  const initializationResourceNamespace = initializationResource?.metadata?.namespace;
   const description = obj?.metadata?.annotations?.description;
   return (
     <div className="co-clusterserviceversion__box">
       <span className="co-resource-item">
-        <ResourceLink kind={crdKind} name={crdKind} namepace={crNamespace} />
+        <ResourceLink
+          kind={initializationResourceKind}
+          name={initializationResourceKind}
+          namepace={initializationResourceNamespace}
+        />
         <ResourceStatus badgeAlt>
           <StatusIconAndText icon={<RedExclamationCircleIcon />} title="Required" />
         </ResourceStatus>
@@ -181,7 +189,7 @@ const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
   csvName,
   obj,
 }) => {
-  const crdMessage = getCRDFromObject(obj)
+  const initializationResourceMessage = getInitializationResourceJSON(obj)
     ? 'The operator has installed successfully. Create the required custom resource to be able to use this operator.'
     : '';
   return (
@@ -189,15 +197,15 @@ const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
       <h2 className="co-clusterserviceversion-install__heading">
         Installed operator - ready for use
       </h2>
-      <span>{crdMessage}</span>
-      <InstallPageCRDRequiredMessage obj={obj} />
+      <span>{initializationResourceMessage}</span>
+      <InitializationResourceRequiredMessage obj={obj} />
       <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
-        {!getCRDFromObject(obj) && (
+        {!getInitializationResourceJSON(obj) && (
           <Link to={resourcePathFromModel(ClusterServiceVersionModel, csvName, namespace)}>
             <Button variant="primary">View Operator</Button>
           </Link>
         )}
-        <CreateCRDButton obj={obj} />
+        <CreateInitializationResourceButton obj={obj} targetNamespace={namespace} />
         <ViewInstalledOperatorsButton namespace={namespace} />
       </ActionGroup>
     </>
@@ -206,10 +214,10 @@ const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
 const InstallingMessage: React.FC<InstallingMessageProps> = ({ namespace, obj }) => {
   const reason = (obj as ClusterServiceVersionKind)?.status?.reason || '';
   const message = (obj as ClusterServiceVersionKind)?.status?.message || '';
-  const crdMessage = getCRDFromObject(obj)
+  const initializationResourceMessage = getInitializationResourceJSON(obj)
     ? 'Once the operator is installed the required custom resource will be available for creation.'
     : '';
-  const installMessage = `The operator is being installed. This may take a few minutes. ${crdMessage}`;
+  const installMessage = `The operator is being installed. This may take a few minutes. ${initializationResourceMessage}`;
   return (
     <>
       <h2 className="co-clusterserviceversion-install__heading">Installing operator</h2>
@@ -219,9 +227,11 @@ const InstallingMessage: React.FC<InstallingMessageProps> = ({ namespace, obj })
         </div>
       )}
       <p>{installMessage}</p>
-      <InstallPageCRDRequiredMessage obj={obj} />
+      <InitializationResourceRequiredMessage obj={obj} />
       <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
-        {getCRDFromObject(obj) && <CreateCRDButton obj={obj} disabled />}
+        {getInitializationResourceJSON(obj) && (
+          <CreateInitializationResourceButton obj={obj} targetNamespace={namespace} disabled />
+        )}
         <ViewInstalledOperatorsButton namespace={namespace} />
       </ActionGroup>
     </>
@@ -438,12 +448,13 @@ type InstallFailedMessageProps = {
   obj: ClusterServiceVersionKind | InstallPlanKind;
   csvName: string;
 };
-type InstallCRDMessageProps = {
+type InitializationResourceRequiredMessageProps = {
   obj: ClusterServiceVersionKind | InstallPlanKind;
 };
-type CRDButtonProps = {
+type InitializationResourceButtonProps = {
   obj: ClusterServiceVersionKind | InstallPlanKind | SubscriptionKind;
   disabled?: boolean;
+  targetNamespace: string;
 };
 type ViewOperatorButtonProps = {
   namespace: string;


### PR DESCRIPTION
This adds a create CR button to the Operator details page for operators that have required CRs. 
It also adds the `Required` badge to the subscribe page so users know it is needed.

Design doc: http://openshift.github.io/openshift-origin-design/designs/administrator/olm/operand-creation-at-operator-install/

![Screenshot_2020-07-27 Operator Installation · OKD](https://user-images.githubusercontent.com/18728857/88587173-c1f0e480-d012-11ea-997e-1d0ace1b66bb.png)
![Screenshot_2020-07-28 portworx-operator v1 3 0 · Details · OKD](https://user-images.githubusercontent.com/18728857/88689041-41d08a80-d0b7-11ea-9b13-34b25cd64136.png)

