### PR TITLE
Bug 1859256: Fix blank page/error on ImageManifestVulnPage

### DIFF
--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -302,16 +302,14 @@ export const ImageManifestVulnList: React.FC<ImageManifestVulnListProps> = (prop
 };
 
 export const ImageManifestVulnPage: React.FC<ImageManifestVulnPageProps> = (props) => {
-  const namespace = props.match.params?.ns;
-
   return (
     <MultiListPage
       {...props}
-      namespace={namespace}
+      namespace={props.namespace}
       resources={[
         {
           kind: referenceForModel(ImageManifestVulnModel),
-          namespace,
+          namespace: props.namespace,
           namespaced: true,
           prop: 'imageManifestVuln',
         },


### PR DESCRIPTION
There was no check for an undefined props.match in ImageManifestVulnPage, leading to a blank page/error message. Adding a check seems to fix the issue.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1859256.