### PR TITLE
Bug 1850513: Disable stop action in VM menu for in process CDI imports

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -102,9 +102,14 @@ export const menuActionStart = (
   };
 };
 
-const menuActionStop = (kindObj: K8sKind, vm: VMKind, { vmi }: ActionArgs): KebabOption => {
+const menuActionStop = (
+  kindObj: K8sKind,
+  vm: VMKind,
+  { vmi, vmStatusBundle }: ActionArgs,
+): KebabOption => {
   const title = 'Stop Virtual Machine';
   return {
+    isDisabled: vmStatusBundle?.status?.isPending(),
     hidden: !isVMExpectedRunning(vm),
     label: title,
     callback: () =>


### PR DESCRIPTION
Backend does not support stopping VMs that are still importing. This PR disables the stop action during the import process.