### PR TITLE
Update upstream-community-operators image for test

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -28,7 +28,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     'ConfigMap',
   ]);
   const jaegerOperatorName = 'jaeger-operator';
-  const jaegerName = 'my-jaeger';
+  const jaegerName = 'jaeger-all-in-one-inmemory';
   const customProviderUID = 'providerType-console-e-2-e-operators';
 
   const catalogNamespace = _.get(browser.params, 'globalCatalogNamespace', 'openshift-marketplace');
@@ -46,7 +46,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     spec: {
       sourceType: 'grpc',
       image:
-        'quay.io/operator-framework/upstream-community-operators@sha256:5ae28f6de8affdb2a2119565ea950a2a777280b159f03b6ddddf104740571e25',
+        'quay.io/operator-framework/upstream-community-operators@sha256:10121664b6ab87b0bd36b0f0011bf0f9b0dd55b41080878058f3c1052e869ed5',
       displayName: 'Console E2E Operators',
       publisher: 'Red Hat, Inc',
     },
@@ -83,7 +83,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     [
       `kubectl delete catalogsource -n ${catalogNamespace} ${catalogSource.metadata.name}`,
       `kubectl delete subscription -n ${globalOperatorsNamespace} jaeger`,
-      `kubectl delete clusterserviceversion -n ${globalOperatorsNamespace} jaeger-operator.v1.8.2`,
+      `kubectl delete clusterserviceversion -n ${globalOperatorsNamespace} jaeger-operator.v1.18.1`,
     ].forEach((cmd) => _.attempt(() => execSync(cmd)));
   });
 
@@ -101,7 +101,9 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     await operatorHubView.operatorModalInstallBtn.click();
     await operatorHubView.createSubscriptionFormLoaded();
 
-    expect(operatorHubView.createSubscriptionFormName.getText()).toEqual('Jaeger Tracing');
+    expect(operatorHubView.createSubscriptionFormName.getText()).toEqual(
+      'Community Jaeger Operator',
+    );
   });
 
   it('selects all namespaces for Operator subscription', async () => {
@@ -129,7 +131,10 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     await operatorHubView.viewInstalledOperator();
     await crudView.isLoaded();
 
-    await browser.wait(until.visibilityOf(operatorView.rowForOperator('Jaeger Tracing')), 60000);
+    await browser.wait(
+      until.visibilityOf(operatorView.rowForOperator('Community Jaeger Operator')),
+      60000,
+    );
   });
 
   it('creates Operator `Deployment`', async () => {
@@ -150,7 +155,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   it('displays metadata about Operator in the "Overview" section', async () => {
     await browser.get(`${appHost}/k8s/ns/${testName}/clusterserviceversions`);
     await crudView.isLoaded();
-    await operatorView.operatorNameLink('Jaeger Tracing').click();
+    await operatorView.operatorNameLink('Community Jaeger Operator').click();
     await browser.wait(until.presenceOf($('.loading-box__loaded')));
 
     expect($('.co-m-pane__details').isDisplayed()).toBe(true);
@@ -228,8 +233,10 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     await browser.wait(until.visibilityOf($('.co-catalog-install-modal')));
     await element(by.cssContainingText('#confirm-action', 'Uninstall')).click();
     await crudView.isLoaded();
-    await browser.wait(until.invisibilityOf(operatorView.rowForOperator('Jaeger Tracing')));
+    await browser.wait(
+      until.invisibilityOf(operatorView.rowForOperator('Community Jaeger Operator')),
+    );
 
-    expect(operatorView.rowForOperator('Jaeger Tracing').isPresent()).toBe(false);
+    expect(operatorView.rowForOperator('Community Jaeger Operator').isPresent()).toBe(false);
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/operator-hub.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/operator-hub.scenario.ts
@@ -19,7 +19,7 @@ describe('Interacting with OperatorHub', () => {
     spec: {
       sourceType: 'grpc',
       image:
-        'quay.io/operator-framework/upstream-community-operators@sha256:5ae28f6de8affdb2a2119565ea950a2a777280b159f03b6ddddf104740571e25',
+        'quay.io/operator-framework/upstream-community-operators@sha256:10121664b6ab87b0bd36b0f0011bf0f9b0dd55b41080878058f3c1052e869ed5',
       displayName: 'Console E2E Operators',
       publisher: 'Red Hat, Inc',
     },
@@ -31,6 +31,7 @@ describe('Interacting with OperatorHub', () => {
       (function checkForPackages() {
         const output = execSync(
           `kubectl get packagemanifests -n ${testName} --selector=catalog=console-e2e -o json`,
+          { maxBuffer: 500 * 1024 * 1024 },
         );
         if (
           JSON.parse(output.toString('utf-8')).items.find(

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -30,7 +30,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     spec: {
       sourceType: 'grpc',
       image:
-        'quay.io/operator-framework/upstream-community-operators@sha256:5ae28f6de8affdb2a2119565ea950a2a777280b159f03b6ddddf104740571e25',
+        'quay.io/operator-framework/upstream-community-operators@sha256:10121664b6ab87b0bd36b0f0011bf0f9b0dd55b41080878058f3c1052e869ed5',
       displayName: 'Console E2E Operators',
       publisher: 'Red Hat, Inc',
     },
@@ -65,7 +65,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     [
       `kubectl delete catalogsource -n ${testName} ${catalogSource.metadata.name}`,
       `kubectl delete subscription -n ${testName} prometheus`,
-      `kubectl delete clusterserviceversion -n ${testName} prometheusoperator.0.27.0`,
+      `kubectl delete clusterserviceversion -n ${testName} prometheusoperator.0.37.0`,
     ].forEach((cmd) => _.attempt(() => execSync(cmd)));
   });
 
@@ -78,8 +78,13 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     await catalogView.categoryTabsPresent();
     await catalogView.categoryTabs.get(0).click();
     await catalogPageView.clickFilterCheckbox(customProviderUID);
-    await catalogPageView.catalogTileFor('Prometheus Operator').click();
-    await browser.wait(until.visibilityOf(operatorHubView.operatorModal));
+    await $$('.co-catalog-page__filter')
+      .get(0)
+      .$('input')
+      .sendKeys('prometheus');
+    await browser.wait(until.visibilityOf(catalogPageView.catalogTileByID(prometheusTileID)));
+    await catalogPageView.catalogTileByID(prometheusTileID).click();
+    await browser.wait(until.visibilityOf(operatorHubView.operatorModalInstallBtn));
     await operatorHubView.operatorModalInstallBtn.click();
     await operatorHubView.createSubscriptionFormLoaded();
 
@@ -226,7 +231,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     await crudView.isLoaded();
     await catalogPageView.clickFilterCheckbox(customProviderUID);
     await catalogPageView.clickFilterCheckbox('installState-installed');
-    await catalogPageView.catalogTileFor('Prometheus Operator').click();
+    await catalogPageView.catalogTileByID(prometheusTileID).click();
     await operatorHubView.operatorModalIsLoaded();
 
     expect(operatorHubView.operatorModalUninstallBtn.isDisplayed()).toBe(true);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -78,10 +78,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     await catalogView.categoryTabsPresent();
     await catalogView.categoryTabs.get(0).click();
     await catalogPageView.clickFilterCheckbox(customProviderUID);
-    await $$('.co-catalog-page__filter')
-      .get(0)
-      .$('input')
-      .sendKeys('prometheus');
+    await catalogPageView.filterTextbox.sendKeys('prometheus');
     await browser.wait(until.visibilityOf(catalogPageView.catalogTileByID(prometheusTileID)));
     await catalogPageView.catalogTileByID(prometheusTileID).click();
     await browser.wait(until.visibilityOf(operatorHubView.operatorModalInstallBtn));


### PR DESCRIPTION
The existing image does not have some of the newer apis required by OLM.

This now points to quay.io/operator-framework/upstream-community-operators:221f356, which was just rebuilt off of the latest operator-registry base image.