### PR TITLE
Bug 1844944: No default storage class in add disk 

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
@@ -5,15 +5,15 @@ import { Alert, AlertVariant } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import { Firehose, FirehoseResult, resourcePath } from '@console/internal/components/utils';
 import { StorageClassResourceKind } from '@console/internal/module/k8s';
-import { createLookup, getAnnotations, getName } from '@console/shared/src';
+import { createLookup, getName } from '@console/shared/src';
 import { PersistentVolumeClaimModel, StorageClassModel } from '@console/internal/models';
 import { VMWizardProps, VMWizardStorage } from '../../types';
 import { getStorages } from '../../selectors/selectors';
 import { iGetCommonData } from '../../selectors/immutable/selectors';
+import { getGefaultStorageClass } from '../../../../selectors/config-map/sc-defaults';
 import { CombinedDisk } from '../../../../k8s/wrapper/vm/combined-disk';
 import { VolumeWrapper } from '../../../../k8s/wrapper/vm/volume-wrapper';
 import { getLoadedData } from '../../../../utils';
-import { DEFAULT_SC_ANNOTATION } from '../../../../constants/sc';
 
 import './storage-review.scss';
 
@@ -81,9 +81,7 @@ const StorageReviewFirehose: React.FC<StorageReviewFirehoseProps> = ({
       combinedDisk.getSource()?.requiresStorageClass() && !combinedDisk.getStorageClassName(),
   );
 
-  const defaultStorageClass = getLoadedData(storageClasses, []).find(
-    (sc) => getAnnotations(sc, {})[DEFAULT_SC_ANNOTATION] === 'true',
-  );
+  const defaultStorageClass = getGefaultStorageClass(getLoadedData(storageClasses, []));
 
   const rows = combinedDisks.map((combinedDisk) => {
     return [

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -333,6 +333,8 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     }
   };
 
+  const isStorageClassDataLoading = !isLoaded(storageClasses) || !isLoaded(_storageClassConfigMap);
+
   return (
     <div className="modal-content">
       <ModalTitle>
@@ -531,7 +533,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
             <K8sResourceSelectRow
               key="storage-class"
               id={asId('storage-class')}
-              isDisabled={isDisabled('storageClass') || !isLoaded(storageClasses)}
+              isDisabled={isDisabled('storageClass') || isStorageClassDataLoading}
               name={storageClassName}
               data={storageClasses}
               model={StorageClassModel}
@@ -559,7 +561,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                     onChange={(vMode) => setVolumeMode(VolumeMode.fromString(vMode))}
                     value={asFormSelectValue(volumeMode?.getValue())}
                     id={asId('volume-mode')}
-                    isDisabled={isDisabled('volumeMode')}
+                    isDisabled={isDisabled('volumeMode') || isStorageClassDataLoading}
                   >
                     <FormSelectPlaceholderOption
                       isDisabled={inProgress}
@@ -585,7 +587,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                     onChange={(aMode) => setAccessMode(AccessMode.fromString(aMode))}
                     value={asFormSelectValue(accessMode?.getValue())}
                     id={asId('access-mode')}
-                    isDisabled={isDisabled('accessMode')}
+                    isDisabled={isDisabled('accessMode') || isStorageClassDataLoading}
                   >
                     <FormSelectPlaceholderOption
                       isDisabled={inProgress}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -160,20 +160,29 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
   );
 
   React.useEffect(() => {
-    if (!isEditing && isLoaded(_storageClassConfigMap)) {
+    if (!isEditing && isLoaded(_storageClassConfigMap) && isLoaded(storageClasses)) {
+      let defaultStorageClass = null;
+
+      if (!storageClassName) {
+        defaultStorageClass = getGefaultStorageClass(getLoadedData(storageClasses, []));
+
+        if (defaultStorageClass) {
+          setStorageClassName(getName(defaultStorageClass) || '');
+        }
+      }
+
       if (source.requiresVolumeMode()) {
-        setVolumeMode(getDefaultSCVolumeMode(storageClassConfigMap));
+        setVolumeMode(
+          getDefaultSCVolumeMode(storageClassConfigMap, storageClassName || defaultStorageClass),
+        );
       }
       if (source.requiresAccessModes()) {
-        setAccessMode(getDefaultSCAccessModes(storageClassConfigMap)[0]);
-      }
-    }
-
-    if (!isEditing && !storageClassName && isLoaded(storageClasses)) {
-      const defaultStorageClass = getGefaultStorageClass(getLoadedData(storageClasses, []));
-
-      if (defaultStorageClass) {
-        setStorageClassName(getName(defaultStorageClass) || '');
+        setAccessMode(
+          getDefaultSCAccessModes(
+            storageClassConfigMap,
+            storageClassName || defaultStorageClass,
+          )[0],
+        );
       }
     }
 

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -19,7 +19,7 @@ import {
   PersistentVolumeClaimModel,
   StorageClassModel,
 } from '@console/internal/models';
-import { getName } from '@console/shared/src';
+import { getName, getAnnotations } from '@console/shared/src';
 import { getLoadedData, isLoaded, prefixedID, resolveDataVolumeName } from '../../../utils';
 import { validateDisk } from '../../../utils/validations/vm';
 import { isValidationError } from '../../../utils/validations/common';
@@ -46,6 +46,7 @@ import { DiskWrapper } from '../../../k8s/wrapper/vm/disk-wrapper';
 import { DataVolumeWrapper } from '../../../k8s/wrapper/vm/data-volume-wrapper';
 import { VolumeWrapper } from '../../../k8s/wrapper/vm/volume-wrapper';
 import { AccessMode, DiskBus, DiskType, VolumeMode } from '../../../constants/vm/storage';
+import { DEFAULT_SC_ANNOTATION } from '../../../constants/sc';
 import { getPvcStorageSize } from '../../../selectors/pvc/selectors';
 import { K8sResourceSelectRow } from '../../form/k8s-resource-select-row';
 import { SizeUnitFormRow } from '../../form/size-unit-form-row';
@@ -140,6 +141,17 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
   const [storageClassName, setStorageClassName] = React.useState<string>(
     combinedDisk.getStorageClassName() || '',
   );
+
+  React.useEffect(() => {
+    if (!isEditing) {
+      const defaultStorageClass = getLoadedData(storageClasses, []).find(
+        (sc) => getAnnotations(sc, {})[DEFAULT_SC_ANNOTATION] === 'true',
+      );
+
+      setStorageClassName(getName(defaultStorageClass) || '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded(storageClasses)]);
 
   const [size, setSize] = React.useState<string>(
     combinedDiskSize ? `${combinedDiskSize.value}` : '',

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -531,7 +531,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
             <K8sResourceSelectRow
               key="storage-class"
               id={asId('storage-class')}
-              isDisabled={isDisabled('storageClass')}
+              isDisabled={isDisabled('storageClass') || !isLoaded(storageClasses)}
               name={storageClassName}
               data={storageClasses}
               model={StorageClassModel}

--- a/frontend/packages/kubevirt-plugin/src/selectors/config-map/sc-defaults.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/config-map/sc-defaults.ts
@@ -1,6 +1,8 @@
 import * as _ from 'lodash';
-import { ConfigMapKind } from '@console/internal/module/k8s';
+import { ConfigMapKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { AccessMode, VolumeMode } from '../../constants/vm/storage';
+import { getAnnotations } from '@console/shared';
+import { DEFAULT_SC_ANNOTATION } from '../../constants/sc';
 
 const getSCConfigMapAttribute = (
   storageClassConfigMap: ConfigMapKind,
@@ -48,3 +50,6 @@ export const getDefaultSCAccessModes = (
 
   return accessMode ? [accessMode] : [AccessMode.READ_WRITE_ONCE];
 };
+
+export const getGefaultStorageClass = (storageClasses: K8sResourceKind[]): K8sResourceKind =>
+  (storageClasses || []).find((sc) => getAnnotations(sc, {})[DEFAULT_SC_ANNOTATION] === 'true');


### PR DESCRIPTION
Fix: No default storage class in add disk modal

Screenshots:
Add a new disk, has the default storageClass pre selected:
![screenshot-localhost_9000-2020 08 05-15_10_13](https://user-images.githubusercontent.com/2181522/89411551-4851a880-d72e-11ea-94bc-7b8527985d31.png)

Edit a disk with no storageClass, the missing storageClass is not fixed:
![screenshot-localhost_9000-2020 08 05-15_10_38](https://user-images.githubusercontent.com/2181522/89411622-66b7a400-d72e-11ea-9352-515575f8b3c9.png)
