### PR TITLE
Monitoring: Add breadcrumbs for Silences and fix for Rule breadcrumbs

### DIFF
--- a/frontend/public/components/monitoring/utils.ts
+++ b/frontend/public/components/monitoring/utils.ts
@@ -80,8 +80,9 @@ export const rulesToProps = (state: RootState, perspective?: string) => {
 export const silencesToProps = ({ UI }) => UI.getIn(['monitoring', 'silences']) || {};
 
 export const silenceParamToProps = (state: RootState, { match }) => {
+  const namespace = match.params?.ns;
   const { data: silences, loaded, loadError }: Silences = silencesToProps(state);
   const { loaded: alertsLoaded }: Alerts = alertsToProps(state);
   const silence = _.find(silences, { id: _.get(match, 'params.id') });
-  return { alertsLoaded, loaded, loadError, silence, silences };
+  return { alertsLoaded, loaded, loadError, namespace, silence, silences };
 };


### PR DESCRIPTION
- Add breadcrumbs to Silence details page
- Fix Rule page's parent breadcrumb link and text in admin perspective
- Just use the `ns` URL parameter to determine which perspective we are
in, which reduces the number of properties being passed around. This is
actually the same logic anyway because `activePerspective` was
determined from the `ns` param.
- Don't bother setting the final breadcrumb path, since it is not used
by `BreadCrumbs` anyway.