### PR TITLE
Bug 1855378:  display Created At value using <Timestamp> if valid date

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { PropertiesSidePanel, PropertyItem } from '@patternfly/react-catalog-view-extension';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
-import { ExternalLink, HintBlock } from '@console/internal/components/utils';
+import { ExternalLink, HintBlock, Timestamp } from '@console/internal/components/utils';
 import { RH_OPERATOR_SUPPORT_POLICY_LINK } from '@console/shared';
 import { MarkdownView } from '../clusterserviceversion';
 import { OperatorHubItem } from './index';
@@ -73,6 +73,7 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
     validSubscription,
   } = item;
   const notAvailable = <span className="properties-side-panel-pf-property-label">N/A</span>;
+  const created = Date.parse(createdAt) ? <Timestamp timestamp={createdAt} /> : createdAt;
 
   const getHintBlock = () => {
     if (installed) {
@@ -164,7 +165,7 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
               )}
               <PropertyItem label="Repository" value={repository || notAvailable} />
               <PropertyItem label="Container Image" value={containerImage || notAvailable} />
-              <PropertyItem label="Created At" value={createdAt || notAvailable} />
+              <PropertyItem label="Created At" value={created || notAvailable} />
               <PropertyItem
                 label="Support"
                 value={


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1855378

After:
<img width="425" alt="Screen Shot 2020-07-28 at 10 23 12 AM" src="https://user-images.githubusercontent.com/895728/88680468-8875b300-d0be-11ea-9909-6da2aed86943.png">
time is not included
<img width="331" alt="Screen Shot 2020-07-28 at 10 23 52 AM" src="https://user-images.githubusercontent.com/895728/88681415-8c560500-d0bf-11ea-82c3-6a50dad2856d.png">
date format is invalid, so just show the invalid string
<img width="370" alt="Screen Shot 2020-07-28 at 10 24 03 AM" src="https://user-images.githubusercontent.com/895728/88681493-a1cb2f00-d0bf-11ea-820d-ddf09efef9c1.png">
`createdAt` not provided
<img width="309" alt="Screen Shot 2020-07-28 at 10 23 32 AM" src="https://user-images.githubusercontent.com/895728/88681547-b27ba500-d0bf-11ea-8f43-3d3e4cfacd87.png">

