### PR TITLE
Bug 1871085: Wait for the first ImageStream update before creating the Deployment

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Formik } from 'formik';
+import { Formik, FormikHelpers } from 'formik';
 import { connect } from 'react-redux';
 import { ALL_APPLICATIONS_KEY } from '@console/shared';
 import { history } from '@console/internal/components/utils';
@@ -139,7 +139,10 @@ const DeployImage: React.FC<Props> = ({
     healthChecks: healthChecksProbeInitialData,
   };
 
-  const handleSubmit = (values, actions) => {
+  const handleSubmit = (
+    values: DeployImageFormData,
+    helpers: FormikHelpers<DeployImageFormData>,
+  ) => {
     const {
       project: { name: projectName },
     } = values;
@@ -160,14 +163,12 @@ const DeployImage: React.FC<Props> = ({
         .catch(() => {});
     }
 
-    resourceActions
+    return resourceActions
       .then(() => {
-        actions.setSubmitting(false);
         history.push(`/topology/ns/${projectName}`);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
-        actions.setStatus({ submitError: err.message });
+        helpers.setStatus({ submitError: err.message });
       });
   };
 

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
 import { FormFooter } from '@console/shared/src/components/form-utils';
+import { usePreventDataLossLock } from '@console/internal/components/utils';
 import { Form } from '@patternfly/react-core';
 import { DeployImageFormProps } from './import-types';
 import ImageSearchSection from './image-search/ImageSearchSection';
@@ -19,26 +20,30 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
   isSubmitting,
   dirty,
   projects,
-}) => (
-  <Form className="co-deploy-image" data-test-id="deploy-image-form" onSubmit={handleSubmit}>
-    <ImageSearchSection />
-    <IconSection />
-    <AppSection
-      project={values.project}
-      noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
-    />
-    <ResourceSection />
-    <AdvancedSection values={values} />
-    <FormFooter
-      handleReset={handleReset}
-      errorMessage={status && status.submitError}
-      isSubmitting={isSubmitting}
-      submitLabel="Create"
-      sticky
-      disableSubmit={!dirty || !_.isEmpty(errors)}
-      resetLabel="Cancel"
-    />
-  </Form>
-);
+}) => {
+  usePreventDataLossLock(isSubmitting);
+
+  return (
+    <Form className="co-deploy-image" data-test-id="deploy-image-form" onSubmit={handleSubmit}>
+      <ImageSearchSection />
+      <IconSection />
+      <AppSection
+        project={values.project}
+        noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
+      />
+      <ResourceSection />
+      <AdvancedSection values={values} />
+      <FormFooter
+        handleReset={handleReset}
+        errorMessage={status && status.submitError}
+        isSubmitting={isSubmitting}
+        submitLabel="Create"
+        sticky
+        disableSubmit={!dirty || !_.isEmpty(errors) || isSubmitting}
+        resetLabel="Cancel"
+      />
+    </Form>
+  );
+};
 
 export default DeployImageForm;

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -7,7 +7,13 @@ import {
   RouteModel,
   RoleBindingModel,
 } from '@console/internal/models';
-import { k8sCreate, K8sResourceKind, K8sVerb, k8sUpdate } from '@console/internal/module/k8s';
+import {
+  K8sResourceKind,
+  K8sVerb,
+  k8sCreate,
+  k8sUpdate,
+  k8sWaitForUpdate,
+} from '@console/internal/module/k8s';
 import { ServiceModel as KnServiceModel } from '@console/knative-plugin';
 import { getKnativeServiceDepResource } from '@console/knative-plugin/src/utils/create-knative-utils';
 import { getRandomChars } from '@console/shared/src/utils';
@@ -23,6 +29,9 @@ import { getProbesData } from '../health-checks/create-health-checks-probe-utils
 import { RegistryType, getRuntime } from '../../utils/imagestream-utils';
 import { AppResources } from '../edit-application/edit-application-types';
 import { DeployImageFormData, Resources } from './import-types';
+
+const WAIT_FOR_IMAGESTREAM_UPDATE_TIMEOUT = 5000;
+const WAIT_FOR_IMAGESTREAM_GENERATION = 2;
 
 export const createSystemImagePullerRoleBinding = (
   formData: DeployImageFormData,
@@ -52,7 +61,7 @@ export const createSystemImagePullerRoleBinding = (
   return k8sCreate(RoleBindingModel, roleBinding, dryRun ? dryRunOpt : {});
 };
 
-export const createOrUpdateImageStream = (
+export const createOrUpdateImageStream = async (
   formData: DeployImageFormData,
   dryRun: boolean,
   originalImageStream?: K8sResourceKind,
@@ -93,11 +102,25 @@ export const createOrUpdateImageStream = (
       ],
     },
   };
-  const imageStream = mergeData(originalImageStream, newImageStream);
 
-  return verb === 'update'
-    ? k8sUpdate(ImageStreamModel, imageStream)
-    : k8sCreate(ImageStreamModel, newImageStream, dryRun ? dryRunOpt : {});
+  if (verb === 'update') {
+    const mergedImageStream = mergeData(originalImageStream, newImageStream);
+    return k8sUpdate(ImageStreamModel, mergedImageStream);
+  }
+  const createdImageStream = await k8sCreate(
+    ImageStreamModel,
+    newImageStream,
+    dryRun ? dryRunOpt : {},
+  );
+  if (dryRun) {
+    return createdImageStream;
+  }
+  return k8sWaitForUpdate(
+    ImageStreamModel,
+    createdImageStream,
+    (imageStream) => imageStream.metadata.generation >= WAIT_FOR_IMAGESTREAM_GENERATION,
+    WAIT_FOR_IMAGESTREAM_UPDATE_TIMEOUT,
+  ).catch(() => createdImageStream);
 };
 
 const getMetadata = (formData: DeployImageFormData) => {

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -24,6 +24,7 @@ export * from './number-spinner';
 export * from './cloud-provider';
 export * from './documentation';
 export * from './router';
+export * from './router-hooks';
 export * from './link';
 export * from './alerts';
 export * from './async';

--- a/frontend/public/components/utils/router-hooks.ts
+++ b/frontend/public/components/utils/router-hooks.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+/**
+ * Hook which adds and remove a beforeunload listener depending on the lock flag.
+ */
+export const usePreventDataLossLock = (lock: boolean) => {
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Chrome requires returnValue to be set
+      // from https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
+      e.returnValue = '';
+    };
+    if (lock) {
+      window.addEventListener('beforeunload', onBeforeUnload);
+    }
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, [lock]);
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3175

**Analysis / Root cause**: 
When the user creates a Deployment based on a container image it creates an ImageStream, a Deployment one some other resources. The Deployment creates a ReplicaSet which creates a Pod which could not deploy until the ImageStream receive information about the latest image tag / hash. So the first set of pods (one by default) fails to start.

After the ImageStream was updated with the latest available image tags / hashes it triggers a Deployment rollout. The rollout creates a new ReplicaSet which creates a set of pods (one by default) which now can fetch the container Image successfully.

**Solution Description**: 
We decided to wait for the first ImageStream "update" for new Deployments in the web console. This update happens normally within a few seconds after an ImageStream is created. (It fetches the latest tags from Docker hub or Quay..., it does not download any image at this time.) 

We interrupt the waiting process after 5 seconds. If the ImageStream is not updated at that time, two ReplicaSets and Pods would be create.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux @andrewballantyne 

Before:
![odc-3175-before webm](https://user-images.githubusercontent.com/139310/88682234-bd036200-d0f2-11ea-9bd0-900a236a6ec4.gif)

After:
![odc-3175-after webm](https://user-images.githubusercontent.com/139310/88682244-bf65bc00-d0f2-11ea-87c2-d55183dcb946.gif)

When trying to close the current browser tab (this is a browser message, text could not be changed):
![odc-3175-try-to-close-tab webm](https://user-images.githubusercontent.com/139310/88698850-e29a6680-d106-11ea-9fc2-f7121c877ecf.gif)

**Unit test coverage report**: 
None change here

**Test setup:**
No new test added yet

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge