### PR TITLE
Continue to show Workers progress bar if not 100% when CV is updated

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     browser: true,
     es6: true,
     jasmine: true,
+    jest: true,
   },
   extends: [
     'eslint:recommended',

--- a/frontend/__tests__/components/cluster-settings.spec.tsx
+++ b/frontend/__tests__/components/cluster-settings.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { shallow, mount, ShallowWrapper } from 'enzyme';
 
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { clusterVersionProps } from '../../__mocks__/clusterVersinMock';
 import {
   ClusterSettingsPage,
@@ -17,12 +18,17 @@ import { GlobalConfigPage } from '../../public/components/cluster-settings/globa
 import { Firehose, HorizontalNav, ResourceLink, Timestamp } from '../../public/components/utils';
 import { AddCircleOIcon } from '@patternfly/react-icons';
 
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
 describe('Cluster Settings page', () => {
   let wrapper: ShallowWrapper<any>;
   const match = { url: '/settings/cluster', params: {}, isExact: true, path: '/settings/cluster' };
 
   beforeEach(() => {
     wrapper = shallow(<ClusterSettingsPage match={match} />);
+    (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
   });
 
   it('should render ClusterSettingsPage component', () => {

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -184,6 +184,15 @@ $co-external-link-padding-right: 15px;
   margin-bottom: 20px;
 }
 
+// PatternFly lacks the ability to have a plain button variant without padding
+.co-help-popover-button {
+  padding: 0 !important;
+
+  &--space-l {
+    margin-left: 0.35em;
+  }
+}
+
 .co-help-text {
   color: $color-pf-black-600;
 }


### PR DESCRIPTION


<img width="800" alt="88720100-51b99000-d0f2-11ea-92ea-b96cbad83f1f copy" src="https://user-images.githubusercontent.com/895728/88813351-d229d080-d186-11ea-9e04-84835d0ffa2b.png">

Video of switch:  https://youtu.be/KglxwTcOeYI

Bonus fix: update Worker Nodes help icon and popover
