### PR TITLE
Rename non-standard annotation to non-standalone

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -78,7 +78,7 @@ import {
   PackageManifestKind,
   SubscriptionKind,
 } from '../types';
-import { operatorTypeAnnotation, nonStandardAnnotationValue } from '../const';
+import { operatorTypeAnnotation, nonStandaloneAnnotationValue } from '../const';
 import { subscriptionForCSV, getSubscriptionStatus } from '../status/csv-status';
 import { getInternalObjects, isInternalObject } from '../utils';
 import { ProvidedAPIsPage, ProvidedAPIPage } from './operand';
@@ -524,9 +524,9 @@ export const NamespacedClusterServiceVersionList: React.SFC<ClusterServiceVersio
     );
   };
 
-  const isStandardCSV = (operator: ClusterServiceVersionKind) => {
+  const isStandaloneCSV = (operator: ClusterServiceVersionKind) => {
     return (
-      operator.metadata.annotations?.[operatorTypeAnnotation] !== nonStandardAnnotationValue ||
+      operator.metadata.annotations?.[operatorTypeAnnotation] !== nonStandaloneAnnotationValue ||
       operator.status?.phase === ClusterServiceVersionPhase.CSVPhaseFailed
     );
   };
@@ -542,9 +542,9 @@ export const NamespacedClusterServiceVersionList: React.SFC<ClusterServiceVersio
       }
       const csv = source as ClusterServiceVersionKind;
       if (allNamespaceActive) {
-        return !isCopiedCSV(csv, kind) && isStandardCSV(csv);
+        return !isCopiedCSV(csv, kind) && isStandaloneCSV(csv);
       }
-      return isStandardCSV(csv);
+      return isStandaloneCSV(csv);
     });
   };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -17,7 +17,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { fromRequirements } from '@console/internal/module/k8s/selector';
 import { PackageManifestModel, OperatorGroupModel, SubscriptionModel } from '../../models';
 import { PackageManifestKind, OperatorGroupKind, SubscriptionKind } from '../../types';
-import { operatorTypeAnnotation, nonStandardAnnotationValue } from '../../const';
+import { operatorTypeAnnotation, nonStandaloneAnnotationValue } from '../../const';
 import { iconFor } from '..';
 import { installedFor, subscriptionFor } from '../operator-group';
 import { getOperatorProviderType } from './operator-hub-utils';
@@ -64,7 +64,7 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
         const { currentCSVDesc } = channels.find((ch) => ch.name === defaultChannel);
         // if CSV contains annotation for a non-standalone operator, filter it out
         return !(
-          currentCSVDesc.annotations?.[operatorTypeAnnotation] === nonStandardAnnotationValue
+          currentCSVDesc.annotations?.[operatorTypeAnnotation] === nonStandaloneAnnotationValue
         );
       })
       .map(

--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -3,4 +3,4 @@ export enum Flags {
 }
 
 export const operatorTypeAnnotation = 'operators.operatorframework.io/operator-type';
-export const nonStandardAnnotationValue = 'non-standard';
+export const nonStandaloneAnnotationValue = 'non-standalone';


### PR DESCRIPTION
There was a mistype in the https://github.com/openshift/console/pull/6020 where the the annotation value should be `non-standalone` instead of `non-standard`.

/assign @spadgett 