### PR TITLE
Fix Context Providers extension not rendering multiple providers

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -174,14 +174,18 @@ class App_ extends React.PureComponent {
       </>
     );
 
+    const GlobalProvider = contextProviderExtensions.reduce(
+      (AccProvider, curProvider) => ({ children }) => (
+        <EnhancedProvider {...curProvider.properties}>
+          <AccProvider>{children}</AccProvider>
+        </EnhancedProvider>
+      ),
+      ({ children }) => <>{children}</>,
+    );
+
     return (
       <DetectPerspective>
-        {contextProviderExtensions.reduce(
-          (children, provider) => (
-            <EnhancedProvider {...provider.properties}>{children}</EnhancedProvider>
-          ),
-          content,
-        )}
+        <GlobalProvider>{content}</GlobalProvider>
       </DetectPerspective>
     );
   }


### PR DESCRIPTION
Reducing the Context Providers extensions array inside the JSX seems to mess up the order of the hooks which React expects. Creating one merged global provider seems to fix the issue.

can you take a look @rawagner @christianvogt @spadgett @rohitkrai03 @sahil143 