### PR TITLE
Hide namespace for pipeline, runs, and resources for admin and dev views in a project context

### DIFF
--- a/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesHeader.tsx
@@ -14,6 +14,7 @@ const PipelineResourcesHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Type',

--- a/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
@@ -21,7 +21,7 @@ const PipelineResourcesRow: RowFunction<PipelineResourceKind> = ({ obj, index, k
           data-test-id={obj.metadata.name}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]} columnId="namespace">
+      <TableData className={tableColumnClasses[1]} columnID="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
@@ -21,7 +21,7 @@ const PipelineResourcesRow: RowFunction<PipelineResourceKind> = ({ obj, index, k
           data-test-id={obj.metadata.name}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      <TableData className={tableColumnClasses[1]} columnId="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunHeader.tsx
@@ -14,6 +14,7 @@ const PipelineRunHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',

--- a/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -26,7 +26,7 @@ const PipelineRunRow: RowFunction<PipelineRun> = ({ obj, index, key, style }) =>
           data-test-id={obj.metadata.name}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]} columnId="namespace">
+      <TableData className={tableColumnClasses[1]} columnID="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -26,7 +26,7 @@ const PipelineRunRow: RowFunction<PipelineRun> = ({ obj, index, key, style }) =>
           data-test-id={obj.metadata.name}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      <TableData className={tableColumnClasses[1]} columnId="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineHeader.tsx
@@ -14,6 +14,7 @@ const PipelineHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Last Run',

--- a/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
@@ -30,7 +30,7 @@ const PipelineRow: RowFunction<Pipeline> = ({ obj, index, key, style }) => {
           title={obj.metadata.name}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]} columnId="namespace">
+      <TableData className={tableColumnClasses[1]} columnID="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
@@ -30,7 +30,7 @@ const PipelineRow: RowFunction<Pipeline> = ({ obj, index, key, style }) => {
           title={obj.metadata.name}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      <TableData className={tableColumnClasses[1]} columnId="namespace">
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>


### PR DESCRIPTION
Addresses: https://issues.redhat.com/browse/CONSOLE-2186 
Design: https://docs.google.com/document/d/1Xmbhm1JBVLvSUM2Daegt0XmzwJ0HVasE49C9owRFX6M/edit#heading=h.4p9jvwsgseiy

On hold until col management pr is merged: https://github.com/openshift/console/pull/5799

![Screen Shot 2020-07-29 at 1 13 10 PM](https://user-images.githubusercontent.com/35978579/88833992-2a6dcc00-d1a1-11ea-857b-fc7af4e592ec.png)
![pipelinenamespace](https://user-images.githubusercontent.com/35978579/88834006-2f328000-d1a1-11ea-9d4a-8f40d7ce1af1.gif)

cc: @gdoyle1 @serenamarie125 @beanh66 