### PR TITLE
Add uid property to all extension instances

### DIFF
--- a/frontend/packages/console-app/src/components/detect-perspective/PerspectiveDetector.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/PerspectiveDetector.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useExtensions, isPerspective } from '@console/plugin-sdk';
+import { useExtensions, Perspective, isPerspective } from '@console/plugin-sdk';
 
 type PerspectiveDetectorProps = {
   setActivePerspective: (string) => void;
@@ -7,7 +7,7 @@ type PerspectiveDetectorProps = {
 
 const PerspectiveDetector: React.FC<PerspectiveDetectorProps> = ({ setActivePerspective }) => {
   let detectedPerspective: string;
-  const perspectiveExtensions = useExtensions(isPerspective);
+  const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
   const defaultPerspective = perspectiveExtensions.find((p) => p.properties.default);
   const detectors = perspectiveExtensions.filter((p) => p.properties.usePerspectiveDetection);
   const detectionResults = detectors.map((p) => p.properties.usePerspectiveDetection());

--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import * as Combinatorics from 'js-combinatorics';
 import { PodModel } from '@console/internal/models';
-import { Extension, ActivePlugin, ModelDefinition } from '../typings';
+import { Extension, ModelDefinition } from '../typings';
 import {
   sanitizeExtension,
   augmentExtension,
@@ -100,25 +100,44 @@ describe('sanitizeExtension', () => {
 });
 
 describe('augmentExtension', () => {
-  const testPlugin: ActivePlugin = Object.freeze({
-    name: 'Test',
-    extensions: [],
-  });
-
-  it('adds the plugin property', () => {
-    const testExtension: Extension = { type: 'Foo/Bar', properties: {} };
-
-    expect(augmentExtension(testExtension, testPlugin)).toEqual({
-      type: 'Foo/Bar',
+  it('adds computed properties to extension', () => {
+    expect(
+      augmentExtension(
+        {
+          type: 'Foo',
+          properties: {},
+        },
+        'Test',
+        0,
+      ),
+    ).toEqual({
+      type: 'Foo',
       properties: {},
-      plugin: testPlugin.name,
+      pluginName: 'Test',
+      uid: 'Test[0]',
+    });
+
+    expect(
+      augmentExtension(
+        {
+          type: 'Bar',
+          properties: {},
+        },
+        'Test',
+        1,
+      ),
+    ).toEqual({
+      type: 'Bar',
+      properties: {},
+      pluginName: 'Test',
+      uid: 'Test[1]',
     });
   });
 
   it('returns the same extension instance', () => {
     const testExtension: Extension = { type: 'Foo/Bar', properties: {} };
 
-    expect(augmentExtension(testExtension, testPlugin)).toBe(testExtension);
+    expect(augmentExtension(testExtension, 'Test', 0)).toBe(testExtension);
   });
 });
 

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { Extension, ExtensionWithMetadata, ActivePlugin } from './typings';
+import { Extension, LoadedExtension, ActivePlugin } from './typings';
 import { ExtensionRegistry } from './registry';
 
 export const sanitizeExtension = (e: Extension): Extension => {
@@ -9,9 +9,15 @@ export const sanitizeExtension = (e: Extension): Extension => {
   return e;
 };
 
-export const augmentExtension = (e: Extension, p: ActivePlugin): ExtensionWithMetadata => {
-  return Object.assign(e, { plugin: p.name });
-};
+export const augmentExtension = (
+  e: Extension,
+  pluginName: string,
+  index: number,
+): LoadedExtension<typeof e> =>
+  Object.assign(e, {
+    pluginName,
+    uid: `${pluginName}[${index}]`,
+  });
 
 export const isExtensionInUse = (e: Extension, flags: FlagsObject): boolean =>
   e.flags.required.every((f) => flags[f] === true) &&
@@ -31,14 +37,16 @@ export const getGatingFlagNames = (extensions: Extension[]): string[] =>
  * _For now, the runtime list of extensions is assumed to be immutable._
  */
 export class PluginStore {
-  private readonly extensions: ExtensionWithMetadata[];
+  private readonly extensions: Extension[];
 
   public readonly registry: ExtensionRegistry; // TODO(vojtech): legacy, remove
 
   public constructor(plugins: ActivePlugin[]) {
     this.extensions = _.flatMap(
       plugins.map((p) =>
-        p.extensions.map((e) => Object.freeze(augmentExtension(sanitizeExtension({ ...e }), p))),
+        p.extensions.map((e, index) =>
+          Object.freeze(augmentExtension(sanitizeExtension(_.cloneDeep(e)), p.name, index)),
+        ),
       ),
     );
     this.registry = new ExtensionRegistry(plugins);

--- a/frontend/packages/console-plugin-sdk/src/typings/base.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/base.ts
@@ -91,8 +91,9 @@ export type ActivePlugin = {
 };
 
 /**
- * An extension enhanced with additional metadata at runtime.
+ * Runtime extension interface, exposing additional metadata.
  */
-export type ExtensionWithMetadata = Extension & {
-  plugin: string;
+export type LoadedExtension<E extends Extension> = E & {
+  pluginName: string;
+  uid: string;
 };

--- a/frontend/packages/console-plugin-sdk/src/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/useExtensions.ts
@@ -7,7 +7,7 @@ import { RootState } from '@console/internal/redux';
 import { stateToFlagsObject, FlagsObject, FeatureState } from '@console/internal/reducers/features';
 import { pluginStore } from '@console/internal/plugins';
 import { getGatingFlagNames, isExtensionInUse } from './store';
-import { Extension, ExtensionTypeGuard } from './typings';
+import { Extension, ExtensionTypeGuard, LoadedExtension } from './typings';
 
 /**
  * React hook for consuming Console extensions.
@@ -42,7 +42,9 @@ import { Extension, ExtensionTypeGuard } from './typings';
  *
  * @param typeGuard Type guard used to narrow the extension type.
  */
-export const useExtensions: UseExtensions = (typeGuard) => {
+export const useExtensions = <E extends Extension>(
+  typeGuard: ExtensionTypeGuard<E>,
+): LoadedExtension<E>[] => {
   const allExtensions = pluginStore.getAllExtensions();
 
   // 1) Narrow extensions according to type guard
@@ -80,7 +82,5 @@ export const useExtensions: UseExtensions = (typeGuard) => {
     [matchedExtensions, gatingFlags],
   );
 
-  return extensionsInUse;
+  return extensionsInUse as LoadedExtension<E>[];
 };
-
-type UseExtensions = <E extends Extension>(typeGuard: ExtensionTypeGuard<E>) => E[];

--- a/frontend/packages/console-plugin-sdk/src/withExtensions.tsx
+++ b/frontend/packages/console-plugin-sdk/src/withExtensions.tsx
@@ -5,7 +5,7 @@ import { RootState } from '@console/internal/redux';
 import { stateToFlagsObject } from '@console/internal/reducers/features';
 import { pluginStore } from '@console/internal/plugins';
 import { getGatingFlagNames, isExtensionInUse } from './store';
-import { Extension, ExtensionTypeGuard } from './typings';
+import { Extension, ExtensionTypeGuard, LoadedExtension } from './typings';
 
 /**
  * React higher-order component (HOC) for consuming Console extensions.
@@ -92,7 +92,7 @@ export const withExtensions = <
 };
 
 type ExtensionProps<E extends Extension> = {
-  [propName: string]: E[];
+  [propName: string]: E[] | LoadedExtension<E>[];
 };
 
 type ExtensionTypeGuardMapper<E extends Extension, P extends ExtensionProps<E>> = {

--- a/frontend/packages/console-shared/src/hooks/plugins-overview-tab-section.ts
+++ b/frontend/packages/console-shared/src/hooks/plugins-overview-tab-section.ts
@@ -10,7 +10,7 @@ export const getResourceTabSectionComp = (t: OverviewTabSection): React.FC<Async
 export const usePluginsOverviewTabSection = (
   item: OverviewItem,
 ): { Component: React.FC<AsyncComponentProps>; key: string }[] => {
-  const tabSections = useExtensions(isOverviewTabSection);
+  const tabSections = useExtensions<OverviewTabSection>(isOverviewTabSection);
   return React.useMemo(
     () =>
       tabSections


### PR DESCRIPTION
This PR adds a `uid` property to all Console extension instances at runtime.

The `uid` property is computed when processing Console plugins via `PluginStore`.

Extension consumer APIs `useExtensions` & `withExtensions` now work with `LoadedExtension` type:

```ts
/**
 * Runtime extension interface, exposing additional metadata.
 */
export type LoadedExtension<E extends Extension> = E & {
  pluginName: string;
  uid: string;
};
```