### PR TITLE
Allows user to set `allowVolumeExpansion` flag for a storage class

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/utils/storage-class-params.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/storage-class-params.tsx
@@ -7,6 +7,7 @@ export const StorageClassFormProvisoners: ExtensionSCProvisionerProp = Object.fr
     'openshift-storage.rbd.csi.ceph.com': {
       title: 'Ceph RBD',
       provisioner: 'rbd.csi.ceph.com',
+      allowVolumeExpansion: true,
       parameters: {
         clusterID: {
           name: 'Cluster ID',
@@ -79,6 +80,7 @@ export const StorageClassFormProvisoners: ExtensionSCProvisionerProp = Object.fr
     'openshift-storage.cephfs.csi.ceph.com': {
       title: 'Ceph FS',
       provisioner: 'cephfs.csi.ceph.com',
+      allowVolumeExpansion: true,
       parameters: {
         clusterID: {
           name: 'Cluster ID',

--- a/frontend/packages/console-plugin-sdk/src/typings/storage-class-params.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/storage-class-params.ts
@@ -24,6 +24,7 @@ export type ExtensionSCProvisionerProp = {
     [key: string]: {
       title: string;
       provisioner: string;
+      allowVolumeExpansion: boolean;
       parameters: {
         [key: string]: {
           name: string;

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -47,6 +47,7 @@ const defaultState = {
     type: null,
     parameters: {},
     reclaim: null,
+    expansion: false,
   },
   customParams: [['', '']],
   validationSuccessful: false,
@@ -73,6 +74,7 @@ export class StorageClassForm_ extends React.Component<
     title: '',
     provisioner: '',
     parameters: {},
+    allowVolumeExpansion: false,
   };
 
   storageTypes = {};
@@ -116,6 +118,7 @@ export class StorageClassForm_ extends React.Component<
     aws: {
       title: 'AWS Elastic Block Storage',
       provisioner: 'kubernetes.io/aws-ebs',
+      allowVolumeExpansion: true,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#aws-ebs',
       parameters: {
         type: {
@@ -153,6 +156,7 @@ export class StorageClassForm_ extends React.Component<
     'gce-pd': {
       title: 'GCE PD',
       provisioner: 'kubernetes.io/gce-pd',
+      allowVolumeExpansion: true,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#gce',
       parameters: {
         type: {
@@ -197,6 +201,7 @@ export class StorageClassForm_ extends React.Component<
     glusterfs: {
       title: 'Glusterfs',
       provisioner: 'kubernetes.io/glusterfs',
+      allowVolumeExpansion: true,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#glusterfs',
       parameters: {
         resturl: {
@@ -241,6 +246,7 @@ export class StorageClassForm_ extends React.Component<
     openstackCinder: {
       title: 'OpenStack Cinder',
       provisioner: 'kubernetes.io/cinder',
+      allowVolumeExpansion: true,
       documentationLink:
         'https://kubernetes.io/docs/concepts/storage/storage-classes/#openstack-cinder',
       parameters: {
@@ -255,6 +261,7 @@ export class StorageClassForm_ extends React.Component<
     azureFile: {
       title: 'Azure File',
       provisioner: 'kubernetes.io/azure-file',
+      allowVolumeExpansion: true,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#azure-file',
       parameters: {
         skuName: {
@@ -274,6 +281,7 @@ export class StorageClassForm_ extends React.Component<
     azureDisk: {
       title: 'Azure Disk',
       provisioner: 'kubernetes.io/azure-disk',
+      allowVolumeExpansion: true,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#azure-disk',
       parameters: {
         storageaccounttype: {
@@ -290,6 +298,7 @@ export class StorageClassForm_ extends React.Component<
     quobyte: {
       title: 'Quobyte',
       provisioner: 'kubernetes.io/quobyte',
+      allowVolumeExpansion: false,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#quobyte',
       parameters: {
         quobyteAPIServer: {
@@ -329,6 +338,7 @@ export class StorageClassForm_ extends React.Component<
     vSphereVolume: {
       title: 'vSphere Volume',
       provisioner: 'kubernetes.io/vsphere-volume',
+      allowVolumeExpansion: false,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#vsphere',
       parameters: {
         diskformat: {
@@ -349,6 +359,7 @@ export class StorageClassForm_ extends React.Component<
     portworxVolume: {
       title: 'Portworx Volume',
       provisioner: 'kubernetes.io/portworx-volume',
+      allowVolumeExpansion: true,
       documentationLink:
         'https://kubernetes.io/docs/concepts/storage/storage-classes/#portworx-volume',
       parameters: {
@@ -421,6 +432,7 @@ export class StorageClassForm_ extends React.Component<
     scaleIo: {
       title: 'ScaleIO',
       provisioner: 'kubernetes.io/scaleio',
+      allowVolumeExpansion: false,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#scaleio',
       parameters: {
         gateway: {
@@ -466,6 +478,7 @@ export class StorageClassForm_ extends React.Component<
     storageOs: {
       title: 'StorageOS',
       provisioner: 'kubernetes.io/storageos',
+      allowVolumeExpansion: false,
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#storageos',
       parameters: {
         pool: {
@@ -616,7 +629,7 @@ export class StorageClassForm_ extends React.Component<
       error: null,
     });
     this.setState({ newStorageClass: this.addDefaultParams() }, () => {
-      const { description, type, reclaim } = this.state.newStorageClass;
+      const { description, type, reclaim, expansion } = this.state.newStorageClass;
       const dataParameters = this.getFormParams();
       const annotations = description ? { description } : {};
       const data: StorageClass = {
@@ -635,6 +648,10 @@ export class StorageClassForm_ extends React.Component<
       const volumeBindingMode = this.storageTypes[type]?.volumeBindingMode;
       if (volumeBindingMode) {
         data.volumeBindingMode = volumeBindingMode;
+      }
+
+      if (this.storageTypes[type].allowVolumeExpansion) {
+        data.allowVolumeExpansion = expansion;
       }
 
       k8sCreate(StorageClassModel, data)
@@ -917,6 +934,9 @@ export class StorageClassForm_ extends React.Component<
     const { newStorageClass, fieldErrors } = this.state;
     const reclaimPolicyKey =
       newStorageClass.reclaim === null ? this.reclaimPolicies.Delete : newStorageClass.reclaim;
+    const expansionFlag =
+      newStorageClass.type && this.storageTypes[newStorageClass.type].allowVolumeExpansion;
+    const allowExpansion = expansionFlag ? newStorageClass.expansion : false;
 
     return (
       <div className="co-m-pane__body co-m-pane__form">
@@ -1000,6 +1020,20 @@ export class StorageClassForm_ extends React.Component<
             </span>
           </div>
 
+          {expansionFlag && (
+            <div className="checkbox">
+              <label>
+                <input
+                  type="checkbox"
+                  className="create-storage-class-form__checkbox"
+                  onChange={(event) => this.setStorageHandler('expansion', event.target.checked)}
+                  checked={allowExpansion}
+                />
+                Allow persistent volume claims to be expanded
+              </label>
+            </div>
+          )}
+
           <div className="co-form-subsection">
             {newStorageClass.type !== null ? this.getProvisionerElements() : null}
           </div>
@@ -1060,6 +1094,7 @@ export type StorageClassData = {
   description: string;
   parameters: any;
   reclaim: string;
+  expansion: boolean;
 };
 
 export type StorageClass = {
@@ -1068,6 +1103,7 @@ export type StorageClass = {
   parameters: object;
   reclaimPolicy?: string;
   volumeBindingMode?: string;
+  allowVolumeExpansion?: boolean;
 };
 
 export type StorageClassFormState = {


### PR DESCRIPTION
Storage class support `allowExpansion` flag for most provisioners (https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion ).The default storageClasses created in the backend (gp2) and also default CSI storageClasses already have these flags in YAML, but if the user creates there own storageClass using UI, they cannot set these flags. This PR helps the user to set that flag.
![Screenshot from 2020-07-30 20-47-28](https://user-images.githubusercontent.com/12200504/89020869-4017f880-d33d-11ea-9a25-616e112f8fb9.png)


Signed-off-by: Kanika Murarka <kmurarka@redhat.com>