### PR TITLE
Monitoring: Add popover help text for some fields

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1,6 +1,6 @@
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { Button } from '@patternfly/react-core';
+import { Button, Popover } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -152,14 +152,16 @@ const MonitoringResourceIcon: React.FC<MonitoringResourceIconProps> = ({ classNa
   </span>
 );
 
-const stateIcons = {
+const alertStateIcons = {
   [AlertStates.Firing]: <BellIcon />,
   [AlertStates.Pending]: <OutlinedBellIcon />,
   [AlertStates.Silenced]: <BellSlashIcon className="text-muted" />,
 };
 
+const AlertStateIcon: React.FC<{ state: string }> = ({ state }) => alertStateIcons[state];
+
 export const AlertState: React.FC<AlertStateProps> = ({ state }) => {
-  const icon = stateIcons[state];
+  const icon = alertStateIcons[state];
   return icon ? (
     <>
       {icon} {_.startCase(state)}
@@ -198,15 +200,14 @@ const AlertStateDescription = ({ alert }) => {
   return null;
 };
 
-const severityIcons = {
-  [AlertSeverity.Critical]: RedExclamationCircleIcon,
-  [AlertSeverity.Info]: BlueInfoCircleIcon,
-  [AlertSeverity.None]: BlueInfoCircleIcon,
-  [AlertSeverity.Warning]: YellowExclamationTriangleIcon,
-};
-
 const SeverityIcon: React.FC<{ severity: string }> = ({ severity }) => {
-  const Icon = severityIcons[severity] || YellowExclamationTriangleIcon;
+  const Icon =
+    {
+      [AlertSeverity.Critical]: RedExclamationCircleIcon,
+      [AlertSeverity.Info]: BlueInfoCircleIcon,
+      [AlertSeverity.None]: BlueInfoCircleIcon,
+      [AlertSeverity.Warning]: YellowExclamationTriangleIcon,
+    }[severity] || YellowExclamationTriangleIcon;
   return <Icon />;
 };
 
@@ -263,12 +264,74 @@ export const StateCounts: React.FC<{ alerts: PrometheusAlert[] }> = ({ alerts })
     <>
       {states.map((s) => (
         <div className="monitoring-icon-wrap" key={s}>
-          {stateIcons[s]} {counts[s]} {_.startCase(s)}
+          <AlertStateIcon state={s} /> {counts[s]} {_.startCase(s)}
         </div>
       ))}
     </>
   );
 };
+
+const PopoverField: React.FC<{ body: React.ReactNode; label: string }> = ({ body, label }) => (
+  <Popover headerContent={label} bodyContent={body}>
+    <Button variant="plain" className="details-item__popover-button">
+      {label}
+    </Button>
+  </Popover>
+);
+
+const alertStateHelp = (
+  <>
+    <p>
+      <AlertStateIcon state={AlertStates.Firing} /> <strong>Firing:</strong> The alert condition is
+      true for the duration of the timeout.
+    </p>
+    <p>
+      <AlertStateIcon state={AlertStates.Pending} /> <strong>Pending:</strong> The alert condition
+      is true, but the timeout has not been reached.
+    </p>
+    <p>
+      <AlertStateIcon state={AlertStates.Silenced} /> <strong>Silenced:</strong> The alert is now
+      silenced.
+    </p>
+  </>
+);
+
+const severityHelp = (
+  <>
+    <p>
+      <SeverityIcon severity={AlertSeverity.Critical} /> <strong>Critical:</strong> The condition
+      that triggered the alert could have a critical impact. The alert requires immediate attention
+      when fired.
+    </p>
+    <p>
+      <SeverityIcon severity={AlertSeverity.Warning} /> <strong>Warning:</strong> The alert provides
+      a warning notification about something that might require attention in order to prevent a
+      problem from occurring.
+    </p>
+    <p>
+      <SeverityIcon severity={AlertSeverity.Info} /> <strong>Info:</strong> The alert is provided
+      for informational purposes only.
+    </p>
+    <p>
+      <SeverityIcon severity={AlertSeverity.None} /> <strong>None:</strong> The alert has no defined
+      severity.
+    </p>
+  </>
+);
+
+const sourceHelp = (
+  <>
+    <p>
+      <strong>Platform:</strong> Platform-level alerts relate only to OpenShift namespaces.
+      OpenShift namespaces provide core OpenShift functionality.
+    </p>
+    <p>
+      <strong>User:</strong> User workload alerts relate to user-defined namespaces and are
+      customizable. User workload monitoring can be enabled post-installation to provide
+      observability into your own services.
+    </p>
+  </>
+);
 
 const Annotation = ({ children, title }) =>
   _.isNil(children) ? null : (
@@ -561,10 +624,12 @@ export const AlertsDetailsPage = withFallback(
                   <dl className="co-m-pane__details">
                     <dt>Name</dt>
                     <dd>{alertname}</dd>
-                  </dl>
-                </div>
-                <div className="col-sm-6">
-                  <dl className="co-m-pane__details">
+                    <dt>
+                      <PopoverField label="Severity" body={severityHelp} />
+                    </dt>
+                    <dd>
+                      <Severity severity={severity} />
+                    </dd>
                     {annotations.description && (
                       <Annotation title="Description">
                         <AlertMessage
@@ -586,19 +651,15 @@ export const AlertsDetailsPage = withFallback(
                     )}
                   </dl>
                 </div>
-              </div>
-              <div className="row">
                 <div className="col-sm-6">
                   <dl className="co-m-pane__details">
-                    <dt>Severity</dt>
-                    <dd>
-                      <Severity severity={severity} />
-                    </dd>
-                  </dl>
-                </div>
-                <div className="col-sm-6">
-                  <dl className="co-m-pane__details">
-                    <dt>State</dt>
+                    <dt>
+                      <PopoverField label="Source" body={sourceHelp} />
+                    </dt>
+                    <dd>{alert && _.startCase(alertSource(alert))}</dd>
+                    <dt>
+                      <PopoverField label="State" body={alertStateHelp} />
+                    </dt>
                     <dd>
                       <AlertState state={state} />
                       <AlertStateDescription alert={alert} />
@@ -756,7 +817,9 @@ export const AlertRulesDetailsPage = withFallback(
                   <dl className="co-m-pane__details">
                     <dt>Name</dt>
                     <dd>{name}</dd>
-                    <dt>Severity</dt>
+                    <dt>
+                      <PopoverField label="Severity" body={severityHelp} />
+                    </dt>
                     <dd>
                       <Severity severity={severity} />
                     </dd>
@@ -767,6 +830,10 @@ export const AlertRulesDetailsPage = withFallback(
                 </div>
                 <div className="col-sm-6">
                   <dl className="co-m-pane__details">
+                    <dt>
+                      <PopoverField label="Source" body={sourceHelp} />
+                    </dt>
+                    <dd>{rule && _.startCase(alertingRuleSource(rule))}</dd>
                     {_.isInteger(duration) && (
                       <>
                         <dt>For</dt>


### PR DESCRIPTION
Add popover help for the State, Source and Severity fields on the alert
details page and for Source and Severity on the alerting rule details
page.

## Severity Field
![severity](https://user-images.githubusercontent.com/460802/88933260-22ee1600-d2ba-11ea-9123-869a84159d70.png)

## Source Field
![source](https://user-images.githubusercontent.com/460802/88933272-25e90680-d2ba-11ea-9d85-6c35c5741eb9.png)

## Alert State Field
![state](https://user-images.githubusercontent.com/460802/88933282-28e3f700-d2ba-11ea-964c-f6d4e3bf87ec.png)


Also adds the Source field to the details pages and moves the alert details Message field down to make space.
-|Before|After
-|-|-
Alert | ![alert-before](https://user-images.githubusercontent.com/460802/88933540-824c2600-d2ba-11ea-9d65-445dbd6ffd97.png) | ![alert-after](https://user-images.githubusercontent.com/460802/88933568-8bd58e00-d2ba-11ea-951a-16d9a0b1f6ad.png)
Rule | ![rule-before](https://user-images.githubusercontent.com/460802/88933484-6e082900-d2ba-11ea-9519-5d90b3fb10f5.png) | ![rule-after](https://user-images.githubusercontent.com/460802/88933504-7496a080-d2ba-11ea-8b3c-f71805ad5474.png)

FYI @cshinn @sichvoge @pneedle-rh 