### PR TITLE
Cypress: Turn of video capture to help performance

### DIFF
--- a/frontend/packages/integration-tests-cypress/cypress.json
+++ b/frontend/packages/integration-tests-cypress/cypress.json
@@ -2,7 +2,7 @@
   "integrationFolder": "tests",
   "screenshotsFolder": "../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../gui_test_screenshots/cypress/videos",
-  "video": true,
+  "video": false,
   "reporter": "../../node_modules/cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "reporter-config.json"


### PR DESCRIPTION
Seeing in cypress logs and videos that tests seem to hang after failure and attempt video capture/compression.  
Disabling video capture until we can root cause the issue.