### PR TITLE
Some followup fine tuning of the installing operatoring visuals

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -328,7 +328,7 @@ const OperatorInstallStatus: React.FC<OperatorInstallPageProps> = (props) => {
         <Bullseye>
           <div id="operator-install-page">
             {loading && (
-              <div>
+              <div className="co-operator-install-page__indicator">
                 Installing... <Spinner size="lg" />
               </div>
             )}

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -256,23 +256,26 @@ $co-affinity-row-margin: 15px;
   margin-bottom: 20px !important;
 }
 
+#operator-install-page {
+  margin: 0 ($grid-gutter-width / 2);
+  @media (min-width: $screen-sm-min) {
+    margin: $grid-gutter-width;
+    max-width: 600px;
+    min-width: 375px;
+    width: 100%;
+  }
+}
+
 #operator-install-page .pf-c-card {
-  margin-bottom: 5px;
-  max-width: 600px;
-  // margin-top: auto;
+  margin: 10px auto;
 }
 
 #operator-install-page .pf-c-alert {
-  margin-bottom: 5px;
-}
-
-#operator-install-page .pf-c-button.co-clusterserviceversion__button {
-  margin-left: 10px;
+  margin-bottom: 10px;
 }
 
 .co-clusterserviceversion-install__heading {
-  font-weight: bold;
-  padding-bottom: 10px;
+  margin-top: 0;
 }
 
 .co-clusterserviceversion__box {
@@ -282,7 +285,12 @@ $co-affinity-row-margin: 15px;
   margin-bottom: 10px;
 }
 
+.co-operator-install-page__indicator {
+  text-align: center;
+}
+
 .co-operator-install-page__pkg-indicator {
+  align-items: center;
   display: flex;
   justify-content: space-between;
 }


### PR DESCRIPTION
cc @spadgett 
- prevent resizing
- uniform width & spacing
- icon vert alignment

<img width="1363" alt="Screen Shot 2020-07-30 at 10 56 11 AM" src="https://user-images.githubusercontent.com/1874151/88938984-fe5f5300-d253-11ea-8949-e76cec3302cb.png">
<img width="1284" alt="Screen Shot 2020-07-30 at 11 05 41 AM" src="https://user-images.githubusercontent.com/1874151/88939546-a9700c80-d254-11ea-8a18-806b52f681f5.png">
