### PR TITLE
fixes overlap issue with KSVC for pubSub

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/layouts/layoutConstraints.ts
+++ b/frontend/packages/knative-plugin/src/topology/layouts/layoutConstraints.ts
@@ -23,7 +23,7 @@ const getNodeTimeStamp = (node: ColaNode): Date => {
 const nodeSorter = (node1: ColaNode, node2: ColaNode) =>
   getNodeTimeStamp(node1) > getNodeTimeStamp(node2) ? -1 : 1;
 
-const alignLeftNodeConnector = (
+const alignNodeConnector = (
   edges: ColaLink[],
   type: string,
   g: ColaGroup | ColaNode,
@@ -47,18 +47,25 @@ const alignLeftNodeConnector = (
         ? (filteredNode as ColaNode).radius + getGroupPadding(g.element)
         : (filteredNode as ColaNode).width / 2;
 
-    const linkSourceConstraint: any = {
+    const linkNodeConstraint: any = {
       type: 'alignment',
       axis: 'y',
       offsets: [{ node: connectorLinks[0].target.index, offset: 0 }],
     };
     let nextOffset = -height / 2;
     connectorLinks.forEach((link: ColaLink) => {
-      // Evenly space out the event sources vertically
-      linkSourceConstraint.offsets.push({
-        node: link.source.index,
-        offset: nextOffset + link.source.height / 2,
-      });
+      // Evenly space out the nodes vertically
+      if (type === TYPE_EVENT_PUB_SUB_LINK) {
+        linkNodeConstraint.offsets.push({
+          node: link.target.index,
+          offset: nextOffset + link.target.height / 2,
+        });
+      } else {
+        linkNodeConstraint.offsets.push({
+          node: link.source.index,
+          offset: nextOffset + link.source.height / 2,
+        });
+      }
       // Keep the event sources to the left
       constraints.push({
         axis: 'x',
@@ -69,7 +76,7 @@ const alignLeftNodeConnector = (
       });
       nextOffset += link.source.height;
     });
-    constraints.push(linkSourceConstraint);
+    constraints.push(linkNodeConstraint);
   }
   return constraints;
 };
@@ -117,7 +124,7 @@ export const layoutConstraints = (
         }
       }
 
-      const eventSourceLinksConnector = alignLeftNodeConnector(
+      const eventSourceLinksConnector = alignNodeConnector(
         edges,
         TYPE_EVENT_SOURCE_LINK,
         g,
@@ -125,7 +132,7 @@ export const layoutConstraints = (
         filteredNode,
       );
 
-      const pubSubLinksConnector = alignLeftNodeConnector(
+      const pubSubLinksConnector = alignNodeConnector(
         edges,
         TYPE_EVENT_PUB_SUB_LINK,
         g,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4407

**Analysis / Root cause**: 
 If multiple KSVC subscribe to channel or broker then they appear to overlap in topology

**Solution Description**: 
Made changes to layout to space out targets for pubsub connector 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/5129024/88950124-d0106080-d2b1-11ea-9d5e-9feaebc6af76.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
