### PR TITLE
Fix react warning in navigation rendering (invalid html props)

### DIFF
--- a/frontend/public/components/nav/items.tsx
+++ b/frontend/public/components/nav/items.tsx
@@ -65,7 +65,7 @@ class NavLink<P extends NavLinkProps> extends React.PureComponent<P> {
       testID,
       children,
       className,
-      ...props
+      'data-tour-id': dataTourId,
     } = this.props;
 
     // onClick is now handled globally by the Nav's onSelect,
@@ -76,13 +76,13 @@ class NavLink<P extends NavLinkProps> extends React.PureComponent<P> {
     return (
       <NavItem className={itemClasses} isActive={isActive}>
         <Link
-          {...props}
           className={linkClasses}
           id={id}
           data-test-id={testID}
           to={this.to}
           onClick={onClick}
           title={tipText}
+          data-tour-id={dataTourId}
         >
           {name}
           {children}


### PR DESCRIPTION
**Fixes**: 
Local warnings with previous changes for the Getting Started Tour

**Analysis / Root cause**: 
With an  change in https://github.com/openshift/console/pull/6011 some navigation props was passed through the ODC NavLink to react-router Link and finally a HTML a-tag.

**Solution Description**: 
This changes reverts that all props are passed through and just pass the new `data-tour-id` to the Link element.

**Screen shots / Gifs for design review**: 
![navigation-error](https://user-images.githubusercontent.com/139310/88954565-e101a780-d29a-11ea-9194-49f4af440e63.png)

**Unit test coverage report**: 
Not affected

**Test setup:**
Just open the browser console start the ODC

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge