### PR TITLE
Bug 1860535: show project description

### DIFF
--- a/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
@@ -89,14 +89,16 @@ describe('Project Dashboard', () => {
       const items = projectDashboardView.detailsCardList.$$('dt');
       const values = projectDashboardView.detailsCardList.$$('dd');
 
-      expect(items.count()).toBe(3);
-      expect(values.count()).toBe(3);
+      expect(items.count()).toBe(4);
+      expect(values.count()).toBe(4);
       expect(items.get(0).getText()).toEqual('Name');
       expect(values.get(0).getText()).toEqual(testName);
       expect(items.get(1).getText()).toEqual('Requester');
       expect(values.get(1).getText()).toEqual('kube:admin');
       expect(items.get(2).getText()).toEqual('Labels');
       expect(values.get(2).getText()).toEqual('No labels');
+      expect(items.get(3).getText()).toEqual('Description');
+      expect(values.get(3).getText()).toEqual('No description');
     });
     it('has View all link', async () => {
       const link = projectDashboardView.detailsCard.$(

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -158,3 +158,9 @@
     }
   }
 }
+
+.co-namespace-summary__description {
+  max-height: 15rem;
+  overflow-y: auto;
+  padding-right: var(--pf-global--spacer--sm);
+}

--- a/frontend/public/components/dashboard/project-dashboard/_details-card.scss
+++ b/frontend/public/components/dashboard/project-dashboard/_details-card.scss
@@ -1,0 +1,3 @@
+.co-project-dashboard-details-card__description {
+  @include co-line-clamp(1);
+}

--- a/frontend/public/components/dashboard/project-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/details-card.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import * as React from 'react';
+import cx from 'classnames';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
@@ -17,6 +18,7 @@ export const DetailsCard: React.FC = () => {
   const keys = _.keys(obj.metadata.labels).sort();
   const labelsSubset = _.take(keys, 3);
   const firstThreelabels = _.pick(obj.metadata.labels, labelsSubset);
+  const description = obj.metadata.annotations?.['openshift.io/description'];
   const detailsLink = `${resourcePathFromModel(ProjectModel, obj.metadata.name)}/details`;
   const serviceMeshEnabled = obj.metadata?.labels?.['maistra.io/member-of'];
   return (
@@ -38,6 +40,16 @@ export const DetailsCard: React.FC = () => {
               <LabelList kind={ProjectModel.kind} labels={firstThreelabels} />
               {keys.length > 3 && <DashboardCardLink to={detailsLink}>View all</DashboardCardLink>}
             </div>
+          </DetailItem>
+          <DetailItem isLoading={!obj} title="Description">
+            <span
+              className={cx({
+                'text-muted': !description,
+                'co-project-dashboard-details-card__description': description,
+              })}
+            >
+              {description || 'No description'}
+            </span>
           </DetailItem>
           {serviceMeshEnabled && (
             <DetailItem isLoading={!obj} title="Service Mesh">

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -822,6 +822,7 @@ const ResourceUsage = requirePrometheus(({ ns }) => (
 
 export const NamespaceSummary = ({ ns }) => {
   const displayName = getDisplayName(ns);
+  const description = getDescription(ns);
   const requester = getRequester(ns);
   const serviceMeshEnabled = ns.metadata?.labels?.['maistra.io/member-of'];
   const canListSecrets = useAccessReview({
@@ -830,13 +831,32 @@ export const NamespaceSummary = ({ ns }) => {
     verb: 'patch',
     namespace: ns.metadata.name,
   });
+
   return (
     <div className="row">
       <div className="col-sm-6 col-xs-12">
         {/* Labels aren't editable on kind Project, only Namespace. */}
         <ResourceSummary resource={ns} showLabelEditor={ns.kind === 'Namespace'}>
-          {displayName && <dt>Display Name</dt>}
-          {displayName && <dd>{displayName}</dd>}
+          <dt>Display Name</dt>
+          <dd
+            className={classNames({
+              'text-muted': !displayName,
+            })}
+          >
+            {displayName || 'No display name'}
+          </dd>
+          <dt>Description</dt>
+          <dd>
+            <p
+              className={classNames({
+                'text-muted': !description,
+                'co-pre-wrap': description,
+                'co-namespace-summary__description': description,
+              })}
+            >
+              {description || 'No description'}
+            </p>
+          </dd>
           {requester && <dt>Requester</dt>}
           {requester && <dd>{requester}</dd>}
         </ResourceSummary>

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -107,5 +107,6 @@
 @import 'components/dashboard/dashboards-page/cluster-dashboard/status-card';
 
 @import 'components/dashboard/project-dashboard/activity-card';
+@import 'components/dashboard/project-dashboard/details-card';
 
 @import 'components/nav/nav-header';


### PR DESCRIPTION
**fixes:**
https://issues.redhat.com/browse/ODC-1854
Fixes #802

**Root Analysis:**
The project description that is being asked for during project creation is not being displayed anywhere in the console

**Solution description:**
- displaying the project description in the details card in the Project Overview tab
- displaying the project description in the Project Details tab
- added Popover if the description exceeds 10 lines
- showing `No description` in the Details tab when there isn't one

**Screenshots & GIF:**
![details](https://user-images.githubusercontent.com/22490998/88956031-621c6700-d2ba-11ea-979f-c646434127b6.png)
![pd](https://user-images.githubusercontent.com/22490998/92587778-b3eede80-f2b5-11ea-8ada-be9792e23837.png)
![project-des](https://user-images.githubusercontent.com/22490998/92587754-af2a2a80-f2b5-11ea-96a6-b8152c59c540.gif)
![detailscard](https://user-images.githubusercontent.com/22490998/88956037-647ec100-d2ba-11ea-831b-c96784eab4f2.png)
![nodd](https://user-images.githubusercontent.com/22490998/88956043-65afee00-d2ba-11ea-8661-fa5445303957.png)
![detailscard](https://user-images.githubusercontent.com/22490998/89050450-66a35700-d370-11ea-980a-fda9de31d65c.png)