### PR TITLE
Add ability to filter topology by resource types

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/Graph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/Graph.spec.tsx
@@ -23,6 +23,7 @@ describe('Graph', () => {
         onSelectTab={() => {}}
         onFiltersChange={() => {}}
         onSupportedFiltersChange={() => {}}
+        onSupportedKindsChange={() => {}}
       />,
     );
   });

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -2882,6 +2882,16 @@ export const sampleClusterServiceVersions: FirehoseResult = {
           'olm.api.e43efcaa45c9f8d0': 'required',
           'olm.copiedFrom': 'openshift-operators',
         },
+        ownerReferences: [
+          {
+            apiVersion: 'operators.coreos.com/v1alpha1',
+            blockOwnerDeletion: false,
+            controller: false,
+            kind: 'ClusterServiceVersion',
+            name: 'jaeger-operator.v1.13.1',
+            uid: '244daf36-98e3-4909-b98a-12835b4ec356',
+          },
+        ],
       },
       spec: {
         customresourcedefinitions: {

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/updateModelFromFilters.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/updateModelFromFilters.spec.ts
@@ -1,4 +1,6 @@
 import * as _ from 'lodash';
+import { ALL_APPLICATIONS_KEY } from '@console/shared';
+import { referenceFor } from '@console/internal/module/k8s';
 import {
   topologyDataModel,
   dataModel,
@@ -8,11 +10,11 @@ import {
 import { updateModelFromFilters } from '../updateModelFromFilters';
 import { EXPAND_GROUPS_FILTER_ID, getFilterById, SHOW_GROUPS_FILTER_ID } from '../../filters';
 import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_APPLICATION_GROUPS_FILTER_ID } from '../../filters/const';
-import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
 import { baseDataModelGetter } from '../data-transformer';
 import { getWorkloadResources } from '../transform-utils';
 import { WORKLOAD_TYPES } from '../../topology-utils';
-import { DisplayFilters } from '../../topology-types';
+import { DisplayFilters, TopologyDisplayFilterType } from '../../topology-types';
+import { TYPE_WORKLOAD } from '../../components';
 
 const namespace = 'test-project';
 
@@ -117,5 +119,32 @@ describe('topology model ', () => {
     );
     expect(newModel.nodes.filter((n) => !n.group).length).toBe(10);
     expect(newModel.nodes.filter((n) => n.group).length).toBe(0);
+  });
+
+  it('should remove filtered kinds', () => {
+    const topologyTransformedData = getTransformedTopologyData();
+    filters.push({
+      type: TopologyDisplayFilterType.kind,
+      id: referenceFor(MockResources.deployments.data[0]),
+      label: 'DeploymentConfig',
+      priority: 1,
+      value: true,
+    });
+    filters.push({
+      type: TopologyDisplayFilterType.kind,
+      id: referenceFor(MockResources.cronJobs.data[0]),
+      label: 'DeploymentConfig',
+      priority: 1,
+      value: true,
+    });
+    const filteredModel = updateModelFromFilters(
+      topologyTransformedData,
+      filters,
+      ALL_APPLICATIONS_KEY,
+      filterers,
+    );
+    expect(filteredModel.nodes.filter((n) => n.type === TYPE_WORKLOAD).length).toBe(
+      MockResources.deployments.data.length + MockResources.cronJobs.data.length,
+    );
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
@@ -1,14 +1,17 @@
-import { Model, NodeModel, createAggregateEdges } from '@patternfly/react-topology';
+import { createAggregateEdges, Model, NodeModel } from '@patternfly/react-topology';
 import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
+import { referenceFor } from '@console/internal/module/k8s';
 import {
-  EXPAND_APPLICATION_GROUPS_FILTER_ID,
   DEFAULT_SUPPORTED_FILTER_IDS,
+  EXPAND_APPLICATION_GROUPS_FILTER_ID,
+  getFilterById,
   isExpanded,
   SHOW_GROUPS_FILTER_ID,
-  getFilterById,
+  showKind,
 } from '../filters';
-import { TYPE_APPLICATION_GROUP, TYPE_AGGREGATE_EDGE } from '../components/const';
-import { TopologyApplyDisplayOptions, DisplayFilters } from '../topology-types';
+import { TYPE_AGGREGATE_EDGE, TYPE_APPLICATION_GROUP } from '../components/const';
+import { DisplayFilters, OdcNodeModel, TopologyApplyDisplayOptions } from '../topology-types';
+import { getTopologyResourceObject } from '../topology-utils';
 
 const getApplicationGroupForNode = (node: NodeModel, groups: NodeModel[]): NodeModel => {
   if (node.type === TYPE_APPLICATION_GROUP) {
@@ -24,18 +27,50 @@ const getApplicationGroupForNode = (node: NodeModel, groups: NodeModel[]): NodeM
   return getApplicationGroupForNode(group, groups);
 };
 
+const getNodeKind = (node: NodeModel) => {
+  let { resource } = node as OdcNodeModel;
+  if (resource) {
+    return referenceFor(resource);
+  }
+  const kind = (node as OdcNodeModel).resourceKind;
+  if (kind) {
+    return kind;
+  }
+  resource = getTopologyResourceObject(node.data);
+  if (resource) {
+    return referenceFor(resource);
+  }
+
+  return null;
+};
+
+const isNodeShown = (node: NodeModel, filters: DisplayFilters, allNodes: NodeModel[]): boolean => {
+  let shown = showKind(getNodeKind(node), filters);
+  if (!shown) {
+    const showGroups = getFilterById(SHOW_GROUPS_FILTER_ID, filters)?.value ?? true;
+    const parentNode = allNodes.find(
+      (n) =>
+        n.group && showGroups && n.type !== TYPE_APPLICATION_GROUP && n.children?.includes(node.id),
+    );
+    shown = parentNode && isNodeShown(parentNode, filters, allNodes);
+  }
+  return shown;
+};
+
 export const updateModelFromFilters = (
   model: Model,
   filters: DisplayFilters,
   application: string = ALL_APPLICATIONS_KEY,
   displayFilterers?: TopologyApplyDisplayOptions[],
   onSupportedFiltersChange?: (supportedFilterIds: string[]) => void,
+  onSupportedKindsChange?: (supportedFilterIds: { [key: string]: number }) => void,
 ): Model => {
   const dataModel: Model = {
     nodes: [...model.nodes],
     edges: [...model.edges],
   };
   const supportedFilters = [...DEFAULT_SUPPORTED_FILTER_IDS];
+  const supportedKinds = {};
   let appGroupFound = false;
   const expanded = isExpanded(EXPAND_APPLICATION_GROUPS_FILTER_ID, filters);
   const showGroups = getFilterById(SHOW_GROUPS_FILTER_ID, filters)?.value ?? true;
@@ -53,6 +88,21 @@ export const updateModelFromFilters = (
         supportedFilters.push(EXPAND_APPLICATION_GROUPS_FILTER_ID);
       }
       d.collapsed = !expanded;
+    }
+    const kind = getNodeKind(d);
+    if (kind) {
+      if (!supportedKinds[kind]) {
+        supportedKinds[kind] = 0;
+      }
+      supportedKinds[kind]++;
+    }
+  });
+
+  dataModel.nodes = dataModel.nodes.filter((d) => isNodeShown(d, filters, dataModel.nodes));
+
+  dataModel.nodes.forEach((d) => {
+    if (d.group && d.children) {
+      d.children = d.children.filter((id) => dataModel.nodes.find((n) => n.id === id));
     }
   });
 
@@ -81,6 +131,10 @@ export const updateModelFromFilters = (
 
   if (onSupportedFiltersChange) {
     onSupportedFiltersChange(supportedFilters);
+  }
+
+  if (onSupportedKindsChange) {
+    onSupportedKindsChange(supportedKinds);
   }
 
   return dataModel;

--- a/frontend/packages/dev-console/src/components/topology/filters/KindFilterDropdown.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/KindFilterDropdown.scss
@@ -1,0 +1,20 @@
+@import '../../../../../../public/style/vars';
+
+.odc-kind-filter-dropdown {
+  &__clear-button {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+  }
+  &__kind-count {
+    background-color: var(--pf-global--BorderColor--300);
+    border-radius: 20px;
+    display: inline-block;
+    line-height: 16px;
+    margin-left: var(--pf-global--spacer--sm);
+    min-width: 18px;
+    padding: 1px 4px;
+    text-align: center;
+    white-space: nowrap;
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/filters/KindFilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/KindFilterDropdown.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { Button, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { modelFor } from '@console/internal/module/k8s';
+import { ResourceIcon } from '@console/internal/components/utils';
+import { TopologyDisplayFilterType, DisplayFilters } from '../topology-types';
+
+import './KindFilterDropdown.scss';
+
+type KindFilterDropdownProps = {
+  filters: DisplayFilters;
+  supportedKinds: { [key: string]: number };
+  onChange: (filter: DisplayFilters) => void;
+  opened?: boolean; // Use only for testing
+};
+
+const KindFilterDropdown: React.FC<KindFilterDropdownProps> = ({
+  filters,
+  supportedKinds,
+  onChange,
+  opened = false,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(opened);
+  const onToggle = (open: boolean): void => setIsOpen(open);
+  let kindFilters = filters.filter(
+    (f) => f.type === TopologyDisplayFilterType.kind && supportedKinds[f.id],
+  );
+  kindFilters = Object.keys(supportedKinds).reduce((acc, kind) => {
+    if (!filters.find((f) => f.id === kind)) {
+      const model = modelFor(kind);
+      acc.push({
+        type: TopologyDisplayFilterType.kind,
+        id: kind,
+        label: model ? model.label : kind,
+        value: false,
+        priority: 1,
+      });
+    }
+    return acc;
+  }, kindFilters);
+  kindFilters.sort((a, b) => a.label.localeCompare(b.label));
+
+  const onSelect = (e: React.MouseEvent, key: string) => {
+    const index = filters.findIndex((f) => f.id === key);
+    let updatedFilters;
+    if (index === -1) {
+      const newFilter = kindFilters.find((f) => f.id === key);
+      if (!newFilter) {
+        return;
+      }
+      const filter = { ...newFilter, value: (e.target as HTMLInputElement).checked };
+      updatedFilters = [...filters, filter];
+    } else {
+      const filter = { ...filters[index], value: (e.target as HTMLInputElement).checked };
+      updatedFilters = [...filters.slice(0, index), filter, ...filters.slice(index + 1)];
+    }
+    onChange(updatedFilters);
+  };
+
+  const onClearFilters = () => {
+    const updateFilters = filters.filter((f) => f.type !== TopologyDisplayFilterType.kind);
+    onChange(updateFilters);
+  };
+
+  const selectContent = (
+    <div className="odc-kind-filter-dropdown">
+      <span className="odc-kind-filter-dropdown__clear-button">
+        <Button variant="link" onClick={onClearFilters}>
+          Clear all filters
+        </Button>
+      </span>
+      {kindFilters.map((filter) => (
+        <SelectOption key={filter.id} value={filter.id} isChecked={filter.value}>
+          <ResourceIcon kind={filter.id} />
+          {filter.label}
+          <span className="odc-kind-filter-dropdown__kind-count">{supportedKinds[filter.id]}</span>
+        </SelectOption>
+      ))}
+    </div>
+  );
+  return (
+    <Select
+      variant={SelectVariant.checkbox}
+      onToggle={onToggle}
+      customContent={selectContent}
+      isOpen={isOpen}
+      onSelect={onSelect}
+      placeholderText="Filter by Resource"
+      isCheckboxSelectionBadgeHidden
+    />
+  );
+};
+
+export default KindFilterDropdown;

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
@@ -13,7 +13,4 @@
   &__kiali-link {
     margin-left: auto;
   }
-  &__text-filter {
-    margin-left: var(--pf-global--spacer--sm);
-  }
 }

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
@@ -1,29 +1,40 @@
 import * as React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { ToolbarGroup, ToolbarContent, Popover, Button } from '@patternfly/react-core';
+import {
+  Toolbar,
+  ToolbarGroup,
+  ToolbarGroupVariant,
+  ToolbarItem,
+  ToolbarContent,
+  Popover,
+  Button,
+} from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Visualization } from '@patternfly/react-topology';
 import { RootState } from '@console/internal/redux';
+import { getActiveNamespace } from '@console/internal/reducers/ui';
+import { ExternalLink } from '@console/internal/components/utils';
 import { TextFilter } from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { setTopologyFilters } from '../redux/action';
 import { DisplayFilters } from '../topology-types';
 import {
   getSupportedTopologyFilters,
+  getSupportedTopologyKinds,
   getTopologyFilters,
   getTopologySearchQuery,
 } from './filter-utils';
-
 import FilterDropdown from './FilterDropdown';
-import './TopologyFilterBar.scss';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
+import KindFilterDropdown from './KindFilterDropdown';
 import { getNamespaceDashboardKialiLink } from '../topology-utils';
-import { ExternalLink } from '@console/internal/components/utils';
+
+import './TopologyFilterBar.scss';
 
 type StateProps = {
   filters: DisplayFilters;
   supportedFilters: string[];
+  supportedKinds: { [key: string]: number };
   consoleLinks: K8sResourceKind[];
   namespace: string;
 };
@@ -48,6 +59,7 @@ type TopologyFilterBarProps = MergeProps;
 const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
   filters,
   supportedFilters,
+  supportedKinds,
   onDisplayFiltersChange,
   onSearchChange,
   visualization,
@@ -72,55 +84,82 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
   );
 
   return (
-    <ToolbarContent className="co-namespace-bar odc-topology-filter-bar">
-      <ToolbarGroup>
-        <FilterDropdown
-          filters={filters}
-          supportedFilters={supportedFilters}
-          onChange={onDisplayFiltersChange}
-        />
-        <TextFilter
-          placeholder="Find by name..."
-          value={searchQuery}
-          autoFocus
-          onChange={onTextFilterChange}
-          className="odc-topology-filter-bar__text-filter"
-        />
-        {showGraphView && (
-          <Popover
-            aria-label="Find by name"
-            position="left"
-            bodyContent={
-              <>
-                Search results may appear outside of the visible area.{' '}
-                <Button variant="link" onClick={() => visualization.getGraph().fit(80)} isInline>
-                  Click here
-                </Button>{' '}
-                to fit to the screen.
-              </>
-            }
-          >
-            <Button variant="link" className="odc-topology-filter-bar__info-icon">
-              <InfoCircleIcon />
-            </Button>
-          </Popover>
-        )}
-      </ToolbarGroup>
-      {kialiLink && (
-        <ToolbarGroup className="odc-topology-filter-bar__kiali-link">
-          <ExternalLink href={kialiLink} text="Kiali" />
+    <Toolbar className="co-namespace-bar odc-topology-filter-bar">
+      <ToolbarContent>
+        <ToolbarGroup variant={ToolbarGroupVariant['filter-group']}>
+          <ToolbarItem>
+            <FilterDropdown
+              filters={filters}
+              supportedFilters={supportedFilters}
+              onChange={onDisplayFiltersChange}
+            />
+          </ToolbarItem>
         </ToolbarGroup>
-      )}
-    </ToolbarContent>
+        <ToolbarGroup variant={ToolbarGroupVariant['filter-group']}>
+          <ToolbarItem>
+            <KindFilterDropdown
+              filters={filters}
+              supportedKinds={supportedKinds}
+              onChange={onDisplayFiltersChange}
+            />
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup variant={ToolbarGroupVariant['filter-group']}>
+          <ToolbarItem>
+            <TextFilter
+              placeholder="Find by name..."
+              value={searchQuery}
+              autoFocus
+              onChange={onTextFilterChange}
+              className="odc-topology-filter-bar__text-filter"
+            />
+          </ToolbarItem>
+          {showGraphView ? (
+            <ToolbarItem>
+              <Popover
+                aria-label="Find by name"
+                position="left"
+                bodyContent={
+                  <>
+                    Search results may appear outside of the visible area.{' '}
+                    <Button
+                      variant="link"
+                      onClick={() => visualization.getGraph().fit(80)}
+                      isInline
+                    >
+                      Click here
+                    </Button>{' '}
+                    to fit to the screen.
+                  </>
+                }
+              >
+                <Button variant="link" className="odc-topology-filter-bar__info-icon">
+                  <InfoCircleIcon />
+                </Button>
+              </Popover>
+            </ToolbarItem>
+          ) : null}
+        </ToolbarGroup>
+        {kialiLink && (
+          <ToolbarItem className="odc-topology-filter-bar__kiali-link">
+            <ExternalLink href={kialiLink} text="Kiali" />
+          </ToolbarItem>
+        )}
+      </ToolbarContent>
+    </Toolbar>
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
-  filters: getTopologyFilters(state),
-  supportedFilters: getSupportedTopologyFilters(state),
-  consoleLinks: state.UI.get('consoleLinks'),
-  namespace: getActiveNamespace(state),
-});
+const mapStateToProps = (state: RootState): StateProps => {
+  const states = {
+    filters: getTopologyFilters(state),
+    supportedFilters: getSupportedTopologyFilters(state),
+    supportedKinds: getSupportedTopologyKinds(state),
+    consoleLinks: state.UI.get('consoleLinks'),
+    namespace: getActiveNamespace(state),
+  };
+  return states;
+};
 
 const dispatchToProps = (dispatch: Dispatch): DispatchProps => ({
   onFiltersChange: (filters: DisplayFilters) => {
@@ -129,12 +168,13 @@ const dispatchToProps = (dispatch: Dispatch): DispatchProps => ({
 });
 
 const mergeProps = (
-  { filters, supportedFilters, consoleLinks, namespace }: StateProps,
+  { filters, supportedFilters, supportedKinds, consoleLinks, namespace }: StateProps,
   { onFiltersChange }: DispatchProps,
   { visualization, onSearchChange, showGraphView }: OwnProps,
 ): MergeProps => ({
   filters,
   supportedFilters,
+  supportedKinds,
   consoleLinks,
   namespace,
   onDisplayFiltersChange: (changedFilters: DisplayFilters) => {

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/KindFilterDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/KindFilterDropdown.spec.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+import { SelectOption } from '@patternfly/react-core';
+import { DisplayFilters, TopologyDisplayFilterType } from '../../topology-types';
+import { DEFAULT_TOPOLOGY_FILTERS, SHOW_GROUPS_FILTER_ID } from '../const';
+import { getFilterById } from '../filter-utils';
+import KindFilterDropdown from '../KindFilterDropdown';
+
+describe(KindFilterDropdown.displayName, () => {
+  let dropdownFilter: DisplayFilters;
+  let onChange: () => void;
+  let supportedKinds;
+  beforeEach(() => {
+    dropdownFilter = [...DEFAULT_TOPOLOGY_FILTERS];
+    onChange = jasmine.createSpy();
+    supportedKinds = {
+      'apps~v1~Deployment': 1,
+      'apps.openshift.io~v1~DeploymentConfig': 1,
+      'apps~v1~DaemonSet': 1,
+      'apps~v1~StatefulSet': 1,
+      'batch~v1~Job': 1,
+      'batch~v1beta1~CronJob': 1,
+      'core~v1~Pod': 1,
+    };
+  });
+
+  it('should exists', () => {
+    const wrapper = shallow(
+      <KindFilterDropdown
+        filters={dropdownFilter}
+        supportedKinds={supportedKinds}
+        onChange={onChange}
+      />,
+    );
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should have the correct number of filters', () => {
+    const wrapper = mount(
+      <KindFilterDropdown
+        filters={dropdownFilter}
+        supportedKinds={supportedKinds}
+        onChange={onChange}
+        opened
+      />,
+    );
+    expect(wrapper.find(SelectOption)).toHaveLength(Object.keys(supportedKinds).length);
+  });
+
+  it('should kinds when filtered', () => {
+    getFilterById(SHOW_GROUPS_FILTER_ID, dropdownFilter).value = false;
+    const keys = Object.keys(supportedKinds);
+    dropdownFilter.push({
+      type: TopologyDisplayFilterType.kind,
+      id: keys[0],
+      label: keys[0],
+      priority: 1,
+      value: true,
+    });
+    const wrapper = mount(
+      <KindFilterDropdown
+        filters={dropdownFilter}
+        supportedKinds={supportedKinds}
+        onChange={onChange}
+        opened
+      />,
+    );
+    expect(
+      wrapper
+        .find(SelectOption)
+        .first()
+        .props().isChecked,
+    ).toBeTruthy();
+  });
+});

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
@@ -3,11 +3,12 @@ import { getQueryArgument } from '@console/internal/components/utils';
 import { getDefaultTopologyFilters } from '../redux/reducer';
 import { getAppliedFilters } from '../redux/action';
 import {
-  TopologyDisplayOption,
   DisplayFilters,
   TopologyDisplayFilterType,
+  TopologyDisplayOption,
 } from '../topology-types';
 import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_GROUPS_FILTER_ID, SHOW_GROUPS_FILTER_ID } from './const';
+import { K8sResourceKindReference } from '@console/internal/module/k8s';
 
 export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
 
@@ -19,6 +20,11 @@ export const getTopologyFilters = (state: RootState): DisplayFilters => {
 export const getSupportedTopologyFilters = (state: RootState): string[] => {
   const topology = state?.plugins?.devconsole?.topology;
   return topology ? topology.get('supportedFilters') : DEFAULT_TOPOLOGY_FILTERS.map((f) => f.id);
+};
+
+export const getSupportedTopologyKinds = (state: RootState): { [key: string]: number } => {
+  const topology = state?.plugins?.devconsole?.topology;
+  return topology ? topology.get('supportedKinds') : {};
 };
 
 export const getAppliedTopologyFilters = (state: RootState): string[] => {
@@ -67,4 +73,18 @@ export const isShown = (id: string, filters: DisplayFilters): boolean => {
 
 export const allowEdgeCreation = (filters: DisplayFilters): boolean => {
   return getFilterById(SHOW_GROUPS_FILTER_ID, filters)?.value ?? true;
+};
+
+export const showKind = (kind: K8sResourceKindReference, filters: DisplayFilters): boolean => {
+  if (!filters || !kind) {
+    return true;
+  }
+  // If no kinds are shown, show all
+  const shownKinds = filters.filter((f) => f.type === TopologyDisplayFilterType.kind && f.value);
+  if (shownKinds.length === 0) {
+    return true;
+  }
+
+  // Return filter value if it exists, otherwise filter it out since there are other set filters
+  return getFilterById(kind, filters)?.value ?? false;
 };

--- a/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
@@ -76,7 +76,6 @@ export const getTopologyHelmReleaseGroupItem = (
     type: TYPE_HELM_RELEASE,
     resourceKind: 'HelmRelease',
     group: true,
-    resource: secret,
     label: releaseName,
     children: [uid],
     width: HELM_GROUP_WIDTH,

--- a/frontend/packages/dev-console/src/components/topology/layouts/TopologyColaLayout.ts
+++ b/frontend/packages/dev-console/src/components/topology/layouts/TopologyColaLayout.ts
@@ -1,8 +1,26 @@
-import { ColaLayout, ColaNode, ColaGroup, ColaLink } from '@patternfly/react-topology';
+import {
+  ColaLayout,
+  ColaNode,
+  ColaGroup,
+  ColaLink,
+  Graph,
+  GraphModel,
+} from '@patternfly/react-topology';
 import { layoutConstraints } from '@console/knative-plugin/src/topology/layouts/layoutConstraints';
 
 export default class TopologyColaLayout extends ColaLayout {
   protected getConstraints(nodes: ColaNode[], groups: ColaGroup[], edges: ColaLink[]): any[] {
     return layoutConstraints(nodes, groups, edges, this.options);
+  }
+
+  protected startLayout(
+    graph: Graph<GraphModel, any>,
+    initialRun: boolean,
+    addingNodes: boolean,
+  ): void {
+    if (graph.getNodes()?.length === 0) {
+      return;
+    }
+    super.startLayout(graph, initialRun, addingNodes);
   }
 }

--- a/frontend/packages/dev-console/src/components/topology/redux/action.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/action.ts
@@ -5,6 +5,7 @@ import { DisplayFilters } from '../topology-types';
 export enum Actions {
   topologyFilters = 'topologyFilters',
   supportedTopologyFilters = 'supportedTopologyFilters',
+  supportedTopologyKinds = 'supportedTopologyKinds',
 }
 
 export const getAppliedFilters = (filters: DisplayFilters): { [id: string]: boolean } => {
@@ -30,9 +31,14 @@ export const setSupportedTopologyFilters = (supportedFilters: string[]) => {
   return action(Actions.supportedTopologyFilters, { supportedFilters });
 };
 
+export const setSupportedTopologyKinds = (supportedKinds: { [key: string]: number }) => {
+  return action(Actions.supportedTopologyKinds, { supportedKinds });
+};
+
 const actions = {
   setTopologyFilters,
   setSupportedTopologyFilters,
+  setSupportedTopologyKinds,
 };
 
 export type TopologyAction = ActionType<typeof actions>;

--- a/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
@@ -40,6 +40,7 @@ export default (state: State, action: TopologyAction) => {
       filters: getDefaultTopologyFilters(),
       appliedFilters: getDefaultAppliedFilters(),
       supportedFilters: DEFAULT_TOPOLOGY_FILTERS.map((f) => f.id),
+      supportedKinds: {},
     });
   }
 
@@ -51,6 +52,10 @@ export default (state: State, action: TopologyAction) => {
 
   if (action.type === Actions.supportedTopologyFilters) {
     return state.set('supportedFilters', action.payload.supportedFilters);
+  }
+
+  if (action.type === Actions.supportedTopologyKinds) {
+    return state.set('supportedKinds', action.payload.supportedKinds);
   }
 
   return state;

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -58,6 +58,7 @@ export type CreateConnectionGetter = (createHints: string[]) => CreateConnection
 export enum TopologyDisplayFilterType {
   show = 'show',
   expand = 'expand',
+  kind = 'kind',
 }
 
 export type TopologyDisplayOption = {

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -106,13 +106,12 @@ export const getTopologyResourceObject = (topologyObject: TopologyDataObject): K
   if (!topologyObject) {
     return null;
   }
-  return _.get(topologyObject, ['resources', 'obj']);
+  return topologyObject.resource || topologyObject.resources?.obj;
 };
 
 export const getResource = (node: Node): K8sResourceKind => {
-  return node instanceof OdcBaseNode
-    ? (node as OdcBaseNode).getResource()
-    : getTopologyResourceObject(node?.getData());
+  const resource = (node as OdcBaseNode)?.getResource();
+  return resource || getTopologyResourceObject(node?.getData());
 };
 
 export const getResourceKind = (node: Node): K8sResourceKindReference => {


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4319

**Description**
As a user, I want to show/hide specific resource types in the topology view

When a resource is selected, that resource and its children are shown.

**Screenshots**

![image](https://user-images.githubusercontent.com/11633780/88963556-00d2a480-d276-11ea-83c7-62d9de281b28.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind feature

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @bgliwa01

