### PR TITLE
Don't download the Cypress binary during downstream builds

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -24,10 +24,11 @@ RUN tar fx yarn-offline.tar
 # bootstrap yarn so we can install and run the other tools.
 RUN container-entrypoint npm install ./yarn-1.9.4.tgz
 
-# prevent download of chromedriver, geckodriver, sass binary, and node headers as part of module installs
+# prevent download of chromedriver, geckodriver, sass, cypress binary, and node headers as part of module installs
 ENV CHROMEDRIVER_SKIP_DOWNLOAD=true \
     GECKODRIVER_SKIP_DOWNLOAD=true \
     SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true \
+    CYPRESS_INSTALL_BINARY=0 \
     NPM_CONFIG_TARBALL=$HOME/node-v12.16.1-headers.tar.gz
 
 # run the build


### PR DESCRIPTION
#4831 broke downstream builds. We need to skip the Cypress binary download.

https://docs.cypress.io/guides/getting-started/installing-cypress.html#Skipping-installation

/assign @dtaylor113 
/cc @sosiouxme 