### PR TITLE
(feat): Add Disk OCS Status column in LSO disk inventory

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/disk-replacement-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/disk-replacement-modal.tsx
@@ -15,16 +15,15 @@ import {
   SecretKind,
 } from '@console/internal/module/k8s';
 import { TemplateModel, TemplateInstanceModel, SecretModel } from '@console/internal/models';
-import { CEPH_STORAGE_NAMESPACE } from '../../../constants';
-
-const OSD_REMOVAL_TEMPLATE = 'ocs-osd-removal';
+import { CEPH_STORAGE_NAMESPACE, OSD_REMOVAL_TEMPLATE } from '../../../constants';
+import { OCSDiskList, OCSColumnStateAction, ActionType, Status } from './state-reducer';
 
 const createTemplateSecret = async (template: TemplateKind, osdId: string) => {
   const parametersSecret: SecretKind = {
     apiVersion: SecretModel.apiVersion,
     kind: SecretModel.kind,
     metadata: {
-      name: `${OSD_REMOVAL_TEMPLATE}-parameters`,
+      name: `${OSD_REMOVAL_TEMPLATE}-${osdId}`,
       namespace: CEPH_STORAGE_NAMESPACE,
     },
     stringData: {
@@ -39,7 +38,7 @@ const createTemplateInstance = async (parametersSecret: SecretKind, template: Te
     apiVersion: apiVersionForModel(TemplateInstanceModel),
     kind: TemplateInstanceModel.kind,
     metadata: {
-      name: `${OSD_REMOVAL_TEMPLATE}-template-instance`,
+      name: parametersSecret.metadata.name,
       namespace: CEPH_STORAGE_NAMESPACE,
     },
     spec: {
@@ -63,7 +62,7 @@ const instantiateTemplate = async (osdId: string) => {
 };
 
 const DiskReplacementAction = (props: DiskReplacementActionProps) => {
-  const { diskName, osdId, cancel, close } = props;
+  const { diskName, diskOsdMap, isRebalancing, dispatch, cancel, close } = props;
 
   const [inProgress, setProgress] = React.useState(false);
   const [errorMessage, setError] = React.useState('');
@@ -71,11 +70,19 @@ const DiskReplacementAction = (props: DiskReplacementActionProps) => {
   const handleSubmit = (event) => {
     event.preventDefault();
     setProgress(true);
-    /*
-     * TODO:(Afreen) Add validations based on ocs status (part of followup PR)
-     */
     try {
-      instantiateTemplate(osdId);
+      const { status, osd } = diskOsdMap[diskName];
+      if (isRebalancing && status !== Status.Offline)
+        throw new Error('Replacement not allowed. Rebalancing is in progress');
+      if (status === Status.Offline || status === Status.NotResponding) {
+        instantiateTemplate(osd);
+        dispatch({
+          type: ActionType.SET_REPLACEMENT_MAP,
+          payload: { [diskName]: { osd, status: Status.PreparingToReplace } },
+        });
+      } else {
+        throw new Error('Replacement not allowed');
+      }
       close();
     } catch (err) {
       setError(err.message);
@@ -107,5 +114,7 @@ export const diskReplacementModal = createModalLauncher(DiskReplacementAction);
 
 export type DiskReplacementActionProps = {
   diskName: string;
-  osdId: string;
+  diskOsdMap: OCSDiskList;
+  isRebalancing: boolean;
+  dispatch: React.Dispatch<OCSColumnStateAction>;
 } & ModalComponentProps;

--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-disks-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-disks-list.tsx
@@ -1,0 +1,273 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import * as cx from 'classnames';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+import {
+  Table,
+  TableProps,
+  TableRow,
+  TableData,
+  RowFunction,
+} from '@console/internal/components/factory';
+import { sortable } from '@patternfly/react-table';
+import { humanizeBinaryBytes, Kebab } from '@console/internal/components/utils';
+import { usePrometheusPoll } from '@console/internal/components/graphs/prometheus-poll-hook';
+import { PrometheusEndpoint } from '@console/internal/components/graphs/helpers';
+import {
+  osdDiskInfoMetric,
+  DATA_RESILIENCY_QUERY,
+  StorageDashboardQuery,
+} from '@console/ceph-storage-plugin/src/constants/queries';
+import { TemplateInstanceModel } from '@console/internal/models';
+import { TemplateInstanceKind } from '@console/internal/module/k8s';
+import { PrometheusResult } from '@console/internal/components/graphs';
+import {
+  useK8sWatchResource,
+  WatchK8sResource,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import { RootState } from '@console/internal/redux';
+import { NotificationAlerts } from '@console/internal/reducers/ui';
+import { Alert } from '@console/internal/components/monitoring/types';
+import { DiskMetadata } from '@console/local-storage-operator-plugin/src/components/disks-list/types';
+import {
+  NodesDisksListPage,
+  NodesDisksListPageProps,
+} from '@console/local-storage-operator-plugin/src/components/disks-list/disks-list-page';
+import {
+  CEPH_STORAGE_NAMESPACE,
+  OSD_DOWN_ALERT,
+  OSD_DOWN_AND_OUT_ALERT,
+} from '../../../constants/index';
+import { OCSKebabOptions } from './ocs-kebab-options';
+import { OCSStatus } from './ocs-status-column';
+import {
+  ActionType,
+  OCSColumnState,
+  initialState,
+  reducer,
+  OCSDiskList,
+  OCSColumnStateAction,
+  Status,
+  OCSDiskStatus,
+} from './state-reducer';
+
+const getTiBasedStatus = (status: string): OCSDiskStatus => {
+  switch (status) {
+    case 'Not Ready':
+      return Status.PreparingToReplace;
+    case 'Ready':
+      return Status.ReplacementReady;
+    case 'Failed':
+      return Status.ReplacementFailed;
+    default:
+      return null;
+  }
+};
+
+const getAlertsBasedStatus = (alertName: string): OCSDiskStatus => {
+  switch (alertName) {
+    case OSD_DOWN_ALERT:
+      return Status.NotResponding;
+    case OSD_DOWN_AND_OUT_ALERT:
+      return Status.Offline;
+    default:
+      return null;
+  }
+};
+
+const tiResource: WatchK8sResource = {
+  kind: TemplateInstanceModel.kind,
+  namespace: CEPH_STORAGE_NAMESPACE,
+  isList: true,
+};
+
+export const tableColumnClasses = [
+  '',
+  '',
+  cx('pf-m-hidden', 'pf-m-visible-on-xl'),
+  cx('pf-m-hidden', 'pf-m-visible-on-2xl'),
+  cx('pf-m-hidden', 'pf-m-visible-on-lg'),
+  cx('pf-m-hidden', 'pf-m-visible-on-xl'),
+  Kebab.columnClass,
+];
+
+const diskHeader = () => [
+  {
+    title: 'Name',
+    sortField: 'path',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[0] },
+  },
+  {
+    title: 'Disk State',
+    sortField: 'status.state',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[1] },
+  },
+  {
+    title: 'OCS Status',
+    sortField: '',
+    transforms: [],
+    props: { className: tableColumnClasses[1] },
+  },
+  {
+    title: 'Type',
+    sortField: 'type',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[2] },
+  },
+  {
+    title: 'Model',
+    sortField: 'model',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[3] },
+  },
+  {
+    title: 'Capacity',
+    sortField: 'size',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[4] },
+  },
+  {
+    title: 'Filesystem',
+    sortField: 'fstype',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[5] },
+  },
+  {
+    title: '',
+    sortField: '',
+    transforms: [],
+    props: { className: tableColumnClasses[6] },
+  },
+];
+
+const diskRow: RowFunction<DiskMetadata, OCSMetadata> = ({
+  obj,
+  index,
+  key,
+  style,
+  customData,
+}) => {
+  const { ocsState, dispatch } = customData;
+  const diskName = obj.path;
+  return (
+    <TableRow id={obj.deviceID} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>{obj.path}</TableData>
+      <TableData className={tableColumnClasses[1]}>{obj.status.state}</TableData>
+      <OCSStatus ocsState={ocsState} diskName={diskName} className={tableColumnClasses[1]} />
+      <TableData className={tableColumnClasses[2]}>{obj.type || '-'}</TableData>
+      <TableData className={cx(tableColumnClasses[3], 'co-break-word')}>
+        {obj.model || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>
+        {humanizeBinaryBytes(obj.size).string || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[5]}>{obj.fstype || '-'}</TableData>
+      <OCSKebabOptions
+        diskName={diskName}
+        diskOsdMap={ocsState.alertsMap}
+        isRebalancing={ocsState.isRebalancing}
+        dispatch={dispatch}
+      />
+    </TableRow>
+  );
+};
+
+const OCSDisksList: React.FC<TableProps> = React.memo((props) => {
+  const [ocsState, dispatch] = React.useReducer(reducer, initialState);
+
+  const [cephDiskData, cephDiskLoadError, cephDiskLoading] = usePrometheusPoll({
+    endpoint: PrometheusEndpoint.QUERY,
+    query: osdDiskInfoMetric({ nodeName: props.customData.node }),
+  });
+  const [progressData, progressLoadError, progressLoading] = usePrometheusPoll({
+    endpoint: PrometheusEndpoint.QUERY,
+    query: DATA_RESILIENCY_QUERY[StorageDashboardQuery.RESILIENCY_PROGRESS],
+  });
+  const [tiData, tiLoaded, tiLoadError] = useK8sWatchResource<TemplateInstanceKind[]>(tiResource);
+  const { data: alertsData, loaded: alertsLoaded, loadError: alertsLoadError } = useSelector<
+    RootState,
+    NotificationAlerts
+  >(({ UI }) => UI.getIn(['monitoring', 'notificationAlerts']));
+
+  const error = alertsLoadError || cephDiskLoadError || progressLoadError;
+  const isLoading = !alertsLoaded || cephDiskLoading || progressLoading;
+
+  if (!error && !isLoading) {
+    const resiliencyResults: string = progressData?.data.result?.[0]?.value[1];
+    const isRebalancing: boolean = resiliencyResults ? resiliencyResults !== '1' : false;
+
+    const cephDisks: PrometheusResult[] = cephDiskData?.data?.result || [];
+    const newMetricsMap: OCSDiskList = cephDisks.reduce((ocsDiskList: OCSDiskList, { metric }) => {
+      ocsDiskList[metric.device] = {
+        osd: metric.ceph_daemon,
+        status: Status.Online,
+      };
+      return ocsDiskList;
+    }, {});
+    const newAlertsMap: OCSDiskList = alertsData.reduce(
+      (ocsDiskList: OCSDiskList, alert: Alert) => {
+        const { rule, labels } = alert;
+        const status = getAlertsBasedStatus(rule.name);
+        if (status) ocsDiskList[labels.device] = { osd: labels.disk, status };
+        return ocsDiskList;
+      },
+      {},
+    );
+
+    if (!_.isEqual(newMetricsMap, ocsState.metricsMap)) {
+      dispatch({ type: ActionType.SET_METRICS_MAP, payload: newMetricsMap });
+    }
+
+    if (!_.isEqual(newAlertsMap, ocsState.alertsMap)) {
+      dispatch({ type: ActionType.SET_ALERTS_MAP, payload: newAlertsMap });
+    }
+
+    if (ocsState.isRebalancing !== isRebalancing) {
+      dispatch({ type: ActionType.SET_IS_REBALANCING, payload: isRebalancing });
+    }
+
+    if (tiLoaded && !tiLoadError && tiData.length) {
+      const { metricsMap } = ocsState;
+      const reverseMap = Object.keys(metricsMap).map((disk) => ({ [metricsMap[disk].osd]: disk }));
+      const newData: OCSDiskList = tiData.reduce((data, ti) => {
+        const osd = ti.spec.template.parameters[0].value;
+        const disk = reverseMap[osd];
+        data[disk] = {
+          osd,
+          status: getTiBasedStatus(ti.status.conditions?.[0].type),
+        };
+        return data;
+      }, {});
+      if (!_.isEqual(newData, ocsState.replacementMap)) {
+        dispatch({
+          type: ActionType.SET_REPLACEMENT_MAP,
+          payload: newData,
+        });
+      }
+    }
+  }
+
+  return (
+    <Table
+      {...props}
+      aria-label="Disks List"
+      Header={diskHeader}
+      Row={diskRow}
+      customData={{ ocsState, dispatch }}
+      virtualize
+    />
+  );
+});
+
+export const OCSNodesDiskListPage = (props: NodesDisksListPageProps) => (
+  <NodesDisksListPage obj={props.obj} ListComponent={OCSDisksList} />
+);
+
+type OCSMetadata = {
+  ocsState: OCSColumnState;
+  dispatch: React.Dispatch<OCSColumnStateAction>;
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-kebab-options.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-kebab-options.tsx
@@ -2,26 +2,41 @@ import * as React from 'react';
 import { TableData } from '@console/internal/components/factory';
 import { KebabOption, Kebab } from '@console/internal/components/utils';
 import { diskReplacementModal } from './disk-replacement-modal';
+import { OCSDiskList, OCSColumnStateAction } from './state-reducer';
 
-const startDiskReplacementAction = (diskName: string, osdId: string): KebabOption => ({
+const startDiskReplacementAction = (
+  diskName,
+  diskOsdMap,
+  isRebalancing,
+  dispatch,
+): KebabOption => ({
   label: 'Start Disk Replacement',
   callback: () =>
     diskReplacementModal({
       diskName,
-      osdId,
+      diskOsdMap,
+      isRebalancing,
+      dispatch,
     }),
 });
 
-export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = ({ diskName, diskOsdMap }) => {
-  const osdId: string = diskOsdMap.get(diskName);
-  const kebabOptions: KebabOption[] = [startDiskReplacementAction(diskName, osdId)];
+export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
+  ({ diskName, diskOsdMap, isRebalancing, dispatch }) => {
+    const kebabOptions: KebabOption[] = [
+      startDiskReplacementAction(diskName, diskOsdMap, isRebalancing, dispatch),
+    ];
+    return (
+      <TableData className={Kebab.columnClass}>
+        {/* Disable options for non OCS based disks */}
+        <Kebab options={kebabOptions} isDisabled={!diskOsdMap[diskName]} />
+      </TableData>
+    );
+  },
+);
 
-  return (
-    <TableData className={Kebab.columnClass}>
-      {/* Disable options for non OCS based disks */}
-      <Kebab options={kebabOptions} isDisabled={!!osdId} />
-    </TableData>
-  );
+type OCSKebabOptionsProps = {
+  diskName: string;
+  diskOsdMap: OCSDiskList;
+  isRebalancing: boolean;
+  dispatch: React.Dispatch<OCSColumnStateAction>;
 };
-
-type OCSKebabOptionsProps = { diskName: string; diskOsdMap: Map<string, string> };

--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-status-column.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-status-column.scss
@@ -1,0 +1,3 @@
+.ceph-ocs-status__status-icon-and-text--color {
+  color: var(--pf-global--icon--Color--dark);
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-status-column.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-status-column.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { OffIcon } from '@patternfly/react-icons';
+import { TableData } from '@console/internal/components/factory';
+import { OCSColumnState, Status, OCSDiskStatus } from './state-reducer';
+import { ExternalLink } from '@console/internal/components/utils';
+import {
+  ErrorStatus,
+  PopoverStatus,
+  SuccessStatus,
+  ProgressStatus,
+  StatusIconAndText,
+} from '@console/shared';
+import './ocs-status-column.scss';
+
+const getOCSStatusBody = (status: OCSDiskStatus, diskName: string): React.ReactNode => {
+  switch (status) {
+    case Status.Online:
+      return <SuccessStatus title={status} />;
+    case Status.PreparingToReplace:
+      return <ProgressStatus title={status} />;
+    case Status.ReplacementReady:
+      return (
+        <PopoverStatus
+          statusBody={
+            <StatusIconAndText
+              className="ceph-ocs-status__status-icon-and-text--color"
+              title={status}
+              icon={<OffIcon />}
+            />
+          }
+        >
+          <p>
+            <strong>{diskName}</strong> can be replaced with a disk of same type.
+          </p>
+        </PopoverStatus>
+      );
+    case Status.Offline:
+    case Status.NotResponding:
+      return (
+        <PopoverStatus statusBody={<ErrorStatus title={status} />}>
+          <span>Troubleshoot the status </span>{' '}
+          <span>
+            <ExternalLink href="https://access.redhat.com/solutions/5194851 " text="here" />
+          </span>
+        </PopoverStatus>
+      );
+    case Status.ReplacementFailed:
+      return <ErrorStatus title={status} />;
+    default:
+      return status;
+  }
+};
+
+export const OCSStatus: React.FC<{
+  ocsState: OCSColumnState;
+  diskName: string;
+  className: string;
+}> = React.memo(({ ocsState, className, diskName }) => {
+  const { replacementMap, alertsMap, metricsMap } = ocsState;
+  let status: OCSDiskStatus;
+  if (replacementMap[diskName]) status = replacementMap[diskName].status;
+  else if (alertsMap[diskName]) status = alertsMap[diskName].status;
+  else if (metricsMap[diskName]) status = metricsMap[diskName].status;
+  return (
+    <TableData className={className}>{status ? getOCSStatusBody(status, diskName) : '-'}</TableData>
+  );
+});

--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/state-reducer.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/state-reducer.ts
@@ -1,0 +1,80 @@
+export enum ActionType {
+  SET_ALERTS_MAP = 'SET_ALERTS_MAP',
+  SET_TEMPLATES_MAP = 'SET_TEMPLATES_MAP',
+  SET_METRICS_MAP = 'SET_METRICS_MAP',
+  SET_IS_REBALANCING = 'SET_IS_REBALANCING',
+  SET_REPLACEMENT_MAP = 'SET_REPLACEMENT_MAP',
+}
+
+export enum Status {
+  Online = 'Online',
+  Offline = 'Offline',
+  NotResponding = 'NotResponding',
+  PreparingToReplace = 'PreparingToReplace',
+  ReplacementReady = 'ReplacementReady',
+  ReplacementFailed = 'ReplacementFailed',
+  Unknown = 'Unknown',
+}
+
+export const initialState: OCSColumnState = {
+  metricsMap: {},
+  alertsMap: {},
+  isRebalancing: false,
+  replacementMap: {},
+};
+
+export const reducer = (state: OCSColumnState, action: OCSColumnStateAction) => {
+  switch (action.type) {
+    case ActionType.SET_ALERTS_MAP: {
+      return {
+        ...state,
+        alertsMap: action.payload,
+      };
+    }
+    case ActionType.SET_METRICS_MAP: {
+      return {
+        ...state,
+        metricsMap: action.payload,
+      };
+    }
+    case ActionType.SET_REPLACEMENT_MAP: {
+      return {
+        ...state,
+        replacementMap: action.payload,
+      };
+    }
+    case ActionType.SET_IS_REBALANCING: {
+      return {
+        ...state,
+        isRebalancing: action.payload,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export type OCSColumnStateAction =
+  | { type: ActionType.SET_ALERTS_MAP; payload: OCSDiskList }
+  | { type: ActionType.SET_METRICS_MAP; payload: OCSDiskList }
+  | { type: ActionType.SET_REPLACEMENT_MAP; payload: OCSDiskList }
+  | { type: ActionType.SET_IS_REBALANCING; payload: boolean };
+
+export type OCSColumnState = {
+  metricsMap: OCSDiskList;
+  alertsMap: OCSDiskList;
+  isRebalancing: boolean;
+  replacementMap: OCSDiskList;
+};
+
+export type OCSDiskList = {
+  [diskName: string]: OCSDiskMetadata;
+};
+
+export type OCSDiskStatus = keyof typeof Status;
+
+export type OCSDiskMetadata = { osd: string; status: OCSDiskStatus };
+
+export type AlertsDiskMap = {
+  [disk: string]: string;
+};

--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -17,6 +17,7 @@ export const OCS_SUPPORT_ANNOTATION = 'features.ocs.openshift.io/enabled';
 export const OCS_DEVICE_SET_REPLICA = 3;
 export const ATTACHED_DEVICES_ANNOTATION = 'cluster.ocs.openshift.io/local-devices';
 export const AVAILABLE = 'Available';
+export const OSD_REMOVAL_TEMPLATE = 'ocs-osd-removal';
 export const dropdownUnits = {
   GiB: 'Gi',
   TiB: 'Ti',
@@ -41,3 +42,6 @@ export enum MODES {
   EXTERNAL = 'External',
   ATTACHED_DEVICES = 'Internal - Attached Devices',
 }
+
+export const OSD_DOWN_ALERT = 'CephOSDDiskNotResponding';
+export const OSD_DOWN_AND_OUT_ALERT = 'CephOSDDiskUnavailable';

--- a/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { ProjectModel, PodModel, StorageClassModel } from '@console/internal/models';
 import { STORAGE_CLASSES, PROJECTS, PODS } from '.';
 
@@ -206,3 +207,7 @@ export const utilizationPopoverQueryMap = [
 
 export const getPVCUsedCapacityQuery = (pvcName: string): string =>
   `kubelet_volume_stats_used_bytes{persistentvolumeclaim='${pvcName}'}`;
+
+export const osdDiskInfoMetric = _.template(
+  `ceph_disk_occupation{exported_instance=~'<%= nodeName %>'}`,
+);

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -20,6 +20,7 @@ import {
 
 export const OCS_INDEPENDENT_FLAG = 'OCS_INDEPENDENT';
 export const OCS_CONVERGED_FLAG = 'OCS_CONVERGED';
+/* INFO: Flag OCS_ATTACHED_DEVICES_FLAG used in local-storage-plugin without import */
 export const OCS_ATTACHED_DEVICES_FLAG = 'OCS_ATTACHED_DEVICES';
 // Used to activate NooBaa dashboard
 export const OCS_FLAG = 'OCS';

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -6,6 +6,7 @@ import {
   DashboardsOverviewHealthResourceSubsystem,
   DashboardsOverviewUtilizationItem,
   DashboardsTab,
+  HorizontalNavTab,
   KebabActions,
   ModelDefinition,
   ModelFeatureFlag,
@@ -15,7 +16,17 @@ import {
   ResourceDetailsPage,
   DashboardsOverviewResourceActivity,
   CustomFeatureFlag,
+  StorageClassProvisioner,
 } from '@console/plugin-sdk';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
+import { GridPosition } from '@console/shared/src/components/dashboard/DashboardGrid';
+import { referenceForModel, referenceFor } from '@console/internal/module/k8s';
+import { PersistentVolumeClaimModel, NodeModel } from '@console/internal/models';
+import { LSO_DEVICE_DISCOVERY } from '@console/local-storage-operator-plugin/src/plugin';
+import { getCephHealthState } from './components/dashboard-page/storage-dashboard/status-card/utils';
+import { isClusterExpandActivity } from './components/dashboard-page/storage-dashboard/activity-card/cluster-expand-activity';
+import { StorageClassFormProvisoners } from './utils/storage-class-params';
+import { WatchCephResource } from './types';
 import {
   detectOCS,
   detectOCSSupportedFeatures,
@@ -24,19 +35,12 @@ import {
   OCS_INDEPENDENT_FLAG,
   OCS_SUPPORT_FLAGS,
   OCS_CONVERGED_FLAG,
+  OCS_ATTACHED_DEVICES_FLAG,
 } from './features';
-import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
-import { GridPosition } from '@console/shared/src/components/dashboard/DashboardGrid';
-import { referenceForModel, referenceFor } from '@console/internal/module/k8s';
-import { PersistentVolumeClaimModel } from '@console/internal/models';
-import { getCephHealthState } from './components/dashboard-page/storage-dashboard/status-card/utils';
-import { isClusterExpandActivity } from './components/dashboard-page/storage-dashboard/activity-card/cluster-expand-activity';
-import { WatchCephResource } from './types';
-import { StorageClassProvisioner } from '@console/plugin-sdk/src/typings/storage-class-params';
-import { StorageClassFormProvisoners } from './utils/storage-class-params';
 
 type ConsumedExtensions =
   | ModelFeatureFlag
+  | HorizontalNavTab
   | ModelDefinition
   | DashboardsTab
   | DashboardsCard
@@ -414,6 +418,23 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [CEPH_FLAG],
+    },
+  },
+  {
+    type: 'HorizontalNavTab',
+    properties: {
+      model: NodeModel,
+      page: {
+        href: 'disks',
+        name: 'Disks',
+      },
+      loader: () =>
+        import(
+          './components/attached-devices-mode/lso-disk-inventory/ocs-disks-list' /* webpackChunkName: "ocs-nodes-disks-list" */
+        ).then((m) => m.OCSNodesDiskListPage),
+    },
+    flags: {
+      required: [OCS_ATTACHED_DEVICES_FLAG, LSO_DEVICE_DISCOVERY],
     },
   },
 ];

--- a/frontend/packages/local-storage-operator-plugin/src/components/disks-list/disks-list-page.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/disks-list/disks-list-page.tsx
@@ -11,13 +11,11 @@ import {
 } from '@console/internal/components/factory';
 import { sortable } from '@patternfly/react-table';
 import { FirehoseResult, humanizeBinaryBytes, Kebab } from '@console/internal/components/utils';
-import { referenceForModel, NodeKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { referenceForModel, NodeKind } from '@console/internal/module/k8s';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
-import { useFlag } from '@console/shared/src/hooks/flag';
-import { OCS_ATTACHED_DEVICES_FLAG } from '@console/ceph-storage-plugin/src/features';
-import { OCSKebabOptions } from '@console/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-kebab-options';
 import { LocalVolumeDiscoveryResult } from '../../models';
 import { LABEL_SELECTOR } from '../../constants/disks-list';
+import { DiskMetadata, DiskStates, LocalVolumeDiscoveryResultKind } from './types';
 
 export const diskFilters: RowFilter[] = [
   {
@@ -27,11 +25,14 @@ export const diskFilters: RowFilter[] = [
       return disk?.status?.state;
     },
     items: [
-      { id: 'Available', title: 'Available' },
-      { id: 'NotAvailable', title: 'NotAvailable' },
-      { id: 'Unknown', title: 'Unknown' },
+      { id: DiskStates.Available, title: DiskStates.Available },
+      { id: DiskStates.NotAvailable, title: DiskStates.NotAvailable },
+      { id: DiskStates.Unknown, title: DiskStates.Unknown },
     ],
-    filter: (states: { all: DiskStates[]; selected: Set<DiskStates> }, disk: DiskMetadata) => {
+    filter: (
+      states: { all: (keyof typeof DiskStates)[]; selected: Set<keyof typeof DiskStates> },
+      disk: DiskMetadata,
+    ) => {
       if (!states || !states.selected || _.isEmpty(states.selected)) {
         return true;
       }
@@ -51,90 +52,67 @@ export const tableColumnClasses = [
   Kebab.columnClass,
 ];
 
-const getDiskHeader = (isOCSAttachedDevices: boolean) => {
-  const headers = [
-    {
-      title: 'Name',
-      sortField: 'path',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[0] },
-    },
-    {
-      title: 'Disk State',
-      sortField: 'status.state',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[1] },
-    },
-    {
-      title: 'Type',
-      sortField: 'type',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[2] },
-    },
-    {
-      title: 'Model',
-      sortField: 'model',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[3] },
-    },
-    {
-      title: 'Capacity',
-      sortField: 'size',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[4] },
-    },
-    {
-      title: 'Filesystem',
-      sortField: 'fstype',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[5] },
-    },
-  ];
-  if (isOCSAttachedDevices) {
-    headers.push({
-      title: '',
-      sortField: '',
-      transforms: [],
-      props: { className: tableColumnClasses[6] },
-    });
-  }
-  return () => headers;
-};
+const diskHeader = () => [
+  {
+    title: 'Name',
+    sortField: 'path',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[0] },
+  },
+  {
+    title: 'Disk State',
+    sortField: 'status.state',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[1] },
+  },
+  {
+    title: 'Type',
+    sortField: 'type',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[2] },
+  },
+  {
+    title: 'Model',
+    sortField: 'model',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[3] },
+  },
+  {
+    title: 'Capacity',
+    sortField: 'size',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[4] },
+  },
+  {
+    title: 'Filesystem',
+    sortField: 'fstype',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[5] },
+  },
+];
 
-const diskRow: RowFunction<DiskMetadata, OCSMetadata> = ({
+const diskRow: RowFunction<DiskMetadata> = ({ obj, index, key, style }) => (
+  <TableRow id={obj.deviceID} index={index} trKey={key} style={style}>
+    <TableData className={tableColumnClasses[0]}>{obj.path}</TableData>
+    <TableData className={tableColumnClasses[1]}>{obj.status.state}</TableData>
+    <TableData className={tableColumnClasses[2]}>{obj.type || '-'}</TableData>
+    <TableData className={cx(tableColumnClasses[3], 'co-break-word')}>{obj.model || '-'}</TableData>
+    <TableData className={tableColumnClasses[4]}>
+      {humanizeBinaryBytes(obj.size).string || '-'}
+    </TableData>
+    <TableData className={tableColumnClasses[5]}>{obj.fstype || '-'}</TableData>
+  </TableRow>
+);
+
+const DisksList: React.FC<TableProps> = (props) => (
+  <Table {...props} aria-label="Disks List" Header={diskHeader} Row={diskRow} virtualize />
+);
+
+export const NodesDisksListPage: React.FC<NodesDisksListPageProps> = ({
   obj,
-  index,
-  key,
-  style,
-  customData,
+  ListComponent = undefined,
 }) => {
-  const { isOCSAttachedDevices, diskOsdMap } = customData;
-  const diskName = obj.path;
-  return (
-    <TableRow id={obj.deviceID} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>{obj.path}</TableData>
-      <TableData className={tableColumnClasses[1]}>{obj.status.state}</TableData>
-      <TableData className={tableColumnClasses[2]}>{obj.type || '-'}</TableData>
-      <TableData className={cx(tableColumnClasses[3], 'co-break-word')}>
-        {obj.model || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
-        {humanizeBinaryBytes(obj.size).string || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>{obj.fstype || '-'}</TableData>
-      {isOCSAttachedDevices && <OCSKebabOptions diskName={diskName} diskOsdMap={diskOsdMap} />}
-    </TableRow>
-  );
-};
-
-const DisksList: React.FC<TableProps> = (props) => {
-  const diskHeader = getDiskHeader(props.customData.isOCSAttachedDevices);
-  return <Table {...props} aria-label="Disks List" Header={diskHeader} Row={diskRow} virtualize />;
-};
-
-const DisksListPage: React.FC<{ obj: NodeKind }> = (props) => {
-  const isOCSAttachedDevices = useFlag(OCS_ATTACHED_DEVICES_FLAG);
-  const nodeName = props.obj.metadata.name;
+  const nodeName = obj.metadata.name;
   const propName = `lvdr-${nodeName}`;
 
   return (
@@ -144,10 +122,10 @@ const DisksListPage: React.FC<{ obj: NodeKind }> = (props) => {
       hideLabelFilter
       textFilter="node-disk-name"
       rowFilters={diskFilters}
-      flatten={(resource: FirehoseResult<LocalVolumeDiscoveryResult>) =>
+      flatten={(resource: FirehoseResult<LocalVolumeDiscoveryResultKind>) =>
         resource[propName]?.data[0]?.status?.discoveredDevices ?? []
       }
-      ListComponent={DisksList}
+      ListComponent={ListComponent ?? DisksList}
       resources={[
         {
           kind: referenceForModel(LocalVolumeDiscoveryResult),
@@ -155,41 +133,12 @@ const DisksListPage: React.FC<{ obj: NodeKind }> = (props) => {
           selector: { [LABEL_SELECTOR]: nodeName },
         },
       ]}
-      customData={{
-        diskOsdMap: new Map() /* TBD(Afreen) Will be changed to actual state with this https://issues.redhat.com/browse/RHSTOR-1194  */,
-        isOCSAttachedDevices,
-      }}
+      customData={{ node: nodeName }}
     />
   );
 };
 
-export default DisksListPage;
-
-type DiskMetadata = LocalVolumeDiscoveryResult['status']['discoveredDevices'];
-type OCSMetadata = {
-  isOCSAttachedDevices: boolean;
-  diskOsdMap: Map<string, string>;
+export type NodesDisksListPageProps = {
+  obj: NodeKind;
+  ListComponent: React.ComponentType;
 };
-
-type LocalVolumeDiscoveryResult = K8sResourceCommon & {
-  spec: {
-    nodeName: string;
-  };
-  status: {
-    discoveredDevices: {
-      deviceID: string;
-      fstype: string;
-      model: string;
-      path: string;
-      serial: string;
-      size: string;
-      status: {
-        state: DiskStates;
-      };
-      type: string;
-      vendor: string;
-    };
-  };
-};
-
-type DiskStates = 'Available' | 'Unknown' | 'NotAvailable';

--- a/frontend/packages/local-storage-operator-plugin/src/components/disks-list/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/disks-list/types.ts
@@ -1,0 +1,30 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+
+export enum DiskStates {
+  Available = 'Available',
+  NotAvailable = 'NotAvailable',
+  Unknown = 'Unknown',
+}
+
+export type LocalVolumeDiscoveryResultKind = K8sResourceCommon & {
+  spec: {
+    nodeName: string;
+  };
+  status: {
+    discoveredDevices: {
+      deviceID: string;
+      fstype: string;
+      model: string;
+      path: string;
+      serial: string;
+      size: string;
+      status: {
+        state: keyof typeof DiskStates;
+      };
+      type: string;
+      vendor: string;
+    };
+  };
+};
+
+export type DiskMetadata = LocalVolumeDiscoveryResultKind['status']['discoveredDevices'];

--- a/frontend/packages/local-storage-operator-plugin/src/plugin.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/plugin.ts
@@ -21,7 +21,9 @@ type ConsumedExtensions =
   | RoutePage;
 
 const LSO_FLAG = 'LSO';
-const LSO_DEVICE_DISCOVERY = 'LSO_DEVICE_DISCOVERY';
+export const LSO_DEVICE_DISCOVERY = 'LSO_DEVICE_DISCOVERY';
+const OCS_ATTACHED_DEVICES_FLAG =
+  'OCS_ATTACHED_DEVICES'; /* Inline with OCS_ATTACHED_DEVICES_FLAG flag of `@console/ceph-storage-plugin/src/fetaures` */
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -71,10 +73,11 @@ const plugin: Plugin<ConsumedExtensions> = [
       loader: () =>
         import(
           './components/disks-list/disks-list-page' /* webpackChunkName: "lso-disks-list" */
-        ).then((m) => m.default),
+        ).then((m) => m.NodesDisksListPage),
     },
     flags: {
       required: [LSO_DEVICE_DISCOVERY],
+      disallowed: [OCS_ATTACHED_DEVICES_FLAG],
     },
   },
   {


### PR DESCRIPTION
- Implements https://issues.redhat.com/browse/RHSTOR-1194
- https://issues.redhat.com/browse/RHSTOR-1198
- Creating a new table component to manage OCS specific state.
  This separates the code of OCS and LSO plugin.
- Completes disk replacement flow

![Screenshot from 2020-07-31 16-43-16](https://user-images.githubusercontent.com/25664409/89039082-1a9be680-d35f-11ea-8b15-cfc21172a995.png)
![Screenshot from 2020-07-31 16-41-53](https://user-images.githubusercontent.com/25664409/89039098-2091c780-d35f-11ea-9485-e6efaf5ee452.png)
![Screenshot from 2020-07-30 22-21-35](https://user-images.githubusercontent.com/25664409/89039141-2daeb680-d35f-11ea-9b30-4413343f77da.png)
![Screenshot from 2020-07-31 16-43-00](https://user-images.githubusercontent.com/25664409/89039201-4323e080-d35f-11ea-9cf4-0d1a005f4c6b.png)


Signed-off-by: Afreen Rahman <afrahman@redhat.com>