### PR TITLE
Monitoring: Use <dl> for popover help text

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -280,57 +280,66 @@ const PopoverField: React.FC<{ body: React.ReactNode; label: string }> = ({ body
 );
 
 const alertStateHelp = (
-  <>
-    <p>
-      <AlertStateIcon state={AlertStates.Firing} /> <strong>Firing:</strong> The alert condition is
-      true for the duration of the timeout.
-    </p>
-    <p>
-      <AlertStateIcon state={AlertStates.Pending} /> <strong>Pending:</strong> The alert condition
-      is true, but the timeout has not been reached.
-    </p>
-    <p>
-      <AlertStateIcon state={AlertStates.Silenced} /> <strong>Silenced:</strong> The alert is now
-      silenced.
-    </p>
-  </>
+  <dl className="co-inline">
+    <dt>
+      <AlertStateIcon state={AlertStates.Firing} /> <strong>Firing: </strong>
+    </dt>
+    <dd>The alert condition is true for the duration of the timeout.</dd>
+    <dt>
+      <AlertStateIcon state={AlertStates.Pending} /> <strong>Pending: </strong>
+    </dt>
+    <dd>The alert condition is true, but the timeout has not been reached.</dd>
+    <dt>
+      <AlertStateIcon state={AlertStates.Silenced} /> <strong>Silenced: </strong>
+    </dt>
+    <dd>The alert is now silenced.</dd>
+  </dl>
 );
 
 const severityHelp = (
-  <>
-    <p>
-      <SeverityIcon severity={AlertSeverity.Critical} /> <strong>Critical:</strong> The condition
-      that triggered the alert could have a critical impact. The alert requires immediate attention
-      when fired.
-    </p>
-    <p>
-      <SeverityIcon severity={AlertSeverity.Warning} /> <strong>Warning:</strong> The alert provides
-      a warning notification about something that might require attention in order to prevent a
-      problem from occurring.
-    </p>
-    <p>
-      <SeverityIcon severity={AlertSeverity.Info} /> <strong>Info:</strong> The alert is provided
-      for informational purposes only.
-    </p>
-    <p>
-      <SeverityIcon severity={AlertSeverity.None} /> <strong>None:</strong> The alert has no defined
-      severity.
-    </p>
-  </>
+  <dl className="co-inline">
+    <dt>
+      <SeverityIcon severity={AlertSeverity.Critical} /> <strong>Critical: </strong>
+    </dt>
+    <dd>
+      The condition that triggered the alert could have a critical impact. The alert requires
+      immediate attention when fired.
+    </dd>
+    <dt>
+      <SeverityIcon severity={AlertSeverity.Warning} /> <strong>Warning: </strong>
+    </dt>
+    <dd>
+      The alert provides a warning notification about something that might require attention in
+      order to prevent a problem from occurring.
+    </dd>
+    <dt>
+      <SeverityIcon severity={AlertSeverity.Info} /> <strong>Info: </strong>
+    </dt>
+    <dd>The alert is provided for informational purposes only.</dd>
+    <dt>
+      <SeverityIcon severity={AlertSeverity.None} /> <strong>None: </strong>
+    </dt>
+    <dd>The alert has no defined severity.</dd>
+  </dl>
 );
 
 const sourceHelp = (
-  <>
-    <p>
-      <strong>Platform:</strong> Platform-level alerts relate only to OpenShift namespaces.
-      OpenShift namespaces provide core OpenShift functionality.
-    </p>
-    <p>
-      <strong>User:</strong> User workload alerts relate to user-defined namespaces and are
-      customizable. User workload monitoring can be enabled post-installation to provide
-      observability into your own services.
-    </p>
-  </>
+  <dl className="co-inline">
+    <dt>
+      <strong>Platform: </strong>
+    </dt>
+    <dd>
+      Platform-level alerts relate only to OpenShift namespaces. OpenShift namespaces provide core
+      OpenShift functionality.
+    </dd>
+    <dt>
+      <strong>User: </strong>
+    </dt>
+    <dd>
+      User workload alerts relate to user-defined namespaces and are customizable. User workload
+      monitoring can be enabled post-installation to provide observability into your own services.
+    </dd>
+  </dl>
 );
 
 const Annotation = ({ children, title }) =>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -1,5 +1,15 @@
 $co-external-link-padding-right: 15px;
 
+dl.co-inline {
+  dd {
+    margin-bottom: 1em;
+  }
+  dt {
+    float: left;
+    margin-right: 0.4em;
+  }
+}
+
 .co-m-pane__body {
   margin: $grid-gutter-width 0 0;
   padding: 0 ($grid-gutter-width / 2) $grid-gutter-width;


### PR DESCRIPTION
These help texts are description lists, so `<dl>` is better for accessibility.

Do you prefer this approach @spadgett?

Before | After
-|-
![before](https://user-images.githubusercontent.com/460802/88992931-878f8c00-d31f-11ea-8d33-6db37a8bd91f.png) | ![after](https://user-images.githubusercontent.com/460802/88992936-8a8a7c80-d31f-11ea-9112-9c93d5f7712e.png)
