### PR TITLE
Bug 1871092: Catch unhandeled promise when metrics are not available (shows an error overlay in the topology in dev mode)

### DIFF
--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -305,9 +305,10 @@ class OverviewMainContent_ extends React.Component<
           throw new Error(`Could not fetch metrics, status: ${status}`);
         }
       })
-      .then(() => {
-        this.metricsInterval = setTimeout(this.fetchMetrics, METRICS_POLL_INTERVAL);
-      });
+      .then(
+        () => (this.metricsInterval = setTimeout(this.fetchMetrics, METRICS_POLL_INTERVAL)),
+        () => {},
+      );
   };
 
   filterItems(items: OverviewItem[]): OverviewItem[] {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4416

**Analysis / Root cause**: 
There is a full screen error message each time I open the Topology on a local CRC (in dev mode) because there is no metrics available on a CRC.

**Solution Description**: 
Handle the promise also in the error case. => Do nothing here.

**Screen shots / Gifs for design review**: 
Before:
![unhandled-promise](https://user-images.githubusercontent.com/139310/89037315-8c176d00-d33e-11ea-8f42-fa3ebb976531.png)

After:
No error message was shoiwn.

**Unit test coverage report**: 
Not covered

**Test setup:**
* Requires a CRC setup
* Start local developer console and open the topology

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge