### PR TITLE
Only show namespace table column when all projects is selected (for all admin workloads)

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -61,6 +61,7 @@ const Header = (disableItems = {}) => () =>
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',
@@ -120,7 +121,7 @@ const Row: RowFunction<VolumeSnapshotKind> = ({ key, obj, style, index, customDa
           namespace={namespace}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      <TableData className={tableColumnClasses[1]} columnID="namespace">
         <ResourceLink kind={NamespaceModel.kind} name={namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -125,6 +125,7 @@ const BuildConfigsTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Labels',
@@ -157,7 +158,10 @@ const BuildConfigsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, s
           title={obj.metadata.name}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -324,6 +324,7 @@ const BuildsTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',
@@ -356,7 +357,10 @@ const BuildsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }
           title={obj.metadata.name}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -34,6 +34,7 @@ const ConfigMapTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Size',
@@ -66,7 +67,10 @@ const ConfigMapTableRow = ({ obj: configMap, index, key, style }) => {
           title={configMap.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={configMap.metadata.namespace}

--- a/frontend/public/components/cron-job.tsx
+++ b/frontend/public/components/cron-job.tsx
@@ -59,6 +59,7 @@ const CronJobTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Schedule',
@@ -97,7 +98,10 @@ const CronJobTableRow: RowFunction<CronJobKind> = ({ obj: cronjob, index, key, s
           namespace={cronjob.metadata.namespace}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={cronjob.metadata.namespace}

--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -60,6 +60,7 @@ const DaemonSetTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',
@@ -98,7 +99,10 @@ const DaemonSetTableRow: RowFunction<K8sResourceKind> = ({ obj: daemonset, index
           title={daemonset.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={daemonset.metadata.namespace}

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -231,6 +231,7 @@ const HorizontalPodAutoscalersTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Labels',
@@ -280,7 +281,10 @@ const HorizontalPodAutoscalersTableRow: RowFunction<K8sResourceKind> = ({
           title={obj.metadata.name}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={obj.metadata.namespace}

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -307,6 +307,7 @@ const ImageStreamsTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Labels',
@@ -339,7 +340,10 @@ const ImageStreamsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, s
           title={obj.metadata.name}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -78,6 +78,7 @@ const IngressTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Labels',
@@ -110,7 +111,10 @@ const IngressTableRow = ({ obj: ingress, index, key, style }) => {
           title={ingress.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={ingress.metadata.namespace}

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -72,6 +72,7 @@ const JobTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Labels',
@@ -111,7 +112,10 @@ const JobTableRow: RowFunction<JobKind> = ({ obj: job, index, key, style }) => {
           title={job.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={job.metadata.namespace}

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -37,7 +37,7 @@ export const LimitRangeTableRow: RowFunction<K8sResourceKind> = ({ obj, index, k
           namespace={obj.metadata.namespace}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      <TableData className={tableColumnClasses[1]} columnID="namespace">
         <ResourceLink
           kind="Namespace"
           name={obj.metadata.namespace}
@@ -67,6 +67,7 @@ export const LimitRangeTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Created',

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -60,6 +60,7 @@ const MachineAutoscalerTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Scale Target',
@@ -97,7 +98,10 @@ const MachineAutoscalerTableRow: RowFunction<K8sResourceKind> = ({ obj, index, k
           namespace={obj.metadata.namespace}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>

--- a/frontend/public/components/machine-health-check.tsx
+++ b/frontend/public/components/machine-health-check.tsx
@@ -44,6 +44,7 @@ const MachineHealthCheckTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Created',
@@ -69,7 +70,10 @@ const MachineHealthCheckTableRow: RowFunction<K8sResourceKind> = ({ obj, index, 
           namespace={obj.metadata.namespace}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -107,6 +107,7 @@ const MachineSetTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Machines',
@@ -132,7 +133,10 @@ const MachineSetTableRow: RowFunction<MachineSetKind> = ({ obj, index, key, styl
           namespace={obj.metadata.namespace}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -56,6 +56,7 @@ const MachineTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Node',
@@ -113,7 +114,10 @@ const MachineTableRow: RowFunction<MachineKind> = ({ obj, index, key, style }) =
           title={obj.metadata.name}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -42,6 +42,7 @@ const NetworkPolicyTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Pod Selector',
@@ -70,7 +71,10 @@ const NetworkPolicyTableRow = ({ obj: np, index, key, style }) => {
           title={np.metadata.name}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind={'Namespace'}
           name={np.metadata.namespace}

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -88,6 +88,7 @@ const PVCTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',
@@ -143,7 +144,10 @@ const PVCTableRow = connect(mapStateToProps)(({ obj, index, key, style, metrics 
       <TableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={name} namespace={namespace} title={name} />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={namespace} title={namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -130,7 +130,10 @@ const ReplicaSetTableRow = ({ obj, index, key, style }) => {
           title={obj.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={obj.metadata.namespace}
@@ -174,6 +177,7 @@ const ReplicaSetTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -180,7 +180,10 @@ const ReplicationControllerTableRow = ({ obj, index, key, style }) => {
           title={obj.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={obj.metadata.namespace}
@@ -224,6 +227,7 @@ const ReplicationControllerTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -113,6 +113,7 @@ const ResourceQuotaTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: '',
@@ -133,7 +134,10 @@ export const ResourceQuotaTableRow = ({ obj: rq, index, key, style }) => {
           className="co-resource-item__resource-name"
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         {rq.metadata.namespace ? (
           <ResourceLink
             kind="Namespace"

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -163,6 +163,7 @@ const RouteTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Status',
@@ -199,7 +200,10 @@ const RouteTableRow: RowFunction<RouteKind> = ({ obj: route, index, key, style }
           title={route.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={route.metadata.namespace}

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -72,6 +72,7 @@ const SecretTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Type',
@@ -111,7 +112,10 @@ const SecretTableRow = ({ obj: secret, index, key, style }) => {
           title={secret.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink
           kind="Namespace"
           name={secret.metadata.namespace}

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -126,6 +126,7 @@ const ServiceAccountTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Secrets',
@@ -157,7 +158,10 @@ const ServiceAccountTableRow = ({ obj: serviceaccount, index, key, style }) => {
       <TableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={name} namespace={namespace} title={uid} />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={namespace} title={namespace} /> {}
       </TableData>
       <TableData className={tableColumnClasses[2]}>{secrets ? secrets.length : 0}</TableData>

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -61,6 +61,7 @@ const ServiceTableHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
     },
     {
       title: 'Labels',
@@ -99,7 +100,10 @@ const ServiceTableRow = ({ obj: s, index, key, style }) => {
           title={s.metadata.uid}
         />
       </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      <TableData
+        className={classNames(tableColumnClasses[1], 'co-break-word')}
+        columnID="namespace"
+      >
         <ResourceLink kind="Namespace" name={s.metadata.namespace} title={s.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>


### PR DESCRIPTION

<img width="1356" alt="Screen Shot 2020-07-31 at 5 24 29 PM" src="https://user-images.githubusercontent.com/35978579/89079560-c0962380-d354-11ea-81d1-c702eaa7dd26.png">
<img width="1360" alt="Screen Shot 2020-07-31 at 5 24 15 PM" src="https://user-images.githubusercontent.com/35978579/89079563-c12eba00-d354-11ea-9e79-22fc7e91c9b1.png">

only show namespace table col for all projects for:

pods, deployments, deployment configs (done in pr: https://github.com/openshift/console/pull/5799)
Stateful sets
secrets
config maps
cron jobs
jobs
daemon sets
replica sets
replication controllers
Horizontal pod autoscalers
Services
Routes,
Ingresses,
Network policies
Persistent volumen claims
Volume snapshots
Build config
Build
Image stream
Pipeline resources (done in pr: https://github.com/openshift/console/pull/5799)
Machines
Machine sets
Machine autoscalers
Machine health checks
Service Accounts
Resource quotas
Limit ranges

