### PR TITLE
Bug 1856675: Fix filter toolbar initialization from URL parameters

### DIFF
--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -48,10 +48,10 @@ export const tableFilters: TableFilterMap = {
   },
 
   alerts: (values, alert: Alert) => {
-    const labels = getLabelsAsString(alert, 'labels');
     if (!values.all) {
       return true;
     }
+    const labels = getLabelsAsString(alert, 'labels');
     return !!values.all.every((v) => labels.includes(v));
   },
 
@@ -120,10 +120,10 @@ export const tableFilters: TableFilterMap = {
   },
 
   labels: (values, obj) => {
-    const labels = getLabelsAsString(obj);
     if (!values.all) {
       return true;
     }
+    const labels = getLabelsAsString(obj);
     return !!values.all.every((v) => labels.includes(v));
   },
 

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -234,8 +234,13 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
 
   // Initial URL parsing
   React.useEffect(() => {
-    !_.isEmpty(labelFilters) && applyFilter(labelFilters, FilterType.LABEL);
-    !_.isEmpty(nameFilter) && applyFilter(nameFilter, FilterType.NAME);
+    if (!hideLabelFilter) {
+      applyFilter(labelFilters, FilterType.LABEL);
+    }
+    if (!hideNameFilter) {
+      setInputText(nameFilter ?? '');
+      applyFilter(nameFilter, FilterType.NAME);
+    }
     if (_.isEmpty(selectedRowFilters)) {
       updateRowFilterSelected(_.uniq(_.flatMap(rowFilters, 'defaultSelected')));
     } else {


### PR DESCRIPTION
Fix a bug on the Monitoring pages where filters where preserved when
switching tabs (list was filtered, but the filter toolbar did not show
the applied filters).

With this change, the filters revert to default when clicking to a
different tab. When URL parameters exist (e.g. when using the browser
back button), those filters are applied to the list and shown in the
filter bar.

With this change, any `name` filter in the URL now causes the text input
to be populated with that value. This change applies to all pages that
use the filter toolbar. This seems like the correct behaviour since we
already set the text input value when the user switches from label
filter to name filter.