### PR TITLE
Bug 1870622: Update topology list view to be more consistent with workloads page

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -61,8 +61,17 @@ export function renderTopology({
   namespace,
   showGraphView,
 }: RenderProps) {
+  const skeletonOverview = (
+    <div className="skeleton-overview">
+      <div className="skeleton-overview--head" />
+      <div className="skeleton-overview--tile" />
+      <div className="skeleton-overview--tile" />
+      <div className="skeleton-overview--tile" />
+    </div>
+  );
   return (
     <StatusBox
+      skeleton={showGraphView ? undefined : skeletonOverview}
       data={model ? model.nodes : null}
       label="Topology"
       loaded={loaded}

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { DataList } from '@patternfly/react-core';
+import * as _ from 'lodash';
+import { connect } from 'react-redux';
 import {
   observer,
   isGraph,
@@ -8,13 +9,32 @@ import {
   Visualization,
   GraphElement,
 } from '@patternfly/react-topology';
-import { useDeepCompareMemoize } from '@console/shared';
+import { DataList } from '@patternfly/react-core';
+import { METRICS_POLL_INTERVAL, useDeepCompareMemoize } from '@console/shared';
+import { PROMETHEUS_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
+import {
+  fetchOverviewMetrics,
+  fetchMonitoringAlerts,
+  OverviewMetrics,
+  METRICS_FAILURE_CODES,
+} from '@console/internal/components/overview/metricUtils';
+import { Alert } from '@console/internal/components/monitoring/types';
+import * as UIActions from '@console/internal/actions/ui';
 import { TYPE_APPLICATION_GROUP } from '../components';
 import { TopologyListViewAppGroup } from './TopologyListViewAppGroup';
 import { getChildKinds, sortGroupChildren } from './list-view-utils';
 import { TopologyListViewUnassignedGroup } from './TopologyListViewUnassignedGroup';
 
 import './TopologyListView.scss';
+
+interface TopologyListViewPropsFromState {
+  metrics: OverviewMetrics;
+}
+
+interface TopologyListViewPropsFromDispatch {
+  updateMetrics: (metrics: OverviewMetrics) => void;
+  updateMonitoringAlerts: (alerts: Alert[]) => void;
+}
 
 interface TopologyListViewProps {
   visualization: Visualization;
@@ -24,159 +44,241 @@ interface TopologyListViewProps {
   onSelect: (ids: string[]) => void;
 }
 
-const TopologyListView: React.FC<TopologyListViewProps> = ({
-  visualization,
-  selectedIds,
-  onSelect,
-}) => {
-  const selectedId = selectedIds[0];
-  const [applicationGroups, setApplicationGroups] = React.useState<Node[]>();
-  const [unassignedItems, setUnassignedItems] = React.useState<Node[]>();
+const ConnectedTopologyListView: React.FC<TopologyListViewProps &
+  TopologyListViewPropsFromDispatch &
+  TopologyListViewPropsFromState> = observer(
+  ({
+    visualization,
+    selectedIds,
+    onSelect,
+    namespace,
+    metrics,
+    updateMetrics,
+    updateMonitoringAlerts,
+  }) => {
+    const selectedId = selectedIds[0];
+    const [applicationGroups, setApplicationGroups] = React.useState<Node[]>();
+    const [unassignedItems, setUnassignedItems] = React.useState<Node[]>();
 
-  const nodes = useDeepCompareMemoize(
-    visualization.getElements().filter((e) => isNode(e)) as Node[],
-  );
-
-  React.useEffect(() => {
-    const appGroups = nodes.filter((n) => n.getType() === TYPE_APPLICATION_GROUP);
-    appGroups.sort((a, b) => a.getLabel().localeCompare(b.getLabel()));
-    const items = nodes.filter(
-      (n) => n.getType() !== TYPE_APPLICATION_GROUP && isGraph(n.getParent()),
+    const nodes = useDeepCompareMemoize(
+      visualization.getElements().filter((e) => isNode(e)) as Node[],
     );
-    setApplicationGroups(appGroups);
-    setUnassignedItems(items);
-  }, [nodes]);
 
-  React.useEffect(() => {
-    if (selectedId) {
-      const element = document.getElementById(selectedId);
-      if (element) {
-        element.scrollIntoView({ block: 'nearest' });
+    React.useEffect(() => {
+      const appGroups = nodes.filter((n) => n.getType() === TYPE_APPLICATION_GROUP);
+      appGroups.sort((a, b) => a.getLabel().localeCompare(b.getLabel()));
+      const items = nodes.filter(
+        (n) => n.getType() !== TYPE_APPLICATION_GROUP && isGraph(n.getParent()),
+      );
+      setApplicationGroups(appGroups);
+      setUnassignedItems(items);
+    }, [nodes]);
+
+    React.useEffect(() => {
+      if (selectedId) {
+        const element = document.getElementById(selectedId);
+        if (element) {
+          element.scrollIntoView({ block: 'nearest' });
+        }
       }
-    }
-  }, [selectedId]);
+    }, [selectedId]);
 
-  React.useEffect(() => {
-    const getFlattenedItems = (): Node[] => {
-      const flattened = [];
-      const addFlattenedNode = (node: Node) => {
-        if (node) {
-          flattened.push(node);
-          const childNodes = sortGroupChildren(node.getChildren());
-          childNodes.forEach((child) => {
-            if (isNode(child)) {
-              addFlattenedNode(child);
-            }
+    React.useEffect(() => {
+      const getFlattenedItems = (): Node[] => {
+        const flattened = [];
+        const addFlattenedNode = (node: Node) => {
+          if (node) {
+            flattened.push(node);
+            const childNodes = sortGroupChildren(node.getChildren());
+            childNodes.forEach((child) => {
+              if (isNode(child)) {
+                addFlattenedNode(child);
+              }
+            });
+          }
+        };
+
+        const addFlattenedKinds = (children: GraphElement[]) => {
+          const { kindsMap, kindKeys } = getChildKinds(children);
+          kindKeys.forEach((key) => {
+            kindsMap[key]
+              .sort((a, b) => a.getLabel().localeCompare(b.getLabel()))
+              .forEach((child) => {
+                addFlattenedNode(child);
+              });
           });
+        };
+
+        applicationGroups.forEach((appGroup) => {
+          flattened.push(appGroup);
+          addFlattenedKinds(appGroup.getChildren());
+        });
+        addFlattenedKinds(unassignedItems);
+        return flattened;
+      };
+
+      const selectPrevious = () => {
+        const flattenedItems = getFlattenedItems();
+        const index = flattenedItems.findIndex((item) => selectedId === item.getId());
+        if (index > 0) {
+          onSelect([flattenedItems[index - 1].getId()]);
         }
       };
 
-      const addFlattenedKinds = (children: GraphElement[]) => {
-        const { kindsMap, kindKeys } = getChildKinds(children);
-        kindKeys.forEach((key) => {
-          kindsMap[key]
-            .sort((a, b) => a.getLabel().localeCompare(b.getLabel()))
-            .forEach((child) => {
-              addFlattenedNode(child);
-            });
-        });
+      const selectNext = () => {
+        const flattenedItems = getFlattenedItems();
+        const index = flattenedItems.findIndex((item) => selectedId === item.getId());
+        if (index < flattenedItems.length - 1) {
+          onSelect([flattenedItems[index + 1].getId()]);
+        }
       };
 
-      applicationGroups.forEach((appGroup) => {
-        flattened.push(appGroup);
-        addFlattenedKinds(appGroup.getChildren());
-      });
-      addFlattenedKinds(unassignedItems);
-      return flattened;
-    };
+      const stopEvent = (e: KeyboardEvent) => {
+        document.activeElement instanceof HTMLElement && document.activeElement.blur();
+        e.stopPropagation();
+        e.preventDefault();
+      };
 
-    const selectPrevious = () => {
-      const flattenedItems = getFlattenedItems();
-      const index = flattenedItems.findIndex((item) => selectedId === item.getId());
-      if (index > 0) {
-        onSelect([flattenedItems[index - 1].getId()]);
+      const onKeyDown = (e: KeyboardEvent) => {
+        const { nodeName } = e.target as Element;
+        if (nodeName === 'INPUT' || nodeName === 'TEXTAREA') {
+          return;
+        }
+
+        switch (e.key) {
+          case 'Escape':
+            stopEvent(e);
+            onSelect([]);
+            break;
+          case 'k':
+          case 'ArrowUp':
+            stopEvent(e);
+            selectPrevious();
+            break;
+          case 'j':
+          case 'ArrowDown':
+            stopEvent(e);
+            selectNext();
+            break;
+          default:
+            break;
+        }
+      };
+
+      if (visualization) {
+        window.addEventListener('keydown', onKeyDown);
       }
-    };
+      return () => {
+        window.removeEventListener('keydown', onKeyDown);
+      };
+    }, [visualization, selectedId, applicationGroups, unassignedItems, onSelect]);
 
-    const selectNext = () => {
-      const flattenedItems = getFlattenedItems();
-      const index = flattenedItems.findIndex((item) => selectedId === item.getId());
-      if (index < flattenedItems.length - 1) {
-        onSelect([flattenedItems[index + 1].getId()]);
-      }
-    };
+    React.useEffect(() => {
+      let metricsInterval: any = null;
+      let alertsInterval: any = null;
 
-    const stopEvent = (e: KeyboardEvent) => {
-      document.activeElement instanceof HTMLElement && document.activeElement.blur();
-      e.stopPropagation();
-      e.preventDefault();
-    };
+      const fetchMetrics = () => {
+        if (!PROMETHEUS_TENANCY_BASE_PATH) {
+          return;
+        }
+        fetchOverviewMetrics(namespace)
+          .then((updatedMetrics) => {
+            updateMetrics(updatedMetrics);
+          })
+          .catch((res) => {
+            const status = res?.response?.status;
+            // eslint-disable-next-line no-console
+            console.error('Could not fetch metrics, status:', status);
+            // Don't retry on some status codes unless a previous request succeeded.
+            if (_.includes(METRICS_FAILURE_CODES, status) && _.isEmpty(metrics)) {
+              throw new Error(`Could not fetch metrics, status: ${status}`);
+            }
+          })
+          .then(() => {
+            metricsInterval = setTimeout(fetchMetrics, METRICS_POLL_INTERVAL);
+          })
+          .catch((e) => {
+            console.error(e); // eslint-disable-line no-console
+          });
+      };
 
-    const onKeyDown = (e: KeyboardEvent) => {
-      const { nodeName } = e.target as Element;
-      if (nodeName === 'INPUT' || nodeName === 'TEXTAREA') {
-        return;
-      }
+      const fetchAlerts = (): void => {
+        fetchMonitoringAlerts(namespace)
+          .then((alerts) => {
+            updateMonitoringAlerts(alerts);
+          })
+          .catch((e) => {
+            console.error(e); // eslint-disable-line no-console
+          })
+          .then(() => {
+            alertsInterval = setTimeout(fetchAlerts, 15 * 1000);
+          })
+          .catch((e) => {
+            console.error(e); // eslint-disable-line no-console
+          });
+      };
 
-      switch (e.key) {
-        case 'Escape':
-          stopEvent(e);
-          onSelect([]);
-          break;
-        case 'k':
-        case 'ArrowUp':
-          stopEvent(e);
-          selectPrevious();
-          break;
-        case 'j':
-        case 'ArrowDown':
-          stopEvent(e);
-          selectNext();
-          break;
-        default:
-          break;
-      }
-    };
+      fetchMetrics();
+      fetchAlerts();
 
-    if (visualization) {
-      window.addEventListener('keydown', onKeyDown);
+      return () => {
+        clearInterval(metricsInterval);
+        clearInterval(alertsInterval);
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [namespace, updateMetrics, updateMonitoringAlerts]);
+
+    if (!applicationGroups || !unassignedItems) {
+      return null;
     }
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, [visualization, selectedId, applicationGroups, unassignedItems, onSelect]);
 
-  if (!applicationGroups || !unassignedItems) {
-    return null;
-  }
+    return (
+      <div className="odc-topology-list-view">
+        <DataList
+          aria-label="Topology List View"
+          className="odc-topology-list-view__data-list"
+          selectedDataListItemId={selectedIds[0]}
+          onSelectDataListItem={(id) => onSelect(selectedIds[0] === id ? [] : [id])}
+        >
+          {applicationGroups.map((g) => (
+            <TopologyListViewAppGroup
+              key={g.getId()}
+              appGroup={g}
+              selectedIds={selectedIds}
+              onSelect={onSelect}
+            />
+          ))}
+          {unassignedItems.length > 0 ? (
+            <TopologyListViewUnassignedGroup
+              key="unassigned"
+              items={unassignedItems}
+              selectedIds={selectedIds}
+              onSelect={onSelect}
+            />
+          ) : null}
+        </DataList>
+      </div>
+    );
+  },
+);
 
-  return (
-    <div className="odc-topology-list-view">
-      <DataList
-        aria-label="Topology List View"
-        className="odc-topology-list-view__data-list"
-        selectedDataListItemId={selectedIds[0]}
-        onSelectDataListItem={(id) => onSelect(selectedIds[0] === id ? [] : [id])}
-      >
-        {applicationGroups.map((g) => (
-          <TopologyListViewAppGroup
-            key={g.getId()}
-            appGroup={g}
-            selectedIds={selectedIds}
-            onSelect={onSelect}
-          />
-        ))}
-        {unassignedItems.length > 0 ? (
-          <TopologyListViewUnassignedGroup
-            key="unassigned"
-            items={unassignedItems}
-            selectedIds={selectedIds}
-            onSelect={onSelect}
-          />
-        ) : null}
-      </DataList>
-    </div>
-  );
+const stateToProps = ({ UI }): TopologyListViewPropsFromState => {
+  return { metrics: UI.get('overview').toJS() };
 };
 
-export default observer(TopologyListView);
+const dispatchToProps = (dispatch): TopologyListViewPropsFromDispatch => ({
+  updateMetrics: (metrics: OverviewMetrics) => dispatch(UIActions.updateOverviewMetrics(metrics)),
+  updateMonitoringAlerts: (alerts: Alert[]) =>
+    dispatch(UIActions.monitoringLoaded('devAlerts', alerts, 'dev')),
+});
+
+const TopologyListView = connect<
+  TopologyListViewPropsFromState,
+  TopologyListViewPropsFromDispatch,
+  TopologyListViewProps
+>(
+  stateToProps,
+  dispatchToProps,
+)(ConnectedTopologyListView);
+
+export default TopologyListView;

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
@@ -27,7 +27,8 @@ import { labelForNodeKind } from './list-view-utils';
 import {
   AlertsCell,
   GroupResourcesCell,
-  MetricsCell,
+  CpuCell,
+  MemoryCell,
   StatusCell,
   TypedResourceBadgeCell,
 } from './cells';
@@ -113,7 +114,10 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
     cells.push(...additionalCells);
   } else {
     cells.push(<AlertsCell key="alerts" item={item} />);
-    cells.push(<MetricsCell key="metrics" item={item} />);
+    if (!selectedIds[0]) {
+      cells.push(<MemoryCell key="memory" item={item} />);
+      cells.push(<CpuCell key="cpu" item={item} />);
+    }
     cells.push(<StatusCell key="status" item={item} />);
   }
 

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/AlertsCell.scss
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/AlertsCell.scss
@@ -1,0 +1,20 @@
+@import '../../../../../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables.scss';
+
+.odc-topology-list-view__alert-cell {
+  min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+  @media (max-width: $screen-sm-max) {
+    grid-row: 2;
+  }
+  @media (min-width: $screen-md-min) {
+    grid-area: alert;
+  }
+
+  &--status .co-icon-and-text {
+    display: inline-flex;
+    margin-right: 12px;
+
+    .odc-topology-list-view__alert-cell__builds & {
+      margin-right: 4px;
+    }
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/AlertsCell.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/AlertsCell.tsx
@@ -6,6 +6,8 @@ import { Status as TooltipStatus } from '@console/shared';
 import { pluralize } from '@console/internal/components/utils';
 import { isMobile } from '../list-view-utils';
 
+import './AlertsCell.scss';
+
 type AlertsProps = {
   item: Node;
 };
@@ -20,7 +22,7 @@ const AlertTooltip = ({ alerts, severity, noSeverityLabel = false }) => {
   const message = _.uniq(alerts.map((a) => a.message)).join('\n');
 
   const status = (
-    <span className="project-overview__status">
+    <span className="odc-topology-list-view__alert-cell--status">
       <TooltipStatus
         status={severity}
         title={noSeverityLabel ? String(count) : pluralize(count, label)}
@@ -72,12 +74,12 @@ export const AlertsCell: React.FC<AlertsProps> = ({ item }) => {
   } = _.groupBy(alerts, 'severity');
   return (
     <DataListCell id={`${item.getId()}_alerts`}>
-      <div className="project-overview__detail project-overview__detail--alert">
+      <div className="odc-topology-list-view__alert-cell">
         {error && <AlertTooltip severity="Error" alerts={error} />}
         {warning && <AlertTooltip severity="Warning" alerts={warning} />}
         {info && <AlertTooltip severity="Info" alerts={info} />}
         {(buildNew || buildPending || buildRunning || buildFailed || buildError) && (
-          <div className="project-overview__builds">
+          <div className="odc-topology-list-view__alert-cell__builds">
             Builds {buildNew && <AlertTooltip severity="New" alerts={buildNew} noSeverityLabel />}{' '}
             {buildPending && (
               <AlertTooltip severity="Pending" alerts={buildPending} noSeverityLabel />

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/CpuCell.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/CpuCell.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Node } from '@patternfly/react-topology';
+import { DataListCell } from '@patternfly/react-core';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { formatBytesAsMiB, formatCores } from '@console/internal/components/utils';
+import { useOverviewMetrics } from '../../../../utils/useOverviewMetrics';
+import { MetricsTooltip } from './MetricsTooltip';
+
+import './MetricsCell.scss';
+
+type CpuCellProps = {
+  item: Node;
+};
+
+export const CpuCell: React.FC<CpuCellProps> = ({ item }) => {
+  const { resources } = item.getData();
+  const metrics = useOverviewMetrics();
+  const getPods = () => {
+    if (resources.obj.kind === 'Pod') {
+      return [resources.obj];
+    }
+    return resources.current ? resources.current.pods : resources.pods;
+  };
+
+  let totalBytes = 0;
+  let totalCores = 0;
+  const memoryByPod = [];
+  const cpuByPod = [];
+  _.each(getPods(), ({ metadata: { name } }: K8sResourceKind) => {
+    const bytes = _.get(metrics, ['memory', name]);
+    if (_.isFinite(bytes)) {
+      totalBytes += bytes;
+      const formattedValue = `${formatBytesAsMiB(bytes)} MiB`;
+      memoryByPod.push({ name, value: bytes, formattedValue });
+    }
+
+    const cores = _.get(metrics, ['cpu', name]);
+    if (_.isFinite(cores)) {
+      totalCores += cores;
+      cpuByPod[name] = `${formatCores(cores)} cores`;
+      const formattedValue = `${formatCores(cores)} cores`;
+      cpuByPod.push({ name, value: cores, formattedValue });
+    }
+  });
+
+  return (
+    <DataListCell id={`${item.getId()}_metrics`}>
+      {_.isEmpty(metrics) || !totalBytes || !totalCores ? null : (
+        <div className="odc-topology-list-view__metrics-cell__detail--cpu">
+          <MetricsTooltip metricLabel="CPU" byPod={cpuByPod}>
+            <span>
+              <span className="odc-topology-list-view__metrics-cell__metric-value">
+                {formatCores(totalCores)}
+              </span>
+              &nbsp;
+              <span className="odc-topology-list-view__metrics-cell__metric-unit">cores</span>
+            </span>
+          </MetricsTooltip>
+        </div>
+      )}
+    </DataListCell>
+  );
+};

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/MemoryCell.scss
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/MemoryCell.scss
@@ -1,0 +1,50 @@
+@import '../../../../../../../public/style/vars';
+@import '../../../../../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables.scss';
+
+.odc-topology-list-view__metrics-cell {
+  &__metric-tooltip {
+    display: flex;
+    min-width: 225px;
+  }
+  &__tooltip-title {
+    margin-bottom: 5px;
+  }
+  &__tooltip-name {
+    flex: 2;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  &__metric-tooltip-value {
+    flex: 1;
+    text-align: right;
+  }
+  &__metric-value {
+    font-size: 18px;
+  }
+  &__metric-unit {
+    color: $color-text-muted;
+    font-size: ($font-size-base - 1);
+    margin-left: 1px;
+  }
+  &__detail--memory {
+    min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+    @media (min-width: $screen-md-min) {
+      grid-area: memory;
+    }
+  }
+  &__detail--cpu {
+    min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+    @media (min-width: $screen-md-min) {
+      grid-area: cpu;
+    }
+  }
+}
+
+@media (min-width: $screen-md-min) {
+  .odc-topology-list-view__metrics-cell__detail--cpu,
+  .odc-topology-list-view__metrics-cell__detail--memory {
+    text-align: right;
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/MemoryCell.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/MemoryCell.tsx
@@ -7,7 +7,9 @@ import { formatBytesAsMiB, formatCores, truncateMiddle } from '@console/internal
 import { useOverviewMetrics } from '../../../../utils/useOverviewMetrics';
 import { isMobile } from '../list-view-utils';
 
-type MetricsProps = {
+import './MemoryCell.scss';
+
+type MemoryCellProps = {
   item: Node;
 };
 
@@ -20,20 +22,22 @@ type MetricsTooltipProps = {
   }[];
 };
 
-const MetricsTooltip: React.FC<MetricsTooltipProps> = ({ metricLabel, byPod, children }) => {
+const MemoryTooltip: React.FC<MetricsTooltipProps> = ({ metricLabel, byPod, children }) => {
   const sortedMetrics = _.orderBy(byPod, ['value', 'name'], ['desc', 'asc']);
   const content: any[] = _.isEmpty(sortedMetrics)
     ? [<React.Fragment key="no-metrics">No {metricLabel} metrics available.</React.Fragment>]
     : _.concat(
-        <div className="project-overview__metric-tooltip-title" key="#title">
+        <div className="odc-topology-list-view__metrics-cell__tooltip-title" key="#title">
           {metricLabel} Usage by Pod
         </div>,
         sortedMetrics.map(({ name, formattedValue }) => (
-          <div key={name} className="project-overview__metric-tooltip">
-            <div className="project-overview__metric-tooltip-name">
+          <div key={name} className="odc-topology-list-view__metrics-cell__metric-tooltip">
+            <div className="odc-topology-list-view__tooltip-name">
               <span className="no-wrap">{truncateMiddle(name)}</span>
             </div>
-            <div className="project-overview__metric-tooltip-value">{formattedValue}</div>
+            <div className="odc-topology-list-view__metrics-cell__metric-tooltip-value">
+              {formattedValue}
+            </div>
           </div>
         )),
       );
@@ -62,7 +66,7 @@ const MetricsTooltip: React.FC<MetricsTooltipProps> = ({ metricLabel, byPod, chi
   );
 };
 
-export const MetricsCell: React.FC<MetricsProps> = ({ item }) => {
+export const MemoryCell: React.FC<MemoryCellProps> = ({ item }) => {
   const { resources } = item.getData();
   const metrics = useOverviewMetrics();
   const getPods = () => {
@@ -71,10 +75,6 @@ export const MetricsCell: React.FC<MetricsProps> = ({ item }) => {
     }
     return resources.current ? resources.current.pods : resources.pods;
   };
-
-  if (_.isEmpty(metrics)) {
-    return null;
-  }
 
   let totalBytes = 0;
   let totalCores = 0;
@@ -97,32 +97,21 @@ export const MetricsCell: React.FC<MetricsProps> = ({ item }) => {
     }
   });
 
-  if (!totalBytes && !totalCores) {
-    return null;
-  }
-
-  const formattedMiB = formatBytesAsMiB(totalBytes);
-  const formattedCores = formatCores(totalCores);
   return (
-    <DataListCell id={`${item.getId()}_metrics`}>
-      <div className="project-overview__detail project-overview__detail--memory">
-        <MetricsTooltip metricLabel="Memory" byPod={memoryByPod}>
-          <span>
-            <span className="project-overview__metric-value">{formattedMiB}</span>
-            &nbsp;
-            <span className="project-overview__metric-unit">MiB</span>
-          </span>
-        </MetricsTooltip>
-      </div>
-      <div className="project-overview__detail project-overview__detail--cpu">
-        <MetricsTooltip metricLabel="CPU" byPod={cpuByPod}>
-          <span>
-            <span className="project-overview__metric-value">{formattedCores}</span>
-            &nbsp;
-            <span className="project-overview__metric-unit">cores</span>
-          </span>
-        </MetricsTooltip>
-      </div>
+    <DataListCell id={`${item.getId()}_memory`}>
+      {_.isEmpty(metrics) || !totalBytes || !totalCores ? null : (
+        <div className="odc-topology-list-view__metrics-cell__detail--memory">
+          <MemoryTooltip metricLabel="Memory" byPod={memoryByPod}>
+            <span>
+              <span className="odc-topology-list-view__metrics-cell__metric-value">
+                {formatBytesAsMiB(totalBytes)}
+              </span>
+              &nbsp;
+              <span className="odc-topology-list-view__metrics-cell__metric-unit">MiB</span>
+            </span>
+          </MemoryTooltip>
+        </div>
+      )}
     </DataListCell>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/MetricsCell.scss
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/MetricsCell.scss
@@ -1,0 +1,50 @@
+@import '../../../../../../../public/style/vars';
+@import '../../../../../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables.scss';
+
+.odc-topology-list-view__metrics-cell {
+  &__metric-tooltip {
+    display: flex;
+    min-width: 225px;
+  }
+  &__tooltip-title {
+    margin-bottom: 5px;
+  }
+  &__tooltip-name {
+    flex: 2;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  &__metric-tooltip-value {
+    flex: 1;
+    text-align: right;
+  }
+  &__metric-value {
+    font-size: 18px;
+  }
+  &__metric-unit {
+    color: $color-text-muted;
+    font-size: ($font-size-base - 1);
+    margin-left: 1px;
+  }
+  &__detail--memory {
+    min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+    @media (min-width: $screen-md-min) {
+      grid-area: memory;
+    }
+  }
+  &__detail--cpu {
+    min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+    @media (min-width: $screen-md-min) {
+      grid-area: cpu;
+    }
+  }
+}
+
+@media (min-width: $screen-md-min) {
+  .odc-topology-list-view__metrics-cell__detail--cpu,
+  .odc-topology-list-view__metrics-cell__detail--memory {
+    text-align: right;
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/MetricsTooltip.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/MetricsTooltip.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { truncateMiddle } from '@console/internal/components/utils';
+import { isMobile } from '../list-view-utils';
+import { Tooltip } from '@patternfly/react-core';
+
+type MetricsTooltipProps = {
+  metricLabel: string;
+  byPod: {
+    formattedValue: string;
+    name: string;
+    value: number;
+  }[];
+};
+
+export const MetricsTooltip: React.FC<MetricsTooltipProps> = ({ metricLabel, byPod, children }) => {
+  const sortedMetrics = _.orderBy(byPod, ['value', 'name'], ['desc', 'asc']);
+  const content: any[] = _.isEmpty(sortedMetrics)
+    ? [<React.Fragment key="no-metrics">No {metricLabel} metrics available.</React.Fragment>]
+    : _.concat(
+        <div className="odc-topology-list-view__metrics-cell__tooltip-title" key="#title">
+          {metricLabel} Usage by Pod
+        </div>,
+        sortedMetrics.map(({ name, formattedValue }) => (
+          <div key={name} className="odc-topology-list-view__metrics-cell__metric-tooltip">
+            <div className="odc-topology-list-view__metrics-cell__tooltip-name">
+              <span className="no-wrap">{truncateMiddle(name)}</span>
+            </div>
+            <div className="odc-topology-list-view__metrics-cell__metric-tooltip-value">
+              {formattedValue}
+            </div>
+          </div>
+        )),
+      );
+
+  const keepLines = 6;
+  // Don't remove a single line to show a "1 other" message since there's space to show the last pod in that case.
+  // Make sure we always remove at least 2 lines if we truncate.
+  if (content.length > keepLines + 1) {
+    const numRemoved = content.length - keepLines;
+    content.splice(
+      keepLines,
+      numRemoved,
+      <div key="#removed-pods">and {numRemoved} other pods</div>,
+    );
+  }
+
+  // Disable the tooltip on mobile since a touch also opens the sidebar, which
+  // immediately covers the tooltip content.
+  if (isMobile()) {
+    return <>{children}</>;
+  }
+  return (
+    <Tooltip content={content} distance={15}>
+      <>{children}</>
+    </Tooltip>
+  );
+};

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/StatusCell.scss
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/StatusCell.scss
@@ -1,7 +1,12 @@
+@import '../../../../../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables.scss';
+
 .odc-topology-list-view__detail--status {
   text-align: right;
   @media (min-width: $screen-md-min) {
     grid-area: status;
+  }
+  .co-icon-and-text {
+    justify-content: flex-end;
   }
 }
 

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/StatusCell.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/StatusCell.tsx
@@ -2,15 +2,17 @@ import { Node } from '@patternfly/react-topology';
 import * as React from 'react';
 import { DataListCell } from '@patternfly/react-core';
 
+import './StatusCell.scss';
+
 type StatusProps = {
   item: Node;
 };
 
 export const StatusCell: React.FC<StatusProps> = ({ item }) => {
   const { status } = item.getData().resources;
-  return status ? (
-    <DataListCell id={`${item.getId()}_metrics`}>
-      <div className="odc-topology-list-view__detail--status">{status}</div>
+  return (
+    <DataListCell id={`${item.getId()}_status`}>
+      {status ? <div className="odc-topology-list-view__detail--status">{status}</div> : null}
     </DataListCell>
-  ) : null;
+  );
 };

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/index.ts
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/index.ts
@@ -1,5 +1,6 @@
 export * from './AlertsCell';
 export * from './GroupResourcesCell';
-export * from './MetricsCell';
+export * from './CpuCell';
+export * from './MemoryCell';
 export * from './StatusCell';
 export * from './TypedResourceBadgeCell';

--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -27,7 +27,8 @@ import {
   resourceObjPath,
   truncateMiddle,
 } from '../utils';
-import { OverviewGroup, OverviewMetrics } from '.';
+import { OverviewGroup } from '.';
+import { OverviewMetrics } from './metricUtils';
 
 // Consider this mobile if the device screen width is less than 768. (This value shouldn't change.)
 const isMobile = window.screen.width < 768;


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4418

**Description**
Update the topology list view to contain separate cells for memory and cpu metrics. Add polling for metric and alert updates. 

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/11633780/89431871-78894f00-d70e-11ea-9578-b012d2296f0b.png)

After:
![image](https://user-images.githubusercontent.com/11633780/89431909-82ab4d80-d70e-11ea-97cb-0c6badfc1f8e.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @bgliwa01

