### PR TITLE
Bug 1863060: Spinner inside the modal footer needs a redesign

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.scss
@@ -1,3 +1,11 @@
 .kubevirt-modal-footer__buttons {
   width: 100%;
 }
+
+#confirm-action {
+  display: flex;
+}
+
+#modal-footer-spinner {
+  margin-right: var(--pf-global--spacer--sm);
+}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
@@ -82,46 +82,53 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
   saveAndRestartText = 'Save and Restart',
   infoMessage = null,
   infoTitle = null,
-}) => (
-  <footer
-    className={classNames('co-m-btn-bar modal-footer kubevirt-modal-footer__buttons', className)}
-  >
-    {warningMessage && isSimpleError && (
-      <ModalSimpleMessage message={warningMessage} variant="warning" />
-    )}
-    {errorMessage && isSimpleError && <ModalSimpleMessage message={errorMessage} />}
-    {errorMessage && !isSimpleError && <ModalErrorMessage message={errorMessage} />}
-    {infoTitle && <ModalInfoMessage title={infoTitle}>{infoMessage}</ModalInfoMessage>}
+}) => {
+  const [showSpinner, setShowSpinner] = React.useState(false);
 
-    <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
-      <Button
-        type="button"
-        variant={ButtonVariant.secondary}
-        data-test-id="modal-cancel-action"
-        onClick={onCancel}
-      >
-        {cancelButtonText}
-      </Button>
-      {isSaveAndRestart && (
+  React.useEffect(() => {
+    setTimeout(() => setShowSpinner(true), 300);
+  }, []);
+
+  return (
+    <footer
+      className={classNames('co-m-btn-bar modal-footer kubevirt-modal-footer__buttons', className)}
+    >
+      {warningMessage && isSimpleError && (
+        <ModalSimpleMessage message={warningMessage} variant="warning" />
+      )}
+      {errorMessage && isSimpleError && <ModalSimpleMessage message={errorMessage} />}
+      {errorMessage && !isSimpleError && <ModalErrorMessage message={errorMessage} />}
+      {infoTitle && <ModalInfoMessage title={infoTitle}>{infoMessage}</ModalInfoMessage>}
+
+      <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
         <Button
           type="button"
           variant={ButtonVariant.secondary}
-          id="save-and-restart"
-          onClick={onSaveAndRestart}
+          data-test-id="modal-cancel-action"
+          onClick={onCancel}
         >
-          {saveAndRestartText}
+          {cancelButtonText}
         </Button>
-      )}
-      <Button
-        variant={ButtonVariant.primary}
-        isDisabled={isDisabled}
-        id="confirm-action"
-        onClick={onSubmit}
-      >
-        {submitButtonText}
-      </Button>
-    </ActionGroup>
-
-    {inProgress && <Spinner />}
-  </footer>
-);
+        {isSaveAndRestart && (
+          <Button
+            type="button"
+            variant={ButtonVariant.secondary}
+            id="save-and-restart"
+            onClick={onSaveAndRestart}
+          >
+            {saveAndRestartText}
+          </Button>
+        )}
+        <Button
+          variant={ButtonVariant.primary}
+          isDisabled={isDisabled}
+          id="confirm-action"
+          onClick={onSubmit}
+        >
+          {inProgress && showSpinner && <Spinner id="modal-footer-spinner" size="md" />}
+          {submitButtonText}
+        </Button>
+      </ActionGroup>
+    </footer>
+  );
+};


### PR DESCRIPTION
**This PR also disables the loading state for the first 300ms after the modal opened to avoid a spinner flickering when some loading is happening for a split second like loading resources etc.**

Before:
![Screen-Recording-2020-08-03-at-1](https://user-images.githubusercontent.com/24938324/89199473-41ecf080-d5b7-11ea-92a7-6630b0db1d27.gif)

---------------------------------

After:
![Screen-Recording-2020-08-03-at-1 (1)](https://user-images.githubusercontent.com/24938324/89199494-4b765880-d5b7-11ea-960d-47a68b71cfc2.gif)

