### PR TITLE
Bug 1854196: Use consistent title case for operand form labels

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
@@ -11,8 +11,8 @@ const UNSUPPORTED_SCHEMA_PROPERTIES = ['allOf', 'anyOf', 'oneOf'];
 export const useSchemaLabel = (schema: JSONSchema6, uiSchema: UiSchema, defaultLabel?: string) => {
   const options = getUiOptions(uiSchema ?? {});
   const showLabel = options?.label ?? true;
-  const label = (options?.title || schema?.title || defaultLabel) as string;
-  return [showLabel, label] as [boolean, string];
+  const label = (options?.title || schema?.title) as string;
+  return [showLabel, label || _.startCase(defaultLabel)] as [boolean, string];
 };
 
 export const useSchemaDescription = (

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
@@ -156,9 +156,9 @@ describe('Using OLM descriptor components', () => {
     expect(fieldGroup.label.getText()).toEqual('Field Group');
     await fieldGroup.toggleButton.click();
     await browser.wait(until.and(until.presenceOf(item1.element), until.presenceOf(item2.element)));
-    expect(item1.label.getText()).toEqual('itemOne');
+    expect(item1.label.getText()).toEqual('Item One');
     expect(item1.input.getAttribute('value')).toEqual(testCR.spec.fieldGroup.itemOne);
-    expect(item2.label.getText()).toEqual('itemTwo');
+    expect(item2.label.getText()).toEqual('Item Two');
     expect(item2.input.getAttribute('value')).toEqual(testCR.spec.fieldGroup.itemTwo.toString());
   });
 


### PR DESCRIPTION
Apply lodash startCase to operand form field labels that are not explicitely set by descriptor (`displayName` property) or schema (`title` property).