### PR TITLE
Fixes for disk replacement

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-kebab-options.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-kebab-options.tsx
@@ -6,7 +6,8 @@ import { OCSDiskList, OCSColumnStateAction } from './state-reducer';
 
 const startDiskReplacementAction = (
   diskName,
-  diskOsdMap,
+  alertsMap,
+  replacementMap,
   isRebalancing,
   dispatch,
 ): KebabOption => ({
@@ -14,21 +15,22 @@ const startDiskReplacementAction = (
   callback: () =>
     diskReplacementModal({
       diskName,
-      diskOsdMap,
+      alertsMap,
+      replacementMap,
       isRebalancing,
       dispatch,
     }),
 });
 
 export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
-  ({ diskName, diskOsdMap, isRebalancing, dispatch }) => {
+  ({ diskName, alertsMap, replacementMap, isRebalancing, dispatch }) => {
     const kebabOptions: KebabOption[] = [
-      startDiskReplacementAction(diskName, diskOsdMap, isRebalancing, dispatch),
+      startDiskReplacementAction(diskName, alertsMap, replacementMap, isRebalancing, dispatch),
     ];
     return (
       <TableData className={Kebab.columnClass}>
-        {/* Disable options for non OCS based disks */}
-        <Kebab options={kebabOptions} isDisabled={!diskOsdMap[diskName]} />
+        {/* Enables the options for the disk with failures */}
+        <Kebab options={kebabOptions} isDisabled={!alertsMap[diskName]} />
       </TableData>
     );
   },
@@ -36,7 +38,8 @@ export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
 
 type OCSKebabOptionsProps = {
   diskName: string;
-  diskOsdMap: OCSDiskList;
+  alertsMap: OCSDiskList;
+  replacementMap: OCSDiskList;
   isRebalancing: boolean;
   dispatch: React.Dispatch<OCSColumnStateAction>;
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-status-column.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-status-column.tsx
@@ -38,7 +38,9 @@ const getOCSStatusBody = (status: OCSDiskStatus, diskName: string): React.ReactN
     case Status.NotResponding:
       return (
         <PopoverStatus statusBody={<ErrorStatus title={status} />}>
-          <span>Troubleshoot the status </span>{' '}
+          <span>
+            Troubleshoot disk <strong>{diskName}</strong>{' '}
+          </span>
           <span>
             <ExternalLink href="https://access.redhat.com/solutions/5194851 " text="here" />
           </span>

--- a/frontend/packages/local-storage-operator-plugin/src/utils/alert-actions-path.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/utils/alert-actions-path.tsx
@@ -1,4 +1,4 @@
 import { Alert } from '@console/internal/components/monitoring/types';
 
 export const getAlertActionPath = (alertData: Alert) =>
-  `/k8s/cluster/nodes/${alertData.labels.host}/disks/node-disk-name=${alertData.labels.device}`;
+  `/k8s/cluster/nodes/${alertData.labels.host}/disks?node-disk-name=${alertData.labels.device}`;


### PR DESCRIPTION
- improved creation of replacement structure by adding annotations in template for disk name and osd name
- fixed the href to disk inventory from alert
- fixed the template status to `NotReady` instead of `Not Ready`
- changed the troubleshoot text in popover
- auto generated names for template instance and secret
- omitted the redundant check for ensuring offline disk
- added the check to disallow disk replacement when replacement is in progress and replacement is done

![Screenshot from 2020-08-04 15-57-25](https://user-images.githubusercontent.com/25664409/89284445-6bb41f00-d66c-11ea-8e3b-2ffbe47a7453.png)

![Screenshot from 2020-08-04 16-18-49](https://user-images.githubusercontent.com/25664409/89285566-3f999d80-d66e-11ea-822a-cee114cfcb22.png)
