### PR TITLE
Bug 1858229: Make Mode Detection independent of Storage Cluster CR name

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
@@ -35,7 +35,7 @@ import { getName } from '@console/shared';
 import { OCSServiceModel } from '../../models';
 import FileUpload from './fileUpload';
 import { isValidJSON, checkError, prettifyJSON, getIPFamily } from './utils';
-import { OCS_INDEPENDENT_FLAG, OCS_FLAG } from '../../features';
+import { OCS_INDEPENDENT_FLAG, OCS_FLAG, OCS_CONVERGED_FLAG } from '../../features';
 import { OCS_EXTERNAL_CR_NAME, IP_FAMILY } from '../../constants';
 import './install.scss';
 
@@ -121,6 +121,7 @@ const CreateExternalCluster = withHandlePromise((props: CreateExternalClusterPro
       Promise.all([k8sCreate(SecretModel, secret), k8sCreate(OCSServiceModel, ocsObj)]),
       (data) => {
         dispatch(setFlag(OCS_INDEPENDENT_FLAG, true));
+        dispatch(setFlag(OCS_CONVERGED_FLAG, false));
         dispatch(setFlag(OCS_FLAG, true));
         history.push(
           `/k8s/ns/${ns}/clusterserviceversions/${getName(

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
@@ -30,7 +30,12 @@ import {
 import { OCSServiceModel } from '../../../models';
 import AttachedDevicesNodeTable from './sc-node-list';
 import { PVsAvailableCapacity } from '../pvs-available-capacity';
-import { OCS_CONVERGED_FLAG, OCS_FLAG, OCS_ATTACHED_DEVICES_FLAG } from '../../../features';
+import {
+  OCS_CONVERGED_FLAG,
+  OCS_FLAG,
+  OCS_ATTACHED_DEVICES_FLAG,
+  OCS_INDEPENDENT_FLAG,
+} from '../../../features';
 import { makeLabelNodesRequest } from '../create-form';
 import { scResource, pvResource } from '../../../constants/resources';
 import { getOCSRequestData } from '../ocs-request-data';
@@ -135,6 +140,7 @@ export const CreateOCS = withHandlePromise<CreateOCSProps & HandlePromiseProps>(
     handlePromise(makeOCSRequest(nodes, storageClass, isEncrypted, isMinimal), () => {
       dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, true));
       dispatch(setFlag(OCS_CONVERGED_FLAG, true));
+      dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
       dispatch(setFlag(OCS_FLAG, true));
       history.push(
         `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -27,7 +27,7 @@ import { OCSServiceModel } from '../../models';
 import { OSDSizeDropdown } from '../../utils/osd-size-dropdown';
 import { cephStorageLabel } from '../../selectors';
 import NodeTable from './node-list';
-import { OCS_FLAG, OCS_CONVERGED_FLAG } from '../../features';
+import { OCS_FLAG, OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG } from '../../features';
 import { getOCSRequestData } from './ocs-request-data';
 import {
   OCSAlert,
@@ -101,6 +101,7 @@ export const CreateInternalCluster = withHandlePromise<
     // eslint-disable-next-line promise/catch-or-return
     handlePromise(makeOCSRequest(nodes, storageClass, osdSize, isEncrypted), () => {
       dispatch(setFlag(OCS_CONVERGED_FLAG, true));
+      dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
       dispatch(setFlag(OCS_FLAG, true));
       history.push(
         `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -9,14 +9,13 @@ import { fetchK8s } from '@console/internal/graphql/client';
 import { StorageClassModel } from '@console/internal/models';
 import { OCSServiceModel } from './models';
 import {
-  OCS_EXTERNAL_CR_NAME,
   CEPH_STORAGE_NAMESPACE,
   OCS_SUPPORT_ANNOTATION,
   ATTACHED_DEVICES_ANNOTATION,
-  OCS_INTERNAL_CR_NAME,
   RGW_PROVISIONER,
   SECOND,
 } from './constants';
+import { OCSStorageClusterKind } from './types';
 
 export const OCS_INDEPENDENT_FLAG = 'OCS_INDEPENDENT';
 export const OCS_CONVERGED_FLAG = 'OCS_CONVERGED';
@@ -70,33 +69,29 @@ export const detectRGW: FeatureDetector = async (dispatch) => {
 
 export const detectOCS: FeatureDetector = async (dispatch) => {
   try {
-    const storageCluster = await fetchK8s(
-      OCSServiceModel,
-      OCS_INTERNAL_CR_NAME,
-      CEPH_STORAGE_NAMESPACE,
+    const storageClusters = await k8sList(OCSServiceModel, { ns: CEPH_STORAGE_NAMESPACE });
+    const storageCluster = storageClusters.find(
+      (sc: OCSStorageClusterKind) => sc.status.phase !== 'Ignored',
     );
+    const isInternal = _.isEmpty(storageCluster.spec.externalStorage);
     const isAttachedDevicesCluster =
       getAnnotations(storageCluster)?.[ATTACHED_DEVICES_ANNOTATION] === 'true';
     dispatch(setFlag(OCS_FLAG, true));
     dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, isAttachedDevicesCluster));
-    dispatch(setFlag(OCS_CONVERGED_FLAG, true));
-    dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
+    dispatch(setFlag(OCS_CONVERGED_FLAG, isInternal));
+    dispatch(setFlag(OCS_INDEPENDENT_FLAG, !isInternal));
   } catch (e) {
-    if (e?.response?.status !== 404) handleError(e, [OCS_CONVERGED_FLAG], dispatch, detectOCS);
+    if (e?.response?.status !== 404)
+      handleError(
+        e,
+        [OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG, OCS_ATTACHED_DEVICES_FLAG],
+        dispatch,
+        detectOCS,
+      );
     else {
       dispatch(setFlag(OCS_CONVERGED_FLAG, false));
+      dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
       dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, false));
-    }
-    try {
-      await fetchK8s(OCSServiceModel, OCS_EXTERNAL_CR_NAME, CEPH_STORAGE_NAMESPACE);
-      dispatch(setFlag(OCS_FLAG, true));
-      dispatch(setFlag(OCS_INDEPENDENT_FLAG, true));
-      dispatch(setFlag(OCS_CONVERGED_FLAG, false));
-      dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, false));
-    } catch (err) {
-      err?.response?.status !== 404
-        ? handleError(err, [OCS_INDEPENDENT_FLAG], dispatch, detectOCS)
-        : dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
     }
   }
 };


### PR DESCRIPTION
Detection of storage cluster mode should be based on `spec.externalStorage` and not on the CR name. 
/assign @cloudbehl @afreen23 
cc @umangachapagain 
