### PR TITLE
Bug 1866214: Delete only KSVC, not Route associated with KSVC

### DIFF
--- a/frontend/packages/dev-console/src/utils/application-utils.ts
+++ b/frontend/packages/dev-console/src/utils/application-utils.ts
@@ -24,10 +24,7 @@ import {
   CronJobModel,
 } from '@console/internal/models';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
-import {
-  ServiceModel as KnativeServiceModel,
-  RouteModel as KnativeRouteModel,
-} from '@console/knative-plugin/src/models';
+import { ServiceModel as KnativeServiceModel } from '@console/knative-plugin/src/models';
 import { isDynamicEventResourceKind } from '@console/knative-plugin/src/utils/fetch-dynamic-eventsources-utils';
 import { checkAccess } from '@console/internal/components/utils';
 import { getOperatorBackedServiceKindMap } from '@console/shared';
@@ -391,7 +388,7 @@ export const cleanUpWorkload = async (workload: OdcNodeModel): Promise<K8sResour
     .then(() => true)
     .catch(() => false);
   const deleteModels = [ServiceModel, RouteModel];
-  const knativeDeleteModels = [KnativeServiceModel, KnativeRouteModel];
+  const knativeDeleteModels = [KnativeServiceModel];
   if (isBuildConfigPresent) {
     deleteModels.push(BuildConfigModel);
     knativeDeleteModels.push(BuildConfigModel);

--- a/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
@@ -27,7 +27,7 @@ import {
   MockKnativeResources,
   sampleDeploymentsCamelConnector,
 } from './topology-knative-test-data';
-import { RouteModel, ServiceModel, EventingBrokerModel } from '../../models';
+import { ServiceModel, EventingBrokerModel } from '../../models';
 import {
   applyKnativeDisplayOptions,
   EXPAND_KNATIVE_SERVICES_FILTER_ID,
@@ -173,9 +173,8 @@ describe('knative data transformer ', () => {
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
-        expect(spy.calls.count()).toEqual(2);
+        expect(spy.calls.count()).toEqual(1);
         expect(removedModels.find((rm) => rm.id === ServiceModel.id)).toBeTruthy();
-        expect(removedModels.find((rm) => rm.id === RouteModel.id)).toBeTruthy();
         done();
       })
       .catch((err) => fail(err));


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4259

**Analysis / Root cause**: 
If user choose to remove that application with knative service, it succeeds but an error is thrown intermittently as even KSVC tried to delete all associated resources i.e CFG, REV, Route etc 

**Solution Description**: 
Should Delete only KSVC


**Unit test**
![image](https://user-images.githubusercontent.com/5129024/89315725-d54a2280-d698-11ea-8037-b76e42fa8f5d.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
