### PR TITLE
Fix missing find by label option in topology view

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/Graph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/Graph.spec.tsx
@@ -24,6 +24,7 @@ describe('Graph', () => {
         onFiltersChange={() => {}}
         onSupportedFiltersChange={() => {}}
         onSupportedKindsChange={() => {}}
+        onSupportedLabelsChange={() => {}}
       />,
     );
   });

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/BaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/BaseNode.tsx
@@ -14,10 +14,11 @@ import {
   observer,
   createSvgIdUrl,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { useAccessReview } from '@console/internal/components/utils';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
-import { getTopologyResourceObject } from '../../topology-utils';
+import { getResource } from '../../topology-utils';
 import {
   getFilterById,
   useDisplayFilters,
@@ -75,7 +76,7 @@ const ObservedBaseNode: React.FC<BaseNodeProps> = ({
   const { width, height } = element.getDimensions();
   const cx = width / 2;
   const cy = height / 2;
-  const resourceObj = getTopologyResourceObject(element.getData());
+  const resourceObj = getResource(element);
   const resourceModel = modelFor(referenceFor(resourceObj));
   const iconRadius = innerRadius * 0.9;
   const editAccess = useAccessReview({
@@ -85,7 +86,7 @@ const ObservedBaseNode: React.FC<BaseNodeProps> = ({
     name: resourceObj.metadata.name,
     namespace: resourceObj.metadata.namespace,
   });
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(resourceObj));
   const displayFilters = useDisplayFilters();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
   const showLabels = showLabelsFilter?.value || hover;

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
@@ -13,4 +13,17 @@
   &__kiali-link {
     margin-left: auto;
   }
+
+  .odc-topology-filter-bar__label-filter {
+    .co-suggestion-line {
+      padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
+    }
+    .pf-c-select__toggle.pf-m-typeahead {
+      min-height: 33px;
+    }
+    .pf-c-select__menu {
+      max-height: 300px;
+      overflow-y: auto;
+    }
+  }
 }

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologySearchFilter.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologySearchFilter.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { connect } from 'react-redux';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Visualization } from '@patternfly/react-topology';
+import {
+  Button,
+  Popover,
+  Select,
+  SelectOption,
+  SelectVariant,
+  ToolbarGroup,
+  ToolbarGroupVariant,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { useDeepCompareMemoize, useQueryParams } from '@console/shared';
+import { RootState } from '@console/internal/redux';
+import { TextFilter } from '@console/internal/components/factory';
+import {
+  DEFAULT_TOPOLOGY_SEARCH_TYPE,
+  getSupportedTopologyLabels,
+  TOPOLOGY_SEARCH_FILTER_KEY,
+  TOPOLOGY_SEARCH_TYPE_FILTER_KEY,
+  TopologySearchType,
+} from './filter-utils';
+
+import './TopologyFilterBar.scss';
+import { fuzzyCaseInsensitive } from '@console/internal/components/factory/table-filters';
+
+type StateProps = {
+  supportedLabels: string[];
+};
+
+type OwnProps = {
+  visualization?: Visualization;
+  showGraphView: boolean;
+  onSearchChange: (searchQuery: string, searchType: string) => void;
+};
+
+type TopologySearchFilterProps = StateProps & OwnProps;
+
+export const ConnectedTopologySearchFilter: React.FC<TopologySearchFilterProps> = ({
+  supportedLabels,
+  visualization,
+  showGraphView,
+  onSearchChange,
+}) => {
+  const queryParams = useQueryParams();
+  const searchQuery = queryParams.get(TOPOLOGY_SEARCH_FILTER_KEY);
+  const searchType = queryParams.get(TOPOLOGY_SEARCH_TYPE_FILTER_KEY);
+  const [isSearchTypeOpen, setSearchTypeIsOpen] = React.useState(false);
+  const onSearchTypeToggle = (open: boolean): void => setSearchTypeIsOpen(open);
+  const [isLabelOpen, setLabelIsOpen] = React.useState(false);
+  const onLabelToggle = (open: boolean): void => setLabelIsOpen(open);
+  const memoizedLabels = useDeepCompareMemoize(supportedLabels);
+  const selectOptionsRef = React.useRef<React.ReactElement[]>();
+
+  const onTextFilterChange = React.useCallback(
+    (text) => {
+      const query = text?.trim();
+      onSearchChange(query, searchType);
+    },
+    [onSearchChange, searchType],
+  );
+  const onSearchTypeChange = React.useCallback(
+    (e, key) => {
+      onSearchChange(searchQuery, key);
+      setSearchTypeIsOpen(false);
+    },
+    [onSearchChange, searchQuery],
+  );
+
+  const clearSearchLabel = () => {
+    onSearchChange('', searchType);
+    setLabelIsOpen(false);
+  };
+
+  const onSearchLabelChange = (
+    event: React.MouseEvent,
+    selection: string,
+    isPlaceholder: boolean,
+  ) => {
+    if (isPlaceholder) {
+      clearSearchLabel();
+      return;
+    }
+    onSearchChange(selection, searchType);
+    setLabelIsOpen(false);
+  };
+
+  const onLabelFilter = (filterText: string): React.ReactElement[] => {
+    const matchLabels = filterText
+      ? memoizedLabels.filter((label) => fuzzyCaseInsensitive(filterText, label))
+      : memoizedLabels;
+    return matchLabels.map((label) => (
+      <SelectOption key={label} value={label}>
+        <span className="co-suggestion-line">
+          <span className="co-text-node">{label}</span>
+        </span>
+      </SelectOption>
+    ));
+  };
+
+  if (!selectOptionsRef.current) {
+    selectOptionsRef.current = memoizedLabels.map((label) => (
+      <SelectOption key={label} value={label}>
+        <span className="co-suggestion-line">
+          <span className="co-text-node">{label}</span>
+        </span>
+      </SelectOption>
+    ));
+  }
+
+  return (
+    <ToolbarGroup variant={ToolbarGroupVariant['filter-group']}>
+      <ToolbarItem>
+        <Select
+          id="filter-type-select"
+          variant={SelectVariant.single}
+          aria-label="Filter Type"
+          onToggle={onSearchTypeToggle}
+          isOpen={isSearchTypeOpen}
+          onSelect={onSearchTypeChange}
+          selections={searchType || DEFAULT_TOPOLOGY_SEARCH_TYPE}
+        >
+          {Object.keys(TopologySearchType).map((type) => (
+            <SelectOption key={TopologySearchType[type]} value={TopologySearchType[type]}>
+              {_.upperFirst(TopologySearchType[type])}
+            </SelectOption>
+          ))}
+        </Select>
+      </ToolbarItem>
+      <ToolbarItem>
+        {!searchType || searchType === TopologySearchType.name ? (
+          <TextFilter
+            placeholder={`Find by name...`}
+            value={searchQuery || ''}
+            autoFocus
+            onChange={onTextFilterChange}
+            className="odc-topology-filter-bar__text-filter"
+          />
+        ) : (
+          <Select
+            className="odc-topology-filter-bar__label-filter"
+            variant={SelectVariant.typeahead}
+            onToggle={onLabelToggle}
+            isOpen={isLabelOpen}
+            selections={searchQuery ? [searchQuery] : undefined}
+            onSelect={onSearchLabelChange}
+            onFilter={(e) => onLabelFilter(e.target.value)}
+            onClear={clearSearchLabel}
+            aria-labelledby="filter-type-select"
+            placeholderText={searchQuery || 'Find by label...'}
+          >
+            {selectOptionsRef.current}
+          </Select>
+        )}
+      </ToolbarItem>
+      {showGraphView ? (
+        <ToolbarItem>
+          <Popover
+            aria-label="Find by"
+            position="left"
+            bodyContent={
+              <>
+                Search results may appear outside of the visible area.{' '}
+                <Button variant="link" onClick={() => visualization.getGraph().fit(80)} isInline>
+                  Click here
+                </Button>{' '}
+                to fit to the screen.
+              </>
+            }
+          >
+            <Button variant="link" className="odc-topology-filter-bar__info-icon">
+              <InfoCircleIcon />
+            </Button>
+          </Popover>
+        </ToolbarItem>
+      ) : null}
+    </ToolbarGroup>
+  );
+};
+
+const mapStateToProps = (state: RootState): StateProps => ({
+  supportedLabels: getSupportedTopologyLabels(state),
+});
+
+export const TopologySearchFilter = connect<StateProps, {}, OwnProps>(
+  mapStateToProps,
+  null,
+)(ConnectedTopologySearchFilter);

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/useSearchFilter.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/useSearchFilter.spec.ts
@@ -1,19 +1,27 @@
 import { testHook } from '../../../../test/test-utils';
 import { useSearchFilter } from '../useSearchFilter';
-import { getTopologySearchQuery } from '../filter-utils';
+import { getTopologySearchQuery, getTopologySearchType, TopologySearchType } from '../filter-utils';
 
-jest.mock('../filter-utils', () => ({
-  getTopologySearchQuery: jest.fn(),
-}));
+jest.mock('../filter-utils', () => {
+  const ActualFilterUtils = require.requireActual('../filter-utils');
+  return {
+    ...ActualFilterUtils,
+    getTopologySearchQuery: jest.fn(),
+    getTopologySearchType: jest.fn(),
+  };
+});
 
 const testUseSearchFilter = (
   text: string | null | undefined,
   searchQuery: string | undefined,
+  labels?: string[],
+  searchType?: string,
 ): ReturnType<typeof useSearchFilter> => {
   (getTopologySearchQuery as jest.Mock).mockImplementation(() => searchQuery);
+  (getTopologySearchType as jest.Mock).mockImplementation(() => searchType || 'name');
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return useSearchFilter(text);
+  return useSearchFilter(text, labels);
 };
 
 describe('useSearchFilter', () => {
@@ -50,6 +58,56 @@ describe('useSearchFilter', () => {
       expect(testUseSearchFilter(null, undefined)[1]).toBe(undefined);
       expect(testUseSearchFilter(null, null)[1]).toBe(null);
       expect(testUseSearchFilter(null, 'test')[1]).toBe('test');
+    });
+  });
+
+  it('should handle null | undefined | empty labels', () => {
+    const searchType = TopologySearchType.label;
+    testHook(() => {
+      expect(testUseSearchFilter(null, 'test', null, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, '', null, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, undefined, null, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, 'test', undefined, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, '', undefined, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, undefined, undefined, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, 'test', [], searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, '', [], searchType)[0]).toBe(false);
+      expect(testUseSearchFilter(null, undefined, [], searchType)[0]).toBe(false);
+    });
+  });
+
+  it('should match labels to search query', () => {
+    const searchType = TopologySearchType.label;
+    const labels = ['fake=fake', 'app=test'];
+    testHook(() => {
+      expect(testUseSearchFilter('', 'app=test', labels, searchType)[0]).toBe(true);
+      expect(testUseSearchFilter('', 'app=Test', labels, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter('', 'app=fake', labels, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter('', 'fake=app', labels, searchType)[0]).toBe(false);
+      expect(testUseSearchFilter('', undefined, labels, searchType)[0]).toBe(false);
+    });
+  });
+
+  it('should return search query', () => {
+    const searchType = TopologySearchType.label;
+    const labels = ['fake=fake', 'app=test'];
+    testHook(() => {
+      expect(testUseSearchFilter(null, undefined, labels, searchType)[1]).toBe(undefined);
+      expect(testUseSearchFilter(null, null, labels, searchType)[1]).toBe(null);
+      expect(testUseSearchFilter(null, 'test', labels, searchType)[1]).toBe('test');
+    });
+  });
+
+  it('should return search type', () => {
+    const searchType = TopologySearchType.label;
+    const labels = ['fake=fake', 'app=test'];
+    testHook(() => {
+      expect(testUseSearchFilter(null, undefined)[2]).toBe(TopologySearchType.name);
+      expect(testUseSearchFilter(null, null, labels)[2]).toBe(TopologySearchType.name);
+      expect(testUseSearchFilter(null, 'test', labels)[2]).toBe(TopologySearchType.name);
+      expect(testUseSearchFilter(null, undefined, labels, searchType)[2]).toBe(searchType);
+      expect(testUseSearchFilter(null, null, labels, searchType)[2]).toBe(searchType);
+      expect(testUseSearchFilter(null, 'test', labels, searchType)[2]).toBe(searchType);
     });
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
@@ -11,6 +11,13 @@ import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_GROUPS_FILTER_ID, SHOW_GROUPS_FILTER_I
 import { K8sResourceKindReference } from '@console/internal/module/k8s';
 
 export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
+export const TOPOLOGY_SEARCH_TYPE_FILTER_KEY = 'searchType';
+
+export enum TopologySearchType {
+  name = 'name',
+  label = 'label',
+}
+export const DEFAULT_TOPOLOGY_SEARCH_TYPE = TopologySearchType.name;
 
 export const getTopologyFilters = (state: RootState): DisplayFilters => {
   const topology = state?.plugins?.devconsole?.topology;
@@ -27,12 +34,19 @@ export const getSupportedTopologyKinds = (state: RootState): { [key: string]: nu
   return topology ? topology.get('supportedKinds') : {};
 };
 
+export const getSupportedTopologyLabels = (state: RootState): string[] => {
+  const topology = state?.plugins?.devconsole?.topology;
+  return topology ? topology.get('supportedLabels') : [];
+};
+
 export const getAppliedTopologyFilters = (state: RootState): string[] => {
   const topology = state?.plugins?.devconsole?.topology;
   return topology ? topology.get('appliedFilters') : getAppliedFilters(DEFAULT_TOPOLOGY_FILTERS);
 };
 
 export const getTopologySearchQuery = () => getQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY) ?? '';
+
+export const getTopologySearchType = () => getQueryArgument(TOPOLOGY_SEARCH_TYPE_FILTER_KEY) ?? '';
 
 export const getFilterById = (id: string, filters: DisplayFilters): TopologyDisplayOption => {
   if (!filters) {

--- a/frontend/packages/dev-console/src/components/topology/filters/useSearchFilter.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/useSearchFilter.ts
@@ -1,17 +1,23 @@
 import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
 import { toLower } from 'lodash';
-import { getTopologySearchQuery } from './filter-utils';
+import { getTopologySearchQuery, getTopologySearchType, TopologySearchType } from './filter-utils';
 
 const fuzzyCaseInsensitive = (a: string, b: string): boolean => fuzzy(toLower(a), toLower(b));
 
-const useSearchFilter = (text: string): [boolean, string] => {
+const useSearchFilter = (text: string, labels?: string[]): [boolean, string, string] => {
   const searchQuery = getTopologySearchQuery();
-  const filtered = React.useMemo(() => fuzzyCaseInsensitive(searchQuery, text), [
-    searchQuery,
-    text,
-  ]);
-  return [filtered && !!searchQuery, searchQuery];
+  const searchType = getTopologySearchType();
+  const filtered = React.useMemo(() => {
+    if (searchType === TopologySearchType.label) {
+      if (!labels) {
+        return false;
+      }
+      return labels.includes(searchQuery);
+    }
+    return fuzzyCaseInsensitive(searchQuery, text);
+  }, [searchQuery, searchType, text, labels]);
+  return [filtered && !!searchQuery, searchQuery, searchType];
 };
 
 export { useSearchFilter };

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
@@ -12,12 +12,14 @@ import {
   observer,
   useCombineRefs,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import {
   NodeShadows,
   NODE_SHADOW_FILTER_ID_HOVER,
   NODE_SHADOW_FILTER_ID,
 } from '../../components/NodeShadows';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
+import { getResource } from '../../topology-utils';
 import {
   getFilterById,
   useDisplayFilters,
@@ -53,7 +55,7 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
   ] = useDragNode(dragSpec, { element });
 
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const displayFilters = useDisplayFilters();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
   const showLabels = showLabelsFilter?.value || hover || innerHover;

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -13,11 +13,13 @@ import {
   observer,
   useCombineRefs,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import {
   NodeShadows,
   NODE_SHADOW_FILTER_ID_HOVER,
   NODE_SHADOW_FILTER_ID,
 } from '../../components/NodeShadows';
+import { getResource } from '../../topology-utils';
 import { useSearchFilter } from '../../filters/useSearchFilter';
 import { GroupNode } from '../../components/groups/GroupNode';
 import { nodeDragSourceSpec } from '../../components/componentUtils';
@@ -45,7 +47,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
     element,
   });
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDropRef, hoverRef);
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const { width, height } = element.getDimensions();
 
   return (

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
+import { connect } from 'react-redux';
 import {
   Button,
   DataList,
@@ -12,9 +13,15 @@ import {
   TooltipPosition,
 } from '@patternfly/react-core';
 import { isNode, Node, observer } from '@patternfly/react-topology';
-import { getSeverityAlertType, AlertSeverityIcon, getFiringAlerts } from '@console/shared';
+import {
+  getSeverityAlertType,
+  AlertSeverityIcon,
+  getFiringAlerts,
+  getLabelsAsString,
+} from '@console/shared';
+import { selectOverviewDetailsTab } from '@console/internal/actions/ui';
 import { useSearchFilter } from '../filters';
-import { getResourceKind } from '../topology-utils';
+import { getResource, getResourceKind } from '../topology-utils';
 import { labelForNodeKind } from './list-view-utils';
 import {
   AlertsCell,
@@ -23,8 +30,6 @@ import {
   StatusCell,
   TypedResourceBadgeCell,
 } from './cells';
-import { selectOverviewDetailsTab } from '@console/internal/actions/ui';
-import { connect } from 'react-redux';
 
 interface DispatchProps {
   onSelectTab?: (name: string) => void;
@@ -51,7 +56,7 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
   additionalCells,
   children,
 }) => {
-  const [filtered] = useSearchFilter(item.getLabel());
+  const [filtered] = useSearchFilter(item.getLabel(), getLabelsAsString(getResource(item)));
   if (!item.isVisible) {
     return null;
   }

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
@@ -11,6 +11,7 @@ import {
   createSvgIdUrl,
   useCombineRefs,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
 import { nodeDragSourceSpec } from '../../components/componentUtils';
 import { TYPE_OPERATOR_BACKED_SERVICE } from './const';
@@ -25,7 +26,7 @@ import {
   NODE_SHADOW_FILTER_ID,
   NODE_SHADOW_FILTER_ID_HOVER,
 } from '../../components/NodeShadows';
-import { getResourceKind } from '../../topology-utils';
+import { getResource, getResourceKind } from '../../topology-utils';
 
 export type OperatorBackedServiceGroupProps = {
   element: Node;
@@ -56,7 +57,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const displayFilters = useDisplayFilters();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
   const showLabels = showLabelsFilter?.value || hover || innerHover;

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
@@ -12,6 +12,7 @@ import {
   useDragNode,
   createSvgIdUrl,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import { useSearchFilter } from '../../filters/useSearchFilter';
 import { nodeDragSourceSpec } from '../../components/componentUtils';
 import { TYPE_OPERATOR_BACKED_SERVICE } from './const';
@@ -21,6 +22,7 @@ import {
   NODE_SHADOW_FILTER_ID_HOVER,
 } from '../../components/NodeShadows';
 import { GroupNode } from '../../components/groups/GroupNode';
+import { getResource } from '../../topology-utils';
 
 export type OperatorBackedServiceNodeProps = {
   element: Node;
@@ -42,7 +44,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
     },
   );
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef, dndDropRef);
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const kind = 'Operator';
   const { width, height } = element.getDimensions();
 

--- a/frontend/packages/dev-console/src/components/topology/redux/action.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/action.ts
@@ -6,6 +6,7 @@ export enum Actions {
   topologyFilters = 'topologyFilters',
   supportedTopologyFilters = 'supportedTopologyFilters',
   supportedTopologyKinds = 'supportedTopologyKinds',
+  supportedTopologyLabels = 'supportedTopologyLabels',
 }
 
 export const getAppliedFilters = (filters: DisplayFilters): { [id: string]: boolean } => {
@@ -35,10 +36,15 @@ export const setSupportedTopologyKinds = (supportedKinds: { [key: string]: numbe
   return action(Actions.supportedTopologyKinds, { supportedKinds });
 };
 
+export const setSupportedTopologyLabels = (supportedLabels: string[]) => {
+  return action(Actions.supportedTopologyLabels, { supportedLabels });
+};
+
 const actions = {
   setTopologyFilters,
   setSupportedTopologyFilters,
   setSupportedTopologyKinds,
+  setSupportedTopologyLabels,
 };
 
 export type TopologyAction = ActionType<typeof actions>;

--- a/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
@@ -41,6 +41,7 @@ export default (state: State, action: TopologyAction) => {
       appliedFilters: getDefaultAppliedFilters(),
       supportedFilters: DEFAULT_TOPOLOGY_FILTERS.map((f) => f.id),
       supportedKinds: {},
+      supportedLabels: [],
     });
   }
 
@@ -56,6 +57,10 @@ export default (state: State, action: TopologyAction) => {
 
   if (action.type === Actions.supportedTopologyKinds) {
     return state.set('supportedKinds', action.payload.supportedKinds);
+  }
+
+  if (action.type === Actions.supportedTopologyLabels) {
+    return state.set('supportedLabels', action.payload.supportedLabels);
   }
 
   return state;

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -18,6 +18,7 @@ import {
   useCombineRefs,
   WithCreateConnectorProps,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import SvgBoxedText from '@console/dev-console/src/components/svg/SvgBoxedText';
 import {
   NodeShadows,
@@ -30,6 +31,7 @@ import {
   useAllowEdgeCreation,
   getFilterById,
   SHOW_LABELS_FILTER_ID,
+  getResource,
 } from '@console/dev-console/src/components/topology';
 import BuildDecorator from '@console/dev-console/src/components/topology/components/nodes/build-decorators/BuildDecorator';
 import { TYPE_KNATIVE_SERVICE, EVENT_MARKER_RADIUS } from '../../const';
@@ -93,7 +95,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
   );
   useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5 + EVENT_MARKER_RADIUS), []));
 
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const displayFilters = useDisplayFilters();
   const allowEdgeCreation = useAllowEdgeCreation();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
@@ -14,6 +14,7 @@ import {
   createSvgIdUrl,
   WithCreateConnectorProps,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import {
   NodeShadows,
   NODE_SHADOW_FILTER_ID,
@@ -22,6 +23,7 @@ import {
   GroupNode,
   useSearchFilter,
   useAllowEdgeCreation,
+  getResource,
 } from '@console/dev-console/src/components/topology';
 import { TYPE_KNATIVE_SERVICE, EVENT_MARKER_RADIUS } from '../../const';
 
@@ -60,7 +62,7 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
     },
   );
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef);
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const allowEdgeCreation = useAllowEdgeCreation();
   const { kind } = element.getData().data;
   const { width, height } = element.getBounds();

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
@@ -12,6 +12,7 @@ import {
   WithDragNodeProps,
   createSvgIdUrl,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import SvgBoxedText from '@console/dev-console/src/components/svg/SvgBoxedText';
 import {
   NodeShadows,
@@ -21,6 +22,7 @@ import {
   useDisplayFilters,
   getFilterById,
   SHOW_LABELS_FILTER_ID,
+  getResource,
 } from '@console/dev-console/src/components/topology';
 import { getEventSourceIcon } from '../../../utils/get-knative-icon';
 
@@ -49,7 +51,7 @@ const EventSource: React.FC<EventSourceProps> = ({
   const svgAnchorRef = useSvgAnchor();
   const [hover, hoverRef] = useHover();
   const groupRefs = useCombineRefs(dragNodeRef, dndDropRef, hoverRef);
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const displayFilters = useDisplayFilters();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
   const showLabels = showLabelsFilter?.value || hover;

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -15,6 +15,7 @@ import {
   AnchorEnd,
   WithCreateConnectorProps,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import SvgBoxedText from '@console/dev-console/src/components/svg/SvgBoxedText';
 import {
   NodeShadows,
@@ -26,6 +27,7 @@ import {
   getFilterById,
   SHOW_LABELS_FILTER_ID,
   getTopologyResourceObject,
+  getResource,
 } from '@console/dev-console/src/components/topology';
 import PubSubSourceAnchor from '../anchors/PubSubSourceAnchor';
 import PubSubTargetAnchor from '../anchors/PubSubTargetAnchor';
@@ -72,7 +74,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
   const [hover, hoverRef] = useHover();
 
   const groupRefs = useCombineRefs(dragNodeRef, dndDropRef, hoverRef);
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const displayFilters = useDisplayFilters();
   const allowEdgeCreation = useAllowEdgeCreation();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);

--- a/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
@@ -17,6 +17,7 @@ import {
   RectAnchor,
   NodeModel,
 } from '@patternfly/react-topology';
+import { getLabelsAsString } from '@console/shared';
 import { useAccessReview } from '@console/internal/components/utils';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import SvgBoxedText from '@console/dev-console/src/components/svg/SvgBoxedText';
@@ -79,7 +80,7 @@ const ObservedVmNode: React.FC<VmNodeProps> = ({
   const { kind, osImage, vmStatusBundle } = vmData;
   const displayFilters = useDisplayFilters();
   const allowEdgeCreation = useAllowEdgeCreation();
-  const [filtered] = useSearchFilter(element.getLabel());
+  const [filtered] = useSearchFilter(element.getLabel(), getLabelsAsString(getResource(element)));
   const iconRadius = Math.min(width, height) * 0.25;
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
   const showLabels = showLabelsFilter?.value || hover;


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4410

**Description**
Update topology filter bar to include filter by label.

**Screenshots**

![image](https://user-images.githubusercontent.com/11633780/89326502-68af3380-d658-11ea-84f5-d4f2a4725c59.png)

![image](https://user-images.githubusercontent.com/11633780/89326563-7cf33080-d658-11ea-9eaa-d07e9607a2a4.png)

![image](https://user-images.githubusercontent.com/11633780/89326582-82507b00-d658-11ea-9be2-1e2fd59d286b.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @bgliwa01
