### PR TITLE
Bug 1854151: Add project list page in developer catalog for all projects

### DIFF
--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -11,6 +11,7 @@ import {
   DevCatalogModel,
   useExtensions,
 } from '@console/plugin-sdk';
+import CreateProjectListPage from '@console/dev-console/src/components/projects/CreateProjectListPage';
 import { CatalogTileViewPage } from './catalog-items';
 import {
   k8sListPartialMetadata,
@@ -516,17 +517,23 @@ export const CatalogPage = withStartGuide(({ match, noProjectsAvailable }) => {
       <Helmet>
         <title>Developer Catalog</title>
       </Helmet>
-      <div className="co-m-page__body">
-        <div className="co-catalog">
-          <PageHeading title="Developer Catalog" />
-          <p className="co-catalog-page__description">
-            Add shared apps, services, or source-to-image builders to your project from the
-            Developer Catalog. Cluster admins can install additional apps which will show up here
-            automatically.
-          </p>
-          <Catalog namespace={namespace} mock={noProjectsAvailable} />
+      {namespace ? (
+        <div className="co-m-page__body">
+          <div className="co-catalog">
+            <PageHeading title="Developer Catalog" />
+            <p className="co-catalog-page__description">
+              Add shared apps, services, or source-to-image builders to your project from the
+              Developer Catalog. Cluster admins can install additional apps which will show up here
+              automatically.
+            </p>
+            <Catalog namespace={namespace} mock={noProjectsAvailable} />
+          </div>
         </div>
-      </div>
+      ) : (
+        <CreateProjectListPage title="Developer Catalog">
+          Select a project to view the Developer Catalog
+        </CreateProjectListPage>
+      )}
     </>
   );
 });


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4293

**Analysis / Root cause**: All of the add flows are designed to work with specific project/namespace.

**Solution Description**:  Developer catalog should show project list page to users when all projects is selected from the project selector.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 
![Peek 2020-08-04 23-29](https://user-images.githubusercontent.com/6041994/89328124-83aa9380-d6aa-11ea-8c4e-f228dac1c7c4.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge