### PR TITLE
Bug 1870469: Check for podName before displaying Task logs

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
@@ -90,15 +90,17 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
             obj.metadata?.name,
           )
         : undefined;
-    const resources = taskCount > 0 && [
-      {
-        name: _.get(taskRunFromYaml[activeItem], ['status', 'podName'], ''),
-        kind: 'Pod',
-        namespace: obj.metadata.namespace,
-        prop: `obj`,
-        isList: false,
-      },
-    ];
+    const podName = taskRunFromYaml[activeItem]?.status?.podName;
+    const resources = taskCount > 0 &&
+      podName && [
+        {
+          name: podName,
+          kind: 'Pod',
+          namespace: obj.metadata.namespace,
+          prop: `obj`,
+          isList: false,
+        },
+      ];
     const path = `${resourcePathFromModel(
       PipelineRunModel,
       obj.metadata.name,
@@ -138,7 +140,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
           )}
         </div>
         <div className="odc-pipeline-run-logs__container">
-          {activeItem ? (
+          {activeItem && resources ? (
             <Firehose key={activeItem} resources={resources}>
               <LogsWrapperComponent
                 taskName={_.get(taskRunFromYaml, [activeItem, 'pipelineTaskName'], '-')}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4273
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
When checking logs for a failed PipelineRun that has not run any pods, a random pod log will be shown from any running pod.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Ensure that `podName` is not empty in the pipelinerun spec before trying to display logs.
<!-- Describe your code changes in detail and explain the solution -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
