### PR TITLE
Bug 1858317: Change type of VLAN attribute for CNV bridge in NADs

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -44,12 +44,11 @@ const buildConfig = (name, networkType, typeParamsData): NetworkAttachmentDefini
     // cnv-bridge should not define type on root
     delete config.type;
 
-    const vlan = _.get(typeParamsData, 'vlanTagNum.value', '');
     config.plugins = [
       {
         type: 'cnv-bridge',
         bridge: _.get(typeParamsData, 'bridge.value', ''),
-        vlan: _.isEmpty(vlan) ? undefined : vlan,
+        vlan: parseInt(typeParamsData?.vlanTagNum?.value, 10) || undefined,
         ipam,
       },
       { type: 'cnv-tuning' },


### PR DESCRIPTION
Currently, the type of the VLAN attribute for network attachment definitions with a network type of CNV bridge is string, but it should be number. This PR makes that change.