### PR TITLE
Bug 1873143: fix pipeline details page breadcrumbs in admin perspective

### DIFF
--- a/frontend/packages/dev-console/src/components/cluster-tasks/ClusterTaskDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/cluster-tasks/ClusterTaskDetailsPage.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { DetailsPageProps, DetailsPage } from '@console/internal/components/factory';
+import { navFactory, Kebab } from '@console/internal/components/utils';
+import { DetailsForKind } from '@console/internal/components/default-resource';
+import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
+
+const ClusterTaskDetailsPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match, kind } = props;
+  const breadcrumbsFor = useTasksBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      menuActions={Kebab.factory.common}
+      breadcrumbsFor={() => breadcrumbsFor}
+      pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}
+    />
+  );
+};
+
+export default ClusterTaskDetailsPage;

--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -6,15 +6,19 @@ import { getPipelineRunKebabActions } from '../../utils/pipeline-actions';
 import { PipelineRunDetails } from './detail-page-tabs/PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './detail-page-tabs/PipelineRunLogs';
 import { useMenuActionsWithUserLabel } from './triggered-by';
+import { usePipelinesBreadcrumbsFor } from '../pipelines/hooks';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match } = props;
   const menuActions: KebabAction[] = useMenuActionsWithUserLabel(getPipelineRunKebabActions(true));
+  const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
 
   return (
     <DetailsPage
       {...props}
       menuActions={menuActions}
       getResourceStatus={pipelineRunStatus}
+      breadcrumbsFor={() => breadcrumbsFor}
       pages={[
         navFactory.details(PipelineRunDetails),
         navFactory.editYaml(viewYamlComponent),

--- a/frontend/packages/dev-console/src/components/pipelines/ClusterTriggerBindingPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/ClusterTriggerBindingPage.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { DetailsPageProps, DetailsPage } from '@console/internal/components/factory';
+import { navFactory, Kebab } from '@console/internal/components/utils';
+import { DetailsForKind } from '@console/internal/components/default-resource';
+import { useTriggersBreadcrumbsFor } from './hooks';
+
+const ClusterTriggerBindingPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match, kind } = props;
+  const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      menuActions={Kebab.factory.common}
+      breadcrumbsFor={() => breadcrumbsFor}
+      pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}
+    />
+  );
+};
+
+export default ClusterTriggerBindingPage;

--- a/frontend/packages/dev-console/src/components/pipelines/EventListenerPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/EventListenerPage.tsx
@@ -2,13 +2,19 @@ import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
 import EventListenerDetails from './detail-page-tabs/EventListenerDetails';
+import { useTriggersBreadcrumbsFor } from './hooks';
 
-const EventListenerPage: React.FC<DetailsPageProps> = (props) => (
-  <DetailsPage
-    {...props}
-    menuActions={Kebab.factory.common}
-    pages={[navFactory.details(EventListenerDetails), navFactory.editYaml()]}
-  />
-);
+const EventListenerPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match } = props;
+  const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+  return (
+    <DetailsPage
+      {...props}
+      breadcrumbsFor={() => breadcrumbsFor}
+      menuActions={Kebab.factory.common}
+      pages={[navFactory.details(EventListenerDetails), navFactory.editYaml()]}
+    />
+  );
+};
 
 export default EventListenerPage;

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -17,12 +17,14 @@ import {
   resourcesValidationSchema,
 } from './detail-page-tabs';
 import { usePipelineTriggerTemplateNames } from './utils/triggers';
+import { usePipelinesBreadcrumbsFor } from './hooks';
 
 const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const [errorCode, setErrorCode] = React.useState(null);
   const [latestPipelineRun, setLatestPipelineRun] = React.useState<PipelineRun>({});
-  const { name, namespace } = props;
+  const { name, namespace, kindObj, match } = props;
   const templateNames = usePipelineTriggerTemplateNames(name, namespace) || [];
+  const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
 
   React.useEffect(() => {
     k8sGet(PipelineModel, name, namespace)
@@ -55,6 +57,7 @@ const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
       {...props}
       menuActions={augmentedMenuActions}
       customData={templateNames}
+      breadcrumbsFor={() => breadcrumbsFor}
       pages={[
         navFactory.details(PipelineDetails),
         navFactory.editYaml(),

--- a/frontend/packages/dev-console/src/components/pipelines/TriggerBindingPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/TriggerBindingPage.tsx
@@ -2,13 +2,20 @@ import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
 import TriggerBindingDetails from './detail-page-tabs/TriggerBindingDetails';
+import { useTriggersBreadcrumbsFor } from './hooks';
 
-const TriggerBindingPage: React.FC<DetailsPageProps> = (props) => (
-  <DetailsPage
-    {...props}
-    menuActions={Kebab.factory.common}
-    pages={[navFactory.details(TriggerBindingDetails), navFactory.editYaml()]}
-  />
-);
+const TriggerBindingPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match } = props;
+  const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      breadcrumbsFor={() => breadcrumbsFor}
+      menuActions={Kebab.factory.common}
+      pages={[navFactory.details(TriggerBindingDetails), navFactory.editYaml()]}
+    />
+  );
+};
 
 export default TriggerBindingPage;

--- a/frontend/packages/dev-console/src/components/pipelines/TriggerTemplatePage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/TriggerTemplatePage.tsx
@@ -2,13 +2,20 @@ import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
 import TriggerTemplateDetails from './detail-page-tabs/TriggerTemplateDetails';
+import { useTriggersBreadcrumbsFor } from './hooks';
 
-const TriggerTemplatePage: React.FC<DetailsPageProps> = (props) => (
-  <DetailsPage
-    {...props}
-    menuActions={Kebab.factory.common}
-    pages={[navFactory.details(TriggerTemplateDetails), navFactory.editYaml()]}
-  />
-);
+const TriggerTemplatePage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match } = props;
+  const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      breadcrumbsFor={() => breadcrumbsFor}
+      menuActions={Kebab.factory.common}
+      pages={[navFactory.details(TriggerTemplateDetails), navFactory.editYaml()]}
+    />
+  );
+};
 
 export default TriggerTemplatePage;

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineConditionDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineConditionDetailsPage.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { DetailsPageProps, DetailsPage } from '@console/internal/components/factory';
+import { navFactory, Kebab } from '@console/internal/components/utils';
+import { DetailsForKind } from '@console/internal/components/default-resource';
+import { usePipelinesBreadcrumbsFor } from '../hooks';
+
+const PipelineConditionDetailsPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match, kind } = props;
+  const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      menuActions={Kebab.factory.common}
+      breadcrumbsFor={() => breadcrumbsFor}
+      pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}
+    />
+  );
+};
+
+export default PipelineConditionDetailsPage;

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineResourceDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineResourceDetailsPage.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { DetailsPageProps, DetailsPage } from '@console/internal/components/factory';
+import { navFactory, Kebab } from '@console/internal/components/utils';
+import { DetailsForKind } from '@console/internal/components/default-resource';
+import { usePipelinesBreadcrumbsFor } from '../hooks';
+
+const PipelineResourceDetailsPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match, kind } = props;
+  const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      menuActions={Kebab.factory.common}
+      breadcrumbsFor={() => breadcrumbsFor}
+      pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}
+    />
+  );
+};
+
+export default PipelineResourceDetailsPage;

--- a/frontend/packages/dev-console/src/components/pipelines/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/hooks.ts
@@ -1,0 +1,43 @@
+import { match as RMatch } from 'react-router-dom';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useSelector } from 'react-redux';
+import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumbs';
+import { K8sKind } from '@console/internal/module/k8s';
+import { RootState } from '@console/internal/redux';
+import { getActivePerspective, getActiveNamespace } from '@console/internal/reducers/ui';
+import { ALL_NAMESPACES_KEY } from '@console/shared';
+import { pipelinesTab } from '../../utils/pipeline-utils';
+
+type Match = RMatch<{ url: string }>;
+
+const useTabbedTableBreadcrumbsFor = (kindObj: K8sKind, match: Match, navOption: string) => {
+  const currentNamespace = useSelector((state: RootState) => getActiveNamespace(state));
+  const isAdminPerspective =
+    useSelector((state: RootState) => getActivePerspective(state)) === 'admin';
+  const nsURL =
+    ALL_NAMESPACES_KEY === currentNamespace ? 'all-namespaces' : `ns/${currentNamespace}`;
+  const subTab = pipelinesTab(kindObj);
+
+  if (subTab == null) {
+    return [];
+  }
+
+  return [
+    {
+      name: kindObj.labelPlural,
+      path: isAdminPerspective ? `/${navOption}/${nsURL}/${subTab}` : getBreadcrumbPath(match),
+    },
+    { name: `${kindObj.label} Details`, path: match.url },
+  ];
+};
+
+export const usePipelinesBreadcrumbsFor = (kindObj: K8sKind, match: Match) =>
+  useTabbedTableBreadcrumbsFor(kindObj, match, 'pipelines');
+
+export const useTasksBreadcrumbsFor = (kindObj: K8sKind, match: Match) =>
+  useTabbedTableBreadcrumbsFor(kindObj, match, 'tasks');
+
+export const useTriggersBreadcrumbsFor = (kindObj: K8sKind, match: Match) =>
+  useTabbedTableBreadcrumbsFor(kindObj, match, 'triggers');

--- a/frontend/packages/dev-console/src/components/taskruns/TaskRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/TaskRunDetailsPage.tsx
@@ -2,11 +2,18 @@ import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { navFactory, viewYamlComponent } from '@console/internal/components/utils';
 import TaskRunDetails from './TaskRunDetails';
+import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
 
-const TaskRunDetailsPage: React.FC<DetailsPageProps> = (props) => (
-  <DetailsPage
-    {...props}
-    pages={[navFactory.details(TaskRunDetails), navFactory.editYaml(viewYamlComponent)]}
-  />
-);
+const TaskRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match } = props;
+  const breadcrumbsFor = useTasksBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      breadcrumbsFor={() => breadcrumbsFor}
+      pages={[navFactory.details(TaskRunDetails), navFactory.editYaml(viewYamlComponent)]}
+    />
+  );
+};
 export default TaskRunDetailsPage;

--- a/frontend/packages/dev-console/src/components/tasks/TaskDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/tasks/TaskDetailsPage.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { DetailsPageProps, DetailsPage } from '@console/internal/components/factory';
+import { navFactory, Kebab } from '@console/internal/components/utils';
+import { DetailsForKind } from '@console/internal/components/default-resource';
+import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
+
+const TaskDetailsPage: React.FC<DetailsPageProps> = (props) => {
+  const { kindObj, match, kind } = props;
+  const breadcrumbsFor = useTasksBreadcrumbsFor(kindObj, match);
+
+  return (
+    <DetailsPage
+      {...props}
+      menuActions={Kebab.factory.common}
+      breadcrumbsFor={() => breadcrumbsFor}
+      pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}
+    />
+  );
+};
+
+export default TaskDetailsPage;

--- a/frontend/packages/dev-console/src/components/tasks/list-page/TasksListsPage.tsx
+++ b/frontend/packages/dev-console/src/components/tasks/list-page/TasksListsPage.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { match as Rmatch } from 'react-router-dom';
-import MultiTabListPage from '../multi-tab-list/MultiTabListPage';
+import MultiTabListPage from '../../multi-tab-list/MultiTabListPage';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { TaskModel, ClusterTaskModel, TaskRunModel } from '../../models';
+import { TaskModel, ClusterTaskModel, TaskRunModel } from '../../../models';
 import { Page } from '@console/internal/components/utils';
 import { TechPreviewBadge } from '@console/shared';
 import { DefaultPage } from '@console/internal/components/default-resource';
-import TaskRunsListPage from '../taskruns/list-page/TaskRunsListPage';
-import { MenuActions } from '../multi-tab-list/multi-tab-list-page-types';
+import TaskRunsListPage from '../../taskruns/list-page/TaskRunsListPage';
+import { MenuActions } from '../../multi-tab-list/multi-tab-list-page-types';
 
 interface TasksListsPageProps {
   match: Rmatch<any>;

--- a/frontend/packages/dev-console/src/models/pipelines.ts
+++ b/frontend/packages/dev-console/src/models/pipelines.ts
@@ -105,7 +105,7 @@ export const ConditionModel: K8sKind = {
   id: 'condition',
   labelPlural: 'Conditions',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -78,11 +78,13 @@ const {
   PipelineModel,
   PipelineResourceModel,
   PipelineRunModel,
+  ConditionModel,
   TaskModel,
   TaskRunModel,
   EventListenerModel,
   TriggerTemplateModel,
   TriggerBindingModel,
+  ClusterTriggerBindingModel,
 } = models;
 
 type ConsumedExtensions =
@@ -374,6 +376,30 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Page/Resource/Details',
     properties: {
+      model: PipelineResourceModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pipelines/detail-page-tabs/PipelineResourceDetailsPage' /* webpackChunkName: "pipelineresource-details" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: ConditionModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pipelines/detail-page-tabs/PipelineConditionDetailsPage' /* webpackChunkName: "pipelinecondition-details" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
       model: TaskRunModel,
       loader: async () =>
         (
@@ -381,6 +407,27 @@ const plugin: Plugin<ConsumedExtensions> = [
             './components/taskruns/TaskRunDetailsPage' /* webpackChunkName: "taskrun-details" */
           )
         ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: ClusterTaskModel,
+      loader: async () =>
+        (
+          await import(
+            './components/cluster-tasks/ClusterTaskDetailsPage' /* webpackChunkName: "clustertask-details" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: TaskModel,
+      loader: async () =>
+        (await import('./components/tasks/TaskDetailsPage' /* webpackChunkName: "task-details" */))
+          .default,
     },
   },
   {
@@ -415,6 +462,18 @@ const plugin: Plugin<ConsumedExtensions> = [
         (
           await import(
             './components/pipelines/TriggerBindingPage' /* webpackChunkName: "trigger-binding-details" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: ClusterTriggerBindingModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pipelines/ClusterTriggerBindingPage' /* webpackChunkName: "cluster-trigger-binding-details" */
           )
         ).default,
     },
@@ -632,7 +691,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       loader: async () =>
         (
           await import(
-            './components/tasks-lists/TasksListsPage' /* webpackChunkName: "admin-tasks`" */
+            './components/tasks/list-page/TasksListsPage' /* webpackChunkName: "admin-tasks`" */
           )
         ).default,
     },

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -7,6 +7,7 @@ import {
   k8sGet,
   SecretKind,
   K8sResourceCommon,
+  K8sKind,
 } from '@console/internal/module/k8s';
 import {
   LOG_SOURCE_RESTARTING,
@@ -30,6 +31,19 @@ import {
   TaskRunKind,
 } from './pipeline-augment';
 import { pipelineFilterReducer, pipelineRunStatus } from './pipeline-filter-reducer';
+import {
+  PipelineRunModel,
+  TaskRunModel,
+  PipelineResourceModel,
+  ConditionModel,
+  ClusterTaskModel,
+  TriggerTemplateModel,
+  TriggerBindingModel,
+  ClusterTriggerBindingModel,
+  PipelineModel,
+  TaskModel,
+  EventListenerModel,
+} from '../models';
 
 interface Resources {
   inputs?: Resource[];
@@ -402,4 +416,31 @@ export const getSecretAnnotations = (annotation: KeyValuePair) => {
     annotations[`${annotationPrefix}/${SecretAnnotationId.Image}-0`] = annotation?.value;
   }
   return annotations;
+};
+
+export const pipelinesTab = (kindObj: K8sKind) => {
+  switch (kindObj.kind) {
+    case PipelineModel.kind:
+    case TaskModel.kind:
+    case EventListenerModel.kind:
+      return '';
+    case PipelineRunModel.kind:
+      return 'pipeline-runs';
+    case PipelineResourceModel.kind:
+      return 'pipeline-resources';
+    case ConditionModel.kind:
+      return 'conditions';
+    case TaskRunModel.kind:
+      return 'task-runs';
+    case ClusterTaskModel.kind:
+      return 'cluster-tasks';
+    case TriggerTemplateModel.kind:
+      return 'trigger-templates';
+    case TriggerBindingModel.kind:
+      return 'trigger-bindings';
+    case ClusterTriggerBindingModel.kind:
+      return 'cluster-trigger-bindings';
+    default:
+      return null;
+  }
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4220

**Analysis / Root cause**: 
 Pipeline details pages on Admin to have breadcrumbs that take the user to default list page of Pipelines instead of to the tabbed list page from where the user came from

**Solution Description**: 
Pipeline details pages on Admin to have breadcrumbs that take the user back to the tabbed list page from where the user came from.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
![Kapture 2020-08-05 at 3 26 28](https://user-images.githubusercontent.com/2561818/89349275-908baf00-d6cb-11ea-8ef9-03651ba78130.gif)