### PR TITLE
Change image stream dropdown labels

### DIFF
--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
@@ -80,7 +80,7 @@ const ImageStreamDropdown: React.FC = () => {
   return (
     <ResourceDropdownField
       name="imageStream.image"
-      label="ImageStreams"
+      label="Image Stream"
       resources={getImageStreamResource(imageStream.namespace)}
       dataSelector={['metadata', 'name']}
       key={imageStream.namespace}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
@@ -81,7 +81,7 @@ const ImageStreamNsDropdown: React.FC = () => {
   return (
     <ResourceDropdownField
       name="imageStream.namespace"
-      label="Projects"
+      label="Project"
       title="Select Project"
       fullWidth
       required


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2425

**Analysis / Root cause**: 
There are a couple things that should be improved since this is a static field and not something dynamically created.

* The title `ImageStreams` should have a space
* The disabled dropdown shouldn't have an ellipsis to a predefined label ("Select Image Strea...")

**Solution Description**: 
Changed the text of "Projects" to "Project" and ImageStreams to "Image Stream". I used singular because the user can select only one Project here. This matches also some other dropdown field labels, like "Application Name".
* The text "Select Image Stream" was ellipsis on my Chrome and Firefox (both Fedora 32) only when the windows is smaller than 1024 pixels. I think this is "acceptable", or? @andrewballantyne 

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 

Before:
![before](https://user-images.githubusercontent.com/139310/89403116-21887780-d718-11ea-82e2-60f0e8c99669.png)

After:
![after](https://user-images.githubusercontent.com/139310/89403127-25b49500-d718-11ea-9be9-34300cd38fb4.png)

**Unit test coverage report**: 
No tests changed

**Test setup:**
* Create a Deployment from a container image with an external image (for example jerolimov/nodeinfo)
* Open the Import from container image page again and select "Image stream tag from internal registry"

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge