### PR TITLE
Bug 1870670: Improve spacing for RadioGroupFields and the image search

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
@@ -5,8 +5,16 @@
     margin-top: 0;
   }
 
-  &__children {
-    padding: var(--pf-global--spacer--md) 0;
+  &:not(.ocs-radio-group-field--inline) {
+    .pf-c-radio {
+      padding-bottom: var(--pf-global--spacer--md);
+    }
+    .pf-c-radio:last-of-type {
+      padding-bottom: 0;
+    }
+    .ocs-radio-group-field__children {
+      padding-top: var(--pf-global--spacer--sm);
+    }
   }
 
   &--inline {

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.scss
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.scss
@@ -1,0 +1,5 @@
+.odc-image-search {
+  &__advanced-options {
+    padding-top: var(--pf-global--spacer--xs);
+  }
+}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -15,6 +15,7 @@ import { InputField, useDebounceCallback, CheckboxField } from '@console/shared'
 import { getSuggestedName, getPorts, makePortName } from '../../../utils/imagestream-utils';
 import { secretModalLauncher } from '../CreateSecretModal';
 import { UNASSIGNED_KEY, CREATE_APPLICATION_KEY } from '../../../const';
+import './ImageSearch.scss';
 
 const ImageSearch: React.FC = () => {
   const { values, setFieldValue, dirty, initialValues, touched } = useFormikContext<FormikValues>();
@@ -203,13 +204,15 @@ const ImageSearch: React.FC = () => {
           actionClose={<AlertActionCloseButton onClose={() => shouldHideAlert(false)} />}
         />
       )}
-      <CheckboxField
-        name="allowInsecureRegistry"
-        label="Allow images from insecure registries"
-        onChange={(val: boolean) => {
-          values.searchTerm && handleSearch(values.searchTerm, val);
-        }}
-      />
+      <div className="odc-image-search__advanced-options">
+        <CheckboxField
+          name="allowInsecureRegistry"
+          label="Allow images from insecure registries"
+          onChange={(val: boolean) => {
+            values.searchTerm && handleSearch(values.searchTerm, val);
+          }}
+        />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2411

**Analysis / Root cause**: 
These radio buttons on the Import from container image page are not spaced appropriately.

**Solution Description**: 
Improve the general RadioGroup spacing. See screenshots below.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux There is also an video available which shows to difference:
https://issues.redhat.com/secure/attachment/12482887/Screencast.mp4

Import from container image, image area...
Before:
![external-image-empty-before](https://user-images.githubusercontent.com/139310/89403894-5ba64900-d719-11ea-9055-8af517529aa6.png)

After:
![external-image-empty-after](https://user-images.githubusercontent.com/139310/89403900-5d700c80-d719-11ea-86bb-532eb2ac96fb.png)

When selecting "internal image registry"
Before:
![internal-registry-no-error-before](https://user-images.githubusercontent.com/139310/89403978-82fd1600-d719-11ea-82c4-f9cbae7db5a5.png)

After:
![internal-registry-no-error-after](https://user-images.githubusercontent.com/139310/89403984-842e4300-d719-11ea-8966-9406045cc4a3.png)

:warning: This changes also the Resource section!
Before:
![resource-select-before](https://user-images.githubusercontent.com/139310/89404030-97411300-d719-11ea-8418-bc1f3f6991aa.png)

After:
![resource-select-after](https://user-images.githubusercontent.com/139310/89404034-98724000-d719-11ea-93be-c999010c3dd7.png)

The change in the Resource section matches now all other areas. Checkout the movie I uploaded to the issue!
https://issues.redhat.com/secure/attachment/12482887/Screencast.mp4

**Unit test coverage report**: 
Not touched

**Test setup:**
* Open the Import from container image screen and select the both options "from external image registry" and "from internal image registry". Test this also when there is no images available in the internal image registry which shows an additional alert then.
* Verify / Compare also the "Resource" section on the Import from container image page.
* The RadioGroupField was also used with inline prop in the Helm chart. To check that this behavior is not changed, go to the developer perspective, select "Add" > "Helm Chart" > Select for example "Nodejs Ex K v0.2.0" > "Install Helm Chart". The configuration switch for "Form View" and "YAML View" should looks like before.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug