### PR TITLE
Bug 1853599: Fixes bug attaching block storage PVC to deployments

### DIFF
--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -29,9 +29,9 @@ class ListDropdown_ extends React.Component {
     this.autocompleteFilter = (text, item) => fuzzy(text, item.props.name);
     // Pass both the resource name and the resource kind to onChange()
     this.onChange = (key) => {
-      const { name, kindLabel } = _.get(this.state, ['items', key], {});
+      const { name, kindLabel, resource } = _.get(this.state, ['items', key], {});
       this.setState({ selectedKey: key, title: <ResourceName kind={kindLabel} name={name} /> });
-      this.props.onChange(name, kindLabel);
+      this.props.onChange(name, kindLabel, resource);
     };
   }
 
@@ -70,6 +70,7 @@ class ListDropdown_ extends React.Component {
               acc[`${resource.metadata.name}-${kindLabel}`] = {
                 kindLabel,
                 name: resource.metadata.name,
+                resource,
               };
             }
             return acc;

--- a/frontend/public/components/utils/pvc-dropdown.tsx
+++ b/frontend/public/components/utils/pvc-dropdown.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ListDropdown } from './list-dropdown';
 import { PersistentVolumeClaimModel } from '../../models';
+import { PersistentVolumeClaimKind } from '../../../public/module/k8s/types';
 
 export const PVCDropdown: React.FC<PVCDropdownProps> = (props) => {
   const kind = PersistentVolumeClaimModel.kind;
@@ -21,7 +22,7 @@ export const PVCDropdown: React.FC<PVCDropdownProps> = (props) => {
 export type PVCDropdownProps = {
   namespace: string;
   selectedKey: string;
-  onChange: (string) => void;
+  onChange: (claimName: string, kindLabel?: string, pvc?: PersistentVolumeClaimKind) => void;
   id?: string;
   desc?: string;
   dataTest?: string;

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -122,6 +122,11 @@ export type VolumeMount = {
   subPathExpr?: string;
 };
 
+export type VolumeDevice = {
+  devicePath: string;
+  name: string;
+};
+
 type ProbePort = string | number;
 
 export type ExecProbe = {
@@ -247,6 +252,7 @@ export type PodAffinity = {
 export type ContainerSpec = {
   name: string;
   volumeMounts?: VolumeMount[];
+  volumeDevices?: VolumeDevice[];
   env?: EnvVar[];
   livenessProbe?: ContainerProbe;
   readinessProbe?: ContainerProbe;


### PR DESCRIPTION
Using  block storage provisioners with RWX access mode incorrectly attaches the path as volumeMount in PodSpec instead of volumeDevice. This caused the pods to be in a state of ContainerCreation indefinitely. This  commit fixes this by  sending the object with the right configuration for block storage.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1853599

Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>