### PR TITLE
Bug 1862537: Change pending changes alert when making a change

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/Alerts/PendingChangesAlert.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/Alerts/PendingChangesAlert.tsx
@@ -1,20 +1,26 @@
 import * as React from 'react';
 import { Alert, AlertVariant } from '@patternfly/react-core';
+import {
+  MODAL_INFO_RESTART_IS_REQUIRED,
+  MODAL_WARNING_RESTART_IS_REQUIRED,
+} from '../../strings/vm/status';
 
 import './PendingChangesAlert.scss';
 
 type PendingChangesAlertProps = {
   warningMsg?: string;
   isWarning?: boolean;
+  title?: string;
 };
 
 export const PendingChangesAlert: React.FC<PendingChangesAlertProps> = ({
   warningMsg,
   isWarning,
+  title,
   children,
 }) => (
   <Alert
-    title="Pending Changes"
+    title={title || 'Pending Changes'}
     isInline
     variant={isWarning ? AlertVariant.warning : AlertVariant.info}
     className="kv__pending_changes-alert"
@@ -22,3 +28,20 @@ export const PendingChangesAlert: React.FC<PendingChangesAlertProps> = ({
     {warningMsg || children}
   </Alert>
 );
+
+type ModalPendingChangesAlertProps = {
+  isChanged: boolean;
+};
+
+export const ModalPendingChangesAlert: React.FC<ModalPendingChangesAlertProps> = ({
+  isChanged,
+}) => {
+  const modalMsg = isChanged ? MODAL_WARNING_RESTART_IS_REQUIRED : MODAL_INFO_RESTART_IS_REQUIRED;
+  return (
+    <PendingChangesAlert
+      warningMsg={modalMsg}
+      isWarning={isChanged}
+      title="Restart required to apply changes"
+    />
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
@@ -46,8 +46,11 @@ export const getSelectedBootableDevices = (vm: VMLikeEntityKind): BootableDevice
   return [...devices];
 };
 
-export const getBootableDevicesInOrder = (vm: VMLikeEntityKind): BootableDeviceType[] =>
-  _.sortBy(getSelectedBootableDevices(vm), 'value.bootOrder');
+export const getBootableDevicesInOrder = (
+  vm: VMLikeEntityKind,
+  bootableDevices?: BootableDeviceType[],
+): BootableDeviceType[] =>
+  _.sortBy(bootableDevices || getSelectedBootableDevices(vm), 'value.bootOrder');
 
 export const getNonBootableDevices = (vm: VMLikeEntityKind): BootableDeviceType[] => {
   const devices = getBootableDevices(vm).filter((device) => !device.value.bootOrder);

--- a/frontend/packages/kubevirt-plugin/src/strings/vm/status.ts
+++ b/frontend/packages/kubevirt-plugin/src/strings/vm/status.ts
@@ -12,6 +12,10 @@ export const IMPORT_CDI_PENDING_MESSAGE =
   'The importer pod is waiting for resources to become available.';
 export const MODAL_RESTART_IS_REQUIRED =
   'The changes you are making require this virtual machine to be updated. Restart this VM to apply these changes.';
+export const MODAL_INFO_RESTART_IS_REQUIRED =
+  'If you make changes to the following settings you will need to restart the virtual machine in order for them to be applied';
+export const MODAL_WARNING_RESTART_IS_REQUIRED =
+  "The changes you've made required this virtual machine to be restarted.";
 export const PENDING_CHANGES_WARNING_MESSAGE =
   'The following areas have pending changes that will be applied when this virtual machine is restarted.';
 export const PENDING_CHANGES_POPOVER_MSG =


### PR DESCRIPTION
While the VM is running and the user make a change
in the Flavor or the boot order modals, the alert text is changing in the modal
as well as the alert variant.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>