### PR TITLE
Fix for topology graph view being auto-reset

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -1,17 +1,11 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { useExtensions } from '@console/plugin-sdk';
 import { isTopologyDataModelFactory, TopologyDataModelFactory } from '../../extensions/topology';
-import { RootState } from '@console/internal/redux';
 import DataModelProvider from './data-transforms/DataModelProvider';
 import { DataModelExtension } from './data-transforms/DataModelExtension';
 import { TopologyExtensionLoader } from './TopologyExtensionLoader';
 
-interface StateProps {
-  kindsInFlight: boolean;
-}
-
-export interface TopologyDataControllerProps extends StateProps {
+export interface TopologyDataControllerProps {
   showGraphView: boolean;
   namespace: string;
   render(RenderProps): React.ReactElement;
@@ -21,7 +15,6 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   showGraphView,
   namespace,
   render,
-  kindsInFlight,
 }) => {
   const modelFactories = useExtensions<TopologyDataModelFactory>(isTopologyDataModelFactory);
 
@@ -31,7 +24,6 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
         <DataModelExtension key={factory.properties.id} dataModelFactory={factory} />
       ))}
       <TopologyExtensionLoader
-        kindsInFlight={kindsInFlight}
         render={render}
         namespace={namespace}
         showGraphView={showGraphView}
@@ -40,10 +32,4 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   );
 };
 
-const DataControllerStateToProps = (state: RootState) => {
-  return {
-    kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight']),
-  };
-};
-
-export default connect(DataControllerStateToProps)(TopologyDataController);
+export default TopologyDataController;

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataRetriever.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataRetriever.tsx
@@ -15,7 +15,6 @@ export const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({
   resourcesList,
   namespace,
   showGraphView,
-  kindsInFlight,
   trafficData,
 }) => {
   const resources = useK8sWatchResources<TopologyResourcesObject>(resourcesList);
@@ -26,7 +25,6 @@ export const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({
       namespace={namespace}
       showGraphView={showGraphView}
       resources={resources}
-      kindsInFlight={kindsInFlight}
       trafficData={trafficData}
     />
   );

--- a/frontend/packages/dev-console/src/components/topology/TopologyExtensionLoader.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyExtensionLoader.tsx
@@ -9,7 +9,6 @@ export const TopologyExtensionLoader: React.FC<TopologyExtensionLoaderProps> = (
   render,
   namespace,
   showGraphView,
-  kindsInFlight,
 }) => {
   const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
   const [resourcesList, setResourcesList] = React.useState<WatchK8sResources<any>>(
@@ -24,18 +23,17 @@ export const TopologyExtensionLoader: React.FC<TopologyExtensionLoaderProps> = (
   }, [dataModelContext]);
 
   React.useEffect(() => {
-    if (kindsInFlight || !loadedState?.extensionsLoaded) {
+    if (!loadedState?.extensionsLoaded) {
       return;
     }
     setResourcesList(loadedState.watchedResources);
-  }, [kindsInFlight, loadedState]);
+  }, [loadedState]);
 
   return (
     <TopologyDataRetriever
       render={render}
       resourcesList={resourcesList}
       namespace={namespace}
-      kindsInFlight={kindsInFlight}
       showGraphView={showGraphView}
     />
   );

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
@@ -22,7 +22,6 @@ describe('TopologyDataController', () => {
       <TopologyDataController
         showGraphView
         namespace="test-project"
-        kindsInFlight={false}
         render={() => <TestInner />}
       />,
       {

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
@@ -24,6 +24,7 @@ import {
   getSupportedTopologyKinds,
   getTopologyFilters,
   getTopologySearchQuery,
+  onSearchChange,
 } from './filter-utils';
 import FilterDropdown from './FilterDropdown';
 import KindFilterDropdown from './KindFilterDropdown';
@@ -45,14 +46,10 @@ type DispatchProps = {
 
 type OwnProps = {
   visualization?: Visualization;
-  onSearchChange: (searchQuery: string) => void;
   showGraphView: boolean;
 };
 
-type MergeProps = {
-  onDisplayFiltersChange: (display: DisplayFilters) => void;
-} & StateProps &
-  OwnProps;
+type MergeProps = StateProps & DispatchProps & OwnProps;
 
 type TopologyFilterBarProps = MergeProps;
 
@@ -60,8 +57,7 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
   filters,
   supportedFilters,
   supportedKinds,
-  onDisplayFiltersChange,
-  onSearchChange,
+  onFiltersChange,
   visualization,
   showGraphView,
   consoleLinks,
@@ -74,14 +70,11 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
     setSearchQuery(query);
   }, []);
 
-  const onTextFilterChange = React.useCallback(
-    (text) => {
-      const query = text?.trim();
-      setSearchQuery(query);
-      onSearchChange(query);
-    },
-    [onSearchChange],
-  );
+  const onTextFilterChange = (text) => {
+    const query = text?.trim();
+    setSearchQuery(query);
+    onSearchChange(query);
+  };
 
   return (
     <Toolbar className="co-namespace-bar odc-topology-filter-bar">
@@ -91,7 +84,7 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
             <FilterDropdown
               filters={filters}
               supportedFilters={supportedFilters}
-              onChange={onDisplayFiltersChange}
+              onChange={onFiltersChange}
             />
           </ToolbarItem>
         </ToolbarGroup>
@@ -100,7 +93,7 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
             <KindFilterDropdown
               filters={filters}
               supportedKinds={supportedKinds}
-              onChange={onDisplayFiltersChange}
+              onChange={onFiltersChange}
             />
           </ToolbarItem>
         </ToolbarGroup>
@@ -170,17 +163,14 @@ const dispatchToProps = (dispatch: Dispatch): DispatchProps => ({
 const mergeProps = (
   { filters, supportedFilters, supportedKinds, consoleLinks, namespace }: StateProps,
   { onFiltersChange }: DispatchProps,
-  { visualization, onSearchChange, showGraphView }: OwnProps,
+  { visualization, showGraphView }: OwnProps,
 ): MergeProps => ({
   filters,
   supportedFilters,
   supportedKinds,
   consoleLinks,
   namespace,
-  onDisplayFiltersChange: (changedFilters: DisplayFilters) => {
-    onFiltersChange(changedFilters);
-  },
-  onSearchChange,
+  onFiltersChange,
   visualization,
   showGraphView,
 });

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
@@ -1,5 +1,9 @@
 import { RootState } from '@console/internal/redux';
-import { getQueryArgument } from '@console/internal/components/utils';
+import {
+  getQueryArgument,
+  removeQueryArgument,
+  setQueryArgument,
+} from '@console/internal/components/utils';
 import { getDefaultTopologyFilters } from '../redux/reducer';
 import { getAppliedFilters } from '../redux/action';
 import {
@@ -11,6 +15,14 @@ import { DEFAULT_TOPOLOGY_FILTERS, EXPAND_GROUPS_FILTER_ID, SHOW_GROUPS_FILTER_I
 import { K8sResourceKindReference } from '@console/internal/module/k8s';
 
 export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
+
+export const onSearchChange = (searchQuery: string): void => {
+  if (searchQuery.length > 0) {
+    setQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY, searchQuery);
+  } else {
+    removeQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY);
+  }
+};
 
 export const getTopologyFilters = (state: RootState): DisplayFilters => {
   const topology = state?.plugins?.devconsole?.topology;

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.scss
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.scss
@@ -16,7 +16,7 @@
   overflow-y: auto;
   padding-left: var(--pf-global--spacer--sm);
   -webkit-overflow-scrolling: touch;
-  &.is-list-view-filtered {
+  &.odc-m-filter-active {
     .odc-topology-list-view__kind-row,
     .odc-topology-list-view__item-row,
     .odc-topology-list-view__application-row {

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
@@ -1,18 +1,13 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
 import { DataList } from '@patternfly/react-core';
 import { isGraph, Node, isNode, Visualization, GraphElement } from '@patternfly/react-topology';
-import { useDeepCompareMemoize } from '@console/shared/src';
-import { setQueryArgument, removeQueryArgument } from '@console/internal/components/utils';
+import { useDeepCompareMemoize } from '@console/shared';
 import { TYPE_APPLICATION_GROUP } from '../components';
-import { getTopologySearchQuery, TOPOLOGY_SEARCH_FILTER_KEY } from '../filters';
 import { TopologyListViewAppGroup } from './TopologyListViewAppGroup';
 import { getChildKinds, sortGroupChildren } from './list-view-utils';
 import { TopologyListViewUnassignedGroup } from './TopologyListViewUnassignedGroup';
 
 import './TopologyListView.scss';
-
-export const FILTER_ACTIVE_CLASS = 'odc-m-filter-active';
 
 interface TopologyListViewProps {
   visualization: Visualization;
@@ -27,11 +22,7 @@ const TopologyListView: React.FC<TopologyListViewProps> = ({
   selectedIds,
   onSelect,
 }) => {
-  const searchParams = window.location.search;
   const selectedId = selectedIds[0];
-  const [searchClass, setSearchClass] = React.useState<string>(
-    getTopologySearchQuery() ? 'is-list-view-filtered' : '',
-  );
   const [applicationGroups, setApplicationGroups] = React.useState<Node[]>();
   const [unassignedItems, setUnassignedItems] = React.useState<Node[]>();
 
@@ -57,22 +48,6 @@ const TopologyListView: React.FC<TopologyListViewProps> = ({
       }
     }
   }, [selectedId]);
-
-  const onSearchChange = (searchQuery) => {
-    if (searchQuery.length > 0) {
-      setQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY, searchQuery);
-      document.body.classList.add(FILTER_ACTIVE_CLASS);
-    } else {
-      removeQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY);
-      document.body.classList.remove(FILTER_ACTIVE_CLASS);
-    }
-  };
-
-  React.useEffect(() => {
-    const searchQuery = getTopologySearchQuery();
-    searchQuery && onSearchChange(searchQuery);
-    setSearchClass(searchQuery ? 'is-list-view-filtered' : '');
-  }, [searchParams]);
 
   React.useEffect(() => {
     const getFlattenedItems = (): Node[] => {
@@ -168,9 +143,8 @@ const TopologyListView: React.FC<TopologyListViewProps> = ({
     return null;
   }
 
-  const classes = classNames('odc-topology-list-view', searchClass);
   return (
-    <div className={classes}>
+    <div className="odc-topology-list-view">
       <DataList
         aria-label="Topology List View"
         className="odc-topology-list-view__data-list"


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4446

**Description**
Fixes an issue where the topology graph view gets reset and the zoom level and layout is lost reverting to its initial state without the user performing any action.

Fix:
Do not reset the topology model when resources get re-initialized (kindsInFlight get set to true, load errors are received, or resources are in the process of loading).

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
