### PR TITLE
Bug 1866114: Don't store OpenAPI definitions in localStorage

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -5,7 +5,7 @@ import {
 } from 'monaco-languageclient/lib/monaco-converter';
 import { getLanguageService, TextDocument } from 'yaml-language-server';
 import { openAPItoJSONSchema } from '@console/internal/module/k8s/openapi-to-json-schema';
-import { getStoredSwagger } from '@console/internal/module/k8s/swagger';
+import { getSwaggerDefinitions } from '@console/internal/module/k8s/swagger';
 import { global_BackgroundColor_dark_100 as editorBackground } from '@patternfly/react-tokens';
 
 window.monaco.editor.defineTheme('console', {
@@ -62,7 +62,7 @@ export const createYAMLService = () => {
   const yamlService = getLanguageService(resolveSchema, workspaceContext, []);
 
   // Prepare the schema
-  const yamlOpenAPI = getStoredSwagger();
+  const yamlOpenAPI = getSwaggerDefinitions();
 
   // Convert the openAPI schema to something the language server understands
   const kubernetesJSONSchema = openAPItoJSONSchema(yamlOpenAPI);

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -4,7 +4,7 @@ import { Breadcrumb, BreadcrumbItem, Button } from '@patternfly/react-core';
 
 import {
   getDefinitionKey,
-  getStoredSwagger,
+  getSwaggerDefinitions,
   getSwaggerPath,
   K8sKind,
   SwaggerDefinition,
@@ -29,7 +29,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
     return null;
   }
 
-  const allDefinitions: SwaggerDefinitions = getStoredSwagger();
+  const allDefinitions: SwaggerDefinitions = getSwaggerDefinitions();
   if (!allDefinitions) {
     return null;
   }


### PR DESCRIPTION
The document is too large, so we hit browser limits for localStorage.
This can break Safari. Since the API server supports ETags for the
OpenAPI document, rely on browser caching instead.

/assign @jhadvig @andrewballantyne 