### PR TITLE
Add fix to prevent application reset

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -23,6 +23,7 @@ export interface DeployImageProps {
 interface StateProps {
   activeApplication: string;
   serviceBindingAvailable: boolean;
+  isInContext: boolean;
 }
 
 type Props = DeployImageProps & StateProps;
@@ -33,6 +34,7 @@ const DeployImage: React.FC<Props> = ({
   activeApplication,
   contextualSource,
   serviceBindingAvailable,
+  isInContext,
 }) => {
   const initialValues: DeployImageFormData = {
     project: {
@@ -44,6 +46,7 @@ const DeployImage: React.FC<Props> = ({
       initial: sanitizeApplicationValue(activeApplication),
       name: sanitizeApplicationValue(activeApplication),
       selectedKey: activeApplication,
+      isInContext,
     },
     name: '',
     searchTerm: '',
@@ -188,9 +191,11 @@ interface OwnProps extends DeployImageProps {
 }
 const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => {
   const activeApplication = ownProps.forApplication || getActiveApplication(state);
+  const isInContext = !!ownProps.forApplication;
   return {
     activeApplication: activeApplication !== ALL_APPLICATIONS_KEY ? activeApplication : '',
     serviceBindingAvailable: state.FLAGS.get(ALLOW_SERVICE_BINDING),
+    isInContext,
   };
 };
 

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -133,7 +133,8 @@ const ImageSearch: React.FC = () => {
       return;
     }
     !nameTouched && setFieldValue('name', '');
-    values.application.selectedKey !== UNASSIGNED_KEY &&
+    !values.application.isInContext &&
+      values.application.selectedKey !== UNASSIGNED_KEY &&
       !applicationNameTouched &&
       setFieldValue('application.name', '');
   };

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -112,6 +112,7 @@ export interface ApplicationData {
   initial?: string;
   name: string;
   selectedKey: string;
+  isInContext?: boolean;
 }
 
 export interface ImageData {


### PR DESCRIPTION
Jira issue - https://issues.redhat.com/browse/ODC-3992

**Problem:**
In deploy-image form in case of external-registry the application is getting reset even when a component is being created in context of an existing application using application context menu.

**Solution:**
Check if the component being created is in context of some application, if yes do not reset the application.

**Gif:**
![Peek 2020-08-05 23-00](https://user-images.githubusercontent.com/20724543/89444904-0f3a2800-d770-11ea-9d3c-c3ce17492ee8.gif)

/kind bug