### PR TITLE
Bug 1860074: Address two issues on the Install Operator form

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { match } from 'react-router';
-import { ActionGroup, Alert, Button, Checkbox, Tooltip } from '@patternfly/react-core';
+import { ActionGroup, Alert, Button, Checkbox, Popover } from '@patternfly/react-core';
 import {
   Dropdown,
   ExternalLink,
@@ -579,21 +579,30 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
           <div className="col-xs-6">
             <>
               <div className="form-group">
-                <Tooltip content="The channel to track and receive the updates from.">
-                  <h5 className="co-required">Update Channel</h5>
-                </Tooltip>
-                <RadioGroup
-                  currentValue={selectedUpdateChannel}
-                  items={channels.map((ch) => ({ value: ch.name, title: ch.name }))}
-                  onChange={(e) => {
-                    setUpdateChannel(e.currentTarget.value);
-                    setInstallMode(null);
-                  }}
-                />
+                <fieldset>
+                  <Popover
+                    headerContent={<div>Update Channel</div>}
+                    bodyContent={<div>The channel to track and receive the updates from.</div>}
+                  >
+                    <h5 className="co-required">
+                      <Button variant="plain" className="co-form-heading__popover-button">
+                        Update Channel
+                      </Button>
+                    </h5>
+                  </Popover>
+                  <RadioGroup
+                    currentValue={selectedUpdateChannel}
+                    items={channels.map((ch) => ({ value: ch.name, title: ch.name }))}
+                    onChange={(e) => {
+                      setUpdateChannel(e.currentTarget.value);
+                      setInstallMode(null);
+                    }}
+                  />
+                </fieldset>
               </div>
               <div className="form-group">
-                <h5 className="co-required">Installation Mode</h5>
-                <div>
+                <fieldset>
+                  <h5 className="co-required">Installation Mode</h5>
                   <RadioInput
                     onChange={(e) => {
                       setInstallMode(e.target.value);
@@ -612,8 +621,6 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                       </p>
                     </div>
                   </RadioInput>
-                </div>
-                <div>
                   <RadioInput
                     onChange={(e) => {
                       setInstallMode(e.target.value);
@@ -633,7 +640,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                       </p>
                     </div>
                   </RadioInput>
-                </div>
+                </fieldset>
               </div>
               <div className="form-group">
                 <h5 className="co-required">Installed Namespace</h5>
@@ -643,17 +650,28 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                   singleNamespaceInstallMode}
               </div>
               <div className="form-group">
-                <Tooltip content="The strategy to determine either manual or automatic updates.">
-                  <h5 className="co-required">Approval Strategy</h5>
-                </Tooltip>
-                <RadioGroup
-                  currentValue={selectedApproval}
-                  items={[
-                    { value: InstallPlanApproval.Automatic, title: 'Automatic' },
-                    { value: InstallPlanApproval.Manual, title: 'Manual' },
-                  ]}
-                  onChange={(e) => setApproval(e.currentTarget.value)}
-                />
+                <fieldset>
+                  <Popover
+                    headerContent={<div>Approval Strategy</div>}
+                    bodyContent={
+                      <div>The strategy to determine either manual or automatic updates.</div>
+                    }
+                  >
+                    <h5 className="co-required">
+                      <Button variant="plain" className="co-form-heading__popover-button">
+                        Approval Strategy
+                      </Button>
+                    </h5>
+                  </Popover>
+                  <RadioGroup
+                    currentValue={selectedApproval}
+                    items={[
+                      { value: InstallPlanApproval.Automatic, title: 'Automatic' },
+                      { value: InstallPlanApproval.Manual, title: 'Manual' },
+                    ]}
+                    onChange={(e) => setApproval(e.currentTarget.value)}
+                  />
+                </fieldset>
               </div>
             </>
             <div className="co-form-section__separator" />

--- a/frontend/public/components/utils/_details-item.scss
+++ b/frontend/public/components/utils/_details-item.scss
@@ -8,27 +8,10 @@
 }
 
 .details-item__popover-button {
-  // Use `background-image: linear-gradient` to draw a dotted underline. This gives us more control over the styling.
-  background-image: linear-gradient(
-    to right,
-    var(--pf-c-button--m-plain--Color) 33%,
-    rgba(255, 255, 255, 0) 0%
-  );
-  background-position: bottom;
-  background-size: 3px 1px;
-  background-repeat: repeat-x;
   color: inherit !important;
   font-weight: inherit !important;
   margin-bottom: 3px;
-  padding: 0 !important;
-  &:focus,
-  &:hover {
-    background-image: linear-gradient(
-      to right,
-      var(--pf-c-button--m-tertiary--Color) 33%,
-      rgba(255, 255, 255, 0) 0%
-    );
-  }
+  @include co-popover-button();
 }
 
 .details-item__value--group {

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -14,6 +14,7 @@
 
 // Mixins
 @import 'style/mixin/break-word';
+@import 'style/mixin/popover-button';
 @import 'style/mixin/font-awesome';
 @import 'style/mixin/prefix';
 @import 'style/mixin/scroll-shadows';

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -24,6 +24,12 @@
   }
 }
 
+.co-form-heading__popover-button {
+  color: inherit !important;
+  font-family: var(--pf-global--FontFamily--heading--sans-serif);
+  @include co-popover-button();
+}
+
 .co-form-section__label {
   font-size: 14px;
   margin-bottom: ($grid-gutter-width / 2);

--- a/frontend/public/style/mixin/_popover-button.scss
+++ b/frontend/public/style/mixin/_popover-button.scss
@@ -1,0 +1,22 @@
+// Generic popover button styling
+
+@mixin co-popover-button() {
+  // Use `background-image: linear-gradient` to draw a dotted underline. This gives us more control over the styling.
+  background-image: linear-gradient(
+    to right,
+    var(--pf-c-button--m-plain--Color) 33%,
+    rgba(255, 255, 255, 0) 0%
+  );
+  background-position: bottom;
+  background-size: 3px 1px;
+  background-repeat: repeat-x;
+  padding: 0 !important;
+  &:focus,
+  &:hover {
+    background-image: linear-gradient(
+      to right,
+      var(--pf-c-button--m-tertiary--Color) 33%,
+      rgba(255, 255, 255, 0) 0%
+    );
+  }
+}


### PR DESCRIPTION
- Wrapping form elements with `<fieldset>` for better accessibility
- Switch Tooltips to Popovers to be consistent with resource details page
-- convert popover-button styles to reusable mixin

fix Bug https://bugzilla.redhat.com/show_bug.cgi?id=1860074

<img width="743" alt="Screen Shot 2020-08-05 at 1 13 02 PM" src="https://user-images.githubusercontent.com/1874151/89446392-78934a00-d722-11ea-8ab9-093b29bc168a.png">


