### PR TITLE
Fix crash when knative deployment is selected in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
 import * as _ from 'lodash';
 import KnativeResourceOverviewPage from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
-import { KebabAction } from '@console/internal/components/utils';
 import { TopologyDataObject } from './topology-types';
 import { ModifyApplication } from '../../actions/modify-application';
 
@@ -12,18 +11,14 @@ export type TopologyResourcePanelProps = {
 
 const TopologyResourcePanel: React.FC<TopologyResourcePanelProps> = ({ item }) => {
   const resourceItemToShowOnSideBar = item && item.resources;
+
   // adds extra check, custom sidebar for all knative resources excluding deployment
-  const itemKind = _.get(item, 'data.kind', null);
+  const itemKind = item?.resource?.kind ?? null;
   if (_.get(item, 'data.isKnativeResource', false) && itemKind && itemKind !== 'Deployment') {
     return <KnativeResourceOverviewPage item={item.resources} />;
   }
 
-  let customActions: KebabAction[] = null;
-  // TODO: remove modify application action from OBS nodes
-  //  if (!item.operatorBackedService) {
-  //    customActions = [ModifyApplication];
-  //  }
-  customActions = [ModifyApplication];
+  const customActions = [ModifyApplication];
 
   return (
     resourceItemToShowOnSideBar && (

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -63,6 +63,10 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
       model.apiVersion === apiInfo.version,
   );
 
+  if (!resourceModel) {
+    return null;
+  }
+
   const actions = [];
   if (resourceModel.kind === RevisionModel.kind) {
     actions.push(...getRevisionActions());


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4453

**Description**
Fixes an issue where the topology view crashes upon selection of a knative deployment. This occurs when a knative revision's deployment resource is selected while in 'flat' mode.


**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
