### PR TITLE
Fix extra whitespace between types in topology sidebar

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
@@ -73,4 +73,19 @@
   .pf-topology-container {
     display: flex;
   }
+  .pf-topology-side-bar {
+    display: flex;
+    flex-direction: column;
+  }
+  .pf-topology-side-bar__body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    .resource-overview {
+      flex: 1;
+    }
+    .overview__sidebar-pane-body {
+      min-height: initial;
+    }
+  }
 }


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4404

**Description**
Fixes an issue where the topology sidebar panel had extra whitespace between types and the action menu becomes unnecessarily scrollable.

**Screen Shots Before**: 

![image](https://user-images.githubusercontent.com/11633780/89455856-f6f6e880-d730-11ea-8a68-c87552e8662d.png)

![image](https://user-images.githubusercontent.com/11633780/89455900-0b3ae580-d731-11ea-8ae3-e9e8e8e22879.png)

**Screen Shots After**

![image](https://user-images.githubusercontent.com/11633780/89456076-4fc68100-d731-11ea-9084-8c11d56b70f2.png)

![image](https://user-images.githubusercontent.com/11633780/89456098-59e87f80-d731-11ea-95cc-42ff5734737b.png)


**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug
