### PR TITLE
Bug 1870628: Fix actions on workload nodes in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
@@ -1,8 +1,24 @@
 import * as _ from 'lodash';
 import { Kebab, KebabAction, KebabOption } from '@console/internal/components/utils';
 import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
+import { menuActions as deploymentConfigMenuActions } from '@console/internal/components/deployment-config';
+import { menuActions as deploymentMenuActions } from '@console/internal/components/deployment';
+import { menuActions as statefulSetMenuActions } from '@console/internal/components/stateful-set';
+import { menuActions as daemonSetMenuActions } from '@console/internal/components/daemon-set';
+import { menuActions as cronJobActions } from '@console/internal/components/cron-job';
+import { menuActions as jobActions } from '@console/internal/components/job';
+import { menuActions as podActions } from '@console/internal/components/pod';
 import { ModifyApplication } from '../../../actions/modify-application';
 
+const defaultMenuForKind = (kind: string) => {
+  const menuActions: KebabAction[] = [];
+  const kindObject = modelFor(kind);
+  const { common } = Kebab.factory;
+  menuActions.push(...Kebab.getExtensionsActionsForKind(kindObject));
+  menuActions.push(...common);
+
+  return menuActions;
+};
 export const workloadActions = (
   contextMenuResource: K8sResourceKind,
   allowRegroup: boolean = true,
@@ -16,10 +32,32 @@ export const workloadActions = (
     menuActions.push(ModifyApplication);
   }
 
-  const kindObject = modelFor(contextMenuResource.kind);
-  const { common } = Kebab.factory;
-  menuActions.push(...Kebab.getExtensionsActionsForKind(kindObject));
-  menuActions.push(...common);
+  switch (contextMenuResource.kind) {
+    case 'DeploymentConfig':
+      menuActions.push(...deploymentConfigMenuActions);
+      break;
+    case 'Deployment':
+      menuActions.push(...deploymentMenuActions);
+      break;
+    case 'StatefulSet':
+      menuActions.push(...statefulSetMenuActions);
+      break;
+    case 'DaemonSet':
+      menuActions.push(...daemonSetMenuActions);
+      break;
+    case 'CronJob':
+      menuActions.push(...cronJobActions);
+      break;
+    case 'Job':
+      menuActions.push(...jobActions);
+      break;
+    case 'Pod':
+      menuActions.push(...podActions);
+      break;
+    default:
+      menuActions.push(...defaultMenuForKind(contextMenuResource.kind));
+      break;
+  }
 
   return _.map(menuActions, (a) =>
     a(modelFor(referenceFor(contextMenuResource)), contextMenuResource),


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4381

**Description**
Fixes an issue where the topology workload nodes do not contain the actions specific to the workload type.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
