### PR TITLE
Bug 1866090: Fix selector spec descriptor link behavior

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.spec.tsx
@@ -165,6 +165,6 @@ describe('Spec descriptors', () => {
     };
     wrapper.setProps({ descriptor });
     expect(wrapper.find(Selector).prop('selector')).toEqual(OBJ.spec.basicSelector);
-    expect(wrapper.find(Selector).prop('kind')).toEqual('core:v1:Service');
+    expect(wrapper.find(Selector).prop('kind')).toEqual('core~v1~Service');
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -114,11 +114,14 @@ const BasicSelector: React.FC<SpecCapabilityProps> = ({
   obj,
   fullPath,
   value,
-}) => (
-  <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
-    <Selector selector={value} kind={capability.split(SpecCapability.selector)[1]} />
-  </DetailsItem>
-);
+}) => {
+  const [, kind] = capability.split(SpecCapability.selector);
+  return (
+    <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+      <Selector selector={value} kind={kind?.replace(/:/g, '~')} />
+    </DetailsItem>
+  );
+};
 
 const BooleanSwitch: React.FC<SpecCapabilityProps> = ({
   model,


### PR DESCRIPTION
Correctly format `group~version~kind` string for spec descriptor selector links.