### PR TITLE
fixes edit access check on edge for pubSub, style on URI help text

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/channels/sections/KafkaChannelSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/sections/KafkaChannelSection.tsx
@@ -7,12 +7,12 @@ const KafkaChannelSection: React.FC = () => (
     <NumberSpinnerField
       name="data.kafkachannel.numPartitions"
       label="Number of Partitions"
-      helpText="The number of partitions of a Kafka topic. By defatul is, set to 1."
+      helpText="The number of partitions of a Kafka topic. By default is, set to 1."
     />
     <NumberSpinnerField
       name="data.kafkachannel.replicationFactor"
       label="Replication Factor"
-      helpText="The Replication Factor of a Kafka topic. By defatul is, set to 1."
+      helpText="The Replication Factor of a Kafka topic. By default is, set to 1."
     />
   </FormSection>
 );

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
@@ -24,7 +24,12 @@ interface SinkResourcesProps {
 }
 
 const SinkUri: React.FC = () => (
-  <>
+  <FormGroup
+    fieldId={getFieldId('sink-name', 'uri')}
+    helperText={`A Universal Resource Indicator where events are going to be delivered. Ex.
+    "http://cluster.example.com/svc"`}
+    isRequired
+  >
     <InputField
       type={TextInputTypes.text}
       name="sink.uri"
@@ -32,11 +37,7 @@ const SinkUri: React.FC = () => (
       data-test-id="sink-section-uri"
       required
     />
-    <div className="help-block">
-      A Universal Resource Indicator where events are going to be delivered. Ex.
-      &quot;http://cluster.example.com/svc&quot;
-    </div>
-  </>
+  </FormGroup>
 );
 
 const SinkResources: React.FC<SinkResourcesProps> = ({ namespace, isMoveSink }) => {

--- a/frontend/packages/knative-plugin/src/topology/components/edges/EventingPubSubLink.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/edges/EventingPubSubLink.tsx
@@ -28,18 +28,18 @@ const EventingPubSubLink: React.FC<EventingPubSubLinkProps> = ({
   children,
   ...others
 }) => {
-  const resourceObj = getTopologyResourceObject(element.getSource().getData());
+  const resourceSourceObj = getTopologyResourceObject(element.getSource().getData());
   const edgeObj = getTopologyResourceObject(element.getData());
   const edgeHasFilter =
-    resourceObj.kind === EventingBrokerModel.kind &&
+    resourceSourceObj.kind === EventingBrokerModel.kind &&
     Object.keys(edgeObj?.spec?.filter?.attributes ?? {}).length > 0;
-  const resourceModel = modelFor(referenceFor(resourceObj));
+  const resourceModel = modelFor(referenceFor(edgeObj));
   const editAccess = useAccessReview({
     group: resourceModel.apiGroup,
     verb: 'update',
     resource: resourceModel.plural,
-    name: resourceObj.metadata.name,
-    namespace: resourceObj.metadata.namespace,
+    name: edgeObj.metadata.name,
+    namespace: edgeObj.metadata.namespace,
   });
   const markerPoint = element.getEndPoint();
   const edgeClasses = classNames('odc-eventing-pubsub-link', { 'odc-m-editable': editAccess });


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/ODC-4309
- https://issues.redhat.com/browse/ODC-4431
- https://issues.redhat.com/browse/ODC-4445

**Analysis / Root cause**: 
Edge action RBAC check was on source of edge for pubsub but should be on edge itself as these are sresources

**Solution Description**: 
fixes edit access check on edge for pubSub, style on URI help text and typo

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/5129024/89489004-13456480-d7c7-11ea-8f8a-b01a66c4fb78.png)


![image](https://user-images.githubusercontent.com/5129024/89488978-00329480-d7c7-11ea-8786-8522722b7fd0.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
