### PR TITLE
ContextProviderExtension: use spread operator instead of clonedeep

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -45,7 +45,7 @@ export class PluginStore {
     this.extensions = _.flatMap(
       plugins.map((p) =>
         p.extensions.map((e, index) =>
-          Object.freeze(augmentExtension(sanitizeExtension(_.cloneDeep(e)), p.name, index)),
+          Object.freeze(augmentExtension(sanitizeExtension({ ...e }), p.name, index)),
         ),
       ),
     );


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-4430

Analysis: The guided tour was not working because of some issue with ContextProvider extension.

Solution: using spread operator instead of lodash cloneDeep while sanitizing extension seems to fix it.

Browser:

- [x] Chrome

