### PR TITLE
Bug 1870607: CloudShell: Remove CloudShell and GuidedTour from QuickStartDrawer Children

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
@@ -4,4 +4,10 @@
     align-items: center;
     flex-wrap: wrap;
   }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    z-index: 0;
+  }
 }

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
@@ -91,7 +91,7 @@ const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
   return (
     <Drawer isExpanded={!!activeQuickStartID} isInline>
       <DrawerContent panelContent={panelContent}>
-        <DrawerContentBody style={{ zIndex: 0 }}>{children}</DrawerContentBody>
+        <DrawerContentBody className="co-quick-start-drawer__body">{children}</DrawerContentBody>
       </DrawerContent>
     </Drawer>
   );


### PR DESCRIPTION

**Fixes**: https://issues.redhat.com/browse/ODC-4353
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: page was scrolling with terminal open
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: take cloudshell out from QuickStartDrawer children
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![quickstart-terminal](https://user-images.githubusercontent.com/9278015/89504295-6af2c880-d7e5-11ea-8dc1-901e32e593d7.gif)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: None
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
