### PR TITLE
PipelineRunLogs: remove padding from pipeline logs task nav

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
@@ -30,12 +30,9 @@
   &__tasklist {
     max-width: 30%;
     margin-top: var(--pf-global--spacer--lg);
-    padding: 0px;
-    padding-left: var(--pf-global--spacer--xl);
   }
   &__container {
     flex: 1;
-    padding-left: var(--pf-global--spacer--xl);
     padding-right: var(--pf-global--spacer--xl);
   }
   &__container .co-m-pane__body {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4266
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: with patternfly 4 update there is extra spacing around the nav of pipeline logs
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: remove extra spacing
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<img width="1004" alt="Screenshot 2020-08-06 at 2 50 17 PM" src="https://user-images.githubusercontent.com/9278015/89515618-00498900-d7f5-11ea-96a0-7f150d3b0bb9.png">

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: None
<!-- Attach test coverage report -->

**Test setup:** None
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
