### PR TITLE
Bug 1872336: Use metadata.generatorName when create a pipeline trigger

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
@@ -42,6 +42,7 @@ export const migratePipelineRun = (pipelineRun: PipelineRun): PipelineRun => {
 export const getPipelineRunData = (
   pipeline: Pipeline = null,
   latestRun?: PipelineRun,
+  options?: { generateName: boolean },
 ): PipelineRun => {
   if (!pipeline && !latestRun) {
     // eslint-disable-next-line no-console
@@ -62,7 +63,13 @@ export const getPipelineRunData = (
     apiVersion: pipeline ? pipeline.apiVersion : latestRun.apiVersion,
     kind: PipelineRunModel.kind,
     metadata: {
-      name: `${pipelineName}-${getRandomChars(6)}`,
+      ...(options?.generateName
+        ? {
+            generateName: `${pipelineName}-`,
+          }
+        : {
+            name: `${pipelineName}-${getRandomChars()}`,
+          }),
       namespace: pipeline ? pipeline.metadata.namespace : latestRun.metadata.namespace,
       labels: _.merge({}, pipeline?.metadata?.labels, latestRun?.metadata?.labels, {
         'tekton.dev/pipeline': pipelineName,
@@ -137,6 +144,7 @@ export const getPipelineRunFromForm = (
   pipeline: Pipeline,
   formValues: CommonPipelineModalFormikValues,
   labels?: { [key: string]: string },
+  options?: { generateName: boolean },
 ) => {
   const { parameters, resources, workspaces } = formValues;
 
@@ -153,5 +161,5 @@ export const getPipelineRunFromForm = (
       workspaces: getPipelineRunWorkspaces(workspaces),
     },
   };
-  return getPipelineRunData(pipeline, pipelineRunData);
+  return getPipelineRunData(pipeline, pipelineRunData, options);
 };

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/resource-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/resource-utils.ts
@@ -2,7 +2,7 @@ import { getRandomChars } from '@console/shared';
 import { apiVersionForModel, RouteKind } from '@console/internal/module/k8s';
 import { RouteModel } from '@console/internal/models';
 import { EventListenerModel, TriggerTemplateModel } from '../../../../models';
-import { PipelineRun } from '../../../../utils/pipeline-augment';
+import { Pipeline, PipelineRun } from '../../../../utils/pipeline-augment';
 import { PIPELINE_SERVICE_ACCOUNT } from '../../const';
 import {
   TriggerBindingKind,
@@ -12,6 +12,7 @@ import {
 } from '../../resource-types';
 
 export const createTriggerTemplate = (
+  pipeline: Pipeline,
   pipelineRun: PipelineRun,
   params: TriggerTemplateKindParam[],
 ): TriggerTemplateKind => {
@@ -19,7 +20,7 @@ export const createTriggerTemplate = (
     apiVersion: apiVersionForModel(TriggerTemplateModel),
     kind: TriggerTemplateModel.kind,
     metadata: {
-      name: `trigger-template-${pipelineRun.metadata.name}`,
+      name: `trigger-template-${pipeline.metadata.name}-${getRandomChars()}`,
     },
     spec: {
       params,

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/submit-utils.ts
@@ -57,11 +57,17 @@ export const submitTrigger = async (
   const { triggerBinding } = formValues;
   const thisNamespace = pipeline.metadata.namespace;
 
-  const pipelineRun: PipelineRun = getPipelineRunFromForm(pipeline, formValues);
+  const pipelineRun: PipelineRun = getPipelineRunFromForm(
+    pipeline,
+    formValues,
+    {},
+    { generateName: true },
+  );
   const triggerTemplateParams: TriggerTemplateKindParam[] = triggerBinding.resource.spec.params.map(
     ({ name }) => ({ name } as TriggerTemplateKindParam),
   );
   const triggerTemplate: TriggerTemplateKind = createTriggerTemplate(
+    pipeline,
     pipelineRun,
     triggerTemplateParams,
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4236

**Analysis / Root cause**: 
When adding a new Trigger for a Pipeline the web console creates an `EventListener` and a `TriggerTemplate`. The trigger templates contains a spec of a PipelineRun configuration (incl. parameters and resources) which will be created when an event is received. The current PipelineRun spec defines a fix name which could be created only once. 

**Solution Description**: 
To create multiple PipelineRun objects it is required to the a metaname `generateName` instead of `name` in the TriggerTemplate spec.

Some background infos I received from Andrew:
* The TriggerTemplate is created in [packages/dev-console/src/components/pipelines/modals/triggers/resource-utils.ts](https://github.com/openshift/console/blob/master/frontend/packages/dev-console/src/components/pipelines/modals/triggers/resource-utils.ts#L14-L29)
* [TriggerTemplate documentation](https://github.com/tektoncd/triggers/blob/master/docs/triggertemplates.md) contains infos about the `generateName` attribute

YAML diff:

```diff
apiVersion: triggers.tekton.dev/v1alpha1
kind: TriggerTemplate
metadata:
  name: trigger-template-docker-kvqrbt
spec:
  resourcetemplates:
    - apiVersion: tekton.dev/v1beta1
      kind: PipelineRun
      metadata:
-       name: docker-3p01ab
+       generateName: docker-
...
```

**Screen shots / Gifs for design review**: 
Nothing changed in the UI

But here you see the relevant part of the test setup below:
![odc-4236](https://user-images.githubusercontent.com/139310/89533851-579b2980-d7f4-11ea-8460-0991ec3cf9a0.gif)

**Unit test coverage report**:
Added some unit tests, no big change here.

Before:
```
=============================== Coverage summary ===============================
Statements   : 27.99% ( 20197/72165 )
Branches     : 17.94% ( 7515/41880 )
Functions    : 16.2% ( 2628/16222 )
Lines        : 29.82% ( 19255/64575 )
================================================================================
```

After:
```
=============================== Coverage summary ===============================
Statements   : 28% ( 20203/72165 )
Branches     : 17.96% ( 7523/41886 )
Functions    : 16.22% ( 2631/16222 )
Lines        : 29.83% ( 19261/64575 )
================================================================================
```

**Test setup:**
* Install the OpenShift Pipeline operator
* Create a Pipeline, for example Import from Git and select "Add Pipeline"
* Open the pipeline and press the menu button in the top right corner and select "Add Trigger"
* Fill the form and validate the generator trigger template
* Please test also Start Pipeline, Re-run pipeline
* And finally you can test the event listener with postman or curl. You find a GitHub POST JSON in the ticket. Ensure that the copied JSON does not contain JSON errors! You can just remove the lines with JSON errors!

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge