### PR TITLE
Bug 1870471: Fix Tech and Dev preview badge styles

### DIFF
--- a/frontend/packages/console-shared/src/components/badges/Badge.scss
+++ b/frontend/packages/console-shared/src/components/badges/Badge.scss
@@ -5,7 +5,11 @@
   }
 }
 
-.tech-preview {
+.ocs-preview-badge {
+  &.pf-c-label {
+    background-color: #d93f00;
+    border-radius: var(--pf-global--BorderRadius--sm);
+  }
   .pf-c-label__content {
     color: var(--pf-global--Color--light-100);
   }

--- a/frontend/packages/console-shared/src/components/badges/DevPreviewBadge.tsx
+++ b/frontend/packages/console-shared/src/components/badges/DevPreviewBadge.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Label } from '@patternfly/react-core';
+import './Badge.scss';
 
-const DevPreviewBadge: React.FC = () => (
-  <Label style={{ backgroundColor: '#D93F00' }}>Dev Preview</Label>
-);
+const DevPreviewBadge: React.FC = () => <Label className="ocs-preview-badge">Dev Preview</Label>;
 
 export default DevPreviewBadge;

--- a/frontend/packages/console-shared/src/components/badges/TechPreviewBadge.tsx
+++ b/frontend/packages/console-shared/src/components/badges/TechPreviewBadge.tsx
@@ -1,17 +1,7 @@
 import * as React from 'react';
 import { Label } from '@patternfly/react-core';
+import './Badge.scss';
 
-const TechPreviewBadge: React.FC = () => (
-  <Label
-    className="tech-preview"
-    style={{
-      backgroundColor: '#D93F00',
-      height: '100%',
-      borderRadius: 'var(--pf-global--BorderRadius--sm)',
-    }}
-  >
-    Tech Preview
-  </Label>
-);
+const TechPreviewBadge: React.FC = () => <Label className="ocs-preview-badge">Tech Preview</Label>;
 
 export default TechPreviewBadge;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4440
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Tech and dev preview badges aren't shown correctly.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Fix and align badge styles.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Before:
![scr1](https://user-images.githubusercontent.com/20013884/89548956-56cebb80-d825-11ea-8427-c2f0ef95322f.png)

After:
![scr0](https://user-images.githubusercontent.com/20013884/89548981-5f26f680-d825-11ea-9d4e-4fe7fc7466be.png)

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
