### PR TITLE
tests: improve OLM scenario reliability

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -63,7 +63,9 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
         );
         if (
           JSON.parse(output.toString('utf-8')).items.find(
-            (pkg) => pkg.status.catalogSource === catalogSource.metadata.name,
+            (pkg) =>
+              pkg.status.catalogSource === catalogSource.metadata.name &&
+              pkg.metadata.name === 'jaeger',
           )
         ) {
           resolve();
@@ -198,12 +200,8 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   it('displays the raw YAML for the `Jaeger`', async () => {
     await element(by.linkText('YAML')).click();
     await yamlView.isLoaded();
-    await yamlView.saveButton.click();
-    await browser.wait(until.visibilityOf(crudView.successMessage));
-
-    expect(crudView.successMessage.getText()).toContain(
-      `${jaegerName} has been updated to version`,
-    );
+    const content = await yamlView.getEditorContent();
+    expect(content.length).not.toEqual(0);
   });
 
   it('displays Kubernetes objects associated with the `Jaeger` in its "Resources" section', async () => {

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -12,6 +12,7 @@ import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import * as catalogView from '@console/internal-integration-tests/views/catalog.view';
 import * as catalogPageView from '@console/internal-integration-tests/views/catalog-page.view';
 import * as sidenavView from '@console/internal-integration-tests/views/sidenav.view';
+import * as yamlView from '@console/internal-integration-tests/views/yaml.view';
 import * as operatorView from '../views/operator.view';
 import * as operatorHubView from '../views/operator-hub.view';
 import { click } from '@console/shared/src/test-utils/utils';
@@ -45,7 +46,9 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
         );
         if (
           JSON.parse(output.toString('utf-8')).items.find(
-            (pkg) => pkg.status.catalogSource === catalogSource.metadata.name,
+            (pkg) =>
+              pkg.status.catalogSource === catalogSource.metadata.name &&
+              pkg.metadata.name === 'prometheus',
           )
         ) {
           resolve();
@@ -203,13 +206,9 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
 
   it('displays the raw YAML for the `Prometheus`', async () => {
     await element(by.linkText('YAML')).click();
-    await browser.wait(until.presenceOf($('.yaml-editor__buttons')));
-    await $('.yaml-editor__buttons')
-      .element(by.buttonText('Save'))
-      .click();
-    await browser.wait(until.visibilityOf(crudView.successMessage));
-
-    expect(crudView.successMessage.getText()).toContain('example has been updated to version');
+    await yamlView.isLoaded();
+    const content = await yamlView.getEditorContent();
+    expect(content.length).not.toEqual(0);
   });
 
   xit('displays Kubernetes objects associated with the `Prometheus` in its "Resources" section', async () => {


### PR DESCRIPTION
1. After creating the custom catalog source, wait until we see the specific package manifest we need. Previously we continued when any package from the catalog source appeared.
2. Skip clicking Save when viewing operand YAML. This avoids 409 conflict errors if the operator applies an update in the background, and the YAML editor is well-tested in the CRUD scenario.

I believe this will fix flakes such as

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/6231/pull-ci-openshift-console-master-e2e-gcp-console/1291399637948698624

and

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/6213/pull-ci-openshift-console-master-e2e-gcp-console/1291389591261024256

See discussion in #6225

/assign @andrewballantyne @TheRealJon 
@ecordell fyi