### PR TITLE
Fix to correctly size collapsed groups in topology view

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/groups/GroupNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/GroupNode.tsx
@@ -31,20 +31,16 @@ type GroupNodeProps = {
   typeIconClass?: string;
 };
 
-const GroupNode: React.FC<GroupNodeProps> = ({
-  element,
-  groupResources,
-  children,
-  kind,
-  emptyValue,
-  typeIconClass,
-}) => {
+const ForwardRefGroupNode: React.FC<GroupNodeProps> = (
+  { element, groupResources, children, kind, emptyValue, typeIconClass },
+  groupRef,
+) => {
   const [textHover, textHoverRef] = useHover();
   const [iconSize, iconRef] = useSize([kind]);
   const iconWidth = iconSize ? iconSize.width : 0;
   const iconHeight = iconSize ? iconSize.height : 0;
   const title = element.getLabel();
-  const { width, height } = element.getDimensions();
+
   return (
     <>
       {typeIconClass && (
@@ -57,41 +53,44 @@ const GroupNode: React.FC<GroupNodeProps> = ({
           iconClass={typeIconClass}
         />
       )}
-      <SvgResourceIcon ref={iconRef} x={LEFT_MARGIN} y={TOP_MARGIN - 2} kind={kind} leftJustified />
-      {title && (
-        <Tooltip
-          content={title}
-          position={TooltipPosition.top}
-          trigger="manual"
-          isVisible={textHover && shouldTruncate(title)}
-        >
-          <text
-            ref={textHoverRef}
-            className="odc-group-node__title"
-            x={LEFT_MARGIN + iconWidth + TEXT_MARGIN}
-            y={TOP_MARGIN + iconHeight}
-            textAnchor="start"
-            dy="-0.25em"
+      <g ref={groupRef}>
+        <SvgResourceIcon
+          ref={iconRef}
+          x={LEFT_MARGIN}
+          y={TOP_MARGIN - 2}
+          kind={kind}
+          leftJustified
+        />
+        {title && (
+          <Tooltip
+            content={title}
+            position={TooltipPosition.top}
+            trigger="manual"
+            isVisible={textHover && shouldTruncate(title)}
           >
-            {truncateMiddle(title, truncateOptions)}
-          </text>
-        </Tooltip>
-      )}
-      {(children || groupResources || emptyValue) && (
-        <g transform={`translate(${LEFT_MARGIN}, ${TOP_MARGIN + iconHeight})`}>
-          {(groupResources || emptyValue) && (
-            <ResourceKindsInfo
-              groupResources={groupResources}
-              emptyValue={emptyValue}
-              width={width - LEFT_MARGIN}
-              height={height - TOP_MARGIN - iconHeight}
-            />
-          )}
-          {children}
-        </g>
-      )}
+            <text
+              ref={textHoverRef}
+              className="odc-group-node__title"
+              x={LEFT_MARGIN + iconWidth + TEXT_MARGIN}
+              y={TOP_MARGIN + iconHeight}
+              textAnchor="start"
+              dy="-0.25em"
+            >
+              {truncateMiddle(title, truncateOptions)}
+            </text>
+          </Tooltip>
+        )}
+        {(children || groupResources || emptyValue) && (
+          <g transform={`translate(${LEFT_MARGIN}, ${TOP_MARGIN + iconHeight})`}>
+            {(groupResources || emptyValue) && (
+              <ResourceKindsInfo groupResources={groupResources} emptyValue={emptyValue} />
+            )}
+            {children}
+          </g>
+        )}
+      </g>
     </>
   );
 };
-
+const GroupNode = React.forwardRef(ForwardRefGroupNode);
 export { GroupNode };

--- a/frontend/packages/dev-console/src/components/topology/components/groups/GroupNodeAnchor.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/GroupNodeAnchor.ts
@@ -1,0 +1,25 @@
+import { Node, Point, AbstractAnchor, getRectAnchorPoint } from '@patternfly/react-topology';
+
+class GroupNodeAnchor extends AbstractAnchor<Node> {
+  protected readonly width: number;
+
+  protected readonly height: number;
+
+  constructor(owner: Node, width: number, height: number, offset: number = 0) {
+    super(owner, offset);
+    this.width = width;
+    this.height = height;
+  }
+
+  getLocation(reference: Point): Point {
+    const center = new Point(
+      this.owner.getPosition().x + this.width / 2,
+      this.owner.getPosition().y + this.height / 2,
+    );
+
+    const offset2x = this.offset * 2;
+    return getRectAnchorPoint(center, this.width + offset2x, this.height + offset2x, reference);
+  }
+}
+
+export { GroupNodeAnchor };

--- a/frontend/packages/dev-console/src/components/topology/components/groups/ResourceKindsInfo.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/ResourceKindsInfo.tsx
@@ -2,23 +2,20 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { modelFor, pluralizeKind, referenceForModel } from '@console/internal/module/k8s';
 import { ResourceIcon } from '@console/internal/components/utils';
+import { OdcNodeModel } from '../../topology-types';
 
 import './ResourceKindsInfo.scss';
-import { OdcNodeModel } from '../../topology-types';
+
+export const RESOURCE_INFO_PADDING = 32;
+export const RESOURCE_KIND_ROW_WIDTH = 250;
+export const RESOURCE_KIND_ROW_HEIGHT = 29;
 
 type ResourceKindsInfoProps = {
   groupResources: OdcNodeModel[];
   emptyValue?: React.ReactNode;
-  width: number;
-  height: number;
 };
 
-const ResourceKindsInfo: React.FC<ResourceKindsInfoProps> = ({
-  groupResources,
-  emptyValue,
-  width,
-  height,
-}) => {
+const ResourceKindsInfo: React.FC<ResourceKindsInfoProps> = ({ groupResources, emptyValue }) => {
   const resourcesData = {};
   _.forEach(groupResources, (node: OdcNodeModel) => {
     const kind = node.resourceKind || node.resource?.kind;
@@ -28,14 +25,20 @@ const ResourceKindsInfo: React.FC<ResourceKindsInfoProps> = ({
 
   if (!resourceTypes.length) {
     return (
-      <foreignObject width={width} height={height}>
+      <foreignObject
+        width={RESOURCE_KIND_ROW_WIDTH}
+        height={RESOURCE_INFO_PADDING + RESOURCE_KIND_ROW_HEIGHT}
+      >
         <div className="odc-resource-kinds-info">{emptyValue}</div>
       </foreignObject>
     );
   }
 
   return (
-    <foreignObject width={width} height={height}>
+    <foreignObject
+      width={RESOURCE_KIND_ROW_WIDTH}
+      height={RESOURCE_INFO_PADDING + resourceTypes.length * RESOURCE_KIND_ROW_HEIGHT}
+    >
       <div className="odc-resource-kinds-info">
         <table className="odc-resource-kinds-info__table">
           <tbody className="odc-resource-kinds-info__body">

--- a/frontend/packages/dev-console/src/components/topology/components/groups/index.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/index.ts
@@ -1,3 +1,4 @@
 export * from './GroupNode';
+export * from './GroupNodeAnchor';
 export * from './Application';
 export * from './ResourceKindsInfo';

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/data-transformer.ts
@@ -104,6 +104,11 @@ const updateAppGroupChildren = (model: Model) => {
       n.data.groupResources = n.children?.map((id) => model.nodes.find((c) => id === c.id)) ?? [];
     }
   });
+
+  // Remove any empty groups
+  model.nodes = model.nodes.filter(
+    (n) => n.type !== TYPE_APPLICATION_GROUP || n.children.length > 0,
+  );
 };
 
 const createVisualConnectors = (model: Model, workloadResources: K8sResourceKind[]) => {

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import {
   useAnchor,
-  RectAnchor,
   useHover,
   Node,
   createSvgIdUrl,
@@ -12,6 +11,7 @@ import {
   WithContextMenuProps,
   observer,
   useCombineRefs,
+  useSize,
 } from '@patternfly/react-topology';
 import {
   NodeShadows,
@@ -20,6 +20,7 @@ import {
 } from '../../components/NodeShadows';
 import { useSearchFilter } from '../../filters/useSearchFilter';
 import { GroupNode } from '../../components/groups/GroupNode';
+import { GroupNodeAnchor } from '../../components/groups/GroupNodeAnchor';
 import { nodeDragSourceSpec } from '../../components/componentUtils';
 import { TYPE_HELM_RELEASE } from './const';
 
@@ -39,14 +40,22 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
   contextMenuOpen,
   dndDropRef,
 }) => {
-  useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(nodeDragSourceSpec(TYPE_HELM_RELEASE, false), {
     element,
   });
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDropRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
-  const { width, height } = element.getDimensions();
+  const { groupResources } = element.getData();
+  const [groupSize, groupRef] = useSize([groupResources]);
+  const width = groupSize ? groupSize.width : 0;
+  const height = groupSize ? groupSize.height : 0;
+  useAnchor(
+    React.useCallback((node: Node) => new GroupNodeAnchor(node, width, height, 1.5), [
+      width,
+      height,
+    ]),
+  );
 
   return (
     <g
@@ -75,10 +84,11 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
         ry="5"
       />
       <GroupNode
+        ref={groupRef}
         kind="HelmRelease"
         element={element}
         typeIconClass={element.getData().data.chartIcon || 'icon-helm'}
-        groupResources={element.getData().groupResources}
+        groupResources={groupResources}
       />
     </g>
   );

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
@@ -6,11 +6,11 @@ import {
   WithSelectionProps,
   WithDndDropProps,
   useAnchor,
-  RectAnchor,
   useCombineRefs,
   useHover,
   useDragNode,
   createSvgIdUrl,
+  useSize,
 } from '@patternfly/react-topology';
 import { useSearchFilter } from '../../filters/useSearchFilter';
 import { nodeDragSourceSpec } from '../../components/componentUtils';
@@ -21,6 +21,7 @@ import {
   NODE_SHADOW_FILTER_ID_HOVER,
 } from '../../components/NodeShadows';
 import { GroupNode } from '../../components/groups/GroupNode';
+import { GroupNodeAnchor } from '../../components/groups/GroupNodeAnchor';
 
 export type OperatorBackedServiceNodeProps = {
   element: Node;
@@ -33,7 +34,6 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   onSelect,
   dndDropRef,
 }) => {
-  useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
     nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
@@ -44,7 +44,16 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef, dndDropRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const kind = 'Operator';
-  const { width, height } = element.getDimensions();
+  const { groupResources } = element.getData();
+  const [groupSize, groupRef] = useSize([groupResources]);
+  const width = groupSize ? groupSize.width : 0;
+  const height = groupSize ? groupSize.height : 0;
+  useAnchor(
+    React.useCallback((node: Node) => new GroupNodeAnchor(node, width, height, 1.5), [
+      width,
+      height,
+    ]),
+  );
 
   return (
     <g
@@ -70,9 +79,10 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
         ry="5"
       />
       <GroupNode
+        ref={groupRef}
         kind={kind}
         element={element}
-        groupResources={element.getData().groupResources}
+        groupResources={groupResources}
         typeIconClass={element.getData().data.builderImage}
       />
     </g>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4373

**Description**
Updates the topology collapsed group nodes to calculate size based on the resources and display the correct size.

**Screen shot before**: 
![image](https://user-images.githubusercontent.com/11633780/89575340-a39d9c80-d7fb-11ea-9a8b-c8e8f8951d5c.png)

**Screen shot after**: 
![image](https://user-images.githubusercontent.com/11633780/89575388-b021f500-d7fb-11ea-9776-f0d5e8016e40.png)


/kind bug
