### PR TITLE
Fix to show correct helm chart icon on collapsed helm groups

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -77,7 +77,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
       <GroupNode
         kind="HelmRelease"
         element={element}
-        typeIconClass="icon-helm"
+        typeIconClass={element.getData().data?.chartIcon || 'icon-helm'}
         groupResources={element.getData().groupResources}
       />
     </g>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4442

**Description**
Updates the topology collapsed helm groups to use the same icon as uncollapsed groups.

**Screen shot before**: 
![image](https://user-images.githubusercontent.com/11633780/89577285-756d8c00-d7fe-11ea-83a2-48ab8ef25bf1.png)

**Screen shot after**: 
![image](https://user-images.githubusercontent.com/11633780/89577297-7b636d00-d7fe-11ea-9828-b77235f75f75.png)

/kind bug
