### PR TITLE
Add create project link in all the dev console pages

### DIFF
--- a/frontend/packages/dev-console/src/components/AddPage.tsx
+++ b/frontend/packages/dev-console/src/components/AddPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
-import { history, Firehose, FirehoseResource, HintBlock } from '@console/internal/components/utils';
+import { Firehose, FirehoseResource, HintBlock } from '@console/internal/components/utils';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ServiceModel } from '@console/knative-plugin';
 import ODCEmptyState from './EmptyState';
@@ -28,9 +28,6 @@ interface EmptyStateLoaderProps {
   loaded?: boolean;
   loadError?: string;
 }
-
-const handleProjectCreate = (project: K8sResourceKind) =>
-  history.push(`/add/ns/${project.metadata.name}`);
 
 const EmptyStateLoader: React.FC<EmptyStateLoaderProps> = ({ resources, loaded, loadError }) => {
   const [noWorkloads, setNoWorkloads] = React.useState(false);
@@ -130,7 +127,9 @@ const AddPage: React.FC<AddPageProps> = ({ match }) => {
             {namespace ? (
               <RenderEmptyState namespace={namespace} />
             ) : (
-              <CreateProjectListPage onCreate={handleProjectCreate} title="Add" />
+              <CreateProjectListPage title="Add">
+                Select a project to start adding to it
+              </CreateProjectListPage>
             )}
           </ProjectsExistWrapper>
         </Firehose>

--- a/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
+++ b/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
 import { BuildConfigsPage } from '@console/internal/components/build-config';
 import { withStartGuide } from '../../../../public/components/start-guide';
-import ProjectListPage from './projects/ProjectListPage';
+import CreateProjectListPage from './projects/CreateProjectListPage';
 
 export interface BuildConfigPageProps {
   match: RMatch<{
@@ -24,9 +24,9 @@ const BuildConfigPage: React.FC<BuildConfigPageProps> = ({ noProjectsAvailable, 
           <BuildConfigsPage {...props} mock={noProjectsAvailable} />
         </div>
       ) : (
-        <ProjectListPage title="Build Configs">
+        <CreateProjectListPage title="Build Configs">
           Select a project to view the list of build configs
-        </ProjectListPage>
+        </CreateProjectListPage>
       )}
     </>
   );

--- a/frontend/packages/dev-console/src/components/ProjectSelectPage.tsx
+++ b/frontend/packages/dev-console/src/components/ProjectSelectPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@console/internal/module/k8s';
 import { ErrorPage404 } from '@console/internal/components/error';
 import { withStartGuide } from '@console/internal/components/start-guide';
-import ProjectListPage from './projects/ProjectListPage';
+import CreateProjectListPage from './projects/CreateProjectListPage';
 import { getBadgeFromType } from '@console/shared/src';
 
 export interface ProjectSelectPageProps {
@@ -40,9 +40,9 @@ const ProjectSelectPage: React.FC<ProjectSelectPageProps> = (props) => {
       <Helmet>
         <title>{kindObj.labelPlural}</title>
       </Helmet>
-      <ProjectListPage title={kindObj.labelPlural} badge={getBadgeFromType(kindObj.badge)}>
+      <CreateProjectListPage title={kindObj.labelPlural} badge={getBadgeFromType(kindObj.badge)}>
         Select a project to view the list of {kindObj.labelPlural}
-      </ProjectListPage>
+      </CreateProjectListPage>
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps } from 'react-router';
 import Helmet from 'react-helmet';
 import { PageHeading } from '@console/internal/components/utils';
 import { withStartGuide } from '@console/internal/components/start-guide';
-import ProjectListPage from '../projects/ProjectListPage';
+import CreateProjectListPage from '../projects/CreateProjectListPage';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import HelmReleaseList from './list/HelmReleaseList';
 
@@ -21,9 +21,9 @@ const PageContents: React.FC<HelmReleaseListPageProps> = (props) => {
       <HelmReleaseList namespace={namespace} />
     </div>
   ) : (
-    <ProjectListPage title="Helm Releases">
+    <CreateProjectListPage title="Helm Releases">
       Select a project to view the list of Helm Releases
-    </ProjectListPage>
+    </CreateProjectListPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/import/SamplesCatalog.tsx
+++ b/frontend/packages/dev-console/src/components/import/SamplesCatalog.tsx
@@ -8,7 +8,7 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { FirehoseResource, LoadingBox, history } from '@console/internal/components/utils';
 import { PageLayout } from '@console/shared';
 import { normalizeBuilderImages, NormalizedBuilderImages } from '../../utils/imagestream-utils';
-import ProjectListPage from '../projects/ProjectListPage';
+import CreateProjectListPage from '../projects/CreateProjectListPage';
 import NamespacedPage from '../NamespacedPage';
 
 const imageStreamResource: FirehoseResource = {
@@ -68,9 +68,9 @@ const SampleCatalog: React.FC<SampleCatalogProps> = ({ match }) => {
             </Gallery>
           </PageLayout>
         ) : (
-          <ProjectListPage title="Samples">
+          <CreateProjectListPage title="Samples">
             Select a project to view the list of Samples.
-          </ProjectListPage>
+          </CreateProjectListPage>
         )}
       </NamespacedPage>
     </>

--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -10,7 +10,7 @@ import {
 import { TechPreviewBadge, ALL_NAMESPACES_KEY } from '@console/shared';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
-import ProjectListPage from '../projects/ProjectListPage';
+import CreateProjectListPage from '../projects/CreateProjectListPage';
 import ConnectedMonitoringDashboard from './dashboard/MonitoringDashboard';
 import ConnectedMonitoringMetrics from './metrics/MonitoringMetrics';
 import MonitoringEvents from './events/MonitoringEvents';
@@ -70,9 +70,9 @@ export const PageContents: React.FC<MonitoringPageProps> = ({ match }) => {
       <HorizontalNav pages={pages} match={match} noStatusBox />
     </>
   ) : (
-    <ProjectListPage badge={<TechPreviewBadge />} title="Monitoring">
+    <CreateProjectListPage badge={<TechPreviewBadge />} title="Monitoring">
       Select a project to view monitoring metrics
-    </ProjectListPage>
+    </CreateProjectListPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as utils from '@console/internal/components/utils';
 import { PageContents } from '../MonitoringPage';
-import ProjectListPage from '../../projects/ProjectListPage';
+import CreateProjectListPage from '../../projects/CreateProjectListPage';
 
 describe('Monitoring Page ', () => {
   let monPageProps: React.ComponentProps<typeof PageContents>;
@@ -17,8 +17,8 @@ describe('Monitoring Page ', () => {
       },
     };
     const component = shallow(<PageContents {...monPageProps} />);
-    expect(component.find(ProjectListPage).exists()).toBe(true);
-    expect(component.find(ProjectListPage).prop('title')).toBe('Monitoring');
+    expect(component.find(CreateProjectListPage).exists()).toBe(true);
+    expect(component.find(CreateProjectListPage).prop('title')).toBe('Monitoring');
   });
 
   it('should render all Tabs of Monitoring page for selected project', () => {

--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router';
 import { getBadgeFromType } from '@console/shared';
 import { PipelineRunModel } from '../../models';
-import ProjectListPage from '../projects/ProjectListPage';
+import CreateProjectListPage from '../projects/CreateProjectListPage';
 import PipelineRunsResourceList from './PipelineRunsResourceList';
 
 type PipelineRunsPageProps = RouteComponentProps<{ ns: string }>;
@@ -18,12 +18,12 @@ const PipelineRunsPage: React.FC<PipelineRunsPageProps> = (props) => {
       <PipelineRunsResourceList {...props} namespace={namespace} />
     </div>
   ) : (
-    <ProjectListPage
+    <CreateProjectListPage
       title={PipelineRunModel.labelPlural}
       badge={getBadgeFromType(PipelineRunModel.badge)}
     >
       Select a project to view the list of {PipelineRunModel.labelPlural}
-    </ProjectListPage>
+    </CreateProjectListPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps } from 'react-router';
 import { getBadgeFromType } from '@console/shared';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import { PipelineModel } from '../../models';
-import ProjectListPage from '../projects/ProjectListPage';
+import CreateProjectListPage from '../projects/CreateProjectListPage';
 import PipelinesResourceList from './PipelinesResourceList';
 
 type PipelinesPageProps = RouteComponentProps<{ ns: string }>;
@@ -24,12 +24,12 @@ export const PipelinesPage: React.FC<PipelinesPageProps> = (props) => {
       />
     </div>
   ) : (
-    <ProjectListPage
+    <CreateProjectListPage
       title={PipelineModel.labelPlural}
       badge={getBadgeFromType(PipelineModel.badge)}
     >
       Select a project to view the list of {PipelineModel.labelPlural}
-    </ProjectListPage>
+    </CreateProjectListPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/__tests__/PipelinesPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/__tests__/PipelinesPage.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
 import { PipelinesPage } from '../PipelinesPage';
-import ProjectListPage from '../../projects/ProjectListPage';
+import CreateProjectListPage from '../../projects/CreateProjectListPage';
 import PipelinesResourceList from '../PipelinesResourceList';
 
 describe('Pipeline List', () => {
@@ -38,6 +38,6 @@ describe('Pipeline List', () => {
       },
     };
     const pipelineWrapperWNS = shallow(<PipelinesPage {...pipelinePagePropsWNS} />);
-    expect(pipelineWrapperWNS.find(ProjectListPage).exists()).toBe(true);
+    expect(pipelineWrapperWNS.find(CreateProjectListPage).exists()).toBe(true);
   });
 });

--- a/frontend/packages/dev-console/src/components/projects/CreateProjectListPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/CreateProjectListPage.tsx
@@ -1,24 +1,37 @@
 import * as React from 'react';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch } from 'react-redux';
 import { Button } from '@patternfly/react-core';
 import { createProjectModal } from '@console/internal/components/modals';
+import { setActiveNamespace } from '@console/internal/actions/ui';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import ProjectListPage, { ProjectListPageProps } from './ProjectListPage';
 
 export interface CreateProjectListPageProps extends ProjectListPageProps {
-  onCreate: (project: K8sResourceKind) => void;
   title: string;
+  onCreate?: (project: K8sResourceKind) => void;
 }
 
 const CreateProjectListPage: React.FC<CreateProjectListPageProps> = ({
   onCreate,
   title,
+  children,
   ...props
 }) => {
-  const openProjectModal = () => createProjectModal({ blocking: true, onSubmit: onCreate });
+  const dispatch = useDispatch();
+
+  const handleSubmit = (project: K8sResourceKind) => {
+    dispatch(setActiveNamespace(project.metadata?.name));
+    onCreate && onCreate(project);
+  };
+
+  const openProjectModal = () => createProjectModal({ blocking: true, onSubmit: handleSubmit });
 
   return (
     <ProjectListPage {...props} title={title}>
-      Select a project to start adding to it or{' '}
+      {children} or{' '}
       <Button isInline variant="link" onClick={openProjectModal}>
         create a project
       </Button>

--- a/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
@@ -10,7 +10,7 @@ import { withStartGuide } from '@console/internal/components/start-guide';
 import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
 import ProjectAccessPage from '../../project-access/ProjectAccessPage';
 import { Helmet } from 'react-helmet';
-import ProjectListPage from '../ProjectListPage';
+import CreateProjectListPage from '../CreateProjectListPage';
 
 export const PROJECT_DETAILS_ALL_NS_PAGE_URI = '/project-details/all-namespaces';
 
@@ -81,7 +81,9 @@ export const PageContents: React.FC<MonitoringPageProps> = ({
       pages={pages}
     />
   ) : (
-    <ProjectListPage title="Project Details">Select a project to view its details</ProjectListPage>
+    <CreateProjectListPage title="Project Details">
+      Select a project to view its details
+    </CreateProjectListPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import * as _ from 'lodash';
 import * as utils from '@console/internal/components/utils';
 import { ProjectDetailsPage, PageContents } from '../ProjectDetailsPage';
-import ProjectListPage from '../../ProjectListPage';
+import CreateProjectListPage from '../../CreateProjectListPage';
 import { DetailsPage } from '@console/internal/components/factory';
 
 const testProjectMatch = { url: '', params: { ns: 'test-project' }, isExact: true, path: '' };
@@ -13,7 +13,7 @@ describe('ProjectDetailsPage', () => {
   it('expect ProjectDetailsPage to render the project list page when in the all-projects namespace', () => {
     const component = shallow(<PageContents match={allNamespaceMatch} />);
 
-    expect(component.find(ProjectListPage).exists()).toBe(true);
+    expect(component.find(CreateProjectListPage).exists()).toBe(true);
   });
 
   it('expect ProjectDetailsPage to show a namespaced details page for a namespace', () => {

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -14,7 +14,7 @@ import {
 import EmptyState from '../EmptyState';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import ProjectsExistWrapper from '../ProjectsExistWrapper';
-import ProjectListPage from '../projects/ProjectListPage';
+import CreateProjectListPage from '../projects/CreateProjectListPage';
 import ConnectedTopologyDataController from './TopologyDataController';
 import { RenderProps } from './TopologyDataRenderer';
 import TopologyShortcuts from './TopologyShortcuts';
@@ -156,9 +156,9 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
                 namespace={namespace}
               />
             ) : (
-              <ProjectListPage title="Topology">
+              <CreateProjectListPage title="Topology">
                 Select a project to view the topology
-              </ProjectListPage>
+              </CreateProjectListPage>
             )}
           </ProjectsExistWrapper>
         </Firehose>

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
@@ -6,7 +6,7 @@ import { TopologyPage, renderTopology } from '../TopologyPage';
 import NamespacedPage from '../../NamespacedPage';
 import { StatusBox } from '@console/internal/components/utils';
 import ConnectedTopologyDataController from '../TopologyDataController';
-import ProjectListPage from '../../projects/ProjectListPage';
+import CreateProjectListPage from '../../projects/CreateProjectListPage';
 import { topologyData } from './topology-test-data';
 import { ConnectedTopologyView } from '../TopologyView';
 
@@ -69,7 +69,7 @@ describe('Topology page tests', () => {
   it('should render projects list page', () => {
     topologyProps.match.params.name = '';
     const wrapper = shallow(<TopologyPage {...topologyProps} />);
-    expect(wrapper.find(ProjectListPage).exists()).toBe(true);
+    expect(wrapper.find(CreateProjectListPage).exists()).toBe(true);
   });
 
   it('should render view shortcuts button on topology page toolbar', () => {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4448

**Analysis / Root cause**: Create project link was missing from project list page on Topology/Monitoring/Builds/Pipelines/Helm pages.

**Solution Description**: Use `CreateProjectListPage` instead of `ProjectListPage` in all pages.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux @parvathyvr 

![Peek 2020-08-07 01-37](https://user-images.githubusercontent.com/6041994/89577870-f3598380-d84e-11ea-9893-42d302ee9767.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge