### PR TITLE
Bug 1857399: Fix  chip to show All when no other selected

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -180,8 +180,14 @@ export class EventsList extends React.Component {
     }
   };
 
+  removeResource = (selection) => {
+    const updateItems = new Set(this.state.selected);
+    updateItems.delete(selection);
+    this.setState({ selected: updateItems });
+  };
+
   clearSelection = () => {
-    this.setState({ selected: new Set(['All']) });
+    this.setState({ selected: new Set() });
   };
 
   render() {
@@ -195,7 +201,6 @@ export class EventsList extends React.Component {
             <ResourceListDropdown
               onChange={this.toggleSelected}
               selected={Array.from(selected)}
-              showAll
               clearSelection={this.clearSelection}
               className="co-search-group__resource"
             />
@@ -213,21 +218,19 @@ export class EventsList extends React.Component {
             />
           </div>
           <div className="form-group">
-            <ChipGroup key="resources-category" categoryName="Resource" defaultIsOpen={false}>
-              {[...selected].map((chip) => (
-                <Chip key={chip} onClick={() => this.toggleSelected(chip)}>
-                  <ResourceIcon kind={chip} />
-                  {kindForReference(chip)}
-                </Chip>
-              ))}
-              {selected.size > 0 && (
-                <>
-                  <Button variant="plain" aria-label="Close" onClick={this.clearSelection}>
-                    <CloseIcon />
-                  </Button>
-                </>
-              )}
-            </ChipGroup>
+            {selected.size > 0 && (
+              <ChipGroup key="resources-category" categoryName="Resource" defaultIsOpen={false}>
+                {[...selected].map((chip) => (
+                  <Chip key={chip} onClick={() => this.removeResource(chip)}>
+                    <ResourceIcon kind={chip} />
+                    {kindForReference(chip)}
+                  </Chip>
+                ))}
+                <Button variant="plain" aria-label="Close" onClick={this.clearSelection}>
+                  <CloseIcon />
+                </Button>
+              </ChipGroup>
+            )}
           </div>
         </PageHeading>
         <EventStream

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
-import { Map as ImmutableMap, OrderedMap, Set as ImmutableSet } from 'immutable';
+import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable';
 import * as classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
 
@@ -53,7 +53,7 @@ const DropdownItem: React.SFC<DropdownItemProps> = ({ model, showGroup, checked 
 );
 
 const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
-  const { selected, onChange, allModels, showAll, className, groupToVersionMap } = props;
+  const { selected, onChange, allModels, className, groupToVersionMap } = props;
   const resources = allModels
     .filter(({ apiGroup, apiVersion, kind, verbs }) => {
       // Remove blacklisted items.
@@ -89,31 +89,16 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
     return _.includes(selected, kind);
   };
   // Create dropdown items for each resource.
-  const items = resources.map((model) => (
-    <DropdownItem
-      key={referenceForModel(model)}
-      model={model}
-      showGroup={isDup(model.kind)}
-      checked={isKindSelected(referenceForModel(model))}
-    />
-  )) as OrderedMap<string, JSX.Element>;
-  // Add an "All" item to the top if `showAll`.
-  const allItems = (showAll
-    ? OrderedMap({
-        All: (
-          <>
-            <span className="co-resource-item">
-              <Checkbox id="all-resources" isChecked={isKindSelected('All')} />
-              <span className="co-resource-icon--fixed-width">
-                <ResourceIcon kind="All" />
-              </span>
-              <span className="co-resource-item__resource-name">All Resources</span>
-            </span>
-          </>
-        ),
-      }).concat(items)
-    : items
-  ).toJS() as { [s: string]: JSX.Element };
+  const items = resources
+    .map((model) => (
+      <DropdownItem
+        key={referenceForModel(model)}
+        model={model}
+        showGroup={isDup(model.kind)}
+        checked={isKindSelected(referenceForModel(model))}
+      />
+    ))
+    .toJS();
 
   const autocompleteFilter = (text, item) => {
     const { model } = item.props;
@@ -125,20 +110,17 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
   };
 
   const handleSelected = (value: string) => {
-    value === 'All' ? onChange('All') : onChange(referenceForModel(modelFor(value)));
+    onChange(referenceForModel(modelFor(value)));
   };
 
   return (
     <Dropdown
       menuClassName="dropdown-menu--text-wrap"
       className={classNames('co-type-selector', className)}
-      items={allItems}
+      items={items}
       title={
         <div key="title-resource">
-          Resources{' '}
-          <Badge isRead>
-            {selected.length === 1 && selected[0] === 'All' ? 'All' : selected.length}
-          </Badge>
+          Resources <Badge isRead>{selected.length}</Badge>
         </div>
       }
       onChange={handleSelected}
@@ -162,7 +144,6 @@ export type ResourceListDropdownProps = ResourceListDropdownStateToProps & {
   onChange: (value: string) => void;
   className?: string;
   id?: string;
-  showAll?: boolean;
 };
 
 type DropdownItemProps = {


### PR DESCRIPTION
Bug was leaving empty `Resource` badge when last selected item removed.  Events should default to "All" when no specific resource is chosen, which also prevents a blank chip. UPDATE: If user clears initial `All` selection, we will show no resources selected which means no filter and show all events.
![event-bug-3](https://user-images.githubusercontent.com/18728857/90801066-ace63900-e2d2-11ea-9509-cc56d1ec9567.gif)



