### PR TITLE
Bug 1866997: Warn user that when HyperConverged and SR-IOVNetwork CRDs are missing

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash';
 import { Form, FormControl, FormGroup, HelpBlock } from 'patternfly-react';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { ActionGroup, Alert, Button } from '@patternfly/react-core';
 import { referenceForModel, k8sCreate } from '@console/internal/module/k8s';
 import {
   ButtonBar,
@@ -249,6 +249,18 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
           <label className="control-label co-required" htmlFor="network-type">
             Network Type
           </label>
+          {_.isEmpty(networkTypeDropdownItems) && (
+            <Alert
+              className="co-alert"
+              isInline
+              variant="warning"
+              title={'Missing installed operators'}
+            >
+              <strong>OpenShift Virtualization Operator</strong> or{' '}
+              <strong>SR-IOV Network Operator </strong>
+              needs to be installed on the cluster, in order to pick the Network Type.
+            </Alert>
+          )}
           <Dropdown
             id="network-type"
             title="Network Type"


### PR DESCRIPTION
If **HyperConverged** and **SR-IOVNetwork** CRDs are missing the Dropdown for the `NetworkType` is disabled, without any warning. We should be warning user that he needs to install the CRDs.

Screen:
<img width="597" alt="Screenshot 2020-08-07 at 13 31 40" src="https://user-images.githubusercontent.com/1668218/89642207-a8258c00-d8b3-11ea-914f-7ac3c6fb8cad.png">


/assign @spadgett 