### PR TITLE
Bug 1865817:  Values for cpu/memeory are empty in Metrics table on HPA detail page

### DIFF
--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -364,16 +364,71 @@ export type DeploymentKind = {
   };
 } & K8sResourceCommon;
 
+type CurrentObject = {
+  averageUtilization?: number;
+  averageValue?: string;
+  value?: string;
+};
+
+type MetricObject = {
+  name: string;
+  selector?: Selector;
+};
+
+type TargetObjcet = {
+  averageUtilization?: number;
+  type: string;
+  averageValue?: string;
+  value?: string;
+};
+
+type DescribedObject = {
+  apiVersion?: string;
+  kind: string;
+  name: string;
+};
 export type HPAMetric = {
-  type: 'Object' | 'Pods' | 'Resource';
-  resource: {
+  type: 'Object' | 'Pods' | 'Resource' | 'External';
+  resource?: {
     name: string;
-    target: {
-      averageUtilization?: number;
-      type: string;
-    };
+    target: TargetObjcet;
+  };
+  external?: {
+    metric: MetricObject;
+    target: TargetObjcet;
+  };
+  object?: {
+    describedObjec: DescribedObject;
+    metric: MetricObject;
+    target: TargetObjcet;
+  };
+  pods?: {
+    metric: MetricObject;
+    target: TargetObjcet;
   };
 };
+
+type HPACurrentMetrics = {
+  type: 'Object' | 'Pods' | 'Resource' | 'External';
+  external?: {
+    current: CurrentObject;
+    metric: MetricObject;
+  };
+  object?: {
+    current: CurrentObject;
+    describedObject: DescribedObject;
+    metric: MetricObject;
+  };
+  pods?: {
+    current: CurrentObject;
+    metric: MetricObject;
+  };
+  resource?: {
+    name: string;
+    current: CurrentObject;
+  };
+};
+
 export type HorizontalPodAutoscalerKind = K8sResourceCommon & {
   spec: {
     scaleTargetRef: {
@@ -388,8 +443,9 @@ export type HorizontalPodAutoscalerKind = K8sResourceCommon & {
   status?: {
     currentReplicas: number;
     desiredReplicas: number;
-    currentMetrics: any;
+    currentMetrics?: HPACurrentMetrics[];
     conditions: NodeCondition[];
+    lastScaleTime?: string;
   };
 };
 


### PR DESCRIPTION
/assign @TheRealJon
/cc @spadgett


<img width="1680" alt="Screen Shot 2020-08-28 at 10 59 16 AM" src="https://user-images.githubusercontent.com/15249132/91587584-f6fb9a00-e924-11ea-8a71-22fbd8f209e5.png">

@spadgett I wanted to test for currentMetrics values, but the yaml update returned `null` value for currentMetrics on save. I am thinking that could be a real time values generated from server api. Is that right?