### PR TITLE
Bug 1866035: fix util to get Kiali link from consoleLinks

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -56,9 +56,8 @@ export const getNamespaceDashboardKialiLink = (
   consoleLinks: K8sResourceKind[],
   namespace: string,
 ): string => {
-  const kialiLink = _.find(consoleLinks, (consoleLink) =>
-    _.includes(consoleLink.spec?.namespaceDashboard?.namespaces, namespace),
-  )?.spec?.href;
+  const kialiLink = _.find(consoleLinks, ['metadata.name', `kiali-namespace-${namespace}`])?.spec
+    ?.href;
   return kialiLink || '';
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4458

**Analysis / Root cause**: 
Incorrectly assumes any "namespace dashboard" link is a Kiali link

**Solution Description**: 
Get the namespace Dashboard Kiali link as per `metadat.name` attributes of the consoleLink.
