### PR TITLE
preselect uri options if no resources exists

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
@@ -12,7 +12,7 @@ import {
   knativeEventingResourcesBroker,
 } from '../../../utils/get-knative-resources';
 import { getDynamicChannelResourceList } from '../../../utils/fetch-dynamic-eventsources-utils';
-import { sourceSinkType } from '../import-types';
+import { sourceSinkType, SinkType } from '../import-types';
 
 interface SinkSectionProps {
   namespace: string;
@@ -41,7 +41,7 @@ const SinkUri: React.FC = () => (
 
 const SinkResources: React.FC<SinkResourcesProps> = ({ namespace, isMoveSink }) => {
   const [resourceAlert, setResourceAlert] = React.useState(false);
-  const { setFieldValue, setFieldTouched, validateForm, initialValues } = useFormikContext<
+  const { setFieldValue, setFieldTouched, validateForm, initialValues, touched } = useFormikContext<
     FormikValues
   >();
   const autocompleteFilter = (strText, item): boolean => fuzzy(strText, item?.props?.name);
@@ -69,8 +69,17 @@ const SinkResources: React.FC<SinkResourcesProps> = ({ namespace, isMoveSink }) 
     ...knativeEventingResourcesBroker(namespace),
   ];
 
-  const handleOnLoad = (resourceList: { [key: string]: string }) =>
-    _.isEmpty(resourceList) ? setResourceAlert(true) : setResourceAlert(false);
+  const handleOnLoad = (resourceList: { [key: string]: string }) => {
+    if (_.isEmpty(resourceList)) {
+      setResourceAlert(true);
+      if (!touched.sinkType) {
+        setFieldValue('sinkType', SinkType.Uri);
+        setFieldTouched('sinkType', true);
+      }
+    } else {
+      setResourceAlert(false);
+    }
+  };
 
   // filter out channels backing brokers
   const resourceFilter = (resource: K8sResourceKind) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4459

**Analysis / Root cause**: 
Currently Resources option is selected even if no resources exists in creation of eventSource flow

**Solution Description**: 
URI option is preselected if no resources exists in creation of eventSource flow

**Screen shots / Gifs for design review**: 
![Aug-07-2020 20-14-26](https://user-images.githubusercontent.com/5129024/89657654-04f06900-d8eb-11ea-82b9-f004fa98f4c1.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
