### PR TITLE
Use helm chart icon for collapsed helm group node

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -77,7 +77,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
       <GroupNode
         kind="HelmRelease"
         element={element}
-        typeIconClass="icon-helm"
+        typeIconClass={element.getData().data.chartIcon || 'icon-helm'}
         groupResources={element.getData().groupResources}
       />
     </g>


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4442

**Analysis / Root cause**: Collapsed helm group node in Topology was using hard coded default helm icon.

**Solution Description**: Update the Helm group node component to use icon available from the helm chart.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux @parvathyvr 
![Peek 2020-08-07 20-58](https://user-images.githubusercontent.com/6041994/89661937-fad16900-d8f0-11ea-9613-72fddb22e7a4.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge