### PR TITLE
Fix to hide view switch in topology when no project selected

### DIFF
--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -73,7 +73,7 @@ const ODCEmptyState: React.FC<Props> = ({
   ).filter(({ properties: { hide } }) => (hide ? hide() : true));
 
   return (
-    <PageLayout title={title} hint={hintBlock}>
+    <PageLayout title={title} hint={hintBlock} isDark>
       <Gallery className="co-catalog-tile-view" hasGutter>
         <QuickStartTile />
         {addActionExtensions.map((action) => (

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useExtensions } from '@console/plugin-sdk';
 import { isTopologyDataModelFactory, TopologyDataModelFactory } from '../../extensions/topology';
-import DataModelProvider from './data-transforms/DataModelProvider';
 import { DataModelExtension } from './data-transforms/DataModelExtension';
 import { TopologyExtensionLoader } from './TopologyExtensionLoader';
 
@@ -17,9 +16,8 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   render,
 }) => {
   const modelFactories = useExtensions<TopologyDataModelFactory>(isTopologyDataModelFactory);
-
   return (
-    <DataModelProvider namespace={namespace}>
+    <>
       {modelFactories.map((factory) => (
         <DataModelExtension key={factory.properties.id} dataModelFactory={factory} />
       ))}
@@ -28,7 +26,7 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
         namespace={namespace}
         showGraphView={showGraphView}
       />
-    </DataModelProvider>
+    </>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
@@ -95,17 +95,17 @@ export const ConnectedTopologyDataRenderer: React.FC<TopologyDataRendererProps &
     dataModelContext
       .getExtensionModels(resources)
       .then((extensionsModel) => {
-        setModel(
-          baseDataModelGetter(
-            extensionsModel,
-            dataModelContext.namespace,
-            resources,
-            workloadResources,
-            showGroups ? depicters : [],
-            trafficData,
-            monitoringAlerts,
-          ),
+        const fullModel = baseDataModelGetter(
+          extensionsModel,
+          dataModelContext.namespace,
+          resources,
+          workloadResources,
+          showGroups ? depicters : [],
+          trafficData,
+          monitoringAlerts,
         );
+        dataModelContext.model = fullModel;
+        setModel(fullModel);
       })
       .catch(() => {});
   }, [resources, trafficData, dataModelContext, kindsInFlight, monitoringAlerts, showGroups]);

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { matchPath, match as RMatch, Link, Redirect } from 'react-router-dom';
 import { Tooltip, Popover, Button } from '@patternfly/react-core';
 import { ListIcon, TopologyIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+import { observer } from '@patternfly/react-topology';
 import { useQueryParams } from '@console/shared/src';
 import {
   StatusBox,
@@ -10,7 +11,6 @@ import {
   HintBlock,
   removeQueryArgument,
 } from '@console/internal/components/utils';
-
 import EmptyState from '../EmptyState';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import ProjectsExistWrapper from '../ProjectsExistWrapper';
@@ -21,6 +21,8 @@ import TopologyShortcuts from './TopologyShortcuts';
 import { ConnectedTopologyView } from './TopologyView';
 import { LAST_TOPOLOGY_VIEW_LOCAL_STORAGE_KEY } from './components/const';
 import { TOPOLOGY_SEARCH_FILTER_KEY } from './filters';
+import DataModelProvider from './data-transforms/DataModelProvider';
+import ModelContext, { ExtensibleModel } from './data-transforms/ModelContext';
 
 import './TopologyPage.scss';
 
@@ -72,10 +74,11 @@ export function renderTopology({
   );
 }
 
-export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
+export const TopologyPageContext: React.FC<TopologyPageProps> = observer(({ match }) => {
   const queryParams = useQueryParams();
   const searchParams = queryParams.get('searchQuery');
   const namespace = match.params.name;
+  const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
   const showListView = !!matchPath(match.path, {
     path: '*/list',
     exact: true,
@@ -115,36 +118,38 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
         variant={showListView ? NamespacedPageVariants.light : NamespacedPageVariants.default}
         onNamespaceChange={handleNamespaceChange}
         toolbar={
-          <>
-            {!showListView && namespace && (
-              <Popover
-                aria-label="Shortcuts"
-                bodyContent={TopologyShortcuts}
-                position="left"
-                maxWidth="100vw"
-              >
-                <Button
-                  type="button"
-                  variant="link"
-                  className="odc-topology__shortcuts-button"
-                  icon={<QuestionCircleIcon />}
-                  data-test-id="topology-view-shortcuts"
+          namespace && !dataModelContext.isEmptyModel ? (
+            <>
+              {!showListView && namespace && (
+                <Popover
+                  aria-label="Shortcuts"
+                  bodyContent={TopologyShortcuts}
+                  position="left"
+                  maxWidth="100vw"
                 >
-                  View shortcuts
-                </Button>
-              </Popover>
-            )}
-            <Tooltip position="left" content={showListView ? 'Topology View' : 'List View'}>
-              <Link
-                className="pf-c-button pf-m-plain"
-                to={`/topology/${namespace ? `ns/${namespace}` : 'all-namespaces'}${
-                  showListView ? '/graph' : '/list'
-                }${searchParams ? `?searchQuery=${searchParams}` : ''}`}
-              >
-                {showListView ? <TopologyIcon size="md" /> : <ListIcon size="md" />}
-              </Link>
-            </Tooltip>
-          </>
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="odc-topology__shortcuts-button"
+                    icon={<QuestionCircleIcon />}
+                    data-test-id="topology-view-shortcuts"
+                  >
+                    View shortcuts
+                  </Button>
+                </Popover>
+              )}
+              <Tooltip position="left" content={showListView ? 'Topology View' : 'List View'}>
+                <Link
+                  className="pf-c-button pf-m-plain"
+                  to={`/topology/${namespace ? `ns/${namespace}` : 'all-namespaces'}${
+                    showListView ? '/graph' : '/list'
+                  }${searchParams ? `?searchQuery=${searchParams}` : ''}`}
+                >
+                  {showListView ? <TopologyIcon size="md" /> : <ListIcon size="md" />}
+                </Link>
+              </Tooltip>
+            </>
+          ) : null
         }
       >
         <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
@@ -164,6 +169,15 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
         </Firehose>
       </NamespacedPage>
     </>
+  );
+});
+
+export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
+  const namespace = match.params.name;
+  return (
+    <DataModelProvider namespace={namespace}>
+      <TopologyPageContext match={match} />
+    </DataModelProvider>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
@@ -5,6 +5,7 @@ import store from '@console/internal/redux';
 import * as utils from '@console/internal/components/utils/url-poll-hook';
 import { TopologyDataControllerProps, TopologyDataController } from '../TopologyDataController';
 import { TopologyExtensionLoader } from '../TopologyExtensionLoader';
+import DataModelProvider from '../data-transforms/DataModelProvider';
 
 const TestInner = () => null;
 
@@ -19,11 +20,13 @@ describe('TopologyDataController', () => {
   beforeEach(() => {
     spyUseURLPoll.mockReturnValue([{}, null, false]);
     wrapper = mount(
-      <TopologyDataController
-        showGraphView
-        namespace="test-project"
-        render={() => <TestInner />}
-      />,
+      <DataModelProvider namespace="test-project">
+        <TopologyDataController
+          showGraphView
+          namespace="test-project"
+          render={() => <TestInner />}
+        />
+      </DataModelProvider>,
       {
         wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,
       },

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
 import { Tooltip } from '@patternfly/react-core';
-import { TopologyPage, renderTopology } from '../TopologyPage';
+import { renderTopology, TopologyPageContext } from '../TopologyPage';
 import NamespacedPage from '../../NamespacedPage';
 import { StatusBox } from '@console/internal/components/utils';
 import ConnectedTopologyDataController from '../TopologyDataController';
@@ -10,11 +10,9 @@ import CreateProjectListPage from '../../projects/CreateProjectListPage';
 import { topologyData } from './topology-test-data';
 import { ConnectedTopologyView } from '../TopologyView';
 
-type TopologyPageProps = React.ComponentProps<typeof TopologyPage>;
-type RenderTopologyProps = React.ComponentProps<typeof renderTopology>;
+type TopologyPageProps = React.ComponentProps<typeof TopologyPageContext>;
 
 let topologyProps: TopologyPageProps;
-let renderTopologyProps: RenderTopologyProps;
 
 jest.mock('react-redux', () => {
   const ActualReactRedux = require.requireActual('react-redux');
@@ -35,6 +33,7 @@ jest.mock('@console/shared', () => {
 
 describe('Topology page tests', () => {
   beforeEach(() => {
+    spyOn(React, 'useContext').and.returnValue({ isEmptyModel: false });
     topologyProps = {
       match: {
         params: {
@@ -45,35 +44,27 @@ describe('Topology page tests', () => {
         url: '',
       },
     };
-
-    renderTopologyProps = {
-      model: topologyData,
-      showGraphView: true,
-      loaded: true,
-      loadError: '',
-      namespace: 'topology-test',
-    };
   });
 
   it('should render topology page', () => {
     topologyProps.match.path = '/topology/ns/topology-test/list';
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     expect(wrapper.find(NamespacedPage).exists()).toBe(true);
   });
 
   it('should render topology graph page', () => {
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     expect(wrapper.find(ConnectedTopologyDataController).exists()).toBe(true);
   });
 
   it('should render projects list page', () => {
     topologyProps.match.params.name = '';
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     expect(wrapper.find(CreateProjectListPage).exists()).toBe(true);
   });
 
   it('should render view shortcuts button on topology page toolbar', () => {
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
     expect(namespacesPageWrapper.find('[data-test-id="topology-view-shortcuts"]').exists()).toBe(
       true,
@@ -82,7 +73,7 @@ describe('Topology page tests', () => {
 
   it('should not render view shortcuts button on topology list page toolbar', () => {
     topologyProps.match.path = '/topology/ns/topology-test/list';
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
     expect(namespacesPageWrapper.find('[data-test-id="topology-view-shortcuts"]').exists()).toBe(
       false,
@@ -91,38 +82,59 @@ describe('Topology page tests', () => {
 
   it('should show the topology icon when on topology list page', () => {
     topologyProps.match.path = '/topology/ns/topology-test/list';
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
     expect(namespacesPageWrapper.find(Tooltip).props().content).toBe('Topology View');
     expect(namespacesPageWrapper.find(Link).props().to).toBe('/topology/ns/topology-test/graph');
   });
 
   it('should show the topology list icon when on topology page', () => {
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
     expect(namespacesPageWrapper.find(Tooltip).props().content).toBe('List View');
     expect(namespacesPageWrapper.find(Link).props().to).toBe('/topology/ns/topology-test/list');
   });
 
   it('should render topology when workload is loaded', () => {
-    const Component = () => renderTopology(renderTopologyProps);
+    const Component = () =>
+      renderTopology({
+        model: topologyData,
+        showGraphView: true,
+        loaded: true,
+        loadError: '',
+        namespace: 'topology-test',
+      });
     const wrapper = shallow(<Component />);
     expect(wrapper.find(StatusBox).exists()).toBe(true);
     expect(wrapper.find(ConnectedTopologyView).exists()).toBe(true);
   });
 
-  it('should render all projects list page for graph view when no project is selected', () => {
+  it('should not contain view switcher when when no project is selected', () => {
     topologyProps.match.params.name = '';
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
-    expect(namespacesPageWrapper.find(Link).props().to).toBe('/topology/all-namespaces/list');
+    expect(namespacesPageWrapper.find(Link).exists()).toBe(false);
+  });
+});
+
+describe('Topology page tests', () => {
+  beforeEach(() => {
+    spyOn(React, 'useContext').and.returnValue({ isEmptyModel: true });
+    topologyProps = {
+      match: {
+        params: {
+          name: 'topology-test',
+        },
+        isExact: true,
+        path: '/topology/ns/topology-test/graph',
+        url: '',
+      },
+    };
   });
 
-  it('should render all projects list page for list view when no project is selected', () => {
-    topologyProps.match.params.name = '';
-    topologyProps.match.path = '/topology/all-namespaces/list';
-    const wrapper = shallow(<TopologyPage {...topologyProps} />);
+  it('should not contain view switcher when no model', () => {
+    const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
-    expect(namespacesPageWrapper.find(Link).props().to).toBe('/topology/all-namespaces/graph');
+    expect(namespacesPageWrapper.find(Link).exists()).toBe(false);
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/ModelContext.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/ModelContext.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import { observable, computed } from 'mobx';
 import { Model } from '@patternfly/react-topology';
 import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
 import {
@@ -27,6 +28,7 @@ export class ExtensibleModel {
 
   private namespaceP: string;
 
+  @observable
   private modelP: Model = { nodes: [], edges: [] };
 
   public dataResources: TopologyDataResources = {};
@@ -123,12 +125,17 @@ export class ExtensibleModel {
     }, []);
   }
 
-  public addDataModel = (model: Model) => {
-    addToTopologyDataModel(model, this.model, this.dataModelDepicters);
-  };
+  public set model(model: Model) {
+    this.modelP = model;
+  }
 
   public get model(): Model {
     return this.modelP;
+  }
+
+  @computed
+  public get isEmptyModel(): boolean {
+    return (this.modelP?.nodes?.length ?? 0) === 0;
   }
 
   public getExtensionModels = (resources: TopologyDataResources): Promise<Model> => {


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4222
https://issues.redhat.com/browse/ODC-4507

**Description**
Fix to not show the grid/list icon when no project is selected or when no items exist in the project (showing Add page). Also updates the Add page background when the user is in list view mode.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
