### PR TITLE
Fix delayed appearance of relationships when exanding groups

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
@@ -126,6 +126,13 @@ export const updateModelFromFilters = (
       dataModel.nodes.find((n) => n.id === d.target),
   );
 
+  // TODO: This works until some extension adds edges they don't want to show
+  // edges may have been hidden via the createAggregateEdges call last time.
+  // make them visible now so they reappear when the hidden endpoints reappear.
+  edges.forEach((edge) => {
+    edge.visible = true;
+  });
+
   // Create any aggregate edges (those create from hidden endpoints)
   dataModel.edges = createAggregateEdges(TYPE_AGGREGATE_EDGE, edges, dataModel.nodes);
 


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4375

**Description**
Fix to immediately reshow edges that were hidden due to the endpoints being hidden when those endpoints are no longer hidden.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
