### PR TITLE
Bug 1840958: Source can be empty in general step

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
@@ -110,11 +110,9 @@ const provisioningSourceUpdater = ({ id, prevState, dispatch, getState }: Update
   dispatch(
     vmWizardInternalActions[InternalActionType.UpdateVmSettings](id, {
       [VMSettingsField.CONTAINER_IMAGE]: {
-        isRequired: asRequired(isContainer, VMSettingsField.PROVISION_SOURCE_TYPE),
         isHidden: asHidden(!isContainer, VMSettingsField.PROVISION_SOURCE_TYPE),
       },
       [VMSettingsField.IMAGE_URL]: {
-        isRequired: asRequired(isUrl, VMSettingsField.PROVISION_SOURCE_TYPE),
         isHidden: asHidden(!isUrl, VMSettingsField.PROVISION_SOURCE_TYPE),
       },
     }),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -63,59 +63,50 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
     } = this.props;
 
     const provisionSourceValue = this.getFieldValue(VMSettingsField.PROVISION_SOURCE_TYPE);
+    const storageBtn = (
+      <Button
+        isDisabled={!steps[VMWizardTab.STORAGE]?.canJumpTo}
+        isInline
+        onClick={() => goToStep(VMWizardTab.STORAGE)}
+        variant={ButtonVariant.link}
+      >
+        <strong>Storage</strong>
+      </Button>
+    );
+    const networkBtn = (
+      <Button
+        isDisabled={!steps[VMWizardTab.NETWORKING]?.canJumpTo}
+        isInline
+        onClick={() => goToStep(VMWizardTab.NETWORKING)}
+        variant={ButtonVariant.link}
+      >
+        <strong>Networking</strong>
+      </Button>
+    );
 
-    const getProvisionSourceDiskHelpMsg = () => {
-      const storageBtn = (
-        <Button
-          isDisabled={!steps[VMWizardTab.STORAGE]?.canJumpTo}
-          isInline
-          onClick={() => goToStep(VMWizardTab.STORAGE)}
-          variant={ButtonVariant.link}
-        >
-          <strong>storage</strong>
-        </Button>
-      );
-
-      const getStorageMsg = () => {
-        switch (provisionSourceValue) {
-          case ProvisionSource.URL.toString():
-            return <>Enter URL here or edit the mounted disk in the {storageBtn} step</>;
-          case ProvisionSource.CONTAINER.toString():
-            return (
-              <>Enter container image here or edit the mounted disk in the {storageBtn} step</>
-            );
-          case ProvisionSource.DISK.toString():
-            return <>Add a source disk in the {storageBtn} step</>;
-          default:
-            return null;
-        }
-      };
-
-      return (
-        <div className="pf-c-form__helper-text" aria-live="polite">
-          {getStorageMsg()}
-        </div>
-      );
+    const getStorageMsg = () => {
+      switch (provisionSourceValue) {
+        case ProvisionSource.URL.toString():
+          return <>Enter URL here or edit the mounted disk in the {storageBtn} step</>;
+        case ProvisionSource.CONTAINER.toString():
+          return <>Enter container image here or edit the mounted disk in the {storageBtn} step</>;
+        case ProvisionSource.DISK.toString():
+          return <>Add a source disk in the {storageBtn} step</>;
+        default:
+          return null;
+      }
     };
+    const provisionSourceDiskHelpMsg = (
+      <div className="pf-c-form__helper-text" aria-live="polite">
+        {getStorageMsg()}
+      </div>
+    );
 
-    const getProvisionSourceNetHelpMsg = () => {
-      const networkBtn = (
-        <Button
-          isDisabled={!steps[VMWizardTab.NETWORKING]?.canJumpTo}
-          isInline
-          onClick={() => goToStep(VMWizardTab.NETWORKING)}
-          variant={ButtonVariant.link}
-        >
-          <strong>networking</strong>
-        </Button>
-      );
-
-      return (
-        <div className="pf-c-form__helper-text" aria-live="polite">
-          Add a network interface in the {networkBtn} step
-        </div>
-      );
-    };
+    const provisionSourceNetHelpMsg = (
+      <div className="pf-c-form__helper-text" aria-live="polite">
+        Add a network interface in the {networkBtn} step
+      </div>
+    );
 
     return (
       <Form className="co-m-pane__body co-m-pane__form kubevirt-create-vm-modal__form">
@@ -198,9 +189,9 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
             ProvisionSource.URL.toString(),
             ProvisionSource.CONTAINER.toString(),
             ProvisionSource.DISK.toString(),
-          ].includes(provisionSourceValue) && getProvisionSourceDiskHelpMsg()}
+          ].includes(provisionSourceValue) && provisionSourceDiskHelpMsg}
           {[ProvisionSource.PXE.toString()].includes(provisionSourceValue) &&
-            getProvisionSourceNetHelpMsg()}
+            provisionSourceNetHelpMsg}
         </FormFieldMemoRow>
         <ContainerSource
           field={this.getField(VMSettingsField.CONTAINER_IMAGE)}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react';
-import { Form, FormSelect, FormSelectOption, TextArea, TextInput } from '@patternfly/react-core';
+import {
+  Form,
+  FormSelect,
+  FormSelectOption,
+  TextArea,
+  TextInput,
+  Button,
+  ButtonVariant,
+} from '@patternfly/react-core';
 import { connect } from 'react-redux';
 import { iGet, iGetIn } from '../../../../utils/immutable';
 import { FormFieldMemoRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
 import { FormSelectPlaceholderOption } from '../../../form/form-select-placeholder-option';
+import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { vmWizardActions } from '../../redux/actions';
 import {
   VMSettingsField,
@@ -18,6 +27,7 @@ import { iGetVmSettings } from '../../selectors/immutable/vm-settings';
 import { ActionType } from '../../redux/types';
 import { getPlaceholder } from '../../utils/renderable-field-utils';
 import { iGetCommonData } from '../../selectors/immutable/selectors';
+import { getStepsMetadata } from '../../selectors/immutable/wizard-selectors';
 import { iGetProvisionSourceStorage } from '../../selectors/immutable/storage';
 import { WorkloadProfile } from './workload-profile';
 import { OSFlavor } from './os-flavor';
@@ -28,7 +38,6 @@ import { URLSource } from './url-source';
 
 import '../../create-vm-wizard-footer.scss';
 import './vm-settings-tab.scss';
-import { getStepsMetadata } from '../../selectors/immutable/wizard-selectors';
 
 export class VMSettingsTabComponent extends React.Component<VMSettingsTabComponentProps> {
   getField = (key: VMSettingsField) => iGet(this.props.vmSettings, key);
@@ -52,6 +61,61 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
       steps,
       goToStep,
     } = this.props;
+
+    const provisionSourceValue = this.getFieldValue(VMSettingsField.PROVISION_SOURCE_TYPE);
+
+    const getProvisionSourceDiskHelpMsg = () => {
+      const storageBtn = (
+        <Button
+          isDisabled={!steps[VMWizardTab.STORAGE]?.canJumpTo}
+          isInline
+          onClick={() => goToStep(VMWizardTab.STORAGE)}
+          variant={ButtonVariant.link}
+        >
+          <strong>storage</strong>
+        </Button>
+      );
+
+      const getStorageMsg = () => {
+        switch (provisionSourceValue) {
+          case ProvisionSource.URL.toString():
+            return <>Enter URL here or edit the mounted disk in the {storageBtn} step</>;
+          case ProvisionSource.CONTAINER.toString():
+            return (
+              <>Enter container image here or edit the mounted disk in the {storageBtn} step</>
+            );
+          case ProvisionSource.DISK.toString():
+            return <>Add a source disk in the {storageBtn} step</>;
+          default:
+            return null;
+        }
+      };
+
+      return (
+        <div className="pf-c-form__helper-text" aria-live="polite">
+          {getStorageMsg()}
+        </div>
+      );
+    };
+
+    const getProvisionSourceNetHelpMsg = () => {
+      const networkBtn = (
+        <Button
+          isDisabled={!steps[VMWizardTab.NETWORKING]?.canJumpTo}
+          isInline
+          onClick={() => goToStep(VMWizardTab.NETWORKING)}
+          variant={ButtonVariant.link}
+        >
+          <strong>networking</strong>
+        </Button>
+      );
+
+      return (
+        <div className="pf-c-form__helper-text" aria-live="polite">
+          Add a network interface in the {networkBtn} step
+        </div>
+      );
+    };
 
     return (
       <Form className="co-m-pane__body co-m-pane__form kubevirt-create-vm-modal__form">
@@ -130,6 +194,13 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
               )}
             </FormSelect>
           </FormField>
+          {[
+            ProvisionSource.URL.toString(),
+            ProvisionSource.CONTAINER.toString(),
+            ProvisionSource.DISK.toString(),
+          ].includes(provisionSourceValue) && getProvisionSourceDiskHelpMsg()}
+          {[ProvisionSource.PXE.toString()].includes(provisionSourceValue) &&
+            getProvisionSourceNetHelpMsg()}
         </FormFieldMemoRow>
         <ContainerSource
           field={this.getField(VMSettingsField.CONTAINER_IMAGE)}


### PR DESCRIPTION
URL and Container source are not required in the general step, they are part of the storage step.

Screenshots:
Edit storage "rootdisk" URL source:
![screenshot-localhost_9000-2020 08 09-15_19_54](https://user-images.githubusercontent.com/2181522/89731985-228d1200-da54-11ea-8bae-60d04b585311.png)

Edit storage "rootdisk" Container source:
![screenshot-localhost_9000-2020 08 09-15_20_32](https://user-images.githubusercontent.com/2181522/89731986-228d1200-da54-11ea-9640-f48c56d23487.png)

Edit storage "rootdisk" "any" source:
![screenshot-localhost_9000-2020 08 09-15_21_07](https://user-images.githubusercontent.com/2181522/89731987-2325a880-da54-11ea-9d2e-d1683ee4f575.png)

Edit network "any" net interface
![screenshot-localhost_9000-2020 08 09-15_29_56](https://user-images.githubusercontent.com/2181522/89732112-3c7b2480-da55-11ea-8ed0-8ac141c06c6c.png)
