### PR TITLE
Bug 1866514: If CSV doesn't have status field, check it's labels for 'olm.copiedFrom' label

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -533,7 +533,8 @@ export const NamespacedClusterServiceVersionList: React.SFC<ClusterServiceVersio
 
   const isCopiedCSV = (source: ClusterServiceVersionKind, kind: string) => {
     return (
-      referenceForModel(ClusterServiceVersionModel) === kind && source.status?.reason === 'Copied'
+      referenceForModel(ClusterServiceVersionModel) === kind &&
+      (source.status?.reason === 'Copied' || source.metadata?.labels?.['olm.copiedFrom'])
     );
   };
 


### PR DESCRIPTION
When global installing/uninstalling operators a flickering is cause due to the fact that there is an extra CSV of the installed/uninstalled operator, that's without a `status` field and so was passing though our `isCopiedCSV` filter. If the CSV doesn't have the `status` field, check it's labels for the `olm.copiedFrom` label. 

/assign @spadgett 