### PR TITLE
Bug 1867526: support pipeline task resources to be an optional field based on spec

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
@@ -30,8 +30,8 @@ const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
       helperTextInvalid={
         dropdownResources.length === 0 ? `No resources available. Add pipeline resources.` : ''
       }
-      isValid={dropdownResources.length > 0}
-      isRequired
+      validated={dropdownResources.length > 0 ? 'default' : 'error'}
+      isRequired={!resource?.optional}
     >
       <SidebarInputWrapper>
         <Dropdown

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -127,11 +127,11 @@ const getErrors = (task: PipelineTask, resource: PipelineResourceTask): TaskErro
   const resources = getTaskResources(resource);
 
   const taskInputResources = task.resources?.inputs?.length || 0;
-  const requiredInputResources = resources.inputs?.length || 0;
+  const requiredInputResources = (resources.inputs || []).filter((r) => !r?.optional).length;
   const missingInputResources = requiredInputResources - taskInputResources > 0;
 
   const taskOutputResources = task.resources?.outputs?.length || 0;
-  const requiredOutputResources = resources.outputs?.length || 0;
+  const requiredOutputResources = (resources.outputs || []).filter((r) => !r?.optional).length;
   const missingOutputResources = requiredOutputResources - taskOutputResources > 0;
 
   const errorListing: TaskErrorType[] = [];

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/validation-utils.ts
@@ -1,12 +1,5 @@
 import * as yup from 'yup';
 
-const taskResourceValidation = yup.array().of(
-  yup.object({
-    name: yup.string().required('Required'),
-    resource: yup.string().required('Required'),
-  }),
-);
-
 export const validationSchema = yup.object({
   name: yup.string().required('Required'),
   params: yup.array().of(
@@ -34,10 +27,6 @@ export const validationSchema = yup.object({
             kind: yup.string(),
           })
           .required('Required'),
-        resources: yup.object({
-          inputs: taskResourceValidation,
-          outputs: taskResourceValidation,
-        }),
       }),
     )
     .min(1, 'Must define at least one task')

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -150,6 +150,7 @@ export interface PipelineResourceTaskParam extends PipelineParam {
 export interface PipelineResourceTaskResource {
   name: string;
   type: string;
+  optional?: boolean;
 }
 export interface PipelineResourceTask extends K8sResourceKind {
   spec: {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-4281

Problem:
Pipelines resources are all set to mandatory while using the pipeline builder

Solution:
Pipeline resources are set as required based on the optional attribute from the pipeline task spec.

This is a manual cherry pick of https://github.com/openshift/console/pull/6228