### PR TITLE
Bug 1867201: fix bug where Routes created set route.spec.port.targetP…

### DIFF
--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -192,7 +192,9 @@ export class CreateRoute extends React.Component<{}, CreateRouteState> {
 
     // If the port is unnamed, there is only one port. Use the port number.
     const targetPort =
-      selectedPort === UNNAMED_PORT_KEY ? _.get(service, 'spec.ports[0].port') : selectedPort;
+      selectedPort === UNNAMED_PORT_KEY
+        ? _.get(service, 'spec.ports[0].targetPort') || _.get(service, 'spec.ports[0].port')
+        : selectedPort;
 
     const alternateBackends = _.filter(alternateServices, 'name').map(
       (serviceData: AlternateServiceEntryType) => {


### PR DESCRIPTION
…ort to the service.spec.ports.port

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1867201

before:
```
kind: Route
apiVersion: route.openshift.io/v1
metadata:
  name: example2-route
  namespace: robb
  selfLink: /apis/route.openshift.io/v1/namespaces/robb/routes/example2-route
  uid: 6dd397f2-8825-44be-9f07-af2fbe79dc5b
  resourceVersion: '440843'
  creationTimestamp: '2020-08-10T19:54:01Z'
  managedFields:
    - manager: Mozilla
      operation: Update
      apiVersion: route.openshift.io/v1
      time: '2020-08-10T19:54:01Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          'f:host': {}
          'f:port':
            .: {}
            'f:targetPort': {}
          'f:to':
            'f:kind': {}
            'f:name': {}
            'f:weight': {}
          'f:wildcardPolicy': {}
    - manager: openshift-router
      operation: Update
      apiVersion: route.openshift.io/v1
      time: '2020-08-10T19:54:01Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          'f:ingress': {}
spec:
  host: www.example.com
  to:
    kind: Service
    name: example2
    weight: 100
  port:
    targetPort: 80
  wildcardPolicy: None
status:
  ingress:
    - host: www.example.com
      routerName: default
      conditions:
        - type: Admitted
          status: 'True'
          lastTransitionTime: '2020-08-10T19:54:01Z'
      wildcardPolicy: None
      routerCanonicalHostname: apps.rhamilto.devcluster.openshift.com
```

after:
```
kind: Route
apiVersion: route.openshift.io/v1
metadata:
  name: example3-route
  namespace: robb
  selfLink: /apis/route.openshift.io/v1/namespaces/robb/routes/example3-route
  uid: 65021983-515a-400a-a036-e2522fdea64f
  resourceVersion: '447220'
  creationTimestamp: '2020-08-10T20:00:26Z'
  managedFields:
    - manager: Mozilla
      operation: Update
      apiVersion: route.openshift.io/v1
      time: '2020-08-10T20:00:49Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          'f:host': {}
          'f:port':
            .: {}
            'f:targetPort': {}
          'f:to':
            'f:kind': {}
            'f:name': {}
            'f:weight': {}
          'f:wildcardPolicy': {}
    - manager: openshift-router
      operation: Update
      apiVersion: route.openshift.io/v1
      time: '2020-08-10T20:00:49Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          'f:ingress': {}
spec:
  host: www.example.org
  to:
    kind: Service
    name: example3
    weight: 100
  port:
    targetPort: 9376
  wildcardPolicy: None
status:
  ingress:
    - host: www.example.org
      routerName: default
      conditions:
        - type: Admitted
          status: 'True'
          lastTransitionTime: '2020-08-10T20:00:49Z'
      wildcardPolicy: None
      routerCanonicalHostname: apps.rhamilto.devcluster.openshift.com
```