### PR TITLE
Bug 1865811: Prevent Firefox bug where cluster names could overlap

### DIFF
--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -152,9 +152,11 @@ $co-channel-height: 60px;
   height: 35px;
   justify-content: flex-end;
   line-height: 1;
+  padding: 0 5px;
   position: absolute;
   text-align: center;
   top: -20px;
+  word-break: break-word;
 
   &--current {
     font-weight: var(--pf-global--FontWeight--bold);


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1865811
applied `word-break` and padding for better readability

<img width="1150" alt="Screen Shot 2020-08-11 at 10 47 17 AM" src="https://user-images.githubusercontent.com/1874151/89913156-5fc2e280-dbc1-11ea-8801-c665c3403769.png">


<img width="456" alt="Screen Shot 2020-08-11 at 10 48 22 AM" src="https://user-images.githubusercontent.com/1874151/89913149-5f2a4c00-dbc1-11ea-8c05-b6b41f85557b.png">
