### PR TITLE
Bug 1868103: adds badge support for KnativeEventing creation

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.scss
@@ -1,0 +1,10 @@
+.olm-create-operand{
+  &__page-heading {
+    padding: 0;
+    margin: 0;
+
+    .co-m-pane__heading{
+      margin: 0;
+    }
+  }
+}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -12,17 +12,19 @@ import {
   definitionFor,
 } from '@console/internal/module/k8s';
 import { CustomResourceDefinitionModel } from '@console/internal/models';
-import { Firehose } from '@console/internal/components/utils/firehose';
 import {
+  PageHeading,
   StatusBox,
   FirehoseResult,
   BreadCrumbs,
   resourcePathFromModel,
 } from '@console/internal/components/utils';
+import { Firehose } from '@console/internal/components/utils/firehose';
 import { RootState } from '@console/internal/redux';
 import { SyncedEditor } from '@console/shared/src/components/synced-editor';
 import { getActivePerspective } from '@console/internal/reducers/ui';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { getBadgeFromType } from '@console/shared/src/components/badges';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
 import { match as RouterMatch } from 'react-router';
@@ -40,6 +42,8 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/camelcase
 import { DEPRECATED_CreateOperandForm } from './DEPRECATED_operand-form';
+
+import './create-operand.scss';
 
 export const CreateOperand: React.FC<CreateOperandProps> = ({
   clusterServiceVersion,
@@ -117,8 +121,13 @@ export const CreateOperand: React.FC<CreateOperandProps> = ({
                 ]}
               />
             </div>
-            <h1 className="co-create-operand__header-text">{`Create ${model.label}`}</h1>
-            <p className="help-block">{helpText}</p>
+            <PageHeading
+              badge={getBadgeFromType(model.badge)}
+              className="olm-create-operand__page-heading"
+              title={`Create ${model.label}`}
+            >
+              <span className="help-block">{helpText}</span>
+            </PageHeading>
           </div>
           <SyncedEditor
             context={{

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -5,7 +5,7 @@ import { match } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { sortable } from '@patternfly/react-table';
 import { JSONSchema6 } from 'json-schema';
-import { Status, SuccessStatus } from '@console/shared';
+import { Status, SuccessStatus, getBadgeFromType } from '@console/shared';
 import { Conditions } from '@console/internal/components/conditions';
 import { ErrorPage404 } from '@console/internal/components/error';
 import {
@@ -440,6 +440,7 @@ export const ProvidedAPIPage = connectToModel((props: ProvidedAPIPageProps) => {
       canCreate={_.get(kindObj, 'verbs', [] as string[]).some((v) => v === 'create')}
       createProps={{ to }}
       namespace={kindObj.namespaced ? namespace : null}
+      badge={getBadgeFromType(kindObj.badge)}
     />
   );
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4263

**Analysis / Root cause**: 
TP badge was not shown for knativeEventing CR creation/list

**Solution Description**: 
Add badge support for Creation/list of CR with model having badge

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/89926400-764d5600-dc22-11ea-962d-efb712fa31dc.png)


![image](https://user-images.githubusercontent.com/5129024/89926432-87966280-dc22-11ea-84b1-8e55159b59be.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
