### PR TITLE
Bug 1866034: Fix to reduce pod donut text size when text is long

### DIFF
--- a/frontend/packages/console-shared/src/utils/pod-ring-text.scss
+++ b/frontend/packages/console-shared/src/utils/pod-ring-text.scss
@@ -5,9 +5,11 @@
     font-size: 14px !important;
     fill: var(--pf-global--Color--200) !important;
   }
-  tspan:first-of-type {
-    font-size: 24px !important;
-    fill: var(--pf-global--Color--100) !important;
+  &:not(.pod-ring__long-text) {
+    tspan:first-of-type {
+      font-size: var(--pf-chart-global--FontSize--2xl) !important;
+      fill: var(--pf-global--Color--100) !important;
+    }
   }
 }
 

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import * as classNames from 'classnames';
 import {
   DeploymentConfigModel,
   DeploymentModel,
@@ -98,11 +99,13 @@ const getTitleAndSubtitle = (
 ) => {
   let titlePhrase;
   let subTitlePhrase = '';
+  let longTitle = false;
   let longSubtitle = false;
 
   // handles the initial state when the first pod is coming up and the state for no pods(scaled to zero)
   if (!currentPodCount) {
     titlePhrase = isPending ? '0' : `Scaled to 0`;
+    longTitle = !isPending;
     if (desiredPodCount) {
       subTitlePhrase = `scaling to ${desiredPodCount}`;
       longSubtitle = true;
@@ -120,17 +123,25 @@ const getTitleAndSubtitle = (
     }
   }
 
-  return { title: titlePhrase, subTitle: subTitlePhrase, longSubtitle };
+  return { title: titlePhrase, longTitle, subTitle: subTitlePhrase, longSubtitle };
 };
 
-const getTitleComponent = (longSubtitle: boolean = false, reversed: boolean = false) =>
-  React.createElement(ChartLabel, {
+const getTitleComponent = (
+  longTitle: boolean = false,
+  longSubtitle: boolean = false,
+  reversed: boolean = false,
+) => {
+  const labelClasses = classNames('pf-chart-donut-title', {
+    'pod-ring__center-text--reversed': reversed,
+    'pod-ring__center-text': !reversed,
+    'pod-ring__long-text': longTitle,
+  });
+  return React.createElement(ChartLabel, {
     dy: longSubtitle ? -5 : 0,
     style: { lineHeight: '11px' },
-    className: `pf-chart-donut-title ${
-      reversed ? 'pod-ring__center-text--reversed' : 'pod-ring__center-text'
-    }`,
+    className: labelClasses,
   });
+};
 
 export const podRingLabel = (
   obj: K8sResourceKind,
@@ -154,7 +165,7 @@ export const podRingLabel = (
       return {
         title: titleData.title,
         subTitle: titleData.subTitle,
-        titleComponent: getTitleComponent(titleData.longSubtitle),
+        titleComponent: getTitleComponent(titleData.longTitle, titleData.longSubtitle),
       };
     case RevisionModel.kind:
       currentPodCount = (obj.status?.readyReplicas || 0) + failedPodCount;
@@ -166,7 +177,7 @@ export const podRingLabel = (
         return {
           title,
           subTitle,
-          titleComponent: getTitleComponent(false, true),
+          titleComponent: getTitleComponent(false, false, true),
         };
       }
       if (isPending) {
@@ -202,7 +213,7 @@ export const podRingLabel = (
       return {
         title: titleData.title,
         subTitle: titleData.subTitle,
-        titleComponent: getTitleComponent(titleData.longSubtitle),
+        titleComponent: getTitleComponent(titleData.longTitle, titleData.longSubtitle),
       };
   }
 };
@@ -220,7 +231,7 @@ export const hpaPodRingLabel = (
   return {
     title: scaling ? 'Autoscaling' : 'Autoscaled',
     subTitle: `to ${desiredPods}`,
-    titleComponent: getTitleComponent(false, true),
+    titleComponent: getTitleComponent(false, false, true),
   };
 };
 


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4046

**Description**
Fixes text size in pod ring donut when showing long text such that the text does not overflow.

**Screen Shots**
![image](https://user-images.githubusercontent.com/11633780/89929436-3614b600-dbd7-11ea-9dc7-0d6f7c50cd64.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
