### PR TITLE
Bug 1868358: Fix pipeline workspace volume-type empty-directory

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
@@ -52,7 +52,12 @@ const PipelineWorkspacesSection: React.FC = () => {
               name={`workspaces.${index}.type`}
               label={workspace.name}
               items={VolumeTypes}
-              onChange={() => setFieldValue(`workspaces.${index}.data`, {})}
+              onChange={(type) =>
+                setFieldValue(
+                  `workspaces.${index}.data`,
+                  VolumeTypes[type] === VolumeTypes.EmptyDirectory ? { emptyDir: {} } : {},
+                )
+              }
               fullWidth
               required
             />

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -30,6 +30,7 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
     workspaces: (pipeline.spec.workspaces || []).map((workspace: PipelineWorkspace) => ({
       ...workspace,
       type: 'EmptyDirectory',
+      data: { emptyDir: {} },
     })),
     secretOpen: false,
   };

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -220,15 +220,35 @@ export interface PipelineRunParam extends Param {
   resource?: object;
 }
 
+export type VolumeTypeSecret = {
+  secretName: string;
+  items?: {
+    key: string;
+    path: string;
+  }[];
+};
+
+export type VolumeTypeConfigMaps = {
+  name: string;
+  items?: {
+    key: string;
+    path: string;
+  }[];
+};
+
+export type VolumeTypePVC = {
+  claimName: string;
+};
+
 export interface PipelineWorkspace extends Param {
   type: string;
   data?: {
-    [key: string]: string;
+    [volumeType: string]: VolumeTypeSecret | VolumeTypeConfigMaps | VolumeTypePVC | {};
   };
 }
 
 export interface PipelineRunWorkspace extends Param {
-  [key: string]: string;
+  [volumeType: string]: VolumeTypeSecret | VolumeTypeConfigMaps | VolumeTypePVC | {};
 }
 
 interface FirehoseResource {


### PR DESCRIPTION
**Jira:** - https://issues.redhat.com/browse/ODC-4489

This PR fixes this issue by adding `emptyDir: {}` in the specific workspace object of `PipelineRun` resource for which `Empty Directory` is selected as the volume-type.

**Gif**
![Peek 2020-08-12 00-43](https://user-images.githubusercontent.com/20724543/89938692-7f472300-dc34-11ea-87f5-d2f8799ece38.gif)

/kind bug