### PR TITLE
Bug 1870606: Update error message for bootstrapServers and topics

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -37,8 +37,7 @@ const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title }) => {
           ];
       placeholder = 'Add Bootstrap Servers';
     } else if (kafkas.loadError) {
-      bootstrapServersOptions = [{ value: kafkas.loadError?.message, disabled: true }];
-      placeholder = 'Error loading Bootstrap Servers';
+      placeholder = `${kafkas.loadError?.message}. Try adding Bootstrap Servers manually.`;
     } else {
       bootstrapServersOptions = [{ value: 'Loading Bootstrap Servers...', disabled: true }];
       placeholder = '...';
@@ -63,8 +62,7 @@ const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title }) => {
           ];
       placeholder = 'Add Topics';
     } else if (kafkatopics.loadError) {
-      topicsOptions = [{ value: kafkatopics.loadError?.message, disabled: true }];
-      placeholder = 'Error loading Topics';
+      placeholder = `${kafkatopics.loadError?.message}. Try adding Topics manually.`;
     } else {
       topicsOptions = [{ value: 'Loading Topics...', disabled: true }];
       placeholder = '...';


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/ODC-4478

This PR updates error message for `bootstrapServers` and `topics` to make it more intuitive so that the user is aware that they can add `bootstrapServers` and `topics` manually irrespective of any error that occurred while fetching the existing ones and create a `KafkaSource`.

**Screenshots**
![image](https://user-images.githubusercontent.com/20724543/90485638-6c14e580-e155-11ea-91e8-0086098f0b17.png)

/kind bug