### PR TITLE
Bug 1856593: Change from hideNameFilter flag to hideToolbar

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -84,7 +84,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   const {
     rowFilters = [],
     data,
-    hideNameFilter,
+    hideToolbar,
     columnLayout,
     hideLabelFilter,
     location,
@@ -224,7 +224,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
 
   const clearAll = () => {
     updateRowFilterSelected(selectedRowFilters);
-    if (!hideNameFilter) {
+    if (!hideToolbar) {
       updateNameFilter('');
     }
     if (!hideLabelFilter) {
@@ -237,7 +237,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     if (!hideLabelFilter) {
       applyFilter(labelFilters, FilterType.LABEL);
     }
-    if (!hideNameFilter) {
+    if (!hideToolbar) {
       setInputText(nameFilter ?? '');
       applyFilter(nameFilter, FilterType.NAME);
     }
@@ -317,7 +317,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
                     title={filterType}
                   />
                 )}
-                {!hideNameFilter && (
+                {!hideToolbar && (
                   <AutocompleteInput
                     className="co-text-node"
                     onSuggestionSelect={(selected) => {
@@ -363,7 +363,7 @@ type FilterToolbarProps = {
   reduxIDs?: string[];
   filterList?: any;
   textFilter?: string;
-  hideNameFilter?: boolean;
+  hideToolbar?: boolean;
   labelFilter?: string;
   hideLabelFilter?: boolean;
   parseAutoComplete?: any;

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -62,8 +62,8 @@ const ResourceList = connectToModel(({ kindObj, mock, namespace, selector, nameF
       autoFocus={false}
       mock={mock}
       badge={getBadgeFromType(kindObj.badge)}
-      hideNameFilter
       hideLabelFilter
+      hideToolbar
     />
   );
 });


### PR DESCRIPTION
The `hideNameFilter` was removed and replaced with `hideToolbar`.  The search page and the FilterToolbar component were not updated to handle the new flag name so the Name filter was showing on the search page when it did not use to. 
EDIT: @spadgett @bipuladh  I am confused what happened here.  I reviewed Bipul's [changes](https://github.com/openshift/console/pull/5481) when he switched this to the `hideToolbar` flag but the FilterToolbar code was reverted at some point I assume because of needing just the `hideLabelFilter`. Anyone have more detail and suggestions on what we should name the flag?


![Screenshot_2020-08-11 Search · OKD](https://user-images.githubusercontent.com/18728857/89944211-a83bc980-dbdc-11ea-8708-8f646f17c57a.png)
