### PR TITLE
Bug 1871767: Add quick start link in dashboard page

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
@@ -19,6 +19,7 @@ import {
   isDashboardsTab,
 } from '@console/plugin-sdk';
 import { RootState } from '../../../redux';
+import QuickStartBadge from './quick-start-badge';
 
 const getCardsOnPosition = (cards: DashboardsCard[], position: GridPosition): GridDashboardCard[] =>
   cards
@@ -75,7 +76,7 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, 
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <PageHeading title={title} detail={true} />
+      <PageHeading title={title} detail={true} badge={<QuickStartBadge />} />
       <HorizontalNav match={match} pages={allPages} noStatusBox />
     </>
   );

--- a/frontend/public/components/dashboard/dashboards-page/quick-start-badge.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/quick-start-badge.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Label, Button } from '@patternfly/react-core';
+import { RouteIcon } from '@patternfly/react-icons';
+import { history } from '../../utils';
+
+const HIDE_QUICK_START_BADGE_STORAGE_KEY = 'bridge/hide-quick-start-badge';
+
+const QuickStartBadge: React.FC = () => {
+  const isQuickStartBadgeHidden =
+    localStorage.getItem(HIDE_QUICK_START_BADGE_STORAGE_KEY) === 'true';
+  const [showQuickStartBadge, setShowQuickStartBadge] = React.useState<boolean>(
+    !isQuickStartBadgeHidden,
+  );
+
+  const handleQuickStartBadgeClose = () => {
+    localStorage.setItem(HIDE_QUICK_START_BADGE_STORAGE_KEY, 'true');
+    setShowQuickStartBadge(false);
+  };
+
+  if (!showQuickStartBadge) {
+    return null;
+  }
+
+  return (
+    <Label color="green" icon={<RouteIcon />} onClose={handleQuickStartBadgeClose}>
+      <Button variant="link" onClick={() => history.push('/quickstart')} isInline>
+        Quick start available
+      </Button>
+    </Label>
+  );
+};
+
+export default QuickStartBadge;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4454
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: There's no link to quick starts catalog from admin perspective.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Add a quick start link in dashboard page of admin perspective.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux @bmignano 
![image](https://user-images.githubusercontent.com/6041994/89944727-eae1be00-dc3d-11ea-9ecc-001a4f4afe74.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge