### PR TITLE
Bug 1868150: Add click-able links to notifications

### DIFF
--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
@@ -100,7 +100,7 @@ const NotificationEntry: React.FC<NotificationEntryProps> = ({
 export type NotificationEntryProps = {
   actionText?: string;
   actionPath?: string;
-  description: string;
+  description: React.ReactNode;
   isRead?: boolean;
   targetPath?: string;
   timestamp?: string;

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -46,6 +46,7 @@ import {
 import { ClusterVersionModel } from '../models';
 import { useK8sWatchResource, WatchK8sResource } from './utils/k8s-watch-hook';
 import { useAccessReview } from './utils/rbac';
+import { LinkifyExternal } from './utils';
 
 const criticalCompare = (a: Alert): boolean => getAlertSeverity(a) === 'critical';
 const otherAlertCompare = (a: Alert): boolean => getAlertSeverity(a) !== 'critical';
@@ -91,6 +92,13 @@ export const getAlertActions = (actionsExtensions: AlertAction[]) => {
   return alertActions;
 };
 
+const AlertDescription: React.FC<AlertDescriptionProps> = ({ alert }) => {
+  if (getAlertName(alert) === 'UpdateAvailable') {
+    return <Linkify>{getAlertDescription(alert) || getAlertMessage(alert)}</Linkify>;
+  }
+  return <LinkifyExternal>{getAlertDescription(alert) || getAlertMessage(alert)}</LinkifyExternal>;
+};
+
 const getAlertNotificationEntries = (
   isLoaded: boolean,
   alertData: Alert[],
@@ -107,9 +115,7 @@ const getAlertNotificationEntries = (
           return (
             <NotificationEntry
               key={`${i}_${alert.activeAt}`}
-              description={
-                <Linkify>{getAlertDescription(alert) || getAlertMessage(alert)}</Linkify>
-              }
+              description={<AlertDescription alert={alert} />}
               timestamp={getAlertTime(alert)}
               type={NotificationTypes[getAlertSeverity(alert)]}
               title={getAlertName(alert)}
@@ -371,6 +377,10 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
       {children}
     </NotificationDrawer>
   );
+};
+
+type AlertDescriptionProps = {
+  alert: Alert;
 };
 
 type NotificationPoll = (

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -31,7 +31,6 @@ import {
 } from '@patternfly/react-core';
 import { isAlertAction, useExtensions, AlertAction } from '@console/plugin-sdk';
 import { usePrevious } from '@console/shared/src/hooks/previous';
-import Linkify from 'react-linkify';
 
 import { coFetchJSON } from '../co-fetch';
 import {
@@ -92,16 +91,6 @@ export const getAlertActions = (actionsExtensions: AlertAction[]) => {
   return alertActions;
 };
 
-const AlertDescription: React.FC<AlertDescriptionProps> = ({ alert }) => {
-  if (
-    getAlertName(alert) === 'UpdateAvailable' ||
-    getAlertName(alert) === 'CannotRetrieveUpdates'
-  ) {
-    return <Linkify>{getAlertDescription(alert) || getAlertMessage(alert)}</Linkify>;
-  }
-  return <LinkifyExternal>{getAlertDescription(alert) || getAlertMessage(alert)}</LinkifyExternal>;
-};
-
 const getAlertNotificationEntries = (
   isLoaded: boolean,
   alertData: Alert[],
@@ -118,7 +107,11 @@ const getAlertNotificationEntries = (
           return (
             <NotificationEntry
               key={`${i}_${alert.activeAt}`}
-              description={<AlertDescription alert={alert} />}
+              description={
+                <LinkifyExternal>
+                  {getAlertDescription(alert) || getAlertMessage(alert)}
+                </LinkifyExternal>
+              }
               timestamp={getAlertTime(alert)}
               type={NotificationTypes[getAlertSeverity(alert)]}
               title={getAlertName(alert)}
@@ -380,10 +373,6 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
       {children}
     </NotificationDrawer>
   );
-};
-
-type AlertDescriptionProps = {
-  alert: Alert;
 };
 
 type NotificationPoll = (

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -93,7 +93,10 @@ export const getAlertActions = (actionsExtensions: AlertAction[]) => {
 };
 
 const AlertDescription: React.FC<AlertDescriptionProps> = ({ alert }) => {
-  if (getAlertName(alert) === 'UpdateAvailable') {
+  if (
+    getAlertName(alert) === 'UpdateAvailable' ||
+    getAlertName(alert) === 'CannotRetrieveUpdates'
+  ) {
     return <Linkify>{getAlertDescription(alert) || getAlertMessage(alert)}</Linkify>;
   }
   return <LinkifyExternal>{getAlertDescription(alert) || getAlertMessage(alert)}</LinkifyExternal>;

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -31,6 +31,7 @@ import {
 } from '@patternfly/react-core';
 import { isAlertAction, useExtensions, AlertAction } from '@console/plugin-sdk';
 import { usePrevious } from '@console/shared/src/hooks/previous';
+import Linkify from 'react-linkify';
 
 import { coFetchJSON } from '../co-fetch';
 import {
@@ -106,7 +107,9 @@ const getAlertNotificationEntries = (
           return (
             <NotificationEntry
               key={`${i}_${alert.activeAt}`}
-              description={getAlertDescription(alert) || getAlertMessage(alert)}
+              description={
+                <Linkify>{getAlertDescription(alert) || getAlertMessage(alert)}</Linkify>
+              }
               timestamp={getAlertTime(alert)}
               type={NotificationTypes[getAlertSeverity(alert)]}
               title={getAlertName(alert)}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1868150

Use linkify to allow clickable links in the body of a notification description in the notification drawer:

![notification-link](https://user-images.githubusercontent.com/35978579/89951324-31f99000-dbf9-11ea-94e9-c2d34f50042c.gif)
