### PR TITLE
traffic splitting modal should source info from spec and not status

### DIFF
--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { Formik, FormikValues, FormikHelpers } from 'formik';
 import { K8sResourceKind, k8sUpdate } from '@console/internal/module/k8s';
 import { ServiceModel } from '../../models';
@@ -27,17 +26,15 @@ const TrafficSplitting: React.FC<TrafficSplittingProps> = ({
   cancel,
   close,
 }) => {
-  const traffic = _.get(
-    service,
-    ['status', 'traffic'],
-    [{ percent: 0, tag: '', revisionName: '' }],
-  );
+  const traffic = service.spec?.traffic ?? [{ percent: 0, tag: '', revisionName: '' }];
+  const latestCreatedRevName = service.status?.latestCreatedRevisionName;
   const revisionItems = getRevisionItems(revisions);
   const initialValues: TrafficSplittingType = {
     trafficSplitting: traffic.map((t) => ({
       percent: t.percent,
       tag: t.tag || '',
-      revisionName: t.revisionName || '',
+      revisionName:
+        t.revisionName || (t.latestRevision && latestCreatedRevName ? latestCreatedRevName : ''),
     })),
   };
   const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4240

**Analysis / Root cause**: 
traffic splitting modal was sourcing traffic info from status

**Solution Description**: 
traffic splitting modal should source info from spec and not status

**Screen shots / Gifs for design review**: 
No visual changes

![image](https://user-images.githubusercontent.com/5129024/89978806-fbb92080-dc8b-11ea-88fe-0e83309b7aa1.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
