### PR TITLE
Add spin animation to pipelinerun log tabs

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
@@ -3,11 +3,11 @@ import * as _ from 'lodash';
 import { RouteComponentProps } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Nav, NavItem, NavList } from '@patternfly/react-core';
-import { StatusIcon } from '@console/shared';
 import { Firehose, resourcePathFromModel } from '@console/internal/components/utils';
 import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
 import { PipelineRun } from '../../../utils/pipeline-augment';
 import { PipelineRunModel } from '../../../models';
+import { ColoredStatusIcon } from '../../pipelines/detail-page-tabs/pipeline-details/StatusIcon';
 import LogsWrapperComponent from '../logs/LogsWrapperComponent';
 import { getDownloadAllLogsCallback } from '../logs/logs-utils';
 import './PipelineRunLogs.scss';
@@ -119,7 +119,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
                       className="odc-pipeline-run-logs__navitem"
                     >
                       <Link to={path + _.get(taskRunFromYaml, [task, `pipelineTaskName`], '-')}>
-                        <StatusIcon
+                        <ColoredStatusIcon
                           status={pipelineRunFilterReducer(
                             _.get(obj, ['status', 'taskRuns', task]),
                           )}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-1857
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
There is inconsistency in status animations when a pipeline is running.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Add spin animation to task tabs in pipelinerun logs.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![anim](https://user-images.githubusercontent.com/20013884/90155383-dec63f80-dda8-11ea-9c44-b5364c88af76.gif)

@openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge