### PR TITLE
remove the explicit chain method in channel selection

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/channels/form-fields/ChannelSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/form-fields/ChannelSelector.tsx
@@ -20,11 +20,12 @@ const ChannelSelector: React.FC<ChannelSelectorProps> = ({
 }) => {
   const [selected] = useField('type');
 
-  const filteredChannels = _.chain(channels)
-    .filter((ch) => EventingChannelModel.kind !== getChannelKind(ch))
-    .partition((ref) => getChannelKind(ref) === defaultConfiguredChannel)
-    .flatten()
-    .value();
+  const eventingChannels = channels.filter(
+    (ch) => EventingChannelModel.kind !== getChannelKind(ch),
+  );
+  const filteredChannels = _.flatten(
+    _.partition(eventingChannels, (ref) => getChannelKind(ref) === defaultConfiguredChannel),
+  );
 
   const channelData = filteredChannels.reduce((acc, channel) => {
     const channelName = getChannelKind(channel);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-4494


Problem: Explicit lodash chain method breaks the UI with the error

Solution: Removed the explict chain method and changed the logic to filter the available channels
![image](https://user-images.githubusercontent.com/9964343/90009618-04294f80-dcbc-11ea-9651-ca0cc61acc1f.png)



/assign @invincibleJai 
/kind bug