### PR TITLE
Bug 1868394: Fix boot-order change alert when VM is running

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-like/next-run-changes.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-like/next-run-changes.ts
@@ -84,7 +84,7 @@ export const isBootOrderChanged = (vm: VMWrapper, vmi: VMIWrapper): boolean => {
     const vmDevices = getDevices(vm.asResource());
     const vmiDevices = getVMIDevices(vmi.asResource());
 
-    return vmDevices.every((bootableDevice, index) => _.isEqual(bootableDevice, vmiDevices[index]));
+    return vmDevices.some((bootableDevice, index) => !_.isEqual(bootableDevice, vmiDevices[index]));
   }
 
   return !vmBootOrder.every(


### PR DESCRIPTION
Show the alert when the disk order is changing in the yaml
while the VM is running.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>