### PR TITLE
Bug 1868426: Unfilter OS dropdown in VM wizard when choosing flavor or workload

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
@@ -81,7 +81,7 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
       operatingSystems = [{ name: display, id: display }];
     } else {
       operatingSystems = openshiftFlag
-        ? ignoreCaseSort(getOperatingSystems(vanillaTemplates, params), ['name'])
+        ? ignoreCaseSort(getOperatingSystems(vanillaTemplates, params.userTemplate), ['name'])
         : operatingSystemsNative;
     }
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/combined-dependent.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/combined-dependent.ts
@@ -34,22 +34,13 @@ export const getFlavorLabel = (flavor: string) => {
   return undefined;
 };
 
-export const getOperatingSystems = (
-  templates: TemplateKind[],
-  { workload, flavor, userTemplate }: { workload: string; flavor: string; userTemplate: string },
-) => {
-  let templatesWithLabels;
+export const getOperatingSystems = (templates: TemplateKind[], userTemplate: string) => {
   if (userTemplate) {
-    templatesWithLabels = [
+    return getTemplateOperatingSystems([
       getTemplatesOfLabelType(templates, TEMPLATE_TYPE_VM).find((t) => getName(t) === userTemplate),
-    ];
-  } else {
-    templatesWithLabels = getTemplatesWithLabels(
-      getTemplatesOfLabelType(templates, TEMPLATE_TYPE_BASE),
-      [getWorkloadLabel(workload), getFlavorLabel(flavor)],
-    );
+    ]);
   }
-  return getTemplateOperatingSystems(templatesWithLabels);
+  return getTemplateOperatingSystems(getTemplatesOfLabelType(templates, TEMPLATE_TYPE_BASE));
 };
 
 export const getWorkloadProfiles = (


### PR DESCRIPTION
 When switching OS, the flavor and workload will be set to NULL
 thus the user would have to pick suitable flavor & workload
 for the new OS.
 
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>