### PR TITLE
Bug 1868353: v2v: do not let backend delete saved secrets

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
@@ -27,3 +27,5 @@ export const CONVERSION_VOLUME_VDDK_NAME = 'volume-vddk';
 export const CONVERSION_VDDK_MOUNT_PATH = '/opt/vmware-vix-disklib-distrib';
 
 export const CONVERSION_PROGRESS_ANNOTATION = 'v2vConversionProgress';
+
+export const V2V_DATA_TTL_KEY = 'timeToLive';

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/correct-vm-import-provider-secret-labels.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/correct-vm-import-provider-secret-labels.ts
@@ -4,7 +4,7 @@ import { compareOwnerReference } from '@console/shared/src/utils/owner-reference
 import { getLabels, getOwnerReferences } from '@console/shared/src';
 import { SecretModel } from '@console/internal/models';
 import { PatchBuilder } from '@console/shared/src/k8s';
-import { V2V_TEMPORARY_LABEL } from '../../../constants/v2v';
+import { V2V_TEMPORARY_LABEL, V2V_DATA_TTL_KEY } from '../../../constants/v2v';
 import { buildOwnerReferenceForModel } from '../../../utils';
 import { VMImportProvider } from '../../../components/create-vm-wizard/types';
 import { OVirtProviderModel, V2VVMwareModel } from '../../../models';
@@ -33,6 +33,7 @@ export const correctVMImportProviderSecretLabels = async ({
       new PatchBuilder('/metadata/labels')
         .setObjectRemove(V2V_TEMPORARY_LABEL, getLabels(secret))
         .build(),
+      new PatchBuilder('/data').setObjectRemove(V2V_DATA_TTL_KEY, secret?.data).build(),
     );
     const ownerReferences = getOwnerReferences(secret);
     if (ownerReferences) {


### PR DESCRIPTION
https://github.com/openshift/console/pull/6296 will cause backend to react to our secrets and mark them for deletion.

it should be ensured that secrets which were requested to be saved are preserved