### PR TITLE
Bug 1866085: Ensure we not submit an invalid selector on label search

### DIFF
--- a/frontend/public/components/search-filter-dropdown.tsx
+++ b/frontend/public/components/search-filter-dropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
+import { Dropdown, DropdownToggle, DropdownItem, Tooltip } from '@patternfly/react-core';
 import { CaretDownIcon, FilterIcon } from '@patternfly/react-icons';
 import { TextFilter } from './factory';
 
@@ -12,7 +12,7 @@ export const SearchFilterDropdown: React.SFC<SearchFilterDropdownProps> = (props
   const [isOpen, setOpen] = React.useState(false);
   const [selected, setSelected] = React.useState(searchFilterValues.Label);
 
-  const { onChange, nameFilterInput, labelFilterInput } = props;
+  const { onChange, nameFilterInput, labelFilterInput, validated, validationMsg } = props;
 
   const onToggle = (open: boolean) => setOpen(open);
   const onSelect = (event: React.SyntheticEvent) => {
@@ -52,16 +52,23 @@ export const SearchFilterDropdown: React.SFC<SearchFilterDropdownProps> = (props
         isOpen={isOpen}
         dropdownItems={dropdownItems}
       />
-      <TextFilter
-        parentClassName="co-search__filter-input"
-        onChange={handleInputValue}
-        placeholder={selected === searchFilterValues.Label ? 'app=frontend' : 'my-resource'}
-        name="search-filter-input"
-        id="search-filter-input"
-        value={selected === searchFilterValues.Label ? labelFilterInput : nameFilterInput}
-        onKeyDown={handleKeyDown}
-        aria-labelledby="toggle-id"
-      />
+      <Tooltip
+        content={validationMsg}
+        isVisible={!!validationMsg}
+        trigger={validationMsg ? 'mouseenter focus' : 'manual'}
+      >
+        <TextFilter
+          parentClassName="co-search__filter-input"
+          onChange={handleInputValue}
+          placeholder={selected === searchFilterValues.Label ? 'app=frontend' : 'my-resource'}
+          name="search-filter-input"
+          id="search-filter-input"
+          value={selected === searchFilterValues.Label ? labelFilterInput : nameFilterInput}
+          onKeyDown={handleKeyDown}
+          aria-labelledby="toggle-id"
+          validated={validated}
+        />
+      </Tooltip>
     </div>
   );
 };
@@ -70,4 +77,6 @@ export type SearchFilterDropdownProps = {
   onChange: (type: string, value: string, endOfString: boolean) => void;
   nameFilterInput: string;
   labelFilterInput: string;
+  validated?: string;
+  validationMsg?: string;
 };

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -12,6 +12,7 @@ import {
   ToolbarContent,
   ToolbarFilter,
   ToolbarItem,
+  ValidatedOptions,
 } from '@patternfly/react-core';
 import { PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { getBadgeFromType } from '@console/shared';
@@ -82,6 +83,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
   const [collapsedKinds, setCollapsedKinds] = React.useState(new Set<string>([]));
   const [labelFilter, setLabelFilter] = React.useState([]);
   const [labelFilterInput, setLabelFilterInput] = React.useState('');
+  const [labelFilterInputError, setLabelFilterInputError] = React.useState(false);
   const [typeaheadNameFilter, setTypeaheadNameFilter] = React.useState('');
   const { namespace, noProjectsAvailable, pinnedResources } = props;
 
@@ -160,17 +162,21 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
   };
 
   const updateNameFilter = (value: string) => {
+    setLabelFilterInputError(false);
     setTypeaheadNameFilter(value);
     setQueryArgument('name', value);
   };
 
   const updateLabelFilter = (value: string, endOfString: boolean) => {
     setLabelFilterInput(value);
+    setLabelFilterInputError(false);
     if (requirementFromString(value) !== undefined && endOfString) {
       const updatedLabels = _.uniq([...labelFilter, value]);
       setLabelFilter(updatedLabels);
       setQueryArgument('q', updatedLabels.join(','));
       setLabelFilterInput('');
+    } else if (requirementFromString(value) === undefined && endOfString) {
+      setLabelFilterInputError(true);
     }
   };
 
@@ -248,6 +254,12 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
                     onChange={updateSearchFilter}
                     nameFilterInput={typeaheadNameFilter}
                     labelFilterInput={labelFilterInput}
+                    validated={labelFilterInputError ? ValidatedOptions.error : ''}
+                    validationMsg={
+                      labelFilterInputError
+                        ? 'Label must start and end with alphanumeric characters.'
+                        : ''
+                    }
                   />
                 </ToolbarFilter>
               </ToolbarFilter>

--- a/frontend/public/module/k8s/selector-requirement.js
+++ b/frontend/public/module/k8s/selector-requirement.js
@@ -8,42 +8,40 @@ export const createEquals = (key, value) => ({
   values: [value],
 });
 
+const validateKey = (key) => /^(([A-Za-z0-9][0-9A-Za-z/\-_.]*)?[A-Za-z0-9])$/.test(key);
+
 export const requirementFromString = (string) => {
   string = string.trim();
 
   // "key"
   if (/^[0-9A-Za-z/\-_.]+$/.test(string)) {
-    return {
-      key: string,
-      operator: 'Exists',
-      values: [],
-    };
+    if (validateKey(string)) {
+      return { key: string, operator: 'Exists', values: [] };
+    }
   }
 
   // "!key"
   if (/^!\s*[0-9A-Za-z/\-_.]+$/.test(string)) {
-    return {
-      key: string.split(/!\s*/)[1],
-      operator: 'DoesNotExist',
-      values: [],
-    };
+    const key = string.split(/!\s*/)[1];
+    if (validateKey(key)) {
+      return { key, operator: 'DoesNotExist', values: [] };
+    }
   }
 
   // "key=value" OR "key==value"
   if (/^[0-9A-Za-z/\-_.]+\s*==?\s*[0-9A-Za-z/\-_.]+$/.test(string)) {
-    const parts = string.split(/\s*==?\s*/);
-    const key = parts[0];
-    const value = parts[1];
-    return createEquals(key, value);
+    const [key, value] = string.split(/\s*==?\s*/);
+    if (validateKey(key)) {
+      return { key, operator: 'Equals', values: [value] };
+    }
   }
 
   // "key!=value"
   if (/^[0-9A-Za-z/\-_.]+\s*!=\s*[0-9A-Za-z/\-_.]+$/.test(string)) {
-    return {
-      key: string.split(/\s*!=\s*/)[0],
-      operator: 'NotEquals',
-      values: [string.split(/\s*!=\s*/)[1]],
-    };
+    const [key, value] = string.split(/\s*!=?\s*/);
+    if (validateKey(key)) {
+      return { key, operator: 'NotEquals', values: [value] };
+    }
   }
 
   // "key in (value1[,value2,...])"
@@ -54,12 +52,9 @@ export const requirementFromString = (string) => {
       .slice(1, -1)
       .split(',')
       .map(_.trim);
-
-    return {
-      key,
-      operator: 'In',
-      values,
-    };
+    if (validateKey(key)) {
+      return { key, operator: 'In', values };
+    }
   }
 
   // "key notin (value1[,value2,...])"
@@ -70,38 +65,25 @@ export const requirementFromString = (string) => {
       .slice(1, -1)
       .split(',')
       .map(_.trim);
-
-    return {
-      key,
-      operator: 'NotIn',
-      values,
-    };
+    if (validateKey(key)) {
+      return { key, operator: 'NotIn', values };
+    }
   }
 
   // "key > value1"
   if (/^[0-9A-Za-z/\-_.]+\s+>\s+[0-9.]+$/.test(string)) {
-    const parts = string.split(/\s+>\s+/);
-    const key = parts[0];
-    const value = parts[1];
-
-    return {
-      key,
-      operator: 'GreaterThan',
-      values: [value],
-    };
+    const [key, value] = string.split(/\s+>\s+/);
+    if (validateKey(key)) {
+      return { key, operator: 'GreaterThan', values: [value] };
+    }
   }
 
   // "key < value1"
   if (/^[0-9A-Za-z/\-_.]+\s+<\s+[0-9.]+$/.test(string)) {
-    const parts = string.split(/\s+<\s+/);
-    const key = parts[0];
-    const value = parts[1];
-
-    return {
-      key,
-      operator: 'LessThan',
-      values: [value],
-    };
+    const [key, value] = string.split(/\s+<\s+/);
+    if (validateKey(key)) {
+      return { key, operator: 'LessThan', values: [value] };
+    }
   }
 
   return; // falsy means parsing failure


### PR DESCRIPTION
We have a bug where we do not verify that the selector string for the label search ends in alphanumeric (0-9A-z). This is updated for `key`,`!key`, `key==val`, and `key!=val`.