### PR TITLE
Bug 1843532: Fix VM import status reporting for CDI imports

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/connected-vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/connected-vm-console/connected-vm-console.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
-import { PodModel, ServiceModel } from '@console/internal/models';
+import { K8sResourceKind, PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
+import { PersistentVolumeClaimModel, PodModel, ServiceModel } from '@console/internal/models';
 import { getVMStatus } from '../../statuses/vm/vm-status';
 import { VMImportKind } from '../../types/vm-import/ovirt/vm-import';
 import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
@@ -24,6 +24,7 @@ const ConnectedVMConsole: React.FC<ConnectedVMConsoleProps> = ({
   vmis,
   pods,
   migrations,
+  pvcs,
   dataVolumes,
   vmImports,
 }) => {
@@ -31,6 +32,7 @@ const ConnectedVMConsole: React.FC<ConnectedVMConsoleProps> = ({
   const loadedVMIs = getLoadedData(vmis);
   const loadedPods = getLoadedData(pods);
   const loadedMigrations = getLoadedData(migrations);
+  const loadedPVCs = getLoadedData(pvcs);
   const loadedDataVolumes = getLoadedData(dataVolumes);
   const loadedImports = getLoadedData(vmImports);
   const vmi = loadedVMIs?.[0];
@@ -40,6 +42,7 @@ const ConnectedVMConsole: React.FC<ConnectedVMConsoleProps> = ({
     vmi,
     pods: loadedPods,
     migrations: loadedMigrations,
+    pvcs: loadedPVCs,
     dataVolumes: loadedDataVolumes,
     vmImports: loadedImports,
   });
@@ -62,6 +65,7 @@ type ConnectedVMConsoleProps = {
   vmis?: FirehoseResult<VMIKind[]>;
   pods?: FirehoseResult<PodKind[]>;
   migrations?: FirehoseResult<K8sResourceKind[]>;
+  pvcs?: FirehoseResult<PersistentVolumeClaimKind[]>;
   dataVolumes?: FirehoseResult<V1alpha1DataVolume[]>;
   vmImports?: FirehoseResult<VMImportKind[]>;
   services?: FirehoseResult;
@@ -106,6 +110,12 @@ const FirehoseVMConsole: React.FC<FirehoseVMConsoleProps> = ({
       namespace,
       prop: 'vmImports',
       optional: true,
+    },
+    {
+      kind: PersistentVolumeClaimModel.kind,
+      isList: true,
+      namespace,
+      prop: 'pvcs',
     },
     {
       kind: DataVolumeModel.kind,

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/overview-dashboard/inventory.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/overview-dashboard/inventory.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { OffIcon } from '@patternfly/react-icons';
 import { getNamespace } from '@console/shared/src/selectors/common';
 import { createBasicLookup } from '@console/shared/src/utils/utils';
-import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
 import { StatusGroupMapper } from '@console/shared/src/components/dashboard/inventory-card/InventoryItem';
 import { InventoryStatusGroup } from '@console/shared/src/components/dashboard/inventory-card/status-group';
 import { getVMStatus } from '../../../statuses/vm/vm-status';
@@ -25,11 +25,13 @@ export const getVMStatusGroups: StatusGroupMapper = (
     vmis,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   }: {
     vmis?: VMIKind[];
     pods?: PodKind[];
+    pvcs?: PersistentVolumeClaimKind[];
     dataVolumes?: V1alpha1DataVolume[];
     migrations?: K8sResourceKind[];
     vmImports?: VMImportKind[];
@@ -113,6 +115,7 @@ export const getVMStatusGroups: StatusGroupMapper = (
         vmi,
         pods,
         migrations,
+        pvcs,
         dataVolumes,
         vmImports,
       }).status.getSimpleLabel();

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -238,6 +238,7 @@ export const VMDisksAndFileSystemsPage: React.FC<VMTabProps> = ({
   vmImports,
   pods,
   migrations,
+  pvcs,
   dataVolumes,
   customData: { kindObj },
 }) => {
@@ -270,6 +271,7 @@ export const VMDisksAndFileSystemsPage: React.FC<VMTabProps> = ({
     vmi,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   });

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -1,7 +1,12 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import { asAccessReview, Kebab, KebabOption } from '@console/internal/components/utils';
-import { K8sKind, K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import {
+  K8sKind,
+  K8sResourceKind,
+  PersistentVolumeClaimKind,
+  PodKind,
+} from '@console/internal/module/k8s';
 import { getName, getNamespace, YellowExclamationTriangleIcon } from '@console/shared';
 import { confirmModal } from '@console/internal/components/modals';
 import { VMIKind, VMKind } from '../../types/vm';
@@ -300,6 +305,7 @@ export type ExtraResources = {
   vmis: VMIKind[];
   pods: PodKind[];
   migrations: K8sResourceKind[];
+  pvcs?: PersistentVolumeClaimKind[];
   dataVolumes: V1alpha1DataVolume[];
   vmImports: VMImportKind[];
 };
@@ -307,10 +313,10 @@ export type ExtraResources = {
 export const vmMenuActionsCreator = (
   kindObj: K8sKind,
   vm: VMKind,
-  { vmis, pods, migrations, vmImports, dataVolumes }: ExtraResources,
+  { vmis, pods, migrations, vmImports, pvcs, dataVolumes }: ExtraResources,
 ) => {
   const vmi = vmis && vmis[0];
-  const vmStatusBundle = getVMStatus({ vm, vmi, pods, migrations, dataVolumes, vmImports });
+  const vmStatusBundle = getVMStatus({ vm, vmi, pods, migrations, pvcs, dataVolumes, vmImports });
 
   return vmMenuActions.map((action) => {
     return action(kindObj, vm, { vmi, vmStatusBundle });

--- a/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
@@ -1,4 +1,10 @@
-import { K8sKind, K8sResourceKind, PodKind, TemplateKind } from '@console/internal/module/k8s';
+import {
+  K8sKind,
+  K8sResourceKind,
+  PersistentVolumeClaimKind,
+  PodKind,
+  TemplateKind,
+} from '@console/internal/module/k8s';
 import { VMIKind, VMKind } from '../../types/vm';
 import { VMGenericLikeEntityKind, VMILikeEntityKind } from '../../types/vmLike';
 import { VMImportKind } from '../../types/vm-import/ovirt/vm-import';
@@ -29,6 +35,7 @@ export type VMTabProps = {
   pods?: PodKind[];
   migrations?: K8sResourceKind[];
   templates?: TemplateKind[];
+  pvcs?: PersistentVolumeClaimKind[];
   dataVolumes?: V1alpha1DataVolume[];
   vmImports?: VMImportKind[];
   customData: {

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -194,6 +194,7 @@ export const VMConsoleFirehose: React.FC<VMTabProps> = ({
   vmImports,
   pods,
   migrations,
+  pvcs,
   dataVolumes,
   customData: { kindObj },
   showOpenInNewWindow,
@@ -215,6 +216,7 @@ export const VMConsoleFirehose: React.FC<VMTabProps> = ({
     vmi,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   });

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
@@ -25,6 +25,7 @@ export const VMDashboard: React.FC<VMTabProps> = (props) => {
     vmis: vmisProp,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   } = props;
@@ -37,6 +38,7 @@ export const VMDashboard: React.FC<VMTabProps> = (props) => {
     vmi,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   });

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { navFactory } from '@console/internal/components/utils';
 import { DetailsPage } from '@console/internal/components/factory';
-import { PodModel, TemplateModel } from '@console/internal/models';
+import { PersistentVolumeClaimModel, PodModel, TemplateModel } from '@console/internal/models';
 import { VMDisksAndFileSystemsPage } from '../vm-disks/vm-disks';
 import {
   DataVolumeModel,
@@ -120,6 +120,12 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
       namespace,
       prop: 'vmImports',
       optional: true,
+    },
+    {
+      kind: PersistentVolumeClaimModel.kind,
+      isList: true,
+      namespace,
+      prop: 'pvcs',
     },
     {
       kind: DataVolumeModel.kind,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
@@ -36,6 +36,7 @@ export const VMDetailsFirehose: React.FC<VMTabProps> = ({
   pods,
   migrations,
   templates,
+  pvcs,
   dataVolumes,
   customData: { kindObj },
 }) => {
@@ -57,6 +58,7 @@ export const VMDetailsFirehose: React.FC<VMTabProps> = ({
     vmi,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   });

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -16,7 +16,12 @@ import {
   getLabels,
 } from '@console/shared';
 import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
-import { NamespaceModel, PodModel, NodeModel } from '@console/internal/models';
+import {
+  NamespaceModel,
+  PodModel,
+  NodeModel,
+  PersistentVolumeClaimModel,
+} from '@console/internal/models';
 import {
   Table,
   MultiListPage,
@@ -31,7 +36,7 @@ import {
   ResourceLink,
   Timestamp,
 } from '@console/internal/components/utils';
-import { K8sKind, PodKind } from '@console/internal/module/k8s';
+import { K8sKind, PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
 import { VMStatus } from '../vm-status/vm-status';
 import {
   DataVolumeModel,
@@ -226,6 +231,12 @@ const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
       prop: 'migrations',
     },
     {
+      kind: PersistentVolumeClaimModel.kind,
+      isList: true,
+      namespace,
+      prop: 'pvcs',
+    },
+    {
       kind: DataVolumeModel.kind,
       isList: true,
       namespace,
@@ -245,6 +256,7 @@ const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
     vmis,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   }: {
@@ -252,6 +264,7 @@ const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
     vmis: FirehoseResult<VMIKind[]>;
     pods: FirehoseResult<PodKind[]>;
     migrations: FirehoseResult;
+    pvcs: FirehoseResult<PersistentVolumeClaimKind[]>;
     dataVolumes: FirehoseResult<V1alpha1DataVolume[]>;
     vmImports: FirehoseResult<VMImportKind[]>;
   }) => {
@@ -260,6 +273,7 @@ const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
     const loadedPods = getLoadedData(pods);
     const loadedMigrations = getLoadedData(migrations);
     const loadedVMImports = getLoadedData(vmImports);
+    const loadedPVCs = getLoadedData(pvcs);
     const loadedDataVolumes = getLoadedData(dataVolumes);
     const isVMImportLoaded = !vmImports || vmImports.loaded || vmImports.loadError; // go in when CRD missing or no permissions
 
@@ -323,6 +337,7 @@ const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
             vmi: objectBundle.vmi,
             pods: loadedPods,
             migrations: loadedMigrations,
+            pvcs: loadedPVCs,
             dataVolumes: loadedDataVolumes,
             vmImports: loadedVMImports,
           });

--- a/frontend/packages/kubevirt-plugin/src/constants/cdi.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/cdi.ts
@@ -1,2 +1,3 @@
 export const CDI_KUBEVIRT_IO = 'cdi.kubevirt.io';
-export const STORAGE_IMPORT_PVC_NAME = 'storage.import.importPvcName';
+export const STORAGE_IMPORT_POD_NAME = 'storage.import.importPodName';
+export const STORAGE_IMPORT_POD_LABEL = `${CDI_KUBEVIRT_IO}/${STORAGE_IMPORT_POD_NAME}`;

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -23,7 +23,7 @@ import {
   PVCStatus,
 } from '@console/plugin-sdk';
 import { DashboardsStorageCapacityDropdownItem } from '@console/ceph-storage-plugin';
-import { TemplateModel, PodModel } from '@console/internal/models';
+import { TemplateModel, PodModel, PersistentVolumeClaimModel } from '@console/internal/models';
 import { getName } from '@console/shared/src/selectors/common';
 import { AddAction } from '@console/dev-console/src/extensions/add-actions';
 import { FirehoseResource } from '@console/internal/components/utils';
@@ -101,6 +101,12 @@ const virtualMachineConfigurations = (namespace: string): FirehoseResource[] => 
       namespace,
       prop: 'migrations',
       optional: true,
+    },
+    {
+      isList: true,
+      optional: true,
+      kind: PersistentVolumeClaimModel.kind,
+      prop: 'pvcs',
     },
     {
       isList: true,
@@ -333,6 +339,11 @@ const plugin: Plugin<ConsumedExtensions> = [
           isList: true,
           kind: models.VirtualMachineInstanceMigrationModel.kind,
         },
+        pvcs: {
+          isList: true,
+          kind: PersistentVolumeClaimModel.kind,
+          optional: true,
+        },
         dataVolumes: {
           kind: models.DataVolumeModel.kind,
           isList: true,
@@ -404,6 +415,12 @@ const plugin: Plugin<ConsumedExtensions> = [
           isList: true,
           kind: models.VirtualMachineInstanceMigrationModel.kind,
           prop: 'migrations',
+        },
+        {
+          isList: true,
+          optional: true,
+          kind: PersistentVolumeClaimModel.kind,
+          prop: 'pvcs',
         },
         {
           isList: true,

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -1,17 +1,14 @@
 import { get } from 'lodash';
 import { getName, getNamespace, getOwnerReferences, getUID } from '@console/shared/src/selectors';
 import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
-import { PodKind } from '@console/internal/module/k8s';
-import { getLabelValue } from '../selectors';
+import { createBasicLookup } from '@console/shared/src/utils/utils';
+import { PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
 import { VMKind, VMIKind } from '../../types';
-import { getDataVolumeTemplates } from '../vm';
-import {
-  CDI_KUBEVIRT_IO,
-  STORAGE_IMPORT_PVC_NAME,
-  VIRT_LAUNCHER_POD_PREFIX,
-} from '../../constants';
+import { VIRT_LAUNCHER_POD_PREFIX } from '../../constants';
 import { buildOwnerReferenceForModel } from '../../utils';
 import { VirtualMachineInstanceModel } from '../../models';
+import { getPvcImportPodName } from '../pvc/selectors';
+import { getDataVolumeTemplates } from '../vm';
 
 export const getHostName = (pod: PodKind) =>
   get(pod, 'spec.hostname') as PodKind['spec']['hostname'];
@@ -77,7 +74,7 @@ export const findVMIPod = (
     );
   });
 
-  // Return the newet most ready Pod created
+  // Return the newest, most ready Pod created
   return prefixedPods
     .sort((a: PodKind, b: PodKind) =>
       a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
@@ -85,23 +82,29 @@ export const findVMIPod = (
     .sort((a: PodKind) => (isPodReady(a) ? -1 : 1))[0];
 };
 
-export const getVMImporterPods = (
+export const getPVCNametoImporterPodsMapForVM = (
   vm: VMKind,
   pods?: PodKind[],
-  pvcNameLabel = `${CDI_KUBEVIRT_IO}/${STORAGE_IMPORT_PVC_NAME}`,
+  pvcs?: PersistentVolumeClaimKind[],
 ) => {
   if (!pods) {
     return null;
   }
 
-  const datavolumeNames = getDataVolumeTemplates(vm)
-    .map((dataVolumeTemplate) => getName(dataVolumeTemplate))
-    .filter((dataVolumeTemplate) => dataVolumeTemplate);
+  const dataVolumeNames = getDataVolumeTemplates(vm).reduce((dataVolumeNameAcc, dvTemplate) => {
+    const dataVolumeName = getName(dvTemplate);
+    if (dataVolumeName) {
+      dataVolumeNameAcc.add(dataVolumeName);
+    }
+    return dataVolumeNameAcc;
+  }, new Set()) as Set<string>;
 
-  return pods.filter(
-    (p) =>
-      getNamespace(p) === getNamespace(vm) &&
-      getLabelValue(p, CDI_KUBEVIRT_IO) === 'importer' &&
-      datavolumeNames.some((name) => getLabelValue(p, pvcNameLabel) === name),
-  );
+  const vmPVCs = pvcs?.filter((pvc) => dataVolumeNames?.has(getName(pvc)));
+
+  const podLookup = createBasicLookup(pods, getName);
+
+  return (vmPVCs || []).reduce((podsMap, pvc) => {
+    podsMap[getName(pvc)] = podLookup[getPvcImportPodName(pvc)];
+    return podsMap;
+  }, {});
 };

--- a/frontend/packages/kubevirt-plugin/src/selectors/pvc/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pvc/selectors.ts
@@ -5,6 +5,7 @@ import {
   CDI_UPLOAD_POD_ANNOTATION,
   CDI_UPLOAD_POD_NAME_ANNOTATION,
 } from '../../components/cdi-upload-provider/consts';
+import { STORAGE_IMPORT_POD_LABEL } from '../../constants';
 
 export const getPvcResources = (pvc) => _.get(pvc, 'spec.resources');
 
@@ -13,6 +14,8 @@ export const getPvcStorageSize = (pvc): string => getStorageSize(getPvcResources
 export const getPvcAccessModes = (pvc) => _.get(pvc, 'spec.accessModes');
 export const getPvcVolumeMode = (pvc) => _.get(pvc, 'spec.volumeMode');
 export const getPvcStorageClassName = (pvc): string => _.get(pvc, 'spec.storageClassName');
+
+export const getPvcImportPodName = (pvc) => getAnnotation(pvc, STORAGE_IMPORT_POD_LABEL);
 
 // upload pvc selectors
 export const getPvcUploadPodName = (pvc) => getAnnotation(pvc, CDI_UPLOAD_POD_NAME_ANNOTATION);

--- a/frontend/packages/kubevirt-plugin/src/selectors/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/selectors.ts
@@ -7,21 +7,8 @@ export const getKind = (value) => _.get(value, 'kind') as K8sResourceKind['kind'
 export const getGeneratedName = (value) =>
   _.get(value, 'metadata.generateName') as K8sResourceKind['metadata']['generateName'];
 
-export const getLabels = (entity: K8sResourceKind, defaultValue?: any) =>
-  _.get(entity, 'metadata.labels', defaultValue) as K8sResourceKind['metadata']['labels'];
-export const getAnnotations = (vm: VMGenericLikeEntityKind, defaultValue?: any) =>
-  _.get(vm, 'metadata.annotations', defaultValue);
-export const getAnnotation = (
-  vm: VMGenericLikeEntityKind,
-  annotationName: string,
-  defaultValue?: any,
-) => _.get(vm, ['metadata', 'annotations', annotationName], defaultValue);
-
 export const getDescription = (vm: VMGenericLikeEntityKind) =>
   _.get(vm, 'metadata.annotations.description');
-
-export const getLabelValue = (entity: K8sResourceKind, label: string): string =>
-  _.get(entity, ['metadata', 'labels', label]);
 
 export const getStorageSize = (value): string => _.get(value, 'requests.storage');
 
@@ -29,6 +16,25 @@ export const getValueByPrefix = (obj = {}, keyPrefix: string): string => {
   const objectKey = Object.keys(obj).find((key) => key.startsWith(keyPrefix));
   return objectKey ? obj[objectKey] : null;
 };
+
+// Labels
+export const getLabels = (entity: K8sResourceKind, defaultValue?: { [key: string]: string }) =>
+  _.get(entity, 'metadata.labels', defaultValue) as K8sResourceKind['metadata']['labels'];
+
+export const getLabelValue = (entity: K8sResourceKind, label: string): string =>
+  _.get(entity, ['metadata', 'labels', label]);
+
+// Annotations
+export const getAnnotations = (
+  vm: VMGenericLikeEntityKind,
+  defaultValue?: { [key: string]: string },
+): { [key: string]: string } => _.get(vm, 'metadata.annotations', defaultValue);
+
+export const getAnnotation = (
+  entity: K8sResourceKind,
+  annotationName: string,
+  defaultValue?: string,
+): string => _.get(entity, ['metadata', 'annotations', annotationName], defaultValue);
 
 export const getAnnotationKeySuffix = (
   entity: K8sResourceKind,

--- a/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
@@ -1,6 +1,7 @@
 import {
   apiVersionForModel,
   K8sResourceKind,
+  PersistentVolumeClaimKind,
   PodKind,
   referenceFor,
 } from '@console/internal/module/k8s';
@@ -84,6 +85,7 @@ const createTopologyVMNodeData = (
   const vmi = vmis.find((instance) => instance.metadata.name === name) as VMIKind;
   const pods = resources.pods?.data as PodKind[];
   const migrations = resources.migrations?.data;
+  const pvcs = resources.pvcs?.data as PersistentVolumeClaimKind[];
   const dataVolumes = resources.dataVolumes?.data as V1alpha1DataVolume[];
   const vmImports = resources.vmImports?.data as VMImportKind[];
 
@@ -92,6 +94,7 @@ const createTopologyVMNodeData = (
     vmi,
     pods,
     migrations,
+    pvcs,
     dataVolumes,
     vmImports,
   });


### PR DESCRIPTION
Status reporting was broken for VMs that are pending for in progress CDI imports due to the removal of the `cdi.kubevirt.io/storage.import.importPvcName` label on data volumes. This PR fixes the reporting status.