### PR TITLE
Bug 1867900: Fixed  incorrect node name in the nodeSelector while creating Auto Discovery CR

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -21,7 +21,11 @@ import {
   LABEL_OPERATOR,
   AUTO_DISCOVER_ERR_MSG,
 } from '@console/local-storage-operator-plugin/src/constants';
-import { getNodes, getLabelIndex } from '@console/local-storage-operator-plugin/src/utils';
+import {
+  getNodes,
+  getLabelIndex,
+  getHostNames,
+} from '@console/local-storage-operator-plugin/src/utils';
 import {
   DiskMechanicalProperty,
   DiskType,
@@ -59,7 +63,8 @@ const makeAutoDiscoveryCall = (
             expIndex
           ]?.values,
         );
-        selectedNodes.forEach((name) => nodes.add(name));
+        const hostNames = getHostNames(selectedNodes, state.hostNamesMapForADV);
+        hostNames.forEach((name) => nodes.add(name));
         const patch = [
           {
             op: 'replace',
@@ -138,6 +143,11 @@ const CreateSC: React.FC<CreateSCProps> = ({ match }) => {
     state.showNodesListOnADV,
     state.allNodeNamesOnADV,
   ]);
+
+  React.useEffect(() => {
+    // this is required to set the hostnames for LVS too
+    dispatch({ type: 'setHostNamesMapForLVS', value: state.hostNamesMapForADV });
+  }, [state.hostNamesMapForADV]);
 
   const steps = [
     {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
@@ -1,3 +1,4 @@
+import { HostNamesMap } from '@console/local-storage-operator-plugin/src/components/auto-detect-volume/types';
 import { diskTypeDropdownItems, diskModeDropdownItems } from '../../../../constants';
 
 export const initialState: State = {
@@ -5,6 +6,7 @@ export const initialState: State = {
   showNodesListOnADV: false,
   nodeNamesForLVS: [], // nodes selected on discovery step, used in LVS step
   allNodeNamesOnADV: [], // all nodes present in the env
+  hostNamesMapForADV: {},
 
   // states for step 2
   volumeSetName: '',
@@ -18,6 +20,7 @@ export const initialState: State = {
   maxDiskSize: '',
   diskSizeUnit: 'TiB',
   isValidMaxSize: true,
+  hostNamesMapForLVS: {},
   // states for chart
   nodesDiscoveries: [],
   filteredDiscoveries: [],
@@ -77,6 +80,8 @@ export type State = {
   filteredDiscoveries: Discoveries[];
   finalStep: boolean;
   showDiskList: boolean;
+  hostNamesMapForADV: HostNamesMap;
+  hostNamesMapForLVS: HostNamesMap;
 };
 
 export type Action =
@@ -105,7 +110,9 @@ export type Action =
   | { type: 'setOnNextClick'; value: OnNextClick }
   | { type: 'setFilteredDiscoveries'; value: Discoveries[] }
   | { type: 'setFinalStep'; value: boolean }
-  | { type: 'setShowDiskList'; value: boolean };
+  | { type: 'setShowDiskList'; value: boolean }
+  | { type: 'setHostNamesMapForADV'; value: HostNamesMap }
+  | { type: 'setHostNamesMapForLVS'; value: HostNamesMap };
 
 export const reducer = (state: State, action: Action) => {
   switch (action.type) {
@@ -159,6 +166,10 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { finalStep: action.value });
     case 'setShowDiskList':
       return Object.assign({}, state, { showDiskList: action.value });
+    case 'setHostNamesMapForADV':
+      return Object.assign({}, state, { hostNamesMapForADV: action.value });
+    case 'setHostNamesMapForLVS':
+      return Object.assign({}, state, { hostNamesMapForLVS: action.value });
     default:
       return initialState;
   }

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume-inner.tsx
@@ -7,7 +7,7 @@ import { getName } from '@console/shared';
 import { NodeModel } from '@console/internal/models';
 import { NodesSelectionList } from '../local-volume-set/nodes-selection-list';
 import { State, Action } from './state';
-import { hasTaints } from '../../utils';
+import { hasTaints, createMapForHostNames } from '../../utils';
 import { nodeResource } from '../../constants/resources';
 import './auto-detect-volume.scss';
 
@@ -22,7 +22,9 @@ export const AutoDetectVolumeInner: React.FC<AutoDetectVolumeInnerProps> = ({
       dispatch({ type: 'setAllNodeNamesOnADV', value: [] });
     } else if (nodeLoaded) {
       const names = nodeData.filter((node) => !hasTaints(node)).map((node) => getName(node));
+      const hostNames = createMapForHostNames(nodeData);
       dispatch({ type: 'setAllNodeNamesOnADV', value: names });
+      dispatch({ type: 'setHostNamesMapForADV', value: hostNames });
     }
   }, [dispatch, nodeData, nodeLoaded, nodeLoadError]);
 

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
@@ -4,16 +4,20 @@ import { ActionGroup, Button, Form } from '@patternfly/react-core';
 import {
   resourcePathFromModel,
   BreadCrumbs,
-  resourceObjPath,
   withHandlePromise,
   HandlePromiseProps,
   ButtonBar,
 } from '@console/internal/components/utils';
 import { history } from '@console/internal/components/utils/router';
-import { k8sCreate, k8sPatch, referenceFor, K8sResourceKind } from '@console/internal/module/k8s';
+import {
+  k8sCreate,
+  k8sPatch,
+  referenceForModel,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
 import { fetchK8s } from '@console/internal/graphql/client';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
-import { getNodes, getLabelIndex } from '../../utils';
+import { getNodes, getLabelIndex, getHostNames } from '../../utils';
 import { AutoDetectVolumeInner, AutoDetectVolumeHeader } from './auto-detect-volume-inner';
 import { getDiscoveryRequestData } from './discovery-request-data';
 import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
@@ -43,7 +47,7 @@ const AutoDetectVolume: React.FC = withHandlePromise<AutoDetectVolumeProps & Han
               ? getLabelIndex(nodeSelectorTerms, HOSTNAME_LABEL_KEY, LABEL_OPERATOR)
               : [-1, -1];
             if (selectorIndex !== -1 && expIndex !== -1) {
-              const nodes = new Set(
+              const nodes = new Set<string>(
                 discoveryRes?.spec?.nodeSelector?.nodeSelectorTerms?.[
                   selectorIndex
                 ]?.matchExpressions?.[expIndex]?.values,
@@ -53,7 +57,8 @@ const AutoDetectVolume: React.FC = withHandlePromise<AutoDetectVolumeProps & Han
                 state.allNodeNamesOnADV,
                 state.nodeNamesForLVS,
               );
-              selectedNodes.forEach((name) => nodes.add(name));
+              const hostNames = getHostNames(selectedNodes, state.hostNamesMapForADV);
+              hostNames.forEach((name) => nodes.add(name));
               const patch = [
                 {
                   op: 'replace',
@@ -74,7 +79,13 @@ const AutoDetectVolume: React.FC = withHandlePromise<AutoDetectVolumeProps & Han
             return k8sCreate(AutoDetectVolumeModel, requestData);
           })
           // eslint-disable-next-line promise/catch-or-return
-          .then((resource) => history.push(resourceObjPath(resource, referenceFor(resource)))),
+          .then(() =>
+            history.push(
+              `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(
+                AutoDetectVolumeModel,
+              )}/${DISCOVERY_CR_NAME}`,
+            ),
+          ),
       );
     };
 

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
@@ -6,36 +6,42 @@ import {
   HOSTNAME_LABEL_KEY,
   LABEL_OPERATOR,
 } from '../../constants';
-import { getNodes } from '../../utils';
+import { getNodes, getHostNames } from '../../utils';
+import { HostNamesMap } from './types';
 
 export const getDiscoveryRequestData = ({
   nodeNamesForLVS,
   allNodeNamesOnADV,
   showNodesListOnADV,
+  hostNamesMapForADV,
 }: {
   nodeNamesForLVS: string[];
   allNodeNamesOnADV: string[];
   showNodesListOnADV: boolean;
-}): AutoDetectVolumeKind => ({
-  apiVersion: apiVersionForModel(AutoDetectVolumeModel),
-  kind: AutoDetectVolumeModel.kind,
-  metadata: { name: DISCOVERY_CR_NAME, namespace: LOCAL_STORAGE_NAMESPACE },
-  spec: {
-    nodeSelector: {
-      nodeSelectorTerms: [
-        {
-          matchExpressions: [
-            {
-              key: HOSTNAME_LABEL_KEY,
-              operator: LABEL_OPERATOR,
-              values: getNodes(showNodesListOnADV, allNodeNamesOnADV, nodeNamesForLVS),
-            },
-          ],
-        },
-      ],
+  hostNamesMapForADV: HostNamesMap;
+}): AutoDetectVolumeKind => {
+  const nodes = getNodes(showNodesListOnADV, allNodeNamesOnADV, nodeNamesForLVS);
+  return {
+    apiVersion: apiVersionForModel(AutoDetectVolumeModel),
+    kind: AutoDetectVolumeModel.kind,
+    metadata: { name: DISCOVERY_CR_NAME, namespace: LOCAL_STORAGE_NAMESPACE },
+    spec: {
+      nodeSelector: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              {
+                key: HOSTNAME_LABEL_KEY,
+                operator: LABEL_OPERATOR,
+                values: getHostNames(nodes, hostNamesMapForADV),
+              },
+            ],
+          },
+        ],
+      },
     },
-  },
-});
+  };
+};
 
 type AutoDetectVolumeKind = K8sResourceCommon & {
   spec: {

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/state.ts
@@ -1,19 +1,24 @@
+import { HostNamesMap } from './types';
+
 export const initialState = {
   showNodesListOnADV: false,
   nodeNamesForLVS: [],
   allNodeNamesOnADV: [],
+  hostNamesMapForADV: {},
 };
 
 export type State = {
   showNodesListOnADV: boolean;
   nodeNamesForLVS: string[];
   allNodeNamesOnADV: string[];
+  hostNamesMapForADV: HostNamesMap;
 };
 
 export type Action =
   | { type: 'setShowNodesListOnADV'; value: boolean }
   | { type: 'setNodeNamesForLVS'; value: string[] }
-  | { type: 'setAllNodeNamesOnADV'; value: string[] };
+  | { type: 'setAllNodeNamesOnADV'; value: string[] }
+  | { type: 'setHostNamesMapForADV'; value: HostNamesMap };
 
 export const reducer = (state: State, action: Action) => {
   switch (action.type) {
@@ -23,6 +28,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { nodeNamesForLVS: action.value });
     case 'setAllNodeNamesOnADV':
       return Object.assign({}, state, { allNodeNamesOnADV: action.value });
+    case 'setHostNamesMapForADV':
+      return Object.assign({}, state, { hostNamesMapForADV: action.value });
     default:
       return initialState;
   }

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/types.ts
@@ -3,3 +3,7 @@ import { MatchExpression } from '@console/internal/module/k8s';
 export type NodeAffinityTerm = {
   matchExpressions?: MatchExpression[];
 };
+
+export type HostNamesMap = {
+  [key: string]: string;
+};

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -3,9 +3,10 @@ import { LocalVolumeSetModel } from '../../models';
 import { LocalVolumeSetKind, DiskType, DiskMechanicalProperty } from './types';
 import { State } from './state';
 import { LOCAL_STORAGE_NAMESPACE, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
-import { getNodes } from '../../utils';
+import { getNodes, getHostNames } from '../../utils';
 
 export const getLocalVolumeSetRequestData = (state: State): LocalVolumeSetKind => {
+  const nodes = getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames);
   const requestData = {
     apiVersion: apiVersionForModel(LocalVolumeSetModel),
     kind: LocalVolumeSetModel.kind,
@@ -28,7 +29,7 @@ export const getLocalVolumeSetRequestData = (state: State): LocalVolumeSetKind =
               {
                 key: HOSTNAME_LABEL_KEY,
                 operator: LABEL_OPERATOR,
-                values: getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames),
+                values: getHostNames(nodes, state.hostNamesMapForLVS),
               },
             ],
           },
@@ -39,9 +40,9 @@ export const getLocalVolumeSetRequestData = (state: State): LocalVolumeSetKind =
 
   if (state.maxDiskLimit) requestData.spec.maxDeviceCount = +state.maxDiskLimit;
   if (state.minDiskSize)
-    requestData.spec.deviceInclusionSpec.minSize = state.minDiskSize.toString();
+    requestData.spec.deviceInclusionSpec.minSize = `${state.minDiskSize}${state.diskSizeUnit}`;
   if (state.maxDiskSize)
-    requestData.spec.deviceInclusionSpec.maxSize = state.maxDiskSize.toString();
+    requestData.spec.deviceInclusionSpec.maxSize = `${state.maxDiskSize}${state.diskSizeUnit}`;
 
   return requestData;
 };

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -1,4 +1,5 @@
 import { diskTypeDropdownItems, diskModeDropdownItems } from '../../constants';
+import { HostNamesMap } from '../auto-detect-volume/types';
 
 export const initialState = {
   volumeSetName: '',
@@ -10,9 +11,10 @@ export const initialState = {
   nodeNames: [],
   minDiskSize: '0',
   maxDiskSize: '',
-  diskSizeUnit: 'TiB',
+  diskSizeUnit: 'Ti',
   isValidMaxSize: true,
   nodeNamesForLVS: [],
+  hostNamesMapForLVS: {},
 };
 
 export type State = {
@@ -28,6 +30,7 @@ export type State = {
   diskSizeUnit: string;
   isValidMaxSize: boolean;
   nodeNamesForLVS: string[];
+  hostNamesMapForLVS: HostNamesMap;
 };
 
 export type Action =
@@ -42,7 +45,8 @@ export type Action =
   | { type: 'setMaxDiskSize'; value: string }
   | { type: 'setDiskSizeUnit'; value: string }
   | { type: 'setIsValidMaxSize'; value: boolean }
-  | { type: 'setNodeNamesForLVS'; value: string[] };
+  | { type: 'setNodeNamesForLVS'; value: string[] }
+  | { type: 'setHostNamesMapForLVS'; value: HostNamesMap };
 
 export const reducer = (state: State, action: Action) => {
   switch (action.type) {
@@ -70,6 +74,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { isValidMaxSize: action.value });
     case 'setNodeNamesForLVS':
       return Object.assign({}, state, { nodeNamesForLVS: action.value });
+    case 'setHostNamesMapForLVS':
+      return Object.assign({}, state, { hostNamesMapForLVS: action.value });
     default:
       return initialState;
   }

--- a/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
@@ -13,8 +13,8 @@ export const allNodesSelectorTxt =
 export const AUTO_DISCOVER_ERR_MSG = 'Failed to update the Auto Detect Volume!';
 
 export const diskSizeUnitOptions = {
-  TiB: 'TiB',
-  GiB: 'GiB',
+  Ti: 'TiB',
+  Gi: 'GiB',
 };
 
 export const DISCOVERY_CR_NAME = 'auto-discover-devices';

--- a/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { NodeKind, MatchExpression } from '@console/internal/module/k8s';
-import { NodeAffinityTerm } from '../components/auto-detect-volume/types';
+import { NodeAffinityTerm, HostNamesMap } from '../components/auto-detect-volume/types';
+import { getName } from '@console/shared';
 
 export const hasTaints = (node: NodeKind): boolean => {
   return !_.isEmpty(node.spec?.taints);
@@ -32,4 +33,17 @@ export const getLabelIndex = (
   });
 
   return [selectorIndex, expIndex];
+};
+
+export const createMapForHostNames = (nodes: NodeKind[]) => {
+  return nodes.reduce((acc, node) => {
+    acc[getName(node)] = node.metadata.labels?.['kubernetes.io/hostname'] ?? '';
+    return acc;
+  }, {});
+};
+
+export const getHostNames = (nodes: string[], hostNamesMap: HostNamesMap) => {
+  return nodes.reduce((acc, node) => {
+    return [...acc, hostNamesMap[node]];
+  }, []);
 };


### PR DESCRIPTION
 - Fixed incorrect node name getting passed in the nodeSelector while creating Auto Discovery CR for AWS infra
- Fixed the post creation URL for Auto Detect Volume and Create Local volume Set
- Passing the units too along with `minSize` and `maxSize` on LVS which were not getting passed before.