### PR TITLE
Bug 1870473: Make quick start headers sticky

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
@@ -1,3 +1,10 @@
+.co-quick-start-drawer-head {
+  position: sticky;
+  top: 0px;
+  background: inherit;
+  z-index: var(--pf-global--ZIndex--xs);
+}
+
 .co-quick-start-drawer {
   &__title {
     display: flex;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import {
@@ -15,6 +16,7 @@ import {
 import { RootState } from '@console/internal/redux';
 import { AsyncComponent } from '@console/internal/components/utils';
 import { confirmModal } from '@console/internal/components/modals';
+import { useScrollDirection, ScrollDirection } from '@console/shared/';
 import {
   getActiveQuickStartID,
   getActiveQuickStartStatus,
@@ -43,6 +45,7 @@ const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
   onClose,
 }) => {
   const quickStart = getQuickStartByName(activeQuickStartID);
+  const [scrollDirection, handleScrollCallback] = useScrollDirection();
 
   const handleClose = () => {
     if (activeQuickStartStatus === QuickStartStatus.IN_PROGRESS) {
@@ -60,25 +63,32 @@ const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
     return onClose();
   };
 
+  const headerClasses = classNames('co-quick-start-drawer-head', {
+    'pf-u-box-shadow-sm-bottom':
+      scrollDirection && scrollDirection !== ScrollDirection.scrolledToTop,
+  });
+
   const panelContent = quickStart ? (
-    <DrawerPanelContent>
-      <DrawerHead>
-        <div className="co-quick-start-drawer__title">
-          <Title
-            headingLevel="h1"
-            size="xl"
-            style={{ marginRight: 'var(--pf-global--spacer--md)' }}
-          >
-            {quickStart?.spec.displayName}
-          </Title>
-          <Title headingLevel="h6" size="md" className="text-secondary">
-            {`${quickStart?.spec.duration} minutes`}
-          </Title>
-        </div>
-        <DrawerActions>
-          <DrawerCloseButton onClick={handleClose} />
-        </DrawerActions>
-      </DrawerHead>
+    <DrawerPanelContent onScroll={handleScrollCallback}>
+      <div className={headerClasses}>
+        <DrawerHead>
+          <div className="co-quick-start-drawer__title">
+            <Title
+              headingLevel="h1"
+              size="xl"
+              style={{ marginRight: 'var(--pf-global--spacer--md)' }}
+            >
+              {quickStart?.spec.displayName}
+            </Title>
+            <Title headingLevel="h6" size="md" className="text-secondary">
+              {`${quickStart?.spec.duration} minutes`}
+            </Title>
+          </div>
+          <DrawerActions>
+            <DrawerCloseButton onClick={handleClose} />
+          </DrawerActions>
+        </DrawerHead>
+      </div>
       <DrawerPanelBody>
         <AsyncComponent
           loader={() => import('./QuickStartController').then((c) => c.default)}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4437
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Quick starts should have sticky headers in the side panel when content overflows.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Make the header sticky and add a drop shadow when scrolled.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![sticky](https://user-images.githubusercontent.com/20013884/90131108-3654b300-dd89-11ea-9c7b-c42fd4121c6c.gif)
@openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
