### PR TITLE
tests: update JUnit report filenames

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -37,6 +37,7 @@ const htmlReporter = new HtmlScreenshotReporter({
 });
 const junitReporter = new JUnitXmlReporter({
   savePath: `./${screenshotsDir}`,
+  filePrefix: 'junit_protractor',
   consolidateAll: true,
 });
 const browserLogs = [];

--- a/frontend/packages/integration-tests-cypress/reporter-config.json
+++ b/frontend/packages/integration-tests-cypress/reporter-config.json
@@ -1,7 +1,7 @@
 {
   "reporterEnabled": "spec, mocha-junit-reporter",
   "mochaJunitReporterReporterOptions": {
-    "mochaFile": "../../gui_test_screenshots/junit-cypress-[hash].xml",
+    "mochaFile": "../../gui_test_screenshots/junit_cypress-[hash].xml",
     "toConsole": false
   }
 }


### PR DESCRIPTION
JUnit reports must match pattern `./junit(_[^_]+)?(_\d+-\d+)?(_\d+)?\.xml$` to be found by ci-search.

/assign @dtaylor113 
/cc @bparees 