### PR TITLE
Bug 1866928:  add support for Grafana valueMaps to monitoring dashboards

### DIFF
--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -25,6 +25,7 @@ const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
     prefix,
     prefixFontSize,
     valueFontSize,
+    valueMaps,
   } = panel;
 
   const [error, setError] = React.useState<string>();
@@ -50,6 +51,12 @@ const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
 
   usePoll(tick, pollInterval, query);
 
+  const filteredVMs = valueMaps?.filter((vm) => vm.op === '=');
+  const valueMap =
+    value === undefined
+      ? filteredVMs?.find((vm) => vm.value === 'null')
+      : filteredVMs?.find((vm) => vm.value === value);
+
   if (isLoading) {
     return <LoadingInline />;
   }
@@ -60,7 +67,9 @@ const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
   return (
     <Body>
       {prefix && <span style={{ fontSize: prefixFontSize }}>{prefix}</span>}
-      <span style={{ fontSize: valueFontSize }}>{formatNumber(value, decimals, format)}</span>
+      <span style={{ fontSize: valueFontSize }}>
+        {valueMap ? valueMap.text : formatNumber(value, decimals, format)}
+      </span>
       {postfix && <span style={{ fontSize: postfixFontSize }}>{postfix}</span>}
     </Body>
   );

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -6,6 +6,12 @@ export type ColumnStyle = {
   type: string;
 };
 
+type ValueMap = {
+  op: string;
+  text: string;
+  value: string;
+};
+
 export type Panel = {
   breakpoint?: string;
   decimals?: number;
@@ -37,4 +43,5 @@ export type Panel = {
   type: string;
   units?: string;
   valueFontSize?: string;
+  valueMaps?: ValueMap[];
 };


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1868463

Note any existing dashboards utilizing `<SingleStat>` with `valueMaps` need to be updated to remove `panel.valueFontSize: "200%"` to not look silly (see screenshots below).

<img width="1312" alt="Screen Shot 2020-08-13 at 11 13 56 AM" src="https://user-images.githubusercontent.com/895728/90154057-b06c4400-dd57-11ea-8bcf-0c9810fb6dcf.png">
<img width="1307" alt="Screen Shot 2020-08-13 at 11 14 13 AM" src="https://user-images.githubusercontent.com/895728/90154061-b19d7100-dd57-11ea-8eac-58ae331afba8.png">
<img width="1301" alt="Screen Shot 2020-08-13 at 11 14 32 AM" src="https://user-images.githubusercontent.com/895728/90154065-b2360780-dd57-11ea-9352-f2a1f5b52932.png">
