### PR TITLE
Bug 1867824: Fix dynamic form field ordering logic

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/const.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/const.ts
@@ -28,7 +28,6 @@ export const K8S_UI_SCHEMA = {
 export const JSON_SCHEMA_GROUP_TYPES: string[] = ['object', 'array'];
 export const JSON_SCHEMA_NUMBER_TYPES: string[] = ['number', 'integer'];
 
-const SORT_WEIGHT_BASE = 10;
-export const SORT_WEIGHT_SCALE_1 = SORT_WEIGHT_BASE ** 1;
-export const SORT_WEIGHT_SCALE_2 = SORT_WEIGHT_BASE ** 2;
-export const SORT_WEIGHT_SCALE_3 = SORT_WEIGHT_BASE ** 3;
+export const THOUSAND = 10 ** 3;
+export const MILLION = 10 ** 6;
+export const BILLION = 10 ** 9;

--- a/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/templates.tsx
@@ -12,6 +12,7 @@ import { getUiOptions, getSchemaType } from 'react-jsonschema-form/lib/utils';
 import { ExpandCollapse } from '@console/internal/components/utils';
 import { FieldSet, FormField } from './fields';
 import { useSchemaLabel } from './utils';
+import { UiSchemaOptionsWithDependency } from './types';
 
 export const AtomicFieldTemplate: React.FC<FieldTemplateProps> = ({
   children,
@@ -53,11 +54,15 @@ export const FieldTemplate: React.FC<FieldTemplateProps> = (props) => {
   const type = getSchemaType(schema);
   const [dependencyMet, setDependencyMet] = React.useState(true);
   React.useEffect(() => {
-    const { dependency } = getUiOptions(uiSchema ?? {}) as DependencyUIOption; // Type defs for this function are awful
+    const { dependency } = getUiOptions(uiSchema ?? {}) as UiSchemaOptionsWithDependency; // Type defs for this function are awful
     if (dependency) {
       setDependencyMet(
-        dependency.value ===
-          _.get(formContext.formData ?? {}, ['spec', ...(dependency.path ?? [])], '').toString(),
+        dependency?.controlFieldValue ===
+          _.get(
+            formContext.formData ?? {},
+            ['spec', ...(dependency?.controlFieldPath ?? [])],
+            '',
+          ).toString(),
       );
     }
   }, [uiSchema, formContext]);
@@ -162,10 +167,3 @@ export const ErrorTemplate: React.FC<{ errors: string[] }> = ({ errors }) => (
     </ul>
   </Alert>
 );
-
-type DependencyUIOption = {
-  dependency?: {
-    path: string;
-    value: string;
-  };
-};

--- a/frontend/packages/console-shared/src/components/dynamic-form/types.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/types.ts
@@ -1,4 +1,4 @@
-export enum SchemaType {
+export enum JSONSchemaType {
   string = 'string',
   number = 'number',
   integer = 'integer',
@@ -7,3 +7,23 @@ export enum SchemaType {
   array = 'array',
   object = 'object',
 }
+
+export type DynamicFormFieldOptionsList = {
+  label: string;
+  value: string;
+}[];
+
+export type DynamicFormFieldDependency = {
+  controlFieldPath: string;
+  controlFieldValue: string;
+  controlFieldName: string;
+};
+
+export type UiSchemaOptionsWithDependency = {
+  dependency?: DynamicFormFieldDependency;
+};
+
+export type DynamicFormSchemaError = {
+  title: string;
+  message: string;
+};

--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.spec.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.spec.ts
@@ -1,39 +1,39 @@
 import { JSONSchema6 } from 'json-schema';
 import { hasNoFields, prune } from './utils';
-import { SchemaType } from './types';
+import { JSONSchemaType } from './types';
 
 const OBJECT: JSONSchema6 = {
-  type: SchemaType.object,
+  type: JSONSchemaType.object,
   properties: {
-    test: { type: SchemaType.string },
+    test: { type: JSONSchemaType.string },
   },
 };
 
 const ARRAY: JSONSchema6 = {
-  type: SchemaType.array,
+  type: JSONSchemaType.array,
   items: {
-    type: SchemaType.string,
+    type: JSONSchemaType.string,
   },
 };
 
 const ADDITIONAL_PROPERTIES_OBJECT: JSONSchema6 = {
-  type: SchemaType.object,
-  additionalProperties: { type: SchemaType.string },
+  type: JSONSchemaType.object,
+  additionalProperties: { type: JSONSchemaType.string },
 };
 
 const NESTED: JSONSchema6 = {
-  type: SchemaType.object,
+  type: JSONSchemaType.object,
   properties: {
     emptyArray: {
-      type: SchemaType.array,
+      type: JSONSchemaType.array,
       items: {
-        type: SchemaType.object,
+        type: JSONSchemaType.object,
         properties: {
-          empty: { type: SchemaType.object },
+          empty: { type: JSONSchemaType.object },
         },
       },
     },
-    emptyObject: { type: SchemaType.object },
+    emptyObject: { type: JSONSchemaType.object },
   },
 };
 
@@ -106,7 +106,7 @@ describe('hasNoFields', () => {
   });
 
   it('Returns false for primitive schema type', () => {
-    expect(hasNoFields({ type: SchemaType.string })).toBeFalsy();
+    expect(hasNoFields({ type: JSONSchemaType.string })).toBeFalsy();
   });
 
   it('Returns false for object schema type with properly defined properties', () => {

--- a/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
+++ b/frontend/packages/console-shared/src/components/dynamic-form/utils.ts
@@ -3,8 +3,8 @@ import * as Immutable from 'immutable';
 import { JSONSchema6 } from 'json-schema';
 import { UiSchema } from 'react-jsonschema-form';
 import { getSchemaType, getUiOptions } from 'react-jsonschema-form/lib/utils';
-import { SchemaType } from './types';
-import { SORT_WEIGHT_SCALE_1, SORT_WEIGHT_SCALE_2, SORT_WEIGHT_SCALE_3 } from './const';
+import { DynamicFormSchemaError, JSONSchemaType } from './types';
+import { THOUSAND, MILLION, BILLION } from './const';
 
 const UNSUPPORTED_SCHEMA_PROPERTIES = ['allOf', 'anyOf', 'oneOf'];
 
@@ -24,7 +24,7 @@ export const useSchemaDescription = (
     schema?.description ||
     defaultDescription) as string;
 
-export const getSchemaErrors = (schema: JSONSchema6): SchemaError[] => {
+export const getSchemaErrors = (schema: JSONSchema6): DynamicFormSchemaError[] => {
   return [
     ...(_.isEmpty(schema)
       ? [
@@ -54,30 +54,100 @@ export const hasNoFields = (jsonSchema: JSONSchema6 = {}, uiSchema: UiSchema = {
   const type = getSchemaType(jsonSchema) ?? '';
   const noUIFieldOrWidget = !uiSchema?.['ui:field'] && !uiSchema?.['ui:widget'];
   switch (type) {
-    case SchemaType.array:
+    case JSONSchemaType.array:
       return noUIFieldOrWidget && hasNoFields(jsonSchema.items as JSONSchema6, uiSchema?.items);
-    case SchemaType.object:
+    case JSONSchemaType.object:
       return (
         noUIFieldOrWidget &&
         _.every(jsonSchema?.properties, (property, propertyName) =>
           hasNoFields(property as JSONSchema6, uiSchema?.[propertyName]),
         )
       );
-    case SchemaType.boolean:
-    case SchemaType.integer:
-    case SchemaType.number:
-    case SchemaType.string:
+    case JSONSchemaType.boolean:
+    case JSONSchemaType.integer:
+    case JSONSchemaType.number:
+    case JSONSchemaType.string:
       return false;
     default:
       return noUIFieldOrWidget;
   }
 };
 
-// Given a JSONSchema and associated uiSchema, create the appropriat ui schema order property for
-// the jsonSchema. Orders properties according to the following rules:
+/**
+ * Give a property name a sort wieght based on whether it has ui schema, is required, or is a
+ * control field for a property with a field dependency. A lower weight means higher sort order.
+ * Fields are weighted according to the following tiers:
+ *  Tier 1 (negative 10^9 - 10^6 magnitude):  Required fields with ui schema
+ *  Tier 2 (negative 10^9 magnitude):         Required fields without ui schema
+ *  Tier 3 (negative 10^6 magnitude):         Optional fields with ui schema
+ *  Tier 4 (positive 10^3 maginitude):        Control fields that don't fit any above
+ *  Tier 5 (Infinity):                        All other fields
+ *
+ * Within each of the above tiers, fields are further weighted based on field dependency and ui
+ * schema defined sort order:
+ *   - Fields without dependency - base weight + ui schema sort order
+ *   - Control field - base weight + ui schema sort order + (nth control field) * 10000
+ *   - Dependent field - control field weight + ui schema sort order + 1
+ *
+ * These weight numbers are arbitrary, but spaced far enough apart to prevent collisions.
+ */
+const getJSONSchemaPropertySortWeight = (
+  property: string,
+  jsonSchema: JSONSchema6,
+  uiSchema: UiSchema,
+): number => {
+  const isRequired = (jsonSchema?.required ?? []).includes(property);
+  const propertyUISchema = uiSchema?.[property];
+
+  // Any sibling has a dependency with this as the control field.
+  const isControlField = _.some(
+    uiSchema,
+    ({ 'ui:dependency': dependency }) => dependency?.controlFieldName === property,
+  );
+
+  // Property sort order from ui schema (adjusted to 1-based origin). Use propertyNames.length
+  // when no uiSchema sortOrder exists. Ensures properties without uiSchema sort order  have a
+  // higher weight than those with.
+  const propertySortOrder = Number(
+    propertyUISchema?.['ui:sortOrder'] ?? _.keys(jsonSchema?.properties).length,
+  );
+
+  // This property's control field name, if it exists
+  const controlFieldName = propertyUISchema?.['ui:dependency']?.controlFieldName;
+
+  // A small offset that is added to the base weight so that control fields get sorted
+  // below other fields in the same 'tier', and allows for depenendt fields to be sorted
+  // directly after their control field.
+  const controlFieldOffset = isControlField ? propertySortOrder * THOUSAND : 0;
+
+  // Total offset to be added to base tier
+  const offset = controlFieldOffset + propertySortOrder;
+
+  // If this property is a dependent, it's weight is based on it's control field
+  if (controlFieldName) {
+    return getJSONSchemaPropertySortWeight(controlFieldName, jsonSchema, uiSchema) + offset + 1;
+  }
+
+  // Tier 1 = -1001000000 (negative one billion one million) + offset
+  // Tier 2 = -1000000000 (negagive one billion) + offset
+  // Tier 3 = -1000000 (negative one million) + offset
+  // Tier 4 = 0 + offset
+  // Tier 5 = Infinity
+  return (
+    // Doesn't meet any sorting criteria, set to infinity
+    (!isRequired && !propertyUISchema && !controlFieldOffset ? Infinity : 0) -
+    (isRequired ? BILLION : 0) -
+    (propertyUISchema ? MILLION : 0) +
+    offset
+  );
+};
+
+// Given a JSONSchema and associated uiSchema, create the appropriate ui schema order property.
+// Orders properties according to the following rules:
 //  - required properties with an associated ui schema come first,
 //  - required properties without an associated ui schema next,
 //  - optional fields with an associated ui schema next,
+//  - field dependency properties (control then dependent)
 //  - all other properties
 export const getJSONSchemaOrder = (jsonSchema, uiSchema) => {
   const type = getSchemaType(jsonSchema ?? {});
@@ -92,87 +162,16 @@ export const getJSONSchemaOrder = (jsonSchema, uiSchema) => {
       return {};
     }
 
-    // Map control fields to an array so that  an index can be used to apply a modifier to sort
-    // weigths of dependent fields
-    const controlProperties = _.reduce(
-      uiSchema,
-      (controlPropertyAccumulator, { 'ui:dependency': dependency }) => {
-        const control = _.last(dependency?.path ?? []);
-        return !control ? controlPropertyAccumulator : [...controlPropertyAccumulator, control];
-      },
-      [],
-    );
-
-    /**
-     * Give a property name a sort wieght based on whether it has a descriptor (uiSchema has
-     * property), is required, or is a control field for a property with a field dependency. A lower
-     * weight means higher sort order. Fields are weighted according to the following criteria:
-     *  - Required fields with descriptor - 0 to 999
-     *  - Required fields without descriptor 1000 to 1999
-     *  - Optional fields with descriptor 2000 to 2999
-     *  - Control fields that don't fit any above - 3000 to 3999
-     *  - All other fields - Infinity
-     *
-     * Within each of the above criteria, fields are further weighted based on field dependency:
-     *   - Fields without dependency - base weight
-     *   - Control field - base weight  + (nth control field) * 100
-     *   - Dependent field - corresponding control field weight + 10
-     *
-     * These weight numbers are arbitrary, but spaced far enough apart to leave room for multiple
-     * levels of sorting.
-     */
-    const getSortWeight = (property: string): number => {
-      // This property's control field, if it exists
-      const control = _.last<string>(uiSchema?.[property]?.['ui:dependency']?.path ?? []);
-
-      // A small offset that is added to the base weight so that control fields get sorted last
-      // within their appropriate group
-      const controlOffset = (controlProperties.indexOf(property) + 1) * SORT_WEIGHT_SCALE_2;
-
-      // If this property is a dependent, it's weight is based on it's control property
-      if (control) {
-        return getSortWeight(control) + controlOffset + SORT_WEIGHT_SCALE_1;
-      }
-
-      const isRequired = (jsonSchema?.required ?? []).includes(property);
-      const hasDescriptor = uiSchema?.[property];
-
-      // Required fields with a desriptor are sorted first (lowest weight).
-      if (isRequired && hasDescriptor) {
-        return SORT_WEIGHT_SCALE_3 + controlOffset;
-      }
-
-      // Fields that are required, but have no descriptors get sorted next
-      if (isRequired) {
-        // Add requiredIndex to sort required properties based on there index in required array
-        const requiredIndex = (jsonSchema?.required ?? []).indexOf(property);
-        return SORT_WEIGHT_SCALE_3 * 2 + requiredIndex + controlOffset;
-      }
-
-      // Optional fields with descriptors get sorted next
-      if (hasDescriptor) {
-        return SORT_WEIGHT_SCALE_3 * 3 + controlOffset;
-      }
-
-      // Control fields that don't fit into any of the above criteria come next
-      if (controlOffset > 0) {
-        return SORT_WEIGHT_SCALE_3 * 4 + controlOffset;
-      }
-
-      // All other fields are sorted in the order in which they are encountered in the schema
-      return Infinity;
-    };
-
     const uiOrder = Immutable.Set(propertyNames)
-      .sortBy(getSortWeight)
+      .sortBy((propertyName) => getJSONSchemaPropertySortWeight(propertyName, jsonSchema, uiSchema))
       .toJS();
 
     return {
       ...(uiOrder.length > 1 && { 'ui:order': uiOrder }),
       ..._.reduce(
         jsonSchema?.properties ?? {},
-        (orderAccumulator, property, propertyName) => {
-          const descendantOrder = getJSONSchemaOrder(property, uiSchema?.[propertyName]);
+        (orderAccumulator, propertySchema, propertyName) => {
+          const descendantOrder = getJSONSchemaOrder(propertySchema, uiSchema?.[propertyName]);
           if (_.isEmpty(descendantOrder)) {
             return orderAccumulator;
           }
@@ -187,9 +186,9 @@ export const getJSONSchemaOrder = (jsonSchema, uiSchema) => {
   };
 
   switch (type) {
-    case SchemaType.array:
+    case JSONSchemaType.array:
       return handleArray();
-    case SchemaType.object:
+    case JSONSchemaType.object:
       return handleObject();
     default:
       return {};
@@ -233,9 +232,4 @@ const pruneRecursive = (current: any, sample: any): any => {
 // Based on https://stackoverflow.com/a/26202058/8895304
 export const prune = (obj: any, sample?: any): any => {
   return pruneRecursive(_.cloneDeep(obj), sample);
-};
-
-type SchemaError = {
-  title: string;
-  message: string;
 };

--- a/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
@@ -7,6 +7,7 @@ import { K8sKind, GroupVersionKind, ImagePullPolicy } from '@console/internal/mo
 import { RadioGroup } from '@console/internal/components/radio';
 import { JSON_SCHEMA_NUMBER_TYPES } from './const';
 import { getSchemaType } from 'react-jsonschema-form/lib/utils';
+import { DynamicFormFieldOptionsList } from './types';
 
 export const TextWidget: React.FC<WidgetProps> = (props) => {
   const {
@@ -157,7 +158,7 @@ export const SelectWidget: React.FC<WidgetProps> = ({
 }) => {
   const { enumOptions = [], title } = options;
   const items = _.reduce(
-    enumOptions as OptionsList,
+    enumOptions as DynamicFormFieldOptionsList,
     (itemAccumulator, option) => {
       return {
         ...itemAccumulator,
@@ -177,11 +178,6 @@ export const SelectWidget: React.FC<WidgetProps> = ({
     />
   );
 };
-
-type OptionsList = {
-  label: string;
-  value: string;
-}[];
 
 type K8sResourceWidgetProps = WidgetProps & {
   options: {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/const.ts
@@ -1,32 +1,32 @@
 import { JSONSchema6 } from 'json-schema';
-import { SchemaType } from '@console/shared/src/components/dynamic-form';
+import { JSONSchemaType } from '@console/shared/src/components/dynamic-form';
 
 export const YAML_HELP_TEXT =
   'Create by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor.';
 export const FORM_HELP_TEXT =
   'Create by completing the form. Default values may be provided by the Operator authors.';
 export const DEFAULT_K8S_SCHEMA: JSONSchema6 = {
-  type: SchemaType.object,
+  type: JSONSchemaType.object,
   properties: {
     metadata: {
-      type: SchemaType.object,
+      type: JSONSchemaType.object,
       properties: {
-        namespace: { type: SchemaType.string },
+        namespace: { type: JSONSchemaType.string },
         name: {
-          type: SchemaType.string,
+          type: JSONSchemaType.string,
           default: 'example',
         },
         labels: {
-          type: SchemaType.object,
+          type: JSONSchemaType.object,
           properties: {},
-          additionalProperties: { type: SchemaType.string },
+          additionalProperties: { type: JSONSchemaType.string },
         },
       },
       required: ['name'],
     },
-    spec: { type: SchemaType.object },
-    apiVersion: { type: SchemaType.string },
-    kind: { type: SchemaType.string },
+    spec: { type: JSONSchemaType.object },
+    apiVersion: { type: JSONSchemaType.string },
+    kind: { type: JSONSchemaType.string },
   },
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
@@ -56,11 +56,19 @@ const k8sResourceCapabilityToUISchema = (capability: SpecCapability): UiSchema =
 };
 
 const fieldDependencyCapabilityToUISchema = (capability: SpecCapability): UiSchema => {
-  const [, path, value] = capability.match(REGEXP_FIELD_DEPENDENCY_PATH_VALUE) ?? [];
-  if (!!path && !!value) {
-    return { 'ui:dependency': { path: descriptorPathToUISchemaPath(path), value } };
-  }
-  return {};
+  const [, path, controlFieldValue] = capability.match(REGEXP_FIELD_DEPENDENCY_PATH_VALUE) ?? [];
+  const controlFieldPath = descriptorPathToUISchemaPath(path);
+  const controlFieldName = _.last(controlFieldPath);
+  return {
+    ...(path &&
+      controlFieldValue && {
+        'ui:dependency': {
+          controlFieldPath,
+          controlFieldValue,
+          controlFieldName,
+        },
+      }),
+  };
 };
 
 const selectCapabilitiesToUISchema = (capabilities: SpecCapability[]): UiSchema => {
@@ -141,6 +149,7 @@ export const descriptorsToUISchema = (
     (
       uiSchemaAccumulator,
       { path, description, displayName, 'x-descriptors': capabilities = [] },
+      index,
     ) => {
       const uiSchemaPath = descriptorPathToUISchemaPath(path);
       if (!jsonSchemaHas(jsonSchema, uiSchemaPath)) {
@@ -166,6 +175,7 @@ export const descriptorsToUISchema = (
             ...(description && { 'ui:description': description }),
             ...(displayName && { 'ui:title': displayName }),
             ...capabilitiesUISchema,
+            'ui:sortOrder': index + 1,
           }),
         );
       });


### PR DESCRIPTION
Update form field ordering logic so that behavior matches documentation. Falls back to ordering by descriptor order.
Move some common dynamic form type definitions into types.ts to prevent dependency cycles.

![image](https://user-images.githubusercontent.com/22625502/90167567-d0a4fe80-dd69-11ea-9e1c-c0e56163736f.png)


cc @tlwu2013 