### PR TITLE
tests: use consistent test names in base scenario

### DIFF
--- a/frontend/integration-tests/tests/base.scenario.ts
+++ b/frontend/integration-tests/tests/base.scenario.ts
@@ -6,7 +6,7 @@ import * as crudView from '../views/crud.view';
 const BROWSER_TIMEOUT = 15000;
 
 describe('Create a test namespace', () => {
-  it(`creates test namespace ${testName} if necessary`, async () => {
+  it('creates test namespace if necessary', async () => {
     // Use projects if OpenShift so non-admin users can run tests.
     const resource = browser.params.openshift === 'true' ? 'projects' : 'namespaces';
     await browser.get(`${appHost}/k8s/cluster/${resource}`);


### PR DESCRIPTION
Use a consistent name for the test that creates a namespace. Otherwise it looks like different tests to tools like testgrid, which creates a separate row for every run.

https://testgrid.k8s.io/redhat-openshift-ocp-release-4.6-informing#release-openshift-ocp-installer-console-aws-4.6&show-stale-tests=

<img width="1406" alt="Screen Shot 2020-08-13 at 4 54 20 PM" src="https://user-images.githubusercontent.com/1167259/90186114-afeaa200-dd85-11ea-9637-6a1a19a60d84.png">

/assign @dtaylor113 