### PR TITLE
Bug 1850538: Persistent dashboard to reflect ceph health status as Warning

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/utils.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/utils.ts
@@ -9,6 +9,7 @@ const CephHealthStatus = {
   },
   HEALTH_WARN: {
     state: HealthState.WARNING,
+    message: 'Warning',
   },
   HEALTH_ERR: {
     state: HealthState.ERROR,


### PR DESCRIPTION
- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1850538
- The status of ceph to be Warning and not Degraded. This is to match with the CR status and well known terminology wrt ceph.

![Screenshot from 2020-08-17 13-07-07](https://user-images.githubusercontent.com/25664409/90371528-bd0cd700-e08c-11ea-9f52-b893c8ee5f53.png)
![Screenshot from 2020-08-17 13-07-07](https://user-images.githubusercontent.com/25664409/90371545-c138f480-e08c-11ea-847c-85be327e2992.png)
