### PR TITLE
Bug 1869127: Don't lowercase names in `k8sCreate`

### DIFF
--- a/frontend/__tests__/resource.spec.ts
+++ b/frontend/__tests__/resource.spec.ts
@@ -1,5 +1,5 @@
 import '../__mocks__/localStorage';
-import { k8sCreate, K8sKind, resourceURL } from '../public/module/k8s';
+import { K8sKind, resourceURL } from '../public/module/k8s';
 import { PodModel, UserModel } from '../public/models';
 
 type ResourceURLOptions = {
@@ -7,20 +7,6 @@ type ResourceURLOptions = {
   ns?: string;
   queryParams?: any;
 };
-
-describe('k8s.k8sResource', () => {
-  describe('create', () => {
-    it('automatically lowercases resource name', () => {
-      const data = { metadata: { name: 'TEST' }, spec: { volumes: [] } };
-
-      k8sCreate(PodModel, data);
-      // Since we're passing by reference we
-      // can simply assert about the mutation of
-      // the object here.
-      expect(data.metadata.name).toEqual('test');
-    });
-  });
-});
 
 describe('resourceURL', () => {
   const testResourceURL = (model: K8sKind, options: ResourceURLOptions, expected: string) => {

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -59,19 +59,8 @@ export const k8sGet = (kind, name, ns, opts) =>
   coFetchJSON(resourceURL(kind, Object.assign({ ns, name }, opts)));
 
 export const k8sCreate = (kind, data, opts = {}) => {
-  // Occassionally, a resource won't have a metadata property.
-  // For example: apps.openshift.io/v1 DeploymentRequest
-  // https://github.com/openshift/api/blob/master/apps/v1/types.go
-  data.metadata = data.metadata || {};
-
-  // Lowercase the resource name
-  // https://github.com/kubernetes/kubernetes/blob/HEAD/docs/user-guide/identifiers.md#names
-  if (data.metadata.name && _.isString(data.metadata.name) && !data.metadata.generateName) {
-    data.metadata.name = data.metadata.name.toLowerCase();
-  }
-
   return coFetchJSON.post(
-    resourceURL(kind, Object.assign({ ns: data.metadata.namespace }, opts)),
+    resourceURL(kind, Object.assign({ ns: data?.metadata?.namespace }, opts)),
     data,
   );
 };


### PR DESCRIPTION
Some resources like `Group` allow uppercase names.

/assign @rhamilto 