### PR TITLE
Bug 1870634: Fix slow reaction time on topology filter changes

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { createAggregateEdges, Model, NodeModel } from '@patternfly/react-topology';
 import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
 import { referenceFor } from '@console/internal/module/k8s';
@@ -66,9 +67,10 @@ export const updateModelFromFilters = (
   onSupportedKindsChange?: (supportedFilterIds: { [key: string]: number }) => void,
 ): Model => {
   const dataModel: Model = {
-    nodes: [...model.nodes],
-    edges: [...model.edges],
+    nodes: _.cloneDeep(model.nodes),
+    edges: _.cloneDeep(model.edges),
   };
+
   const supportedFilters = [...DEFAULT_SUPPORTED_FILTER_IDS];
   const supportedKinds = {};
   let appGroupFound = false;
@@ -78,7 +80,7 @@ export const updateModelFromFilters = (
     d.visible = true;
     if (displayFilterers) {
       displayFilterers.forEach((displayFilterer) => {
-        const appliedFilters = displayFilterer(model, filters);
+        const appliedFilters = displayFilterer(dataModel, filters);
         supportedFilters.push(...appliedFilters.filter((f) => !supportedFilters.includes(f)));
       });
     }
@@ -125,13 +127,6 @@ export const updateModelFromFilters = (
       dataModel.nodes.find((n) => n.id === d.source) &&
       dataModel.nodes.find((n) => n.id === d.target),
   );
-
-  // TODO: This works until some extension adds edges they don't want to show
-  // edges may have been hidden via the createAggregateEdges call last time.
-  // make them visible now so they reappear when the hidden endpoints reappear.
-  edges.forEach((edge) => {
-    edge.visible = true;
-  });
 
   // Create any aggregate edges (those create from hidden endpoints)
   dataModel.edges = createAggregateEdges(TYPE_AGGREGATE_EDGE, edges, dataModel.nodes);

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { DataList } from '@patternfly/react-core';
-import { isGraph, Node, isNode, Visualization, GraphElement } from '@patternfly/react-topology';
+import {
+  observer,
+  isGraph,
+  Node,
+  isNode,
+  Visualization,
+  GraphElement,
+} from '@patternfly/react-topology';
 import { useDeepCompareMemoize } from '@console/shared';
 import { TYPE_APPLICATION_GROUP } from '../components';
 import { TopologyListViewAppGroup } from './TopologyListViewAppGroup';
@@ -172,4 +179,4 @@ const TopologyListView: React.FC<TopologyListViewProps> = ({
   );
 };
 
-export default TopologyListView;
+export default observer(TopologyListView);


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4417

**Description**
Fix to topology view to update display on filter changes w/o waiting on a backend data update. 

**Fix**
Modified code to keep the original backend model intact when filtering so on next filter change the unfiltered model is available.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug