### PR TITLE
Bug 1869600: add resource icon to the items in the `select task` dropdown in the pipeline builder page

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/hooks.ts
@@ -133,17 +133,14 @@ export const useNodes = (
     onUpdateTasks(taskGroupRef.current, { type: UpdateOperationType.CONVERT_LIST_TO_TASK, data });
   };
 
-  // TODO: Fix id collisions then remove this utility; we shouldn't need to trim the tasks
-  const noDuplicates = (resource: PipelineResourceTask) =>
-    !taskGroupRef.current.tasks.find((pt) => pt.name === resource.metadata.name);
   const newListNode = (
     name: string,
     runAfter?: string[],
     firstTask?: boolean,
   ): PipelineTaskListNodeModel =>
     createTaskListNode(name, {
-      namespaceTaskList: namespacedTasks?.filter(noDuplicates),
-      clusterTaskList: clusterTasks?.filter(noDuplicates),
+      namespaceTaskList: namespacedTasks,
+      clusterTaskList: clusterTasks,
       onNewTask: (resource: PipelineResourceTask) => {
         onNewTask(resource, name, runAfter);
       },
@@ -163,8 +160,8 @@ export const useNodes = (
   const soloTask = (name = 'initial-node') => newListNode(name, undefined, true);
   const newInvalidListNode = (name: string, runAfter?: string[]): PipelineTaskListNodeModel =>
     createInvalidTaskListNode(name, {
-      namespaceTaskList: namespacedTasks?.filter(noDuplicates),
-      clusterTaskList: clusterTasks?.filter(noDuplicates),
+      namespaceTaskList: namespacedTasks,
+      clusterTaskList: clusterTasks,
       onNewTask: (resource: PipelineResourceTask) => {
         const data: UpdateOperationFixInvalidTaskListData = {
           existingName: name,

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -201,14 +201,16 @@ const addListNode: UpdateOperationAction<UpdateOperationAddData> = (tasks, listT
   }
 };
 
+const getTaskNames = (tasks: PipelineTask[]) => tasks.map((t) => t.name);
+
 const convertListToTask: UpdateOperationAction<UpdateOperationConvertToTaskData> = (
   tasks,
   listTasks,
   data,
 ) => {
   const { name, resource, runAfter } = data;
-
-  const newPipelineTask: PipelineTask = convertResourceToTask(resource, runAfter);
+  const usedNames = getTaskNames(tasks);
+  const newPipelineTask: PipelineTask = convertResourceToTask(usedNames, resource, runAfter);
 
   return {
     tasks: [
@@ -384,8 +386,8 @@ const fixInvalidListTask: UpdateOperationAction<UpdateOperationFixInvalidTaskLis
   data,
 ) => {
   const { existingName, resource, runAfter } = data;
-
-  const newPipelineTask: PipelineTask = convertResourceToTask(resource, runAfter);
+  const usedNames = getTaskNames(tasks);
+  const newPipelineTask: PipelineTask = convertResourceToTask(usedNames, resource, runAfter);
 
   return {
     tasks: [

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -1,6 +1,7 @@
 import { history, resourcePathFromModel } from '@console/internal/components/utils';
 import { apiVersionForModel, referenceForModel } from '@console/internal/module/k8s';
-import { ClusterTaskModel, PipelineModel } from '../../../models';
+import { getRandomChars } from '@console/shared';
+import { PipelineModel, TaskModel } from '../../../models';
 import {
   Pipeline,
   PipelineResourceTask,
@@ -29,15 +30,28 @@ export const taskParamIsRequired = (param: PipelineResourceTaskParam): boolean =
   return !('default' in param);
 };
 
+export const safeName = (reservedNames: string[], desiredName: string): string => {
+  if (reservedNames.includes(desiredName)) {
+    const newName = `${desiredName}-${getRandomChars(3)}`;
+    if (reservedNames.includes(newName)) {
+      return safeName(reservedNames, desiredName);
+    }
+    return newName;
+  }
+  return desiredName;
+};
+
 export const convertResourceToTask = (
+  usedNames: string[],
   resource: PipelineResourceTask,
   runAfter?: string[],
 ): PipelineTask => {
+  const kind = resource.kind ?? TaskModel.kind;
   return {
-    name: resource.metadata.name,
+    name: safeName(usedNames, resource.metadata.name),
     runAfter,
     taskRef: {
-      kind: resource.kind === ClusterTaskModel.kind ? ClusterTaskModel.kind : undefined,
+      kind,
       name: resource.metadata.name,
     },
     params: getTaskParameters(resource).map((param) => ({

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
@@ -3,20 +3,28 @@ import * as FocusTrap from 'focus-trap-react';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import Popper from '@console/shared/src/components/popper/Popper';
-import { KebabItem, KebabOption } from '@console/internal/components/utils';
+import { KebabItem, KebabOption, ResourceIcon } from '@console/internal/components/utils';
 import { observer, Node, NodeModel } from '@patternfly/react-topology';
 import { PipelineResourceTask } from '../../../utils/pipeline-augment';
 import { NewTaskNodeCallback, TaskListNodeModelData } from './types';
 
 import './TaskListNode.scss';
 
-const taskToOption = (task: PipelineResourceTask, callback: NewTaskNodeCallback): KebabOption => {
+type KeyedKebabOption = KebabOption & { key: string };
+
+const taskToOption = (
+  task: PipelineResourceTask,
+  callback: NewTaskNodeCallback,
+): KeyedKebabOption => {
   const {
+    kind,
     metadata: { name },
   } = task;
 
   return {
+    key: `${name}-${kind}`,
     label: name,
+    icon: <ResourceIcon kind={kind} />,
     callback: () => {
       callback(task);
     },
@@ -82,7 +90,7 @@ const TaskListNode: React.FC<TaskListNodeProps> = ({ element, unselectedText }) 
           <div className="pf-c-dropdown pf-m-expanded">
             <ul className="pf-c-dropdown__menu pf-m-align-right oc-kebab__popper-items odc-task-list-node__list-items">
               {options.map((option) => (
-                <li key={option.label}>
+                <li key={option.key}>
                   <KebabItem
                     option={option}
                     onClick={() => {


### PR DESCRIPTION
**Fixes:**
- https://issues.redhat.com/browse/ODC-4280
- https://issues.redhat.com/browse/ODC-3182

**Root Analysis:**
Tasks and ClusterTasks are not visually distinguishable in the `Select Task` dropdown list in the pipeline builder page.

**Solution Description:**
- added resource badge to the items in the `Select Task` dropdown
- fixed the issue with Task & ClusterTask having the same name
- fixed the issue with Tasks not showing up again in the dropdown if it is already selected

**GIF:**
![taskdropdown](https://user-images.githubusercontent.com/22490998/90424715-3253c880-e0dc-11ea-9247-74d8d9bf1486.gif)