### PR TITLE
Bug 1869196: Disable card model if using SRIOV interface

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -204,6 +204,14 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
     setMultusNetworkName(newMultusNetworkName);
   };
 
+  const onNetworkInterfaceChange = (iType: string) => {
+    if (iType === NetworkInterfaceType.SRIOV.toString()) {
+      setModel(NetworkInterfaceModel.VIRTIO);
+    }
+
+    setInterfaceType(NetworkInterfaceType.fromString(iType));
+  };
+
   const submit = (e) => {
     e.preventDefault();
 
@@ -246,7 +254,7 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
               }
               value={asFormSelectValue(model)}
               id={asId('model')}
-              isDisabled={isDisabled('model')}
+              isDisabled={isDisabled('model') || interfaceType === NetworkInterfaceType.SRIOV}
             >
               <FormSelectPlaceholderOption isDisabled placeholder="--- Select Model ---" />
               {NetworkInterfaceModel.getAll().map((ifaceModel) => {
@@ -275,7 +283,7 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
           />
           <FormRow title="Type" fieldId={asId('type')} isRequired>
             <FormSelect
-              onChange={(iType) => setInterfaceType(NetworkInterfaceType.fromString(iType))}
+              onChange={onNetworkInterfaceChange}
               value={asFormSelectValue(interfaceType)}
               id={asId('type')}
               isDisabled={isDisabled('type')}


### PR DESCRIPTION
Currently, it is possible to select the model if sriov is selected. But this selection has no meaning in this situation and should be disabled

Screenshot:
After:
![screenshot-localhost_9000-2020 08 18-11_39_39](https://user-images.githubusercontent.com/2181522/90490815-c313be00-e147-11ea-87b4-26a8590ea804.png)


Before:
![screenshot-localhost_9000-2020 08 18-11_40_51](https://user-images.githubusercontent.com/2181522/90490807-c018cd80-e147-11ea-93dc-f7990076abc6.png)
