### PR TITLE
Add color to vm imports

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/models/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/index.ts
@@ -107,6 +107,7 @@ export const VirtualMachineImportModel: K8sKind = {
   namespaced: true,
   kind: 'VirtualMachineImport',
   id: 'virtualmachineimport',
+  color: '#FF1493',
 };
 
 export const UploadTokenRequestModel: K8sKind = {


### PR DESCRIPTION
Currently VM (VirtualMachine) and VIM (VIrtualMachineImports) share the same label colour,
We show VM, VMI and VIM objects on the same list in the Virtualization table.
It will be nice to have better visual hint to distinguish between VM and VIM.

This PR adds more colour to the VIM object.

After:
![screenshot-localhost_9000-2020 08 18-13_22_11](https://user-images.githubusercontent.com/2181522/90502424-7683af00-e156-11ea-93e2-5b83339c5b60.png)

Before:
![screenshot-localhost_9000-2020 08 18-13_21_11](https://user-images.githubusercontent.com/2181522/90502429-7aafcc80-e156-11ea-972c-c6c13d73d1b1.png)
  