### PR TITLE
Bug 1870478: Avoid adding a newline between pipelinerun log fetches

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/logs/Logs.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/logs/Logs.tsx
@@ -33,9 +33,14 @@ const Logs: React.FC<LogsProps> = ({
   const onCompleteRef = React.useRef<(name) => void>();
   onCompleteRef.current = onComplete;
   const appendMessage = React.useRef<(blockContent) => void>();
+  const prevFetchNewline = React.useRef(true);
   appendMessage.current = React.useCallback(
-    (blockContent) => {
+    (blockContent: string) => {
       const contentLines = blockContent.split('\n').filter((line) => !!line);
+      if (!prevFetchNewline.current && contentRef.current.lastChild) {
+        contentRef.current.lastChild.textContent += contentLines.shift();
+      }
+      prevFetchNewline.current = blockContent.endsWith('\n');
       if (contentRef.current && contentLines.length >= 0) {
         const elements = contentLines.map((content) => {
           const customElement = document.createElement('div');


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4361
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
There is a new line added after each api call, which shows incorrectly if the logs are streamed with one or more lines broken down into multiple parts between calls.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Check if the previously streamed chunk ends in a newline before displaying the next chunk, avoid adding a newline if it doesn't.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review:**
Before:
![scr0](https://user-images.githubusercontent.com/20013884/90512442-caed5580-e17b-11ea-869b-237f12acf048.png)
After:
![scr1](https://user-images.githubusercontent.com/20013884/90512453-d04aa000-e17b-11ea-9bfc-7e852358f515.png)

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Test setup:**
Prevalent in a PipelineRun with lots of logs.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
