### PR TITLE
Bug 1871652: Fix style, behavior and appearance uniformity issues of the drop-downs in OCS

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/__tests__/independent-dashboard-breakdown-card.spec.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/__tests__/independent-dashboard-breakdown-card.spec.tsx
@@ -2,18 +2,21 @@ import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 
 import { DashboardItemProps } from '@console/internal/components/dashboard/with-dashboard-resources';
-import { Dropdown } from '@console/internal/components/utils';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
+import { Select } from '@patternfly/react-core';
 import { BreakdownCard } from '../components/independent-dashboard-page/breakdown-card';
 import { dashboardData } from '../__mocks__/independent-mode-dashboard-data';
 import { HeaderPrometheusViewLink } from '../components/dashboard-page/storage-dashboard/breakdown-card/breakdown-header';
 import { BreakdownCardBody } from '../components/dashboard-page/storage-dashboard/breakdown-card/breakdown-body';
+import { getSelectOptions } from '../components/dashboard-page/storage-dashboard/breakdown-card/breakdown-dropdown';
+import { breakdownIndependentQueryMap } from '../constants/queries';
 
 describe('BreakdownCard', () => {
   let wrapper: ShallowWrapper<DashboardItemProps>;
-
+  const keys = Object.keys(breakdownIndependentQueryMap);
+  const breakdownSelectItems = getSelectOptions(keys);
   beforeEach(() => {
     wrapper = shallow(
       <BreakdownCard
@@ -48,9 +51,8 @@ describe('BreakdownCard', () => {
   });
 
   it('Should render Dropdown', () => {
-    expect(wrapper.find(Dropdown).exists()).toBe(true);
-    expect(wrapper.find(Dropdown).props().items).toEqual(dashboardData.expectedDropDownItems);
-    expect(wrapper.find(Dropdown).props().title).toEqual('Projects');
+    expect(wrapper.find(Select).exists()).toBe(true);
+    expect(wrapper.find(Select).props().children).toEqual(breakdownSelectItems);
   });
 
   it('Should render Card body', () => {

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-dropdown.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import {
+  SelectOption,
+  SelectGroup,
+  OptionsMenuItemGroup,
+  OptionsMenuItem,
+} from '@patternfly/react-core';
+
+type GroupedSelectItems = {
+  group: string;
+  items: string[];
+}[];
+
+export const getSelectOptions = (selectItems: string[]): React.ReactElement[] =>
+  selectItems.map((item) => <SelectOption key={item} value={item} />);
+
+export const getGroupedSelectOptions = (
+  groupedSelectItems: GroupedSelectItems,
+): React.ReactElement[] =>
+  groupedSelectItems.map(({ group, items }) => (
+    <SelectGroup key={group} label={group}>
+      {getSelectOptions(items)}
+    </SelectGroup>
+  ));
+
+export const getOptionsMenuItems = (
+  dropdownItems: GroupedSelectItems,
+  selectedItems: string[],
+  onSelect: (e) => void,
+) => {
+  return dropdownItems.map(({ group, items }) => (
+    <OptionsMenuItemGroup
+      className="nb-data-consumption-card__dropdown-item--hide-list-style"
+      key={group}
+      groupTitle={group}
+    >
+      {items.map((item) => (
+        <OptionsMenuItem
+          onSelect={onSelect}
+          isSelected={selectedItems.includes(item)}
+          id={item}
+          key={item}
+        >
+          {item}
+        </OptionsMenuItem>
+      ))}
+    </OptionsMenuItemGroup>
+  ));
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.scss
@@ -1,7 +1,16 @@
+@import '~@patternfly/patternfly/sass-utilities/all';
+
 .ceph-capacity-breakdown-card__body {
-    padding-top: 24px;
+  padding-top: 24px;
 }
 
-.ceph-capacity-breakdown-card__header{
-    display: flex;
+.ceph-capacity-breakdown-card__header {
+  display: flex;
+}
+
+.ceph-capacity-breakdown-card-header__dropdown {
+  max-width: 12em;
+  @media screen and (min-width: $pf-global--breakpoint--lg) {
+    min-width: 12em;
+  }
 }

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Dropdown, humanizeBinaryBytes } from '@console/internal/components/utils';
+import { Select, SelectProps } from '@patternfly/react-core';
+import { humanizeBinaryBytes } from '@console/internal/components/utils';
 import {
   DashboardItemProps,
   withDashboardResources,
@@ -15,10 +16,11 @@ import { PROJECTS } from '../../../../constants/index';
 import { BreakdownCardBody } from '../breakdown-card/breakdown-body';
 import { HeaderPrometheusViewLink } from '../breakdown-card/breakdown-header';
 import { getStackChartStats, sortInstantVectorStats } from '../breakdown-card/utils';
+import { getSelectOptions } from '../breakdown-card/breakdown-dropdown';
 import './capacity-breakdown-card.scss';
 
 const keys = Object.keys(breakdownQueryMap);
-const dropdownOptions = _.zipObject(keys, keys);
+const breakdownSelectItems = getSelectOptions(keys);
 
 const BreakdownCard: React.FC<DashboardItemProps> = ({
   watchPrometheus,
@@ -26,6 +28,7 @@ const BreakdownCard: React.FC<DashboardItemProps> = ({
   prometheusResults,
 }) => {
   const [metricType, setMetricType] = React.useState(PROJECTS);
+  const [isOpenBreakdownSelect, setBreakdownSelect] = React.useState(false);
   const { queries, model, metric } = breakdownQueryMap[metricType];
   const queryKeys = Object.keys(queries);
 
@@ -50,18 +53,30 @@ const BreakdownCard: React.FC<DashboardItemProps> = ({
   const cephUsed = _.get(results[3], 'data.result[0].value[1]');
   const link = `topk(20, (${CAPACITY_BREAKDOWN_QUERIES[queryKeys[0]]}))`;
 
+  const handleMetricsChange: SelectProps['onSelect'] = (_e, breakdown) => {
+    setMetricType(breakdown as string);
+    setBreakdownSelect(!isOpenBreakdownSelect);
+  };
+
   return (
     <DashboardCard>
       <DashboardCardHeader>
         <DashboardCardTitle>Capacity breakdown</DashboardCardTitle>
         <div className="ceph-capacity-breakdown-card__header">
           <HeaderPrometheusViewLink link={link} />
-          <Dropdown
-            items={dropdownOptions}
-            onChange={setMetricType}
-            selectedKey={metricType}
-            title={metricType}
-          />
+          <Select
+            className="ceph-capacity-breakdown-card-header__dropdown"
+            autoFocus={false}
+            onSelect={handleMetricsChange}
+            onToggle={() => setBreakdownSelect(!isOpenBreakdownSelect)}
+            isOpen={isOpenBreakdownSelect}
+            selections={[metricType]}
+            placeholderText={metricType}
+            aria-label="Break By Dropdown"
+            isCheckboxSelectionBadgeHidden
+          >
+            {breakdownSelectItems}
+          </Select>
         </div>
       </DashboardCardHeader>
       <DashboardCardBody classname="ceph-capacity-breakdown-card__body">

--- a/frontend/packages/ceph-storage-plugin/src/components/independent-dashboard-page/breakdown-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/independent-dashboard-page/breakdown-card.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import * as _ from 'lodash';
-import { Dropdown, humanizeBinaryBytes } from '@console/internal/components/utils';
+import { Select, SelectProps } from '@patternfly/react-core';
+import { humanizeBinaryBytes } from '@console/internal/components/utils';
 import {
   DashboardItemProps,
   withDashboardResources,
@@ -18,10 +18,11 @@ import {
 } from '../dashboard-page/storage-dashboard/breakdown-card/utils';
 import { HeaderPrometheusViewLink } from '../dashboard-page/storage-dashboard/breakdown-card/breakdown-header';
 import { BreakdownCardBody } from '../dashboard-page/storage-dashboard/breakdown-card/breakdown-body';
+import { getSelectOptions } from '../dashboard-page/storage-dashboard/breakdown-card/breakdown-dropdown';
 import '../dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.scss';
 
 const keys = Object.keys(breakdownIndependentQueryMap);
-const dropdownOptions = _.zipObject(keys, keys);
+const breakdownSelectItems = getSelectOptions(keys);
 
 export const BreakdownCard: React.FC<DashboardItemProps> = ({
   watchPrometheus,
@@ -29,6 +30,7 @@ export const BreakdownCard: React.FC<DashboardItemProps> = ({
   prometheusResults,
 }) => {
   const [metricType, setMetricType] = React.useState(PROJECTS);
+  const [isOpenBreakdownSelect, setBreakdownSelect] = React.useState(false);
   const { queries, model, metric } = breakdownIndependentQueryMap[metricType];
   const queryKeys = Object.keys(queries);
 
@@ -51,18 +53,30 @@ export const BreakdownCard: React.FC<DashboardItemProps> = ({
   const metricTotal = results[1]?.data?.result[0]?.value[1];
   const link = `topk(20, (${CAPACITY_BREAKDOWN_QUERIES[queryKeys[0]]}))`;
 
+  const handleMetricsChange: SelectProps['onSelect'] = (_e, breakdown) => {
+    setMetricType(breakdown as string);
+    setBreakdownSelect(!isOpenBreakdownSelect);
+  };
+
   return (
     <DashboardCard>
       <DashboardCardHeader>
         <DashboardCardTitle>Capacity breakdown</DashboardCardTitle>
         <div className="ceph-capacity-breakdown-card__header">
           <HeaderPrometheusViewLink link={link} />
-          <Dropdown
-            items={dropdownOptions}
-            onChange={setMetricType}
-            selectedKey={metricType}
-            title={metricType}
-          />
+          <Select
+            className="ceph-capacity-breakdown-card-header__dropdown"
+            autoFocus={false}
+            onSelect={handleMetricsChange}
+            onToggle={() => setBreakdownSelect(!isOpenBreakdownSelect)}
+            isOpen={isOpenBreakdownSelect}
+            selections={[metricType]}
+            placeholderText={metricType}
+            aria-label="Break By Dropdown"
+            isCheckboxSelectionBadgeHidden
+          >
+            {breakdownSelectItems}
+          </Select>
         </div>
       </DashboardCardHeader>
       <DashboardCardBody classname="ceph-capacity-breakdown-card__body">

--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-breakdown/capacity-breakdown-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-breakdown/capacity-breakdown-card.scss
@@ -14,6 +14,6 @@
     min-width: 12em;
   }
   &--margin {
-    margin-left: 0.4em;
+    margin-right: var(--pf-global--spacer--xs);
   }
 }

--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-breakdown/capacity-breakdown-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-breakdown/capacity-breakdown-card.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Select, SelectVariant, SelectGroup, SelectOption } from '@patternfly/react-core';
+import { Select, SelectGroup, SelectOption, SelectProps } from '@patternfly/react-core';
 import { FirehoseResource, humanizeBinaryBytes } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
@@ -23,9 +23,9 @@ import { PrometheusResponse, DataPoint } from '@console/internal/components/grap
 import { getInstantVectorStats } from '@console/internal/components/graphs/utils';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { RGW_FLAG } from '@console/ceph-storage-plugin/src/features';
+import { getGroupedSelectOptions } from '@console/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-dropdown';
 import { ServiceType, CapacityBreakdown, Groups } from '../../constants';
 import { breakdownQueryMap, CAPACITY_BREAKDOWN_QUERIES } from '../../queries';
-import { getSelectOptions } from '../data-consumption-card/data-consumption-card-dropdown';
 import './capacity-breakdown-card.scss';
 
 const subscriptionResource: FirehoseResource = {
@@ -104,16 +104,19 @@ const BreakdownCard: React.FC = () => {
     [serviceType],
   );
 
-  const serviceSelectItems = getSelectOptions(ServiceItems);
+  const serviceSelectItems = getGroupedSelectOptions(ServiceItems);
   const breakdownSelectItems = getDisableableSelectOptions(breakdownItems);
 
   const handleServiceChange = (_e: React.MouseEvent, service: ServiceType) => {
     setServiceType(service);
     setMetricType(CapacityBreakdown.defaultMetrics[service]);
+    setServiceSelect(!isOpenServiceSelect);
   };
 
-  const handleMetricsChange = (_e: React.MouseEvent, breakdown: CapacityBreakdown.Metrics) =>
-    setMetricType(breakdown);
+  const handleMetricsChange: SelectProps['onSelect'] = (_e, breakdown) => {
+    setMetricType(breakdown as CapacityBreakdown.Metrics);
+    setBreakdownSelect(!isOpenBreakdownSelect);
+  };
 
   const padding =
     serviceType !== ServiceType.MCG ? { top: 0, bottom: 0, left: 0, right: 50 } : undefined;
@@ -161,7 +164,6 @@ const BreakdownCard: React.FC = () => {
           )}
           {RGW && (
             <Select
-              variant={SelectVariant.single}
               className="nb-capacity-breakdown-card-header__dropdown nb-capacity-breakdown-card-header__dropdown--margin"
               autoFocus={false}
               onSelect={handleServiceChange}
@@ -178,8 +180,7 @@ const BreakdownCard: React.FC = () => {
             </Select>
           )}
           <Select
-            variant={SelectVariant.single}
-            className="nb-capacity-breakdown-card-header__dropdown nb-capacity-breakdown-card-header__dropdown--margin"
+            className="nb-capacity-breakdown-card-header__dropdown"
             autoFocus={false}
             onSelect={handleMetricsChange}
             onToggle={() => setBreakdownSelect(!isOpenBreakdownSelect)}

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-dropdown.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-dropdown.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import {
-  SelectGroup,
-  SelectOption,
   Select,
   SelectVariant,
-  OptionsMenuItemGroup,
-  OptionsMenuItem,
   OptionsMenu,
   OptionsMenuPosition,
   OptionsMenuToggle,
 } from '@patternfly/react-core';
+import {
+  getOptionsMenuItems,
+  getGroupedSelectOptions,
+} from '@console/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-dropdown';
 import {
   Breakdown,
   Metrics,
@@ -19,46 +19,6 @@ import {
   defaultBreakdown,
 } from '../../constants';
 import './data-consumption-card.scss';
-
-type SelectItems = {
-  group: string;
-  items: string[];
-}[];
-
-export const getSelectOptions = (dropdownItems: SelectItems) => {
-  return dropdownItems.map(({ group, items }) => (
-    <SelectGroup key={group} label={group}>
-      {items.map((item) => (
-        <SelectOption key={item} value={item} />
-      ))}
-    </SelectGroup>
-  ));
-};
-
-const getOptionsMenuItems = (
-  dropdownItems: SelectItems,
-  selectedItems: string[],
-  onSelect: (e) => void,
-) => {
-  return dropdownItems.map(({ group, items }) => (
-    <OptionsMenuItemGroup
-      className="nb-data-consumption-card__dropdown-item--hide-list-style"
-      key={group}
-      groupTitle={group}
-    >
-      {items.map((item) => (
-        <OptionsMenuItem
-          onSelect={onSelect}
-          isSelected={selectedItems.includes(item)}
-          id={item}
-          key={item}
-        >
-          {item}
-        </OptionsMenuItem>
-      ))}
-    </OptionsMenuItemGroup>
-  ));
-};
 
 const RGWDropdown = [
   {
@@ -120,6 +80,9 @@ export const DataConsumptionDropdown: React.FC<DataConsumptionDropdownProps> = (
       default:
         break;
     }
+    if (selectedService !== ServiceType.MCG) {
+      setComboDropdown(!isOpenComboDropdown);
+    }
   };
 
   const onSelectServiceDropdown = (_e: React.MouseEvent, selection: ServiceType) => {
@@ -130,6 +93,7 @@ export const DataConsumptionDropdown: React.FC<DataConsumptionDropdownProps> = (
     } else {
       setSelectedBreakdown(null);
     }
+    setServiceTypeDropdown(!isOpenServiceTypeDropdown);
   };
 
   const comboDropdownItems = (() => {
@@ -141,14 +105,14 @@ export const DataConsumptionDropdown: React.FC<DataConsumptionDropdownProps> = (
     );
   })();
 
-  const serviceDropdownItems = getSelectOptions(ServiceTypeDropdown);
+  const serviceDropdownItems = getGroupedSelectOptions(ServiceTypeDropdown);
 
   return (
     <div className="nb-data-consumption-card__dropdown">
       {isRgwSupported && (
         <Select
           variant={SelectVariant.single}
-          className="nb-data-consumption-card__dropdown-item"
+          className="nb-data-consumption-card__dropdown-item nb-data-consumption-card__dropdown-item--margin"
           autoFocus={false}
           onSelect={onSelectServiceDropdown}
           onToggle={() => setServiceTypeDropdown(!isOpenServiceTypeDropdown)}

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.scss
@@ -5,15 +5,21 @@
 }
 
 .nb-data-consumption-card__dropdown-item {
-  margin-right: 0.4em;
+  max-width: 12em;
   @media screen and (min-width: $pf-global--breakpoint--lg) {
-    max-width: 12em;
     min-width: 12em;
   }
   &--hide-list-style {
     li {
       list-style: none;
     }
+  }
+  &--margin {
+    margin-right: var(--pf-global--spacer--xs);
+  }
+  /* Override Options Menu item style to make it similar to Select Menu */
+  .pf-c-options-menu__menu-item {
+    padding-left: 0;
   }
 }
 

--- a/frontend/packages/noobaa-storage-plugin/src/constants/capacity-breakdown.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/capacity-breakdown.ts
@@ -1,6 +1,6 @@
 export enum ServiceType {
   MCG = 'Multi Cloud Gateway',
-  RGW = 'Rados Gateway',
+  RGW = 'RADOS Gateway',
   ALL = 'All',
 }
 


### PR DESCRIPTION
Converts dropdowns in all the capacity dropdowns(Persistent Storage in both Modes) to Select
Clicking the Single Select item will close the dropdown at once
Stop items from stretching outside of the viewport(Performance card in Object Storage)
Screenshots: 
Before:
![Screenshot from 2020-08-18 16-51-52](https://user-images.githubusercontent.com/54092533/90507214-2535e880-e173-11ea-898a-10887f87f5a3.png)
![Screenshot from 2020-08-18 16-52-11](https://user-images.githubusercontent.com/54092533/90507233-2ebf5080-e173-11ea-994e-e3170d893a20.png)

After:
![Screenshot from 2020-08-18 16-45-05](https://user-images.githubusercontent.com/54092533/90507034-d8eaa880-e172-11ea-9d13-20d705744214.png)
![Screenshot from 2020-08-18 16-44-17](https://user-images.githubusercontent.com/54092533/90507085-f15ac300-e172-11ea-837e-b4ca66d94fb3.png)
