### PR TITLE
Bug 1869617: Add 'pending restart' label for new disks and NICs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/table/validation-cell.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/table/validation-cell.scss
@@ -1,6 +1,16 @@
-.kubevirt-validation-cell__cell--error {
+.kv-validation-cell__cell--error {
   color: var(--pf-global--danger-color--100);
 }
-.kubevirt-validation-cell__cell--warning {
+.kv-validation-cell__cell--warning {
   color: var(--pf-global--Color--200);
+}
+
+.kv-validation-cell__additional-label {
+  color: #795600;
+  padding-left: var(--pf-global--spacer--sm);
+}
+
+.kv-validation-cell__cell--row-flex-direction {
+  display: flex;
+  flex-direction: row;
 }

--- a/frontend/packages/kubevirt-plugin/src/components/table/validation-cell.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/table/validation-cell.tsx
@@ -7,20 +7,34 @@ import './validation-cell.scss';
 export type SimpleCellProps = {
   children?: React.ReactNode;
   validation?: ValidationObject;
+  additionalLabel?: string;
 };
 
-export const ValidationCell: React.FC<SimpleCellProps> = ({ children, validation }) => {
+export const ValidationCell: React.FC<SimpleCellProps> = ({
+  children,
+  validation,
+  additionalLabel,
+}) => {
   return (
     <>
-      {children}
+      <div
+        className={classNames({
+          'kv-validation-cell__cell--row-flex-direction': !!additionalLabel,
+        })}
+      >
+        {children}
+        {additionalLabel && (
+          <div className="kv-validation-cell__additional-label">{additionalLabel}</div>
+        )}
+      </div>
       {validation && (
         <div
           className={classNames({
-            'kubevirt-validation-cell__cell--error': [
+            'kv-validation-cell__cell--error': [
               ValidationErrorType.Error,
               ValidationErrorType.TrivialError,
             ].includes(validation.type),
-            'kubevirt-validation-cell__cell--warning': validation.type === ValidationErrorType.Warn,
+            'kv-validation-cell__cell--warning': validation.type === ValidationErrorType.Warn,
           })}
         >
           {validation.message}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -25,6 +25,7 @@ import {
   VMStorageRowCustomData,
 } from './types';
 import { validateDisk } from '../../utils/validations/vm/disk';
+import { PENDING_RESTART_LABEL } from '../../constants';
 
 const menuActionEdit = (
   disk: CombinedDisk,
@@ -97,6 +98,7 @@ export type VMDiskSimpleRowProps = {
   actionsComponent: React.ReactNode;
   index: number;
   style: object;
+  isPendingRestart?: boolean;
 };
 
 export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
@@ -106,6 +108,7 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
   actionsComponent,
   index,
   style,
+  isPendingRestart,
 }) => {
   const dimensify = dimensifyRow(columnClasses);
 
@@ -114,7 +117,12 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
   return (
     <TableRow id={name} index={index} trKey={name} style={style}>
       <TableData className={dimensify()}>
-        <ValidationCell validation={validation.name}>{name}</ValidationCell>
+        <ValidationCell
+          validation={validation.name}
+          additionalLabel={isPendingRestart ? PENDING_RESTART_LABEL : null}
+        >
+          {name}
+        </ValidationCell>
       </TableData>
       <TableData className={dimensify()}>
         <ValidationCell validation={validation.source}>{source || DASH}</ValidationCell>
@@ -146,7 +154,14 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
 
 export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
   obj: { disk, ...restData },
-  customData: { isDisabled, withProgress, vmLikeEntity, columnClasses, templateValidations },
+  customData: {
+    isDisabled,
+    withProgress,
+    vmLikeEntity,
+    columnClasses,
+    templateValidations,
+    pendingChangesDisks,
+  },
   index,
   style,
 }) => {
@@ -157,6 +172,7 @@ export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
     disk.persistentVolumeClaimWrapper,
     { templateValidations },
   );
+  const isPendingRestart = !!pendingChangesDisks?.has(restData.name);
   return (
     <DiskSimpleRow
       data={restData}
@@ -171,6 +187,7 @@ export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
             diskValidations.validations.pvc,
         }
       }
+      isPendingRestart={isPendingRestart}
       columnClasses={columnClasses}
       index={index}
       style={style}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -42,4 +42,5 @@ export type VMStorageRowCustomData = {
   vmLikeEntity: VMLikeEntityKind;
   columnClasses: string[];
   isDisabled: boolean;
+  pendingChangesDisks?: Set<string>;
 } & VMStorageRowActionOpts;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -31,6 +31,10 @@ import { FileSystemsList } from './guest-agent-file-systems';
 import { VM_DISKS_DESCRIPTION } from '../../strings/vm/messages';
 import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
 import { asVM } from '../../selectors/vm';
+import { VMIKind } from '../../types';
+import { VMWrapper } from '../../k8s/wrapper/vm/vm-wrapper';
+import { VMIWrapper } from '../../k8s/wrapper/vm/vmi-wrapper';
+import { changedDisks } from '../../selectors/vm-like/next-run-changes';
 
 const getStoragesData = ({
   vmLikeEntity,
@@ -147,14 +151,18 @@ type VMDisksProps = {
   pvcs?: FirehoseResult<K8sResourceKind[]>;
   datavolumes?: FirehoseResult<V1alpha1DataVolume[]>;
   vmTemplate?: FirehoseResult<TemplateKind>;
+  vmi?: VMIKind;
 };
 
-export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, vmTemplate }) => {
+export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, vmTemplate, vmi }) => {
   const namespace = getNamespace(vmLikeEntity);
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
   const templateValidations = getTemplateValidationsFromTemplate(getLoadedData(vmTemplate));
   const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
+  const pendingChangesDisks: Set<string> = vmi
+    ? new Set(changedDisks(new VMWrapper(asVM(vmLikeEntity)), new VMIWrapper(vmi)))
+    : null;
 
   const resources = [
     getResource(PersistentVolumeClaimModel, {
@@ -206,6 +214,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, vmTemplate }) =>
         templateValidations,
         columnClasses: diskTableColumnClasses,
         showGuestAgentHelp: true,
+        pendingChangesDisks,
       }}
       hideLabelFilter
     />
@@ -276,7 +285,7 @@ export const VMDisksAndFileSystemsPage: React.FC<VMTabProps> = ({
 
   return (
     <Firehose resources={resources}>
-      <VMDisks vmLikeEntity={vmLikeEntity} />
+      <VMDisks vmLikeEntity={vmLikeEntity} vmi={vmi} />
       <FileSystemsList vmi={vmi} vmStatusBundle={vmStatusBundle} />
     </Firehose>
   );

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
@@ -17,6 +17,7 @@ import {
   NetworkSimpleDataValidation,
   VMNicRowCustomData,
 } from './types';
+import { PENDING_RESTART_LABEL } from '../../constants';
 
 const menuActionEdit = (
   nic,
@@ -72,6 +73,7 @@ export type VMNicSimpleRowProps = {
   actionsComponent: React.ReactNode;
   index: number;
   style: object;
+  isPendingRestart?: boolean;
 };
 
 export const NicSimpleRow: React.FC<VMNicSimpleRowProps> = ({
@@ -81,13 +83,19 @@ export const NicSimpleRow: React.FC<VMNicSimpleRowProps> = ({
   actionsComponent,
   index,
   style,
+  isPendingRestart,
 }) => {
   const dimensify = dimensifyRow(columnClasses);
 
   return (
     <TableRow id={name} index={index} trKey={name} style={style}>
       <TableData className={dimensify()}>
-        <ValidationCell validation={validation.name}>{name}</ValidationCell>
+        <ValidationCell
+          validation={validation.name}
+          additionalLabel={isPendingRestart ? PENDING_RESTART_LABEL : null}
+        >
+          {name}
+        </ValidationCell>
       </TableData>
       <TableData className={dimensify()}>
         <ValidationCell validation={validation.model}>{model || DASH}</ValidationCell>
@@ -110,7 +118,7 @@ export const NicSimpleRow: React.FC<VMNicSimpleRowProps> = ({
 
 export const NicRow: RowFunction<NetworkBundle, VMNicRowCustomData> = ({
   obj: { name, nic, network, ...restData },
-  customData: { isDisabled, withProgress, vmLikeEntity, columnClasses },
+  customData: { isDisabled, withProgress, vmLikeEntity, columnClasses, pendingChangesNICs },
   index,
   style,
 }) => (
@@ -119,6 +127,7 @@ export const NicRow: RowFunction<NetworkBundle, VMNicRowCustomData> = ({
     columnClasses={columnClasses}
     index={index}
     style={style}
+    isPendingRestart={!!pendingChangesNICs?.has(name)}
     actionsComponent={
       <Kebab
         options={getActions(nic, network, vmLikeEntity, { withProgress })}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
@@ -28,4 +28,5 @@ export type VMNicRowCustomData = {
   vmLikeEntity: VMLikeEntityKind;
   columnClasses: string[];
   isDisabled: boolean;
+  pendingChangesNICs?: Set<string>;
 } & VMNicRowActionOpts;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -7,7 +7,7 @@ import { EmptyBox } from '@console/internal/components/utils';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { VMGenericLikeEntityKind } from '../../types/vmLike';
 import { isVMI, isVM } from '../../selectors/check-type';
-import { VMLikeEntityTabProps } from '../vms/types';
+import { VMTabProps } from '../vms/types';
 import { NetworkInterfaceWrapper } from '../../k8s/wrapper/vm/network-interface-wrapper';
 import { nicModalEnhanced } from '../modals/nic-modal/nic-modal-enhanced';
 import { getSimpleName } from '../../selectors/utils';
@@ -20,6 +20,9 @@ import { asVMILikeWrapper } from '../../k8s/wrapper/utils/convert';
 import { ADD_NETWORK_INTERFACE } from '../../utils/strings';
 import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
 import { asVM } from '../../selectors/vm';
+import { VMWrapper } from '../../k8s/wrapper/vm/vm-wrapper';
+import { VMIWrapper } from '../../k8s/wrapper/vm/vmi-wrapper';
+import { changedNics } from '../../selectors/vm-like/next-run-changes';
 
 const getNicsData = (vmLikeEntity: VMGenericLikeEntityKind): NetworkBundle[] => {
   const vmiLikeWrapper = asVMILikeWrapper(vmLikeEntity);
@@ -109,10 +112,14 @@ export const VMNicsTable: React.FC<VMNicsTableProps> = ({
   );
 };
 
-export const VMNics: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEntity }) => {
+export const VMNics: React.FC<VMTabProps> = ({ obj: vmLikeEntity, vmis: vmisProp }) => {
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
   const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
+  const pendingChangesNICs: Set<string> =
+    vmisProp.length > 0 && isVMI(vmisProp[0])
+      ? new Set(changedNics(new VMWrapper(asVM(vmLikeEntity)), new VMIWrapper(vmisProp[0])))
+      : null;
 
   return (
     <div className="co-m-list">
@@ -145,6 +152,7 @@ export const VMNics: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEntity }) =>
             vmLikeEntity,
             withProgress,
             isDisabled: isLocked,
+            pendingChangesNICs,
           }}
           row={NicRow}
           columnClasses={nicTableColumnClasses}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.scss
@@ -1,4 +1,8 @@
-.kubevirt-vm-list {
+.kv-vm-list {
   // Give kebab from last row enough space so it will be included in WindowScroller computation
   padding-bottom: 15em;
+}
+
+.kv-vm-row_status-extra-label {
+  color: var(--pf-global--Color--100);
 }

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -149,7 +149,7 @@ const VMRow: RowFunction<VMRowObjType> = ({ obj, index, key, style }) => {
           vmStatusBundle={vmStatusBundle}
           arePendingChanges={arePendingChanges}
         />
-        {arePendingChanges && <div>Pending changes</div>}
+        {arePendingChanges && <div className="kv-vm-row_status-extra-label">Pending changes</div>}
       </TableData>
       <TableData className={dimensify()}>
         <Timestamp timestamp={creationTimestamp} />
@@ -168,7 +168,7 @@ const VMRow: RowFunction<VMRowObjType> = ({ obj, index, key, style }) => {
 };
 
 const VMList: React.FC<React.ComponentProps<typeof Table> & VMListProps> = (props) => (
-  <div className="kubevirt-vm-list">
+  <div className="kv-vm-list">
     <Table
       {...props}
       aria-label={VirtualMachineModel.labelPlural}

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -60,3 +60,5 @@ export const WINTOOLS_CONTAINER_NAMES = {
   azure: 'registry.redhat.io/container-native-virtualization/virtio-win',
   okd: 'kubevirt/virtio-container-disk',
 };
+
+export const PENDING_RESTART_LABEL = '(pending restart)';


### PR DESCRIPTION
Add a label beside Disks and NICs names at 'Disks' and 'Network Interfaces' tabs
for devices which were added while the VM is running

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>