### PR TITLE
Bug 1869631: Mode Detection independent of Storage Cluster CR name

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/independent-mode/install.tsx
@@ -34,7 +34,7 @@ import { getName } from '@console/shared';
 import { OCSServiceModel } from '../../models';
 import FileUpload from './fileUpload';
 import { isValidJSON, checkError, prettifyJSON } from './utils';
-import { OCS_INDEPENDENT_FLAG, OCS_FLAG } from '../../features';
+import { OCS_INDEPENDENT_FLAG, OCS_FLAG, OCS_CONVERGED_FLAG } from '../../features';
 import { OCS_INDEPENDENT_CR_NAME } from '../../constants';
 import './install.scss';
 
@@ -110,6 +110,7 @@ const InstallExternalCluster = withHandlePromise((props: InstallExternalClusterP
     handlePromise(Promise.all([k8sCreate(SecretModel, secret), k8sCreate(OCSServiceModel, ocsObj)]))
       .then((data) => {
         dispatch(setFlag(OCS_INDEPENDENT_FLAG, true));
+        dispatch(setFlag(OCS_CONVERGED_FLAG, false));
         dispatch(setFlag(OCS_FLAG, true));
         history.push(
           `/k8s/ns/${ns}/clusterserviceversions/${getName(

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -37,7 +37,7 @@ import { OSDSizeDropdown } from '../../utils/osd-size-dropdown';
 import { cephStorageLabel } from '../../selectors';
 import NodeTable from './node-list';
 import { PVsAvailableCapacity } from './pvs-available-capacity';
-import { OCS_FLAG, OCS_CONVERGED_FLAG } from '../../features';
+import { OCS_FLAG, OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG } from '../../features';
 import './ocs-install.scss';
 
 const makeLabelNodesRequest = (selectedNodes: NodeKind[]): Promise<NodeKind>[] => {
@@ -107,6 +107,7 @@ export const CreateOCSServiceForm = withHandlePromise<
     // eslint-disable-next-line promise/catch-or-return
     handlePromise(makeOCSRequest(selectedNodes, storageClass, osdSize)).then(() => {
       dispatch(setFlag(OCS_CONVERGED_FLAG, true));
+      dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
       dispatch(setFlag(OCS_FLAG, true));
       history.push(
         `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(


### PR DESCRIPTION
Detection of storage cluster mode should be based on spec.externalStorage and not on the CR name.