### PR TITLE
Bug 1870627: Fix to maintain URL params on topology view switch

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -76,7 +76,6 @@ export function renderTopology({
 
 export const TopologyPageContext: React.FC<TopologyPageProps> = observer(({ match }) => {
   const queryParams = useQueryParams();
-  const searchParams = queryParams.get('searchQuery');
   const namespace = match.params.name;
   const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
   const showListView = !!matchPath(match.path, {
@@ -104,7 +103,7 @@ export const TopologyPageContext: React.FC<TopologyPageProps> = observer(({ matc
       <Redirect
         to={`/topology/${namespace ? `ns/${namespace}` : 'all-namespaces'}/${
           getTopologyActiveView() === 'list' ? 'list' : 'graph'
-        }`}
+        }${queryParams ? `?${queryParams.toString()}` : ''}`}
       />
     );
   }
@@ -143,7 +142,7 @@ export const TopologyPageContext: React.FC<TopologyPageProps> = observer(({ matc
                   className="pf-c-button pf-m-plain"
                   to={`/topology/${namespace ? `ns/${namespace}` : 'all-namespaces'}${
                     showListView ? '/graph' : '/list'
-                  }${searchParams ? `?searchQuery=${searchParams}` : ''}`}
+                  }${queryParams ? `?${queryParams.toString()}` : ''}`}
                 >
                   {showListView ? <TopologyIcon size="md" /> : <ListIcon size="md" />}
                 </Link>

--- a/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
@@ -141,7 +141,7 @@ export const TopologyView: React.FC<ComponentProps> = ({
   const searchParams = queryParams.get('searchQuery');
   const onSelect = (ids: string[]) => {
     // set empty selection when selecting the graph
-    if (ids.length > 0 && ids[0] === TOPOLOGY_GRAPH_ID) {
+    if (!ids || ids.length === 0 || ids[0] === TOPOLOGY_GRAPH_ID) {
       setSelectedIds([]);
       removeQueryArgument('selectId');
     } else {
@@ -281,16 +281,24 @@ export const TopologyView: React.FC<ComponentProps> = ({
   React.useEffect(() => {
     if (filteredModel) {
       visualization.fromModel(filteredModel);
-      if (selectedIds.length && !visualization.getElementById(selectedIds[0])) {
-        setSelectedIds([]);
+      let selectedItem = selectedIds.length ? visualization.getElementById(selectedIds[0]) : null;
+      if (!selectedItem || !selectedItem.isVisible()) {
+        onSelect([]);
       } else {
         const selectId = queryParams.get('selectId');
-        const selectTab = queryParams.get('selectTab');
-        visualization.getElementById(selectId) && setSelectedIds([selectId]);
-        if (selectTab) {
-          onSelectTab(selectTab);
-          removeQueryArgument('selectTab');
+        if (selectId) {
+          selectedItem = visualization.getElementById(selectId);
+          if (selectedItem && selectedItem.isVisible()) {
+            setSelectedIds([selectId]);
+            const selectTab = queryParams.get('selectTab');
+            if (selectTab) {
+              onSelectTab(selectTab);
+            }
+          } else {
+            onSelect([]);
+          }
         }
+        removeQueryArgument('selectTab');
       }
       if (showGraphView) {
         if (groupsShown && showGroupsRef.current === false) {

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
@@ -85,14 +85,18 @@ describe('Topology page tests', () => {
     const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
     expect(namespacesPageWrapper.find(Tooltip).props().content).toBe('Topology View');
-    expect(namespacesPageWrapper.find(Link).props().to).toBe('/topology/ns/topology-test/graph');
+    expect(namespacesPageWrapper.find(Link).props().to).toContain(
+      '/topology/ns/topology-test/graph',
+    );
   });
 
   it('should show the topology list icon when on topology page', () => {
     const wrapper = shallow(<TopologyPageContext {...topologyProps} />);
     const namespacesPageWrapper = wrapper.find(NamespacedPage).shallow();
     expect(namespacesPageWrapper.find(Tooltip).props().content).toBe('List View');
-    expect(namespacesPageWrapper.find(Link).props().to).toBe('/topology/ns/topology-test/list');
+    expect(namespacesPageWrapper.find(Link).props().to).toContain(
+      '/topology/ns/topology-test/list',
+    );
   });
 
   it('should render topology when workload is loaded', () => {

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Visualization } from '@patternfly/react-topology';
+import { useQueryParams } from '@console/shared';
 import { RootState } from '@console/internal/redux';
 import { getActiveNamespace } from '@console/internal/reducers/ui';
 import { ExternalLink } from '@console/internal/components/utils';
@@ -23,7 +24,6 @@ import {
   getSupportedTopologyFilters,
   getSupportedTopologyKinds,
   getTopologyFilters,
-  getTopologySearchQuery,
   onSearchChange,
 } from './filter-utils';
 import FilterDropdown from './FilterDropdown';
@@ -63,16 +63,12 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
   consoleLinks,
   namespace,
 }) => {
-  const [searchQuery, setSearchQuery] = React.useState<string>('');
   const kialiLink = getNamespaceDashboardKialiLink(consoleLinks, namespace);
-  React.useEffect(() => {
-    const query = getTopologySearchQuery();
-    setSearchQuery(query);
-  }, []);
+  const queryParams = useQueryParams();
+  const searchQuery = queryParams.get('searchQuery') || '';
 
   const onTextFilterChange = (text) => {
     const query = text?.trim();
-    setSearchQuery(query);
     onSearchChange(query);
   };
 


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4508
https://issues.redhat.com/browse/ODC-4509

**Description**
Fix to topology view to keep URL params on switching views. When no selection, remove the select parameter (rather then setting to undefined).

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug