### PR TITLE
Bug 1869942: Monitoring: Clarify popover help text

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -282,17 +282,28 @@ const PopoverField: React.FC<{ body: React.ReactNode; label: string }> = ({ body
 const alertStateHelp = (
   <dl className="co-inline">
     <dt>
-      <AlertStateIcon state={AlertStates.Firing} /> <strong>Firing: </strong>
-    </dt>
-    <dd>The alert condition is true for the duration of the timeout.</dd>
-    <dt>
       <AlertStateIcon state={AlertStates.Pending} /> <strong>Pending: </strong>
     </dt>
-    <dd>The alert condition is true, but the timeout has not been reached.</dd>
+    <dd>
+      The alert is active but is waiting for the duration that is specified in the alerting rule
+      before it fires.
+    </dd>
+    <dt>
+      <AlertStateIcon state={AlertStates.Firing} /> <strong>Firing: </strong>
+    </dt>
+    <dd>
+      The alert is firing because the alert condition is true and the optional `for` duration has
+      passed. The alert will continue to fire as long as the condition remains true.
+    </dd>
     <dt>
       <AlertStateIcon state={AlertStates.Silenced} /> <strong>Silenced: </strong>
     </dt>
-    <dd>The alert is now silenced.</dd>
+    <dt></dt>
+    <dd>
+      The alert is now silenced for a defined time period. Silences temporarily mute alerts based on
+      a set of label selectors that you define. Notifications will not be sent for alerts that match
+      all the listed values or regular expressions.
+    </dd>
   </dl>
 );
 
@@ -303,14 +314,16 @@ const severityHelp = (
     </dt>
     <dd>
       The condition that triggered the alert could have a critical impact. The alert requires
-      immediate attention when fired.
+      immediate attention when fired and is typically paged to an individual or to a critical
+      response team.
     </dd>
     <dt>
       <SeverityIcon severity={AlertSeverity.Warning} /> <strong>Warning: </strong>
     </dt>
     <dd>
       The alert provides a warning notification about something that might require attention in
-      order to prevent a problem from occurring.
+      order to prevent a problem from occurring. Warnings are typically routed to a ticketing system
+      for non-immediate review.
     </dd>
     <dt>
       <SeverityIcon severity={AlertSeverity.Info} /> <strong>Info: </strong>
@@ -320,6 +333,7 @@ const severityHelp = (
       <SeverityIcon severity={AlertSeverity.None} /> <strong>None: </strong>
     </dt>
     <dd>The alert has no defined severity.</dd>
+    <dd>You can also create custom severity definitions for user workload alerts.</dd>
   </dl>
 );
 
@@ -336,8 +350,9 @@ const sourceHelp = (
       <strong>User: </strong>
     </dt>
     <dd>
-      User workload alerts relate to user-defined namespaces and are customizable. User workload
-      monitoring can be enabled post-installation to provide observability into your own services.
+      User workload alerts relate to user-defined namespaces. These alerts are user-created and are
+      customizable. User workload monitoring can be enabled post-installation to provide
+      observability into your own services.
     </dd>
   </dl>
 );


### PR DESCRIPTION
Update text to be more helpful and to align with the 4.6 docs.

Before | After
-|-
![before-severity](https://user-images.githubusercontent.com/460802/90591487-32f47800-e21e-11ea-8cff-22aa58619de5.png) | ![after-severity](https://user-images.githubusercontent.com/460802/90591494-3851c280-e21e-11ea-9dad-84f2453cf63d.png)
![before-source](https://user-images.githubusercontent.com/460802/90591570-61725300-e21e-11ea-993d-2554678b1040.png) | ![after-source](https://user-images.githubusercontent.com/460802/90591577-646d4380-e21e-11ea-9da0-7044a7f5cd8a.png)
![before-state](https://user-images.githubusercontent.com/460802/90591579-66cf9d80-e21e-11ea-94b7-61019be81127.png) | ![after-state](https://user-images.githubusercontent.com/460802/90591582-68996100-e21e-11ea-98d7-e02e30775d7b.png)
