### PR TITLE
Bug 1866296: Cypress CRUD tests flake fixes

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
@@ -82,6 +82,8 @@ describe('Kubernetes resource CRUD operations', () => {
         if (resourcesWithCreationForm.has(kind)) {
           cy.byTestID('yaml-link').click();
         }
+        // sidebar needs to be fully loaded, else it sometimes overlays the Create button
+        cy.byTestID('resource-sidebar').should('exist');
         yamlEditor.isLoaded();
         let newContent;
         // get, update, and set yaml editor content.
@@ -143,6 +145,9 @@ describe('Kubernetes resource CRUD operations', () => {
             namespaced ? `ns/${testName}` : 'all-namespaces'
           }?kind=${kind}&q=${testLabel}%3d${testName}&name=${name}`,
         );
+
+        // filter should have 3 chip groups: resource, label, and name
+        listPage.filter.numberOfActiveFiltersShouldBe(3);
         listPage.rows.shouldExist(name);
 
         cy.log('link to to details page');

--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -24,6 +24,9 @@ export const listPage = {
     byName: (name: string) => {
       cy.byLegacyTestID('item-filter').type(name);
     },
+    numberOfActiveFiltersShouldBe: (numFilters: number) => {
+      cy.get("[class='pf-c-toolbar__item pf-m-chip-group']").should('have.length', numFilters);
+    },
   },
   rows: {
     shouldBeLoaded: () => {

--- a/frontend/packages/integration-tests-cypress/views/yaml-editor.ts
+++ b/frontend/packages/integration-tests-cypress/views/yaml-editor.ts
@@ -10,6 +10,8 @@ export const setEditorContent = (text: string) => {
   });
 };
 
-export const isLoaded = () => cy.window().should('have.property', 'yamlEditorReady', true);
+// initially yamlEditor loads with all grey text, finished loading when editor is color coded
+// class='mtk26' is the light blue color of property such as 'apiVersion'
+export const isLoaded = () => cy.get("[class='mtk26']").should('exist');
 export const clickSaveCreateButton = () => cy.byTestID('save-changes').click();
 export const clickReloadButton = () => cy.byTestID('reload-object').click();

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -196,9 +196,6 @@ export const EditYAML_ = connect(stateToProps)(
 
       loadYaml(reload = false, obj = this.props.obj) {
         if (this.state.initialized && !reload) {
-          if (window.Cypress) {
-            window.yamlEditorReady = true;
-          }
           return;
         }
 

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -46,7 +46,6 @@ declare interface Window {
   store?: {}; // Redux store
   pluginStore?: {}; // Console plugin store
   Cypress?: {};
-  yamlEditorReady?: boolean;
 }
 
 // From https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html


### PR DESCRIPTION
Ran Cypress locally many times, was able to see and fix some flakes:

1. `yamlEditorReady` Cypress env var seemed to have a race condition; removed it.  Yaml Editor is completely loaded when it is color coded, added test for that.  Had to test by `class` as we can't add an ID due to it being a 3rd party component.
2. When using url with query params for Search page, noticed page would load initially with just name filter/chip, and show the resource so test would continue, then page would reload and display with all three query params/filter chip groups (resource, label, name).  This would cause flakes.  Fixed by looking for all three chips.  Had to search by `class` as it's a PF component.