### PR TITLE
 Bug 1872283: Align UI with gitops-backend and remove mock-data

### DIFF
--- a/frontend/packages/dev-console/src/components/gitops/GitOpsDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/GitOpsDetailsPage.tsx
@@ -2,11 +2,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { RouteComponentProps } from 'react-router-dom';
 import * as _ from 'lodash';
-import { BreadCrumbs, ResourceIcon, LoadingBox } from '@console/internal/components/utils';
-import { Split, SplitItem, Label } from '@patternfly/react-core';
 import { GitOpsAppGroupData, GitOpsEnvironment } from './utils/gitops-types';
-import GitOpsDetailsController from './details/GitOpsDetailsController';
-import { routeDecoratorIcon } from '../import/render-utils';
 import {
   fetchAppGroups,
   getEnvData,
@@ -14,12 +10,16 @@ import {
   getApplicationsBaseURI,
 } from './utils/gitops-utils';
 import useDefaultSecret from './utils/useDefaultSecret';
+import GitOpsDetailsPageHeading from './details/GitOpsDetailsPageHeading';
+import GitOpsDetailsController from './details/GitOpsDetailsController';
+import { LoadingBox } from '@console/internal/components/utils';
 
 type GitOpsDetailsPageProps = RouteComponentProps<{ appName?: string }>;
 
 const GitOpsDetailsPage: React.FC<GitOpsDetailsPageProps> = ({ match, location }) => {
   const [envs, setEnvs] = React.useState<string[]>(null);
   const [envsData, setEnvsData] = React.useState<GitOpsEnvironment[]>(null);
+  const [emptyStateMsg, setEmptyStateMsg] = React.useState(null);
   const [secretNS, secretName] = useDefaultSecret();
   const { appName } = match.params;
   const searchParams = new URLSearchParams(location.search);
@@ -28,30 +28,24 @@ const GitOpsDetailsPage: React.FC<GitOpsDetailsPageProps> = ({ match, location }
   const applicationBaseURI = getApplicationsBaseURI(appName, secretNS, secretName, manifestURL);
   const environmentBaseURI = `/api/gitops/environments`;
 
-  const breadcrumbs = [
-    {
-      name: 'Application Stages',
-      path: '/applicationstages',
-    },
-    {
-      name: 'Application Details',
-      path: `${match.url}`,
-    },
-  ];
-
   React.useEffect(() => {
     let ignore = false;
 
     const getEnvs = async () => {
       if (!pipelinesBaseURI) return;
       let appGroups: GitOpsAppGroupData[];
+      let emptyMsg = null;
       try {
         appGroups = await fetchAppGroups(pipelinesBaseURI, manifestURL);
       } catch {} // eslint-disable-line no-empty
       if (ignore) return;
       const app = _.find(appGroups, (appObj) => appName === appObj?.name);
+      if (!app?.environments) {
+        emptyMsg =
+          'Environment details were not found. Try reloading the page or contacting an administrator.';
+      }
+      setEmptyStateMsg(emptyMsg);
       setEnvs(app?.environments);
-      setEnvs(['dev', 'test', 'qa', 'stage', 'prod']); // will remove this once backend is ready
     };
 
     getEnvs();
@@ -82,37 +76,12 @@ const GitOpsDetailsPage: React.FC<GitOpsDetailsPageProps> = ({ match, location }
       <Helmet>
         <title>{`${appName} · Details`}</title>
       </Helmet>
-      <div className="co-m-nav-title co-m-nav-title--breadcrumbs">
-        <BreadCrumbs breadcrumbs={breadcrumbs} />
-        <h1>
-          <div className="co-m-pane__name co-resource-item">
-            <ResourceIcon kind="application" className="co-m-resource-icon--lg" />
-            <span className="co-resource-item__resource-name">{appName}</span>
-          </div>
-        </h1>
-        <Split style={{ alignItems: 'center' }} hasGutter>
-          <SplitItem style={{ fontWeight: 'bold', fontSize: '12px' }}>
-            Manifest File Repo:
-          </SplitItem>
-          <SplitItem isFilled>
-            <Label
-              style={{ fontSize: '12px' }}
-              color="blue"
-              icon={routeDecoratorIcon(manifestURL, 12)}
-            >
-              <a
-                style={{ color: 'var(--pf-c-label__content--Color)' }}
-                href={manifestURL}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                {manifestURL}
-              </a>
-            </Label>
-          </SplitItem>
-        </Split>
-      </div>
-      {envsData ? <GitOpsDetailsController envsData={envsData} /> : <LoadingBox />}
+      <GitOpsDetailsPageHeading url={match.url} appName={appName} manifestURL={manifestURL} />
+      {!envsData && !emptyStateMsg ? (
+        <LoadingBox />
+      ) : (
+        <GitOpsDetailsController envsData={envsData} emptyStateMsg={emptyStateMsg} />
+      )}
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/gitops/GitOpsEmptyState.scss
+++ b/frontend/packages/dev-console/src/components/gitops/GitOpsEmptyState.scss
@@ -1,0 +1,6 @@
+.odc-gitops-empty-state {
+  &__icon {
+    height: var(--pf-c-empty-state__icon--FontSize);
+    max-width: 100%;
+  }
+}

--- a/frontend/packages/dev-console/src/components/gitops/GitOpsEmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/GitOpsEmptyState.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import * as gitopsIcon from '../../images/gitops.svg';
+import './GitOpsEmptyState.scss';
+
+interface GitOpsEmptyStateProps {
+  emptyStateMsg: string;
+}
+
+const gitopsImage = () => (
+  <img className="odc-gitops-empty-state__icon" src={gitopsIcon} alt="GitOps" />
+);
+
+const GitOpsEmptyState: React.FC<GitOpsEmptyStateProps> = ({ emptyStateMsg }) => (
+  <EmptyState variant={EmptyStateVariant.full}>
+    <EmptyStateIcon variant="container" component={gitopsImage} />
+    <EmptyStateBody>{emptyStateMsg}</EmptyStateBody>
+  </EmptyState>
+);
+
+export default GitOpsEmptyState;

--- a/frontend/packages/dev-console/src/components/gitops/GitOpsListPage.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/GitOpsListPage.tsx
@@ -37,17 +37,17 @@ const GitOpsListPage: React.FC = () => {
     };
   }, [baseURL, namespaces, nsError, nsLoaded]);
 
-  if (!appGroups && !emptyStateMsg) {
-    return <LoadingBox />;
-  }
-
   return (
     <>
       <Helmet>
         <title>Application Stages</title>
       </Helmet>
       <PageHeading title="Application Stages" />
-      <GitOpsList appGroups={appGroups} emptyStateMsg={emptyStateMsg} />
+      {!appGroups && !emptyStateMsg ? (
+        <LoadingBox />
+      ) : (
+        <GitOpsList appGroups={appGroups} emptyStateMsg={emptyStateMsg} />
+      )}
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/gitops/details/CommitDetails.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/CommitDetails.tsx
@@ -17,7 +17,7 @@ interface CommitDetailsProps {
 const CommitDetails: React.FC<CommitDetailsProps> = ({ imageName }) => {
   const [commitData, setCommitData] = React.useState<CommitData>(null);
   const namespace = useSelector(getActiveNamespace);
-  const importImage = {
+  const importImage = imageName && {
     kind: 'ImageStreamImport',
     apiVersion: 'image.openshift.io/v1',
     metadata: {
@@ -46,11 +46,13 @@ const CommitDetails: React.FC<CommitDetailsProps> = ({ imageName }) => {
       let lastCommitData: CommitData = { author: '', timestamp: '', id: '' };
       let imageStreamImport;
       try {
-        imageStreamImport = await k8sCreate(ImageStreamImportsModel, importImage);
+        imageStreamImport = importImage
+          ? await k8sCreate(ImageStreamImportsModel, importImage)
+          : {};
       } catch {} // eslint-disable-line no-empty
       if (ignore) return;
       const status = imageStreamImport?.status?.images?.[0]?.status;
-      if (status.status === 'Success') {
+      if (status?.status === 'Success') {
         const imageLabels =
           imageStreamImport?.status?.images?.[0]?.image?.dockerImageMetadata?.Config?.Labels;
         lastCommitData = {
@@ -67,7 +69,6 @@ const CommitDetails: React.FC<CommitDetailsProps> = ({ imageName }) => {
     return () => {
       ignore = true;
     };
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.scss
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.scss
@@ -23,6 +23,10 @@
       display: inline-flex;
       align-items: center;
     }
+    &__url-empty-state {
+      font-size: 12px;
+      color: var(--pf-global--palette--black-600);
+    }
     article {
       border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
     }

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.tsx
@@ -13,43 +13,59 @@ interface GitOpsDetailsProps {
 const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs }) => {
   return (
     <div className="odc-gitops-details">
-      {_.map(envs, (env) => (
-        <Stack className="odc-gitops-details__env-section" key={env.environment}>
-          <StackItem>
-            <Card>
-              <CardTitle className="odc-gitops-details__env-section__header">
-                <Stack hasGutter>
-                  <StackItem>
-                    <Split style={{ alignItems: 'center' }}>
-                      <SplitItem className="odc-gitops-details__env-section__title" isFilled>
-                        {env.environment}
-                      </SplitItem>
-                      <SplitItem>
-                        <Label className="odc-gitops-details__env-section__timestamp" color="grey">
-                          <span style={{ color: 'var(--pf-global--palette--black-600)' }}>
-                            {env?.timestamp}
-                          </span>
-                        </Label>
-                      </SplitItem>
-                    </Split>
-                  </StackItem>
-                  <StackItem className="co-truncate co-nowrap">
-                    <ExternalLink
-                      additionalClassName="odc-gitops-details__env-section__url"
-                      href={env?.cluster}
-                      text={env?.cluster}
-                    />
-                  </StackItem>
-                  <StackItem>
-                    <ResourceLink kind="Project" name={env.environment} />
-                  </StackItem>
-                </Stack>
-              </CardTitle>
-            </Card>
-          </StackItem>
-          <GitOpsServiceDetailsSection services={env?.services} />
-        </Stack>
-      ))}
+      {_.map(
+        envs,
+        (env) =>
+          env && (
+            <Stack className="odc-gitops-details__env-section" key={env.environment}>
+              <StackItem>
+                <Card>
+                  <CardTitle className="odc-gitops-details__env-section__header">
+                    <Stack hasGutter>
+                      <StackItem>
+                        <Split style={{ alignItems: 'center' }} hasGutter>
+                          <SplitItem
+                            className="odc-gitops-details__env-section__title co-truncate co-nowrap"
+                            isFilled
+                          >
+                            {env.environment}
+                          </SplitItem>
+                          <SplitItem>
+                            <Label
+                              className="odc-gitops-details__env-section__timestamp"
+                              color="grey"
+                            >
+                              <span style={{ color: 'var(--pf-global--palette--black-600)' }}>
+                                {env.timestamp}
+                              </span>
+                            </Label>
+                          </SplitItem>
+                        </Split>
+                      </StackItem>
+                      <StackItem className="co-truncate co-nowrap">
+                        {env.cluster ? (
+                          <ExternalLink
+                            additionalClassName="odc-gitops-details__env-section__url"
+                            href={env.cluster}
+                            text={env.cluster}
+                          />
+                        ) : (
+                          <div className="odc-gitops-details__env-section__url-empty-state">
+                            Cluster URL not available
+                          </div>
+                        )}
+                      </StackItem>
+                      <StackItem className="co-truncate co-nowrap">
+                        <ResourceLink kind="Project" name={env.environment} />
+                      </StackItem>
+                    </Stack>
+                  </CardTitle>
+                </Card>
+              </StackItem>
+              <GitOpsServiceDetailsSection services={env.services} />
+            </Stack>
+          ),
+      )}
     </div>
   );
 };

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsController.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsController.tsx
@@ -6,45 +6,65 @@ import PodRingWrapper from './PodRingWrapper';
 import TimestampWrapper from './TimestampWrapper';
 import { WORKLOAD_KINDS, GitOpsResource, GitOpsEnvironment } from '../utils/gitops-types';
 import CommitDetails from './CommitDetails';
+import GitOpsEmptyState from '../GitOpsEmptyState';
 
 interface GitOpsDetailsControllerProps {
   envsData: GitOpsEnvironment[];
+  emptyStateMsg: string;
 }
 
-const GitOpsDetailsController: React.FC<GitOpsDetailsControllerProps> = ({ envsData }) => {
-  const getWorkLoad = (resources: GitOpsResource[]) => {
-    return _.find(resources, (res) => _.includes(WORKLOAD_KINDS, res.kind));
-  };
+const getWorkLoad = (resources: GitOpsResource[]) => {
+  return _.find(resources, (res) => _.includes(WORKLOAD_KINDS, res.kind));
+};
 
-  const getTransformedEnvsData = () => {
-    return _.map(envsData, (env) => {
+const getTransformedServices = (originalEnv: GitOpsEnvironment) => {
+  return _.sortBy(
+    _.map(originalEnv?.services, (service) => {
+      const workload = getWorkLoad(service?.resources);
+      const image = service?.images?.[0];
+      return {
+        ...service,
+        source: {
+          ...service?.source,
+          icon: routeDecoratorIcon(service?.source?.url, 12),
+        },
+        workloadKind: workload?.kind,
+        image,
+        podRing: <PodRingWrapper workload={workload} />,
+        commitDetails: <CommitDetails imageName={image} />,
+      };
+    }),
+    ['name'],
+  );
+};
+
+const getTransformedEnvsData = (originalEnvsData: GitOpsEnvironment[]) => {
+  return _.map(originalEnvsData, (env) => {
+    if (env) {
       const resModels = _.flatten(_.map(env?.services, (service) => service.resources));
-      const services = _.sortBy(
-        _.map(env?.services, (service) => {
-          const workload = getWorkLoad(service.resources);
-          return {
-            ...service,
-            source: {
-              ...service?.source,
-              icon: routeDecoratorIcon(service?.source?.url, 12),
-            },
-            workloadKind: workload?.kind,
-            image: service?.images?.[0],
-            podRing: <PodRingWrapper workload={workload} />,
-            commitDetails: <CommitDetails imageName={service?.images?.[0]} />,
-          };
-        }),
-        ['name'],
-      );
+      const timestamp = <TimestampWrapper resModels={resModels} />;
+      const services = getTransformedServices(env);
       return {
         ...env,
         services,
-        timestamp: <TimestampWrapper resModels={resModels} />,
+        timestamp,
       };
-    });
-  };
+    }
+    return undefined;
+  });
+};
 
-  return <GitOpsDetails envs={getTransformedEnvsData()} />;
+const GitOpsDetailsController: React.FC<GitOpsDetailsControllerProps> = ({
+  envsData,
+  emptyStateMsg,
+}) => {
+  const envs = React.useMemo(() => getTransformedEnvsData(envsData), [envsData]);
+
+  return emptyStateMsg ? (
+    <GitOpsEmptyState emptyStateMsg={emptyStateMsg} />
+  ) : (
+    <GitOpsDetails envs={envs} />
+  );
 };
 
 export default GitOpsDetailsController;

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsPageHeading.scss
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsPageHeading.scss
@@ -1,0 +1,7 @@
+.odc-gitops-details-page-heading {
+  &__repo {
+    align-items: center;
+    font-weight: bold;
+    font-size: 12px;
+  }
+}

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsPageHeading.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsPageHeading.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { BreadCrumbs, ResourceIcon } from '@console/internal/components/utils';
+import { Split, SplitItem, Label } from '@patternfly/react-core';
+import { routeDecoratorIcon } from '../../import/render-utils';
+import './GitOpsDetailsPageHeading.scss';
+
+interface GitOpsDetailsPageHeadingProps {
+  url: string;
+  appName: string;
+  manifestURL: string;
+}
+
+const GitOpsDetailsPageHeading: React.FC<GitOpsDetailsPageHeadingProps> = ({
+  url,
+  appName,
+  manifestURL,
+}) => {
+  const breadcrumbs = [
+    {
+      name: 'Application Stages',
+      path: '/applicationstages',
+    },
+    {
+      name: 'Application Details',
+      path: `${url}`,
+    },
+  ];
+
+  return (
+    <div className="co-m-nav-title co-m-nav-title--breadcrumbs">
+      <BreadCrumbs breadcrumbs={breadcrumbs} />
+      <h1>
+        <div className="co-m-pane__name co-resource-item">
+          <ResourceIcon kind="application" className="co-m-resource-icon--lg" />
+          <span className="co-resource-item__resource-name">{appName}</span>
+        </div>
+      </h1>
+      <Split className="odc-gitops-details-page-heading__repo" hasGutter>
+        <SplitItem>Manifest File Repo:</SplitItem>
+        <SplitItem isFilled>
+          <Label
+            style={{ fontSize: '12px' }}
+            color="blue"
+            icon={routeDecoratorIcon(manifestURL, 12)}
+          >
+            <a
+              style={{ color: 'var(--pf-c-label__content--Color)' }}
+              href={manifestURL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {manifestURL}
+            </a>
+          </Label>
+        </SplitItem>
+      </Split>
+    </div>
+  );
+};
+
+export default GitOpsDetailsPageHeading;

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsServiceDetailsSection.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsServiceDetailsSection.tsx
@@ -20,42 +20,52 @@ interface GitOpsServiceDetailsSectionProps {
 const GitOpsServiceDetailsSection: React.FC<GitOpsServiceDetailsSectionProps> = ({ services }) => {
   return (
     <>
-      {_.map(services, (service) => (
-        <StackItem className="odc-gitops-service" key={service.name}>
-          <Card>
-            <CardTitle className="odc-gitops-service__title co-nowrap">
-              {service?.workloadKind ? (
-                <ResourceLink kind={service?.workloadKind} name={service.name} linkTo={false} />
-              ) : (
-                <span className="co-resource-item__resource-name">{service.name}</span>
-              )}
-            </CardTitle>
-            <CardBody>
-              <Label className="co-nowrap" style={{ fontSize: '12px' }} color="cyan">
-                {service?.image}
-              </Label>
-              <Split className="odc-gitops-service__details">
-                <SplitItem>
-                  <div className="odc-gitops-service__pod">{service?.podRing}</div>
-                </SplitItem>
-                <SplitItem className="odc-gitops-service__pr" isFilled>
-                  {service?.commitDetails}
-                </SplitItem>
-              </Split>
-              <ExternalLink
-                additionalClassName="odc-gitops-service__url co-truncate co-nowrap"
-                href={service?.source?.url}
-                text={
-                  <>
-                    {service?.source?.icon}&nbsp;
-                    {service?.source?.url}
-                  </>
-                }
-              />
-            </CardBody>
-          </Card>
-        </StackItem>
-      ))}
+      {_.map(
+        services,
+        (service) =>
+          service && (
+            <StackItem className="odc-gitops-service" key={service.name}>
+              <Card>
+                <CardTitle className="odc-gitops-service__title co-nowrap">
+                  {service.workloadKind ? (
+                    <ResourceLink kind={service.workloadKind} name={service.name} linkTo={false} />
+                  ) : (
+                    <span className="co-resource-item__resource-name">{service.name}</span>
+                  )}
+                </CardTitle>
+                <CardBody>
+                  <Label className="co-nowrap" style={{ fontSize: '12px' }} color="cyan">
+                    {service.image || <div>Image not available</div>}
+                  </Label>
+                  <Split className="odc-gitops-service__details">
+                    <SplitItem>
+                      <div className="odc-gitops-service__pod">{service.podRing}</div>
+                    </SplitItem>
+                    <SplitItem className="odc-gitops-service__pr" isFilled>
+                      {service.commitDetails}
+                    </SplitItem>
+                  </Split>
+                  {service.source?.url ? (
+                    <ExternalLink
+                      additionalClassName="odc-gitops-service__url co-truncate co-nowrap"
+                      href={service.source?.url}
+                      text={
+                        <>
+                          {service.source?.icon}&nbsp;
+                          {service.source?.url}
+                        </>
+                      }
+                    />
+                  ) : (
+                    <div className="odc-gitops-service__details">
+                      Service source URL not available
+                    </div>
+                  )}
+                </CardBody>
+              </Card>
+            </StackItem>
+          ),
+      )}
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/gitops/details/PodRingWrapper.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/PodRingWrapper.tsx
@@ -51,7 +51,7 @@ const PodRingWrapper: React.FC<PodRingWrapperProps> = ({ workload }) => {
           enableScaling={false}
         />
       ) : (
-        <div>Pod Info Not Available</div>
+        <div style={{ border: '1px solid' }}>Pod Info Not Available</div>
       )}
     </>
   );

--- a/frontend/packages/dev-console/src/components/gitops/list/GitOpsList.scss
+++ b/frontend/packages/dev-console/src/components/gitops/list/GitOpsList.scss
@@ -2,13 +2,4 @@
   padding: var(--pf-global--spacer--lg);
   flex: 1;
   border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
-  &__empty-state {
-    &__msg {
-      font-size: var(--pf-global--FontSize--lg);
-    }
-    &__icon {
-      height: var(--pf-c-empty-state__icon--FontSize);
-      max-width: 100%;
-    }
-  }
 }

--- a/frontend/packages/dev-console/src/components/gitops/list/GitOpsList.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/list/GitOpsList.tsx
@@ -1,27 +1,15 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import GitOpsListItem from './GitOpsListItem';
-import {
-  Stack,
-  StackItem,
-  Split,
-  SplitItem,
-  EmptyState,
-  EmptyStateVariant,
-  EmptyStateIcon,
-} from '@patternfly/react-core';
+import { Stack, StackItem, Split, SplitItem } from '@patternfly/react-core';
 import { GitOpsAppGroupData } from '../utils/gitops-types';
-import * as gitopsIcon from '../../../images/gitops.svg';
 import './GitOpsList.scss';
+import GitOpsEmptyState from '../GitOpsEmptyState';
 
 interface GitOpsListProps {
   appGroups: GitOpsAppGroupData[];
   emptyStateMsg: string;
 }
-
-const gitopsImage = () => (
-  <img className="odc-gitops-list__empty-state__icon" src={gitopsIcon} alt="GitOps" />
-);
 
 const GitOpsList: React.FC<GitOpsListProps> = ({ appGroups, emptyStateMsg }) => (
   <div className="odc-gitops-list">
@@ -40,10 +28,7 @@ const GitOpsList: React.FC<GitOpsListProps> = ({ appGroups, emptyStateMsg }) => 
         ))}
       </Stack>
     ) : (
-      <EmptyState variant={EmptyStateVariant.full}>
-        <p className="odc-gitops-list__empty-state__msg">{emptyStateMsg}</p>
-        <EmptyStateIcon variant="container" component={gitopsImage} />
-      </EmptyState>
+      <GitOpsEmptyState emptyStateMsg={emptyStateMsg} />
     )}
   </div>
 );

--- a/frontend/packages/dev-console/src/components/gitops/utils/gitops-utils.ts
+++ b/frontend/packages/dev-console/src/components/gitops/utils/gitops-utils.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { GitOpsManifestData, GitOpsAppGroupData } from './gitops-types';
-import { mockEnvsData } from './gitops-data';
 
 export const getManifestURLs = (namespaces: K8sResourceKind[]): string[] => {
   const annotation = 'app.openshift.io/vcs-uri';
@@ -58,7 +57,6 @@ export const getEnvData = async (envURI: string, env: string, appURI: string) =>
   try {
     data = await coFetchJSON(`${envURI}/${env}${appURI}`);
   } catch {} // eslint-disable-line no-empty
-  data = await Promise.resolve(mockEnvsData[env]); // will remove this once backend is ready
   return data;
 };
 


### PR DESCRIPTION
In this PR I have removed any usage of mock-data and aligned UI with gitops-backend. Some fields in the environment data returned by backend (Cluster URL, Service source URL etc) are optional and thus I have added some empty states for these fields. 

**Screenshots:**
When environment(s) info is not available:
![image](https://user-images.githubusercontent.com/20724543/90638471-ff7c1280-e24a-11ea-853f-1fee830c07fc.png)
When environment(s) info is available:
![image](https://user-images.githubusercontent.com/20724543/90638557-19b5f080-e24b-11ea-90c3-5503f21a3691.png)
![image](https://user-images.githubusercontent.com/20724543/90638575-1fabd180-e24b-11ea-9a44-0cf0e376f421.png)

**Updates:**
![image](https://user-images.githubusercontent.com/20724543/91180838-c5f14e80-e705-11ea-99b5-c272a4f22b3e.png)
![Screenshot from 2020-09-02 18-57-50](https://user-images.githubusercontent.com/20724543/91992074-54db1800-ed51-11ea-9008-ce67c3b30248.png)

**Test setup:**
Follow steps in : https://github.com/openshift/console/pull/6137
Public repo - https://github.com/rhd-gitops-example/gitops 
Private repo - https://github.com/rhd-gitops-example/gitops-private