### PR TITLE
Fix task header alignment in quick starts

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.scss
@@ -13,7 +13,6 @@
 
   &__title {
     color: var(--pf-global--primary-color--100) !important;
-    display: inline-block;
     margin-right: var(--pf-global--spacer--md) !important;
   }
 
@@ -30,7 +29,8 @@
       background-color: var(--pf-global--palette--blue-400);
       border-radius: var(--pf-global--BorderRadius--lg);
       color: var(--pf-global--Color--light-100);
-      display: inline-block;
+      display: inline-flex;
+      justify-content: center;
       height: 1.5em;
       width: 1.5em;
     }


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4436
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The numbers in the task header were not aligned to the center.

**Solution Description**: Use flex to align the numbers in task headers.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux @bmignano 

Before - 
![image](https://user-images.githubusercontent.com/6041994/90652744-08291480-e25c-11ea-94cf-c877736e9d1f.png)


After - 
![image](https://user-images.githubusercontent.com/6041994/90652677-f34c8100-e25b-11ea-8d7c-16f88af6d8a5.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
