### PR TITLE
Bug 1870271:  fix vertical alignment of Capability Level line

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -350,7 +350,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
     height: 6px;
     left: -13px;
     position: absolute;
-    top: 22px;
+    top: 21px;
     width: 1px;
   }
 }


### PR DESCRIPTION
Before:
<img width="1223" alt="Screen Shot 2020-08-19 at 11 45 57 AM" src="https://user-images.githubusercontent.com/895728/90659021-38e45c00-e212-11ea-8daf-356b1b8465a2.png">

After:
<img width="1208" alt="Screen Shot 2020-08-19 at 11 47 30 AM" src="https://user-images.githubusercontent.com/895728/90659059-41d52d80-e212-11ea-9247-50ba62aac3fc.png">
