### PR TITLE
Center the pipelines tour task numbers within their blue circle.

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.scss
@@ -32,6 +32,7 @@
       color: var(--pf-global--Color--light-100);
       display: inline-block;
       height: 1.5em;
+      text-align: center;
       width: 1.5em;
     }
 


### PR DESCRIPTION
seen on Mac Chrome, Firefox and Windows Edge
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1870319
@rohitkrai03 please confirm this fix looks correct on your system.

**Before**
<img width="419" alt="Screen Shot 2020-08-19 at 1 21 50 PM" src="https://user-images.githubusercontent.com/1874151/90674497-350f0480-e227-11ea-80f3-c6a0fca0f900.png">


**After**
<img width="430" alt="Screen Shot 2020-08-19 at 2 18 38 PM" src="https://user-images.githubusercontent.com/1874151/90674466-29bbd900-e227-11ea-98ff-435ca985b4f9.png">
