### PR TITLE
Bug 1870360: Fix toolbar spacing issue on search page

### DIFF
--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -320,7 +320,7 @@ export const ImageManifestVulnPage: React.FC<ImageManifestVulnPageProps> = (prop
       title="Image Manifest Vulnerabilities"
       canCreate={false}
       showTitle
-      hideToolbar
+      hideNameLabelFilters
       ListComponent={ImageManifestVulnList}
     />
   );

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -59,7 +59,7 @@ export const TextFilter = (props) => {
 TextFilter.displayName = 'TextFilter';
 
 // TODO (jon) make this into "withListPageFilters" HOC
-/** @augments {React.PureComponent<{ListComponent: React.ComponentType<any>, kinds: string[], filters?:any, flatten?: function, data?: any[], rowFilters?: any[], hideToolbar?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout }>} */
+/** @augments {React.PureComponent<{ListComponent: React.ComponentType<any>, kinds: string[], filters?:any, flatten?: function, data?: any[], rowFilters?: any[], hideNameLabelFilters?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout }>} */
 export class ListPageWrapper_ extends React.PureComponent {
   render() {
     const {
@@ -68,7 +68,7 @@ export class ListPageWrapper_ extends React.PureComponent {
       reduxIDs,
       rowFilters,
       textFilter,
-      hideToolbar,
+      hideNameLabelFilters,
       hideLabelFilter,
       columnLayout,
     } = this.props;
@@ -79,7 +79,7 @@ export class ListPageWrapper_ extends React.PureComponent {
         data={data}
         reduxIDs={reduxIDs}
         textFilter={textFilter}
-        hideToolbar={hideToolbar}
+        hideNameLabelFilters={hideNameLabelFilters}
         hideLabelFilter={hideLabelFilter}
         columnLayout={columnLayout}
         {...this.props}
@@ -107,7 +107,7 @@ ListPageWrapper_.propTypes = {
   rowFilters: PropTypes.array,
   staticFilters: PropTypes.array,
   customData: PropTypes.any,
-  hideToolbar: PropTypes.bool,
+  hideNameLabelFilters: PropTypes.bool,
   hideLabelFilter: PropTypes.bool,
 };
 
@@ -306,7 +306,7 @@ FireMan_.propTypes = {
   title: PropTypes.string,
 };
 
-/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean, badge?: React.ReactNode, createHandler?: any, hideToolbar?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout, customData?: any} >} */
+/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean, badge?: React.ReactNode, createHandler?: any, hideNameLabelFilters?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout, customData?: any, hideColumnManagement?: boolean } >} */
 export const ListPage = withFallback((props) => {
   const {
     autoFocus,
@@ -331,8 +331,9 @@ export const ListPage = withFallback((props) => {
     textFilter,
     match,
     badge,
-    hideToolbar,
     hideLabelFilter,
+    hideNameLabelFilters,
+    hideColumnManagement,
     columnLayout,
   } = props;
   let { createProps } = props;
@@ -398,8 +399,9 @@ export const ListPage = withFallback((props) => {
       textFilter={textFilter}
       title={title}
       badge={badge}
-      hideToolbar={hideToolbar}
       hideLabelFilter={hideLabelFilter}
+      hideNameLabelFilters={hideNameLabelFilters}
+      hideColumnManagement={hideColumnManagement}
       columnLayout={columnLayout}
     />
   );
@@ -407,7 +409,7 @@ export const ListPage = withFallback((props) => {
 
 ListPage.displayName = 'ListPage';
 
-/** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, createAccessReview?: Object, flatten?: Function, title?: string, label?: string, hideTextFilter?: boolean, showTitle?: boolean, helpText?: any, filterLabel?: string, textFilter?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string, customData?: any, badge?: React.ReactNode, hideToolbar?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout >} */
+/** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, createAccessReview?: Object, flatten?: Function, title?: string, label?: string, hideTextFilter?: boolean, showTitle?: boolean, helpText?: any, filterLabel?: string, textFilter?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string, customData?: any, badge?: React.ReactNode, hideNameLabelFilters?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout, hideColumnManagement?: boolean >} */
 export const MultiListPage = (props) => {
   const {
     autoFocus,
@@ -429,8 +431,9 @@ export const MultiListPage = (props) => {
     title,
     customData,
     badge,
-    hideToolbar,
     hideLabelFilter,
+    hideNameLabelFilters,
+    hideColumnManagement,
     columnLayout,
   } = props;
 
@@ -466,8 +469,9 @@ export const MultiListPage = (props) => {
           rowFilters={rowFilters}
           staticFilters={staticFilters}
           customData={customData}
-          hideToolbar={hideToolbar}
           hideLabelFilter={hideLabelFilter}
+          hideNameLabelFilters={hideNameLabelFilters}
+          hideColumnManagement={hideColumnManagement}
           columnLayout={columnLayout}
         />
       </Firehose>

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -84,9 +84,10 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   const {
     rowFilters = [],
     data,
-    hideToolbar,
-    columnLayout,
+    hideColumnManagement,
     hideLabelFilter,
+    hideNameLabelFilters,
+    columnLayout,
     location,
     textFilter = filterTypeMap[FilterType.NAME],
     labelFilter = filterTypeMap[FilterType.LABEL],
@@ -224,20 +225,20 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
 
   const clearAll = () => {
     updateRowFilterSelected(selectedRowFilters);
-    if (!hideToolbar) {
+    if (!hideNameLabelFilters) {
       updateNameFilter('');
     }
-    if (!hideLabelFilter) {
+    if (!hideNameLabelFilters || !hideLabelFilter) {
       updateLabelFilter([]);
     }
   };
 
   // Initial URL parsing
   React.useEffect(() => {
-    if (!hideLabelFilter) {
+    if (!hideNameLabelFilters || !hideLabelFilter) {
       applyFilter(labelFilters, FilterType.LABEL);
     }
-    if (!hideToolbar) {
+    if (!hideNameLabelFilters) {
       setInputText(nameFilter ?? '');
       applyFilter(nameFilter, FilterType.NAME);
     }
@@ -255,7 +256,6 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   };
 
   const dropdownItems = getDropdownItems(rowFilters, selectedRowFilters, data, props);
-
   return (
     <Toolbar id="filter-toolbar" clearAllFilters={clearAll}>
       <ToolbarContent>
@@ -294,30 +294,30 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
             )}
           </ToolbarItem>
         )}
-        <ToolbarItem className="co-filter-search--full-width">
-          <ToolbarFilter
-            deleteChipGroup={() => updateLabelFilter([])}
-            chips={[...labelFilters]}
-            deleteChip={(filter, chip: string) =>
-              updateLabelFilter(_.difference(labelFilters, [chip]))
-            }
-            categoryName="Label"
-          >
+        {!hideNameLabelFilters && (
+          <ToolbarItem className="co-filter-search--full-width">
             <ToolbarFilter
-              chips={nameFilter && nameFilter.length > 0 ? [nameFilter] : []}
-              deleteChip={() => updateNameFilter('')}
-              categoryName="Name"
+              deleteChipGroup={() => updateLabelFilter([])}
+              chips={[...labelFilters]}
+              deleteChip={(filter, chip: string) =>
+                updateLabelFilter(_.difference(labelFilters, [chip]))
+              }
+              categoryName="Label"
             >
-              <div className="pf-c-input-group">
-                {!hideLabelFilter && (
-                  <DropdownInternal
-                    items={FilterType}
-                    onChange={switchFilter}
-                    selectedKey={filterType}
-                    title={filterType}
-                  />
-                )}
-                {!hideToolbar && (
+              <ToolbarFilter
+                chips={nameFilter && nameFilter.length > 0 ? [nameFilter] : []}
+                deleteChip={() => updateNameFilter('')}
+                categoryName="Name"
+              >
+                <div className="pf-c-input-group">
+                  {!hideLabelFilter && (
+                    <DropdownInternal
+                      items={FilterType}
+                      onChange={switchFilter}
+                      selectedKey={filterType}
+                      title={filterType}
+                    />
+                  )}
                   <AutocompleteInput
                     className="co-text-node"
                     onSuggestionSelect={(selected) => {
@@ -332,12 +332,12 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
                     data={data}
                     labelPath={props.labelPath}
                   />
-                )}
-              </div>
+                </div>
+              </ToolbarFilter>
             </ToolbarFilter>
-          </ToolbarFilter>
-        </ToolbarItem>
-        {columnLayout?.id && (
+          </ToolbarItem>
+        )}
+        {columnLayout?.id && !hideColumnManagement && (
           <ToolbarItem>
             <Button
               variant="plain"
@@ -363,9 +363,10 @@ type FilterToolbarProps = {
   reduxIDs?: string[];
   filterList?: any;
   textFilter?: string;
-  hideToolbar?: boolean;
-  labelFilter?: string;
+  hideColumnManagement?: boolean;
   hideLabelFilter?: boolean;
+  hideNameLabelFilters?: boolean;
+  labelFilter?: string;
   parseAutoComplete?: any;
   kinds?: any;
   labelPath?: string;

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -62,8 +62,8 @@ const ResourceList = connectToModel(({ kindObj, mock, namespace, selector, nameF
       autoFocus={false}
       mock={mock}
       badge={getBadgeFromType(kindObj.badge)}
-      hideLabelFilter
-      hideToolbar
+      hideNameLabelFilters
+      hideColumnManagement
     />
   );
 });


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1870360

If both hide toolbar and hide label filters are enabled, then be sure to hide the entire div that houses them both.

Before:
![Screen Shot 2020-08-19 at 4 53 49 PM](https://user-images.githubusercontent.com/35978579/90688747-e40a0b00-e23c-11ea-9f5b-09d525a33742.png)

After:
![Screen Shot 2020-08-19 at 4 50 53 PM](https://user-images.githubusercontent.com/35978579/90688777-f4ba8100-e23c-11ea-83b7-cb9c4cc8ee1e.png)


