### PR TITLE
Bug 1870537: Navigating to an uploading golden PVC page results in 404

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -42,7 +42,7 @@ import { createUploadPVC } from '../../../k8s/requests/cdi-upload/cdi-upload-req
 import { CDIUploadContext } from '../cdi-upload-provider';
 import { UploadPVCFormStatus } from './upload-pvc-form-status';
 import { PersistentVolumeClaimModel, TemplateModel } from '@console/internal/models';
-import { getName } from '@console/shared';
+import { getName, getNamespace } from '@console/shared';
 import { V1alpha1DataVolume } from '../../../types/vm/disk/V1alpha1DataVolume';
 import { getTemplateOperatingSystems } from '../../../selectors/vm-template/advanced';
 import { FormSelectPlaceholderOption } from '../../form/form-select-placeholder-option';
@@ -361,7 +361,7 @@ export const UploadPVCPage: React.FC<UploadPVCPageProps> = (props) => {
   );
 
   const { uploads, uploadData } = React.useContext(CDIUploadContext);
-  const namespace = props?.match?.params?.ns;
+  const namespace = getNamespace(dvObj) || props?.match?.params?.ns;
   const title = 'Upload Data to Persistent Volume Claim';
 
   const save = (e: React.FormEvent<EventTarget>) => {


### PR DESCRIPTION
When a user begins uploading Golden image to PVC from namespace other than openshift-cnv-base-images, clicking View persistent volume claim details once the upload began will result in 404