### PR TITLE
Bug 1862885: Stop immediate event propagation in dropdown onClick

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -51,6 +51,7 @@ export class DropdownMixin extends React.PureComponent {
   onClick_(selectedKey, e) {
     e.preventDefault();
     e.stopPropagation();
+    e.nativeEvent?.stopImmediatePropagation?.();
 
     const { items, actionItems, onChange, noSelection, title } = this.props;
 


### PR DESCRIPTION
According to https://github.com/patternfly/patternfly-react/issues/4698#issuecomment-676639509 this will make Dropdowns work in Popups. I've tested it and it works, didnt find any other issues.