### PR TITLE
Bug 1862500: Use initialization-resource annotation for yaml

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -223,7 +223,7 @@ export const getEventSourceConnectorList = (
   _.reduce(
     csvData,
     (acm, cv) => {
-      const parseCSVData = parseALMExamples(cv);
+      const parseCSVData = parseALMExamples(cv, false);
       _.forEach(parseCSVData, (res) => {
         if (
           _.findIndex(acm, res) === -1 &&

--- a/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
@@ -112,8 +112,17 @@ export const providedAPIForModel = (csv: ClusterServiceVersionKind, model: K8sKi
     (crd) => referenceForProvidedAPI(crd) === referenceForModel(model),
   );
 
-export const parseALMExamples = (csv: ClusterServiceVersionKind) => {
+export const parseALMExamples = (
+  csv: ClusterServiceVersionKind,
+  useInitializationResource: boolean,
+) => {
   try {
+    if (useInitializationResource) {
+      const resource = JSON.parse(
+        csv?.metadata?.annotations?.['operatorframework.io/initialization-resource'],
+      );
+      return [resource];
+    }
     return JSON.parse(csv?.metadata?.annotations?.['alm-examples'] ?? '[]');
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -130,7 +139,10 @@ export const exampleForModel = (csv: ClusterServiceVersionKind, model: K8sKind) 
       apiVersion: `${model.apiGroup}/${model.apiVersion}`,
     },
     _.find(
-      parseALMExamples(csv),
+      parseALMExamples(
+        csv,
+        new URLSearchParams(window.location.search).has('useInitializationResource'),
+      ),
       (s: K8sResourceKind) => referenceFor(s) === referenceForModel(model),
     ),
   );

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -142,7 +142,7 @@ export const CreateInitializationResourceButton: React.FC<InitializationResource
         ClusterServiceVersionModel,
         obj.metadata.name,
         initializationResourceNamespace,
-      )}/${reference}/~new`}
+      )}/${reference}/~new?useInitializationResource`}
     >
       <Button isDisabled={disabled} variant="primary">
         Create {kind}


### PR DESCRIPTION
If the initialization-resource annotation value is set for a CR, use it on the yaml pages instead of the alm-example annotation.

![Screenshot_2020-08-20 Create StorageCluster · OKD](https://user-images.githubusercontent.com/18728857/90822024-08bfba80-e2f1-11ea-90ee-3e26c722c421.png)

Note to self: For testing, use TW's operators that have CR values set in the initialization-resource annotation and then do a patch to change the values from the alm-example: `oc patch csv portworx-operator.v1.3.1 --patch "$(cat ~/openshift/portworx-test.json)" --type=merge`
and portworx-test.json looks like:
```
{
  "metadata": {
    "annotations": {
      "operatorframework.io/initialization-resource": "{\n    \"apiVersion\": \"core.libopenstorage.org/v1alpha1\",\n    \"kind\": \"StorageCluster\",\n    \"metadata\": {\n      \"name\": \"portworx-initvalue\",\n      \"namespace\": \"test-operator\"\n    },\n    \"spec\": {\n      \"userInterface\": {\n        \"enabled\": true\n      },\n      \"autopilot\": {\n        \"enabled\": false\n      }\n    }\n  }\n"
    }
  }
}
```
