### PR TITLE
Bug 1871063: Prefill name for subscription/trigger

### DIFF
--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSub.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSub.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Formik, FormikValues, FormikHelpers } from 'formik';
 import { K8sResourceKind, k8sCreate } from '@console/internal/module/k8s';
+import { getRandomChars } from '@console/shared/src/utils';
 import PubSubModal from './PubSubModal';
 import { EventingBrokerModel, EventingTriggerModel, EventingSubscriptionModel } from '../../models';
 import { pubsubValidationSchema } from './pubsub-validation-utils';
@@ -49,7 +50,7 @@ const PubSub: React.FC<PubSubProps> = ({
   const initialValues = {
     apiVersion: `${apiGroup}/${apiVersion}`,
     kind,
-    metadata: { name: '', namespace },
+    metadata: { name: `${sourceName}-${getRandomChars()}`, namespace },
     spec: {
       ...getSpecForKind(kind),
       subscriber: {

--- a/frontend/packages/knative-plugin/src/components/pub-sub/pubsub-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/pubsub-validation-utils.ts
@@ -2,13 +2,4 @@ import * as yup from 'yup';
 
 export const pubsubValidationSchema = yup.object().shape({
   metadata: yup.object().shape({ name: yup.string().required('Required') }),
-  spec: yup.object().shape({
-    subscriber: yup.object().shape({
-      ref: yup.object().shape({
-        kind: yup.string().required('Required'),
-        apiVersion: yup.string().required('Required'),
-        name: yup.string().required('Required'),
-      }),
-    }),
-  }),
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4467

**Analysis / Root cause**: 
When a user adds a Subscription and Trigger via the modal in the topology view, there is not currently default text in the Name field.

**Solution Description**: 
Pre-fill name for subscription/trigger with name of channel/broker followed by random characters

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/5129024/90873648-1b52f600-e3bc-11ea-8538-ca236bf3c19d.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
