### PR TITLE
Bug 1871174: Fix CR badges and operator link

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedPanel.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
-import {
-  ResourceIcon,
-  ResourceLink,
-  SimpleTabNav,
-  ResourceSummary,
-  SectionHeading,
-} from '@console/internal/components/utils';
-import { referenceFor } from '@console/internal/module/k8s';
+import { SimpleTabNav, ResourceSummary, SectionHeading } from '@console/internal/components/utils';
 import TopologyOperatorBackedResources from './TopologyOperatorBackedResources';
 import { TopologyDataObject } from '../topology-types';
 import { OperatorGroupData } from './operator-topology-types';
+import { ManagedByOperatorResourceLink } from '@console/internal/components/utils/managed-by';
 
 export type TopologyOperatorBackedPanelProps = {
   item: TopologyDataObject<OperatorGroupData>;
 };
 
 const TopologyOperatorBackedPanel: React.FC<TopologyOperatorBackedPanelProps> = ({ item }) => {
-  const { name, resource, data } = item;
+  const { name, resource } = item;
+  const csvName = resource.metadata.selfLink.split('/').pop();
   const ResourcesSection = () => <TopologyOperatorBackedResources item={item} />;
   const DetailsSection = () => (
     <div className="overview__sidebar-pane-body">
@@ -30,12 +25,15 @@ const TopologyOperatorBackedPanel: React.FC<TopologyOperatorBackedPanelProps> = 
       <div className="overview__sidebar-pane-head resource-overview__heading">
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name co-resource-item">
-            <ResourceIcon kind={data.operatorKind || 'Operator'} />
-            <ResourceLink
-              kind={referenceFor(resource)}
-              name={name}
+            <ManagedByOperatorResourceLink
+              csvName={csvName}
               namespace={resource.metadata.namespace}
-              hideIcon
+              owner={{
+                name,
+                kind: resource.kind,
+                uid: resource.metadata.uid,
+                apiVersion: resource.apiVersion,
+              }}
             />
           </div>
         </h1>

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
@@ -26,6 +26,7 @@ import {
   NODE_SHADOW_FILTER_ID_HOVER,
 } from '../../components/NodeShadows';
 import { getResourceKind } from '../../topology-utils';
+import { referenceFor } from '@console/internal/module/k8s';
 
 export type OperatorBackedServiceGroupProps = {
   element: Node;
@@ -56,6 +57,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();
+  const ownerReferenceKind = referenceFor({ kind: data.operatorKind, apiVersion: data.apiVersion });
   const [filtered] = useSearchFilter(element.getLabel());
   const displayFilters = useDisplayFilters();
   const showLabelsFilter = getFilterById(SHOW_LABELS_FILTER_ID, displayFilters);
@@ -112,7 +114,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
           y={y + height + 20}
           paddingX={8}
           paddingY={4}
-          kind={data.operatorKind}
+          kind={ownerReferenceKind}
           dragRef={dragLabelRef}
           typeIconClass={data.builderImage}
         >

--- a/frontend/packages/dev-console/src/components/topology/operators/operator-topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operator-topology-types.ts
@@ -1,4 +1,5 @@
 export type OperatorGroupData = {
   operatorKind: string;
   builderImage: string;
+  apiVersion: string;
 };

--- a/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
@@ -237,6 +237,7 @@ export const getOperatorTopologyDataModel = (
         operatorKind: operatorMap[grp].kind,
         builderImage:
           getImageForCSVIcon(operatorMap?.[grp]?.spec?.icon?.[0]) || getDefaultOperatorIcon(),
+        apiVersion: operatorMap[grp].apiVersion,
       },
     };
     groupDataModel.nodes.push(

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -2,12 +2,7 @@ import * as React from 'react';
 
 import { connectToModel } from '../../kinds';
 import { referenceForModel } from '../../module/k8s';
-import OperatorBackedOwnerReferences, {
-  AsyncComponent,
-  Kebab,
-  ResourceOverviewHeading,
-  ResourceSummary,
-} from '../utils';
+import { AsyncComponent, Kebab, ResourceOverviewHeading, ResourceSummary } from '../utils';
 
 import { BuildOverview } from './build-overview';
 import { HPAOverview } from './hpa-overview';
@@ -15,6 +10,7 @@ import { NetworkingOverview } from './networking-overview';
 import { PodsOverview } from './pods-overview';
 import { resourceOverviewPages } from './resource-overview-pages';
 import { OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
+import { ManagedByOperatorLink } from '../utils/managed-by';
 
 const { common } = Kebab.factory;
 
@@ -25,7 +21,7 @@ export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabP
   const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <div className="overview__sidebar-pane-body">
-      <OperatorBackedOwnerReferences item={item} />
+      <ManagedByOperatorLink obj={item.obj} />
       <PodsOverview pods={pods} obj={obj} />
       <BuildOverview buildConfigs={buildConfigs} />
       <HPAOverview hpas={hpas} />

--- a/frontend/public/components/utils/managed-by.tsx
+++ b/frontend/public/components/utils/managed-by.tsx
@@ -10,30 +10,39 @@ import {
   referenceForModel,
   referenceForOwnerRef,
   OwnerReference,
+  modelFor,
 } from '../../module/k8s';
 import { findOwner, matchOwnerAndCSV } from '../../module/k8s/managed-by';
 import { k8sList } from '../../module/k8s/resource';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
+import { ResourceLink } from '.';
 
-const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = (props) => {
-  const { csvName, namespace, owner } = props;
+export const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = (props) => {
+  const { csvName, namespace, owner, className } = props;
   const name = owner.name;
   const { group, version } = groupVersionFor(owner.apiVersion);
   const kind = owner.kind;
 
   const reference = referenceForGroupVersionKind(group)(version)(kind);
+  const { namespaced } = modelFor(reference);
 
   const link = `/k8s/ns/${namespace}/${referenceForModel(
     ClusterServiceVersionModel,
   )}/${csvName}/${reference}/${name}`;
 
   return (
-    <span className="co-resource-item">
-      <ResourceIcon kind={referenceForOwnerRef(owner)} />
-      <Link to={link} className="co-resource-item__resource-name" data-test-operand-link={name}>
-        {name}
-      </Link>
+    <span className={className}>
+      {namespaced ? (
+        <>
+          <ResourceIcon kind={referenceForOwnerRef(owner)} />
+          <Link to={link} className="co-resource-item__resource-name" data-test-operand-link={name}>
+            {name}
+          </Link>
+        </>
+      ) : (
+        <ResourceLink kind={reference} name={name} />
+      )}
     </span>
   );
 };
@@ -61,6 +70,7 @@ export const ManagedByOperatorLink: React.SFC<ManagedByLinkProps> = (props) => {
       <div className={classNames('co-m-pane__heading-owner', className)}>
         Managed by{' '}
         <ManagedByOperatorResourceLink
+          className="co-resource-item"
           namespace={namespace}
           csvName={csv.metadata.name}
           owner={owner}
@@ -80,4 +90,5 @@ type ManagerLinkProps = {
   csvName: string;
   namespace: string;
   owner: OwnerReference;
+  className?: string;
 };

--- a/frontend/public/module/k8s/managed-by.ts
+++ b/frontend/public/module/k8s/managed-by.ts
@@ -9,12 +9,15 @@ const isOwnedByOperator = (csv: ClusterServiceVersionKind, owner: OwnerReference
   });
 };
 
+const isOwnedByCSV = (csv: ClusterServiceVersionKind, owner: OwnerReference) =>
+  csv.kind === owner.kind && csv.apiVersion === owner.apiVersion;
+
 export const matchOwnerAndCSV = (owner: OwnerReference, csvs: ClusterServiceVersionKind[] = []) => {
-  return csvs.find((csv) => isOwnedByOperator(csv, owner));
+  return csvs.find((csv) => isOwnedByOperator(csv, owner) || isOwnedByCSV(csv, owner));
 };
 
 export const findOwner = (obj: K8sResourceCommon, data: ClusterServiceVersionKind[]) => {
   return obj?.metadata?.ownerReferences?.find((o) =>
-    data?.some((csv) => isOwnedByOperator(csv, o)),
+    data?.some((csv) => isOwnedByOperator(csv, o) || isOwnedByCSV(csv, o)),
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4471
https://issues.redhat.com/browse/ODC-4640
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The CSV badge is not of the right color.
The title of Operator Backed Service and it's resources do not link to the Operator page in the context of the CSV
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Fix badge color in CSV sidebar and topology node.
- Fix links in CSV sidebar title and it's resources sidebars.
- Fix `Managed by ...` link in details page of resources managed by operator service.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![rec0](https://user-images.githubusercontent.com/20013884/90896884-fffae180-e3e1-11ea-9fcc-b1d98565a453.gif)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
