### PR TITLE
Bug 1870109: Help text if golden image is missing is not helpful

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
@@ -9,3 +9,4 @@ export enum UPLOAD_STATUS {
 export const CDI_UPLOAD_POD_ANNOTATION = 'cdi.kubevirt.io/storage.pod.phase';
 export const CDI_UPLOAD_POD_NAME_ANNOTATION = 'cdi.kubevirt.io/storage.uploadPodName';
 export const CDI_UPLOAD_RUNNING = 'Running';
+export const CDI_UPLOAD_OS_URL_PARAM = 'os';

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
@@ -26,10 +26,11 @@ export const TabTitleResolver = {
 };
 
 export const BASE_IMAGE_AND_PVC_SHORT = '(Source available)';
+export const BASE_IMAGE_AND_PVC_UPLOADING_SHORT = '(Source uploading)';
 export const NO_BASE_IMAGE_SHORT = '';
 export const NO_BASE_IMAGE_AND_NO_PVC_SHORT = '';
 export const BASE_IMAGE_AND_PVC_MESSAGE = '';
-export const NO_BASE_IMAGE_MESSAGE =
-  'The disk image defined for this Operating System is not available, a custom boot source must be defined manually';
+export const BASE_IMAGE_UPLOADING_MESSAGE =
+  'The upload process for this Operating system must complete before it can be cloned';
 export const NO_BASE_IMAGE_AND_NO_PVC_MESSAGE =
   'The Operating System Template is missing disk image definitions, a custom boot source must be defined manually';

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   ButtonVariant,
 } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import { ValidationErrorType, asValidationObject } from '@console/shared/src/utils/validation';
 import {
   concatImmutableLists,
@@ -32,15 +33,23 @@ import { getPlaceholder, getFieldId } from '../../utils/renderable-field-utils';
 import { nullOnEmptyChange } from '../../utils/utils';
 import { operatingSystemsNative } from '../../../../constants/vm-templates/os';
 import { OperatingSystemRecord } from '../../../../types';
+import { iGetAnnotation } from '../../../../selectors/immutable/common';
 import { iGetName, iGetNamespace } from '../../selectors/immutable/selectors';
+import { PVC_UPLOAD_URL } from '../../../../constants';
 import {
   BASE_IMAGE_AND_PVC_SHORT,
   BASE_IMAGE_AND_PVC_MESSAGE,
   NO_BASE_IMAGE_SHORT,
   NO_BASE_IMAGE_AND_NO_PVC_MESSAGE,
   NO_BASE_IMAGE_AND_NO_PVC_SHORT,
-  NO_BASE_IMAGE_MESSAGE,
+  BASE_IMAGE_AND_PVC_UPLOADING_SHORT,
+  BASE_IMAGE_UPLOADING_MESSAGE,
 } from '../../strings/strings';
+import {
+  CDI_UPLOAD_OS_URL_PARAM,
+  CDI_UPLOAD_POD_ANNOTATION,
+  CDI_UPLOAD_RUNNING,
+} from '../../../cdi-upload-provider/consts';
 
 export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
   ({
@@ -63,7 +72,6 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
     const displayOnly = !!display;
     const cloneBaseDiskImage = iGetFieldValue(cloneBaseDiskImageField);
     const mountWindowsGuestTools = iGetFieldValue(mountWindowsGuestToolsField);
-
     const params = {
       userTemplate,
       flavor,
@@ -124,22 +132,36 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
         const baseImageFoundInCluster = loadedBaseImages?.find(
           (pvc) => iGetName(pvc) === pvcName && iGetNamespace(pvc) === pvcNamespace,
         );
-        const osField = {
+        const isBaseImageUploading =
+          iGetAnnotation(baseImageFoundInCluster, CDI_UPLOAD_POD_ANNOTATION) === CDI_UPLOAD_RUNNING;
+        const osField: any = {
           id: operatingSystem.id,
           name: operatingSystem.name,
           pvcName,
           baseImageFoundInCluster,
           message: '',
           longMessage: '',
+          checkboxDescription: '',
         };
 
         if (!userTemplate) {
           if (baseImageFoundInCluster && pvcName) {
-            osField.message = BASE_IMAGE_AND_PVC_SHORT;
+            osField.message = isBaseImageUploading
+              ? BASE_IMAGE_AND_PVC_UPLOADING_SHORT
+              : BASE_IMAGE_AND_PVC_SHORT;
             osField.longMessage = BASE_IMAGE_AND_PVC_MESSAGE;
+            osField.checkboxDescription = isBaseImageUploading ? BASE_IMAGE_UPLOADING_MESSAGE : '';
           } else if (pvcName) {
             osField.message = NO_BASE_IMAGE_SHORT;
-            osField.longMessage = NO_BASE_IMAGE_MESSAGE;
+            osField.longMessage = (
+              <>
+                Operating system image not available. You can either{' '}
+                <Link to={`${PVC_UPLOAD_URL}?${CDI_UPLOAD_OS_URL_PARAM}=${operatingSystem.id}`}>
+                  upload a new disk image
+                </Link>{' '}
+                or define a boot source manually in the boot source dropdown
+              </>
+            );
           } else {
             osField.message = NO_BASE_IMAGE_AND_NO_PVC_SHORT;
             osField.longMessage = NO_BASE_IMAGE_AND_NO_PVC_MESSAGE;
@@ -204,6 +226,7 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
             <Checkbox
               id={getFieldId(cloneBaseDiskImageField)}
               onChange={(v) => onChange(VMSettingsField.CLONE_COMMON_BASE_DISK_IMAGE, v)}
+              description={baseImage?.checkboxDescription}
             />
           </FormField>
         </FormFieldRow>

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -63,3 +63,4 @@ export const WINTOOLS_CONTAINER_NAMES = {
 };
 
 export const PENDING_RESTART_LABEL = '(pending restart)';
+export const PVC_UPLOAD_URL = `/k8s/ns/${TEMPLATE_VM_GOLDEN_OS_NAMESPACE}/persistentvolumeclaims/~new/upload-form`;

--- a/frontend/packages/kubevirt-plugin/src/selectors/immutable/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/immutable/common.ts
@@ -11,3 +11,5 @@ export const iGetPrameterValue = (obj, name: string, defaultValue = null): any =
 
   return iGetIn(parameter, ['value'], defaultValue);
 };
+export const iGetAnnotation = (obj, key: string, defaultValue = undefined): string =>
+  iGetIn(obj, ['metadata', 'annotations', key], defaultValue);


### PR DESCRIPTION
* Added link to the form for OS that misses a golden image
<img width="686" alt="Screen Shot 2020-08-23 at 12 23 59" src="https://user-images.githubusercontent.com/24938324/90975424-b83c9d00-e53c-11ea-96ae-0be73d9d86ca.png">


* Upload form now has an `os` URL param for initiating it with golden checkbox as true with the specific os

* Added `(Source uploading)` message for OS list
<img width="678" alt="Screen Shot 2020-08-23 at 12 16 04" src="https://user-images.githubusercontent.com/24938324/90975405-8aefef00-e53c-11ea-927a-c631c8bc5a10.png">

* Disabled checkbox for cloning source if the image is currently uploading
<img width="688" alt="Screen Shot 2020-08-23 at 12 23 53" src="https://user-images.githubusercontent.com/24938324/90975430-cf7b8a80-e53c-11ea-888b-7b8305caa16a.png">
