### PR TITLE
Bug 1871646: Fix location of Minimal Deployment message and calculation for Internal Mode deployment

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
@@ -44,11 +44,12 @@ import {
   SelectNodesSection,
   StorageClassSection,
   EncryptSection,
+  MinimalDeploymentAlert,
 } from '../../../utils/common-ocs-install-el';
 import {
   filterSCWithNoProv,
   getAssociatedNodes,
-  shouldDeployMinimally,
+  shouldDeployAttachedAsMinimal,
 } from '../../../utils/install';
 import { getSCAvailablePVs } from '../../../selectors';
 import '../ocs-install.scss';
@@ -94,7 +95,7 @@ export const CreateOCS = withHandlePromise<CreateOCSProps & HandlePromiseProps>(
   );
   const [pvData, pvLoaded, pvLoadError] = useK8sWatchResource<K8sResourceKind[]>(pvResource);
 
-  const isMinimal = shouldDeployMinimally(nodes);
+  const isMinimal = shouldDeployAttachedAsMinimal(nodes);
 
   React.useEffect(() => {
     // this is needed to ensure that the useEffect should be called only when setHasNoProvSC is defined
@@ -176,15 +177,7 @@ export const CreateOCS = withHandlePromise<CreateOCSProps & HandlePromiseProps>(
             <SelectNodesSection
               table={AttachedDevicesNodeTable}
               customData={{ filteredNodes, nodes, setNodes }}
-            >
-              {isMinimal && (
-                <div className="ceph-ocs-install__minimal-msg">
-                  Since the selected nodes do not satisfy the recommended requirements of 16 CPUs
-                  and 64 GiB of RAM per node, a minimal cluster will be deployed, limited to a
-                  single storage device set.
-                </div>
-              )}
-            </SelectNodesSection>
+            />
           </>
         )}
         {storageClass && filteredNodes?.length < minSelectedNode && (
@@ -204,6 +197,7 @@ export const CreateOCS = withHandlePromise<CreateOCSProps & HandlePromiseProps>(
             </div>
           </Alert>
         )}
+        <>{isMinimal && <MinimalDeploymentAlert />}</>
         <ButtonBar errorMessage={errorMessage} inProgress={inProgress}>
           <ActionGroup className="pf-c-form">
             <Button

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-install.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-install.scss
@@ -40,6 +40,10 @@
 }
 
 .ceph-ocs-install__minimal-msg {
-  margin-top: var(--pf-global--spacer--sm);
   margin-bottom: var(--pf-global--spacer--sm);
+}
+
+.ceph-minimal-deployment-alert__header {
+  display: flex;
+  justify-content: space-between;
 }

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
@@ -52,7 +52,7 @@ export const getOCSRequestData = (
   } as K8sResourceKind;
 
   if (isMinimal) {
-    requestData.spec = {
+    requestData.spec = Object.assign(requestData.spec, {
       resources: {
         mds: {
           limits: {
@@ -65,7 +65,7 @@ export const getOCSRequestData = (
           },
         },
       },
-    };
+    });
   }
 
   if (provisioner === NO_PROVISIONER) {

--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -4,6 +4,7 @@ import { ListPage } from '@console/internal/components/factory';
 import { NodeModel } from '@console/internal/models';
 import { FieldLevelHelp } from '@console/internal/components/utils';
 import { StorageClassResourceKind } from '@console/internal/module/k8s';
+import { TechPreviewBadge } from '@console/shared';
 import { OCSStorageClassDropdown } from '../components/modals/storage-class-dropdown';
 import { storageClassTooltip } from '../constants/ocs-install';
 import '../components/ocs-install/ocs-install.scss';
@@ -15,6 +16,30 @@ export const OCSAlert = () => (
     title="A bucket will be created to provide the OCS Service."
     isInline
   />
+);
+
+type MinimalDeploymentAlertProps = {
+  isInternalMode?: boolean;
+};
+
+export const MinimalDeploymentAlert: React.FC<MinimalDeploymentAlertProps> = ({
+  isInternalMode,
+}) => (
+  <Alert
+    className="co-alert"
+    variant="warning"
+    title={
+      <div className="ceph-minimal-deployment-alert__header">
+        A minimal cluster deployment will be performed.
+        <TechPreviewBadge />
+      </div>
+    }
+    isInline
+  >
+    {isInternalMode
+      ? 'The selected nodes do not match the OCS storage cluster recommended requirements of an aggregated 30 CPUs and 72 GiB of RAM. If the selection won’t be modified, a minimal cluster will be deployed and may face some performance issues.'
+      : 'The selected nodes do not match the OCS storage cluster recommended requirements of at least 10 CPU and 64 GiB of RAM per node. If the selection won’t be modified, a minimal cluster will be deployed and may face some performance issues.'}
+  </Alert>
 );
 
 export const SelectNodesSection: React.FC<SelectNodesSectionProps> = ({

--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -58,12 +58,30 @@ export const getAssociatedNodes = (pvs: K8sResourceKind[]): string[] => {
   return Array.from(nodes);
 };
 
-export const shouldDeployMinimally = (nodes: NodeKind[]) =>
+export const shouldDeployInternalAsMinimal = (nodes: NodeKind[]) => {
+  const { totalCPU, totalMemory } = nodes.reduce(
+    (acc, curr) => {
+      const cpus = humanizeCpuCores(getNodeCPUCapacity(curr)).value;
+      const memoryRaw = getNodeAllocatableMemory(curr);
+      const memory = humanizeBinaryBytes(convertToBaseValue(memoryRaw)).value;
+      acc.totalCPU += cpus;
+      acc.totalMemory += memory;
+      return acc;
+    },
+    {
+      totalCPU: 0,
+      totalMemory: 0,
+    },
+  );
+  return totalCPU < 30 || totalMemory < 60;
+};
+
+export const shouldDeployAttachedAsMinimal = (nodes: NodeKind[]) =>
   nodes.reduce((acc, curr) => {
     const cpus = humanizeCpuCores(getNodeCPUCapacity(curr)).value;
     const memoryRaw = getNodeAllocatableMemory(curr);
     const memory = humanizeBinaryBytes(convertToBaseValue(memoryRaw)).value;
-    if (memory < 60 || cpus < 16) {
+    if (memory < 60 || cpus < 10) {
       return [...acc, curr];
     }
     return acc;


### PR DESCRIPTION
- Fixes calculation for Internal mode where if the total CPU < 30 then only the minimal deployment will occur.
- Fixes calculation for an Attached mode where if the CPU per node < 10 then the minimal deployment will occur.
- Moves the message as an alert to the bottom. 
![Screenshot from 2020-08-26 16-33-52](https://user-images.githubusercontent.com/54092533/91296331-11fdcb00-e7ba-11ea-9ae4-6ece092d9c2c.png)
