### PR TITLE
Bug 1871816: Convert quick start task help to markdown

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
@@ -58,7 +58,9 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
           onChange={() => onTaskReview(QuickStartTaskStatus.FAILED)}
         />
       </span>
-      {taskStatus === QuickStartTaskStatus.FAILED && taskHelp && <h5>{taskHelp}</h5>}
+      {taskStatus === QuickStartTaskStatus.FAILED && taskHelp && (
+        <SyncMarkdownView content={taskHelp} />
+      )}
     </Alert>
   );
 };

--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTaskReview.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTaskReview.spec.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Alert } from '@patternfly/react-core';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import { getQuickStartByName } from '../../utils/quick-start-utils';
+import { QuickStartTaskStatus } from '../../utils/quick-start-types';
+import QuickStartTaskReview from '../QuickStartTaskReview';
+
+type QuickStartTaskReviewProps = React.ComponentProps<typeof QuickStartTaskReview>;
+let wrapper: ShallowWrapper<QuickStartTaskReviewProps>;
+const props: QuickStartTaskReviewProps = {
+  review: getQuickStartByName('explore-serverless').spec.tasks[0].review,
+  taskStatus: QuickStartTaskStatus.REVIEW,
+  onTaskReview: jest.fn(),
+};
+
+describe('QuickStartTaskReview', () => {
+  it('should render alert with info variant when task status is review', () => {
+    wrapper = shallow(<QuickStartTaskReview {...props} />);
+    expect(wrapper.find(Alert).props().variant).toBe('info');
+  });
+
+  it('should render alert with success variant when task status is success', () => {
+    props.taskStatus = QuickStartTaskStatus.SUCCESS;
+    wrapper = shallow(<QuickStartTaskReview {...props} />);
+    expect(wrapper.find(Alert).props().variant).toBe('success');
+  });
+
+  it('should render alert with danger variant when task status is failed', () => {
+    props.taskStatus = QuickStartTaskStatus.FAILED;
+    wrapper = shallow(<QuickStartTaskReview {...props} />);
+    expect(wrapper.find(Alert).props().variant).toBe('danger');
+  });
+
+  it('should render task help in markdown when task status is failed', () => {
+    wrapper = shallow(<QuickStartTaskReview {...props} />);
+    expect(
+      wrapper
+        .find(SyncMarkdownView)
+        .at(1)
+        .props().content,
+    ).toEqual(props.review.taskHelp);
+  });
+});


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4625
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Task help is not rendered in markdown.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Render task help in markdown.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux @serenamarie125 
![Peek 2020-08-24 15-52](https://user-images.githubusercontent.com/6041994/91034190-3626a400-e622-11ea-86a6-0134286918b7.gif)

**Unit Tests Added**:
![image](https://user-images.githubusercontent.com/6041994/91037924-805e5400-e627-11ea-9ecd-a966cc6e6d44.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
