### PR TITLE
Bug 1870515: PVC Network Upload error should be more detailed

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
@@ -89,6 +89,23 @@ export const useCDIUploadHook = (): CDIUploadContextProps => {
               ...newUpload,
               uploadStatus: UPLOAD_STATUS.CANCELED,
             });
+          } else if (typeof err.response === 'undefined') {
+            updateUpload({
+              ...newUpload,
+              uploadStatus: UPLOAD_STATUS.ERROR,
+              uploadError: {
+                message: (
+                  <>
+                    It seems that your browser does not trust the certificate of the upload proxy.
+                    Please{' '}
+                    <a href={`https://${uploadProxyURL}`} rel="noopener noreferrer" target="_blank">
+                      approve this certificate
+                    </a>{' '}
+                    and try again
+                  </>
+                ),
+              },
+            });
           } else {
             updateUpload({ ...newUpload, uploadStatus: UPLOAD_STATUS.ERROR, uploadError: err });
           }


### PR DESCRIPTION
Errors coming from the CORS preflight are not catchable by the UI ([see thread](https://github.com/axios/axios/issues/838#issuecomment-294956982))

All other errors will be more detailed. For this specific case, I added the text below:
<img width="621" alt="Screen Shot 2020-08-24 at 13 22 01" src="https://user-images.githubusercontent.com/24938324/91035074-adead380-e60e-11ea-8f3d-347f845fa50f.png">

Please approve the message @jelkosz @matthewcarleton 