### PR TITLE
Bug 1871742: can't delete a PVC created using a data upload

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/pvc.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/pvc.ts
@@ -1,4 +1,5 @@
-import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { PersistentVolumeClaimKind } from '@console/internal/module/k8s';
+import { AlertVariant } from '@patternfly/react-core';
 import { Extension, LazyLoader } from './base';
 
 namespace ExtensionProperties {
@@ -11,7 +12,7 @@ namespace ExtensionProperties {
     /** Loader for the corresponding Status component. */
     loader: LazyLoader<T>;
     /** predicate that tells if to render the status or not */
-    predicate: (pvc: K8sResourceCommon) => boolean;
+    predicate: (pvc: PersistentVolumeClaimKind) => boolean;
     /** priority for the corresponding Status component. bigger is prioritized */
     priority: number;
   }
@@ -21,6 +22,22 @@ namespace ExtensionProperties {
     label: string;
     /** path for the create prop */
     path: string;
+  }
+
+  export interface PVCDelete {
+    /** predicate that tells if to use the extension or not */
+    predicate: (pvc: PersistentVolumeClaimKind) => boolean;
+    /** method for the pvc delete operation */
+    onPVCKill: (pvc: PersistentVolumeClaimKind) => Promise<void>;
+    /** alert for additional info */
+    alert?: {
+      /** alert title */
+      title: string;
+      /** alert variant */
+      type: AlertVariant;
+      /** alert body */
+      body: LazyLoader<{ pvc: PersistentVolumeClaimKind }>;
+    };
   }
 }
 
@@ -36,6 +53,10 @@ export interface PVCCreateProp extends Extension<ExtensionProperties.PVCCreatePr
   type: 'PVCCreateProp';
 }
 
+export interface PVCDelete extends Extension<ExtensionProperties.PVCDelete> {
+  type: 'PVCDelete';
+}
+
 export const isPVCAlert = (e: Extension): e is PVCAlert => {
   return e.type === 'PVCAlert';
 };
@@ -46,4 +67,8 @@ export const isPVCStatus = (e: Extension): e is PVCStatus => {
 
 export const isPVCCreateProp = (e: Extension): e is PVCCreateProp => {
   return e.type === 'PVCCreateProp';
+};
+
+export const isPVCDelete = (e: Extension): e is PVCDelete => {
+  return e.type === 'PVCDelete';
 };

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
@@ -8,5 +8,6 @@ export enum UPLOAD_STATUS {
 
 export const CDI_UPLOAD_POD_ANNOTATION = 'cdi.kubevirt.io/storage.pod.phase';
 export const CDI_UPLOAD_POD_NAME_ANNOTATION = 'cdi.kubevirt.io/storage.uploadPodName';
+export const CDI_BOUND_PVC_ANNOTATION = 'cdi.kubevirt.io/storage.condition.bound';
 export const CDI_UPLOAD_RUNNING = 'Running';
 export const CDI_UPLOAD_OS_URL_PARAM = 'os';

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/pvc-delete-extension.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/pvc-delete-extension.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { k8sKill, PersistentVolumeClaimKind } from '@console/internal/module/k8s';
+import { DataVolumeModel } from '../../models';
+import {
+  useK8sWatchResource,
+  WatchK8sResource,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import { PersistentVolumeClaimModel } from '@console/internal/models';
+import { TEMPLATE_VM_GOLDEN_OS_NAMESPACE } from '../../constants';
+
+export const killCDIBoundPVC = (pvc: PersistentVolumeClaimKind) =>
+  k8sKill(DataVolumeModel, {
+    metadata: {
+      name: pvc?.metadata?.name,
+      namespace: pvc?.metadata?.namespace,
+    },
+  });
+
+export const PVCDeleteAlertExtension: React.FC<{ pvc: PersistentVolumeClaimKind }> = ({ pvc }) => {
+  const goldenPvcsResource: WatchK8sResource = {
+    isList: true,
+    optional: true,
+    kind: PersistentVolumeClaimModel.kind,
+    namespace: TEMPLATE_VM_GOLDEN_OS_NAMESPACE,
+  };
+  const [goldenPvcs, loadedPvcs, errorPvcs] = useK8sWatchResource<PersistentVolumeClaimKind[]>(
+    goldenPvcsResource,
+  );
+
+  const isGolden =
+    pvc?.metadata?.namespace === TEMPLATE_VM_GOLDEN_OS_NAMESPACE &&
+    goldenPvcs.find((goldenPvc) => goldenPvc?.metadata?.name === pvc?.metadata?.name);
+
+  return (
+    <>
+      <p>
+        Deleting this PVC will also delete{' '}
+        <strong className="co-break-word">{pvc?.metadata?.name}</strong> Data Volume
+      </p>
+      {!loadedPvcs && <p>Checking for usages of this PVC...</p>}
+      {errorPvcs && <p>Error checking for usages of this PVC.</p>}
+      {isGolden && (
+        <p>
+          <strong className="co-break-word">WARNING:</strong> this PVC is used as a base operating
+          system image. New VMs will not be able to clone this image
+        </p>
+      )}
+    </>
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/pvc/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pvc/selectors.ts
@@ -4,6 +4,7 @@ import {
   CDI_UPLOAD_RUNNING,
   CDI_UPLOAD_POD_ANNOTATION,
   CDI_UPLOAD_POD_NAME_ANNOTATION,
+  CDI_BOUND_PVC_ANNOTATION,
 } from '../../components/cdi-upload-provider/consts';
 import { STORAGE_IMPORT_POD_LABEL } from '../../constants';
 
@@ -24,3 +25,5 @@ export const getPvcUploadPhase = (pvc) => getAnnotation(pvc, CDI_UPLOAD_POD_ANNO
 
 export const isPvcUploading = (pvc) =>
   getPvcUploadPodName(pvc) && getPvcUploadPhase(pvc) === CDI_UPLOAD_RUNNING;
+
+export const isPvcBoundToCDI = (pvc) => getAnnotation(pvc, CDI_BOUND_PVC_ANNOTATION) === 'true';

--- a/frontend/public/components/modals/delete-pvc-modal.tsx
+++ b/frontend/public/components/modals/delete-pvc-modal.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { Alert, Stack, StackItem } from '@patternfly/react-core';
+import { AsyncComponent, HandlePromiseProps, withHandlePromise } from '../utils';
+import { getName, YellowExclamationTriangleIcon } from '@console/shared';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+  ModalComponentProps,
+} from '../factory';
+import { k8sKill, PersistentVolumeClaimKind } from '@console/internal/module/k8s';
+import { PersistentVolumeClaimModel } from '../../models';
+import { isPVCDelete, PVCDelete, useExtensions } from '@console/plugin-sdk';
+
+const DeletePVCModal = withHandlePromise<DeletePVCModalProps>((props) => {
+  const { pvc, inProgress, errorMessage, handlePromise, close, cancel } = props;
+  const pvcDeleteExtensions = useExtensions<PVCDelete>(isPVCDelete);
+  const pvcName = getName(pvc);
+
+  const submit = (e) => {
+    e.preventDefault();
+
+    const promise = k8sKill(PersistentVolumeClaimModel, pvc);
+    const extensionPromises = pvcDeleteExtensions.map(
+      ({ properties: { predicate, onPVCKill } }) => predicate(pvc) && onPVCKill(pvc),
+    );
+    return handlePromise(Promise.all([promise, ...extensionPromises]), close);
+  };
+
+  const alertComponents = pvcDeleteExtensions.map(
+    ({ properties: { predicate, alert }, uid }) =>
+      predicate(pvc) && (
+        <StackItem key={uid}>
+          <Alert className="co-m-form-row" isInline variant={alert?.type} title={alert?.title}>
+            <AsyncComponent loader={alert?.body} pvc={pvc} />
+          </Alert>
+        </StackItem>
+      ),
+  );
+
+  return (
+    <form onSubmit={submit} className="modal-content">
+      <ModalTitle>
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete Persistent Volume Claim
+      </ModalTitle>
+      <ModalBody>
+        <Stack hasGutter>
+          {alertComponents}
+          <StackItem>
+            Are you sure you want to delete <strong className="co-break-word">{pvcName}</strong>{' '}
+            Persistent Volume Claim?
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalSubmitFooter
+        errorMessage={errorMessage}
+        inProgress={inProgress}
+        submitText="Delete"
+        submitDanger
+        cancel={cancel}
+      />
+    </form>
+  );
+});
+
+export type DeletePVCModalProps = {
+  pvc: PersistentVolumeClaimKind;
+} & ModalComponentProps &
+  HandlePromiseProps;
+
+export default createModalLauncher(DeletePVCModal);

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -22,20 +22,32 @@ import {
   humanizeBinaryBytes,
   convertToBaseValue,
   AsyncComponent,
+  asAccessReview,
 } from './utils';
 import { ResourceEventStream } from './events';
 import { PersistentVolumeClaimModel } from '../models';
 import { setPVCMetrics } from '../actions/ui';
 import { PrometheusEndpoint } from './graphs/helpers';
 import { usePrometheusPoll } from './graphs/prometheus-poll-hook';
+import deletePVCModal from './modals/delete-pvc-modal';
 
-const { common, ExpandPVC, PVCSnapshot, ClonePVC } = Kebab.factory;
+const { ModifyLabels, ModifyAnnotations, Edit, ExpandPVC, PVCSnapshot, ClonePVC } = Kebab.factory;
 const menuActions = [
   ...Kebab.getExtensionsActionsForKind(PersistentVolumeClaimModel),
   ExpandPVC,
   PVCSnapshot,
   ClonePVC,
-  ...common,
+  ModifyLabels,
+  ModifyAnnotations,
+  Edit,
+  (kind, obj) => ({
+    label: `Delete ${kind.label}`,
+    callback: () =>
+      deletePVCModal({
+        pvc: obj,
+      }),
+    accessReview: asAccessReview(kind, obj, 'delete'),
+  }),
 ];
 
 export const PVCStatus = ({ pvc }) => {


### PR DESCRIPTION
For Normal PVCs the modal is the same:
<img width="617" alt="Screen Shot 2020-08-24 at 16 36 25" src="https://user-images.githubusercontent.com/24938324/91051207-72f59980-e628-11ea-8d45-e7e781e81193.png">

For CDI Bound PVCs the modal is:
<img width="624" alt="Screen Shot 2020-08-24 at 16 36 32" src="https://user-images.githubusercontent.com/24938324/91051243-7e48c500-e628-11ea-95a9-3a08eb0b5e4d.png">

@matthewcarleton how do we want this to look?