### PR TITLE
Bug 1871866: Monitoring: Fix list style for the table pagination dropdowns

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -362,6 +362,11 @@ h6 {
   }
 }
 
+// Necessary due to setting $pf-global--enable-reset to false
+.pf-c-pagination .pf-c-options-menu__menu {
+  list-style: none;
+}
+
 // pf table overrides
 
 .pf-c-table tr > th {


### PR DESCRIPTION
Affects the Monitoring UI, "Metrics" and "Dashboards" pages. These are the only pages using the PatternFly `Pagination` component.

Before | After
-|-
![before](https://user-images.githubusercontent.com/460802/91053492-dbab3900-e65d-11ea-9b66-63701037262c.png) | ![after](https://user-images.githubusercontent.com/460802/91053507-e06fed00-e65d-11ea-9a7e-787a1d8e23e0.png)
