### PR TITLE
Bug 1871895: Use form data for application ImageStream name

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -378,7 +378,7 @@ export const getInternalImageInitialValues = (editAppResource: K8sResourceKind) 
     'metadata.labels["app.openshift.io/runtime-namespace"]',
     '',
   );
-  const imageStreamName = _.get(editAppResource, 'metadata.labels["app.openshift.io/runtime"]', '');
+  const imageStreamName = _.get(editAppResource, 'metadata.labels["app.kubernetes.io/name"]', '');
   const imageStreamTag = _.get(
     editAppResource,
     'metadata.labels["app.openshift.io/runtime-version"]',

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -129,10 +129,9 @@ const getMetadata = (formData: DeployImageFormData) => {
     name,
     isi: { image },
     labels: userLabels,
-    imageStream: { tag: selectedTag, namespace },
+    imageStream: { image: imageStreamName, tag: selectedTag, namespace },
     runtimeIcon,
   } = formData;
-  const imageStreamName = getRuntime(image.metadata?.labels);
   const defaultLabels = getAppLabels({
     name,
     applicationName,

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
@@ -64,7 +64,14 @@ const ImageStreamNsDropdown: React.FC = () => {
   );
 
   React.useEffect(() => {
+    if (
+      initialValues.imageStream.image &&
+      values.imageStream.image !== initialValues.imageStream.image
+    ) {
+      initialValues.imageStream.image = values.imageStream.image;
+    }
     values.imageStream.namespace && onDropdownChange(values.imageStream.namespace);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onDropdownChange, values.imageStream.namespace]);
 
   React.useEffect(() => {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-4615
https://issues.redhat.com/browse/ODC-4649

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
The add flow tries to get image name from imagestream labels, which may not be always present.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Use application form data to get image stream name.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![rec](https://user-images.githubusercontent.com/20013884/91058444-14d7af00-e646-11ea-9cc8-8f66a1e61bc3.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
Passing.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
