### PR TITLE
Bug 1871920: pick latestCRDversion instead of latest/served true for eventSources/channels

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
@@ -11,7 +11,7 @@ const PingSourceSection: React.FC<PingSourceSectionProps> = ({ title }) => (
   <FormSection title={title} extraMargin>
     <InputField
       type={TextInputTypes.text}
-      name="data.pingsource.data"
+      name="data.pingsource.jsonData"
       label="Data"
       helpText="The data posted to the target function"
     />

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -114,7 +114,7 @@ export const EventSourceCronJobModel: K8sKind = {
 
 export const EventSourcePingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   kind: 'PingSource',
   label: 'Ping Source',
   labelPlural: 'Ping Sources',
@@ -184,7 +184,7 @@ export const EventSourceKafkaModel: K8sKind = {
 
 export const EventSourceSinkBindingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   kind: 'SinkBinding',
   label: 'SinkBinding',
   labelPlural: 'SinkBindings',

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
@@ -47,11 +47,6 @@ export const mockEventSourcCRDData = {
             served: true,
             storage: true,
           },
-          {
-            name: 'v1alpha2',
-            served: false,
-            storage: false,
-          },
         ],
       },
     },

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -59,6 +59,7 @@ describe('Create knative Utils', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
     const mockData = _.cloneDeep(defaultEventingData);
     mockData.type = 'SinkBinding';
+    mockData.apiVersion = 'sources.knative.dev/v1alpha2';
     const knEventingResource: k8sModels.K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.kind).toBe(EventSourceSinkBindingModel.kind);
     expect(knEventingResource.apiVersion).toBe(

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -157,7 +157,7 @@ export const getEventSourceData = (source: string) => {
       schedule: '',
     },
     pingsource: {
-      data: '',
+      jsonData: '',
       schedule: '',
     },
     sinkbinding: {

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -2,7 +2,12 @@ import * as _ from 'lodash';
 import { useEffect } from 'react';
 import { coFetch } from '@console/internal/co-fetch';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
-import { K8sKind, kindToAbbr, referenceForModel } from '@console/internal/module/k8s';
+import {
+  K8sKind,
+  kindToAbbr,
+  referenceForModel,
+  getLatestVersionForCRD,
+} from '@console/internal/module/k8s';
 import { chart_color_red_300 as knativeEventingColor } from '@patternfly/react-tokens/dist/js/chart_color_red_300';
 import { EventingSubscriptionModel, EventingTriggerModel } from '../models';
 
@@ -35,15 +40,14 @@ export const fetchEventSourcesCrd = async () => {
           metadata: { labels },
           spec: {
             group,
-            versions,
             names: { kind, plural, singular },
           },
         } = crd;
-        const { name: version } = versions?.find((ver) => ver.served && ver.storage);
-        if (version) {
+        const crdLatestVersion = getLatestVersionForCRD(crd);
+        if (crdLatestVersion) {
           const sourceModel = {
             apiGroup: group,
-            apiVersion: version,
+            apiVersion: crdLatestVersion,
             kind,
             plural,
             id: singular,
@@ -154,14 +158,13 @@ export const fetchChannelsCrd = async () => {
         const {
           spec: {
             group,
-            versions,
             names: { kind, plural, singular },
           },
         } = crd;
-        const { name: version } = versions?.find((ver) => ver.served && ver.storage);
+        const crdLatestVersion = getLatestVersionForCRD(crd);
         const sourceModel = {
           apiGroup: group,
-          apiVersion: version,
+          apiVersion: crdLatestVersion,
           kind,
           plural,
           id: singular,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4477

**Analysis / Root cause**: 
- Currently in ODC Version is picked from CRDs bases on field `storage` and `served` as true however should pick latest version as done for search creation across
- PingSouce with latest version `sources.knative.dev/v1alpha2` , `data` in spec is updated with `jsonData`

**Solution Description**: 
- Made use of latest versions available for CRD
- updated `data` to `jsonData` for PingSource

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/5129024/91063660-e5c43c00-e64b-11ea-90ad-1364aae46a4a.png)

**Test**
Tested on 4.6 nightly build with Serverless 1.7.x
- [x] InMemoryChannel
- [x] ApiServerSource
- [x] PingSource
- [x] SinkBindingSource
- [x] CamelSource
- [x] KafkaSource

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
