### PR TITLE
Bug 1871925: Change name of "Show Groups" Toggle that switches the modes in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.scss
@@ -1,9 +1,20 @@
 @import '../../../../../../public/style/vars';
 
 .odc-topology-filter-dropdown {
+  &__radio-group {
+    padding-left: var(--pf-global--spacer--md);
+  }
+  &__radio {
+    padding-top: var(--pf-global--spacer--sm);
+    padding-bottom: var(--pf-global--spacer--sm);
+    .pf-c-radio__input {
+      margin: 0;
+    }
+  }
   &__expand-groups-switcher {
     display: flex;
     align-items: center;
+    margin-top: var(--pf-global--spacer--sm);
 
     .pf-c-select__menu-group-title {
       flex: 1;
@@ -25,8 +36,11 @@
     }
   }
 
-  &__expand-groups-label .pf-c-select__menu-group-title {
-    padding-top: 0;
+  .pf-c-select__menu-group-title {
     padding-bottom: 0;
+  }
+
+  &__expand-groups-label > .pf-c-select__menu-group-title {
+    padding-top: 0;
   }
 }

--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Select, SelectGroup, SelectOption, SelectVariant, Switch } from '@patternfly/react-core';
+import {
+  Radio,
+  Select,
+  SelectGroup,
+  SelectOption,
+  SelectVariant,
+  Switch,
+} from '@patternfly/react-core';
 import { TopologyDisplayFilterType, DisplayFilters } from '../topology-types';
 import { EXPAND_GROUPS_FILTER_ID, SHOW_GROUPS_FILTER_ID } from './const';
 
@@ -71,10 +78,25 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
   const selectContent = (
     <div className="odc-topology-filter-dropdown">
       <div className="odc-topology-filter-dropdown__group">
-        <span className="odc-topology-filter-dropdown__expand-groups-switcher">
-          <span className="pf-c-select__menu-group-title">Show Groups</span>
-          <Switch aria-label="Show Groups" isChecked={showGroups} onChange={onShowGroupsChange} />
-        </span>
+        <span className="pf-c-select__menu-group-title">Mode</span>
+        <div className="odc-topology-filter-dropdown__radio-group">
+          <Radio
+            className="odc-topology-filter-dropdown__radio"
+            id="showGroups"
+            isChecked={showGroups}
+            label="Connectivity"
+            name="Connectivity"
+            onChange={() => onShowGroupsChange(true)}
+          />
+          <Radio
+            className="odc-topology-filter-dropdown__radio"
+            id="hideGroups"
+            isChecked={!showGroups}
+            label="Consumption"
+            name="Consumption"
+            onChange={() => onShowGroupsChange(false)}
+          />
+        </div>
       </div>
       {expandFilters.length ? (
         <div className="odc-topology-filter-dropdown__group">

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
-import { SelectOption, Switch } from '@patternfly/react-core';
+import { Radio, SelectOption, Switch } from '@patternfly/react-core';
 import FilterDropdown from '../FilterDropdown';
 import { DisplayFilters, TopologyDisplayFilterType } from '../../topology-types';
 import {
@@ -72,7 +72,39 @@ describe(FilterDropdown.displayName, () => {
     expect(wrapper.find(SelectOption)).toHaveLength(1);
   });
 
-  it('should contain the show groups and expand groups switches', () => {
+  it('should contain the connectivity mode radio buttons', () => {
+    let wrapper = mount(
+      <FilterDropdown
+        filters={dropdownFilter}
+        showGraphView
+        supportedFilters={dropdownFilter.map((f) => f.id)}
+        onChange={onChange}
+        opened
+      />,
+    );
+    let radioButtons = wrapper.find(Radio);
+    expect(radioButtons).toHaveLength(2);
+    // expect(radioButtons.at(0).prop('isChecked')).toBe(true);
+    // expect(radioButtons.at(1).prop('isChecked')).toBe(false);
+
+    getFilterById(SHOW_GROUPS_FILTER_ID, dropdownFilter).value = false;
+
+    wrapper = mount(
+      <FilterDropdown
+        filters={dropdownFilter}
+        showGraphView
+        supportedFilters={dropdownFilter.map((f) => f.id)}
+        onChange={onChange}
+        opened
+      />,
+    );
+    radioButtons = wrapper.find(Radio);
+    expect(radioButtons).toHaveLength(2);
+    expect(radioButtons.at(0).prop('isChecked')).toBe(false);
+    expect(radioButtons.at(1).prop('isChecked')).toBe(true);
+  });
+
+  it('should contain the expand groups switch', () => {
     const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
@@ -82,7 +114,7 @@ describe(FilterDropdown.displayName, () => {
         opened
       />,
     );
-    expect(wrapper.find(Switch)).toHaveLength(2);
+    expect(wrapper.find(Switch)).toHaveLength(1);
   });
 
   it('should disable individual group expand when expand groups is false', () => {
@@ -118,7 +150,7 @@ describe(FilterDropdown.displayName, () => {
     expect(
       wrapper
         .find(Switch)
-        .at(1)
+        .at(0)
         .props().isDisabled,
     ).toBeTruthy();
     expect(


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4519

**Description**
Change topology view display options from `Show Groups` to a choice of modes: `Connectivity` and `Consumption`.

**Screenshots**
![image](https://user-images.githubusercontent.com/11633780/91064906-dae2ba80-e5fd-11ea-90e0-76d5b918feed.png)

![image](https://user-images.githubusercontent.com/11633780/91064946-e3d38c00-e5fd-11ea-8ad2-b59bf5b10703.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug

/cc @bgliwa01 @beaumorley @serenamarie125 