### PR TITLE
Bug 1871940: Add count badge to topology "Filter by Resource" dropdown

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.scss
@@ -23,6 +23,9 @@
       margin-top: var(--pf-global--spacer--sm);
       border-top: 1px solid var(--pf-global--BorderColor--300);
     }
+    .pf-c-check__input {
+      margin-top: 0;
+    }
   }
 
   &__expand-groups-label .pf-c-select__menu-group-title {

--- a/frontend/packages/dev-console/src/components/topology/filters/KindFilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/KindFilterDropdown.tsx
@@ -24,6 +24,7 @@ const KindFilterDropdown: React.FC<KindFilterDropdownProps> = ({
   let kindFilters = filters.filter(
     (f) => f.type === TopologyDisplayFilterType.kind && supportedKinds[f.id],
   );
+  const selectedFilterCount = kindFilters.filter((f) => f.value).length;
   kindFilters = Object.keys(supportedKinds).reduce((acc, kind) => {
     if (!filters.find((f) => f.id === kind)) {
       const model = modelFor(kind);
@@ -62,7 +63,7 @@ const KindFilterDropdown: React.FC<KindFilterDropdownProps> = ({
   };
 
   const selectContent = (
-    <div className="odc-kind-filter-dropdown">
+    <div className="odc-topology-filter-dropdown__group odc-kind-filter-dropdown">
       <span className="odc-kind-filter-dropdown__clear-button">
         <Button variant="link" onClick={onClearFilters}>
           Clear all filters
@@ -71,8 +72,7 @@ const KindFilterDropdown: React.FC<KindFilterDropdownProps> = ({
       {kindFilters.map((filter) => (
         <SelectOption key={filter.id} value={filter.id} isChecked={filter.value}>
           <ResourceIcon kind={filter.id} />
-          {filter.label}
-          <span className="odc-kind-filter-dropdown__kind-count">{supportedKinds[filter.id]}</span>
+          {filter.label} ({supportedKinds[filter.id]})
         </SelectOption>
       ))}
     </div>
@@ -84,7 +84,14 @@ const KindFilterDropdown: React.FC<KindFilterDropdownProps> = ({
       customContent={selectContent}
       isOpen={isOpen}
       onSelect={onSelect}
-      placeholderText="Filter by Resource"
+      placeholderText={
+        <span>
+          Filter by Resource
+          {selectedFilterCount ? (
+            <span className="odc-kind-filter-dropdown__kind-count">{selectedFilterCount}</span>
+          ) : null}
+        </span>
+      }
       isCheckboxSelectionBadgeHidden
     />
   );

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/KindFilterDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/KindFilterDropdown.spec.tsx
@@ -14,13 +14,13 @@ describe(KindFilterDropdown.displayName, () => {
     dropdownFilter = [...DEFAULT_TOPOLOGY_FILTERS];
     onChange = jasmine.createSpy();
     supportedKinds = {
-      'apps~v1~Deployment': 1,
-      'apps.openshift.io~v1~DeploymentConfig': 1,
-      'apps~v1~DaemonSet': 1,
-      'apps~v1~StatefulSet': 1,
-      'batch~v1~Job': 1,
-      'batch~v1beta1~CronJob': 1,
-      'core~v1~Pod': 1,
+      'Kind-B': 3,
+      'Kind-A': 4,
+      'Kind-D': 5,
+      'Kind-E': 6,
+      'Kind-F': 7,
+      'Kind-C': 2,
+      'Kind-G': 8,
     };
   });
 
@@ -47,13 +47,52 @@ describe(KindFilterDropdown.displayName, () => {
     expect(wrapper.find(SelectOption)).toHaveLength(Object.keys(supportedKinds).length);
   });
 
-  it('should kinds when filtered', () => {
-    getFilterById(SHOW_GROUPS_FILTER_ID, dropdownFilter).value = false;
-    const keys = Object.keys(supportedKinds);
+  it('should have no badge when there are no filters', () => {
+    const wrapper = mount(
+      <KindFilterDropdown
+        filters={dropdownFilter}
+        supportedKinds={supportedKinds}
+        onChange={onChange}
+        opened
+      />,
+    );
+    expect(wrapper.find('.odc-kind-filter-dropdown__kind-count').exists()).toBeFalsy();
+  });
+
+  it('should have the correct badge count when there are filters', () => {
     dropdownFilter.push({
       type: TopologyDisplayFilterType.kind,
-      id: keys[0],
-      label: keys[0],
+      id: 'Kind-A',
+      label: 'Kind-A',
+      priority: 1,
+      value: true,
+    });
+    dropdownFilter.push({
+      type: TopologyDisplayFilterType.kind,
+      id: 'Kind-C',
+      label: 'Kind-C',
+      priority: 1,
+      value: true,
+    });
+    const wrapper = mount(
+      <KindFilterDropdown
+        filters={dropdownFilter}
+        supportedKinds={supportedKinds}
+        onChange={onChange}
+        opened
+      />,
+    );
+    const badge = wrapper.find('.odc-kind-filter-dropdown__kind-count');
+    expect(badge.exists()).toBeTruthy();
+    expect(badge.first().text()).toEqual('2');
+  });
+
+  it('should select kinds when filtered', () => {
+    getFilterById(SHOW_GROUPS_FILTER_ID, dropdownFilter).value = false;
+    dropdownFilter.push({
+      type: TopologyDisplayFilterType.kind,
+      id: 'Kind-A',
+      label: 'Kind-A',
       priority: 1,
       value: true,
     });
@@ -71,5 +110,23 @@ describe(KindFilterDropdown.displayName, () => {
         .first()
         .props().isChecked,
     ).toBeTruthy();
+  });
+
+  it('should show resource counts correctly', () => {
+    const wrapper = mount(
+      <KindFilterDropdown
+        filters={dropdownFilter}
+        supportedKinds={supportedKinds}
+        onChange={onChange}
+        opened
+      />,
+    );
+    const selectOptions = wrapper.find(SelectOption);
+    const firstType = selectOptions.at(0);
+    const secondType = selectOptions.at(1);
+    const thirdType = selectOptions.at(2);
+    expect(firstType.find('.pf-c-check__label').text()).toContain('(4)');
+    expect(secondType.find('.pf-c-check__label').text()).toContain('(3)');
+    expect(thirdType.find('.pf-c-check__label').text()).toContain('(2)');
   });
 });


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4513

**Description**
Currently, there is no indication that a resource is being filtered if the dropdown is closed. UX recommends that there should be a number badge on the top of the dropdown indicating how many resources are being filtered. The number badges indicating how many of each resource there is inside the dropdown should be changed to numbers within parentheses to not cause confusion between the number badges

**Screenshots**
![image](https://user-images.githubusercontent.com/11633780/91070269-85f67280-e604-11ea-82eb-2954b495b3a5.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug

/cc @bgliwa01 @beaumorley @serenamarie125 