### PR TITLE
Bug 1848512: Wrong interpretation of labels for resource quota diagram

### DIFF
--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -191,16 +191,24 @@ const NoQuotaGuage = ({ title, className }) => (
 
 export const QuotaGaugeCharts = ({ quota, resourceTypes, chartClassName = null }) => {
   const resourceTypesSet = new Set(resourceTypes);
+  const cpuRequestUsagePercent = getResourceUsage(
+    quota,
+    resourceTypesSet.has('requests.cpu') ? 'requests.cpu' : 'cpu',
+  ).percent;
+  const cpuLimitUsagePercent = getResourceUsage(quota, 'limits.cpu').percent;
+  const memoryRequestUsagePercent = getResourceUsage(
+    quota,
+    resourceTypesSet.has('requests.memory') ? 'requests.memory' : 'memory',
+  ).percent;
+  const memoryLimitUsagePercent = getResourceUsage(quota, 'limits.memory').percent;
   return (
     <div className="co-resource-quota-chart-row">
       {resourceTypesSet.has('requests.cpu') || resourceTypesSet.has('cpu') ? (
         <div className="co-resource-quota-gauge-chart">
           <GaugeChart
             data={{
-              y: getResourceUsage(
-                quota,
-                resourceTypesSet.has('requests.cpu') ? 'requests.cpu' : 'cpu',
-              ).percent,
+              x: `${cpuRequestUsagePercent}%`,
+              y: cpuRequestUsagePercent,
             }}
             thresholds={gaugeChartThresholds}
             title="CPU Request"
@@ -215,7 +223,7 @@ export const QuotaGaugeCharts = ({ quota, resourceTypes, chartClassName = null }
       {resourceTypesSet.has('limits.cpu') ? (
         <div className="co-resource-quota-gauge-chart">
           <GaugeChart
-            data={{ y: getResourceUsage(quota, 'limits.cpu').percent }}
+            data={{ x: `${cpuLimitUsagePercent}%`, y: cpuLimitUsagePercent }}
             thresholds={gaugeChartThresholds}
             title="CPU Limit"
             className={chartClassName}
@@ -230,10 +238,8 @@ export const QuotaGaugeCharts = ({ quota, resourceTypes, chartClassName = null }
         <div className="co-resource-quota-gauge-chart">
           <GaugeChart
             data={{
-              y: getResourceUsage(
-                quota,
-                resourceTypesSet.has('requests.memory') ? 'requests.memory' : 'memory',
-              ).percent,
+              x: `${memoryRequestUsagePercent}%`,
+              y: memoryRequestUsagePercent,
             }}
             thresholds={gaugeChartThresholds}
             title="Memory Request"
@@ -248,7 +254,7 @@ export const QuotaGaugeCharts = ({ quota, resourceTypes, chartClassName = null }
       {resourceTypesSet.has('limits.memory') ? (
         <div className="co-resource-quota-gauge-chart">
           <GaugeChart
-            data={{ y: getResourceUsage(quota, 'limits.memory').percent }}
+            data={{ x: `${memoryLimitUsagePercent}%`, y: memoryLimitUsagePercent }}
             thresholds={gaugeChartThresholds}
             title="Memory Limit"
             className={chartClassName}


### PR DESCRIPTION
Needed to provide `data.x` for chart labels/tooltip

### Before
![image](https://user-images.githubusercontent.com/12733153/91075474-22704300-e60c-11ea-8e0f-005999bfad77.png)

### After
![image](https://user-images.githubusercontent.com/12733153/91075489-27cd8d80-e60c-11ea-8df3-b4ff58b419da.png)
