### PR TITLE
Bug 1875600: fix empty default value for pipeline parameters

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { Formik } from 'formik';
 import { k8sUpdate, K8sResourceKind } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
+import { removeEmptyDefaultFromPipelineParams } from './utils';
 
 export interface PipelineFormProps {
   PipelineFormComponent: React.ComponentType<any>;
@@ -27,7 +28,14 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
 
     k8sUpdate(
       PipelineModel,
-      { ...obj, spec: { ...obj.spec, params: values.parameters, resources: values.resources } },
+      {
+        ...obj,
+        spec: {
+          ...obj.spec,
+          params: removeEmptyDefaultFromPipelineParams(values.parameters),
+          resources: values.resources,
+        },
+      },
       obj.metadata.namespace,
       obj.metadata.name,
     )

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/__tests__/utils-data.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/__tests__/utils-data.ts
@@ -1,0 +1,34 @@
+import { PipelineParam } from '@console/dev-console/src/utils/pipeline-augment';
+
+export const pipelineParameters: PipelineParam[] = [
+  {
+    name: 'param1',
+    default: 'abc',
+    description: 'This is param 1',
+  },
+  {
+    name: 'param2',
+    default: '',
+    description: 'This is param 2',
+  },
+  {
+    name: 'param3',
+    default: 'xyz',
+    description: 'This is param 3',
+  },
+];
+
+export const pipelineParametersWithoutDefaults: PipelineParam[] = [
+  {
+    name: 'param1',
+    description: 'This is param 1',
+  },
+  {
+    name: 'param2',
+    description: 'This is param 2',
+  },
+  {
+    name: 'param3',
+    description: 'This is param 3',
+  },
+];

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/__tests__/utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/__tests__/utils.spec.ts
@@ -1,0 +1,48 @@
+import * as _ from 'lodash';
+import { PipelineParam } from '@console/dev-console/src/utils/pipeline-augment';
+import { pipelineParameters, pipelineParametersWithoutDefaults } from './utils-data';
+import { removeEmptyDefaultFromPipelineParams } from '../utils';
+
+describe('removeEmptyDefaultFromPipelineParams omits empty default values', () => {
+  it('should return pipline parameters by only omitting empty default values', () => {
+    const result = removeEmptyDefaultFromPipelineParams(pipelineParameters);
+    const expectedPipelineParameters: PipelineParam[] = [
+      {
+        name: 'param1',
+        default: 'abc',
+        description: 'This is param 1',
+      },
+      {
+        name: 'param2',
+        description: 'This is param 2',
+      },
+      {
+        name: 'param3',
+        default: 'xyz',
+        description: 'This is param 3',
+      },
+    ];
+
+    expect(result).toEqual(expectedPipelineParameters);
+  });
+
+  it('should return empty array if pipline parameters is empty', () => {
+    let result = removeEmptyDefaultFromPipelineParams(null);
+    expect(result).toEqual([]);
+
+    result = removeEmptyDefaultFromPipelineParams([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return pipline parameters as is if default is non-empty', () => {
+    const pipelineParams = _.cloneDeep(pipelineParameters);
+    pipelineParams[1].default = 'mno';
+    const result = removeEmptyDefaultFromPipelineParams(pipelineParams);
+    expect(result).toEqual(pipelineParams);
+  });
+
+  it('should return pipline parameters as is if the default property is not present', () => {
+    const result = removeEmptyDefaultFromPipelineParams(pipelineParametersWithoutDefaults);
+    expect(result).toEqual(pipelineParametersWithoutDefaults);
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/index.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/index.ts
@@ -6,3 +6,4 @@ export { default as PipelineResourcesForm } from './PipelineResourcesForm';
 export { default as PipelineRuns } from './PipelineRuns';
 export { default as PipelineForm } from './PipelineForm';
 export * from './pipelineForm-validation-utils';
+export * from './utils';

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/utils.ts
@@ -1,0 +1,11 @@
+import * as _ from 'lodash';
+import { PipelineParam } from '@console/dev-console/src/utils/pipeline-augment';
+
+export const removeEmptyDefaultFromPipelineParams = (
+  parameters: PipelineParam[],
+): PipelineParam[] =>
+  _.map(
+    parameters,
+    (parameter) =>
+      _.omit(parameter, _.isEmpty(parameter.default) ? ['default'] : []) as PipelineParam,
+  );

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -12,6 +12,7 @@ import {
 import { getTaskParameters } from '../resource-utils';
 import { TASK_ERROR_STRINGS, TaskErrorType } from './const';
 import { PipelineBuilderFormikValues, PipelineBuilderFormValues, TaskErrorMap } from './types';
+import { removeEmptyDefaultFromPipelineParams } from '../detail-page-tabs/utils';
 
 export const getErrorMessage = (errorTypes: TaskErrorType[], errorMap: TaskErrorMap) => (
   taskName: string,
@@ -113,7 +114,7 @@ export const convertBuilderFormToPipeline = (
     },
     spec: {
       ...existingPipeline?.spec,
-      params,
+      params: removeEmptyDefaultFromPipelineParams(params),
       resources,
       tasks: tasks.map((task) => removeEmptyDefaultParams(removeListRunAfters(task, listIds))),
     },


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-4493

**Root Analysis:**
Removing default value for parameter from devconsole UI replaces default value with <empty string>

**Solution Description:**
removing `default` property if null or empty string

**GIF:**
![defaultval](https://user-images.githubusercontent.com/22490998/91081485-d9001200-e664-11ea-8eeb-58c50a153775.gif)
