### PR TITLE
Bug 1867034: Fix no-show pods and filesystem queries

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -432,7 +432,8 @@ const fetchNodeMetrics = (): Promise<NodeMetrics> => {
     },
     {
       key: 'usedStorage',
-      query: 'sum by (instance) (node_filesystem_size_bytes - node_filesystem_free_bytes)',
+      query:
+        'sum by (instance) (node_filesystem_size_bytes{fstype!=""} - node_filesystem_avail_bytes{fstype!=""})',
     },
     {
       key: 'totalStorage',
@@ -444,7 +445,7 @@ const fetchNodeMetrics = (): Promise<NodeMetrics> => {
     },
     {
       key: 'pods',
-      query: 'sum by(node)(kubelet_running_pod_count)',
+      query: 'sum by(node)(kubelet_running_pods)',
     },
   ];
   const promises = metrics.map(({ key, query }) => {

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
@@ -35,9 +35,9 @@ const queries = {
     `node_memory_MemTotal_bytes{instance='<%= node %>'} - node_memory_MemAvailable_bytes{instance='<%= node %>'}`,
   ),
   [NodeQueries.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance='<%= node %>'}`),
-  [NodeQueries.POD_COUNT]: _.template(`kubelet_running_pod_count{instance=~'<%= ipAddress %>:.*'}`),
+  [NodeQueries.POD_COUNT]: _.template(`kubelet_running_pods{instance=~'<%= ipAddress %>:.*'}`),
   [NodeQueries.FILESYSTEM_USAGE]: _.template(
-    `instance:node_filesystem_usage:sum{instance='<%= node %>'}`,
+    `sum(node_filesystem_size_bytes{instance="<%= node %>",fstype!=""} - node_filesystem_avail_bytes{instance="<%= node %>",fstype!=""})`,
   ),
   [NodeQueries.FILESYSTEM_TOTAL]: _.template(`node_filesystem_size_bytes{instance='<%= node %>'}`),
   [NodeQueries.NETWORK_IN_UTILIZATION]: _.template(


### PR DESCRIPTION
Fixed no-show Pods bug on Compute -> Nodes page and details page caused by query name change. Attempted a fix for monitoring - new query from monitoring gave negative values and I'm not sure how to verify correctness. This one at least gives positive values. Asked on Slack and received no response.

<img width="1011" alt="Screen Shot 2020-08-24 at 2 51 09 PM" src="https://user-images.githubusercontent.com/7014965/91084038-5aca4e00-e619-11ea-90f7-c3daad9c8978.png">

<img width="494" alt="Screen Shot 2020-08-24 at 2 51 33 PM" src="https://user-images.githubusercontent.com/7014965/91084049-5ef66b80-e619-11ea-9fa4-c74fb1e7221a.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1867034.