### PR TITLE
Support Service Binding breaking api changes in console

### DIFF
--- a/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
+++ b/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
@@ -14,7 +14,7 @@ export const gitRepoUrl = element(by.id('form-input-git-url-field'));
 export const importFromGitHeader = $('[data-test-id="resource-title"]');
 export const applicationNameField = element(by.id('form-input-application-name-field'));
 
-export const applicationSelector = element(by.id('form-dropdown-application-name-field'));
+export const application = element(by.id('form-dropdown-application-name-field'));
 export const applicationDropdown = element(
   by.className('dropdown-menu__autocomplete-filter pf-c-dropdown__menu dropdown-menu--text-wrap'),
 );
@@ -237,7 +237,7 @@ export const safeSendKeys = async function(
 
 export const addApplication = async function(name: string, nodeName: string) {
   // These are not visible when a user first runs the UI on an empty project
-  //  await applicationSelector.click();
+  //  await application.click();
   //  await browser.wait(until.presenceOf(applicationDropdown));
   //  await createApplication.click();
   await applicationNameField.click();
@@ -246,9 +246,9 @@ export const addApplication = async function(name: string, nodeName: string) {
 };
 
 export const addApplicationWithExistingApps = async function(name: string, nodeName: string) {
-  await browser.wait(until.visibilityOf(applicationSelector));
-  await browser.wait(until.elementToBeClickable(applicationSelector));
-  await applicationSelector.click();
+  await browser.wait(until.visibilityOf(application));
+  await browser.wait(until.elementToBeClickable(application));
+  await application.click();
   await browser.wait(until.presenceOf(applicationDropdown));
   await createApplication.click();
   await applicationNameField.click();

--- a/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
@@ -3,25 +3,25 @@ import { TopologyDataResources } from '../topology-types';
 
 export const serviceBindingRequest: K8sResourceKind = {
   data: {
-    apiVersion: 'apps.openshift.io/v1alpha1',
-    kind: 'ServiceBindingRequest',
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'ServiceBinding',
     metadata: {
       name: 'analytics-deployment-D-wit-deployment-D',
       namespace: 'testproject1',
     },
     spec: {
-      applicationSelector: {
+      application: {
         group: 'apps',
         resource: 'deployments',
-        resourceRef: 'analytics-deployment',
+        name: 'analytics-deployment',
         version: 'v1',
       },
-      backingServiceSelector: {
+      services: [{
         group: '',
         kind: undefined,
-        resourceRef: undefined,
+        name: undefined,
         version: undefined,
-      },
+      }],
       detectBindingResources: true,
     },
   },
@@ -79,30 +79,30 @@ export const sbrBackingServiceSelectors: Partial<TopologyDataResources> = {
     loadError: null,
     data: [
       {
-        apiVersion: 'apps.openshift.io/v1alpha1',
-        kind: 'ServiceBindingRequest',
+        apiVersion: 'operators.coreos.com/v1alpha1',
+        kind: 'ServiceBinding',
         metadata: {
           name: 'sbr-1',
         },
         spec: {
-          applicationSelector: {
-            resourceRef: 'app',
+          application: {
+            name: 'app',
             group: 'apps',
             version: 'v1',
             resource: 'deployments',
           },
-          backingServiceSelectors: [
+          services: [
             {
               group: 'postgresql.baiju.dev',
               version: 'v1alpha1',
               kind: 'Database',
-              resourceRef: 'db-demo1',
+              name: 'db-demo1',
             },
             {
               group: 'postgresql.baiju.dev',
               version: 'v1alpha1',
               kind: 'Database',
-              resourceRef: 'db-demo2',
+              name: 'db-demo2',
             },
           ],
           detectBindingResources: true,
@@ -148,23 +148,23 @@ export const sbrBackingServiceSelector: Partial<TopologyDataResources> = {
     loadError: null,
     data: [
       {
-        apiVersion: 'apps.openshift.io/v1alpha1',
-        kind: 'ServiceBindingRequest',
+        apiVersion: 'operators.coreos.com/v1alpha1',
+        kind: 'ServiceBinding',
         metadata: {
           name: 'sbr-2',
         },
         spec: {
-          applicationSelector: {
-            resourceRef: 'app',
+          application: {
+            name: 'app',
             group: 'apps',
             version: 'v1',
             resource: 'deployments',
           },
-          backingServiceSelector: {
+          services: {
             group: 'postgresql.baiju.dev',
             version: 'v1alpha1',
             kind: 'Database',
-            resourceRef: 'db-demo1',
+            name: 'db-demo1',
           },
           detectBindingResources: true,
         },

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -19,7 +19,7 @@ export const TEST_KINDS_MAP = {
   statefulSets: 'StatefulSet',
   secrets: 'Secret',
   clusterServiceVersions: 'operators.coreos.com~v1alpha1~ClusterServiceVersion',
-  serviceBindingRequests: 'apps.openshift.io~v1alpha1~ServiceBinding',
+  serviceBindingRequests: 'operators.coreos.com~v1alpha1~ServiceBinding',
   revisions: 'serving.knative.dev~v1~Revision',
   configurations: 'serving.knative.dev~v1~Configuration',
   ksroutes: 'serving.knative.dev~v1~Route',

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -19,7 +19,7 @@ export const TEST_KINDS_MAP = {
   statefulSets: 'StatefulSet',
   secrets: 'Secret',
   clusterServiceVersions: 'operators.coreos.com~v1alpha1~ClusterServiceVersion',
-  serviceBindingRequests: 'apps.openshift.io~v1alpha1~ServiceBindingRequest',
+  serviceBindingRequests: 'apps.openshift.io~v1alpha1~ServiceBinding',
   revisions: 'serving.knative.dev~v1~Revision',
   configurations: 'serving.knative.dev~v1~Configuration',
   ksroutes: 'serving.knative.dev~v1~Route',

--- a/frontend/packages/dev-console/src/components/topology/operators/actions/serviceBindings.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/actions/serviceBindings.ts
@@ -23,25 +23,25 @@ export const createServiceBinding = (
   }`;
 
   const serviceBindingRequest = {
-    apiVersion: 'apps.openshift.io/v1alpha1',
-    kind: 'ServiceBindingRequest',
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'ServiceBinding',
     metadata: {
       name: sbrName,
       namespace,
     },
     spec: {
-      applicationSelector: {
-        resourceRef: sourceName,
+      application: {
+        name: sourceName,
         group: sourceGroup[0],
         version: sourceGroup[1],
         resource: modelFor(referenceFor(source)).plural,
       },
-      backingServiceSelector: {
+      services: [{
         group: targetResourceGroup[0],
         version: targetResourceGroup[1],
         kind: targetResourceKind,
-        resourceRef: targetResourceRefName,
-      },
+        name: targetResourceRefName,
+      }],
       detectBindingResources: true,
     },
   };

--- a/frontend/packages/dev-console/src/components/topology/operators/operator-resources.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operator-resources.ts
@@ -8,7 +8,7 @@ export const operatorResources = (namespace: string): FirehoseResource[] => {
       isList: true,
       kind: referenceForModel(ServiceBindingRequestModel),
       namespace,
-      prop: 'serviceBindingRequests',
+      prop: 'ServiceBindings',
       optional: true,
     },
   ];

--- a/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
@@ -45,13 +45,13 @@ export const edgesFromServiceBinding = (
   sbrs.forEach((sbr) => {
     let edgeExists = false;
     const reference = referenceFor(source);
-    if (reference && sbr?.spec?.applicationSelector?.resource === modelFor(reference)?.plural) {
-      if (sbr?.spec?.applicationSelector?.resourceRef === source.metadata.name) {
+    if (reference && sbr?.spec?.application?.resource === modelFor(reference)?.plural) {
+      if (sbr?.spec?.application?.name === source.metadata.name) {
         edgeExists = true;
       } else {
-        const matchLabels = sbr?.spec?.applicationSelector?.matchLabels;
+        const matchLabels = sbr?.spec?.application?.matchLabels;
         if (matchLabels) {
-          const sbrSelector = new LabelSelector(sbr.spec.applicationSelector);
+          const sbrSelector = new LabelSelector(sbr.spec.application);
           if (sbrSelector.matches(source)) {
             edgeExists = true;
           }
@@ -71,15 +71,14 @@ export const getServiceBindingEdges = (
   const edges = [];
 
   _.forEach(edgesFromServiceBinding(dc, sbrs), (sbr) => {
-    // look for multiple backing services first in `backingServiceSelectors`
-    // followed by a fallback to the single reference in `backingServiceSelector`
-    _.forEach(sbr.spec.backingServiceSelectors || [sbr.spec.backingServiceSelector], (bss) => {
+    // look for multiple backing services in `services`
+    _.forEach(sbr.spec.services, (bss) => {
       if (bss) {
         // handles multiple edges
         const targetResource = resources.find(
           (deployment) =>
             deployment?.metadata?.ownerReferences?.[0]?.kind === bss.kind &&
-            deployment?.metadata?.ownerReferences?.[0]?.name === bss.resourceRef,
+            deployment?.metadata?.ownerReferences?.[0]?.name === bss.name,
         );
         const target = targetResource?.metadata?.uid;
         const source = dc?.metadata?.uid;

--- a/frontend/packages/dev-console/src/models/service-binding.ts
+++ b/frontend/packages/dev-console/src/models/service-binding.ts
@@ -2,10 +2,10 @@ import { K8sKind } from '@console/internal/module/k8s';
 
 export const ServiceBindingRequestModel: K8sKind = {
   id: 'servicebindingrequest',
-  kind: 'ServiceBindingRequest',
+  kind: 'ServiceBinding',
   plural: 'servicebindingrequests',
-  label: 'ServiceBindingRequest',
-  labelPlural: 'ServiceBindingRequests',
+  label: 'ServiceBinding',
+  labelPlural: 'ServiceBindings',
   abbr: 'SBR',
   apiGroup: 'apps.openshift.io',
   apiVersion: 'v1alpha1',


### PR DESCRIPTION
This PR isn't meant to be merged, this is just to illustrate what changes UI needs to make in order to make use of updated Service Binding API. 

Ref: Backed PR for this https://github.com/redhat-developer/service-binding-operator/pull/608

**Note:**
This changes would cause problem when user wants to use latest Service Binding Operator with Openshift 4.5 or previous versions, because DevConsole would still create older version of Service Binding Request which won't be supported if latest version of SBO is installed. 
To fix this issues user can install SBO using different channel(This is being discussed how to use different channel to serve different version of SBO). This will be clearly documented in SBO repo. wdyt @sbose78 ? cc: @pedjak 