### PR TITLE
Bug 1864351: Add support for block volumes

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/providers/ovirt/ovirt-prefill-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/providers/ovirt/ovirt-prefill-vm.ts
@@ -82,6 +82,7 @@ export const getDisks = (vm: OvirtVM, storageClassConfigMap: ConfigMapKind): VMW
         disableEditing: true,
         isFieldEditableOverride: {
           storageClass: true,
+          volumeMode: true,
         },
       },
     };

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-ovirt.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-ovirt.ts
@@ -85,16 +85,17 @@ const getNetworkMappings = (networks: VMWizardNetwork[]) => {
 const getDiskMappings = (storage: VMWizardStorage[]) =>
   storage
     .filter(({ type, importData }) => type === VMWizardStorageType.V2V_OVIRT_IMPORT && importData)
-    .map(
-      ({ persistentVolumeClaim, importData: { id } }) =>
-        ({
-          source: { id },
-          target: {
-            name:
-              new PersistentVolumeClaimWrapper(persistentVolumeClaim).getStorageClassName() || '',
-          },
-        } as DiskMapping),
-    );
+    .map(({ persistentVolumeClaim, importData: { id } }) => {
+      const persistentVolumeClaimWrapper = new PersistentVolumeClaimWrapper(persistentVolumeClaim);
+
+      return {
+        source: { id },
+        target: {
+          name: persistentVolumeClaimWrapper.getStorageClassName() || '',
+        },
+        volumeMode: persistentVolumeClaimWrapper.getVolumeMode() || null,
+      } as DiskMapping;
+    });
 
 const createVMImport = async (
   {

--- a/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/vm-import.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/vm-import.ts
@@ -17,13 +17,13 @@ export type NetworkMapping = {
 export type StorageMapping = {
   source: Source; // Storage Domain ID
   target: Target;
-  volumeMode?: 'Block' | 'Filesystem';
+  volumeMode?: string;
 };
 
 export type DiskMapping = {
   source: Source; // Disk ID
   target: Target;
-  volumeMode?: 'Block' | 'Filesystem';
+  volumeMode?: string;
 };
 
 export type VMImportOvirtSource = {

--- a/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/vm-import.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/vm-import.ts
@@ -17,11 +17,13 @@ export type NetworkMapping = {
 export type StorageMapping = {
   source: Source; // Storage Domain ID
   target: Target;
+  volumeMode?: 'Block' | 'Filesystem';
 };
 
 export type DiskMapping = {
   source: Source; // Disk ID
   target: Target;
+  volumeMode?: 'Block' | 'Filesystem';
 };
 
 export type VMImportOvirtSource = {


### PR DESCRIPTION
`vm-import-operator` introduced a `volumeMode` field in [1] , this PR adds the UI option to use this field.

Screenshots:
![Peek 2020-08-25 09-18](https://user-images.githubusercontent.com/2181522/91130277-117b0c80-e6b4-11ea-8fd3-6532643dbe44.gif)

[1] https://github.com/kubevirt/vm-import-operator/pull/347