### PR TITLE
Bug 1872157: Query Browser: Make series button width constant when data is loading

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -330,7 +330,7 @@ const SeriesButton_: React.FC<SeriesButtonProps> = ({
   toggleSeries,
 }) => {
   if (isSeriesEmpty) {
-    return null;
+    return <div className="query-browser__series-btn-wrap"></div>;
   }
   const title = `${isDisabled ? 'Show' : 'Hide'} series`;
 


### PR DESCRIPTION
This keeps the width of the table's first column constant regardless of
whether the series data has finished loading or not.