### PR TITLE
Bug 1870114: Updated template PVC name and namespace to use parameters

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -21,6 +21,7 @@ import {
   TEMPLATE_TYPE_VM,
   VMWizardMode,
   VMWizardView,
+  TEMPLATE_VM_GOLDEN_OS_NAMESPACE,
 } from '../../constants/vm';
 import { getResource } from '../../utils';
 import { IDReferences, makeIDReferences } from '../../utils/redux/id-reference';
@@ -386,7 +387,7 @@ export const CreateVMWizardPageComponent: React.FC<CreateVMWizardPageComponentPr
           matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_BASE },
         }),
         getResource(PersistentVolumeClaimModel, {
-          namespace: 'openshift-cnv-base-images',
+          namespace: TEMPLATE_VM_GOLDEN_OS_NAMESPACE,
           prop: VMWizardProps.openshiftCNVBaseImages,
         }),
       );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
@@ -25,7 +25,11 @@ import {
 } from '../../../../selectors/config-map/sc-defaults';
 import { toShallowJS, iGetIn } from '../../../../utils/immutable';
 import { generateDataVolumeName } from '../../../../utils';
-import { DUMMY_VM_NAME, TEMPLATE_DATAVOLUME_ANNOTATION } from '../../../../constants/vm';
+import {
+  DUMMY_VM_NAME,
+  TEMPLATE_DATAVOLUME_NAME_PARAMETER,
+  TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER,
+} from '../../../../constants/vm';
 import {
   iGetVmSettingValue,
   iGetProvisionSource,
@@ -33,7 +37,7 @@ import {
 } from '../../selectors/immutable/vm-settings';
 import { iGetLoadedCommonData, iGetName } from '../../selectors/immutable/selectors';
 import { iGetRelevantTemplate } from '../../../../selectors/immutable/template/combined';
-import { iGetAnnotation } from '../../../../selectors/immutable/common';
+import { iGetPrameterValue } from '../../../../selectors/immutable/common';
 
 const ROOT_DISK_NAME = 'rootdisk';
 const WINTOOLS_DISK_NAME = 'windows-guest-tools';
@@ -186,11 +190,8 @@ export const getNewProvisionSourceStorage = (state: any, id: string): VMWizardSt
     const iCommonTemplates = iGetLoadedCommonData(state, id, VMWizardProps.commonTemplates);
     const iTemplate =
       iCommonTemplates && iGetRelevantTemplate(null, iCommonTemplates, relevantOptions);
-    const pvcName = iGetAnnotation(
-      iTemplate,
-      `${TEMPLATE_DATAVOLUME_ANNOTATION}/${relevantOptions.os}`,
-    );
-    const pvcNamespace = iGetAnnotation(iTemplate, `${TEMPLATE_DATAVOLUME_ANNOTATION}/namespace`);
+    const pvcName = iGetPrameterValue(iTemplate, TEMPLATE_DATAVOLUME_NAME_PARAMETER);
+    const pvcNamespace = iGetPrameterValue(iTemplate, TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER);
 
     const iBaseImage = iGetLoadedCommonData(state, id, VMWizardProps.openshiftCNVBaseImages)
       .valueSeq()

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
@@ -121,7 +121,16 @@ const baseImageUpdater = ({ id, prevState, dispatch, getState }: UpdateOptions) 
   if (iGetCommonData(state, id, VMWizardProps.isProviderImport)) {
     return;
   }
-  if (!hasVMSettingsValueChanged(prevState, state, id, VMSettingsField.OPERATING_SYSTEM)) {
+  if (
+    !hasVMSettingsValueChanged(
+      prevState,
+      state,
+      id,
+      VMSettingsField.OPERATING_SYSTEM,
+      VMSettingsField.FLAVOR,
+      VMSettingsField.WORKLOAD_PROFILE,
+    )
+  ) {
     return;
   }
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
@@ -15,12 +15,17 @@ import {
   iGetCommonData,
   iGetLoadedCommonData,
   iGetName,
+  iGetNamespace,
 } from '../../selectors/immutable/selectors';
 import { iGetRelevantTemplate } from '../../../../selectors/immutable/template/combined';
-import { CUSTOM_FLAVOR, TEMPLATE_DATAVOLUME_ANNOTATION } from '../../../../constants/vm';
+import {
+  CUSTOM_FLAVOR,
+  TEMPLATE_DATAVOLUME_NAME_PARAMETER,
+  TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER,
+} from '../../../../constants/vm';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { prefillVmTemplateUpdater } from './prefill-vm-template-state-update';
-import { iGetAnnotation } from '../../../../selectors/immutable/common';
+import { iGetPrameterValue } from '../../../../selectors/immutable/common';
 
 const selectUserTemplateOnLoadedUpdater = (options: UpdateOptions) => {
   const { id, dispatch, getState } = options;
@@ -129,14 +134,16 @@ const baseImageUpdater = ({ id, prevState, dispatch, getState }: UpdateOptions) 
     const iCommonTemplates = iGetLoadedCommonData(state, id, VMWizardProps.commonTemplates);
     const iTemplate =
       iCommonTemplates && iGetRelevantTemplate(null, iCommonTemplates, relevantOptions);
-    const pvcName = iGetAnnotation(
-      iTemplate,
-      `${TEMPLATE_DATAVOLUME_ANNOTATION}/${relevantOptions?.os}`,
-    );
+    const pvcName = iGetPrameterValue(iTemplate, TEMPLATE_DATAVOLUME_NAME_PARAMETER);
+    const pvcNamespace = iGetPrameterValue(iTemplate, TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER);
 
     const iBaseImages = iGetLoadedCommonData(state, id, VMWizardProps.openshiftCNVBaseImages);
     iBaseImage =
-      pvcName && iBaseImages && iBaseImages.valueSeq().find((iPVC) => iGetName(iPVC) === pvcName);
+      pvcName &&
+      iBaseImages &&
+      iBaseImages
+        .valueSeq()
+        .find((iPVC) => iGetName(iPVC) === pvcName && iGetNamespace(iPVC) === pvcNamespace);
   }
 
   dispatch(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
@@ -32,7 +32,7 @@ import { getPlaceholder, getFieldId } from '../../utils/renderable-field-utils';
 import { nullOnEmptyChange } from '../../utils/utils';
 import { operatingSystemsNative } from '../../../../constants/vm-templates/os';
 import { OperatingSystemRecord } from '../../../../types';
-import { iGetName } from '../../selectors/immutable/selectors';
+import { iGetName, iGetNamespace } from '../../selectors/immutable/selectors';
 import {
   BASE_IMAGE_AND_PVC_SHORT,
   BASE_IMAGE_AND_PVC_MESSAGE,
@@ -120,7 +120,10 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
     const operatingSystemBaseImages = operatingSystems.map(
       (operatingSystem: OperatingSystemRecord) => {
         const pvcName = operatingSystem?.dataVolumeName;
-        const baseImageFoundInCluster = loadedBaseImages?.find((pvc) => iGetName(pvc) === pvcName);
+        const pvcNamespace = operatingSystem?.dataVolumeNamespace;
+        const baseImageFoundInCluster = loadedBaseImages?.find(
+          (pvc) => iGetName(pvc) === pvcName && iGetNamespace(pvc) === pvcNamespace,
+        );
         const osField = {
           id: operatingSystem.id,
           name: operatingSystem.name,

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -21,10 +21,11 @@ export const TEMPLATE_TYPE_BASE = 'base';
 export const TEMPLATE_WORKLOAD_LABEL = 'workload.template.kubevirt.io';
 export const TEMPLATE_VM_NAME_LABEL = 'vm.kubevirt.io/name';
 export const TEMPLATE_OS_NAME_ANNOTATION = 'name.os.template.kubevirt.io';
-export const TEMPLATE_DATAVOLUME_ANNOTATION = 'datavolume.template.kubevirt.io';
+export const TEMPLATE_DATAVOLUME_NAME_PARAMETER = 'SRC_PVC_NAME';
+export const TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER = 'SRC_PVC_NAMESPACE';
 export const TEMPLATE_VM_DOMAIN_LABEL = 'kubevirt.io/domain';
 export const TEMPLATE_VM_SIZE_LABEL = 'kubevirt.io/size';
-export const TEMPLATE_VM_GOLDEN_OS_NAMESPACE = 'openshift-cnv-base-images';
+export const TEMPLATE_VM_GOLDEN_OS_NAMESPACE = 'openshift-kubevirt-base-images';
 export const TEMPLATE_VM_COMMON_NAMESPACE = 'openshift';
 
 export const LABEL_USED_TEMPLATE_NAME = 'vm.kubevirt.io/template';

--- a/frontend/packages/kubevirt-plugin/src/selectors/immutable/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/immutable/common.ts
@@ -4,5 +4,10 @@ import { ILabels } from '../../types/template';
 export const iGetLabels = (obj): ILabels => iGetIn(obj, ['metadata', 'labels']);
 export const iGetCreationTimestamp = (obj): string =>
   iGetIn(obj, ['metadata', 'creationTimestamp']);
-export const iGetAnnotation = (obj, key: string, defaultValue = undefined): string =>
-  iGetIn(obj, ['metadata', 'annotations', key], defaultValue);
+export const iGetPrameterValue = (obj, name: string, defaultValue = null): any => {
+  const parameter = iGetIn(obj, ['parameters'])
+    ?.valueSeq()
+    .find((p) => iGetIn(p, ['name']) === name);
+
+  return iGetIn(parameter, ['value'], defaultValue);
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
@@ -86,6 +86,13 @@ export const iGetRelevantTemplates = (
         const versionCMP = compareVersions(splitVersion(aVersion), splitVersion(bVersion)) * -1; // descending
 
         if (versionCMP !== 0) {
+          // 'devel' version if exist is always the highst version.
+          if (aVersion === 'devel') {
+            return -1;
+          }
+          if (bVersion === 'devel') {
+            return 1;
+          }
           return versionCMP;
         }
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
@@ -8,7 +8,7 @@ import {
 import { iGetName } from '../../../components/create-vm-wizard/selectors/immutable/selectors';
 import { ITemplate } from '../../../types/template';
 import { iGetCreationTimestamp, iGetLabels } from '../common';
-import { compareVersions, splitVersion } from '../../../utils/sort';
+import { compareVersions } from '../../../utils/sort';
 
 type FindTemplateOptions = {
   userTemplateName?: string;
@@ -83,16 +83,9 @@ export const iGetRelevantTemplates = (
         const aVersion = aLabels?.get(TEMPLATE_VERSION_LABEL);
         const bVersion = bLabels?.get(TEMPLATE_VERSION_LABEL);
 
-        const versionCMP = compareVersions(splitVersion(aVersion), splitVersion(bVersion)) * -1; // descending
+        const versionCMP = compareVersions(aVersion, bVersion) * -1; // descending
 
         if (versionCMP !== 0) {
-          // 'devel' version if exist is always the highst version.
-          if (aVersion === 'devel') {
-            return -1;
-          }
-          if (bVersion === 'devel') {
-            return 1;
-          }
           return versionCMP;
         }
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/selectors.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { K8sResourceKind, TemplateParameter } from '@console/internal/module/k8s';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { VMGenericLikeEntityKind } from '../types/vmLike';
 
 export const getKind = (value) => _.get(value, 'kind') as K8sResourceKind['kind'];
@@ -36,8 +36,9 @@ export const getAnnotation = (
   defaultValue?: string,
 ): string => _.get(entity, ['metadata', 'annotations', annotationName], defaultValue);
 
-export const getParameter = (obj, name: string, defaultValue = {}): TemplateParameter =>
-  _.get(obj, ['parameters'], []).find((parameter) => parameter.name === name) || defaultValue;
+export const getParameterValue = (obj, name: string, defaultValue = null): string =>
+  _.get(obj, ['parameters'], []).find((parameter) => parameter.name === name)?.value ||
+  defaultValue;
 
 export const getAnnotationKeySuffix = (
   entity: K8sResourceKind,

--- a/frontend/packages/kubevirt-plugin/src/selectors/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/selectors.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, TemplateParameter } from '@console/internal/module/k8s';
 import { VMGenericLikeEntityKind } from '../types/vmLike';
 
 export const getKind = (value) => _.get(value, 'kind') as K8sResourceKind['kind'];
@@ -35,6 +35,9 @@ export const getAnnotation = (
   annotationName: string,
   defaultValue?: string,
 ): string => _.get(entity, ['metadata', 'annotations', annotationName], defaultValue);
+
+export const getParameter = (obj, name: string, defaultValue = {}): TemplateParameter =>
+  _.get(obj, ['parameters'], []).find((parameter) => parameter.name === name) || defaultValue;
 
 export const getAnnotationKeySuffix = (
   entity: K8sResourceKind,

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
@@ -4,7 +4,7 @@ import {
   CloudInitDataHelper,
   CloudInitDataFormKeys,
 } from '../../k8s/wrapper/vm/cloud-init-data-helper';
-import { getAnnotation, getAnnotations, getLabels } from '../selectors';
+import { getAnnotation, getAnnotations, getLabels, getParameter } from '../selectors';
 import {
   TEMPLATE_FLAVOR_LABEL,
   TEMPLATE_OS_LABEL,
@@ -12,12 +12,10 @@ import {
   TEMPLATE_TYPE_LABEL,
   TEMPLATE_TYPE_VM,
   TEMPLATE_WORKLOAD_LABEL,
+  TEMPLATE_DATAVOLUME_NAME_PARAMETER,
+  TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER,
 } from '../../constants/vm';
-import {
-  getCloudInitVolume,
-  getOperatingSystemDataVolumeAnnotation,
-  getOperatingSystemDataVolumeNamespaceAnnotation,
-} from '../vm/selectors';
+import { getCloudInitVolume } from '../vm/selectors';
 import { VolumeWrapper } from '../../k8s/wrapper/vm/volume-wrapper';
 import { selectVM } from './basic';
 import { removeOSDups } from '../../utils/sort';
@@ -83,11 +81,12 @@ export const getTemplateOperatingSystems = (templates: TemplateKind[]) => {
         (t) =>
           !!Object.keys(getAnnotations(t, {})).find((annotation) => annotation === nameAnnotation),
       );
+
       return {
         id: osId,
         name: getAnnotation(template, nameAnnotation),
-        dataVolumeName: getOperatingSystemDataVolumeAnnotation(template, osId),
-        dataVolumeNamespace: getOperatingSystemDataVolumeNamespaceAnnotation(template),
+        dataVolumeName: getParameter(template, TEMPLATE_DATAVOLUME_NAME_PARAMETER)?.value,
+        dataVolumeNamespace: getParameter(template, TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER)?.value,
       };
     }),
   );

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
@@ -4,7 +4,7 @@ import {
   CloudInitDataHelper,
   CloudInitDataFormKeys,
 } from '../../k8s/wrapper/vm/cloud-init-data-helper';
-import { getAnnotation, getAnnotations, getLabels, getParameter } from '../selectors';
+import { getAnnotation, getAnnotations, getLabels, getParameterValue } from '../selectors';
 import {
   TEMPLATE_FLAVOR_LABEL,
   TEMPLATE_OS_LABEL,
@@ -85,8 +85,8 @@ export const getTemplateOperatingSystems = (templates: TemplateKind[]) => {
       return {
         id: osId,
         name: getAnnotation(template, nameAnnotation),
-        dataVolumeName: getParameter(template, TEMPLATE_DATAVOLUME_NAME_PARAMETER)?.value,
-        dataVolumeNamespace: getParameter(template, TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER)?.value,
+        dataVolumeName: getParameterValue(template, TEMPLATE_DATAVOLUME_NAME_PARAMETER),
+        dataVolumeNamespace: getParameterValue(template, TEMPLATE_DATAVOLUME_NAMESPACE_PARAMETER),
       };
     }),
   );

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 import { getName } from '@console/shared/src/selectors/common';
 import { createBasicLookup } from '@console/shared/src/utils/utils';
 import {
-  TEMPLATE_DATAVOLUME_ANNOTATION,
   TEMPLATE_FLAVOR_LABEL,
   TEMPLATE_OS_LABEL,
   TEMPLATE_OS_NAME_ANNOTATION,
@@ -182,15 +181,3 @@ export const getIsGraphicsConsoleAttached = (vm: VMKind) =>
 
 export const getIsSerialConsoleAttached = (vm: VMKind) =>
   vm?.spec?.template?.spec?.domain?.devices?.autoattachSerialConsole;
-
-export const getOperatingSystemDataVolumeAnnotation = (
-  vmLike: VMGenericLikeEntityKind,
-  osId?: string,
-) =>
-  getValueByPrefix(
-    getAnnotations(vmLike),
-    `${TEMPLATE_DATAVOLUME_ANNOTATION}/${osId || getOperatingSystem(vmLike)}`,
-  );
-
-export const getOperatingSystemDataVolumeNamespaceAnnotation = (vmLike: VMGenericLikeEntityKind) =>
-  getValueByPrefix(getAnnotations(vmLike), `${TEMPLATE_DATAVOLUME_ANNOTATION}/namespace`);

--- a/frontend/packages/kubevirt-plugin/src/utils/__tests__/sort.spec.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/__tests__/sort.spec.ts
@@ -10,16 +10,17 @@ import { OperatingSystemRecord } from '../../types/types';
  */
 
 describe('compareVersions', () => {
-  const osVersion0: number[] = null;
-  const osVersion1: number[] = [1, 2, 3];
-  const osVersion2: number[] = [1, 2, 4];
-  const osVersion3: number[] = [1, 1];
-  const osVersion4: number[] = [1];
-  const osVersion5: number[] = [2];
-  const osVersion6: number[] = [1, 0];
-  const osVersion7: number[] = [1, 0, 0];
-  const osVersion8: number[] = [0];
-  const osVersion9: number[] = [0, 0, 0];
+  const osVersion0: string = null;
+  const osVersion1: string = 'v1.2.3';
+  const osVersion2: string = 'v1.2.4';
+  const osVersion3: string = '1.1';
+  const osVersion4: string = '1';
+  const osVersion5: string = '2';
+  const osVersion6: string = '1.0';
+  const osVersion7: string = '1.0.0';
+  const osVersion8: string = '0';
+  const osVersion9: string = '0.0.0';
+  const osVersion10: string = 'devel';
 
   it('check non-equal versions with same length', () => {
     expect(compareVersions(osVersion1, osVersion2)).toEqual(-1);
@@ -58,6 +59,10 @@ describe('compareVersions', () => {
 
   it('check equal versions when both of them are null', () => {
     expect(compareVersions(osVersion0, osVersion0)).toEqual(0);
+  });
+
+  it('check devel version when both of them are not null', () => {
+    expect(compareVersions(osVersion10, osVersion9)).toEqual(1);
   });
 });
 

--- a/frontend/packages/kubevirt-plugin/src/utils/sort.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/sort.ts
@@ -48,7 +48,7 @@ export const ignoreCaseSort = <T>(
   return array.sort((a, b) => resolve(a).localeCompare(resolve(b)));
 };
 
-export const splitVersion = (osID: string): number[] =>
+const splitVersion = (osID: string): number[] =>
   (osID || '')
     .split(/\D/)
     .filter((x) => x)
@@ -72,13 +72,21 @@ export const splitVersion = (osID: string): number[] =>
  * return 0 when equal.
  *
  */
-export const compareVersions = (version1: number[], version2: number[]): number => {
+export const compareVersions = (version1: string, version2: string): number => {
   if (!version1 && !version2) {
     return 0;
   }
 
-  const finalVersion1 = version1 || [];
-  const finalVersion2 = version2 || [];
+  // 'devel' version if exist is always the highst version.
+  if (version1 === 'devel') {
+    return 1;
+  }
+  if (version2 === 'devel') {
+    return -1;
+  }
+
+  const finalVersion1 = splitVersion(version1) || [];
+  const finalVersion2 = splitVersion(version2) || [];
 
   const zipped = _.zip(finalVersion1, finalVersion2);
   let idx = 0;
@@ -111,7 +119,7 @@ const descSortOSes = (os1: OperatingSystemRecord, os2: OperatingSystemRecord): n
     return nameCMP * -1;
   }
 
-  return compareVersions(splitVersion(os1.id), splitVersion(os2.id)) * -1;
+  return compareVersions(os1.id, os2.id) * -1;
 };
 
 export const removeOSDups = (osArr: OperatingSystemRecord[]): OperatingSystemRecord[] =>


### PR DESCRIPTION
https://issues.redhat.com/browse/CNV-4764 updated the way PVC name and namespace are stated in the template.
We currently use the old way, we need to update according to latest updates.

Refs:
https://github.com/kubevirt/common-templates/pull/168
https://github.com/kubevirt/kubevirt-ssp-operator/pull/212