### PR TITLE
Bug 1872092:  Make 'Volume Snapshot *' labels consistent

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
@@ -92,7 +92,7 @@ const SnapshotClassDropdown: React.FC<SnapshotClassDropdownProps> = (props) => {
       dataFilter={filter}
       resources={resources}
       selectedKeyKind={kind}
-      placeholder="Select snapshot class"
+      placeholder="Select volume snapshot class"
       selectedKey={selectedKey}
     />
   );
@@ -252,7 +252,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
         {pvcObj && (
           <div className="form-group co-volume-snapshot__form">
             <label className="control-label co-required" htmlFor="snapshot-class">
-              Snapshot Class
+              Volume Snapshot Class
             </label>
             <SnapshotClassDropdown
               onChange={setSnapshotClassName}

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-class-details.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-class-details.tsx
@@ -13,7 +13,7 @@ const { editYaml, events } = navFactory;
 
 const Details: React.FC<DetailsProps> = ({ obj }) => (
   <div className="co-m-pane__body">
-    <SectionHeading text="Volume Snapshot Details" />
+    <SectionHeading text="Volume Snapshot Class Details" />
     <div className="row">
       <div className="col-md-6 col-xs-12">
         <ResourceSummary resource={obj}>

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content-details.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-content-details.tsx
@@ -25,7 +25,7 @@ const Details: React.FC<DetailsProps> = ({ obj }) => {
 
   return (
     <div className="co-m-pane__body">
-      <SectionHeading text="Volume Snapshot Details" />
+      <SectionHeading text="Volume Snapshot Content Details" />
       <div className="row">
         <div className="col-md-6 col-xs-12">
           <ResourceSummary resource={obj}>
@@ -51,7 +51,7 @@ const Details: React.FC<DetailsProps> = ({ obj }) => {
                 namespace={snapshotNamespace}
               />
             </dd>
-            <dt>Snapshot Class</dt>
+            <dt>Volume Snapshot Class</dt>
             <dd>
               <ResourceLink
                 kind={referenceForModel(VolumeSnapshotClassModel)}

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-details.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot-details.tsx
@@ -69,7 +69,7 @@ const Details: React.FC<DetailsProps> = ({ obj }) => {
                 </dd>
               </>
             )}
-            <dt>Snapshot Class</dt>
+            <dt>Volume Snapshot Class</dt>
             <dd>
               <ResourceLink
                 kind={referenceForModel(VolumeSnapshotClassModel)}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1872092

Note I did not add `Volume` to `Snapshot Class` and `Snapshot Content` on the Volume Content and Volume Snapshot Content table headers in order to keep them shorter.