### PR TITLE
Bug 1872303: Fix delay in topology view on changing namespace

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
@@ -61,6 +61,11 @@ export const ConnectedTopologyDataRenderer: React.FC<TopologyDataRendererProps &
     return { data: alerts, loaded: !loading, loadError: error };
   }, [response, error, loading]);
 
+  // Wipe the current model on a namespace change
+  React.useEffect(() => {
+    setModel(null);
+  }, [namespace]);
+
   React.useEffect(() => {
     const { extensionsLoaded, watchedResources } = dataModelContext;
     if (!extensionsLoaded) {

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
@@ -18,6 +18,12 @@
     top: var(--pf-global--spacer--sm);
   }
 
+  &__view-switcher.pf-m-plain {
+    @media (min-width: 768px) {
+      padding-bottom: 7px !important;
+    }
+  }
+
   &__layout-group {
     display: flex;
     flex-wrap: wrap;

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -148,7 +148,7 @@ export const TopologyPageContext: React.FC<TopologyPageProps> = observer(({ matc
               )}
               <Tooltip position="left" content={showListView ? 'Topology View' : 'List View'}>
                 <Link
-                  className="pf-c-button pf-m-plain"
+                  className="pf-c-button pf-m-plain odc-topology__view-switcher"
                   to={`/topology/${namespace ? `ns/${namespace}` : 'all-namespaces'}${
                     showListView ? '/graph' : '/list'
                   }${queryParams ? `?${queryParams.toString()}` : ''}`}


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4633

**Description**
Update code to reset the model on a namespace change so that the status box is shown during the loading process for the new namespace. Also noticed that the namespace bar jumps in size when switching due to the view switcher being hidden and re-displayed. The height of the switcher was larger than the rest of the bar causing the resize.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
