### PR TITLE
Bug 1879517: Add support for External mode RGW queries in Data Resiliency and Capacity breakdown Cards

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/prometheus-hook.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/prometheus-hook.ts
@@ -81,7 +81,7 @@ export const usePrometheusQueries = <R extends any>(
       return [...acc, value];
     }, []);
     const loadError: boolean = queryResults.some((res) => !!res.get('loadError'));
-    const loading: boolean = values.some((res) => _.isEmpty(res));
+    const loading: boolean = values.some((res) => !res);
     return [values, loading, loadError];
   }, [queryResults, queries, parser]);
 

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/object-service-health.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/object-service-health.tsx
@@ -39,7 +39,7 @@ export const ObjectServiceStatus: React.FC<ObjectServiceStatusProps> = ({
       {statusType === StatusType.HEALTH ? healthString : dataResiliency}
       <StatusPopupSection firstColumn="Services" secondColumn="Status">
         <Status icon={healthStateMapping[MCGMetrics.state]?.icon}>Multi Cloud Gateway </Status>
-        <Status icon={healthStateMapping[RGWMetrics.state]?.icon}>RADOS Gateway </Status>
+        <Status icon={healthStateMapping[RGWMetrics.state]?.icon}>Object Gateway (RGW) </Status>
       </StatusPopupSection>
     </HealthItem>
   );

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/statuses.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/statuses.tsx
@@ -1,9 +1,8 @@
 import { PrometheusHealthHandler, SubsystemHealth } from '@console/plugin-sdk';
 import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { MODES } from '@console/ceph-storage-plugin/src/constants';
 import { getGaugeValue } from '../../utils';
-import { Phase, Health } from '../../constants';
+import { Phase } from '../../constants';
 
 const nooBaaStatus = {
   '0': { state: HealthState.OK },
@@ -47,25 +46,19 @@ export const getNooBaaState: PrometheusHealthHandler = (responses, noobaa) => {
   );
 };
 
-export const getRGWHealthState = (cr: K8sResourceKind, mode: MODES): SubsystemHealth => {
-  const health = mode !== MODES.EXTERNAL ? cr?.status?.phase : cr?.status?.bucketStatus?.health;
+export const getRGWHealthState = (cr: K8sResourceKind): SubsystemHealth => {
+  const health = cr?.status?.phase;
   if (!health) {
     return { state: HealthState.NOT_AVAILABLE };
   }
-  if (mode !== MODES.EXTERNAL) {
-    if (health === Phase.READY) {
+  switch (health) {
+    case Phase.CONNECTED:
       return { state: HealthState.OK };
-    }
-    if (health === Phase.FAILURE) {
+    case Phase.PROGRESSING:
+      return { state: HealthState.PROGRESS };
+    case Phase.FAILURE:
       return { state: HealthState.ERROR };
-    }
-  } else {
-    if (health === Health.HEALTHY) {
-      return { state: HealthState.OK };
-    }
-    if (health === Health.FAILURE) {
-      return { state: HealthState.ERROR };
-    }
+    default:
+      return { state: HealthState.UNKNOWN };
   }
-  return { state: HealthState.UNKNOWN };
 };

--- a/frontend/packages/noobaa-storage-plugin/src/constants/capacity-breakdown.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/capacity-breakdown.ts
@@ -1,6 +1,6 @@
 export enum ServiceType {
   MCG = 'Multi Cloud Gateway',
-  RGW = 'RADOS Gateway',
+  RGW = 'Object Gateway (RGW)',
   ALL = 'All',
 }
 
@@ -20,10 +20,10 @@ export namespace CapacityBreakdown {
 
   export const serviceMetricMap = Object.freeze({
     [ServiceType.ALL]: {
-      [CapacityBreakdown.Metrics.TOTAL]: ['RADOS Gateway', 'Multi Cloud Gateway'],
+      [CapacityBreakdown.Metrics.TOTAL]: ['Object Gateway (RGW)', 'Multi Cloud Gateway'],
     },
     [ServiceType.RGW]: {
-      [CapacityBreakdown.Metrics.TOTAL]: ['RADOS Gateway'],
+      [CapacityBreakdown.Metrics.TOTAL]: ['Object Gateway (RGW)'],
     },
     [ServiceType.MCG]: {
       [CapacityBreakdown.Metrics.TOTAL]: ['Multi Cloud Gateway'],

--- a/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
@@ -3,3 +3,4 @@ export * from './providers';
 export * from './common';
 export * from './capacity-breakdown';
 export * from './status';
+export * from './resources';

--- a/frontend/packages/noobaa-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/resources.ts
@@ -1,0 +1,11 @@
+import { CEPH_STORAGE_NAMESPACE } from '@console/ceph-storage-plugin/src/constants';
+import { SecretModel } from '@console/internal/models';
+import { FirehoseResource } from '@console/internal/components/utils';
+
+export const secretResource: FirehoseResource = {
+  isList: false,
+  kind: SecretModel.kind,
+  prop: 'secret',
+  namespace: CEPH_STORAGE_NAMESPACE,
+  name: 'rook-ceph-external-cluster-details',
+};

--- a/frontend/packages/noobaa-storage-plugin/src/constants/status.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/status.ts
@@ -4,12 +4,8 @@ export enum StatusType {
 }
 
 export enum Phase {
-  READY = 'Ready',
-  FAILURE = 'Failure',
-}
-
-export enum Health {
-  HEALTHY = 'Healthy',
+  CONNECTED = 'Connected',
+  PROGRESSING = 'Progressing',
   FAILURE = 'Failure',
 }
 

--- a/frontend/packages/noobaa-storage-plugin/src/queries.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/queries.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { ProjectModel } from '@console/internal/models';
 import { CapacityBreakdown, ServiceType, Metrics, Breakdown } from './constants';
 import { NooBaaBucketClassModel } from './models';
@@ -25,13 +26,24 @@ export enum ObjectServiceDashboardQuery {
   PROVIDERS_BY_PHYSICAL_VS_LOGICAL_USAGE = 'PROVIDERS_BY_PHYSICAL_VS_LOGICAL_USAGE',
   RGW_TOTAL_USED = 'RGW_TOTAL_USED',
   RGW_USED = 'RGW_USED',
+  // Data Resiliency Query
+  MCG_REBUILD_PROGRESS_QUERY = 'MCG_REBUILD_PROGRESS_QUERY',
+  MCG_REBUILD_TIME_QUERY = 'MCG_REBUILD_TIME_QUERY',
+  RGW_REBUILD_PROGRESS_QUERY = 'RGW_REBUILD_PROGRESS_QUERY',
 }
 
-export enum DATA_RESILIENCE_QUERIES {
-  REBUILD_PROGRESS_QUERY = 'NooBaa_rebuild_progress/100',
-  REBUILD_TIME_QUERY = 'NooBaa_rebuild_time',
-  RGW_PROGRESS_QUERY = '(sum(ceph_pool_metadata{name=~".*rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pg_clean) / sum(ceph_pool_metadata{name=~".*rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pg_total))',
-}
+export const dataResiliencyQueryMap = {
+  [ObjectServiceDashboardQuery.MCG_REBUILD_PROGRESS_QUERY]: 'NooBaa_rebuild_progress/100',
+  [ObjectServiceDashboardQuery.MCG_REBUILD_TIME_QUERY]: 'NooBaa_rebuild_time',
+  [ObjectServiceDashboardQuery.RGW_REBUILD_PROGRESS_QUERY]: (rgwPrefix: string = '') =>
+    _.template(
+      'sum(ceph_pool_metadata{name=~"<%= name %>"}*on (job, namesapce, pool_id) group_right(name) (ceph_pg_active and ceph_pg_clean)) / sum(ceph_pool_metadata{name=~"<%= name %>"} *on (job, namesapce, pool_id) group_right(name) ceph_pg_total)',
+    )({
+      name: rgwPrefix
+        ? `${rgwPrefix}.rgw.*`
+        : '(ocs-storagecluster-cephblockpool)|(ocs-storagecluster-cephfilesystem-data0)',
+    }),
+};
 
 export enum ObjectDataReductionQueries {
   EFFICIENCY_QUERY = 'NooBaa_reduction_ratio',
@@ -42,17 +54,22 @@ export enum ObjectDataReductionQueries {
 export enum StatusCardQueries {
   HEALTH_QUERY = 'NooBaa_health_status',
   MCG_REBUILD_PROGRESS_QUERY = 'NooBaa_rebuild_progress',
-  RGW_RESILIENCY_QUERY = '(sum(ceph_pool_metadata{name=~".*rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pg_clean) / sum(ceph_pool_metadata{name=~".*rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pg_total)) * 100 ',
 }
 
 export const CAPACITY_BREAKDOWN_QUERIES = {
   [ObjectServiceDashboardQuery.PROJECTS_BY_USED]: 'NooBaa_projects_capacity_usage',
   [ObjectServiceDashboardQuery.BUCKETS_BY_USED]: 'NooBaa_bucket_class_capacity_usage',
   [ObjectServiceDashboardQuery.NOOBAA_TOTAL_USED]: 'NooBaa_total_usage',
-  [ObjectServiceDashboardQuery.RGW_TOTAL_USED]:
-    'sum(ceph_pool_metadata{name=~".*rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pool_stored_raw) - sum(NooBaa_projects_capacity_usage)',
-  [ObjectServiceDashboardQuery.OBJECT_STORAGE_TOTAL_USED]:
-    'sum(ceph_pool_metadata{name=~".*rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pool_stored_raw)',
+  [ObjectServiceDashboardQuery.RGW_TOTAL_USED]: (rgwPrefix: string = '') =>
+    _.template(
+      'sum(ceph_pool_metadata{name=~"<%= name %>rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pool_stored_raw) - sum(NooBaa_projects_capacity_usage)',
+    )({ name: rgwPrefix ? `${rgwPrefix}.` : '.*' }),
+  [ObjectServiceDashboardQuery.OBJECT_STORAGE_TOTAL_USED]: (rgwPrefix: string = '') =>
+    _.template(
+      'sum(ceph_pool_metadata{name=~"<%= name %>rgw.*"} *on (job, namesapce, pool_id) group_right(name) ceph_pool_stored_raw)',
+    )({
+      name: rgwPrefix ? `${rgwPrefix}.` : '.*',
+    }),
 };
 
 export const breakdownQueryMap = {
@@ -60,15 +77,16 @@ export const breakdownQueryMap = {
     [CapacityBreakdown.Metrics.TOTAL]: {
       model: null,
       metric: '',
-      queries: {
-        [ObjectServiceDashboardQuery.RGW_TOTAL_USED]:
-          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.RGW_TOTAL_USED],
-        [ObjectServiceDashboardQuery.NOOBAA_TOTAL_USED]: `sum(${
-          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.NOOBAA_TOTAL_USED]
-        })`,
-        [ObjectServiceDashboardQuery.OBJECT_STORAGE_TOTAL_USED]:
-          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.OBJECT_STORAGE_TOTAL_USED],
-      },
+      queries: (rgwPrefix: string = '') => ({
+        [ObjectServiceDashboardQuery.RGW_TOTAL_USED]: (() =>
+          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.RGW_TOTAL_USED](rgwPrefix))(),
+        [ObjectServiceDashboardQuery.NOOBAA_TOTAL_USED]:
+          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.NOOBAA_TOTAL_USED],
+        [ObjectServiceDashboardQuery.OBJECT_STORAGE_TOTAL_USED]: (() =>
+          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.OBJECT_STORAGE_TOTAL_USED](
+            rgwPrefix,
+          ))(),
+      }),
     },
   },
   [ServiceType.MCG]: {
@@ -109,19 +127,16 @@ export const breakdownQueryMap = {
       },
     },
   },
-  // Todo: Change these with RGW Metrics
   [ServiceType.RGW]: {
     [CapacityBreakdown.Metrics.TOTAL]: {
       model: null,
       metric: '',
-      queries: {
-        [ObjectServiceDashboardQuery.RGW_TOTAL_USED]: `sum(${
-          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.RGW_TOTAL_USED]
-        })`,
-        [ObjectServiceDashboardQuery.RGW_USED]: `sum(${
-          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.RGW_TOTAL_USED]
-        })`,
-      },
+      queries: (rgwPrefix: string = '') => ({
+        [ObjectServiceDashboardQuery.RGW_TOTAL_USED]: (() =>
+          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.RGW_TOTAL_USED](rgwPrefix))(),
+        [ObjectServiceDashboardQuery.RGW_USED]: (() =>
+          CAPACITY_BREAKDOWN_QUERIES[ObjectServiceDashboardQuery.RGW_TOTAL_USED](rgwPrefix))(),
+      }),
     },
   },
 };

--- a/frontend/packages/noobaa-storage-plugin/src/utils.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/utils.ts
@@ -27,3 +27,16 @@ export const getPhase = (obj: K8sResourceKind): string => {
 export const isBound = (obj: K8sResourceKind): boolean => getPhase(obj) === 'Bound';
 
 export const getSCProvisioner = (obj: StorageClass) => obj.provisioner;
+
+export const isFunctionThenApply = (fn: any) => (args: string) =>
+  typeof fn === 'function' ? fn(args) : fn;
+
+export const decodeRGWPrefix = (secretData: K8sResourceKind) => {
+  try {
+    return JSON.parse(atob(secretData?.data?.external_cluster_details)).find(
+      (item) => item?.name === 'ceph-rgw',
+    )?.data?.poolPrefix;
+  } catch {
+    return '';
+  }
+};


### PR DESCRIPTION
- Extract RGW prefix from Secret and use it in the queries
- Make the default Selection in Capacity Breakdown to 'All'
- Changes in the health metrics response map.