### PR TITLE
Bug 1871108: usability bug: the ui selections are unclear

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/form/form-field.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/form/form-field.tsx
@@ -16,6 +16,7 @@ export enum FormFieldType {
   TEXT = 'TEXT',
   TEXT_AREA = 'TEXT_AREA',
   SELECT = 'SELECT',
+  PF_SELECT = 'PF_SELECT',
   CHECKBOX = 'CHECKBOX',
   INLINE_CHECKBOX = 'INLINE_CHECKBOX',
   FILE_UPLOAD = 'FILE_UPLOAD',
@@ -35,6 +36,7 @@ const hasIsDisabled = new Set([
   FormFieldType.INLINE_CHECKBOX,
   FormFieldType.FILE_UPLOAD,
   FormFieldType.CUSTOM,
+  FormFieldType.PF_SELECT,
 ]);
 const hasDisabled = new Set([FormFieldType.TEXT_AREA]);
 const hasIsChecked = new Set([FormFieldType.CHECKBOX, FormFieldType.INLINE_CHECKBOX]);
@@ -54,6 +56,8 @@ const hasIsRequired = new Set([
   FormFieldType.CUSTOM,
 ]);
 const hasLabel = new Set([FormFieldType.INLINE_CHECKBOX]);
+const hasSelections = new Set([FormFieldType.PF_SELECT]);
+const hasPlaceholderText = new Set([FormFieldType.PF_SELECT]);
 
 const validatedValidationErrorTypes = new Set([
   ValidationErrorType.Error,
@@ -99,6 +103,8 @@ export const FormField: React.FC<FormFieldProps> = ({ children, isDisabled, valu
               validated: set(hasValidated, validated),
               id: getFieldId(key),
               label: set(hasLabel, getFieldTitle(key)),
+              selections: set(hasSelections, val),
+              placeholderText: set(hasPlaceholderText, getPlaceholder(key)),
             },
             _.isUndefined,
           ),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/renderable-field.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/renderable-field.ts
@@ -6,7 +6,6 @@ import {
   VMWareProviderField,
   OvirtProviderField,
 } from '../types';
-import { ProvisionSource } from '../../../constants/vm/provision-source';
 
 export const titleResolver: RenderableFieldResolver = {
   [OvirtProviderField.OVIRT_ENGINE_SECRET_NAME]: 'RHV Instance',
@@ -35,7 +34,7 @@ export const titleResolver: RenderableFieldResolver = {
   [VMSettingsField.MEMORY]: 'Memory',
   [VMSettingsField.CPU]: 'CPUs',
   [VMSettingsField.WORKLOAD_PROFILE]: 'Workload Profile',
-  [VMSettingsField.PROVISION_SOURCE_TYPE]: 'Source',
+  [VMSettingsField.PROVISION_SOURCE_TYPE]: 'Boot Source',
   [VMSettingsField.CONTAINER_IMAGE]: 'Container Image',
   [VMSettingsField.IMAGE_URL]: 'URL',
   [VMSettingsField.START_VM]: 'Start virtual machine on creation',
@@ -52,13 +51,6 @@ export const placeholderResolver = {
   [VMSettingsField.FLAVOR]: '--- Select Flavor ---',
   [VMSettingsField.WORKLOAD_PROFILE]: '--- Select Workload Profile ---',
   [VMSettingsField.PROVISION_SOURCE_TYPE]: '--- Select Source ---',
-};
-
-const provisionSourceHelpResolver = {
-  [ProvisionSource.URL.getValue()]: 'An external URL to the .iso, .img, .qcow2 or .raw that the virtual machine should be created from.',
-  [ProvisionSource.PXE.getValue()]: 'Discover provisionable virtual machines over the network.',
-  [ProvisionSource.CONTAINER.getValue()]: 'Ephemeral virtual machine disk image which will be pulled from container registry.',
-  [ProvisionSource.DISK.getValue()]: 'Select an existing PVC in Storage tab',
 };
 
 const providerHelpResolver = {
@@ -89,6 +81,6 @@ export const helpResolver = {
     'The number of virtual CPU cores that will be dedicated to the virtual machine.',
   [VMSettingsField.WORKLOAD_PROFILE]: () =>
     'The category of workload that this virtual machine will be used for.',
-  [VMSettingsField.PROVISION_SOURCE_TYPE]: (sourceType: string) =>
-    provisionSourceHelpResolver[sourceType],
+  [VMSettingsField.PROVISION_SOURCE_TYPE]: () =>
+    'Select a method of adding an operating system image source',
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
@@ -7,6 +7,7 @@ import { FormField, FormFieldType } from '../../form/form-field';
 import { VMWizardStorage } from '../../types';
 import { VolumeWrapper } from '../../../../k8s/wrapper/vm/volume-wrapper';
 import { VolumeType } from '../../../../constants/vm/storage';
+import { EXAMPLE_CONTAINER } from '../../../../utils/strings';
 
 export const ContainerSource: React.FC<ContainerSourceProps> = React.memo(
   ({ field, provisionSourceStorage, onProvisionSourceStorageChange }) => {
@@ -34,6 +35,9 @@ export const ContainerSource: React.FC<ContainerSourceProps> = React.memo(
             }
           />
         </FormField>
+        <div className="pf-c-form__helper-text" aria-live="polite">
+          Example: {EXAMPLE_CONTAINER}
+        </div>
       </FormFieldRow>
     );
   },

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/flavor.tsx
@@ -1,0 +1,115 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import { SelectOption } from '@patternfly/react-core';
+import { ValidationErrorType, asValidationObject } from '@console/shared/src/utils/validation';
+import {
+  iGetIsLoaded,
+  iGetLoadedData,
+  iGetLoadError,
+  immutableListToShallowJS,
+  toShallowJS,
+} from '../../../../utils/immutable';
+import { FormFieldRow } from '../../form/form-field-row';
+import { FormField, FormFieldType } from '../../form/form-field';
+import {
+  getFlavors,
+  getWorkloadProfiles,
+} from '../../../../selectors/vm-template/combined-dependent';
+import { flavorSort } from '../../../../utils/sort';
+import { VMSettingsField } from '../../types';
+import { iGetFieldValue } from '../../selectors/immutable/field';
+import { nullOnEmptyChange } from '../../utils/utils';
+import { FormPFSelect } from '../../../form/form-pf-select';
+
+export const Flavor: React.FC<FlavorProps> = React.memo(
+  ({
+    iUserTemplate,
+    commonTemplates,
+    os,
+    flavorField,
+    workloadProfile,
+    cnvBaseImages,
+    onChange,
+    openshiftFlag,
+  }) => {
+    const flavor = iGetFieldValue(flavorField);
+    const isUserTemplateValid = iGetIsLoaded(iUserTemplate) && !iGetLoadError(iUserTemplate);
+
+    const params = {
+      flavor,
+      workload: workloadProfile,
+      os,
+    };
+
+    const templates = iUserTemplate
+      ? isUserTemplateValid
+        ? [toShallowJS(iGetLoadedData(iUserTemplate))]
+        : []
+      : immutableListToShallowJS(iGetLoadedData(commonTemplates));
+
+    const flavors = flavorSort(getFlavors(templates, params));
+
+    const workloadProfiles = getWorkloadProfiles(templates, params);
+
+    const loadingResources = openshiftFlag
+      ? {
+          commonTemplates,
+          cnvBaseImages,
+        }
+      : {};
+
+    if (openshiftFlag && iUserTemplate) {
+      Object.assign(loadingResources, { iUserTemplate });
+    }
+
+    let flavorValidation;
+
+    if (
+      iGetIsLoaded(commonTemplates) &&
+      (!iUserTemplate || isUserTemplateValid) &&
+      (flavors.length === 0 || workloadProfiles.length === 0)
+    ) {
+      const validation = asValidationObject(
+        'There is no valid template for this combination. Please install required template or select different os/flavor/workload profile combination.',
+        ValidationErrorType.Info,
+      );
+      if (!flavorField.get('validation')) {
+        flavorValidation = validation;
+      }
+    }
+
+    return (
+      <FormFieldRow
+        field={flavorField}
+        fieldType={FormFieldType.PF_SELECT}
+        validation={flavorValidation}
+        loadingResources={loadingResources}
+      >
+        <FormField value={flavor} isDisabled={flavor && flavors.length === 1}>
+          <FormPFSelect
+            onSelect={(e, v) => nullOnEmptyChange(onChange, VMSettingsField.FLAVOR)(v.toString())}
+          >
+            {flavors.map((f) => {
+              return (
+                <SelectOption key={f} value={f}>
+                  {_.capitalize(f)}
+                </SelectOption>
+              );
+            })}
+          </FormPFSelect>
+        </FormField>
+      </FormFieldRow>
+    );
+  },
+);
+
+type FlavorProps = {
+  iUserTemplate: any;
+  commonTemplates: any;
+  flavorField: any;
+  os: string;
+  workloadProfile: string;
+  cnvBaseImages: any;
+  openshiftFlag: boolean;
+  onChange: (key: string, value: string | boolean) => void;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
@@ -1,13 +1,5 @@
-import * as _ from 'lodash';
 import * as React from 'react';
-import {
-  FormSelect,
-  FormSelectOption,
-  Checkbox,
-  Text,
-  Button,
-  ButtonVariant,
-} from '@patternfly/react-core';
+import { Checkbox, Text, Button, ButtonVariant, SelectOption } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { ValidationErrorType, asValidationObject } from '@console/shared/src/utils/validation';
 import {
@@ -20,7 +12,6 @@ import {
 } from '../../../../utils/immutable';
 import { FormFieldRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
-import { FormSelectPlaceholderOption } from '../../../form/form-select-placeholder-option';
 import {
   getFlavors,
   getWorkloadProfiles,
@@ -29,7 +20,7 @@ import { flavorSort, ignoreCaseSort } from '../../../../utils/sort';
 import { pluralize } from '../../../../utils/strings';
 import { VMSettingsField } from '../../types';
 import { iGetFieldValue } from '../../selectors/immutable/field';
-import { getPlaceholder, getFieldId } from '../../utils/renderable-field-utils';
+import { getFieldId } from '../../utils/renderable-field-utils';
 import { nullOnEmptyChange } from '../../utils/utils';
 import { operatingSystemsNative } from '../../../../constants/vm-templates/os';
 import { OperatingSystemRecord } from '../../../../types';
@@ -51,22 +42,22 @@ import {
   CDI_UPLOAD_RUNNING,
 } from '../../../cdi-upload-provider/consts';
 import { getTemplateOperatingSystems } from '../../../../selectors/vm-template/advanced';
+import { FormPFSelect } from '../../../form/form-pf-select';
 
-export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
+export const OS: React.FC<OSProps> = React.memo(
   ({
     iUserTemplate,
     commonTemplates,
     operatinSystemField,
     cloneBaseDiskImageField,
     mountWindowsGuestToolsField,
-    flavorField,
+    flavor,
     workloadProfile,
     cnvBaseImages,
     onChange,
     openshiftFlag,
     goToStorageStep,
   }) => {
-    const flavor = iGetFieldValue(flavorField);
     const os = iGetFieldValue(operatinSystemField);
     const display = iGet(operatinSystemField, 'display');
     const displayOnly = !!display;
@@ -112,7 +103,6 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
     }
 
     let operatingSystemValidation;
-    let flavorValidation;
 
     if (
       iGetIsLoaded(commonTemplates) &&
@@ -125,8 +115,6 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
       );
       if (!operatinSystemField.get('validation')) {
         operatingSystemValidation = validation;
-      } else if (!flavorField.get('validation')) {
-        flavorValidation = validation;
       }
     }
 
@@ -199,22 +187,23 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
       <>
         <FormFieldRow
           field={operatinSystemField}
-          fieldType={FormFieldType.SELECT}
+          fieldType={FormFieldType.PF_SELECT}
           validation={operatingSystemValidation}
           loadingResources={loadingResources}
         >
-          <FormField value={displayOnly ? display : undefined}>
-            <FormSelect onChange={nullOnEmptyChange(onChange, VMSettingsField.OPERATING_SYSTEM)}>
-              {!displayOnly && (
-                <FormSelectPlaceholderOption
-                  placeholder={getPlaceholder(VMSettingsField.OPERATING_SYSTEM)}
-                  isDisabled={!!os}
-                />
-              )}
+          <FormField value={displayOnly ? display : os}>
+            <FormPFSelect
+              onSelect={(e, v) =>
+                nullOnEmptyChange(onChange, VMSettingsField.OPERATING_SYSTEM)(v.toString())
+              }
+            >
               {operatingSystemBaseImages.map(({ id, name, message }) => (
-                <FormSelectOption key={id} value={id} label={`${name || id} ${message}`} />
+                <SelectOption key={id} value={id}>
+                  {name || id}
+                  {message ? ` ${message}` : ''}
+                </SelectOption>
               ))}
-            </FormSelect>
+            </FormPFSelect>
           </FormField>
           {baseImage && baseImage?.longMessage && (
             <div className="pf-c-form__helper-text" aria-live="polite">
@@ -250,33 +239,15 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
           </FormField>
         </FormFieldRow>
         {mountedDisksHelpMsg}
-        <FormFieldRow
-          field={flavorField}
-          fieldType={FormFieldType.SELECT}
-          validation={flavorValidation}
-          loadingResources={loadingResources}
-        >
-          <FormField isDisabled={flavor && flavors.length === 1}>
-            <FormSelect onChange={nullOnEmptyChange(onChange, VMSettingsField.FLAVOR)}>
-              <FormSelectPlaceholderOption
-                placeholder={getPlaceholder(VMSettingsField.FLAVOR)}
-                isDisabled={!!flavor}
-              />
-              {flavors.map((f) => {
-                return <FormSelectOption key={f} value={f} label={_.capitalize(f)} />;
-              })}
-            </FormSelect>
-          </FormField>
-        </FormFieldRow>
       </>
     );
   },
 );
 
-type OSFlavorProps = {
+type OSProps = {
   iUserTemplate: any;
   commonTemplates: any;
-  flavorField: any;
+  flavor: string;
   operatinSystemField: any;
   cloneBaseDiskImageField: any;
   mountWindowsGuestToolsField: any;

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/provision-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/provision-source.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { FormSelect, FormSelectOption, Button, ButtonVariant } from '@patternfly/react-core';
-import { FormSelectPlaceholderOption } from '../../../form/form-select-placeholder-option';
+import { Button, ButtonVariant, SelectOption, Text, TextContent } from '@patternfly/react-core';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { FormFieldRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
 import { iGetFieldValue } from '../../selectors/immutable/field';
 import { VMSettingsField } from '../../types';
-import { getPlaceholder } from '../../utils/renderable-field-utils';
 import { iGet } from '../../../../utils/immutable';
+import { FormPFSelect } from '../../../form/form-pf-select';
 
 const ProvisionSourceDiskHelpMsg: React.FC<ProvisionSourceDiskHelpMsgProps> = ({
   provisionSourceValue,
@@ -26,9 +25,21 @@ const ProvisionSourceDiskHelpMsg: React.FC<ProvisionSourceDiskHelpMsgProps> = ({
   const getStorageMsg = () => {
     switch (ProvisionSource.fromString(provisionSourceValue)) {
       case ProvisionSource.URL:
-        return <>Enter URL here or edit the mounted disk in the {storageBtn} step</>;
+        return (
+          <TextContent>
+            <div className="pf-c-form__helper-text" aria-live="polite">
+              Enter URL here or edit the mounted disk in the {storageBtn} step.
+            </div>
+            <div className="pf-c-form__helper-text" aria-live="polite">
+              To boot this source from a CD-ROM edit the disk in the storage step and change to
+              type: CD-ROM
+            </div>
+          </TextContent>
+        );
       case ProvisionSource.CONTAINER:
-        return <>Enter container image here or edit the mounted disk in the {storageBtn} step</>;
+        return (
+          <Text>Enter container image here or edit the mounted disk in the {storageBtn} step.</Text>
+        );
       case ProvisionSource.DISK:
         return <>Add a source disk in the {storageBtn} step</>;
       default:
@@ -70,22 +81,31 @@ export const ProvisionSourceComponent: React.FC<ProvisionSourceComponentProps> =
     const sources = iGet(provisionSourceField, 'sources');
 
     return (
-      <FormFieldRow field={provisionSourceField} fieldType={FormFieldType.SELECT}>
-        <FormField>
-          <FormSelect onChange={(v) => onChange(VMSettingsField.PROVISION_SOURCE_TYPE, v)}>
-            <FormSelectPlaceholderOption
-              placeholder={getPlaceholder(VMSettingsField.PROVISION_SOURCE_TYPE)}
-              isDisabled={!!provisionSourceValue}
-            />
-            {(sources || []).map((source) => (
-              <FormSelectOption key={source} value={source} label={source} />
-            ))}
-          </FormSelect>
+      <FormFieldRow field={provisionSourceField} fieldType={FormFieldType.PF_SELECT}>
+        <FormField value={provisionSourceValue}>
+          <FormPFSelect
+            onSelect={(e, v) => {
+              onChange(VMSettingsField.PROVISION_SOURCE_TYPE, v.toString());
+            }}
+          >
+            {(sources || [])
+              .map(ProvisionSource.fromString)
+              .sort((a, b) => a.getOrder() - b.getOrder())
+              .map((source) => (
+                <SelectOption
+                  key={source.getValue()}
+                  value={source.getValue()}
+                  description={source.getDescription()}
+                >
+                  {source.toString()}
+                </SelectOption>
+              ))}
+          </FormPFSelect>
         </FormField>
         {[
-          ProvisionSource.URL.toString(),
-          ProvisionSource.CONTAINER.toString(),
-          ProvisionSource.DISK.toString(),
+          ProvisionSource.URL.getValue(),
+          ProvisionSource.CONTAINER.getValue(),
+          ProvisionSource.DISK.getValue(),
         ].includes(provisionSourceValue) && (
           <ProvisionSourceDiskHelpMsg
             provisionSourceValue={provisionSourceValue}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/url-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/url-source.tsx
@@ -7,9 +7,11 @@ import { FormField, FormFieldType } from '../../form/form-field';
 import { VMWizardStorage } from '../../types';
 import { DataVolumeSourceType } from '../../../../constants/vm/storage';
 import { DataVolumeWrapper } from '../../../../k8s/wrapper/vm/data-volume-wrapper';
+import { RHEL_IMAGE_LINK, FEDORA_IMAGE_LINK } from '../../../../utils/strings';
 
 export const URLSource: React.FC<URLSourceProps> = React.memo(
   ({ field, provisionSourceStorage, onProvisionSourceStorageChange }) => {
+    const isUpstream = window.SERVER_FLAGS.branding === 'okd';
     const storage: VMWizardStorage = toShallowJS(provisionSourceStorage);
     const dataVolumeWrapper = new DataVolumeWrapper(storage?.dataVolume);
 
@@ -34,6 +36,17 @@ export const URLSource: React.FC<URLSourceProps> = React.memo(
             }
           />
         </FormField>
+        <div className="pf-c-form__helper-text" aria-live="polite">
+          Example: Visit the{' '}
+          <a
+            href={isUpstream ? FEDORA_IMAGE_LINK : RHEL_IMAGE_LINK}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <strong>{isUpstream ? 'Fedora' : 'RHEL'} cloud image list</strong>
+          </a>{' '}
+          and copy a url for the field above
+        </div>
       </FormFieldRow>
     );
   },

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -19,7 +19,8 @@ import { iGetCommonData } from '../../selectors/immutable/selectors';
 import { getStepsMetadata } from '../../selectors/immutable/wizard-selectors';
 import { iGetProvisionSourceStorage } from '../../selectors/immutable/storage';
 import { WorkloadProfile } from './workload-profile';
-import { OSFlavor } from './os-flavor';
+import { OS } from './os';
+import { Flavor } from './flavor';
 import { MemoryCPU } from './memory-cpu';
 import { ContainerSource } from './container-source';
 import { ProvisionSourceComponent } from './provision-source';
@@ -71,11 +72,11 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
           />
         </FormField>
       </FormFieldMemoRow>
-      <OSFlavor
+      <OS
         iUserTemplate={iUserTemplate}
         commonTemplates={commonTemplates}
         operatinSystemField={getField(VMSettingsField.OPERATING_SYSTEM)}
-        flavorField={getField(VMSettingsField.FLAVOR)}
+        flavor={getFieldValue(VMSettingsField.FLAVOR)}
         cloneBaseDiskImageField={getField(VMSettingsField.CLONE_COMMON_BASE_DISK_IMAGE)}
         mountWindowsGuestToolsField={getField(VMSettingsField.MOUNT_WINDOWS_GUEST_TOOLS)}
         workloadProfile={getFieldValue(VMSettingsField.WORKLOAD_PROFILE)}
@@ -85,20 +86,6 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
         goToStorageStep={
           steps[VMWizardTab.STORAGE]?.canJumpTo ? () => goToStep(VMWizardTab.STORAGE) : null
         }
-      />
-      <MemoryCPU
-        memoryField={getField(VMSettingsField.MEMORY)}
-        cpuField={getField(VMSettingsField.CPU)}
-        onChange={onFieldChange}
-      />
-      <WorkloadProfile
-        iUserTemplate={iUserTemplate}
-        commonTemplates={commonTemplates}
-        workloadProfileField={getField(VMSettingsField.WORKLOAD_PROFILE)}
-        operatingSystem={getFieldValue(VMSettingsField.OPERATING_SYSTEM)}
-        flavor={getFieldValue(VMSettingsField.FLAVOR)}
-        cnvBaseImages={cnvBaseImages}
-        onChange={onFieldChange}
       />
       <ProvisionSourceComponent
         provisionSourceField={getField(VMSettingsField.PROVISION_SOURCE_TYPE)}
@@ -115,6 +102,30 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
         field={getField(VMSettingsField.IMAGE_URL)}
         onProvisionSourceStorageChange={updateStorage}
         provisionSourceStorage={provisionSourceStorage}
+      />
+      <Flavor
+        iUserTemplate={iUserTemplate}
+        commonTemplates={commonTemplates}
+        os={getFieldValue(VMSettingsField.OPERATING_SYSTEM)}
+        flavorField={getField(VMSettingsField.FLAVOR)}
+        workloadProfile={getFieldValue(VMSettingsField.WORKLOAD_PROFILE)}
+        cnvBaseImages={cnvBaseImages}
+        onChange={onFieldChange}
+        openshiftFlag={openshiftFlag}
+      />
+      <MemoryCPU
+        memoryField={getField(VMSettingsField.MEMORY)}
+        cpuField={getField(VMSettingsField.CPU)}
+        onChange={onFieldChange}
+      />
+      <WorkloadProfile
+        iUserTemplate={iUserTemplate}
+        commonTemplates={commonTemplates}
+        workloadProfileField={getField(VMSettingsField.WORKLOAD_PROFILE)}
+        operatingSystem={getFieldValue(VMSettingsField.OPERATING_SYSTEM)}
+        flavor={getFieldValue(VMSettingsField.FLAVOR)}
+        cnvBaseImages={cnvBaseImages}
+        onChange={onFieldChange}
       />
     </Form>
   );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/workload-profile.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/workload-profile.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { SelectOption } from '@patternfly/react-core';
 import {
   iGetLoadedData,
   immutableListToShallowJS,
@@ -9,13 +9,12 @@ import {
 } from '../../../../utils/immutable';
 import { FormFieldRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
-import { FormSelectPlaceholderOption } from '../../../form/form-select-placeholder-option';
 import { getWorkloadProfiles } from '../../../../selectors/vm-template/combined-dependent';
 import { ignoreCaseSort } from '../../../../utils/sort';
 import { VMSettingsField } from '../../types';
-import { getPlaceholder } from '../../utils/renderable-field-utils';
 import { nullOnEmptyChange } from '../../utils/utils';
 import { iGetFieldValue } from '../../selectors/immutable/field';
+import { FormPFSelect } from '../../../form/form-pf-select';
 
 export const WorkloadProfile: React.FC<WorkloadProps> = React.memo(
   ({
@@ -55,25 +54,19 @@ export const WorkloadProfile: React.FC<WorkloadProps> = React.memo(
       <>
         <FormFieldRow
           field={workloadProfileField}
-          fieldType={FormFieldType.SELECT}
+          fieldType={FormFieldType.PF_SELECT}
           loadingResources={loadingResources}
         >
-          <FormField>
-            <FormSelect onChange={nullOnEmptyChange(onChange, VMSettingsField.WORKLOAD_PROFILE)}>
-              <FormSelectPlaceholderOption
-                placeholder={getPlaceholder(VMSettingsField.WORKLOAD_PROFILE)}
-                isDisabled={!!iGetFieldValue(workloadProfileField)}
-              />
+          <FormField value={iGetFieldValue(workloadProfileField)}>
+            <FormPFSelect
+              onSelect={(e, v) =>
+                nullOnEmptyChange(onChange, VMSettingsField.WORKLOAD_PROFILE)(v.toString())
+              }
+            >
               {workloadProfiles.map((workloadProfile) => {
-                return (
-                  <FormSelectOption
-                    key={workloadProfile}
-                    value={workloadProfile}
-                    label={workloadProfile}
-                  />
-                );
+                return <SelectOption key={workloadProfile} value={workloadProfile} />;
               })}
-            </FormSelect>
+            </FormPFSelect>
           </FormField>
         </FormFieldRow>
       </>

--- a/frontend/packages/kubevirt-plugin/src/components/form/form-pf-select.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/form-pf-select.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Select, SelectProps } from '@patternfly/react-core';
+
+export const FormPFSelect: React.FC<FormPFSelectProps> = ({
+  onSelect,
+  children,
+  menuAppendTo = 'parent',
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <Select
+      menuAppendTo={menuAppendTo}
+      isOpen={isOpen}
+      onToggle={(isExpanded) => setIsOpen(isExpanded)}
+      onSelect={(e, v, i) => {
+        onSelect(e, v, i);
+        setIsOpen(false);
+      }}
+      {...props}
+    >
+      {children}
+    </Select>
+  );
+};
+
+type FormPFSelectProps = Omit<SelectProps, 'onToggle' | 'isOpen'>;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -7,6 +7,7 @@ import {
   FormSelectOption,
   TextInput,
   ExpandableSection,
+  SelectOption,
 } from '@patternfly/react-core';
 import {
   FirehoseResult,
@@ -61,6 +62,7 @@ import { UIStorageEditConfig } from '../../../types/ui/storage';
 import { isFieldDisabled } from '../../../utils/ui/edit-config';
 import { PendingChangesAlert } from '../../Alerts/PendingChangesAlert';
 import { MODAL_RESTART_IS_REQUIRED } from '../../../strings/vm/status';
+import { FormPFSelect } from '../../form/form-pf-select';
 
 import './disk-modal.scss';
 
@@ -308,7 +310,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     }
   };
 
-  const onSourceChanged = (uiSource) => {
+  const onSourceChanged = (e, uiSource) => {
     setSize('');
     setUnit('Gi');
     setURL('');
@@ -339,7 +341,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     const newType = DiskType.fromString(t);
     setType(newType);
     if (newType === DiskType.CDROM && source === StorageUISource.BLANK) {
-      onSourceChanged(StorageUISource.URL.getValue());
+      onSourceChanged(null, StorageUISource.URL.getValue());
     }
   };
 
@@ -354,11 +356,11 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
         {isVMRunning && <PendingChangesAlert warningMsg={MODAL_RESTART_IS_REQUIRED} />}
         <Form>
           <FormRow title="Source" fieldId={asId('source')} isRequired>
-            <FormSelect
-              onChange={onSourceChanged}
-              value={asFormSelectValue(source)}
-              id={asId('source')}
+            <FormPFSelect
+              menuAppendTo={() => document.body}
               isDisabled={isDisabled('source', !source.canBeChangedToThisSource(type))}
+              selections={asFormSelectValue(source.toString())}
+              onSelect={onSourceChanged}
             >
               {StorageUISource.getAll()
                 .filter(
@@ -366,16 +368,19 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                     storageUISource.canBeChangedToThisSource(type) ||
                     !source.canBeChangedToThisSource(type),
                 )
+                .sort((a, b) => a.getOrder() - b.getOrder())
                 .map((uiType) => {
                   return (
-                    <FormSelectOption
+                    <SelectOption
                       key={uiType.getValue()}
                       value={uiType.getValue()}
-                      label={uiType.toString()}
-                    />
+                      description={uiType.getDescription()}
+                    >
+                      {uiType.toString()}
+                    </SelectOption>
                   );
                 })}
-            </FormSelect>
+            </FormPFSelect>
           </FormRow>
           {source.requiresURL() && (
             <FormRow title="URL" fieldId={asId('url')} isRequired validation={urlValidation}>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
@@ -1,37 +1,89 @@
 /* eslint-disable lines-between-class-members */
-
 import { ObjectEnum, VolumeType } from '../../../constants';
 import { DataVolumeSourceType, DiskType } from '../../../constants/vm/storage';
 import { getStringEnumValues } from '../../../utils/types';
 import { BinaryUnit } from '../../form/size-unit-utils';
+import {
+  UI_SOURCE_ATTACH_CLONED_DISK_DESC,
+  UI_SOURCE_ATTACH_DISK_DESC,
+  UI_SOURCE_BLANK_DESC,
+  UI_SOURCE_CONTAINER_DESC,
+  UI_SOURCE_IMPORT_DISK_DESC,
+  UI_SOURCE_URL_DESC,
+} from '../../../utils/strings';
+import {
+  SelectDropdownData,
+  SelectDropdownObjectEnum,
+} from '../../../constants/select-dropdown-object-enum';
 
-export class StorageUISource extends ObjectEnum<string> {
+export class StorageUISource extends SelectDropdownObjectEnum<string> {
   static readonly BLANK = new StorageUISource(
     'Blank',
-    VolumeType.DATA_VOLUME,
-    DataVolumeSourceType.BLANK,
+    {
+      volumeType: VolumeType.DATA_VOLUME,
+      dataVolumeSourceType: DataVolumeSourceType.BLANK,
+    },
+    {
+      description: UI_SOURCE_BLANK_DESC,
+      order: 1,
+    },
   );
   static readonly URL = new StorageUISource(
     'URL',
-    VolumeType.DATA_VOLUME,
-    DataVolumeSourceType.HTTP,
+    {
+      volumeType: VolumeType.DATA_VOLUME,
+      dataVolumeSourceType: DataVolumeSourceType.HTTP,
+    },
+    {
+      label: 'Upload via URL',
+      description: UI_SOURCE_URL_DESC,
+      order: 2,
+    },
   );
-  static readonly CONTAINER = new StorageUISource('Container', VolumeType.CONTAINER_DISK);
+  static readonly CONTAINER = new StorageUISource(
+    'Container',
+    {
+      volumeType: VolumeType.CONTAINER_DISK,
+    },
+    {
+      description: UI_SOURCE_CONTAINER_DESC,
+      order: 6,
+    },
+  );
   static readonly ATTACH_CLONED_DISK = new StorageUISource(
     'Attach Cloned Disk',
-    VolumeType.DATA_VOLUME,
-    DataVolumeSourceType.PVC,
+    {
+      volumeType: VolumeType.DATA_VOLUME,
+      dataVolumeSourceType: DataVolumeSourceType.PVC,
+    },
+    {
+      label: 'Clone an existing PVC',
+      description: UI_SOURCE_ATTACH_CLONED_DISK_DESC,
+      order: 4,
+    },
   );
   static readonly ATTACH_DISK = new StorageUISource(
     'Attach Disk',
-    VolumeType.PERSISTENT_VOLUME_CLAIM,
-    undefined,
+    {
+      volumeType: VolumeType.PERSISTENT_VOLUME_CLAIM,
+    },
+    {
+      label: 'Use an existing PVC',
+      description: UI_SOURCE_ATTACH_DISK_DESC,
+      order: 3,
+    },
   );
   static readonly IMPORT_DISK = new StorageUISource(
     'Import Disk',
-    VolumeType.PERSISTENT_VOLUME_CLAIM,
-    undefined,
-    true,
+    {
+      volumeType: VolumeType.PERSISTENT_VOLUME_CLAIM,
+      hasNewPVC: true,
+    },
+    {
+      label: 'Import an existing PVC',
+      description: UI_SOURCE_IMPORT_DISK_DESC,
+      order: 7,
+    },
   );
 
   static readonly OTHER = new StorageUISource('Other');
@@ -54,11 +106,18 @@ export class StorageUISource extends ObjectEnum<string> {
 
   protected constructor(
     value: string,
-    volumeType?: VolumeType,
-    dataVolumeSourceType?: DataVolumeSourceType,
-    hasNewPVC: boolean = false,
+    {
+      volumeType,
+      dataVolumeSourceType,
+      hasNewPVC = false,
+    }: {
+      volumeType?: VolumeType;
+      dataVolumeSourceType?: DataVolumeSourceType;
+      hasNewPVC?: boolean;
+    } = {},
+    selectData: SelectDropdownData = {},
   ) {
-    super(value);
+    super(value, selectData);
     this.volumeType = volumeType;
     this.dataVolumeSourceType = dataVolumeSourceType;
     this.hasNewPVC = hasNewPVC;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -5,6 +5,7 @@ import {
   Form,
   FormSelect,
   FormSelectOption,
+  SelectOption,
   TextInput,
 } from '@patternfly/react-core';
 import {
@@ -39,6 +40,7 @@ import { isFieldDisabled } from '../../../utils/ui/edit-config';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { PendingChangesAlert } from '../../Alerts/PendingChangesAlert';
 import { MODAL_RESTART_IS_REQUIRED } from '../../../strings/vm/status';
+import { FormPFSelect } from '../../form/form-pf-select';
 
 const getNetworkChoices = (
   nads: K8sResourceKind[],
@@ -265,27 +267,28 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
             />
           </FormRow>
           <FormRow title="Model" fieldId={asId('model')} isRequired>
-            <FormSelect
-              onChange={(networkInterfaceModel) =>
-                setModel(NetworkInterfaceModel.fromString(networkInterfaceModel))
-              }
-              value={asFormSelectValue(model)}
+            <FormPFSelect
+              menuAppendTo={() => document.body}
               id={asId('model')}
+              placeholderText="--- Select Model ---"
               isDisabled={isDisabled('model') || interfaceType === NetworkInterfaceType.SRIOV}
+              selections={asFormSelectValue(model?.getValue())}
+              onSelect={(e, v) => setModel(NetworkInterfaceModel.fromString(v.toString()))}
             >
-              <FormSelectPlaceholderOption isDisabled placeholder="--- Select Model ---" />
               {NetworkInterfaceModel.getAll()
                 .filter((ifaceModel) => ifaceModel.isSupported() || ifaceModel === model)
                 .map((ifaceModel) => {
                   return (
-                    <FormSelectOption
+                    <SelectOption
                       key={ifaceModel.getValue()}
                       value={ifaceModel.getValue()}
-                      label={ifaceModel.toString()}
-                    />
+                      description={ifaceModel.getDescription()}
+                    >
+                      {ifaceModel.toString()}
+                    </SelectOption>
                   );
                 })}
-            </FormSelect>
+            </FormPFSelect>
           </FormRow>
           <Network
             id={asId('network')}
@@ -306,24 +309,27 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
             acceptEmptyValues={editConfig?.acceptEmptyValuesOverride?.network}
           />
           <FormRow title="Type" fieldId={asId('type')} isRequired>
-            <FormSelect
-              onChange={onNetworkInterfaceChange}
-              value={asFormSelectValue(interfaceType)}
+            <FormPFSelect
+              menuAppendTo={() => document.body}
+              onSelect={(e, v) => onNetworkInterfaceChange(v.toString())}
               id={asId('type')}
+              placeholderText="--- Select Type ---"
+              selections={asFormSelectValue(interfaceType?.getValue())}
               isDisabled={isDisabled('type')}
             >
-              <FormSelectPlaceholderOption isDisabled placeholder="--- Select Type ---" />
               {(resultNetwork.getType()
                 ? resultNetwork.getType().getAllowedInterfaceTypes()
                 : NetworkType.getSupportedAllowedInterfaceTypes()
               ).map((iType) => (
-                <FormSelectOption
+                <SelectOption
                   key={iType.getValue()}
                   value={iType.getValue()}
-                  label={iType.toString()}
-                />
+                  description={iType.getDescription()}
+                >
+                  {iType.toString()}
+                </SelectOption>
               ))}
-            </FormSelect>
+            </FormPFSelect>
           </FormRow>
           <FormRow
             title="MAC Address"

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/__tests__/__snapshots__/vm-template-source.spec.tsx.snap
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/__tests__/__snapshots__/vm-template-source.spec.tsx.snap
@@ -105,7 +105,13 @@ ShallowWrapper {
       "error": undefined,
       "source": undefined,
       "type": ProvisionSource {
+        "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+        "getDescription": [Function],
+        "getOrder": [Function],
         "getValue": [Function],
+        "label": "PXE (network boot - adds network interface)",
+        "order": 4,
+        "toString": [Function],
         "value": "PXE",
       },
     },
@@ -122,7 +128,13 @@ ShallowWrapper {
         "error": undefined,
         "source": undefined,
         "type": ProvisionSource {
+          "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+          "getDescription": [Function],
+          "getOrder": [Function],
           "getValue": [Function],
+          "label": "PXE (network boot - adds network interface)",
+          "order": 4,
+          "toString": [Function],
           "value": "PXE",
         },
       },
@@ -269,7 +281,13 @@ ShallowWrapper {
           source={undefined}
           type={
             ProvisionSource {
+              "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "PXE (network boot - adds network interface)",
+              "order": 4,
+              "toString": [Function],
               "value": "PXE",
             }
           }
@@ -279,7 +297,13 @@ ShallowWrapper {
           source={undefined}
           type={
             ProvisionSource {
+              "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "PXE (network boot - adds network interface)",
+              "order": 4,
+              "toString": [Function],
               "value": "PXE",
             }
           }
@@ -296,7 +320,13 @@ ShallowWrapper {
           "detailed": true,
           "source": undefined,
           "type": ProvisionSource {
+            "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+            "getDescription": [Function],
+            "getOrder": [Function],
             "getValue": [Function],
+            "label": "PXE (network boot - adds network interface)",
+            "order": 4,
+            "toString": [Function],
             "value": "PXE",
           },
         },
@@ -312,7 +342,13 @@ ShallowWrapper {
           "error": undefined,
           "source": undefined,
           "type": ProvisionSource {
+            "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+            "getDescription": [Function],
+            "getOrder": [Function],
             "getValue": [Function],
+            "label": "PXE (network boot - adds network interface)",
+            "order": 4,
+            "toString": [Function],
             "value": "PXE",
           },
         },
@@ -335,7 +371,13 @@ ShallowWrapper {
             source={undefined}
             type={
               ProvisionSource {
+                "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+                "getDescription": [Function],
+                "getOrder": [Function],
                 "getValue": [Function],
+                "label": "PXE (network boot - adds network interface)",
+                "order": 4,
+                "toString": [Function],
                 "value": "PXE",
               }
             }
@@ -345,7 +387,13 @@ ShallowWrapper {
             source={undefined}
             type={
               ProvisionSource {
+                "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+                "getDescription": [Function],
+                "getOrder": [Function],
                 "getValue": [Function],
+                "label": "PXE (network boot - adds network interface)",
+                "order": 4,
+                "toString": [Function],
                 "value": "PXE",
               }
             }
@@ -362,7 +410,13 @@ ShallowWrapper {
             "detailed": true,
             "source": undefined,
             "type": ProvisionSource {
+              "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "PXE (network boot - adds network interface)",
+              "order": 4,
+              "toString": [Function],
               "value": "PXE",
             },
           },
@@ -378,7 +432,13 @@ ShallowWrapper {
             "error": undefined,
             "source": undefined,
             "type": ProvisionSource {
+              "description": "Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "PXE (network boot - adds network interface)",
+              "order": 4,
+              "toString": [Function],
               "value": "PXE",
             },
           },
@@ -526,7 +586,14 @@ ShallowWrapper {
       "error": undefined,
       "source": "fooContainer",
       "type": ProvisionSource {
+        "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+        "getDescription": [Function],
+        "getOrder": [Function],
         "getValue": [Function],
+        "label": "Container",
+        "order": 3,
+        "toString": [Function],
         "value": "Container",
       },
     },
@@ -543,7 +610,14 @@ ShallowWrapper {
         "error": undefined,
         "source": "fooContainer",
         "type": ProvisionSource {
+          "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+          "getDescription": [Function],
+          "getOrder": [Function],
           "getValue": [Function],
+          "label": "Container",
+          "order": 3,
+          "toString": [Function],
           "value": "Container",
         },
       },
@@ -692,7 +766,14 @@ ShallowWrapper {
           source="fooContainer"
           type={
             ProvisionSource {
+              "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "Container",
+              "order": 3,
+              "toString": [Function],
               "value": "Container",
             }
           }
@@ -702,7 +783,14 @@ ShallowWrapper {
           source="fooContainer"
           type={
             ProvisionSource {
+              "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "Container",
+              "order": 3,
+              "toString": [Function],
               "value": "Container",
             }
           }
@@ -719,7 +807,14 @@ ShallowWrapper {
           "detailed": true,
           "source": "fooContainer",
           "type": ProvisionSource {
+            "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+            "getDescription": [Function],
+            "getOrder": [Function],
             "getValue": [Function],
+            "label": "Container",
+            "order": 3,
+            "toString": [Function],
             "value": "Container",
           },
         },
@@ -735,7 +830,14 @@ ShallowWrapper {
           "error": undefined,
           "source": "fooContainer",
           "type": ProvisionSource {
+            "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+            "getDescription": [Function],
+            "getOrder": [Function],
             "getValue": [Function],
+            "label": "Container",
+            "order": 3,
+            "toString": [Function],
             "value": "Container",
           },
         },
@@ -758,7 +860,14 @@ ShallowWrapper {
             source="fooContainer"
             type={
               ProvisionSource {
+                "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+                "getDescription": [Function],
+                "getOrder": [Function],
                 "getValue": [Function],
+                "label": "Container",
+                "order": 3,
+                "toString": [Function],
                 "value": "Container",
               }
             }
@@ -768,7 +877,14 @@ ShallowWrapper {
             source="fooContainer"
             type={
               ProvisionSource {
+                "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+                "getDescription": [Function],
+                "getOrder": [Function],
                 "getValue": [Function],
+                "label": "Container",
+                "order": 3,
+                "toString": [Function],
                 "value": "Container",
               }
             }
@@ -785,7 +901,14 @@ ShallowWrapper {
             "detailed": true,
             "source": "fooContainer",
             "type": ProvisionSource {
+              "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "Container",
+              "order": 3,
+              "toString": [Function],
               "value": "Container",
             },
           },
@@ -801,7 +924,14 @@ ShallowWrapper {
             "error": undefined,
             "source": "fooContainer",
             "type": ProvisionSource {
+              "description": "Link to a bootable operating system container located in a registry accessible from the cluster. Example: kubevirt/fedora-cloud-container-disk-demo. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step",
+              "getDescription": [Function],
+              "getOrder": [Function],
               "getValue": [Function],
+              "label": "Container",
+              "order": 3,
+              "toString": [Function],
               "value": "Container",
             },
           },

--- a/frontend/packages/kubevirt-plugin/src/constants/select-dropdown-object-enum.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/select-dropdown-object-enum.ts
@@ -1,0 +1,28 @@
+import { ObjectEnum } from './object-enum';
+
+export type SelectDropdownData = {
+  description?: string;
+  label?: string;
+  order?: number;
+};
+
+export abstract class SelectDropdownObjectEnum<T> extends ObjectEnum<T> {
+  private readonly label: string;
+
+  private readonly description: string;
+
+  private readonly order: number;
+
+  protected constructor(value: T, { description, label, order }: SelectDropdownData = {}) {
+    super(value);
+    this.label = label;
+    this.description = description;
+    this.order = order;
+  }
+
+  toString = () => this.label || super.toString();
+
+  getDescription = () => this.description;
+
+  getOrder = () => this.order;
+}

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -1,5 +1,5 @@
 export const VIRT_LAUNCHER_POD_PREFIX = 'virt-launcher-';
-export const READABLE_VIRTIO = 'VirtIO';
+export const READABLE_VIRTIO = 'virtio';
 export const ANNOTATION_FIRST_BOOT = 'kubevirt.ui/firstBoot';
 export const ANNOTATION_DESCRIPTION = 'description';
 export const ANNOTATION_PXE_INTERFACE = 'kubevirt.ui/pxeInterface';

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-model.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-model.ts
@@ -1,22 +1,68 @@
 /* eslint-disable lines-between-class-members */
 import { ObjectEnum } from '../../object-enum';
 import { READABLE_VIRTIO } from '../constants';
+import { NIC_MODEL_E1000E_DESC, NIC_MODEL_VIRTIO_DESC } from '../../../utils/strings';
+import { SelectDropdownObjectEnum, SelectDropdownData } from '../../select-dropdown-object-enum';
 
-export class NetworkInterfaceModel extends ObjectEnum<string> {
-  static readonly VIRTIO = new NetworkInterfaceModel('virtio');
-  static readonly E1000 = new NetworkInterfaceModel('e1000', { isSupported: false });
-  static readonly E1000E = new NetworkInterfaceModel('e1000e');
-  static readonly NE2kPCI = new NetworkInterfaceModel('ne2kPCI', { isSupported: false });
-  static readonly PCNET = new NetworkInterfaceModel('pcnet', { isSupported: false });
-  static readonly RTL8139 = new NetworkInterfaceModel('rtl8139', { isSupported: false });
+export class NetworkInterfaceModel extends SelectDropdownObjectEnum<string> {
+  static readonly VIRTIO = new NetworkInterfaceModel(
+    'virtio',
+    { isSupported: true },
+    {
+      label: READABLE_VIRTIO,
+      description: NIC_MODEL_VIRTIO_DESC,
+      order: 1,
+    },
+  );
+  static readonly E1000 = new NetworkInterfaceModel(
+    'e1000',
+    { isSupported: false },
+    {
+      label: 'E1000',
+      order: 2,
+    },
+  );
+  static readonly E1000E = new NetworkInterfaceModel(
+    'e1000e',
+    { isSupported: true },
+    {
+      label: 'e1000e',
+      order: 3,
+      description: NIC_MODEL_E1000E_DESC,
+    },
+  );
+  static readonly NE2kPCI = new NetworkInterfaceModel(
+    'ne2kPCI',
+    { isSupported: false },
+    {
+      order: 4,
+    },
+  );
+  static readonly PCNET = new NetworkInterfaceModel(
+    'pcnet',
+    { isSupported: false },
+    {
+      label: 'PCnet',
+      order: 5,
+    },
+  );
+  static readonly RTL8139 = new NetworkInterfaceModel(
+    'rtl8139',
+    { isSupported: false },
+    {
+      label: 'RTL8139',
+      order: 6,
+    },
+  );
 
   private readonly supported: boolean;
 
   protected constructor(
     value: string,
     { isSupported = true }: NetworkInterfaceModelConstructorOpts = {},
+    selectData: SelectDropdownData = {},
   ) {
-    super(value);
+    super(value, selectData);
     this.supported = isSupported;
   }
 
@@ -38,13 +84,6 @@ export class NetworkInterfaceModel extends ObjectEnum<string> {
     NetworkInterfaceModel.stringMapper[model];
 
   isSupported = () => this.supported;
-
-  toString() {
-    if (this === NetworkInterfaceModel.VIRTIO) {
-      return READABLE_VIRTIO;
-    }
-    return this.value;
-  }
 }
 
 type NetworkInterfaceModelConstructorOpts = {

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-type.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-type.ts
@@ -1,10 +1,28 @@
 /* eslint-disable lines-between-class-members */
 import { ObjectEnum } from '../../object-enum';
+import { SelectDropdownObjectEnum } from '../../select-dropdown-object-enum';
+import {
+  NIC_TYPE_BRIDGE_DESC,
+  NIC_TYPE_MASQUERADE_DESC,
+  NIC_TYPE_SRIOV_DESC,
+} from '../../../utils/strings';
 
-export class NetworkInterfaceType extends ObjectEnum<string> {
-  static readonly MASQUERADE = new NetworkInterfaceType('masquerade');
-  static readonly BRIDGE = new NetworkInterfaceType('bridge');
-  static readonly SRIOV = new NetworkInterfaceType('sriov');
+export class NetworkInterfaceType extends SelectDropdownObjectEnum<string> {
+  static readonly MASQUERADE = new NetworkInterfaceType('masquerade', {
+    label: 'Masquerade',
+    description: NIC_TYPE_MASQUERADE_DESC,
+    order: 1,
+  });
+  static readonly BRIDGE = new NetworkInterfaceType('bridge', {
+    label: 'Bridge',
+    description: NIC_TYPE_BRIDGE_DESC,
+    order: 2,
+  });
+  static readonly SRIOV = new NetworkInterfaceType('sriov', {
+    label: 'SR-IOV',
+    description: NIC_TYPE_SRIOV_DESC,
+    order: 3,
+  });
   static readonly SLIRP = new NetworkInterfaceType('slirp');
 
   private static readonly ALL = Object.freeze(

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/provision-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/provision-source.ts
@@ -15,6 +15,13 @@ import { VolumeWrapper } from '../../k8s/wrapper/vm/volume-wrapper';
 import { DataVolumeWrapper } from '../../k8s/wrapper/vm/data-volume-wrapper';
 import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 import { VolumeType } from './storage';
+import {
+  PROVISION_SOURCE_PXE_DESC,
+  PROVISION_SOURCE_CONTAINER_DESC,
+  PROVISION_SOURCE_URL_DESC,
+  PROVISION_SOURCE_DISK_DESC,
+} from '../../utils/strings';
+import { SelectDropdownObjectEnum } from '../select-dropdown-object-enum';
 
 type ProvisionSourceDetails = {
   type?: ProvisionSource;
@@ -22,11 +29,27 @@ type ProvisionSourceDetails = {
   error?: string;
 };
 
-export class ProvisionSource extends ObjectEnum<string> {
-  static readonly PXE = new ProvisionSource('PXE');
-  static readonly CONTAINER = new ProvisionSource('Container');
-  static readonly URL = new ProvisionSource('URL');
-  static readonly DISK = new ProvisionSource('Disk');
+export class ProvisionSource extends SelectDropdownObjectEnum<string> {
+  static readonly URL = new ProvisionSource('URL', {
+    label: 'URL (adds disk)',
+    description: PROVISION_SOURCE_URL_DESC,
+    order: 1,
+  });
+  static readonly DISK = new ProvisionSource('Disk', {
+    label: 'Existing PVC (adds disk)',
+    description: PROVISION_SOURCE_DISK_DESC,
+    order: 2,
+  });
+  static readonly CONTAINER = new ProvisionSource('Container', {
+    label: 'Container',
+    description: PROVISION_SOURCE_CONTAINER_DESC,
+    order: 3,
+  });
+  static readonly PXE = new ProvisionSource('PXE', {
+    label: 'PXE (network boot - adds network interface)',
+    description: PROVISION_SOURCE_PXE_DESC,
+    order: 4,
+  });
 
   private static readonly ALL = Object.freeze(
     ObjectEnum.getAllClassEnumProperties<ProvisionSource>(ProvisionSource),

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -17,6 +17,43 @@ export const ADD_DISK = 'Add Disk';
 export const ADD_NETWORK_INTERFACE = 'Add Network Interface';
 export const ADD_SNAPSHOT = 'Take Snapshot';
 export const RESTORE_SNAPSHOT = 'Restore Snapshot';
+export const EXAMPLE_CONTAINER = 'kubevirt/fedora-cloud-container-disk-demo';
+export const FEDORA_IMAGE_LINK = 'https://alt.fedoraproject.org/cloud/';
+export const RHEL_IMAGE_LINK =
+  'https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.2/x86_64/product-software';
+
+// storage ui sources descriptions
+export const UI_SOURCE_BLANK_DESC = 'Create an empty disk (PVC)';
+export const UI_SOURCE_URL_DESC =
+  'Upload content via URL (HTTP or S3 endpoint). A new persistent volume claim (PVC) will be created';
+export const UI_SOURCE_CONTAINER_DESC = `Upload content from a container located in a registry accessible from the cluster. Example: ${EXAMPLE_CONTAINER}. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. A new persistent volume claim (PVC) will be created`;
+export const UI_SOURCE_ATTACH_CLONED_DISK_DESC =
+  'Clone a persistent volume claim (PVC) already available in the cluster';
+export const UI_SOURCE_ATTACH_DISK_DESC =
+  'Use a persistent volume claim (PVC) already available on the cluster';
+export const UI_SOURCE_IMPORT_DISK_DESC = 'TBD';
+
+// provision sources descriptions
+export const PROVISION_SOURCE_PXE_DESC =
+  'Boot an operating system from a server on a network. Requires a PXE bootable network attachment definition';
+export const PROVISION_SOURCE_CONTAINER_DESC = `Link to a bootable operating system container located in a registry accessible from the cluster. Example: ${EXAMPLE_CONTAINER}. The container disk is meant to be used only for read-only filesystems such
+as CD-ROMs or for small short-lived throw-away VMs. This will show up as a disk in the Storage step`;
+export const PROVISION_SOURCE_URL_DESC =
+  'Link to an operating system image via URL (HTTP or S3 endpoint). A new persistent volume claim (PVC) will be created to store this image. This will show up as a disk in the Storage step';
+export const PROVISION_SOURCE_DISK_DESC = UI_SOURCE_ATTACH_DISK_DESC;
+
+// nics descriptions
+export const NIC_MODEL_VIRTIO_DESC =
+  'Optimized for best performance. Supported by most Linux distributions. Windows requires additional drivers to use this model.';
+export const NIC_MODEL_E1000E_DESC =
+  'Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio.';
+export const NIC_TYPE_MASQUERADE_DESC =
+  'Put the VM behind a NAT Proxy for high compability with different network providers. The VMs IP will differ from the IP seen on the pod network';
+export const NIC_TYPE_BRIDGE_DESC =
+  'The VM will be bridged to the selected network, ideal for L2 devices';
+export const NIC_TYPE_SRIOV_DESC =
+  'Attach a virtual function network device to the VM for high performance';
 
 export const getDialogUIError = (hasAllRequiredFilled) =>
   hasAllRequiredFilled


### PR DESCRIPTION
As of now, I only updated the Provision Source dropdown so we can examine the differences.
Until now, we used a component which renders the browser's native select component

Example
<img width="710" alt="Screen Shot 2020-08-25 at 17 18 10" src="https://user-images.githubusercontent.com/24938324/91186118-4f4d5480-e6f7-11ea-81c2-0bd86986dd78.png">

For us to have a more robust UI with descriptions and other props, we need to convert to the new PF `Select` component, its a change that could break tests, and it could take time to change all the selects in the wizard.

1 Key difference between the components is the new Select rendering the dropdown to the bottom or top is not automatic like the native select. causing it to get hidden by the wizard footer: (changing z-index didn't fix the issue)
<img width="720" alt="Screen Shot 2020-08-25 at 17 15 47" src="https://user-images.githubusercontent.com/24938324/91186048-3b095780-e6f7-11ea-8fe3-b0a083365ba9.png">

The solution is to change the direction manually for some of the selects.
<img width="683" alt="Screen Shot 2020-08-25 at 17 12 29" src="https://user-images.githubusercontent.com/24938324/91186089-46f51980-e6f7-11ea-9359-801cc2ffefc4.png">
