### PR TITLE
bug 1871109: Add a user friendly error message in VM import wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/error-components/resource-load-errors.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/error-components/resource-load-errors.tsx
@@ -34,6 +34,7 @@ const asError = ({
 }): Error => {
   const firehoseResult = iGetCommonData(state, wizardReduxID, key);
   const loadError = iGet(firehoseResult, 'loadError');
+
   if (firehoseResult && (!loadError || (ignore404 && loadError?.response?.status === 404))) {
     return null;
   }

--- a/frontend/packages/kubevirt-plugin/src/components/errors/errors.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/errors/errors.scss
@@ -5,3 +5,13 @@
 .kubevirt-errors__error-group--end {
   margin-bottom: 1.5em;
 }
+
+.kubevirt-errors__expendable {
+  background-color: var(--pf-global--palette--red-50);
+  white-space: pre-wrap;
+  border-width: 0;
+}
+
+.kubevirt-errors__description {
+  margin-bottom: var(--pf-global--spacer--xs);
+}

--- a/frontend/packages/kubevirt-plugin/src/components/errors/errors.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/errors/errors.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Alert, AlertVariant } from '@patternfly/react-core';
+import { Alert, AlertVariant, ExpandableSection } from '@patternfly/react-core';
 import * as classNames from 'classnames';
+import { formatError } from '../create-vm-wizard/error-components/utils';
 
 import './errors.scss';
 
@@ -20,20 +21,35 @@ export const Errors: React.FC<ErrorsProps> = ({ errors, endMargin }) => {
   return (
     <>
       {errors &&
-        errors.map(({ message, key, title, variant }, idx, arr) => (
-          <Alert
-            isInline
-            key={key || idx}
-            variant={variant || AlertVariant.danger}
-            title={title}
-            className={classNames({
-              'kubevirt-errors__error-group--item': idx !== arr.length - 1,
-              'kubevirt-errors__error-group--end ': endMargin && idx === arr.length - 1,
-            })}
-          >
-            {message}
-          </Alert>
-        ))}
+        errors.map(({ message, key, title, variant }, idx, arr) => {
+          const { isLong, errTitle, description } = formatError(title, message);
+
+          return (
+            <Alert
+              isInline
+              key={key || idx}
+              variant={variant || AlertVariant.danger}
+              title={errTitle}
+              className={classNames({
+                'kubevirt-errors__error-group--item': idx !== arr.length - 1,
+                'kubevirt-errors__error-group--end ': endMargin && idx === arr.length - 1,
+              })}
+            >
+              {!isLong && message}
+              {isLong && (
+                <div>
+                  {description && <div className="kubevirt-errors__description">{description}</div>}
+                  <ExpandableSection
+                    toggleTextCollapsed="View details"
+                    toggleTextExpanded="Hide details"
+                  >
+                    <pre className="kubevirt-errors__expendable">{message}</pre>
+                  </ExpandableSection>
+                </div>
+              )}
+            </Alert>
+          );
+        })}
     </>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/constants/errors/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/errors/common.ts
@@ -1,0 +1,3 @@
+export const INSUFFICIENT_PERMISSIONS_ERROR_TITLE = 'Insufficient permissions';
+export const INSUFFICIENT_PERMISSIONS_ERROR_DESC =
+  'You do not have the required permissions to perform this action. Please contact your administrator.';

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/start-v2vvmware-controller.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/start-v2vvmware-controller.ts
@@ -132,7 +132,7 @@ export const startV2VVMWareController = async (
     kubevirtVmwareConfigMap = await getVmwareConfigMap({ k8sGet });
 
     if (!kubevirtVmwareConfigMap) {
-      return; // pass through finally()
+      throw new Error('V2V VMWare: v2v-vmware configMap not found');
     }
 
     activeDeployment = await k8sGet(DeploymentModel, name, namespace);
@@ -159,6 +159,7 @@ export const startV2VVMWareController = async (
       { name, namespace },
       enhancedK8sMethods,
     );
+
     await startVmWare(
       { name, namespace, serviceAccount, role, roleBinding, kubevirtVmwareConfigMap },
       enhancedK8sMethods,


### PR DESCRIPTION
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>

When non-admin user picks a provider to import a VM from and lacks the permissions to do so.
![minimized_error](https://user-images.githubusercontent.com/18301938/91205152-c55cb600-e70d-11ea-9303-78f6c05cd2d9.png)

The error expended :
![maximaized_error](https://user-images.githubusercontent.com/18301938/91205295-fccb6280-e70d-11ea-8b0b-2e9007b63b75.png)

