### PR TITLE
Bug 1872774: In Import flow support builder image if sample repo is used

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
@@ -36,7 +36,9 @@ const EditApplicationForm: React.FC<FormikProps<FormikValues> & EditApplicationF
   <>
     <PageHeading title={createFlowType} style={{ padding: '0px' }} />
     <Form onSubmit={handleSubmit}>
-      {createFlowType !== CreateApplicationFlow.Container && <GitSection />}
+      {createFlowType !== CreateApplicationFlow.Container && (
+        <GitSection builderImages={builderImages} />
+      )}
       {createFlowType === CreateApplicationFlow.Git && (
         <BuilderSection image={values.image} builderImages={builderImages} />
       )}

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -24,7 +24,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
   projects,
 }) => (
   <Form onSubmit={handleSubmit} data-test-id="import-git-form">
-    <GitSection />
+    <GitSection builderImages={builderImages} />
     <BuilderSection image={values.image} builderImages={builderImages} />
     <DockerSection buildStrategy={values.build.strategy} />
     <AppSection


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4204

**Analysis / Root cause**: 
When entering a git repo url from our sample repositories, it is expected that we should be able to detect the correct builder image.

**Solution Description**: 
Check sample repos with builder images available;

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
