### PR TITLE
Bug 1872138: Rules to correct checkbox input and label alignment with this operatorhub filter-panel

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -26,6 +26,17 @@ form.pf-c-form {
   @include co-break-word;
 }
 
+// For input & label alignment while using bootstrap with @patternfly/react-catalog-view-extension
+.filter-panel-pf-category-item {
+  .pf-c-check {
+    align-items: inherit;
+  }
+
+  .pf-c-check__input {
+    margin-top: 2px;
+  }
+}
+
 kbd {
   border-radius: 3px;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
Off alignment most significant on Firefox 
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1872138

**After**
<img width="240" alt="Screen Shot 2020-08-26 at 12 43 03 PM" src="https://user-images.githubusercontent.com/1874151/91333986-55e1d780-e79c-11ea-950e-96b3dbf6d366.png">
<img width="238" alt="Screen Shot 2020-08-26 at 12 43 31 PM" src="https://user-images.githubusercontent.com/1874151/91333987-57130480-e79c-11ea-98de-ec618eb7ace5.png">


**Before**
<img width="233" alt="Screen Shot 2020-08-26 at 12 46 51 PM" src="https://user-images.githubusercontent.com/1874151/91334011-5ed2a900-e79c-11ea-90f4-43059c13af79.png">

<img width="234" alt="Screen Shot 2020-08-26 at 12 47 09 PM" src="https://user-images.githubusercontent.com/1874151/91334019-61350300-e79c-11ea-8265-2d0f347cbc8c.png">


