### PR TITLE
Bug 1872848:  Align quick start labels vertically

### DIFF
--- a/frontend/public/components/_icon-and-text.scss
+++ b/frontend/public/components/_icon-and-text.scss
@@ -1,6 +1,11 @@
 .co-icon-and-text {
   align-items: baseline;
   display: flex;
+
+  // fix bug where concurrent .pf-c-label are misaligned vertically
+  .pf-c-label__icon & {
+    display: block;
+  }
 }
 
 .co-icon-and-text__icon {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1872848

Before
<img width="318" alt="Screen Shot 2020-08-26 at 1 56 06 PM" src="https://user-images.githubusercontent.com/895728/91339092-f8ea1f80-e7a3-11ea-8328-f6b46de84360.png">

After
<img width="322" alt="Screen Shot 2020-08-26 at 1 54 10 PM" src="https://user-images.githubusercontent.com/895728/91338998-d3f5ac80-e7a3-11ea-9b26-c93a637be397.png">
