### PR TITLE
Bug 1872881: Fix crash when selecting Sink URI node in topology

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -969,6 +969,7 @@ export const transformKnNodeData = (
               },
               spec: { sinkUri },
               type: { nodeType: NodeType.SinkUri },
+              kind: 'SinkUri',
             };
             const sinkData: TopologyDataObject = {
               id: sinkTargetUid,


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4648

**Description**
Fix for crash when selecting Sink URI node.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug