### PR TITLE
Bug 1873147: cypress crud tests - moved create & delete out of before/after[all] hooks and into specific tests

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
@@ -69,8 +69,7 @@ describe('Kubernetes resource CRUD operations', () => {
     describe(kind, () => {
       const name = `${testName}-${_.kebabCase(kind)}`;
 
-      const createResource = () => {
-        cy.log(`Create ${kind}: ${name}`);
+      it(`creates the resource instance`, () => {
         cy.visit(
           `${namespaced ? `/k8s/ns/${testName}` : '/k8s/cluster'}/${resource}?name=${testName}`,
         );
@@ -99,26 +98,6 @@ describe('Kubernetes resource CRUD operations', () => {
           yamlEditor.clickSaveCreateButton();
           cy.get(errorMessage).should('not.exist');
         });
-      };
-
-      const deleteResource = () => {
-        cy.log(`Delete ${name}`);
-        cy.visit(`${namespaced ? `/k8s/ns/${testName}` : '/k8s/cluster'}/${resource}`);
-        listPage.filter.byName(name);
-        listPage.rows.countShouldBe(1);
-        listPage.rows.clickKebabAction(name, deleteHumanizedKind(kind));
-        modal.shouldBeOpened();
-        modal.submit();
-        modal.shouldBeClosed();
-        cy.resourceShouldBeDeleted(testName, resource, name);
-      };
-
-      before(() => {
-        createResource();
-      });
-
-      after(() => {
-        deleteResource();
       });
 
       it('displays detail view for newly created resource instance', () => {
@@ -173,6 +152,17 @@ describe('Kubernetes resource CRUD operations', () => {
           yamlEditor.clickReloadButton();
         }
         yamlEditor.clickSaveCreateButton();
+      });
+
+      it(`deletes the resource instance`, () => {
+        cy.visit(`${namespaced ? `/k8s/ns/${testName}` : '/k8s/cluster'}/${resource}`);
+        listPage.filter.byName(name);
+        listPage.rows.countShouldBe(1);
+        listPage.rows.clickKebabAction(name, deleteHumanizedKind(kind));
+        modal.shouldBeOpened();
+        modal.submit();
+        modal.shouldBeClosed();
+        cy.resourceShouldBeDeleted(testName, resource, name);
       });
     });
   });


### PR DESCRIPTION
This will allow us to take advantage of Cypress's new native retry ability which does not work in before/after hooks as shown in this previous message: "Although you have test retries enabled, we do not retry tests when `before all` or `after all` hooks fail"

It also helps readability of logs and console output:
```
  Pod
      ✓ creates the resource instance (9304ms)
      ✓ displays detail view for newly created resource instance (806ms)
      ✓ displays a list view for the resource (3103ms)
      ✓ search view displays created resource instance (3589ms)
      ✓ edits the resource instance (8998ms)
      ✓ deletes the resource instance (13528ms)

```