### PR TITLE
Bug 1873037: Show inline alert message "Waiting for build" only if there is a BuildConfig

### DIFF
--- a/frontend/public/components/overview/pods-overview.tsx
+++ b/frontend/public/components/overview/pods-overview.tsx
@@ -127,6 +127,7 @@ export const PodsOverview: React.SFC<PodsOverviewProps> = ({
   obj,
   allPodsLink,
   emptyText,
+  hasBuildConfig,
 }) => {
   const {
     metadata: { name, namespace },
@@ -134,7 +135,7 @@ export const PodsOverview: React.SFC<PodsOverviewProps> = ({
 
   const [showWaitingPods, setShowWaitingPods] = React.useState(false);
   const showWaitingForBuildAlert =
-    isDeploymentGeneratedByWebConsole(obj) && pods.some(isPodWithoutImageId);
+    hasBuildConfig && isDeploymentGeneratedByWebConsole(obj) && pods.some(isPodWithoutImageId);
 
   let filteredPods = [...pods];
   if (showWaitingForBuildAlert && !showWaitingPods) {
@@ -189,4 +190,5 @@ type PodsOverviewProps = {
   obj: K8sResourceKind;
   allPodsLink?: string;
   emptyText?: string;
+  hasBuildConfig?: boolean;
 };

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -18,11 +18,12 @@ export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabP
   item,
 }) => {
   const { buildConfigs, hpas, routes, services, pods, obj } = item;
+  const hasBuildConfig = buildConfigs?.length > 0;
   const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <div className="overview__sidebar-pane-body">
       <ManagedByOperatorLink obj={item.obj} />
-      <PodsOverview pods={pods} obj={obj} />
+      <PodsOverview pods={pods} obj={obj} hasBuildConfig={hasBuildConfig} />
       <BuildOverview buildConfigs={buildConfigs} />
       <HPAOverview hpas={hpas} />
       {pluginComponents.map(({ Component, key }) => (


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4468
https://bugzilla.redhat.com/show_bug.cgi?id=1873037

**Analysis / Root cause**: 
When importing a Deployment from a Container the invalid message "Waiting for the build" was displayed. This message was introduced in [ODC-3875](https://issues.redhat.com/browse/ODC-3875) / #6155, but should only be displayed when a `BuildConfig` is available.

**Solution Description**: 
Only the parent component knows if there are also BuildConfigs for the selected Deployment. Added a new prop to the PodOverview which is required to show the alert message.

**Screen shots / Gifs for design review**: 
Git Import before:
![image-deployment-before](https://user-images.githubusercontent.com/139310/91418416-66548980-e852-11ea-8750-47e8eba95d12.png)

Git Import after (unchanged!):
![git-deployment-after](https://user-images.githubusercontent.com/139310/91418451-74a2a580-e852-11ea-8044-3c170e9943b5.png)

Image container import before:
![image-deployment-before](https://user-images.githubusercontent.com/139310/91418475-7b311d00-e852-11ea-93ce-9920a0c0510c.png)

Image container import after (Alert message was not shown anymore):
![image-deployment-after3](https://user-images.githubusercontent.com/139310/91418490-7f5d3a80-e852-11ea-9fcc-ffcd4145d272.png)

The two pods here are tracked in [ODC-3175](https://issues.redhat.com/browse/ODC-3175) and fixed in #6138.

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Create a `Deployment` from a Git repository and from a container image.
* Check the sidebar areas `Pods` and `Builds` in the Topology of the new Deployment while the Build is running and finished.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge