### PR TITLE
Bug 1871676: Monitoring: Change rules list to filter by alert state, not rule state

### DIFF
--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -18,7 +18,7 @@ import {
 } from '../../module/k8s';
 import {
   alertDescription,
-  alertingRuleIsActive,
+  alertingRuleHasAlertState,
   alertingRuleSource,
   alertSource,
   alertState,
@@ -64,8 +64,8 @@ export const tableFilters: TableFilterMap = {
   'alert-state': (filter, alert: Alert) =>
     filter.selected.has(alertState(alert)) || _.isEmpty(filter.selected),
 
-  'alerting-rule-active': (filter, rule: Rule) =>
-    filter.selected.has(alertingRuleIsActive(rule)) || _.isEmpty(filter.selected),
+  'alerting-rule-has-alert-state': (filter, rule: Rule) =>
+    alertingRuleHasAlertState(rule, filter.selected) || _.isEmpty(filter.selected),
 
   'alerting-rule-name': (filter, rule: Rule) => fuzzyCaseInsensitive(filter, rule.name),
 

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -428,6 +428,7 @@ export type TableProps = {
   loaded?: boolean;
   reduxID?: string;
   reduxIDs?: string[];
+  rowFilters?: any[];
   label?: string;
   columnManagementID?: string;
 };

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -72,7 +72,9 @@ const getDropdownItems = (rowFilters: RowFilter[], selectedItems, data, props) =
               </span>
               <span className="co-filter-dropdown-item__name">{item.title}</span>
               <Badge key={item.id} isRead>
-                {_.countBy(data, grp.reducer)?.[item.id] ?? '0'}
+                {grp.isMatch
+                  ? _.filter(data, (d) => grp.isMatch(d, item.id)).length
+                  : _.countBy(data, grp.reducer)?.[item.id] ?? '0'}
               </Badge>
             </div>
           </DropdownItem>
@@ -378,12 +380,13 @@ type FilterToolbarProps = {
 export type RowFilter<R = any> = {
   defaultSelected?: string[];
   filterGroupName: string;
+  isMatch?: (param: R, id: string) => boolean;
   type: string;
   items?: {
     [key: string]: string;
   }[];
   itemsGenerator?: (...args) => { [key: string]: string }[];
-  reducer: (param: R) => React.ReactText;
+  reducer?: (param: R) => React.ReactText;
   filter?: any;
 };
 

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -36,7 +36,6 @@ import {
 import { K8sKind } from '../../module/k8s';
 import {
   alertDescription,
-  alertingRuleIsActive,
   alertingRuleSource,
   alertSource,
   alertState,
@@ -1273,6 +1272,7 @@ const MonitoringListPage_: React.FC<ListPageProps> = ({
               loadError={loadError}
               reduxID={reduxID}
               Row={Row}
+              rowFilters={rowFilters}
               virtualize
             />
           </div>
@@ -1301,15 +1301,24 @@ const AlertsPage_: React.FC<Alerts> = ({ data, loaded, loadError }) => (
 );
 const AlertsPage = withFallback(connect(alertsToProps)(AlertsPage_));
 
+const ruleHasAlertState = (rule: Rule, state: AlertStates): boolean =>
+  _.some(rule.alerts, { state });
+
+const ruleAlertStateFilter = (filter, rule: Rule) =>
+  _.some(rule.alerts, (a) => filter.selected.has(a.state)) || _.isEmpty(filter.selected);
+
 const rulesRowFilters: RowFilter[] = [
   {
-    filterGroupName: 'Rule State',
+    filter: ruleAlertStateFilter,
+    filterGroupName: 'Alert State',
+    isMatch: ruleHasAlertState,
     items: [
-      { id: 'true', title: 'Active' },
-      { id: 'false', title: 'Inactive' },
+      { id: AlertStates.Firing, title: 'Firing' },
+      { id: AlertStates.Pending, title: 'Pending' },
+      { id: AlertStates.Silenced, title: 'Silenced' },
+      { id: AlertStates.NotFiring, title: 'Not Firing' },
     ],
-    reducer: alertingRuleIsActive,
-    type: 'alerting-rule-active',
+    type: 'alerting-rule-has-alert-state',
   },
   severityRowFilter,
   {

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -16,6 +16,7 @@ export const enum AlertSource {
 
 export const enum AlertStates {
   Firing = 'firing',
+  NotFiring = 'not-firing',
   Pending = 'pending',
   Silenced = 'silenced',
 }

--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -13,8 +13,8 @@ import {
 export const alertState = (a: Alert): AlertStates => a?.state;
 export const silenceState = (s: Silence): SilenceStates => s?.status?.state;
 
-export const alertingRuleIsActive = (rule: Rule): string =>
-  rule.state === 'inactive' ? 'false' : 'true';
+export const alertingRuleHasAlertState = (rule: Rule, state: AlertStates) =>
+  state === AlertStates.NotFiring ? rule.alerts.length === 0 : _.some(rule.alerts, { state });
 
 export const alertingRuleSource = (rule: Rule): AlertSource =>
   rule.labels?.prometheus === 'openshift-monitoring/k8s' ? AlertSource.Platform : AlertSource.User;


### PR DESCRIPTION
Instead of filtering by rule state ("Active" or "Inactive") allow
filtering the rules by alert state ("Firing", "Pending", "Silenced" or
"Not Firing").

This now mirrors the states shown in the Alert State table column.
Having the filter states be different from the states in the column was
confusing.

![screenshot](https://user-images.githubusercontent.com/460802/91426121-09c78d80-e897-11ea-8c36-156929fd1b31.png)
