### PR TITLE
Bug 1858179: Add Storage Class filter for SC dropdown in Backing Store creation page for PVC type

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
@@ -28,12 +28,13 @@ import {
   K8sResourceKind,
 } from '@console/internal/module/k8s';
 import { ModalComponentProps } from '@console/internal/components/factory';
-import { ResourceDropdown, getAPIVersion, getName } from '@console/shared';
+import { ResourceDropdown, getAPIVersion, getName, isObjectSC } from '@console/shared';
 import { SecretModel } from '@console/internal/models';
 import { DashboardCardPopupLink } from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardLink';
 import { SecretType } from '@console/internal/components/secrets/create-secret';
 import { history } from '@console/internal/components/utils/router';
 import { StorageClassDropdown } from '@console/internal/components/utils/storage-class-dropdown';
+import { StorageClass } from '@console/internal/components/storage-class-form';
 import { NooBaaBackingStoreModel } from '../../models';
 import './create-bs.scss';
 import {
@@ -224,6 +225,8 @@ const PVCType: React.FC<PVCTypeProps> = ({ state, dispatch }) => {
     }
   };
 
+  const onlyPvcSCs = React.useCallback((sc: StorageClass) => !isObjectSC(sc), []);
+
   return (
     <>
       <FormGroup
@@ -263,6 +266,7 @@ const PVCType: React.FC<PVCTypeProps> = ({ state, dispatch }) => {
           onChange={(sc) => dispatch({ type: 'setStorageClass', value: getName(sc) })}
           defaultClass="ocs-storagecluster-ceph-rbd"
           id="sc-dropdown"
+          filter={onlyPvcSCs}
           required
         />
       </FormGroup>


### PR DESCRIPTION
- Add filter for PVC BS type storage class dropdown. 
- Only shows storage classes that are used to create PVCs and not OBCs.