### PR TITLE
Bug 1873192: show empty state in monitoring when no datapoint available

### DIFF
--- a/frontend/public/components/graphs/graph-empty.tsx
+++ b/frontend/public/components/graphs/graph-empty.tsx
@@ -9,6 +9,7 @@ export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = 
       justifyContent: 'center',
       padding: '5px',
       width: '100%',
+      flexGrow: 1,
     }}
   >
     {loading ? (

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -19,6 +19,12 @@ $tooltip-background-color: #151515;
 
 .graph-empty-state {
   min-height: 310px;
+  &__loaded {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
 }
 
 .graph-wrapper__horizontal-bar {
@@ -194,7 +200,9 @@ $screen-phone-landscape-min-width: 567px;
 
 $monitoring-line-height: 18px;
 
-.monitoring-description, .monitoring-label-list, .monitoring-timestamp {
+.monitoring-description,
+.monitoring-label-list,
+.monitoring-timestamp {
   line-height: $monitoring-line-height;
   margin-top: 4px;
 }
@@ -239,7 +247,7 @@ $monitoring-line-height: 18px;
     align-items: baseline;
     display: flex;
     justify-content: space-between;
-    @media(min-width: $grid-float-breakpoint) {
+    @media (min-width: $grid-float-breakpoint) {
       padding-top: 26px;
     }
   }

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -680,10 +680,13 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
     setSpan(to - from);
   };
 
+  const isGraphDataEmpty = !graphData || graphData.every((d) => d.length === 0);
+
   return (
     <div
       className={classNames('query-browser__wrapper', {
-        'graph-empty-state': _.isEmpty(graphData),
+        'graph-empty-state': isGraphDataEmpty,
+        'graph-empty-state__loaded': isGraphDataEmpty && !updating,
       })}
     >
       {hideControls ? (
@@ -702,8 +705,8 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
         </div>
       )}
       {error && <Error error={error} />}
-      {_.isEmpty(graphData) && !updating && <GraphEmpty />}
-      {!_.isEmpty(graphData) && (
+      {isGraphDataEmpty && !updating && <GraphEmpty />}
+      {!isGraphDataEmpty && (
         <>
           {samples < maxSamplesForSpan && !updating && (
             <Alert


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-4469
https://issues.redhat.com/browse/ODC-3297

Analysis / Root cause:
the monitoring tab shows empty charts when there are no datapoints available
Solution Description:
show empty state when there are no datapoints

Screens:
**Before**
![Screenshot from 2020-08-27 20-30-00](https://user-images.githubusercontent.com/38663217/91459493-54033b80-e8a4-11ea-9938-fea232a2bca9.png)
![Screenshot from 2020-08-27 20-30-54](https://user-images.githubusercontent.com/38663217/91459510-58c7ef80-e8a4-11ea-9386-407c832f0475.png)
![Screenshot from 2020-08-27 20-31-26](https://user-images.githubusercontent.com/38663217/91459525-5c5b7680-e8a4-11ea-862c-1ea418ff1ca7.png)

**After**
![Screenshot from 2020-08-27 20-34-30](https://user-images.githubusercontent.com/38663217/91460861-f8d24880-e8a5-11ea-9334-6aaa7ce30629.png)
![Screenshot from 2020-08-27 20-34-49](https://user-images.githubusercontent.com/38663217/91460881-fe2f9300-e8a5-11ea-82e3-94b0f8ce1212.png)
![Screenshot from 2020-08-27 20-33-51](https://user-images.githubusercontent.com/38663217/91460905-05ef3780-e8a6-11ea-940a-adc104350236.png)

Test Coverage:
NA

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge