### PR TITLE
Add option for Deep Compare hook to use JSON.stringify.

### DIFF
--- a/frontend/packages/console-shared/src/hooks/deep-compare-memoize.ts
+++ b/frontend/packages/console-shared/src/hooks/deep-compare-memoize.ts
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 
-export const useDeepCompareMemoize = <T = any>(value: T): T => {
+export const useDeepCompareMemoize = <T = any>(value: T, strinfigy?: boolean): T => {
   const ref = React.useRef<T>();
 
-  if (!_.isEqual(value, ref.current)) {
+  if (
+    strinfigy
+      ? JSON.stringify(value) !== JSON.stringify(ref.current)
+      : !_.isEqual(value, ref.current)
+  ) {
     ref.current = value;
   }
 


### PR DESCRIPTION
Use the strinfigy version in k8s watch hooks.

Just an idea that we could reuse existing `useDeepCompareMemoize` hook, but instead of deep equal we could do JSON.strinfigy.  K8sWatch hooks would use JSON.stringify version of `useDeepCompareMemoize`. 

Results in cleaner code (IMO) and we also dont have to turn the eslint rule off, which is quite dangerous.

I've also improved Model error detection which was incorrect if caller changed watched model during rerenders (due to useEffect async nature)

@spadgett WDYT ?