### PR TITLE
Bug 1873230: show message for retrying in conclusion if there are failed tasks

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartConclusion.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartConclusion.tsx
@@ -22,6 +22,7 @@ const QuickStartConclusion: React.FC<QuickStartConclusionProps> = ({
   onQuickStartChange,
   onTaskSelect,
 }) => {
+  const hasFailedTask = allTaskStatuses.includes(QuickStartTaskStatus.FAILED);
   return (
     <>
       {tasks.map((task, index) => (
@@ -34,8 +35,14 @@ const QuickStartConclusion: React.FC<QuickStartConclusionProps> = ({
           onTaskSelect={onTaskSelect}
         />
       ))}
-      <SyncMarkdownView content={conclusion} />
-      {nextQuickStart && (
+      <SyncMarkdownView
+        content={
+          hasFailedTask
+            ? 'One or more verifications did not pass during this quick start. Revisit the tasks or the help links, and then try again.'
+            : conclusion
+        }
+      />
+      {nextQuickStart && !hasFailedTask && (
         <Button variant="link" onClick={() => onQuickStartChange(nextQuickStart)} isInline>
           {`Start ${nextQuickStart} quick start`}{' '}
           <ArrowRightIcon

--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartConclusion.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartConclusion.spec.tsx
@@ -4,15 +4,16 @@ import { Button } from '@patternfly/react-core';
 import { getQuickStartByName } from '../../utils/quick-start-utils';
 import { QuickStartTaskStatus } from '../../utils/quick-start-types';
 import QuickStartConclusion from '../QuickStartConclusion';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 
 type QuickStartConclusionProps = React.ComponentProps<typeof QuickStartConclusion>;
 let wrapper: ShallowWrapper<QuickStartConclusionProps>;
 const props: QuickStartConclusionProps = {
   tasks: getQuickStartByName('explore-serverless').spec.tasks,
   allTaskStatuses: [
-    QuickStartTaskStatus.INIT,
-    QuickStartTaskStatus.INIT,
-    QuickStartTaskStatus.INIT,
+    QuickStartTaskStatus.SUCCESS,
+    QuickStartTaskStatus.SUCCESS,
+    QuickStartTaskStatus.SUCCESS,
   ],
   conclusion: 'conclusion',
   onTaskSelect: jest.fn(),
@@ -24,11 +25,16 @@ describe('QuickStartConclusion', () => {
     wrapper = shallow(<QuickStartConclusion {...props} />);
   });
 
-  it('should not render link for next quick start if nextQuickStart props is available', () => {
-    expect(wrapper.find(Button).length).toBe(0);
+  it('should render conclusion if there are no failed tasks', () => {
+    expect(
+      wrapper
+        .find(SyncMarkdownView)
+        .first()
+        .props().content,
+    ).toEqual('conclusion');
   });
 
-  it('should render link for next quick start if nextQuickStart props is available', () => {
+  it('should render link for next quick start if nextQuickStart prop is available and there are no failed tasks', () => {
     wrapper = shallow(<QuickStartConclusion {...props} nextQuickStart="Serverless Application" />);
     expect(
       wrapper
@@ -36,5 +42,32 @@ describe('QuickStartConclusion', () => {
         .at(0)
         .props().children[0],
     ).toEqual('Start Serverless Application quick start');
+  });
+
+  it('should not render link for next quick start if nextQuickStart props is not available', () => {
+    expect(wrapper.find(Button).length).toBe(0);
+  });
+
+  it('should not render conclusion, link for next quick start and should render message for retrying if there are failed tasks', () => {
+    wrapper = shallow(
+      <QuickStartConclusion
+        {...props}
+        nextQuickStart="Serverless Application"
+        allTaskStatuses={[
+          QuickStartTaskStatus.FAILED,
+          QuickStartTaskStatus.SUCCESS,
+          QuickStartTaskStatus.SUCCESS,
+        ]}
+      />,
+    );
+    expect(
+      wrapper
+        .find(SyncMarkdownView)
+        .first()
+        .props().content,
+    ).toEqual(
+      'One or more verifications did not pass during this quick start. Revisit the tasks or the help links, and then try again.',
+    );
+    expect(wrapper.find(Button).length).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-4638

Analysis / Root cause:
Currently when one or more steps have not been accomplished successfully, the Quick Start displays the positive conclusion message provided

Solution Description:
If one or more steps have not been accomplished successfully, on the last page of the Quick Start

1. Post this generic message rather than the conclusion "One or more verifications did not pass during this quick start. Revisit the tasks or the help links, and then try again."
2. If there's a follow on tour, do not link to it

Screens:
**Before**
![Screenshot from 2020-08-27 22-21-51](https://user-images.githubusercontent.com/38663217/91471577-ea8b2900-e8b3-11ea-8bf8-946e5a995d1e.png)
![Screenshot from 2020-08-27 22-22-49](https://user-images.githubusercontent.com/38663217/91471617-f2e36400-e8b3-11ea-8ee0-8b71b388e81a.png)

**After**
![Screenshot from 2020-08-27 21-42-27](https://user-images.githubusercontent.com/38663217/91471327-8b2d1900-e8b3-11ea-82c8-bae10f39d8ca.png)
![Screenshot from 2020-08-27 21-42-54](https://user-images.githubusercontent.com/38663217/91471346-92ecbd80-e8b3-11ea-9a4c-b9bce222bd5e.png)

Test Coverage:
![Screenshot from 2020-08-27 22-19-45](https://user-images.githubusercontent.com/38663217/91471365-984a0800-e8b3-11ea-8f71-8bc93b4dff27.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge