### PR TITLE
Bug 1870831: Fix operator displayName on subscribe form

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -687,7 +687,9 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
           </div>
           <div className="col-xs-6">
             <ClusterServiceVersionLogo
-              displayName={_.get(channels, '[0].currentCSVDesc.displayName')}
+              displayName={
+                currentCSVDesc?.displayName || channels?.[0]?.currentCSVDesc?.displayName
+              }
               icon={iconFor(props.packageManifest.data[0])}
               provider={provider}
             />


### PR DESCRIPTION
Update OperatorHubSubscribeForm to use the currently selected channel display name above the
provided APIs.