### PR TITLE
Bug 1873420: Do not show non-workload nodes in topology consumption mode

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/updateModelFromFilters.ts
@@ -31,7 +31,10 @@ const getApplicationGroupForNode = (node: NodeModel, groups: NodeModel[]): NodeM
 const getNodeKind = (node: NodeModel) => {
   let { resource } = node as OdcNodeModel;
   if (resource) {
-    return referenceFor(resource);
+    const ref = referenceFor(resource);
+    if (ref) {
+      return ref;
+    }
   }
   const kind = (node as OdcNodeModel).resourceKind;
   if (kind) {

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -690,6 +690,7 @@ export const getSinkUriTopologyNodeItems = (
     id,
     type,
     resource: data.resource,
+    resourceKind: 'Uri',
     data,
     ...(nodeProps || {}),
   });
@@ -969,7 +970,7 @@ export const transformKnNodeData = (
               },
               spec: { sinkUri },
               type: { nodeType: NodeType.SinkUri },
-              kind: 'SinkUri',
+              kind: 'Uri',
             };
             const sinkData: TopologyDataObject = {
               id: sinkTargetUid,

--- a/frontend/packages/knative-plugin/src/topology/knativeFilters.ts
+++ b/frontend/packages/knative-plugin/src/topology/knativeFilters.ts
@@ -1,10 +1,25 @@
 import { Model } from '@patternfly/react-topology';
 import {
   DisplayFilters,
+  getFilterById,
   isExpanded,
+  SHOW_GROUPS_FILTER_ID,
   TopologyDisplayFilterType,
 } from '@console/dev-console/src/components/topology';
-import { TYPE_KNATIVE_SERVICE } from './const';
+import {
+  TYPE_EVENT_SOURCE,
+  TYPE_KNATIVE_REVISION,
+  TYPE_KNATIVE_SERVICE,
+  TYPE_SINK_URI,
+  TYPE_EVENT_PUB_SUB,
+} from './const';
+
+const KNATIVE_NON_CONSUMPTION_TYPES = [
+  TYPE_EVENT_SOURCE,
+  TYPE_KNATIVE_REVISION,
+  TYPE_SINK_URI,
+  TYPE_EVENT_PUB_SUB,
+];
 
 export const EXPAND_KNATIVE_SERVICES_FILTER_ID = 'knativeServices';
 
@@ -22,6 +37,7 @@ export const getTopologyFilters = () => {
 
 export const applyKnativeDisplayOptions = (model: Model, filters: DisplayFilters): string[] => {
   const expandServices = isExpanded(EXPAND_KNATIVE_SERVICES_FILTER_ID, filters);
+  const groupsShown = getFilterById(SHOW_GROUPS_FILTER_ID, filters)?.value ?? true;
   const appliedFilters = [];
   let serviceFound = false;
   model.nodes.forEach((d) => {
@@ -31,6 +47,9 @@ export const applyKnativeDisplayOptions = (model: Model, filters: DisplayFilters
         appliedFilters.push(EXPAND_KNATIVE_SERVICES_FILTER_ID);
       }
       d.collapsed = !expandServices;
+    }
+    if (!groupsShown && KNATIVE_NON_CONSUMPTION_TYPES.includes(d.type)) {
+      d.visible = false;
     }
   });
   return appliedFilters;


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4652
https://issues.redhat.com/browse/ODC-4693


**Description**
Filter out knative URI, Revisions, Sinks, an Event sources from topology view in consumption mode.
Fix to not show URIs when its type is filtered out.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
