### PR TITLE
Bug 1873481: Show workspace volume-type item fields only when added

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/MultipleKeySelector.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/MultipleKeySelector.scss
@@ -10,10 +10,6 @@
     cursor: pointer;
     position: absolute;
     right: -22px;
-    top: 25px;
-    &.--disabled {
-      pointer-events: none;
-      color: var(--pf-global--disabled-color--200);
-    }
+    top: 10px;
   }
 }

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/MultipleKeySelector.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/MultipleKeySelector.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { FieldArray, useFormikContext, FormikValues } from 'formik';
 import * as _ from 'lodash';
-import cx from 'classnames';
 import { PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { DropdownField, InputField, getFieldId, useFormikValidationFix } from '@console/shared';
-import { TextInputTypes, Button, FormGroup, Tooltip } from '@patternfly/react-core';
+import { TextInputTypes, Button, FormGroup, Tooltip, Flex, FlexItem } from '@patternfly/react-core';
 import './MultipleKeySelector.scss';
 
 interface MultipleKeySelectorProps {
@@ -21,7 +20,7 @@ const MultipleKeySelector: React.FC<MultipleKeySelectorProps> = ({
   tooltip,
 }) => {
   const { values } = useFormikContext<FormikValues>();
-  const items = _.get(values, name, [{ key: '', path: '' }]);
+  const items = _.get(values, name, []);
   useFormikValidationFix(items);
   return (
     <FieldArray
@@ -39,23 +38,24 @@ const MultipleKeySelector: React.FC<MultipleKeySelectorProps> = ({
                 const fieldKey = `${name}.${index}.${item.key}`;
                 return (
                   <div className="form-group odc-multiple-key-selector__item" key={fieldKey}>
-                    <DropdownField
-                      name={`${name}.${index}.key`}
-                      title="Select a key"
-                      items={keys}
-                      fullWidth
-                    />
-                    <InputField
-                      name={`${name}.${index}.path`}
-                      type={TextInputTypes.text}
-                      placeholder="Enter a path"
-                      isDisabled={!item.key}
-                    />
-                    <div
-                      className={cx('odc-multiple-key-selector__deleteButton', {
-                        '--disabled': items.length <= 1,
-                      })}
-                    >
+                    <Flex direction={{ default: 'column', lg: 'row' }}>
+                      <FlexItem grow={{ default: 'grow' }}>
+                        <DropdownField
+                          name={`${name}.${index}.key`}
+                          title="Select a key"
+                          items={keys}
+                          fullWidth
+                        />
+                      </FlexItem>
+                      <FlexItem grow={{ default: 'grow' }}>
+                        <InputField
+                          name={`${name}.${index}.path`}
+                          type={TextInputTypes.text}
+                          placeholder="Enter a path"
+                        />
+                      </FlexItem>
+                    </Flex>
+                    <div className="odc-multiple-key-selector__deleteButton">
                       <Tooltip content={tooltip || 'Remove'}>
                         <MinusCircleIcon aria-hidden="true" onClick={() => remove(index)} />
                       </Tooltip>

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/MultipleResourceKeySelector.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/MultipleResourceKeySelector.tsx
@@ -21,6 +21,7 @@ interface MultipleResourceKeySelectorProps {
   required?: boolean;
   resourceNameField: string;
   resourceKeysField: string;
+  addString?: string;
 }
 
 interface StateProps {
@@ -34,6 +35,7 @@ const MultipleResourceKeySelector: React.FC<StateProps & MultipleResourceKeySele
   required,
   resourceNameField,
   resourceKeysField,
+  addString,
 }) => {
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const [field, { touched, error }] = useField(resourceNameField);
@@ -61,7 +63,7 @@ const MultipleResourceKeySelector: React.FC<StateProps & MultipleResourceKeySele
     const selectedResource: K8sResourceKind = _.find(resources, (res) => {
       return _.get(res, 'metadata.name') === resourceName;
     });
-    const keyMap = selectedResource?.data;
+    const keyMap = selectedResource?.data ?? {};
     const itemKeys = Object.keys(keyMap).reduce((acc, key) => ({ ...acc, [key]: key }), {});
     setKeys(itemKeys);
   };
@@ -93,7 +95,9 @@ const MultipleResourceKeySelector: React.FC<StateProps & MultipleResourceKeySele
         }}
         showBadge
       />
-      {field.value && <MultipleKeySelector name={resourceKeysField} keys={keys} />}
+      {field.value && !_.isEmpty(keys) && (
+        <MultipleKeySelector name={resourceKeysField} keys={keys} addString={addString} />
+      )}
     </FormGroup>
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
@@ -17,6 +17,7 @@ const getVolumeTypeFields = (volumeType: VolumeTypes, index: number) => {
           resourceKeysField={`workspaces.${index}.data.secret.items`}
           label="Secret"
           resourceModel={SecretModel}
+          addString="Add item"
           required
         />
       );
@@ -28,6 +29,7 @@ const getVolumeTypeFields = (volumeType: VolumeTypes, index: number) => {
           resourceKeysField={`workspaces.${index}.data.configMap.items`}
           label="Config Map"
           resourceModel={ConfigMapModel}
+          addString="Add item"
           required
         />
       );

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/validation-utils.ts
@@ -66,11 +66,8 @@ const volumeTypeSchema = yup
         secretName: yup.string().required('Required'),
         items: yup.array().of(
           yup.object().shape({
-            key: yup.string(),
-            path: yup.string().when('key', {
-              is: (key) => !!key,
-              then: yup.string().required('Required'),
-            }),
+            key: yup.string().required('Required'),
+            path: yup.string().required('Required'),
           }),
         ),
       }),
@@ -83,11 +80,8 @@ const volumeTypeSchema = yup
         name: yup.string().required('Required'),
         items: yup.array().of(
           yup.object().shape({
-            key: yup.string(),
-            path: yup.string().when('key', {
-              is: (key) => !!key,
-              then: yup.string().required('Required'),
-            }),
+            key: yup.string().required('Required'),
+            path: yup.string().required('Required'),
           }),
         ),
       }),


### PR DESCRIPTION
Jira - https://issues.redhat.com/browse/ODC-3571

This PR adds a fix to show workspace volume-type item fields only when added and also some UX enhancement changes to item fields.

Screenshots:
![Screenshot from 2020-08-28 18-31-05](https://user-images.githubusercontent.com/20724543/91564045-9c326480-e95d-11ea-9ba1-752ec38ea3e3.png)
![Screenshot from 2020-08-28 18-32-32](https://user-images.githubusercontent.com/20724543/91564051-9d639180-e95d-11ea-9c01-a563f214e00e.png)

/kind bug