### PR TITLE
Bug 1880118: Improve Cypress `checkErrors` output

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -3,6 +3,7 @@ import './project';
 import './selectors';
 import './nav';
 import './resources';
+
 import { a11yTestResults } from './a11y';
 
 Cypress.Cookies.defaults({
@@ -38,11 +39,22 @@ after(() => {
   });
 });
 
+const formatWindowError = (windowError: Error | PromiseRejectionEvent) => {
+  if (!windowError) {
+    return 'no window error detected';
+  }
+  const { reason } = windowError as PromiseRejectionEvent;
+  if (reason) {
+    return reason;
+  }
+  const { message, stack } = windowError as Error;
+  const formattedStack = stack?.replace(/\\n/g, '\n');
+  return `window error detected: ${message} ${formattedStack}`;
+};
+
 export const checkErrors = () =>
   cy.window().then((win) => {
-    if (win.windowError) {
-      throw new Error(`window/js runtime error detected: ${win.windowError}`);
-    }
+    assert.isTrue(!win.windowError, formatWindowError(win.windowError));
   });
 
 export const testName = `test-${Math.random()

--- a/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
@@ -46,6 +46,6 @@ describe('Namespace', () => {
     cy.testA11y('Delete Namespace modal');
     modal.submit();
     modal.shouldBeClosed();
-    listPage.rows.shouldNotExist(newName);
+    cy.resourceShouldBeDeleted(testName, 'namespaces', newName);
   });
 });

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -214,11 +214,16 @@ setInterval(() => store.dispatch(UIActions.updateTimestamps(Date.now())), 10000)
 fetchSwagger();
 
 // Used by GUI tests to check for unhandled exceptions
-window.windowError = false;
-window.onerror = window.onunhandledrejection = (e) => {
+window.windowError = null;
+window.onerror = (message, source, lineno, colno, error) => {
   // eslint-disable-next-line no-console
-  console.error('Uncaught error', e);
-  window.windowError = e || true;
+  console.error('Uncaught error', error);
+  window.windowError = error;
+};
+window.onunhandledrejection = (promiseRejectionEvent) => {
+  // eslint-disable-next-line no-console
+  console.error('Unhandled promise rejection', promiseRejectionEvent);
+  window.windowError = promiseRejectionEvent;
 };
 
 if ('serviceWorker' in navigator) {

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -41,7 +41,7 @@ declare interface Window {
     GOOS: string;
     graphqlBaseURL: string;
   };
-  windowError?: boolean | string;
+  windowError?: Error | PromiseRejectionEvent;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
   store?: {}; // Redux store
   pluginStore?: {}; // Console plugin store


### PR DESCRIPTION
This PR updates our usage of `window.windowError` in `app.js` and also improves Cypress `checkErrors()` output:
```
2) Monitoring: Alerts
       "after each" hook for "creates and expires a Silence":
     window error detected: {
 "message": "y is not defined",
 "stack": "ReferenceError: y is not defined
    at http://localhost:9000/static/main-e0abc76e4ffb6fa60c4c.js:95489:9
    at renderWithHooks (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:371358:18)
    at mountIndeterminateComponent (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:373592:13)
    at beginWork$1 (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:374736:16)
    at HTMLUnknownElement.callCallback (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:356597:14)
    at Object.invokeGuardedCallbackDev (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:356647:16)
    at invokeGuardedCallback (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:356704:31)
    at beginWork$$1 (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:379467:7)
    at performUnitOfWork (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:378458:12)
    at workLoopSync (http://localhost:9000/static/vendors~main-2e679479202da74be6e9.js:378435:22)"
```