### PR TITLE
Bug 1843387: update queryInput on change to pre-fill Query

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
@@ -45,6 +45,7 @@ const MetricsQueryInput: React.FC<MetricsQueryInputProps> = ({ query }) => {
   const dispatch = useDispatch();
   const [title, setTitle] = React.useState('Select Query');
   const [selectedKey, setSelectedKey] = React.useState('');
+  const [changeKey, setChangeKey] = React.useState(false);
   const [metric, setMetric] = React.useState('');
   const [showPromQl, setShowPromQl] = React.useState(false);
   const [isPromQlDisabled, setIsPromQlDisabled] = React.useState(false);
@@ -57,7 +58,7 @@ const MetricsQueryInput: React.FC<MetricsQueryInputProps> = ({ query }) => {
       patchQuery({ text: queryMetrics || '' });
       runQueries();
     }
-  }, [dispatch, metric, namespace]);
+  }, [dispatch, metric, namespace, changeKey]);
 
   React.useEffect(() => {
     const q = queries?.query;
@@ -102,6 +103,7 @@ const MetricsQueryInput: React.FC<MetricsQueryInputProps> = ({ query }) => {
 
   const onChange = (selectedValue: string) => {
     setMetric(metricsQuery[selectedValue]);
+    setChangeKey(!changeKey);
     if (selectedValue && selectedValue === ADD_NEW_QUERY) {
       setTitle(CUSTOM_QUERY);
       setIsPromQlDisabled(true);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4096

**Description**:
Goto Dev Console, click "Monitoring" and select any project, then click the "Metrics" tab, click "Show PromQL" button, select any defined metrics from the dropdown list, example: CPU Usage
after the graph is shown, click "x" button in the metrics input text area to remove expression, select "CPU Usage" again, the metrics expression is not shown in the metrics input text area

**Analysis / Root cause**: 
Query Input text area not shows query in it's cleared by user and tried to select to same Query again

**Solution Description**: 
On Each change update the QueryInput

**Screen shots / Gifs for design review**: 
![Aug-31-2020 12-26-26](https://user-images.githubusercontent.com/5129024/91691471-4b9d5000-eb85-11ea-9cc5-9335bb2b9e6b.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
