### PR TITLE
Bug 1869620: kubevirt support only e1000e and virtio

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -257,15 +257,17 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
               isDisabled={isDisabled('model') || interfaceType === NetworkInterfaceType.SRIOV}
             >
               <FormSelectPlaceholderOption isDisabled placeholder="--- Select Model ---" />
-              {NetworkInterfaceModel.getAll().map((ifaceModel) => {
-                return (
-                  <FormSelectOption
-                    key={ifaceModel.getValue()}
-                    value={ifaceModel.getValue()}
-                    label={ifaceModel.toString()}
-                  />
-                );
-              })}
+              {NetworkInterfaceModel.getAll()
+                .filter((ifaceModel) => !ifaceModel.isDeprecated())
+                .map((ifaceModel) => {
+                  return (
+                    <FormSelectOption
+                      key={ifaceModel.getValue()}
+                      value={ifaceModel.getValue()}
+                      label={ifaceModel.toString()}
+                    />
+                  );
+                })}
             </FormSelect>
           </FormRow>
           <Network

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -258,7 +258,10 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
             >
               <FormSelectPlaceholderOption isDisabled placeholder="--- Select Model ---" />
               {NetworkInterfaceModel.getAll()
-                .filter((ifaceModel) => ifaceModel.isSupported())
+                .filter(
+                  (ifaceModel) =>
+                    ifaceModel.isSupported() || ifaceModel.toString() === model.toString(),
+                )
                 .map((ifaceModel) => {
                   return (
                     <FormSelectOption

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -258,10 +258,7 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
             >
               <FormSelectPlaceholderOption isDisabled placeholder="--- Select Model ---" />
               {NetworkInterfaceModel.getAll()
-                .filter(
-                  (ifaceModel) =>
-                    ifaceModel.isSupported() || ifaceModel.toString() === model.toString(),
-                )
+                .filter((ifaceModel) => ifaceModel.isSupported() || ifaceModel === model)
                 .map((ifaceModel) => {
                   return (
                     <FormSelectOption

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -258,7 +258,7 @@ export const NICModal = withHandlePromise((props: NICModalProps) => {
             >
               <FormSelectPlaceholderOption isDisabled placeholder="--- Select Model ---" />
               {NetworkInterfaceModel.getAll()
-                .filter((ifaceModel) => !ifaceModel.isDeprecated())
+                .filter((ifaceModel) => ifaceModel.isSupported())
                 .map((ifaceModel) => {
                   return (
                     <FormSelectOption

--- a/frontend/packages/kubevirt-plugin/src/constants/v2v-import/ovirt/ovirt-network-interface-model.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/v2v-import/ovirt/ovirt-network-interface-model.ts
@@ -3,10 +3,10 @@ import { ObjectEnum } from '../../object-enum';
 import { NetworkInterfaceModel } from '../../vm/network';
 
 export class OvirtNetworkInterfaceModel extends ObjectEnum<string> {
-  static readonly E1000 = new OvirtNetworkInterfaceModel('e1000', NetworkInterfaceModel.E1000);
+  static readonly E1000 = new OvirtNetworkInterfaceModel('e1000', NetworkInterfaceModel.E1000E);
   static readonly PCI_PASSTHROUGH = new OvirtNetworkInterfaceModel(
     'pci_passthrough',
-    NetworkInterfaceModel.E1000,
+    NetworkInterfaceModel.E1000E,
   );
   static readonly RTL8139 = new OvirtNetworkInterfaceModel(
     'rtl8139',

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-model.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-model.ts
@@ -4,11 +4,21 @@ import { READABLE_VIRTIO } from '../constants';
 
 export class NetworkInterfaceModel extends ObjectEnum<string> {
   static readonly VIRTIO = new NetworkInterfaceModel('virtio');
-  static readonly E1000 = new NetworkInterfaceModel('e1000');
+  static readonly E1000 = new NetworkInterfaceModel('e1000', { isDeprecated: true });
   static readonly E1000E = new NetworkInterfaceModel('e1000e');
-  static readonly NE2kPCI = new NetworkInterfaceModel('ne2kPCI');
-  static readonly PCNET = new NetworkInterfaceModel('pcnet');
-  static readonly RTL8139 = new NetworkInterfaceModel('rtl8139');
+  static readonly NE2kPCI = new NetworkInterfaceModel('ne2kPCI', { isDeprecated: true });
+  static readonly PCNET = new NetworkInterfaceModel('pcnet', { isDeprecated: true });
+  static readonly RTL8139 = new NetworkInterfaceModel('rtl8139', { isDeprecated: true });
+
+  private readonly deprecated: boolean;
+
+  protected constructor(
+    value: string,
+    { isDeprecated = false }: NetworkInterfaceModelConstructorOpts = {},
+  ) {
+    super(value);
+    this.deprecated = isDeprecated;
+  }
 
   private static readonly ALL = Object.freeze(
     ObjectEnum.getAllClassEnumProperties<NetworkInterfaceModel>(NetworkInterfaceModel),
@@ -27,6 +37,8 @@ export class NetworkInterfaceModel extends ObjectEnum<string> {
   static fromString = (model: string): NetworkInterfaceModel =>
     NetworkInterfaceModel.stringMapper[model];
 
+  isDeprecated = () => this.deprecated;
+
   toString() {
     if (this === NetworkInterfaceModel.VIRTIO) {
       return READABLE_VIRTIO;
@@ -34,3 +46,7 @@ export class NetworkInterfaceModel extends ObjectEnum<string> {
     return this.value;
   }
 }
+
+type NetworkInterfaceModelConstructorOpts = {
+  isDeprecated?: boolean;
+};

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-model.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/network/network-interface-model.ts
@@ -4,20 +4,20 @@ import { READABLE_VIRTIO } from '../constants';
 
 export class NetworkInterfaceModel extends ObjectEnum<string> {
   static readonly VIRTIO = new NetworkInterfaceModel('virtio');
-  static readonly E1000 = new NetworkInterfaceModel('e1000', { isDeprecated: true });
+  static readonly E1000 = new NetworkInterfaceModel('e1000', { isSupported: false });
   static readonly E1000E = new NetworkInterfaceModel('e1000e');
-  static readonly NE2kPCI = new NetworkInterfaceModel('ne2kPCI', { isDeprecated: true });
-  static readonly PCNET = new NetworkInterfaceModel('pcnet', { isDeprecated: true });
-  static readonly RTL8139 = new NetworkInterfaceModel('rtl8139', { isDeprecated: true });
+  static readonly NE2kPCI = new NetworkInterfaceModel('ne2kPCI', { isSupported: false });
+  static readonly PCNET = new NetworkInterfaceModel('pcnet', { isSupported: false });
+  static readonly RTL8139 = new NetworkInterfaceModel('rtl8139', { isSupported: false });
 
-  private readonly deprecated: boolean;
+  private readonly supported: boolean;
 
   protected constructor(
     value: string,
-    { isDeprecated = false }: NetworkInterfaceModelConstructorOpts = {},
+    { isSupported = true }: NetworkInterfaceModelConstructorOpts = {},
   ) {
     super(value);
-    this.deprecated = isDeprecated;
+    this.supported = isSupported;
   }
 
   private static readonly ALL = Object.freeze(
@@ -37,7 +37,7 @@ export class NetworkInterfaceModel extends ObjectEnum<string> {
   static fromString = (model: string): NetworkInterfaceModel =>
     NetworkInterfaceModel.stringMapper[model];
 
-  isDeprecated = () => this.deprecated;
+  isSupported = () => this.supported;
 
   toString() {
     if (this === NetworkInterfaceModel.VIRTIO) {
@@ -48,5 +48,5 @@ export class NetworkInterfaceModel extends ObjectEnum<string> {
 }
 
 type NetworkInterfaceModelConstructorOpts = {
-  isDeprecated?: boolean;
+  isSupported?: boolean;
 };


### PR DESCRIPTION
The correct list of supported models is: e1000e and virtio

Screenshots:
Before:
![Peek 2020-08-31 14-26](https://user-images.githubusercontent.com/2181522/91716298-0afb0200-eb98-11ea-9ddc-e0b47686a1a3.gif)
After:
![Peek 2020-08-31 14-29](https://user-images.githubusercontent.com/2181522/91716300-0c2c2f00-eb98-11ea-99d4-836cf40c2a70.gif)
