### PR TITLE
Bug 1874895: Enabling use of $BRIDGE_E2E_BROWSER_NAME with Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ yarn run test-cypress
 ```
 
 This will launch the Cypress test runner where you can run one or all cypress tests.
+By default, it will look for Chrome in the system and use it, but if you want to use Firefox instead, set `BRIDGE_E2E_BROWSER_NAME` environment variable in your shell with the value `firefox`.
 
 [**_More information on Console's Cypress usage_**](frontend/packages/integration-tests-cypress/README.md)
+
 #### Protractor
 
 Integration tests are run in a headless browser driven by [protractor](http://www.protractortest.org/#/).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "test-gui": "yarn run test-suite --suite all",
     "test-suite": "ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/protractor integration-tests/protractor.conf.ts",
     "test-cypress": "cd packages/integration-tests-cypress && cypress open --env openshift=true",
-    "test-cypress-headless": "cd packages/integration-tests-cypress && node --max-old-space-size=4096 ../../node_modules/.bin/cypress run --env openshift=true --browser chrome --headless",
+    "test-cypress-headless": "cd packages/integration-tests-cypress && node --max-old-space-size=4096 ../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
     "cypress-merge": "mochawesome-merge ./gui_test_screenshots/cypress_report*.json > ./gui_test_screenshots/cypress.json",
     "cypress-generate": "marge -o ./gui_test_screenshots/ -f cypress-report -t 'OpenShift Console Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ./gui_test_screenshots/cypress/assets ./gui_test_screenshots/cypress.json",
     "cypress-postreport": "yarn run cypress-merge && yarn run cypress-generate && rm -f ./gui_test_screenshots/cypress*.json",


### PR DESCRIPTION
Like we did with Protractor, this PR will enable the (re)use of `$BRIDGE_E2E_BROWSER_NAME` with Cypress.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>