### PR TITLE
Bug 1871768: Add supported types to file upload

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
@@ -11,3 +11,6 @@ export const CDI_UPLOAD_POD_NAME_ANNOTATION = 'cdi.kubevirt.io/storage.uploadPod
 export const CDI_BOUND_PVC_ANNOTATION = 'cdi.kubevirt.io/storage.condition.bound';
 export const CDI_UPLOAD_RUNNING = 'Running';
 export const CDI_UPLOAD_OS_URL_PARAM = 'os';
+
+export const CDI_UPLOAD_SUPPORTED_TYPES_URL =
+  'https://docs.openshift.com/container-platform/4.5/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.html#virt-cdi-supported-operations-matrix_virt-importing-virtual-machine-images-datavolumes';

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form-status.tsx
@@ -170,7 +170,7 @@ export type UploadPVCStatusProps = {
   upload: DataUpload;
   isSubmitting: boolean;
   isAllocating: boolean;
-  allocateError: string;
+  allocateError: React.ReactNode;
   onErrorClick: () => void;
   onSuccessClick: () => void;
   onCancelFinish: () => void;
@@ -180,7 +180,7 @@ export type UploadPVCFormStatusProps = {
   upload: DataUpload;
   isSubmitting: boolean;
   isAllocating: boolean;
-  allocateError: string;
+  allocateError: React.ReactNode;
   onErrorClick: () => void;
   onSuccessClick: () => void;
   onCancelFinish: () => void;

--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -36,7 +36,7 @@ const SuccessMessage = ({ message }) => (
 // NOTE: DO NOT use <a> elements within a ButtonBar.
 // They don't support the disabled attribute, and therefore
 // can't be disabled during a pending promise/request.
-/** @type {React.SFC<{children: any, className?: string, errorMessage?: string, infoMessage?: string, successMessage?: string, inProgress?: boolean}}>} */
+/** @type {React.SFC<{children: any, className?: string, errorMessage?: React.ReactNode, infoMessage?: string, successMessage?: string, inProgress?: boolean}}>} */
 export const ButtonBar = ({
   children,
   className,
@@ -59,7 +59,7 @@ export const ButtonBar = ({
 ButtonBar.propTypes = {
   children: PropTypes.node.isRequired,
   successMessage: PropTypes.string,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
   infoMessage: PropTypes.string,
   inProgress: PropTypes.bool,
   className: PropTypes.string,


### PR DESCRIPTION
Now when browsing for a file, you can only pick one of the following files: `.iso,.img,.qcow2,.gz,.xz`
If a user drags an unsupported file to the file input, it will register, but when he submits the form he will see the following screenshot:

<img width="644" alt="Screen Shot 2020-08-31 at 22 56 20" src="https://user-images.githubusercontent.com/24938324/91841593-50343800-ec5b-11ea-9102-9c8e6ead640b.png">
