### PR TITLE
Bug 1873612: Handle empty responses if Content-Length is not specified

### DIFF
--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -144,24 +144,17 @@ export const getImpersonateHeaders = () => {
   }
 };
 
-export const coFetchCommon = (url, method = 'GET', options = {}, timeout) => {
+export const coFetchCommon = async (url, method = 'GET', options = {}, timeout) => {
   const headers = getImpersonateHeaders() || {};
   // Pass headers last to let callers to override Accept.
   const allOptions = _.defaultsDeep({ method }, options, { headers });
-  return coFetch(url, allOptions, timeout).then((response) => {
-    if (!response.ok) {
-      return response.text();
-    }
-
-    // If the response has no body, return promise that resolves with an empty object
-    if (response.headers.get('Content-Length') === '0') {
-      return Promise.resolve(response.headers.get('Content-Type') === 'text/plain' ? '' : {});
-    }
-    if (response.headers.get('Content-Type') === 'text/plain') {
-      return response.text();
-    }
-    return response.json();
-  });
+  const response = await coFetch(url, allOptions, timeout);
+  const text = await response.text();
+  const isPlainText = response.headers.get('Content-Type') === 'text/plain';
+  if (!text) {
+    return isPlainText ? '' : {};
+  }
+  return isPlainText || !response.ok ? text : JSON.parse(text);
 };
 
 export const coFetchJSON = (url, method = 'GET', options = {}, timeout) => {


### PR DESCRIPTION
`Content-Length` is not a required response header. Check if `response.text()` is empty instead of relying on the header.

/assign @dtaylor113 