### PR TITLE
Bug 1875308: Add support for more params and create resources only if required

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -1,8 +1,13 @@
 import * as _ from 'lodash';
 import { k8sCreate } from '@console/internal/module/k8s';
+import { Pipeline } from 'packages/dev-console/src/utils/pipeline-augment';
 import { PipelineModel } from '../../../models';
 import { GitImportFormData } from '../import-types';
 import { createPipelineResource } from '../../pipelines/pipeline-resource/pipelineResource-utils';
+
+const getImageUrl = (name: string, namespace: string) => {
+  return `image-registry.openshift-image-registry.svc:5000/${namespace}/${name}`;
+};
 
 export const createGitResource = (url: string, namespace: string, ref: string = 'master') => {
   const params = { url, revision: ref };
@@ -11,7 +16,7 @@ export const createGitResource = (url: string, namespace: string, ref: string = 
 
 export const createImageResource = (name: string, namespace: string) => {
   const params = {
-    url: `image-registry.openshift-image-registry.svc:5000/${namespace}/${name}`,
+    url: getImageUrl(name, namespace),
   };
 
   return createPipelineResource(params, 'image', namespace);
@@ -24,7 +29,7 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
     git,
     pipeline,
   } = formData;
-  const template = _.cloneDeep(pipeline.template);
+  const template = _.cloneDeep(pipeline.template) as Pipeline;
 
   template.metadata = {
     name: `${name}`,
@@ -32,20 +37,26 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
     labels: { ...template.metadata.labels, 'app.kubernetes.io/instance': name },
   };
 
-  template.spec.params =
-    template.spec.params &&
-    template.spec.params.map((param) => {
-      if (param.name === 'APP_NAME') {
-        param.default = name;
-      }
-      return param;
-    });
+  template.spec.params = template.spec.params?.map((param) => {
+    switch (param.name) {
+      case 'APP_NAME':
+        return { ...param, default: name };
+      case 'GIT_REPO':
+        return { ...param, default: git.url };
+      case 'GIT_REVISION':
+        return { ...param, default: git.ref || 'master' };
+      case 'IMAGE_NAME':
+        return { ...param, default: getImageUrl(name, namespace) };
+      default:
+        return param;
+    }
+  });
 
-  try {
+  if (template.spec.resources?.find((r) => r.type === 'git' && r.name === 'app-source')) {
     await createGitResource(git.url, namespace, git.ref);
+  }
+  if (template.spec.resources?.find((r) => r.type === 'image' && r.name === 'app-image')) {
     await createImageResource(name, namespace);
-  } catch (err) {
-    throw err;
   }
 
   return k8sCreate(PipelineModel, template, { ns: namespace });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4466
https://bugzilla.redhat.com/show_bug.cgi?id=1875308

**Analysis / Root cause**: 
With the new OpenShift Pipeline Operator 1.1 (currently available as preview) the Tasks changes and uses (new) parameters instead of resources to link the Git repository and Image registry.

**Solution Description**: 
* Check if the Pipeline (template) provides more known parameters (GIT_REPO, GIT_REVISION and IMAGE_NAME) and fill the default parameters of the new pipeline.
* Check if the Pipeline (template) defines resources for the Git repository and Image registry. Create new resources only if there are such parameters defined.  

**Screen shots / Gifs for design review**:
**Unchanged behavior with the Pipeline Operator 1.0.x (with this PR):**

Pipeline Details:
![odc-4466-details-v10](https://user-images.githubusercontent.com/139310/92102400-da58d980-edde-11ea-83b7-e94a8f724c81.png)

Pipeline Parameters:
![odc-4466-parameters-v10](https://user-images.githubusercontent.com/139310/92102440-ea70b900-edde-11ea-9e6a-c019ce6149d4.png)

Pipeline Resources:
![odc-4466-resources-v10](https://user-images.githubusercontent.com/139310/92102452-ee044000-edde-11ea-8cb5-5b7511e70615.png)

Start Pipeline Modal:
![odc-4466-startpipeline-v10](https://user-images.githubusercontent.com/139310/92102490-f52b4e00-edde-11ea-871f-defbbb1cc6e1.png)

**Changed behavior with the Pipeline Operator 1.1.x (with this PR):**

Pipeline Details:
![odc-4466-details-v11](https://user-images.githubusercontent.com/139310/92105438-2148ce00-ede3-11ea-8b14-7c2cef436ecb.png)

Pipeline Parameters:
![odc-4466-parameters-v11](https://user-images.githubusercontent.com/139310/92105441-23ab2800-ede3-11ea-8c17-6088ba103f91.png)

Pipeline Resources:
![odc-4466-resources-v11](https://user-images.githubusercontent.com/139310/92105447-26a61880-ede3-11ea-98cc-bfc9cd7951b4.png)

Start Pipeline Modal:
![odc-4466-startpipeline-v11](https://user-images.githubusercontent.com/139310/92105459-286fdc00-ede3-11ea-82d9-b81fccaa3757.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Install the Pipeline Operator 1.0.1 (4.5) or 1.1.1 (preview)
* Create a new Deployment with Pipeline with the Import from Git flow
* Check the generated Pipeline
* You should start it without adding additional parameters on the 1.1 version.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge