### PR TITLE
Bug 1875376: Show helm charts created by operators as a child of the operator

### DIFF
--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -874,9 +874,10 @@ export const createCronJobItems = (
   return cronJobs.map((d) => createCronJobItem(d, resources, utils));
 };
 
-export const getStandaloneJobs = (jobs: JobKind[]) => {
-  return jobs.filter((job) => !job.metadata?.ownerReferences?.length);
-};
+const isStandaloneJob = (job: K8sResourceKind) =>
+  !_.find(job.metadata?.ownerReferences, (owner) => owner.kind === CronJobModel.kind);
+
+export const getStandaloneJobs = (jobs: JobKind[]) => jobs.filter((job) => isStandaloneJob(job));
 
 export const createWorkloadItems = (
   model: K8sKind,
@@ -987,9 +988,9 @@ export const createOverviewItemForType = (
         utils,
       );
     case 'jobs':
-      return resource.metadata?.ownerReferences?.length
-        ? null
-        : getOverviewItemsForResource(resource, resources, isKindMonitorable(JobModel), utils);
+      return isStandaloneJob(resource)
+        ? getOverviewItemsForResource(resource, resources, isKindMonitorable(JobModel), utils)
+        : null;
     case 'pods':
       return createPodItem(resource as PodKind, resources);
     default:

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
@@ -96,8 +96,7 @@ export const ConnectedTopologyDataRenderer: React.FC<TopologyDataRendererProps &
     const workloadResources = dataModelContext.getWorkloadResources(resources);
 
     // Get model from each extension
-    const extensions = dataModelContext.getExtensions();
-    const depicters = Object.keys(extensions).map((key) => extensions[key].dataModelDepicter);
+    const depicters = dataModelContext.dataModelDepicters;
     dataModelContext
       .getExtensionModels(resources)
       .then((extensionsModel) => {
@@ -110,6 +109,7 @@ export const ConnectedTopologyDataRenderer: React.FC<TopologyDataRendererProps &
           trafficData,
           monitoringAlerts,
         );
+        dataModelContext.reconcileModel(fullModel, resources);
         dataModelContext.model = fullModel;
         setModel(fullModel);
       })

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -1,16 +1,6 @@
 import * as k8s from '@console/internal/module/k8s';
-import {
-  createTopologyResourceConnection,
-  getTopologyResourceObject,
-  isHelmReleaseNode,
-} from '../topology-utils';
-import {
-  topologyDataModel,
-  sampleHelmChartDeploymentConfig,
-  sampleDeploymentConfigs,
-  sampleHelmResourcesMap,
-  sampleDeployments,
-} from './topology-test-data';
+import { createTopologyResourceConnection, getTopologyResourceObject } from '../topology-utils';
+import { topologyDataModel, sampleDeployments } from './topology-test-data';
 import { OdcNodeModel } from '../topology-types';
 
 let patchData = null;
@@ -51,11 +41,6 @@ describe('Topology Utils', () => {
 
     expect(patchData[0]).toEqual(expectedPatchData);
     done();
-  });
-
-  it('should return true for nodes created by helm charts', () => {
-    expect(isHelmReleaseNode(sampleDeploymentConfigs.data[0], sampleHelmResourcesMap)).toBe(false);
-    expect(isHelmReleaseNode(sampleHelmChartDeploymentConfig, sampleHelmResourcesMap)).toBe(true);
   });
 
   it('should return topology resource object', () => {

--- a/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
@@ -23,6 +23,7 @@ import {
   DragEvent,
   DragOperationWithType,
 } from '@patternfly/react-topology';
+import { isWorkloadRegroupable } from '../../../utils/application-utils';
 import { createConnection } from './createConnection';
 import { moveNodeToGroup } from './moveNodeToGroup';
 import { graphContextMenu, groupContextMenu } from './nodeContextMenu';
@@ -113,7 +114,7 @@ const nodeDragSourceSpec = (
 > => ({
   item: { type: NODE_DRAG_TYPE },
   operation: (monitor, props) => {
-    return (canEdit || props.canEdit) && allowRegroup
+    return (canEdit || props.canEdit) && allowRegroup && isWorkloadRegroupable(props.element)
       ? {
           [Modifiers.SHIFT]: { type: REGROUP_OPERATION, edit: true },
         }
@@ -123,7 +124,8 @@ const nodeDragSourceSpec = (
   begin: (monitor, props): DragNodeObject => {
     return {
       element: props.element,
-      allowRegroup: (canEdit || props.canEdit) && allowRegroup,
+      allowRegroup:
+        (canEdit || props.canEdit) && allowRegroup && isWorkloadRegroupable(props.element),
     };
   },
   end: async (dropResult, monitor, props) => {

--- a/frontend/packages/dev-console/src/components/topology/components/groups/ResourceKindsInfo.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/ResourceKindsInfo.tsx
@@ -18,6 +18,9 @@ type ResourceKindsInfoProps = {
 const ResourceKindsInfo: React.FC<ResourceKindsInfoProps> = ({ groupResources, emptyValue }) => {
   const resourcesData = {};
   _.forEach(groupResources, (node: OdcNodeModel) => {
+    if (!node) {
+      return;
+    }
     const kind = node.resourceKind || node.resource?.kind;
     resourcesData[kind] = [...(resourcesData[kind] ? resourcesData[kind] : []), node.resource];
   });

--- a/frontend/packages/dev-console/src/components/topology/components/nodeContextMenu.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodeContextMenu.tsx
@@ -8,6 +8,7 @@ import {
   kebabOptionsToMenu,
   isKebabSubMenu,
 } from '@console/internal/components/utils';
+import { isWorkloadRegroupable } from '../../../utils/application-utils';
 import { workloadActions } from '../actions/workloadActions';
 import { groupActions } from '../actions/groupActions';
 import { graphActions } from '../actions/graphActions';
@@ -38,7 +39,9 @@ export const createMenuItems = (actions: KebabMenuOption[]) =>
   );
 
 export const workloadContextMenu = (element: Node) =>
-  createMenuItems(kebabOptionsToMenu(workloadActions(getResource(element))));
+  createMenuItems(
+    kebabOptionsToMenu(workloadActions(getResource(element), isWorkloadRegroupable(element))),
+  );
 
 export const noRegroupWorkloadContextMenu = (element: Node) =>
   createMenuItems(kebabOptionsToMenu(workloadActions(getResource(element), false)));

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/DataModelExtension.tsx
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/DataModelExtension.tsx
@@ -48,6 +48,22 @@ export const DataModelExtension: React.FC<DataModelExtensionProps> = ({ dataMode
           extensionContext.current.dataModelDepicter = () => false;
           dataModelContext.updateExtension(id, extensionContext.current);
         });
+
+      const reconcilerPromise = dataModelFactory.properties.getDataModelReconciler;
+      if (reconcilerPromise) {
+        reconcilerPromise()
+          .then((reconciler) => {
+            extensionContext.current.dataModelReconciler = reconciler;
+            dataModelContext.updateExtension(id, extensionContext.current);
+          })
+          .catch(() => {
+            extensionContext.current.dataModelReconciler = () => {};
+            dataModelContext.updateExtension(id, extensionContext.current);
+          });
+      } else {
+        extensionContext.current.dataModelReconciler = () => {};
+        dataModelContext.updateExtension(id, extensionContext.current);
+      }
     }
   }, [dataModelContext, dataModelFactory.properties, id, priority, resources, workloadKeys]);
 

--- a/frontend/packages/dev-console/src/components/topology/helm/__tests__/helm-data-transformer.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/__tests__/helm-data-transformer.spec.ts
@@ -4,6 +4,7 @@ import { TopologyDataResources, TopologyDisplayFilterType } from '../../topology
 import {
   getHelmGraphModelFromMap,
   getTopologyHelmReleaseGroupItem,
+  isHelmReleaseNode,
 } from '../helm-data-transformer';
 import {
   MockResources,
@@ -119,5 +120,10 @@ describe('HELM data transformer ', () => {
     const newModel = updateModelFromFilters(graphData, filters, ALL_APPLICATIONS_KEY, filterers);
     expect(newModel.nodes.filter((n) => n.type === TYPE_HELM_RELEASE)).toHaveLength(1);
     expect(newModel.nodes.filter((n) => n.type === TYPE_HELM_WORKLOAD)).toHaveLength(1);
+  });
+
+  it('should return true for nodes created by helm charts', () => {
+    expect(isHelmReleaseNode(sampleDeploymentConfigs.data[0], sampleHelmResourcesMap)).toBe(false);
+    expect(isHelmReleaseNode(sampleHelmChartDeploymentConfig, sampleHelmResourcesMap)).toBe(true);
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/list-view/ListElementWrapper.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/ListElementWrapper.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { Node, isNode } from '@patternfly/react-topology';
 import { listViewNodeComponentFactory } from './listViewComponentFactory';
+import { labelForNodeKind } from './list-view-utils';
+import { getResourceKind } from '../topology-utils';
 
 interface ListElementWrapperProps {
   item: Node;
@@ -29,6 +31,9 @@ const ListElementChildren: React.FC<ListElementWrapperProps> = observer(
       {item
         .getChildren()
         .filter(isNode)
+        .sort((a, b) =>
+          labelForNodeKind(getResourceKind(a)).localeCompare(labelForNodeKind(getResourceKind(b))),
+        )
         .map((e) => (
           <ListElementWrapper
             key={e.getId()}

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.scss
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.scss
@@ -3,7 +3,7 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
 .odc-topology-list-view {
-  --odc-topology-list-view-type-icon-size: 24px;
+  --odc-topology-list-view-type-icon-size: 16px;
   --odc-topology-list-view-sidebar-width: 550px;
   --pf-c-data-list__item--m-selectable--OutlineOffset: 0;
   background-color: var(--pf-global--palette--white);
@@ -75,20 +75,23 @@
   &__resource-icon__container {
     display: flex;
     align-items: center;
+    margin-right: var(--pf-global--spacer--sm);
   }
   &__resource-icon {
     margin: 2px 0;
   }
-  &__type-icon {
+  &__type-icon-bg {
     background-color: var(--pf-global--palette--white);
     border: solid 1px var(--pf-global--BorderColor--300);
-    border-radius: calc(var(--odc-topology-list-view-type-icon-size) / 2);
+    border-radius: 12px;
     box-shadow: 2px 2px 3px var(--pf-global--BorderColor--100);
-    font-size: var(--odc-topology-list-view-type-icon-size);
-    max-height: var(--odc-topology-list-view-type-icon-size);
-    max-width: var(--odc-topology-list-view-type-icon-size);
     margin-left: var(--pf-global--spacer--xs);
-    padding: 3px;
+    padding: 0 3px 1px;
+  }
+  &__type-icon {
+    font-size: var(--odc-topology-list-view-type-icon-size);
+    height: var(--odc-topology-list-view-type-icon-size);
+    min-width: var(--odc-topology-list-view-type-icon-size);
   }
   &__application {
     margin-top: var(--pf-global--spacer--sm);

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.scss
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.scss
@@ -85,8 +85,8 @@
     border-radius: calc(var(--odc-topology-list-view-type-icon-size) / 2);
     box-shadow: 2px 2px 3px var(--pf-global--BorderColor--100);
     font-size: var(--odc-topology-list-view-type-icon-size);
-    height: var(--odc-topology-list-view-type-icon-size);
-    width: var(--odc-topology-list-view-type-icon-size);
+    max-height: var(--odc-topology-list-view-type-icon-size);
+    max-width: var(--odc-topology-list-view-type-icon-size);
     margin-left: var(--pf-global--spacer--xs);
     padding: 3px;
   }
@@ -127,8 +127,18 @@
       }
     }
   }
-  .odc-topology-list-view__group-children .odc-topology-list-view__item-row {
-    padding-left: var(--pf-global--spacer--2xl);
+  .odc-topology-list-view__group-children {
+    .odc-topology-list-view__item-row {
+      padding-left: var(--pf-global--spacer--2xl);
+    }
+    .odc-topology-list-view__group-children {
+      .odc-topology-list-view__item-row {
+        padding-left: var(--pf-global--spacer--3xl);
+      }
+      .odc-topology-list-view__group-children .odc-topology-list-view__item-row {
+        padding-left: var(--pf-global--spacer--4xl);
+      }
+    }
   }
 
   // PF Overrides

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
@@ -85,7 +85,6 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
   }
 
   const cells = [];
-  cells.push(badgeCell || <TypedResourceBadgeCell key="type-icon" kind={kind} />);
   cells.push(
     labelCell || (
       <DataListCell
@@ -93,6 +92,7 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
         key="label"
         id={`${item.getId()}_label`}
       >
+        {badgeCell || <TypedResourceBadgeCell key="type-icon" kind={kind} />}
         {item.getLabel()}
         {alertIndicator}
       </DataListCell>

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   TooltipPosition,
 } from '@patternfly/react-core';
-import { isNode, Node, observer } from '@patternfly/react-topology';
+import { Node, observer } from '@patternfly/react-topology';
 import {
   getSeverityAlertType,
   AlertSeverityIcon,
@@ -23,7 +23,6 @@ import { selectOverviewDetailsTab } from '@console/internal/actions/ui';
 
 import { useSearchFilter } from '../filters';
 import { getResourceKind } from '../topology-utils';
-import { labelForNodeKind } from './list-view-utils';
 import {
   AlertsCell,
   GroupResourcesCell,
@@ -63,13 +62,6 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
     return null;
   }
   const kind = getResourceKind(item);
-  const childNodes =
-    item.isGroup() && !item.isCollapsed()
-      ? (item.getChildren().filter((n) => isNode(n)) as Node[])
-      : [];
-  childNodes.sort((a, b) =>
-    labelForNodeKind(getResourceKind(a)).localeCompare(labelForNodeKind(getResourceKind(b))),
-  );
 
   let alertIndicator = null;
   const alerts = getFiringAlerts(item.getData().data?.monitoringAlerts ?? []);
@@ -127,7 +119,7 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
       key={item.getId()}
       id={item.getId()}
       aria-labelledby={`${item.getId()}_label`}
-      isExpanded={childNodes.length > 0}
+      isExpanded={children !== undefined}
     >
       <DataListItemRow className={className}>
         <DataListItemCells dataListCells={cells} />

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/TypedResourceBadgeCell.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/TypedResourceBadgeCell.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { DataListCell } from '@patternfly/react-core';
 import { observer } from '@patternfly/react-topology';
 import { isValidUrl } from '@console/shared';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
@@ -34,20 +33,20 @@ const ObservedTypedResourceBadgeCell: React.FC<TypedResourceBadgeCellProps> = ({
   }
 
   const typeIcon = typeIconClass ? (
-    <img
-      className="odc-topology-list-view__type-icon"
-      alt={kind}
-      src={isValidUrl(typeIconClass) ? typeIconClass : getImageForIconClass(typeIconClass)}
-    />
+    <span className="odc-topology-list-view__type-icon-bg">
+      <img
+        className="odc-topology-list-view__type-icon"
+        alt={kind}
+        src={isValidUrl(typeIconClass) ? typeIconClass : getImageForIconClass(typeIconClass)}
+      />
+    </span>
   ) : null;
 
   return (
-    <DataListCell isIcon className="odc-topology-list-view__resource-icon-cell">
-      <span className="odc-topology-list-view__resource-icon__container">
-        {itemIcon}
-        {typeIcon}
-      </span>
-    </DataListCell>
+    <span className="odc-topology-list-view__resource-icon__container">
+      {itemIcon}
+      {typeIcon}
+    </span>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedResources.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedResources.tsx
@@ -10,7 +10,7 @@ const TopologyOperatorBackedResources: React.FC<TopologyOperatorBackedResourcesP
   item,
 }) => {
   const { groupResources = [] } = item;
-  const finalRes = groupResources.map((val) => val.resource);
+  const finalRes = groupResources.map((val) => val.resource).filter((r) => r !== undefined);
 
   return (
     <div className="overview__sidebar-pane-body">

--- a/frontend/packages/dev-console/src/components/topology/operators/__tests__/operator-data-transformer.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/__tests__/operator-data-transformer.spec.ts
@@ -7,13 +7,14 @@ import {
   TopologyDisplayFilterType,
 } from '../../topology-types';
 import { MockResources, TEST_KINDS_MAP } from '../../__tests__/topology-test-data';
-import { TYPE_OPERATOR_BACKED_SERVICE, TYPE_OPERATOR_WORKLOAD } from '../components/const';
+import { TYPE_OPERATOR_BACKED_SERVICE } from '../components/const';
 import {
   DEFAULT_TOPOLOGY_FILTERS,
   EXPAND_GROUPS_FILTER_ID,
   SHOW_GROUPS_FILTER_ID,
 } from '../../filters/const';
 import {
+  getOperatorGroupResources,
   getOperatorTopologyDataModel,
   getServiceBindingEdges,
 } from '../operators-data-transformer';
@@ -33,14 +34,17 @@ import {
   sbrBackingServiceSelector,
   sbrBackingServiceSelectors,
 } from '../../__tests__/service-binding-test-data';
-import { TYPE_SERVICE_BINDING } from '../../components';
+import { TYPE_SERVICE_BINDING, TYPE_WORKLOAD } from '../../components';
+import { operatorsDataModelReconciler } from '../operatorsDataModelReconciler';
 
 const filterers = [applyOperatorDisplayOptions];
 
 const getTransformedTopologyData = (mockData: TopologyDataResources) => {
   const workloadResources = getWorkloadResources(mockData, TEST_KINDS_MAP, WORKLOAD_TYPES);
   return getOperatorTopologyDataModel('test-project', mockData, workloadResources).then((model) => {
-    return baseDataModelGetter(model, 'test-project', mockData, workloadResources, []);
+    const fullModel = baseDataModelGetter(model, 'test-project', mockData, workloadResources, []);
+    operatorsDataModelReconciler(fullModel, mockData);
+    return fullModel;
   });
 };
 
@@ -137,14 +141,16 @@ describe('operator data transformer ', () => {
     });
     const newModel = updateModelFromFilters(graphData, filters, ALL_APPLICATIONS_KEY, filterers);
     expect(newModel.nodes.filter((n) => n.type === TYPE_OPERATOR_BACKED_SERVICE)).toHaveLength(1);
-    expect(newModel.nodes.filter((n) => n.type === TYPE_OPERATOR_WORKLOAD)).toHaveLength(1);
+    expect(newModel.nodes.filter((n) => n.type === TYPE_WORKLOAD)).toHaveLength(1);
   });
-  it('should support single  binding service selectors', async () => {
-    const topologyTransformedData = await getTransformedTopologyData(mockResources);
-    const deployments = sbrBackingServiceSelector.deployments.data;
-    const sbrs = sbrBackingServiceSelector.serviceBindingRequests.data;
 
-    expect(getServiceBindingEdges(deployments[0], topologyTransformedData.nodes, sbrs)).toEqual([
+  it('should support single  binding service selectors', async () => {
+    const deployments = sbrBackingServiceSelector.deployments.data;
+    const obsGroups = getOperatorGroupResources(mockResources);
+    const sbrs = sbrBackingServiceSelector.serviceBindingRequests.data;
+    const installedOperators = mockResources?.clusterServiceVersions?.data;
+
+    expect(getServiceBindingEdges(deployments[0], obsGroups, sbrs, installedOperators)).toEqual([
       {
         id: `uid-app_3006a8f3-6e2b-4a19-b37e-fbddd9a41f51`,
         type: TYPE_SERVICE_BINDING,
@@ -157,11 +163,12 @@ describe('operator data transformer ', () => {
   });
 
   it('should support multiple binding service selectors', async () => {
-    const topologyTransformedData = await getTransformedTopologyData(mockResources);
     const deployments = sbrBackingServiceSelectors.deployments.data;
+    const obsGroups = getOperatorGroupResources(mockResources);
     const sbrs = sbrBackingServiceSelectors.serviceBindingRequests.data;
+    const installedOperators = mockResources?.clusterServiceVersions?.data;
 
-    expect(getServiceBindingEdges(deployments[0], topologyTransformedData.nodes, sbrs)).toEqual([
+    expect(getServiceBindingEdges(deployments[0], obsGroups, sbrs, installedOperators)).toEqual([
       {
         id: `uid-app_3006a8f3-6e2b-4a19-b37e-fbddd9a41f51`,
         type: TYPE_SERVICE_BINDING,

--- a/frontend/packages/dev-console/src/components/topology/operators/index.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/index.ts
@@ -13,6 +13,11 @@ export const getIsOperatorResource = () =>
     (m) => m.isOperatorResource,
   );
 
+export const getDataModelReconciler = () =>
+  import(
+    './operatorsDataModelReconciler' /* webpackChunkName: "operators-topology-components" */
+  ).then((m) => m.operatorsDataModelReconciler);
+
 export const getTopologyFilters = () =>
   import('./operatorFilters' /* webpackChunkName: "operators-topology-components" */).then(
     (m) => m.getTopologyFilters,

--- a/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { EdgeModel, Model } from '@patternfly/react-topology';
 import {
   K8sResourceKind,
   LabelSelector,
@@ -6,33 +7,11 @@ import {
   referenceFor,
 } from '@console/internal/module/k8s';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager/src';
-import {
-  createOverviewItemForType,
-  getDefaultOperatorIcon,
-  getImageForCSVIcon,
-  getOperatorBackedServiceKindMap,
-} from '@console/shared';
-import { EdgeModel, Model, NodeShape } from '@patternfly/react-topology';
-import { OdcNodeModel, TopologyDataObject, TopologyDataResources } from '../topology-types';
-import {
-  OPERATOR_GROUP_WIDTH,
-  OPERATOR_GROUP_HEIGHT,
-  OPERATOR_GROUP_PADDING,
-  TYPE_OPERATOR_BACKED_SERVICE,
-  TYPE_OPERATOR_WORKLOAD,
-} from './components/const';
-import {
-  addToTopologyDataModel,
-  createTopologyNodeData,
-  getTopologyGroupItems,
-  getTopologyNodeItem,
-  mergeGroup,
-  WorkloadModelProps,
-} from '../data-transforms/transform-utils';
+import { getOperatorBackedServiceKindMap } from '@console/shared';
+import { isOperatorBackedKnResource } from '@console/knative-plugin/src/topology/knative-topology-utils';
 import { WORKLOAD_TYPES } from '../topology-utils';
 import { TYPE_SERVICE_BINDING } from '../components';
-import { isOperatorBackedKnResource } from '@console/knative-plugin/src/topology/knative-topology-utils';
-import { OperatorGroupData } from './operator-topology-types';
+import { TopologyDataResources } from '../topology-types';
 
 export const edgesFromServiceBinding = (
   source: K8sResourceKind,
@@ -65,25 +44,25 @@ export const edgesFromServiceBinding = (
 
 export const getServiceBindingEdges = (
   dc: K8sResourceKind,
-  nodes: OdcNodeModel[],
+  obsGroups: K8sResourceKind[],
   sbrs: K8sResourceKind[],
+  installedOperators: K8sResourceKind[],
 ): EdgeModel[] => {
   const edges = [];
+  if (!sbrs?.length || !installedOperators?.length) {
+    return edges;
+  }
 
   _.forEach(edgesFromServiceBinding(dc, sbrs), (sbr) => {
     // look for multiple backing services first in `backingServiceSelectors`
     // followed by a fallback to the single reference in `backingServiceSelector`
     _.forEach(sbr.spec.backingServiceSelectors || [sbr.spec.backingServiceSelector], (bss) => {
       if (bss) {
-        // handles multiple edges
-        const targetGroup = nodes.find(
-          (node) =>
-            node.type === TYPE_OPERATOR_BACKED_SERVICE &&
-            node.resource?.kind === bss.kind &&
-            node.resource?.metadata.name === bss.resourceRef,
+        const targetGroup = obsGroups.find(
+          (group) => group.kind === bss.kind && group.metadata.name === bss.resourceRef,
         );
-        const source = dc?.metadata?.uid;
-        const target = targetGroup?.id;
+        const target = targetGroup?.metadata.uid;
+        const source = dc.metadata.uid;
         if (source && target) {
           edges.push({
             id: `${source}_${target}`,
@@ -99,17 +78,6 @@ export const getServiceBindingEdges = (
   });
 
   return edges;
-};
-
-const OBSModelProps = {
-  width: OPERATOR_GROUP_WIDTH,
-  height: OPERATOR_GROUP_HEIGHT,
-  visible: true,
-  group: true,
-  shape: NodeShape.rect,
-  style: {
-    padding: OPERATOR_GROUP_PADDING,
-  },
 };
 
 const isOperatorBackedService = (
@@ -133,6 +101,58 @@ const isOperatorBackedService = (
     (!_.isEmpty(operatorResource) || kind in operatorBackedServiceKindMap)
   );
 };
+
+export const getOperatorGroupResource = (
+  resource: K8sResourceKind,
+  resources?: TopologyDataResources,
+): K8sResourceKind => {
+  const installedOperators = resources?.clusterServiceVersions?.data as ClusterServiceVersionKind[];
+  const operatorBackedServiceKindMap = getOperatorBackedServiceKindMap(installedOperators);
+
+  if (isOperatorBackedService(resource, installedOperators, resources)) {
+    const ownerReference = resource?.metadata?.ownerReferences?.[0];
+    const ownerUid = ownerReference?.uid;
+    const nodeResourceKind = ownerReference?.kind;
+    const operatorBackedServiceKind = operatorBackedServiceKindMap?.[nodeResourceKind];
+    const appGroup = resource?.metadata?.labels?.['app.kubernetes.io/part-of'];
+    const operator: K8sResourceKind =
+      (installedOperators.find((op) => op.metadata.uid === ownerUid) as K8sResourceKind) ||
+      operatorBackedServiceKind;
+
+    const operatorName =
+      ownerReference?.name ?? appGroup
+        ? `${appGroup}:${operator.metadata.name}`
+        : operator.metadata.name;
+
+    const groupUid = ownerReference?.uid ?? `${operatorName}:${operator.metadata.uid}`;
+    return _.merge({}, operator, {
+      apiVersion: ownerReference?.apiVersion ?? '',
+      kind: ownerReference?.kind ?? 'Operator',
+      metadata: {
+        name: ownerReference?.name ?? operator.metadata.name,
+        uid: groupUid,
+      },
+    });
+  }
+  return null;
+};
+
+export const getOperatorGroupResources = (resources: TopologyDataResources) => {
+  const obsGroups = [];
+  WORKLOAD_TYPES.forEach((key) => {
+    if (resources[key]?.data && resources[key].data.length) {
+      resources[key].data.forEach((resource) => {
+        const group = getOperatorGroupResource(resource, resources);
+        if (!group) {
+          return;
+        }
+        obsGroups.push(group);
+      });
+    }
+  });
+  return obsGroups;
+};
+
 export const getOperatorTopologyDataModel = (
   namespace: string,
   resources: TopologyDataResources,
@@ -142,120 +162,17 @@ export const getOperatorTopologyDataModel = (
     nodes: [],
     edges: [],
   };
-  const installedOperators = resources?.clusterServiceVersions?.data as ClusterServiceVersionKind[];
-  const operatorBackedServiceKindMap = getOperatorBackedServiceKindMap(installedOperators);
-  const operatorMap = {};
-  const obsGroups = {};
+  const obsGroups = getOperatorGroupResources(resources);
   const serviceBindingRequests = resources?.serviceBindingRequests?.data;
+  const installedOperators = resources?.clusterServiceVersions?.data as ClusterServiceVersionKind[];
 
-  WORKLOAD_TYPES.forEach((key) => {
-    if (resources[key]?.data && resources[key].data.length) {
-      const typedDataModel: Model = { nodes: [], edges: [] };
-
-      resources[key].data.forEach((resource) => {
-        const item = createOverviewItemForType(key, resource, resources);
-        if (item && isOperatorBackedService(resource, installedOperators, resources)) {
-          const ownerReference = resource?.metadata?.ownerReferences?.[0];
-          const ownerUid = ownerReference?.uid;
-          const nodeResourceKind = ownerReference?.kind;
-          const operatorBackedServiceKind = operatorBackedServiceKindMap?.[nodeResourceKind];
-          const appGroup = resource?.metadata?.labels?.['app.kubernetes.io/part-of'];
-          let operator: K8sResourceKind = installedOperators.find(
-            (op) => op.metadata.uid === ownerUid,
-          ) as K8sResourceKind;
-
-          if (!operator) {
-            operator = operatorBackedServiceKind;
-          }
-
-          const csvIcon = operatorBackedServiceKind?.spec?.icon?.[0] || operator?.spec?.icon?.[0];
-
-          const operatorName =
-            ownerReference?.name ?? appGroup
-              ? `${appGroup}:${operator.metadata.name}`
-              : operator.metadata.name;
-          const data = createTopologyNodeData(
-            resource,
-            item,
-            TYPE_OPERATOR_WORKLOAD,
-            getImageForCSVIcon(csvIcon) || getDefaultOperatorIcon(),
-            true,
-          );
-          typedDataModel.nodes.push(
-            getTopologyNodeItem(resource, TYPE_OPERATOR_WORKLOAD, data, WorkloadModelProps),
-          );
-
-          const groupUid = ownerReference?.uid ?? `${operatorName}:${operator.metadata.uid}`;
-          operatorMap[operatorName] = _.merge({}, operator, {
-            apiVersion: ownerReference?.apiVersion ?? '',
-            kind: ownerReference?.kind ?? 'Operator',
-            metadata: {
-              name: ownerReference?.name ?? operator.metadata.name,
-              uid: groupUid,
-            },
-          });
-          if (!(operatorName in obsGroups)) {
-            obsGroups[operatorName] = [];
-          }
-          obsGroups[operatorName].push(resource.metadata.uid);
-
-          if (appGroup) {
-            const newGroup = getTopologyGroupItems(
-              _.merge({}, resource, {
-                metadata: {
-                  uid: groupUid,
-                },
-              }),
-            );
-            mergeGroup(newGroup, typedDataModel.nodes);
-          }
-        }
-      });
-      addToTopologyDataModel(typedDataModel, operatorsDataModel);
-    }
-  });
-
-  _.forIn(obsGroups, (children: string[], grp: string) => {
-    const groupDataModel: Model = { nodes: [], edges: [] };
-    const data: TopologyDataObject<OperatorGroupData> = {
-      id: operatorMap[grp].metadata.uid,
-      name: operatorMap[grp].metadata.name,
-      type: TYPE_OPERATOR_BACKED_SERVICE,
-      resources: {
-        obj: operatorMap[grp],
-        buildConfigs: [],
-        routes: [],
-        services: [],
-        isOperatorBackedService: true,
-      },
-      resource: operatorMap[grp],
-      groupResources: children.map((id) => operatorsDataModel.nodes.find((n) => id === n.id)),
-      data: {
-        operatorKind: operatorMap[grp].kind,
-        builderImage:
-          getImageForCSVIcon(operatorMap?.[grp]?.spec?.icon?.[0]) || getDefaultOperatorIcon(),
-        apiVersion: operatorMap[grp].apiVersion,
-      },
-    };
-    groupDataModel.nodes.push(
-      getTopologyNodeItem(
-        operatorMap[grp],
-        TYPE_OPERATOR_BACKED_SERVICE,
-        data,
-        OBSModelProps,
-        children,
-        'Operator Backed Service',
-      ),
-    );
-
-    addToTopologyDataModel(groupDataModel, operatorsDataModel);
-  });
-
-  workloads.forEach((dc) => {
-    operatorsDataModel.edges.push(
-      ...getServiceBindingEdges(dc, operatorsDataModel.nodes, serviceBindingRequests),
-    );
-  });
+  if (serviceBindingRequests?.length && installedOperators?.length) {
+    workloads.forEach((dc) => {
+      operatorsDataModel.edges.push(
+        ...getServiceBindingEdges(dc, obsGroups, serviceBindingRequests, installedOperators),
+      );
+    });
+  }
 
   return Promise.resolve(operatorsDataModel);
 };

--- a/frontend/packages/dev-console/src/components/topology/operators/operatorsDataModelReconciler.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operatorsDataModelReconciler.ts
@@ -1,0 +1,145 @@
+import { Model, NodeShape } from '@patternfly/react-topology';
+import { getDefaultOperatorIcon, getImageForCSVIcon } from '@console/shared/src';
+import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager/src';
+import { isOperatorBackedKnResource } from '@console/knative-plugin/src/topology/knative-topology-utils';
+import { OdcNodeModel, TopologyDataResources } from '../topology-types';
+import {
+  OPERATOR_GROUP_HEIGHT,
+  OPERATOR_GROUP_PADDING,
+  OPERATOR_GROUP_WIDTH,
+  TYPE_OPERATOR_BACKED_SERVICE,
+} from './components/const';
+import { getTopologyNodeItem } from '../data-transforms';
+import { getOperatorGroupResource } from './operators-data-transformer';
+import { TYPE_APPLICATION_GROUP } from '../components';
+
+const topLevelParent = (node: OdcNodeModel, model: Model): OdcNodeModel => {
+  const parent = model.nodes.find((n) => n.children?.includes(node.id));
+  if (parent) {
+    return topLevelParent(parent, model);
+  }
+  return node;
+};
+
+const topLevelDataParent = (node: OdcNodeModel, model: Model): OdcNodeModel => {
+  const parent = model.nodes
+    .filter((g) => g.type !== TYPE_APPLICATION_GROUP)
+    .find((n) => n.children?.includes(node.id));
+  if (parent) {
+    return topLevelParent(parent, model);
+  }
+  return node;
+};
+
+const OBSModelProps = {
+  width: OPERATOR_GROUP_WIDTH,
+  height: OPERATOR_GROUP_HEIGHT,
+  visible: true,
+  group: true,
+  shape: NodeShape.rect,
+  style: {
+    padding: OPERATOR_GROUP_PADDING,
+  },
+};
+
+export const operatorsDataModelReconciler = (
+  model: Model,
+  resources: TopologyDataResources,
+): void => {
+  if (!model || !model.nodes) {
+    return;
+  }
+  // const groupDataModel: Model = { nodes: [], edges: [] };
+  const installedOperators = resources?.clusterServiceVersions?.data as ClusterServiceVersionKind[];
+  if (!installedOperators?.length) {
+    return;
+  }
+  const defaultIcon = getImageForIconClass(`icon-openshift`);
+
+  installedOperators.forEach((csv) => {
+    const crds = csv?.spec?.customresourcedefinitions?.owned ?? [];
+    const crdKinds = crds.map((crd) => crd.kind);
+    const operatorNodes = model.nodes.filter((node: OdcNodeModel) => {
+      const { resource } = node;
+
+      // Hide operator backed if belong to source
+      if (resources && isOperatorBackedKnResource(resource, resources)) {
+        return false;
+      }
+
+      const owner = resource?.metadata?.ownerReferences?.[0];
+      if (!owner) {
+        return false;
+      }
+
+      const nodeOwnerKind = owner.kind;
+      const nodeOwnerId = owner.uid;
+      return nodeOwnerId === csv.metadata.uid || crdKinds.includes(nodeOwnerKind);
+    });
+
+    if (operatorNodes.length) {
+      // TODO: https://issues.redhat.com/browse/ODC-4730
+      // Here we should be creating different operator groups based on the ownerReference data from
+      // each node, it has the correct UID, kind, and name.
+
+      const baseNode = operatorNodes[0] as OdcNodeModel;
+      const operatorGroupItem = getOperatorGroupResource(baseNode.resource, resources);
+      if (operatorGroupItem) {
+        const data = {
+          id: operatorGroupItem.metadata.uid,
+          name: operatorGroupItem.metadata.name,
+          type: TYPE_OPERATOR_BACKED_SERVICE,
+          resources: {
+            obj: operatorGroupItem,
+            buildConfigs: [],
+            routes: [],
+            services: [],
+            isOperatorBackedService: true,
+          },
+          resource: operatorGroupItem,
+          groupResources: operatorNodes,
+          data: {
+            operatorKind: operatorGroupItem.kind,
+            builderImage:
+              getImageForCSVIcon(operatorGroupItem?.spec?.icon?.[0]) || getDefaultOperatorIcon(),
+            apiVersion: operatorGroupItem.apiVersion,
+          },
+        };
+        const csvIcon = operatorGroupItem?.spec?.icon?.[0] || csv?.spec?.icon?.[0];
+        const operatorIcon = getImageForCSVIcon(csvIcon) || getDefaultOperatorIcon();
+
+        const children = operatorNodes.reduce((acc, node) => {
+          const parent = topLevelParent(node, model);
+          const dataParent = topLevelDataParent(node, model);
+          if (parent.type === TYPE_APPLICATION_GROUP) {
+            parent.children = parent.children.filter((c) => c !== node.id);
+            if (!parent.children.includes(operatorGroupItem.metadata.uid)) {
+              parent.children.push(operatorGroupItem.metadata.uid);
+            }
+          }
+          if (node.data.data.builderImage === defaultIcon) {
+            node.data.data.builderImage = operatorIcon;
+          }
+          if (!acc.includes(dataParent)) {
+            if (!data.groupResources.includes(dataParent)) {
+              data.groupResources.push(dataParent);
+            }
+            acc.push(dataParent.id);
+          }
+          return acc;
+        }, []);
+
+        const obsNode = getTopologyNodeItem(
+          operatorGroupItem,
+          TYPE_OPERATOR_BACKED_SERVICE,
+          data,
+          OBSModelProps,
+          children,
+          'Operator Backed Service',
+        );
+        model.nodes.push(obsNode);
+      }
+    }
+  });
+};

--- a/frontend/packages/dev-console/src/components/topology/operators/operatorsTopologyPlugin.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operatorsTopologyPlugin.ts
@@ -15,6 +15,7 @@ import {
   getIsOperatorResource,
   getOperatorsComponentFactory,
   getOperatorTopologyDataModel,
+  getDataModelReconciler,
   getTopologyFilters,
   applyDisplayOptions,
 } from './index';
@@ -57,6 +58,7 @@ export const operatorsTopologyPlugin: Plugin<OperatorsTopologyConsumedExtensions
       getDataModel: getOperatorTopologyDataModel,
       resources: getOperatorWatchedResources,
       isResourceDepicted: getIsOperatorResource,
+      getDataModelReconciler,
     },
   },
   {

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -48,6 +48,8 @@ export type ViewComponentFactory = (
 
 export type TopologyDataModelDepicted = (resource: K8sResourceKind, model: Model) => boolean;
 
+export type TopologyDataModelReconciler = (model: Model, resources: TopologyDataResources) => void;
+
 export type CreateConnection = (
   source: Node,
   target: Node | Graph,

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -16,7 +16,6 @@ import {
 } from '../../utils/application-utils';
 import { TopologyDataObject } from './topology-types';
 import { TYPE_OPERATOR_BACKED_SERVICE } from './operators/components/const';
-import { HelmReleaseResourcesMap } from '../helm/helm-types';
 import { ALLOW_SERVICE_BINDING } from '../../const';
 import { OdcBaseNode } from './elements';
 
@@ -38,18 +37,6 @@ export const getCheURL = (consoleLinks: K8sResourceKind[]) =>
 
 export const getEditURL = (gitURL: string, cheURL: string) => {
   return gitURL && cheURL ? `${cheURL}/f?url=${gitURL}&policies.create=peruser` : gitURL;
-};
-
-export const getHelmReleaseKey = (resource) => `${resource.kind}---${resource.metadata.name}`;
-
-export const isHelmReleaseNode = (
-  obj: K8sResourceKind,
-  helmResourcesMap: HelmReleaseResourcesMap,
-): boolean => {
-  if (helmResourcesMap) {
-    return helmResourcesMap.hasOwnProperty(getHelmReleaseKey(obj));
-  }
-  return false;
 };
 
 export const getNamespaceDashboardKialiLink = (

--- a/frontend/packages/dev-console/src/extensions/topology.ts
+++ b/frontend/packages/dev-console/src/extensions/topology.ts
@@ -7,6 +7,7 @@ import {
   TopologyDisplayOption,
   CreateConnectionGetter,
   ViewComponentFactory,
+  TopologyDataModelReconciler,
 } from '../components/topology';
 
 namespace ExtensionProperties {
@@ -28,6 +29,8 @@ namespace ExtensionProperties {
     getDataModel: () => Promise<TopologyDataModelGetter>;
     /** Getter for function to determine if a resource is depicted by this model factory */
     isResourceDepicted: () => Promise<TopologyDataModelDepicted>;
+    /** Getter for function to reconcile data model after all extensions' models have loaded */
+    getDataModelReconciler?: () => Promise<TopologyDataModelReconciler>;
   }
 
   export interface TopologyCreateConnector {

--- a/frontend/packages/dev-console/src/utils/application-utils.ts
+++ b/frontend/packages/dev-console/src/utils/application-utils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { isGraph, Node } from '@patternfly/react-topology';
 import {
   K8sKind,
   k8sGet,
@@ -36,6 +37,10 @@ import {
 } from '../components/topology/topology-types';
 import { detectGitType } from '../components/import/import-validation-utils';
 import { createServiceBinding } from '../components/topology/operators/actions/serviceBindings';
+import { TYPE_APPLICATION_GROUP } from '../components/topology/components/const';
+
+export const isWorkloadRegroupable = (node: Node): boolean =>
+  isGraph(node?.getParent()) || node?.getParent().getType() === TYPE_APPLICATION_GROUP;
 
 export const sanitizeApplicationValue = (
   application: string,


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4697

**Description**
Fixes UI crash when adding operators which create helm charts.
Updates the view to show the created helm chart as a child of the operator.
Updates the images in the nodes to reflect the parent type when there is no specified runtime icon.

**Screenshots**
![image](https://user-images.githubusercontent.com/11633780/92488136-25e2fd00-f1bc-11ea-80ca-94b07eeb9dcf.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug

/cc @bgliwa01 @beaumorley @serenamarie125 