### PR TITLE
Bug 1871676: Monitoring: Fix "Not Firing" option in Rules list filter

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1302,10 +1302,12 @@ const AlertsPage_: React.FC<Alerts> = ({ data, loaded, loadError }) => (
 const AlertsPage = withFallback(connect(alertsToProps)(AlertsPage_));
 
 const ruleHasAlertState = (rule: Rule, state: AlertStates): boolean =>
-  _.some(rule.alerts, { state });
+  state === AlertStates.NotFiring ? _.isEmpty(rule.alerts) : _.some(rule.alerts, { state });
 
 const ruleAlertStateFilter = (filter, rule: Rule) =>
-  _.some(rule.alerts, (a) => filter.selected.has(a.state)) || _.isEmpty(filter.selected);
+  (filter.selected.has(AlertStates.NotFiring) && _.isEmpty(rule.alerts)) ||
+  _.some(rule.alerts, (a) => filter.selected.has(a.state)) ||
+  _.isEmpty(filter.selected);
 
 const rulesRowFilters: RowFilter[] = [
   {


### PR DESCRIPTION
PR https://github.com/openshift/console/pull/6460 switched the filter from rule states to alert states, but did not handle the `NotFiring` case correctly.