### PR TITLE
Bug 1875488: Fix sample application form create

### DIFF
--- a/frontend/packages/dev-console/src/components/import/ImportSampleForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportSampleForm.tsx
@@ -22,7 +22,6 @@ const ImportSampleForm: React.FC<Props> = ({
   builderImage,
   status,
   isSubmitting,
-  dirty,
 }) => {
   const {
     image: { tag: selectedImagetag },
@@ -55,7 +54,7 @@ const ImportSampleForm: React.FC<Props> = ({
         errorMessage={status && status.submitError}
         isSubmitting={isSubmitting}
         submitLabel="Create"
-        disableSubmit={!dirty || !_.isEmpty(errors)}
+        disableSubmit={!_.isEmpty(errors)}
         resetLabel="Cancel"
         sticky
       />


### PR DESCRIPTION
Jira - https://issues.redhat.com/browse/ODC-4728

Keep the create button enabled even when the form is not dirty since it is a sample application form and user might not want to change anything at all and straightaway create the application.

**Screenshot:**
![image](https://user-images.githubusercontent.com/20724543/92123889-be732900-ee1a-11ea-9956-eec25efce99c.png)

/kind bug