### PR TITLE
Bug 1875599: trigger groupings in Event Listener details page

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
@@ -1,23 +1,14 @@
 import * as React from 'react';
 import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
-import { TriggerBindingModel, TriggerTemplateModel } from '../../../models';
 import { EventListenerKind } from '../resource-types';
 import EventListenerURL from './EventListenerURL';
-import DynamicResourceLinkList, {
-  ResourceModelLink,
-} from '../resource-overview/DynamicResourceLinkList';
-import {
-  getEventListenerTriggerTemplateNames,
-  getEventListenerTriggerBindingNames,
-} from '../utils/triggers';
+import EventListenerTriggers from './EventListenerTriggers';
 
 export interface EventListenerDetailsProps {
   obj: EventListenerKind;
 }
 
 const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventListener }) => {
-  const templates: ResourceModelLink[] = getEventListenerTriggerTemplateNames(eventListener);
-  const bindings: ResourceModelLink[] = getEventListenerTriggerBindingNames(eventListener);
   return (
     <div className="co-m-pane__body">
       <SectionHeading text="Event Listener Details" />
@@ -30,15 +21,9 @@ const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventL
             eventListener={eventListener}
             namespace={eventListener.metadata.namespace}
           />
-          <DynamicResourceLinkList
-            links={templates}
+          <EventListenerTriggers
             namespace={eventListener.metadata.namespace}
-            title={TriggerTemplateModel.labelPlural}
-          />
-          <DynamicResourceLinkList
-            links={bindings}
-            namespace={eventListener.metadata.namespace}
-            title={TriggerBindingModel.labelPlural}
+            triggers={eventListener.spec.triggers}
           />
         </div>
       </div>

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerTriggers.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerTriggers.scss
@@ -1,0 +1,6 @@
+.odc-event-listener-triggers {
+  &__bindings {
+    margin-left: var(--pf-global--spacer--md);
+    margin-bottom: var(--pf-global--spacer--sm);
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerTriggers.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerTriggers.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { ResourceLink } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { TriggerTemplateModel } from '../../../models';
+import { EventListenerKindTrigger } from '../resource-types';
+import DynamicResourceLinkList, {
+  ResourceModelLink,
+} from '../resource-overview/DynamicResourceLinkList';
+import { getEventListenerTriggerBindingNames } from '../utils/triggers';
+import './EventListenerTriggers.scss';
+
+interface EventListenerTriggersProps {
+  triggers: EventListenerKindTrigger[];
+  namespace: string;
+}
+
+const EventListenerTriggers: React.FC<EventListenerTriggersProps> = ({ namespace, triggers }) => {
+  return (
+    <dl>
+      <dt>Triggers</dt>
+      <dd>
+        {triggers.map((trigger) => {
+          const triggerTemplateKind = referenceForModel(TriggerTemplateModel);
+          const triggerTemplateName = trigger.template.name;
+          const bindings: ResourceModelLink[] = getEventListenerTriggerBindingNames(
+            trigger.bindings,
+          );
+          return (
+            <div key={`${triggerTemplateKind}/${triggerTemplateName}`}>
+              <ResourceLink
+                kind={triggerTemplateKind}
+                name={triggerTemplateName}
+                displayName={triggerTemplateName}
+                namespace={namespace}
+                title={triggerTemplateName}
+                inline
+              />
+              {!_.isEmpty(bindings) && (
+                <div className="odc-event-listener-triggers__bindings">
+                  <DynamicResourceLinkList
+                    links={bindings}
+                    namespace={namespace}
+                    removeSpaceBelow
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </dd>
+    </dl>
+  );
+};
+
+export default EventListenerTriggers;

--- a/frontend/packages/dev-console/src/components/pipelines/resource-overview/DynamicResourceLinkList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-overview/DynamicResourceLinkList.scss
@@ -1,3 +1,5 @@
 .odc-dynamic-resource-link-list {
-  margin-bottom: var(--pf-global--spacer--lg);
+  &--addSpaceBelow {
+    margin-bottom: var(--pf-global--spacer--lg);
+  }
 }

--- a/frontend/packages/dev-console/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { ResourceLink } from '@console/internal/components/utils';
 import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
 
@@ -13,21 +14,27 @@ export type ResourceModelLink = {
 type DynamicResourceLinkListProps = {
   links: ResourceModelLink[];
   namespace: string;
-  title: string;
+  title?: string;
+  removeSpaceBelow?: boolean;
 };
 
 const DynamicResourceLinkList: React.FC<DynamicResourceLinkListProps> = ({
   links = [],
   namespace,
   title,
+  removeSpaceBelow,
 }) => {
   if (links.length === 0) {
     return null;
   }
   return (
-    <div className="odc-dynamic-resource-link-list">
+    <div
+      className={classNames('odc-dynamic-resource-link-list', {
+        'odc-dynamic-resource-link-list--addSpaceBelow': !removeSpaceBelow,
+      })}
+    >
       <dl>
-        <dt>{title}</dt>
+        {title && <dt>{title}</dt>}
         <dd>
           {links.map(({ name, model, displayName = '' }) => {
             const kind = referenceForModel(model);

--- a/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
@@ -19,6 +19,7 @@ import {
   EventListenerKindTrigger,
   TriggerBindingKind,
   TriggerTemplateKind,
+  EventListenerKindBindingReference,
 } from '../resource-types';
 import { ResourceModelLink } from '../resource-overview/DynamicResourceLinkList';
 
@@ -162,28 +163,13 @@ export const useEventListenerURL = (
   return routeLoaded && route?.status?.ingress ? getRouteWebURL(route) : null;
 };
 
-export const getEventListenerTriggerTemplateNames = (
-  eventListener: EventListenerKind,
-): ResourceModelLink[] =>
-  eventListener.spec.triggers.map((trigger) => ({
-    model: TriggerTemplateModel,
-    name: trigger.template.name,
-  }));
-
 export const getEventListenerTriggerBindingNames = (
-  eventListener: EventListenerKind,
-): ResourceModelLink[] => {
-  return eventListener.spec.triggers.reduce(
-    (acc, trigger) => [
-      ...acc,
-      ...trigger.bindings.map((binding) => ({
-        model: getResourceModelFromBindingKind(binding.kind),
-        name: binding.name,
-      })),
-    ],
-    [] as ResourceModelLink[],
-  );
-};
+  bindings: EventListenerKindBindingReference[],
+): ResourceModelLink[] =>
+  bindings?.map((binding) => ({
+    model: getResourceModelFromBindingKind(binding.kind),
+    name: binding.name,
+  }));
 
 export const getTriggerTemplatePipelineName = (triggerTemplate: TriggerTemplateKind): string => {
   return (


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-3710

**Root Analysis:**
In the EventListener spec there is a property called "triggers" which can have 1 to n TriggerBindings and a single TriggerTemplate associated to it. Currently we do not have a good way to represent this. We flatten the content today, and it's a bit misleading.

**Solution Description:**
Nested the associated Trigger Bindings under Trigger Templates

**Screenshot:**
![TB](https://user-images.githubusercontent.com/22490998/92124780-d5664b00-ee1b-11ea-9dcb-e791b4aa8499.png)
