### PR TITLE
Bug 1875397: Update wording in quick start panel

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartIntroduction.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartIntroduction.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { pluralize } from '@patternfly/react-core';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 import { QuickStartTask, QuickStartTaskStatus } from '../utils/quick-start-types';
 import TaskHeader from './QuickStartTaskHeader';
@@ -19,7 +20,7 @@ const QuickStartIntroduction: React.FC<QuickStartIntroductionProps> = ({
   <>
     <SyncMarkdownView content={introduction} />
     <p style={{ marginBottom: 'var(--pf-global--spacer--md)' }}>
-      In this tour, you will complete {tasks.length} tasks:
+      In this quick start, you will complete {pluralize(tasks.length, 'task')}:
     </p>
     {tasks.map((task, index) => (
       <TaskHeader

--- a/frontend/packages/console-app/src/components/quick-starts/data/explore-pipeline-quickstart.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/data/explore-pipeline-quickstart.ts
@@ -14,7 +14,7 @@ export const explorePipelinesQuickStart = {
     description:
       'Install the OpenShift® Pipelines Operator to start building pipelines using Tekton',
     prerequisites: 'User must have access to install operators to run this Quick Start.',
-    introduction: `### In this tour, you will complete 3 tasks:
+    introduction: `### In this quick start, you will complete 3 tasks:
 1. Create an application from git.
 2. Explore your application in topology.
 3. Explore your pipeline run.`,

--- a/frontend/packages/console-app/src/components/quick-starts/data/explore-serverless-quickstart.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/data/explore-serverless-quickstart.ts
@@ -18,7 +18,7 @@ export const exploreServerlessQuickStart = {
 
 Serverless reduces the needs to manage infrastructure or perform back-end development. Application scaling is automated. Choosing Serverless means simplicity, portability, and efficiency.
 
-Adding Serverless to your OpenShift cluster is quick and easy. This guided tour walks you through the process in just a few minutes.`,
+Adding Serverless to your OpenShift cluster is quick and easy. This quick start walks you through the process in just a few minutes.`,
     tasks: [
       {
         title: `Install Serverless Operator`,
@@ -71,7 +71,7 @@ Adding Serverless to your OpenShift cluster is quick and easy. This guided tour 
       },
     ],
     conclusion:
-      'Your Serverless Operator is ready! If you want to learn how to deploy a serverless application, take the Serverless Application tour.',
+      'Your Serverless Operator is ready! If you want to learn how to deploy a serverless application, take the Serverless Application quick start.',
     nextQuickStart: 'serverless-application',
   },
 };

--- a/frontend/packages/console-app/src/components/quick-starts/data/install-associate-pipeline-quickstart.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/data/install-associate-pipeline-quickstart.ts
@@ -14,7 +14,7 @@ export const installAssociatePipelineQuickStart = {
     description:
       'Install an application, associate a pipeline, start the pipeline and explore the pipeline run',
     prerequisites: 'OpenShift® Pipelines Operator must be installed',
-    introduction: `### In this tour you will complete 3 tasks:
+    introduction: `### In this quick start you will complete 3 tasks:
 1. Create an application from Git.
 2. Explore your application
 3. Explore your Pipeline Run`,

--- a/frontend/packages/console-app/src/components/quick-starts/data/serverless-application-quickstart.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/data/serverless-application-quickstart.ts
@@ -24,9 +24,9 @@ Serverless gives you access to a rich ecosystem of built-in and third-party even
 **Iteration**
 Deploying new versions of apps is simple with Serverless. Perform canary, A/B, and blue-green testing with confidence. By using app revisions, you can roll things back, or split traffic between revisions, as needed.
 
-This guided tour shows you how to create a Serverless app that realizes these benefits.
+This quick start shows you how to create a Serverless app that realizes these benefits.
 
-In this tour, you perform five tasks:
+In this quick start, you perform five tasks:
 1. Create a Serverless application
 2. Demo scalability
 3. Wire an event source to your Knative Service


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4642
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
- Text in quick start panel should show "quick start" instead of "tour".
- Text showing number of tasks should be singular when there is only one task.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Replace "tour" with "quick start".
- Pluralize text showing number of tasks.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp0](https://user-images.githubusercontent.com/20013884/92124876-ee6efc00-ee1b-11ea-8df0-ea013ca53354.png)
-
![tmp1](https://user-images.githubusercontent.com/20013884/92124886-f333b000-ee1b-11ea-9e55-5622960ad085.png)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
