### PR TITLE
Bug 1875440: Make pipeline task parameter editable (if it was only defined in the pipeline, not in the task)

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/update-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/update-utils.spec.ts
@@ -1,0 +1,84 @@
+import { PipelineTask } from '../../../../utils/pipeline-augment';
+import { applyParamsUpdate } from '../update-utils';
+import { UpdateTaskParamData } from '../types';
+
+describe('applyParamsUpdate', () => {
+  it('change an existing task param', () => {
+    const inputTask: PipelineTask = {
+      name: 'pipeline-task',
+      taskRef: {
+        name: 'task',
+      },
+      params: [
+        { name: 'EXISTING_TASK_PARAM', value: 'old value' },
+        { name: 'ANOTHER_EXISTING_TASK_PARAM', value: 'ignored value' },
+      ],
+    };
+    const params: UpdateTaskParamData = {
+      newValue: 'new value',
+      taskParamName: 'EXISTING_TASK_PARAM',
+    };
+    const updatedTask = applyParamsUpdate(inputTask, params);
+    expect(updatedTask).not.toBe(inputTask);
+    expect(updatedTask.params).not.toBe(inputTask.params);
+    expect(updatedTask).toEqual({
+      name: 'pipeline-task',
+      taskRef: {
+        name: 'task',
+      },
+      params: [
+        { name: 'EXISTING_TASK_PARAM', value: 'new value' },
+        { name: 'ANOTHER_EXISTING_TASK_PARAM', value: 'ignored value' },
+      ],
+    });
+  });
+
+  it('change a non-existing task param', () => {
+    const inputTask: PipelineTask = {
+      name: 'pipeline-task',
+      taskRef: {
+        name: 'task',
+      },
+      params: [{ name: 'ANOTHER_EXISTING_TASK_PARAM', value: 'ignored value' }],
+    };
+    const params: UpdateTaskParamData = {
+      newValue: 'new value',
+      taskParamName: 'NEW_TASK_PARAM',
+    };
+    const updatedTask = applyParamsUpdate(inputTask, params);
+    expect(updatedTask).not.toBe(inputTask);
+    expect(updatedTask.params).not.toBe(inputTask.params);
+    expect(updatedTask).toEqual({
+      name: 'pipeline-task',
+      taskRef: {
+        name: 'task',
+      },
+      params: [
+        { name: 'ANOTHER_EXISTING_TASK_PARAM', value: 'ignored value' },
+        { name: 'NEW_TASK_PARAM', value: 'new value' },
+      ],
+    });
+  });
+
+  it('change a non-existing task param in a task without any param', () => {
+    const inputTask: PipelineTask = {
+      name: 'pipeline-task',
+      taskRef: {
+        name: 'task',
+      },
+    };
+    const params: UpdateTaskParamData = {
+      newValue: 'new value',
+      taskParamName: 'NEW_TASK_PARAM',
+    };
+    const updatedTask = applyParamsUpdate(inputTask, params);
+    expect(updatedTask).not.toBe(inputTask);
+    expect(updatedTask).toEqual({
+      name: 'pipeline-task',
+      taskRef: {
+        name: 'task',
+      },
+      params: [{ name: 'NEW_TASK_PARAM', value: 'new value' }],
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { getRandomChars } from '@console/shared/src/utils';
+import { getRandomChars } from '@console/shared';
 import {
   PipelineResourceTask,
   PipelineTask,
@@ -306,26 +306,37 @@ const applyResourceUpdate = (
   };
 };
 
-const applyParamsUpdate = (
+export const applyParamsUpdate = (
   pipelineTask: PipelineTask,
   params: UpdateTaskParamData,
 ): PipelineTask => {
   const { newValue, taskParamName } = params;
 
-  return {
-    ...pipelineTask,
-    params: pipelineTask.params.map(
+  let foundParam = false;
+  const changedParams =
+    pipelineTask.params?.map(
       (param): PipelineTaskParam => {
         if (param.name !== taskParamName) {
           return param;
         }
-
+        foundParam = true;
         return {
           ...param,
           value: newValue,
         };
       },
-    ),
+    ) || [];
+
+  if (!foundParam) {
+    changedParams.push({
+      name: taskParamName,
+      value: newValue,
+    });
+  }
+
+  return {
+    ...pipelineTask,
+    params: changedParams,
   };
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4414
https://bugzilla.redhat.com/show_bug.cgi?id=1875440

**Analysis / Root cause**: 
When editing a generated pipeline PATH_CONTEXT is not editable. Root cause is that the task param is not editable if it was only defined in the pipeline params section and not in the tasks params section.

**Solution Description**: 
Extend the method which updates the Pipeline -> selected task -> params section that it automatically adds a param if the param does not exist yet.

**Screen shots / Gifs for design review**: 
![odc-4414 webm](https://user-images.githubusercontent.com/139310/92128190-73e5b280-ee02-11ea-9031-c0f7c3c60507.gif)

**Unit test coverage report**: 
Add some tests, will not change the coverage

**Test setup:**
1. Install the OpenShift Pipelines Operator
2. Import a Java app via import Git flow and check "add pipeline"
3. Go to pipeline and edit pipeline to open it up in the pipeline builder
4. Click on the "build" task
5. Edit the PATH_CONTEXT param

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge