### PR TITLE
Bug 1872926: Remove overriding of generic CSS from LSO plugin

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.scss
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.scss
@@ -2,7 +2,9 @@
   padding-bottom: var(--pf-global--spacer--sm);
 }
 
-// required to hide the space between radio button and node list
-.co-m-nav-title {
-  margin-top: 0;
+.ceph-ocs-install__form-wrapper {
+  // required to hide the space between radio button and node list
+  .co-m-nav-title {
+    margin-top: 0;
+  }
 }

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
@@ -37,8 +37,3 @@
 .lso-create-lvs__disk-size-form-group-max-input {
   max-width: 100px;
 }
-
-// required to hide the space between radio button and node list
-.co-m-nav-title {
-  margin-top: 0;
-}


### PR DESCRIPTION
Before: 
![Screenshot from 2020-09-04 11-41-28](https://user-images.githubusercontent.com/54092533/92205575-9da2e600-eea3-11ea-84a0-cdfae3122563.png)
After:
![Screenshot from 2020-09-04 11-41-06](https://user-images.githubusercontent.com/54092533/92205580-a1366d00-eea3-11ea-98b3-906aa50bb07a.png)
