### PR TITLE
Bug 1875702: Add test to check network supported models

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/vm.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/vm.ts
@@ -50,11 +50,7 @@ export enum VM_STATUS {
 // Network
 export enum NIC_MODEL {
   VirtIO = 'VirtIO',
-  e1000 = 'e1000',
   e1000e = 'e1000e',
-  net2kPCI = 'net2kPCI',
-  pcnet = 'pcnet',
-  rtl8139 = 'rtl8139',
 }
 
 export enum NIC_TYPE {


### PR DESCRIPTION
Add test to check network supported models are virtio and e1000e.
Add test to check model is disabled when sriov is selected.

Implementation for:
https://polarion.engineering.redhat.com/polarion/#/project/CNV/workitem?id=CNV-4780
https://polarion.engineering.redhat.com/polarion/#/project/CNV/workitem?id=CNV-4781