### PR TITLE
Bug 1875878: Move pipelinerun log scroll handler to parent element

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/logs/MultiStreamLogs.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/logs/MultiStreamLogs.tsx
@@ -136,12 +136,12 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
           </span>
         )}
       </div>
-      <div className="odc-multi-stream-logs__container" data-test-id="logs-task-container">
-        <div
-          className="odc-multi-stream-logs__container__logs"
-          ref={scrollPane}
-          onScroll={handleScrollCallback}
-        >
+      <div
+        className="odc-multi-stream-logs__container"
+        onScroll={handleScrollCallback}
+        data-test-id="logs-task-container"
+      >
+        <div className="odc-multi-stream-logs__container__logs" ref={scrollPane}>
           {containers.map((container, idx) => {
             const resourceStatus = containerToLogSourceStatus(containerStatus[idx]);
             return (


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4517
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The scroll event listener was attached to a div that did not have the `overflow-y` property, hence no events were being fired.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Move the event listener to it's parent element, which had the `overflow-y` property set to `scroll`. It is likely that a CSS change introduced this bug.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![rec](https://user-images.githubusercontent.com/20013884/92257126-52fc8a80-eef2-11ea-9546-830ae0d3c427.gif)
@openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
