### PR TITLE
Bug 1867034: Updated cluster dashboard queries

### DIFF
--- a/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
@@ -44,9 +44,9 @@ const top25Queries = {
   [OverviewQuery.NODES_BY_MEMORY]:
     'topk(25, sort_desc(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes))',
   [OverviewQuery.NODES_BY_STORAGE]:
-    'topk(25, sort_desc(avg_over_time(instance:node_filesystem_usage:sum[5m])))',
+    'topk(25, sort_desc(avg_over_time(sum(node_filesystem_size_bytes{instance="<%= node %>",fstype!="tmpfs",mountpoint!="/boot|/boot/efi"}[5m] - node_filesystem_avail_bytes{instance="<%= node %>",fstype!="tmpfs",mountpoint!="/boot|/boot/efi"}[5m]))))',
   [OverviewQuery.NODES_BY_PODS]:
-    'topk(25, sort_desc(sum(avg_over_time(kube_pod_info[5m])) BY (node)))',
+    'topk(25, sort_desc(sum(avg_over_time(kubelet_running_pods{instance=~"<%= ipAddress %>:.*"}[5m])) BY (node)))',
   [OverviewQuery.NODES_BY_NETWORK_IN]:
     'topk(25, sort_desc(sum(instance:node_network_receive_bytes_excluding_lo:rate1m) BY (instance)))',
   [OverviewQuery.NODES_BY_NETWORK_OUT]:


### PR DESCRIPTION
Updated cluster dashboard queries to reflect updated name and more correct query.

I never heard back from the nodes team, but I incorporated feedback from the monitoring folks.

Fixes QA request in https://bugzilla.redhat.com/show_bug.cgi?id=1867034.