### PR TITLE
Bug 1876442: fixes custom query selection should not show any query

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
@@ -53,11 +53,9 @@ const MetricsQueryInput: React.FC<MetricsQueryInputProps> = ({ query }) => {
   React.useEffect(() => {
     const runQueries = () => dispatch(queryBrowserRunQueries());
     const patchQuery = (v: QueryObj) => dispatch(queryBrowserPatchQuery(0, v));
-    if (metric) {
-      const queryMetrics = getTopMetricsQueries(namespace)[metric];
-      patchQuery({ text: queryMetrics || '' });
-      runQueries();
-    }
+    const queryMetrics = metric && getTopMetricsQueries(namespace)[metric];
+    patchQuery({ text: queryMetrics || '' });
+    runQueries();
   }, [dispatch, metric, namespace, changeKey]);
 
   React.useEffect(() => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4738

**Analysis / Root cause**: 
On selection of customQuery Query editor used to persist last entered query

**Solution Description**: 
On change on Query metric to Custom Query as well updated query editor with empty value

**Screen shots / Gifs for design review**: 
![Sep-07-2020 14-16-09](https://user-images.githubusercontent.com/5129024/92368005-c382f180-f114-11ea-8f4d-0fbe43973159.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
