### PR TITLE
Bug 1876511: fixes issue with validation on pubsub modal

### DIFF
--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
@@ -27,26 +27,29 @@ const PubSubModal: React.FC<Props> = ({
   cancel,
   isSubmitting,
   status,
-  dirty,
   errors,
-}) => (
-  <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
-    <ModalTitle>{labelTitle}</ModalTitle>
-    <ModalBody>
-      <FormSection fullWidth>
-        <InputField type={TextInputTypes.text} name="metadata.name" label="Name" required />
-        <PubSubSubscriber />
-        {filterEnabled && <PubSubFilter />}
-      </FormSection>
-    </ModalBody>
-    <ModalSubmitFooter
-      inProgress={isSubmitting}
-      submitText="Add"
-      submitDisabled={!dirty || !_.isEmpty(errors)}
-      cancel={cancel}
-      errorMessage={status.error}
-    />
-  </form>
-);
+  values,
+}) => {
+  const dirty = values?.metadata?.name && values?.spec?.subscriber?.ref?.name;
+  return (
+    <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
+      <ModalTitle>{labelTitle}</ModalTitle>
+      <ModalBody>
+        <FormSection fullWidth>
+          <InputField type={TextInputTypes.text} name="metadata.name" label="Name" required />
+          <PubSubSubscriber />
+          {filterEnabled && <PubSubFilter />}
+        </FormSection>
+      </ModalBody>
+      <ModalSubmitFooter
+        inProgress={isSubmitting}
+        submitText="Add"
+        submitDisabled={!dirty || !_.isEmpty(errors)}
+        cancel={cancel}
+        errorMessage={status.error}
+      />
+    </form>
+  );
+};
 
 export default PubSubModal;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4760

**Analysis / Root cause**: 
Subscription and trigger form Add button is disabled on opening the form if dropped on KSVC from channel/broker. Since required field is pre-populated the Add button should not be disabled as the user might not want to change anything and straightaway create the resource.

**Solution Description**: 
if name and subscriber name are there set dirty to true

**Screen shots / Gifs for design review**: 
![Sep-07-2020 17-03-15](https://user-images.githubusercontent.com/5129024/92383521-1c11b900-f12c-11ea-8663-13f334406eb8.gif)




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
