### PR TITLE
Bug 1876778: fixes issue with metrics not showing graph via topology

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
@@ -7,7 +7,12 @@ import { useSelector, useDispatch } from 'react-redux';
 import * as fuzzy from 'fuzzysearch';
 import { RootState } from '@console/internal/redux';
 import { Button } from '@patternfly/react-core';
-import { Dropdown, removeQueryArgument, useSafeFetch } from '@console/internal/components/utils';
+import {
+  Dropdown,
+  removeQueryArgument,
+  useSafeFetch,
+  getURLSearchParams,
+} from '@console/internal/components/utils';
 import {
   queryBrowserRunQueries,
   queryBrowserPatchQuery,
@@ -24,11 +29,9 @@ import './MetricsQueryInput.scss';
 const ADD_NEW_QUERY = '#ADD_NEW_QUERY#';
 const CUSTOM_QUERY = 'Custom Query';
 
-type MetricsQueryInputProps = {
-  query?: string;
-};
-
-const MetricsQueryInput: React.FC<MetricsQueryInputProps> = ({ query }) => {
+const MetricsQueryInput: React.FC = () => {
+  const params = getURLSearchParams();
+  const query = params.query0;
   const items = metricsQuery;
   const autocompleteFilter = (strText, item) => fuzzy(strText, item);
   const defaultActionItem = [
@@ -54,9 +57,9 @@ const MetricsQueryInput: React.FC<MetricsQueryInputProps> = ({ query }) => {
     const runQueries = () => dispatch(queryBrowserRunQueries());
     const patchQuery = (v: QueryObj) => dispatch(queryBrowserPatchQuery(0, v));
     const queryMetrics = metric && getTopMetricsQueries(namespace)[metric];
-    patchQuery({ text: queryMetrics || '' });
+    patchQuery({ text: queryMetrics || query || '' });
     runQueries();
-  }, [dispatch, metric, namespace, changeKey]);
+  }, [dispatch, metric, query, namespace, changeKey]);
 
   React.useEffect(() => {
     const q = queries?.query;

--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MonitoringMetrics.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MonitoringMetrics.tsx
@@ -1,47 +1,22 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import MetricsQueryInput from './MetricsQueryInput';
-import { connect } from 'react-redux';
-import { getURLSearchParams } from '@console/internal/components/utils';
-import { queryBrowserRunQueries, queryBrowserPatchQuery } from '@console/internal/actions/ui';
-import { QueryObj } from '@console/internal/components/monitoring/query-browser';
 import ConnectedMetricsChart from './MetricsChart';
 
-type MonitoringMetricsProps = {
-  patchQuery?: (patch: QueryObj) => void;
-  runQueries?: () => never;
-};
-
-export const MonitoringMetrics: React.FC<MonitoringMetricsProps> = ({ patchQuery, runQueries }) => {
-  const params = getURLSearchParams();
-  const query = params.query0;
-  React.useEffect(() => {
-    if (query) {
-      patchQuery({ text: query });
-      runQueries();
-    }
-  }, [query, patchQuery, runQueries]);
-
-  return (
-    <>
-      <Helmet>
-        <title>Metrics</title>
-      </Helmet>
-      <div className="co-m-pane__body">
-        <MetricsQueryInput query={query} />
-        <div className="row">
-          <div className="col-xs-12">
-            <ConnectedMetricsChart />
-          </div>
+export const MonitoringMetrics: React.FC = () => (
+  <>
+    <Helmet>
+      <title>Metrics</title>
+    </Helmet>
+    <div className="co-m-pane__body">
+      <MetricsQueryInput />
+      <div className="row">
+        <div className="col-xs-12">
+          <ConnectedMetricsChart />
         </div>
       </div>
-    </>
-  );
-};
+    </div>
+  </>
+);
 
-const mapDispatchToProps = (dispatch) => ({
-  runQueries: () => dispatch(queryBrowserRunQueries()),
-  patchQuery: (v: QueryObj) => dispatch(queryBrowserPatchQuery(0, v)),
-});
-
-export default connect(null, mapDispatchToProps)(MonitoringMetrics);
+export default MonitoringMetrics;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4765

**Analysis / Root cause**: 
When the user clicks on the workload monitoring graph on the side panel of the topology it is redirected to the Monitoring Metrics page but the graph does not get rendered.

**Solution Description**: 
Added query as well id `useEffect` to patch if exists


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
