### PR TITLE
Bug 1876741: undo filtering of incompatible helm charts

### DIFF
--- a/frontend/__mocks__/catalogItemsMocks.ts
+++ b/frontend/__mocks__/catalogItemsMocks.ts
@@ -1,6 +1,5 @@
 export const catalogListPageProps = {
   namespace: 'default',
-  kubernetesVersion: 'v1.18.0+ui896hui',
   helmCharts: {
     data: [
       {

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
@@ -138,7 +138,6 @@ export const mockHelmChartData: HelmChartMetaData[] = [
     version: '1.0.3',
   },
   {
-    appVersion: '3.12',
     apiVersion: 'v1',
     description: 'abc',
     name: 'hazelcast-enterprise',
@@ -146,7 +145,6 @@ export const mockHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.2.tgz',
     ],
     version: '1.0.2',
-    kubeVersion: '>=1.10.0',
   },
   {
     appVersion: '3.10.5',
@@ -157,27 +155,6 @@ export const mockHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.1.tgz',
     ],
     version: '1.0.1',
-    kubeVersion: '>=1.11.0',
-  },
-];
-
-export const mockHelmChartData2: HelmChartMetaData[] = [
-  {
-    appVersion: '3.12',
-    apiVersion: 'v1',
-    name: 'hazelcast-enterprise',
-    urls: [
-      'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.3.tgz',
-    ],
-    version: '1.0.3',
-  },
-  {
-    apiVersion: 'v1',
-    name: 'hazelcast-enterprise',
-    urls: [
-      'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.2.tgz',
-    ],
-    version: '1.0.2',
   },
 ];
 

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import {
   OtherReleaseStatuses,
   releaseStatusReducer,
@@ -13,7 +12,6 @@ import { HelmReleaseStatus } from '../helm-types';
 import {
   mockHelmReleases,
   mockHelmChartData,
-  mockHelmChartData2,
   mockReleaseResources,
   flattenedMockReleaseResources,
 } from './helm-release-mock-data';
@@ -58,17 +56,9 @@ describe('Helm Releases Utils', () => {
   });
 
   it('should return the chart versions, concatenated with the App Version, available for the helm chart', () => {
-    const chartVersions = getChartVersions(mockHelmChartData, 'v1.18.2+ui678hjj');
+    const chartVersions = getChartVersions(mockHelmChartData);
     expect(chartVersions).toEqual({
       '1.0.1': '1.0.1 / App Version 3.10.5',
-      '1.0.2': '1.0.2 / App Version 3.12',
-      '1.0.3': '1.0.3 / App Version 3.12',
-    });
-  });
-
-  it('should concatenate App Version with the Chart Version only when it is available', () => {
-    const chartVersions = getChartVersions(mockHelmChartData2, 'v1.18.2');
-    expect(chartVersions).toEqual({
       '1.0.2': '1.0.2',
       '1.0.3': '1.0.3 / App Version 3.12',
     });
@@ -76,48 +66,6 @@ describe('Helm Releases Utils', () => {
 
   it('should omit resources with no data and flatten them', () => {
     expect(flattenReleaseResources(mockReleaseResources)).toEqual(flattenedMockReleaseResources);
-  });
-
-  it('should filter the chart versions which are incompatible with the kubernetes version', () => {
-    let kubernetesVersion = 'v1.18.0';
-    mockHelmChartData[2].kubeVersion = '>=1.25.0';
-    let chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
-    const expectedChartVersions = {
-      '1.0.1': '1.0.1 / App Version 3.10.5',
-      '1.0.2': '1.0.2 / App Version 3.12',
-      '1.0.3': '1.0.3 / App Version 3.12',
-    };
-    expect(chartVersions).toEqual(_.omit(expectedChartVersions, '1.0.1'));
-
-    kubernetesVersion = '-';
-    chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
-    expect(chartVersions).toEqual(expectedChartVersions);
-
-    kubernetesVersion = 'unknown';
-    chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
-    expect(chartVersions).toEqual(expectedChartVersions);
-
-    kubernetesVersion = 'v1.18.3+e1ba7b6';
-    chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
-    expect(chartVersions).toEqual(_.omit(expectedChartVersions, '1.0.1'));
-
-    kubernetesVersion = 'v1.20.3-alpha.1';
-    mockHelmChartData[2].kubeVersion = '>=1.20.3-0';
-    chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
-    expect(chartVersions).toEqual(_.omit(expectedChartVersions, '1.0.2'));
-
-    kubernetesVersion = 'v1.20.3-alpha.1';
-    mockHelmChartData[2].kubeVersion = '>=1.19.3-0';
-    chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
-    expect(chartVersions).toEqual({
-      '1.0.3': '1.0.3 / App Version 3.12',
-    });
-
-    kubernetesVersion = 'v1.18.3+8uinj';
-    mockHelmChartData[0].kubeVersion = '>1.14.1';
-    mockHelmChartData[2].kubeVersion = '>= 1.13.0 < 1.14.0 || >= 1.14.1 < 1.15.0';
-    chartVersions = getChartVersions(mockHelmChartData, kubernetesVersion);
-    expect(chartVersions).toEqual(_.omit(expectedChartVersions, '1.0.1'));
   });
 
   it('should return the readme for the chart provided', () => {

--- a/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmChartVersionDropdown.tsx
@@ -7,8 +7,6 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { coFetchJSON, coFetch } from '@console/internal/co-fetch';
 import { DropdownField } from '@console/shared';
 import { confirmModal } from '@console/internal/components/modals/confirm-modal';
-import { k8sVersion } from '@console/internal/module/status';
-import { getK8sGitVersion } from '@console/internal/module/k8s';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { HelmChartMetaData, HelmChart, HelmActionType, HelmChartEntries } from '../helm-types';
 import {
@@ -40,7 +38,6 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   } = useFormikContext<FormikValues>();
   const [helmChartVersions, setHelmChartVersions] = React.useState({});
   const [helmChartEntries, setHelmChartEntries] = React.useState<HelmChartMetaData[]>([]);
-  const [kubernetesVersion, setKubernetesVersion] = React.useState<string>();
   const [initialYamlData, setInitialYamlData] = React.useState<string>('');
   const [initialFormData, setInitialFormData] = React.useState<object>();
 
@@ -78,12 +75,6 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   };
 
   React.useEffect(() => {
-    k8sVersion()
-      .then((response) => setKubernetesVersion(getK8sGitVersion(response) || '-'))
-      .catch(() => setKubernetesVersion('unknown'));
-  }, []);
-
-  React.useEffect(() => {
     setInitialYamlData(yamlData);
     setInitialFormData(formData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -104,13 +95,13 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
       }
       if (ignore) return;
       setHelmChartEntries(json?.entries?.[chartName]);
-      setHelmChartVersions(getChartVersions(json?.entries?.[chartName], kubernetesVersion));
+      setHelmChartVersions(getChartVersions(json?.entries?.[chartName]));
     };
     fetchChartVersions();
     return () => {
       ignore = true;
     };
-  }, [chartName, kubernetesVersion]);
+  }, [chartName]);
 
   const onChartVersionChange = (value: string) => {
     const chartURL = getChartURL(helmChartEntries, value);

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,7 +1,6 @@
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
 import { safeDump } from 'js-yaml';
-import * as semver from 'semver';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
@@ -87,17 +86,10 @@ export const concatVersions = (chartVersion: string, appVersion: string): string
   return appVersion ? `${chartVersion} / App Version ${appVersion}` : chartVersion;
 };
 
-export const getChartVersions = (chartEntries: HelmChartMetaData[], kubernetesVersion: string) => {
+export const getChartVersions = (chartEntries: HelmChartMetaData[]) => {
   const chartVersions = _.reduce(
     chartEntries,
     (obj, chart) => {
-      if (
-        chart?.kubeVersion &&
-        semver.valid(kubernetesVersion) &&
-        !semver.satisfies(kubernetesVersion, chart?.kubeVersion)
-      ) {
-        return obj;
-      }
       obj[chart.version] = concatVersions(chart.version, chart.appVersion);
       return obj;
     },

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { safeLoad } from 'js-yaml';
-import * as semver from 'semver';
 import { PropertyItem } from '@patternfly/react-catalog-view-extension';
 import { ANNOTATIONS, FLAGS, APIError } from '@console/shared';
 import {
@@ -22,8 +21,6 @@ import {
   PartialObjectMetadata,
   TemplateKind,
 } from '../../module/k8s';
-import { k8sVersion } from '../../module/status';
-import { getK8sGitVersion } from '../../module/k8s/cluster-settings';
 import { withStartGuide } from '../start-guide';
 import { connectToFlags, flagPending, FlagsObject } from '../../reducers/features';
 import {
@@ -67,7 +64,6 @@ export const CatalogListPage = withExtensions<CatalogListPageExtensionProps>({
         helmCharts,
         namespace,
         loaded,
-        kubernetesVersion,
       } = this.props;
       if (
         (!prevProps.loaded && loaded) ||
@@ -76,8 +72,7 @@ export const CatalogListPage = withExtensions<CatalogListPageExtensionProps>({
         !_.isEqual(templateMetadata, prevProps.templateMetadata) ||
         !_.isEqual(projectTemplateMetadata, prevProps.projectTemplateMetadata) ||
         !_.isEqual(imageStreams, prevProps.imageStreams) ||
-        !_.isEqual(helmCharts, prevProps.helmCharts) ||
-        !_.isEqual(kubernetesVersion, prevProps.kubernetesVersion)
+        !_.isEqual(helmCharts, prevProps.helmCharts)
       ) {
         const items = this.getItems();
         this.setState({ items });
@@ -216,20 +211,13 @@ export const CatalogListPage = withExtensions<CatalogListPageExtensionProps>({
     }
 
     normalizeHelmCharts(chartEntries: HelmChartEntries): Item[] {
-      const { namespace: currentNamespace = '', kubernetesVersion } = this.props;
+      const { namespace: currentNamespace = '' } = this.props;
       const notAvailable = <span className="properties-side-panel-pf-property-label">N/A</span>;
 
       return _.reduce(
         chartEntries,
         (normalizedCharts, charts) => {
           charts.forEach((chart: HelmChart) => {
-            if (
-              chart?.kubeVersion &&
-              semver.valid(kubernetesVersion) &&
-              !semver.satisfies(kubernetesVersion, chart?.kubeVersion)
-            ) {
-              return;
-            }
             const tags = chart.keywords;
             const chartName = chart.name;
             const chartVersion = chart.version;
@@ -403,7 +391,6 @@ export const Catalog = connectToFlags<CatalogProps>(
   );
   const [projectTemplateError, setProjectTemplateError] = React.useState<APIError>();
   const [helmCharts, setHelmCharts] = React.useState<HelmChartEntries>();
-  const [kubernetesVersion, setKubernetesVersion] = React.useState<string>();
 
   const loadTemplates = openshiftFlag && !mock;
 
@@ -447,12 +434,6 @@ export const Catalog = connectToFlags<CatalogProps>(
       const json = safeLoad(yaml);
       setHelmCharts(json.entries);
     });
-  }, []);
-
-  React.useEffect(() => {
-    k8sVersion()
-      .then((response) => setKubernetesVersion(getK8sGitVersion(response) || '-'))
-      .catch(() => setKubernetesVersion('unknown'));
   }, []);
 
   const error = templateError || projectTemplateError;
@@ -502,7 +483,6 @@ export const Catalog = connectToFlags<CatalogProps>(
           templateMetadata={templateMetadata}
           projectTemplateMetadata={projectTemplateMetadata}
           helmCharts={helmCharts}
-          kubernetesVersion={kubernetesVersion}
           {...(props as any)}
         />
       </Firehose>
@@ -551,7 +531,6 @@ export type CatalogListPageProps = CatalogListPageExtensionProps & {
   loaded: boolean;
   loadError?: string;
   namespace?: string;
-  kubernetesVersion?: string;
 };
 
 export type CatalogListPageState = {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-4746
reverts changes made in https://github.com/openshift/console/pull/5767


**Root Analysis:**
- version range `>=1.10.11` is not compatible with pre-released versions like `v1.10.11-rc.2+068702d`
- version range `>=1.10.11-0` only accepts prerelease tags on the version 1.10.11 like `v1.10.11-rc.2+068702d` & not `v1.17.3-rc.2+0687785`

Before Change:
![before](https://user-images.githubusercontent.com/22490998/92483032-f22cc500-f205-11ea-8de3-733262e29058.png)


After Change:
![after](https://user-images.githubusercontent.com/22490998/92483072-01137780-f206-11ea-8f01-da9616e90227.png)
