### PR TITLE
Bug 1871104: PXE requires NADs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -12,6 +12,8 @@ import {
 import { TemplateModel } from '@console/internal/models';
 import { Firehose, history } from '@console/internal/components/utils';
 import { usePrevious } from '@console/shared/src/hooks/previous';
+import { PersistentVolumeClaimKind, referenceForModel } from '@console/internal/module/k8s';
+import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
 import { Location } from 'history';
 import { match as RouterMatch } from 'react-router';
 import { withReduxID } from '../../utils/redux/common';
@@ -63,7 +65,6 @@ import { ValidTabGuard } from './tabs/valid-tab-guard';
 import { FirehoseResourceEnhanced } from '../../types/custom';
 
 import './create-vm-wizard.scss';
-import { PersistentVolumeClaimKind } from '@console/internal/module/k8s';
 
 type CreateVMWizardComponentProps = {
   isSimpleView: boolean;
@@ -407,6 +408,19 @@ export const CreateVMWizardPageComponent: React.FC<CreateVMWizardPageComponentPr
         prop: VMWizardProps.dataVolumes,
       }),
     ];
+
+    if (userMode !== VMWizardMode.IMPORT) {
+      resources.push({
+        kind: referenceForModel(NetworkAttachmentDefinitionModel),
+        model: NetworkAttachmentDefinitionModel,
+        isList: true,
+        namespace: activeNamespace,
+        prop: VMWizardProps.nads,
+        errorBehaviour: {
+          ignore404: true,
+        },
+      });
+    }
 
     if (flags[FLAGS.OPENSHIFT]) {
       resources.push(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
@@ -16,7 +16,12 @@ import {
   VIRTUAL_MACHINE_TEMPLATE_EXISTS,
 } from '../../../../utils/validations/strings';
 import { getFieldTitle } from '../../utils/renderable-field-utils';
-import { iGet, immutableListToJS } from '../../../../utils/immutable';
+import {
+  iGet,
+  iGetLoadedData,
+  iGetLoadError,
+  immutableListToJS,
+} from '../../../../utils/immutable';
 import {
   checkTabValidityChanged,
   iGetCommonData,
@@ -29,6 +34,11 @@ import { combineIntegerValidationResults } from '../../../../utils/validations/t
 import { getFieldsValidity, getValidationUpdate } from './utils';
 import { getTemplateValidations } from '../../selectors/template';
 import { BinaryUnit, convertToBytes } from '../../../form/size-unit-utils';
+import {
+  VALIDATION_PXE_NAD_ERROR_INFO,
+  VALIDATION_PXE_NAD_MISSING_INFO,
+} from '../../strings/networking';
+import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { UIValidation } from '../../../../types/ui/ui';
 
 const validateVm: Validator = (field, options) => {
@@ -110,6 +120,24 @@ const asVMSettingsFieldValidator = (
     subject: getFieldTitle(iGetFieldKey(field)),
   });
 
+const validateSource: Validator = (field, options): ValidationObject => {
+  const value = iGetFieldValue(field);
+
+  if (value === ProvisionSource.PXE.getValue()) {
+    const { getState, id } = options;
+    const state = getState();
+
+    const nads = iGetCommonData(state, id, VMWizardProps.nads);
+    return iGetLoadError(nads)
+      ? asValidationObject(VALIDATION_PXE_NAD_ERROR_INFO)
+      : iGetLoadedData(nads)?.size === 0
+      ? asValidationObject(VALIDATION_PXE_NAD_MISSING_INFO)
+      : null;
+  }
+
+  return null;
+};
+
 const validationConfig: ValidationConfig = {
   [VMSettingsField.NAME]: {
     detectValueChanges: [VMSettingsField.NAME],
@@ -141,6 +169,10 @@ const validationConfig: ValidationConfig = {
     ],
     detectCommonDataChanges: [VMWizardProps.userTemplate, VMWizardProps.commonTemplates],
     validator: memoryValidation,
+  },
+  [VMSettingsField.PROVISION_SOURCE_TYPE]: {
+    detectValueChanges: [VMSettingsField.PROVISION_SOURCE_TYPE],
+    validator: validateSource,
   },
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/networking.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/networking.ts
@@ -1,3 +1,11 @@
 export const PXE_NIC_NOT_FOUND_ERROR = 'A PXE-capable network interface could not be found.';
 export const PXE_INFO = 'Pod network is not PXE bootable';
 export const SELECT_PXE_NIC = '--- Select PXE network interface ---';
+export const VALIDATION_PXE_NAD_ERROR_INFO =
+  'Error fetching available Network Attachment Definitions. PXE capable Network Attachment Definition is required to successfully create this virtual machine. Contact your system administrator for additional support.';
+export const VALIDATION_PXE_NAD_MISSING_INFO =
+  'No Network Attachment Definitions available. PXE capable Network Attachment Definition is required to successfully create this virtual machine. Contact your system administrator for additional support.';
+export const SELECT_PXE_NAD_ERROR_INFO =
+  'Error fetching available Network Attachment Definitions. Contact your system administrator for additional support.';
+export const SELECT_PXE_NAD_MISSING_INFO =
+  'No Network Attachment Definitions available. Contact your system administrator for additional support.';

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/provision-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/provision-source.tsx
@@ -5,8 +5,9 @@ import { FormFieldRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
 import { iGetFieldValue } from '../../selectors/immutable/field';
 import { VMSettingsField } from '../../types';
-import { iGet } from '../../../../utils/immutable';
+import { iGet, iGetIn } from '../../../../utils/immutable';
 import { FormPFSelect } from '../../../form/form-pf-select';
+import { ValidationErrorType } from '@console/shared';
 
 const ProvisionSourceDiskHelpMsg: React.FC<ProvisionSourceDiskHelpMsgProps> = ({
   provisionSourceValue,
@@ -79,6 +80,7 @@ export const ProvisionSourceComponent: React.FC<ProvisionSourceComponentProps> =
   ({ provisionSourceField, onChange, goToStorageStep, goToNetworkingStep }) => {
     const provisionSourceValue = iGetFieldValue(provisionSourceField);
     const sources = iGet(provisionSourceField, 'sources');
+    const validationType = iGetIn(provisionSourceField, ['validation', 'type']);
 
     return (
       <FormFieldRow field={provisionSourceField} fieldType={FormFieldType.PF_SELECT}>
@@ -112,9 +114,10 @@ export const ProvisionSourceComponent: React.FC<ProvisionSourceComponentProps> =
             goToStorageStep={goToStorageStep}
           />
         )}
-        {[ProvisionSource.PXE.getValue()].includes(provisionSourceValue) && (
-          <ProvisionSourceNetHelpMsg goToNetworkingStep={goToNetworkingStep} />
-        )}
+        {[ProvisionSource.PXE.getValue()].includes(provisionSourceValue) &&
+          validationType !== ValidationErrorType.Error && (
+            <ProvisionSourceNetHelpMsg goToNetworkingStep={goToNetworkingStep} />
+          )}
       </FormFieldRow>
     );
   },

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -33,6 +33,7 @@ export enum VMWizardProps {
   dataVolumes = 'dataVolumes',
   openshiftCNVBaseImages = 'openshiftCNVBaseImages',
   storageClassConfigMap = 'storageClassConfigMap',
+  nads = 'nads',
 }
 
 // order important
@@ -216,6 +217,7 @@ export type ChangedCommonDataProp =
   | VMWizardProps.dataVolumes
   | VMWizardProps.openshiftCNVBaseImages
   | VMWizardProps.storageClassConfigMap
+  | VMWizardProps.nads
   | VMWareProviderProps.deployment
   | VMWareProviderProps.deploymentPods
   | VMWareProviderProps.v2vvmware
@@ -246,6 +248,7 @@ export const DetectCommonDataChanges = new Set<ChangedCommonDataProp>([
   VMWizardProps.storageClassConfigMap,
   VMWizardProps.dataVolumes,
   VMWizardProps.openshiftCNVBaseImages,
+  VMWizardProps.nads,
   VMWareProviderProps.deployment,
   VMWareProviderProps.deploymentPods,
   VMWareProviderProps.v2vvmware,

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal.tsx
@@ -41,6 +41,10 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 import { PendingChangesAlert } from '../../Alerts/PendingChangesAlert';
 import { MODAL_RESTART_IS_REQUIRED } from '../../../strings/vm/status';
 import { FormPFSelect } from '../../form/form-pf-select';
+import {
+  SELECT_PXE_NAD_ERROR_INFO,
+  SELECT_PXE_NAD_MISSING_INFO,
+} from '../../create-vm-wizard/strings/networking';
 
 const getNetworkChoices = (
   nads: K8sResourceKind[],
@@ -96,15 +100,22 @@ export const Network: React.FC<NetworkProps> = ({
     allowPodNetwork,
     allowedMultusNetworkTypes,
   ).filter((n) => n.getType().isSupported());
+  const validationMessage = nadsLoadError
+    ? SELECT_PXE_NAD_ERROR_INFO
+    : networkChoices.length === 0
+    ? SELECT_PXE_NAD_MISSING_INFO
+    : null;
+  const validationType =
+    nadsLoadError || networkChoices.length === 0 ? ValidationErrorType.Error : null;
 
   return (
     <FormRow
       title="Network"
       fieldId={id}
       isRequired
-      isLoading={nadsLoading}
-      validationMessage={nadsLoadError}
-      validationType={nadsLoadError && ValidationErrorType.Error}
+      isLoading={nadsLoading && !nadsLoadError}
+      validationMessage={validationMessage}
+      validationType={validationType}
     >
       <FormSelect
         onChange={(net, event) => {
@@ -116,15 +127,11 @@ export const Network: React.FC<NetworkProps> = ({
         }}
         value={asFormSelectValue(network?.getReadableName())}
         id={id}
-        isDisabled={isDisabled || nadsLoading || nadsLoadError}
+        isDisabled={isDisabled || nadsLoading || nadsLoadError || networkChoices.length === 0}
       >
         <FormSelectPlaceholderOption
           isDisabled={!acceptEmptyValues}
-          placeholder={
-            networkChoices.length === 0
-              ? '--- No Network Attachment Definitions available ---'
-              : '--- Select Network Attachment Definition ---'
-          }
+          placeholder={'--- Select Network Attachment Definition ---'}
         />
         {ignoreCaseSort(networkChoices, undefined, (n) => n.getReadableName()).map(
           (networkWrapper: NetworkWrapper) => {


### PR DESCRIPTION
On a cluster without a newtwork attachment definition, it is not possible to use a PXE boot. Yet the user can pick it and get lost.

The ask is to provide a warning right in the first screen blocking the user from continuing to the next screen. The warning needs to explain that a new network attachment definition needs to be created in this namespace and that the administrator needs to be contacted to do it.

Screenshot:
![Peek 2020-09-21 17-02](https://user-images.githubusercontent.com/2181522/93776560-58fda580-fc2c-11ea-9df6-81140ba511d2.gif)

