### PR TITLE
Bug 1873326: Adding accessibility alt and title to icons within overview status and activity sections

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
@@ -40,7 +40,11 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
             </div>
             <div className="co-recent-item__title-message">
               {isWarning && (
-                <YellowExclamationTriangleIcon className="co-dashboard-icon co-recent-item__icon--warning" />
+                <YellowExclamationTriangleIcon
+                  alt="Warning"
+                  title="Warning"
+                  className="co-dashboard-icon co-recent-item__icon--warning"
+                />
               )}
               {!expanded && (
                 <>

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -14,13 +14,15 @@ import {
   getAlertTime,
 } from './alert-utils';
 
+const CriticalIcon = () => <RedExclamationCircleIcon alt="Critical" title="Critical" />;
+const WarningIcon = () => <YellowExclamationTriangleIcon alt="Warning" title="Warning" />;
 const getSeverityIcon = (severity: string) => {
   switch (severity) {
     case 'critical':
-      return RedExclamationCircleIcon;
+      return CriticalIcon;
     case 'warning':
     default:
-      return YellowExclamationTriangleIcon;
+      return WarningIcon;
   }
 };
 

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
@@ -23,36 +23,36 @@ export const healthStateMapping: { [key in HealthState]: HealthStateMappingValue
   [HealthState.OK]: {
     priority: 0,
     health: HealthState.OK,
-    icon: <GreenCheckCircleIcon />,
+    icon: <GreenCheckCircleIcon alt="Healthy" title="Healthy" />,
   },
   [HealthState.UNKNOWN]: {
     priority: 1,
     health: HealthState.UNKNOWN,
-    icon: <GrayUnknownIcon />,
+    icon: <GrayUnknownIcon alt="Unknown" title="Unknown" />,
     message: 'Unknown',
   },
   [HealthState.PROGRESS]: {
     priority: 2,
     health: HealthState.PROGRESS,
-    icon: <InProgressIcon />,
+    icon: <InProgressIcon alt="In progress" title="In progress" />,
     message: 'Pending',
   },
   [HealthState.UPDATING]: {
     priority: 3,
     health: HealthState.UPDATING,
-    icon: <BlueSyncIcon />,
+    icon: <BlueSyncIcon alt="Updating" title="Updating" />,
     message: 'Updating',
   },
   [HealthState.WARNING]: {
     priority: 4,
     health: HealthState.WARNING,
-    icon: <YellowExclamationTriangleIcon />,
+    icon: <YellowExclamationTriangleIcon alt="Warning" title="Warning" />,
     message: 'Degraded',
   },
   [HealthState.ERROR]: {
     priority: 5,
     health: HealthState.ERROR,
-    icon: <RedExclamationCircleIcon />,
+    icon: <RedExclamationCircleIcon alt="Error" title="Error" />,
     message: 'Degraded',
   },
   [HealthState.LOADING]: {
@@ -64,7 +64,7 @@ export const healthStateMapping: { [key in HealthState]: HealthStateMappingValue
   [HealthState.NOT_AVAILABLE]: {
     priority: 7,
     health: HealthState.NOT_AVAILABLE,
-    icon: <GrayUnknownIcon />,
+    icon: <GrayUnknownIcon alt="Not available" title="Not available" />,
     message: 'Not available',
   },
 };

--- a/frontend/packages/console-shared/src/components/status/icons.tsx
+++ b/frontend/packages/console-shared/src/components/status/icons.tsx
@@ -17,48 +17,87 @@ import { global_palette_blue_300 as blueInfoColor } from '@patternfly/react-toke
 import { global_palette_green_500 as okColor } from '@patternfly/react-tokens/dist/js/global_palette_green_500';
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 
-export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, alt, size }) => (
-  <CheckCircleIcon size={size} color={okColor.value} className={className} alt={alt} />
+export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({
+  className,
+  alt,
+  title,
+  size,
+}) => (
+  <CheckCircleIcon
+    size={size}
+    color={okColor.value}
+    className={className}
+    alt={alt}
+    title={title}
+  />
 );
 
-export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({ className, alt, size }) => (
-  <ExclamationCircleIcon size={size} color={dangerColor.value} className={className} alt={alt} />
+export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({
+  className,
+  alt,
+  title,
+  size,
+}) => (
+  <ExclamationCircleIcon
+    size={size}
+    color={dangerColor.value}
+    className={className}
+    alt={alt}
+    title={title}
+  />
 );
 
 export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
   className,
   alt,
+  title,
   size,
 }) => (
-  <ExclamationTriangleIcon size={size} color={warningColor.value} className={className} alt={alt} />
+  <ExclamationTriangleIcon
+    size={size}
+    color={warningColor.value}
+    className={className}
+    alt={alt}
+    title={title}
+  />
 );
 
-export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <InfoCircleIcon color={blueInfoColor.value} className={className} alt={alt} />
+export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({ className, alt, title }) => (
+  <InfoCircleIcon color={blueInfoColor.value} className={className} alt={alt} title={title} />
 );
 
-export const GrayUnknownIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <UnknownIcon color={disabledColor.value} className={className} alt={alt} />
+export const GrayUnknownIcon: React.FC<ColoredIconProps> = ({ className, alt, title }) => (
+  <UnknownIcon color={disabledColor.value} className={className} alt={alt} title={title} />
 );
 
-export const BlueSyncIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <SyncAltIcon color={blueInfoColor.value} className={className} alt={alt} />
+export const BlueSyncIcon: React.FC<ColoredIconProps> = ({ className, alt, title }) => (
+  <SyncAltIcon color={blueInfoColor.value} className={className} alt={alt} title={title} />
 );
 
-export const RedResourcesFullIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <ResourcesFullIcon color={dangerColor.value} className={className} alt={alt} />
+export const RedResourcesFullIcon: React.FC<ColoredIconProps> = ({ className, alt, title }) => (
+  <ResourcesFullIcon color={dangerColor.value} className={className} alt={alt} title={title} />
 );
 
-export const YellowResourcesAlmostFullIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <ResourcesAlmostFullIcon color={warningColor.value} className={className} alt={alt} />
+export const YellowResourcesAlmostFullIcon: React.FC<ColoredIconProps> = ({
+  className,
+  alt,
+  title,
+}) => (
+  <ResourcesAlmostFullIcon
+    color={warningColor.value}
+    className={className}
+    alt={alt}
+    title={title}
+  />
 );
 
-export const BlueArrowCircleUpIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <ArrowCircleUpIcon color={blueDefaultColor.value} className={className} alt={alt} />
+export const BlueArrowCircleUpIcon: React.FC<ColoredIconProps> = ({ className, alt, title }) => (
+  <ArrowCircleUpIcon color={blueDefaultColor.value} className={className} alt={alt} title={title} />
 );
 
 export type ColoredIconProps = {
   className?: string;
   alt?: string;
+  title?: string;
   size?: 'sm' | 'md' | 'lg' | 'xl';
 };


### PR DESCRIPTION
Currently `aria-hidden="true"` are on these icons, a label isn't required since it's not accessible to a screen reader. Including `alt` attribute to be consistent with https://github.com/openshift/console/pull/6497#issuecomment-686546767
Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1873326