### PR TITLE
Bug 1877595: fix height for reason column of knative service table

### DIFF
--- a/frontend/packages/console-shared/src/components/index.ts
+++ b/frontend/packages/console-shared/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './badges';
+export * from './text';
 export * from './contextMenu';
 export * from './dropdown';
 export * from './form-utils';

--- a/frontend/packages/console-shared/src/components/text/ClampedText.scss
+++ b/frontend/packages/console-shared/src/components/text/ClampedText.scss
@@ -1,0 +1,6 @@
+.ocs-clamped-text {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--ocs-clamped-text--line-clamp);
+}

--- a/frontend/packages/console-shared/src/components/text/ClampedText.tsx
+++ b/frontend/packages/console-shared/src/components/text/ClampedText.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import Measure from 'react-measure';
+import { Popover } from '@patternfly/react-core';
+import { useDebounceCallback } from '../../hooks';
+import './ClampedText.scss';
+
+type ClampedTextProps = {
+  children: React.ReactNode;
+  lineClamp?: number;
+};
+
+const ClampedText: React.FC<ClampedTextProps> = ({ children, lineClamp = 1 }) => {
+  const [isContentClamped, setContentClamped] = React.useState<boolean>(false);
+  const debouncedSetContentClamped = useDebounceCallback(
+    ({ scroll: { height: scrollHeight }, offset: { height: offsetHeight } }) =>
+      setContentClamped(scrollHeight > offsetHeight),
+    [setContentClamped],
+  );
+  const style = { '--ocs-clamped-text--line-clamp': lineClamp } as React.CSSProperties;
+
+  return (
+    <Measure offset scroll onResize={debouncedSetContentClamped}>
+      {({ measureRef }) => (
+        <div ref={measureRef} className="ocs-clamped-text" style={style}>
+          {isContentClamped ? (
+            <Popover bodyContent={children}>
+              <div tabIndex={0} role="button">
+                {children}
+              </div>
+            </Popover>
+          ) : (
+            <>{children}</>
+          )}
+        </div>
+      )}
+    </Measure>
+  );
+};
+
+export default ClampedText;

--- a/frontend/packages/console-shared/src/components/text/index.ts
+++ b/frontend/packages/console-shared/src/components/text/index.ts
@@ -1,0 +1,1 @@
+export { default as ClampedText } from './ClampedText';

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as cx from 'classnames';
 import * as _ from 'lodash';
+import { ClampedText } from '@console/shared';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { ResourceLink, ResourceKebab, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -51,7 +52,10 @@ const RevisionRow: RowFunction<RevisionKind> = ({ obj, index, key, style }) => {
         {(readyCondition && readyCondition.status) || '-'}
       </TableData>
       <TableData className={tableColumnClasses[6]}>
-        {(readyCondition && readyCondition.message) || '-'}
+        {(readyCondition?.message && (
+          <ClampedText lineClamp={5}>{readyCondition?.message}</ClampedText>
+        )) ||
+          '-'}
       </TableData>
       <TableData className={tableColumnClasses[7]}>
         <ResourceKebab actions={getRevisionActions()} kind={revisionReference} resource={obj} />

--- a/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme';
 import * as _ from 'lodash';
+import { ClampedText } from '@console/shared';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { ResourceLink } from '@console/internal/components/utils';
 import { K8sResourceConditionStatus } from '@console/internal/module/k8s';
@@ -91,6 +92,12 @@ describe('RevisionRow', () => {
     const readyColData = wrapper.find(TableData).at(5);
     const reasonColData = wrapper.find(TableData).at(6);
     expect(readyColData.props().children).toEqual('False');
-    expect(reasonColData.props().children).toEqual('Something went wrong.');
+    expect(
+      reasonColData
+        .dive()
+        .find(ClampedText)
+        .at(0)
+        .props().children,
+    ).toEqual('Something went wrong.');
   });
 });

--- a/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
@@ -10,6 +10,7 @@ import {
   kindObj,
 } from '@console/internal/components/utils';
 import { referenceForModel, referenceFor, K8sKind } from '@console/internal/module/k8s';
+import { ClampedText } from '@console/shared';
 import { ServiceModel } from '../../models';
 import { getConditionString, getCondition } from '../../utils/condition-utils';
 import { ServiceKind, ConditionTypes } from '../../types';
@@ -58,7 +59,10 @@ const ServiceRow: RowFunction<ServiceKind> = ({ obj, index, key, style }) => {
         {(readyCondition && readyCondition.status) || '-'}
       </TableData>
       <TableData className={tableColumnClasses[7]}>
-        {(readyCondition && readyCondition.message) || '-'}
+        {(readyCondition?.message && (
+          <ClampedText lineClamp={5}>{readyCondition?.message}</ClampedText>
+        )) ||
+          '-'}
       </TableData>
       <TableData className={tableColumnClasses[8]}>
         <ResourceKebab actions={menuActions} kind={serviceReference} resource={obj} />

--- a/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
@@ -1,5 +1,6 @@
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
+import { ClampedText } from '@console/shared';
 import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { ExternalLink } from '@console/internal/components/utils';
 import { knativeServiceObj } from '../../../topology/__tests__/topology-knative-test-data';
@@ -66,6 +67,13 @@ describe('ServiceRow', () => {
     expect(conditionsColData.props().children).toEqual('-');
   });
 
+  it('should show appropriate ready status and reason for ready state', () => {
+    const readyColData = wrapper.find(TableData).at(6);
+    const reasonColData = wrapper.find(TableData).at(7);
+    expect(readyColData.props().children).toEqual('True');
+    expect(reasonColData.props().children).toEqual('-');
+  });
+
   it('should show appropriate ready status and reason for not ready state', () => {
     svcData.obj.status = {
       ...svcData.obj.status,
@@ -85,6 +93,12 @@ describe('ServiceRow', () => {
     const readyColData = wrapper.find(TableData).at(6);
     const reasonColData = wrapper.find(TableData).at(7);
     expect(readyColData.props().children).toEqual('False');
-    expect(reasonColData.props().children).toEqual('Something went wrong.');
+    expect(
+      reasonColData
+        .dive()
+        .find(ClampedText)
+        .at(0)
+        .props().children,
+    ).toEqual('Something went wrong.');
   });
 });


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-1912

Analysis / Root cause:
The reason text of a Service can be very large. As a result it makes browsing the list of Services very difficult.
Solution Description:
limit text to a five lines and then use a popover to display the full text.

Screens:
![Screenshot from 2020-09-09 03-54-47](https://user-images.githubusercontent.com/38663217/92811829-70db5b00-f3dc-11ea-85c7-ab7d05fb8c1f.png)
[screen for popover open state TBD]

Test Coverage:
![Screenshot from 2020-09-11 03-09-21](https://user-images.githubusercontent.com/38663217/92811637-44bfda00-f3dc-11ea-820b-2c1133f1fb94.png)
![Screenshot from 2020-09-11 03-08-51](https://user-images.githubusercontent.com/38663217/92811669-4b4e5180-f3dc-11ea-8e6a-1017863ba9f1.png)


Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge