### PR TITLE
Bug 1876985: Change the text message display for guest agent feature

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/strings/vm/messages.ts
+++ b/frontend/packages/kubevirt-plugin/src/strings/vm/messages.ts
@@ -2,7 +2,7 @@ export const PAUSED_VM_MODAL_MESSAGE =
   'This VM has been paused. If you wish to unpause it, please click the Unpause button below. For further details, please check with your system administrator.';
 export const VIRTUAL_MACHINE_IS_NOT_RUNNING = 'Virtual Machine is not running';
 export const NO_GUEST_AGENT_MESSAGE =
-  'A guest agent has not been found for this VM. This could be because the VM has not finished booting or a guest agent is not installed. Without a guest agent installed, some management features will not be available and some metrics may be inaccurate.';
+  'A guest agent was not found for this VM. Either the guest agent was not installed or the VM has not finished booting. When a guest agent is not installed, some management features are unavailable and the metrics might be inaccurate.';
 export const GUEST_AGENT_REQUIRED_MESSAGE = 'Guest agent required';
 export const NOT_AVAILABLE_MESSAGE = 'Not available';
 export const VM_NOT_RUNNING_MESSAGE = 'VM not running';


### PR DESCRIPTION
BZ recommends that we use active voice, tighter wording, fewer words, and stylistic compliance with the IBM Style Guide. The text message noted above should be replaced with the following:

"A guest agent was not found for this VM. Either the guest agent was not installed or the VM has not finished booting. When a guest agent is not installed, some management features are unavailable and the metrics might be inaccurate."

Screesnshot:
![screenshot-localhost_9000-2020 09 09-08_12_09](https://user-images.githubusercontent.com/2181522/92557149-3ce52600-f274-11ea-9bb4-ab4d844a2269.png)
