### PR TITLE
Bug 1873402: Add deleting status

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/overview-dashboard/inventory.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/overview-dashboard/inventory.tsx
@@ -50,6 +50,7 @@ export const getVMStatusGroups: StatusGroupMapper = (
         VMStatusSimpleLabel.Migrating,
         VMStatusSimpleLabel.Stopping,
         StatusSimpleLabel.Pending,
+        VMStatusSimpleLabel.Deleting,
       ],
       count: 0,
       filterType: 'vm-status',

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -8,14 +8,11 @@ import {
   dimensifyHeader,
   dimensifyRow,
   getCreationTimestamp,
-  getDeletetionTimestamp,
   getName,
   getNamespace,
-  getOwnerReferences,
   getUID,
   getLabels,
 } from '@console/shared';
-import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import {
   NamespaceModel,
   PodModel,
@@ -46,7 +43,7 @@ import {
   VirtualMachineModel,
 } from '../../models';
 import { VMIKind, VMKind } from '../../types';
-import { buildOwnerReferenceForModel, getBasicID, getLoadedData } from '../../utils';
+import { getBasicID, getLoadedData } from '../../utils';
 import { getVMStatus } from '../../statuses/vm/vm-status';
 import { getVmiIpAddresses, getVMINodeName } from '../../selectors/vmi';
 import { isVMImport, isVM, isVMI } from '../../selectors/check-type';
@@ -359,21 +356,7 @@ const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
           ...objectBundle,
         };
       })
-      .filter(({ vm, vmi, vmImport, metadata }) => {
-        if (vmImport && metadata.vmImportStatus?.isCompleted()) {
-          return false;
-        }
-
-        if (vm || !getDeletetionTimestamp(vmi)) {
-          return true;
-        }
-        const vmOwnerReference = buildOwnerReferenceForModel(VirtualMachineModel, getName(vmi));
-
-        // show finalizing VMIs only if they are not owned by VM
-        return !(getOwnerReferences(vmi) || []).some((o) =>
-          compareOwnerReference(o, vmOwnerReference),
-        );
-      });
+      .filter(({ vmImport, metadata }) => !(vmImport && metadata.vmImportStatus?.isCompleted()));
   };
 
   const createAccessReview = skipAccessReview ? null : { model: VirtualMachineModel, namespace };

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/vm-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/vm-status.ts
@@ -13,6 +13,7 @@ export enum VMStatusSimpleLabel {
   Stopping = 'Stopping',
   Running = 'Running',
   Off = 'Off',
+  Deleting = 'Deleting',
 }
 
 export const VM_STATUS_SIMPLE_LABELS = [
@@ -41,6 +42,9 @@ export class VMStatus extends StatusEnum<VMStatusSimpleLabel | StatusSimpleLabel
     isPending: true,
   });
   static readonly STOPPING = new VMStatus('VMStatus_STOPPING', VMStatusSimpleLabel.Stopping, {
+    isInProgress: true,
+  });
+  static readonly DELETING = new VMStatus('VMStatus_DELETING', VMStatusSimpleLabel.Deleting, {
     isInProgress: true,
   });
   static readonly VM_ERROR = new VMStatus('VMStatus_VM_ERROR', 'VM error', { isError: true });

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
@@ -62,11 +62,6 @@ import { PAUSED_VM_MODAL_MESSAGE } from '../../strings/vm/messages';
 const isPaused = (vmi: VMIKind): VMStatusBundle =>
   isVMIPaused(vmi) ? { status: VMStatus.PAUSED, message: PAUSED_VM_MODAL_MESSAGE } : null;
 
-const isDeleting = (vm: VMKind, vmi: VMIKind): VMStatusBundle =>
-  (vm && !!getDeletetionTimestamp(vm)) || (!vm && vmi && !!getDeletetionTimestamp(vmi))
-    ? { status: VMStatus.DELETING }
-    : null;
-
 const isV2VVMWareConversion = (vm: VMKind, pods?: PodKind[]): VMStatusBundle => {
   if (!vm || !pods) {
     return null;
@@ -212,6 +207,11 @@ const isBeingImported = (
     importerPodsStatuses,
   };
 };
+
+const isDeleting = (vm: VMKind, vmi: VMIKind): VMStatusBundle =>
+  (vm && !!getDeletetionTimestamp(vm)) || (!vm && vmi && !!getDeletetionTimestamp(vmi))
+    ? { status: VMStatus.DELETING }
+    : null;
 
 const isVMError = (vm: VMKind): VMStatusBundle => {
   const vmFailureCond = getStatusConditionOfType(vm, 'Failure');

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
@@ -208,11 +208,6 @@ const isBeingImported = (
   };
 };
 
-const isDeleting = (vm: VMKind, vmi: VMIKind): VMStatusBundle =>
-  (vm && !!getDeletetionTimestamp(vm)) || (!vm && vmi && !!getDeletetionTimestamp(vmi))
-    ? { status: VMStatus.DELETING }
-    : null;
-
 const isVMError = (vm: VMKind): VMStatusBundle => {
   const vmFailureCond = getStatusConditionOfType(vm, 'Failure');
   if (vmFailureCond) {
@@ -224,6 +219,11 @@ const isVMError = (vm: VMKind): VMStatusBundle => {
 
   return null;
 };
+
+const isDeleting = (vm: VMKind, vmi: VMIKind): VMStatusBundle =>
+  (vm && !!getDeletetionTimestamp(vm)) || (!vm && vmi && !!getDeletetionTimestamp(vmi))
+    ? { status: VMStatus.DELETING }
+    : null;
 
 const isBeingStopped = (vm: VMKind): VMStatusBundle => {
   if (vm && !isVMExpectedRunning(vm) && isVMCreated(vm)) {
@@ -319,8 +319,8 @@ export const getVMStatus = ({
     isV2VVMImportConversion(vm, vmImports) ||
     isBeingMigrated(vm, vmi, migrations) ||
     isBeingImported(vm, pods, pvcs, dataVolumes) ||
-    isDeleting(vm, vmi) ||
     isVMError(vm) ||
+    isDeleting(vm, vmi) ||
     isBeingStopped(vm) ||
     isOff(vm) ||
     isError(vm, vmi, launcherPod) ||

--- a/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
@@ -125,6 +125,7 @@ const ObservedVmNode: React.FC<VmNodeProps> = ({
     case VMStatus.STARTING:
       statusClass = 'kubevirt-m-not-ready';
       break;
+    case VMStatus.DELETING:
     case VMStatus.STOPPING:
       statusClass = 'kubevirt-m-terminating';
       break;


### PR DESCRIPTION
When a running VM is deleted, it may take up to terminationGracePeriod for the VMI to be deleted. In that period of time the VM is removed from the UI and there's no indication for the user that the VMI is still running.

This PR adds a "Deleting" status for VMIs with deleting timestamp.

Screen shot:
![Peek 2020-09-09 09-32](https://user-images.githubusercontent.com/2181522/92563128-bdf5ea80-f27f-11ea-9b67-22e1d27380cb.gif)
