### PR TITLE
Bug 1877390: Do not show helm resources until helm release is ready.

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/helm/isHelmResource.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/isHelmResource.ts
@@ -1,16 +1,5 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { Model } from '@patternfly/react-topology';
-import { TYPE_HELM_WORKLOAD } from './components/const';
-import { OdcNodeModel } from '../topology-types';
 
-export const isHelmResource = (resource: K8sResourceKind, model: Model): boolean => {
-  if (!model?.nodes?.length) {
-    return false;
-  }
-  return !!model.nodes.find((node) => {
-    if (node.type !== TYPE_HELM_WORKLOAD) {
-      return false;
-    }
-    return (node as OdcNodeModel).resource?.metadata?.uid === resource?.metadata?.uid;
-  });
+export const isHelmResource = (resource: K8sResourceKind): boolean => {
+  return resource?.metadata?.labels?.['app.kubernetes.io/managed-by'] === 'Helm';
 };


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-3478

**Description**
Update topology to not show helm workloads prior to the helm release being loaded.
Fetch the helm releases if we detect there are helm secrets available for helm releases that are not yet loaded.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
