### PR TITLE
Use better fix for messed JSON output in yarn analyze command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "cypress-generate": "marge -o ./gui_test_screenshots/ -f cypress-report -t 'OpenShift Console Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ./gui_test_screenshots/cypress/assets ./gui_test_screenshots/cypress.json",
     "cypress-postreport": "yarn run cypress-merge && yarn run cypress-generate && rm -f ./gui_test_screenshots/cypress*.json",
     "debug-test-suite": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node -r ts-node/register --inspect-brk ./node_modules/.bin/protractor integration-tests/protractor.conf.ts",
-    "analyze": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production --profile --json | awk '{if(NR>2)print}' > public/dist/stats.json && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack-bundle-analyzer --mode static -r public/dist/report.html public/dist/stats.json",
+    "analyze": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production --profile --json | sed '0,/^{/s/^[^{].*//g' > public/dist/stats.json && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack-bundle-analyzer --mode static -r public/dist/report.html public/dist/stats.json",
     "prettier-all": "prettier --write '**/*.{js,jsx,ts,tsx,json}'",
     "gql-generate": "graphql-codegen"
   },


### PR DESCRIPTION
`yarn analyze` command generates webpack bundle stats (`public/dist/stats.json`) and passes it to [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) which generates visual HTML report (`public/dist/report.html`).

Unfortunately, above mentioned `stats.json` file gets polluted with logging messages:

```
Starting type checking service...
Using 1 worker with 2048MB memory limit
{
  (JSON stats here)
}
```

The current fix `awk '{if(NR>2)print}'` simply removes the first 2 lines, which isn't very robust or future-proof.

The proposed fix `sed '0,/^{/s/^[^{].*//g'` works like this:
- use a character range that starts from beginning (0) and ends with first occurence of regexp `^{` which marks the start of JSON stats object
- on this character range, replace regexp `^[^{].*` (any line that doesn't start with `{`) with empty string

Verification:

```sh
$ cat <<EOF >test
foo bar {
baz qux
{
  "errors": [],
  "warnings": [],
  "test": {}
}
EOF
# writes above to 'test' file

$ cat test | sed '0,/^{/s/^[^{].*//g'


{
  "errors": [],
  "warnings": [],
  "test": {}
}
# replaces extra logs with empty strings
```