### PR TITLE
Bug 1877736: fixes warning shown on close of delete revision modal

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModal.tsx
@@ -17,12 +17,13 @@ interface TrafficSplittingDeleteModalProps {
   revisionItems: RevisionItems;
   deleteRevision: K8sResourceKind;
   showTraffic: boolean;
+  cancel?: () => void;
 }
 
 type Props = FormikProps<FormikValues> & TrafficSplittingDeleteModalProps;
 
 const DeleteRevisionModal: React.FC<Props> = (props) => {
-  const { deleteRevision, handleSubmit, handleReset, isSubmitting, status, showTraffic } = props;
+  const { deleteRevision, handleSubmit, isSubmitting, status, showTraffic, cancel } = props;
   const serviceName = deleteRevision.metadata.labels[KNATIVE_SERVING_LABEL];
 
   return (
@@ -52,7 +53,7 @@ const DeleteRevisionModal: React.FC<Props> = (props) => {
       <ModalSubmitFooter
         inProgress={isSubmitting}
         submitText="Delete"
-        cancel={handleReset}
+        cancel={cancel}
         errorMessage={status.error}
         submitDanger
       />

--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
@@ -87,7 +87,7 @@ const Controller: React.FC<ControllerProps> = ({ loaded, resources, revision, ca
 
   const revisionItems = getRevisionItems(revisions);
 
-  const traffic = service?.status?.traffic ?? [{ percent: 0, tag: '', revisionName: '' }];
+  const traffic = service?.spec?.traffic ?? [{ percent: 0, tag: '', revisionName: '' }];
   const deleteTraffic = traffic.find((t) => t.revisionName === revision.metadata.name);
 
   const initialValues: TrafficSplittingType = {
@@ -160,6 +160,7 @@ const Controller: React.FC<ControllerProps> = ({ loaded, resources, revision, ca
           revisionItems={revisionItems}
           deleteRevision={revision}
           showTraffic={deleteTraffic?.percent > 0}
+          cancel={cancel}
         />
       )}
     </Formik>


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/OCPBUGSM-17243

**Analysis / Root cause**: 
Warning shown on close of Delete Revision modal

**Solution Description**: 
- used cancel for close action
- make use of spec to fetch traffic as done in traffic split modal


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
