### PR TITLE
Bug 1877806: Skip updating iframe height when component is unmounted

### DIFF
--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -50,6 +50,7 @@ export class SyncMarkdownView extends React.Component<
   {}
 > {
   private frame: any;
+  private timeoutHandle: any;
 
   constructor(props) {
     super(props);
@@ -59,6 +60,10 @@ export class SyncMarkdownView extends React.Component<
     this.updateDimensions();
   }
 
+  componentWillUnmount() {
+    clearTimeout(this.timeoutHandle);
+  }
+
   updateDimensions() {
     if (!this.frame?.contentWindow?.document.body.firstChild) {
       return;
@@ -66,7 +71,7 @@ export class SyncMarkdownView extends React.Component<
     this.frame.style.height = `${this.frame.contentWindow.document.body.firstChild.scrollHeight}px`;
 
     // Let the new height take effect, then reset again once we recompute
-    setTimeout(() => {
+    this.timeoutHandle = setTimeout(() => {
       if (this.props.exactHeight) {
         this.frame.style.height = `${this.frame.contentWindow.document.body.firstChild.scrollHeight}px`;
       } else {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4777
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: he code in markdown-view component uses `setTimeout` to update the height of the iframe, by quickly going through the steps sometimes the timeout function gets executed after the component has been unmounted. That's why it throws that error.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: In setTimeout check if component is unmounted and skip setting of height if unmounted.
<!-- Describe your code changes in detail and explain the solution -->


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
