### PR TITLE
Bug 1877821: Show quick start prerequisites only if provided

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
@@ -17,8 +17,12 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
       {description}
     </Text>
     <div className="co-quick-start-tile-description">
-      <Text component={TextVariants.h5}>Prerequisites</Text>
-      <Text component={TextVariants.small}>{prerequisites}</Text>
+      {prerequisites && (
+        <>
+          <Text component={TextVariants.h5}>Prerequisites</Text>
+          <Text component={TextVariants.small}>{prerequisites}</Text>
+        </>
+      )}
     </div>
   </>
 );

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/__tests__/QuickStartTileDescription.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/__tests__/QuickStartTileDescription.spec.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Text } from '@patternfly/react-core';
+import QuickStartTileDescription from '../QuickStartTileDescription';
+import { getQuickStarts } from '../../utils/quick-start-utils';
+
+describe('QuickStartCatalog', () => {
+  it('should show prerequisites only if provided', () => {
+    const QuickStartTileDescriptionProps = getQuickStarts()[0].spec;
+    const QuickStartTileDescriptionWrapper = shallow(
+      <QuickStartTileDescription description={QuickStartTileDescriptionProps.description} />,
+    );
+    expect(QuickStartTileDescriptionWrapper.find(Text)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4639
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
If there are no prerequisites, the UI still shows Prerequisites on the QS card, with no additional information.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Show quick start prerequisites only if provided.
<!-- Describe your code changes in detail and explain the solution -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge