### PR TITLE
Bug 1877842: Replace quick start route icon with rocket icon

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CatalogTile } from '@patternfly/react-catalog-view-extension';
-import { RouteIcon } from '@patternfly/react-icons';
+import { RocketIcon } from '@patternfly/react-icons';
 import { FallbackImg } from '@console/shared';
 import { QuickStartStatus, QuickStart } from '../utils/quick-start-types';
 import QuickStartTileHeader from './QuickStartTileHeader';
@@ -31,7 +31,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
     <FallbackImg
       className="co-catalog-item-icon__img--large"
       src={iconURL}
-      fallback={<RouteIcon />}
+      fallback={<RocketIcon />}
     />
   );
 

--- a/frontend/public/components/dashboard/dashboards-page/quick-start-badge.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/quick-start-badge.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Label } from '@patternfly/react-core';
-import { RouteIcon } from '@patternfly/react-icons';
+import { RocketIcon } from '@patternfly/react-icons';
 import { history } from '../../utils';
 
 import './quick-start-badge.scss';
@@ -36,7 +36,7 @@ const QuickStartBadge: React.FC = () => {
       color="green"
       className="co-quick-start-badge"
       href="/quickstart"
-      icon={<RouteIcon />}
+      icon={<RocketIcon />}
       onClick={handleQuickStartBadgeClick}
       onClose={handleQuickStartBadgeClose}
     >


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4696
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Quick start icon needs to be updated to the rocket icon.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Replace quick start route icon with rocket icon.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp0](https://user-images.githubusercontent.com/20013884/92748543-e3c7e000-f3a2-11ea-8adf-5137e3008aa7.png)
![tmp1](https://user-images.githubusercontent.com/20013884/92748606-f17d6580-f3a2-11ea-85a2-2ffaf82b1113.png)

@openshift/team-devconsole-ux
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
