### PR TITLE
Bug 1875193: Check if resource model is loaded in firehose

### DIFF
--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -118,15 +118,18 @@ const stateToProps = ({ k8s }, { resources }) => {
     (models, { kind }) => models.set(kind, k8s.getIn(['RESOURCES', 'models', kind])),
     ImmutableMap(),
   );
-  const loaded = (r) =>
-    r.optional ||
-    k8s.getIn([
-      makeReduxID(
-        k8sModels.get(r.kind),
-        makeQuery(r.namespace, r.selector, r.fieldSelector, r.name),
-      ),
-      'loaded',
-    ]);
+  const loaded = (r) => {
+    return (
+      (r.optional && _.isUndefined(k8sModels.get(r.kind))) ||
+      k8s.getIn([
+        makeReduxID(
+          k8sModels.get(r.kind),
+          makeQuery(r.namespace, r.selector, r.fieldSelector, r.name),
+        ),
+        'loaded',
+      ])
+    );
+  };
 
   return {
     k8sModels,


### PR DESCRIPTION
Prior to marking the resource as `loaded` we should check it's model is loaded. We should not set the resource as loaded if the model is missing.

/assign @spadgett @rhamilto 

@mareklibra FYI