### PR TITLE
Bug 1867034: follow on fix cluster dashboard queries

### DIFF
--- a/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
@@ -44,9 +44,9 @@ const top25Queries = {
   [OverviewQuery.NODES_BY_MEMORY]:
     'topk(25, sort_desc(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes))',
   [OverviewQuery.NODES_BY_STORAGE]:
-    'topk(25, sort_desc(avg_over_time(sum(node_filesystem_size_bytes{instance="<%= node %>",fstype!="tmpfs",mountpoint!="/boot|/boot/efi"}[5m] - node_filesystem_avail_bytes{instance="<%= node %>",fstype!="tmpfs",mountpoint!="/boot|/boot/efi"}[5m]))))',
+    'topk(25, sort_desc(sum(node_filesystem_size_bytes{instance=~".*",fstype!="tmpfs",mountpoint!="/boot|/boot/efi"} - node_filesystem_avail_bytes{instance=~".*",fstype!="tmpfs",mountpoint!="/boot|/boot/efi"}) BY (instance)))',
   [OverviewQuery.NODES_BY_PODS]:
-    'topk(25, sort_desc(sum(avg_over_time(kubelet_running_pods{instance=~"<%= ipAddress %>:.*"}[5m])) BY (node)))',
+    'topk(25, sort_desc(sum(avg_over_time(kubelet_running_pods{instance=~".*:.*"}[5m])) BY (node)))',
   [OverviewQuery.NODES_BY_NETWORK_IN]:
     'topk(25, sort_desc(sum(instance:node_network_receive_bytes_excluding_lo:rate1m) BY (instance)))',
   [OverviewQuery.NODES_BY_NETWORK_OUT]:


### PR DESCRIPTION
The previous query doesn't work, I tried these new queries locally and proved they worked. Metrics data is returned and top consumer list is rendered.
But still need confirmation if these queries are correct or not.


**Before**
<img width="357" alt="Screen Shot 2020-09-11 at 5 54 48 PM" src="https://user-images.githubusercontent.com/12692381/92907468-f05a4000-f457-11ea-855d-b9ece0e16351.png"> 
<img width="356" alt="Screen Shot 2020-09-11 at 5 54 37 PM" src="https://user-images.githubusercontent.com/12692381/92907507-f7814e00-f457-11ea-81f8-c2fb467a5a16.png">

**After**
<img width="386" alt="Screen Shot 2020-09-11 at 5 40 42 PM" src="https://user-images.githubusercontent.com/12692381/92907101-9e191f00-f457-11ea-82a6-c0ebe26a7000.png">
<img width="412" alt="Screen Shot 2020-09-11 at 5 53 19 PM" src="https://user-images.githubusercontent.com/12692381/92907277-c143ce80-f457-11ea-9677-de693ca471ab.png">


