### PR TITLE
Bug 1878117: Fix monitoring dashboard margin

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
@@ -31,6 +31,7 @@ $no-wrap-breakpoint: 915px;
   }
   &__resource-toolbar {
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--xl);
+    margin-right: 0;
   }
   &__workload-filter {
     li[role='presentation'] {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4782
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Resource dropdown in monitoring dashboard inherits an unwanted right margin.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Set the mragin to zero.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp0](https://user-images.githubusercontent.com/20013884/92918942-7f158f80-f44d-11ea-8c41-5d17e84a4082.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
