### PR TITLE
CONSOLE-2396: Add skip to content component

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -39,7 +39,7 @@ import '../vendor.scss';
 import '../style.scss';
 
 //PF4 Imports
-import { Page } from '@patternfly/react-core';
+import { Page, SkipToContent } from '@patternfly/react-core';
 
 const breakpointMD = 768;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
@@ -164,6 +164,13 @@ class App_ extends React.PureComponent {
                 onNavSelect={this._onNavSelect}
                 onPerspectiveSelected={this._onNavSelect}
               />
+            }
+            skipToContent={
+              <SkipToContent
+                href={`${this.props.location.pathname}${this.props.location.search}#content`}
+              >
+                Skip to Content
+              </SkipToContent>
             }
           >
             <ConnectedNotificationDrawer


### PR DESCRIPTION
Currently keyboard users have to tab through the entire top nav and then the side nav in order to get to the main content. Adding a skip to content allows keyboard users to quickly and easily get to the main content of a page and helps support section [2.4.1 Bypass Blocks of WCAG](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0&showtechniques=241#qr-navigation-mechanisms-skip) and the VPAT. It's also only visible if you're using a keyboard so it shouldn't negatively affect anything visually. (When the page loads, press Tab. Focus should move to the skip to content component. Press enter and focus will shift to the main content.)

[CONSOLE-2396](https://issues.redhat.com/browse/CONSOLE-2396)