### PR TITLE
Wording tweaks to VM PVC areas

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form-status.tsx
@@ -91,7 +91,7 @@ const AllocatingStatus: React.FC = () => (
       Allocating Resources
     </Title>
     <EmptyStateBody>
-      Please wait, once the Data Volume has been created The data will start uploading into this
+      Please wait. After the Data Volume is created the data will start uploading into the
       Persistent Volume Claim.
     </EmptyStateBody>
   </>
@@ -101,7 +101,7 @@ const CancellingStatus: React.FC = () => (
   <>
     <EmptyStateIcon icon={Spinner} />
     <Title headingLevel="h4" size="lg">
-      Cancelling Upload
+      Canceling Upload
     </Title>
     <EmptyStateBody>Resources are being removed, please wait.</EmptyStateBody>
   </>
@@ -138,15 +138,15 @@ const UploadingStatus: React.FC<UploadingStatusProps> = ({
               className="kv--create-upload__alert"
               isInline
               variant={AlertVariant.warning}
-              title="Please don’t close this browser tab"
+              title="Please don't close this browser tab"
             >
-              Closing it will cause the upload to fail. You may still navigate the console.
+              Closing this tab will cause the upload to fail. Please wait until it completes.
             </Alert>
           </StackItem>
         )}
         <StackItem>
-          Persistent Volume Claim has been created and your data source is now being uploaded to it.
-          Once the uploading is completed the Persisten Volume Claim will become available
+          A Persistent Volume Claim has been created and your data source is now being uploaded to it.
+          Once the upload is complete the Persistent Volume Claim will become available.
         </StackItem>
         <StackItem>
           <Progress value={upload?.progress} variant={getProgressVariant(upload?.uploadStatus)} />

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -376,8 +376,8 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
               inputID="request-size-input"
             />
             <p className="help-block" id="request-size-help">
-              Ensure your PVC size covers the requirements of the uncompressed image and any other
-              space requirements
+              Ensure that the Persistent Volume Claim is larger than the uncompressed image and meets any other
+              space requirements.
             </p>
           </SplitItem>
         </Split>

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-popover.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-popover.tsx
@@ -64,7 +64,7 @@ export const UploadPVCPopover: React.FC<PVCUploadStatusProps> = ({ pvc }) => {
       case UPLOAD_STATUS.UPLOADING:
         return {
           title: `Uploading`,
-          body: 'Please do not close this window, you can keep navigating the app freely.',
+          body: "Please don't close this browser tab until the upload is complete.",
           icon: <InProgressIcon className="co-icon-and-text__icon" />,
         };
       case UPLOAD_STATUS.SUCCESS:


### PR DESCRIPTION
Just some minor wording tweaks, fixes, and consistency adjustments to consider. WDYT @matthewcarleton @rawagner?

Note: I confirmed with PatternFly that there should be one `l` in `Canceling` to align with the corporate style guide - the [Terminology page](https://www.patternfly.org/v4/design-guidelines/content/terminology) will be updated soon.