### PR TITLE
Bug 1878375: Show different operator instances from same CSV separately in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
@@ -86,6 +86,7 @@ const highlightNode = (monitor: DropTargetMonitor, element: Node): boolean => {
   if (operation.type === CREATE_CONNECTOR_OPERATION) {
     return (
       monitor.getItem() !== element &&
+      monitor.getItem().getParent() !== element &&
       !monitor
         .getItem()
         .getSourceEdges()

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/ModelContext.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/ModelContext.ts
@@ -171,31 +171,40 @@ export class ExtensibleModel {
     const getters = this.dataModelGetters;
     const depicters = this.dataModelDepicters;
     const workloadResources = this.getWorkloadResources(resources);
-    const promises = getters?.length ? getters : [Promise.resolve];
+    const promises = getters?.length
+      ? getters.map((getter) => getter(this.namespace, resources, workloadResources))
+      : [Promise.resolve(null)];
 
     const topologyModel: Model = {
       nodes: [],
       edges: [],
     };
 
-    const addToModel = async (promise: any): Promise<Model> => {
-      const model = await promise(this.namespace, resources, workloadResources);
-      addToTopologyDataModel(model, topologyModel, depicters);
-      return topologyModel;
-    };
-
-    for (const i in promises) {
-      if (promises[i]) {
-        // eslint-disable-next-line no-await-in-loop
-        await addToModel(promises[i]);
-      }
-    }
+    await Promise.all(promises).then((models) => {
+      models.forEach((model) => {
+        if (model) {
+          try {
+            addToTopologyDataModel(model, topologyModel, depicters);
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error('Unable to add some resources to topology', e);
+          }
+        }
+      });
+    });
 
     return Promise.resolve(topologyModel);
   };
 
   public reconcileModel = (model: Model, resources: TopologyDataResources): void => {
-    this.dataModelReconcilers.forEach((reconciler) => reconciler(model, resources));
+    this.dataModelReconcilers.forEach((reconciler) => {
+      try {
+        reconciler(model, resources);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Unable to reconcile some resources in topology', e);
+      }
+    });
   };
 }
 


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4730

**Screen Shot**
![image](https://user-images.githubusercontent.com/11633780/93001412-c870e800-f4fc-11ea-846e-85a09b90518c.png)

**Description**
Fix to show separate operator instances from the same operator separately in Topology.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug

/cc @bgliwa01 @beaumorley @serenamarie125 