### PR TITLE
Bug 1878653: fixes event source form create button enabled when form is invalid

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -18,6 +18,7 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
   const {
     values: {
       application: { selectedKey },
+      type,
     },
     setFieldValue,
     setFieldTouched,
@@ -27,29 +28,31 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
   } = useFormikContext<FormikValues>();
   const handleItemChange = React.useCallback(
     (item: string) => {
-      setErrors({});
-      setStatus({});
-      if (isKnownEventSource(item)) {
-        const nameData = `data.${item.toLowerCase()}`;
-        const sourceData = getEventSourceData(item.toLowerCase());
-        setFieldValue(nameData, sourceData);
-        setFieldTouched(nameData, true);
+      if (item !== type) {
+        setErrors({});
+        setStatus({});
+        if (isKnownEventSource(item)) {
+          const nameData = `data.${item.toLowerCase()}`;
+          const sourceData = getEventSourceData(item.toLowerCase());
+          setFieldValue(nameData, sourceData);
+          setFieldTouched(nameData, true);
+        }
+        setFieldValue('data.itemData', eventSourceList[item]);
+        const selDataModel = _.find(getEventSourceModels(), { kind: item });
+        const selApiVersion = selDataModel
+          ? `${selDataModel?.apiGroup}/${selDataModel?.apiVersion}`
+          : `${KNATIVE_EVENT_SOURCE_APIGROUP}/v1alpha1`;
+        const name = _.kebabCase(item);
+        setFieldValue('name', name);
+        setFieldTouched('name', true);
+        if (!selectedKey || selectedKey === CREATE_APPLICATION_KEY) {
+          setFieldValue('application.name', `${name}-app`);
+          setFieldTouched('application.name', true);
+        }
+        setFieldValue('apiVersion', selApiVersion);
+        setFieldTouched('apiVersion', true);
+        validateForm();
       }
-      setFieldValue('data.itemData', eventSourceList[item]);
-      const selDataModel = _.find(getEventSourceModels(), { kind: item });
-      const selApiVersion = selDataModel
-        ? `${selDataModel?.apiGroup}/${selDataModel?.apiVersion}`
-        : `${KNATIVE_EVENT_SOURCE_APIGROUP}/v1alpha1`;
-      const name = _.kebabCase(item);
-      setFieldValue('name', name);
-      setFieldTouched('name', true);
-      if (!selectedKey || selectedKey === CREATE_APPLICATION_KEY) {
-        setFieldValue('application.name', `${name}-app`);
-        setFieldTouched('application.name', true);
-      }
-      setFieldValue('apiVersion', selApiVersion);
-      setFieldTouched('apiVersion', true);
-      validateForm();
     },
     [
       setErrors,
@@ -59,6 +62,7 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
       selectedKey,
       validateForm,
       eventSourceList,
+      type,
     ],
   );
 

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
@@ -72,6 +72,17 @@ describe('EventSourcesSelector', () => {
     expect(wrapper.find(ItemSelectorField).props().loadingItems).toBe(false);
   });
 
+  it('should not call getEventSourceData onSelect if selected type is same', () => {
+    const spyGetEventSourceData = jest.spyOn(sourceUtils, 'getEventSourceData');
+    const spyKebabCase = jest.spyOn(lodash, 'kebabCase');
+    wrapper
+      .find(ItemSelectorField)
+      .props()
+      .onSelect('SinkBinding');
+    expect(spyGetEventSourceData).toHaveBeenCalledTimes(0);
+    expect(spyKebabCase).toHaveBeenCalledTimes(0);
+  });
+
   it('should call getEventSourceData onSelect', () => {
     const spyGetEventSourceData = jest.spyOn(sourceUtils, 'getEventSourceData');
     const spyKebabCase = jest.spyOn(lodash, 'kebabCase');


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4302

**Analysis / Root cause**: 
event source form create button enabled when form is invalid on clicking on it again

**Solution Description**: 
If type is same as selected type then not needed to update formik values

**Screenshot/Gif**:
![Sep-14-2020 15-22-54](https://user-images.githubusercontent.com/5129024/93071843-46202980-f69e-11ea-8460-3b4f265eebc9.gif)


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/93071190-70251c00-f69d-11ea-8e5f-520a4dbb47ea.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
