### PR TITLE
Bug 1878835: Make whole quick start badge clickable

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/quick-start-badge.scss
+++ b/frontend/public/components/dashboard/dashboards-page/quick-start-badge.scss
@@ -1,0 +1,6 @@
+.co-quick-start-badge {
+  // need to override this explicitly because bootstrap __scaffolding.scss overrides a:hover
+  > a.pf-c-label__content:hover {
+    color: var(--pf-c-label__content--Color);
+  }
+}

--- a/frontend/public/components/dashboard/dashboards-page/quick-start-badge.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/quick-start-badge.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { Label, Button } from '@patternfly/react-core';
+import { Label } from '@patternfly/react-core';
 import { RouteIcon } from '@patternfly/react-icons';
 import { history } from '../../utils';
+
+import './quick-start-badge.scss';
 
 const HIDE_QUICK_START_BADGE_STORAGE_KEY = 'bridge/hide-quick-start-badge';
 
@@ -12,7 +14,15 @@ const QuickStartBadge: React.FC = () => {
     !isQuickStartBadgeHidden,
   );
 
-  const handleQuickStartBadgeClose = () => {
+  const handleQuickStartBadgeClick = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    history.push('/quickstart');
+  };
+
+  const handleQuickStartBadgeClose = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
     localStorage.setItem(HIDE_QUICK_START_BADGE_STORAGE_KEY, 'true');
     setShowQuickStartBadge(false);
   };
@@ -22,10 +32,15 @@ const QuickStartBadge: React.FC = () => {
   }
 
   return (
-    <Label color="green" icon={<RouteIcon />} onClose={handleQuickStartBadgeClose}>
-      <Button variant="link" onClick={() => history.push('/quickstart')} isInline>
-        Quick start available
-      </Button>
+    <Label
+      color="green"
+      className="co-quick-start-badge"
+      href="/quickstart"
+      icon={<RouteIcon />}
+      onClick={handleQuickStartBadgeClick}
+      onClose={handleQuickStartBadgeClose}
+    >
+      Quick start available
     </Label>
   );
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4812
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The quick start badge is not fully clickable.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Update the badge to make it all clickable.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux @gdoyle1 

![Peek 2020-09-14 22-08](https://user-images.githubusercontent.com/6041994/93113702-26f1be00-f6d7-11ea-985b-f5e94a9cdd74.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
