### PR TITLE
Bug 1878748: Set the PATH_CONTEXT default param if its part of the pipeline template

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/__tests__/pipeline-template-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/__tests__/pipeline-template-utils.spec.ts
@@ -1,0 +1,291 @@
+import { k8sCreate } from '@console/internal/module/k8s';
+import { Pipeline } from 'packages/dev-console/src/utils/pipeline-augment';
+import { PipelineModel } from '../../../../models';
+import { GitImportFormData } from '../../import-types';
+import { createPipelineResource } from '../../../pipelines/pipeline-resource/pipelineResource-utils';
+import { createPipelineForImportFlow } from '../pipeline-template-utils';
+
+jest.mock('@console/internal/module/k8s', () => ({
+  k8sCreate: jest.fn(),
+}));
+jest.mock('../../../pipelines/pipeline-resource/pipelineResource-utils', () => ({
+  createPipelineResource: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('createPipelineForImportFlow', () => {
+  const createFormData = (pipelineTemplate: Pipeline): GitImportFormData => {
+    const minimalFormData = {
+      name: 'an-app',
+      project: { name: 'a-project' },
+      git: {
+        type: 'github',
+        url: 'https://github.com/openshift/console',
+        ref: 'master',
+        dir: '/',
+        showGitType: true,
+        secret: '',
+        isUrlValidating: false,
+      },
+    } as GitImportFormData;
+    const formData: GitImportFormData = {
+      ...minimalFormData,
+      pipeline: {
+        enabled: true,
+        template: pipelineTemplate,
+      },
+    };
+    return formData;
+  };
+
+  it('should create an almost empty pipeline for a template with only task data (empty task)', async () => {
+    const pipelineTemplate: Pipeline = {
+      spec: {
+        tasks: [],
+      },
+    };
+
+    await createPipelineForImportFlow(createFormData(pipelineTemplate));
+
+    const expectedPipeline: Pipeline = {
+      metadata: {
+        name: 'an-app',
+        namespace: 'a-project',
+        labels: { 'app.kubernetes.io/instance': 'an-app' },
+      },
+      spec: {
+        params: undefined,
+        tasks: [],
+      },
+    };
+
+    expect(k8sCreate).toHaveBeenCalledTimes(1);
+    expect(k8sCreate).toHaveBeenCalledWith(PipelineModel, expectedPipeline, {
+      ns: 'a-project',
+    });
+    expect(createPipelineResource).toHaveBeenCalledTimes(0);
+  });
+
+  it('should create a pipeline for a template with params, resources, workspaces, tasks (all empty)', async () => {
+    const pipelineTemplate: Pipeline = {
+      spec: {
+        params: [],
+        resources: [],
+        workspaces: [],
+        tasks: [],
+        serviceAccountName: 'service-account',
+      },
+    };
+
+    await createPipelineForImportFlow(createFormData(pipelineTemplate));
+
+    const expectedPipeline: Pipeline = {
+      metadata: {
+        name: 'an-app',
+        namespace: 'a-project',
+        labels: { 'app.kubernetes.io/instance': 'an-app' },
+      },
+      spec: {
+        params: [],
+        resources: [],
+        workspaces: [],
+        tasks: [],
+        serviceAccountName: 'service-account',
+      },
+    };
+
+    expect(k8sCreate).toHaveBeenCalledTimes(1);
+    expect(k8sCreate).toHaveBeenCalledWith(PipelineModel, expectedPipeline, {
+      ns: 'a-project',
+    });
+    expect(createPipelineResource).toHaveBeenCalledTimes(0);
+  });
+
+  it('should create a pipeline for a template with filled params, resources, workspaces and tasks', async () => {
+    const pipelineTemplate: Pipeline = {
+      spec: {
+        params: [{ name: 'a-param', default: 'default value', description: 'a description' }],
+        resources: [{ type: 'resource-type', name: 'a-resource' }],
+        workspaces: [{ name: 'a-workspace' }],
+        tasks: [
+          {
+            name: 'build',
+            taskRef: {
+              name: 'a-task',
+            },
+          },
+        ],
+      },
+    };
+
+    await createPipelineForImportFlow(createFormData(pipelineTemplate));
+
+    const expectedPipeline: Pipeline = {
+      metadata: {
+        name: 'an-app',
+        namespace: 'a-project',
+        labels: { 'app.kubernetes.io/instance': 'an-app' },
+      },
+      spec: {
+        params: [{ name: 'a-param', default: 'default value', description: 'a description' }],
+        resources: [{ type: 'resource-type', name: 'a-resource' }],
+        workspaces: [{ name: 'a-workspace' }],
+        tasks: [
+          {
+            name: 'build',
+            taskRef: {
+              name: 'a-task',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(k8sCreate).toHaveBeenCalledTimes(1);
+    expect(k8sCreate).toHaveBeenCalledWith(PipelineModel, expectedPipeline, {
+      ns: 'a-project',
+    });
+    expect(createPipelineResource).toHaveBeenCalledTimes(0);
+  });
+
+  it('should create a pipeline and two resources if the template defines a git and image resources', async () => {
+    const pipelineTemplate: Pipeline = {
+      spec: {
+        params: [],
+        resources: [
+          { type: 'git', name: 'app-source' },
+          { type: 'image', name: 'app-image' },
+        ],
+        tasks: [],
+      },
+    };
+
+    const formData = createFormData(pipelineTemplate);
+    await createPipelineForImportFlow(formData);
+
+    const expectedPipeline: Pipeline = {
+      metadata: {
+        name: 'an-app',
+        namespace: 'a-project',
+        labels: { 'app.kubernetes.io/instance': 'an-app' },
+      },
+      spec: {
+        params: [],
+        resources: [
+          { type: 'git', name: 'app-source' },
+          { type: 'image', name: 'app-image' },
+        ],
+        tasks: [],
+      },
+    };
+
+    expect(k8sCreate).toHaveBeenCalledTimes(1);
+    expect(k8sCreate).toHaveBeenCalledWith(PipelineModel, expectedPipeline, {
+      ns: 'a-project',
+    });
+    expect(createPipelineResource).toHaveBeenCalledTimes(2);
+    expect(createPipelineResource).toHaveBeenCalledWith(
+      { revision: 'master', url: 'https://github.com/openshift/console' },
+      'git',
+      'a-project',
+    );
+    expect(createPipelineResource).toHaveBeenCalledWith(
+      { url: 'image-registry.openshift-image-registry.svc:5000/a-project/an-app' },
+      'image',
+      'a-project',
+    );
+  });
+
+  it('should fill different pipeline parameters if the template contains known params', async () => {
+    const pipelineTemplate: Pipeline = {
+      spec: {
+        params: [
+          { name: 'APP_NAME' },
+          { name: 'GIT_REPO' },
+          { name: 'GIT_REVISION' },
+          { name: 'PATH_CONTEXT', default: '.' },
+          { name: 'IMAGE_NAME' },
+        ],
+        tasks: [],
+      },
+    };
+
+    await createPipelineForImportFlow(createFormData(pipelineTemplate));
+
+    const expectedPipeline: Pipeline = {
+      metadata: {
+        name: 'an-app',
+        namespace: 'a-project',
+        labels: { 'app.kubernetes.io/instance': 'an-app' },
+      },
+      spec: {
+        params: [
+          { name: 'APP_NAME', default: 'an-app' },
+          { name: 'GIT_REPO', default: 'https://github.com/openshift/console' },
+          { name: 'GIT_REVISION', default: 'master' },
+          { name: 'PATH_CONTEXT', default: '.' },
+          {
+            name: 'IMAGE_NAME',
+            default: 'image-registry.openshift-image-registry.svc:5000/a-project/an-app',
+          },
+        ],
+        tasks: [],
+      },
+    };
+
+    expect(k8sCreate).toHaveBeenCalledTimes(1);
+    expect(k8sCreate).toHaveBeenCalledWith(PipelineModel, expectedPipeline, {
+      ns: 'a-project',
+    });
+    expect(createPipelineResource).toHaveBeenCalledTimes(0);
+  });
+
+  it('should remove prefix slash of the git directory from the PATH_CONTEXT param', async () => {
+    const pipelineTemplate: Pipeline = {
+      spec: {
+        params: [
+          { name: 'APP_NAME' },
+          { name: 'GIT_REPO' },
+          { name: 'GIT_REVISION' },
+          { name: 'PATH_CONTEXT' },
+          { name: 'IMAGE_NAME' },
+        ],
+        tasks: [],
+      },
+    };
+
+    const formData = createFormData(pipelineTemplate);
+    formData.git.dir = '/anotherpath';
+    await createPipelineForImportFlow(formData);
+
+    const expectedPipeline: Pipeline = {
+      metadata: {
+        name: 'an-app',
+        namespace: 'a-project',
+        labels: { 'app.kubernetes.io/instance': 'an-app' },
+      },
+      spec: {
+        params: [
+          { name: 'APP_NAME', default: 'an-app' },
+          { name: 'GIT_REPO', default: 'https://github.com/openshift/console' },
+          { name: 'GIT_REVISION', default: 'master' },
+          { name: 'PATH_CONTEXT', default: 'anotherpath' },
+          {
+            name: 'IMAGE_NAME',
+            default: 'image-registry.openshift-image-registry.svc:5000/a-project/an-app',
+          },
+        ],
+        tasks: [],
+      },
+    };
+
+    expect(k8sCreate).toHaveBeenCalledTimes(1);
+    expect(k8sCreate).toHaveBeenCalledWith(PipelineModel, expectedPipeline, {
+      ns: 'a-project',
+    });
+    expect(createPipelineResource).toHaveBeenCalledTimes(0);
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -34,7 +34,7 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
   template.metadata = {
     name: `${name}`,
     namespace,
-    labels: { ...template.metadata.labels, 'app.kubernetes.io/instance': name },
+    labels: { ...template.metadata?.labels, 'app.kubernetes.io/instance': name },
   };
 
   template.spec.params = template.spec.params?.map((param) => {
@@ -45,6 +45,8 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
         return { ...param, default: git.url };
       case 'GIT_REVISION':
         return { ...param, default: git.ref || 'master' };
+      case 'PATH_CONTEXT':
+        return { ...param, default: git.dir.replace(/^\//, '') || param.default };
       case 'IMAGE_NAME':
         return { ...param, default: getImageUrl(name, namespace) };
       default:

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { useFormikContext, FormikValues, useField } from 'formik';
 import { SecretModel, ConfigMapModel } from '@console/internal/models';
 import { DropdownField } from '@console/shared';
-import { PipelineWorkspace } from '../../../../utils/pipeline-augment';
 import FormSection from '../../../import/section/FormSection';
 import { VolumeTypes } from '../../const';
+import { PipelineRunWorkspaceFormEntry } from '../start-pipeline/types';
 import PVCDropdown from './PVCDropdown';
 import MultipleResourceKeySelector from './MultipleResourceKeySelector';
 
@@ -44,7 +44,7 @@ const getVolumeTypeFields = (volumeType: VolumeTypes, index: number) => {
 
 const PipelineWorkspacesSection: React.FC = () => {
   const { setFieldValue } = useFormikContext<FormikValues>();
-  const [{ value: workspaces }] = useField<PipelineWorkspace[]>('workspaces');
+  const [{ value: workspaces }] = useField<PipelineRunWorkspaceFormEntry[]>('workspaces');
   return (
     workspaces.length > 0 && (
       <FormSection title="Workspaces" fullWidth>

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/types.ts
@@ -1,7 +1,17 @@
+import {
+  VolumeTypeConfigMaps,
+  VolumeTypePVC,
+  VolumeTypeSecret,
+} from 'packages/dev-console/src/utils/pipeline-augment';
 import { CommonPipelineModalFormikValues } from '../common/types';
-import { PipelineWorkspace } from '../../../../utils/pipeline-augment';
+
+export type PipelineRunWorkspaceFormEntry = {
+  name: string;
+  type: string;
+  [volumeType: string]: VolumeTypeSecret | VolumeTypeConfigMaps | VolumeTypePVC | {};
+};
 
 export type StartPipelineFormValues = CommonPipelineModalFormikValues & {
-  workspaces: PipelineWorkspace[];
+  workspaces: PipelineRunWorkspaceFormEntry[];
   secretOpen: boolean;
 };

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -64,8 +64,14 @@ export interface PipelineTask {
   taskRef: PipelineTaskRef;
   params?: PipelineTaskParam[];
   resources?: PipelineTaskResources;
+  workspaces?: PipelineTaskWorkspace[];
 }
-
+export interface PipelineTaskWorkspace {
+  name: string;
+  description?: string;
+  mountPath?: string;
+  readOnly?: boolean;
+}
 export interface Resource {
   propsReferenceForRuns: string[];
   resources: FirehoseResource[];
@@ -92,6 +98,8 @@ export type PipelineRunReferenceResource = PipelineRunResourceCommonProperties &
   };
 };
 export type PipelineRunResource = PipelineRunReferenceResource | PipelineRunInlineResource;
+
+export type PipelineWorkspace = Param;
 
 export interface Runs {
   data?: PipelineRun[];
@@ -239,13 +247,6 @@ export type VolumeTypeConfigMaps = {
 export type VolumeTypePVC = {
   claimName: string;
 };
-
-export interface PipelineWorkspace extends Param {
-  type: string;
-  data?: {
-    [volumeType: string]: VolumeTypeSecret | VolumeTypeConfigMaps | VolumeTypePVC | {};
-  };
-}
 
 export interface PipelineRunWorkspace extends Param {
   [volumeType: string]: VolumeTypeSecret | VolumeTypeConfigMaps | VolumeTypePVC | {};

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -26,7 +26,6 @@ import {
   PipelineParam,
   PipelineRunParam,
   PipelineTaskRef,
-  PipelineWorkspace,
   PipelineRunWorkspace,
   TaskRunKind,
 } from './pipeline-augment';
@@ -44,6 +43,7 @@ import {
   TaskModel,
   EventListenerModel,
 } from '../models';
+import { PipelineRunWorkspaceFormEntry } from '../components/pipelines/modals/start-pipeline/types';
 
 interface Resources {
   inputs?: Resource[];
@@ -336,7 +336,7 @@ export const getPipelineRunParams = (pipelineParams: PipelineParam[]): PipelineR
 };
 
 export const getPipelineRunWorkspaces = (
-  pipelineWorkspaces: PipelineWorkspace[],
+  pipelineWorkspaces: PipelineRunWorkspaceFormEntry[],
 ): PipelineRunWorkspace[] => {
   return (
     pipelineWorkspaces &&


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4413
https://bugzilla.redhat.com/show_bug.cgi?id=1878748

**Analysis / Root cause**: 
When adding a pipeline via the import flow, user can provide a context dir for the git repository of the application. This context dir is not set in the generated pipeline and therefore the pipeline does not find the application code in the given git repo.

This is follow up PR for https://issues.redhat.com/browse/ODC-4466 / #6506. To cherry-pick this new PR for older releases, we must cherry-pick #6506 first.

**Solution Description**: 
If the pipeline templates contains a param PATH_CONTEXT we set the default value to the given Advanced Git Option "Context Dir".

:warning:  Notice: This change only copy and fills a PATH_CONTEXT param of a pipeline template. But this param is not available YET in the preinstalled OpenShift Pipeline Operator templates. This will be fixed with a second PR based on https://github.com/openshift/tektoncd-pipeline-operator/pull/413.

**Screen shots / Gifs for design review**: 
Not changed

**Unit test coverage report**: 
Add new tests:

```
PASS  packages/dev-console/src/components/import/pipeline/__tests__/pipeline-template-utils.spec.ts
  createPipelineForImportFlow
    ✓ should create an almost empty pipeline for a template with only task data (empty task) (4ms)
    ✓ should create a pipeline for a template with params, resources, workspaces, tasks (all empty) (1ms)
    ✓ should create a pipeline for a template with filled params, resources, workspaces and tasks (1ms)
    ✓ should create a pipeline and two resources if the template defines a git and image resources (1ms)
    ✓ should fill different pipeline parameters if the template contains known params (1ms)
    ✓ should remove prefix slash of the git directory from the PATH_CONTEXT param (1ms)
```

**Test setup:**
* Add the OpenShift Pipeline Operator (separate test is required for 1.0 or 1.1)
* Change the preinstalled Pipeline `ClusterTask`, for example (change URLs to match your cluster installation)
  * http://localhost:9000/k8s/cluster/tekton.dev~v1beta1~ClusterTask/s2i-nodejs/yaml or
  * http://localhost:9000/k8s/ns/openshift/tekton.dev~v1beta1~Pipeline/s2i-nodejs-deployment/yaml
* Import a new Deployment based on this Pipeline, for example:
  * Git repository: `https://github.com/jerolimov/docker`
  * Context Dir: `/nodeinfo`
  * Enable "Add Pipeline" option
* Start the new created Pipeline, this should work on Pipeline Operator 1.0 and 1.1

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge