### PR TITLE
Bug 1878713: Add fallback to builder image detection

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
@@ -35,7 +35,9 @@ const EditApplicationForm: React.FC<FormikProps<FormikValues> & EditApplicationF
   <>
     <PageHeading title={createFlowType} style={{ padding: '0px' }} />
     <Form onSubmit={handleSubmit}>
-      {createFlowType !== CreateApplicationFlow.Container && <GitSection />}
+      {createFlowType !== CreateApplicationFlow.Container && (
+        <GitSection builderImages={builderImages} />
+      )}
       {createFlowType === CreateApplicationFlow.Git && (
         <BuilderSection image={values.image} builderImages={builderImages} />
       )}

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -24,7 +24,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
   projects,
 }) => (
   <Form onSubmit={handleSubmit} data-test-id="import-git-form">
-    <GitSection />
+    <GitSection builderImages={builderImages} />
     <BuilderSection image={values.image} builderImages={builderImages} />
     <DockerSection buildStrategy={values.build.strategy} />
     <AppSection

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -24,7 +24,7 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
 }) => (
   <Form onSubmit={handleSubmit}>
     <BuilderSection image={values.image} builderImages={builderImages} />
-    <GitSection showSample />
+    <GitSection showSample builderImages={builderImages} />
     <AppSection
       project={values.project}
       noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useFormikContext, FormikValues, FormikTouched } from 'formik';
 import { Alert, TextInputTypes, ValidatedOptions } from '@patternfly/react-core';
-import { getGitService, GitProvider } from '@console/git-service';
+import { getGitService, GitProvider, BuildType } from '@console/git-service';
 import {
   InputField,
   DropdownField,
@@ -10,7 +10,12 @@ import {
 } from '@console/shared';
 import { GitReadableTypes, GitTypes } from '../import-types';
 import { detectGitType, detectGitRepoName } from '../import-validation-utils';
-import { getSampleRepo, getSampleRef, getSampleContextDir } from '../../../utils/imagestream-utils';
+import {
+  getSampleRepo,
+  getSampleRef,
+  getSampleContextDir,
+  NormalizedBuilderImages,
+} from '../../../utils/imagestream-utils';
 import FormSection from '../section/FormSection';
 import SampleRepo from './SampleRepo';
 import AdvancedGitOptions from './AdvancedGitOptions';
@@ -18,9 +23,10 @@ import { UNASSIGNED_KEY, CREATE_APPLICATION_KEY } from '../../../const';
 
 export interface GitSectionProps {
   showSample?: boolean;
+  builderImages: NormalizedBuilderImages;
 }
 
-const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
+const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) => {
   const { values, setFieldValue, setFieldTouched, touched, dirty } = useFormikContext<
     FormikValues
   >();
@@ -56,12 +62,14 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
           values.application.selectedKey !== UNASSIGNED_KEY &&
           setFieldValue('application.name', `${gitRepoName}-app`);
         setFieldValue('image.isRecommending', true);
-        const buildTools = await gitService.detectBuildTypes();
+        const buildTools: BuildType[] = await gitService.detectBuildTypes();
         setFieldValue('image.isRecommending', false);
-        if (buildTools.length > 0) {
-          const buildTool = buildTools[0].buildType;
+        const buildTool = buildTools.find(
+          ({ buildType: recommended }) => recommended && builderImages.hasOwnProperty(recommended),
+        );
+        if (buildTool && buildTool.buildType) {
           setFieldValue('image.couldNotRecommend', false);
-          setFieldValue('image.recommended', buildTool);
+          setFieldValue('image.recommended', buildTool.buildType);
         } else {
           setFieldValue('image.couldNotRecommend', true);
           setFieldValue('image.recommended', '');
@@ -73,6 +81,7 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
       }
     },
     [
+      builderImages,
       setFieldTouched,
       setFieldValue,
       values.application.name,


### PR DESCRIPTION
This is a manual cherry pick of https://github.com/openshift/console/pull/6570

Fixes: https://issues.redhat.com/browse/ODC-4205

Problem:
If there are multiple builder image recommendations, then builder detection should pick the releavant builder image based on the list of supported builderImages.

Solution:
Builder image detection needs to match with the first supported builder images in the console.

cc: @divyanshiGupta 