### PR TITLE
Bug 1879089: Use new parameter prefix (tt.param.) for Tekton Trigger version 0.6+

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerBindingSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerBindingSection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useFormikContext } from 'formik';
 import { Badge, ExpandableSection, FormHelperText } from '@patternfly/react-core';
 import FormSection from '../../../import/section/FormSection';
+import { usePipelineOperatorVersion } from '../../utils/pipeline-operator';
 import { TriggerBindingKind, TriggerBindingParam } from '../../resource-types';
 import TriggerBindingSelector from './TriggerBindingSelector';
 import { AddTriggerFormValues } from './types';
@@ -9,8 +10,17 @@ import { AddTriggerFormValues } from './types';
 import './TriggerBindingSection.scss';
 
 const TriggerBindingSection: React.FC = () => {
-  const { setFieldValue } = useFormikContext<AddTriggerFormValues>();
+  const { values, setFieldValue } = useFormikContext<AddTriggerFormValues>();
   const [bindingVars, setBindingVars] = React.useState<TriggerBindingParam[]>(null);
+
+  // Starting with Pipeline Operator 1.1 (Tekton Triggers 0.6) we should use a new param name.
+  const pipelineOperatorVersion = usePipelineOperatorVersion(values.namespace);
+  const paramPrefix =
+    pipelineOperatorVersion?.major === 0 ||
+    (pipelineOperatorVersion?.major === 1 && pipelineOperatorVersion?.minor === 0)
+      ? 'params.'
+      : 'tt.params.';
+
   const updateTriggerBindingVariables = React.useCallback(
     (selectedTriggerBinding: TriggerBindingKind) => {
       setBindingVars(selectedTriggerBinding.spec.params);
@@ -47,7 +57,7 @@ const TriggerBindingSection: React.FC = () => {
               className="odc-trigger-binding-section__variable-help-text"
             >
               Use this format when referencing variables in this form:{' '}
-              <code>{'$(params.parameter)'}</code>
+              <code>{`$(${paramPrefix}parameter)`}</code>
             </FormHelperText>
           </ExpandableSection>
         )}

--- a/frontend/packages/dev-console/src/components/pipelines/utils/pipeline-operator.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/utils/pipeline-operator.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { compare, parse, SemVer } from 'semver';
 import {
   ClusterServiceVersionKind,
@@ -22,4 +23,17 @@ export const getPipelineOperatorVersion = async (namespace: string): Promise<Sem
     return versions[versions.length - 1];
   }
   return null;
+};
+
+export const usePipelineOperatorVersion = (namespace: string): SemVer | null => {
+  const [version, setVersion] = React.useState<SemVer | null>(null);
+  React.useEffect(() => {
+    getPipelineOperatorVersion(namespace)
+      .then(setVersion)
+      .catch((error) =>
+        // eslint-disable-next-line no-console
+        console.warn('Error while determinate OpenShift Pipelines Operator version:', error),
+      );
+  }, [namespace]);
+  return version;
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4452
https://bugzilla.redhat.com/show_bug.cgi?id=1879089

**Analysis / Root cause**: 
Part of Tekton Triggers v0.6.0 comes a deprecation notice that changes the way parameters are referenced. The UI makes a note to inform the user how to approach using variables and this will need to be updated.

We have until v0.7.0 (v1.2 of the Operator, aka TP3) to implement this change before we start misleading the user. There shouldn't be any code break as it's entirely user driven input.

**Solution Description**: 
Check the installed Tekton TriggerTemplate CRD `version` label. The version label is missing for Tekton CRDs before 0.6. So we just verify if the version is available or not. We use the new param syntax ("tt.params.parameter") as default and switch to the old one ("params.parameter") if we find a CRD without a version.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/139310/93210850-a7103600-f760-11ea-8734-763b26a40c29.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Install the OpenShift Pipeline Operator 1.0.x and 1.1.x
* Create a Deployment and enable the option "Add Pipeline"
* Open the Pipeline and select the action "Add Trigger"
* Select a Git Type Provider and press "Show variables" 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge