### PR TITLE
Bug 1880118: Cypress:  Disable eslint rule, remove `return cy...`'s to fix flake

### DIFF
--- a/frontend/packages/integration-tests-cypress/.eslintrc
+++ b/frontend/packages/integration-tests-cypress/.eslintrc
@@ -9,6 +9,7 @@
     "no-console": "off",
     "no-namespace": "off",
     "no-redeclare": "off",
-    "promise/catch-or-return": "off"
+    "promise/catch-or-return": "off",
+    "promise/no-nesting": "off"
   }
 }

--- a/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
@@ -87,16 +87,17 @@ describe('Kubernetes resource CRUD operations', () => {
         cy.testA11y(`YAML Editor for ${kind}: ${name}`);
         let newContent;
         // get, update, and set yaml editor content.
-        return yamlEditor.getEditorContent().then((content) => {
+        yamlEditor.getEditorContent().then((content) => {
           newContent = _.defaultsDeep(
             {},
             { metadata: { name, labels: { [testLabel]: testName } } },
             safeLoad(content),
           );
-          yamlEditor.setEditorContent(safeDump(newContent, { sortKeys: true }));
           cy.log('creates a new resource instance');
-          yamlEditor.clickSaveCreateButton();
-          cy.get(errorMessage).should('not.exist');
+          yamlEditor.setEditorContent(safeDump(newContent, { sortKeys: true })).then(() => {
+            yamlEditor.clickSaveCreateButton();
+            cy.get(errorMessage).should('not.exist');
+          });
         });
       });
 

--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -96,11 +96,11 @@ describe('Monitoring: Alerts', () => {
     cy.byTestID('start-immediately').should('not.be.checked');
     // Allow for some difference in times
     cy.byTestID('from').should('not.have.value', 'Now');
-    return cy.byTestID('from').then(($fromElement) => {
+    cy.byTestID('from').then(($fromElement) => {
       const fromText = $fromElement[0].getAttribute('value');
       expect(Date.parse(fromText) - Date.now()).toBeLessThan(10000);
       // eslint-disable-next-line promise/no-nesting
-      return cy.byTestID('until').then(($untilElement) => {
+      cy.byTestID('until').then(($untilElement) => {
         expect(Date.parse($untilElement[0].getAttribute('value')) - Date.parse(fromText)).toEqual(
           60 * 60 * 1000,
         );


### PR DESCRIPTION
"promise/catch-or-return" was actually disabled on 9/2, this PR removes `return cy...`'s which were in place to get around this rule. Noticed some flakyness around using `return cy..`; noticeably Monitoring 'Expire Silence' -even though reported 'pass' looking at improved headless logging (PR #6629) and watching movie noticed that 'Expire Silence' modal never actually called due to returning too early!

Disabled `promise/no-nesting` rule due to yamlEditor using `cy.window` which is async, so we do need to nest promises to handle set/get window-yaml-editor content appropriately. 