### PR TITLE
Bug 1880118: Cypress better headless logging

### DIFF
--- a/frontend/packages/integration-tests-cypress/cypress.json
+++ b/frontend/packages/integration-tests-cypress/cypress.json
@@ -12,7 +12,7 @@
   "fixturesFolder": "fixtures",
   "defaultCommandTimeout": 30000,
   "retries": {
-    "runMode": 2,
-    "openMode": 1
+    "runMode": 1,
+    "openMode": 0
   }
 }

--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -20,6 +20,11 @@ Cypress.Cookies.defaults({
   preserve: ['openshift-session-token', 'csrf-token'],
 });
 
+Cypress.Commands.overwrite('log', (originalFn, message) => {
+  cy.task('log', `      ${message}`, { log: false }); // log:false means do not log task in runner GUI
+  originalFn(message); // calls original cy.log(message)
+});
+
 Cypress.Commands.add('logA11yViolations', (violations: Result[], target: string) => {
   // pluck specific keys to keep the table readable
   const violationData = violations.map(({ id, impact, description, nodes }) => ({

--- a/frontend/packages/integration-tests-cypress/support/login.ts
+++ b/frontend/packages/integration-tests-cypress/support/login.ts
@@ -15,16 +15,16 @@ const KUBEADMIN_IDP = 'kube:admin';
 
 // any command added below, must be added to global Cypress interface above
 
-// This will add to 'login(provider, username, password)' to cy
+// This will add 'cy.login(...)'
 // ex: cy.login('test', 'test', 'test')
 Cypress.Commands.add('login', (provider: string, username: string, password: string) => {
   // if local, no need to login
   if (!Cypress.env('BRIDGE_KUBEADMIN_PASSWORD')) {
-    cy.task('log', 'No BRIDGE_KUBEADMIN_PASSWORD set, skipping login');
+    cy.task('log', '  skipping login, no BRIDGE_KUBEADMIN_PASSWORD set');
     return;
   }
   const idp = provider || KUBEADMIN_IDP;
-  cy.task('log', `  Logging into IDP ${idp}, using baseUrl ${Cypress.config('baseUrl')}`);
+  cy.task('log', `  Logging in as ${username || KUBEADMIN_USERNAME}`);
   cy.visit(''); // visits baseUrl which is set in plugins/index.js
   cy.byLegacyTestID('login').should('be.visible');
   cy.contains(idp)
@@ -38,7 +38,7 @@ Cypress.Commands.add('login', (provider: string, username: string, password: str
 
 Cypress.Commands.add('logout', () => {
   if (!Cypress.env('BRIDGE_KUBEADMIN_PASSWORD')) {
-    cy.task('log', 'No BRIDGE_KUBEADMIN_PASSWORD set, skipping logout');
+    cy.task('log', '  skipping logout');
     return;
   }
   cy.task('log', '  Logging out');

--- a/frontend/packages/integration-tests-cypress/support/project.ts
+++ b/frontend/packages/integration-tests-cypress/support/project.ts
@@ -16,6 +16,7 @@ declare global {
 // This will add to 'createProject(...)' to cy
 // ex: cy.createProject(name)
 Cypress.Commands.add('createProject', (name: string) => {
+  cy.log(`create project`);
   cy.visit(`/k8s/cluster/projects`);
   listPage.clickCreateYAMLbutton();
   modal.shouldBeOpened();
@@ -27,6 +28,7 @@ Cypress.Commands.add('createProject', (name: string) => {
 });
 
 Cypress.Commands.add('deleteProject', (name: string) => {
+  cy.log(`delete project`);
   cy.visit(`/k8s/cluster/projects/${name}`);
   detailsPage.clickPageActionFromDropdown('Delete Project');
   modal.shouldBeOpened();

--- a/frontend/packages/integration-tests-cypress/support/resources.ts
+++ b/frontend/packages/integration-tests-cypress/support/resources.ts
@@ -41,16 +41,12 @@ Cypress.Commands.add(
       )
       .then((result) => {
         if (result.code !== 0) {
-          if (result.stderr.includes('NotFound')) {
-            cy.log(
-              `'oc get -n ${namespace} ${resource}/${name}' returned 'NotFound' indicating resource was successfully deleted`,
-            );
-          } else {
-            // this typically would be a 'You must be logged in to the server (Unauthorized)'
+          // if stderr === NotFound, means resource was succesfully deleted
+          if (!result.stderr.includes('NotFound')) {
+            // error other than 'NotFound', this typically would be a 'You must be logged in to the server (Unauthorized)'
             assert.fail('', '', `Error during 'oc get ${resource}/${name}', ${result.stderr} `);
           }
         } else {
-          cy.log(`expect ${resource}/${name} to have a deletionTimestamp`);
           expect(result.stdout).not.toContain(`<no value>`);
         }
       }),

--- a/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
@@ -93,7 +93,6 @@ describe('Kubernetes resource CRUD operations', () => {
             { metadata: { name, labels: { [testLabel]: testName } } },
             safeLoad(content),
           );
-          cy.log('creates a new resource instance');
           yamlEditor.setEditorContent(safeDump(newContent, { sortKeys: true })).then(() => {
             yamlEditor.clickSaveCreateButton();
             cy.get(errorMessage).should('not.exist');
@@ -112,11 +111,11 @@ describe('Kubernetes resource CRUD operations', () => {
           `${namespaced ? `/k8s/ns/${testName}` : '/k8s/cluster'}/${resource}?name=${testName}`,
         );
         if (namespaced) {
-          cy.log('has a working namespace dropdown on namespaced objects');
+          // should have a namespace dropdown for namespaced objects');
           listPage.projectDropdownShouldExist();
           listPage.projectDropdownShouldContain(testName);
         } else {
-          cy.log('does not have a namespace dropdown on non-namespaced objects');
+          // should not have a namespace dropdown for non-namespaced objects');
           listPage.projectDropdownShouldNotExist();
         }
         listPage.rows.shouldBeLoaded();
@@ -135,7 +134,7 @@ describe('Kubernetes resource CRUD operations', () => {
         listPage.rows.shouldExist(name);
         cy.testA11y(`Search page for ${kind}: ${name}`);
 
-        cy.log('link to to details page');
+        // link to to details page
         listPage.rows.clickRowByName(name);
         cy.url().should('include', `/${name}`);
         detailsPage.titleShouldContain(name);

--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -39,7 +39,7 @@ describe('Monitoring: Alerts', () => {
   });
 
   it('displays and filters the Alerts list page, links to detail pages', () => {
-    cy.log('use vert. nav. menu to goto Monitoring -> Alerting');
+    cy.log('use sidebar nav to goto Monitoring -> Alerting');
     nav.sidenav.clickNavLink(['Monitoring', 'Alerting']);
     // TODO, switch to 'listPage.titleShouldHaveText('Alerting');', when we switch to new test id
     cy.byLegacyTestID('resource-title').should('have.text', 'Alerting');

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -9,7 +9,7 @@ INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
 function copyArtifacts {
   if [ -d "$ARTIFACT_DIR" ] && [ -d "$SCREENSHOTS_DIR" ]; then
     echo "Copying artifacts from $(pwd)..."
-    cp -rv "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}/gui_test_screenshots"
+    cp -r "$SCREENSHOTS_DIR" "${ARTIFACT_DIR}/gui_test_screenshots"
   fi
 }
 


### PR DESCRIPTION
This PR improves logging in headless mode.  Cypress best-practice of test independence results in larger independent tests, as opposed to previously many small dependent tests.  In headless mode, cypress only outputs the test names as they run; as a result of fewer tests, there isn't a lot of output:

**BEFORE**
```
  Monitoring: Alerts
No BRIDGE_KUBEADMIN_PASSWORD set, skipping login
    ✓ displays and filters the Alerts list page, links to detail pages (4419ms)
No BRIDGE_KUBEADMIN_PASSWORD set, skipping logout
    ✓ creates and expires a Silence (2885ms)
```
In the gui Cypress Test Runner we use `cy.log(...)`'s to help determine test progression:

![image](https://user-images.githubusercontent.com/12733153/92611676-0664d680-f287-11ea-896d-c5921abcac89.png)


This PR exports these `cy.log` messages to headless terminal output, as well as improving logging messages:

**AFTER**
```
Monitoring: Alerts
  skipping login, no BRIDGE_KUBEADMIN_PASSWORD set
      create project
      use sidebar nav to goto Monitoring -> Alerting
      filter Alerts
      drills down to Alert details page
      drill down to the Alerting Rule details page
      drill back up to the Alert details page
    ✓ displays and filters the Alerts list page, links to detail pages (8727ms)
      filter to Watchdog alert
      silence Watchdog alert
*     shows the silenced Alert in the Silenced Alerts list 
*     shows the newly created Silence in the Silenced By list
*     expires the Silence
      delete project
  skipping logout
    ✓ creates and expires a Silence (25350ms)
```
`*` _These log messages will only appear after #6628 merges (flake)!_

In addition this PR:

- updates retries in headless to 1, and 0 when in test runner.
- changes mochawesomeReporter to quiet mode which removes: `[mochawesome] Report JSON saved to /home/dtaylor/repos/openshift/origin/src/github.com/openshift/console/frontend/gui_test_screenshots/cypress_report_004.json` output
- turns off 'verbose' copying of artifacts to `gui_test_screenshots` dir