### PR TITLE
Bug 1871736: Fixes clone for block mode PVCs

### DIFF
--- a/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
@@ -200,6 +200,8 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
     });
   };
 
+  const isBound = (pvc: PersistentVolumeClaimKind) => pvc?.status?.phase === 'Bound';
+
   return (
     <div className="co-m-pane__body co-volume-snapshot__body">
       <Helmet>
@@ -212,14 +214,6 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
             Creating snapshot for claim <strong>{resourceName}</strong>
           </p>
         )}
-        {pvcName && pvcObj && pvcObj?.status?.phase !== 'Bound' && (
-          <Alert
-            className="co-alert co-volume-snapshot__alert-body"
-            variant="warning"
-            title="Snapshot creation for unbound claim is not recommended."
-            isInline
-          />
-        )}
         {kindObj.kind === VolumeSnapshotModel.kind && (
           /* eslint-disable jsx-a11y/label-has-associated-control */
           <>
@@ -231,6 +225,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
               namespace={namespace}
               onChange={handlePVCName}
               selectedKey={pvcName}
+              dataFilter={isBound}
               desc={`Persistent Volume Claim in ${namespace} namespace`}
             />
           </>

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -334,6 +334,8 @@ const kebabFactory: KebabFactory = {
   }),
   PVCSnapshot: (kind, obj) => ({
     label: 'Create Snapshot',
+    isDisabled: obj?.status?.phase !== 'Bound',
+    tooltip: obj?.status?.phase !== 'Bound' ? 'PVC is not Bound' : '',
     href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/${
       VolumeSnapshotModel.plural
     }/~new/form`,
@@ -341,6 +343,8 @@ const kebabFactory: KebabFactory = {
   }),
   ClonePVC: (kind, obj) => ({
     label: 'Clone PVC',
+    isDisabled: obj?.status?.phase !== 'Bound',
+    tooltip: obj?.status?.phase !== 'Bound' ? 'PVC is not Bound' : '',
     callback: () =>
       clonePVCModal({
         kind,
@@ -350,6 +354,8 @@ const kebabFactory: KebabFactory = {
   }),
   RestorePVC: (kind, obj) => ({
     label: 'Restore as new PVC',
+    isDisabled: obj?.status?.phase !== 'Ready',
+    tooltip: obj?.status?.phase !== 'Ready' ? 'Volume Snapshot is not Ready' : '',
     callback: () =>
       restorePVCModal({
         kind,

--- a/frontend/public/components/utils/pvc-dropdown.tsx
+++ b/frontend/public/components/utils/pvc-dropdown.tsx
@@ -26,4 +26,5 @@ export type PVCDropdownProps = {
   id?: string;
   desc?: string;
   dataTest?: string;
+  dataFilter?: (pvc: PersistentVolumeClaimKind) => boolean;
 };


### PR DESCRIPTION
1. Replace the constants with shared constants.
2. Sets `volumeMode` while creating clone
3. Disable the clone and snapshot actions for unbound PVCs and restore action for non-ready snapshots
![Screenshot from 2020-09-18 14-11-01](https://user-images.githubusercontent.com/12200504/93576730-d28d5d80-f9b8-11ea-845e-125bef1a3ce9.png)
![Screenshot from 2020-09-18 14-10-49](https://user-images.githubusercontent.com/12200504/93576739-d4572100-f9b8-11ea-9458-747459751513.png)


Signed-off-by: Kanika Murarka <kmurarka@redhat.com>