### PR TITLE
Bug 1879164: fixes route decorator to show up if unique route is there for that revision

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -69,10 +69,10 @@ export const filterBasedOnActiveApplication = (
  */
 const getRouteData = (resource: K8sResourceKind, ksroutes: K8sResourceKind[]): string => {
   if (ksroutes && ksroutes.length > 0 && !_.isEmpty(ksroutes[0].status)) {
-    const trafficData = _.find(ksroutes[0].status.traffic, {
+    const trafficData: { [x: string]: any } = _.find(ksroutes[0].status.traffic, {
       revisionName: resource.metadata.name,
     });
-    return _.get(trafficData, 'url', ksroutes[0].status.url);
+    return trafficData?.url;
   }
   return null;
 };

--- a/frontend/packages/knative-plugin/src/topology/components/anchors/RevisionTrafficTargetAnchor.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/anchors/RevisionTrafficTargetAnchor.ts
@@ -22,7 +22,8 @@ export default class RevisionTrafficTargetAnchor extends AbstractAnchor {
     }
 
     // location is edge of outer node
-    return getEllipseAnchorPoint(bounds.getCenter(), bounds.width, bounds.height, reference);
+    const center = new Point(bounds.right() - 13, bounds.y + 13);
+    return getEllipseAnchorPoint(center, 0, 0, reference);
   }
 
   getReferencePoint(): Point {

--- a/frontend/packages/knative-plugin/src/topology/components/anchors/__tests__/RevisionTrafficTargetAnchor.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/anchors/__tests__/RevisionTrafficTargetAnchor.spec.ts
@@ -28,7 +28,7 @@ describe('RevisionTrafficTargetAnchor', () => {
   it('should return the outer edge as anchor location', () => {
     const anchor = new RevisionTrafficTargetAnchor(createMockNode(new Rect(10, 20, 130, 140)), 0);
     const loc = anchor.getLocation(new Point(50, 60));
-    expect(loc.x).toBeCloseTo(31.59);
-    expect(loc.y).toBeCloseTo(37.9);
+    expect(loc.x).toBeCloseTo(127);
+    expect(loc.y).toBeCloseTo(33);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4803

**Analysis / Root cause**: 
Decorator for Knative revision should show up for Revision if unique route is available

**Solution Description**: 
Handled Route in data based on availability of associated route 

**Screenshot/Gif**:
![image](https://user-images.githubusercontent.com/5129024/93225683-1c472f80-f790-11ea-97e8-14e27dd2534e.png)


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/93226980-88766300-f791-11ea-884b-1ddb4cce7c20.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
