### PR TITLE
Bug 1879507: QuickStart fix - Add styling for checkwork info

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.scss
@@ -1,4 +1,7 @@
 .co-quick-start-task-review {
+  font-size: var(--pf-global--FontSize--md);
+  line-height: var(--pf-global--FontSize--xl);
+
   &__actions {
     display: flex;
     align-items: flex-start;
@@ -14,13 +17,9 @@
 
   &--success {
     color: var(--pf-global--palette--green-500);
-    font-size: var(--pf-global--FontSize--md);
-    line-height: var(--pf-global--FontSize--xl);
   }
 
   &--failed {
     color: var(--pf-chart-global--danger--Color--100);
-    font-size: var(--pf-global--FontSize--md);
-    line-height: var(--pf-global--FontSize--xl);
   }
 }

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
@@ -30,7 +30,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
 }) => {
   const { instructions, taskHelp } = review;
 
-  const alertClassNames = cx({
+  const alertClassNames = cx('co-quick-start-task-review', {
     'co-quick-start-task-review--success': taskStatus === QuickStartTaskStatus.SUCCESS,
     'co-quick-start-task-review--failed': taskStatus === QuickStartTaskStatus.FAILED,
   });


### PR DESCRIPTION
# Issue
https://issues.redhat.com/browse/ODC-4778

# Problem
misalignment of quick start check your work header

# Solution
Created a base Style for Check Work

# ScreenShot
![check-work](https://user-images.githubusercontent.com/24852534/93336327-3f7fe680-f845-11ea-890d-fdc5ce52efa1.gif)

![Screenshot from 2020-09-16 16-02-42](https://user-images.githubusercontent.com/24852534/93336416-5de5e200-f845-11ea-8b72-f88a83257146.png)

![Screenshot from 2020-09-16 16-02-54](https://user-images.githubusercontent.com/24852534/93336432-6211ff80-f845-11ea-9aee-f7f243650d7f.png)

# Test
no tests altered

# Browser Conformance
Chromr