### PR TITLE
Bug 1879171: Fix for lost selectedId param in URL when navigating to topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
@@ -282,24 +282,12 @@ export const TopologyView: React.FC<ComponentProps> = ({
   React.useEffect(() => {
     if (filteredModel) {
       visualization.fromModel(filteredModel);
-      let selectedItem = selectedIds.length ? visualization.getElementById(selectedIds[0]) : null;
+      const selectId = selectedIds.length ? selectedIds[0] : queryParams.get('selectId');
+      const selectedItem = selectId ? visualization.getElementById(selectId) : null;
       if (!selectedItem || !selectedItem.isVisible()) {
         onSelect([]);
-      } else {
-        const selectId = queryParams.get('selectId');
-        if (selectId) {
-          selectedItem = visualization.getElementById(selectId);
-          if (selectedItem && selectedItem.isVisible()) {
-            setSelectedIds([selectId]);
-            const selectTab = queryParams.get('selectTab');
-            if (selectTab) {
-              onSelectTab(selectTab);
-            }
-          } else {
-            onSelect([]);
-          }
-        }
-        removeQueryArgument('selectTab');
+      } else if (!selectedIds.length) {
+        setSelectedIds([selectId]);
       }
       if (showGraphView) {
         if (groupsShown && showGroupsRef.current === false) {


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4837

**Description**
Fixes an issue where the selected id coming from the URL was discarded.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
