### PR TITLE
Bug 1868653: Convert Pipeline StartedBy Label to Annotation

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -5,12 +5,14 @@ import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
 import { getPipelineRunKebabActions } from '../../utils/pipeline-actions';
 import { PipelineRunDetails } from './detail-page-tabs/PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './detail-page-tabs/PipelineRunLogs';
-import { useMenuActionsWithUserLabel } from './triggered-by';
+import { useMenuActionsWithUserAnnotation } from './triggered-by';
 import { usePipelinesBreadcrumbsFor } from '../pipelines/hooks';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
-  const menuActions: KebabAction[] = useMenuActionsWithUserLabel(getPipelineRunKebabActions(true));
+  const menuActions: KebabAction[] = useMenuActionsWithUserAnnotation(
+    getPipelineRunKebabActions(true),
+  );
   const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
 
   return (

--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/TriggeredBySection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/TriggeredBySection.tsx
@@ -3,7 +3,7 @@ import { ResourceLink } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { EventListenerModel } from '../../../models';
 import { PipelineRun } from '../../../utils/pipeline-augment';
-import { StartedByLabel } from '../../pipelines/const';
+import { StartedByAnnotation, StartedByLabel } from '../../pipelines/const';
 
 type TriggeredByProps = {
   pipelineRun: PipelineRun;
@@ -12,12 +12,12 @@ type TriggeredByProps = {
 const TriggeredBySection: React.FC<TriggeredByProps> = (props) => {
   const {
     pipelineRun: {
-      metadata: { namespace, labels },
+      metadata: { annotations, namespace, labels },
     },
   } = props;
 
-  const manualTrigger = labels[StartedByLabel.user];
-  const autoTrigger = labels[StartedByLabel.triggers];
+  const manualTrigger = annotations?.[StartedByAnnotation.user];
+  const autoTrigger = labels?.[StartedByLabel.triggers];
 
   if (!manualTrigger && !autoTrigger) {
     return null;

--- a/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/ResourceKebabWithUserLabel.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/ResourceKebabWithUserLabel.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { KebabAction, ResourceKebab } from '@console/internal/components/utils';
-import { useMenuActionsWithUserLabel } from './hooks';
+import { useMenuActionsWithUserAnnotation } from './hooks';
 
 const ResourceKebabWithUserLabel: React.FC<React.ComponentProps<typeof ResourceKebab>> = ({
   actions,
   ...otherProps
 }) => {
-  const augmentedMenuActions: KebabAction[] = useMenuActionsWithUserLabel(actions);
+  const augmentedMenuActions: KebabAction[] = useMenuActionsWithUserAnnotation(actions);
 
   return <ResourceKebab {...otherProps} actions={augmentedMenuActions} />;
 };

--- a/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
@@ -6,15 +6,15 @@ import { useSelector } from 'react-redux';
 import { KebabAction, Kebab } from '@console/internal/components/utils';
 import { K8sResourceCommon } from '@console/internal/module/k8s';
 import { PipelineRun } from '../../../utils/pipeline-augment';
-import { StartedByLabel } from '../../pipelines/const';
+import { StartedByAnnotation } from '../../pipelines/const';
 
-type LabelMap = { [labelKey: string]: string };
+type AnnotationMap = { [annotationKey: string]: string };
 
-const mergeLabelsWithResource = (labels: LabelMap, resource: K8sResourceCommon) => {
-  return merge({}, resource, { metadata: { labels } });
+const mergeAnnotationsWithResource = (annotations: AnnotationMap, resource: K8sResourceCommon) => {
+  return merge({}, resource, { metadata: { annotations } });
 };
 
-export const useUserLabelForManualStart = (): LabelMap => {
+export const useUserAnnotationForManualStart = (): AnnotationMap => {
   const user = useSelector((state) => state.UI.get('user'));
 
   if (!user?.metadata?.name) {
@@ -22,25 +22,24 @@ export const useUserLabelForManualStart = (): LabelMap => {
   }
 
   return {
-    // kube:admin is an invalid k8s label value
-    [StartedByLabel.user]: user.metadata.name.replace(/:/, ''),
+    [StartedByAnnotation.user]: user.metadata.name,
   };
 };
 
-export const usePipelineRunWithUserLabel = (plr: PipelineRun): PipelineRun => {
-  const labels = useUserLabelForManualStart();
+export const usePipelineRunWithUserAnnotation = (plr: PipelineRun): PipelineRun => {
+  const annotations = useUserAnnotationForManualStart();
 
-  return plr && mergeLabelsWithResource(labels, plr);
+  return plr && mergeAnnotationsWithResource(annotations, plr);
 };
 
-export const useMenuActionsWithUserLabel = (menuActions: KebabAction[]): KebabAction[] => {
-  const labels = useUserLabelForManualStart();
+export const useMenuActionsWithUserAnnotation = (menuActions: KebabAction[]): KebabAction[] => {
+  const annotations = useUserAnnotationForManualStart();
 
   return menuActions.map((kebabAction) => {
     if (Object.values(Kebab.factory).includes(kebabAction)) {
       return kebabAction;
     }
     return (kind, resource, ...rest) =>
-      kebabAction(kind, mergeLabelsWithResource(labels, resource), ...rest);
+      kebabAction(kind, mergeAnnotationsWithResource(annotations, resource), ...rest);
   });
 };

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -6,7 +6,7 @@ import { ErrorPage404 } from '@console/internal/components/error';
 import { getPipelineKebabActions } from '../../utils/pipeline-actions';
 import { getLatestRun, PipelineRun } from '../../utils/pipeline-augment';
 import { PipelineRunModel, PipelineModel } from '../../models';
-import { useMenuActionsWithUserLabel } from '../pipelineruns/triggered-by';
+import { useMenuActionsWithUserAnnotation } from '../pipelineruns/triggered-by';
 import {
   PipelineDetails,
   PipelineForm,
@@ -45,7 +45,7 @@ const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
       .catch((error) => setErrorCode(error.response.status));
   }, [name, namespace]);
 
-  const augmentedMenuActions: KebabAction[] = useMenuActionsWithUserLabel(
+  const augmentedMenuActions: KebabAction[] = useMenuActionsWithUserAnnotation(
     getPipelineKebabActions(latestPipelineRun, templateNames.length > 0),
   );
 

--- a/frontend/packages/dev-console/src/components/pipelines/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/const.ts
@@ -1,6 +1,8 @@
 export enum StartedByLabel {
-  user = 'pipeline.openshift.io/started-by',
   triggers = 'triggers.tekton.dev/eventlistener',
+}
+export enum StartedByAnnotation {
+  user = 'pipeline.openshift.io/started-by',
 }
 
 export enum PipelineResourceType {

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/__tests__/utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/__tests__/utils.spec.ts
@@ -124,13 +124,14 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
       anotherlabel: 'another-label-value',
     };
 
-    const runData = getPipelineRunFromForm(actionPipelines[0], formValues, labels, {
+    const runData = getPipelineRunFromForm(actionPipelines[0], formValues, labels, null, {
       generateName: true,
     });
     expect(runData).toEqual({
       apiVersion: 'abhiapi/v1',
       kind: 'PipelineRun',
       metadata: {
+        annotations: {},
         namespace: 'corazon',
         generateName: 'sansa-stark-',
         labels: { ...labels, 'tekton.dev/pipeline': 'sansa-stark' },

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
@@ -70,6 +70,7 @@ export const getPipelineRunData = (
         : {
             name: `${pipelineName}-${getRandomChars()}`,
           }),
+      annotations: _.merge({}, pipeline?.metadata?.annotations, latestRun?.metadata?.annotations),
       namespace: pipeline ? pipeline.metadata.namespace : latestRun.metadata.namespace,
       labels: _.merge({}, pipeline?.metadata?.labels, latestRun?.metadata?.labels, {
         'tekton.dev/pipeline': pipelineName,
@@ -144,12 +145,14 @@ export const getPipelineRunFromForm = (
   pipeline: Pipeline,
   formValues: CommonPipelineModalFormikValues,
   labels?: { [key: string]: string },
+  annotations?: { [key: string]: string },
   options?: { generateName: boolean },
 ) => {
   const { parameters, resources, workspaces } = formValues;
 
   const pipelineRunData: PipelineRun = {
     metadata: {
+      annotations,
       labels,
     },
     spec: {

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -6,7 +6,7 @@ import {
 } from '@console/internal/components/factory/modal';
 import { errorModal } from '@console/internal/components/modals';
 import { Pipeline, PipelineRun, PipelineWorkspace } from '../../../../utils/pipeline-augment';
-import { useUserLabelForManualStart } from '../../../pipelineruns/triggered-by';
+import { useUserAnnotationForManualStart } from '../../../pipelineruns/triggered-by';
 import ModalStructure from '../common/ModalStructure';
 import { convertPipelineToModalData } from '../common/utils';
 import { startPipelineSchema } from '../common/validation-utils';
@@ -23,7 +23,7 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
   close,
   onSubmit,
 }) => {
-  const userStartedLabel = useUserLabelForManualStart();
+  const userStartedAnnotation = useUserAnnotationForManualStart();
 
   const initialValues: StartPipelineFormValues = {
     ...convertPipelineToModalData(pipeline),
@@ -38,7 +38,7 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
   const handleSubmit = (values: StartPipelineFormValues, actions): void => {
     actions.setSubmitting(true);
 
-    submitStartPipeline(values, pipeline, userStartedLabel)
+    submitStartPipeline(values, pipeline, null, userStartedAnnotation)
       .then((res) => {
         actions.setSubmitting(false);
         onSubmit && onSubmit(res);

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/submit-utils.ts
@@ -28,7 +28,8 @@ export const resourceSubmit = async (
 export const submitStartPipeline = async (
   values: StartPipelineFormValues,
   pipeline: Pipeline,
-  labels: { [key: string]: string },
+  labels?: { [key: string]: string },
+  annotations?: { [key: string]: string },
 ): Promise<PipelineRun> => {
   const { namespace, resources } = values;
 
@@ -64,7 +65,7 @@ export const submitStartPipeline = async (
 
   const pipelineRunResource: PipelineRun = await k8sCreate(
     PipelineRunModel,
-    getPipelineRunFromForm(pipeline, formValues, labels),
+    getPipelineRunFromForm(pipeline, formValues, labels, annotations),
   );
 
   return Promise.resolve(pipelineRunResource);

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/submit-utils.ts
@@ -57,12 +57,9 @@ export const submitTrigger = async (
   const { triggerBinding } = formValues;
   const thisNamespace = pipeline.metadata.namespace;
 
-  const pipelineRun: PipelineRun = getPipelineRunFromForm(
-    pipeline,
-    formValues,
-    {},
-    { generateName: true },
-  );
+  const pipelineRun: PipelineRun = getPipelineRunFromForm(pipeline, formValues, null, null, {
+    generateName: true,
+  });
   const triggerTemplateParams: TriggerTemplateKindParam[] = triggerBinding.resource.spec.params.map(
     ({ name }) => ({ name } as TriggerTemplateKindParam),
   );

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
@@ -7,7 +7,7 @@ import { useAccessReview } from '@console/internal/components/utils';
 import { AccessReviewResourceAttributes } from '@console/internal/module/k8s';
 import { rerunPipelineAndStay } from '../../../utils/pipeline-actions';
 import { PipelineRunModel } from '../../../models';
-import { usePipelineRunWithUserLabel } from '../../pipelineruns/triggered-by';
+import { usePipelineRunWithUserAnnotation } from '../../pipelineruns/triggered-by';
 import { getLatestRun, PipelineRun } from '../../../utils/pipeline-augment';
 
 type TriggerLastRunButtonProps = {
@@ -21,7 +21,7 @@ const TriggerLastRunButton: React.FC<TriggerLastRunButtonProps> = ({
   namespace,
   impersonate,
 }) => {
-  const latestRun = usePipelineRunWithUserLabel(
+  const latestRun = usePipelineRunWithUserAnnotation(
     getLatestRun({ data: pipelineRuns }, 'startTimestamp'),
   );
   const { label, callback, accessReview: utilityAccessReview } = rerunPipelineAndStay(

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -13,7 +13,7 @@ import {
   removeTriggerModal,
 } from '../components/pipelines/modals';
 import { getPipelineRunData } from '../components/pipelines/modals/common/utils';
-import { StartedByLabel } from '../components/pipelines/const';
+import { StartedByAnnotation } from '../components/pipelines/const';
 import { EventListenerModel, PipelineModel, PipelineRunModel } from '../models';
 import { Pipeline, PipelineRun } from './pipeline-augment';
 import { pipelineRunFilterReducer } from './pipeline-filter-reducer';
@@ -203,7 +203,7 @@ const addTrigger: KebabAction = (kind: K8sKind, pipeline: Pipeline) => ({
       ...pipeline,
       metadata: {
         ...pipeline.metadata,
-        labels: _.omit(pipeline.metadata.labels, [StartedByLabel.user]),
+        annotations: _.omit(pipeline.metadata.annotations, [StartedByAnnotation.user]),
       },
     };
     addTriggerModal({ pipeline: cleanPipeline, modalClassName: 'modal-lg' });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4862

**Analysis / Root cause**: 
StartedBy was added in 4.5, it was added as a label. Labels have limitations, it was unclear the full usage of the name and it was incorrectly assigned to a label, whereas we need to support a full range of characters beyond what labels can have.

**Solution Description**: 
Annotations do not have this limitation, moving the started by content from labels to annnotations.

**Screen shots / Gifs for design review**: 

kube:admin
![image](https://user-images.githubusercontent.com/8126518/93273976-27e22880-f787-11ea-9030-178bfafe033e.png)

Email username:
![Screen Shot 2020-09-15 at 7 06 47 PM](https://user-images.githubusercontent.com/8126518/93273765-b4401b80-f786-11ea-9f1f-d5caef8de769.png)

Trigger:
![image](https://user-images.githubusercontent.com/8126518/93274066-6ed01e00-f787-11ea-886d-42e0cfd77c0e.png)


**Unit test coverage report**: 
No change

**Test setup:**
* Setup a Pipeline
* Start said Pipeline, notice the started by information that is your user
    * Try `kube:admin`
    * Try creating a user with an email address
* Setup a trigger and invoke it to see it still shows the trigger details

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge