### PR TITLE
Bug 1847845: Sending requested storage size as min PV Size for Bare Metal

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -119,7 +119,7 @@ const CreateSC: React.FC<CreateSCProps> = ({ match }) => {
             if (
               discovery?.status?.state === AVAILABLE &&
               discovery.property === DiskMechanicalProperties.SSD &&
-              discovery.type === DiskType.RawDisk
+              (discovery.type === DiskType.RawDisk || discovery.type === DiskType.Partition)
             ) {
               discovery.node = name;
               return true;

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { StorageClassResourceKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { humanizeBinaryBytes } from '@console/internal/components/utils/';
 import { getName } from '@console/shared';
-import { pvResource } from '../../constants/resources';
 import { calcPVsCapacity, getSCAvailablePVs } from '../../selectors';
 import '../modals/add-capacity-modal/_add-capacity-modal.scss';
 import './pvs-available-capacity.scss';
@@ -11,8 +9,9 @@ import './pvs-available-capacity.scss';
 export const PVsAvailableCapacity: React.FC<PVAvaialbleCapacityProps> = ({
   replica,
   storageClass,
+  pvsList,
 }) => {
-  const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>(pvResource);
+  const [data, loaded, loadError] = pvsList;
   let availableCapacity: string = '';
 
   let availableStatusElement = (
@@ -40,4 +39,5 @@ export const PVsAvailableCapacity: React.FC<PVAvaialbleCapacityProps> = ({
 type PVAvaialbleCapacityProps = {
   replica: number;
   storageClass: StorageClassResourceKind;
+  pvsList: [K8sResourceKind[], boolean, any];
 };

--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -72,3 +72,10 @@ export const calcPVsCapacity = (pvs: K8sResourceKind[]): number =>
 
 export const getSCAvailablePVs = (pvsData: K8sResourceKind[], sc: string): K8sResourceKind[] =>
   pvsData.filter((pv) => getPVStorageClass(pv) === sc && pv.status.phase === status.AVAILABLE);
+
+export const getMinSizePVCapacity = (pvs: K8sResourceKind[]): number => {
+  const capacities: number[] = pvs.map((pv) =>
+    Number(convertToBaseValue(pv.spec.capacity.storage)),
+  );
+  return Math.min(...capacities);
+};


### PR DESCRIPTION
- Sending requested storage size as of the minimum PV size for create OCS and add capacity on BM/Attached Devices
- Allowed the manually partition disks too for discovery results