### PR TITLE
Bug 1879485: fix application selector incontext for add forms

### DIFF
--- a/frontend/packages/dev-console/src/components/dropdown/ApplicationSelector.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ApplicationSelector.tsx
@@ -27,16 +27,21 @@ interface DispatchProps {
 type Props = ApplicationSelectorProps & StateProps & DispatchProps;
 
 const ApplicationSelector: React.FC<Props> = ({ namespace, application, onChange, disabled }) => {
-  if (namespace === ALL_NAMESPACES_KEY) return null;
-
   const allApplicationsTitle = 'all applications';
   const noApplicationsTitle = 'unassigned';
-  const title: string =
+  const dropdownTitle: string =
     application === ALL_APPLICATIONS_KEY
       ? allApplicationsTitle
       : application === UNASSIGNED_APPLICATIONS_KEY
       ? noApplicationsTitle
       : application;
+  const [title, setTitle] = React.useState<string>(dropdownTitle);
+  React.useEffect(() => {
+    if (!disabled) {
+      setTitle(dropdownTitle);
+    }
+  }, [disabled, dropdownTitle]);
+  if (namespace === ALL_NAMESPACES_KEY) return null;
 
   const onApplicationChange = (newApplication: string, key: string) => {
     key === ALL_APPLICATIONS_KEY ? onChange(key) : onChange(newApplication);

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -23,7 +23,6 @@ export interface DeployImageProps {
 interface StateProps {
   activeApplication: string;
   serviceBindingAvailable: boolean;
-  isInContext: boolean;
 }
 
 type Props = DeployImageProps & StateProps;
@@ -34,7 +33,6 @@ const DeployImage: React.FC<Props> = ({
   activeApplication,
   contextualSource,
   serviceBindingAvailable,
-  isInContext,
 }) => {
   const initialValues: DeployImageFormData = {
     project: {
@@ -46,7 +44,7 @@ const DeployImage: React.FC<Props> = ({
       initial: sanitizeApplicationValue(activeApplication),
       name: sanitizeApplicationValue(activeApplication),
       selectedKey: activeApplication,
-      isInContext,
+      isInContext: !!sanitizeApplicationValue(activeApplication),
     },
     name: '',
     searchTerm: '',
@@ -192,11 +190,10 @@ interface OwnProps extends DeployImageProps {
 }
 const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => {
   const activeApplication = ownProps.forApplication || getActiveApplication(state);
-  const isInContext = !!ownProps.forApplication;
+
   return {
     activeApplication: activeApplication !== ALL_APPLICATIONS_KEY ? activeApplication : '',
     serviceBindingAvailable: state.FLAGS.get(ALLOW_SERVICE_BINDING),
-    isInContext,
   };
 };
 

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -54,6 +54,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       initial: sanitizeApplicationValue(activeApplication),
       name: sanitizeApplicationValue(activeApplication),
       selectedKey: activeApplication === 'unassigned' ? UNASSIGNED_KEY : activeApplication,
+      isInContext: !!sanitizeApplicationValue(activeApplication),
     },
     git: {
       url: '',

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -172,7 +172,8 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) =>
       return;
     }
     !nameTouched && setFieldValue('name', '');
-    values.application.selectedKey !== UNASSIGNED_KEY &&
+    !values.application.isInContext &&
+      values.application.selectedKey !== UNASSIGNED_KEY &&
       !applicationNameTouched &&
       setFieldValue('application.name', '');
   };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-2386
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: when the application is selected using the ApplicationSelector in the secondary masthead . Context for the selected application is not kept in the import forms
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Keep the context of application
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: Coming soon
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: None
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
