### PR TITLE
Bug 1880117: Fix Protractor flake: display Global Configuration page, click Explore Console API in dropdown link

### DIFF
--- a/frontend/integration-tests/tests/cluster-settings.scenario.ts
+++ b/frontend/integration-tests/tests/cluster-settings.scenario.ts
@@ -95,7 +95,7 @@ describe('Cluster Settings', () => {
     expect(crudView.actionForLabel('Explore Console API').isDisplayed()).toBe(true);
     await crudView.actionForLabel('Explore Console API').click();
 
-    expect(clusterSettingsView.globalConfigDetailsTitle.isDisplayed()).toBe(true);
+    await clusterSettingsView.globalConfigDetailsTitleIsLoaded();
     expect(clusterSettingsView.globalConfigDetailsTitle.getText()).toBe('Console');
   });
 });

--- a/frontend/integration-tests/views/cluster-settings.view.ts
+++ b/frontend/integration-tests/views/cluster-settings.view.ts
@@ -1,4 +1,4 @@
-import { element, by, browser, $$, $ } from 'protractor';
+import { element, by, browser, $$, $, ExpectedConditions as until } from 'protractor';
 import { waitForNone } from '../protractor.conf';
 
 export const heading = element(
@@ -16,3 +16,5 @@ export const clusterOperatorResourceLink = $('[data-test-id="console"]');
 export const globalConfigResourceLink = $('[data-test-id="Console"]');
 export const clusterResourceDetailsTitle = $('[data-test-id="resource-title"]');
 export const globalConfigDetailsTitle = $('[data-test-id="api-explorer-resource-title"]');
+export const globalConfigDetailsTitleIsLoaded = async () =>
+  await browser.wait(until.presenceOf(globalConfigDetailsTitle));


### PR DESCRIPTION
Saw this flake in two of my open PRs, also seems to be happening pretty consistently [search](https://search.ci.openshift.org/?search=display+Global+Configuration+page%2C+click+Explore+Console+API+in+dropdown+link&maxAge=48h&context=2&type=junit&name=&maxMatches=5&maxBytes=20971520&groupBy=job)