### PR TITLE
Add useResolvedExtensions hook and improve related code

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
+import {
+  Extension,
+  ExtensionTypeGuard,
+  LoadedExtension,
+} from '@console/plugin-sdk/src/typings/base';
+import { resolveCodeRefProperties } from '../coderefs/coderef-resolver';
+import {
+  ResolvedCodeRefProperties,
+  ExtensionProperties,
+  UpdateExtensionProperties,
+} from '../types';
+
+/**
+ * React hook for consuming Console extensions with resolved `CodeRef` properties.
+ *
+ * This hook accepts the same argument(s) as `useExtensions` hook and returns an
+ * adapted list of extension instances, resolving all code references within each
+ * extension's properties.
+ *
+ * Initially, the hook returns an empty array. Once the resolution is complete,
+ * the React component is re-rendered with the hook returning an adapted list of
+ * extensions.
+ *
+ * When the list of matching extensions changes, the resolution is restarted. The
+ * hook will continue to return the previous result until the resolution completes.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * const navItemExtensions = useResolvedExtensions<NavItem>(isNavItem);
+ * const perspectiveExtensions = useResolvedExtensions<Perspective>(isPerspective);
+ * ```
+ *
+ * The hook's result is guaranteed to be referentially stable across re-renders.
+ *
+ * @param typeGuards Type guard(s) used to narrow the extension instances.
+ *
+ * @returns List of adapted extension instances with resolved code references.
+ */
+export const useResolvedExtensions = <E extends Extension>(
+  ...typeGuards: ExtensionTypeGuard<E>[]
+): ResolvedExtension<E>[] => {
+  const extensions = useExtensions<E>(...typeGuards);
+
+  const [resolvedExtensions, setResolvedExtensions] = React.useState<ResolvedExtension<E>[]>([]);
+
+  React.useEffect(() => {
+    let disposed = false;
+
+    // eslint-disable-next-line promise/catch-or-return
+    Promise.all(
+      extensions.map(async (e) => {
+        const properties = await resolveCodeRefProperties(e);
+        return Object.freeze(_.merge({}, e, { properties })) as ResolvedExtension<E>;
+      }),
+    ).then((result) => {
+      if (!disposed) {
+        setResolvedExtensions(result);
+      }
+    });
+
+    return () => {
+      disposed = true;
+    };
+  }, [extensions]);
+
+  return resolvedExtensions;
+};
+
+type ResolvedExtension<E extends Extension, P = ExtensionProperties<E>> = UpdateExtensionProperties<
+  LoadedExtension<E>,
+  ResolvedCodeRefProperties<P>
+>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/feature-flags.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/feature-flags.ts
@@ -1,5 +1,5 @@
 import { Extension } from '@console/plugin-sdk/src/typings/base';
-import { CodeRef, EncodedCodeRef, Update } from '../types';
+import { CodeRef, EncodedCodeRef, UpdateExtensionProperties } from '../types';
 
 export namespace ExtensionProperties {
   export type FeatureFlag = {
@@ -7,12 +7,9 @@ export namespace ExtensionProperties {
     handler: EncodedCodeRef;
   };
 
-  export type ResolvedFeatureFlag = Update<
-    FeatureFlag,
-    {
-      handler: CodeRef<FeatureFlagHandler>;
-    }
-  >;
+  export type FeatureFlagCodeRefs = {
+    handler: CodeRef<FeatureFlagHandler>;
+  };
 
   export type ModelFeatureFlag = {
     /** The name of the flag to set once the CRD is detected. */
@@ -32,11 +29,9 @@ export type FeatureFlag = Extension<ExtensionProperties.FeatureFlag> & {
   type: 'console.flag';
 };
 
-export type ResolvedFeatureFlag = Update<
+export type ResolvedFeatureFlag = UpdateExtensionProperties<
   FeatureFlag,
-  {
-    properties: ExtensionProperties.ResolvedFeatureFlag;
-  }
+  ExtensionProperties.FeatureFlagCodeRefs
 >;
 
 export type ModelFeatureFlag = Extension<ExtensionProperties.ModelFeatureFlag> & {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
@@ -14,8 +14,6 @@ type ConsolePluginData = {
   entryCallbackFired: boolean;
 };
 
-let pluginEntryCallbackRegistered = false;
-
 const pluginMap = new Map<string, ConsolePluginData>();
 
 const getPluginID = (m: ConsolePluginManifestJSON) => `${m.name}@${m.version}`;
@@ -46,12 +44,6 @@ export const loadDynamicPlugin = (baseURL: string, manifest: ConsolePluginManife
 };
 
 export const registerPluginEntryCallback = (pluginStore: PluginStore) => {
-  if (pluginEntryCallbackRegistered) {
-    throw new Error('Plugin entry callback is already registered');
-  }
-
-  pluginEntryCallbackRegistered = true;
-
   window.loadPluginEntry = (pluginID: string, entryModule: RemoteEntryModule) => {
     if (!pluginMap.has(pluginID)) {
       console.error(`Received callback for unknown plugin ${pluginID}`);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
@@ -1,3 +1,5 @@
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+
 /**
  * Remote (i.e. webpack container) entry module interface.
  */
@@ -7,7 +9,7 @@ export type RemoteEntryModule = {
    *
    * Fails if the requested module doesn't exist in container.
    */
-  get: <T extends object>(moduleName: string) => Promise<() => T>;
+  get: <T extends {}>(moduleName: string) => Promise<() => T>;
 
   /**
    * Override module(s) that were flagged by the container as "overridable".
@@ -28,13 +30,39 @@ export type RemoteEntryModule = {
 export type EncodedCodeRef = { $codeRef: string };
 
 /**
- * Code reference, resolved to a function that returns the object `T`.
+ * Code reference, represented by a function that returns a promise for the object `T`.
  */
-export type CodeRef<T> = () => Promise<T>;
+export type CodeRef<T = any> = () => Promise<T>;
+
+/**
+ * Infer resolved `CodeRef` properties from object `O`.
+ */
+export type ResolvedCodeRefProperties<O extends {}> = {
+  [K in keyof O]: O[K] extends CodeRef<infer T> ? T : never;
+};
 
 /**
  * Update existing properties of object `O` with ones declared in object `U`.
  */
-export type Update<O extends object, U extends object> = {
+export type Update<O extends {}, U extends {}> = {
   [K in keyof O]: K extends keyof U ? U[K] : O[K];
 } & {};
+
+/**
+ * Infer the properties of extension `E`.
+ */
+export type ExtensionProperties<E> = E extends Extension<infer P> ? P : never;
+
+/**
+ * Update existing properties of extension `E` with ones declared in object `U`.
+ */
+export type UpdateExtensionProperties<
+  E extends Extension<P>,
+  U extends {},
+  P = ExtensionProperties<E>
+> = Update<
+  E,
+  {
+    properties: Update<P, U>;
+  }
+>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
@@ -3,7 +3,10 @@ import * as _ from 'lodash';
 import { ValidationResult } from './ValidationResult';
 import { ConsolePluginMetadata } from '../schema/plugin-package';
 import { SupportedExtension } from '../schema/console-extensions';
-import { filterCodeRefProperties, parseEncodedCodeRefValue } from '../coderefs/coderef-resolver';
+import {
+  filterEncodedCodeRefProperties,
+  parseEncodedCodeRefValue,
+} from '../coderefs/coderef-resolver';
 
 type ExtensionCodeRefData = {
   index: number;
@@ -14,12 +17,9 @@ type ExposedPluginModules = ConsolePluginMetadata['exposedModules'];
 
 const collectCodeRefData = (extensions: SupportedExtension[]) =>
   extensions.reduce((acc, e, index) => {
-    const codeRefProperties = filterCodeRefProperties(e.properties);
-    if (!_.isEmpty(codeRefProperties)) {
-      acc.push({
-        index,
-        propToCodeRefValue: _.mapValues(codeRefProperties, (obj) => obj.$codeRef),
-      });
+    const refs = filterEncodedCodeRefProperties(e.properties);
+    if (!_.isEmpty(refs)) {
+      acc.push({ index, propToCodeRefValue: _.mapValues(refs, (obj) => obj.$codeRef) });
     }
     return acc;
   }, [] as ExtensionCodeRefData[]);

--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -107,14 +107,16 @@ describe('augmentExtension', () => {
           type: 'Foo',
           properties: {},
         },
+        'Test@1.2.3',
         'Test',
         0,
       ),
     ).toEqual({
       type: 'Foo',
       properties: {},
+      pluginID: 'Test@1.2.3',
       pluginName: 'Test',
-      uid: 'Test[0]',
+      uid: 'Test@1.2.3[0]',
     });
 
     expect(
@@ -124,11 +126,13 @@ describe('augmentExtension', () => {
           properties: {},
         },
         'Test',
+        'Test',
         1,
       ),
     ).toEqual({
       type: 'Bar',
       properties: {},
+      pluginID: 'Test',
       pluginName: 'Test',
       uid: 'Test[1]',
     });
@@ -137,7 +141,7 @@ describe('augmentExtension', () => {
   it('returns the same extension instance', () => {
     const testExtension: Extension = { type: 'Foo/Bar', properties: {} };
 
-    expect(augmentExtension(testExtension, 'Test', 0)).toBe(testExtension);
+    expect(augmentExtension(testExtension, 'Test@1.2.3', 'Test', 0)).toBe(testExtension);
   });
 });
 

--- a/frontend/packages/console-plugin-sdk/src/api/subscribeToExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/subscribeToExtensions.ts
@@ -1,8 +1,8 @@
 import { Store } from 'redux';
 import * as _ from 'lodash';
 import { RootState } from '@console/internal/redux';
-import { isExtensionInUse, PluginStore } from './store';
-import { Extension, ExtensionTypeGuard } from './typings';
+import { isExtensionInUse, PluginStore } from '../store';
+import { Extension, ExtensionTypeGuard } from '../typings';
 
 let subscriptionServiceInitialized = false;
 

--- a/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { useForceRender } from '@console/shared/src/hooks/useForceRender';
 import { subscribeToExtensions } from './subscribeToExtensions';
-import { Extension, ExtensionTypeGuard, LoadedExtension } from './typings';
+import { Extension, ExtensionTypeGuard, LoadedExtension } from '../typings';
 
 /**
  * React hook for consuming Console extensions.
@@ -16,23 +17,20 @@ import { Extension, ExtensionTypeGuard, LoadedExtension } from './typings';
  * - all feature flags referenced by its `flags` object are resolved to the right
  *   values
  *
+ * When the list of matching extensions changes, the React component is re-rendered
+ * with the hook returning an updated list of extensions.
+ *
  * Example usage:
  *
  * ```ts
- * import {
- *   useExtensions,
- *   NavItem,
- *   Perspective,
- *   isNavItem,
- *   isPerspective,
- * } from '@console/plugin-sdk';
- *
  * const Example = () => {
  *   const navItemExtensions = useExtensions<NavItem>(isNavItem);
  *   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
  *   // process extensions and render your component
  * };
  * ```
+ *
+ * The hook's result is guaranteed to be referentially stable across re-renders.
  *
  * @param typeGuards Type guard(s) used to narrow the extension instances.
  *
@@ -46,16 +44,18 @@ export const useExtensions = <E extends Extension>(
     throw new Error('You must pass at least one type guard to useExtensions');
   }
 
+  const forceRender = useForceRender();
+
+  const isMountedRef = React.useRef(true);
   const unsubscribeRef = React.useRef<VoidFunction>(null);
   const extensionsInUseRef = React.useRef<E[]>([]);
   const latestTypeGuardsRef = React.useRef<ExtensionTypeGuard<E>[]>(typeGuards);
-  const forceRender = React.useReducer((s: boolean) => !s, false)[1] as VoidFunction;
 
   const trySubscribe = React.useCallback(() => {
     if (unsubscribeRef.current === null) {
       unsubscribeRef.current = subscribeToExtensions<E>((extensions) => {
         extensionsInUseRef.current = extensions;
-        forceRender();
+        isMountedRef.current && forceRender();
       }, ...latestTypeGuardsRef.current);
     }
   }, [forceRender]);
@@ -74,7 +74,13 @@ export const useExtensions = <E extends Extension>(
 
   trySubscribe();
 
-  React.useEffect(() => tryUnsubscribe, [tryUnsubscribe]);
+  React.useEffect(
+    () => () => {
+      isMountedRef.current = false;
+      tryUnsubscribe();
+    },
+    [tryUnsubscribe],
+  );
 
   return extensionsInUseRef.current as LoadedExtension<E>[];
 };

--- a/frontend/packages/console-plugin-sdk/src/api/withExtensions.tsx
+++ b/frontend/packages/console-plugin-sdk/src/api/withExtensions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as hoistStatics from 'hoist-non-react-statics';
 import { useExtensions } from './useExtensions';
-import { Extension, ExtensionTypeGuard, LoadedExtension } from './typings';
+import { Extension, ExtensionTypeGuard, LoadedExtension } from '../typings';
 
 /**
  * React higher-order component (HOC) for consuming Console extensions.
@@ -13,14 +13,6 @@ import { Extension, ExtensionTypeGuard, LoadedExtension } from './typings';
  * Example usage:
  *
  * ```ts
- * import {
- *   withExtensions,
- *   NavItem,
- *   Perspective,
- *   isNavItem,
- *   isPerspective,
- * } from '@console/plugin-sdk';
- *
  * const Example = withExtensions<ExampleExtensionProps>({
  *   navItemExtensions: isNavItem,
  *   perspectiveExtensions: isPerspective,

--- a/frontend/packages/console-plugin-sdk/src/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/index.ts
@@ -4,5 +4,5 @@ export * from './registry';
 export * from './store';
 
 // React integrations
-export * from './useExtensions';
-export * from './withExtensions';
+export * from './api/useExtensions';
+export * from './api/withExtensions';

--- a/frontend/packages/console-plugin-sdk/src/typings/base.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/base.ts
@@ -26,7 +26,7 @@ export type ExtensionFlags = Partial<{
  *
  * TODO(vojtech): write ESLint rule to guard against extension type duplicity
  */
-export type Extension<P = any> = {
+export type Extension<P extends {} = any> = {
   type: string;
   properties: P;
   flags?: ExtensionFlags;
@@ -35,7 +35,7 @@ export type Extension<P = any> = {
 /**
  * An extension that is always effective, regardless of feature flags.
  */
-export type AlwaysOnExtension<P = any> = Omit<Extension<P>, 'flags'>;
+export type AlwaysOnExtension<P extends {} = any> = Omit<Extension<P>, 'flags'>;
 
 /**
  * From plugin author perspective, a plugin is simply a list of extensions.
@@ -101,6 +101,7 @@ export type ActivePlugin = {
  * Runtime extension interface, exposing additional metadata.
  */
 export type LoadedExtension<E extends Extension> = E & {
+  pluginID: string;
   pluginName: string;
   uid: string;
 };

--- a/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
@@ -9,7 +9,7 @@ import { OverviewItem } from '../../types/resource';
 import { testHook } from '../../test-utils/hooks-utils';
 import { usePluginsOverviewTabSection } from '../plugins-overview-tab-section';
 
-jest.mock('@console/plugin-sdk/src/useExtensions', () => ({
+jest.mock('@console/plugin-sdk/src/api/useExtensions', () => ({
   useExtensions: jest.fn(),
 }));
 describe('usePluginsOverviewTabSection', () => {

--- a/frontend/packages/console-shared/src/hooks/useForceRender.ts
+++ b/frontend/packages/console-shared/src/hooks/useForceRender.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+/**
+ * React hook that forces component render.
+ */
+export const useForceRender = () => React.useReducer((s: boolean) => !s, false)[1] as VoidFunction;

--- a/frontend/packages/dev-console/src/components/topology/__tests__/DataModelProvider.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/DataModelProvider.spec.tsx
@@ -7,7 +7,7 @@ import DataModelProvider from '../data-transforms/DataModelProvider';
 import { TopologyDataRetriever } from '../TopologyDataRetriever';
 import { TopologyPageContext } from '../TopologyPage';
 
-jest.mock('@console/plugin-sdk/src/useExtensions', () => ({
+jest.mock('@console/plugin-sdk/src/api/useExtensions', () => ({
   useExtensions: () => [],
 }));
 jest.mock('@console/shared', () => {

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
@@ -14,7 +14,7 @@ import KnativeServiceResources from '../KnativeServiceResources';
 import KSRoutesOverviewList from '../RoutesOverviewList';
 import RevisionsOverviewList from '../RevisionsOverviewList';
 
-jest.mock('@console/plugin-sdk/src/useExtensions', () => ({
+jest.mock('@console/plugin-sdk/src/api/useExtensions', () => ({
   useExtensions: jest.fn(),
 }));
 

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -7,7 +7,7 @@ import { isCustomFeatureFlag } from '@console/plugin-sdk/src/typings';
 import {
   subscribeToExtensions,
   extensionDiffListener,
-} from '@console/plugin-sdk/src/subscribeToExtensions';
+} from '@console/plugin-sdk/src/api/subscribeToExtensions';
 import store from '../redux';
 import { GroupModel, UserModel, VolumeSnapshotContentModel } from '../models';
 import { ClusterVersionKind } from '../module/k8s';

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -2,7 +2,7 @@ import { Store } from 'redux';
 import { RootState } from '@console/internal/redux';
 import { PluginStore } from '@console/plugin-sdk/src/store';
 import { ActivePlugin } from '@console/plugin-sdk/src/typings';
-import { initSubscriptionService } from '@console/plugin-sdk/src/subscribeToExtensions';
+import { initSubscriptionService } from '@console/plugin-sdk/src/api/subscribeToExtensions';
 import { fetchPluginManifest } from '@console/dynamic-plugin-sdk/src/runtime/plugin-manifest';
 import {
   loadDynamicPlugin,

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -7,7 +7,7 @@ import { isModelFeatureFlag } from '@console/plugin-sdk/src/typings';
 import {
   subscribeToExtensions,
   extensionDiffListener,
-} from '@console/plugin-sdk/src/subscribeToExtensions';
+} from '@console/plugin-sdk/src/api/subscribeToExtensions';
 import {
   ChargebackReportModel,
   ClusterServiceClassModel,


### PR DESCRIPTION
This PR adds new `useResolvedExtensions` hook as an alternative to existing `useExtensions` hook.

The purpose of `useResolvedExtensions` hook is to resolve *all* code references within each extension's `properties` object for *all* matching extensions (narrowed by `typeGuards` and currently in use).

```ts
const fooResolvedExtensions = useResolvedExtensions<Foo>(isFoo);
```

Here's a runtime value comparison (`fooExtensions` vs. `fooResolvedExtensions`):

![useExtensions](https://user-images.githubusercontent.com/648971/93365168-c040e180-f849-11ea-97c9-3f24dc747b3a.jpg)

![useResolvedExtensions](https://user-images.githubusercontent.com/648971/93365184-c5059580-f849-11ea-8205-4f6417a0f8e9.jpg)


Internally, `useResolvedExtensions` calls `useExtensions` and adapts its result, preserving the order of elements in the array.

Other code improvements:
- `useExtensions` and `useResolvedExtensions` trigger re-render only for mounted components
- more reliable way of tracking `CodeRef<T>` functions via [`Symbol`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) marker property
- added `pluginID: string` to `LoadedExtension` interface
- removed `pluginEntryCallbackRegistered` flag in `plugin-loader.ts`

Verified that plugin-specific exposed module chunks (e.g. `utils_bar_ts-chunk.js`) are fetched over the network just once; subsequent `CodeRef<T>` resolutions use the cached module.

---

cc @spadgett @christianvogt 