### PR TITLE
Bug 1879422: Rename VMI 'Consoles' tab to 'Console'

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
@@ -45,7 +45,7 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
 
   const consolePage = {
     href: VM_DETAIL_CONSOLES_HREF,
-    name: 'Consoles',
+    name: 'Console',
     component: VMConsoleFirehose,
   };
 


### PR DESCRIPTION
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>