### PR TITLE
Bug 1872147: Disable health checks if BMO is not running or there's no power mgmt

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeAlerts.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeAlerts.tsx
@@ -143,7 +143,7 @@ const HealthChecksLink: React.FC = () => {
   );
 };
 
-const NodeAlerts: React.FC = () => {
+const NodeAlerts: React.FC = ({ children }) => {
   const { cpuLimit, memoryLimit, healthCheck } = React.useContext(NodeDashboardContext);
 
   const cpuMessage = getMessage(cpuLimit, {
@@ -199,6 +199,7 @@ const NodeAlerts: React.FC = () => {
           />
         </StatusItem>
       )}
+      {children}
     </AlertsBody>
   );
 };

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/StatusCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/StatusCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { Gallery, GalleryItem, Stack, StackItem } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
@@ -7,16 +8,64 @@ import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboa
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import { NodeDashboardContext } from '@console/app/src/components/nodes/node-dashboard/NodeDashboardContext';
 import { HealthChecksItem } from '@console/app/src/components/nodes/node-dashboard/NodeHealth';
+import NodeAlerts from '@console/app/src/components/nodes/node-dashboard/NodeAlerts';
+import { useFlag } from '@console/shared/src/hooks/flag';
+import { StatusItem } from '@console/shared/src/components/dashboard/status-card/AlertItem';
+import { BlueInfoCircleIcon } from '@console/shared';
+import { resourcePathFromModel } from '@console/internal/components/utils';
 
 import { BareMetalNodeDashboardContext } from './BareMetalNodeDashboardContext';
 import { bareMetalNodeStatus } from '../../../status/baremetal-node-status';
 import BareMetalNodeStatus from '../BareMetalNodeStatus';
-import NodeAlerts from '@console/app/src/components/nodes/node-dashboard/NodeAlerts';
+import { BMO_ENABLED_FLAG } from '../../../features';
+import { hasPowerManagement } from '../../../selectors';
+import { BareMetalHostModel } from '../../../models';
+import { BareMetalHostKind } from '../../../types';
+
+const POWER_MGMT_MSG =
+  'Power operations cannot be performed on this host until Baseboard Management Controller (BMC) credentials are provided for the underlying host.';
+
+const POWER_MGMT_ALERT = (host: BareMetalHostKind) => ({
+  title: 'Power management not available',
+  message: (
+    <Stack hasGutter>
+      <StackItem>{POWER_MGMT_MSG}</StackItem>
+      <StackItem>
+        <Link
+          to={`${resourcePathFromModel(
+            BareMetalHostModel,
+            host.metadata.name,
+            host.metadata.namespace,
+          )}/edit?powerMgmt`}
+        >
+          Add credentials
+        </Link>
+      </StackItem>
+    </Stack>
+  ),
+});
+
+const BMO_DISABLED_ALERT = {
+  title: 'Bare Metal Operator not available',
+  message: 'The Bare Metal Operator that enables this capability is not available or disabled.',
+};
+
+const getDisabledAlert = (bmoEnabled: boolean, hasPowerMgmt: boolean, host: BareMetalHostKind) => {
+  if (!bmoEnabled) {
+    return BMO_DISABLED_ALERT;
+  }
+  if (host && !hasPowerMgmt) {
+    return POWER_MGMT_ALERT(host);
+  }
+  return undefined;
+};
 
 const StatusCard: React.FC = () => {
   const { obj } = React.useContext(NodeDashboardContext);
-  const { nodeMaintenance, csr } = React.useContext(BareMetalNodeDashboardContext);
+  const { nodeMaintenance, csr, host } = React.useContext(BareMetalNodeDashboardContext);
+  const bmoEnabled = useFlag(BMO_ENABLED_FLAG);
   const status = bareMetalNodeStatus({ node: obj, nodeMaintenance, csr });
+  const hasPowerMgmt = hasPowerManagement(host);
   return (
     <DashboardCard gradient data-test-id="status-card">
       <DashboardCardHeader>
@@ -34,11 +83,25 @@ const StatusCard: React.FC = () => {
               />
             </GalleryItem>
             <GalleryItem>
-              <HealthChecksItem />
+              <HealthChecksItem disabledAlert={getDisabledAlert(bmoEnabled, hasPowerMgmt, host)} />
             </GalleryItem>
           </Gallery>
         </HealthBody>
-        <NodeAlerts />
+        <NodeAlerts>
+          {host && !hasPowerMgmt && (
+            <StatusItem Icon={BlueInfoCircleIcon} message={POWER_MGMT_MSG}>
+              <Link
+                to={`${resourcePathFromModel(
+                  BareMetalHostModel,
+                  host.metadata.name,
+                  host.metadata.namespace,
+                )}/edit?powerMgmt`}
+              >
+                Add credentials
+              </Link>
+            </StatusItem>
+          )}
+        </NodeAlerts>
       </DashboardCardBody>
     </DashboardCard>
   );


### PR DESCRIPTION
Depends on https://github.com/openshift/console/pull/6662

![Screenshot from 2020-09-17 11-19-21](https://user-images.githubusercontent.com/2078045/93451875-017fd280-f8d8-11ea-9bb3-d9ce5fb171ce.png)
![Screenshot from 2020-09-17 11-20-18](https://user-images.githubusercontent.com/2078045/93451891-05135980-f8d8-11ea-8603-592643c926a7.png)

@andybraren Is this ok or do we want more descriptive messages ? maybe in popup ?