### PR TITLE
Bug 1850569: Fix incorrect oVirt connection status message

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/providers/ovirt/ovirt-provider-actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/providers/ovirt/ovirt-provider-actions.ts
@@ -92,7 +92,7 @@ export const createConnectionObjects = async (
 
   if (prevNamespace && prevOvirtProviderName) {
     const deleteParams = { name: prevOvirtProviderName, namespace: prevNamespace };
-    consoleInfo('destroying stale OvirtPovider object ', deleteParams);
+    consoleInfo('destroying stale OvirtProvider object ', deleteParams);
     deleteOvirtProviderObject(deleteParams);
     dispatch(
       vmWizardInternalActions[InternalActionType.UpdateImportProvider](id, VMImportProvider.OVIRT, {

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/vm-import-provider-object-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/vm-import-provider-object-status.tsx
@@ -23,14 +23,18 @@ const CheckingCredentials: React.FC<StatusProps> = ({ provider }) => (
   />
 );
 
-const LoadingData: React.FC<StatusProps> = () => (
-  <StatusIconAndText
-    spin
-    noTooltip
-    title="Connection successful. Loading data"
-    icon={<InProgressIcon />}
-  />
-);
+const LoadingData: React.FC<StatusProps> = (props) => {
+  return props.provider === VMImportProvider.OVIRT ? (
+    CheckingCredentials(props)
+  ) : (
+    <StatusIconAndText
+      spin
+      noTooltip
+      title="Connection successful. Loading data"
+      icon={<InProgressIcon />}
+    />
+  );
+};
 
 const ConnectionFailed: React.FC<StatusProps> = ({ provider }) => (
   <Alert
@@ -56,13 +60,11 @@ const ConnectionSuccessful: React.FC<StatusProps> = () => <>Connection successfu
 
 const ConnectionUnknown: React.FC<StatusProps> = () => <>Status unknown</>;
 
-const ReadVmsListFailed: React.FC<StatusProps> = ({ provider }) => (
+const ReadVmsListFailed: React.FC<StatusProps> = () => (
   <Alert
     isInline
     variant={AlertVariant.warning}
-    title={`Connection succeeded but could not read list of virtual machines from ${getProviderEndpointName(
-      provider,
-    )} instance`}
+    title={`Connection failed. Please check your credentials and ensure that the API you're attempting to connect to is operational.`}
   />
 );
 

--- a/frontend/packages/kubevirt-plugin/src/statuses/v2v/v2vvmware-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/v2v/v2vvmware-status.ts
@@ -7,7 +7,7 @@ type V2VProviderStatusFlags = {
   requestsVM?: boolean;
 };
 
-const hasV2vVMWareStatus = (providerCR: K8sResourceKind, flags: V2VProviderStatusFlags) => {
+const hasV2VStatus = (providerCR: K8sResourceKind, flags: V2VProviderStatusFlags) => {
   if (providerCR && flags.requestsVM) {
     return { status: V2VProviderStatus.LOADING_VM_DETAIL };
   }
@@ -34,14 +34,13 @@ const hasSetStatus = (flags: V2VProviderStatusFlags) => {
   return null;
 };
 
-export const getV2VPRoviderStatus = (
+export const getV2VProviderStatus = (
   providerCR?: K8sResourceKind,
   flags: V2VProviderStatusFlags = { hasConnectionFailed: false, requestsVM: false },
 ) =>
-  hasV2vVMWareStatus(providerCR, flags) ||
-  hasSetStatus(flags) || { status: V2VProviderStatus.UNKNOWN };
+  hasV2VStatus(providerCR, flags) || hasSetStatus(flags) || { status: V2VProviderStatus.UNKNOWN };
 
 export const getSimpleV2VPRoviderStatus = (
   providerCR: K8sResourceKind,
   flags: V2VProviderStatusFlags = { hasConnectionFailed: false, requestsVM: false },
-) => getV2VPRoviderStatus(providerCR, flags).status;
+) => getV2VProviderStatus(providerCR, flags).status;


### PR DESCRIPTION
Currently, when logging in with invalid credentials for the RHV provider, the UI will display a connection successful message and then an error stating that it failed to load the VMs list. The ideal solution would be to provide a detailed error for why the connection fails, but at this time it is not possible to determine the specific cause of failures to connect to the oVirt backend. This PR changes the messages to be more generic and to solely inform the user that the connection failed. 