### PR TITLE
Bug 1880018: Fix for Topology drag crash, update react-topology package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
     "@patternfly/react-core": "4.40.2",
     "@patternfly/react-table": "4.15.3",
     "@patternfly/react-tokens": "4.9.2",
-    "@patternfly/react-topology": "4.4.61",
+    "@patternfly/react-topology": "4.5.15",
     "@patternfly/react-virtualized-extension": "4.5.49",
     "abort-controller": "3.0.0",
     "ajv": "^6.12.3",

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -10,28 +10,50 @@ import {
   ComponentFactory,
   Visualization,
   VisualizationSurface,
+  GraphElement,
   isNode,
   BaseEdge,
   VisualizationProvider,
+  Model,
+  BOTTOM_LAYER,
+  GROUPS_LAYER,
+  DEFAULT_LAYER,
+  TOP_LAYER,
+  SelectionEventListener,
+  SELECTION_EVENT,
 } from '@patternfly/react-topology';
-import { isTopologyComponentFactory, TopologyComponentFactory } from '../../extensions/topology';
+import { useQueryParams } from '@console/shared';
 import { useExtensions } from '@console/plugin-sdk';
+import { isTopologyComponentFactory, TopologyComponentFactory } from '../../extensions/topology';
 import { SHOW_GROUPING_HINT_EVENT, ShowGroupingHintEventListener } from './topology-types';
-import { COLA_LAYOUT, COLA_FORCE_LAYOUT } from './layouts/layoutFactory';
+import { COLA_LAYOUT, COLA_FORCE_LAYOUT, layoutFactory } from './layouts/layoutFactory';
 import { componentFactory } from './components';
+import { odcElementFactory } from './elements';
+
+const TOPOLOGY_GRAPH_ID = 'odc-topology-graph';
+const graphModel: Model = {
+  graph: {
+    id: TOPOLOGY_GRAPH_ID,
+    type: 'graph',
+    layout: COLA_LAYOUT,
+    layers: [BOTTOM_LAYER, GROUPS_LAYER, 'groups2', DEFAULT_LAYER, TOP_LAYER],
+  },
+};
 
 interface TopologyProps {
-  visualization: Visualization;
+  model: Model;
   application: string;
   namespace: string;
-  selectedIds: string[];
+  onSelect: (entity?: GraphElement) => void;
+  setVisualization: (vis: Visualization) => void;
 }
 
-const Topology: React.FC<TopologyProps> = ({ visualization, application, selectedIds }) => {
+const Topology: React.FC<TopologyProps> = ({ model, application, onSelect, setVisualization }) => {
   const applicationRef = React.useRef<string>(null);
-  const [layout, setLayout] = React.useState<string>(COLA_LAYOUT);
   const [visualizationReady, setVisualizationReady] = React.useState<boolean>(false);
   const [dragHint, setDragHint] = React.useState<string>('');
+  const queryParams = useQueryParams();
+  const selectedId = queryParams.get('selectId');
   const [componentFactories, setComponentFactories] = React.useState<ComponentFactory[]>([]);
   const componentFactoryExtensions = useExtensions<TopologyComponentFactory>(
     isTopologyComponentFactory,
@@ -40,6 +62,38 @@ const Topology: React.FC<TopologyProps> = ({ visualization, application, selecte
     () => componentFactoryExtensions.map((factory) => factory.properties.getFactory()),
     [componentFactoryExtensions],
   );
+  const createVisualization = () => {
+    const newVisualization = new Visualization();
+    newVisualization.registerElementFactory(odcElementFactory);
+    newVisualization.registerLayoutFactory(layoutFactory);
+    newVisualization.fromModel(graphModel);
+    newVisualization.addEventListener<SelectionEventListener>(SELECTION_EVENT, (ids: string[]) => {
+      const selectedEntity = ids[0] ? newVisualization.getElementById(ids[0]) : null;
+      onSelect(selectedEntity);
+    });
+    setVisualization(newVisualization);
+    return newVisualization;
+  };
+
+  const visualizationRef = React.useRef<Visualization>();
+  if (!visualizationRef.current) {
+    visualizationRef.current = createVisualization();
+  }
+  const visualization = visualizationRef.current;
+
+  React.useEffect(() => {
+    if (model && visualizationReady) {
+      visualization.fromModel(model);
+      const selectedItem = selectedId ? visualization.getElementById(selectedId) : null;
+      if (!selectedItem || !selectedItem.isVisible()) {
+        onSelect();
+      } else {
+        onSelect(selectedItem);
+      }
+    }
+    // Do not update on selectedId change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model, visualization, visualizationReady]);
 
   React.useEffect(() => {
     Promise.all(componentFactoriesPromises)
@@ -85,8 +139,8 @@ const Topology: React.FC<TopologyProps> = ({ visualization, application, selecte
   React.useEffect(() => {
     let resizeTimeout = null;
     if (visualization) {
-      if (selectedIds.length > 0) {
-        const selectedEntity = visualization.getElementById(selectedIds[0]);
+      if (selectedId) {
+        const selectedEntity = visualization.getElementById(selectedId);
         if (selectedEntity) {
           const visibleEntity = isNode(selectedEntity)
             ? selectedEntity
@@ -108,21 +162,14 @@ const Topology: React.FC<TopologyProps> = ({ visualization, application, selecte
         clearTimeout(resizeTimeout);
       }
     };
-  }, [selectedIds, visualization]);
-
-  React.useEffect(() => {
-    action(() => {
-      if (visualizationReady) {
-        visualization.getGraph().setLayout(layout);
-      }
-    })();
-  }, [layout, visualization, visualizationReady]);
+  }, [selectedId, visualization]);
 
   if (!visualizationReady) {
     return null;
   }
 
   const renderControlBar = () => {
+    const layout = visualization.getGraph()?.getLayout() ?? 'COLA_LAYOUT';
     return (
       <TopologyControlBar
         controlButtons={[
@@ -153,7 +200,10 @@ const Topology: React.FC<TopologyProps> = ({ visualization, application, selecte
                   'pf-m-active': layout === COLA_LAYOUT,
                 })}
                 variant="tertiary"
-                onClick={() => setLayout(COLA_LAYOUT)}
+                onClick={() => {
+                  visualization.getGraph().setLayout(COLA_LAYOUT);
+                  visualization.getGraph().layout();
+                }}
               >
                 <TopologyIcon className="odc-topology__layout-button__icon" aria-label="Layout" />1
               </Button>
@@ -166,7 +216,10 @@ const Topology: React.FC<TopologyProps> = ({ visualization, application, selecte
                   'pf-m-active': layout === COLA_FORCE_LAYOUT,
                 })}
                 variant="tertiary"
-                onClick={() => setLayout(COLA_FORCE_LAYOUT)}
+                onClick={() => {
+                  visualization.getGraph().setLayout(COLA_FORCE_LAYOUT);
+                  visualization.getGraph().layout();
+                }}
               >
                 <TopologyIcon className="odc-topology__layout-button__icon" aria-label="Layout" />2
               </Button>
@@ -183,7 +236,7 @@ const Topology: React.FC<TopologyProps> = ({ visualization, application, selecte
 
   return (
     <VisualizationProvider controller={visualization}>
-      <VisualizationSurface state={{ selectedIds }} />
+      <VisualizationSurface state={{ selectedIds: [selectedId] }} />
       {dragHint && <div className="odc-topology__hint-container">{dragHint}</div>}
       <span className="pf-topology-control-bar">{renderControlBar()}</span>
     </VisualizationProvider>

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
@@ -8,9 +8,10 @@ import {
   isNode,
   Visualization,
   GraphElement,
+  Model,
 } from '@patternfly/react-topology';
 import { DataList } from '@patternfly/react-core';
-import { METRICS_POLL_INTERVAL } from '@console/shared';
+import { METRICS_POLL_INTERVAL, useQueryParams } from '@console/shared';
 import { PROMETHEUS_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
 import {
   fetchOverviewMetrics,
@@ -21,12 +22,20 @@ import {
 import { Alert } from '@console/internal/components/monitoring/types';
 import * as UIActions from '@console/internal/actions/ui';
 import { TYPE_APPLICATION_GROUP } from '../components';
+import { odcElementFactory } from '../elements';
 import { TopologyListViewAppGroup } from './TopologyListViewAppGroup';
 import { getChildKinds, sortGroupChildren } from './list-view-utils';
 import { TopologyListViewUnassignedGroup } from './TopologyListViewUnassignedGroup';
 
 import './TopologyListView.scss';
 
+const TOPOLOGY_LIST_ID = 'odc-topology-list';
+const listModel: Model = {
+  graph: {
+    id: TOPOLOGY_LIST_ID,
+    type: 'graph',
+  },
+};
 interface TopologyListViewPropsFromState {
   metrics: OverviewMetrics;
 }
@@ -37,26 +46,55 @@ interface TopologyListViewPropsFromDispatch {
 }
 
 interface TopologyListViewProps {
-  visualization: Visualization;
+  model: Model;
   application: string;
   namespace: string;
-  selectedIds: string[];
-  onSelect: (ids: string[]) => void;
+  onSelect: (entity?: GraphElement) => void;
+  setVisualization: (vis: Visualization) => void;
 }
 
 const ConnectedTopologyListView: React.FC<TopologyListViewProps &
   TopologyListViewPropsFromDispatch &
   TopologyListViewPropsFromState> = observer(
   ({
-    visualization,
-    selectedIds,
+    model,
     onSelect,
+    setVisualization,
     namespace,
     metrics,
     updateMetrics,
     updateMonitoringAlerts,
   }) => {
-    const selectedId = selectedIds[0];
+    const queryParams = useQueryParams();
+    const selectedId = queryParams.get('selectId');
+
+    const createVisualization = () => {
+      const newVisualization = new Visualization();
+      newVisualization.registerElementFactory(odcElementFactory);
+      newVisualization.fromModel(listModel);
+      setVisualization(newVisualization);
+      return newVisualization;
+    };
+
+    const visualizationRef = React.useRef<Visualization>();
+    if (!visualizationRef.current) {
+      visualizationRef.current = createVisualization();
+    }
+
+    const visualization = visualizationRef.current;
+
+    React.useEffect(() => {
+      if (model) {
+        visualization.fromModel(model);
+        const selectedItem = selectedId ? visualization.getElementById(selectedId) : null;
+        if (!selectedItem || !selectedItem.isVisible()) {
+          onSelect();
+        } else {
+          onSelect(selectedItem);
+        }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [model, onSelect, visualization]);
 
     const nodes = visualization.getElements().filter((e) => isNode(e)) as Node[];
     const applicationGroups = nodes.filter((n) => n.getType() === TYPE_APPLICATION_GROUP);
@@ -112,7 +150,7 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
         const flattenedItems = getFlattenedItems();
         const index = flattenedItems.findIndex((item) => selectedId === item.getId());
         if (index > 0) {
-          onSelect([flattenedItems[index - 1].getId()]);
+          onSelect(flattenedItems[index - 1]);
         }
       };
 
@@ -120,7 +158,7 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
         const flattenedItems = getFlattenedItems();
         const index = flattenedItems.findIndex((item) => selectedId === item.getId());
         if (index < flattenedItems.length - 1) {
-          onSelect([flattenedItems[index + 1].getId()]);
+          onSelect(flattenedItems[index + 1]);
         }
       };
 
@@ -139,7 +177,7 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
         switch (e.key) {
           case 'Escape':
             stopEvent(e);
-            onSelect([]);
+            onSelect();
             break;
           case 'k':
           case 'ArrowUp':
@@ -228,23 +266,23 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
         <DataList
           aria-label="Topology List View"
           className="odc-topology-list-view__data-list"
-          selectedDataListItemId={selectedIds[0]}
-          onSelectDataListItem={(id) => onSelect(selectedIds[0] === id ? [] : [id])}
+          selectedDataListItemId={selectedId}
+          onSelectDataListItem={(id) => onSelect(visualization.getElementById(id))}
         >
           {applicationGroups.map((g) => (
             <TopologyListViewAppGroup
               key={g.getId()}
               appGroup={g}
-              selectedIds={selectedIds}
-              onSelect={onSelect}
+              selectedIds={[selectedId]}
+              onSelect={(ids) => onSelect(ids ? visualization.getElementById(ids[0]) : undefined)}
             />
           ))}
           {unassignedItems.length > 0 ? (
             <TopologyListViewUnassignedGroup
               key="unassigned"
               items={unassignedItems}
-              selectedIds={selectedIds}
-              onSelect={onSelect}
+              selectedIds={[selectedId]}
+              onSelect={(ids) => onSelect(ids ? visualization.getElementById(ids[0]) : undefined)}
             />
           ) : null}
         </DataList>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2075,15 +2075,38 @@
     tippy.js "5.1.2"
     tslib "^1.11.1"
 
+"@patternfly/react-core@^4.50.2":
+  version "4.50.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.50.2.tgz#b66d9bd8804994af70c2d80ce43a0dee6b90de5c"
+  integrity sha512-EAzrgsNivoYJb+Zk0YGKgr24J4qqY8dnPt96NJKhEcSRmVeqJEvL6Uhd1xJF1hRKQ5Bzrn/Lp66C+u5fgmnUBw==
+  dependencies:
+    "@patternfly/react-icons" "^4.7.6"
+    "@patternfly/react-styles" "^4.7.5"
+    "@patternfly/react-tokens" "^4.9.8"
+    focus-trap "4.0.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^1.11.1"
+
 "@patternfly/react-icons@^4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.1.tgz#e5ebf45c25c9cd6c6b338a3421b7bc423034a90d"
   integrity sha512-k5x47dzMvjtLpskJiU1PqF6UQcUHHbicnFl4hKFj3OKeYFm+Z3S+1ToXa47JZIbfOt2gdMsEKdT4cJ50N4hNsw==
 
+"@patternfly/react-icons@^4.7.6":
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.6.tgz#d5f19192912284fc334abb034bc08967b4245f22"
+  integrity sha512-B1+gVqe4zS+xQGrQh09z846rWxS6JNAs7PpQJYPEJ1SLzLOwy5wEaOK67im9dD6niEJifJqCcbacCNtVZjlWag==
+
 "@patternfly/react-styles@^4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.7.1.tgz#f2f134cbe9968e66699d89b7830085d4f2d7ecea"
   integrity sha512-/oWfSoDC+iQdOEEiv1tQP1wz3OHhm07H+xd/T3wKNBYsEn1hXtvfa4e5xHo6SqzyhutdbvwAzkMPlaVXORjEyw==
+
+"@patternfly/react-styles@^4.7.5":
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.7.5.tgz#b5d7161c0c75b54974b7a4db5a69ab30f6dbcb45"
+  integrity sha512-xom9hI2QzztT5pxByTFj2h3E0s4zD/+wVVLqvugl98cy8bCNpfo97OftfDCxBSV0MuhFDMs8/zr9QJUcq/O8Lw==
 
 "@patternfly/react-table@4.15.3":
   version "4.15.3"
@@ -2103,14 +2126,19 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.2.tgz#a3c46c0e7d29be5a7d1293bd3d3ff222e0ed4daa"
   integrity sha512-27LqjLwsNJW7XpkKggF5/gP8ieYk6AeLyJV0wE4fHrX7W/x5FNaZpZF027zC9migO84UaavoZS50aMU2xQjiUA==
 
-"@patternfly/react-topology@4.4.61":
-  version "4.4.61"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.4.61.tgz#e7e3fcb0f62277d5f8a1d2093cd5db340b3dfad9"
-  integrity sha512-A5bY2ucEXLItZEBal9NK/Ief8FK7/eCn2WJEIV+ekC6McKBDfNvixkYtsD4FQv4qNKPLau/893+u3BagcrnBFw==
+"@patternfly/react-tokens@^4.9.8":
+  version "4.9.8"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.8.tgz#260079b01359bcaf23875890e412f3c6e87e0202"
+  integrity sha512-HBbtQHlWl3/B9KrS1fI3/k6sXDowfTsmw0zKuHXWjG552l0ApOrDmzh120Q7m6cvvkFv/Cw6XRwtJIDZBCEiyg==
+
+"@patternfly/react-topology@4.5.15":
+  version "4.5.15"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.5.15.tgz#5a4fc25e76eae62ac21e262718fd38d96975da79"
+  integrity sha512-+AzT4sTSSKo8LyfAV/tm7dp4Bv5eVUjXppY9jHdwkYIK1aE4k2a3aWW5cH7s5zShfdE4VbWbKy7Tmktxg3OHfA==
   dependencies:
-    "@patternfly/react-core" "^4.40.2"
-    "@patternfly/react-icons" "^4.7.1"
-    "@patternfly/react-styles" "^4.7.1"
+    "@patternfly/react-core" "^4.50.2"
+    "@patternfly/react-icons" "^4.7.6"
+    "@patternfly/react-styles" "^4.7.5"
     "@types/d3" "^5.7.2"
     "@types/d3-force" "^1.2.1"
     "@types/dagre" "0.7.42"


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4834

**Description**
Update version of patternfly react-topology package to pickup a fix for crashing the UI when a node is being dragged and a data update occurs. Update topology list and graph components to use their own `Visualization`. This fixes an initial layout issue and prevents the list view from actually laying out nodes that are never drawn. Some minor adjustments to handle difference in layout call ordering done in the react-topology package.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
