### PR TITLE
Bug 1880004: Disable submit button of import forms while submitting

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
@@ -50,14 +50,12 @@ const EditApplication: React.FC<EditApplicationProps & StateProps> = ({
   };
 
   const handleSubmit = (values, actions) => {
-    updateResources(values)
+    return updateResources(values)
       .then(() => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: '' });
         handleRedirect(namespace, perspective, perspectiveExtensions);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplicationForm.tsx
@@ -54,7 +54,7 @@ const EditApplicationForm: React.FC<FormikProps<FormikValues> & EditApplicationF
         errorMessage={status && status.submitError}
         isSubmitting={isSubmitting}
         submitLabel="Save"
-        disableSubmit={!dirty || !_.isEmpty(errors)}
+        disableSubmit={!dirty || !_.isEmpty(errors) || isSubmitting}
         resetLabel="Cancel"
         sticky
       />

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -40,7 +40,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
       isSubmitting={isSubmitting}
       submitLabel="Create"
       sticky
-      disableSubmit={!dirty || !_.isEmpty(errors)}
+      disableSubmit={!dirty || !_.isEmpty(errors) || isSubmitting}
       resetLabel="Cancel"
     />
   </Form>

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -170,13 +170,11 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         .catch(() => {});
     }
 
-    resourceActions
+    return resourceActions
       .then(() => {
-        actions.setSubmitting(false);
         handleRedirect(projectName, perspective, perspectiveExtensions);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/dev-console/src/components/import/ImportSampleForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportSampleForm.tsx
@@ -54,7 +54,7 @@ const ImportSampleForm: React.FC<Props> = ({
         errorMessage={status && status.submitError}
         isSubmitting={isSubmitting}
         submitLabel="Create"
-        disableSubmit={!_.isEmpty(errors)}
+        disableSubmit={!_.isEmpty(errors) || isSubmitting}
         resetLabel="Cancel"
         sticky
       />

--- a/frontend/packages/dev-console/src/components/import/ImportSamplePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportSamplePage.tsx
@@ -167,13 +167,11 @@ const ImportSamplePage: React.FC<ImportSamplePageProps> = ({ match }) => {
       true,
     ).then(() => createOrUpdateResources(values, imageStream as K8sResourceKind));
 
-    resourceActions
+    return resourceActions
       .then(() => {
-        actions.setSubmitting(false);
         history.push(`/topology/ns/${namespace}`);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -37,7 +37,7 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
       errorMessage={status && status.submitError}
       isSubmitting={isSubmitting}
       submitLabel="Create"
-      disableSubmit={!dirty || !_.isEmpty(errors)}
+      disableSubmit={!dirty || !_.isEmpty(errors) || isSubmitting}
       resetLabel="Cancel"
       sticky
     />


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3903
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Formik expects the submit handler to return a promise based on which it sets `isSubmitting` to `false`. The import forms were not returning promise from submit handler.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Return promise from submit handler of all the import forms.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Peek 2020-09-17 20-25](https://user-images.githubusercontent.com/6041994/93488525-197d4380-f924-11ea-9b72-4c91a2d381dd.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
