### PR TITLE
Bug 1879875: Fix that the Start Pipeline form is not always validated correctly

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx
@@ -33,8 +33,9 @@ const DropdownField: React.FC<DropdownFieldProps> = ({ label, helpText, required
         aria-describedby={`${fieldId}-helper`}
         onChange={(value: string) => {
           props.onChange && props.onChange(value);
-          setFieldValue(props.name, value);
-          setFieldTouched(props.name, true);
+          // Validation is automatically done by the useFormikValidationFix above
+          setFieldValue(props.name, value, false);
+          setFieldTouched(props.name, true, false);
         }}
       />
     </FormGroup>

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
@@ -58,6 +58,8 @@ const PipelineWorkspacesSection: React.FC = () => {
                 setFieldValue(
                   `workspaces.${index}.data`,
                   VolumeTypes[type] === VolumeTypes.EmptyDirectory ? { emptyDir: {} } : {},
+                  // Validation is automatically done by DropdownField useFormikValidationFix
+                  false,
                 )
               }
               fullWidth


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4364
https://bugzilla.redhat.com/show_bug.cgi?id=1879875

**Analysis / Root cause**: 
When switching between different volume types in start pipeline modal and switching back to a valid volume type the "start" button is still disabled. This happen because Formik does not remove the errors when the user switches from "Empty Directory" to "Secret" and "Empty Directory" again.

The error was set to an invalidate state because the form was validated multiple times with the old and the new form fields.

To check how often and in which order the schema validation was called, you can add a console.warn (for example) output to `volumeTypeSchema` in `frontend/packages/dev-console/src/components/pipelines/modals/common/validation-utils.ts`. Like this one:

```diff
const volumeTypeSchema = yup
  .object()
  .when('type', {
-    is: (type) => VolumeTypes[type] === VolumeTypes.Secret,
+    is: (type) => {
+      console.warn('Validate pipeline form', type);
+      return VolumeTypes[type] === VolumeTypes.Secret,
+    }
    then: yup.object().shape({
```

**Solution Description**: 
The problem is based on the order of changes to the form. The Workspace type dropdown uses the DropdownField `onChange` prop to clear the workspace.data. But the `DropdownField` itself sets the type field after this change. Both method calls automatically triggers a form validation.

See `DropdownField` `onChange`: https://github.com/openshift/console/blob/910f7ce7c622ed3bcd073bd62cd2b3a12fa8f3d4/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx#L34-L38

The form was also additional changed each time when the value of a DropdownField changes: https://github.com/openshift/console/blob/910f7ce7c622ed3bcd073bd62cd2b3a12fa8f3d4/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx#L17

All these calls triggers an asynchronous form validation with old and new data which confuses the form error state.

As solution I added an 3rd parameter to the `setFieldValue` and `setFieldTouched` calls to disable that the fields are marked as "needs revalidation". The revalidation was now only triggered by the already used `useFormikValidationFix` hook.

## :warning: Component compatibility and alternatives

**Alternative 1**
Component tree:
```
  StartPipelineTree
    ..
    PipelineWorkspacesSection
      console-shared/formik-fields/components/DropdownField (to select the workspace type)
        console/internal/components/Dropdown
      MultipleResourceKeySelector (if workspace type = ConfigMap or Secret)
```

Also if this is a really small code change this affects the widely used `DropdownField` component.

As alternative its also possible to change just the `PiplelineWorkspacesSection` component instead. Instead of using the DropdownField this component could directly use the Dropdown to keep the same UI, but handle the formik state (calling `setFieldValue` in `onChange`) itself.

@divyanshiGupta WDYT?

**Alternative 2**
When starting with the analyse of this issue, I expected that the problem cause is that the data was removed and the errors for removed data wasn't re-validated. My initial idea was then to not save the sub-data (config / secretMap) in one data field and use different sub-keys instead.

This also fixes that the entered data was removed when the user switches between the types. I expected that this is also a (small) issue because we have different issues like [ODC-2443](https://issues.redhat.com/browse/ODC-2443) which says that form fields shouldn't be cleared when switching such a type selection.

But after implementing this I noticed that the original issue (could not submit form with Empty Directory after selecting ConfigMap) still exists. This also requires this code change I proposed with this PR here, or the Alternative 1.

The much bigger change looks like this: https://github.com/openshift/console/compare/master...jerolimov:odc-4364-fix-datadrop

@divyanshiGupta WDYT? Should we change this here as well or should we change / fix this after we start 4.7?

**Screen shots / Gifs for design review**: 
![odc-4364 webm](https://user-images.githubusercontent.com/139310/93589534-39a51500-f9ad-11ea-976f-4b5f7b65b74e.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
Unchanged

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge