### PR TITLE
Bug 1880379: Clicking on a project link in gitops application details page should navigate to topology view with that project selected

### DIFF
--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.scss
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.scss
@@ -5,7 +5,8 @@
   display: flex;
   &__env-section {
     margin-right: 35px;
-    min-width: 280px;
+    min-width: 285px;
+    max-width: 285px;
     &__header {
       display: flex;
       flex-direction: column;

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Stack, StackItem, Card, CardTitle, SplitItem, Split, Label } from '@patternfly/react-core';
-import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { ResourceIcon } from '@console/internal/components/utils';
 import GitOpsServiceDetailsSection from './GitOpsServiceDetailsSection';
 import { GitOpsEnvironment } from '../utils/gitops-types';
+import GitOpsEnvClusterLink from './GitOpsEnvClusterLink';
+import useConsoleURL from '../utils/useConsoleURL';
 import './GitOpsDetails.scss';
 
 interface GitOpsDetailsProps {
@@ -11,6 +13,7 @@ interface GitOpsDetailsProps {
 }
 
 const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs }) => {
+  const consoleURL = useConsoleURL();
   return (
     <div className="odc-gitops-details">
       {_.map(
@@ -44,11 +47,13 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs }) => {
                       </StackItem>
                       <StackItem className="co-truncate co-nowrap">
                         {env.cluster ? (
-                          <ExternalLink
-                            additionalClassName="odc-gitops-details__env-section__url"
-                            href={env.cluster}
-                            text={env.cluster}
-                          />
+                          <GitOpsEnvClusterLink
+                            className="odc-gitops-details__env-section__url"
+                            consoleURL={consoleURL}
+                            url={env.cluster}
+                          >
+                            {env.cluster}
+                          </GitOpsEnvClusterLink>
                         ) : (
                           <div className="odc-gitops-details__env-section__url-empty-state">
                             Cluster URL not available
@@ -56,7 +61,23 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs }) => {
                         )}
                       </StackItem>
                       <StackItem className="co-truncate co-nowrap">
-                        <ResourceLink kind="Project" name={env.environment} />
+                        <span className="co-resource-item">
+                          <ResourceIcon kind="Project" />
+                          {env.cluster ? (
+                            <GitOpsEnvClusterLink
+                              className="co-resource-item__resource-name"
+                              consoleURL={consoleURL}
+                              url={env.cluster}
+                              path={`/topology/ns/${env.environment}`}
+                            >
+                              {env.environment}
+                            </GitOpsEnvClusterLink>
+                          ) : (
+                            <span className="co-resource-item__resource-name">
+                              {env.environment}
+                            </span>
+                          )}
+                        </span>
                       </StackItem>
                     </Stack>
                   </CardTitle>

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsEnvClusterLink.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsEnvClusterLink.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { ExternalLink, LoadingInline } from '@console/internal/components/utils';
+
+interface GitOpsEnvClusterLinkProps {
+  url: string;
+  consoleURL: any[];
+  path?: string;
+  children?: React.ReactNode;
+  className: string;
+}
+
+const GitOpsEnvClusterLink: React.FC<GitOpsEnvClusterLinkProps> = ({
+  url,
+  consoleURL,
+  path,
+  children,
+  className,
+}) => {
+  const [currentClusterURL, loaded, loadError] = consoleURL;
+
+  if (!loaded && !loadError) return <LoadingInline />;
+
+  return currentClusterURL === url ? (
+    <Link to={path} className={className}>
+      {children}
+    </Link>
+  ) : (
+    <ExternalLink
+      additionalClassName={className}
+      href={path ? `${url}${path}` : url}
+      text={children}
+    />
+  );
+};
+
+export default GitOpsEnvClusterLink;

--- a/frontend/packages/dev-console/src/components/gitops/utils/useConsoleURL.ts
+++ b/frontend/packages/dev-console/src/components/gitops/utils/useConsoleURL.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import { ConfigMapModel } from '@console/internal/models';
+import { K8sResourceKind, k8sGet } from '@console/internal/module/k8s';
+
+const useConsoleURL = () => {
+  const [consoleURL, setConsoleURL] = useState<string>(null);
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const [loadError, setLoadError] = useState<Error>(null);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const getConsoleURL = async () => {
+      let configMap: K8sResourceKind;
+      let error: Error = null;
+      try {
+        configMap = await k8sGet(
+          ConfigMapModel,
+          'console-public',
+          'openshift-config-managed',
+          null,
+        );
+      } catch (e) {
+        error = e;
+      }
+      if (ignore) return;
+      if (configMap) {
+        setLoaded(true);
+        setConsoleURL(configMap.data?.consoleURL);
+      }
+      setLoadError(error);
+    };
+
+    getConsoleURL();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return [consoleURL, loaded, loadError];
+};
+
+export default useConsoleURL;


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/ODC-4870

![Peek 2020-09-23 21-50](https://user-images.githubusercontent.com/20724543/94040260-58107380-fde6-11ea-9c55-0d46bf694a72.gif)

/kind bug