### PR TITLE
Bug 1880492: Fix topology list view to not show empty application groups

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewAppGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewAppGroup.tsx
@@ -31,7 +31,7 @@ const ObservedTopologyListViewAppGroup: React.FC<TopologyListViewAppGroupProps> 
   const collapsed = appGroup.isCollapsed();
   const children = appGroup.getChildren();
 
-  if (!visible) {
+  if (!visible || !children?.length) {
     return null;
   }
 


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4884

**Description**
Hide application groups in the topology list view that have no children (due to filters).

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
