### PR TITLE
Bug 1880494: Fix to show helm workloads in all helm releases

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/helm/index.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/index.ts
@@ -10,7 +10,7 @@ export const getHelmComponentFactory = () =>
 
 export const getIsHelmResource = () =>
   import('./isHelmResource' /* webpackChunkName: "helm-topology-components" */).then(
-    (m) => m.isHelmResource,
+    (m) => m.isHelmResourceInModel,
   );
 
 export const getTopologyFilters = () =>

--- a/frontend/packages/dev-console/src/components/topology/helm/isHelmResource.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/isHelmResource.ts
@@ -1,5 +1,16 @@
+import { Model } from '@patternfly/react-topology';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { OdcNodeModel } from '../topology-types';
 
 export const isHelmResource = (resource: K8sResourceKind): boolean => {
   return resource?.metadata?.labels?.['app.kubernetes.io/managed-by'] === 'Helm';
+};
+
+export const isHelmResourceInModel = (resource: K8sResourceKind, model: Model): boolean => {
+  if (!isHelmResource(resource)) {
+    return false;
+  }
+  return !!model.nodes.find((node) => {
+    return (node as OdcNodeModel).resource?.metadata?.uid === resource?.metadata?.uid;
+  });
 };


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4883

**Description**
Fix to show all helm workloads in the helm release. The depicter method was erroneously marking helm resources as already depicted.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
