### PR TITLE
Bug 1880946: Fix crash when Deployment is removed (pod data are not available)

### DIFF
--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -127,7 +127,12 @@ const DeploymentDetails: React.FC<DeploymentDetailsProps> = ({ obj: deployment }
           namespace={deployment.metadata.namespace}
           kind={deployment.kind}
           render={(d) => {
-            return d.loaded ? (
+            if (!d.loaded) {
+              return <LoadingInline />;
+            } else if (!d.data[deployment.metadata.uid]) {
+              return null;
+            }
+            return (
               <PodRingSet
                 key={deployment.metadata.uid}
                 podData={d.data[deployment.metadata.uid]}
@@ -135,8 +140,6 @@ const DeploymentDetails: React.FC<DeploymentDetailsProps> = ({ obj: deployment }
                 resourceKind={DeploymentModel}
                 path="/spec/replicas"
               />
-            ) : (
-              <LoadingInline />
             );
           }}
         />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4295
https://bugzilla.redhat.com/show_bug.cgi?id=1880946

**Analysis / Root cause**: 
When deleting the Deployment in another tab (or with the cli) the PodRing crashes because there are no data available for the pods.

**Solution Description**: 
Check if the data is available and skip PodRing rendering otherwise.

**Screen shots / Gifs for design review**: 
![odc-4295 webm](https://user-images.githubusercontent.com/139310/93749973-196a9580-fbfb-11ea-881a-43ffa4055db2.gif)

**Unit test coverage report**: 
Not touched

**Test setup:**
Not touched

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge