### PR TITLE
Bug 1881898: fix Quickstart subtitle block

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.scss
@@ -22,4 +22,7 @@
   &__modal > .pf-c-modal-box__footer {
     display: block;
   }
+  &__duration {
+    display: inline-block;
+  }
 }

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartDrawer.tsx
@@ -78,10 +78,10 @@ const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
               size="xl"
               style={{ marginRight: 'var(--pf-global--spacer--md)' }}
             >
-              {quickStart?.spec.displayName}
-            </Title>
-            <Title headingLevel="h6" size="md" className="text-secondary">
-              {`${quickStart?.spec.duration} minutes`}
+              {quickStart?.spec.displayName}{' '}
+              <small className="co-quick-start-drawer__duration text-secondary">
+                {`${quickStart?.spec.duration} minutes`}
+              </small>
             </Title>
           </div>
           <DrawerActions>

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.scss
@@ -16,6 +16,10 @@
     margin-right: var(--pf-global--spacer--md) !important;
   }
 
+  &__subtitle {
+    display: inline-block;
+  }
+
   &__title-success {
     color: var(--pf-global--palette--green-500) !important;
   }

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import cx from 'classnames';
-import { Title, WizardNavItem, Text, TextVariants } from '@patternfly/react-core';
+import { Title, WizardNavItem } from '@patternfly/react-core';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import { QuickStartTaskStatus } from '../utils/quick-start-types';
 
@@ -71,12 +71,15 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
       <Title headingLevel="h3" size={size} className={classNames}>
         <TaskIcon taskIndex={taskIndex} taskStatus={taskStatus} isActiveTask={isActiveTask} />
         {title}
+        {isActiveTask && subtitle && (
+          <>
+            {' '}
+            <small className="co-quick-start-task-header__subtitle text-secondary">
+              {subtitle}
+            </small>
+          </>
+        )}
       </Title>
-      {isActiveTask && subtitle && (
-        <Text component={TextVariants.small} className="text-secondary">
-          {subtitle}
-        </Text>
-      )}
     </span>
   );
 

--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTaskHeader.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTaskHeader.spec.tsx
@@ -32,11 +32,10 @@ describe('QuickStartTaskHeader', () => {
       wrapper
         .find(WizardNavItem)
         .dive()
-        .find(Text)
+        .find('small')
         .props().children,
     ).toEqual(props.subtitle);
   });
-
   it('should not render subtitle if task is not active', () => {
     wrapper = shallow(<QuickStartTaskHeader {...props} isActiveTask={false} />);
     expect(


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-4779

# Problem
The sub title of the main and step headers are misaligned when the header text is wrapping to another line

# Solution
- Put Step no inside h3 and within inline-block wrapper
- Put Duration inside Header and within inline-block wrapper

# Screenshots
![Screenshot from 2020-10-01 13-43-29](https://user-images.githubusercontent.com/24852534/94785632-8b0dc500-03ed-11eb-911a-53cd593b0564.png)
![Screenshot from 2020-10-01 13-42-57](https://user-images.githubusercontent.com/24852534/94785645-906b0f80-03ed-11eb-88cf-e59602c6aa2f.png)
![Screenshot from 2020-10-01 13-42-47](https://user-images.githubusercontent.com/24852534/94785663-9660f080-03ed-11eb-907c-f263907304cb.png)
![Screenshot from 2020-10-01 13-42-34](https://user-images.githubusercontent.com/24852534/94785687-9e209500-03ed-11eb-92c2-f01af2687c00.png)


# Tests
Altered tests QuickStartHeader.spec.scss

# Browser conformance

Chrome, Firefox
