### PR TITLE
Bug 1881314: fix application selector in eventsource form

### DIFF
--- a/frontend/packages/dev-console/src/components/import/app/__tests__/ApplicationSelector.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/__tests__/ApplicationSelector.spec.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import * as formik from 'formik';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { InputField } from '@console/shared';
+import { CREATE_APPLICATION_KEY } from '../../../../const';
+import ApplicationDropdown from '../../../dropdown/ApplicationDropdown';
+import ApplicationSelector from '../ApplicationSelector';
+
+type ApplicationSelectorProps = React.ComponentProps<typeof ApplicationSelector>;
+
+let applicationSelectorProps: ApplicationSelectorProps;
+
+describe('ApplicationSelector', () => {
+  let wrapper: ShallowWrapper<ApplicationSelectorProps>;
+  const spyUseFormikContext = jest.spyOn(formik, 'useFormikContext');
+  const spyUseField = jest.spyOn(formik, 'useField');
+  const setFieldTouched = jest.fn();
+  const setFieldValue = jest.fn();
+
+  beforeEach(() => {
+    applicationSelectorProps = {
+      noProjectsAvailable: true,
+      namespace: 'rhd-test-ns',
+    };
+    spyUseField.mockReturnValue([{ value: CREATE_APPLICATION_KEY }, {}]);
+    spyUseFormikContext.mockReturnValue({
+      setFieldValue,
+      setFieldTouched,
+      values: {
+        application: {
+          initial: '',
+          name: '',
+          selectedKey: CREATE_APPLICATION_KEY,
+        },
+      },
+    });
+    wrapper = shallow(<ApplicationSelector {...applicationSelectorProps} />);
+    jest.clearAllMocks();
+  });
+
+  it('should show InputField if no projects are available', () => {
+    expect(wrapper.find(InputField).exists()).toBe(true);
+    expect(wrapper.find(InputField).props().required).toBe(true);
+  });
+
+  it('should show ApplicationDropdown if projects are available', () => {
+    spyUseField.mockImplementationOnce(() => [{ value: CREATE_APPLICATION_KEY }]);
+    wrapper.setProps({ noProjectsAvailable: false });
+    expect(wrapper.find(ApplicationDropdown).exists()).toBe(true);
+  });
+
+  it('should reset the selectedKey if the applications are not loaded', () => {
+    wrapper.setProps({ noProjectsAvailable: false });
+    wrapper
+      .find(ApplicationDropdown)
+      .props()
+      .onLoad({});
+    expect(setFieldValue).toHaveBeenCalledWith('application.selectedKey', '');
+  });
+
+  it('should reset the application name if the application list is empty', () => {
+    spyUseField.mockImplementationOnce(() => [{ value: CREATE_APPLICATION_KEY }]);
+    wrapper.setProps({ noProjectsAvailable: false });
+    wrapper
+      .find(ApplicationDropdown)
+      .props()
+      .onLoad({});
+    expect(setFieldValue).toHaveBeenCalledWith('application.selectedKey', '');
+    expect(setFieldValue).toHaveBeenCalledWith('application.name', '');
+    expect(setFieldValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set the application name and selectedKey on dropdown change', () => {
+    wrapper.setProps({ noProjectsAvailable: false });
+    wrapper
+      .find(ApplicationDropdown)
+      .props()
+      .onChange('one', 'test-application');
+
+    expect(setFieldValue).toHaveBeenCalledWith('application.selectedKey', 'one');
+    expect(setFieldValue).toHaveBeenCalledWith('application.name', 'test-application');
+    expect(setFieldTouched).toHaveBeenCalledWith('application.selectedKey', true);
+    expect(setFieldValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not set the application name on dropdown change if the application is undefined', () => {
+    wrapper.setProps({ noProjectsAvailable: false });
+    wrapper
+      .find(ApplicationDropdown)
+      .props()
+      .onChange('one', undefined);
+
+    expect(setFieldValue).toHaveBeenCalledWith('application.selectedKey', 'one');
+    expect(setFieldTouched).toHaveBeenCalledWith('application.selectedKey', true);
+    expect(setFieldValue).toHaveBeenCalledWith('application.name', undefined);
+    expect(setFieldValue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -16,7 +16,12 @@ import { sanitizeApplicationValue } from '@console/dev-console/src/utils/applica
 import { eventSourceValidationSchema } from './eventSource-validation-utils';
 import EventSourceForm from './EventSourceForm';
 import { getEventSourceResource } from '../../utils/create-eventsources-utils';
-import { EventSourceFormData, EventSourceListData, SinkType } from './import-types';
+import {
+  EventSourceFormData,
+  EventSourceListData,
+  SinkType,
+  EVENT_SOURCES_APP,
+} from './import-types';
 
 interface EventSourceProps {
   namespace: string;
@@ -49,7 +54,7 @@ export const EventSource: React.FC<Props> = ({
     },
     application: {
       initial: sanitizeApplicationValue(activeApplication),
-      name: sanitizeApplicationValue(activeApplication),
+      name: sanitizeApplicationValue(activeApplication) || EVENT_SOURCES_APP,
       selectedKey: activeApplication,
     },
     name: '',

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -3,11 +3,10 @@ import * as _ from 'lodash';
 import { useFormikContext, FormikValues } from 'formik';
 import { ItemSelectorField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
-import { NormalizedEventSources } from '../import-types';
+import { NormalizedEventSources, EVENT_SOURCES_APP } from '../import-types';
 import { KNATIVE_EVENT_SOURCE_APIGROUP } from '../../../const';
 import { getEventSourceModels } from '../../../utils/fetch-dynamic-eventsources-utils';
 import { isKnownEventSource, getEventSourceData } from '../../../utils/create-eventsources-utils';
-import { CREATE_APPLICATION_KEY } from '@console/dev-console/src/const';
 
 interface EventSourcesSelectorProps {
   eventSourceList: NormalizedEventSources;
@@ -17,7 +16,7 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
   const eventSourceItems = Object.keys(eventSourceList).length;
   const {
     values: {
-      application: { selectedKey },
+      application: { name: applicationName, selectedKey },
       type,
     },
     setFieldValue,
@@ -26,6 +25,18 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
     setErrors,
     setStatus,
   } = useFormikContext<FormikValues>();
+
+  const [recommended, setRecommended] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!applicationName && !selectedKey && !recommended) {
+      setFieldValue('application.name', EVENT_SOURCES_APP);
+      setFieldTouched('application.name', true);
+      setRecommended(true);
+      validateForm();
+    }
+  }, [selectedKey, applicationName, validateForm, recommended, setFieldValue, setFieldTouched]);
+
   const handleItemChange = React.useCallback(
     (item: string) => {
       if (item !== type) {
@@ -45,25 +56,12 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
         const name = _.kebabCase(item);
         setFieldValue('name', name);
         setFieldTouched('name', true);
-        if (!selectedKey || selectedKey === CREATE_APPLICATION_KEY) {
-          setFieldValue('application.name', `${name}-app`);
-          setFieldTouched('application.name', true);
-        }
         setFieldValue('apiVersion', selApiVersion);
         setFieldTouched('apiVersion', true);
         validateForm();
       }
     },
-    [
-      setErrors,
-      setStatus,
-      setFieldValue,
-      setFieldTouched,
-      selectedKey,
-      validateForm,
-      eventSourceList,
-      type,
-    ],
+    [type, setErrors, setStatus, setFieldValue, eventSourceList, setFieldTouched, validateForm],
   );
 
   return (

--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -82,6 +82,8 @@ export enum SinkType {
   Uri = 'uri',
 }
 
+export const EVENT_SOURCES_APP = 'event-sources-app';
+
 export const sourceSinkType = {
   Resource: {
     value: SinkType.Resource,


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3960

**Problem**:
In event source page, the application name is not auto populated when a event source is selected for the first time.
**Solution**:
Prevent resetting the application name if it already has a recommended name.

**Screenshots**:

**Scenario 1:**
Given: Namespace has application groups.
If User chooses unassigned option from the dropdown.
![unassigned-key](https://user-images.githubusercontent.com/9964343/94014992-ea564e80-fdc9-11ea-9bc8-b333ff3459ed.gif)

**Scenario 2:**
**Given:** Namespace has **no** application groups.
If User manually enters the application name
![user-application](https://user-images.githubusercontent.com/9964343/94015167-22f62800-fdca-11ea-8b19-2dd4296f60c3.gif)

**Scenario 3:**
**Given:** Namespace has **no** application groups.
If User removes the recommended application name
![user-removing-recommendation](https://user-images.githubusercontent.com/9964343/94015267-4325e700-fdca-11ea-9c81-92b988d44048.gif)



**Tests**:
![image](https://user-images.githubusercontent.com/9964343/93807350-207bbd00-fc68-11ea-83b6-a3959c9810ec.png)

cc: @invincibleJai 