### PR TITLE
Bug 1881356: fixes add page notification if dynamic channel/sources or broker exists

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-channels-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-channels-crd-mock.ts
@@ -1,0 +1,62 @@
+export const mockChannelCRDData = {
+  kind: 'CustomResourceDefinitionList',
+  apiVersion: 'apiextensions.k8s.io/v1',
+  metadata: {
+    selfLink: '/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
+    resourceVersion: '157889',
+  },
+  items: [
+    {
+      metadata: {
+        name: 'channels.messaging.knative.dev',
+        labels: {
+          'duck.knative.dev/addressable': 'true',
+          'eventing.knative.dev/release': 'v0.14.2',
+          'knative.dev/crd-install': 'true',
+          'messaging.knative.dev/subscribable': 'true',
+        },
+      },
+      spec: {
+        group: 'messaging.knative.dev',
+        names: {
+          plural: 'channels',
+          singular: 'channel',
+          shortNames: ['ch'],
+          kind: 'Channel',
+          listKind: 'ChannelList',
+          categories: ['all', 'knative', 'messaging', 'channel'],
+        },
+        versions: [
+          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1beta1', served: true, storage: false },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'inmemorychannels.messaging.knative.dev',
+        labels: {
+          'duck.knative.dev/addressable': 'true',
+          'eventing.knative.dev/release': 'v0.14.2',
+          'knative.dev/crd-install': 'true',
+          'messaging.knative.dev/subscribable': 'true',
+        },
+      },
+      spec: {
+        group: 'messaging.knative.dev',
+        names: {
+          plural: 'inmemorychannels',
+          singular: 'inmemorychannel',
+          shortNames: ['imc'],
+          kind: 'InMemoryChannel',
+          listKind: 'InMemoryChannelList',
+          categories: ['all', 'knative', 'messaging', 'channel'],
+        },
+        versions: [
+          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1beta1', served: true, storage: false },
+        ],
+      },
+    },
+  ],
+};

--- a/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
@@ -7,17 +7,24 @@ import {
   EventSourceContainerModel,
   EventSourcePingModel,
   ServiceModel,
+  EventingIMCModel,
 } from '../../models';
 import {
   getEventSourceModels,
   fetchEventSourcesCrd,
+  fetchChannelsCrd,
   isDynamicEventResourceKind,
+  isEventingChannelResourceKind,
   getDynamicEventSourcesModelRefs,
+  getDynamicChannelModelRefs,
   getDynamicEventSourceModel,
+  getDynamicChannelResourceList,
+  getDynamicEventSourcesResourceList,
 } from '../fetch-dynamic-eventsources-utils';
 import { mockEventSourcCRDData } from '../__mocks__/dynamic-event-source-crd-mock';
+import { mockChannelCRDData } from '../__mocks__/dynamic-channels-crd-mock';
 
-describe('fetch-dynamic-eventsources: ', () => {
+describe('fetch-dynamic-eventsources: EventSources', () => {
   beforeEach(() => {
     jest.spyOn(coFetch, 'coFetch').mockImplementation(() =>
       Promise.resolve({
@@ -72,5 +79,54 @@ describe('fetch-dynamic-eventsources: ', () => {
   it('should return undefined if model is not found', () => {
     const resultModel = getDynamicEventSourceModel(referenceForModel(ServiceModel));
     expect(resultModel).toBe(undefined);
+  });
+
+  it('should return limit if passed to getDynamicEventSourcesResourceList', async () => {
+    await fetchEventSourcesCrd();
+    const resultModel = getDynamicEventSourcesResourceList('sample-app', 1);
+    expect(resultModel[0].limit).toBe(1);
+  });
+
+  it('should not return limit if not passed to getDynamicEventSourcesResourceList', async () => {
+    await fetchEventSourcesCrd();
+    const resultModel = getDynamicEventSourcesResourceList('sample-app');
+    expect(resultModel[0].limit).toBeUndefined();
+  });
+});
+
+describe('fetch-dynamic-eventsources: Channels', () => {
+  beforeEach(async () => {
+    jest.spyOn(coFetch, 'coFetch').mockImplementation(() =>
+      Promise.resolve({
+        json: () => ({ ...mockChannelCRDData }),
+      }),
+    );
+    await fetchChannelsCrd();
+  });
+
+  it('should return true for IMC channel model', async () => {
+    expect(isEventingChannelResourceKind(referenceForModel(EventingIMCModel))).toBe(true);
+  });
+
+  it('should return false for ksvc model', async () => {
+    expect(isEventingChannelResourceKind(referenceForModel(ServiceModel))).toBe(false);
+  });
+
+  it('should return refs for all channel models', async () => {
+    const expectedRefs = [referenceForModel(EventingIMCModel)];
+    const modelRefs = getDynamicChannelModelRefs();
+    expectedRefs.forEach((ref) => {
+      expect(modelRefs.includes(ref)).toBe(true);
+    });
+  });
+
+  it('should return limit if passed to getDynamicChannelResourceList', async () => {
+    const resultModel = getDynamicChannelResourceList('sample-app', 1);
+    expect(resultModel[0].limit).toBe(1);
+  });
+
+  it('should not return limit if not passed to getDynamicChannelResourceList', async () => {
+    const resultModel = getDynamicChannelResourceList('sample-app');
+    expect(resultModel[0].limit).toBeUndefined();
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -105,7 +105,7 @@ export const useEventSourceModels = (): EventSourcetData => {
 
 export const getEventSourceModels = (): K8sKind[] => eventSourceData.eventSourceModels;
 
-export const getDynamicEventSourcesResourceList = (namespace: string) => {
+export const getDynamicEventSourcesResourceList = (namespace: string, limit?: number) => {
   return eventSourceData.eventSourceModels.map((model) => {
     return {
       isList: true,
@@ -113,6 +113,7 @@ export const getDynamicEventSourcesResourceList = (namespace: string) => {
       namespace,
       prop: referenceForModel(model),
       optional: true,
+      ...(limit && { limit }),
     };
   });
 };
@@ -188,7 +189,7 @@ export const fetchChannelsCrd = async () => {
   return eventSourceData.eventSourceChannels;
 };
 
-export const getDynamicChannelResourceList = (namespace: string) => {
+export const getDynamicChannelResourceList = (namespace: string, limit?: number) => {
   return eventSourceData.eventSourceChannels.map((model) => {
     return {
       isList: true,
@@ -196,6 +197,7 @@ export const getDynamicChannelResourceList = (namespace: string) => {
       namespace,
       prop: referenceForModel(model),
       optional: true,
+      ...(limit && { limit }),
     };
   });
 };

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -117,7 +117,10 @@ export const knativeServingResourcesRoutes = (namespace: string): FirehoseResour
   return knativeResource;
 };
 
-export const knativeServingResourcesServices = (namespace: string): FirehoseResource[] => {
+export const knativeServingResourcesServices = (
+  namespace: string,
+  limit?: number,
+): FirehoseResource[] => {
   const knativeResource = [
     {
       isList: true,
@@ -125,6 +128,7 @@ export const knativeServingResourcesServices = (namespace: string): FirehoseReso
       namespace,
       prop: 'ksservices',
       optional: true,
+      ...(limit && { limit }),
     },
   ];
   return knativeResource;
@@ -143,7 +147,10 @@ export const knativeEventingResourcesSubscription = (namespace: string): Firehos
   return knativeResource;
 };
 
-export const knativeEventingResourcesBroker = (namespace: string): FirehoseResource[] => {
+export const knativeEventingResourcesBroker = (
+  namespace: string,
+  limit?: number,
+): FirehoseResource[] => {
   const knativeResource = [
     {
       isList: true,
@@ -151,6 +158,7 @@ export const knativeEventingResourcesBroker = (namespace: string): FirehoseResou
       namespace,
       prop: EventingBrokerModel.plural,
       optional: true,
+      ...(limit && { limit }),
     },
   ];
   return knativeResource;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4878

**Analysis / Root cause**: 
On add  page notification is Shown "No workloads found"  even if nameSpace has EventSource, Channel, Broker

**Solution Description**: 
Add check for dynamic Sources/Channels/Brokers if they exists

**Screen shots / Gifs for design review**: 
![Sep-22-2020 14-28-15](https://user-images.githubusercontent.com/5129024/93862610-ee0da680-fcdf-11ea-86c6-600ff0ef3fde.gif)


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/93862454-b69efa00-fcdf-11ea-9475-4df66550f7e1.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
