### PR TITLE
Bug 1881347: fix createVMWizard onClose destructor

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/form/form-field.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/form/form-field.tsx
@@ -40,10 +40,13 @@ const hasIsDisabled = new Set([
 ]);
 const hasDisabled = new Set([FormFieldType.TEXT_AREA]);
 const hasIsChecked = new Set([FormFieldType.CHECKBOX, FormFieldType.INLINE_CHECKBOX]);
-const hasValidated = new Set([FormFieldType.SELECT, FormFieldType.FILE_UPLOAD]);
-const hasIsValid = new Set([
+const hasValidated = new Set([
   FormFieldType.TEXT,
   FormFieldType.TEXT_AREA,
+  FormFieldType.SELECT,
+  FormFieldType.FILE_UPLOAD,
+]);
+const hasIsValid = new Set([
   FormFieldType.CHECKBOX,
   FormFieldType.INLINE_CHECKBOX,
   FormFieldType.CUSTOM,


### PR DESCRIPTION
- run it on unMount so all providers get a chance for a cleanup
- make onClose idempotent, so multiple calls are not stacked
- use useRef instead so the value is propagated to the destructor
- remove code duplication for checking checking the common data changes
- disable relevant fields until cnvBaseImages are loaded plus allow for non admin user as well

please take a look 
@rawagner @yaacov @irosenzw @glekner @pcbailey 