### PR TITLE
Bug 1881516: fix topology failing to load after installing a Helm Chart

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/details/resources/HelmReleaseResources.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/resources/HelmReleaseResources.tsx
@@ -24,8 +24,9 @@ export interface HelmReleaseResourcesProps {
 const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ match, customData }) => {
   const namespace = match.params.ns;
   const helmManifest = customData ? safeLoadAll(customData.manifest) : [];
-  const helmManifestResources: FirehoseResource[] = helmManifest.map(
-    (resource: K8sResourceKind) => {
+  const helmManifestResources: FirehoseResource[] = helmManifest
+    .filter((obj) => obj)
+    .map((resource: K8sResourceKind) => {
       const resourceKind = referenceFor(resource);
       const model = modelFor(resourceKind);
       return {
@@ -36,8 +37,7 @@ const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ match, cust
         isList: false,
         optional: true,
       };
-    },
-  );
+    });
   return (
     <MultiListPage
       filterLabel="Resources by name"

--- a/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
@@ -164,7 +164,8 @@ const getHelmReleaseMap = (namespace: string) => {
     .then((releases) =>
       releases.reduce((acc, release) => {
         try {
-          const manifestResources: K8sResourceKind[] = safeLoadAll(release.manifest);
+          let manifestResources: K8sResourceKind[] = safeLoadAll(release.manifest);
+          manifestResources = manifestResources.filter((obj) => obj);
           manifestResources.forEach((resource) => {
             const resourceKindName = getHelmReleaseKey(resource);
             if (!acc.hasOwnProperty(resourceKindName)) {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-4899
https://issues.redhat.com/browse/ODC-4900

**Root Analysis:**
For some charts, the chart manifest data can return null objects

**Solution Description:**
Removing the null objects from the helm manifest data before passing it in the map

**GIF:**
![helm-fix](https://user-images.githubusercontent.com/22490998/93896269-5a9f9a00-fd0e-11ea-8fb8-fd4173ce1611.gif)
