### PR TITLE
Bug 1881541: Add pipeline workspace section also to Add Trigger modal

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
@@ -60,7 +60,7 @@ export const getLogSnippet = (pipelineRun: PipelineRun): PipelineRunErrorDetails
   }
 
   const containerName = failedTaskRun.status.steps?.find(
-    (step: PLRTaskRunStep) => step.terminated.exitCode !== 0,
+    (step: PLRTaskRunStep) => step.terminated?.exitCode !== 0,
   )?.container;
 
   if (!failedTaskRun.status.podName || !containerName) {

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PiplelineWorkspacesSection.tsx
@@ -4,9 +4,9 @@ import { SecretModel, ConfigMapModel } from '@console/internal/models';
 import { DropdownField } from '@console/shared';
 import FormSection from '../../../import/section/FormSection';
 import { VolumeTypes } from '../../const';
-import { PipelineRunWorkspaceFormEntry } from '../start-pipeline/types';
 import PVCDropdown from './PVCDropdown';
 import MultipleResourceKeySelector from './MultipleResourceKeySelector';
+import { PipelineModalFormWorkspace } from './types';
 
 const getVolumeTypeFields = (volumeType: VolumeTypes, index: number) => {
   switch (VolumeTypes[volumeType]) {
@@ -44,7 +44,7 @@ const getVolumeTypeFields = (volumeType: VolumeTypes, index: number) => {
 
 const PipelineWorkspacesSection: React.FC = () => {
   const { setFieldValue } = useFormikContext<FormikValues>();
-  const [{ value: workspaces }] = useField<PipelineRunWorkspaceFormEntry[]>('workspaces');
+  const [{ value: workspaces }] = useField<PipelineModalFormWorkspace[]>('workspaces');
   return (
     workspaces.length > 0 && (
       <FormSection title="Workspaces" fullWidth>

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/__tests__/utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/__tests__/utils.spec.ts
@@ -96,6 +96,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
       namespace: 'corazon',
       parameters: [],
       resources: [],
+      workspaces: [],
     };
     const labels: { [key: string]: string } = {
       anotherlabel: 'another-label-value',
@@ -119,6 +120,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
       namespace: 'corazon',
       parameters: [],
       resources: [],
+      workspaces: [],
     };
     const labels: { [key: string]: string } = {
       anotherlabel: 'another-label-value',
@@ -141,7 +143,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
         params: [],
         resources: [],
         status: null,
-        workspaces: undefined,
+        workspaces: [],
       },
     });
   });
@@ -157,6 +159,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
         },
       ],
       resources: [],
+      workspaces: [],
     };
     const labels: { [key: string]: string } = {
       anotherlabel: 'another-label-value',
@@ -181,7 +184,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
         ],
         resources: [],
         status: null,
-        workspaces: undefined,
+        workspaces: [],
       },
     });
   });
@@ -201,6 +204,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
           },
         },
       ],
+      workspaces: [],
     };
     const labels: { [key: string]: string } = {
       anotherlabel: 'another-label-value',
@@ -227,7 +231,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
           },
         ],
         status: null,
-        workspaces: undefined,
+        workspaces: [],
       },
     });
   });

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/types.ts
@@ -1,5 +1,10 @@
 import { FormikValues } from 'formik';
-import { PipelineParam } from '../../../../utils/pipeline-augment';
+import {
+  PipelineParam,
+  VolumeTypeConfigMaps,
+  VolumeTypePVC,
+  VolumeTypeSecret,
+} from '../../../../utils/pipeline-augment';
 
 export type PipelineModalFormResource = {
   name: string;
@@ -11,8 +16,27 @@ export type PipelineModalFormResource = {
   };
 };
 
+export type PipelineModalFormWorkspace = {
+  name: string;
+  type: string;
+  data:
+    | {
+        emptyDir: {};
+      }
+    | {
+        secret: VolumeTypeSecret;
+      }
+    | {
+        configMap: VolumeTypeConfigMaps;
+      }
+    | {
+        persistentVolumeClaim: VolumeTypePVC;
+      };
+};
+
 export type CommonPipelineModalFormikValues = FormikValues & {
   namespace: string;
   parameters: PipelineParam[];
   resources: PipelineModalFormResource[];
+  workspaces: PipelineModalFormWorkspace[];
 };

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
@@ -8,6 +8,7 @@ import {
   PipelineRunInlineResourceParam,
   PipelineRunReferenceResource,
   PipelineRunResource,
+  PipelineWorkspace,
 } from '../../../../utils/pipeline-augment';
 import { PipelineRunModel } from '../../../../models';
 import { getPipelineRunParams, getPipelineRunWorkspaces } from '../../../../utils/pipeline-utils';
@@ -117,6 +118,11 @@ export const convertPipelineToModalData = (
         ...initialResourceFormValues[resource.type],
         type: resource.type,
       },
+    })),
+    workspaces: (pipeline.spec.workspaces || []).map((workspace: PipelineWorkspace) => ({
+      ...workspace,
+      type: 'EmptyDirectory',
+      data: { emptyDir: {} },
     })),
   };
 };

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/validation-utils.ts
@@ -105,15 +105,15 @@ const commonPipelineSchema = yup.object().shape({
     }),
   ),
   resources: formResources,
-});
-
-export const startPipelineSchema = commonPipelineSchema.shape({
   workspaces: yup.array().of(
     yup.object().shape({
       type: yup.string().required('Required'),
       data: volumeTypeSchema,
     }),
   ),
+});
+
+export const startPipelineSchema = commonPipelineSchema.shape({
   secretOpen: yup.boolean().equals([false]),
 });
 

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -5,7 +5,7 @@ import {
   ModalComponentProps,
 } from '@console/internal/components/factory/modal';
 import { errorModal } from '@console/internal/components/modals';
-import { Pipeline, PipelineRun, PipelineWorkspace } from '../../../../utils/pipeline-augment';
+import { Pipeline, PipelineRun } from '../../../../utils/pipeline-augment';
 import { useUserAnnotationForManualStart } from '../../../pipelineruns/triggered-by';
 import ModalStructure from '../common/ModalStructure';
 import { convertPipelineToModalData } from '../common/utils';
@@ -27,11 +27,6 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
 
   const initialValues: StartPipelineFormValues = {
     ...convertPipelineToModalData(pipeline),
-    workspaces: (pipeline.spec.workspaces || []).map((workspace: PipelineWorkspace) => ({
-      ...workspace,
-      type: 'EmptyDirectory',
-      data: { emptyDir: {} },
-    })),
     secretOpen: false,
   };
 

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/types.ts
@@ -1,17 +1,5 @@
-import {
-  VolumeTypeConfigMaps,
-  VolumeTypePVC,
-  VolumeTypeSecret,
-} from 'packages/dev-console/src/utils/pipeline-augment';
 import { CommonPipelineModalFormikValues } from '../common/types';
 
-export type PipelineRunWorkspaceFormEntry = {
-  name: string;
-  type: string;
-  [volumeType: string]: VolumeTypeSecret | VolumeTypeConfigMaps | VolumeTypePVC | {};
-};
-
 export type StartPipelineFormValues = CommonPipelineModalFormikValues & {
-  workspaces: PipelineRunWorkspaceFormEntry[];
   secretOpen: boolean;
 };

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/AddTriggerForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/AddTriggerForm.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FormikProps } from 'formik';
 import PipelineResourceSection from '../common/PipelineResourceSection';
 import PipelineParameterSection from '../common/PipelineParameterSection';
+import PipelineWorkspacesSection from '../common/PiplelineWorkspacesSection';
 import TriggerBindingSection from './TriggerBindingSection';
 import { AddTriggerFormValues } from './types';
 
@@ -15,6 +16,7 @@ const AddTriggerForm: React.FC<AddTriggerFormProps> = (props) => {
       <TriggerBindingSection />
       <PipelineParameterSection parameters={values.parameters} />
       <PipelineResourceSection />
+      <PipelineWorkspacesSection />
     </>
   );
 };

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -18,6 +18,7 @@ import {
 import { ServiceAccountModel } from '@console/internal/models';
 import { errorModal } from '@console/internal/components/modals/error-modal';
 import { PIPELINE_SERVICE_ACCOUNT, SecretAnnotationId } from '../components/pipelines/const';
+import { PipelineModalFormWorkspace } from '../components/pipelines/modals/common/types';
 import {
   getLatestRun,
   Pipeline,
@@ -43,7 +44,6 @@ import {
   TaskModel,
   EventListenerModel,
 } from '../models';
-import { PipelineRunWorkspaceFormEntry } from '../components/pipelines/modals/start-pipeline/types';
 
 interface Resources {
   inputs?: Resource[];
@@ -339,7 +339,7 @@ export const getPipelineRunParams = (pipelineParams: PipelineParam[]): PipelineR
 };
 
 export const getPipelineRunWorkspaces = (
-  pipelineWorkspaces: PipelineRunWorkspaceFormEntry[],
+  pipelineWorkspaces: PipelineModalFormWorkspace[],
 ): PipelineRunWorkspace[] => {
   return (
     pipelineWorkspaces &&


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4186
https://bugzilla.redhat.com/show_bug.cgi?id=1881541

**Analysis / Root cause**: 
Workspaces are used in most (all?) predefined Pipelines of the Pipeline Operators 1.1.1. These are automatically used when import a Deployment and enable "Add Pipelines". Pipeline workspaces are already support in the "Start Pipeline" modal but not in the "Add Trigger" modal.

**Solution Description**: 
Add the workspaces section also to the "Add Trigger" modal and move some type informations and helpers from the Start pipeline specific part to the more generic implementation.

**Screen shots / Gifs for design review**: 
![odc-4186 webm](https://user-images.githubusercontent.com/139310/93911696-03e09300-fd03-11ea-8ac7-06fabe07924a.gif)

**Unit test coverage report**: 
Small changes, coverage not changed.

**Test setup:**
Small unit test changes and type changes. To reproduce this fix create a new pipeline and compare Start pipeline and Add trigger modals.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug