### PR TITLE
Bug 1881659: fix guided tour alert to not show up if skipped once

### DIFF
--- a/frontend/packages/console-app/src/components/tour/GuidedTourMastheadTrigger.tsx
+++ b/frontend/packages/console-app/src/components/tour/GuidedTourMastheadTrigger.tsx
@@ -10,7 +10,11 @@ const GuidedTourMastheadTrigger: React.FC<GuidedTourMastheadTriggerProps> = ({ c
   const { tourDispatch, tour } = React.useContext(TourContext);
   if (!tour) return null;
   return (
-    <button className={className} type="button" onClick={() => tourDispatch(TourActions.start)}>
+    <button
+      className={className}
+      type="button"
+      onClick={() => tourDispatch({ type: TourActions.start })}
+    >
       Guided Tour
     </button>
   );

--- a/frontend/packages/console-app/src/components/tour/StepComponent.tsx
+++ b/frontend/packages/console-app/src/components/tour/StepComponent.tsx
@@ -42,12 +42,16 @@ const StepComponent: React.FC<StepComponentProps> = ({
       showStepBadge={showStepBadge}
       nextButtonText={nextButtonText}
       backButtonText={backButtonText}
-      onClose={() => tourDispatch(TourActions.complete)}
+      onClose={() => tourDispatch({ type: TourActions.complete })}
       onNext={() =>
-        step > totalSteps ? tourDispatch(TourActions.complete) : tourDispatch(TourActions.next)
+        step > totalSteps
+          ? tourDispatch({ type: TourActions.complete })
+          : tourDispatch({ type: TourActions.next })
       }
       onBack={() =>
-        step === 0 ? tourDispatch(TourActions.complete) : tourDispatch(TourActions.back)
+        step === 0
+          ? tourDispatch({ type: TourActions.complete })
+          : tourDispatch({ type: TourActions.back })
       }
     />
   );

--- a/frontend/packages/console-app/src/components/tour/__tests__/tour-context.spec.ts
+++ b/frontend/packages/console-app/src/components/tour/__tests__/tour-context.spec.ts
@@ -13,7 +13,7 @@ describe('guided-tour-context', () => {
     });
 
     it('should return startTour as true for StartAction', () => {
-      const result = tourReducer(mockState, TourActions.start);
+      const result = tourReducer(mockState, { type: TourActions.start });
       expect(result).toEqual({
         startTour: true,
         completedTour: false,
@@ -22,17 +22,17 @@ describe('guided-tour-context', () => {
     });
 
     it('should return increment in stepNumber  for next action', () => {
-      const result = tourReducer(mockState, TourActions.next);
+      const result = tourReducer(mockState, { type: TourActions.next });
       expect(result.stepNumber).toEqual(mockState.stepNumber + 1);
     });
 
     it('should return decrease in stepNumber  for back action', () => {
-      const result = tourReducer(mockState, TourActions.back);
+      const result = tourReducer(mockState, { type: TourActions.back });
       expect(result.stepNumber).toEqual(mockState.stepNumber - 1);
     });
 
     it('should return completedTour as true for complete action', () => {
-      const result = tourReducer(mockState, TourActions.complete);
+      const result = tourReducer(mockState, { type: TourActions.complete });
       expect(result).toEqual({
         startTour: false,
         completedTour: true,

--- a/frontend/packages/console-app/src/components/tour/const.ts
+++ b/frontend/packages/console-app/src/components/tour/const.ts
@@ -1,6 +1,7 @@
 export const TOUR_LOCAL_STORAGE_KEY = 'getting-started-tour';
 
 export enum TourActions {
+  initialize = 'initialize',
   start = 'start',
   next = 'next',
   back = 'back',


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-4799

**Analysis / Root cause:**
Even though the user chooses to skip the guided tour of the dev perspective, the system will nag them again if they happen to follow these steps.

**Solution Description:**
User should not see guided tour if they have previously skipped or completed it.

**Screens:**
_Before_
![guided-tour-before](https://user-images.githubusercontent.com/38663217/93934132-4bd1db00-fd40-11ea-8d84-1dba7778c770.gif)

_After_
![guided-tour](https://user-images.githubusercontent.com/38663217/93934179-61470500-fd40-11ea-8daa-84d434ef3bde.gif)

**Test Coverage**
![Screenshot from 2020-09-23 01-55-18](https://user-images.githubusercontent.com/38663217/93934230-76bc2f00-fd40-11ea-92bd-e3b5a3fb1b03.png)

**Browser Conformance**
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge