### PR TITLE
Bug 1881820: Fix external mode queries for RGW Performance Card

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -76,7 +76,7 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
           setIndepModeSupportedPlatform(true);
         }
       });
-  });
+  }, []);
 
   return (
     <>

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/performance-graph.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/performance-graph.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
+import * as _ from 'lodash';
 import {
   humanizeDecimalBytesPerSec,
   useRefWidth,
@@ -44,9 +45,11 @@ const PerformanceGraph: React.FC<PerformanceGraphProps> = ({
   const PUTLatestValue = humanize(getLatestValue(putData)).string;
   const GETLatestValue = humanize(getLatestValue(getData)).string;
 
-  const legends = [{ name: `PUT ${PUTLatestValue}` }, { name: `GET ${GETLatestValue}` }];
+  const legends = [{ name: `GET ${GETLatestValue}` }, { name: `PUT ${PUTLatestValue}` }];
 
-  if (loadError) {
+  const emptyData = dataPoints.some(_.isEmpty);
+
+  if (loadError || emptyData) {
     return <GraphEmpty />;
   }
   if (!loading && !loadError) {

--- a/frontend/packages/noobaa-storage-plugin/src/queries.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/queries.ts
@@ -176,14 +176,12 @@ export const DATA_CONSUMPTION_QUERIES = {
   },
   [ServiceType.RGW]: {
     [Metrics.LATENCY]: {
-      latencyGet:
-        'ceph_rgw_get_initial_lat_sum{ceph_daemon="rgw.ocs.storagecluster.cephobjectstore.a"}',
-      latencyPut:
-        'ceph_rgw_put_initial_lat_sum{ceph_daemon="rgw.ocs.storagecluster.cephobjectstore.a"}',
+      latencyGet: 'avg(rate(ceph_rgw_get_initial_lat_sum[1m]))',
+      latencyPut: 'avg(rate(ceph_rgw_put_initial_lat_sum[1m]))',
     },
     [Metrics.BANDWIDTH]: {
-      bandwidthGet: 'ceph_rgw_get_b{ceph_daemon="rgw.ocs.storagecluster.cephobjectstore.a"}',
-      bandwidthPut: 'ceph_rgw_put_b{ceph_daemon="rgw.ocs.storagecluster.cephobjectstore.a"}',
+      bandwidthGet: 'sum(rate(ceph_rgw_get_b[1m]))',
+      bandwidthPut: 'sum(rate(ceph_rgw_put_b[1m]))',
     },
   },
 };


### PR DESCRIPTION
- Fix the queries for External Mode
- Show an empty graph for empty data frames. 
- Add dependency array for Infrastructure Detection Logic in Ceph
After Fix:
![Screenshot from 2020-09-23 19-57-14](https://user-images.githubusercontent.com/54092533/94026209-001e4080-fdd7-11ea-872a-4618dd8d62fe.png)
