### PR TITLE
Bug 1881881: Replace route dropdown input with typeahead select menu in import/edit flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
@@ -1,26 +1,19 @@
 import * as React from 'react';
-import * as _ from 'lodash';
-import { useFormikContext, FormikValues } from 'formik';
+import { useFormikContext } from 'formik';
 import { TextInputTypes } from '@patternfly/react-core';
-import { InputField, DropdownField } from '@console/shared';
-import { makePortName } from '../../../utils/imagestream-utils';
+import { InputField } from '@console/shared';
+import { DeployImageFormData, GitImportFormData } from '../import-types';
+import PortInputField from './PortInputField';
 
 const CreateRoute: React.FC = () => {
   const {
     values: {
       image: { ports },
-      route: { defaultUnknownPort, targetPort },
+      route: { defaultUnknownPort },
     },
-  } = useFormikContext<FormikValues>();
-  const portOptions = ports.reduce((acc, port) => {
-    const name = makePortName(port);
-    acc[name] = (
-      <>
-        {port.containerPort} &rarr; {port.containerPort} ({port.protocol})
-      </>
-    );
-    return acc;
-  }, {});
+  } = useFormikContext<DeployImageFormData | GitImportFormData>();
+  const portOptions = ports.map((port) => port.containerPort.toString());
+  const placeholderPort = ports[0]?.containerPort || defaultUnknownPort;
 
   return (
     <>
@@ -37,24 +30,13 @@ const CreateRoute: React.FC = () => {
         placeholder="/"
         helpText="Path that the router watches to route traffic to the service."
       />
-      {_.isEmpty(ports) ? (
-        <InputField
-          type={TextInputTypes.text}
-          name="route.unknownTargetPort"
-          label="Target Port"
-          placeholder={defaultUnknownPort}
-          helpText="Target port for traffic."
-        />
-      ) : (
-        <DropdownField
-          name="route.targetPort"
-          label="Target Port"
-          items={portOptions}
-          title={portOptions[targetPort] || 'Select target port'}
-          helpText="Target port for traffic."
-          fullWidth
-        />
-      )}
+      <PortInputField
+        name="route.unknownTargetPort"
+        label="Target Port"
+        placeholderText={placeholderPort.toString()}
+        helpText="Target port for traffic."
+        options={portOptions}
+      />
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/import/route/PortInputField.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/PortInputField.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import { FormGroup, Select, SelectVariant, SelectOption } from '@patternfly/react-core';
+import { useFormikValidationFix, getFieldId } from '@console/shared';
+
+interface RouteInputFieldProps {
+  name: string;
+  label: string;
+  options: string[];
+  placeholderText: string;
+  helpText: string;
+}
+
+const PortInputField: React.FC<RouteInputFieldProps> = ({
+  name,
+  label,
+  options,
+  placeholderText,
+  helpText,
+}) => {
+  const [field, { touched, error }] = useField<string>(name);
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const fieldId = getFieldId(name, 'select-input');
+  const isValid = !(touched && error);
+  const errorMessage = !isValid ? error : '';
+
+  useFormikValidationFix(field.value);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (_event, selection: string) => {
+    setFieldValue(name, selection);
+    setFieldTouched(name);
+    onToggle();
+  };
+
+  const onClearSelection = () => {
+    setFieldValue(name, '');
+    setFieldTouched(name);
+  };
+
+  return (
+    <FormGroup
+      fieldId={fieldId}
+      validated={isValid ? 'default' : 'error'}
+      label={label}
+      helperText={helpText}
+      helperTextInvalid={errorMessage}
+    >
+      <Select
+        variant={SelectVariant.typeahead}
+        onToggle={onToggle}
+        onSelect={onSelect}
+        onClear={onClearSelection}
+        isOpen={isOpen}
+        selections={field.value}
+        placeholderText={placeholderText}
+        isCreatable
+      >
+        {options.map((val) => (
+          <SelectOption value={val} key={val} />
+        ))}
+      </Select>
+    </FormGroup>
+  );
+};
+
+export default PortInputField;

--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import * as _ from 'lodash';
-import { TextInputTypes } from '@patternfly/react-core';
-import { useFormikContext, FormikValues } from 'formik';
-import { InputField, DropdownField } from '@console/shared';
+import { useFormikContext } from 'formik';
 import FormSection from '../section/FormSection';
-import { RouteData } from '../import-types';
+import { RouteData, GitImportFormData, DeployImageFormData } from '../import-types';
+import PortInputField from '../route/PortInputField';
 
 export interface ServerlessRouteSectionProps {
   route: RouteData;
@@ -14,40 +12,21 @@ const ServerlessRouteSection: React.FC<ServerlessRouteSectionProps> = ({ route }
   const {
     values: {
       image: { ports },
-      route: { defaultUnknownPort, targetPort: routeTargetPort },
+      route: { defaultUnknownPort },
     },
-  } = useFormikContext<FormikValues>();
-  const targetPort = routeTargetPort.split('-')[0];
-  const portOptions = ports.reduce((acc, port) => {
-    const name = port?.containerPort;
-    if (name) {
-      acc[name] = <>{port.containerPort}</>;
-    }
-    return acc;
-  }, {});
+  } = useFormikContext<DeployImageFormData | GitImportFormData>();
+  const placeholderPort = defaultUnknownPort;
+  const portOptions = ports.map((port) => port?.containerPort.toString());
   return (
     <FormSection title="Routing">
       {route.create && (
-        <>
-          {_.isEmpty(ports) ? (
-            <InputField
-              type={TextInputTypes.text}
-              name="route.unknownTargetPort"
-              label="Target Port"
-              placeholder={defaultUnknownPort}
-              helpText="Target port for traffic."
-            />
-          ) : (
-            <DropdownField
-              name="route.targetPort"
-              label="Target Port"
-              items={portOptions}
-              title={portOptions[targetPort] || 'Select target port'}
-              helpText="Target port for traffic."
-              fullWidth
-            />
-          )}
-        </>
+        <PortInputField
+          name="route.unknownTargetPort"
+          label="Target Port"
+          placeholderText={placeholderPort.toString()}
+          helpText="Target port for traffic."
+          options={portOptions}
+        />
       )}
     </FormSection>
   );

--- a/frontend/packages/dev-console/src/components/import/validation-schema.ts
+++ b/frontend/packages/dev-console/src/components/import/validation-schema.ts
@@ -136,8 +136,11 @@ export const routeValidationSchema = yup.object().shape({
     .string()
     .matches(pathRegex, { message: 'Path must start with /.', excludeEmptyString: true }),
   unknownTargetPort: yup
-    .string()
-    .matches(/^\d+$/, { message: 'Port must be an Integer.', excludeEmptyString: true }),
+    .number()
+    .typeError('Port must be an Integer.')
+    .integer('Port must be an Integer.')
+    .min(1, 'Port must be between 1 and 65535.')
+    .max(65535, 'Port must be between 1 and 65535.'),
 });
 
 export const limitsValidationSchema = yup.object().shape({

--- a/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
@@ -51,7 +51,7 @@ describe('Shared submit utils', () => {
       routeObj = createRoute(mockDeployImageData);
       expect(routeObj.spec.port.targetPort).toEqual('8082-tcp');
 
-      mockDeployImageData.route.targetPort = '8081-tcp';
+      mockDeployImageData.route.unknownTargetPort = '8081';
       routeObj = createRoute(mockDeployImageData);
       expect(routeObj.spec.port.targetPort).toEqual('8081-tcp');
     });

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-knative-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-knative-utils.spec.ts
@@ -8,12 +8,14 @@ import { defaultData } from './knative-serving-data';
 
 describe('Create knative Utils', () => {
   describe('knative Service creation', () => {
-    it('expect knativeServingResourcesConfigurations to not have Ports id if unknownTargetPort is empty', () => {
+    it('expect knativeServingResourcesConfigurations to use defaultUnknownPort if unknownTargetPort is empty', () => {
       const knDeploymentResource: K8sResourceKind = getKnativeServiceDepResource(
         defaultData,
         'imgStream',
       );
-      expect(knDeploymentResource.spec.template.spec.containers[0].ports).toBeUndefined();
+      expect(knDeploymentResource.spec.template.spec.containers[0].ports[0].containerPort).toBe(
+        8080,
+      );
     });
     it('expect to have Ports if unknownTargetPort is defined', () => {
       defaultData.route.unknownTargetPort = '8080';

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -24,7 +24,7 @@ export const getKnativeServiceDepResource = (
     runtimeIcon,
     serverless: { scaling },
     limits,
-    route: { unknownTargetPort, create, targetPort },
+    route: { unknownTargetPort, create, defaultUnknownPort },
     labels,
     image: { tag: imageTag },
     deployment: {
@@ -34,9 +34,7 @@ export const getKnativeServiceDepResource = (
     healthChecks,
     resources,
   } = formData;
-  const contTargetPort = targetPort
-    ? parseInt(targetPort.split('-')[0], 10)
-    : parseInt(unknownTargetPort, 10);
+  const contTargetPort = parseInt(unknownTargetPort, 10) || defaultUnknownPort;
   const imgPullPolicy = imagePolicy ? ImagePullPolicy.Always : ImagePullPolicy.IfNotPresent;
   const { concurrencylimit, concurrencytarget, minpods, maxpods } = scaling;
   const {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4869
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The dropdown only allows for the selection of the exposed ports from the builder image.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
The user should have the ability to specify their target port to ensure the route works.
Relevant Slack thread: https://coreos.slack.com/archives/CHC2R6AGG/p1600757882002000
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp](https://user-images.githubusercontent.com/20013884/93998624-6fce0480-fdb2-11ea-86b0-b359fe8fb9d0.png)
![tmp](https://user-images.githubusercontent.com/20013884/93998087-b8d18900-fdb1-11ea-8d84-fe45dedec850.gif)
cc: @openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Test setup:**
- Navigate to +Add -> From git
- Fill form, select Routing in advanced options
- Notice the port input field provides typeahead for default ports, and also allows adding a custom port.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
