### PR TITLE
Bug 1881747: fix link for upload os disk

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os.tsx
@@ -26,7 +26,7 @@ import { operatingSystemsNative } from '../../../../constants/vm-templates/os';
 import { OperatingSystemRecord } from '../../../../types';
 import { iGetAnnotation } from '../../../../selectors/immutable/common';
 import { iGetName, iGetNamespace } from '../../selectors/immutable/selectors';
-import { PVC_UPLOAD_URL } from '../../../../constants';
+import { getPVCUploadURL } from '../../../../constants';
 import {
   BASE_IMAGE_AND_PVC_SHORT,
   BASE_IMAGE_AND_PVC_MESSAGE,
@@ -149,18 +149,23 @@ export const OS: React.FC<OSProps> = React.memo(
         };
 
         if (!iUserTemplate && !baseImagesLoadError) {
-          if (baseImageFoundInCluster && pvcName) {
+          if (baseImageFoundInCluster && pvcName && pvcNamespace) {
             osField.message = isBaseImageUploading
               ? BASE_IMAGE_AND_PVC_UPLOADING_SHORT
               : BASE_IMAGE_AND_PVC_SHORT;
             osField.longMessage = BASE_IMAGE_AND_PVC_MESSAGE;
             osField.checkboxDescription = isBaseImageUploading ? BASE_IMAGE_UPLOADING_MESSAGE : '';
-          } else if (pvcName) {
+          } else if (pvcName && pvcNamespace) {
             osField.message = NO_BASE_IMAGE_SHORT;
             osField.longMessage = canUploadGoldenImage ? (
               <>
                 Operating system image not available. You can either{' '}
-                <Link to={`${PVC_UPLOAD_URL}?${CDI_UPLOAD_OS_URL_PARAM}=${operatingSystem.id}`}>
+                <Link
+                  className="co-external-link"
+                  to={`${getPVCUploadURL(pvcNamespace)}?${CDI_UPLOAD_OS_URL_PARAM}=${
+                    operatingSystem.id
+                  }`}
+                >
                   upload a new disk image
                 </Link>{' '}
                 or define a boot source manually in the boot source dropdown

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -63,4 +63,5 @@ export const WINTOOLS_CONTAINER_NAMES = {
 };
 
 export const PENDING_RESTART_LABEL = '(pending restart)';
-export const PVC_UPLOAD_URL = `/k8s/ns/${TEMPLATE_VM_GOLDEN_OS_NAMESPACE}/persistentvolumeclaims/~new/upload-form`;
+export const getPVCUploadURL = (pvcNamespace: string): string =>
+  `/k8s/ns/${pvcNamespace}/persistentvolumeclaims/~new/upload-form`;


### PR DESCRIPTION
The namespace of 'upload a new disk image' in wizard is `openshift-kubevirt-base-images`, which should be `openshift-virtualization-os-images`.