### PR TITLE
Bug 1881934:  Fix for clearing topology kind filters whenever filters change

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
@@ -231,7 +231,9 @@ export const TopologyView: React.FC<ComponentProps> = ({
       const updatedFilters = filters.filter((f) => f.type !== TopologyDisplayFilterType.kind);
       onFiltersChange(updatedFilters);
     }
-  }, [filters, namespace, onFiltersChange]);
+    // Only clear kind filters on namespace change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [namespace]);
 
   React.useEffect(() => {
     const searchQuery = getTopologySearchQuery();


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4909

**Description**
Fix for topology to allow filtering by kinds.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
