### PR TITLE
Bug 1882026: update notifications message on Topology and removes from Add

### DIFF
--- a/frontend/packages/dev-console/src/components/AddPage.tsx
+++ b/frontend/packages/dev-console/src/components/AddPage.tsx
@@ -1,22 +1,7 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
-import { Firehose, FirehoseResource, HintBlock } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
-import { TopologyDataResources } from '@console/dev-console/src/components/topology';
-import { EventingBrokerModel } from '@console/knative-plugin/src/models';
-import {
-  getDynamicChannelResourceList,
-  getDynamicEventSourcesResourceList,
-  getDynamicChannelModelRefs,
-  getDynamicEventSourcesModelRefs,
-} from '@console/knative-plugin/src/utils/fetch-dynamic-eventsources-utils';
-import { getKnativeDynamicResources } from '@console/knative-plugin/src/topology/knative-topology-utils';
-import {
-  knativeEventingResourcesBroker,
-  knativeServingResourcesServices,
-} from '@console/knative-plugin/src/utils/get-knative-resources';
+import { Firehose } from '@console/internal/components/utils';
 import ODCEmptyState from './EmptyState';
 import NamespacedPage from './NamespacedPage';
 import ProjectsExistWrapper from './ProjectsExistWrapper';
@@ -27,107 +12,6 @@ export interface AddPageProps {
     ns?: string;
   }>;
 }
-
-interface EmptyStateLoaderProps {
-  resources?: TopologyDataResources;
-  loaded?: boolean;
-  loadError?: string;
-}
-
-const EmptyStateLoader: React.FC<EmptyStateLoaderProps> = ({ resources, loaded, loadError }) => {
-  const [noWorkloads, setNoWorkloads] = React.useState(false);
-  const daemonSets = resources?.daemonSets?.data;
-  const deploymentConfigs = resources?.deploymentConfigs?.data;
-  const deployments = resources?.deployments?.data;
-  const statefulSets = resources?.statefulSets?.data;
-  const knativeServices = resources?.ksservices?.data;
-  const knDynamicResources: K8sResourceKind[] = getKnativeDynamicResources(resources, [
-    ...getDynamicChannelModelRefs(),
-    ...getDynamicEventSourcesModelRefs(),
-    EventingBrokerModel.plural,
-  ]);
-
-  React.useEffect(() => {
-    if (loaded) {
-      setNoWorkloads(
-        _.isEmpty(daemonSets) &&
-          _.isEmpty(deploymentConfigs) &&
-          _.isEmpty(deployments) &&
-          _.isEmpty(statefulSets) &&
-          _.isEmpty(knativeServices) &&
-          _.isEmpty(knDynamicResources),
-      );
-    } else if (loadError) {
-      setNoWorkloads(false);
-    }
-  }, [
-    loaded,
-    loadError,
-    daemonSets,
-    deploymentConfigs,
-    deployments,
-    statefulSets,
-    knativeServices,
-    knDynamicResources,
-  ]);
-  return noWorkloads ? (
-    <ODCEmptyState
-      title="Add"
-      hintBlock={
-        <HintBlock title="No workloads found">
-          <p>
-            To add content to your project, create an application, component or service using one of
-            these options.
-          </p>
-        </HintBlock>
-      }
-    />
-  ) : (
-    <ODCEmptyState title="Add" />
-  );
-};
-
-const RenderEmptyState = ({ namespace }) => {
-  const resources: FirehoseResource[] = [
-    {
-      isList: true,
-      kind: 'DeploymentConfig',
-      namespace,
-      prop: 'deploymentConfigs',
-      limit: 1,
-    },
-    {
-      isList: true,
-      kind: 'Deployment',
-      namespace,
-      prop: 'deployments',
-      limit: 1,
-    },
-    {
-      isList: true,
-      kind: 'DaemonSet',
-      namespace,
-      prop: 'daemonSets',
-      limit: 1,
-    },
-    {
-      isList: true,
-      kind: 'StatefulSet',
-      namespace,
-      prop: 'statefulSets',
-      limit: 1,
-    },
-    ...knativeServingResourcesServices(namespace, 1),
-    ...knativeEventingResourcesBroker(namespace, 1),
-    ...getDynamicChannelResourceList(namespace, 1),
-    ...getDynamicEventSourcesResourceList(namespace, 1),
-  ];
-  return (
-    <Firehose resources={resources}>
-      <EmptyStateLoader />
-    </Firehose>
-  );
-};
 
 const AddPage: React.FC<AddPageProps> = ({ match }) => {
   const namespace = match.params.ns;
@@ -141,7 +25,7 @@ const AddPage: React.FC<AddPageProps> = ({ match }) => {
         <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
           <ProjectsExistWrapper title="Add">
             {namespace ? (
-              <RenderEmptyState namespace={namespace} />
+              <ODCEmptyState title="Add" />
             ) : (
               <CreateProjectListPage title="Add">
                 Select a project to start adding to it

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -44,7 +44,7 @@ const EmptyMsg = () => (
   <EmptyState
     title="Topology"
     hintBlock={
-      <HintBlock title="No workloads found">
+      <HintBlock title="No resources found">
         <p>
           To add content to your project, create an application, component or service using one of
           these options.


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4907

**Analysis / Root cause**: 
- In Topology view Notification is shown to user "No workloads found" if there are no resources exists but currently topology shows more then regular workloads i.e channels/broker/sources (some may not have underlying deployments)
- In Add view Notification is shown to user "No workloads found" if there are no resources exists , for this we fetch lot of resources to figure that out which may not be needed as if user directly comes to Add, they would be interested to Add a resource

**Solution Description**: 
- if user goes to Topology view then show notification and add option as we show now and update message to "No resources found" from "No workloads found" 
- Don't show notification in Add view

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 
- Topology view with no resources
![image](https://user-images.githubusercontent.com/5129024/94036313-cd2d7a00-fde1-11ea-948d-14bc74b9da0c.png)


- Add view with no resources
![image](https://user-images.githubusercontent.com/5129024/94036404-e6362b00-fde1-11ea-9b6f-0dd646ce5fbc.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
