### PR TITLE
Bug 1877739: Update git repo unreachable error to warning and better msg

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -77,7 +77,7 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) =>
       } else {
         setFieldValue('image.recommended', '');
         setFieldValue('image.couldNotRecommend', false);
-        setValidated(ValidatedOptions.error);
+        setValidated(ValidatedOptions.warning);
       }
     },
     [
@@ -151,8 +151,8 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) =>
     if (validated === ValidatedOptions.success) {
       return 'Validated';
     }
-    if (validated === ValidatedOptions.error) {
-      return 'Git repository is not reachable.';
+    if (validated === ValidatedOptions.warning) {
+      return 'URL is valid but cannot be reached. If this is a private repository, enter a source secret in Advanced Git Options';
     }
     return '';
   };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3650
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Git import form shows error when a private repo is entered but the form can still be submitted.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Change the error message to better explain what went wrong and change the error to warning.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux @parvathyvr 

![Peek 2020-09-23 21-29](https://user-images.githubusercontent.com/6041994/94038659-5a71ce00-fde4-11ea-87d4-d8a28ebcd3f9.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
