### PR TITLE
Bug 1882088: Remove vertical scrollbar on the page when builder dropdown is open

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.scss
@@ -1,6 +1,10 @@
 .odc-task-list-node {
   border: 1px solid var(--pf-global--BorderColor--light-100);
 
+  &__container {
+    overflow: hidden;
+    box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
+  }
   &__label {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
@@ -87,7 +87,7 @@ const TaskListNode: React.FC<TaskListNodeProps> = ({ element, unselectedText }) 
         <FocusTrap
           focusTrapOptions={{ clickOutsideDeactivates: true, returnFocusOnDeactivate: false }}
         >
-          <div className="pf-c-dropdown pf-m-expanded">
+          <div className="pf-c-dropdown pf-m-expanded odc-task-list-node__container">
             <ul className="pf-c-dropdown__menu pf-m-align-right oc-kebab__popper-items odc-task-list-node__list-items">
               {options.map((option) => (
                 <li key={option.key}>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4783
https://bugzilla.redhat.com/show_bug.cgi?id=1882088

**Analysis / Root cause**: 
Modal div around the content has the full height of the content.

**Solution Description**: 
Apply CSS rule `overflow: hidden` to the div around the content. Because it hides also the shadow (of the `<ul className="pf-c-dropdown__menu`) I need to add this to the div again.

**Screen shots / Gifs for design review**: 
![odc-4783 webm](https://user-images.githubusercontent.com/139310/94056043-11b71680-fdde-11ea-9359-0dfff22f5681.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Install pipelines operator
2. Open up the pipeline builder builder via +Add => pipeline
3. Click the task node in the pipeline builder to open the dropdown menu

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge