### PR TITLE
Bug 1882097: Fix layout issue which appears only on Safari

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
@@ -2,7 +2,6 @@
 
 $border-color: var(--pf-global--BorderColor--light-100);
 .odc-pipeline-vis-task {
-  position: relative;
   width: 10em;
   cursor: default;
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.scss
@@ -14,6 +14,7 @@
     background: var(--pf-global--BackgroundColor--light-100);
   }
   &__trigger {
+    position: fixed;
     padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--md);
     width: 100%;
   }

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskListNode.tsx
@@ -49,7 +49,7 @@ const TaskListNode: React.FC<TaskListNodeProps> = ({ element, unselectedText }) 
 
   return (
     <foreignObject width={width} height={height} className="odc-task-list-node">
-      <div className="odc-task-list-node__trigger-background" ref={triggerRef}>
+      <div ref={triggerRef} className="odc-task-list-node__trigger-background" style={{ height }}>
         <Button
           className="odc-task-list-node__trigger"
           isDisabled={options.length === 0}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4910
https://bugzilla.redhat.com/show_bug.cgi?id=1882097

**Analysis / Root cause**: 
There are `position:` issues which only appears in Safari when viewing and editing a pipeline.

**Solution Description**: 
Remove and add a position css rule so that the pipeline visualization looks similar in Safari and the others browsers. Tested this in latest Chrome, Firefox and Safari.

**Screen shots / Gifs for design review**: 
Chrome 85, Firefox 80 and Safari 14 on macOS:
![odc-4910 mov](https://user-images.githubusercontent.com/139310/94082450-45576800-fe01-11ea-8980-2a9e6080157a.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Test a Pipeline visualization in read only mode (open an existing pipeline)
* Create a new pipeline and check if the Select task was also shown at the right position

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge