### PR TITLE
Bug 1882142: Automatically select correct PipelineResource when starting a PipelineRun (or create a trigger)

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -9,17 +9,21 @@ const getImageUrl = (name: string, namespace: string) => {
   return `image-registry.openshift-image-registry.svc:5000/${namespace}/${name}`;
 };
 
-export const createGitResource = (url: string, namespace: string, ref: string = 'master') => {
+export const createGitResource = (
+  name: string,
+  namespace: string,
+  url: string,
+  ref: string = 'master',
+) => {
   const params = { url, revision: ref };
-  return createPipelineResource(params, 'git', namespace);
+  return createPipelineResource(name, namespace, 'git', params);
 };
 
 export const createImageResource = (name: string, namespace: string) => {
   const params = {
     url: getImageUrl(name, namespace),
   };
-
-  return createPipelineResource(params, 'image', namespace);
+  return createPipelineResource(name, namespace, 'image', params);
 };
 
 export const createPipelineForImportFlow = async (formData: GitImportFormData) => {
@@ -53,7 +57,7 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
   });
 
   if (template.spec.resources?.find((r) => r.type === 'git' && r.name === 'app-source')) {
-    await createGitResource(git.url, namespace, git.ref);
+    await createGitResource(name, namespace, git.url, git.ref);
   }
   if (template.spec.resources?.find((r) => r.type === 'image' && r.name === 'app-image')) {
     await createImageResource(name, namespace);

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineResourceDropdownField.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineResourceDropdownField.tsx
@@ -8,8 +8,10 @@ import { PipelineModalFormResource } from './types';
 import PipelineResourceDropdown from './PipelineResourceDropdown';
 
 type PipelineResourceDropdownFieldProps = DropdownFieldProps & {
+  pipelineName: string;
   filterType?: string;
 };
+
 const PipelineResourceDropdownField: React.FC<PipelineResourceDropdownFieldProps> = (props) => {
   const { filterType, name, label } = props;
 

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineResourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineResourceSection.tsx
@@ -59,6 +59,7 @@ const PipelineResourceSection: React.FC = () => {
                       name={`resources.${formikIndex}`}
                       filterType={type}
                       label={resource.name}
+                      pipelineName={resource.pipelineName}
                     />
                   );
                 })}

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/__tests__/utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/__tests__/utils.spec.ts
@@ -192,6 +192,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
       parameters: [],
       resources: [
         {
+          pipelineName: 'PipelineA',
           name: 'ResourceA',
           selection: 'SelectionA',
           data: {

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/types.ts
@@ -2,6 +2,7 @@ import { FormikValues } from 'formik';
 import { PipelineParam } from '../../../../utils/pipeline-augment';
 
 export type PipelineModalFormResource = {
+  pipelineName: string;
   name: string;
   selection: string;
   data: {

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
@@ -98,21 +98,20 @@ export const getPipelineRunData = (
   return migratePipelineRun(newPipelineRun);
 };
 
-export const convertPipelineToModalData = (
-  pipeline: Pipeline,
-  alwaysCreateResources: boolean = false,
-): CommonPipelineModalFormikValues => {
+export const convertPipelineToModalData = (pipeline: Pipeline): CommonPipelineModalFormikValues => {
   const {
-    metadata: { namespace },
+    metadata: { name, namespace },
     spec: { params, resources },
   } = pipeline;
 
   return {
+    name,
     namespace,
     parameters: params || [],
     resources: (resources || []).map((resource: PipelineResource) => ({
+      pipelineName: name,
       name: resource.name,
-      selection: alwaysCreateResources ? CREATE_PIPELINE_RESOURCE : null,
+      selection: null,
       data: {
         ...initialResourceFormValues[resource.type],
         type: resource.type,

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/submit-utils.ts
@@ -15,14 +15,15 @@ export const resourceSubmit = async (
   namespace: string,
 ): Promise<K8sResourceCommon> => {
   const {
+    name,
     data: { params, secrets, type },
   } = resourceValues;
 
   return secrets
     ? createSecretResource(secrets, type, namespace).then((secretResp) => {
-        return createPipelineResource(params, type, namespace, secretResp);
+        return createPipelineResource(name, namespace, type, secretResp);
       })
-    : createPipelineResource(params, type, namespace);
+    : createPipelineResource(name, namespace, type, params);
 };
 
 export const submitStartPipeline = async (

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
@@ -19,7 +19,7 @@ type AddTriggerModalProps = ModalComponentProps & {
 
 const AddTriggerModal: React.FC<AddTriggerModalProps> = ({ pipeline, close }) => {
   const initialValues: AddTriggerFormValues = {
-    ...convertPipelineToModalData(pipeline, true),
+    ...convertPipelineToModalData(pipeline),
     triggerBinding: {
       name: TRIGGER_BINDING_EMPTY,
       resource: null,

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/pipelineResource-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/pipelineResource-utils.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import { k8sCreate, K8sResourceKind } from '@console/internal/module/k8s';
 import { SecretModel } from '@console/internal/models';
 import { getRandomChars } from '@console/shared/src/utils/utils';
+import { getCommonAnnotations } from 'packages/dev-console/src/utils/resource-label-utils';
 import { PipelineResourceModel } from '../../../models';
 import { convertMapToNameValueArray } from '../modals/common/utils';
 
@@ -14,9 +15,10 @@ export const getDefinedObj = (objData: ParamData): ParamData => {
 };
 
 export const createPipelineResource = (
-  params: ParamData,
-  type: string,
+  pipelineName: string,
   namespace: string,
+  type: string,
+  params: ParamData,
   secretResp?: K8sResourceKind,
 ): Promise<K8sResourceKind> => {
   const resourceName = `${type}-${getRandomChars(6)}`;
@@ -26,6 +28,10 @@ export const createPipelineResource = (
     metadata: {
       name: resourceName,
       namespace,
+      labels: {
+        ...getCommonAnnotations(),
+        'tekton.dev/pipeline': pipelineName,
+      },
     },
     spec: {
       type,

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/pipelineResource-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/pipelineResource-utils.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { k8sCreate, K8sResourceKind } from '@console/internal/module/k8s';
 import { SecretModel } from '@console/internal/models';
 import { getRandomChars } from '@console/shared/src/utils/utils';
-import { getCommonAnnotations } from 'packages/dev-console/src/utils/resource-label-utils';
+import { getCommonAnnotations } from '@console/dev-console/src/utils/resource-label-utils';
 import { PipelineResourceModel } from '../../../models';
 import { convertMapToNameValueArray } from '../modals/common/utils';
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3327
https://bugzilla.redhat.com/show_bug.cgi?id=1882142

**Analysis / Root cause**: 
For pipeline templates with input and output resources the console automatically creates PipelineResources (for known resource names). This PipelineResources has no link to the Pipeline instance.

When starting a PipelineRun the user needs to select the correct PipelineResources which is hard when there is more than one PipelineResource available.

**Solution Description**:
This change adds a new label to the auto-generated pipeline resources. `tekton.dev/pipeline: $pipelineName`.

When starting a pipeline (create a PipelineRun) the modal automatically select resources based on the pipeline name and this resource label.

**Screen shots / Gifs for design review**: 
![odc-3327 webm](https://user-images.githubusercontent.com/139310/94073591-083aa800-fdf8-11ea-9f97-28706425bb20.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Requires OpenShift Pipelines Operator 1.0.1 (or earlier)
* Import a Deployment from git and enable the "Add Pipeline" option
* Check the created PipelineResources
* Open "Start Pipeline" or "Add Trigger" modal and check if the correct resource is preselected

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge