### PR TITLE
Bug 1882152: Make "Add to Navigation" accessible for tabs

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -47,9 +47,6 @@
     padding-right: var(--pf-global--spacer--xs);
     margin-right: var(--pf-global--spacer--sm);
     text-align: left;
-    &:focus {
-      outline: none;
-    }
   }
   .co-search-group__pin-toggle__icon {
     margin-right: var(--pf-global--spacer--xs);

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -7,6 +7,8 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionToggle,
+  Button,
+  ButtonVariant,
   Toolbar,
   ToolbarChip,
   ToolbarContent,
@@ -269,8 +271,9 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
                 >
                   {getToggleText(resource)}
                   {props.perspective !== 'admin' && (
-                    <a
-                      className="pf-c-button pf-m-link co-search-group__pin-toggle"
+                    <Button
+                      className="co-search-group__pin-toggle"
+                      variant={ButtonVariant.link}
                       onClick={(e) => pinToggle(e, resource)}
                     >
                       {pinnedResources.includes(resource) ? (
@@ -284,7 +287,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
                           Add to navigation
                         </>
                       )}
-                    </a>
+                    </Button>
                   )}
                 </AccordionToggle>
                 <AccordionContent isHidden={isCollapsed}>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3796
https://bugzilla.redhat.com/show_bug.cgi?id=1882152

**Analysis / Root cause**: 
A link without href is not "tab-able"

**Solution Description**: 
Change to button and remove the css which remove that the outline was not shown.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux button shows now an outline:
![odc-3796 webm](https://user-images.githubusercontent.com/139310/94078135-65395c80-fdfe-11ea-8ab9-84bbc14ecba7.gif)

**Unit test coverage report**: 
Not changed

**Test setup:**
* Open the search in developer perspective

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug