### PR TITLE
Bug 1882284: Fix React warnings when open dashboard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card.tsx
@@ -76,7 +76,7 @@ const BreakdownCard: React.FC<DashboardItemProps> = ({
           </Select>
         </div>
       </DashboardCardHeader>
-      <DashboardCardBody classname="ceph-capacity-breakdown-card__body">
+      <DashboardCardBody className="ceph-capacity-breakdown-card__body">
         <BreakdownCardBody
           isLoading={queriesDataLoaded}
           hasLoadError={queriesLoadError}

--- a/frontend/packages/ceph-storage-plugin/src/components/independent-dashboard-page/breakdown-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/independent-dashboard-page/breakdown-card.tsx
@@ -76,7 +76,7 @@ export const BreakdownCard: React.FC<DashboardItemProps> = ({
           </Select>
         </div>
       </DashboardCardHeader>
-      <DashboardCardBody classname="ceph-capacity-breakdown-card__body">
+      <DashboardCardBody className="ceph-capacity-breakdown-card__body">
         <BreakdownCardBody
           isLoading={queriesDataLoaded}
           hasLoadError={queriesLoadError}

--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-breakdown/capacity-breakdown-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-breakdown/capacity-breakdown-card.tsx
@@ -207,7 +207,7 @@ const BreakdownCard: React.FC = () => {
           </Select>
         </div>
       </DashboardCardHeader>
-      <DashboardCardBody classname="nb-capacity-breakdown-card__body">
+      <DashboardCardBody className="nb-capacity-breakdown-card__body">
         <BreakdownCardBody
           isLoading={loading}
           hasLoadError={queriesLoadError}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -102,7 +102,11 @@ const ClusterAlerts = withDashboardResources(
 
     if (hasCVResource && cvLoaded && hasAvailableUpdates(cv) && clusterVersionIsEditable) {
       items.push(
-        <StatusItem Icon={UpdateIcon} message="A cluster version update is available">
+        <StatusItem
+          key="clusterUpdate"
+          Icon={UpdateIcon}
+          message="A cluster version update is available"
+        >
           <Link to="/settings/cluster?showVersions">Update cluster</Link>
         </StatusItem>,
       );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4913
https://bugzilla.redhat.com/show_bug.cgi?id=1882284

**Analysis / Root cause**: 
Missing react key and invalid classname capitalization.

**Solution Description**: 
Add react key and change capitalization.

**Screen shots / Gifs for design review**: 
Not required

**Unit test coverage report**: 
Unchanged

**Test setup:**
Just open the console dashboard and open the browser console on a cluster which provides a cluster update.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge