### PR TITLE
Bug 1874890: Include accessibility text for screenreaders only, applied to dashboard status sections when displaying loading status skeleton

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
@@ -16,7 +16,9 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
     return (
       <div className={classNames('co-status-card__health-item', className)}>
         {state === HealthState.LOADING ? (
-          <div className="skeleton-health" />
+          <div className="skeleton-health">
+            <span className="pf-u-screen-reader">Loading {title} Status</span>
+          </div>
         ) : (
           !noIcon && <HealthItemIcon state={state} />
         )}


### PR DESCRIPTION
@spadgett Is this an acceptable approach?

Bug https://bugzilla.redhat.com/show_bug.cgi?id=1874890

<img width="712" alt="Screen Shot 2020-09-24 at 2 27 00 PM" src="https://user-images.githubusercontent.com/1874151/94184564-1af1c300-fe72-11ea-9b5f-5ad19d2a831a.png">
