### PR TITLE
Bug 1882529: Removes the kubectl annotation from the created PLRs

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/utils.ts
@@ -58,6 +58,14 @@ export const getPipelineRunData = (
   const latestRunParams = latestRun?.spec.params;
   const pipelineParams = pipeline?.spec.params;
   const params = latestRunParams || getPipelineRunParams(pipelineParams);
+  // TODO: We should craft a better method to allow us to provide configurable annotations and labels instead of
+  // blinding merging existing content from potential real Pipeline and PipelineRun resources
+  const annotations = _.merge(
+    {},
+    pipeline?.metadata?.annotations,
+    latestRun?.metadata?.annotations,
+  );
+  delete annotations['kubectl.kubernetes.io/last-applied-configuration'];
 
   const newPipelineRun = {
     apiVersion: pipeline ? pipeline.apiVersion : latestRun.apiVersion,
@@ -70,7 +78,7 @@ export const getPipelineRunData = (
         : {
             name: `${pipelineName}-${getRandomChars()}`,
           }),
-      annotations: _.merge({}, pipeline?.metadata?.annotations, latestRun?.metadata?.annotations),
+      annotations,
       namespace: pipeline ? pipeline.metadata.namespace : latestRun.metadata.namespace,
       labels: _.merge({}, pipeline?.metadata?.labels, latestRun?.metadata?.labels, {
         'tekton.dev/pipeline': pipelineName,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4917

**Analysis / Root cause**: 
Blindly copying all the annotations over seems to cause an issue with the TriggerTemplate creation if there is an issue in the `kubectl.kubernetes.io/last-applied-configuration` annotation

**[Temp] Solution Description**: 
Remove the annotation as it's a hold over from the previous configuration.

There is a growing need to refactor this method and subsequently the callers to properly define a clean structure... however this shouldn't be done in 4.6 and definitely not this close to Code Freeze.

**Screen shots / Gifs for design review**: 
No visual change.

**Test setup:**
See the ticket.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge