### PR TITLE
Bug 1866337: Changes placeholder to 'Search by node name/label' in install page

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -188,7 +188,8 @@ export const CreateInternalCluster = withHandlePromise<
           customData={{
             onRowSelected: setNodes,
           }}
-          filterPlaceholder="Search by node name..."
+          nameFilterPlaceholder="Search by node name..."
+          labelFilterPlaceholder="Search by node label..."
         >
           <>
             <div>

--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -46,7 +46,8 @@ export const SelectNodesSection: React.FC<SelectNodesSectionProps> = ({
   table,
   customData,
   children,
-  filterPlaceholder,
+  nameFilterPlaceholder,
+  labelFilterPlaceholder,
 }) => (
   <>
     <FormGroup fieldId="select-nodes">
@@ -63,7 +64,8 @@ export const SelectNodesSection: React.FC<SelectNodesSectionProps> = ({
         showTitle={false}
         ListComponent={table}
         customData={customData}
-        filterPlaceholder={filterPlaceholder}
+        nameFilterPlaceholder={nameFilterPlaceholder}
+        labelFilterPlaceholder={labelFilterPlaceholder}
       />
     </FormGroup>
   </>
@@ -128,7 +130,8 @@ type SelectNodesSectionProps = {
   table: React.ComponentType<any>;
   customData?: any;
   children?: React.ReactChild;
-  filterPlaceholder?: string;
+  nameFilterPlaceholder?: string;
+  labelFilterPlaceholder?: string;
 };
 
 type StorageClassSectionProps = {

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -68,7 +68,8 @@ export class ListPageWrapper_ extends React.PureComponent {
       reduxIDs,
       rowFilters,
       textFilter,
-      filterPlaceholder,
+      nameFilterPlaceholder,
+      labelFilterPlaceholder,
       hideNameLabelFilters,
       hideLabelFilter,
       columnLayout,
@@ -78,7 +79,8 @@ export class ListPageWrapper_ extends React.PureComponent {
       <FilterToolbar
         rowFilters={rowFilters}
         data={data}
-        filterPlaceholder={filterPlaceholder}
+        nameFilterPlaceholder={nameFilterPlaceholder}
+        labelFilterPlaceholder={labelFilterPlaceholder}
         reduxIDs={reduxIDs}
         textFilter={textFilter}
         hideNameLabelFilters={hideNameLabelFilters}
@@ -308,7 +310,7 @@ FireMan_.propTypes = {
   title: PropTypes.string,
 };
 
-/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean, badge?: React.ReactNode, createHandler?: any, hideNameLabelFilters?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout, customData?: any, hideColumnManagement?: boolean, filterPlaceholder?: string } >} */
+/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean, badge?: React.ReactNode, createHandler?: any, hideNameLabelFilters?: boolean, hideLabelFilter?: boolean, columnLayout?: ColumnLayout, customData?: any, hideColumnManagement?: boolean, labelFilterPlaceholder?: string, nameFilterPlaceholder?: string } >} */
 export const ListPage = withFallback((props) => {
   const {
     autoFocus,
@@ -318,7 +320,8 @@ export const ListPage = withFallback((props) => {
     customData,
     fieldSelector,
     filterLabel,
-    filterPlaceholder,
+    labelFilterPlaceholder,
+    nameFilterPlaceholder,
     filters,
     helpText,
     kind,
@@ -389,7 +392,8 @@ export const ListPage = withFallback((props) => {
       createProps={createProps}
       customData={customData}
       filterLabel={filterLabel || 'by name'}
-      filterPlaceholder={filterPlaceholder}
+      nameFilterPlaceholder={nameFilterPlaceholder}
+      labelFilterPlaceholder={labelFilterPlaceholder}
       flatten={(_resources) => _.get(_resources, name || kind, {}).data}
       helpText={helpText}
       label={labelPlural}
@@ -422,7 +426,8 @@ export const MultiListPage = (props) => {
     createButtonText,
     createProps,
     filterLabel,
-    filterPlaceholder,
+    nameFilterPlaceholder,
+    labelFilterPlaceholder,
     flatten,
     helpText,
     label,
@@ -478,7 +483,8 @@ export const MultiListPage = (props) => {
           hideNameLabelFilters={hideNameLabelFilters}
           hideColumnManagement={hideColumnManagement}
           columnLayout={columnLayout}
-          filterPlaceholder={filterPlaceholder}
+          nameFilterPlaceholder={nameFilterPlaceholder}
+          labelFilterPlaceholder={labelFilterPlaceholder}
         />
       </Firehose>
     </FireMan_>

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -91,7 +91,8 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     hideLabelFilter,
     hideNameLabelFilters,
     columnLayout,
-    filterPlaceholder,
+    nameFilterPlaceholder,
+    labelFilterPlaceholder,
     location,
     textFilter = filterTypeMap[FilterType.NAME],
     labelFilter = filterTypeMap[FilterType.LABEL],
@@ -100,8 +101,9 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   const [inputText, setInputText] = React.useState('');
   const [filterType, setFilterType] = React.useState(FilterType.NAME);
   const [isOpen, setOpen] = React.useState(false);
-  const placeholder =
-    filterPlaceholder || (FilterType.NAME === filterType ? 'Search by name...' : 'app=frontend');
+  const [placeholder, setPlaceholder] = React.useState(
+    nameFilterPlaceholder || 'Search by name...',
+  );
 
   // (rowFilters) => {'rowFilterTypeA': ['staA', 'staB'], 'rowFilterTypeB': ['stbA'] }
   const filters: Filter = rowFilters.reduce((acc, curr) => {
@@ -258,6 +260,16 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
 
   const switchFilter = (type: FilterType) => {
     setFilterType(FilterType[type]);
+    switch (FilterType[type]) {
+      case 'Name':
+        setPlaceholder(nameFilterPlaceholder || 'Search by name...');
+        break;
+      case 'Label':
+        setPlaceholder(labelFilterPlaceholder || 'Search by label...');
+        break;
+      default:
+        setPlaceholder('app=frontend');
+    }
     setInputText(nameFilter && FilterType[type] === FilterType.NAME ? nameFilter : '');
   };
 
@@ -377,7 +389,8 @@ type FilterToolbarProps = {
   kinds?: any;
   labelPath?: string;
   columnLayout?: ColumnLayout;
-  filterPlaceholder?: string;
+  nameFilterPlaceholder?: string;
+  labelFilterPlaceholder?: string;
 };
 
 export type RowFilter<R = any> = {


### PR DESCRIPTION
This PR add fixes to previous https://github.com/openshift/console/pull/6621. Now we can pass a resource name to display the placeholder appropriately and it will change the placeholder according to the type (Name, Label etc) selected 


Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>