### PR TITLE
Bug 1874558: Fix resource log performance issue

### DIFF
--- a/frontend/public/components/utils/_log-window.scss
+++ b/frontend/public/components/utils/_log-window.scss
@@ -24,7 +24,7 @@ $color-log-window-divider: $color-log-window-header-bg;
   padding-top: 10px;
 }
 
-.log-window__contents__text{
+.log-window__lines {
   padding-left: 10px;
   padding-right: 10px;
   white-space: pre;

--- a/frontend/public/components/utils/log-window.jsx
+++ b/frontend/public/components/utils/log-window.jsx
@@ -29,7 +29,7 @@ export class LogWindow extends React.PureComponent {
   static getDerivedStateFromProps(nextProps) {
     if (nextProps.status !== STREAM_PAUSED) {
       return {
-        content: nextProps.lines.join(''),
+        content: nextProps.lines.join('\n'),
       };
     }
     return null;
@@ -129,7 +129,7 @@ export class LogWindow extends React.PureComponent {
         <div className="log-window__body">
           <div className="log-window__scroll-pane" ref={this._setScrollPane}>
             <div className="log-window__contents" ref={this._setLogContents} style={{ height }}>
-              <div className="log-window__contents__text">{content}</div>
+              <div className="log-window__lines">{content}</div>
             </div>
           </div>
         </div>

--- a/frontend/public/components/utils/resource-log.jsx
+++ b/frontend/public/components/utils/resource-log.jsx
@@ -4,7 +4,12 @@ import { Base64 } from 'js-base64';
 import { saveAs } from 'file-saver';
 import { Alert, AlertActionLink, Button } from '@patternfly/react-core';
 import * as _ from 'lodash-es';
-import { CompressIcon, ExpandIcon, DownloadIcon } from '@patternfly/react-icons';
+import {
+  CompressIcon,
+  ExpandIcon,
+  DownloadIcon,
+  OutlinedWindowRestoreIcon,
+} from '@patternfly/react-icons';
 import * as classNames from 'classnames';
 import { FLAGS } from '@console/shared/src/constants';
 import { LoadingInline, LogWindow, TogglePlay, ExternalLink } from './';
@@ -50,7 +55,7 @@ const replaceVariables = (template, values) => {
 // Component for log stream controls
 export const LogControls = ({
   dropdown,
-  onDownload,
+  logURL,
   toggleFullscreen,
   isFullscreen,
   status,
@@ -111,10 +116,17 @@ export const LogControls = ({
               </React.Fragment>
             );
           })}
-        <Button variant="link" isInline onClick={onDownload}>
+        <a href={logURL} target="_blank" rel="noopener noreferrer">
+          <OutlinedWindowRestoreIcon className="co-icon-space-r" />
+          Raw
+        </a>
+        <span aria-hidden="true" className="co-action-divider hidden-xs">
+          |
+        </span>
+        <a href={logURL} download>
           <DownloadIcon className="co-icon-space-r" />
           Download
-        </Button>
+        </a>
         {screenfull.enabled && (
           <>
             <span aria-hidden="true" className="co-action-divider hidden-xs">
@@ -170,6 +182,7 @@ class ResourceLog_ extends React.Component {
     this._resourceLogRef = React.createRef();
     this.state = {
       error: false,
+      hasTruncated: false,
       lines: [],
       linesBehind: 0,
       resourceStatus: LOG_SOURCE_WAITING,
@@ -277,6 +290,7 @@ class ResourceLog_ extends React.Component {
       this.setState({
         linesBehind: status === STREAM_PAUSED ? linesBehind + linesAdded : linesBehind,
         lines: this._buffer.getLines(),
+        hasTruncated: this._buffer.getHasTruncated(),
       });
     }
   }
@@ -292,6 +306,7 @@ class ResourceLog_ extends React.Component {
     this.setState(
       {
         error: false,
+        hasTruncated: false,
         lines: [],
         linesBehind: 0,
         stale: false,
@@ -375,6 +390,7 @@ class ResourceLog_ extends React.Component {
     const { resource, containerName, dropdown, bufferSize } = this.props;
     const {
       error,
+      hasTruncated,
       lines,
       linesBehind,
       stale,
@@ -384,7 +400,12 @@ class ResourceLog_ extends React.Component {
       namespaceUID,
     } = this.state;
     const bufferFull = lines.length === bufferSize;
-
+    const logURL = resourceURL(modelFor(resource.kind), {
+      name: resource.metadata.name,
+      ns: resource.metadata.namespace,
+      path: 'log',
+      queryParams: { container: containerName || '' },
+    });
     return (
       <>
         {error && (
@@ -395,6 +416,24 @@ class ResourceLog_ extends React.Component {
             title="An error occurred while retrieving the requested logs."
             actionLinks={<AlertActionLink onClick={this._restartStream}>Retry</AlertActionLink>}
           />
+        )}
+        {hasTruncated && (
+          <Alert
+            isInline
+            className="co-alert"
+            variant="warning"
+            title={'Some lines have been abridged because they are exceptionally long.'}
+          >
+            To view unabridged log content, you can either{' '}
+            <a href={logURL} target="_blank" rel="noopener noreferrer">
+              open the raw file in another window
+            </a>{' '}
+            or{' '}
+            <a href={logURL} download>
+              download it
+            </a>
+            .
+          </Alert>
         )}
         {stale && (
           <Alert
@@ -412,7 +451,8 @@ class ResourceLog_ extends React.Component {
           <LogControls
             dropdown={dropdown}
             isFullscreen={isFullscreen}
-            onDownload={this._download}
+            logURL={logURL}
+            setLineWrap={this._setLineWrap}
             status={status}
             toggleFullscreen={this._toggleFullscreen}
             toggleStreaming={this._toggleStreaming}
@@ -422,10 +462,10 @@ class ResourceLog_ extends React.Component {
             namespaceUID={namespaceUID}
           />
           <LogWindow
-            lines={lines}
-            linesBehind={linesBehind}
             bufferFull={bufferFull}
             isFullscreen={isFullscreen}
+            lines={lines}
+            linesBehind={linesBehind}
             status={status}
             updateStatus={this._updateStatus}
           />


### PR DESCRIPTION
- Truncate log lines over 1024 characters
- If any log line has been truncated, add a warning alert 
- Add ability to view raw logs in another tab. 
- Adjust download behavior so that all raw logs are downloaded.

![image](https://user-images.githubusercontent.com/22625502/94312195-755e5280-ff4a-11ea-9773-fd519ebb1ab7.png)
