### PR TITLE
Bug 1880246:Entry keys in aggregated Helm index are appended with the name of source Helm repo

### DIFF
--- a/docs/helm/endpoints_api.md
+++ b/docs/helm/endpoints_api.md
@@ -321,3 +321,28 @@ _Returns all chart details for the given chart URL_
 
   * **Code:** 400 BAD REQUEST <br />
     **Content:** `{ error : "error message" }`
+
+**Retrieve Helm Repository Index**
+----
+
+_Returns repository index file containing all entries from all configured repositories_
+
+* **URL**
+
+    `/api/helm/charts/index.yaml`
+
+* **Method:**
+
+  `GET`
+
+* **Success Response:**
+
+  * **Code:** 200 <br />
+  * JSON representation of [Index file](https://github.com/helm/helm/blob/master/pkg/repo/index.go#L79)
+  * Each entry key is appended with [source repo name](https://github.com/openshift/api/blob/master/helm/v1beta1/types_helm.go#L16).
+    Double dash (`--`) serves as the separate between the chart and repo name (e.g. `foo-chart--my-repo`)
+
+* **Error Response:**
+
+  * **Code:** 400 BAD REQUEST <br />
+    **Content:** `{ error : "error message" }`

--- a/pkg/helm/chartproxy/proxy.go
+++ b/pkg/helm/chartproxy/proxy.go
@@ -69,13 +69,15 @@ func (p *proxy) IndexFile() (*repo.IndexFile, error) {
 		return nil, err
 	}
 
-	var indexFiles []*repo.IndexFile
+	indexFile := repo.NewIndexFile()
 	for _, helmRepo := range helmRepos {
 		idxFile, err := helmRepo.IndexFile()
 		if err != nil {
 			return nil, err
 		}
-		indexFiles = append(indexFiles, idxFile)
+		for key, entry := range idxFile.Entries {
+			indexFile.Entries[key+"--"+helmRepo.Name] = entry
+		}
 	}
-	return mergeIndexFiles(indexFiles...), nil
+	return indexFile, nil
 }

--- a/pkg/helm/chartproxy/proxy_test.go
+++ b/pkg/helm/chartproxy/proxy_test.go
@@ -19,13 +19,18 @@ func TestProxy_IndexFile(t *testing.T) {
 	}{
 		{
 			name:       "returned index file for configured helm repo",
-			indexFiles: []string{"testdata/azureRepoIndex.yaml"},
-			mergedFile: "testdata/azureRepoIndex.yaml",
+			indexFiles: []string{"testdata/sampleRepoIndex.yaml"},
+			mergedFile: "testdata/mergedSampleRepoIndex2.yaml",
 		},
 		{
 			name:       "returned merged index file for configured helm repos",
 			indexFiles: []string{"testdata/azureRepoIndex.yaml", "testdata/sampleRepoIndex.yaml"},
 			mergedFile: "testdata/mergedRepoIndex.yaml",
+		},
+		{
+			name:       "returned merged index contains all entries from source repos - helm names are appended with repo names to avoid duplicate removal",
+			indexFiles: []string{"testdata/sampleRepoIndex2.yaml", "testdata/sampleRepoIndex2.yaml"},
+			mergedFile: "testdata/mergedRepoIndexWithDuplicates.yaml",
 		},
 		{
 			name:       "return empty index file when no repositories declared in cluster",
@@ -64,7 +69,7 @@ func TestProxy_IndexFile(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				if reflect.DeepEqual(indexFile, expectedIndexFile) {
+				if !reflect.DeepEqual(indexFile.Entries, expectedIndexFile.Entries) {
 					t.Errorf("Expected index content \n%v but got \n%v", expectedIndexFile, indexFile)
 				}
 			} else {

--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -175,16 +175,6 @@ func (b helmRepoGetter) unmarshallConfig(repo unstructured.Unstructured) (*helmR
 	return h, nil
 }
 
-func mergeIndexFiles(files ...*repo.IndexFile) *repo.IndexFile {
-	indexFile := repo.NewIndexFile()
-	for _, file := range files {
-		for key, entry := range file.Entries {
-			indexFile.Entries[key] = entry
-		}
-	}
-	return indexFile
-}
-
 func (b *helmRepoGetter) List() ([]*helmRepo, error) {
 	var helmRepos []*helmRepo
 	repos, err := b.Client.Resource(helmChartRepositoryGVK).List(context.TODO(), v1.ListOptions{})

--- a/pkg/helm/chartproxy/testdata/mergedRepoIndexWithDuplicates.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedRepoIndexWithDuplicates.yaml
@@ -1,0 +1,233 @@
+apiVersion: v1
+entries:
+  ibm-cpq-prod--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.11.0'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+  ibm-object-storage-plugin--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 2.0.0
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+      version: 2.0.0
+  ibm-oms-ent-prod--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.11.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+  ibm-cpq-prod--sample-repo-2:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.11.0'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+  ibm-object-storage-plugin--sample-repo-2:
+    - apiVersion: v2
+      appVersion: 2.0.0
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+      version: 2.0.0
+  ibm-oms-ent-prod--sample-repo-2:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.11.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/mergedSampleRepoIndex2.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedSampleRepoIndex2.yaml
@@ -1,167 +1,6 @@
 apiVersion: v1
 entries:
-  aks-helloworld--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4350608-05:00"
-      description: A Helm chart for Kubernetes
-      digest: a9bc374461e31cb1429021a898ef83d0a650783033f3bc121ed536ad99301bbc
-      name: aks-helloworld
-      response:
-        - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.1.tgz
-      version: 0.1.1
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.433497-05:00"
-      description: A Helm chart for Kubernetes
-      digest: f4eb20e7116b24c4825861e6ff6f4303bbe83bcee4a7b2b6ea9fe6929852f34d
-      name: aks-helloworld
-      response:
-        - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.0.tgz
-      version: 0.1.0
-  azure-vote--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4454224-05:00"
-      description: A Helm chart for Kubernetes
-      digest: ac7698878230b11c766c0fcbfce36e7a1c8ab4ab18d55eae9e6551217042c164
-      name: azure-vote
-      response:
-        - https://azure-samples.github.io/helm-charts/azure-vote-0.1.1.tgz
-      version: 0.1.1
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4436157-05:00"
-      description: A Helm chart for Kubernetes
-      digest: da054ba832f52ff3e8da26ffe705d6ad6c2ed0818c04588c832c716e8e8d84a7
-      name: azure-vote
-      response:
-        - https://azure-samples.github.io/helm-charts/azure-vote-0.1.0.tgz
-      version: 0.1.0
-  azure-vote-osba--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4518442-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 64f7688099208066cef552afc560bd4d0ff04a297365c4260d3116fd1af061da
-      name: azure-vote-osba
-      response:
-        - https://azure-samples.github.io/helm-charts/azure-vote-osba-0.1.0.tgz
-      version: 0.1.0
-  burst-scheduler--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.455658-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 326910e7174b98c337e508c1b2baa1e430720758e013256aa8fcbcf1551c2c13
-      name: burst-scheduler
-      response:
-        - https://azure-samples.github.io/helm-charts/burst-scheduler-0.1.0.tgz
-      version: 0.1.0
-  image-pull-secret--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4592817-05:00"
-      description: A Helm chart for Kubernetes
-      digest: ee937e26d72c420a9eb5af8eb0ef23206260858c830b06e7b5ec37c5752fa6a3
-      name: image-pull-secret
-      response:
-        - https://azure-samples.github.io/helm-charts/image-pull-secret-0.1.0.tgz
-      version: 0.1.0
-  open-service-broker-azure--sample-repo-1:
-    - apiVersion: v1
-      appVersion: v0.0.1
-      created: "2020-03-30T16:27:13.4706997-05:00"
-      dependencies:
-        - condition: redis.embedded
-          name: redis
-          repository: https://kubernetes-charts.storage.googleapis.com/
-          version: 0.10.0
-      description: A Helm chart for Open Service Broker For Azure
-      digest: 407ba56844a0e8ed67014ea3d7ef32d2b2e15f7f34bf691b237da6f10818e265
-      home: https://github.com/azure/open-service-broker-azure
-      keywords:
-        - azure
-        - services
-        - service broker
-      maintainers:
-        - email: kent.rancourt@microsoft.com
-          name: Kent Rancourt
-        - email: jeremy.rickard@microsoft.com
-          name: Jeremy Rickard
-      name: open-service-broker-azure
-      sources:
-        - https://github.com/azure/open-service-broker-azure
-        - https://hub.docker.com/r/microsoft/azure-service-broker/
-      response:
-        - https://azure-samples.github.io/helm-charts/open-service-broker-azure-v0.0.1.tgz
-      version: v0.0.1
-  osba-container-instances-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4798738-05:00"
-      description: A Helm chart for Kubernetes
-      digest: b5f25ecf64d72644166835e48afda396b83acaff341bcb7c1e60efc12e547df6
-      name: osba-container-instances-demo
-      response:
-        - https://azure-samples.github.io/helm-charts/osba-container-instances-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-cosmos-mongodb-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.489062-05:00"
-      description: A Helm chart for Kubernetes
-      digest: b581f67458cdf999ef0308786dc29f603bab6aadf5ad0a127f5fb1a816aef091
-      name: osba-cosmos-mongodb-demo
-      response:
-        - https://azure-samples.github.io/helm-charts/osba-cosmos-mongodb-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-mysql-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4958437-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 034fe8960dcc4948ae28110622c6ea5b5439eb5ee35750899446da2455acf6ea
-      name: osba-mysql-demo
-      response:
-        - https://azure-samples.github.io/helm-charts/osba-mysql-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-storage-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5013751-05:00"
-      description: A Helm chart for Kubernetes
-      digest: d74b4c6a348b988e4dfa8fb2ad6873f533aeb0390ee5a1a88fedcee9fc2abc3a
-      name: osba-storage-demo
-      response:
-        - https://azure-samples.github.io/helm-charts/osba-storage-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-text-analytics-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5060898-05:00"
-      description: A Helm chart for Kubernetes
-      digest: d249a3f0926c24f448e36bc40211faee4b320927919e27c1aabe337065496db0
-      name: osba-text-analytics-demo
-      response:
-        - https://azure-samples.github.io/helm-charts/osba-text-analytics-demo-0.1.0.tgz
-      version: 0.1.0
-  tweet-factory-operator--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5104606-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 8186cd27426d20d607f093f90ee05fe65be0e27fda7ecaeb6b98c1ee6204f11a
-      name: tweet-factory-operator
-      response:
-        - https://azure-samples.github.io/helm-charts/tweet-factory-operator-0.1.0.tgz
-      version: 0.1.0
-  twitter-sentiment--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5145249-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 0a71fceec9bc133c4d2e7a9475e19478bb997cd10898803eaf68f3ce33ff271a
-      name: twitter-sentiment
-      response:
-        - https://azure-samples.github.io/helm-charts/twitter-sentiment-0.1.0.tgz
-      version: 0.1.0
-  twitter-sentiment-cnab--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5192786-05:00"
-      description: A Helm chart for Kubernetes
-      digest: f6446a210a13c6f8a3b5d5feb7cd70115e3b00c8b445dc14c5186e5d2a56de2a
-      name: twitter-sentiment-cnab
-      response:
-        - https://azure-samples.github.io/helm-charts/twitter-sentiment-cnab-0.1.0.tgz
-      version: 0.1.0
-  ibm-cpq-prod--sample-repo-2:
+  ibm-cpq-prod--sample-repo-1:
     - apiVersion: v2
       appVersion: 10.0.0.6
       created: "2020-07-15T16:32:34.607411698+05:30"
@@ -203,7 +42,7 @@ entries:
       response:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
       version: 2.0.0
-  ibm-object-storage-plugin--sample-repo-2:
+  ibm-object-storage-plugin--sample-repo-1:
     - apiVersion: v2
       appVersion: 2.0.0
       created: "2020-07-15T16:32:34.612556197+05:30"
@@ -238,7 +77,7 @@ entries:
       response:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
       version: 2.0.0
-  ibm-oms-ent-prod--sample-repo-2:
+  ibm-oms-ent-prod--sample-repo-1:
     - apiVersion: v2
       appVersion: 10.0.0
       created: "2020-07-15T16:32:34.663118186+05:30"
@@ -276,7 +115,7 @@ entries:
       response:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
       version: 5.0.0
-  ibm-oms-pro-prod--sample-repo-2:
+  ibm-oms-pro-prod--sample-repo-1:
     - apiVersion: v2
       appVersion: 10.0.0
       created: "2020-07-15T16:32:34.695882333+05:30"
@@ -314,7 +153,7 @@ entries:
       response:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
       version: 5.0.0
-  ibm-operator-catalog-enablement--sample-repo-2:
+  ibm-operator-catalog-enablement--sample-repo-1:
     - apiVersion: v2
       appVersion: 1.0.0
       created: "2020-07-15T16:32:34.697730479+05:30"
@@ -347,7 +186,7 @@ entries:
       response:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
       version: 1.0.0
-  nodejs-ex-k--sample-repo-2:
+  nodejs-ex-k--sample-repo-1:
     - apiVersion: v2
       appVersion: 1.16.0
       created: "2020-07-15T16:32:34.700484147+05:30"
@@ -368,5 +207,4 @@ entries:
       response:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
       version: 0.1.1
-
-generated: "2020-03-30T16:27:13.4275217-05:00"
+generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndex2.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndex2.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+entries:
+  ibm-cpq-prod:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.11.0'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+  ibm-object-storage-plugin:
+    - apiVersion: v2
+      appVersion: 2.0.0
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+      version: 2.0.0
+  ibm-oms-ent-prod:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.11.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-07-15T16:32:34.538582491+05:30"


### PR DESCRIPTION
The introduced convention enables that all charts with the same name, but
in different source Helm repo, appear in the aggregated index file under
the name following the pattern: `foo-chart--my-repo`, where `my-repo` is the name
of `HelmChartRepository` available in the cluster.