### PR TITLE
Bug 1883080: add legends under devconsole monitoring dashboard graphs

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -46,7 +46,7 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
   pollInterval,
 }) => {
   return (
-    <DashboardCard className="odc-monitoring-dashboard-graph">
+    <DashboardCard className="monitoring-dashboards__card odc-monitoring-dashboard-graph">
       <DashboardCardHeader>
         <DashboardCardTitle>{title}</DashboardCardTitle>
       </DashboardCardHeader>
@@ -62,6 +62,7 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
               isStack={graphType === GraphTypes.area}
               timespan={timespan}
               pollInterval={pollInterval}
+              formatLegendLabel={(labels) => labels.pod}
             />
           </div>
         </PrometheusGraphLink>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3558

**Analysis / Root cause**: 
The charts on the dashboard do not have legends. This makes it hard to tell which objects are represented.

**Solution Description**: 
added legends under dev console monitoring dashboard graphs

**Screen shots / Gifs for design review**: 
<img width="1511" alt="Screenshot 2020-09-28 at 8 02 47 AM" src="https://user-images.githubusercontent.com/2561818/94385301-6a7e0a80-0162-11eb-8eda-54bd25c049b0.png">

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge