### PR TITLE
Bug 1883200: fix silence toggle in devconsole monitoring

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceAlert.tsx
@@ -1,36 +1,75 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch } from 'react-redux';
 import { Switch } from '@patternfly/react-core';
 import { Rule, RuleStates } from '@console/internal/components/monitoring/types';
 import { StateTimestamp } from '@console/internal/components/monitoring/alerting';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import SilenceDurationDropDown from './SilenceDurationDropdown';
+import { monitoringSetRules } from '@console/internal/actions/ui';
+import {
+  ALERT_MANAGER_TENANCY_BASE_PATH,
+  PROMETHEUS_TENANCY_BASE_PATH,
+} from '@console/internal/components/graphs';
+import { getAlertsAndRules } from '@console/internal/components/monitoring/utils';
+import { alertingRuleStateOrder } from '@console/internal/reducers/monitoring';
+import { refreshNotificationPollers } from '@console/internal/components/notification-drawer';
 
 type SilenceAlertProps = {
   rule: Rule;
+  namespace: string;
 };
-
-const { alertManagerBaseURL } = window.SERVER_FLAGS;
 
 const SilenceUntil = ({ rule }) => {
   if (!_.isEmpty(rule.silencedBy)) {
-    return <StateTimestamp text="Until" timestamp={_.max(_.map(rule.silencedBy, 'endsAt'))} />;
+    return (
+      <div onClick={(e) => e.preventDefault()} role="presentation">
+        <StateTimestamp text="Until" timestamp={_.max(_.map(rule.silencedBy, 'endsAt'))} />
+      </div>
+    );
   }
   return null;
 };
 
-const SilenceAlert: React.FC<SilenceAlertProps> = ({ rule }) => {
-  const [isChecked, setIsChecked] = React.useState(rule.state !== RuleStates.Silenced);
-  const [ruleState] = React.useState(rule);
-  React.useEffect(() => setIsChecked(ruleState.state !== RuleStates.Silenced), [ruleState]);
+const SilenceAlert: React.FC<SilenceAlertProps> = ({ rule, namespace }) => {
+  const [isChecked, setIsChecked] = React.useState(true);
+  const [isInprogress, setIsInprogress] = React.useState(false);
+  const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    if (rule.state === RuleStates.Silenced) {
+      setIsChecked(false);
+    }
+  }, [rule]);
 
   const handleChange = (checked: boolean) => {
+    setIsChecked(checked);
     if (checked) {
       _.each(rule.silencedBy, (silence) => {
-        coFetchJSON.delete(`${alertManagerBaseURL}/api/v2/silence/${silence.id}`);
+        coFetchJSON
+          .delete(`${ALERT_MANAGER_TENANCY_BASE_PATH}/api/v2/silence/${silence.id}`)
+          .then(() => {
+            refreshNotificationPollers();
+            // eslint-disable-next-line promise/no-nesting
+            return coFetchJSON(
+              `${PROMETHEUS_TENANCY_BASE_PATH}/api/v1/rules?namespace=${namespace}`,
+            ).then((response) => {
+              const thanosAlertsAndRules = getAlertsAndRules(response?.data);
+              const sortThanosRules = _.sortBy(thanosAlertsAndRules.rules, alertingRuleStateOrder);
+              dispatch(monitoringSetRules('devRules', sortThanosRules, 'dev'));
+              setIsChecked(true);
+            });
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn('Could not expire silence:', err);
+            setIsChecked(false);
+          });
       });
     }
-    setIsChecked(checked);
   };
 
   return (
@@ -39,12 +78,16 @@ const SilenceAlert: React.FC<SilenceAlertProps> = ({ rule }) => {
       className="odc-silence-alert"
       label={null}
       labelOff={
-        rule.state === RuleStates.Silenced ? (
+        rule.state === RuleStates.Silenced && !isChecked ? (
           <SilenceUntil rule={rule} />
         ) : (
-          <SilenceDurationDropDown rule={rule} />
+          <SilenceDurationDropDown
+            silenceInProgress={(progress) => setIsInprogress(progress)}
+            rule={rule}
+          />
         )
       }
+      isDisabled={isInprogress}
       isChecked={isChecked}
       onChange={handleChange}
     />

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.scss
@@ -1,0 +1,3 @@
+.odc-silence-duration-dropdown {
+  display: inline-block;
+}

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/SilenceDurationDropdown.tsx
@@ -3,29 +3,44 @@ import * as _ from 'lodash';
 // FIXME upgrading redux types is causing many errors at this time
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
-import { useSelector } from 'react-redux';
-import { Dropdown } from '@console/internal/components/utils';
+import { useSelector, useDispatch } from 'react-redux';
+import { Dropdown, LoadingInline } from '@console/internal/components/utils';
 import { RootState } from '@console/internal/redux';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
 import { coFetchJSON } from '@console/internal/co-fetch';
-import { Rule } from '@console/internal/components/monitoring/types';
+import {
+  AlertStates,
+  Rule,
+  RuleStates,
+  SilenceStates,
+} from '@console/internal/components/monitoring/types';
 import { ALERT_MANAGER_TENANCY_BASE_PATH } from '@console/internal/components/graphs';
+import { monitoringSetRules } from '@console/internal/actions/ui';
+import { isSilenced } from '@console/internal/reducers/monitoring';
+import { refreshNotificationPollers } from '@console/internal/components/notification-drawer';
+import './SilenceDurationDropdown.scss';
 
 type SilenceDurationDropDownProps = {
   rule: Rule;
+  silenceInProgress?: (progress: boolean) => void;
 };
 
 const durations = {
-  silenceFor: 'Silence for',
   '30m': '30 minutes',
   '1h': '1 hour',
   '2h': '2 hours',
   '1d': '1 day',
 };
 
-const SilenceDurationDropDown: React.FC<SilenceDurationDropDownProps> = ({ rule }) => {
+const SilenceDurationDropDown: React.FC<SilenceDurationDropDownProps> = ({
+  rule,
+  silenceInProgress,
+}) => {
+  const [silencing, setSilencing] = React.useState(false);
   const createdBy = useSelector((state: RootState) => state.UI.get('user')?.metadata?.name);
+  const rules = useSelector((state: RootState) => state.UI.getIn(['monitoring', 'devRules']));
   const ruleMatchers = _.map(rule?.labels, (value, key) => ({ isRegex: false, name: key, value }));
+  const dispatch = useDispatch();
 
   const matchers = [
     {
@@ -37,29 +52,61 @@ const SilenceDurationDropDown: React.FC<SilenceDurationDropDownProps> = ({ rule 
   ];
 
   const setDuration = (duration: string) => {
-    if (duration !== 'silenceFor') {
-      const startsAt = new Date();
-      const endsAt = new Date(startsAt.getTime() + parsePrometheusDuration(duration));
+    const startsAt = new Date();
+    const endsAt = new Date(startsAt.getTime() + parsePrometheusDuration(duration));
 
-      const payload = {
-        createdBy,
-        endsAt: endsAt.toISOString(),
-        startsAt: startsAt.toISOString(),
-        matchers,
-        comment: '',
-      };
-
-      coFetchJSON.post(`${ALERT_MANAGER_TENANCY_BASE_PATH}/api/v2/silences`, payload);
-    }
+    const payload = {
+      createdBy,
+      endsAt: endsAt.toISOString(),
+      startsAt: startsAt.toISOString(),
+      matchers,
+      comment: '',
+    };
+    setSilencing(true);
+    silenceInProgress && silenceInProgress(true);
+    coFetchJSON
+      .post(`${ALERT_MANAGER_TENANCY_BASE_PATH}/api/v2/silences`, payload)
+      .then(() => {
+        // eslint-disable-next-line promise/no-nesting
+        return coFetchJSON(`${ALERT_MANAGER_TENANCY_BASE_PATH}/api/v2/silences`).then(
+          (silences) => {
+            refreshNotificationPollers();
+            rule.silencedBy = _.filter(
+              silences,
+              (s) => s.status.state === SilenceStates.Active && _.some(rule.alerts, isSilenced),
+            );
+            if (!_.isEmpty(rule.silencedBy)) {
+              _.each(rule.alerts, (a) => (a.state = AlertStates.Silenced));
+              rule.state = RuleStates.Silenced;
+            }
+            const ruleIndex = rules.findIndex((r) => r.id === rule.id);
+            const updatedRules = _.cloneDeep(rules);
+            updatedRules.splice(ruleIndex, 1, rule);
+            dispatch(monitoringSetRules('devRules', updatedRules, 'dev'));
+            setSilencing(false);
+            silenceInProgress && silenceInProgress(false);
+          },
+        );
+      })
+      .catch((err) => {
+        setSilencing(false);
+        silenceInProgress && silenceInProgress(false);
+        // eslint-disable-next-line no-console
+        console.warn('Could not set silence:', err);
+      });
   };
 
   return (
-    <Dropdown
-      dropDownClassName="dropdown--full-width"
-      items={durations}
-      onChange={(v: string) => setDuration(v)}
-      selectedKey={'silenceFor'}
-    />
+    <>
+      <Dropdown
+        dropDownClassName="dropdown--full-width"
+        className="odc-silence-duration-dropdown"
+        items={durations}
+        onChange={(v: string) => setDuration(v)}
+        title="Silence for"
+      />
+      {silencing && <LoadingInline />}
+    </>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
@@ -24,12 +24,7 @@ import {
   alertSeverityOrder,
   alertingRuleStateOrder,
 } from '@console/internal/reducers/monitoring';
-import {
-  Alert,
-  Rule,
-  RuleStates,
-  AlertStates,
-} from '@console/internal/components/monitoring/types';
+import { Alert, Rule, AlertStates } from '@console/internal/components/monitoring/types';
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { labelsToParams } from '@console/internal/components/monitoring/utils';
 import SilenceAlert from './SilenceAlert';
@@ -108,7 +103,7 @@ export const monitoringAlertRows = (
           title: _.isEmpty(rls.alerts) ? '-' : <StateCounts alerts={rls.alerts} />,
         },
         {
-          title: <SilenceAlert rule={rls} />,
+          title: <SilenceAlert rule={rls} namespace={namespace} />,
         },
         {
           title: (
@@ -157,13 +152,15 @@ const setOrderBy = (orderBy: SortByDirection, data: Rule[]): Rule[] => {
   return orderBy === SortByDirection.asc ? data : data.reverse();
 };
 
-const alertingRuleNotificationsOrder = (rule: Rule) => [
-  rule.state === RuleStates.Silenced ? 1 : 0,
-  rule.state,
-];
+export const alertingRuleNotificationsOrder = (rule: Rule): number[] => {
+  const counts = _.countBy(rule.alerts, 'state');
+  return [AlertStates.Silenced, AlertStates.Firing, AlertStates.Pending].map(
+    (state) => Number.MAX_SAFE_INTEGER - (counts[state] ?? 0),
+  );
+};
 
 const sortFunc = {
-  nameOrder: (rule) => rule.name,
+  nameOrder: (rule: Rule) => rule.name,
   alertSeverityOrder,
   alertingRuleStateOrder,
   alertingRuleNotificationsOrder,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4423

**GIF**
![Kapture 2020-10-01 at 12 43 25](https://user-images.githubusercontent.com/2561818/94779106-01a5c500-03e4-11eb-9774-4d1a5d322232.gif)

**Test Setup**
1. `oc apply -f https://gist.githubusercontent.com/vikram-raj/d801e9ef6400cc1bd5af5a336bbedfa0/raw/61d90b705617ba8070da80f8c97ac16376a9ca58/prometheus-example-app.yaml`
2. `oc apply -f https://gist.githubusercontent.com/vikram-raj/86300d923a7a3a3a3348e359327e2307/raw/535d889923141a3f3e26e355d6bccec4650a0fcd/user-workload-config.yaml`
3. After applying the above 2 YAML it will create a rule and alert in `ns1` namespace. But in local setup all alerts and rules will be visible so, filter by name `CriticalAlert` and to test this PR.