### PR TITLE
Bug 1882735: Remove unexpected comma from <title>

### DIFF
--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -375,7 +375,7 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
   return (
     <div className="co-m-pane__body co-m-pane__form">
       <Helmet>
-        <title>{titleVerb} Receiver</title>
+        <title>{`${titleVerb} Receiver`}</title>
       </Helmet>
       <form className="co-m-pane__body-group" onSubmit={save}>
         <h1 className="co-m-pane__heading">


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1882735

Before:
<img width="147" alt="Screen Shot 2020-09-28 at 8 42 03 AM" src="https://user-images.githubusercontent.com/895728/94433694-b632b300-0166-11eb-824d-f5a6cb3c2976.png">

After:
<img width="160" alt="Screen Shot 2020-09-28 at 8 41 17 AM" src="https://user-images.githubusercontent.com/895728/94433708-ba5ed080-0166-11eb-8a63-54acf0c61aeb.png">
