### PR TITLE
Bug 1883220: fix for generic channel creation, sink and visualisation

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/channels/ChannelForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/ChannelForm.tsx
@@ -54,9 +54,9 @@ const ChannelForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
         const sourceData = getChannelData(kind.toLowerCase());
         setFieldValue(nameData, sourceData);
         setFieldTouched(nameData, true);
+        setFieldValue('yamlData', '');
+        setFieldTouched('yamlData', true);
       }
-      setFieldValue('yamlData', '');
-      setFieldTouched('yamlData', true);
 
       setFieldValue('type', item);
       setFieldTouched('type', true);
@@ -80,7 +80,6 @@ const ChannelForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
               channels={channels.channelList}
               onChange={onTypeChange}
               defaultConfiguredChannel={defaultConfiguredChannel}
-              defaultConfiguredChannelLoaded={defaultConfiguredChannelLoaded}
             />
             {channelHasFormView && <FormViewSection namespace={namespace} kind={channelKind} />}
             {!channelHasFormView && <ChannelYamlEditor />}

--- a/frontend/packages/knative-plugin/src/components/add/channels/form-fields/ChannelSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/form-fields/ChannelSelector.tsx
@@ -9,50 +9,41 @@ import { EventingChannelModel } from '../../../../models';
 type ChannelSelectorProps = {
   channels: string[];
   defaultConfiguredChannel: string;
-  defaultConfiguredChannelLoaded: boolean;
 } & Omit<DropdownFieldProps, 'name'>;
 
 const ChannelSelector: React.FC<ChannelSelectorProps> = ({
   channels,
   onChange,
   defaultConfiguredChannel,
-  defaultConfiguredChannelLoaded,
 }) => {
   const [selected] = useField('type');
 
-  const eventingChannels = channels.filter(
-    (ch) => EventingChannelModel.kind !== getChannelKind(ch),
-  );
   const filteredChannels = _.flatten(
-    _.partition(eventingChannels, (ref) => getChannelKind(ref) === defaultConfiguredChannel),
+    _.partition(channels, (ref) => getChannelKind(ref) === EventingChannelModel.kind),
   );
 
   const channelData = filteredChannels.reduce((acc, channel) => {
     const channelName = getChannelKind(channel);
     acc[channel] =
-      channelName === defaultConfiguredChannel ? `${channelName} (Default)` : channelName;
+      channelName === EventingChannelModel.kind && defaultConfiguredChannel
+        ? `Default ${channelName} (${defaultConfiguredChannel})`
+        : channelName;
     return acc;
   }, {});
 
-  const getDefaultChannel = React.useCallback((): string => {
+  const getGenericChannel = React.useCallback((): string => {
     return (
-      filteredChannels.find((ch) => getChannelKind(ch) === defaultConfiguredChannel) ||
+      filteredChannels.find((ch) => getChannelKind(ch) === EventingChannelModel.kind) ||
       filteredChannels[0]
     );
-  }, [defaultConfiguredChannel, filteredChannels]);
+  }, [filteredChannels]);
 
   React.useEffect(() => {
-    if (!selected.value && defaultConfiguredChannelLoaded && filteredChannels.length > 0) {
-      const channel = getDefaultChannel();
+    if (!selected.value && filteredChannels.length > 0) {
+      const channel = getGenericChannel();
       onChange && onChange(channel);
     }
-  }, [
-    selected.value,
-    defaultConfiguredChannelLoaded,
-    getDefaultChannel,
-    onChange,
-    filteredChannels.length,
-  ]);
+  }, [selected.value, getGenericChannel, onChange, filteredChannels.length]);
 
   return (
     <FormSection extraMargin>

--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -6,7 +6,6 @@ import {
   EventSourceKafkaModel,
   EventSourcePingModel,
   EventSourceSinkBindingModel,
-  EventingChannelModel,
   EventingIMCModel,
   EventingKafkaChannelModel,
 } from '../../models';
@@ -20,7 +19,6 @@ export const EventSources = {
   SinkBinding: EventSourceSinkBindingModel.kind,
 };
 export const defaultChannels = {
-  Channel: EventingChannelModel,
   InMemoryChannel: EventingIMCModel,
   KafkaChannel: EventingKafkaChannelModel,
 };

--- a/frontend/packages/knative-plugin/src/components/overview/EventPubSubResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventPubSubResources.tsx
@@ -98,6 +98,7 @@ const EventPubSubResources: React.FC<EventPubSubResourcesProps> = ({ item }) => 
         <>
           <PubSubResourceOverviewList items={eventSources} title="Event Sources" />
           <PubSubSubscribers subscribers={subscribers} />
+          {channels?.length > 0 && <PubSubResourceOverviewList items={channels} title="Channel" />}
         </>
       );
   }

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -583,6 +583,11 @@ export const createPubSubDataItems = (
     metadata: { name },
     spec,
   } = resource;
+  const channelProps = getDynamicChannelModelRefs();
+  const depChannelResources = getOwnedResources(
+    resource,
+    getKnativeDynamicResources(resources, channelProps),
+  );
   const subscriptionData = resources?.eventingsubscription?.data ?? [];
   const triggerList = resources?.triggers?.data ?? [];
   let triggersData = {};
@@ -645,6 +650,7 @@ export const createPubSubDataItems = (
     buildConfigs: [],
     routes: [],
     services: [],
+    ...(depChannelResources && { channels: depChannelResources }),
     eventSources,
     ...channelSubsData,
     ...triggersData,

--- a/frontend/packages/knative-plugin/src/utils/create-channel-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-channel-utils.ts
@@ -15,7 +15,7 @@ import {
   ChannelListProps,
   AddChannelFormData,
 } from '../components/add/import-types';
-import { EventingChannelModel, EventingIMCModel, EventingKafkaChannelModel } from '../models';
+import { EventingIMCModel, EventingKafkaChannelModel } from '../models';
 import {
   getCommonAnnotations,
   getAppLabels,
@@ -110,7 +110,6 @@ export const getCreateChannelData = (formData: AddChannelFormData): K8sResourceK
 
 export const getCreateChannelResource = (formData: AddChannelFormData) => {
   switch (getChannelKind(formData.type)) {
-    case EventingChannelModel.kind:
     case EventingIMCModel.kind:
     case EventingKafkaChannelModel.kind:
       return getCreateChannelData(formData);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4887

**Analysis / Root cause**: 
User is unable to create generic channel of kind `Channel`

**Solution Description**: 
- user will be shown with `Default Channel ({ChannelName})` in dropdown resource along with other channel implementation, on selection of generic channel would be shown with Yaml Editor.
- user can view created channel (generic) in topology and default/backing channel created in sidebar
- user can sink to generic channel in EventSources form Sink option




**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
0. If user goes to Add Channel view , generic channel will be preselected and will show (Default to only for it) 

![image](https://user-images.githubusercontent.com/5129024/94692271-fc973600-034f-11eb-99eb-a7164e0749ff.png)



1 . Creation : user will be shown with `Default Channel ({defaultChannel})` in dropdown resource along with other channel implementation, on selection of generic channel would be shown with Yaml Editor

![image](https://user-images.githubusercontent.com/5129024/94692634-5ef03680-0350-11eb-9d14-c2ece7dbe26c.png)



2. user can view created channel (generic) in topology and default/backing channel created in sidebar

![image](https://user-images.githubusercontent.com/5129024/94437602-99749a80-01bb-11eb-9f02-e7bb3bb849b0.png)


3. user can sink to generic channel in EventSources form Sink option

![image](https://user-images.githubusercontent.com/5129024/94429126-78a64800-01af-11eb-94f0-4ea7bfa8e712.png)

@openshift/team-devconsole-ux


**Test setup:**
1. Install Serverless operator

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
