### PR TITLE
Bug 1883737: Update Rotue section in Knative revision sidebar

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KSRoutes.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRoutes.tsx
@@ -1,20 +1,14 @@
 import * as React from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { RoutesOverviewListItem } from '../../types';
 import KSRoutesOverviewListItem from './KSRoutesOverviewListItem';
-import KSRouteSplitListItem from './KSRouteSplitListItem';
 
 type KSRoutesProps = {
   route: K8sResourceKind;
-  routeLinks: RoutesOverviewListItem[];
 };
 
-const KSRoutes: React.FC<KSRoutesProps> = ({ route, routeLinks }) => (
+const KSRoutes: React.FC<KSRoutesProps> = ({ route }) => (
   <>
     <KSRoutesOverviewListItem ksroute={route} />
-    {routeLinks.map((splitRoute) => (
-      <KSRouteSplitListItem key={splitRoute.uid} route={splitRoute} />
-    ))}
   </>
 );
 

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
@@ -1,28 +1,29 @@
 import * as React from 'react';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { ResourceLink } from '@console/internal/components/utils';
 import { RouteModel } from '../../models';
 import { RoutesOverviewListItem } from '../../types';
+import RoutesUrlLink from './RoutesUrlLink';
 
 export type RoutesOverviewListItemProps = {
   routeLink: RoutesOverviewListItem;
+  uniqueRoutes?: string[];
+  totalPercent?: string;
 };
 
 const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({
   routeLink: { url, name, namespace, percent },
+  totalPercent,
+  uniqueRoutes,
 }) => (
   <li className="list-group-item">
     <div className="row">
       <div className="col-xs-10">
         <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
-        {url.length > 0 && (
-          <>
-            <span className="text-muted">Location: </span>
-            <ExternalLink href={url} additionalClassName="co-external-link--block" text={url} />
-          </>
-        )}
+        {url.length > 0 && <RoutesUrlLink urls={[url]} title="Location" />}
+        {uniqueRoutes?.length > 0 && <RoutesUrlLink urls={uniqueRoutes} title="Unique Route" />}
       </div>
-      {percent.length > 0 && <span className="col-xs-2 text-right">{percent}</span>}
+      {percent.length > 0 && <span className="col-xs-2 text-right">{totalPercent || percent}</span>}
     </div>
   </li>
 );

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { ExternalLink } from '@console/internal/components/utils';
+
+export type RoutesUrlLinkProps = {
+  urls: string[];
+  title?: string;
+};
+
+const RoutesUrlLink: React.FC<RoutesUrlLinkProps> = ({ urls = [], title }) =>
+  urls.length > 0 && (
+    <>
+      {title && <span className="text-muted">{title}: </span>}
+      {urls.length > 0 &&
+        urls.map((url) => (
+          <ExternalLink href={url} additionalClassName="co-external-link--block" text={url} />
+        ))}
+    </>
+  );
+
+export default RoutesUrlLink;

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewList.spec.tsx
@@ -4,6 +4,7 @@ import * as utils from '@console/internal/components/utils';
 import { MockKnativeResources } from '../../../topology/__tests__/topology-knative-test-data';
 import RoutesOverviewList from '../RoutesOverviewList';
 import RoutesOverviewListItem from '../RoutesOverviewListItem';
+import { K8sResourceKind } from '@console/internal/module/k8s/types';
 
 type RoutesOverviewListProps = React.ComponentProps<typeof RoutesOverviewList>;
 
@@ -29,5 +30,64 @@ describe('RoutesOverviewList', () => {
 
   it('should render RoutesOverviewListItem', () => {
     expect(wrapper.find(RoutesOverviewListItem)).toHaveLength(1);
+  });
+
+  it('should render RoutesOverviewListItem without unique routes', () => {
+    const routesOverviewListItemProps = wrapper.find(RoutesOverviewListItem).props();
+    expect(routesOverviewListItemProps.uniqueRoutes).toHaveLength(0);
+  });
+
+  it('should render RoutesOverviewListItem with unique routes', () => {
+    const mockRouteData: K8sResourceKind = {
+      ...MockKnativeResources.ksroutes.data[0],
+      status: {
+        ...MockKnativeResources.ksroutes.data[0].status,
+        traffic: [
+          {
+            ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+            tag: 'tag1',
+            url: 'http://tag1.test.com',
+          },
+        ],
+      },
+    };
+
+    wrapper.setProps({ ksroutes: [mockRouteData] });
+    const routesOverviewListItemProps = wrapper.find(RoutesOverviewListItem).props();
+    expect(routesOverviewListItemProps.uniqueRoutes).toHaveLength(1);
+    expect(routesOverviewListItemProps.uniqueRoutes).toEqual(['http://tag1.test.com']);
+  });
+
+  it('should handle multiple traffic splitting for the same revision', () => {
+    const mockRouteData: K8sResourceKind = {
+      ...MockKnativeResources.ksroutes.data[0],
+      status: {
+        ...MockKnativeResources.ksroutes.data[0].status,
+        traffic: [
+          {
+            ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+            tag: 'tag1',
+            url: 'http://tag1.test.com',
+            percent: 20,
+          },
+          {
+            ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+            tag: 'tag2',
+            url: 'http://tag2.test.com',
+            percent: 30,
+          },
+        ],
+      },
+    };
+
+    wrapper.setProps({ ksroutes: [mockRouteData] });
+
+    const routesOverviewListItemProps = wrapper.find(RoutesOverviewListItem).props();
+    expect(routesOverviewListItemProps.uniqueRoutes).toHaveLength(2);
+    expect(routesOverviewListItemProps.uniqueRoutes).toEqual([
+      'http://tag1.test.com',
+      'http://tag2.test.com',
+    ]);
+    expect(routesOverviewListItemProps.totalPercent).toEqual('50%');
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/resource-overview-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/resource-overview-utils.ts
@@ -1,6 +1,11 @@
 import { K8sResourceKind, referenceFor, referenceForModel } from '@console/internal/module/k8s';
 import { ServiceModel as knServiceModel, RevisionModel } from '../models';
 import { Traffic, RoutesOverviewListItem } from '../types';
+
+export const filterTrafficBasedOnResource = (resource) => (tr: Traffic) =>
+  referenceFor(resource) === referenceForModel(knServiceModel) ||
+  (referenceFor(resource) === referenceForModel(RevisionModel) &&
+    tr.revisionName === resource.metadata.name);
 /**
  * Return the knative routes list items.
  * @param route
@@ -15,22 +20,43 @@ export const getKnativeRoutesLinks = (
   }
   const {
     metadata: { name, namespace },
-    status: {
-      url = '',
-      traffic: trafficData = [{ revisionName: resource.metadata.name, url: route?.status?.url }],
-    },
+    status: { url = '', traffic: trafficData = [{ revisionName: resource.metadata.name }] },
   } = route;
-  const filterTrafficBasedOnResource = (tr: Traffic) =>
-    referenceFor(resource) === referenceForModel(knServiceModel) ||
-    (referenceFor(resource) === referenceForModel(RevisionModel) &&
-      tr.revisionName === resource.metadata.name);
+
   return trafficData
-    .filter(filterTrafficBasedOnResource)
+    .filter(filterTrafficBasedOnResource(resource))
     .map((traffic: Traffic, index: number) => ({
       uid: `${traffic.revisionName}-${traffic?.tag ? traffic?.tag : 'tag'}-${index}`,
-      url: traffic?.url || url,
+      url,
       percent: traffic.percent ? `${traffic.percent}%` : '',
       name,
       namespace,
     }));
+};
+
+/**
+ * Return the grouped knative resource by revision name.
+ * @param route
+ * @param resource | resource can be a knative service or revision;
+ */
+export const groupTrafficByRevision = (route: K8sResourceKind, resource: K8sResourceKind) => {
+  if (!route.status) {
+    return [];
+  }
+  const {
+    status: { traffic: trafficData = [{ revisionName: resource.metadata.name }] },
+  } = route;
+
+  const tData = trafficData.filter(filterTrafficBasedOnResource(resource)).reduce(
+    (acc, traffic: Traffic) => {
+      traffic.url && acc.urls.push(traffic.url);
+      acc.percent += traffic.percent ? traffic.percent : 0;
+      return acc;
+    },
+    {
+      urls: [],
+      percent: 0,
+    },
+  );
+  return { ...tData, percent: tData.percent ? `${tData.percent}%` : '' };
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4879

**Problem**:
Revision/Service Route section in sidebar shows incorrect traffic percent for unique url.

**Solution**:
Update Route section in the knative Revision sidebar and service sidebar to have unique and base url information.
**Screenshots:**
**Revision with unique tag:**

![image](https://user-images.githubusercontent.com/9964343/94550456-5f65d000-0271-11eb-8a62-10f614a0bcf0.png)

**Knative Service sidebar:**

![image](https://user-images.githubusercontent.com/9964343/94550533-7f958f00-0271-11eb-813d-28e9a3d31d6b.png)


**Test cases:**
RoutesOverviewList:
![image](https://user-images.githubusercontent.com/9964343/94642107-deeeb000-0300-11eb-9b8b-672300eb7af6.png)

RoutesOverveiwListItem
![image](https://user-images.githubusercontent.com/9964343/94463873-43afea80-01db-11eb-8c65-f5520456f018.png)
RevisionsOverveiwListItem
![image](https://user-images.githubusercontent.com/9964343/94463941-562a2400-01db-11eb-9c37-29f2517312a6.png)
resource-overview-utils:
![image](https://user-images.githubusercontent.com/9964343/94642075-c2527800-0300-11eb-85c1-d48a28b8ced5.png)

/kind bug
cc: @bgliwa01 @invincibleJai @openshift/team-devconsole-ux 