### PR TITLE
CONSOLE-2297: Added Create Namespace option during operator install

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,10 @@
     "test-gui": "yarn run test-suite --suite all",
     "test-suite": "ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/protractor integration-tests/protractor.conf.ts",
     "test-cypress": "cd packages/integration-tests-cypress && cypress open --env openshift=true",
-    "test-cypress-headless": "cd packages/integration-tests-cypress && node --max-old-space-size=4096 ../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
+    "test-cypress-olm": "cd packages/operator-lifecycle-manager/integration-tests-cypress && ../../../node_modules/.bin/cypress open --config-file cypress-olm.json --env openshift=true",
+    "test-cypress-console-headless": "cd packages/integration-tests-cypress && node --max-old-space-size=4096 ../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
+    "test-cypress-olm-headless": "cd packages/operator-lifecycle-manager/integration-tests-cypress && node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --config-file cypress-olm.json --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
+    "test-cypress-headless": "yarn test-cypress-console-headless && yarn test-cypress-olm-headless",
     "cypress-merge": "mochawesome-merge ./gui_test_screenshots/cypress_report*.json > ./gui_test_screenshots/cypress.json",
     "cypress-generate": "marge -o ./gui_test_screenshots/ -f cypress-report -t 'OpenShift Console Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ./gui_test_screenshots/cypress/assets ./gui_test_screenshots/cypress.json",
     "cypress-a11y-report": "echo '\nA11y Test Results:' && mv packages/integration-tests-cypress/cypress-a11y-report.json ./gui_test_screenshots/ && node -e \"console.table(JSON.parse(require('fs').readFileSync(process.argv[1])));\" ./gui_test_screenshots/cypress-a11y-report.json",
@@ -66,7 +69,7 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
-      "<rootDir>/packages/integration-tests-cypress"
+      "<rootDir>/.*/integration-tests-cypress"
     ],
     "testRegex": ".*\\.spec\\.(ts|tsx|js|jsx)$",
     "testURL": "http://localhost",

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/cypress-olm.json
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/cypress-olm.json
@@ -1,0 +1,18 @@
+{
+  "integrationFolder": "tests",
+  "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
+  "videosFolder": "../../../gui_test_screenshots/cypress/videos",
+  "video": true,
+  "reporter": "../../../node_modules/cypress-multi-reporters",
+  "reporterOptions": {
+    "configFile": "reporter-config.json"
+  },
+  "supportFile": "../../integration-tests-cypress/support/index.ts",
+  "pluginsFile": "../../integration-tests-cypress/plugins/index.js",
+  "fixturesFolder": "fixtures",
+  "defaultCommandTimeout": 30000,
+  "retries": {
+    "runMode": 1,
+    "openMode": 0
+  }
+}

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/reporter-config.json
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/reporter-config.json
@@ -1,0 +1,14 @@
+{
+  "reporterEnabled": "mocha-junit-reporter, mochawesome",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../../gui_test_screenshots/junit_cypress-[hash].xml",
+    "toConsole": false
+  },
+  "mochawesomeReporterOptions": {
+    "reportDir": "../../../gui_test_screenshots/",
+    "reportFilename": "cypress_report_olm",
+    "overwrite": false,
+    "html": false,
+    "json": true
+  }
+}

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -1,0 +1,57 @@
+import { checkErrors, testName } from '../../../integration-tests-cypress/support';
+import { modal } from '../../../integration-tests-cypress/views/modal';
+
+describe('Create namespace from install operators', () => {
+  before(() => {
+    cy.login();
+    cy.createProject(testName);
+  });
+
+  afterEach(() => {
+    checkErrors();
+  });
+
+  after(() => {
+    cy.deleteProject(testName);
+    cy.logout();
+  });
+
+  const nsName = `${testName}-ns`;
+
+  it('creates namespace from operator install page', () => {
+    const operatorSelector = 'advanced-cluster-management-redhat-operators-openshift-marketplace';
+    cy.log('test namespace creation from dropdown');
+    cy.visit(`/operatorhub/ns/${testName}`);
+    cy.byTestID(operatorSelector).click();
+    cy.byLegacyTestID('operator-install-btn').click({ force: true });
+
+    // configure operator install
+    cy.byTestID('Select a namespace-radio-input').check();
+    cy.byTestID('dropdown-selectbox')
+      .click()
+      .get('[data-test-dropdown-menu="Create_Namespace"]')
+      .click();
+
+    // verify namespace modal is opened
+    modal.shouldBeOpened();
+    cy.byTestID('input-name').type(nsName);
+    modal.submit();
+    modal.shouldBeClosed();
+
+    // verify the dropdown selection shows the newly created namespace
+    cy.byTestID('dropdown-selectbox').should('contain', `${nsName}`);
+
+    cy.get('button')
+      .contains('Install')
+      .click();
+
+    // verify operator began installation
+    cy.byTestID('view-installed-operators-btn').should(
+      'contain',
+      `View Installed Operators in namespace ${nsName}`,
+    );
+
+    // Verify namespace was created successfully
+    cy.deleteProject(nsName);
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -506,7 +506,8 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     <NsDropdown
       id="dropdown-selectbox"
       selectedKey={selectedTargetNamespace}
-      onChange={setTargetNamespace}
+      onChange={(ns) => setTargetNamespace(ns)}
+      dataTest="dropdown-selectbox"
     />
   ) : (
     <div className="form-group">
@@ -531,13 +532,14 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         }}
         value={suggestedNamespace}
         checked={!useSuggestedNSForSingleInstallMode}
-        title="Pick an existing namespace"
+        title="Select a namespace"
       />
       {!useSuggestedNSForSingleInstallMode && (
         <NsDropdown
           id="dropdown-selectbox"
           selectedKey={selectedTargetNamespace}
-          onChange={setTargetNamespace}
+          onChange={(ns) => setTargetNamespace(ns)}
+          dataTest="dropdown-selectbox"
         />
       )}
     </div>

--- a/frontend/public/components/radio.tsx
+++ b/frontend/public/components/radio.tsx
@@ -15,7 +15,7 @@ export const RadioInput: React.SFC<RadioInputProps> = (props) => {
       <label
         className={classNames({ 'radio-inline': props.inline, 'co-disabled': props.disabled })}
       >
-        <input type="radio" {...inputProps} />
+        <input type="radio" {...inputProps} data-test={`${props.title}-radio-input`} />
         {props.title} {props.subTitle && <span className="co-no-bold">{props.subTitle}</span>}
       </label>
       {props.desc && <p className="co-m-radio-desc text-muted">{props.desc}</p>}


### PR DESCRIPTION
This change adds an option `Create Namespace` to the namespace dropdown list in the install operators page.
Jira: https://issues.redhat.com/browse/CONSOLE-2297

Signed-off-by: Harish <hgovinda@redhat.com>