### PR TITLE
Bug 1883353: Prevent text overlap of operand status, remove nonbreaking space..

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -223,8 +223,7 @@ export const OperandStatus: React.FunctionComponent<OperandStatusProps> = ({ ope
   const { type, value } = status;
   return (
     <span className="co-icon-and-text">
-      {type}:&nbsp;
-      {value === 'Running' ? <SuccessStatus title={value} /> : <Status status={value} />}
+      {type}: {value === 'Running' ? <SuccessStatus title={value} /> : <Status status={value} />}
     </span>
   );
 };


### PR DESCRIPTION
Status messages such as`Conditions:&nbsp;InstallSucceeded, Ready` are not wrapping.