### PR TITLE
Bug 1883479: Add uri value to URI list item and side bar, fix initial scroll to selected item

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
@@ -67,6 +67,7 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
   }) => {
     const queryParams = useQueryParams();
     const selectedId = queryParams.get('selectId');
+    const [visualizationReady, setVisualizationReady] = React.useState<boolean>(false);
 
     const createVisualization = () => {
       const newVisualization = new Visualization();
@@ -93,6 +94,7 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
           onSelect(selectedItem);
         }
       }
+      setVisualizationReady(true);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [model, onSelect, visualization]);
 
@@ -103,14 +105,14 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
       (n) => n.getType() !== TYPE_APPLICATION_GROUP && isGraph(n.getParent()) && n.isVisible(),
     );
 
-    React.useEffect(() => {
-      if (selectedId) {
+    React.useLayoutEffect(() => {
+      if (visualizationReady && selectedId) {
         const element = document.getElementById(selectedId);
         if (element) {
           element.scrollIntoView({ block: 'nearest' });
         }
       }
-    }, [selectedId]);
+    }, [selectedId, visualizationReady]);
 
     React.useEffect(() => {
       const getFlattenedItems = (): Node[] => {
@@ -257,7 +259,7 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [namespace, updateMetrics, updateMonitoringAlerts]);
 
-    if (!applicationGroups || !unassignedItems) {
+    if (!visualizationReady) {
       return null;
     }
 

--- a/frontend/packages/dev-console/src/components/topology/list-view/listViewComponentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/list-view/listViewComponentFactory.ts
@@ -1,8 +1,9 @@
 /* eslint-disable import/no-cycle */
 import * as React from 'react';
 import { Node } from '@patternfly/react-topology';
-import { TYPE_KNATIVE_SERVICE } from '@console/knative-plugin/src/topology/const';
+import { TYPE_KNATIVE_SERVICE, TYPE_SINK_URI } from '@console/knative-plugin/src/topology/const';
 import { KnativeServiceListViewNode } from '@console/knative-plugin/src/topology/listView/KnativeServiceListViewNode';
+import { SinkUriListViewNode } from '@console/knative-plugin/src/topology/listView/SinkUriListViewNode';
 import { TYPE_WORKLOAD } from '../components/const';
 import { TopologyListViewNode } from './TopologyListViewNode';
 import { TYPE_OPERATOR_BACKED_SERVICE } from '../operators/components/const';
@@ -28,6 +29,8 @@ export const listViewNodeComponentFactory = (
       return HelmReleaseListViewNode;
     case TYPE_KNATIVE_SERVICE:
       return KnativeServiceListViewNode;
+    case TYPE_SINK_URI:
+      return SinkUriListViewNode;
     default:
       return TopologyListViewNode;
   }

--- a/frontend/packages/knative-plugin/src/components/overview/SinkUriResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/SinkUriResourcesTab.tsx
@@ -9,6 +9,7 @@ import {
   SidebarSectionHeading,
   ExternalLink,
   KebabAction,
+  ResourceIcon,
 } from '@console/internal/components/utils';
 
 export type SinkUriResourcesTabProps = {
@@ -29,7 +30,10 @@ const SinkUriResourcesTab: React.FC<SinkUriResourcesTabProps> = ({ itemData, men
     <div className="overview__sidebar-pane resource-overview">
       <div className="overview__sidebar-pane-head resource-overview__heading">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name co-resource-item">URI</div>
+          <div className="co-m-pane__name co-resource-item">
+            <ResourceIcon className="co-m-resource-icon--lg" kind={obj?.kind || 'Uri'} />
+            <ExternalLink href={sinkUri} text={sinkUri} />
+          </div>
           <div className="co-actions">
             <ActionsMenu actions={actions} />
           </div>
@@ -48,19 +52,6 @@ const SinkUriResourcesTab: React.FC<SinkUriResourcesTabProps> = ({ itemData, men
         </li>
       </ul>
       <div className="overview__sidebar-pane-body">
-        <SidebarSectionHeading text="URI" />
-        <ul className="list-group">
-          {sinkUri && (
-            <li className="list-group-item  container-fluid">
-              <ExternalLink
-                href={sinkUri}
-                additionalClassName="co-external-link--block"
-                text={sinkUri}
-              />
-            </li>
-          )}
-        </ul>
-
         <SidebarSectionHeading text="Event Sources" />
         <ul className="list-group">
           {_.map(eventSources, (resource) => {

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -690,7 +690,7 @@ export const getSinkUriTopologyNodeItems = (
     id,
     type,
     resource: data.resource,
-    resourceKind: 'Uri',
+    resourceKind: 'URI',
     data,
     ...(nodeProps || {}),
   });
@@ -970,7 +970,7 @@ export const transformKnNodeData = (
               },
               spec: { sinkUri },
               type: { nodeType: NodeType.SinkUri },
-              kind: 'Uri',
+              kind: 'URI',
             };
             const sinkData: TopologyDataObject = {
               id: sinkTargetUid,

--- a/frontend/packages/knative-plugin/src/topology/listView/SinkUriListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/SinkUriListViewNode.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { observer } from '@patternfly/react-topology';
+import {
+  OdcBaseNode,
+  TopologyListViewNode,
+  TypedResourceBadgeCell,
+} from '@console/dev-console/src/components/topology';
+import { DataListCell } from '@patternfly/react-core';
+
+interface KnativeServiceListViewNodeProps {
+  item: OdcBaseNode;
+  selectedIds: string[];
+  onSelect: (ids: string[]) => void;
+}
+
+const ObservedSinkUriListViewNode: React.FC<KnativeServiceListViewNodeProps> = ({
+  item,
+  selectedIds,
+  onSelect,
+  children,
+}) => {
+  const sinkUri = item.getResource()?.spec?.sinkUri;
+
+  const labelCell = (
+    <DataListCell className="odc-topology-list-view__label-cell" key="label" id={sinkUri}>
+      <TypedResourceBadgeCell key="type-icon" kind={item.getResourceKind()} />
+      {sinkUri}
+    </DataListCell>
+  );
+
+  return (
+    <TopologyListViewNode
+      item={item}
+      selectedIds={selectedIds}
+      onSelect={onSelect}
+      labelCell={labelCell}
+    >
+      {children}
+    </TopologyListViewNode>
+  );
+};
+
+const SinkUriListViewNode = observer(ObservedSinkUriListViewNode);
+export { SinkUriListViewNode };


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4911

**Description**
Add the URI link to the list view row for the URI item.
Add the URI link to the header of the URI side panel details (move up from `Resources`)
Fix to scroll to initial selection for topology list view.

**Screenshots**
![image](https://user-images.githubusercontent.com/11633780/94568448-7ccb7780-023a-11eb-9bac-4e3c596ba7aa.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug

/cc @bgliwa01