### PR TITLE
Bug 1885343: Fallback to GQL HTTP on iOS devices

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,6 +103,7 @@
     "ajv": "^6.12.3",
     "apollo-cache-inmemory": "^1.6.5",
     "apollo-client": "^2.6.8",
+    "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
     "axios": "^0.19.2",
     "classnames": "2.x",

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -230,7 +230,7 @@ const ssarCheckActions = ssarChecks.map(({ flag, resourceAttributes, after }) =>
             after(dispatch, allowed);
           }
         },
-        (err) => handleError({ response: err.graphQLErrors[0].extensions }, flag, dispatch, fn),
+        (err) => handleError({ response: err.graphQLErrors[0]?.extensions }, flag, dispatch, fn),
       );
   return fn;
 });

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -14,7 +14,7 @@ import { getBrandingDetails, Masthead } from './masthead';
 import { ConsoleNotifier } from './console-notifier';
 import { ConnectedNotificationDrawer } from './notification-drawer';
 import { Navigation } from './nav';
-import { history, AsyncComponent } from './utils';
+import { history, AsyncComponent, LoadingBox } from './utils';
 import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources } from '../module/k8s';
 import { receivedResources, watchAPIServices } from '../actions/k8s';
@@ -40,6 +40,7 @@ const breakpointMD = 768;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
 // Edge lacks URLSearchParams
 import 'url-search-params-polyfill';
+import { graphQLReady } from '../graphql/client';
 
 // Disable linkify 'fuzzy links' across the app.
 // Only linkify url strings beginning with a proper protocol scheme.
@@ -192,80 +193,86 @@ class App_ extends React.PureComponent {
 
 const App = withExtensions({ contextProviderExtensions: isContextProvider })(App_);
 
-const startDiscovery = () => store.dispatch(watchAPIServices());
+render(<LoadingBox />, document.getElementById('app'));
 
-// Load cached API resources from localStorage to speed up page load.
-getCachedResources()
-  .then((resources) => {
-    if (resources) {
-      store.dispatch(receivedResources(resources));
+graphQLReady.onReady(() => {
+  const startDiscovery = () => store.dispatch(watchAPIServices());
+
+  // Load cached API resources from localStorage to speed up page load.
+  getCachedResources()
+    .then((resources) => {
+      if (resources) {
+        store.dispatch(receivedResources(resources));
+      }
+      // Still perform discovery to refresh the cache.
+      startDiscovery();
+    })
+    .catch(startDiscovery);
+
+  store.dispatch(detectFeatures());
+
+  // Global timer to ensure all <Timestamp> components update in sync
+  setInterval(() => store.dispatch(UIActions.updateTimestamps(Date.now())), 10000);
+
+  // Fetch swagger on load if it's stale.
+  fetchSwagger();
+
+  // Used by GUI tests to check for unhandled exceptions
+  window.windowError = null;
+  window.onerror = (message, source, lineno, colno, error) => {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught error', error);
+    window.windowError = error;
+  };
+  window.onunhandledrejection = (promiseRejectionEvent) => {
+    // eslint-disable-next-line no-console
+    console.error('Unhandled promise rejection', promiseRejectionEvent);
+    window.windowError = promiseRejectionEvent;
+  };
+
+  if ('serviceWorker' in navigator) {
+    if (window.SERVER_FLAGS.loadTestFactor > 1) {
+      // eslint-disable-next-line import/no-unresolved
+      import('file-loader?name=load-test.sw.js!../load-test.sw.js')
+        .then(() => navigator.serviceWorker.register('/load-test.sw.js'))
+        .then(
+          () =>
+            new Promise((r) =>
+              navigator.serviceWorker.controller
+                ? r()
+                : navigator.serviceWorker.addEventListener('controllerchange', () => r()),
+            ),
+        )
+        .then(() =>
+          navigator.serviceWorker.controller.postMessage({
+            topic: 'setFactor',
+            value: window.SERVER_FLAGS.loadTestFactor,
+          }),
+        );
+    } else {
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((registrations) => registrations.forEach((reg) => reg.unregister()))
+        // eslint-disable-next-line no-console
+        .catch((e) => console.warn('Error unregistering service workers', e));
     }
-    // Still perform discovery to refresh the cache.
-    startDiscovery();
-  })
-  .catch(startDiscovery);
-
-store.dispatch(detectFeatures());
-
-// Global timer to ensure all <Timestamp> components update in sync
-setInterval(() => store.dispatch(UIActions.updateTimestamps(Date.now())), 10000);
-
-// Fetch swagger on load if it's stale.
-fetchSwagger();
-
-// Used by GUI tests to check for unhandled exceptions
-window.windowError = null;
-window.onerror = (message, source, lineno, colno, error) => {
-  // eslint-disable-next-line no-console
-  console.error('Uncaught error', error);
-  window.windowError = error;
-};
-window.onunhandledrejection = (promiseRejectionEvent) => {
-  // eslint-disable-next-line no-console
-  console.error('Unhandled promise rejection', promiseRejectionEvent);
-  window.windowError = promiseRejectionEvent;
-};
-
-if ('serviceWorker' in navigator) {
-  if (window.SERVER_FLAGS.loadTestFactor > 1) {
-    // eslint-disable-next-line import/no-unresolved
-    import('file-loader?name=load-test.sw.js!../load-test.sw.js')
-      .then(() => navigator.serviceWorker.register('/load-test.sw.js'))
-      .then(
-        () =>
-          new Promise((r) =>
-            navigator.serviceWorker.controller
-              ? r()
-              : navigator.serviceWorker.addEventListener('controllerchange', () => r()),
-          ),
-      )
-      .then(() =>
-        navigator.serviceWorker.controller.postMessage({
-          topic: 'setFactor',
-          value: window.SERVER_FLAGS.loadTestFactor,
-        }),
-      );
-  } else {
-    navigator.serviceWorker
-      .getRegistrations()
-      .then((registrations) => registrations.forEach((reg) => reg.unregister()))
-      // eslint-disable-next-line no-console
-      .catch((e) => console.warn('Error unregistering service workers', e));
   }
-}
 
-render(
-  <Provider store={store}>
-    <Router history={history} basename={window.SERVER_FLAGS.basePath}>
-      <Switch>
-        <Route
-          path="/k8s/ns/:ns/virtualmachineinstances/:name/standaloneconsole"
-          render={(componentProps) => <AsyncComponent loader={consoleLoader} {...componentProps} />}
-        />
-        <Route path="/terminal" component={CloudShellTab} />
-        <Route path="/" component={App} />
-      </Switch>
-    </Router>
-  </Provider>,
-  document.getElementById('app'),
-);
+  render(
+    <Provider store={store}>
+      <Router history={history} basename={window.SERVER_FLAGS.basePath}>
+        <Switch>
+          <Route
+            path="/k8s/ns/:ns/virtualmachineinstances/:name/standaloneconsole"
+            render={(componentProps) => (
+              <AsyncComponent loader={consoleLoader} {...componentProps} />
+            )}
+          />
+          <Route path="/terminal" component={CloudShellTab} />
+          <Route path="/" component={App} />
+        </Switch>
+      </Router>
+    </Provider>,
+    document.getElementById('app'),
+  );
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3401,13 +3401,22 @@ apollo-client@^2.6.8:
     tslib "^1.10.0"
     zen-observable "^0.8.0"
 
-apollo-link-http-common@^0.2.14:
+apollo-link-http-common@^0.2.14, apollo-link-http-common@^0.2.16:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz#756749dafc732792c8ca0923f9a40564b7c59ecc"
   integrity sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==
   dependencies:
     apollo-link "^1.2.14"
     ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+
+apollo-link-http@^1.0.20:
+  version "1.5.17"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.17.tgz#499e9f1711bf694497f02c51af12d82de5d8d8ba"
+  integrity sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==
+  dependencies:
+    apollo-link "^1.2.14"
+    apollo-link-http-common "^0.2.16"
     tslib "^1.9.3"
 
 apollo-link-ws@^1.0.20:


### PR DESCRIPTION
iOS does not allow connecting to wss with self signed certificate. There's also no way to know why the connection wasnt successful (given by WebSocket specification). 

To overcome the issue I've added code specific for iOS(iPhone/iPad):
 - if graphql ws connection fails 5 times in a row, fallback to http connection
 - delay console App rendering until we know which type of connection we can use (show Loading in the meantime)

@spadgett WDYT ?