### PR TITLE
Bug 1883566: adds check for kind before accessing

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -55,13 +55,15 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
   if (kindsInFlight) {
     return !knativeModels ? null : <LoadingBox />;
   }
-  const apiInfo = groupVersionFor(item.obj.apiVersion);
-  const resourceModel = knativeModels.find(
-    (model) =>
-      model.kind === item.obj.kind &&
-      model.apiGroup === apiInfo.group &&
-      model.apiVersion === apiInfo.version,
-  );
+  const apiInfo = item?.obj && groupVersionFor(item.obj.apiVersion);
+  const resourceModel =
+    apiInfo &&
+    knativeModels.find(
+      (model) =>
+        model.kind === item?.obj?.kind &&
+        model.apiGroup === apiInfo.group &&
+        model.apiVersion === apiInfo.version,
+    );
 
   if (!resourceModel) {
     return null;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4344

**Analysis / Root cause**: 
this scenario occurs if cluster is low on resources for knative service UI shows underlying Deployment and thus now the sidebar is trying to open up a Knative sidebar when it needs a Deployment sidebar. It fails to match up the model used for this particular workload and hits a NPE failing to get it with error `can not read property kind of undefined`.

**Solution Description**: 
adds check for kind before accessing


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
