### PR TITLE
Bug 1883602: Fix for disappearing backgrounds in topology on firefox

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.scss
+++ b/frontend/packages/dev-console/src/components/topology/Topology.scss
@@ -1,7 +1,21 @@
+@mixin firefox-only {
+  @at-root {
+    @-moz-document url-prefix() {
+      & {
+        @content;
+      }
+    }
+  }
+}
 .odc-topology-graph-view {
   position: absolute;
   top: 0;
   bottom: 0;
   right: 0;
   left: 0;
+  @include firefox-only {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
 }

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -240,7 +240,11 @@ const Topology: React.FC<TopologyProps> = ({ model, application, onSelect, setVi
     <div className="odc-topology-graph-view">
       <VisualizationProvider controller={visualization}>
         <VisualizationSurface state={{ selectedIds: [selectedId] }} />
-        {dragHint && <div className="odc-topology__hint-container">{dragHint}</div>}
+        {dragHint && (
+          <div className="odc-topology__hint-container">
+            <div className="odc-topology__hint-background">{dragHint}</div>
+          </div>
+        )}
         <span className="pf-topology-control-bar">{renderControlBar()}</span>
       </VisualizationProvider>
     </div>

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
@@ -7,15 +7,20 @@
   }
 
   &__hint-container {
-    align-items: center;
-    background: var(--pf-global--Color--light-100);
-    border: 1px solid var(--pf-global--BorderColor--light-100);
-    border-radius: 8px;
+    justify-content: center;
     display: flex;
-    padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
     pointer-events: none;
     position: absolute;
     top: var(--pf-global--spacer--sm);
+    left: 0;
+    right: 0;
+  }
+  &__hint-background{
+    background: var(--pf-global--Color--light-100);
+    border: 1px solid var(--pf-global--BorderColor--light-100);
+    border-radius: 8px;
+    padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
+    pointer-events: none;
   }
 
   &__view-switcher.pf-m-plain {


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4929

**Description**
Fixes an issue with firefox for the topology graph view where upon selection group backgrounds and node shadows disappear. This is due to the `absolute` positioning of the container which is necessary for redraw performance in other browsers.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

/kind bug
