### PR TITLE
 Bug 1883601: fixes: re-creating terminal after deleting workspace doesn't immediately restart

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -98,7 +98,6 @@ const useCloudShellWorkspace = (
       (async () => {
         setNoNamespaceFound(false);
         setSearching(true);
-        setNamespace(undefined);
         try {
           const projects = await k8sList(ProjectModel);
           if (unmounted) return;


### PR DESCRIPTION

**Fixes**: https://issues.redhat.com/browse/ODC-4172
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: once the dev workspace resource is deleted, it resets the namespace to undefined which causes the useK8sWatchResource to watch on undefined and in turn returns undefined. Since there is no resource to watch terminal doesn't show up on UI.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Do not reset the namespace to undefined.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![web-terminal](https://user-images.githubusercontent.com/9278015/94589036-622ce900-02a2-11eb-93ac-e60b226d3e78.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Install web terminal operator.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
