### PR TITLE
Bug 1883918: Proposed fix for duplicate UpdateAvailable notifications in the notification drawer

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -192,7 +192,12 @@ export const refreshNotificationPollers = () => {
 const getAlerts = (alertsResults: PrometheusRulesResponse): Alert[] =>
   alertsResults
     ? getAlertsAndRules(alertsResults.data)
-        .alerts.filter((a) => a.state === 'firing' && getAlertName(a) !== 'Watchdog')
+        .alerts.filter(
+          (a) =>
+            a.state === 'firing' &&
+            getAlertName(a) !== 'Watchdog' &&
+            getAlertName(a) !== 'UpdateAvailable',
+        )
         .sort((a, b) => +new Date(getAlertTime(b)) - +new Date(getAlertTime(a)))
     : [];
 


### PR DESCRIPTION
Eliminate duplicate notification entries in the notification drawer to update a cluster. There is currently an ota alert named UpdateAvailalble and also a recommendation created from data in clusterversion. They provide duplicate info, and the solution proposed is to filter out the ota alert. This pr addresses that solution.

Before:
<img width="460" alt="Screen Shot 2020-09-29 at 10 56 07 PM" src="https://user-images.githubusercontent.com/35978579/94638041-14ff4600-02a7-11eb-9cfa-67093749b1ab.png">


After:
<img width="461" alt="Screen Shot 2020-09-29 at 10 56 20 PM" src="https://user-images.githubusercontent.com/35978579/94638053-1c265400-02a7-11eb-8d19-3205e855ee23.png">

