### PR TITLE
Bug 1883764: fix issue in topology when channel with different kind have same name

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -40,6 +40,7 @@ export const EventSource: React.FC<Props> = ({
   const [sinkGroupVersionKind = '', sinkName = ''] = contextSource?.split('/') ?? [];
   const [sinkGroup = '', sinkVersion = '', sinkKind = ''] =
     getGroupVersionKind(sinkGroupVersionKind) ?? [];
+  const sinkKey = sinkName && sinkKind ? `${sinkKind}-${sinkName}` : '';
   const sinkApiVersion = sinkGroup ? `${sinkGroup}/${sinkVersion}` : '';
   const initialValues: EventSourceFormData = {
     project: {
@@ -59,6 +60,7 @@ export const EventSource: React.FC<Props> = ({
       apiVersion: sinkApiVersion,
       kind: sinkKind,
       name: sinkName,
+      key: sinkKey,
       uri: '',
     },
     limits: {

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
@@ -21,6 +21,7 @@ describe('Event Source ValidationUtils', () => {
         apiVersion: '',
         name: '',
         kind: '',
+        key: '',
       };
       await eventSourceValidationSchema
         .resolve({ value: mockData })
@@ -50,6 +51,7 @@ describe('Event Source ValidationUtils', () => {
         apiVersion: '',
         name: '',
         kind: '',
+        key: '',
       };
       mockData.data.apiserversource.resources[0] = { apiVersion: '', kind: '' };
       await eventSourceValidationSchema

--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -44,6 +44,7 @@ export interface SinkResourceData {
   apiVersion: string;
   name: string;
   kind: string;
+  key: string;
   uri?: string;
 }
 

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -165,8 +165,22 @@ export const isInternalResource = (resource: K8sResourceKind): boolean => {
   return false;
 };
 
-const isSubscriber = (resource: K8sResourceKind, relatedResource: K8sResourceKind): boolean => {
+const isSubscriber = (
+  resource: K8sResourceKind,
+  relatedResource: K8sResourceKind,
+  mainResource: K8sResourceKind,
+): boolean => {
   const subscriberRef = relatedResource?.spec?.subscriber?.ref;
+  // check for channel reference as channel with different kind can have same name
+  const channelRef = relatedResource?.spec?.channel;
+  if (
+    channelRef &&
+    (mainResource.metadata.name !== channelRef.name ||
+      mainResource.kind !== channelRef.kind ||
+      mainResource.apiVersion !== channelRef.apiVersion)
+  ) {
+    return false;
+  }
   return (
     subscriberRef &&
     referenceFor(resource) === referenceFor(subscriberRef) &&
@@ -191,7 +205,11 @@ const isPublisher = (
     return relationshipResource.spec?.broker === relatedResource.metadata.name;
   }
   const channel = relationshipResource.spec?.channel;
-  return channel && channel.name === relatedResource.metadata.name;
+  return (
+    channel &&
+    channel.name === relatedResource.metadata.name &&
+    channel.kind === relatedResource.kind
+  );
 };
 
 export const getTriggerFilters = (resource: K8sResourceKind) => {
@@ -749,9 +767,10 @@ export const getEventTopologyEdgeItems = (resource: K8sResourceKind, { data }): 
   if (sinkTarget) {
     _.forEach(data, (res) => {
       const {
+        kind,
         metadata: { uid: resUid, name: resName },
       } = res;
-      if (resName === sinkTarget.name) {
+      if (resName === sinkTarget.name && kind === sinkTarget.kind) {
         edges.push({
           id: `${uid}_${resUid}`,
           type: EdgeType.EventSource,
@@ -811,13 +830,14 @@ export const getSubscriptionTopologyEdgeItems = (
   resources,
 ): EdgeModel[] => {
   const {
+    kind,
     metadata: { uid, name },
   } = resource;
   const { eventingsubscription, ksservices } = resources;
   const edges = [];
   _.forEach(eventingsubscription?.data, (subRes) => {
     const channelData = subRes?.spec?.channel;
-    if (name === channelData?.name && ksservices) {
+    if (name === channelData?.name && kind === channelData?.kind && ksservices) {
       const svcData = subRes?.spec?.subscriber?.ref;
       svcData &&
         _.forEach(ksservices?.data, (res) => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -346,6 +346,7 @@ export const getDefaultEventingData = (typeEventSource: string): EventSourceForm
       apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
       name: 'event-display',
       kind: ServiceModel.kind,
+      key: `${ServiceModel.kind}-event-display`,
     },
     limits: {
       cpu: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4931

**Analysis / Root cause**: 
if user created a channel of kind `IMC` name `my-channel` and sink to ksvc and then create another channel for kind other then IMC say `NATS` with name `my-channel`. Can see below issues

- user will see sidebar with subscriber KSVC for NATSS channel as well along with connetor
- In sink for eventSources user see only one channel

**Solution Description**: 
- Added check for kind as well as channel with different name can have same kind
- Key for resource dropdown was channel name , have made use of custom key `kind-channelname`




**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
- Sidebar and topology

![image](https://user-images.githubusercontent.com/5129024/94667696-c72d2100-032c-11eb-8d23-b8cdfa79968b.png)


**Test setup:**
1. Install Serverless operator

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
