### PR TITLE
Bug 1883826: Fix misleading help text and update helm empty state

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
@@ -56,7 +56,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
         className="co-alert co-break-word"
         variant="info"
         title={
-          'Note: Some fields may not be represented in this form. Please select "YAML View" for full control of object creation.'
+          'Note: Some fields may not be represented in this form view. Please select "YAML view" for full control.'
         }
       />
       <Accordion asDefinitionList={false} className="co-dynamic-form__accordion">

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -130,8 +130,7 @@ export const getHelmActionConfig = (
         subTitle: {
           form:
             'The Helm chart can be installed by completing the form. Default values may be provided by the Helm chart authors.',
-          yaml:
-            'The Helm chart can be installed by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor.',
+          yaml: 'The Helm chart can be installed by manually entering YAML or JSON definitions.',
         },
         helmReleaseApi: `/api/helm/chart?url=${chartURL}`,
         fetch: coFetchJSON.post,

--- a/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { EmptyState, EmptyStateIcon, EmptyStateVariant } from '@patternfly/react-core';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { SecretModel } from '@console/internal/models';
@@ -95,9 +101,13 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
     const installURL = { pathname: `/catalog/ns/${namespace}`, search: '?kind=%5B"HelmChart"%5D' };
     return (
       <EmptyState variant={EmptyStateVariant.full}>
-        <p className="odc-helm-release__empty-list__title">No Helm Releases found</p>
         <EmptyStateIcon variant="container" component={helmImage} />
-        <Link to={installURL}>Install a Helm Chart from the developer catalog</Link>
+        <Title headingLevel="h3" size="lg">
+          No Helm Releases found
+        </Title>
+        <EmptyStateSecondaryActions>
+          <Link to={installURL}>Install a Helm Chart from the developer catalog</Link>
+        </EmptyStateSecondaryActions>
       </EmptyState>
     );
   };


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/ODC-4932
- https://issues.redhat.com/browse/ODC-4785
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
- The helm form had help text that was misleading that the yaml editor supported drag and drop. 
- The alert msg for form view in install/upgrade form was not generic enough according to design.
- Empty state for helm list page was not following standard PF patterns.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Updated the help text, alert text and empty state as per the design guidelines.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux @parvathyvr 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![Screenshot from 2020-09-30 16-29-21](https://user-images.githubusercontent.com/6041994/94677274-437a3100-033a-11eb-959a-334e448f7a78.png)
![Screenshot from 2020-09-30 16-29-52](https://user-images.githubusercontent.com/6041994/94677279-4412c780-033a-11eb-9dc9-61a98f3a340e.png)
![Screenshot from 2020-09-30 16-30-13](https://user-images.githubusercontent.com/6041994/94677284-44ab5e00-033a-11eb-8909-644de44dd560.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
