### PR TITLE
Bug 1883591: Support ServiceBinding breaking api changes

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
@@ -1,27 +1,30 @@
-import { DeploymentKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { apiVersionForModel, DeploymentKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { ServiceBindingModel } from '../../../models';
 import { TopologyDataResources } from '../topology-types';
 
 export const serviceBindingRequest: K8sResourceKind = {
   data: {
-    apiVersion: 'apps.openshift.io/v1alpha1',
-    kind: 'ServiceBindingRequest',
+    apiVersion: apiVersionForModel(ServiceBindingModel),
+    kind: ServiceBindingModel.kind,
     metadata: {
       name: 'analytics-deployment-D-wit-deployment-D',
       namespace: 'testproject1',
     },
     spec: {
-      applicationSelector: {
+      application: {
         group: 'apps',
         resource: 'deployments',
-        resourceRef: 'analytics-deployment',
+        name: 'analytics-deployment',
         version: 'v1',
       },
-      backingServiceSelector: {
-        group: '',
-        kind: undefined,
-        resourceRef: undefined,
-        version: undefined,
-      },
+      services: [
+        {
+          group: '',
+          kind: undefined,
+          name: undefined,
+          version: undefined,
+        },
+      ],
       detectBindingResources: true,
     },
   },
@@ -79,30 +82,30 @@ export const sbrBackingServiceSelectors: Partial<TopologyDataResources> = {
     loadError: null,
     data: [
       {
-        apiVersion: 'apps.openshift.io/v1alpha1',
-        kind: 'ServiceBindingRequest',
+        apiVersion: apiVersionForModel(ServiceBindingModel),
+        kind: ServiceBindingModel.kind,
         metadata: {
           name: 'sbr-1',
         },
         spec: {
-          applicationSelector: {
-            resourceRef: 'app',
+          application: {
+            name: 'app',
             group: 'apps',
             version: 'v1',
             resource: 'deployments',
           },
-          backingServiceSelectors: [
+          services: [
             {
               group: 'postgresql.baiju.dev',
               version: 'v1alpha1',
               kind: 'Jaeger',
-              resourceRef: 'jaeger-all-in-one-inmemory',
+              name: 'jaeger-all-in-one-inmemory',
             },
             {
               group: 'postgresql.baiju.dev',
               version: 'v1alpha1',
               kind: 'Jaeger',
-              resourceRef: 'jaeger-all-in-one-inmemory',
+              name: 'jaeger-all-in-one-inmemory',
             },
           ],
           detectBindingResources: true,
@@ -148,24 +151,26 @@ export const sbrBackingServiceSelector: Partial<TopologyDataResources> = {
     loadError: null,
     data: [
       {
-        apiVersion: 'apps.openshift.io/v1alpha1',
-        kind: 'ServiceBindingRequest',
+        apiVersion: apiVersionForModel(ServiceBindingModel),
+        kind: ServiceBindingModel.kind,
         metadata: {
           name: 'sbr-2',
         },
         spec: {
-          applicationSelector: {
-            resourceRef: 'app',
+          application: {
+            name: 'app',
             group: 'apps',
             version: 'v1',
             resource: 'deployments',
           },
-          backingServiceSelector: {
-            group: 'postgresql.baiju.dev',
-            version: 'v1alpha1',
-            kind: 'Jaeger',
-            resourceRef: 'jaeger-all-in-one-inmemory',
-          },
+          services: [
+            {
+              group: 'postgresql.baiju.dev',
+              version: 'v1alpha1',
+              kind: 'Jaeger',
+              name: 'jaeger-all-in-one-inmemory',
+            },
+          ],
           detectBindingResources: true,
         },
       },

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -19,7 +19,7 @@ export const TEST_KINDS_MAP = {
   statefulSets: 'StatefulSet',
   secrets: 'Secret',
   clusterServiceVersions: 'operators.coreos.com~v1alpha1~ClusterServiceVersion',
-  serviceBindingRequests: 'apps.openshift.io~v1alpha1~ServiceBindingRequest',
+  serviceBindingRequests: 'operators.coreos.com~v1alpha1~ServiceBinding',
   revisions: 'serving.knative.dev~v1~Revision',
   configurations: 'serving.knative.dev~v1~Configuration',
   ksroutes: 'serving.knative.dev~v1~Route',

--- a/frontend/packages/dev-console/src/components/topology/operators/actions/serviceBindings.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/actions/serviceBindings.ts
@@ -1,7 +1,8 @@
 import * as _ from 'lodash';
 import { k8sCreate, K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
 import { Node } from '@patternfly/react-topology';
-import { ServiceBindingRequestModel } from '../../../../models';
+import { apiVersionForModel } from '@console/kubevirt-plugin/integration-tests/tests/utils/selectors';
+import { ServiceBindingModel } from '../../../../models';
 
 export const createServiceBinding = (
   source: K8sResourceKind,
@@ -19,31 +20,33 @@ export const createServiceBinding = (
   const targetGroup = _.split(target.apiVersion, '/');
   const sbrName = `${sourceName}-${sourceModel.abbr.toLowerCase()}-${targetName}-${targetModel.abbr.toLowerCase()}`;
 
-  const serviceBindingRequest = {
-    apiVersion: 'apps.openshift.io/v1alpha1',
-    kind: 'ServiceBindingRequest',
+  const serviceBinding = {
+    apiVersion: apiVersionForModel(ServiceBindingModel),
+    kind: ServiceBindingModel.kind,
     metadata: {
       name: sbrName,
       namespace,
     },
     spec: {
-      applicationSelector: {
-        resourceRef: sourceName,
+      application: {
+        name: sourceName,
         group: sourceGroup[0],
         version: sourceGroup[1],
         resource: modelFor(referenceFor(source)).plural,
       },
-      backingServiceSelector: {
-        group: targetGroup[0],
-        version: targetGroup[1],
-        kind: target.kind,
-        resourceRef: targetName,
-      },
+      services: [
+        {
+          group: targetGroup[0],
+          version: targetGroup[1],
+          kind: target.kind,
+          name: targetName,
+        },
+      ],
       detectBindingResources: true,
     },
   };
 
-  return k8sCreate(ServiceBindingRequestModel, serviceBindingRequest);
+  return k8sCreate(ServiceBindingModel, serviceBinding);
 };
 
 const createServiceBindingConnection = (source: Node, target: Node) => {

--- a/frontend/packages/dev-console/src/components/topology/operators/operator-resources.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operator-resources.ts
@@ -1,14 +1,14 @@
 import { FirehoseResource } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { ServiceBindingRequestModel } from '../../../models';
+import { ServiceBindingModel } from '../../../models';
 
 export const operatorResources = (namespace: string): FirehoseResource[] => {
   const serviceBindings = [
     {
       isList: true,
-      kind: referenceForModel(ServiceBindingRequestModel),
+      kind: referenceForModel(ServiceBindingModel),
       namespace,
-      prop: 'serviceBindingRequests',
+      prop: 'serviceBindings',
       optional: true,
     },
   ];

--- a/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operators-data-transformer.ts
@@ -24,13 +24,13 @@ export const edgesFromServiceBinding = (
   sbrs.forEach((sbr) => {
     let edgeExists = false;
     const reference = referenceFor(source);
-    if (reference && sbr?.spec?.applicationSelector?.resource === modelFor(reference)?.plural) {
-      if (sbr?.spec?.applicationSelector?.resourceRef === source.metadata.name) {
+    if (reference && sbr?.spec?.application?.resource === modelFor(reference)?.plural) {
+      if (sbr?.spec?.application?.name === source.metadata.name) {
         edgeExists = true;
       } else {
-        const matchLabels = sbr?.spec?.applicationSelector?.matchLabels;
+        const matchLabels = sbr?.spec?.application?.matchLabels;
         if (matchLabels) {
-          const sbrSelector = new LabelSelector(sbr.spec.applicationSelector);
+          const sbrSelector = new LabelSelector(sbr.spec.application);
           if (sbrSelector.matches(source)) {
             edgeExists = true;
           }
@@ -54,12 +54,10 @@ export const getServiceBindingEdges = (
   }
 
   _.forEach(edgesFromServiceBinding(dc, sbrs), (sbr) => {
-    // look for multiple backing services first in `backingServiceSelectors`
-    // followed by a fallback to the single reference in `backingServiceSelector`
-    _.forEach(sbr.spec.backingServiceSelectors || [sbr.spec.backingServiceSelector], (bss) => {
+    _.forEach(sbr.spec.services, (bss) => {
       if (bss) {
         const targetGroup = obsGroups.find(
-          (group) => group.kind === bss.kind && group.metadata.name === bss.resourceRef,
+          (group) => group.kind === bss.kind && group.metadata.name === bss.name,
         );
         const target = targetGroup?.metadata.uid;
         const source = dc.metadata.uid;

--- a/frontend/packages/dev-console/src/components/topology/operators/operatorsTopologyPlugin.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operatorsTopologyPlugin.ts
@@ -9,7 +9,7 @@ import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src';
 import { ALLOW_SERVICE_BINDING } from '../../../const';
-import { ServiceBindingRequestModel } from '../../../models';
+import { ServiceBindingModel } from '../../../models';
 import { getCreateConnector } from './actions';
 import {
   getIsOperatorResource,
@@ -36,7 +36,7 @@ const getOperatorWatchedResources = (namespace: string): WatchK8sResources<any> 
     },
     serviceBindingRequests: {
       isList: true,
-      kind: referenceForModel(ServiceBindingRequestModel),
+      kind: referenceForModel(ServiceBindingModel),
       namespace,
       optional: true,
     },

--- a/frontend/packages/dev-console/src/models/service-binding.ts
+++ b/frontend/packages/dev-console/src/models/service-binding.ts
@@ -1,13 +1,13 @@
 import { K8sKind } from '@console/internal/module/k8s';
 
-export const ServiceBindingRequestModel: K8sKind = {
-  id: 'servicebindingrequest',
-  kind: 'ServiceBindingRequest',
-  plural: 'servicebindingrequests',
-  label: 'ServiceBindingRequest',
-  labelPlural: 'ServiceBindingRequests',
-  abbr: 'SBR',
-  apiGroup: 'apps.openshift.io',
+export const ServiceBindingModel: K8sKind = {
+  id: 'servicebinding',
+  kind: 'ServiceBinding',
+  plural: 'servicebindings',
+  label: 'ServiceBinding',
+  labelPlural: 'ServiceBindings',
+  abbr: 'SB',
+  apiGroup: 'operators.coreos.com',
   apiVersion: 'v1alpha1',
   namespaced: true,
   crd: true,

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -126,7 +126,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'FeatureFlag/Model',
     properties: {
-      model: models.ServiceBindingRequestModel,
+      model: models.ServiceBindingModel,
       flag: ALLOW_SERVICE_BINDING,
     },
   },


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/ODC-4928

**Analysis / Root cause:**
Service Binding Operator (starting with v0.2.0) has changed API (CRD) https://github.com/redhat-developer/service-binding-operator/pull/608 that is not supported in OCP 4.6 and hence service-binding is not working.

**Solution Description:**
Refactor code based on the latest API changes. Also fix failing unit tests accordingly

**Gifs:**
Create service-binding using:

1. Binding connector
![Peek 2020-09-30 16-32](https://user-images.githubusercontent.com/20724543/94677630-db781a80-033a-11eb-8f7d-a1423bfbd392.gif)

2. Import YAML
![Peek 2020-09-30 16-35](https://user-images.githubusercontent.com/20724543/94677684-f5196200-033a-11eb-8b3b-61f449682b26.gif)

**PR Test setup:**
Install community version of Service Binding from OperatorHub using the beta channel.