### PR TITLE
Treat console-extensions.json file as JSON with Comments (jsonc)

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -48,6 +48,9 @@
     "**/.cache-loader": true,
     "**/public/dist": true
   },
+  "files.associations": {
+    "**/console-extensions.json": "jsonc"
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   }

--- a/frontend/dynamic-demo-plugin/console-extensions.json
+++ b/frontend/dynamic-demo-plugin/console-extensions.json
@@ -1,3 +1,10 @@
+/**
+ * This file declares all extensions contributed by the plugin.
+ *
+ * The '$schema' property is optional but recommended, allowing code editors to validate
+ * the content as well as provide additional features such as code completion and property
+ * description.
+ */
 {
   "$schema": "../packages/console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
   "data": [

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -9,6 +9,7 @@
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"
   },
   "devDependencies": {
+    "comment-json": "4.x",
     "ts-json-schema-generator": "0.71.x",
     "webpack": "5.0.0-beta.16"
   }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
@@ -32,6 +32,7 @@ import {
  * ```ts
  * const navItemExtensions = useResolvedExtensions<NavItem>(isNavItem);
  * const perspectiveExtensions = useResolvedExtensions<Perspective>(isPerspective);
+ * // process adapted extensions and render your component
  * ```
  *
  * The hook's result is guaranteed to be referentially stable across re-renders.

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
@@ -1,5 +1,7 @@
 import * as webpack from 'webpack';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as jsonc from 'comment-json';
 import { ConsolePackageJSON } from '../schema/plugin-package';
 import { ConsoleExtensionsJSON } from '../schema/console-extensions';
 import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
@@ -33,8 +35,11 @@ export class ConsoleAssetPlugin {
   private readonly manifest: ConsolePluginManifestJSON;
 
   constructor(private readonly pkg: ConsolePackageJSON) {
-    // eslint-disable-next-line
-    const ext = require(path.resolve(process.cwd(), extensionsFile)) as ConsoleExtensionsJSON;
+    const ext = jsonc.parse(
+      fs.readFileSync(path.resolve(process.cwd(), extensionsFile), 'utf-8'),
+      null,
+      true,
+    ) as ConsoleExtensionsJSON;
     validateExtensionsFile(ext).report();
 
     this.manifest = {

--- a/frontend/packages/console-plugin-sdk/src/api/subscribeToExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/subscribeToExtensions.ts
@@ -2,7 +2,7 @@ import { Store } from 'redux';
 import * as _ from 'lodash';
 import { RootState } from '@console/internal/redux';
 import { isExtensionInUse, PluginStore } from '../store';
-import { Extension, ExtensionTypeGuard } from '../typings';
+import { Extension, ExtensionTypeGuard, LoadedExtension } from '../typings';
 
 let subscriptionServiceInitialized = false;
 
@@ -90,7 +90,7 @@ export const initSubscriptionService = (pluginStore: PluginStore, reduxStore: St
  * @returns Function that unsubscribes the listener.
  */
 export const subscribeToExtensions = <E extends Extension>(
-  listener: ExtensionListener<E>,
+  listener: ExtensionListener<LoadedExtension<E>>,
   ...typeGuards: ExtensionTypeGuard<E>[]
 ): VoidFunction => {
   if (typeGuards.length === 0) {

--- a/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
@@ -48,7 +48,7 @@ export const useExtensions = <E extends Extension>(
 
   const isMountedRef = React.useRef(true);
   const unsubscribeRef = React.useRef<VoidFunction>(null);
-  const extensionsInUseRef = React.useRef<E[]>([]);
+  const extensionsInUseRef = React.useRef<LoadedExtension<E>[]>([]);
   const latestTypeGuardsRef = React.useRef<ExtensionTypeGuard<E>[]>(typeGuards);
 
   const trySubscribe = React.useCallback(() => {
@@ -82,5 +82,5 @@ export const useExtensions = <E extends Extension>(
     [tryUnsubscribe],
   );
 
-  return extensionsInUseRef.current as LoadedExtension<E>[];
+  return extensionsInUseRef.current;
 };

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -41,10 +41,10 @@ export const getGatingFlagNames = (extensions: Extension[]): string[] =>
  */
 export class PluginStore {
   // Extensions contributed by static plugins
-  private readonly staticExtensions: Extension[];
+  private readonly staticExtensions: LoadedExtension[];
 
   // Extensions contributed by dynamic plugins
-  private dynamicExtensions: Extension[] = [];
+  private dynamicExtensions: LoadedExtension[] = [];
 
   // TODO(vojtech): legacy, remove
   public readonly registry: ExtensionRegistry;
@@ -65,14 +65,14 @@ export class PluginStore {
     this.updateDynamicExtensions = _.debounce(this.updateDynamicExtensions, 1000);
   }
 
-  public getAllExtensions(): Extension[] {
+  public getAllExtensions() {
     return [...this.staticExtensions, ...this.dynamicExtensions];
   }
 
   private updateDynamicExtensions() {
     this.dynamicExtensions = Array.from(this.dynamicPlugins.values()).reduce(
       (acc, plugin) => (plugin.enabled ? [...acc, ...plugin.resolvedExtensions] : acc),
-      [] as Extension[],
+      [],
     );
 
     this.listeners.forEach((listener) => {
@@ -150,6 +150,6 @@ type DynamicPluginMetadata = Omit<DynamicPluginManifest, 'extensions'>;
 
 type DynamicPlugin = {
   manifest: DynamicPluginManifest;
-  resolvedExtensions: Extension[];
+  resolvedExtensions: Readonly<LoadedExtension[]>;
   enabled: boolean;
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/base.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/base.ts
@@ -100,7 +100,7 @@ export type ActivePlugin = {
 /**
  * Runtime extension interface, exposing additional metadata.
  */
-export type LoadedExtension<E extends Extension> = E & {
+export type LoadedExtension<E extends Extension = Extension> = E & {
   pluginID: string;
   pluginName: string;
   uid: string;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4802,6 +4802,16 @@ commander@~6.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.0.0.tgz#2b270da94f8fb9014455312f829a1129dbf8887e"
   integrity sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==
 
+comment-json@4.x:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-4.0.6.tgz#b9fa19400c558fba4fe70d1d77ed5871e47e9bdf"
+  integrity sha512-zDy9tUDLaqbIHksqMlCg/gD6VUc5EIS7ei9CO0lasIrw1tU0qaXKctbtLVUCx4WNpmxg2CpJVEhSX4kCarcjhQ==
+  dependencies:
+    core-util-is "^1.0.2"
+    esprima "^4.0.1"
+    has-own-prop "^2.0.0"
+    repeat-string "^1.6.1"
+
 common-tags@1.8.0, common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
@@ -5007,7 +5017,7 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@1.0.2, core-util-is@^1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -6939,7 +6949,7 @@ esprima@^3.1.3, esprima@~3.1.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -8604,6 +8614,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-own-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-own-prop/-/has-own-prop-2.0.0.tgz#f0f95d58f65804f5d218db32563bb85b8e0417af"
+  integrity sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==
 
 has-symbols@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Plugin developers can now use comments in their `console-extensions.json` file.

Some other improvements included in this PR:

- Updated typings in extension consuming APIs and `PluginStore` to work with `LoadedExtension` (runtime extension interface exposing additional metadata) where appropriate.

- In `dynamic-demo-plugin`, use `link` instead of `file` protocol when referencing dynamic plugin SDK package. This means we can modify the referenced package and re-build demo plugin without having to re-run `yarn` again.

cc @spadgett @christianvogt 