### PR TITLE
Bug 1881844: Fix OperatorHub item badges and alerts

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
@@ -1,19 +1,11 @@
-import * as _ from 'lodash';
-
 export const operatorProviderTypeMap = {
-  redhat: 'Red Hat',
-  marketplace: 'Marketplace',
-  certified: 'Certified',
-  community: 'Community',
+  'redhat-operators': 'Red Hat',
+  'redhat-marketplace': 'Marketplace',
+  'certified-operators': 'Certified',
+  'community-operators': 'Community',
 };
 
-const getCustomOperatorProviderType = (packageManifest) =>
-  packageManifest.status.catalogSourceDisplayName || packageManifest.status.catalogSource;
 export const getOperatorProviderType = (packageManifest) => {
-  const srcProvider = _.get(packageManifest, 'metadata.labels.opsrc-provider');
-  return _.get(
-    operatorProviderTypeMap,
-    srcProvider,
-    getCustomOperatorProviderType(packageManifest),
-  );
+  const { catalogSource, catalogSourceDisplayName } = packageManifest.status;
+  return operatorProviderTypeMap?.[catalogSource] || catalogSourceDisplayName || catalogSource;
 };


### PR DESCRIPTION
Drive operator hub item Marketplace and Community badges and alerts with catalog source name instead
of `opsrc-provider` label, which was deprecated in 4.6.