### PR TITLE
Bug 1884664: Start the install status page as soon as subscription exist

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -252,6 +252,7 @@ const OperatorInstallStatus: React.FC<OperatorInstallPageProps> = (props) => {
     loading = false;
   } else if (subscription) {
     // There is no ClusterServiceVersion for the package, so look at Subscriptions/InstallPlans
+    loading = false;
     status = subscription?.status?.state || null;
     const installPlanName = subscription?.status?.installplan?.name || '';
     const installPlan: InstallPlanKind = resources?.installPlan?.data?.find(
@@ -259,7 +260,6 @@ const OperatorInstallStatus: React.FC<OperatorInstallPageProps> = (props) => {
     );
     if (installPlan) {
       installObj = installPlan;
-      loading = false;
     }
   }
 


### PR DESCRIPTION
Currently, the install status page does not show until either a CSV or an install plan has been created; instead we show an "Installing..." message.  This was to ensure we could get the needed info and CSV logo from the csv object or indirectly from the installPlan object.  However, the information is also available on the package manifest (which we now use) as soon as we have the subscription. We can therefore show the install page immediately which look more finished.
(I do realize the description here is longer than the code change)

![no-loading](https://user-images.githubusercontent.com/18728857/94751798-a83b8880-0346-11eb-9097-e47550f5d903.gif)

