### PR TITLE
Bug 1884181: fix kafkachannel plural to be lowercase

### DIFF
--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -244,7 +244,7 @@ export const EventingKafkaChannelModel: K8sKind = {
   kind: 'KafkaChannel',
   label: 'Kafka Channel',
   labelPlural: 'Kafka Channels',
-  plural: 'kafkaChannels',
+  plural: 'kafkachannels',
   id: 'kafkaChannel',
   abbr: 'KC',
   namespaced: true,


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1884181

**Analysis / Root cause**: 
KafkaChannel list and create api calls fail for version v1beta1 with 404 as plural has typo in model

**Solution Description**: 
updated the plural for KafkaChannel model


**Test setup:**
1. Install Serverless operator , create CR for knativeServing, KnativeEventing
2. Install Knative Kafka operator, create CR KEK in knative-eventing namespace
3. go to Dev Console -> Add -> channel -> Select kafka Channel
4. Click on Create

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
