### PR TITLE
Bug 1884402: Fix to draw aggregate edges to Event Brokers correctly in topology

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -14,6 +14,7 @@ import {
   WithDragNodeProps,
   AnchorEnd,
   WithCreateConnectorProps,
+  RectAnchor,
 } from '@patternfly/react-topology';
 import SvgBoxedText from '@console/dev-console/src/components/svg/SvgBoxedText';
 import {
@@ -26,6 +27,7 @@ import {
   getFilterById,
   SHOW_LABELS_FILTER_ID,
   getTopologyResourceObject,
+  TYPE_AGGREGATE_EDGE,
 } from '@console/dev-console/src/components/topology';
 import PubSubSourceAnchor from '../anchors/PubSubSourceAnchor';
 import PubSubTargetAnchor from '../anchors/PubSubTargetAnchor';
@@ -69,6 +71,8 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
 }) => {
   useAnchor(PubSubSourceAnchor, AnchorEnd.source);
   useAnchor(PubSubTargetAnchor, AnchorEnd.target);
+  useAnchor(RectAnchor, AnchorEnd.source, TYPE_AGGREGATE_EDGE);
+  useAnchor(RectAnchor, AnchorEnd.target, TYPE_AGGREGATE_EDGE);
   const [hover, hoverRef] = useHover();
 
   const groupRefs = useCombineRefs(dragNodeRef, dndDropRef, hoverRef);


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4946

**Description**
Fix the end points for aggregate edges to Event Broker nodes

**Screenshots**
Before:
![image](https://user-images.githubusercontent.com/11633780/94861263-39713480-0405-11eb-8a71-9589193e460f.png)

After:
![image](https://user-images.githubusercontent.com/11633780/94861344-5efe3e00-0405-11eb-9218-e0a35d01d645.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug

/cc @bgliwa01 @beaumorley @serenamarie125 