### PR TITLE
Bug 1884613: Fix runtime error for basic users creating Prometheus instance

### DIFF
--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -49,7 +49,13 @@ export const definitionFor = _.memoize((model: K8sKind): SwaggerDefinition => {
     return null;
   }
   const key = getDefinitionKey(model, swaggerDefinitions);
-  return _.get(swaggerDefinitions, key);
+  // Some schemas might use $ref to reference an external schmema. In order for $ref to resolve,
+  // the referenced schema must be defined in the `definitions` property of the
+  // referencing schema.
+  return {
+    definitions: swaggerDefinitions,
+    ...(swaggerDefinitions?.[key] ?? {}),
+  };
 }, referenceForModel);
 
 const getRef = (definition: SwaggerDefinition): string => {
@@ -118,6 +124,7 @@ export const getResourceDescription = _.memoize((kindObj: K8sKind): string => {
 }, referenceForModel);
 
 export type SwaggerDefinition = {
+  definitions?: SwaggerDefinitions;
   description?: string;
   type?: string;
   enum?: string[];


### PR DESCRIPTION
Add `definitions` property to the schema returned by `definitionFor` so that `$ref` properties can be
resolved.