### PR TITLE
Bug 1884654: show vmi utilization data

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -20,7 +20,6 @@ import {
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { findVMIPod } from '../../../selectors/pod/selectors';
-import { isVMCreated } from '../../../selectors/vm';
 import { getUtilizationQueries, getMultilineUtilizationQueries, VMQueries } from './queries';
 import { getPrometheusQueryEndTimestamp } from '@console/internal/components/graphs/helpers';
 
@@ -52,7 +51,7 @@ export const VMUtilizationCard: React.FC = () => {
   const vmName = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
   const launcherPodName = getName(findVMIPod(vmi, pods));
-  const vmiIsRunning = isVMCreated(vm) && !!vmi;
+  const vmiIsRunning = !!vmi;
 
   const queries = React.useMemo(
     () =>


### PR DESCRIPTION
Utilization card should not be disabled for VMIs

Screenshot:
After:
![screenshot-localhost_9000-2020 10 05-11_13_04](https://user-images.githubusercontent.com/2181522/95055337-cfee7000-06fb-11eb-8122-74008bb0d90d.png)

Before:
![screenshot-localhost_9000-2020 10 05-11_14_22](https://user-images.githubusercontent.com/2181522/95055460-f6141000-06fb-11eb-8037-fc69558cb536.png)
