### PR TITLE
[release-4.4] Bug 1881058: Use library-go crypto to setup default TLSConfig

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -565,6 +565,7 @@ func main() {
 		Handler: srv.HTTPHandler(),
 		// Disable HTTP/2, which breaks WebSockets.
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
+		TLSConfig:    oscrypto.SecureTLSConfig(&tls.Config{}),
 	}
 
 	log.Infof("Binding to %s...", httpsrv.Addr)


### PR DESCRIPTION
/assign @spadgett 