### PR TITLE
Bug 1885309:  Fix bug where <Timestamp> for 12 hour has incorrect suffix

### DIFF
--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -38,8 +38,10 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
 
   let a = 'am';
   let hours = mdate.getHours();
-  if (hours > 12) {
-    hours -= 12;
+  if (hours >= 12) {
+    if (hours > 12) {
+      hours -= 12;
+    }
     a = 'pm';
   }
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1883779

Before:
<img width="1243" alt="Screen Shot 2020-10-05 at 9 50 40 AM" src="https://user-images.githubusercontent.com/895728/95088579-1ee2d800-06f1-11eb-9e25-3cfa5f86327f.png">

After:
<img width="1248" alt="Screen Shot 2020-10-05 at 9 49 08 AM" src="https://user-images.githubusercontent.com/895728/95088613-2ace9a00-06f1-11eb-8878-db20fade135f.png">

This is a pretty bad bug, so we're gonna want to back port to 4.5?