### PR TITLE
Update TaskRun List Page Columns & PipelineRun Tab

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -7,6 +7,7 @@ import { PipelineRunDetails } from './detail-page-tabs/PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './detail-page-tabs/PipelineRunLogs';
 import { useMenuActionsWithUserAnnotation } from './triggered-by';
 import { usePipelinesBreadcrumbsFor } from '../pipelines/hooks';
+import TaskRuns from './detail-page-tabs/TaskRuns';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
@@ -24,6 +25,11 @@ const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
       pages={[
         navFactory.details(PipelineRunDetails),
         navFactory.editYaml(viewYamlComponent),
+        {
+          href: 'task-runs',
+          name: 'Task Runs',
+          component: TaskRuns,
+        },
         {
           href: 'logs',
           path: 'logs/:name?',

--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/TaskRuns.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/TaskRuns.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import TaskRunsListPage from '../../taskruns/list-page/TaskRunsListPage';
+import { TaskRunKind } from '../../../utils/pipeline-augment';
+
+interface TaskRunsProps {
+  obj: TaskRunKind;
+}
+
+const TaskRuns: React.FC<TaskRunsProps> = ({ obj }) => (
+  <TaskRunsListPage
+    showTitle={false}
+    selector={{ 'tekton.dev/pipelineRun': obj.metadata.name }}
+    showPipelineColumn={false}
+    hideBadge
+  />
+);
+
+export default TaskRuns;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsHeader.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsHeader.tsx
@@ -1,7 +1,7 @@
 import { sortable } from '@patternfly/react-table';
 import { tableColumnClasses } from './taskruns-table';
 
-const TaskRunsHeader = () => {
+const TaskRunsHeader = (showPipelineColumn: boolean = true) => () => {
   return [
     {
       title: 'Name',
@@ -14,30 +14,43 @@ const TaskRunsHeader = () => {
       sortField: 'metadata.namespace',
       transforms: [sortable],
       props: { className: tableColumnClasses[1] },
+      id: 'namespace',
+    },
+    {
+      title: 'Pipeline',
+      sortField: 'metadata.labels["tekton.dev/pipeline"]',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Task',
+      sortField: 'spec.taskRef.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Pod',
+      sortField: 'status.podName',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[4] },
     },
     {
       title: 'Status',
       sortField: 'status.conditions[0].reason',
       transforms: [sortable],
-      props: { className: tableColumnClasses[2] },
+      props: { className: tableColumnClasses[5] },
     },
     {
       title: 'Started',
       sortField: 'status.startTime',
       transforms: [sortable],
-      props: { className: tableColumnClasses[3] },
-    },
-    {
-      title: 'Duration',
-      sortField: 'status.completionTime',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[4] },
+      props: { className: tableColumnClasses[6] },
     },
     {
       title: '',
-      props: { className: tableColumnClasses[5] },
+      props: { className: tableColumnClasses[7] },
     },
-  ];
+  ].filter((item) => !(item.title === 'Pipeline' && !showPipelineColumn));
 };
 
 export default TaskRunsHeader;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsList.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsList.tsx
@@ -1,14 +1,21 @@
 import * as React from 'react';
 import { Table } from '@console/internal/components/factory';
+import { SortByDirection } from '@patternfly/react-table';
 import { TaskRunModel } from '../../../models';
 import TaskRunsHeader from './TaskRunsHeader';
 import TaskRunsRow from './TaskRunsRow';
 
-const TaskRunsList: React.FC = (props) => (
+interface TaskRunsListProps {
+  customData?: { [key: string]: any };
+}
+
+const TaskRunsList: React.FC<TaskRunsListProps> = (props) => (
   <Table
     {...props}
     aria-label={TaskRunModel.labelPlural}
-    Header={TaskRunsHeader}
+    defaultSortField="status.startTime"
+    defaultSortOrder={SortByDirection.desc}
+    Header={TaskRunsHeader(props.customData?.showPipelineColumn)}
     Row={TaskRunsRow}
     virtualize
   />

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -2,29 +2,34 @@ import * as React from 'react';
 import { getBadgeFromType } from '@console/shared';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { getURLSearchParams } from '@console/internal/components/utils';
 import TaskRunsList from './TaskRunsList';
 import { TaskRunModel } from '../../../models';
 import { runFilters as taskRunFilters } from '../../pipelines/detail-page-tabs/PipelineRuns';
 
 interface TaskRunsListPageProps {
   hideBadge?: boolean;
+  showPipelineColumn?: boolean;
 }
 
 const TaskRunsListPage: React.FC<Omit<
   React.ComponentProps<typeof ListPage>,
   'canCreate' | 'kind' | 'ListComponent' | 'rowFilters'
 > &
-  TaskRunsListPageProps> = (props) => {
+  TaskRunsListPageProps> = ({ hideBadge, showPipelineColumn = true, ...props }) => {
+  const searchParams = getURLSearchParams();
+  const kind = searchParams?.kind;
+
   return (
     <ListPage
       {...props}
-      canCreate={false}
+      customData={{ showPipelineColumn }}
+      canCreate={kind?.includes(referenceForModel(TaskRunModel)) ?? false}
       kind={referenceForModel(TaskRunModel)}
       ListComponent={TaskRunsList}
       rowFilters={taskRunFilters}
-      badge={props.hideBadge ? null : getBadgeFromType(TaskRunModel.badge)}
+      badge={hideBadge ? null : getBadgeFromType(TaskRunModel.badge)}
     />
   );
 };
-
 export default TaskRunsListPage;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -3,40 +3,70 @@ import { TableRow, TableData, RowFunction } from '@console/internal/components/f
 import { ResourceLink, Timestamp, Kebab, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskRunKind } from '../../../utils/pipeline-augment';
-import { TaskRunModel } from '../../../models';
+import { TaskRunModel, PipelineModel, TaskModel } from '../../../models';
 import { tableColumnClasses } from './taskruns-table';
 import { Status } from '@console/shared';
 import { pipelineRunFilterReducer as taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
-import { pipelineRunDuration as taskRunDuration } from '../../../utils/pipeline-utils';
 
-const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style }) => {
-  const taskRunsReference = referenceForModel(TaskRunModel);
-  return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={taskRunsReference}
-          name={obj.metadata.name}
-          namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
-          data-test-id={obj.metadata.name}
-        />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
-        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
+const taskRunsReference = referenceForModel(TaskRunModel);
+const taskReference = referenceForModel(TaskModel);
+const pipelineReference = referenceForModel(PipelineModel);
+
+const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...props }) => (
+  <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+    <TableData className={tableColumnClasses[0]}>
+      <ResourceLink
+        kind={taskRunsReference}
+        name={obj.metadata.name}
+        namespace={obj.metadata.namespace}
+        title={obj.metadata.name}
+        data-test-id={obj.metadata.name}
+      />
+    </TableData>
+    <TableData className={tableColumnClasses[1]} columnID="namespace">
+      <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
+    </TableData>
+    {props.customData?.showPipelineColumn && (
       <TableData className={tableColumnClasses[2]}>
-        <Status status={taskRunFilterReducer(obj)} />
+        {obj.metadata.labels['tekton.dev/pipeline'] ? (
+          <ResourceLink
+            kind={pipelineReference}
+            name={obj.metadata.labels['tekton.dev/pipeline']}
+            namespace={obj.metadata.namespace}
+          />
+        ) : (
+          '-'
+        )}
       </TableData>
-      <TableData className={tableColumnClasses[3]}>
-        <Timestamp timestamp={obj?.status?.startTime} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>{taskRunDuration(obj)}</TableData>
-      <TableData className={tableColumnClasses[5]}>
-        <ResourceKebab actions={Kebab.factory.common} kind={taskRunsReference} resource={obj} />
-      </TableData>
-    </TableRow>
-  );
-};
+    )}
+    <TableData className={tableColumnClasses[3]}>
+      {obj.spec.taskRef?.name ? (
+        <ResourceLink
+          kind={taskReference}
+          name={obj.spec.taskRef.name}
+          namespace={obj.metadata.namespace}
+        />
+      ) : (
+        '-'
+      )}
+    </TableData>
+    <TableData className={tableColumnClasses[4]}>
+      {obj.status?.podName ? (
+        <ResourceLink kind="Pod" name={obj.status.podName} namespace={obj.metadata.namespace} />
+      ) : (
+        '-'
+      )}
+    </TableData>
+    <TableData className={tableColumnClasses[5]}>
+      <Status status={taskRunFilterReducer(obj)} />
+    </TableData>
+    <TableData className={tableColumnClasses[6]}>
+      <Timestamp timestamp={obj?.status?.startTime} />
+    </TableData>
+    <TableData className={tableColumnClasses[7]}>
+      <ResourceKebab actions={Kebab.factory.common} kind={taskRunsReference} resource={obj} />
+    </TableData>
+  </TableRow>
+);
 
 export default TaskRunsRow;

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/__tests__/TaskRunsRow.spec.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/__tests__/TaskRunsRow.spec.tsx
@@ -1,0 +1,74 @@
+import { shallow } from 'enzyme';
+import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
+import { TaskRunKind } from '../../../../utils/pipeline-augment';
+import TaskRunsRow from '../TaskRunsRow';
+import { ResourceLink, Timestamp } from '@console/internal/components/utils';
+
+let taskRunsData: RowFunctionArgs<TaskRunKind>;
+
+describe('TaskRunsRow', () => {
+  beforeEach(() => {
+    taskRunsData = {
+      obj: {
+        metadata: {
+          uid: '121231',
+          name: 'task-run',
+          namespace: 'xyz',
+          labels: {
+            'tekton.dev/pipeline': 'pipeline1',
+          },
+        },
+        spec: {
+          taskRef: {
+            name: 'task1',
+          },
+        },
+        status: {
+          podName: 'pod-1',
+          startTime: '-',
+        },
+      },
+      customData: {
+        showPipelineColumn: true,
+      },
+      index: 0,
+      key: '0',
+      style: {
+        height: 'auto',
+        left: 0,
+        position: 'absolute',
+        top: 0,
+        width: '100%',
+      },
+      columns: null,
+      isScrolling: true,
+    };
+  });
+
+  it('should show the pipeline column', () => {
+    const wrapper = shallow(TaskRunsRow(taskRunsData));
+    expect(wrapper.find(TableData)).toHaveLength(8);
+  });
+
+  it('should render proper data', () => {
+    const wrapper = shallow(TaskRunsRow(taskRunsData));
+    let taskData = wrapper.find(TableData).at(0);
+    expect(taskData.find(ResourceLink).props().name).toBe('task-run');
+    taskData = wrapper.find(TableData).at(1);
+    expect(taskData.find(ResourceLink).props().name).toBe('xyz');
+    taskData = wrapper.find(TableData).at(2);
+    expect(taskData.find(ResourceLink).props().name).toBe('pipeline1');
+    taskData = wrapper.find(TableData).at(3);
+    expect(taskData.find(ResourceLink).props().name).toBe('task1');
+    taskData = wrapper.find(TableData).at(4);
+    expect(taskData.find(ResourceLink).props().name).toBe('pod-1');
+    taskData = wrapper.find(TableData).at(6);
+    expect(taskData.find(Timestamp).props().timestamp).toBe('-');
+  });
+
+  it('should not show the pipeline column', () => {
+    taskRunsData.customData.showPipelineColumn = false;
+    const wrapper = shallow(TaskRunsRow(taskRunsData));
+    expect(wrapper.find(TableData)).toHaveLength(7);
+  });
+});

--- a/frontend/packages/dev-console/src/components/taskruns/list-page/taskruns-table.ts
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/taskruns-table.ts
@@ -3,8 +3,10 @@ import { Kebab } from '@console/internal/components/utils';
 export const tableColumnClasses = [
   '', // name
   '', // namespace
+  '', // pipeline
+  'pf-m-hidden pf-m-visible-on-sm', // task
+  'pf-m-hidden pf-m-visible-on-sm', // pod
   'pf-m-hidden pf-m-visible-on-sm', // status
   'pf-m-hidden pf-m-visible-on-sm', // started
-  'pf-m-hidden pf-m-visible-on-sm', // duration
   Kebab.columnClass,
 ];

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -504,6 +504,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Resource/List',
+    properties: {
+      model: TaskRunModel,
+      loader: async () =>
+        (
+          await import(
+            './components/taskruns/list-page/TaskRunsListPage' /* webpackChunkName: "taskrun-resource-list" */
+          )
+        ).default,
+    },
+  },
+  {
     type: 'Perspective',
     properties: {
       id: 'dev',


### PR DESCRIPTION
**JIRA story:**
https://issues.redhat.com/browse/ODC-4800

**Solution Description:**
- added `Task Runs` tab in the pipelineRun details page which lists all the Task Runs associated with the Pipeline Run
- Added columns `pipeline` , `task` & `pod`  & removed `duration`
- The pipeline column is not shown in the TaskRun Tab under Pipeline Run details page
- fixed the TaskRun list in the Search page
- added tests for `TaskRunsRow`

**GIF/Screenshots:**
![PDtaskruns](https://user-images.githubusercontent.com/22490998/96102292-fd090280-0ef3-11eb-8e8f-01a2547610b2.png)
![taskruns1](https://user-images.githubusercontent.com/22490998/95115541-47a3b580-0763-11eb-8146-96afdb15e647.png)
![TaskRuns](https://user-images.githubusercontent.com/22490998/96102314-05613d80-0ef4-11eb-9ce7-4d9a018f25a0.gif)
![all-pro](https://user-images.githubusercontent.com/22490998/95191629-a104f680-07ee-11eb-8ebf-adc6547e7430.gif)
![search](https://user-images.githubusercontent.com/22490998/95191642-a4987d80-07ee-11eb-9f30-be1684f05ee6.png)

**Test Coverage:**
![test1](https://user-images.githubusercontent.com/22490998/96110275-427dfd80-0efd-11eb-83c5-d4709227ab0f.png)
