### PR TITLE
Don't attempt to retrieve pipeline data in topology when unsupported

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -18,7 +18,6 @@ import {
   TYPE_KNATIVE_REVISION,
 } from '@console/knative-plugin/src/topology/const';
 import { edgesFromAnnotations } from '../../../utils/application-utils';
-import { tknPipelineAndPipelineRunsWatchResources } from '../../../utils/pipeline-plugin-utils';
 import {
   TopologyDataObject,
   TopologyOverviewItem,
@@ -435,6 +434,5 @@ export const getBaseWatchedResources = (namespace: string): WatchK8sResources<an
       namespace,
       optional: true,
     },
-    ...tknPipelineAndPipelineRunsWatchResources(namespace),
   };
 };

--- a/frontend/packages/dev-console/src/components/topology/pipelines/pipelinesTopologyPlugin.ts
+++ b/frontend/packages/dev-console/src/components/topology/pipelines/pipelinesTopologyPlugin.ts
@@ -1,0 +1,25 @@
+import { Plugin } from '@console/plugin-sdk';
+import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { TopologyDataModelFactory } from '../../../extensions/topology';
+import { tknPipelineAndPipelineRunsWatchResources } from '../../../utils/pipeline-plugin-utils';
+import { FLAG_OPENSHIFT_PIPELINE } from '../../../const';
+
+export type PipelineTopologyConsumedExtensions = TopologyDataModelFactory;
+
+const getPipelineWatchedResources = (namespace: string): WatchK8sResources<any> => {
+  return tknPipelineAndPipelineRunsWatchResources(namespace);
+};
+
+export const pipelinesTopologyPlugin: Plugin<PipelineTopologyConsumedExtensions> = [
+  {
+    type: 'Topology/DataModelFactory',
+    properties: {
+      id: 'pipeline-topology-model-factory',
+      priority: 800,
+      resources: getPipelineWatchedResources,
+    },
+    flags: {
+      required: [FLAG_OPENSHIFT_PIPELINE],
+    },
+  },
+];

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -70,6 +70,7 @@ import {
   OperatorsTopologyConsumedExtensions,
   operatorsTopologyPlugin,
 } from './components/topology/operators/operatorsTopologyPlugin';
+import { pipelinesTopologyPlugin } from './components/topology/pipelines/pipelinesTopologyPlugin';
 import { usePerspectiveDetection } from './utils/usePerspectiveDetection';
 import { getGuidedTour } from './components/guided-tour';
 
@@ -1176,6 +1177,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   },
   ...helmTopologyPlugin,
   ...operatorsTopologyPlugin,
+  ...pipelinesTopologyPlugin,
 ];
 
 export default plugin;


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4971

**Description**
Do not attempt to retrieve pipeline resources for topology when not supported.
Non-functional change

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup