### PR TITLE
Add Vulnerabilities tab in project details page

### DIFF
--- a/frontend/packages/console-shared/src/components/badges/EmptyStateResourceBadge.scss
+++ b/frontend/packages/console-shared/src/components/badges/EmptyStateResourceBadge.scss
@@ -1,0 +1,10 @@
+.ocs-empty-state-resource-badge {
+  margin-bottom: var(--pf-global--spacer--md);
+  &--badge {
+    &.pf-c-badge {
+      color: var(--pf-global--palette--white);
+      font-size: var(--pf-global--icon--FontSize--md);
+      background-color: var(--pf-global--Color--400);
+    }
+  }
+}

--- a/frontend/packages/console-shared/src/components/badges/EmptyStateResourceBadge.tsx
+++ b/frontend/packages/console-shared/src/components/badges/EmptyStateResourceBadge.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Badge } from '@patternfly/react-core';
+import { K8sKind, kindToAbbr } from '@console/internal/module/k8s';
+import './EmptyStateResourceBadge.scss';
+
+type EmptyStateResourceBadgeProps = {
+  model: K8sKind;
+};
+
+const EmptyStateResourceBadge: React.FC<EmptyStateResourceBadgeProps> = ({ model }) => (
+  <div className="ocs-empty-state-resource-badge">
+    <Badge className="ocs-empty-state-resource-badge--badge" isRead>
+      {model.abbr || kindToAbbr(model.kind)}
+    </Badge>
+  </div>
+);
+
+export default EmptyStateResourceBadge;

--- a/frontend/packages/console-shared/src/components/badges/index.ts
+++ b/frontend/packages/console-shared/src/components/badges/index.ts
@@ -1,4 +1,5 @@
 export * from './badge-factory';
 export { default as DevPreviewBadge } from './DevPreviewBadge';
 export { default as TechPreviewBadge } from './TechPreviewBadge';
+export { default as EmptyStateResourceBadge } from './EmptyStateResourceBadge';
 export * from './InlineBadge';

--- a/frontend/packages/container-security/locales/en/container-security.json
+++ b/frontend/packages/container-security/locales/en/container-security.json
@@ -1,0 +1,23 @@
+{
+  "Vulnerability": "Vulnerability",
+  "Severity": "Severity",
+  "Package": "Package",
+  "Current Version": "Current Version",
+  "Fixed in Version": "Fixed in Version",
+  "Quay Security Scanner has detected {{total, number}} vulnerabilities.": "Quay Security Scanner has detected {{total, number}} vulnerabilities.",
+  "Patches are available for {{fixableCount, number}} vulnerabilities.": "Patches are available for {{fixableCount, number}} vulnerabilities.",
+  "{{title}} vulnerabilities": "{{title}} vulnerabilities",
+  "Affected Pods": "Affected Pods",
+  "Image Name": "Image Name",
+  "Namespace": "Namespace",
+  "Highest Severity": "Highest Severity",
+  "Fixable": "Fixable",
+  "Total": "Total",
+  "Manifest": "Manifest",
+  "No Image Vulnerabilities found": "No Image Vulnerabilities found",
+  "Image Manifest Vulnerabilities": "Image Manifest Vulnerabilities",
+  "Container": "Container",
+  "Image": "Image",
+  "Security Scan": "Security Scan",
+  "No vulnerabilities found": "No vulnerabilities found"
+}

--- a/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
+++ b/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
@@ -10,9 +10,18 @@ import {
   ImageVulnerabilitiesTableProps,
   ImageManifestVulnDetails,
   ImageManifestVulnDetailsProps,
+  totalCount,
 } from '../image-manifest-vuln';
 import { fakeVulnFor } from '../../../integration-tests/bad-pods';
 import { Priority, vulnPriority, totalFor, priorityFor } from '../../const';
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
 
 describe(ImageVulnerabilityRow.displayName, () => {
   let wrapper: ShallowWrapper<ImageVulnerabilityRowProps>;
@@ -47,6 +56,20 @@ describe(ImageVulnerabilitiesTable.displayName, () => {
       .find(ImageVulnerabilityRow)
       .map((r) => priorityFor(r.props().vulnerability.severity).index);
     expect(indexes).toEqual(_.sortBy(indexes));
+  });
+});
+
+describe('totalCount', () => {
+  it('should return 0 if vuln status not present', () => {
+    const vuln = fakeVulnFor(Priority.Critical);
+    delete vuln.status;
+    const tCount = totalCount(vuln);
+    expect(tCount).toBe(0);
+  });
+  it('Total vuln should be 2', () => {
+    const vuln = fakeVulnFor(Priority.Critical);
+    const tCount = totalCount(vuln);
+    expect(tCount).toBe(2);
   });
 });
 

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -17,7 +17,7 @@ import { ImageManifestVulnModel } from './models';
 import { ContainerSecurityFlag } from './const';
 import { securityHealthHandler } from './components/summary';
 import { WatchImageVuln } from './types';
-import { PodModel } from '@console/internal/models';
+import { NamespaceModel, PodModel, ProjectModel } from '@console/internal/models';
 
 type ConsumedExtensions =
   | ModelDefinition
@@ -143,6 +143,40 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/image-manifest-vuln' /* webpackChunkName: "container-security" */
         ).then((m) => m.ImageManifestVulnPodTab),
+    },
+    flags: {
+      required: [ContainerSecurityFlag],
+    },
+  },
+  {
+    type: 'HorizontalNavTab',
+    properties: {
+      model: ProjectModel,
+      page: {
+        name: 'Vulnerabilities',
+        href: 'vulnerabilities',
+      },
+      loader: () =>
+        import(
+          './components/image-manifest-vuln' /* webpackChunkName: "project-image-vuln-list" */
+        ).then((m) => m.ProjectImageManifestVulnListPage),
+    },
+    flags: {
+      required: [ContainerSecurityFlag],
+    },
+  },
+  {
+    type: 'HorizontalNavTab',
+    properties: {
+      model: NamespaceModel,
+      page: {
+        name: 'Vulnerabilities',
+        href: 'vulnerabilities',
+      },
+      loader: () =>
+        import(
+          './components/image-manifest-vuln' /* webpackChunkName: "project-image-vuln-list" */
+        ).then((m) => m.ProjectImageManifestVulnListPage),
     },
     flags: {
       required: [ContainerSecurityFlag],

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -274,6 +274,7 @@ export const tableFilters: TableFilterMap = {
     return statuses.selected.has(status) || !_.includes(statuses.all, status);
   },
   'node-disk-name': (name, disks) => fuzzyCaseInsensitive(name, disks?.path),
+  'image-name': (str, imageManifestVuln) => fuzzyCaseInsensitive(str, imageManifestVuln.spec.image),
 };
 
 export interface TableFilterGroups {

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -98,6 +98,7 @@ i18n
         'workload',
         'devconsole',
         'knative-plugin',
+        'container-security',
       ],
       defaultNS: 'public',
       nsSeparator: '~',

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -205,6 +205,7 @@ const config: Configuration = {
     ]),
     new CopyWebpackPlugin([{ from: './packages/dev-console/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/knative-plugin/locales', to: 'locales' }]),
+    new CopyWebpackPlugin([{ from: './packages/container-security/locales', to: 'locales' }]),
     new MomentLocalesPlugin({
       localesToKeep: Object.keys(SUPPORTED_LOCALES).map((key) => (key === 'zh' ? 'zh-cn' : key)),
     }),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4882

**Description**: 
1. Show Vulnerabilities tab for each Project
2. Vulnerabilities tab should show list of IMVs (Image Manifest Vulnerability) for each Project
3. Click on IMV should redirect to details view for IMVs

**Screen shots / Gifs for design review**: 
<img width="1513" alt="Screenshot 2020-11-03 at 7 06 10 PM" src="https://user-images.githubusercontent.com/2561818/97991890-00632000-1e08-11eb-8f38-be0256db98a1.png">
<img width="1503" alt="Screenshot 2020-11-03 at 7 06 48 PM" src="https://user-images.githubusercontent.com/2561818/97991900-048f3d80-1e08-11eb-8052-bda1d7e2ec39.png">

<img width="1516" alt="Screenshot 2020-11-03 at 11 25 02 AM" src="https://user-images.githubusercontent.com/2561818/97953895-e1dd3480-1dc7-11eb-8c04-870727859bf1.png">


![Kapture 2020-11-03 at 19 07 52](https://user-images.githubusercontent.com/2561818/97991920-0c4ee200-1e08-11eb-8eb5-38cacbe114b4.gif)




**Unit test coverage report**: 
<img width="876" alt="Screenshot 2020-10-08 at 6 26 54 PM" src="https://user-images.githubusercontent.com/2561818/95461482-e7478a80-0993-11eb-9f77-2f12ac5a2cde.png">


**Test setup:**
Install Quay Container Security operator to see the Vulnerabilities.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge