### PR TITLE
Bug 1908598: Fix events filter for persitent dashboard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -20,6 +20,7 @@ export const ATTACHED_DEVICES_ANNOTATION = 'cluster.ocs.openshift.io/local-devic
 export const DASHBOARD_LINK = '/dashboards/persistent-storage';
 export const AVAILABLE = 'Available';
 export const OSD_REMOVAL_TEMPLATE = 'ocs-osd-removal';
+export const PVC_PROVISIONER_ANNOTATION = 'volume.beta.kubernetes.io/storage-provisioner';
 export const dropdownUnits = {
   GiB: 'Gi',
   TiB: 'Ti',

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -1,11 +1,17 @@
 import { FirehoseResource } from '@console/internal/components/utils/index';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
 import { PrometheusEndpoint } from '@console/internal/components/graphs/helpers';
-import { PersistentVolumeModel, StorageClassModel, NodeModel } from '@console/internal/models';
+import {
+  PersistentVolumeModel,
+  StorageClassModel,
+  NodeModel,
+  PersistentVolumeClaimModel,
+  EventModel,
+} from '@console/internal/models';
 import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { SubscriptionModel } from '@console/operator-lifecycle-manager';
 import { LocalVolumeDiscoveryResult } from '@console/local-storage-operator-plugin/src/models';
-import { CephClusterModel, CephBlockPoolModel } from '../models';
+import { CephClusterModel, CephBlockPoolModel, OCSServiceModel } from '../models';
 import { CEPH_STORAGE_NAMESPACE } from '.';
 import { CAPACITY_USAGE_QUERIES, StorageDashboardQuery } from './queries';
 
@@ -22,6 +28,12 @@ export const pvResource: WatchK8sResource = {
   isList: true,
 };
 
+export const pvcResource: FirehoseResource = {
+  isList: true,
+  kind: PersistentVolumeClaimModel.kind,
+  prop: 'pvcs',
+};
+
 export const scResource: WatchK8sResource = {
   kind: StorageClassModel.kind,
   namespaced: false,
@@ -32,6 +44,13 @@ export const LSOSubscriptionResource: WatchK8sResource = {
   kind: referenceForModel(SubscriptionModel),
   fieldSelector: 'metadata.name=local-storage-operator',
   isList: true,
+};
+
+export const subscriptionResource: FirehoseResource = {
+  isList: true,
+  kind: referenceForModel(SubscriptionModel),
+  namespaced: false,
+  prop: 'subs',
 };
 
 export const cephBlockPoolResource: WatchK8sResource = {
@@ -57,4 +76,17 @@ export const nodesDiscoveriesResource: WatchK8sResource = {
   kind: referenceForModel(LocalVolumeDiscoveryResult),
   namespaced: false,
   isList: true,
+};
+
+export const storageClusterResource: FirehoseResource = {
+  isList: true,
+  kind: referenceForModel(OCSServiceModel),
+  namespaced: false,
+  prop: 'storage-cluster',
+};
+
+export const eventsResource: FirehoseResource = {
+  isList: true,
+  kind: EventModel.kind,
+  prop: 'events',
 };


### PR DESCRIPTION
- Activity card component cleanup
- Filters the PVC event only for `volume.beta.kubernetes.io/storage-provisioner: (ceph provisioner)` PVCs

Jira: https://issues.redhat.com/browse/RHSTOR-1106
Signed-off-by: Kanika Murarka <kmurarka@redhat.com>