### PR TITLE
Bug 1856354: Keep swagger definitions up to date

### DIFF
--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -11,7 +11,7 @@ import { k8sList, k8sWatch, k8sGet } from '../module/k8s/resource';
 import { makeReduxID } from '../components/utils/k8s-watcher';
 import { APIServiceModel } from '../models';
 import { coFetchJSON } from '../co-fetch';
-import { referenceForModel, K8sResourceKind, K8sKind } from '../module/k8s';
+import { referenceForModel, K8sResourceKind, K8sKind, fetchSwagger } from '../module/k8s';
 
 export enum ActionType {
   ReceivedResources = 'resources',
@@ -65,7 +65,10 @@ export const getResources = () => (dispatch: Dispatch) => {
       dispatch(receivedResources(resources));
     })
     // eslint-disable-next-line no-console
-    .catch((err) => console.error(err));
+    .catch((err) => console.error(err))
+    .finally(() => {
+      setTimeout(fetchSwagger, 10000);
+    });
 };
 
 export const filterList = (id: string, name: string, value: string) =>

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -222,8 +222,10 @@ graphQLReady.onReady(() => {
   // Global timer to ensure all <Timestamp> components update in sync
   setInterval(() => store.dispatch(UIActions.updateTimestamps(Date.now())), 10000);
 
-  // Fetch swagger on load if it's stale.
+  // Fetch swagger definitions immediately upon application start
   fetchSwagger();
+  // then poll swagger definitions every 5 minutes to ensure they stay up to date
+  setInterval(fetchSwagger, 5 * 60 * 1000);
 
   // Used by GUI tests to check for unhandled exceptions
   window.windowError = null;


### PR DESCRIPTION
Poll k8s openapi/v2 endpoint every 5 minutes and every time API discovery occurs to ensure swagger definitions stay up to date.