### PR TITLE
Append '\n' to ssh private key, if it ends without one.

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -920,7 +920,9 @@ export class SSHAuthSubform extends React.Component<SSHAuthSubformProps, SSHAuth
   changeData(event) {
     this.setState(
       {
-        'ssh-privatekey': event.target.value,
+        'ssh-privatekey': event.target.value.endsWith('\n')
+          ? event.target.value
+          : `${event.target.value}\n`,
       },
       () => this.props.onChange(this.state),
     );
@@ -928,7 +930,7 @@ export class SSHAuthSubform extends React.Component<SSHAuthSubformProps, SSHAuth
   onFileChange(fileData) {
     this.setState(
       {
-        'ssh-privatekey': fileData,
+        'ssh-privatekey': fileData.endsWith('\n') ? fileData : `${fileData}\n`,
       },
       () => this.props.onChange(this.state),
     );


### PR DESCRIPTION
Source code checkout will fail if an ssh private key is created
without a newline as the last character.

Fixes: #6858