### PR TITLE
Bug 1854567: Dont list Subscrition when matching CSV exists on the Installed Operators page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -648,7 +648,7 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
       ),
     ].filter(
       (obj, i, all) =>
-        isSubscription(obj) ||
+        isCSV(obj) ||
         _.isUndefined(
           all.find(({ metadata }) =>
             [_.get(obj, 'status.currentCSV'), _.get(obj, 'spec.startingCSV')].includes(


### PR DESCRIPTION
The logic here is vice versa, meaning the if the tested **obj**ect is CSV it should be filtered out **OR** if the Subscription 's `currentCSV` and `startingCSV` is in any CSV's `metadata.name`.

/assign @TheRealJon 