### PR TITLE
fix pod donut information

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRingSet.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRingSet.tsx
@@ -33,7 +33,7 @@ const PodRingSet: React.FC<PodRingSetProps> = ({ podData, resourceKind, obj, pat
         <PodRing
           key={inProgressDeploymentData ? 'deploy' : 'notDeploy'}
           pods={completedDeploymentData}
-          rc={completedRC}
+          rc={podData.isRollingOut ? completedRC : undefined}
           resourceKind={resourceKind}
           obj={obj}
           path={path}

--- a/frontend/packages/console-shared/src/constants/resource.ts
+++ b/frontend/packages/console-shared/src/constants/resource.ts
@@ -30,6 +30,7 @@ export const TRIGGERS_ANNOTATION = 'image.openshift.io/triggers';
 export enum DEPLOYMENT_STRATEGY {
   rolling = 'Rolling',
   recreate = 'Recreate',
+  rollingUpdate = 'RollingUpdate',
 }
 
 export enum DEPLOYMENT_PHASE {

--- a/frontend/packages/console-shared/src/utils/pod-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-utils.ts
@@ -193,7 +193,9 @@ export const getPodData = (
 
   // Deploy - Rolling - Recreate
   if (
-    (strategy === DEPLOYMENT_STRATEGY.recreate || strategy === DEPLOYMENT_STRATEGY.rolling) &&
+    (strategy === DEPLOYMENT_STRATEGY.recreate ||
+      strategy === DEPLOYMENT_STRATEGY.rolling ||
+      strategy === DEPLOYMENT_STRATEGY.rollingUpdate) &&
     isRollingOut
   ) {
     return {

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -96,8 +96,8 @@ export const mergeData = (originalResource: K8sResourceKind, newResource: K8sRes
   if (mergedData.spec?.template?.spec?.containers) {
     mergedData.spec.template.spec.containers = newResource.spec.template.spec.containers;
   }
-  if (mergedData?.spec?.strategy) {
-    mergedData.spec.strategy = newResource.spec.strategy;
+  if (mergedData?.spec?.hasOwnProperty('strategy')) {
+    mergedData.spec.strategy = newResource.spec?.strategy ?? originalResource?.spec?.strategy;
   }
   if (mergedData.spec?.triggers) {
     mergedData.spec.triggers = newResource.spec.triggers;


### PR DESCRIPTION
**fixes:**
https://issues.redhat.com/browse/ODC-3292

**root analysis:**
- rc should be read only when there is a rolling out taking place

**Solution Description:**
- read from the resource obj data when there is no rolling out happening
- show multiple rings for multiple replica set
- fixed the issue where update strategy resets to RollingUpdate in the edit flow after manually updating the strategy to Recreate

**Screeshot:**
- Scenario 1: While creating an app set the scaling to 2 & RL to 0,1,0,1
![scenario1-rolling](https://user-images.githubusercontent.com/22490998/95432791-bdc73880-096c-11eb-949b-56ebdd5857ac.png)

Edit the update strategy to Recreate
![scenario1 -recreate](https://user-images.githubusercontent.com/22490998/95432859-d46d8f80-096c-11eb-976f-2eabaf04582f.png)

- Scenario 2: Create an app, edit the app to set the scaling to 2 & RL to 0,1,0,1
![scenario2-rolling](https://user-images.githubusercontent.com/22490998/95432895-e3544200-096c-11eb-9d5a-2b1d358c2608.png)

Edit the update strategy to Recreate
![scenario2-recreate](https://user-images.githubusercontent.com/22490998/95432915-ebac7d00-096c-11eb-9b3b-c579c39c7abb.png)

- Scenario 3: Create an app (DC), edit the app to set the scaling to 2 & RL to 0,1,0,1
![sceanrio2-DC](https://user-images.githubusercontent.com/22490998/95433039-13034a00-096d-11eb-8cfa-9c3a0bf6df92.png)
 
