### PR TITLE
Add Node qualifier to Affinity table

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -84,6 +84,7 @@ export const Status: React.FC<StatusProps> = ({
     case 'Ready':
     case 'Up to date':
     case 'Provisioned as node':
+    case 'Preferred':
       return <SuccessStatus {...statusProps} />;
 
     case 'Info':

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import {
   Form,
   FormSelect,
@@ -15,18 +14,15 @@ import { ModalBody } from '@console/internal/components/factory';
 import { ValidationErrorType } from '@console/shared';
 import { isLoaded } from '../../../../../../utils';
 import { ModalFooter } from '../../../../modal/modal-footer';
-import {
-  AFFINITY_TYPE_LABLES,
-  AFFINITY_CONDITIONS,
-  AFFINITY_CONDITION_LABELS,
-} from '../../../shared/consts';
+import { AFFINITY_TYPE_LABLES, AFFINITY_CONDITION_LABELS } from '../../../shared/consts';
 import { FormRow } from '../../../../../form/form-row';
 import { isWeightValid, isTermsInvalid, getTopologyKeyValidation } from '../../validations';
 import { useIDEntities } from '../../../../../../hooks/use-id-entities';
 import { NodeChecker } from '../../../shared/NodeChecker/node-checker';
 import { useNodeQualifier } from '../../../shared/hooks';
-import { AffinityLabel, AffinityRowData } from '../../types';
+import { AffinityCondition, AffinityLabel, AffinityRowData } from '../../types';
 import { AffinityExpressionList } from '../affinity-expression-list/affinity-expression-list';
+import { getIntersectedQualifiedNodes } from '../../helpers';
 import './affinity-edit.scss';
 
 export const AffinityEdit: React.FC<AffinityEditProps> = ({
@@ -78,19 +74,6 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
 
   const qualifiedExpressionNodes = useNodeQualifier(nodes, 'label', affinityExpressions);
   const qualifiedFieldNodes = useNodeQualifier(nodes, 'field', affinityFields);
-
-  const getQualifiedNodes = () => {
-    if (affinityExpressions.length > 0 && affinityFields.length > 0) {
-      return _.intersection(qualifiedExpressionNodes, qualifiedFieldNodes);
-    }
-    if (affinityExpressions.length > 0) {
-      return qualifiedExpressionNodes;
-    }
-    if (affinityFields.length > 0) {
-      return qualifiedFieldNodes;
-    }
-    return [];
-  };
 
   const isExpressionsInvalid = isTermsInvalid(affinityExpressions);
   const isFieldsInvalid = isTermsInvalid(affinityFields);
@@ -150,18 +133,18 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
               isDisabled={isDisabled}
             >
               <FormSelectOption
-                key={AFFINITY_CONDITIONS.preferred}
-                value={AFFINITY_CONDITIONS.preferred}
-                label={AFFINITY_CONDITION_LABELS[AFFINITY_CONDITIONS.preferred]}
+                key={AffinityCondition.preferred}
+                value={AffinityCondition.preferred}
+                label={AFFINITY_CONDITION_LABELS[AffinityCondition.preferred]}
               />
               <FormSelectOption
-                key={AFFINITY_CONDITIONS.required}
-                value={AFFINITY_CONDITIONS.required}
-                label={AFFINITY_CONDITION_LABELS[AFFINITY_CONDITIONS.required]}
+                key={AffinityCondition.required}
+                value={AffinityCondition.required}
+                label={AFFINITY_CONDITION_LABELS[AffinityCondition.required]}
               />
             </FormSelect>
           </FormRow>
-          {focusedAffinity?.condition === AFFINITY_CONDITIONS.preferred && (
+          {focusedAffinity?.condition === AffinityCondition.preferred && (
             <FormRow
               title="Weight"
               fieldId={'weight'}
@@ -284,8 +267,16 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
                   rowID="affinity-field"
                 />
               </FormRow>
-              {(affinityExpressions.length > 0 || affinityFields.length > 0) &&
-                !isAffinityInvalid && <NodeChecker qualifiedNodes={getQualifiedNodes()} />}
+              {(affinityExpressions.length > 0 || affinityFields.length > 0) && !isAffinityInvalid && (
+                <NodeChecker
+                  qualifiedNodes={getIntersectedQualifiedNodes({
+                    expressionNodes: qualifiedExpressionNodes,
+                    fieldNodes: qualifiedFieldNodes,
+                    expressions: affinityExpressions,
+                    fields: affinityFields,
+                  })}
+                />
+              )}
             </>
           )}
         </Form>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/types.ts
@@ -1,6 +1,17 @@
 import { Selector } from '@console/internal/module/k8s';
 import { IDEntity } from '../../../../types';
 
+export enum AffinityType {
+  node = 'nodeAffinity',
+  pod = 'podAffinity',
+  podAnti = 'podAntiAffinity',
+}
+
+export enum AffinityCondition {
+  required = 'requiredDuringSchedulingIgnoredDuringExecution',
+  preferred = 'preferredDuringSchedulingIgnoredDuringExecution',
+}
+
 export type MatchExpression =
   | { key: string; operator: 'Exists' | 'DoesNotExist' }
   | {
@@ -28,8 +39,8 @@ export type PreferredNodeAffinityTerm = {
 };
 
 export type NodeAffinity = {
-  preferredDuringSchedulingIgnoredDuringExecution?: PreferredNodeAffinityTerm[];
-  requiredDuringSchedulingIgnoredDuringExecution?: RequiredNodeAffinityTerm;
+  [AffinityCondition.preferred]?: PreferredNodeAffinityTerm[];
+  [AffinityCondition.required]?: RequiredNodeAffinityTerm;
 };
 
 export type PodAffinityTerm = {
@@ -44,8 +55,8 @@ export type PreferredPodAffinityTerm = {
 };
 
 export type PodAffinity = {
-  preferredDuringSchedulingIgnoredDuringExecution: PreferredPodAffinityTerm[];
-  requiredDuringSchedulingIgnoredDuringExecution: PodAffinityTerm[];
+  [AffinityCondition.preferred]: PreferredPodAffinityTerm[];
+  [AffinityCondition.required]: PodAffinityTerm[];
 };
 
 export type Affinity = {
@@ -62,10 +73,8 @@ export type AffinityLabel = IDEntity & {
 
 export type AffinityRowData = {
   id: string;
-  type: 'nodeAffinity' | 'podAffinity' | 'podAntiAffinity';
-  condition:
-    | 'requiredDuringSchedulingIgnoredDuringExecution'
-    | 'preferredDuringSchedulingIgnoredDuringExecution';
+  type: AffinityType;
+  condition: AffinityCondition;
   weight?: number;
   topologyKey?: string;
   expressions?: AffinityLabel[];

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/validations.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/validations.ts
@@ -1,8 +1,7 @@
-import { AFFINITY_CONDITIONS } from '../shared/consts';
-import { AffinityRowData, AffinityLabel } from './types';
+import { AffinityRowData, AffinityLabel, AffinityCondition, AffinityType } from './types';
 
 export const isWeightValid = (focusedAffinity: AffinityRowData) =>
-  focusedAffinity.condition === AFFINITY_CONDITIONS.required ||
+  focusedAffinity.condition === AffinityCondition.required ||
   (focusedAffinity.weight > 0 && focusedAffinity.weight <= 100);
 
 export const isTermsInvalid = (terms: AffinityLabel[]) =>
@@ -18,15 +17,15 @@ export const getTopologyKeyValidation = ({ type, condition, topologyKey }: Affin
     topologyValidationMessage: '',
   };
 
-  if (condition === AFFINITY_CONDITIONS.required) {
-    if (type === 'podAffinity') {
+  if (condition === AffinityCondition.required) {
+    if (type === AffinityType.pod) {
       topology.topologyValidationMessage = 'Topology key must not be empty';
       topology.isTopologyInvalid = !topologyKey;
     } else {
       topology.isTopologyDisabled = true;
       topology.topologyValidationMessage = 'topologyKey is limited with current config';
     }
-  } else if (type === 'podAntiAffinity') {
+  } else if (type === AffinityType.podAnti) {
     topology.topologyValidationMessage = 'Empty topologyKey is interpreted as “all topologies”';
   }
   return topology;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/NodeChecker/node-checker.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/NodeChecker/node-checker.scss
@@ -5,6 +5,13 @@
   .co-external-link {
     display: flex;
     justify-content: space-between;
+    min-width: 110px;
     align-items: center;
+  }
+  .kv-node-checker__preferred-status{
+    display: flex;
+    justify-content: flex-end;
+    margin-left: var(--pf-global--spacer--md);
+    padding-right: var(--pf-global--spacer--md);
   }
 }

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/consts.ts
@@ -1,10 +1,14 @@
+import { AffinityCondition, AffinityType } from '../affinity-modal/types';
 import { pluralize } from '@console/internal/components/utils';
-import { AffinityRowData } from '../affinity-modal/types';
 
 // Node Checker
 const pluralNode = (size) => pluralize(size, 'node', 'nodes', false);
 export const SCHEDULING_NODES_MATCH_TEXT = (nodeAmount) =>
   `${nodeAmount} matching ${pluralNode(nodeAmount)} found`;
+export const SCHEDULING_WITH_PREFERRED_NODES_MATCH_TEXT = (nodeAmount, preferredNodeAmount) =>
+  `${nodeAmount} matching ${pluralNode(
+    nodeAmount,
+  )} found, ${preferredNodeAmount} matching preferred ${pluralNode(preferredNodeAmount)} found`;
 export const SCHEDULING_NODES_MATCH_BUTTON_TEXT = (nodeAmount) =>
   `View ${nodeAmount} matching ${pluralNode(nodeAmount)}`;
 export const SCHEDULING_NO_NODES_MATCH_BUTTON_TEXT =
@@ -34,19 +38,14 @@ export const AFFINITY_CREATE = 'New Affinity';
 export const AFFINITY_EDITING = 'Edit Affinity';
 
 export const AFFINITY_CONDITION_LABELS = {
-  preferredDuringSchedulingIgnoredDuringExecution: 'Preferred during scheduling',
-  requiredDuringSchedulingIgnoredDuringExecution: 'Required during scheduling',
-};
-
-export const AFFINITY_CONDITIONS = {
-  preferred: 'preferredDuringSchedulingIgnoredDuringExecution' as AffinityRowData['condition'],
-  required: 'requiredDuringSchedulingIgnoredDuringExecution' as AffinityRowData['condition'],
+  [AffinityCondition.preferred]: 'Preferred during scheduling',
+  [AffinityCondition.required]: 'Required during scheduling',
 };
 
 export const AFFINITY_TYPE_LABLES = {
-  nodeAffinity: 'Node Affinity',
-  podAffinity: 'Workload (pod) Affinity',
-  podAntiAffinity: 'Workload (pod) Anti-Affinity',
+  [AffinityType.node]: 'Node Affinity',
+  [AffinityType.pod]: 'Workload (pod) Affinity',
+  [AffinityType.podAnti]: 'Workload (pod) Anti-Affinity',
 };
 
 export const EXPRESSION_OPERATORS = ['In', 'NotIn', 'Exists', 'DoesNotExist'];

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/hooks.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/hooks.ts
@@ -5,6 +5,7 @@ import { NodeKind } from '@console/internal/module/k8s';
 import { getLabels, getNodeTaints } from '@console/shared';
 import { getLoadedData, isLoaded } from '../../../../utils';
 import { IDLabel } from '../../../LabelsList/types';
+import { AffinityRowData } from '../affinity-modal/types';
 
 const withOperatorPredicate = <T extends IDLabel = IDLabel>(store: any, label: T) => {
   const { key, value, values, operator } = label;
@@ -41,7 +42,7 @@ export const useNodeQualifier = <T extends IDLabel = IDLabel>(
   React.useEffect(() => {
     const filteredConstraints = constraints.filter(({ key }) => !!key);
     if (!_.isEmpty(filteredConstraints) && isNodesLoaded) {
-      const filteredNodes = [];
+      const suitableNodes = [];
       loadedNodes.forEach((node) => {
         if (constraintType === 'label') {
           const nodeLabels = getLabels(node);
@@ -49,14 +50,14 @@ export const useNodeQualifier = <T extends IDLabel = IDLabel>(
             nodeLabels &&
             filteredConstraints.every((label) => withOperatorPredicate<T>(nodeLabels, label))
           ) {
-            filteredNodes.push(node);
+            suitableNodes.push(node);
           }
         }
         if (
           constraintType === 'field' &&
           filteredConstraints.every((field) => withOperatorPredicate<T>(node, field))
         ) {
-          filteredNodes.push(node);
+          suitableNodes.push(node);
         }
 
         if (constraintType === 'taint') {
@@ -70,15 +71,40 @@ export const useNodeQualifier = <T extends IDLabel = IDLabel>(
               ),
             )
           ) {
-            filteredNodes.push(node);
+            suitableNodes.push(node);
           }
         }
       });
-      setQualifiedNodes(filteredNodes);
+      setQualifiedNodes(suitableNodes);
     }
   }, [constraintType, constraints, loadedNodes, isNodesLoaded]);
 
   return qualifiedNodes;
+};
+
+export const useAffinitiesQualifiedNodes = (
+  nodes: FirehoseResult<NodeKind[]>,
+  affinities: AffinityRowData[],
+  filter: (nodes: NodeKind[][]) => NodeKind[],
+): NodeKind[] => {
+  const loadedNodes = getLoadedData(nodes, []);
+  const isNodesLoaded = isLoaded(nodes);
+
+  return React.useMemo(() => {
+    if (isNodesLoaded) {
+      const suitableNodes = affinities.map((aff) =>
+        loadedNodes.filter(
+          (node) =>
+            getLabels(node) &&
+            (aff?.expressions || []).every((exp) => withOperatorPredicate(getLabels(node), exp)) &&
+            (aff?.fields || []).every((field) => withOperatorPredicate(node, field)),
+        ),
+      );
+      // OR/AND relation between nodes
+      return filter(suitableNodes);
+    }
+    return [];
+  }, [affinities, filter, isNodesLoaded, loadedNodes]);
 };
 
 export type NodeQualifierPropertyType = 'label' | 'taint' | 'field';

--- a/frontend/packages/kubevirt-plugin/src/selectors/affinity/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/affinity/selectors.ts
@@ -1,25 +1,26 @@
 // import * as _ from 'lodash';
 import {
+  AffinityCondition,
   NodeAffinity,
   PodAffinity,
 } from '../../components/modals/scheduling-modals/affinity-modal/types';
 
 export const getRequiredScheduling = (affinity: NodeAffinity | PodAffinity) =>
-  affinity?.requiredDuringSchedulingIgnoredDuringExecution;
+  affinity?.[AffinityCondition.required];
 
 export const getPreferredScheduling = (affinity: NodeAffinity | PodAffinity) =>
-  affinity?.preferredDuringSchedulingIgnoredDuringExecution;
+  affinity?.[AffinityCondition.preferred];
 
 // Node Affinity
 export const getNodeAffinityRequiredTerms = (affinity: NodeAffinity) =>
-  affinity?.requiredDuringSchedulingIgnoredDuringExecution?.nodeSelectorTerms;
+  affinity?.[AffinityCondition.required]?.nodeSelectorTerms;
 
 export const getNodeAffinityPreferredTerms = (affinity: NodeAffinity) =>
-  affinity?.preferredDuringSchedulingIgnoredDuringExecution;
+  affinity?.[AffinityCondition.preferred];
 
 // Pod Affinity
 export const getPodAffinityRequiredTerms = (affinity: PodAffinity) =>
-  affinity?.requiredDuringSchedulingIgnoredDuringExecution;
+  affinity?.[AffinityCondition.required];
 
 export const getPodAffinityPreferredTerms = (affinity: PodAffinity) =>
-  affinity?.preferredDuringSchedulingIgnoredDuringExecution;
+  affinity?.[AffinityCondition.preferred];


### PR DESCRIPTION
* Fixed a bug where new affinities didn't have `id`
* Fixed Node count in Affinity Edit, by creating `getIntersectedQualifiedNodes`
* Added ability to `NodeChecker` which can display qualified preferred nodes aside from qualified required nodes. Preferred nodes are always taken out of the required qualified nodes pool.

![image](https://user-images.githubusercontent.com/24938324/95438842-856d2d80-095f-11eb-80a2-4f5ad728fde0.png)
