### PR TITLE
Add events tab in pipelinerun and taskrun details page

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -8,6 +8,7 @@ import { PipelineRunLogsWithActiveTask } from './detail-page-tabs/PipelineRunLog
 import { useMenuActionsWithUserAnnotation } from './triggered-by';
 import { usePipelinesBreadcrumbsFor } from '../pipelines/hooks';
 import TaskRuns from './detail-page-tabs/TaskRuns';
+import PipelineRunEvents from './events/PipelineRunEvents';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
@@ -36,6 +37,7 @@ const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
           name: 'Logs',
           component: PipelineRunLogsWithActiveTask,
         },
+        navFactory.events(PipelineRunEvents),
       ]}
     />
   );

--- a/frontend/packages/dev-console/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/__tests__/PipelineRunDetailsPage.spec.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { DetailsPage } from '@console/internal/components/factory';
+import { PipelineRunModel } from '../../../models';
+import * as utils from '../triggered-by';
+import * as hookUtils from '../../pipelines/hooks';
+import PipelineRunDetailsPage from '../PipelineRunDetailsPage';
+import { getPipelineRunKebabActions } from '../../../utils/pipeline-actions';
+import PipelineRunEvents from '../events/PipelineRunEvents';
+import TaskRuns from '../detail-page-tabs/TaskRuns';
+
+const menuActions = jest.spyOn(utils, 'useMenuActionsWithUserAnnotation');
+const breadCrumbs = jest.spyOn(hookUtils, 'usePipelinesBreadcrumbsFor');
+type PipelineRunDetailsPageProps = React.ComponentProps<typeof PipelineRunDetailsPage>;
+
+describe('PipelineRunDetailsPage:', () => {
+  let pipelineRunDetailsPageProps: PipelineRunDetailsPageProps;
+  let wrapper: ShallowWrapper<PipelineRunDetailsPageProps>;
+  beforeEach(() => {
+    pipelineRunDetailsPageProps = {
+      kind: PipelineRunModel.kind,
+      kindObj: PipelineRunModel,
+      match: {
+        isExact: true,
+        path: `/k8s/ns/:ns/${referenceForModel(PipelineRunModel)}/events`,
+        url: `k8s/ns/rhd-test/${referenceForModel(PipelineRunModel)}/events`,
+        params: {
+          ns: 'rhd-test',
+        },
+      },
+    };
+    menuActions.mockReturnValue([getPipelineRunKebabActions(true)]);
+    breadCrumbs.mockReturnValue([{ label: 'PipelineRuns' }, { label: 'PipelineRuns Details' }]);
+    wrapper = shallow(<PipelineRunDetailsPage {...pipelineRunDetailsPageProps} />);
+  });
+
+  it('Should render a DetailsPage component', () => {
+    expect(wrapper.find(DetailsPage).exists()).toBe(true);
+  });
+
+  it('Should contain five tabs in the details page', () => {
+    const { pages } = wrapper.props();
+    expect(pages).toHaveLength(5);
+  });
+
+  it('Should contain events page', () => {
+    const { pages } = wrapper.props();
+    const eventPage = pages.find((page) => page.name === 'Events');
+    expect(eventPage).toBeDefined();
+    expect(eventPage.component).toBe(PipelineRunEvents);
+  });
+
+  it('Should contain task runs page', () => {
+    const { pages } = wrapper.props();
+    const taskRunsPage = pages.find((page) => page.name === 'Task Runs');
+    expect(taskRunsPage).toBeDefined();
+    expect(taskRunsPage.component).toBe(TaskRuns);
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelineruns/events/PipelineRunEvents.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/events/PipelineRunEvents.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router';
+import { ResourcesEventStream } from '@console/internal/components/events';
+import { PipelineRun } from '../../../utils/pipeline-augment';
+import { usePipelineRunFilters } from './event-utils';
+
+type PipelineRunEventsProps = {
+  obj: PipelineRun;
+  match: RMatch<{
+    ns?: string;
+  }>;
+};
+
+const PipelineRunEvents: React.FC<PipelineRunEventsProps> = ({
+  obj: pipelineRun,
+  match: {
+    params: { ns: namespace },
+  },
+}) => (
+  <ResourcesEventStream
+    filters={usePipelineRunFilters(namespace, pipelineRun)}
+    namespace={namespace}
+  />
+);
+export default PipelineRunEvents;

--- a/frontend/packages/dev-console/src/components/pipelineruns/events/__tests__/PipelineRunEvents.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/events/__tests__/PipelineRunEvents.spec.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ResourcesEventStream } from '@console/internal/components/events';
+import { PipelineRunModel } from '../../../../models';
+import { DataState, PipelineExampleNames, pipelineTestData } from '../../../../test/pipeline-data';
+import PipelineRunEvents from '../PipelineRunEvents';
+import * as utils from '../event-utils';
+
+const pipeline = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
+const pipelineRun = pipeline.pipelineRuns[DataState.SUCCESS];
+const { taskRuns, pods } = pipeline;
+
+const spyUsePipelineRunRelatedResources = jest.spyOn(utils, 'usePipelineRunRelatedResources');
+type PipelineRunEventsProps = React.ComponentProps<typeof PipelineRunEvents>;
+
+describe('PipelineRunEvents:', () => {
+  let pipelineRunEventsProps: PipelineRunEventsProps;
+  beforeEach(() => {
+    pipelineRunEventsProps = {
+      obj: pipelineRun,
+      match: {
+        isExact: true,
+        path: `/k8s/ns/:ns/${referenceForModel(PipelineRunModel)}/events`,
+        url: `k8s/ns/rhd-test/${referenceForModel(PipelineRunModel)}/events`,
+        params: {
+          ns: 'rhd-test',
+        },
+      },
+    };
+    spyUsePipelineRunRelatedResources.mockReturnValue({
+      taskruns: { data: taskRuns, loaded: true },
+      pods: { data: pods, loaded: true },
+    });
+  });
+
+  it('Should render a ResourcesEventStream', () => {
+    const pipelineRunEventsWrapper = shallow(<PipelineRunEvents {...pipelineRunEventsProps} />);
+    expect(pipelineRunEventsWrapper.find(ResourcesEventStream).exists()).toBe(true);
+  });
+
+  it('Should pass three filters in the props to the ResourcesEventStream', () => {
+    const pipelineRunEventsWrapper = shallow(<PipelineRunEvents {...pipelineRunEventsProps} />);
+    expect(pipelineRunEventsWrapper.props().filters).toHaveLength(3);
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelineruns/events/__tests__/event-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/events/__tests__/event-utils.spec.ts
@@ -1,0 +1,148 @@
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { testHook } from '@console/shared/src/test-utils/hooks-utils';
+import { EventInvolvedObject } from '@console/internal/module/k8s';
+import { DataState, PipelineExampleNames, pipelineTestData } from '../../../../test/pipeline-data';
+import { PipelineRun } from '../../../../utils/pipeline-augment';
+import * as eventUtils from '../event-utils';
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResources: jest.fn(),
+}));
+
+const pipeline = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
+const pipelineRun: PipelineRun = pipeline.pipelineRuns[DataState.SUCCESS];
+const {
+  metadata: { namespace },
+} = pipelineRun;
+const { taskRuns, pods } = pipeline;
+
+describe('usePipelineRunFilters:', () => {
+  beforeEach(() => {
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      taskruns: { data: taskRuns, loaded: true },
+      pods: { data: pods, loaded: true },
+    });
+  });
+  it('should return the pipeline run filters', () => {
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      taskruns: { data: [], loaded: true },
+      pods: { data: [], loaded: true },
+    });
+    testHook(() => {
+      const filters = eventUtils.usePipelineRunFilters(namespace, pipelineRun);
+      expect(filters).toHaveLength(3);
+    });
+  });
+
+  it('should return true if the involved objects matches with assoicated pipelinerun resources', () => {
+    const PipelineRunInvolvedObj: EventInvolvedObject = {
+      uid: pipelineRun.metadata.uid,
+      kind: pipelineRun.kind,
+    };
+    const taskRunInvolvedObj: EventInvolvedObject = {
+      uid: taskRuns[0].metadata.uid,
+      kind: taskRuns[0].kind,
+    };
+    const podInvolvedObj: EventInvolvedObject = {
+      uid: pods[0].metadata.uid,
+      kind: pods[0].kind,
+    };
+    testHook(() => {
+      const filters = eventUtils.usePipelineRunFilters(namespace, pipelineRun);
+      expect(filters.some((filter) => filter(PipelineRunInvolvedObj))).toBeTruthy();
+      expect(filters.some((filter) => filter(taskRunInvolvedObj))).toBeTruthy();
+      expect(filters.some((filter) => filter(podInvolvedObj))).toBeTruthy();
+    });
+  });
+
+  it('should return false if the involved objects matches with assoicated pipelinerun resources', () => {
+    const unrelatedPlrInvolvedObj: EventInvolvedObject = {
+      uid: 'cbe7e8db-c641-11e8-8889-0242ac110004',
+      kind: pipelineRun.kind,
+    };
+
+    testHook(() => {
+      const filters = eventUtils.usePipelineRunFilters(namespace, pipelineRun);
+      expect(filters.some((filter) => filter(unrelatedPlrInvolvedObj))).toBeFalsy();
+    });
+  });
+});
+
+describe('useTaskRunFilters:', () => {
+  beforeEach(() => {
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      taskruns: { data: taskRuns, loaded: true },
+      pods: { data: pods, loaded: true },
+    });
+  });
+  it('should return the task run and associated pod filters', () => {
+    testHook(() => {
+      const filters = eventUtils.useTaskRunFilters(namespace, taskRuns[0]);
+      expect(filters).toHaveLength(2);
+    });
+  });
+
+  it('should return true if the taskrun matches with event involved object', () => {
+    const involvedObj: EventInvolvedObject = {
+      uid: taskRuns[0].metadata.uid,
+      kind: taskRuns[0].kind,
+    };
+
+    testHook(() => {
+      const filters = eventUtils.useTaskRunFilters(namespace, taskRuns[0]);
+      expect(filters.some((filter) => filter(involvedObj))).toBeTruthy();
+    });
+  });
+
+  it('should return true if the pod matches with event involved object', () => {
+    const involvedObj: EventInvolvedObject = {
+      uid: pods[0].metadata.uid,
+      kind: pods[0].kind,
+    };
+
+    testHook(() => {
+      const filters = eventUtils.useTaskRunFilters(namespace, taskRuns[0]);
+      expect(filters.some((filter) => filter(involvedObj))).toBeTruthy();
+    });
+  });
+
+  it('should return false if involved object uid is not matched', () => {
+    const unrelatedInvolvedObj: EventInvolvedObject = {
+      uid: 'cbe7e8db-c641-11e8-8889-0242ac110004',
+      kind: pods[0].kind,
+    };
+
+    testHook(() => {
+      const filters = eventUtils.useTaskRunFilters(namespace, taskRuns[0]);
+      expect(filters.some((filter) => filter(unrelatedInvolvedObj))).toBeFalsy();
+    });
+  });
+
+  it('should return false if unsupported kind is supplied in event involved object', () => {
+    const involvedObj: EventInvolvedObject = {
+      uid: pods[0].metadata.uid,
+      kind: 'Depolyment',
+    };
+
+    testHook(() => {
+      const filters = eventUtils.useTaskRunFilters(namespace, taskRuns[0]);
+      expect(filters.some((filter) => filter(involvedObj))).toBeFalsy();
+    });
+  });
+
+  it('should return false if watched resources are empty', () => {
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      taskruns: { data: [], loaded: true },
+      pods: { data: [], loaded: true },
+    });
+    const involvedObj: EventInvolvedObject = {
+      uid: pods[0].metadata.uid,
+      kind: pods[0].kind,
+    };
+
+    testHook(() => {
+      const filters = eventUtils.useTaskRunFilters(namespace, taskRuns[0]);
+      expect(filters.some((filter) => filter(involvedObj))).toBeFalsy();
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelineruns/events/event-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/events/event-utils.ts
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import {
+  WatchK8sResources,
+  useK8sWatchResources,
+  WatchK8sResults,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import { PodModel } from '@console/internal/models';
+import {
+  EventInvolvedObject,
+  K8sResourceKind,
+  referenceForModel,
+} from '@console/internal/module/k8s';
+import { PipelineRun, TaskRunKind } from '../../../utils/pipeline-augment';
+import { PipelineRunModel, TaskRunModel } from '../../../models';
+import { TektonResourceLabel } from '../../pipelines/const';
+
+export type EventFilter = (eventObj: EventInvolvedObject) => boolean;
+type ResourcesType = { [key: string]: K8sResourceKind[] };
+/**
+ * Returns the pod resource for watchK8sResource
+ * @param namespace
+ * @param labels metadata lables to query
+ */
+export const getPodsByLabels = (namespace: string, labels: { [label: string]: string }) => {
+  return {
+    kind: PodModel.kind,
+    selector: {
+      matchLabels: labels,
+    },
+    namespace,
+    isList: true,
+    optional: true,
+  };
+};
+/**
+ * Get associated taskruns and pods for a given namespace.
+ * @param namespace
+ */
+export const usePipelineRunRelatedResources = (
+  namespace: string,
+  pipelineRunName: string,
+): WatchK8sResults<ResourcesType> => {
+  const plrRelatedResources: WatchK8sResources<ResourcesType> = React.useMemo(() => {
+    return {
+      taskruns: {
+        kind: referenceForModel(TaskRunModel),
+        namespace,
+        selector: {
+          matchLabels: { [TektonResourceLabel.pipelinerun]: pipelineRunName },
+        },
+        isList: true,
+        optional: true,
+      },
+      pods: getPodsByLabels(namespace, { [TektonResourceLabel.pipelinerun]: pipelineRunName }),
+    };
+  }, [namespace, pipelineRunName]);
+  return useK8sWatchResources<ResourcesType>(plrRelatedResources);
+};
+/**
+ * Returns the pods associated with the taskRuns
+ * @param namespace
+ * @param taskRunName
+ */
+export const useTaskRunRelatedResources = (
+  namespace: string,
+  taskRunName: string,
+): WatchK8sResults<ResourcesType> => {
+  const tsrRelatedResources: WatchK8sResources<ResourcesType> = React.useMemo(() => {
+    return {
+      pods: getPodsByLabels(namespace, { [TektonResourceLabel.taskrun]: taskRunName }),
+    };
+  }, [namespace, taskRunName]);
+  return useK8sWatchResources<ResourcesType>(tsrRelatedResources);
+};
+
+const isTaskRunMatched = (taskruns): EventFilter => (taskRun: EventInvolvedObject): boolean =>
+  taskRun.kind === TaskRunModel.kind && taskruns.data.find((t) => t.metadata.uid === taskRun.uid);
+
+const isPodMatched = (pods): EventFilter => (pod: EventInvolvedObject): boolean =>
+  pod.kind === PodModel.kind && pods.data.find((p) => p.metadata.uid === pod.uid);
+
+/**
+ * Custom hook to return the list of event filters to find the pipelinerun related resources.
+ * @param namespace
+ * @param pipelineRun
+ */
+export const usePipelineRunFilters = (
+  namespace: string,
+  pipelineRun: PipelineRun,
+): EventFilter[] => {
+  const { taskruns, pods } = usePipelineRunRelatedResources(namespace, pipelineRun.metadata.name);
+  const isPipelineRunMatched: EventFilter = (plr: EventInvolvedObject): boolean => {
+    return plr.kind === PipelineRunModel.kind && plr.uid === pipelineRun.metadata.uid;
+  };
+  return [isPipelineRunMatched, isTaskRunMatched(taskruns), isPodMatched(pods)];
+};
+
+/**
+ * Custom hook to return the list of event filters to find the taskrun related resources.
+ * @param namespace
+ * @param taskRun
+ */
+export const useTaskRunFilters = (namespace: string, taskRun: TaskRunKind): EventFilter[] => {
+  const { pods } = useTaskRunRelatedResources(namespace, taskRun.metadata.name);
+
+  const isTaskRun: EventFilter = (tRun: EventInvolvedObject): boolean => {
+    return tRun.kind === TaskRunModel.kind && tRun.uid === taskRun.metadata.uid;
+  };
+  return [isTaskRun, isPodMatched(pods)];
+};

--- a/frontend/packages/dev-console/src/components/pipelines/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/const.ts
@@ -5,6 +5,11 @@ export enum StartedByAnnotation {
   user = 'pipeline.openshift.io/started-by',
 }
 
+export enum TektonResourceLabel {
+  pipelinerun = 'tekton.dev/pipelineRun',
+  taskrun = 'tekton.dev/taskRun',
+}
+
 export enum PipelineResourceType {
   git = 'git',
   image = 'image',

--- a/frontend/packages/dev-console/src/components/taskruns/TaskRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/TaskRunDetailsPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { navFactory, viewYamlComponent } from '@console/internal/components/utils';
 import TaskRunDetails from './TaskRunDetails';
+import TaskRunEvents from './events/TaskRunEvents';
 import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
 
 const TaskRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
@@ -12,7 +13,11 @@ const TaskRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
     <DetailsPage
       {...props}
       breadcrumbsFor={() => breadcrumbsFor}
-      pages={[navFactory.details(TaskRunDetails), navFactory.editYaml(viewYamlComponent)]}
+      pages={[
+        navFactory.details(TaskRunDetails),
+        navFactory.editYaml(viewYamlComponent),
+        navFactory.events(TaskRunEvents),
+      ]}
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/taskruns/events/TaskRunEvents.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/events/TaskRunEvents.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router';
+import { ResourcesEventStream } from '@console/internal/components/events';
+import { TaskRunKind } from '../../../utils/pipeline-augment';
+import { useTaskRunFilters } from '../../pipelineruns/events/event-utils';
+
+type TaskRunEventsProps = {
+  obj: TaskRunKind;
+  match: RMatch<{
+    ns?: string;
+  }>;
+};
+
+const TaskRunEvents: React.FC<TaskRunEventsProps> = ({
+  obj: taskRun,
+  match: {
+    params: { ns: namespace },
+  },
+}) => (
+  <ResourcesEventStream filters={useTaskRunFilters(namespace, taskRun)} namespace={namespace} />
+);
+export default TaskRunEvents;

--- a/frontend/packages/dev-console/src/components/taskruns/events/__tests__/TaskRunDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/events/__tests__/TaskRunDetailsPage.spec.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { DetailsPage } from '@console/internal/components/factory';
+import { TaskRunModel } from '../../../../models';
+import * as hookUtils from '../../../pipelines/hooks';
+import TaskRunDetailsPage from '../../TaskRunDetailsPage';
+import TaskRunEvents from '../TaskRunEvents';
+
+const breadCrumbs = jest.spyOn(hookUtils, 'useTasksBreadcrumbsFor');
+type TaskRunDetailsPageProps = React.ComponentProps<typeof TaskRunDetailsPage>;
+
+describe('TaskRunDetailsPage:', () => {
+  let taskRunDetailsPageProps: TaskRunDetailsPageProps;
+  beforeEach(() => {
+    taskRunDetailsPageProps = {
+      kind: TaskRunModel.kind,
+      kindObj: TaskRunModel,
+      match: {
+        isExact: true,
+        path: `/k8s/ns/:ns/${referenceForModel(TaskRunModel)}/events`,
+        url: `k8s/ns/rhd-test/${referenceForModel(TaskRunModel)}/events`,
+        params: {
+          ns: 'rhd-test',
+        },
+      },
+    };
+    breadCrumbs.mockReturnValue([{ label: 'TaskRuns' }, { label: 'TaskRuns Details' }]);
+  });
+
+  it('Should render a DetailsPage component', () => {
+    const wrapper = shallow(<TaskRunDetailsPage {...taskRunDetailsPageProps} />);
+    expect(wrapper.find(DetailsPage).exists()).toBe(true);
+  });
+
+  it('Should contain three tabs in the Details Page', () => {
+    const wrapper = shallow(<TaskRunDetailsPage {...taskRunDetailsPageProps} />);
+    const { pages } = wrapper.props();
+    expect(pages).toHaveLength(3);
+  });
+
+  it('Should contain events page', () => {
+    const wrapper = shallow(<TaskRunDetailsPage {...taskRunDetailsPageProps} />);
+    const { pages } = wrapper.props();
+    const eventPage = pages.find((page) => page.name === 'Events');
+    expect(eventPage).toBeDefined();
+    expect(eventPage.component).toBe(TaskRunEvents);
+  });
+});

--- a/frontend/packages/dev-console/src/components/taskruns/events/__tests__/TaskRunEvents.spec.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/events/__tests__/TaskRunEvents.spec.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ResourcesEventStream } from '@console/internal/components/events';
+import { TaskRunModel } from '../../../../models';
+import { PipelineExampleNames, pipelineTestData } from '../../../../test/pipeline-data';
+import TaskRunEvents from '../TaskRunEvents';
+import * as utils from '../../../pipelineruns/events/event-utils';
+
+const pipeline = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
+const { pods } = pipeline;
+
+const spyUseTaskRunRelatedResources = jest.spyOn(utils, 'useTaskRunRelatedResources');
+type TaskRunEventsProps = React.ComponentProps<typeof TaskRunEvents>;
+
+describe('TaskRunEvents:', () => {
+  let taskRunEventsProps: TaskRunEventsProps;
+  beforeEach(() => {
+    taskRunEventsProps = {
+      obj: pipeline.taskRuns[0],
+      match: {
+        isExact: true,
+        path: `/k8s/ns/:ns/${referenceForModel(TaskRunModel)}/events`,
+        url: `k8s/ns/rhd-test/${referenceForModel(TaskRunModel)}/events`,
+        params: {
+          ns: 'rhd-test',
+        },
+      },
+    };
+    spyUseTaskRunRelatedResources.mockReturnValue({
+      pods: { data: pods, loaded: true },
+    });
+  });
+
+  it('Should render a ResourcesEventStream', () => {
+    const taskRunEventsWrapper = shallow(<TaskRunEvents {...taskRunEventsProps} />);
+    expect(taskRunEventsWrapper.find(ResourcesEventStream).exists()).toBe(true);
+  });
+
+  it('Should pass two filters in the props to the ResourcesEventStream', () => {
+    const taskRunEventsWrapper = shallow(<TaskRunEvents {...taskRunEventsProps} />);
+    expect(taskRunEventsWrapper.props().filters).toHaveLength(2);
+  });
+});

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -6,7 +6,12 @@ import {
   chart_color_black_400 as skippedColor,
   chart_color_black_500 as cancelledColor,
 } from '@patternfly/react-tokens';
-import { K8sKind, K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import {
+  K8sKind,
+  K8sResourceKind,
+  PersistentVolumeClaimKind,
+  referenceForModel,
+} from '@console/internal/module/k8s';
 import {
   ClusterTaskModel,
   ClusterTriggerBindingModel,
@@ -81,6 +86,7 @@ export interface PipelineTaskWorkspace {
   description?: string;
   mountPath?: string;
   readOnly?: boolean;
+  workspace?: string;
 }
 export interface Resource {
   propsReferenceForRuns: string[];
@@ -128,8 +134,27 @@ export interface Pipeline extends K8sResourceKind {
   };
 }
 
-/** TODO: Define */
-export type TaskRunKind = K8sResourceKind;
+export type TaskRunWorkspace = {
+  name: string;
+  volumeClaimTemplate?: PersistentVolumeClaimKind;
+  persistentVolumeClaim?: VolumeTypePVC;
+  configMap?: VolumeTypeConfigMaps;
+  emptyDir?: {};
+  secret?: VolumeTypeSecret;
+  subPath?: string;
+};
+
+export interface TaskRunKind extends K8sResourceKind {
+  spec: {
+    taskRef?: PipelineTaskRef;
+    taskSpec?: PipelineTaskSpec;
+    serviceAccountName?: string;
+    params?: PipelineTaskParam[];
+    resources?: PipelineResource[];
+    timeout?: string;
+    workspaces?: TaskRunWorkspace[];
+  };
+}
 
 export type PLRTaskRunStep = {
   container: string;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4802

**Description**:
Add Events tab to the pipelinerun details page and in taskrun details page.

**Screenshots:**
PipelineRun Details page:
![image](https://user-images.githubusercontent.com/9964343/95445563-cc1d5080-097c-11eb-9046-c9eefed2bc75.png)
TaskRun Details page:
![image](https://user-images.githubusercontent.com/9964343/95445510-bc9e0780-097c-11eb-94df-b132f9031a84.png)

**Test cases:**
Taskrun details page
![image](https://user-images.githubusercontent.com/9964343/95445780-0686ed80-097d-11eb-9607-46c3dc636177.png)

Pipelinerun details page
![image](https://user-images.githubusercontent.com/9964343/96558937-06221700-12da-11eb-92fa-266e6b8dbe13.png)

PipelienRun Events
![image](https://user-images.githubusercontent.com/9964343/95445909-3930e600-097d-11eb-821f-7a3d3b393a85.png)
TaskRun Events
![image](https://user-images.githubusercontent.com/9964343/95446023-5f568600-097d-11eb-8c49-034b7be6dff2.png)
event-utils:
![image](https://user-images.githubusercontent.com/9964343/95446126-80b77200-097d-11eb-9ab4-ceb31de936ca.png)


/kind feature
cc: @andrewballantyne @siamaksade @openshift/team-devconsole-ux 