### PR TITLE
Bug 1885706:  Cypress: Fix 'link-name' accesibility violation

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -135,6 +135,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
 
     const chart = (
       <AreaChart
+        title={title}
         data={data}
         loading={!error && isLoading}
         query={query}

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -121,7 +121,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
   return (
     <PrometheusGraph className={className} ref={containerRef} title={title}>
       {processedData?.length ? (
-        <PrometheusGraphLink query={query}>
+        <PrometheusGraphLink query={query} title={title}>
           <Chart
             containerComponent={container}
             domainPadding={{ y: 20 }}

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -35,6 +35,7 @@ export const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
   perspective,
   query,
   namespace,
+  title,
 }) => {
   if (!query) {
     return <>{children}</>;
@@ -49,7 +50,11 @@ export const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
       : `/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`;
 
   return (
-    <Link to={url} style={{ color: 'inherit', textDecoration: 'none' }}>
+    <Link
+      to={url}
+      aria-label={`View ${title ? title : ''} Graph in Query Browser`}
+      style={{ color: 'inherit', textDecoration: 'none' }}
+    >
       {children}
     </Link>
   );
@@ -70,6 +75,7 @@ type PrometheusGraphLinkProps = {
   perspective: string;
   query: string;
   namespace?: string;
+  title?: string;
 };
 
 type PrometheusGraphProps = {


### PR DESCRIPTION
Added `aria-label`'s to Cluster Dashboard Utilization chart's links.

**Before:**
```
 Running:  crud/other-routes.spec.ts                                                       (1 of 1)
1 accessibility violation was detected for / page
┌─────────┬─────────────┬───────────┬───────────────────────────────────────┬───────┐
│ (index) │     id      │  impact   │              description              │ nodes │
├─────────┼─────────────┼───────────┼───────────────────────────────────────┼───────┤
│    0    │ 'link-name' │ 'serious' │ 'Ensures links have discernible text' │   5   │
└─────────┴─────────────┴───────────┴───────────────────────────────────────┴───────┘
    ✓ successfully displays view for route: / (7398ms)
```
**After:**
```
  Running:  crud/other-routes.spec.ts                                                       (1 of 1)
    ✓ successfully displays view for route: / (7400ms)
    ✓ successfully displays view for route: /k8s/cluster/clusterroles/view (6159ms)
    ✓ successfully displays view for route: /k8s/cluster/nodes (5539ms)
    ✓ successfully displays view for route: /k8s/all-namespaces/events (5554ms)
```
