### PR TITLE
Bug 1856351: Fix build details page charts

### DIFF
--- a/frontend/__tests__/components/graphs/utils.spec.ts
+++ b/frontend/__tests__/components/graphs/utils.spec.ts
@@ -41,9 +41,7 @@ describe('getRangeVectorStats()', () => {
 
     const [d1, d2] = data[0];
     const date1 = new Date(1000);
-    date1.setSeconds(0, 0);
     const date2 = new Date(2000);
-    date2.setSeconds(0, 0);
     expect(d1.x).toEqual(date1);
     expect(d1.y).toEqual(123.4);
     expect(d2.x).toEqual(date2);

--- a/frontend/packages/console-shared/src/constants/index.ts
+++ b/frontend/packages/console-shared/src/constants/index.ts
@@ -2,3 +2,4 @@ export * from './pod';
 export * from './resource';
 export * from './common';
 export * from './ui';
+export * from './time';

--- a/frontend/packages/console-shared/src/constants/time.ts
+++ b/frontend/packages/console-shared/src/constants/time.ts
@@ -1,0 +1,5 @@
+export const ONE_SECOND = 1000;
+export const ONE_MINUTE = 60 * ONE_SECOND;
+export const ONE_HOUR = 60 * ONE_MINUTE;
+export const ONE_DAY = 24 * ONE_HOUR;
+export const ONE_WEEK = 7 * ONE_DAY;

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -21,7 +21,6 @@ import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { findVMIPod } from '../../../selectors/pod/selectors';
 import { getUtilizationQueries, getMultilineUtilizationQueries, VMQueries } from './queries';
-import { getPrometheusQueryEndTimestamp } from '@console/internal/components/graphs/helpers';
 
 // TODO: extend humanizeCpuCores() from @console/internal for the flexibility of space
 const humanizeCpuCores = (v) => {
@@ -36,7 +35,7 @@ const adjustDurationForStart = (start: number, createdAt: string): number => {
   if (!createdAt) {
     return start;
   }
-  const endTimestamp = getPrometheusQueryEndTimestamp();
+  const endTimestamp = Date.now();
   const startTimestamp = endTimestamp - start;
   const createdAtTimestamp = Date.parse(createdAt);
   const adjustedStart = endTimestamp - createdAtTimestamp;

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
@@ -147,6 +147,16 @@ const networkOutQueriesPopup = [
   },
 ];
 
+// TODO (jon) Fix PrometheusMultilineUtilization so that x-values returned from multiple prometheus
+// queries are "synced" on the x-axis (same number of points with the same x-values). In order to do
+// so, we have to make sure that the same end time, samples, and duration are used across all
+// queries. This is a temporary work around. See https://issues.redhat.com/browse/CONSOLE-2424
+const trimSecondsXMutator = (x) => {
+  const d = new Date(x * 1000);
+  d.setSeconds(0, 0);
+  return d;
+};
+
 export const PrometheusUtilizationItem = withDashboardResources<PrometheusUtilizationItemProps>(
   ({
     watchPrometheus,
@@ -307,7 +317,7 @@ export const PrometheusMultilineUtilizationItem = withDashboardResources<
           isLoading = true;
           return false;
         }
-        stats.push(getRangeVectorStats(response, query.desc)?.[0] || []);
+        stats.push(getRangeVectorStats(response, query.desc, null, trimSecondsXMutator)?.[0] || []);
       });
     }
 

--- a/frontend/public/components/graphs/helpers.ts
+++ b/frontend/public/components/graphs/helpers.ts
@@ -1,6 +1,10 @@
 import * as _ from 'lodash-es';
-
-import { PROMETHEUS_BASE_PATH, PROMETHEUS_TENANCY_BASE_PATH } from './index';
+import {
+  PROMETHEUS_BASE_PATH,
+  PROMETHEUS_TENANCY_BASE_PATH,
+  DEFAULT_PROMETHEUS_SAMPLES,
+  DEFAULT_PROMETHEUS_TIMESPAN,
+} from './index';
 
 export enum PrometheusEndpoint {
   LABEL = 'api/v1/label',
@@ -9,20 +13,16 @@ export enum PrometheusEndpoint {
   QUERY_RANGE = 'api/v1/query_range',
 }
 
-export const getPrometheusQueryEndTimestamp = () => Date.now();
-
 // Range vector queries require end, start, and step search params
 const getRangeVectorSearchParams = (
-  timespan: number,
-  endTime: number = getPrometheusQueryEndTimestamp(),
-  samples: number = 60,
+  endTime: number = Date.now(),
+  samples: number = DEFAULT_PROMETHEUS_SAMPLES,
+  timespan: number = DEFAULT_PROMETHEUS_TIMESPAN,
 ): URLSearchParams => {
   const params = new URLSearchParams();
-  if (timespan > 0) {
-    params.append('start', `${(endTime - timespan) / 1000}`);
-    params.append('end', `${endTime / 1000}`);
-    params.append('step', `${timespan / samples / 1000}`);
-  }
+  params.append('start', `${(endTime - timespan) / 1000}`);
+  params.append('end', `${endTime / 1000}`);
+  params.append('step', `${timespan / samples / 1000}`);
   return params;
 };
 
@@ -35,7 +35,7 @@ const getSearchParams = ({
 }: PrometheusURLProps): URLSearchParams => {
   const searchParams =
     endpoint === PrometheusEndpoint.QUERY_RANGE
-      ? getRangeVectorSearchParams(timespan, endTime, samples)
+      ? getRangeVectorSearchParams(endTime, samples, timespan)
       : new URLSearchParams();
   _.each(params, (value, key) => value && searchParams.append(key, value.toString()));
   return searchParams;

--- a/frontend/public/components/graphs/index.tsx
+++ b/frontend/public/components/graphs/index.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { createContainer } from '@patternfly/react-charts';
 import { AsyncComponent } from '../utils/async';
+import { ONE_HOUR } from '@console/shared/src/constants/time';
 
 // Constants
 export const PROMETHEUS_BASE_PATH = window.SERVER_FLAGS.prometheusBaseURL;
 export const PROMETHEUS_TENANCY_BASE_PATH = window.SERVER_FLAGS.prometheusTenancyBaseURL;
 export const ALERT_MANAGER_BASE_PATH = window.SERVER_FLAGS.alertManagerBaseURL;
 export const ALERT_MANAGER_TENANCY_BASE_PATH = 'api/alertmanager-tenancy'; // remove it once it get added to SERVER_FLAGS
-
+export const DEFAULT_PROMETHEUS_SAMPLES = 60;
+export const DEFAULT_PROMETHEUS_TIMESPAN = ONE_HOUR;
 // Components
 export * from './require-prometheus';
 export { errorStatus, Status } from './status';

--- a/frontend/public/components/graphs/prometheus-poll-hook.ts
+++ b/frontend/public/components/graphs/prometheus-poll-hook.ts
@@ -1,19 +1,16 @@
 import { useURLPoll } from '../utils/url-poll-hook';
 import { getPrometheusURL, PrometheusEndpoint } from './helpers';
-import { PrometheusResponse } from '.';
-
-const DEFAULT_SAMPLES = 60;
-const DEFAULT_TIMESPAN = 60 * 60 * 1000; // 1 hour
+import { DEFAULT_PROMETHEUS_SAMPLES, DEFAULT_PROMETHEUS_TIMESPAN, PrometheusResponse } from '.';
 
 export const usePrometheusPoll = ({
   delay,
   endpoint,
-  endTime = undefined,
+  endTime,
   namespace,
   query,
-  samples = DEFAULT_SAMPLES,
+  samples = DEFAULT_PROMETHEUS_SAMPLES,
   timeout,
-  timespan = DEFAULT_TIMESPAN,
+  timespan = DEFAULT_PROMETHEUS_TIMESPAN,
 }: PrometheusPollProps) => {
   const url = getPrometheusURL({ endpoint, endTime, namespace, query, samples, timeout, timespan });
 

--- a/frontend/public/components/graphs/stack.tsx
+++ b/frontend/public/components/graphs/stack.tsx
@@ -120,7 +120,7 @@ export const StackChart: React.FC<AreaChartProps> = ({
             padding={padding}
             theme={theme}
           >
-            {xAxis && <ChartAxis tickCount={tickCount} tickFormat={formatDate} />}
+            {xAxis && <ChartAxis tickCount={tickCount} tickFormat={(tick) => formatDate(tick)} />}
             {yAxis && <ChartAxis dependentAxis tickCount={tickCount} tickFormat={tickFormat} />}
             <ChartStack height={height} width={width}>
               {processedData.map((datum, index) => (
@@ -160,7 +160,7 @@ export const Stack: React.FC<StackProps> = ({
     timeout,
     timespan,
   });
-  const data = getRangeVectorStats(utilization, description, null);
+  const data = getRangeVectorStats(utilization, description);
   const ChartComponent = data?.length === 1 ? AreaChart : StackChart;
   return <ChartComponent data={data} loading={loading} query={query} {...rest} />;
 };

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -47,9 +47,9 @@ import {
   formatPrometheusDuration,
   parsePrometheusDuration,
   twentyFourHourTime,
-  twentyFourHourTimeWithSeconds,
 } from '../utils/datetime';
 import { PrometheusAPIError } from './types';
+import { ONE_MINUTE } from '@console/shared/src/constants/time';
 
 const spans = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2w'];
 const dropdownItems = _.zipObject(spans, spans);
@@ -193,9 +193,7 @@ const TooltipInner_: React.FC<TooltipInnerProps> = ({
               style={{ backgroundColor: colors[seriesIndex % colors.length] }}
             />
             {datumX && (
-              <div className="query-browser__tooltip-time">
-                {twentyFourHourTimeWithSeconds(datumX)}
-              </div>
+              <div className="query-browser__tooltip-time">{twentyFourHourTime(datumX, true)}</div>
             )}
           </div>
           <div className="query-browser__tooltip-group">
@@ -309,9 +307,7 @@ const Graph: React.FC<GraphProps> = React.memo(
         yTickFormat = (v: number) => (v === 0 ? '0' : v.toExponential(1));
       }
     }
-
-    const xTickFormat = span < 5 * 60 * 1000 ? twentyFourHourTimeWithSeconds : twentyFourHourTime;
-
+    const xTickFormat = (d) => twentyFourHourTime(d, span < 5 * ONE_MINUTE);
     let xAxisStyle;
     if (width < 225) {
       xAxisStyle = {

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -83,15 +83,9 @@ export const parsePrometheusDuration = (duration: string): number => {
 
 const zeroPad = (number: number) => (number < 10 ? `0${number}` : number);
 
-export const twentyFourHourTime = (date: Date): string => {
-  const hours = zeroPad(date.getHours());
-  const minutes = zeroPad(date.getMinutes());
-  return `${hours}:${minutes}`;
-};
-
-export const twentyFourHourTimeWithSeconds = (date: Date): string => {
-  const hours = zeroPad(date.getHours());
-  const minutes = zeroPad(date.getMinutes());
-  const seconds = zeroPad(date.getSeconds());
-  return `${hours}:${minutes}:${seconds}`;
+export const twentyFourHourTime = (date: Date, showSeconds?: boolean): string => {
+  const hours = zeroPad(date.getHours() ?? 0);
+  const minutes = `:${zeroPad(date.getMinutes() ?? 0)}`;
+  const seconds = showSeconds ? `:${zeroPad(date.getSeconds() ?? 0)}` : '';
+  return `${hours}${minutes}${seconds}`;
 };


### PR DESCRIPTION
Update build details page charts to only show utilization data from when the build ran.

- Create new global time related constants
- Update build details page area charts to only show data from build start to completion
- Minimum queried timepan to one minute
- Show seconds on build charts if timespan is less than 5 minutes
- Force x domain on build charts to match the queried timespan so that chart will not show less than
  one minute on the x-axis.
- Add new xMutator callback arg to graph util `mapLimitsRequests` function to allow for post-processing of
  utilization chart x values
- Add new xMutator and yMutator callback args to graph util `getRangeVectorStats` function to allow
  for post-processing of prometheus response data x and y values
- Remove logic from getRangeVectorStats function that removed second and millisecond data from all x
  values
- Update PrometheusMultilineUtilizationItem to use new xMutator argument to trim seconds and
  milliseconds off of multiline area chart data points.
- Create new global constants for prometheus query default samples and timespan
- Update Area and AreaChart components to use new global prometheus constants and accept domain prop
- Update twentyFourHourTime util function to accept `showSeconds` arg and get rid of
  twentyFourHourTimeWithSeconds function.
- Update usage of twentyFourHourTime/twentyFourHourTimeWithSeconds function where needed