### PR TITLE
Monitoring: Fix graph refresh on alert and rule details pages

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -565,7 +565,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
 
   const [containerRef, width] = useRefWidth();
 
-  const endTime = _.get(xDomain, '[1]');
+  const endTime = xDomain?.[1];
 
   const safeFetch = useSafeFetch();
 


### PR DESCRIPTION
Pass `query` and `ruleDuration` to `Graph` instead of the whole `rule`
object to prevent some unnecessary re-rendering. This also removes the
need to memoize `queries`.

Memoize `labels` in `AlertsDetailsPage` to avoid triggering unnecessary
re-renders of `Graph`.

Initialize `pollInterval` to `undefined` instead of `null`. `null`
indicates that polling was disabled, whereas `undefined` indicates that
it is not specified and the `QueryBrowser` should use its default poll
interval.