### PR TITLE
Cover static and dynamic plugin SDKs with unit tests

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
@@ -1,0 +1,242 @@
+import * as _ from 'lodash';
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+import {
+  isEncodedCodeRef,
+  isExecutableCodeRef,
+  filterEncodedCodeRefProperties,
+  filterExecutableCodeRefProperties,
+  parseEncodedCodeRefValue,
+  loadReferencedObject,
+  resolveEncodedCodeRefs,
+  resolveCodeRefProperties,
+} from '../coderef-resolver';
+import { EncodedCodeRef } from '../../types';
+import {
+  getExecutableCodeRefMock,
+  getEntryModuleMocks,
+  ModuleFactoryMock,
+  RemoteEntryModuleMock,
+} from '../../utils/test-utils';
+
+describe('isEncodedCodeRef', () => {
+  it('returns true if obj is structured as { $codeRef: string }', () => {
+    expect(isEncodedCodeRef({})).toBe(false);
+    expect(isEncodedCodeRef({ $codeRef: true })).toBe(false);
+    expect(isEncodedCodeRef({ $codeRef: 'foo' })).toBe(true);
+    expect(isEncodedCodeRef({ $codeRef: 'foo', bar: true })).toBe(false);
+  });
+});
+
+describe('isExecutableCodeRef', () => {
+  it('returns true if obj is a function marked with CodeRef symbol', () => {
+    expect(isExecutableCodeRef(() => {})).toBe(false);
+    expect(isExecutableCodeRef(getExecutableCodeRefMock('qux'))).toBe(true);
+  });
+});
+
+describe('filterEncodedCodeRefProperties', () => {
+  it('picks properties whose values match isEncodedCodeRef predicate', () => {
+    expect(
+      filterEncodedCodeRefProperties({
+        foo: { $codeRef: 'foo' },
+        bar: ['test'],
+        baz: () => {},
+        qux: getExecutableCodeRefMock('qux'),
+      }),
+    ).toEqual({
+      foo: { $codeRef: 'foo' },
+    });
+  });
+});
+
+describe('filterExecutableCodeRefProperties', () => {
+  it('picks properties whose values match isExecutableCodeRef predicate', () => {
+    const ref = getExecutableCodeRefMock('qux');
+
+    expect(
+      filterExecutableCodeRefProperties({
+        foo: { $codeRef: 'foo' },
+        bar: ['test'],
+        baz: () => {},
+        qux: ref,
+      }),
+    ).toEqual({
+      qux: ref,
+    });
+  });
+});
+
+describe('parseEncodedCodeRefValue', () => {
+  it('returns [moduleName, exportName] tuple if value has the right format', () => {
+    expect(parseEncodedCodeRefValue('foo.bar')).toEqual(['foo', 'bar']);
+    expect(parseEncodedCodeRefValue('foo')).toEqual(['foo', 'default']);
+  });
+
+  it('returns an empty array if value does not have the expected format', () => {
+    expect(parseEncodedCodeRefValue('')).toEqual([]);
+    expect(parseEncodedCodeRefValue('.')).toEqual([]);
+    expect(parseEncodedCodeRefValue('.bar')).toEqual([]);
+    expect(parseEncodedCodeRefValue('.bar.')).toEqual([]);
+  });
+});
+
+describe('loadReferencedObject', () => {
+  const testResult = async (
+    ref: EncodedCodeRef,
+    requestedModule: {},
+    beforeResult: (entryModule: RemoteEntryModuleMock, moduleFactory: ModuleFactoryMock) => void,
+    afterResult: (
+      result: any,
+      errorCallback: jest.Mock<void>,
+      entryModule: RemoteEntryModuleMock,
+      moduleFactory: ModuleFactoryMock,
+    ) => void,
+  ) => {
+    const errorCallback = jest.fn<void>();
+    const [moduleFactory, entryModule] = getEntryModuleMocks(requestedModule);
+    beforeResult(entryModule, moduleFactory);
+
+    const result = await loadReferencedObject(ref, entryModule, 'Test@1.2.3', errorCallback);
+    afterResult(result, errorCallback, entryModule, moduleFactory);
+  };
+
+  it('returns the referenced object via remote entry module', async () => {
+    await testResult(
+      { $codeRef: 'foo.bar' },
+      { bar: 'value1', default: 'value2' },
+      _.noop,
+      (result, errorCallback, entryModule, moduleFactory) => {
+        expect(result).toBe('value1');
+        expect(errorCallback).not.toHaveBeenCalled();
+        expect(entryModule.get).toHaveBeenCalledWith('foo');
+        expect(moduleFactory).toHaveBeenCalledWith();
+      },
+    );
+
+    await testResult(
+      { $codeRef: 'foo' },
+      { bar: 'value1', default: 'value2' },
+      _.noop,
+      (result, errorCallback, entryModule, moduleFactory) => {
+        expect(result).toBe('value2');
+        expect(errorCallback).not.toHaveBeenCalled();
+        expect(entryModule.get).toHaveBeenCalledWith('foo');
+        expect(moduleFactory).toHaveBeenCalledWith();
+      },
+    );
+  });
+
+  it('fails on malformed code reference', async () => {
+    await testResult(
+      { $codeRef: '' },
+      { bar: 'value1', default: 'value2' },
+      _.noop,
+      (result, errorCallback, entryModule, moduleFactory) => {
+        expect(result).toBe(null);
+        expect(errorCallback).toHaveBeenCalledWith();
+        expect(entryModule.get).not.toHaveBeenCalled();
+        expect(moduleFactory).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it('fails when requested module resolution throws an error', async () => {
+    await testResult(
+      { $codeRef: 'foo.bar' },
+      { bar: 'value1', default: 'value2' },
+      (entryModule) => {
+        entryModule.get.mockImplementation(() => {
+          throw new Error('boom');
+        });
+      },
+      (result, errorCallback, entryModule, moduleFactory) => {
+        expect(result).toBe(null);
+        expect(errorCallback).toHaveBeenCalledWith();
+        expect(entryModule.get).toHaveBeenCalledWith('foo');
+        expect(moduleFactory).not.toHaveBeenCalled();
+      },
+    );
+
+    await testResult(
+      { $codeRef: 'foo.bar' },
+      { bar: 'value1', default: 'value2' },
+      (entryModule, moduleFactory) => {
+        moduleFactory.mockImplementation(() => {
+          throw new Error('boom');
+        });
+      },
+      (result, errorCallback, entryModule, moduleFactory) => {
+        expect(result).toBe(null);
+        expect(errorCallback).toHaveBeenCalledWith();
+        expect(entryModule.get).toHaveBeenCalledWith('foo');
+        expect(moduleFactory).toHaveBeenCalledWith();
+      },
+    );
+  });
+
+  it('fails on missing module export', async () => {
+    await testResult(
+      { $codeRef: 'foo.bar' },
+      { default: 'value2' },
+      _.noop,
+      (result, errorCallback, entryModule, moduleFactory) => {
+        expect(result).toBe(null);
+        expect(errorCallback).toHaveBeenCalledWith();
+        expect(entryModule.get).toHaveBeenCalledWith('foo');
+        expect(moduleFactory).toHaveBeenCalledWith();
+      },
+    );
+  });
+});
+
+describe('resolveEncodedCodeRefs', () => {
+  it('replaces encoded code references with executable CodeRef functions', () => {
+    const extensions: Extension[] = [
+      {
+        type: 'Foo',
+        properties: { test: true },
+      },
+      {
+        type: 'Bar',
+        properties: { baz: 1, qux: { $codeRef: 'a.b' } },
+      },
+    ];
+
+    const errorCallback = jest.fn();
+    const [, entryModule] = getEntryModuleMocks({ b: 'value' });
+
+    const resolvedExtensions = resolveEncodedCodeRefs(
+      extensions,
+      entryModule,
+      'Test@1.2.3',
+      errorCallback,
+    );
+
+    expect(resolvedExtensions.length).toBe(extensions.length);
+    expect(resolvedExtensions[0]).toEqual(extensions[0]);
+
+    expect(_.omit(resolvedExtensions[1], 'properties.qux')).toEqual(
+      _.omit(extensions[1], 'properties.qux'),
+    );
+
+    expect(isExecutableCodeRef(resolvedExtensions[1].properties.qux)).toBe(true);
+  });
+});
+
+describe('resolveCodeRefProperties', () => {
+  it('replaces executable CodeRef functions with corresponding objects', async () => {
+    const extensions: Extension[] = [
+      {
+        type: 'Foo',
+        properties: { test: true },
+      },
+      {
+        type: 'Bar',
+        properties: { baz: 1, qux: getExecutableCodeRefMock('value') },
+      },
+    ];
+
+    expect(await resolveCodeRefProperties(extensions[0])).toEqual({});
+    expect(await resolveCodeRefProperties(extensions[1])).toEqual({ qux: 'value' });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-utils.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-utils.spec.ts
@@ -1,0 +1,39 @@
+import { executeReferencedFunction } from '../coderef-utils';
+
+describe('executeReferencedFunction', () => {
+  it('executes the referenced function with given args and returns its result', async () => {
+    const func = jest.fn(() => 'value');
+    const args = ['foo', true, { bar: [1, 'qux'] }];
+    const ref = jest.fn(() => Promise.resolve(func));
+
+    const result = await executeReferencedFunction(ref, ...args);
+
+    expect(ref).toHaveBeenCalledWith();
+    expect(func).toHaveBeenCalledWith(...args);
+    expect(result).toBe('value');
+  });
+
+  it('returns null when the referenced object is not a function', async () => {
+    const args = ['foo', true, { bar: [1, 'qux'] }];
+    const ref = jest.fn(() => Promise.resolve('value'));
+
+    const result = await executeReferencedFunction(ref, ...args);
+
+    expect(ref).toHaveBeenCalledWith();
+    expect(result).toBe(null);
+  });
+
+  it('returns null when the referenced function throws an error', async () => {
+    const func = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const args = ['foo', true, { bar: [1, 'qux'] }];
+    const ref = jest.fn(() => Promise.resolve(func));
+
+    const result = await executeReferencedFunction(ref, ...args);
+
+    expect(ref).toHaveBeenCalledWith();
+    expect(func).toHaveBeenCalledWith(...args);
+    expect(result).toBe(null);
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-utils.ts
@@ -9,13 +9,13 @@ import { CodeRef } from '../types';
  *
  * _Does not throw errors by design._
  */
-export const executeReferencedFunction = async <T extends (...args: any) => any>(
+export const executeReferencedFunction = async <T extends (...args: any[]) => any>(
   ref: CodeRef<T>,
   ...args: Parameters<T>
 ): Promise<ReturnType<T>> => {
   try {
     const func = await ref();
-    return func(args);
+    return func(...args);
   } catch (error) {
     console.error('Failed to execute referenced function', error);
     return null;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
@@ -1,0 +1,231 @@
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+import { PluginStore } from '@console/plugin-sdk/src/store';
+import {
+  scriptIDPrefix,
+  getPluginID,
+  getScriptElementID,
+  loadDynamicPlugin,
+  registerPluginEntryCallback,
+  getPluginEntryCallback,
+  getStateForTestPurposes,
+  resetStateAndEnvForTestPurposes,
+} from '../plugin-loader';
+import { ConsolePluginManifestJSON } from '../../schema/plugin-manifest';
+import {
+  getPluginManifest,
+  getExecutableCodeRefMock,
+  getEntryModuleMocks,
+} from '../../utils/test-utils';
+
+beforeEach(() => {
+  resetStateAndEnvForTestPurposes();
+});
+
+describe('getPluginID', () => {
+  it('returns a string formatted as {name}@{version}', () => {
+    expect(getPluginID(getPluginManifest('Test', '1.2.3'))).toBe('Test@1.2.3');
+  });
+});
+
+describe('getScriptElementID', () => {
+  it('returns a string formatted as {prefix}@{name}', () => {
+    expect(getScriptElementID(getPluginManifest('Test', '1.2.3'))).toBe('console-plugin-Test');
+  });
+});
+
+describe('loadDynamicPlugin', () => {
+  const getScriptElement = (manifest: ConsolePluginManifestJSON) =>
+    document.querySelector<HTMLScriptElement>(`[id="${getScriptElementID(manifest)}"]`);
+
+  const getAllScriptElements = () =>
+    document.querySelectorAll<HTMLScriptElement>(`[id^="${scriptIDPrefix}"]`);
+
+  it('updates pluginMap and adds script element to document head', () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    loadDynamicPlugin('http://example.com/test', manifest);
+
+    const { pluginMap } = getStateForTestPurposes();
+    expect(pluginMap.size).toBe(1);
+    expect(pluginMap.has('Test@1.2.3')).toBe(true);
+    expect(pluginMap.get('Test@1.2.3').manifest).toBe(manifest);
+    expect(pluginMap.get('Test@1.2.3').entryCallbackFired).toBe(false);
+
+    const script = getScriptElement(manifest);
+    expect(script instanceof HTMLScriptElement).toBe(true);
+    expect(script.parentElement).toBe(document.head);
+    expect(script.id).toBe('console-plugin-Test');
+    expect(script.src).toBe('http://example.com/test/plugin-entry.js');
+    expect(script.async).toBe(true);
+  });
+
+  it('does nothing if a plugin with the same name is already registered', () => {
+    const manifest1 = getPluginManifest('Test', '1.2.3');
+    const manifest2 = getPluginManifest('Test', '2.3.4');
+    loadDynamicPlugin('http://example.com/test1', manifest1);
+    loadDynamicPlugin('http://example.com/test2', manifest2);
+
+    const { pluginMap } = getStateForTestPurposes();
+    expect(pluginMap.size).toBe(1);
+    expect(pluginMap.has('Test@1.2.3')).toBe(true);
+    expect(pluginMap.get('Test@1.2.3').manifest).toBe(manifest1);
+    expect(pluginMap.get('Test@1.2.3').entryCallbackFired).toBe(false);
+
+    const allScripts = getAllScriptElements();
+    expect(allScripts.length).toBe(1);
+    expect(allScripts[0].id).toBe('console-plugin-Test');
+    expect(allScripts[0].src).toBe('http://example.com/test1/plugin-entry.js');
+    expect(allScripts[0].async).toBe(true);
+  });
+});
+
+describe('registerPluginEntryCallback', () => {
+  it('adds loadPluginEntry function to window global object', () => {
+    const pluginStore = new PluginStore([]);
+    expect(window.loadPluginEntry).toBeUndefined();
+
+    registerPluginEntryCallback(pluginStore);
+    expect(typeof window.loadPluginEntry === 'function').toBe(true);
+  });
+});
+
+describe('window.loadPluginEntry', () => {
+  it('marks the plugin as loaded, resolves its extensions and adds it to plugin store', () => {
+    const pluginStore = new PluginStore([]);
+    const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
+
+    const extensions: Extension[] = [
+      {
+        type: 'Foo',
+        properties: { test: true },
+      },
+      {
+        type: 'Bar',
+        properties: { baz: 1, qux: { $codeRef: 'a.b' } },
+      },
+    ];
+
+    const resolvedExtensions: Extension[] = [
+      {
+        type: 'Foo',
+        properties: { test: true },
+      },
+      {
+        type: 'Bar',
+        properties: { baz: 1, qux: getExecutableCodeRefMock('value') },
+      },
+    ];
+
+    const manifest = getPluginManifest('Test', '1.2.3', extensions);
+    const [, entryModule] = getEntryModuleMocks({});
+
+    const overrideSharedModules = jest.fn();
+    const resolveEncodedCodeRefs = jest.fn(() => resolvedExtensions);
+
+    loadDynamicPlugin('http://example.com/test', manifest);
+
+    getPluginEntryCallback(
+      pluginStore,
+      overrideSharedModules,
+      resolveEncodedCodeRefs,
+    )('Test@1.2.3', entryModule);
+
+    const { pluginMap } = getStateForTestPurposes();
+    expect(pluginMap.size).toBe(1);
+    expect(pluginMap.get('Test@1.2.3').manifest).toBe(manifest);
+    expect(pluginMap.get('Test@1.2.3').entryCallbackFired).toBe(true);
+
+    expect(overrideSharedModules).toHaveBeenCalledWith(entryModule);
+
+    expect(resolveEncodedCodeRefs).toHaveBeenCalledWith(
+      manifest.extensions,
+      entryModule,
+      'Test@1.2.3',
+      expect.any(Function),
+    );
+
+    expect(addDynamicPlugin).toHaveBeenCalledWith('Test@1.2.3', manifest, resolvedExtensions);
+  });
+
+  it('does nothing if the plugin ID is not registered', () => {
+    const pluginStore = new PluginStore([]);
+    const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
+
+    const [, entryModule] = getEntryModuleMocks({});
+
+    const overrideSharedModules = jest.fn();
+    const resolveEncodedCodeRefs = jest.fn(() => []);
+
+    getPluginEntryCallback(
+      pluginStore,
+      overrideSharedModules,
+      resolveEncodedCodeRefs,
+    )('Test@1.2.3', entryModule);
+
+    const { pluginMap } = getStateForTestPurposes();
+    expect(pluginMap.size).toBe(0);
+
+    expect(overrideSharedModules).not.toHaveBeenCalled();
+    expect(resolveEncodedCodeRefs).not.toHaveBeenCalled();
+    expect(addDynamicPlugin).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if called a second time for the same plugin', () => {
+    const pluginStore = new PluginStore([]);
+    const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
+
+    const manifest = getPluginManifest('Test', '1.2.3');
+    const [, entryModule] = getEntryModuleMocks({});
+
+    const overrideSharedModules = jest.fn();
+    const resolveEncodedCodeRefs = jest.fn(() => []);
+
+    loadDynamicPlugin('http://example.com/test', manifest);
+
+    getPluginEntryCallback(
+      pluginStore,
+      overrideSharedModules,
+      resolveEncodedCodeRefs,
+    )('Test@1.2.3', entryModule);
+
+    getPluginEntryCallback(
+      pluginStore,
+      overrideSharedModules,
+      resolveEncodedCodeRefs,
+    )('Test@1.2.3', entryModule);
+
+    const { pluginMap } = getStateForTestPurposes();
+    expect(pluginMap.size).toBe(1);
+
+    expect(overrideSharedModules).toHaveBeenCalledTimes(1);
+    expect(resolveEncodedCodeRefs).toHaveBeenCalledTimes(1);
+    expect(addDynamicPlugin).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing if overriding shared modules throws an error', () => {
+    const pluginStore = new PluginStore([]);
+    const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
+
+    const manifest = getPluginManifest('Test', '1.2.3');
+    const [, entryModule] = getEntryModuleMocks({});
+
+    const overrideSharedModules = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const resolveEncodedCodeRefs = jest.fn(() => []);
+
+    loadDynamicPlugin('http://example.com/test', manifest);
+
+    getPluginEntryCallback(
+      pluginStore,
+      overrideSharedModules,
+      resolveEncodedCodeRefs,
+    )('Test@1.2.3', entryModule);
+
+    const { pluginMap } = getStateForTestPurposes();
+    expect(pluginMap.size).toBe(1);
+
+    expect(overrideSharedModules).toHaveBeenCalledWith(entryModule);
+    expect(resolveEncodedCodeRefs).not.toHaveBeenCalled();
+    expect(addDynamicPlugin).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
@@ -1,0 +1,66 @@
+import * as coFetchModule from '@console/internal/co-fetch';
+import * as pluginManifestModule from '../plugin-manifest';
+import { SchemaValidator } from '../../validation/SchemaValidator';
+import { getPluginManifest } from '../../utils/test-utils';
+
+const coFetch = jest.spyOn(coFetchModule, 'coFetch');
+const validatePluginManifest = jest.spyOn(pluginManifestModule, 'validatePluginManifest');
+
+const { fetchPluginManifest } = pluginManifestModule;
+
+beforeEach(() => {
+  [coFetch, validatePluginManifest].forEach((mock) => mock.mockReset());
+});
+
+describe('fetchPluginManifest', () => {
+  it('loads, validates and returns the manifest object', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    const manifestURL = 'http://example.com/test/plugin-manifest.json';
+
+    const validator = new SchemaValidator(manifestURL);
+    const validatorResultReport = jest.spyOn(validator.result, 'report');
+
+    coFetch.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
+    validatePluginManifest.mockImplementation(() => Promise.resolve(validator.result));
+
+    const result = await fetchPluginManifest('http://example.com/test');
+
+    expect(result).toBe(manifest);
+    expect(coFetch).toHaveBeenCalledWith(manifestURL, { method: 'GET' });
+    expect(validatePluginManifest).toHaveBeenCalledWith(manifest, manifestURL);
+    expect(validatorResultReport).toHaveBeenCalledWith();
+  });
+
+  it('throws an error if the HTTP request fails', async () => {
+    coFetch.mockImplementation(() => Promise.reject(new Error('boom')));
+
+    expect.assertions(2);
+    try {
+      await fetchPluginManifest('http://example.com/test');
+    } catch (e) {
+      expect(coFetch).toHaveBeenCalled();
+      expect(validatePluginManifest).not.toHaveBeenCalled();
+    }
+  });
+
+  it('throws an error if the validation fails', async () => {
+    const manifest = getPluginManifest('Test', '1.2.3');
+    const manifestURL = 'http://example.com/test/plugin-manifest.json';
+
+    const validator = new SchemaValidator(manifestURL);
+    jest.spyOn(validator.result, 'report').mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    coFetch.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
+    validatePluginManifest.mockImplementation(() => Promise.resolve(validator.result));
+
+    expect.assertions(2);
+    try {
+      await fetchPluginManifest('http://example.com/test');
+    } catch (e) {
+      expect(coFetch).toHaveBeenCalled();
+      expect(validatePluginManifest).toHaveBeenCalled();
+    }
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
@@ -1,18 +1,38 @@
+import * as _ from 'lodash';
 import { coFetch } from '@console/internal/co-fetch';
 import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
 import { pluginManifestFile } from '../constants';
 import pluginManifestSchema from '../../dist/schema/plugin-manifest';
+import { resolveURL } from '../utils/url';
 
-export const fetchPluginManifest = async (baseURL: string) => {
-  const url = new URL(pluginManifestFile, baseURL).toString();
-  const response: Response = await coFetch(url, { method: 'GET' });
-  const manifest = (await response.json()) as ConsolePluginManifestJSON;
-
-  // Avoid pulling ajv dependency into main vendors chunk
+export const validatePluginManifest = async (
+  manifest: ConsolePluginManifestJSON,
+  manifestURL: string,
+) => {
+  // Use dynamic import to avoid pulling ajv dependency tree into main vendors chunk
   const SchemaValidator = await import(
     '@console/dynamic-plugin-sdk/src/validation/SchemaValidator'
   ).then((m) => m.SchemaValidator);
 
-  new SchemaValidator(url).validate(pluginManifestSchema, manifest).report();
+  const validator = new SchemaValidator(manifestURL);
+  validator.validate(pluginManifestSchema, manifest, 'manifest');
+
+  validator.assert.nonEmptyString(manifest.name, 'manifest.name');
+  validator.assert.nonEmptyString(manifest.version, 'manifest.version');
+
+  if (_.isPlainObject(manifest.dependencies)) {
+    Object.entries(manifest.dependencies).forEach(([depName, versionRange]) => {
+      validator.assert.validSemverRangeString(versionRange, `manifest.dependencies['${depName}']`);
+    });
+  }
+
+  return validator.result;
+};
+
+export const fetchPluginManifest = async (baseURL: string) => {
+  const url = resolveURL(baseURL, pluginManifestFile, { trailingSlashInBaseURL: true });
+  const response: Response = await coFetch(url, { method: 'GET' });
+  const manifest = (await response.json()) as ConsolePluginManifestJSON;
+  (await validatePluginManifest(manifest, url)).report();
   return manifest;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/test-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/test-utils.ts
@@ -1,0 +1,48 @@
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+import { codeRefSymbol } from '../coderefs/coderef-resolver';
+import { SupportedExtension } from '../schema/console-extensions';
+import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
+import { RemoteEntryModule, CodeRef, Update } from '../types';
+
+export const getPluginManifest = (
+  name: string,
+  version: string,
+  extensions: Extension[] = [],
+): ConsolePluginManifestJSON => ({
+  name,
+  version,
+  extensions: extensions as SupportedExtension[],
+  dependencies: { '@console/pluginAPI': '~0.0.1' },
+});
+
+export const getExecutableCodeRefMock = <T = any>(
+  resolvedValue: T,
+): jest.Mock<ReturnType<CodeRef<T>>> => {
+  const ref = jest.fn(() => Promise.resolve(resolvedValue));
+  ref[codeRefSymbol] = true;
+  return ref;
+};
+
+export const getEntryModuleMocks = (requestedModule: {}): [
+  ModuleFactoryMock,
+  RemoteEntryModuleMock,
+] => {
+  const moduleFactory = jest.fn<VoidFunction>(() => requestedModule);
+
+  const entryModule = {
+    get: jest.fn(async () => moduleFactory),
+    override: jest.fn<void>(),
+  };
+
+  return [moduleFactory, entryModule];
+};
+
+export type ModuleFactoryMock = jest.Mock<VoidFunction>;
+
+export type RemoteEntryModuleMock = Update<
+  RemoteEntryModule,
+  {
+    get: jest.Mock<ReturnType<RemoteEntryModule['get']>>;
+    override: jest.Mock<void>;
+  }
+>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/url.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/url.ts
@@ -1,0 +1,21 @@
+/**
+ * Resolve URL string using `base` and `to` URLs.
+ *
+ * Delegates to `new URL(to, base)` for the actual resolution.
+ *
+ * @param base Base URL.
+ * @param to Target resource URL.
+ * @param options Resolution options.
+ */
+export const resolveURL = (
+  base: string,
+  to: string,
+  options: {
+    trailingSlashInBaseURL: boolean;
+  } = {
+    trailingSlashInBaseURL: false,
+  },
+): string => {
+  const from = options.trailingSlashInBaseURL && !base.endsWith('/') ? `${base}/` : base;
+  return new URL(to, from).toString();
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
@@ -15,7 +15,7 @@ type ExtensionCodeRefData = {
 
 type ExposedPluginModules = ConsolePluginMetadata['exposedModules'];
 
-const collectCodeRefData = (extensions: SupportedExtension[]) =>
+export const collectCodeRefData = (extensions: SupportedExtension[]) =>
   extensions.reduce((acc, e, index) => {
     const refs = filterEncodedCodeRefProperties(e.properties);
     if (!_.isEmpty(refs)) {
@@ -24,7 +24,7 @@ const collectCodeRefData = (extensions: SupportedExtension[]) =>
     return acc;
   }, [] as ExtensionCodeRefData[]);
 
-const findWebpackModules = (
+export const findWebpackModules = (
   compilation: webpack.Compilation,
   exposedModules: ExposedPluginModules,
 ) => {
@@ -38,7 +38,7 @@ const findWebpackModules = (
 };
 
 export class ExtensionValidator {
-  public readonly result: ValidationResult;
+  readonly result: ValidationResult;
 
   constructor(description: string) {
     this.result = new ValidationResult(description);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/SchemaValidator.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/SchemaValidator.ts
@@ -1,13 +1,15 @@
 import * as Ajv from 'ajv';
 import { ValidationResult } from './ValidationResult';
+import { ValidationAssertions } from './ValidationAssertions';
 
 export class SchemaValidator {
-  private readonly ajv = new Ajv({ allErrors: true });
+  readonly result: ValidationResult;
 
-  public readonly result: ValidationResult;
+  readonly assert: ValidationAssertions;
 
-  constructor(description: string) {
+  constructor(description: string, private readonly ajv = new Ajv({ allErrors: true })) {
     this.result = new ValidationResult(description);
+    this.assert = new ValidationAssertions(this.result);
   }
 
   validate(schema: object, data: any, dataVar: string = 'obj') {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
@@ -1,0 +1,25 @@
+import * as semver from 'semver';
+import { ValidationResult } from './ValidationResult';
+
+export class ValidationAssertions {
+  // eslint-disable-next-line no-empty-function
+  constructor(private readonly result: ValidationResult) {}
+
+  nonEmptyString(obj: any, objPath: string) {
+    if (typeof obj === 'string') {
+      this.result.assertThat(obj.trim().length > 0, `${objPath} must not be empty`);
+    }
+  }
+
+  validSemverString(obj: any, objPath: string) {
+    if (typeof obj === 'string') {
+      this.result.assertThat(!!semver.valid(obj), `${objPath} must be semver compliant`);
+    }
+  }
+
+  validSemverRangeString(obj: any, objPath: string) {
+    if (typeof obj === 'string') {
+      this.result.assertThat(!!semver.validRange(obj), `${objPath} semver range is not valid`);
+    }
+  }
+}

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationResult.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationResult.ts
@@ -20,15 +20,21 @@ export class ValidationResult {
     return this.errors.length > 0;
   }
 
+  getErrors() {
+    return [...this.errors];
+  }
+
   formatErrors() {
     const prefix = `${chalk.bold(this.description)} (${this.errors.length} errors)\n\n`;
     const errorLines = this.errors.map((e) => `    ${chalk.red(e)}`);
     return prefix + errorLines.join('\n');
   }
 
-  report(throwOnErrors: boolean = true, console: Console = global.console) {
+  report(throwOnErrors: boolean = true) {
     if (this.hasErrors()) {
+      // eslint-disable-next-line no-console
       console.error(this.formatErrors());
+
       if (throwOnErrors) {
         throw new Error('Validation failed');
       }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ExtensionValidator.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ExtensionValidator.spec.ts
@@ -1,0 +1,222 @@
+import * as webpack from 'webpack';
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+import { collectCodeRefData, findWebpackModules, ExtensionValidator } from '../ExtensionValidator';
+import { ValidationResult } from '../ValidationResult';
+import { SupportedExtension } from '../../schema/console-extensions';
+
+const getWebpackCompilationMocks = (
+  webpackModules: {}[],
+): [webpack.Compilation, jest.Mock<any>] => {
+  const getProvidedExports = jest.fn();
+
+  const compilation = {} as webpack.Compilation;
+  compilation.modules = new Set();
+  compilation.moduleGraph = { getProvidedExports } as any;
+
+  webpackModules.forEach((m) => {
+    compilation.modules.add(m as webpack.Module);
+  });
+
+  return [compilation, getProvidedExports];
+};
+
+describe('collectCodeRefData', () => {
+  it('returns CodeRef data for the given list of extensions', () => {
+    const extensions: Extension[] = [
+      {
+        type: 'Foo',
+        properties: { test: true },
+      },
+      {
+        type: 'Bar',
+        properties: { baz: 1, qux: { $codeRef: 'a.b' } },
+      },
+    ];
+
+    expect(collectCodeRefData(extensions as SupportedExtension[])).toEqual([
+      {
+        index: 1,
+        propToCodeRefValue: {
+          qux: 'a.b',
+        },
+      },
+    ]);
+  });
+});
+
+describe('findWebpackModules', () => {
+  it('maps plugin-exposed modules to webpack modules if they exist in compilation', () => {
+    const [compilation] = getWebpackCompilationMocks([
+      {}, // not a NormalModule
+      { rawRequest: './foo' },
+    ]);
+
+    expect(findWebpackModules(compilation, { fooModule: './foo', barModule: './bar' })).toEqual({
+      fooModule: { rawRequest: './foo' },
+      barModule: undefined,
+    });
+  });
+});
+
+describe('ExtensionValidator', () => {
+  describe('validate', () => {
+    const testValidate = (
+      extensions: Extension[],
+      webpackModules: {}[],
+      exposedModules: { [moduleName: string]: string },
+      beforeResult: (getProvidedExports: jest.Mock<any>) => void,
+      afterResult: (result: ValidationResult, getProvidedExports: jest.Mock<any>) => void,
+    ) => {
+      const [compilation, getProvidedExports] = getWebpackCompilationMocks(webpackModules);
+      beforeResult(getProvidedExports);
+
+      const result = new ExtensionValidator('test').validate(
+        compilation,
+        extensions as SupportedExtension[],
+        exposedModules,
+      );
+      afterResult(result, getProvidedExports);
+    };
+
+    it('checks that each exposed module has at least one code reference', () => {
+      testValidate(
+        [
+          {
+            type: 'Foo',
+            properties: { test: true },
+          },
+          {
+            type: 'Bar',
+            properties: { baz: 1, qux: { $codeRef: 'fooModule.fooExport' } },
+          },
+        ],
+        [
+          {}, // not a NormalModule
+          { rawRequest: './foo' },
+        ],
+        {
+          fooModule: './foo',
+          barModule: './bar',
+        },
+        (getProvidedExports) => {
+          getProvidedExports.mockImplementation((m) =>
+            m.rawRequest === './foo' ? ['fooExport'] : [],
+          );
+        },
+        (result, getProvidedExports) => {
+          expect(result.getErrors().length).toBe(1);
+          expect(result.getErrors()[0]).toBe(
+            "Exposed module 'barModule' is not referenced by any extension",
+          );
+          expect(getProvidedExports).toHaveBeenCalledWith({ rawRequest: './foo' });
+        },
+      );
+    });
+
+    it('checks that each code reference points to a valid webpack module export', () => {
+      testValidate(
+        [
+          {
+            type: 'Foo',
+            properties: { test: true },
+          },
+          {
+            type: 'Bar',
+            properties: {
+              baz: 1,
+              qux: { $codeRef: 'fooModule.fooExport' },
+              mux: { $codeRef: '.fooExport' },
+            },
+          },
+        ],
+        [
+          {}, // not a NormalModule
+          { rawRequest: './foo' },
+        ],
+        {
+          fooModule: './foo',
+        },
+        (getProvidedExports) => {
+          getProvidedExports.mockImplementation((m) =>
+            m.rawRequest === './foo' ? ['fooExport'] : [],
+          );
+        },
+        (result, getProvidedExports) => {
+          expect(result.getErrors().length).toBe(1);
+          expect(result.getErrors()[0].startsWith("Invalid code reference '.fooExport'")).toBe(
+            true,
+          );
+          expect(getProvidedExports).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      testValidate(
+        [
+          {
+            type: 'Foo',
+            properties: { test: true },
+          },
+          {
+            type: 'Bar',
+            properties: {
+              baz: 1,
+              qux: { $codeRef: 'fooModule.fooExport' },
+              mux: { $codeRef: 'barModule.barExport' },
+            },
+          },
+        ],
+        [
+          {}, // not a NormalModule
+          { rawRequest: './foo' },
+        ],
+        {
+          fooModule: './foo',
+        },
+        (getProvidedExports) => {
+          getProvidedExports.mockImplementation((m) =>
+            m.rawRequest === './foo' ? ['fooExport'] : [],
+          );
+        },
+        (result, getProvidedExports) => {
+          expect(result.getErrors().length).toBe(1);
+          expect(result.getErrors()[0].startsWith("Invalid module 'barModule'")).toBe(true);
+          expect(getProvidedExports).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      testValidate(
+        [
+          {
+            type: 'Foo',
+            properties: { test: true },
+          },
+          {
+            type: 'Bar',
+            properties: {
+              baz: 1,
+              qux: { $codeRef: 'fooModule.fooExport' },
+              mux: { $codeRef: 'fooModule.barExport' },
+            },
+          },
+        ],
+        [
+          {}, // not a NormalModule
+          { rawRequest: './foo' },
+        ],
+        {
+          fooModule: './foo',
+        },
+        (getProvidedExports) => {
+          getProvidedExports.mockImplementation((m) =>
+            m.rawRequest === './foo' ? ['fooExport'] : [],
+          );
+        },
+        (result, getProvidedExports) => {
+          expect(result.getErrors().length).toBe(1);
+          expect(result.getErrors()[0].startsWith("Invalid module export 'barExport'")).toBe(true);
+          expect(getProvidedExports).toHaveBeenCalledTimes(2);
+        },
+      );
+    });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/SchemaValidator.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/SchemaValidator.spec.ts
@@ -1,0 +1,50 @@
+import * as Ajv from 'ajv';
+import { SchemaValidator } from '../SchemaValidator';
+
+const getAjvMocks = (): [Ajv.Ajv, jest.Mock<any>] => {
+  const validate = jest.fn();
+
+  const ajv = {} as Ajv.Ajv;
+  ajv.validate = validate;
+
+  return [ajv, validate];
+};
+
+describe('SchemaValidator', () => {
+  describe('validate', () => {
+    it('does nothing if ajv.validate returns truthy value', () => {
+      const [ajv, ajvValidate] = getAjvMocks();
+      ajvValidate.mockImplementation(() => true);
+
+      const schema = { description: 'dummy schema' };
+      const data = { foo: true, bar: [1, 'qux'] };
+
+      const result = new SchemaValidator('test', ajv).validate(schema, data, 'foo');
+
+      expect(result.hasErrors()).toBe(false);
+      expect(ajvValidate).toHaveBeenCalledWith(schema, data);
+    });
+
+    it('adds ajv.errors to validation result if ajv.validate returns falsy value', () => {
+      const [ajv, ajvValidate] = getAjvMocks();
+      ajvValidate.mockImplementation(() => {
+        ajv.errors = [
+          { dataPath: '.x', message: 'test message for path x' },
+          { dataPath: '.y', message: 'test message for path y' },
+        ] as Ajv.ErrorObject[];
+        return false;
+      });
+
+      const schema = { description: 'dummy schema' };
+      const data = { foo: true, bar: [1, 'qux'] };
+
+      const result = new SchemaValidator('test', ajv).validate(schema, data, 'foo');
+
+      expect(result.hasErrors()).toBe(true);
+      expect(result.getErrors().length).toBe(2);
+      expect(result.getErrors()[0]).toBe('foo.x test message for path x');
+      expect(result.getErrors()[1]).toBe('foo.y test message for path y');
+      expect(ajvValidate).toHaveBeenCalledWith(schema, data);
+    });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ValidationResult.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ValidationResult.spec.ts
@@ -1,0 +1,69 @@
+import { ValidationResult } from '../ValidationResult';
+
+const consoleError = jest.spyOn(console, 'error');
+
+beforeEach(() => {
+  consoleError.mockReset();
+});
+
+describe('ValidationResult', () => {
+  describe('addError', () => {
+    it('adds the given message to errors', () => {
+      const result = new ValidationResult('test');
+      expect(result.hasErrors()).toBe(false);
+      expect(result.getErrors().length).toBe(0);
+
+      result.addError('foo');
+      expect(result.hasErrors()).toBe(true);
+      expect(result.getErrors().length).toBe(1);
+      expect(result.getErrors()[0]).toBe('foo');
+    });
+  });
+
+  describe('assertThat', () => {
+    it('adds the given message to errors only if the condition is falsy', () => {
+      const result = new ValidationResult('test');
+
+      result.assertThat(false, 'foo');
+      result.assertThat(!!0, 'bar');
+      result.assertThat(true, 'qux');
+      result.assertThat(!0, 'mux');
+
+      expect(result.hasErrors()).toBe(true);
+      expect(result.getErrors().length).toBe(2);
+      expect(result.getErrors()[0]).toBe('foo');
+      expect(result.getErrors()[1]).toBe('bar');
+    });
+  });
+
+  describe('report', () => {
+    it('logs formatted errors to console and optionally throws an error', () => {
+      const result = new ValidationResult('test');
+
+      result.addError('foo');
+
+      expect(() => {
+        result.report(true);
+      }).toThrow();
+
+      expect(consoleError).toHaveBeenLastCalledWith(result.formatErrors());
+
+      expect(() => {
+        result.report(false);
+      }).not.toThrow();
+
+      expect(consoleError).toHaveBeenLastCalledWith(result.formatErrors());
+    });
+
+    it('does nothing if the error list is empty', () => {
+      const result = new ValidationResult('test');
+
+      expect(() => {
+        result.report(true);
+        result.report(false);
+      }).not.toThrow();
+
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -1,7 +1,6 @@
 import * as webpack from 'webpack';
 import { ReplaceSource } from 'webpack-sources';
 import * as readPkg from 'read-pkg';
-import * as semver from 'semver';
 import * as _ from 'lodash';
 import { ConsoleAssetPlugin } from './ConsoleAssetPlugin';
 import { ConsolePackageJSON } from '../schema/plugin-package';
@@ -15,21 +14,21 @@ const remoteEntryCallback = 'window.loadPluginEntry';
 
 const validatePackageFile = (pkg: ConsolePackageJSON) => {
   const validator = new SchemaValidator('package.json');
-  validator.result.assertThat(!!semver.valid(pkg.version), 'version must be semver compliant');
+  validator.assert.validSemverString(pkg.version, 'pkg.version');
 
   if (pkg.consolePlugin) {
-    validator.validate(consolePkgMetadataSchema, pkg.consolePlugin, 'consolePlugin');
+    validator.validate(consolePkgMetadataSchema, pkg.consolePlugin, 'pkg.consolePlugin');
 
     if (_.isPlainObject(pkg.consolePlugin.dependencies)) {
-      Object.entries(pkg.consolePlugin.dependencies).forEach(([pluginName, versionRange]) => {
-        validator.result.assertThat(
-          !!semver.validRange(versionRange),
-          `consolePlugin.dependencies['${pluginName}'] version range is not valid`,
+      Object.entries(pkg.consolePlugin.dependencies).forEach(([depName, versionRange]) => {
+        validator.assert.validSemverRangeString(
+          versionRange,
+          `pkg.consolePlugin.dependencies['${depName}']`,
         );
       });
     }
   } else {
-    validator.result.addError('consolePlugin object is missing');
+    validator.result.addError('pkg.consolePlugin object is missing');
   }
 
   return validator.result;

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-integration-tests.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-integration-tests.spec.ts
@@ -5,7 +5,7 @@ import { getTemplatePackage } from './plugin-resolver.spec';
 
 describe('plugin-integration-tests', () => {
   describe('getTestSuitesForPluginPackage', () => {
-    let globMock;
+    let globMock: jest.SpyInstance<typeof glob.sync>;
 
     beforeEach(() => {
       globMock = jest.spyOn(glob, 'sync');

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-resolver.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-resolver.spec.ts
@@ -63,7 +63,7 @@ describe('plugin-resolver', () => {
   });
 
   describe('readPackages', () => {
-    let readPkgMock;
+    let readPkgMock: jest.SpyInstance<typeof readPkg.sync>;
 
     beforeEach(() => {
       readPkgMock = jest.spyOn(readPkg, 'sync');

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -71,7 +71,7 @@ export class PluginStore {
 
   private updateDynamicExtensions() {
     this.dynamicExtensions = Array.from(this.dynamicPlugins.values()).reduce(
-      (acc, plugin) => (plugin.enabled ? [...acc, ...plugin.resolvedExtensions] : acc),
+      (acc, plugin) => (plugin.enabled ? [...acc, ...plugin.processedExtensions] : acc),
       [],
     );
 
@@ -100,7 +100,7 @@ export class PluginStore {
     if (!this.dynamicPlugins.has(pluginID)) {
       this.dynamicPlugins.set(pluginID, {
         manifest: Object.freeze(manifest),
-        resolvedExtensions: resolvedExtensions.map((e, index) =>
+        processedExtensions: resolvedExtensions.map((e, index) =>
           Object.freeze(augmentExtension(sanitizeExtension(e), pluginID, manifest.name, index)),
         ),
         enabled: false,
@@ -140,6 +140,15 @@ export class PluginStore {
       return acc;
     }, {} as { [pluginID: string]: DynamicPluginMetadata });
   }
+
+  public getStateForTestPurposes() {
+    return {
+      staticExtensions: this.staticExtensions,
+      dynamicExtensions: this.dynamicExtensions,
+      dynamicPlugins: this.dynamicPlugins,
+      listeners: this.listeners,
+    };
+  }
 }
 
 type FlagsObject = { [key: string]: boolean };
@@ -150,6 +159,6 @@ type DynamicPluginMetadata = Omit<DynamicPluginManifest, 'extensions'>;
 
 type DynamicPlugin = {
   manifest: DynamicPluginManifest;
-  resolvedExtensions: Readonly<LoadedExtension[]>;
+  processedExtensions: Readonly<LoadedExtension[]>;
   enabled: boolean;
 };


### PR DESCRIPTION
This PR adds code coverage for key parts of both plugin SDKs:
- `@console/plugin-sdk` (primary goal is to support static plugins within the monorepo)
- `@console/dynamic-plugin-sdk` (primary goal is to develop and build dynamic plugins)

In future, we'll reconcile these packages as part of transforming existing static plugins to dynamic ones.