### PR TITLE
Query Browser: Remove SeriesButton's key prop

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -708,11 +708,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
     transforms: [sortable, wrappable],
   };
 
-  // TableBody's shouldComponentUpdate seems to struggle with SeriesButton, so add a unique key to help TableBody
-  // determine when it should update
-  const buttonCell = (labels) => ({
-    title: <SeriesButton index={index} key={_.uniqueId()} labels={labels} />,
-  });
+  const buttonCell = (labels) => ({ title: <SeriesButton index={index} labels={labels} /> });
 
   let columns, rows;
   if (resultType === 'scalar') {


### PR DESCRIPTION
It appears that we no longer need this hack. (I can no longer recreate
the bug that it was fixing.)