### PR TITLE
Only re-create pod donut if data changes

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRing.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRing.tsx
@@ -4,7 +4,7 @@ import { Button, Split, SplitItem, Bullseye } from '@patternfly/react-core';
 import { K8sResourceKind, k8sPatch, K8sKind } from '@console/internal/module/k8s';
 import { AngleUpIcon, AngleDownIcon } from '@patternfly/react-icons';
 import { useRelatedHPA } from '@console/dev-console/src/components/hpa/hooks';
-import { hpaPodRingLabel, podRingLabel, usePodScalingAccessStatus } from '../../utils';
+import { usePodRingLabel, usePodScalingAccessStatus } from '../../utils';
 import { ExtPodKind } from '../../types';
 import PodStatus from './PodStatus';
 import './PodRing.scss';
@@ -80,9 +80,13 @@ const PodRing: React.FC<PodRingProps> = ({
   const isScalingAllowed = isAccessScalingAllowed && !hpaControlledScaling;
 
   const resourceObj = rc || obj;
-  const { title, subTitle, titleComponent } = hpaControlledScaling
-    ? hpaPodRingLabel(resourceObj, hpa, pods)
-    : podRingLabel(resourceObj, kind, pods);
+  const { title, subTitle, titleComponent } = usePodRingLabel(
+    resourceObj,
+    kind,
+    pods,
+    hpaControlledScaling,
+    hpa,
+  );
 
   return (
     <Split>

--- a/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
@@ -3,8 +3,10 @@ import * as _ from 'lodash';
 import { ChartDonut } from '@patternfly/react-charts';
 import { Tooltip } from '@patternfly/react-core';
 import { ExtPodKind } from '../../types';
+import { useForceUpdate } from '../../hooks/useForceUpdate';
 import { calculateRadius, podStatus, getPodStatus } from '../../utils/pod-utils';
 import { podColor, AllPodStatus } from '../../constants';
+
 import './PodStatus.scss';
 
 const ANIMATION_DURATION = 350;
@@ -14,7 +16,7 @@ type PodData = {
   y: number;
 };
 
-type PodStatusProps = {
+interface PodStatusProps {
   innerRadius?: number;
   outerRadius?: number;
   size?: number;
@@ -27,13 +29,7 @@ type PodStatusProps = {
   titleComponent?: React.ReactElement;
   subTitle?: string;
   subTitleComponent?: React.ReactElement;
-};
-
-type PodStatusState = {
-  vData: PodData[];
-  updateOnEnd: boolean;
-  tipIndex?: number;
-};
+}
 
 const { podStatusInnerRadius, podStatusOuterRadius } = calculateRadius(130); // default value of size is 130
 
@@ -46,70 +42,56 @@ const podStatusIsNumeric = (podStatusValue: string) => {
   );
 };
 
-class PodStatus extends React.Component<PodStatusProps, PodStatusState> {
-  constructor(props) {
-    super(props);
-    this.state = {
-      vData: [],
-      updateOnEnd: false,
-    };
-  }
+const PodStatus: React.FC<PodStatusProps> = ({
+  innerRadius = podStatusInnerRadius,
+  outerRadius = podStatusOuterRadius,
+  x,
+  y,
+  size = 130,
+  standalone = false,
+  showTooltip = true,
+  title = '',
+  subTitle = '',
+  titleComponent,
+  subTitleComponent,
+  data,
+}) => {
+  const [updateOnEnd, setUpdateOnEnd] = React.useState<boolean>(false);
+  const forceUpdate = useForceUpdate();
+  const prevVData = React.useRef<PodData[]>(null);
 
-  static getDerivedStateFromProps(
-    nextProps: PodStatusProps,
-    prevState: PodStatusState,
-  ): PodStatusState {
-    const { data } = nextProps;
-
-    if (prevState.updateOnEnd) {
-      // Animations complete, remove empty slices
-      return {
-        vData: _.filter(prevState.vData, (nextData) => nextData.y !== 0),
-        updateOnEnd: false,
-      };
-    }
-
-    const vData: PodData[] = podStatus.map((pod) => ({
+  const vData = React.useMemo(() => {
+    const updateVData: PodData[] = podStatus.map((pod) => ({
       x: pod,
       y: _.sumBy(data, (d) => +(getPodStatus(d) === pod)) || 0,
     }));
 
     if (_.isEmpty(data)) {
-      _.update(vData, `[${_.findKey(vData, { x: AllPodStatus.ScaledTo0 })}]['y']`, () => 1);
+      _.update(
+        updateVData,
+        `[${_.findKey(updateVData, { x: AllPodStatus.ScaledTo0 })}]['y']`,
+        () => 1,
+      );
     }
 
-    // Determine if we have moved to just 1 data point left
-    const prevDataPoints = _.size(_.filter(prevState.vData, (nextData) => nextData.y !== 0));
-    const dataPoints = _.size(_.filter(vData, (nextData) => nextData.y !== 0));
-    return { vData, updateOnEnd: dataPoints === 1 && prevDataPoints > 1 };
-  }
+    const prevDataPoints = _.size(_.filter(prevVData.current, (nextData) => nextData.y !== 0));
+    const dataPoints = _.size(_.filter(updateVData, (nextData) => nextData.y !== 0));
+    setUpdateOnEnd(dataPoints === 1 && prevDataPoints > 1);
 
-  doUpdate = () => {
-    // Animations complete, update to remove empty slices
-    this.forceUpdate();
-  };
+    if (!_.isEqual(prevVData.current, updateVData)) {
+      prevVData.current = updateVData;
+      return updateVData;
+    }
+    return prevVData.current;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
-  render() {
-    const {
-      innerRadius = podStatusInnerRadius,
-      outerRadius = podStatusOuterRadius,
-      x,
-      y,
-      size = 130,
-      standalone = false,
-      showTooltip = true,
-      title = '',
-      subTitle = '',
-      titleComponent,
-      subTitleComponent,
-    } = this.props;
-    const { vData, updateOnEnd } = this.state;
-
-    const chartDonut = (
+  const chartDonut = React.useMemo(() => {
+    return (
       <ChartDonut
         animate={{
           duration: ANIMATION_DURATION,
-          onEnd: updateOnEnd ? this.doUpdate : undefined,
+          onEnd: updateOnEnd ? forceUpdate : undefined,
         }}
         standalone={standalone}
         innerRadius={innerRadius}
@@ -137,31 +119,50 @@ class PodStatus extends React.Component<PodStatusProps, PodStatusState> {
         }}
       />
     );
-    if (showTooltip) {
-      const tipContent = (
-        <div className="odc-pod-status-tooltip">
-          {vData.map((data) => {
-            return data.y > 0 ? (
-              <div key={data.x} className="odc-pod-status-tooltip__content">
-                <span
-                  className="odc-pod-status-tooltip__status-box"
-                  style={{ background: podColor[data.x] }}
-                />
-                {podStatusIsNumeric(data.x) && (
-                  <span key={3} className="odc-pod-status-tooltip__status-count">
-                    {`${Math.round(data.y)}`}
-                  </span>
-                )}
-                {data.x}
-              </div>
-            ) : null;
-          })}
-        </div>
-      );
-      return <Tooltip content={tipContent}>{chartDonut}</Tooltip>;
-    }
-    return chartDonut;
+  }, [
+    forceUpdate,
+    innerRadius,
+    outerRadius,
+    size,
+    standalone,
+    subTitle,
+    subTitleComponent,
+    title,
+    titleComponent,
+    updateOnEnd,
+    vData,
+    x,
+    y,
+  ]);
+
+  if (!vData) {
+    return null;
   }
-}
+
+  if (showTooltip) {
+    const tipContent = (
+      <div className="odc-pod-status-tooltip">
+        {vData.map((d) => {
+          return d.y > 0 ? (
+            <div key={d.x} className="odc-pod-status-tooltip__content">
+              <span
+                className="odc-pod-status-tooltip__status-box"
+                style={{ background: podColor[d.x] }}
+              />
+              {podStatusIsNumeric(d.x) && (
+                <span key={3} className="odc-pod-status-tooltip__status-count">
+                  {`${Math.round(d.y)}`}
+                </span>
+              )}
+              {d.x}
+            </div>
+          ) : null;
+        })}
+      </div>
+    );
+    return <Tooltip content={tipContent}>{chartDonut}</Tooltip>;
+  }
+  return chartDonut;
+};
 
 export default React.memo((props: PodStatusProps) => <PodStatus {...props} />);

--- a/frontend/packages/console-shared/src/hooks/useForceUpdate.ts
+++ b/frontend/packages/console-shared/src/hooks/useForceUpdate.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export const useForceUpdate = () => {
+  const [, setTick] = React.useState(0);
+  const update = React.useCallback(() => {
+    setTick((tick) => tick + 1);
+  }, []);
+  return update;
+};

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -39,81 +39,79 @@ describe('pod-ring utils:', () => {
   it('should return title 0, subtitle scaling to 2 and titleComponent for podRingLabel when scaling from 1 to 2 pods', () => {
     const deploymentWithReplicas = _.set(_.cloneDeep(deployment), 'spec.replicas', 2);
     const mockDeploymentData = _.set(deploymentWithReplicas, 'status.readyReplicas', 1);
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).title,
-    ).toEqual('1');
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).subTitle,
-    ).toEqual('scaling to 2');
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
-        .titleComponent,
-    ).not.toBeUndefined();
+    const podRingLabelData = podRingLabel(mockDeploymentData, mockDeploymentData.kind, [
+      mockPod as ExtPodKind,
+    ]);
+    expect(podRingLabelData.title).toEqual('1');
+    expect(podRingLabelData.subTitle).toEqual('scaling to 2');
+    expect(podRingLabelData.longTitle).toBeFalsy();
+    expect(podRingLabelData.longSubtitle).toBeTruthy();
+    expect(podRingLabelData.reversed).toBeFalsy();
   });
 
   it('should return title 0, subtitle scaling to 1 and titleComponent for podRingLabel when the first pod is being created', () => {
     const deploymentWithReplicas = _.set(_.cloneDeep(deployment), 'spec.replicas', 1);
     const mockDeploymentData = _.set(deploymentWithReplicas, 'status.readyReplicas', 0);
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).title,
-    ).toEqual('0');
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).subTitle,
-    ).toEqual('scaling to 1');
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
-        .titleComponent,
-    ).not.toBeUndefined();
+    const podRingLabelData = podRingLabel(mockDeploymentData, mockDeploymentData.kind, [
+      mockPod as ExtPodKind,
+    ]);
+
+    expect(podRingLabelData.title).toEqual('0');
+    expect(podRingLabelData.subTitle).toEqual('scaling to 1');
+    expect(podRingLabelData.longTitle).toBeFalsy();
+    expect(podRingLabelData.longSubtitle).toBeTruthy();
+    expect(podRingLabelData.reversed).toBeFalsy();
   });
 
   it('should return title 0, subtitle scaling to 1 and titleComponent for podRingLabel when pod count is 1 and status is pending', () => {
     const mockDeploymentData = _.set(_.cloneDeep(deployment), 'spec.replicas', 1);
     const mockPodData = _.set(_.cloneDeep(mockPod), 'status.phase', 'Pending');
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind]).title,
-    ).toEqual('0');
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind])
-        .subTitle,
-    ).toEqual('scaling to 1');
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind])
-        .titleComponent,
-    ).not.toBeUndefined();
+    const podRingLabelData = podRingLabel(mockDeploymentData, mockDeploymentData.kind, [
+      mockPodData as ExtPodKind,
+    ]);
+    expect(podRingLabelData.title).toEqual('0');
+    expect(podRingLabelData.subTitle).toEqual('scaling to 1');
+    expect(podRingLabelData.longTitle).toBeFalsy();
+    expect(podRingLabelData.longSubtitle).toBeTruthy();
+    expect(podRingLabelData.reversed).toBeFalsy();
   });
 
   it('should return proper title, subtitle for podRingLabel for Daemon sets', () => {
     const mockDaemonData = _.cloneDeep(daemonSet);
-    expect(
-      podRingLabel(mockDaemonData, mockDaemonData.kind, [mockPod as ExtPodKind]).title,
-    ).toEqual('2');
-    expect(
-      podRingLabel(mockDaemonData, mockDaemonData.kind, [mockPod as ExtPodKind]).subTitle,
-    ).toEqual('pods');
+    const podRingLabelData = podRingLabel(mockDaemonData, mockDaemonData.kind, [
+      mockPod as ExtPodKind,
+    ]);
+    expect(podRingLabelData.title).toEqual('2');
+    expect(podRingLabelData.subTitle).toEqual('pods');
+    expect(podRingLabelData.longTitle).toBeFalsy();
+    expect(podRingLabelData.longSubtitle).toBeFalsy();
+    expect(podRingLabelData.reversed).toBeFalsy();
   });
 
   it('should return proper title, subtitle for podRingLabel for Deployment Config', () => {
     const deploymentConfigWithReplicas = _.set(_.cloneDeep(deploymentConfig), 'spec.replicas', 2);
     const mockDeploymentConfigData = _.set(deploymentConfigWithReplicas, 'status.readyReplicas', 2);
-    expect(
-      podRingLabel(mockDeploymentConfigData, mockDeploymentConfigData.kind, [mockPod as ExtPodKind])
-        .title,
-    ).toEqual('2');
-    expect(
-      podRingLabel(mockDeploymentConfigData, mockDeploymentConfigData.kind, [mockPod as ExtPodKind])
-        .subTitle,
-    ).toEqual('pods');
+    const podRingLabelData = podRingLabel(mockDeploymentConfigData, mockDeploymentConfigData.kind, [
+      mockPod as ExtPodKind,
+    ]);
+    expect(podRingLabelData.title).toEqual('2');
+    expect(podRingLabelData.subTitle).toEqual('pods');
+    expect(podRingLabelData.longTitle).toBeFalsy();
+    expect(podRingLabelData.longSubtitle).toBeFalsy();
+    expect(podRingLabelData.reversed).toBeFalsy();
   });
 
   it('should return proper title, subtitle for podRingLabel for Stateful sets', () => {
     const statefulSetWithReplicas = _.set(_.cloneDeep(statefulSets), 'spec.replicas', 2);
     const mockStatefulSetData = _.set(statefulSetWithReplicas, 'status.readyReplicas', 2);
-    expect(
-      podRingLabel(mockStatefulSetData, mockStatefulSetData.kind, [mockPod as ExtPodKind]).title,
-    ).toEqual('2');
-    expect(
-      podRingLabel(mockStatefulSetData, mockStatefulSetData.kind, [mockPod as ExtPodKind]).subTitle,
-    ).toEqual('pods');
+    const podRingLabelData = podRingLabel(mockStatefulSetData, mockStatefulSetData.kind, [
+      mockPod as ExtPodKind,
+    ]);
+    expect(podRingLabelData.title).toEqual('2');
+    expect(podRingLabelData.subTitle).toEqual('pods');
+    expect(podRingLabelData.longTitle).toBeFalsy();
+    expect(podRingLabelData.longSubtitle).toBeFalsy();
+    expect(podRingLabelData.reversed).toBeFalsy();
   });
 
   it('should return proper title, subtitle for podRingLabel for failed pods', () => {
@@ -137,6 +135,9 @@ describe('pod-ring utils:', () => {
     ]);
     expect(podRingLabelData.title).toEqual('1');
     expect(podRingLabelData.subTitle).toEqual('pod');
+    expect(podRingLabelData.longTitle).toBeFalsy();
+    expect(podRingLabelData.longSubtitle).toBeFalsy();
+    expect(podRingLabelData.reversed).toBeFalsy();
   });
 });
 

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
@@ -3,9 +3,8 @@ import {
   PodStatus,
   calculateRadius,
   getPodData,
-  podRingLabel,
   podDataInProgress,
-  hpaPodRingLabel,
+  usePodRingLabel,
 } from '@console/shared';
 import { RevisionModel } from '@console/knative-plugin/src/models';
 import { DonutStatusData } from '../../topology-types';
@@ -79,9 +78,13 @@ const PodSet: React.FC<PodSetProps> = ({ size, data, x = 0, y = 0, showPodCount 
 
   const obj = data.current?.obj || data.dc;
   const ownerKind = RevisionModel.kind === data.dc?.kind ? data.dc.kind : obj.kind;
-  const { title, subTitle, titleComponent } = hpaControlledScaling
-    ? hpaPodRingLabel(obj, hpa, data?.pods)
-    : podRingLabel(obj, ownerKind, data?.pods);
+  const { title, subTitle, titleComponent } = usePodRingLabel(
+    obj,
+    ownerKind,
+    data?.pods,
+    hpaControlledScaling,
+    hpa,
+  );
   return (
     <>
       <PodStatus


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-5001

**Description**
Currently, the pod donut chart is updated whenever the pod resource object changes. Update to determine if the visible data has changed and only update when it does.

Non-functional change

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup