### PR TITLE
Bug 1875516: - disabled scheduling is easy to miss in node page of OCP console

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -497,3 +497,7 @@ button.pf-c-dropdown__menu-item.pf-m-disabled {
 #modal-container .pf-c-backdrop {
   position: absolute !important;
 }
+
+.text-muted{
+  color: var(--pf-global--Color--200);
+}


### PR DESCRIPTION
/assign @TheRealJon
/cc @spadgett

Overrode `text-muted` style property with  PF `--pf-global--Color--200` and change  `co-status-card__health-item-subtitle`   color to `--pf-global--Color--200` See screenshot attached:

![Screen Shot 2020-10-20 at 9 54 23 AM](https://user-images.githubusercontent.com/15249132/96596151-699c4c80-12ba-11eb-87cb-af420a462a19.png)
![Screen Shot 2020-10-20 at 9 55 06 AM](https://user-images.githubusercontent.com/15249132/96596153-6a34e300-12ba-11eb-9cc5-a3ea6df8a6b8.png)




