### PR TITLE
Add graph view to project overview workloads tab

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.tsx
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.tsx
@@ -12,6 +12,7 @@ export enum NamespacedPageVariants {
 
 export interface NamespacedPageProps {
   disabled?: boolean;
+  hideProjects?: boolean;
   hideApplications?: boolean;
   onNamespaceChange?: (newNamespace: string) => void;
   variant?: NamespacedPageVariants;
@@ -22,12 +23,17 @@ const NamespacedPage: React.FC<NamespacedPageProps> = ({
   children,
   disabled,
   onNamespaceChange,
+  hideProjects = false,
   hideApplications = false,
   variant = NamespacedPageVariants.default,
   toolbar,
 }) => (
   <div className="odc-namespaced-page">
-    <NamespaceBar disabled={disabled} onNamespaceChange={onNamespaceChange}>
+    <NamespaceBar
+      disabled={disabled}
+      onNamespaceChange={onNamespaceChange}
+      hideProjects={hideProjects}
+    >
       {!hideApplications && <ApplicationSelector disabled={disabled} />}
       {toolbar && <div className="odc-namespaced-page__toolbar">{toolbar}</div>}
     </NamespaceBar>

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
@@ -7,30 +7,34 @@ import EmptyState from '../EmptyState';
 
 interface TopologyDataRendererProps {
   showGraphView: boolean;
+  title: string;
 }
 
-const EmptyMsg = () => (
-  <EmptyState
-    title="Topology"
-    hintBlock={
-      <HintBlock title="No resources found">
-        <p>
-          To add content to your project, create an application, component or service using one of
-          these options.
-        </p>
-      </HintBlock>
-    }
-  />
-);
-
 export const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observer(
-  ({ showGraphView }) => {
+  ({ showGraphView, title }) => {
     const { namespace, model, loaded, loadError } = React.useContext<ExtensibleModel>(ModelContext);
+    const EmptyMsg = React.useCallback(
+      () => (
+        <EmptyState
+          title={title}
+          hintBlock={
+            <HintBlock title="No resources found">
+              <p>
+                To add content to your project, create an application, component or service using
+                one of these options.
+              </p>
+            </HintBlock>
+          }
+        />
+      ),
+      [title],
+    );
+
     return (
       <StatusBox
         skeleton={
           !showGraphView && (
-            <div className="skeleton-overview">
+            <div className="co-m-pane__body skeleton-overview">
               <div className="skeleton-overview--head" />
               <div className="skeleton-overview--tile" />
               <div className="skeleton-overview--tile" />

--- a/frontend/packages/dev-console/src/components/topology/TopologyPageToolbar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPageToolbar.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { observer } from '@patternfly/react-topology';
+import { Tooltip, Popover, Button } from '@patternfly/react-core';
+import { ListIcon, TopologyIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+import TopologyShortcuts from './TopologyShortcuts';
+import ModelContext, { ExtensibleModel } from './data-transforms/ModelContext';
+
+interface TopologyPageToolbarProps {
+  showGraphView: boolean;
+  onViewChange: (graphView: boolean) => void;
+}
+
+export const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
+  ({ showGraphView, onViewChange }) => {
+    const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
+    const { namespace, isEmptyModel } = dataModelContext;
+
+    if (!namespace || isEmptyModel) {
+      return null;
+    }
+
+    return (
+      <>
+        {showGraphView ? (
+          <Popover
+            aria-label="Shortcuts"
+            bodyContent={TopologyShortcuts}
+            position="left"
+            maxWidth="100vw"
+          >
+            <Button
+              type="button"
+              variant="link"
+              className="odc-topology__shortcuts-button"
+              icon={<QuestionCircleIcon />}
+              data-test-id="topology-view-shortcuts"
+            >
+              View shortcuts
+            </Button>
+          </Popover>
+        ) : null}
+        <Tooltip position="left" content={showGraphView ? 'List View' : 'Topology View'}>
+          <Button
+            variant="link"
+            className="pf-m-plain odc-topology__view-switcher"
+            onClick={() => onViewChange(!showGraphView)}
+          >
+            {showGraphView ? <ListIcon size="md" /> : <TopologyIcon size="md" />}
+          </Button>
+        </Tooltip>
+      </>
+    );
+  },
+);

--- a/frontend/packages/dev-console/src/components/topology/__tests__/DataModelProvider.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/DataModelProvider.spec.tsx
@@ -5,7 +5,7 @@ import store from '@console/internal/redux';
 import * as utils from '@console/internal/components/utils/url-poll-hook';
 import DataModelProvider from '../data-transforms/DataModelProvider';
 import { TopologyDataRetriever } from '../TopologyDataRetriever';
-import { TopologyPageContext } from '../TopologyPage';
+import { TopologyDataRenderer } from '../TopologyDataRenderer';
 
 jest.mock('@console/plugin-sdk/src/api/useExtensions', () => ({
   useExtensions: () => [],
@@ -25,20 +25,12 @@ type Props = {
 describe('DataModelProvider', () => {
   let wrapper: ReactWrapper<Props>;
   const spyUseURLPoll = jest.spyOn(utils, 'useURLPoll');
-  const match = {
-    params: {
-      name: 'topology-test',
-    },
-    isExact: true,
-    path: '/topology/ns/topology-test/graph',
-    url: '',
-  };
 
   beforeEach(() => {
     spyUseURLPoll.mockReturnValue([{}, null, false]);
     wrapper = mount(
       <DataModelProvider namespace="test-project">
-        <TopologyPageContext match={match} />
+        <TopologyDataRenderer showGraphView title="Topology" />
       </DataModelProvider>,
       {
         wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,
@@ -48,6 +40,6 @@ describe('DataModelProvider', () => {
 
   it('should render inner components', () => {
     expect(wrapper.find(TopologyDataRetriever)).toHaveLength(1);
-    expect(wrapper.find(TopologyPageContext)).toHaveLength(1);
+    expect(wrapper.find(TopologyDataRenderer)).toHaveLength(1);
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPageToolbar.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPageToolbar.spec.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { TopologyPageToolbar } from '../TopologyPageToolbar';
+
+jest.mock('react', () => {
+  const ActualReact = require.requireActual('react');
+  return {
+    ...ActualReact,
+    useContext: () => jest.fn(),
+  };
+});
+
+jest.mock('react-redux', () => {
+  const ActualReactRedux = require.requireActual('react-redux');
+  return {
+    ...ActualReactRedux,
+    useSelector: jest.fn(),
+    useDispatch: jest.fn(),
+  };
+});
+
+jest.mock('@console/shared', () => {
+  const ActualShared = require.requireActual('@console/shared');
+  return {
+    ...ActualShared,
+    useQueryParams: () => new Map(),
+  };
+});
+
+describe('TopologyPageToolbar tests', () => {
+  it('should render view shortcuts button on topology page toolbar', () => {
+    const mockViewChange = jest.fn();
+    spyOn(React, 'useContext').and.returnValue({
+      isEmptyModel: false,
+      namespace: 'test-namespace',
+    });
+    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    expect(wrapper.find('[data-test-id="topology-view-shortcuts"]').exists()).toBe(true);
+  });
+
+  it('should not render view shortcuts button on topology list page toolbar', () => {
+    const mockViewChange = jest.fn();
+    spyOn(React, 'useContext').and.returnValue({
+      isEmptyModel: false,
+      namespace: 'test-namespace',
+    });
+    const wrapper = shallow(
+      <TopologyPageToolbar showGraphView={false} onViewChange={mockViewChange} />,
+    );
+    expect(wrapper.find('[data-test-id="topology-view-shortcuts"]').exists()).toBe(false);
+  });
+
+  it('should show the topology icon when on topology list page', () => {
+    const mockViewChange = jest.fn();
+    spyOn(React, 'useContext').and.returnValue({
+      isEmptyModel: false,
+      namespace: 'test-namespace',
+    });
+    const wrapper = shallow(
+      <TopologyPageToolbar showGraphView={false} onViewChange={mockViewChange} />,
+    );
+    expect(wrapper.find(Tooltip).props().content).toBe('Topology View');
+  });
+
+  it('should show the topology list icon when on topology page', () => {
+    const mockViewChange = jest.fn();
+    spyOn(React, 'useContext').and.returnValue({
+      isEmptyModel: false,
+      namespace: 'test-namespace',
+    });
+    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    expect(wrapper.find(Tooltip).props().content).toBe('List View');
+  });
+
+  it('should not contain view switcher when when no project is selected', () => {
+    const mockViewChange = jest.fn();
+    spyOn(React, 'useContext').and.returnValue({
+      isEmptyModel: false,
+      namespace: undefined,
+    });
+    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    expect(wrapper.find(Button).exists()).toBe(false);
+  });
+
+  it('should not contain view switcher when no model', () => {
+    const mockViewChange = jest.fn();
+    spyOn(React, 'useContext').and.returnValue({
+      isEmptyModel: true,
+      namespace: 'test-namespace',
+    });
+    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    expect(wrapper.find(Button).exists()).toBe(false);
+  });
+});

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/ModelContext.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/ModelContext.ts
@@ -28,6 +28,7 @@ export type ModelExtensionContext = {
 export class ExtensibleModel {
   private extensions: { [id: string]: ModelExtensionContext } = {};
 
+  @observable
   public namespace: string;
 
   @observable.ref

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -1068,18 +1068,32 @@ const NamespaceBarDropdowns = connect(
   namespaceBarDropdownDispatchToProps,
 )(NamespaceBarDropdowns_);
 
-const NamespaceBar_ = ({ useProjects, children, disabled, onNamespaceChange }) => {
+const NamespaceBar_ = ({
+  hideProjects = false,
+  useProjects,
+  children,
+  disabled,
+  onNamespaceChange,
+}) => {
   return (
     <div className="co-namespace-bar">
-      <Firehose resources={[{ kind: getModel(useProjects).kind, prop: 'namespace', isList: true }]}>
-        <NamespaceBarDropdowns
-          useProjects={useProjects}
-          disabled={disabled}
-          onNamespaceChange={onNamespaceChange}
-        >
+      {hideProjects ? (
+        <div className="co-namespace-bar__items" data-test-id="namespace-bar-dropdown">
           {children}
-        </NamespaceBarDropdowns>
-      </Firehose>
+        </div>
+      ) : (
+        <Firehose
+          resources={[{ kind: getModel(useProjects).kind, prop: 'namespace', isList: true }]}
+        >
+          <NamespaceBarDropdowns
+            useProjects={useProjects}
+            disabled={disabled}
+            onNamespaceChange={onNamespaceChange}
+          >
+            {children}
+          </NamespaceBarDropdowns>
+        </Firehose>
+      )}
     </div>
   );
 };
@@ -1090,7 +1104,7 @@ const namespaceBarStateToProps = ({ k8s }) => {
     useProjects,
   };
 };
-/** @type {React.FC<{children?: ReactNode, disabled?: boolean, onNamespaceChange?: Function}>} */
+/** @type {React.FC<{children?: ReactNode, disabled?: boolean, onNamespaceChange?: Function, hideProjects?: boolean}>} */
 export const NamespaceBar = connect(namespaceBarStateToProps)(NamespaceBar_);
 
 export const NamespacesDetailsPage = (props) => (

--- a/frontend/public/components/overview/OverviewListPage.tsx
+++ b/frontend/public/components/overview/OverviewListPage.tsx
@@ -1,13 +1,23 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
-import DataModelProvider from '@console/dev-console/src/components/topology/data-transforms/DataModelProvider';
-import { TopologyDataRenderer } from '@console/dev-console/src/components/topology/TopologyDataRenderer';
+import { match as RMatch } from 'react-router';
+import { STORAGE_PREFIX } from '@console/shared/src';
+import { TopologyPage } from '@console/dev-console/src/components/topology/TopologyPage';
 
-export const OverviewListPage: React.FC = () => {
-  const namespace = useParams().name;
+type OverviewListPageProps = {
+  match: RMatch<{
+    name?: string;
+  }>;
+};
+
+const LAST_TOPOLOGY_WORKLOADS_VIEW_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-topology-workloads-view`;
+
+export const OverviewListPage: React.FC<OverviewListPageProps> = ({ match }) => {
   return (
-    <DataModelProvider namespace={namespace}>
-      <TopologyDataRenderer showGraphView={false} />
-    </DataModelProvider>
+    <TopologyPage
+      match={match}
+      hideProjects
+      title=""
+      activeViewStorageKey={LAST_TOPOLOGY_WORKLOADS_VIEW_LOCAL_STORAGE_KEY}
+    />
   );
 };


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4925

**Description**
Adds the ability to switch to the graph view in the workloads tab for the project overview page.

**Screen Shots**: 
![image](https://user-images.githubusercontent.com/11633780/95758415-73003600-0c76-11eb-969c-90b856165cda.png)

![image](https://user-images.githubusercontent.com/11633780/95758463-86130600-0c76-11eb-99b9-18e391c53295.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

@bgliwa01 @bmignano @serenamarie125 