### PR TITLE
Remove notification drawer header override fix

### DIFF
--- a/frontend/public/components/_notification-drawer.scss
+++ b/frontend/public/components/_notification-drawer.scss
@@ -4,11 +4,6 @@
   @include co-break-word;
 }
 
-.pf-c-drawer.pf-m-inline .pf-c-notification-drawer__header {
-  // fix upstream bug where header overlays divider
-  margin-left: 1px;
-}
-
 .pf-c-drawer__content {
   --pf-c-drawer__content--ZIndex: auto;
 }


### PR DESCRIPTION
We previously added this override fix to correct for an upstream bug in PatternFly.  The upstream bug was fixed, but the override did not get removed.

Before:
<img width="799" alt="Screen Shot 2020-10-12 at 2 06 07 PM" src="https://user-images.githubusercontent.com/895728/95777488-422ef980-0c94-11eb-9d5f-6ca28524c26c.png">

After:
<img width="799" alt="Screen Shot 2020-10-12 at 2 04 07 PM" src="https://user-images.githubusercontent.com/895728/95777499-48bd7100-0c94-11eb-8ffd-359781c04e8e.png">
