### PR TITLE
Bug 1887472: Fix to allow shift-drag to regroup knative services in topology

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,7 @@
     "@patternfly/react-core": "4.63.3",
     "@patternfly/react-table": "4.18.14",
     "@patternfly/react-tokens": "4.9.12",
-    "@patternfly/react-topology": "4.6.25",
+    "@patternfly/react-topology": "4.6.31",
     "@patternfly/react-virtualized-extension": "4.5.105",
     "abort-controller": "3.0.0",
     "ajv": "^6.12.3",

--- a/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
@@ -155,6 +155,21 @@ const nodeDragSourceSpec = (
   }),
 });
 
+const noRegroupDragSourceSpec: DragSourceSpec<
+  DragObjectWithType,
+  DragSpecOperationType<EditableDragOperationType>,
+  Node,
+  {
+    dragging?: boolean;
+  },
+  NodeComponentProps
+> = {
+  item: { type: NODE_DRAG_TYPE },
+  collect: (monitor) => ({
+    dragging: monitor.isDragging(),
+  }),
+};
+
 const nodesEdgeIsDragging = (monitor, props) => {
   if (!monitor.isDragging()) {
     return false;
@@ -354,6 +369,7 @@ export {
   EditableDragOperationType,
   DragNodeObject,
   nodesEdgeIsDragging,
+  noRegroupDragSourceSpec,
   nodeDragSourceSpec,
   nodeDropTargetSpec,
   graphDropTargetSpec,

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
@@ -24,8 +24,7 @@ import {
   useSearchFilter,
   SHOW_LABELS_FILTER_ID,
 } from '../../filters';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_HELM_RELEASE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 
 export type HelmReleaseGroupProps = {
   element: Node;
@@ -45,13 +44,8 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const dragSpec = nodeDragSourceSpec(TYPE_HELM_RELEASE, false);
-  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(dragSpec, { element });
-  const [
-    { dragging: labelDragging, regrouping: labelRegrouping },
-    dragLabelRef,
-  ] = useDragNode(dragSpec, { element });
-
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
+  const [{ dragging: labelDragging }, dragLabelRef] = useDragNode(noRegroupDragSourceSpec);
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const displayFilters = useDisplayFilters();
@@ -71,9 +65,7 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
       })}
     >
       <NodeShadows />
-      <Layer
-        id={(dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'}
-      >
+      <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
         <g
           ref={nodeRefs}
           className={classNames('odc-helm-release', {

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -21,8 +21,7 @@ import {
 import { useSearchFilter } from '../../filters/useSearchFilter';
 import { GroupNode } from '../../components/groups/GroupNode';
 import { GroupNodeAnchor } from '../../components/groups/GroupNodeAnchor';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_HELM_RELEASE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 
 export type HelmReleaseNodeProps = {
   element: Node;
@@ -41,9 +40,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
   dndDropRef,
 }) => {
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(nodeDragSourceSpec(TYPE_HELM_RELEASE, false), {
-    element,
-  });
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDropRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const { groupResources } = element.getData();

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
@@ -15,8 +15,7 @@ import {
   RectAnchor,
 } from '@patternfly/react-topology';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_OPERATOR_BACKED_SERVICE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 import {
   getFilterById,
   useDisplayFilters,
@@ -49,19 +48,8 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
-  const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
-
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
+  const [{ dragging: labelDragging }, dragLabelRef] = useDragNode(noRegroupDragSourceSpec);
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();
@@ -84,9 +72,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
       })}
     >
       <NodeShadows />
-      <Layer
-        id={(dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'}
-      >
+      <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
         <Tooltip
           content="Create a binding connector"
           trigger="manual"

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
@@ -14,8 +14,7 @@ import {
   useSize,
 } from '@patternfly/react-topology';
 import { useSearchFilter } from '../../filters/useSearchFilter';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_OPERATOR_BACKED_SERVICE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 import {
   NodeShadows,
   NODE_SHADOW_FILTER_ID,
@@ -41,12 +40,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   dropTarget,
 }) => {
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef, dndDropRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const kind = 'Operator';

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -66,19 +66,15 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),
-    {
-      element,
-    },
-  );
+  const dragSpec = React.useMemo(() => nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess), [
+    editAccess,
+  ]);
+  const dragProps = React.useMemo(() => ({ element }), [element]);
+  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(dragSpec, dragProps);
   const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),
-    {
-      element,
-    },
+    dragSpec,
+    dragProps,
   );
-
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
@@ -53,12 +53,11 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
   onShowCreateConnector,
 }) => {
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),
-    {
-      element,
-    },
-  );
+  const dragSpec = React.useMemo(() => nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess), [
+    editAccess,
+  ]);
+  const dragProps = React.useMemo(() => ({ element }), [element]);
+  const [{ dragging }, dragNodeRef] = useDragNode(dragSpec, dragProps);
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const allowEdgeCreation = useAllowEdgeCreation();

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1669,10 +1669,28 @@
     tippy.js "5.1.2"
     tslib "^1.11.1"
 
+"@patternfly/react-core@^4.64.5":
+  version "4.64.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.64.5.tgz#6e8479843fa9b2874ac6c9db84e28984b09f0f25"
+  integrity sha512-f7q0kB8FIWNU76FTv5gsM6o5Twg/j92LXo4EmDaKvz35qPGWR7jqstTZ0zHXcUuDOYTPZeiQS1kbNsHVXRqZzg==
+  dependencies:
+    "@patternfly/react-icons" "^4.7.12"
+    "@patternfly/react-styles" "^4.7.8"
+    "@patternfly/react-tokens" "^4.9.12"
+    focus-trap "4.0.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "1.13.0"
+
 "@patternfly/react-icons@^4.7.11":
   version "4.7.11"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.11.tgz#630174e1a6e1ec4c5256198c4c897e1508a6cb74"
   integrity sha512-kvOTwzv31krjXeMYUrmr9lABPCwtnuEWKWQCcGdrngdYzxB6mg1D0oIux8JzKqX6oitXzsI/OhvnWkIyCdirNw==
+
+"@patternfly/react-icons@^4.7.12":
+  version "4.7.12"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.12.tgz#4ea029b45f35f62ab92b78d93263a9ac093726b3"
+  integrity sha512-46kCsX4IIKQj5FzB/D2AkgG/TRkKjrH2U9v8H1kaU6WpXRmfLbxCq89neZ6UMoTF8tYhIXB0B3DaMMTvlQewRg==
 
 "@patternfly/react-styles@^4.7.8":
   version "4.7.8"
@@ -1697,13 +1715,13 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.12.tgz#ff56acc98823c723c1ccb7e46f38fcc8ea780f15"
   integrity sha512-bO4eaZRZOYRDnO096RCFMhV1VHXE9woRFxIs+i9Q7eSTlxpJm2b8FAIb7RDtOURGAfBlJKd/d1dFgZnPq7xQ0g==
 
-"@patternfly/react-topology@4.6.25":
-  version "4.6.25"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.6.25.tgz#f02db64f2c3684b7a4bacfca306af93bbbd51c8c"
-  integrity sha512-3GfaVlKf/FGgNXmYgO4DbB9OnerMa5RLTki9uRW3STgUbO7cyVxL3A5HNeZnM/dBMmV3rncsgm+I2uqQmclJKg==
+"@patternfly/react-topology@4.6.31":
+  version "4.6.31"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.6.31.tgz#4c3cd648319c1abd135abce1148899a818f77cad"
+  integrity sha512-s/6Kpkq6bmCNk2JCi03+tKZoRQH5U32ItptFnuoMlvkxXO0w5sNkBpGZBJwQjzHBEl4uv3x5c7jMqmf6AtvSgg==
   dependencies:
-    "@patternfly/react-core" "^4.63.3"
-    "@patternfly/react-icons" "^4.7.11"
+    "@patternfly/react-core" "^4.64.5"
+    "@patternfly/react-icons" "^4.7.12"
     "@patternfly/react-styles" "^4.7.8"
     "@types/d3" "^5.7.2"
     "@types/d3-force" "^1.2.1"
@@ -1717,7 +1735,7 @@
     point-in-svg-path "^1.0.1"
     popper.js "^1.16.1"
     react-measure "^2.3.0"
-    tslib "^1.11.1"
+    tslib "1.13.0"
     webcola "3.4.0"
 
 "@patternfly/react-virtualized-extension@4.5.105":
@@ -16528,7 +16546,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.11.1:
+tslib@1.13.0, tslib@^1.10.0, tslib@^1.11.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4979

**Description**
Update @patternfly/react-topology to gain a fix for maintaining drag regrouping on component updates and update group nodes to no re-create drag specs every time.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
