### PR TITLE
Bug 1885702: Cypress: Fix 'aria-hidden-focus' accesibility violations

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/a11y.ts
+++ b/frontend/packages/integration-tests-cypress/support/a11y.ts
@@ -50,7 +50,7 @@ Cypress.Commands.add('testA11y', (target: string) => {
       includedImpacts: ['serious', 'critical'],
     },
     (violations) => cy.logA11yViolations(violations, target),
-    true,
+    false,
   );
 });
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -149,7 +149,7 @@ class App_ extends React.PureComponent {
     const content = (
       <>
         <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
-        <QuickStartDrawer>
+        <QuickStartDrawer id="app-container">
           <ConsoleNotifier location="BannerTop" />
           <Page
             header={<Masthead onNavToggle={this._onNavToggle} />}
@@ -168,11 +168,11 @@ class App_ extends React.PureComponent {
               <AppContents />
             </ConnectedNotificationDrawer>
           </Page>
-          <div id="modal-container" />
           <CloudShell />
           <GuidedTour />
           <ConsoleNotifier location="BannerBottom" />
         </QuickStartDrawer>
+        <div id="modal-container" />
       </>
     );
 

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -22,7 +22,7 @@ export const createModal: CreateModal = (getModalContainer) => {
       ReactDOM.unmountComponentAtNode(modalContainer);
       resolve();
     };
-    Modal.setAppElement(modalContainer);
+    Modal.setAppElement(document.getElementById('app-container'));
     ReactDOM.render(getModalContainer(closeModal), modalContainer);
   });
   return { result };

--- a/frontend/public/components/modals/delete-namespace-modal.jsx
+++ b/frontend/public/components/modals/delete-namespace-modal.jsx
@@ -51,6 +51,7 @@ class DeleteNamespaceModal extends PromiseComponent {
             className="pf-c-form-control"
             onKeyUp={this._matchTypedNamespace}
             placeholder="Enter name"
+            aria-label={`Enter the name of the ${this.props.kind.label} to delete`}
             autoFocus={true}
           />
         </ModalBody>


### PR DESCRIPTION
Root cause was the `<div id="modal-container">...</div>` was getting a `aria-hidden=true` attribute which hide it and it's children (modal header, footer, body) from accesibility tools.  A11y violation due to form fields within modal could have focus, but they were hidden.

Changed element passed to `react-modal`'s `setAppElement(...)` to be 'app-container' instead of 'modal-container'.  `setAppElement(...)` will set `aria-hidden=true` for the element (and all it's children!) and 'hide' them from accesibility tools.  This is done in order to 'hide' app elements behind the open modal, and will toggle/remove `aria-hidden` once the modal is closed.  So previously setting `AppElement` to the modal was hiding the modal and it's contents from accesiblity tools!  This fix requires `app-container` and `modal-container` to be sibling elements, and not child-parent.

This fix allowed the modal contents to be included in accesibility tools and thus, once fixed, raised another violation:
```
Running:  crud/namespace-crud.spec.ts
  Namespace
  ...
1 accessibility violation was detected for Delete Namespace modal
┌─────────┬─────────┬────────────┬──────────────────────────────────────────┬───────┐
│ (index) │   id    │   impact   │               description                │ nodes │
├─────────┼─────────┼────────────┼──────────────────────────────────────────┼───────┤
│    0    │ 'label' │ 'critical' │ 'Ensures every form element has a label' │   1   │
└─────────┴─────────┴────────────┴──────────────────────────────────────────┴───────┘

```
This required adding `aria-label` to a form element.

###  This PR will also cause the CI to fail upon detection of a11y violations!!
Running `test-cypress.sh` reported no a11y violoations, so going forward, any violations will need to be fixed prior to PR merge.

CC @jessiehuff
