### PR TITLE
Query Browser: All pressing Escape key to cancel zoom

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -497,6 +497,9 @@ $monitoring-line-height: 18px;
 .query-browser__zoom {
   cursor: ew-resize;
   position: relative;
+  &:focus {
+    outline: none;
+  }
 }
 
 .query-browser__zoom-overlay {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -449,6 +449,13 @@ const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
   const [x1, setX1] = React.useState(0);
   const [x2, setX2] = React.useState(0);
 
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setIsZooming(false);
+    }
+  };
+
   const onMouseDown = (e: React.MouseEvent) => {
     setIsZooming(true);
     const x = e.clientX - e.currentTarget.getBoundingClientRect().left;
@@ -486,7 +493,10 @@ const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
     onZoom(from, to);
   };
 
-  const handlers = isZooming ? { onMouseMove, onMouseUp } : { onMouseDown };
+  // tabIndex is required to enable the onKeyDown handler
+  const handlers = isZooming
+    ? { onKeyDown, onMouseMove, onMouseUp, tabIndex: -1 }
+    : { onMouseDown };
 
   return (
     <div className="query-browser__zoom" {...handlers}>


### PR DESCRIPTION
Once you started a zoom action (by selecting an area of the graph with
the mouse), there was no way to cancel the action. This makes it
possible to cancel by pressing the Escape key.