### PR TITLE
Save/Restore topology graph layout during current session

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,7 @@
     "@patternfly/react-core": "4.63.3",
     "@patternfly/react-table": "4.18.14",
     "@patternfly/react-tokens": "4.9.12",
-    "@patternfly/react-topology": "4.6.31",
+    "@patternfly/react-topology": "4.6.32",
     "@patternfly/react-virtualized-extension": "4.5.105",
     "abort-controller": "3.0.0",
     "ajv": "^6.12.3",

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { action } from 'mobx';
+import { debounce } from '@patternfly/react-core';
 import {
   ComponentFactory,
   Visualization,
@@ -9,23 +11,64 @@ import {
   BaseEdge,
   VisualizationProvider,
   Model,
+  GraphModel,
+  NodeModel,
   BOTTOM_LAYER,
   GROUPS_LAYER,
   DEFAULT_LAYER,
   TOP_LAYER,
   SelectionEventListener,
   SELECTION_EVENT,
+  NODE_POSITIONED_EVENT,
+  GRAPH_POSITION_CHANGE_EVENT,
 } from '@patternfly/react-topology';
-import { useQueryParams } from '@console/shared';
+import { STORAGE_PREFIX, useQueryParams } from '@console/shared';
 import { useExtensions } from '@console/plugin-sdk';
+import { RootState } from '@console/internal/redux';
 import { isTopologyComponentFactory, TopologyComponentFactory } from '../../extensions/topology';
 import { SHOW_GROUPING_HINT_EVENT, ShowGroupingHintEventListener } from './topology-types';
+import { getTopologyGraphModel, setTopologyGraphModel } from './redux/action';
 import { COLA_LAYOUT, layoutFactory } from './layouts/layoutFactory';
 import { componentFactory } from './components';
 import { odcElementFactory } from './elements';
 import TopologyControlBar from './TopologyControlBar';
 
 import './Topology.scss';
+
+const TOPOLOGY_LAYOUT_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/topology-layout`;
+const STORED_NODE_LAYOUT_FIELDS = ['id', 'x', 'y', 'collapsed', 'visible', 'style', 'shape'];
+
+type StoredLayout = {
+  nodes: NodeModel[];
+  layout: string;
+};
+
+const getStoredLayouts = (): { [namespace: string]: StoredLayout } => {
+  const storedLayoutsString = localStorage.getItem(TOPOLOGY_LAYOUT_LOCAL_STORAGE_KEY);
+  try {
+    return JSON.parse(storedLayoutsString) || {};
+  } catch (e) {
+    return {};
+  }
+};
+
+const getTopologyLayout = (namespace: string): StoredLayout => getStoredLayouts()[namespace];
+
+const setTopologyLayout = (namespace: string, nodes: NodeModel[], layout: string) => {
+  const currentStore = getStoredLayouts();
+  currentStore[namespace] = {
+    nodes: nodes?.map((n) =>
+      Object.keys(n).reduce((acc, key) => {
+        if (STORED_NODE_LAYOUT_FIELDS.includes(key)) {
+          acc[key] = n[key];
+        }
+        return acc;
+      }, {} as NodeModel),
+    ),
+    layout,
+  };
+  localStorage.setItem(TOPOLOGY_LAYOUT_LOCAL_STORAGE_KEY, JSON.stringify(currentStore));
+};
 
 interface TopologyGraphViewProps {
   visualizationReady: boolean;
@@ -65,6 +108,14 @@ const graphModel: Model = {
   },
 };
 
+interface StateProps {
+  getStoredGraphModel: (namespace: string) => GraphModel;
+}
+
+interface DispatchProps {
+  onGraphModelChange: (namespace: string, model: GraphModel) => void;
+}
+
 interface TopologyProps {
   model: Model;
   application: string;
@@ -73,10 +124,19 @@ interface TopologyProps {
   setVisualization: (vis: Visualization) => void;
 }
 
-const Topology: React.FC<TopologyProps> = ({ model, application, onSelect, setVisualization }) => {
+const Topology: React.FC<TopologyProps & StateProps & DispatchProps> = ({
+  model,
+  application,
+  namespace,
+  onSelect,
+  setVisualization,
+  onGraphModelChange,
+  getStoredGraphModel,
+}) => {
   const applicationRef = React.useRef<string>(null);
   const [visualizationReady, setVisualizationReady] = React.useState<boolean>(false);
   const [dragHint, setDragHint] = React.useState<string>('');
+  const storedLayoutApplied = React.useRef<boolean>(false);
   const queryParams = useQueryParams();
   const selectedId = queryParams.get('selectId');
   const [componentFactories, setComponentFactories] = React.useState<ComponentFactory[]>([]);
@@ -88,9 +148,35 @@ const Topology: React.FC<TopologyProps> = ({ model, application, onSelect, setVi
     [componentFactoryExtensions],
   );
   const createVisualization = () => {
+    const storedLayout = getTopologyLayout(namespace);
     const newVisualization = new Visualization();
     newVisualization.registerElementFactory(odcElementFactory);
     newVisualization.registerLayoutFactory(layoutFactory);
+
+    const onCurrentGraphModelChange = debounce(() => {
+      const visModel = newVisualization.toModel();
+      const saveGraphModel = {
+        id: visModel.graph.id,
+        type: visModel.graph.type,
+        x: visModel.graph.x,
+        y: visModel.graph.y,
+        scale: visModel.graph.scale,
+        scaleExtent: visModel.graph.scaleExtent,
+      };
+      onGraphModelChange(namespace, saveGraphModel);
+    }, 200);
+
+    const onVisualizationLayoutChange = debounce(() => {
+      const visModel = newVisualization.toModel();
+      setTopologyLayout(namespace, visModel.nodes, visModel.graph.layout);
+    }, 200);
+
+    newVisualization.addEventListener(NODE_POSITIONED_EVENT, onVisualizationLayoutChange);
+    newVisualization.addEventListener(GRAPH_POSITION_CHANGE_EVENT, onCurrentGraphModelChange);
+
+    if (storedLayout) {
+      graphModel.graph.layout = storedLayout.layout;
+    }
     newVisualization.fromModel(graphModel);
     newVisualization.addEventListener<SelectionEventListener>(SELECTION_EVENT, (ids: string[]) => {
       const selectedEntity = ids[0] ? newVisualization.getElementById(ids[0]) : null;
@@ -108,6 +194,30 @@ const Topology: React.FC<TopologyProps> = ({ model, application, onSelect, setVi
 
   React.useEffect(() => {
     if (model && visualizationReady) {
+      if (!storedLayoutApplied.current) {
+        const storedGraphModel = getStoredGraphModel(namespace);
+        if (storedGraphModel) {
+          model.graph = {
+            ...graphModel.graph,
+            x: storedGraphModel.x,
+            y: storedGraphModel.y,
+            scale: storedGraphModel.scale,
+            scaleExtent: storedGraphModel.scaleExtent,
+          };
+        }
+        const storedLayout = getTopologyLayout(namespace);
+        if (storedLayout) {
+          model.nodes.forEach((n) => {
+            const storedNode = storedLayout.nodes.find((sn) => sn.id === n.id);
+            if (storedNode) {
+              Object.keys(storedNode).forEach((key) => {
+                n[key] = storedNode[key];
+              });
+            }
+          });
+        }
+        storedLayoutApplied.current = true;
+      }
       visualization.fromModel(model);
       const selectedItem = selectedId ? visualization.getElementById(selectedId) : null;
       if (!selectedItem || !selectedItem.isVisible()) {
@@ -116,7 +226,7 @@ const Topology: React.FC<TopologyProps> = ({ model, application, onSelect, setVi
         onSelect(selectedItem);
       }
     }
-    // Do not update on selectedId change
+    // Do not update on selectedId change or stored layout change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, visualization, visualizationReady]);
 
@@ -199,4 +309,19 @@ const Topology: React.FC<TopologyProps> = ({ model, application, onSelect, setVi
   );
 };
 
-export default React.memo(Topology);
+const TopologyStateToProps = (state: RootState): StateProps => {
+  return {
+    getStoredGraphModel: (namespace: string) => getTopologyGraphModel(state, namespace),
+  };
+};
+
+const TopologyDispatchToProps = (dispatch): DispatchProps => ({
+  onGraphModelChange: (namespace: string, model: GraphModel) => {
+    dispatch(setTopologyGraphModel(namespace, model));
+  },
+});
+
+export default connect<StateProps, DispatchProps, TopologyProps>(
+  TopologyStateToProps,
+  TopologyDispatchToProps,
+)(React.memo(Topology));

--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListView.tsx
@@ -164,6 +164,10 @@ const ConnectedTopologyListView: React.FC<TopologyListViewProps &
 
     React.useEffect(() => {
       if (model) {
+        // Clear out any layout that might have been saved
+        if (model.graph?.layout) {
+          delete model.graph.layout;
+        }
         visualization.fromModel(model);
         const selectedItem = selectedId ? visualization.getElementById(selectedId) : null;
         if (!selectedItem || !selectedItem.isVisible()) {

--- a/frontend/packages/dev-console/src/components/topology/redux/action.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/action.ts
@@ -1,3 +1,5 @@
+import { GraphModel } from '@patternfly/react-topology';
+import { RootState } from '@console/internal/redux';
 import { action, ActionType } from 'typesafe-actions';
 import { TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY } from './const';
 import { DisplayFilters } from '../topology-types';
@@ -6,6 +8,7 @@ export enum Actions {
   topologyFilters = 'topologyFilters',
   supportedTopologyFilters = 'supportedTopologyFilters',
   supportedTopologyKinds = 'supportedTopologyKinds',
+  topologyGraphModel = 'topologyGraphModel',
 }
 
 export const getAppliedFilters = (filters: DisplayFilters): { [id: string]: boolean } => {
@@ -35,10 +38,20 @@ export const setSupportedTopologyKinds = (supportedKinds: { [key: string]: numbe
   return action(Actions.supportedTopologyKinds, { supportedKinds });
 };
 
+export const setTopologyGraphModel = (namespace: string, graphModel: GraphModel) => {
+  return action(Actions.topologyGraphModel, { namespace, graphModel });
+};
+
+export const getTopologyGraphModel = (state: RootState, namespace: string): GraphModel => {
+  const topology = state?.plugins?.devconsole?.topology;
+  return topology?.get('topologyGraphModel')?.[namespace];
+};
+
 const actions = {
   setTopologyFilters,
   setSupportedTopologyFilters,
   setSupportedTopologyKinds,
+  setTopologyGraphModel,
 };
 
 export type TopologyAction = ActionType<typeof actions>;

--- a/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
@@ -58,5 +58,14 @@ export default (state: State, action: TopologyAction) => {
     return state.set('supportedKinds', action.payload.supportedKinds);
   }
 
+  if (action.type === Actions.topologyGraphModel) {
+    const savedGraphModels = state.get('topologyGraphModel');
+    const updatedGraphModels = {
+      ...savedGraphModels,
+      [action.payload.namespace]: action.payload.graphModel,
+    };
+    return state.set('topologyGraphModel', updatedGraphModels);
+  }
+
   return state;
 };

--- a/frontend/packages/knative-plugin/src/topology/layouts/layoutConstraints.ts
+++ b/frontend/packages/knative-plugin/src/topology/layouts/layoutConstraints.ts
@@ -35,6 +35,8 @@ const alignNodeConnector = (
     .filter(
       (e) =>
         e.element.getType() === type &&
+        !e.target.isFixed &&
+        !e.source.isFixed &&
         (e.target.element === g.element || e.target.element.getParent() === g.element),
     )
     .sort((l1: ColaLink, l2: ColaLink) => nodeSorter(l1.source, l2.source));
@@ -94,7 +96,8 @@ export const layoutConstraints = (
       [TYPE_EVENT_PUB_SUB, TYPE_SINK_URI, TYPE_KNATIVE_SERVICE].includes(g.element.getType()),
     )
     .forEach((g) => {
-      const leafNodes = g instanceof ColaGroup && g.leaves.sort(nodeSorter);
+      const leafNodes =
+        g instanceof ColaGroup && g.leaves.sort(nodeSorter).filter((n) => !n.isFixed);
       const filteredNode = (leafNodes && _.first(leafNodes)) || g;
       if (g.element.getType() === TYPE_KNATIVE_SERVICE) {
         const serviceConstraint: any = {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1715,10 +1715,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.12.tgz#ff56acc98823c723c1ccb7e46f38fcc8ea780f15"
   integrity sha512-bO4eaZRZOYRDnO096RCFMhV1VHXE9woRFxIs+i9Q7eSTlxpJm2b8FAIb7RDtOURGAfBlJKd/d1dFgZnPq7xQ0g==
 
-"@patternfly/react-topology@4.6.31":
-  version "4.6.31"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.6.31.tgz#4c3cd648319c1abd135abce1148899a818f77cad"
-  integrity sha512-s/6Kpkq6bmCNk2JCi03+tKZoRQH5U32ItptFnuoMlvkxXO0w5sNkBpGZBJwQjzHBEl4uv3x5c7jMqmf6AtvSgg==
+"@patternfly/react-topology@4.6.32":
+  version "4.6.32"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.6.32.tgz#c2558c364a342bdf2783538ce94d743476f11ffb"
+  integrity sha512-EJ5FhPb9MBkftDDLwDlY2xh+z31LOb4lhRwG9r9vAw+F9Pk7EnPkVXEfpZ8nOpQ5FnUMJ9mLx1H0gHSOb600Lg==
   dependencies:
     "@patternfly/react-core" "^4.64.5"
     "@patternfly/react-icons" "^4.7.12"


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-2344

**Description**
Stores the topology graph view's node locations and graph settings during the current session and restores them upon navigation back to the topology view.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

