### PR TITLE
Avoid traversing node_modules when running i18next on packages/*

### DIFF
--- a/frontend/i18n-scripts/build-i18n.sh
+++ b/frontend/i18n-scripts/build-i18n.sh
@@ -2,9 +2,11 @@
 
 set -exuo pipefail
 
-i18next "public/!(dist)**/**/*.{js,jsx,ts,tsx}" [-oc] -c "./public/i18next-parser.config.js" -o "public/locales/\$LOCALE/\$NAMESPACE.json"
+FILE_PATTERN="!(dist|node_modules)**/**/*.{js,jsx,ts,tsx}"
+
+i18next "public/${FILE_PATTERN}" [-oc] -c "./public/i18next-parser.config.js" -o "public/locales/\$LOCALE/\$NAMESPACE.json"
 
 cd packages
 for d in */ ; do
-  i18next "${d}!(dist)**/**/*.{js,jsx,ts,tsx}" [-oc] -c "./../public/i18next-parser.config.js" -o "${d}locales/\$LOCALE/\$NAMESPACE.json"
+  i18next "${d}${FILE_PATTERN}" [-oc] -c "./../public/i18next-parser.config.js" -o "${d}locales/\$LOCALE/\$NAMESPACE.json"
 done


### PR DESCRIPTION
This fixes a problem with #6101 where `yarn i18n` fails when processing dynamic plugin SDK package.