### PR TITLE
add details page for eventing trigger and subscription

### DIFF
--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/DynamicResourceLink.scss
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/DynamicResourceLink.scss
@@ -1,0 +1,5 @@
+.kn-resource-link-list {
+    &--addSpaceBelow {
+      margin-bottom: var(--pf-global--spacer--lg);
+    }
+  }

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/DynamicResourceLink.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/DynamicResourceLink.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { ResourceLink } from '@console/internal/components/utils';
+
+import './DynamicResourceLink.scss';
+
+interface DynamicResourceLinkProps {
+  title: string;
+  name: string;
+  namespace: string;
+  kind: string;
+}
+
+const DynamicResourceLink: React.FC<DynamicResourceLinkProps> = ({
+  title,
+  name,
+  namespace,
+  kind,
+}) => (
+  <div className="kn-resource-link-list kn-resource-link-list--addSpaceBelow">
+    <dl>
+      <dt>{title}</dt>
+      <dd>
+        <ResourceLink kind={kind} name={name} namespace={namespace} />
+      </dd>
+    </dl>
+  </div>
+);
+
+export default DynamicResourceLink;

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/SubscriptionDetails.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/SubscriptionDetails.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
+import { Conditions } from '@console/internal/components/conditions';
+import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
+import DynamicResourceLink from './DynamicResourceLink';
+
+interface SubscriptionDetails {
+  obj: K8sResourceKind;
+}
+
+const SubscriptionDetails: React.FC<SubscriptionDetails> = ({ obj: subscription }) => (
+  <>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Subscription Details" />
+      <div className="row">
+        <div className="col-sm-6">
+          <ResourceSummary resource={subscription} />
+        </div>
+        <div className="col-sm-6">
+          {subscription.spec?.channel?.kind && (
+            <DynamicResourceLink
+              title="Channel"
+              name={subscription.spec.channel.name}
+              namespace={subscription.metadata.namespace}
+              kind={referenceFor(subscription.spec.channel)}
+            />
+          )}
+          {subscription.spec?.subscriber?.ref && (
+            <DynamicResourceLink
+              title="Subscriber"
+              name={subscription.spec.subscriber.ref.name}
+              namespace={subscription.metadata.namespace}
+              kind={referenceFor(subscription.spec.subscriber.ref)}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+    {_.isArray(subscription?.status?.conditions) && (
+      <div className="co-m-pane__body">
+        <SectionHeading text="Conditions" />
+        <Conditions conditions={subscription.status.conditions} />
+      </div>
+    )}
+  </>
+);
+
+export default SubscriptionDetails;

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/SubscriptionDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/SubscriptionDetailsPage.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { DetailsPage } from '@console/internal/components/factory';
+import { Kebab, navFactory } from '@console/internal/components/utils';
+import SubscriptionDetails from './SubscriptionDetails';
+import { EventingSubscriptionModel } from '../../../models';
+
+const SubscriptionDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => {
+  const pages = [navFactory.details(SubscriptionDetails), navFactory.editYaml()];
+  const commonActions = Kebab.factory.common.map((action) => action);
+  const menuActionsCreator = [
+    ...Kebab.getExtensionsActionsForKind(EventingSubscriptionModel),
+    ...commonActions,
+  ];
+
+  return <DetailsPage {...props} pages={pages} menuActions={menuActionsCreator} />;
+};
+
+export default SubscriptionDetailsPage;

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/TriggerDetails.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/TriggerDetails.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
+import { Conditions } from '@console/internal/components/conditions';
+import { K8sResourceKind, referenceFor, referenceForModel } from '@console/internal/module/k8s';
+import { EventingBrokerModel } from '../../../models';
+import FilterTable from '../../overview/FilterTable';
+import { getTriggerFilters } from '../../../topology/knative-topology-utils';
+import DynamicResourceLink from './DynamicResourceLink';
+
+import './DynamicResourceLink.scss';
+
+interface TriggerDetailsProps {
+  obj: K8sResourceKind;
+}
+
+const TriggerDetails: React.FC<TriggerDetailsProps> = ({ obj: trigger }) => {
+  const { filters: filterData } = getTriggerFilters(trigger);
+  return (
+    <>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Trigger Details" />
+        <div className="row">
+          <div className="col-sm-6">
+            <ResourceSummary resource={trigger} />
+          </div>
+          <div className="col-sm-6">
+            {filterData.length > 0 && (
+              <div className="kn-resource-link-list kn-resource-link-list--addSpaceBelow">
+                <dl>
+                  <dt>Filter</dt>
+                  <dd>
+                    <FilterTable filters={filterData} />
+                  </dd>
+                </dl>
+              </div>
+            )}
+            {trigger.spec?.broker && (
+              <DynamicResourceLink
+                title="Broker"
+                name={trigger.spec.broker}
+                namespace={trigger.metadata.namespace}
+                kind={referenceForModel(EventingBrokerModel)}
+              />
+            )}
+            {trigger.spec?.subscriber?.ref && (
+              <DynamicResourceLink
+                title="Subscriber"
+                name={trigger.spec.subscriber.ref.name}
+                namespace={trigger.metadata.namespace}
+                kind={referenceFor(trigger.spec.subscriber.ref)}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+      {_.isArray(trigger?.status?.conditions) && (
+        <div className="co-m-pane__body">
+          <SectionHeading text="Conditions" />
+          <Conditions conditions={trigger.status.conditions} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TriggerDetails;

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/TriggerDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/TriggerDetailsPage.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { DetailsPage } from '@console/internal/components/factory';
+import { Kebab, navFactory } from '@console/internal/components/utils';
+import TriggerDetails from './TriggerDetails';
+import { EventingTriggerModel } from '../../../models';
+
+const TriggerDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => {
+  const pages = [navFactory.details(TriggerDetails), navFactory.editYaml()];
+  const commonActions = Kebab.factory.common.map((action) => action);
+  const menuActionsCreator = [
+    ...Kebab.getExtensionsActionsForKind(EventingTriggerModel),
+    ...commonActions,
+  ];
+
+  return <DetailsPage {...props} pages={pages} menuActions={menuActionsCreator} />;
+};
+
+export default TriggerDetailsPage;

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/DynamicResourceLink.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/DynamicResourceLink.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { ResourceLink } from '@console/internal/components/utils';
+import DynamicResourceLink from '../DynamicResourceLink';
+
+type DynamicResourceLinkProps = React.ComponentProps<typeof DynamicResourceLink>;
+let sampleProps: DynamicResourceLinkProps;
+let wrapper: ShallowWrapper<DynamicResourceLinkProps>;
+
+describe('DynamicResourceLink', () => {
+  beforeEach(() => {
+    sampleProps = {
+      title: 'Subscriber',
+      name: 'sample-name',
+      namespace: 'sample-app',
+      kind: 'serving.knative.dev~v1~Service',
+    };
+  });
+
+  it('should render ResourceLink with proper kind based on model', () => {
+    wrapper = shallow(<DynamicResourceLink {...sampleProps} />);
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(wrapper.find(ResourceLink).props().kind).toEqual('serving.knative.dev~v1~Service');
+  });
+
+  it('should render ResourceLink with proper kind based on refResource', () => {
+    const sampleResourceRef = {
+      ...sampleProps,
+      refResource: {
+        apiVersion: 'serving.knative.dev/v1',
+        kind: 'Service',
+        name: 'ksvc-display0',
+      },
+    };
+    wrapper = shallow(<DynamicResourceLink {...sampleResourceRef} />);
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(wrapper.find(ResourceLink).props().kind).toEqual('serving.knative.dev~v1~Service');
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/SubscriptionDetails.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/SubscriptionDetails.spec.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { shallow } from 'enzyme';
+import { Conditions } from '@console/internal/components/conditions';
+import SubscriptionDetails from '../SubscriptionDetails';
+import { subscriptionData } from '../../../../utils/__tests__/knative-eventing-data';
+import DynamicResourceLink from '../DynamicResourceLink';
+
+describe('SubscriptionDetails', () => {
+  const wrapper = shallow(<SubscriptionDetails obj={subscriptionData} />);
+  it('should render two DynamicResourceLink with respective props', () => {
+    const dynamicResourceLink = wrapper.find(DynamicResourceLink);
+    expect(dynamicResourceLink).toHaveLength(2);
+    expect(dynamicResourceLink.at(0).props().title).toEqual('Channel');
+    expect(dynamicResourceLink.at(0).props().name).toEqual('testchannel');
+    expect(dynamicResourceLink.at(1).props().title).toEqual('Subscriber');
+    expect(dynamicResourceLink.at(1).props().name).toEqual('channel-display0');
+  });
+
+  it('should render Conditions if status is present', () => {
+    expect(wrapper.find(Conditions)).toHaveLength(1);
+  });
+
+  it('should not render Conditions if status is not present', () => {
+    const subscriptionDataClone = _.omit(_.cloneDeep(subscriptionData), 'status');
+    const subscriptionDetailsWrapper = shallow(<SubscriptionDetails obj={subscriptionDataClone} />);
+    expect(subscriptionDetailsWrapper.find(Conditions)).toHaveLength(0);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/TriggerDetails.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/details/__test__/TriggerDetails.spec.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { shallow } from 'enzyme';
+import { Conditions } from '@console/internal/components/conditions';
+import TriggerDetails from '../TriggerDetails';
+import { triggerData } from '../../../../utils/__tests__/knative-eventing-data';
+import DynamicResourceLink from '../DynamicResourceLink';
+import FilterTable from '../../../overview/FilterTable';
+
+describe('SubscriptionDetails', () => {
+  const wrapper = shallow(<TriggerDetails obj={triggerData} />);
+  it('should render two DynamicResourceLink with respective props', () => {
+    const dynamicResourceLink = wrapper.find(DynamicResourceLink);
+    expect(dynamicResourceLink).toHaveLength(2);
+    expect(dynamicResourceLink.at(0).props().title).toEqual('Broker');
+    expect(dynamicResourceLink.at(0).props().name).toEqual('default');
+    expect(dynamicResourceLink.at(1).props().title).toEqual('Subscriber');
+    expect(dynamicResourceLink.at(1).props().name).toEqual('broker-display');
+  });
+
+  it('should render FilterTable if filter is present', () => {
+    expect(wrapper.find(FilterTable)).toHaveLength(1);
+  });
+
+  it('should render Conditions if status is present', () => {
+    expect(wrapper.find(Conditions)).toHaveLength(1);
+  });
+
+  it('should not render FilterTable if filter is not present', () => {
+    const triggerDataClone = _.omit(_.cloneDeep(triggerData), 'spec.filter');
+    const triggerDetailsWrapper = shallow(<TriggerDetails obj={triggerDataClone} />);
+    expect(triggerDetailsWrapper.find(FilterTable)).toHaveLength(0);
+  });
+
+  it('should not render Conditions if status is not present', () => {
+    const triggerDataClone = _.omit(_.cloneDeep(triggerData), 'status');
+    const triggerDetailsWrapper = shallow(<TriggerDetails obj={triggerDataClone} />);
+    expect(triggerDetailsWrapper.find(Conditions)).toHaveLength(0);
+  });
+});

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -198,7 +198,7 @@ export const EventSourceSinkBindingModel: K8sKind = {
 
 export const EventingSubscriptionModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_MESSAGE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1',
   kind: 'Subscription',
   label: 'Subscription',
   labelPlural: 'Subscriptions',
@@ -268,7 +268,7 @@ export const EventingBrokerModel: K8sKind = {
 
 export const EventingTriggerModel: K8sKind = {
   apiGroup: KNATIVE_EVENTING_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1',
   kind: 'Trigger',
   label: 'Trigger',
   labelPlural: 'Triggers',

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -197,6 +197,30 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.EventingTriggerModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pub-sub/details/TriggerDetailsPage' /* webpackChunkName: "trigger-details-page" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.EventingSubscriptionModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pub-sub/details/SubscriptionDetailsPage' /* webpackChunkName: "subscription-details-page" */
+          )
+        ).default,
+    },
+  },
+  {
     type: 'Page/Resource/List',
     properties: {
       model: models.RouteModel,

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-eventing-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-eventing-data.ts
@@ -1,0 +1,243 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const subscriptionData: K8sResourceKind = {
+  apiVersion: 'messaging.knative.dev/v1beta1',
+  kind: 'Subscription',
+  metadata: {
+    annotations: {
+      'kubectl.kubernetes.io/last-applied-configuration':
+        '{"apiVersion":"messaging.knative.dev/v1beta1","kind":"Subscription","metadata":{"annotations":{},"name":"sub1","namespace":"sample-app"},"spec":{"channel":{"apiVersion":"messaging.knative.dev/v1beta1","kind":"InMemoryChannel","name":"testchannel"},"subscriber":{"ref":{"apiVersion":"serving.knative.dev/v1","kind":"Service","name":"channel-display0"}}}}\n',
+      'messaging.knative.dev/creator': 'kube:admin',
+      'messaging.knative.dev/lastModifier': 'kube:admin',
+    },
+    selfLink: '/apis/messaging.knative.dev/v1beta1/namespaces/sample-app/subscriptions/sub1',
+    resourceVersion: '43908',
+    name: 'sub1',
+    uid: '26152eb3-f36b-4b13-b26f-3ba165642b01',
+    creationTimestamp: '2020-10-14T06:32:12Z',
+    generation: 1,
+    managedFields: [
+      {
+        apiVersion: 'messaging.knative.dev/v1beta1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:metadata': {
+            'f:annotations': {
+              '.': {},
+              'f:kubectl.kubernetes.io/last-applied-configuration': {},
+            },
+          },
+          'f:spec': {
+            '.': {},
+            'f:channel': {
+              '.': {},
+              'f:apiVersion': {},
+              'f:kind': {},
+              'f:name': {},
+            },
+            'f:subscriber': {
+              '.': {},
+              'f:ref': {
+                '.': {},
+                'f:apiVersion': {},
+                'f:kind': {},
+                'f:name': {},
+              },
+            },
+          },
+        },
+        manager: 'oc',
+        operation: 'Update',
+        time: '2020-10-14T06:32:12Z',
+      },
+      {
+        apiVersion: 'messaging.knative.dev/v1beta1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:metadata': {
+            'f:finalizers': {
+              '.': {},
+              'v:"subscriptions.messaging.knative.dev"': {},
+            },
+          },
+          'f:status': {
+            '.': {},
+            'f:conditions': {},
+            'f:observedGeneration': {},
+            'f:physicalSubscription': {},
+          },
+        },
+        manager: 'controller',
+        operation: 'Update',
+        time: '2020-10-14T06:32:22Z',
+      },
+    ],
+    namespace: 'sample-app',
+    finalizers: ['subscriptions.messaging.knative.dev'],
+  },
+  spec: {
+    channel: {
+      apiVersion: 'messaging.knative.dev/v1beta1',
+      kind: 'InMemoryChannel',
+      name: 'testchannel',
+    },
+    subscriber: {
+      ref: {
+        apiVersion: 'serving.knative.dev/v1',
+        kind: 'Service',
+        name: 'channel-display0',
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2020-10-14T06:32:22Z',
+        status: 'True',
+        type: 'AddedToChannel',
+      },
+      {
+        lastTransitionTime: '2020-10-14T06:32:22Z',
+        status: 'True',
+        type: 'ChannelReady',
+      },
+      {
+        lastTransitionTime: '2020-10-14T06:32:22Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2020-10-14T06:32:22Z',
+        status: 'True',
+        type: 'ReferencesResolved',
+      },
+    ],
+    observedGeneration: 1,
+    physicalSubscription: {
+      subscriberUri: 'http://channel-display0.sample-app.svc.cluster.local',
+    },
+  },
+};
+
+export const triggerData: K8sResourceKind = {
+  apiVersion: 'eventing.knative.dev/v1beta1',
+  kind: 'Trigger',
+  metadata: {
+    annotations: {
+      'eventing.knative.dev/creator': 'kube:admin',
+      'eventing.knative.dev/lastModifier': 'kube:admin',
+      'kubectl.kubernetes.io/last-applied-configuration':
+        '{"apiVersion":"eventing.knative.dev/v1beta1","kind":"Trigger","metadata":{"annotations":{},"name":"testevents-trigger0","namespace":"sample-app"},"spec":{"broker":"default","filter":{"attributes":{"type":"dev.knative.sources.ping"}},"subscriber":{"ref":{"apiVersion":"serving.knative.dev/v1","kind":"Service","name":"broker-display"}}}}\n',
+    },
+    selfLink:
+      '/apis/eventing.knative.dev/v1beta1/namespaces/sample-app/triggers/testevents-trigger0',
+    resourceVersion: '483312',
+    name: 'testevents-trigger0',
+    uid: 'f600e386-90d3-4405-a28a-9c96b7a286ab',
+    creationTimestamp: '2020-10-14T06:32:53Z',
+    generation: 1,
+    managedFields: [
+      {
+        apiVersion: 'eventing.knative.dev/v1beta1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:metadata': {
+            'f:annotations': {
+              '.': {},
+              'f:kubectl.kubernetes.io/last-applied-configuration': {},
+            },
+          },
+          'f:spec': {
+            '.': {},
+            'f:broker': {},
+            'f:filter': {
+              '.': {},
+              'f:attributes': {
+                '.': {},
+                'f:type': {},
+              },
+            },
+            'f:subscriber': {
+              '.': {},
+              'f:ref': {
+                '.': {},
+                'f:apiVersion': {},
+                'f:kind': {},
+                'f:name': {},
+              },
+            },
+          },
+        },
+        manager: 'oc',
+        operation: 'Update',
+        time: '2020-10-14T06:32:53Z',
+      },
+      {
+        apiVersion: 'eventing.knative.dev/v1beta1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: {
+          'f:status': {
+            '.': {},
+            'f:conditions': {},
+            'f:observedGeneration': {},
+            'f:subscriberUri': {},
+          },
+        },
+        manager: 'mtchannel-broker',
+        operation: 'Update',
+        time: '2020-10-14T10:25:10Z',
+      },
+    ],
+    namespace: 'sample-app',
+    labels: {
+      'eventing.knative.dev/broker': 'default',
+    },
+  },
+  spec: {
+    broker: 'default',
+    filter: {
+      attributes: {
+        type: 'dev.knative.sources.ping',
+      },
+    },
+    subscriber: {
+      ref: {
+        apiVersion: 'serving.knative.dev/v1',
+        kind: 'Service',
+        name: 'broker-display',
+        namespace: 'sample-app',
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2020-10-14T10:25:10Z',
+        status: 'True',
+        type: 'BrokerReady',
+      },
+      {
+        lastTransitionTime: '2020-10-14T06:32:53Z',
+        status: 'True',
+        type: 'DependencyReady',
+      },
+      {
+        lastTransitionTime: '2020-10-14T10:25:10Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2020-10-14T06:32:53Z',
+        status: 'True',
+        type: 'SubscriberResolved',
+      },
+      {
+        lastTransitionTime: '2020-10-14T06:32:53Z',
+        status: 'True',
+        type: 'SubscriptionReady',
+      },
+    ],
+    observedGeneration: 1,
+    subscriberUri: 'http://broker-display.sample-app.svc.cluster.local',
+  },
+};


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/ODC-4995
- https://issues.redhat.com/browse/ODC-4996

**Analysis / Root cause**: 
- user were not able to see associated filter, broker and subscriber for triggers 
- user were not able to see associated channel and subscriber for triggers 

**Solution Description**: 
Added details page for Trigger/Subscription to show info about filters, broker/channel and subscriber.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
- Trigger

![image](https://user-images.githubusercontent.com/5129024/96713855-eb759e00-13be-11eb-89da-f26c2eb6ff90.png)



- Subscriptions

![image](https://user-images.githubusercontent.com/5129024/95965076-2871eb80-0e27-11eb-8295-4fc39f72afbc.png)

@openshift/team-devconsole-ux

**Unit test coverage report**: 

![image](https://user-images.githubusercontent.com/5129024/96018174-8b37a700-0e68-11eb-8c2c-1c07048ae3a5.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
