### PR TITLE
Bug 1887783: PVC upload cannot continue after approve the certificate

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
@@ -5,7 +5,7 @@ import {
   useK8sWatchResource,
 } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { UPLOAD_STATUS } from './consts';
+import { CDI_UPLOAD_URL_BUILDER, UPLOAD_STATUS } from './consts';
 import { CDIConfigModel } from '../../models';
 import { getUploadProxyURL } from '../../selectors/cdi';
 
@@ -65,7 +65,7 @@ export const useCDIUploadHook = (): CDIUploadContextProps => {
 
       axios({
         method: 'POST',
-        url: `https://${uploadProxyURL}/v1beta1/upload-form-async`,
+        url: CDI_UPLOAD_URL_BUILDER(uploadProxyURL),
         data: form,
         cancelToken: cancelSource.token,
         headers: {
@@ -89,23 +89,6 @@ export const useCDIUploadHook = (): CDIUploadContextProps => {
               ...newUpload,
               uploadStatus: UPLOAD_STATUS.CANCELED,
             });
-          } else if (typeof err.response === 'undefined') {
-            updateUpload({
-              ...newUpload,
-              uploadStatus: UPLOAD_STATUS.ERROR,
-              uploadError: {
-                message: (
-                  <>
-                    It seems that your browser does not trust the certificate of the upload proxy.
-                    Please{' '}
-                    <a href={`https://${uploadProxyURL}`} rel="noopener noreferrer" target="_blank">
-                      approve this certificate
-                    </a>{' '}
-                    and try again
-                  </>
-                ),
-              },
-            });
           } else {
             updateUpload({ ...newUpload, uploadStatus: UPLOAD_STATUS.ERROR, uploadError: err });
           }
@@ -123,6 +106,7 @@ export const useCDIUploadHook = (): CDIUploadContextProps => {
   return {
     uploads,
     uploadData,
+    uploadProxyURL,
   };
 };
 
@@ -139,6 +123,7 @@ export type DataUpload = {
 type CDIUploadContextProps = {
   uploads: DataUpload[];
   uploadData: ({ file, token, pvcName, namespace }: UploadDataProps) => void;
+  uploadProxyURL?: string;
 };
 
 type UploadDataProps = {

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
@@ -5,7 +5,8 @@ export enum UPLOAD_STATUS {
   ERROR = 'ERROR',
   CANCELED = 'CANCELED',
 }
-
+export const CDI_UPLOAD_URL_BUILDER = (uploadProxyURL) =>
+  `https://${uploadProxyURL}/v1beta1/upload-form-async`;
 export const CDI_UPLOAD_POD_ANNOTATION = 'cdi.kubevirt.io/storage.pod.phase';
 export const CDI_UPLOAD_POD_NAME_ANNOTATION = 'cdi.kubevirt.io/storage.uploadPodName';
 export const CDI_PHASE_PVC_ANNOTATION = 'cdi.kubevirt.io/storage.pod.phase';


### PR DESCRIPTION
We now check for a valid upload proxy certificate before allocating resources, so the user can quickly resume the upload after approving it. The invalid error will now be shown in the form it self:
![image](https://user-images.githubusercontent.com/24938324/95989333-ccad5f80-0e32-11eb-95ca-9aba3712d4a3.png)
