### PR TITLE
Handle missing labels as empty

### DIFF
--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -75,9 +75,6 @@ export const silenceStateOrder = (silence: Silence): ListOrder => [
 export const isSilenced = (alert: Alert, silence: Silence): boolean =>
   [AlertStates.Firing, AlertStates.Silenced].includes(alert.state) &&
   _.every(silence.matchers, (m) => {
-    const alertValue = _.get(alert.labels, m.name);
-    return (
-      alertValue !== undefined &&
-      (m.isRegex ? new RegExp(`^${m.value}$`).test(alertValue) : alertValue === m.value)
-    );
+    const alertValue = _.get(alert.labels, m.name, '');
+    return m.isRegex ? new RegExp(`^${m.value}$`).test(alertValue) : alertValue === m.value;
   });


### PR DESCRIPTION
To implement the same logic as in AlertManager which handles missing
labels as the empty label [1].

[1] https://github.com/prometheus/alertmanager/blob/a8ed0d58509d0251adcb159552b9ab098e206f1f/types/match.go#L72

Solves https://access.redhat.com/support/cases/#/case/02776669