### PR TITLE
Bug 1886168: Check if the label exists before comparing its value

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsPage.tsx
@@ -31,11 +31,11 @@ const NodeDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (pro
         <PodsPage showTitle={false} fieldSelector={`spec.nodeName=${obj.metadata.name}`} />
       )),
       events(ResourceEventStream),
-      ...(_.find(
+      ...(!_.some(
         node?.metadata?.labels,
-        (label) =>
-          label['corev1.LabelOSStable'] !== 'windows' ||
-          label['node.openshift.io/os_id'] !== 'Windows',
+        (v, k) =>
+          (k === 'node.openshift.io/os_id' && v === 'Windows') ||
+          (k === 'corev1.LabelOSStable' && v === 'windows'),
       )
         ? [{ href: 'terminal', name: 'Terminal', component: NodeTerminal }]
         : []),


### PR DESCRIPTION
We need to check if the label exists before comparing to a value. If it does not exists then the statement result will true. Additional PR to https://github.com/openshift/console/pull/6876
/assign @spadgett 