### PR TITLE
Add start button to fresh start pipeline from sidebar

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import PipelineOverview from './PipelineOverview';
+import PipelineStartButton from './PipelineStartButton';
+import TriggerLastRunButton from './TriggerLastRunButton';
+
+describe('Pipeline sidebar overview', () => {
+  let props: React.ComponentProps<typeof PipelineOverview>;
+
+  beforeEach(() => {
+    props = {
+      item: {
+        buildConfigs: [],
+        obj: {},
+        routes: [],
+        services: [],
+        pipelines: [{ metadata: { name: 'pipeline', namespace: 'test' }, spec: { tasks: [] } }],
+        pipelineRuns: [],
+      },
+    };
+  });
+
+  it('should show view all link if there are more than MAX_VISIBLE pipelineruns', () => {
+    props.item.pipelineRuns = ['pr0', 'pr1', 'pr2', 'pr3'].map((pr) => ({
+      metadata: { name: pr, namespace: 'test' },
+    }));
+    const wrapper = shallow(<PipelineOverview {...props} />);
+    expect(wrapper.find('Link').text()).toBe('View all (4)');
+  });
+
+  it('should show not view all link if there exactly MAX_VISIBLE pipelineruns', () => {
+    props.item.pipelineRuns = ['pr0', 'pr1', 'pr2'].map((pr) => ({
+      metadata: { name: pr, namespace: 'test' },
+    }));
+    const wrapper = shallow(<PipelineOverview {...props} />);
+    expect(wrapper.find('Link')).toHaveLength(0);
+  });
+
+  it('should show Start button when no pipelineruns are available', () => {
+    const wrapper = shallow(<PipelineOverview {...props} />);
+    expect(wrapper.find(PipelineStartButton)).toHaveLength(1);
+  });
+
+  it('should show Start last run button when pipelineruns are available', () => {
+    props.item.pipelineRuns = [{ metadata: { name: 'pipelinerun', namespace: 'test' } }];
+    const wrapper = shallow(<PipelineOverview {...props} />);
+    expect(wrapper.find(TriggerLastRunButton)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
@@ -12,6 +12,7 @@ import { PipelineRunModel, PipelineModel } from '@console/dev-console/src/models
 import { TopologyOverviewItem } from '../../topology/topology-types';
 import TriggerLastRunButton from './TriggerLastRunButton';
 import PipelineRunItem from './PipelineRunItem';
+import PipelineStartButton from './PipelineStartButton';
 
 const MAX_VISIBLE = 3;
 
@@ -52,7 +53,11 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
               />
             </FlexItem>
             <FlexItem>
-              <TriggerLastRunButton pipelineRuns={pipelineRuns} namespace={namespace} />
+              {pipelineRuns.length === 0 ? (
+                <PipelineStartButton pipeline={pipeline} namespace={namespace} />
+              ) : (
+                <TriggerLastRunButton pipelineRuns={pipelineRuns} namespace={namespace} />
+              )}
             </FlexItem>
           </Flex>
         </li>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineStartButton.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineStartButton.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Button } from '@patternfly/react-core';
+import { useAccessReview } from '@console/internal/components/utils';
+import { AccessReviewResourceAttributes } from '@console/internal/module/k8s';
+import { impersonateStateToProps } from '@console/internal/reducers/ui';
+import { PipelineRunModel } from '../../../models';
+import { Pipeline } from '../../../utils/pipeline-augment';
+import { startPipelineModal } from '../modals';
+
+type StateProps = {
+  impersonate?: {
+    kind: string;
+    name: string;
+    subprotocols: string[];
+  };
+};
+
+type PipelineStartButtonProps = {
+  pipeline: Pipeline;
+  namespace: string;
+};
+
+const PipelineStartButton: React.FC<PipelineStartButtonProps & StateProps> = ({
+  pipeline,
+  namespace,
+  impersonate,
+}) => {
+  const openPipelineModal = () =>
+    startPipelineModal({
+      pipeline,
+      modalClassName: 'modal-lg',
+    });
+  const defaultAccessReview: AccessReviewResourceAttributes = {
+    group: PipelineRunModel.apiGroup,
+    resource: PipelineRunModel.plural,
+    namespace,
+    verb: 'create',
+  };
+  const isAllowed = useAccessReview(defaultAccessReview, impersonate);
+
+  return (
+    isAllowed && (
+      <Button variant="secondary" onClick={openPipelineModal}>
+        Start
+      </Button>
+    )
+  );
+};
+
+export default connect(impersonateStateToProps)(PipelineStartButton);


### PR DESCRIPTION
**Story**: 
https://issues.redhat.com/browse/ODC-2441
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
If the pipeline in sidebar does not have any associated pipelineruns, display a start button which opens the start pipeline modal.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp](https://user-images.githubusercontent.com/20013884/96496208-90309800-1266-11eb-8821-12c2fa4b244a.png)
cc: @openshift/team-devconsole-ux @andrewballantyne 

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge