### PR TITLE
Bug 1872923: Fix cancel button to return to operator details

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
@@ -28,6 +28,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
   onChange = _.noop,
   onError = _.noop,
   onSubmit = _.noop,
+  onCancel,
   schema,
   uiSchema = {},
   widgets = {},
@@ -87,7 +88,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
                 <Button type="submit" variant="primary">
                   Create
                 </Button>
-                <Button onClick={history.goBack} variant="secondary">
+                <Button onClick={onCancel || history.goBack} variant="secondary">
                   Cancel
                 </Button>
               </ActionGroup>
@@ -104,6 +105,7 @@ type DynamicFormProps = FormProps<any> & {
   ErrorTemplate?: React.FC<{ errors: string[] }>;
   noActions?: boolean;
   customUISchema?: boolean;
+  onCancel?: () => void;
 };
 
 export * from './types';

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
@@ -1,8 +1,13 @@
 import { JSONSchema6 } from 'json-schema';
 import { k8sCreate, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
-import { history, useScrollToTopOnMount } from '@console/internal/components/utils';
+import {
+  history,
+  resourcePathFromModel,
+  useScrollToTopOnMount,
+} from '@console/internal/components/utils';
 import * as _ from 'lodash';
 import * as React from 'react';
+import { ClusterServiceVersionModel } from '../../models';
 import { ClusterServiceVersionKind, CRDDescription, APIServiceDefinition } from '../../types';
 import { ClusterServiceVersionLogo } from '../index';
 import { DynamicForm } from '@console/shared/src/components/dynamic-form';
@@ -40,6 +45,20 @@ export const OperandForm: React.FC<OperandFormProps> = ({
       .catch((e) => setErrors([e.message]));
   };
 
+  const handleCancel = () => {
+    if (new URLSearchParams(window.location.search).has('useInitializationResource')) {
+      history.replace(
+        resourcePathFromModel(
+          ClusterServiceVersionModel,
+          csv.metadata.name,
+          csv.metadata.namespace,
+        ),
+      );
+    } else {
+      history.goBack();
+    }
+  };
+
   const uiSchema = React.useMemo(() => getUISchema(schema, providedAPI), [schema, providedAPI]);
 
   useScrollToTopOnMount();
@@ -69,6 +88,7 @@ export const OperandForm: React.FC<OperandFormProps> = ({
             onChange={onChange}
             onError={setErrors}
             onSubmit={handleSubmit}
+            onCancel={handleCancel}
             schema={schema}
           />
         </div>


### PR DESCRIPTION
Cancel button uses goBack which in the case of the new operator install status screen, would go back to the install subscription page instead of the operator details page (which is where you go when you come from operator details page initially). 