### PR TITLE
Bug 1889630: - Scheduling disabled popovers are missing for Node status in Node Overview and Details pages 

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsOverview.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsOverview.tsx
@@ -17,6 +17,7 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 import { getNodeMachineNameAndNamespace, getNodeAddresses } from '@console/shared';
 import NodeIPList from './NodeIPList';
 import NodeStatus from './NodeStatus';
+import MarkAsSchedulablePopover from './popovers/MarkAsSchedulablePopover';
 
 type NodeDetailsOverviewProps = {
   node: NodeKind;
@@ -41,7 +42,11 @@ const NodeDetailsOverview: React.FC<NodeDetailsOverviewProps> = ({ node }) => {
             <dd>{node.metadata.name || '-'}</dd>
             <dt>Status</dt>
             <dd>
-              <NodeStatus node={node} />
+              {!node.spec.unschedulable ? (
+                <NodeStatus node={node} showPopovers />
+              ) : (
+                <MarkAsSchedulablePopover node={node} />
+              )}
             </dd>
             <dt>External ID</dt>
             <dd>{_.get(node, 'spec.externalID', '-')}</dd>

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeHealth.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/NodeHealth.tsx
@@ -31,6 +31,7 @@ import { ResourceLink } from '@console/internal/components/utils';
 import { NodeDashboardContext } from './NodeDashboardContext';
 import NodeStatus from '../NodeStatus';
 import { CONDITIONS_WARNING } from './messages';
+import MarkAsSchedulablePopover from '../popovers/MarkAsSchedulablePopover';
 
 import './node-health.scss';
 
@@ -260,7 +261,11 @@ const NodeHealth: React.FC = () => {
     <HealthBody>
       <Gallery className="co-overview-status__health" hasGutter>
         <GalleryItem>
-          <NodeStatus node={obj} className="co-node-health__status" />
+          {!obj.spec.unschedulable ? (
+            <NodeStatus className="co-node-health__status" node={obj} showPopovers />
+          ) : (
+            <MarkAsSchedulablePopover node={obj} />
+          )}
         </GalleryItem>
         <GalleryItem>
           <HealthChecksItem />


### PR DESCRIPTION
/assign @spadgett 

This PR is a follow on for [](https://github.com/openshift/console/pull/6852) to fix missing popovers for Node Status in overview and details pages