### PR TITLE
Bug 1889783: Support ServiceBinding breaking api changes

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -7,7 +7,7 @@ import { getResourceList } from '@console/shared';
 import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
 import { RootState } from '@console/internal/redux';
 import { safeLoadAll } from 'js-yaml';
-import { ServiceBindingRequestModel } from '../../models';
+import { ServiceBindingModel } from '../../models';
 import { transformTopologyData } from './data-transforms/data-transformer';
 import { allowedResources, getHelmReleaseKey, getServiceBindingStatus } from './topology-utils';
 import { TopologyDataModel, TopologyDataResources, TrafficData } from './topology-types';
@@ -124,7 +124,7 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   if (serviceBinding) {
     resources.push({
       isList: true,
-      kind: referenceForModel(ServiceBindingRequestModel),
+      kind: referenceForModel(ServiceBindingModel),
       namespace,
       prop: 'serviceBindingRequests',
       optional: true,

--- a/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
@@ -1,27 +1,30 @@
-import { DeploymentKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { apiVersionForModel, DeploymentKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { ServiceBindingModel } from '../../../models';
 import { TopologyDataResources } from '../topology-types';
 
 export const serviceBindingRequest: K8sResourceKind = {
   data: {
-    apiVersion: 'apps.openshift.io/v1alpha1',
-    kind: 'ServiceBindingRequest',
+    apiVersion: apiVersionForModel(ServiceBindingModel),
+    kind: ServiceBindingModel.kind,
     metadata: {
       name: 'analytics-deployment-D-wit-deployment-D',
       namespace: 'testproject1',
     },
     spec: {
-      applicationSelector: {
+      application: {
         group: 'apps',
         resource: 'deployments',
-        resourceRef: 'analytics-deployment',
+        name: 'analytics-deployment',
         version: 'v1',
       },
-      backingServiceSelector: {
-        group: '',
-        kind: undefined,
-        resourceRef: undefined,
-        version: undefined,
-      },
+      services: [
+        {
+          group: '',
+          kind: undefined,
+          name: undefined,
+          version: undefined,
+        },
+      ],
       detectBindingResources: true,
     },
   },
@@ -79,30 +82,30 @@ export const sbrBackingServiceSelectors: Partial<TopologyDataResources> = {
     loadError: null,
     data: [
       {
-        apiVersion: 'apps.openshift.io/v1alpha1',
-        kind: 'ServiceBindingRequest',
+        apiVersion: apiVersionForModel(ServiceBindingModel),
+        kind: ServiceBindingModel.kind,
         metadata: {
           name: 'sbr-1',
         },
         spec: {
-          applicationSelector: {
-            resourceRef: 'app',
+          application: {
+            name: 'app',
             group: 'apps',
             version: 'v1',
             resource: 'deployments',
           },
-          backingServiceSelectors: [
+          services: [
             {
               group: 'postgresql.baiju.dev',
               version: 'v1alpha1',
               kind: 'Database',
-              resourceRef: 'db-demo1',
+              name: 'db-demo1',
             },
             {
               group: 'postgresql.baiju.dev',
               version: 'v1alpha1',
               kind: 'Database',
-              resourceRef: 'db-demo2',
+              name: 'db-demo2',
             },
           ],
           detectBindingResources: true,
@@ -148,24 +151,26 @@ export const sbrBackingServiceSelector: Partial<TopologyDataResources> = {
     loadError: null,
     data: [
       {
-        apiVersion: 'apps.openshift.io/v1alpha1',
-        kind: 'ServiceBindingRequest',
+        apiVersion: apiVersionForModel(ServiceBindingModel),
+        kind: ServiceBindingModel.kind,
         metadata: {
           name: 'sbr-2',
         },
         spec: {
-          applicationSelector: {
-            resourceRef: 'app',
+          application: {
+            name: 'app',
             group: 'apps',
             version: 'v1',
             resource: 'deployments',
           },
-          backingServiceSelector: {
-            group: 'postgresql.baiju.dev',
-            version: 'v1alpha1',
-            kind: 'Database',
-            resourceRef: 'db-demo1',
-          },
+          services: [
+            {
+              group: 'postgresql.baiju.dev',
+              version: 'v1alpha1',
+              kind: 'Database',
+              name: 'db-demo1',
+            },
+          ],
           detectBindingResources: true,
         },
       },

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -179,15 +179,13 @@ export const getTopologyEdgeItems = (
   });
 
   _.forEach(edgesFromServiceBinding(dc, sbrs), (sbr) => {
-    // look for multiple backing services first in `backingServiceSelectors`
-    // followed by a fallback to the single reference in `backingServiceSelector`
-    _.forEach(sbr.spec.backingServiceSelectors || [sbr.spec.backingServiceSelector], (bss) => {
+    _.forEach(sbr.spec.services, (bss) => {
       if (bss) {
         // handles multiple edges
         const targetResource = resources.find(
           (deployment) =>
             deployment?.metadata?.ownerReferences?.[0]?.kind === bss.kind &&
-            deployment?.metadata?.ownerReferences?.[0]?.name === bss.resourceRef,
+            deployment?.metadata?.ownerReferences?.[0]?.name === bss.name,
         );
         const target = targetResource?.metadata?.uid;
         const source = dc?.metadata?.uid;

--- a/frontend/packages/dev-console/src/models/service-binding.ts
+++ b/frontend/packages/dev-console/src/models/service-binding.ts
@@ -1,13 +1,13 @@
 import { K8sKind } from '@console/internal/module/k8s';
 
-export const ServiceBindingRequestModel: K8sKind = {
-  id: 'servicebindingrequest',
-  kind: 'ServiceBindingRequest',
-  plural: 'servicebindingrequests',
-  label: 'ServiceBindingRequest',
-  labelPlural: 'ServiceBindingRequests',
-  abbr: 'SBR',
-  apiGroup: 'apps.openshift.io',
+export const ServiceBindingModel: K8sKind = {
+  id: 'servicebinding',
+  kind: 'ServiceBinding',
+  plural: 'servicebindings',
+  label: 'ServiceBinding',
+  labelPlural: 'ServiceBindings',
+  abbr: 'SB',
+  apiGroup: 'operators.coreos.com',
   apiVersion: 'v1alpha1',
   namespaced: true,
   crd: true,

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -103,7 +103,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'FeatureFlag/Model',
     properties: {
-      model: models.ServiceBindingRequestModel,
+      model: models.ServiceBindingModel,
       flag: ALLOW_SERVICE_BINDING,
     },
   },


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/ODC-4661

This PR is a manual cherry-pick of https://github.com/openshift/console/pull/6792

**Analysis / Root cause:**
Service Binding Operator (starting with v0.2.0) has changed API (CRD) https://github.com/redhat-developer/service-binding-operator/pull/608 that is not supported in OCP 4.6 and hence service-binding is not working.

**Solution Description:**
Refactor code based on the latest API changes. Also fix failing unit tests accordingly.

**Gif:**

1. Binding connector
![Peek 2020-10-20 18-38](https://user-images.githubusercontent.com/20724543/96594660-7e073600-1308-11eb-8c0e-cf8c5a113679.gif)

2. Import YAML
![Peek 2020-10-20 18-45](https://user-images.githubusercontent.com/20724543/96594706-88c1cb00-1308-11eb-8d96-77b95dd50030.gif)

