### PR TITLE
Add missing key when mapping urls

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesUrlLink.tsx
@@ -10,10 +10,14 @@ const RoutesUrlLink: React.FC<RoutesUrlLinkProps> = ({ urls = [], title }) =>
   urls.length > 0 && (
     <>
       {title && <span className="text-muted">{title}: </span>}
-      {urls.length > 0 &&
-        urls.map((url) => (
-          <ExternalLink href={url} additionalClassName="co-external-link--block" text={url} />
-        ))}
+      {urls.map((url) => (
+        <ExternalLink
+          key={url}
+          href={url}
+          text={url}
+          additionalClassName="co-external-link--block"
+        />
+      ))}
     </>
   );
 


### PR DESCRIPTION
**Fixes**: 
No ticket, just fixing a react warning

**Analysis / Root cause**: 
Missing key when mapping over an array.

**Solution Description**: 
Add key.

**Screen shots / Gifs for design review**: 
None

**Unit test coverage report**: 
None

**Test setup:**
* Install Serverless Operator
* Create a Serverless / Knative Deployment
* Open the sidebar

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge