### PR TITLE
[release-4.5.z] Bug 1889982: pick latestCRDversion instead of latest/served true

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
@@ -30,7 +30,7 @@ const ApiServerSection: React.FC = () => {
     [setFieldValue],
   );
   const modeItems = {
-    Ref: 'Ref',
+    Reference: 'Reference',
     Resource: 'Resource',
   };
   const fieldId = getFieldId(values.type, 'res-input');
@@ -61,7 +61,7 @@ const ApiServerSection: React.FC = () => {
         name="data.apiserversource.mode"
         label="Mode"
         items={modeItems}
-        title={modeItems.Ref}
+        title={modeItems.Reference}
         helpText="The mode the receive adapter controller runs under"
         fullWidth
       />

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
@@ -15,7 +15,6 @@ import KafkaSourceSection from './KafkaSourceSection';
 import YAMLEditorSection from './YAMLEditorSection';
 import { EventSources } from '../import-types';
 import SinkSection from './SinkSection';
-import AdvancedSection from '../AdvancedSection';
 import { isKnownEventSource } from '../../../utils/create-eventsources-utils';
 
 interface EventSourceSectionProps {
@@ -66,7 +65,6 @@ const EventSourceSection: React.FC<EventSourceSectionProps> = ({ namespace }) =>
           />
         </>
       )}
-      {values.type === EventSources.KafkaSource && <AdvancedSection />}
     </>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -4,7 +4,6 @@ import FormSection from '@console/dev-console/src/components/import/section/Form
 import { InputField, TextColumnField } from '@console/shared';
 import { TextInputTypes } from '@patternfly/react-core';
 import KafkaSourceNetSection from './KafkaSourceNetSection';
-import ServiceAccountDropdown from '../../dropdowns/ServiceAccountDropdown';
 
 const KafkaSourceSection: React.FC = () => {
   const { values } = useFormikContext<FormikValues>();
@@ -42,7 +41,6 @@ const KafkaSourceSection: React.FC = () => {
         required
       />
       <KafkaSourceNetSection />
-      <ServiceAccountDropdown name="data.kafkasource.serviceAccountName" />
     </FormSection>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
@@ -7,7 +7,7 @@ const PingSourceSection: React.FC = () => (
   <FormSection title="PingSource" extraMargin>
     <InputField
       type={TextInputTypes.text}
-      name="data.pingsource.data"
+      name="data.pingsource.jsonData"
       label="Data"
       helpText="The data posted to the target function"
     />

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
@@ -4,7 +4,6 @@ import FormSection from '@console/dev-console/src/components/import/section/Form
 import KafkaSourceSection from '../KafkaSourceSection';
 import { EventSources } from '../../import-types';
 import KafkaSourceNetSection from '../KafkaSourceNetSection';
-import ServiceAccountDropdown from '../../../dropdowns/ServiceAccountDropdown';
 
 type KafkaSourceSectionProps = React.ComponentProps<typeof KafkaSourceSection>;
 
@@ -48,12 +47,11 @@ describe('KafkaSourceSection', () => {
     expect(topicsField.props().required).toBeTruthy();
   });
 
-  it('should render consumergroup, netsection and service dropdown', () => {
+  it('should render consumergroup, netsection', () => {
     const consumerGroupField = wrapper.find('[data-test-id="kafkasource-consumergroup-field"]');
     expect(consumerGroupField).toHaveLength(1);
     expect(consumerGroupField.props().required).toBeTruthy();
 
     expect(wrapper.find(KafkaSourceNetSection)).toHaveLength(1);
-    expect(wrapper.find(ServiceAccountDropdown)).toHaveLength(1);
   });
 });

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -113,7 +113,7 @@ export const EventSourceCronJobModel: K8sKind = {
 
 export const EventSourcePingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   kind: 'PingSource',
   label: 'Ping Source',
   labelPlural: 'Ping Sources',
@@ -169,7 +169,7 @@ export const EventSourceCamelModel: K8sKind = {
 
 export const EventSourceKafkaModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   kind: 'KafkaSource',
   label: 'KafkaSource',
   labelPlural: 'KafkaSources',
@@ -183,7 +183,7 @@ export const EventSourceKafkaModel: K8sKind = {
 
 export const EventSourceSinkBindingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   kind: 'SinkBinding',
   label: 'SinkBinding',
   labelPlural: 'SinkBindings',

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
@@ -47,11 +47,6 @@ export const mockEventSourcCRDData = {
             served: true,
             storage: true,
           },
-          {
-            name: 'v1alpha2',
-            served: false,
-            storage: false,
-          },
         ],
       },
     },

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -1,11 +1,6 @@
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import {
-  ServiceModel,
-  EventSourceCronJobModel,
-  EventSourceSinkBindingModel,
-  EventSourceKafkaModel,
-} from '../../models';
+import { ServiceModel, EventSourceCronJobModel, EventSourceSinkBindingModel } from '../../models';
 import { getEventSourceResource } from '../create-eventsources-utils';
 import { getDefaultEventingData } from './knative-serving-data';
 import { EventSources } from '../../components/add/import-types';
@@ -43,25 +38,11 @@ describe('Create knative Utils', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
     const mockData = _.cloneDeep(defaultEventingData);
     mockData.type = 'SinkBinding';
+    mockData.apiVersion = 'sources.knative.dev/v1alpha2';
     const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.kind).toBe(EventSourceSinkBindingModel.kind);
     expect(knEventingResource.apiVersion).toBe(
       `${EventSourceSinkBindingModel.apiGroup}/${EventSourceSinkBindingModel.apiVersion}`,
     );
-  });
-
-  it('expect response to be of kind kafkaSource with resource limits', () => {
-    const defaultEventingData = getDefaultEventingData(EventSources.KafkaSource);
-    const mockData = _.cloneDeep(defaultEventingData);
-    mockData.type = 'KafkaSource';
-    mockData.limits.cpu.limit = '200';
-    mockData.limits.cpu.request = '100';
-    const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
-    expect(knEventingResource.kind).toBe(EventSourceKafkaModel.kind);
-    expect(knEventingResource.apiVersion).toBe(
-      `${EventSourceKafkaModel.apiGroup}/${EventSourceKafkaModel.apiVersion}`,
-    );
-    expect(knEventingResource.spec?.resources?.limits?.cpu).toBe('200m');
-    expect(knEventingResource.spec?.resources?.requests?.cpu).toBe('100m');
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { safeLoad } from 'js-yaml';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { checkAccess } from '@console/internal/components/utils';
@@ -60,9 +59,6 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
 };
 
 export const getKafkaSourceResource = (formData: EventSourceFormData): K8sResourceKind => {
-  const {
-    limits: { cpu, memory },
-  } = formData;
   const baseResource = getEventSourcesDepResource(formData);
   const { net } = baseResource.spec;
   baseResource.spec.net = {
@@ -70,25 +66,7 @@ export const getKafkaSourceResource = (formData: EventSourceFormData): K8sResour
     ...(!net.sasl?.enable && { sasl: { user: {}, password: {} } }),
     ...(!net.tls?.enable && { tls: { caCert: {}, cert: {}, key: {} } }),
   };
-  const kafkaSource = {
-    spec: {
-      resources: {
-        ...((cpu.limit || memory.limit) && {
-          limits: {
-            ...(cpu.limit && { cpu: `${cpu.limit}${cpu.limitUnit}` }),
-            ...(memory.limit && { memory: `${memory.limit}${memory.limitUnit}` }),
-          },
-        }),
-        ...((cpu.request || memory.request) && {
-          requests: {
-            ...(cpu.request && { cpu: `${cpu.request}${cpu.requestUnit}` }),
-            ...(memory.request && { memory: `${memory.request}${memory.requestUnit}` }),
-          },
-        }),
-      },
-    },
-  };
-  return _.merge({}, baseResource, kafkaSource);
+  return baseResource;
 };
 
 export const getEventSourceResource = (formData: EventSourceFormData): K8sResourceKind => {
@@ -113,7 +91,7 @@ export const getEventSourceData = (source: string) => {
       schedule: '',
     },
     pingsource: {
-      data: '',
+      jsonData: '',
       schedule: '',
     },
     sinkbinding: {
@@ -126,7 +104,7 @@ export const getEventSourceData = (source: string) => {
       },
     },
     apiserversource: {
-      mode: 'Ref',
+      mode: 'Reference',
       serviceAccountName: '',
       resources: [
         {
@@ -152,7 +130,6 @@ export const getEventSourceData = (source: string) => {
           key: { secretKeyRef: { name: '', key: '' } },
         },
       },
-      serviceAccountName: '',
     },
     containersource: {
       template: {

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -2,7 +2,12 @@ import * as _ from 'lodash';
 import { useEffect } from 'react';
 import { coFetch } from '@console/internal/co-fetch';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
-import { K8sKind, kindToAbbr, referenceForModel } from '@console/internal/module/k8s';
+import {
+  K8sKind,
+  kindToAbbr,
+  referenceForModel,
+  getLatestVersionForCRD,
+} from '@console/internal/module/k8s';
 import { chart_color_red_300 as knativeEventingColor } from '@patternfly/react-tokens';
 import {
   EventSourceContainerModel,
@@ -59,15 +64,14 @@ export const fetchEventSourcesCrd = async () => {
           metadata: { labels },
           spec: {
             group,
-            versions,
             names: { kind, plural, singular },
           },
         } = crd;
-        const { name: version } = versions?.find((ver) => ver.served && ver.storage);
-        if (version) {
+        const crdLatestVersion = getLatestVersionForCRD(crd);
+        if (crdLatestVersion) {
           const sourceModel = {
             apiGroup: group,
-            apiVersion: version,
+            apiVersion: crdLatestVersion,
             kind,
             plural,
             id: singular,


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/console/pull/6412 

Handled spec changes for Event sources wrt channel 4.5 in serverless operator 1.10