### PR TITLE
Bug 1889928: add more tests for golden os

### DIFF
--- a/frontend/packages/console-shared/src/test-utils/utils.ts
+++ b/frontend/packages/console-shared/src/test-utils/utils.ts
@@ -86,6 +86,24 @@ export async function withResource(
   }
 }
 
+export async function withResources(
+  resourceSet: Set<string>,
+  resources: any,
+  callback: Function,
+  keepResource: boolean = false,
+) {
+  resources.forEach((resource) => {
+    addLeakableResource(resourceSet, resource);
+  });
+  await callback();
+  if (!keepResource) {
+    resources.forEach((resource) => {
+      deleteResource(resource);
+      removeLeakableResource(resourceSet, resource);
+    });
+  }
+}
+
 export async function click(elem: any, timeout?: number) {
   const _timeout = resolveTimeout(timeout, config.jasmineNodeOpts.defaultTimeoutInterval);
   await browser.wait(until.elementToBeClickable(elem), _timeout);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/cdi-upload.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/cdi-upload.scenario.ts
@@ -1,60 +1,90 @@
+/* eslint-disable no-await-in-loop */
 import { execSync } from 'child_process';
 import { testName } from '@console/internal-integration-tests/protractor.conf';
 import { browser, ExpectedConditions as until } from 'protractor';
-import { click } from '@console/shared/src/test-utils/utils';
-import { errorMessage, saveChangesBtn } from '@console/internal-integration-tests/views/crud.view';
-import { pvcStatus } from '@console/ceph-storage-plugin/integration-tests/views/pvc.view';
-import { PVC_STATUS } from '@console/ceph-storage-plugin/integration-tests/utils/consts';
-import { CDI_UPLOAD_TIMEOUT_SECS, STORAGE_CLASS } from './utils/constants/common';
-import { OperatingSystem } from './utils/constants/wizard';
-import * as cdiUploadView from '../views/cdiUploadView';
+import {
+  removeLeakedResources,
+  withResource,
+  withResources,
+} from '@console/shared/src/test-utils/utils';
+import { errorMessage } from '@console/internal-integration-tests/views/crud.view';
+import {
+  CLONE_VM_TIMEOUT_SECS,
+  CDI_UPLOAD_TIMEOUT_SECS,
+  VM_BOOTUP_TIMEOUT_SECS,
+  STORAGE_CLASS,
+  CIRROS_IMAGE,
+  FEDORA_IMAGE,
+  RHEL7_IMAGE,
+  WIN10_IMAGE,
+} from './utils/constants/common';
+import { VM_STATUS } from './utils/constants/vm';
+import {
+  CIRROS_PVC,
+  LOCAL_CIRROS_IMAGE,
+  FEDORA_PVC,
+  RHEL7_PVC,
+  WIN10_PVC,
+} from './utils/constants/pvc';
 import { PVCData } from './types/pvc';
 import { UploadForm } from './models/pvcUploadForm';
+import { PVC } from './models/pvc';
+import { VMBuilder } from './models/vmBuilder';
+import { getBasicVMBuilder } from './mocks/vmBuilderPresets';
+import { flavorConfigs } from './mocks/mocks';
 
-// this scenario tests the upload procedure, without creating a vm from the uploaded resource.
-// https://issues.redhat.com/browse/CNV-6020
+function imagePull(src, dest) {
+  if (src === CIRROS_IMAGE) {
+    execSync(`ln -s -f ${LOCAL_CIRROS_IMAGE} ${dest}`);
+  } else {
+    execSync(`test -f ${dest} || curl --fail ${src} -o ${dest}`);
+  }
+}
 
-describe('KubeVirt CDI Upload', () => {
-  const uploadForm = new UploadForm();
-  const srcImage =
-    'http://cnv-qe-server.rhevdev.lab.eng.rdu2.redhat.com/files/cnv-tests/cirros-images/cirros-0.4.0-x86_64-disk.qcow2';
-  const desImage = '/tmp/cirros.qcow2';
+describe('KubeVirt Auto Clone', () => {
+  const leakedResources = new Set<string>();
+  const cirrosPVC = new PVC(CIRROS_PVC);
+  const rhel7PVC = new PVC(RHEL7_PVC);
   const invalidImage = '/tmp/cirros.txt';
-  const pvcName = `upload-pvc-${testName}`;
+  const imageFormats = ['/tmp/cirros.iso', '/tmp/cirros.img', '/tmp/cirros.gz', '/tmp/cirros.xz'];
 
   beforeAll(async () => {
-    execSync(`curl ${srcImage} -o ${desImage}`);
-    execSync(`ln -s -f ${desImage} ${invalidImage}`);
+    execSync(`test -f ${cirrosPVC.image} || curl --fail ${CIRROS_IMAGE} -o ${cirrosPVC.image}`);
+    execSync(`ln -s -f ${cirrosPVC.image} ${invalidImage}`);
+    imageFormats.forEach((image) => {
+      execSync(`ln -s -f ${cirrosPVC.image} ${image}`);
+    });
+    imageFormats.push(LOCAL_CIRROS_IMAGE);
+    imagePull(RHEL7_IMAGE, rhel7PVC.image);
   });
 
   afterAll(async () => {
-    execSync(`rm ${desImage} ${invalidImage}`);
-    execSync(`kubectl delete -n ${testName} dv ${pvcName}`);
+    execSync(`rm ${rhel7PVC.image} ${invalidImage}`);
+    imageFormats.forEach((image) => {
+      execSync(`rm ${image}`);
+    });
+    removeLeakedResources(leakedResources);
   });
 
-  it(
-    'ID(CNV-4718) Upload data to CDI',
-    async () => {
-      const pvc: PVCData = {
-        image: desImage,
-        pvcName: `upload-pvc-${testName}`,
-        pvcSize: '1',
-        pvcSizeUnits: 'Gi',
-        storageClass: STORAGE_CLASS,
-      };
+  describe('KubeVirt CDI Upload', () => {
+    const uploadForm = new UploadForm();
 
-      await uploadForm.upload(pvc);
+    it(
+      'ID(CNV-4778) Images with supported format can be uploaded',
+      async () => {
+        for (const img of imageFormats) {
+          CIRROS_PVC.pvcName = `pvc-image-with-suffix-${img.split('.').pop()}`;
+          CIRROS_PVC.image = img;
+          const pvc = new PVC(CIRROS_PVC);
+          await withResource(leakedResources, pvc.getDVResource(), async () => {
+            await pvc.create();
+          });
+        }
+      },
+      4 * CDI_UPLOAD_TIMEOUT_SECS,
+    );
 
-      await browser.wait(until.textToBePresentInElement(cdiUploadView.uploadProgress, '100%'));
-      await click(cdiUploadView.viewStatusID);
-      await browser.wait(until.textToBePresentInElement(pvcStatus, PVC_STATUS.BOUND));
-    },
-    CDI_UPLOAD_TIMEOUT_SECS,
-  );
-
-  it(
-    'ID(CNV-4891) It shows error messsages when image format is not supported',
-    async () => {
+    it('ID(CNV-4891) It shows an error when image format is not supported', async () => {
       const pvc: PVCData = {
         image: invalidImage,
         pvcName: `upload-pvc-${testName}-invalid`,
@@ -66,28 +96,123 @@ describe('KubeVirt CDI Upload', () => {
       await uploadForm.upload(pvc);
       await browser.wait(until.presenceOf(errorMessage));
       expect(errorMessage.getText()).toContain('not supported');
-    },
-    CDI_UPLOAD_TIMEOUT_SECS,
-  );
+    });
 
-  it(
-    'ID(CNV-4890) Upload image for golden OS',
-    async () => {
-      const pvc: PVCData = {
-        image: desImage,
-        os: OperatingSystem.RHEL7,
-        pvcSize: '1',
-        pvcSizeUnits: 'Gi',
-        storageClass: STORAGE_CLASS,
-      };
+    it(
+      'ID(CNV-5038) Upload data to golden OS template again after delete',
+      async () => {
+        await withResource(leakedResources, rhel7PVC.getDVResource(), async () => {
+          await rhel7PVC.create();
+        });
+        // it can be associated again.
+        await withResource(leakedResources, rhel7PVC.getDVResource(), async () => {
+          await rhel7PVC.create();
+        });
+      },
+      2 * CDI_UPLOAD_TIMEOUT_SECS,
+    );
 
-      await uploadForm.upload(pvc);
-      // It has to click the upload button again to trigger uploading based on actual test results.
-      await click(saveChangesBtn);
-      await browser.wait(until.textToBePresentInElement(cdiUploadView.uploadProgress, '100%'));
-      await click(cdiUploadView.viewStatusID);
-      await browser.wait(until.textToBePresentInElement(pvcStatus, PVC_STATUS.BOUND));
-    },
-    CDI_UPLOAD_TIMEOUT_SECS,
-  );
+    it('ID(CNV-5176) It shows an error when uploading data to golden OS again', async () => {
+      await withResource(leakedResources, rhel7PVC.getDVResource(), async () => {
+        await rhel7PVC.create();
+        await uploadForm.openForm();
+        await uploadForm.selectGoldenOS(rhel7PVC.os);
+        await browser.wait(until.presenceOf(errorMessage));
+        expect(errorMessage.getText()).toContain('Operating system source already defined');
+      });
+    });
+  });
+
+  describe('KubeVirt GOLDEN OS Creation', () => {
+    const fedoraPVC = new PVC(FEDORA_PVC);
+    const win10PVC = new PVC(WIN10_PVC);
+
+    beforeAll(async () => {
+      imagePull(FEDORA_IMAGE, fedoraPVC.image);
+      imagePull(WIN10_IMAGE, win10PVC.image);
+    });
+
+    afterAll(async () => {
+      execSync(`rm ${FEDORA_PVC.image} ${WIN10_PVC.image}`);
+    });
+
+    it(
+      'ID(CNV-5042) Create multiple VMs from the same golden os template',
+      async () => {
+        const vm1 = new VMBuilder(getBasicVMBuilder())
+          .setOS(rhel7PVC.os)
+          .generateNameForPrefix('auto-clone-vm1')
+          .setStartOnCreation(true)
+          .build();
+
+        const vm2 = new VMBuilder(getBasicVMBuilder())
+          .setOS(rhel7PVC.os)
+          .generateNameForPrefix('auto-clone-vm2')
+          .setStartOnCreation(true)
+          .build();
+
+        await withResources(
+          leakedResources,
+          [vm1.asResource(), vm2.asResource(), rhel7PVC.getDVResource()],
+          async () => {
+            await rhel7PVC.create();
+            await vm1.create();
+            await vm1.navigateToDetail();
+            await vm2.create();
+            await vm2.navigateToDetail();
+          },
+        );
+      },
+      VM_BOOTUP_TIMEOUT_SECS + CLONE_VM_TIMEOUT_SECS,
+    );
+
+    it(
+      'ID(CNV-5041) VM can be up after deleting backend golden PVC',
+      async () => {
+        const fedora = new VMBuilder(getBasicVMBuilder())
+          .setOS(fedoraPVC.os)
+          .generateNameForPrefix('auto-clone-vm-with-pvc-deleted')
+          .setStartOnCreation(false)
+          .build();
+
+        await withResources(
+          leakedResources,
+          [fedora.asResource(), fedoraPVC.getDVResource()],
+          async () => {
+            await fedoraPVC.create();
+            await fedora.create();
+            await fedora.waitForStatus(VM_STATUS.Off);
+            await fedoraPVC.delete();
+            await fedora.start();
+            await fedora.navigateToDetail();
+          },
+        );
+      },
+      VM_BOOTUP_TIMEOUT_SECS + CLONE_VM_TIMEOUT_SECS,
+    );
+
+    it(
+      'ID(CNV-5043) Create Fedora/RHEL/Windows VMs from golden os template',
+      async () => {
+        // skip creating fedora/rhel vm here as it's covered above.
+        const win10 = new VMBuilder(getBasicVMBuilder())
+          .setOS(win10PVC.os)
+          .setFlavor(flavorConfigs.Medium)
+          .generateNameForPrefix('auto-clone-win10-vm')
+          .setStartOnCreation(true)
+          .build();
+
+        await withResources(
+          leakedResources,
+          [win10.asResource(), win10PVC.getDVResource()],
+          async () => {
+            await win10PVC.create();
+            await win10.create();
+            await win10.navigateToDetail();
+          },
+        );
+      },
+      VM_BOOTUP_TIMEOUT_SECS + CLONE_VM_TIMEOUT_SECS,
+    );
+  });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvc.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvc.ts
@@ -1,0 +1,68 @@
+/* eslint-disable no-await-in-loop */
+import { browser, ExpectedConditions as until } from 'protractor';
+import { PersistentVolumeClaimModel } from '@console/internal/models';
+import * as crudView from '@console/internal-integration-tests/views/crud.view';
+import {
+  namespaceDropdown,
+  selectItemFromDropdown,
+  pvcStatus,
+} from '@console/ceph-storage-plugin/integration-tests/views/pvc.view';
+import { clickNavLink } from '@console/internal-integration-tests/views/sidenav.view';
+import * as pvcView from '../../views/pvc.view';
+import { OperatingSystem } from '../utils/constants/wizard';
+import { PVC_STATUS } from '@console/ceph-storage-plugin/integration-tests/utils/consts';
+import { getTestDataVolume } from '../mocks/mocks';
+import { click } from '@console/shared/src/test-utils/utils';
+import { PVCData } from '../types/pvc';
+import { UploadForm } from './pvcUploadForm';
+import { UIResource } from './uiResource';
+
+export class PVC<T extends PVCData> extends UIResource {
+  protected data: T;
+
+  readonly os: OperatingSystem;
+
+  readonly image: string;
+
+  constructor(data: T) {
+    super({ name: data.pvcName, namespace: data.namespace, PersistentVolumeClaimModel });
+    this.data = data;
+    this.os = data.os;
+    this.image = data.image;
+  }
+
+  async create() {
+    const uploadForm = new UploadForm();
+    await uploadForm.upload(this.data);
+    // It has to click twice if uploading golden images.
+    if (this.data.os) {
+      await click(crudView.saveChangesBtn);
+    }
+    await browser.wait(until.textToBePresentInElement(pvcView.uploadProgress, '100%'));
+    await click(pvcView.viewStatusID);
+    await browser.wait(until.textToBePresentInElement(pvcStatus, PVC_STATUS.BOUND));
+  }
+
+  async delete() {
+    await clickNavLink(['Storage', 'Persistent Volume Claims']);
+    await crudView.isLoaded();
+    await selectItemFromDropdown(this.namespace, namespaceDropdown);
+    await crudView.resourceRowsPresent();
+    await crudView.filterForName(this.name);
+    await crudView.isLoaded();
+    await crudView.deleteRow('PersistentVolumeClaim')(this.name);
+    await crudView.isLoaded();
+    await browser.wait(until.stalenessOf(pvcView.pvcName(this.name)));
+  }
+
+  getDVResource() {
+    return {
+      kind: getTestDataVolume().kind,
+      apiVersion: getTestDataVolume().apiVersion,
+      metadata: {
+        namespace: this.namespace,
+        name: this.name,
+      },
+    };
+  }
+}

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvcUploadForm.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvcUploadForm.ts
@@ -16,7 +16,7 @@ import {
 } from '@console/ceph-storage-plugin/integration-tests/views/pvc.view';
 import { click, fillInput } from '@console/shared/src/test-utils/utils';
 import { selectOptionByText } from '../utils/utils';
-import * as cdiUploadView from '../../views/cdiUploadView';
+import * as pvcView from '../../views/pvc.view';
 import { PVCData } from '../types/pvc';
 
 export class UploadForm {
@@ -24,7 +24,7 @@ export class UploadForm {
     await clickNavLink(['Storage', 'Persistent Volume Claims']);
     await isLoaded();
     await click(createItemButton);
-    await click(cdiUploadView.uploadCdiFormButton);
+    await click(pvcView.uploadCdiFormButton);
 
     await browser.wait(
       until.textToBePresentInElement(
@@ -40,12 +40,12 @@ export class UploadForm {
       (document.querySelector('input[type="file"]') as HTMLElement).style.display = 'inline';
       callback();
     });
-    await cdiUploadView.uploadInput.sendKeys(name);
+    await pvcView.uploadInput.sendKeys(name);
   }
 
   async selectGoldenOS(os: string) {
-    await click(cdiUploadView.goldenOSCheckbox);
-    await selectOptionByText(cdiUploadView.goldenOSDropDownID, os);
+    await click(pvcView.goldenOSCheckbox);
+    await selectOptionByText(pvcView.goldenOSDropDownID, os);
   }
 
   async fillPVCName(pvcName: string) {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
@@ -21,6 +21,7 @@ import { AddDialog } from '../dialogs/schedulingDialog';
 import { saveButton } from '../../views/kubevirtUIResource.view';
 import { VMBuilderData } from '../types/vm';
 import { VM_ACTION, TAB, VM_STATUS } from '../utils/constants/vm';
+
 import { MatchLabels } from 'public/module/k8s';
 import { Wizard } from './wizard';
 import { CloneVirtualMachineDialog } from '../dialogs/cloneVirtualMachineDialog';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -31,6 +31,7 @@ import { NetworkInterfaceDialog } from '../dialogs/networkInterfaceDialog';
 import { DiskDialog } from '../dialogs/diskDialog';
 import { Flavor } from '../utils/constants/wizard';
 import { resourceHorizontalTab } from '../../views/uiResource.view';
+import { confirmActionButton } from '../../views/importWizard.view';
 import { virtualizationTitle } from '../../views/vms.list.view';
 import { VMBuilderData } from '../types/vm';
 import { ProvisionSource } from '../utils/constants/enums/provisionSource';
@@ -99,7 +100,7 @@ export class Wizard {
   }
 
   async selectFlavor(flavor: FlavorConfig) {
-    await selectItemFromDropdown(view.flavorSelect, view.dropDownItem(flavor.flavor));
+    await selectItemFromDropdown(view.flavorSelect, view.dropDownItemMain(flavor.flavor));
     if (flavor.flavor === Flavor.CUSTOM && (!flavor.memory || !flavor.cpu)) {
       throw Error('Custom Flavor requires memory and cpu values.');
     }
@@ -112,7 +113,10 @@ export class Wizard {
   }
 
   async selectWorkloadProfile(workloadProfile: string) {
-    await selectItemFromDropdown(view.workloadProfileSelect, view.dropDownItem(workloadProfile));
+    await selectItemFromDropdown(
+      view.workloadProfileSelect,
+      view.dropDownItemMain(workloadProfile),
+    );
   }
 
   async disableGoldenImageCloneCheckbox() {
@@ -132,7 +136,7 @@ export class Wizard {
   async selectProvisionSource(provisionSource: ProvisionSource) {
     await selectItemFromDropdown(
       view.provisionSourceSelect,
-      view.dropDownItemTitle(provisionSource.getDescription()),
+      view.dropDownItemMain(provisionSource.getDescription()),
     );
     if (provisionSource.getSource()) {
       await fillInput(
@@ -151,6 +155,8 @@ export class Wizard {
       await click(view.cloudInitCustomScriptCheckbox);
       await fillInput(view.customCloudInitScriptTextArea, cloudInitOptions.customScript);
     } else {
+      await click(view.cloudInitFirstOption);
+      await click(confirmActionButton);
       await fillInput(view.cloudInitHostname, cloudInitOptions.hostname || '');
       await asyncForEach(cloudInitOptions.sshKeys, async (sshKey: string, index: number) => {
         await fillInput(view.cloudInitSSHKey(index + 1), sshKey);
@@ -257,9 +263,8 @@ export class Wizard {
       if (provisionSource) {
         await this.disableGoldenImageCloneCheckbox();
         await this.selectProvisionSource(provisionSource);
-      } else {
-        throw Error('VM Provision source not defined');
       }
+
       if (workload) {
         await this.selectWorkloadProfile(workload);
       } else {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/non-admin.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/non-admin.scenario.ts
@@ -1,22 +1,30 @@
 import { execSync } from 'child_process';
 import { browser, ExpectedConditions as until } from 'protractor';
 import { appHost, testName } from '@console/internal-integration-tests/protractor.conf';
-import * as loginView from '@console/internal-integration-tests/views/login.view';
+import { VirtualMachineModel } from '@console/kubevirt-plugin/src/models';
 import {
-  withResource,
+  addLeakableResource,
   removeLeakedResources,
-  waitForCount,
-  removeLeakableResource,
+  click,
+  withResource,
+  withResources,
 } from '@console/shared/src/test-utils/utils';
-import { isLoaded, resourceRows } from '@console/internal-integration-tests/views/crud.view';
+import * as crudView from '@console/internal-integration-tests/views/crud.view';
+import * as loginView from '@console/internal-integration-tests/views/login.view';
+import * as pvcView from '../views/pvc.view';
 import { restrictedAccessBlock } from '../views/vms.list.view';
+import { uploadLink } from '../views/wizard.view';
 import { createProject } from './utils/utils';
-import { PAGE_LOAD_TIMEOUT_SECS, VM_CREATE_AND_EDIT_TIMEOUT_SECS } from './utils/constants/common';
-import { VM_STATUS, VM_ACTION } from './utils/constants/vm';
+import { RHEL7_IMAGE, VM_CREATE_AND_EDIT_TIMEOUT_SECS } from './utils/constants/common';
+import { GOLDEN_OS_IMAGES_NS, FEDORA_PVC, RHEL7_PVC } from './utils/constants/pvc';
+import { OperatingSystem } from './utils/constants/wizard';
+import { ProvisionSource } from './utils/constants/enums/provisionSource';
 import { VMBuilder } from './models/vmBuilder';
 import { getBasicVMBuilder } from './mocks/vmBuilderPresets';
 import { rootDisk } from './mocks/mocks';
-import { ProvisionSource } from './utils/constants/enums/provisionSource';
+import { UploadForm } from './models/pvcUploadForm';
+import { PVC } from './models/pvc';
+import { Wizard } from './models/wizard';
 
 const testNonAdminNamespace = `${testName}-non-admin`;
 const KUBEADMIN_IDP = 'kube:admin';
@@ -30,52 +38,102 @@ const {
 
 describe('Kubevirt non-admin Flow', () => {
   const leakedResources = new Set<string>();
-  const vm = new VMBuilder(getBasicVMBuilder())
-    .setNamespace(testNonAdminNamespace)
-    .setProvisionSource(ProvisionSource.URL)
-    .setDisks([rootDisk])
-    .build();
+  const pvc = new PVC(RHEL7_PVC);
 
   beforeAll(async () => {
+    // Prepare golden pvc for normal user.
+    execSync(`test -f ${pvc.image} || curl --fail ${RHEL7_IMAGE} -o ${pvc.image}`);
+    await pvc.create();
+    addLeakableResource(leakedResources, pvc.getDVResource());
+
     await loginView.logout();
     await loginView.login(BRIDGE_HTPASSWD_IDP, BRIDGE_HTPASSWD_USERNAME, BRIDGE_HTPASSWD_PASSWORD);
     await createProject(testNonAdminNamespace);
-    await browser.get(`${appHost}/k8s/ns/${testNonAdminNamespace}/virtualization`);
-    await isLoaded();
   });
 
   afterAll(async () => {
+    execSync(`rm ${pvc.image}`);
     removeLeakedResources(leakedResources);
     execSync(`kubectl delete --ignore-not-found=true project ${testNonAdminNamespace}`);
+
     await loginView.logout();
     await loginView.login(KUBEADMIN_IDP, KUBEADMIN_USERNAME, BRIDGE_KUBEADMIN_PASSWORD);
   });
 
-  it(
-    'ID(CNV-1718) Non-admin create and remove a vm in its own namespace',
-    async () => {
-      await vm.create();
-      await withResource(
-        leakedResources,
-        vm.asResource(),
-        async () => {
-          await vm.action(VM_ACTION.Start, false); // Without waiting for the VM to be Running
-          await vm.waitForStatus(VM_STATUS.Starting); // Just to make sure it is actually starting,
-          await vm.action(VM_ACTION.Delete, false);
-          await vm.navigateToListView();
-          await isLoaded();
-          await browser.wait(until.and(waitForCount(resourceRows, 0)), PAGE_LOAD_TIMEOUT_SECS);
-        },
-        true,
-      );
-      removeLeakableResource(leakedResources, vm.asResource());
-    },
-    VM_CREATE_AND_EDIT_TIMEOUT_SECS,
-  );
+  describe('Kubevirt non-admin virtualization Flow', () => {
+    const vm = new VMBuilder(getBasicVMBuilder())
+      .setNamespace(testNonAdminNamespace)
+      .setProvisionSource(ProvisionSource.URL)
+      .setDisks([rootDisk])
+      .build();
 
-  it('ID(CNV-1720) Non-admin cannot create vm in a foreign namespace', async () => {
-    // Check access is restricted on foreign namespace.
-    await browser.get(`${appHost}/k8s/ns/default/virtualmachines`);
-    await browser.wait(until.textToBePresentInElement(restrictedAccessBlock, 'Restricted Access'));
+    it(
+      'ID(CNV-1718) Non-admin create and remove a vm in its own namespace',
+      async () => {
+        await browser.get(`${appHost}/k8s/ns/${testNonAdminNamespace}/virtualization`);
+        await crudView.isLoaded();
+        await withResource(leakedResources, vm.asResource(), async () => {
+          await vm.create();
+          await vm.navigateToDetail();
+        });
+      },
+      VM_CREATE_AND_EDIT_TIMEOUT_SECS,
+    );
+
+    it('ID(CNV-1720) Non-admin cannot create vm in a foreign namespace', async () => {
+      // Check access is restricted on foreign namespace.
+      await browser.get(`${appHost}/k8s/ns/default/virtualmachines`);
+      await browser.wait(
+        until.textToBePresentInElement(restrictedAccessBlock, 'Restricted Access'),
+      );
+    });
+  });
+
+  describe('Kubevirt non-admin PVC Flow', () => {
+    const vm = new VMBuilder(getBasicVMBuilder())
+      .setNamespace(testNonAdminNamespace)
+      .setOS(pvc.os)
+      .setStartOnCreation(true)
+      .generateNameForPrefix('auto-clone-vm-with-normal-user')
+      .build();
+
+    it('ID(CNV-5039) Non-admin cannot create golden pvc', async () => {
+      await browser.get(`${appHost}/k8s/ns/${testNonAdminNamespace}/persistentvolumeclaims`);
+      const uploadForm = new UploadForm();
+      FEDORA_PVC.image = pvc.image;
+      await uploadForm.upload(FEDORA_PVC);
+      await click(crudView.saveChangesBtn);
+      await browser.wait(until.presenceOf(crudView.errorMessage));
+      expect(pvcView.errorUploading.getText()).toContain('forbidden');
+    });
+
+    it('ID(CNV-5040) Non-admin cannot delete golden pvc', async () => {
+      await browser.get(`${appHost}/k8s/ns/${GOLDEN_OS_IMAGES_NS}/persistentvolumeclaims`);
+      await crudView.resourceRowsPresent();
+      await crudView.filterForName(pvc.name);
+      await crudView.isLoaded();
+      await click(pvcView.pvcKebabButton);
+      expect(pvcView.pvcDeleteButton.getAttribute('class')).toContain('pf-m-disabled');
+    });
+
+    it('ID(CNV-5055) Non-admin has no link on wizard page to upload data', async () => {
+      await browser.get(`${appHost}/k8s/ns/${testNonAdminNamespace}/virtualization`);
+      const wizard = new Wizard();
+      await wizard.openWizard(VirtualMachineModel);
+      await wizard.selectOperatingSystem(OperatingSystem.RHEL8);
+      expect(uploadLink.isPresent()).toBe(false);
+      await wizard.closeWizard();
+    });
+
+    it(
+      'ID(CNV-4893) Non-admin can create vm from golden os template',
+      async () => {
+        await withResources(leakedResources, [vm.asResource(), pvc.getDVResource()], async () => {
+          await vm.create();
+          await vm.navigateToDetail();
+        });
+      },
+      VM_CREATE_AND_EDIT_TIMEOUT_SECS,
+    );
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/types/pvc.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/types/pvc.ts
@@ -1,6 +1,9 @@
+import { OperatingSystem } from '../utils/constants/wizard';
+
 export type PVCData = {
+  namespace?: string;
   image: string;
-  os?: string;
+  os?: OperatingSystem;
   pvcName?: string;
   pvcSize: string;
   pvcSizeUnits: string;

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/common.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/common.ts
@@ -5,6 +5,14 @@ export const {
   KUBEVIRT_PROJECT_NAME = 'openshift-cnv',
   VOLUME_MODE,
 } = process.env;
+export const REMOTE_IMAGE =
+  'http://cnv-qe-server.rhevdev.lab.eng.rdu2.redhat.com/files/cnv-tests/cirros-images/cirros-0.4.0-x86_64-disk.qcow2';
+export const {
+  CIRROS_IMAGE = REMOTE_IMAGE,
+  FEDORA_IMAGE = REMOTE_IMAGE,
+  RHEL7_IMAGE = REMOTE_IMAGE,
+  WIN10_IMAGE = REMOTE_IMAGE,
+} = process.env;
 
 const rhelTinyCommonTemplateName = execSync(
   "kubectl get template -n openshift | grep rhel7-desktop-tiny | awk '{print $1}'",
@@ -80,6 +88,7 @@ export const DEFAULT_YAML_VM_NAME = 'vm-example';
 
 export const KUBEVIRT_SCRIPTS_PATH =
   './packages/kubevirt-plugin/integration-tests/tests/utils/scripts';
+export const EXPECT_LOGIN_SCRIPT_PATH = `${KUBEVIRT_SCRIPTS_PATH}/expect-login.sh`;
 export const KUBEVIRT_TEMPLATES_PATH =
   './packages/kubevirt-plugin/integration-tests/tests/utils/templates';
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/pvc.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/pvc.ts
@@ -1,0 +1,56 @@
+import { testName } from '@console/internal-integration-tests/protractor.conf';
+import { PVCData } from '../../types/pvc';
+import { OperatingSystem } from './wizard';
+import { STORAGE_CLASS } from './common';
+
+export const GOLDEN_OS_IMAGES_NS = 'openshift-virtualization-os-images';
+export enum GOLDEN_OS_PVC_NAME {
+  FEDORA = 'fedora32',
+  RHEL7 = 'rhel7',
+  RHEL8 = 'rhel8',
+  WIN10 = 'win10',
+}
+
+export const { LOCAL_CIRROS_IMAGE = '/tmp/cirros.qcow2' } = process.env;
+export const { LOCAL_FEDORA_IMAGE = '/tmp/fedora.qcow2' } = process.env;
+export const { LOCAL_RHEL7_IMAGE = '/tmp/rhel7.qcow2' } = process.env;
+export const { LOCAL_WIN10_IMAGE = '/tmp/win10.qcow2' } = process.env;
+
+export const CIRROS_PVC: PVCData = {
+  namespace: testName,
+  image: LOCAL_CIRROS_IMAGE,
+  pvcName: `test-upload-pvc-${testName}`,
+  pvcSize: '1',
+  pvcSizeUnits: 'Gi',
+  storageClass: STORAGE_CLASS,
+};
+
+export const FEDORA_PVC: PVCData = {
+  namespace: GOLDEN_OS_IMAGES_NS,
+  image: LOCAL_FEDORA_IMAGE,
+  os: OperatingSystem.FEDORA,
+  pvcName: GOLDEN_OS_PVC_NAME.FEDORA,
+  pvcSize: '10',
+  pvcSizeUnits: 'Gi',
+  storageClass: STORAGE_CLASS,
+};
+
+export const RHEL7_PVC: PVCData = {
+  namespace: GOLDEN_OS_IMAGES_NS,
+  image: LOCAL_RHEL7_IMAGE,
+  os: OperatingSystem.RHEL7,
+  pvcName: GOLDEN_OS_PVC_NAME.RHEL7,
+  pvcSize: '10',
+  pvcSizeUnits: 'Gi',
+  storageClass: STORAGE_CLASS,
+};
+
+export const WIN10_PVC: PVCData = {
+  namespace: GOLDEN_OS_IMAGES_NS,
+  image: LOCAL_WIN10_IMAGE,
+  os: OperatingSystem.WINDOWS_10,
+  pvcName: GOLDEN_OS_PVC_NAME.WIN10,
+  pvcSize: '10',
+  pvcSizeUnits: 'Gi',
+  storageClass: STORAGE_CLASS,
+};

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/wizard.ts
@@ -1,9 +1,10 @@
 export enum OperatingSystem {
   RHEL7 = 'Red Hat Enterprise Linux 7.0 or higher',
+  RHEL8 = 'Red Hat Enterprise Linux 8.0 or higher',
+  FEDORA = 'Fedora 31 or higher',
   CENTOS7 = 'CentOS 7 or higher',
   WINDOWS_10 = 'Microsoft Windows 10',
   VALIDATION_TEST = 'Validation Test',
-  FEDORA = 'Fedora 31 or higher',
 }
 
 export const OSIDLookup = {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-login.sh
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-login.sh
@@ -2,8 +2,7 @@
 # usage ./expect-login.sh <vm name> <vm namespace>
 set vm_name [lindex $argv 0]
 set vm_namespace [lindex $argv 1]
-set hostname cirros
-set login_prompt "$hostname login: "
+set login_prompt "*login: "
 
 spawn virtctl console $vm_name -n $vm_namespace --timeout 7
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/pvc.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/pvc.view.ts
@@ -7,3 +7,9 @@ export const uploadProgress = element.all(by.css('.pf-c-progress__measure')).fir
 export const goldenOSCheckbox = $('#golden-os-switch');
 export const goldenOSDropDownID = $('#golden-os-select');
 export const viewStatusID = $('#cdi-upload-primary-pvc');
+
+export const pvcName = (name) => $(`[data-test-id="${name}"]`);
+export const pvcKebabButton = $('[data-test-id="kebab-button"]');
+export const pvcDeleteButton = element(by.buttonText('Delete Persistent Volume Claim'));
+export const errorUploading = $('.pf-c-empty-state__body');
+export const disabled = $('.pf-c-dropdown__menu-item.pf-m-disabled');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
@@ -57,6 +57,8 @@ export const customCloudInitScriptTextArea = $('#cloudinit-custom-custom-script'
 export const cloudInitAddKeyButton = $('#cloudinit-ssh_authorized_keys-add');
 export const cloudInitHostname = $('#cloudinit-hostname');
 export const cloudInitSSHKey = (rowNumber) => $(`#cloudinit-ssh_authorized_keys-key-${rowNumber}`);
+export const cloudInitFirstOption = $('#cloud-init-edit-mode-first-option');
+export const cloudInitSecondOption = $('#cloud-init-edit-mode-second-option');
 
 // Review tab
 export const nameReviewValue = $('#wizard-review-name');
@@ -89,5 +91,6 @@ export const tableRowAttribute = async (name: string, columnIndex: number): Prom
 };
 export const dropDownItem = (text) =>
   element(by.cssContainingText('.pf-c-select__menu-item', text));
-export const dropDownItemTitle = (text) =>
+export const dropDownItemMain = (text) =>
   element(by.cssContainingText('.pf-c-select__menu-item-main', text));
+export const uploadLink = element(by.linkText('upload a new disk image'));


### PR DESCRIPTION
Add more tests for golden os, so it covers:

- normal user can create vm from golden os template
- normal user cannot create/delete golden pvc.
- normal user don't have link to upload data on vm wizard.
- admin can create/delete goldne pvc
- admin create Fedora/RHEL/Windows VM from golden os template
- create more than two VMs from the same golden os template
- once a VM is created from golden os template, delete the golden pvc will not affect the VM which is created already.
- verify it throws an error is the format of upload data is not supported.
- verify it throws an error when uploading to golden OS again.