### PR TITLE
update pending Icon in Pipeline Run visualization

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
@@ -5,7 +5,7 @@ import {
   CheckCircleIcon,
   CircleIcon,
   ExclamationCircleIcon,
-  PendingIcon,
+  HourglassHalfIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
 import { getRunStatusColor, runStatus } from '../../../../utils/pipeline-augment';
@@ -30,7 +30,7 @@ export const StatusIcon: React.FC<StatusIconProps> = ({ status, ...props }) => {
 
     case runStatus.Idle:
     case runStatus.Pending:
-      return <PendingIcon {...props} />;
+      return <HourglassHalfIcon {...props} />;
 
     case runStatus.Cancelled:
       return <BanIcon {...props} />;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4918

**Description**:
To match all other pending icons in the console, the pending icon in the PLR visualization and the PLR visualization tooltip should be changed from the pf pending icon to the hourglass half icon.

**Screens:**
![image](https://user-images.githubusercontent.com/9964343/96714932-83c05280-13c0-11eb-9cb1-f7d82e3929de.png)

cc: @bgliwa01 
/kind bug