### PR TITLE
Bug 1890145: Add classname to decrease font size for Status Ready

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { DashboardCardPopupLink } from '../dashboard-card/DashboardCardLink';
 import { HealthState, healthStateMapping } from './states';
+import { SecondaryStatus } from '../../status';
 
 const HealthItemIcon: React.FC<HealthItemIconProps> = ({ state }) => (
   <div className="co-dashboard-icon">
@@ -37,9 +38,7 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
             )}
           </span>
           {state !== HealthState.LOADING && detailMessage && (
-            <div className="co-dashboard-text--small co-status-card__health-item-text co-status-card__health-item-subtitle">
-              {detailMessage}
-            </div>
+            <SecondaryStatus status={detailMessage} className="co-status-card__health-item-text" />
           )}
         </div>
       </div>

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -98,11 +98,6 @@
   padding: 0;
 }
 
-.co-status-card__health-item-subtitle {
-  color: $pf-color-black-500;
-  font-size: 0.7rem;
-}
-
 .skeleton-health {
   animation: $skeleton-animation;
   border-radius: 50px;

--- a/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
@@ -3,14 +3,16 @@ import * as _ from 'lodash';
 
 type SecondaryStatusProps = {
   status?: string | string[];
+  className?: string;
 };
 
-const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status }) => {
+const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status, className }) => {
   const statusLabel = _.compact(_.concat([], status)).join(', ');
+  const cssClassName = className || '';
   if (statusLabel) {
     return (
       <div>
-        <small className="text-muted">{statusLabel}</small>
+        <small className={`${cssClassName} text-muted`}>{statusLabel}</small>
       </div>
     );
   }


### PR DESCRIPTION
Bug 1890145: The mismatched of font size for Status Ready
and Health Check secondary text

The image shows the applied fix:


![font_size](https://user-images.githubusercontent.com/39300150/96912985-102a4e00-1471-11eb-86f1-f3b2896a3f54.png)

