### PR TITLE
Bug 1887465: Fall back to "all namespaces" when currently active namespace is deleted

### DIFF
--- a/frontend/packages/console-shared/src/hooks/promise-handler.ts
+++ b/frontend/packages/console-shared/src/hooks/promise-handler.ts
@@ -1,17 +1,24 @@
 import * as React from 'react';
 
-export const usePromiseHandler: PromisHandlerHook = () => {
+export const usePromiseHandler: PromisHandlerHook = <T extends unknown = any>() => {
   const [inProgress, setInProgress] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
-  const handlePromise = (promise) => {
+  const handlePromise: PromiseHandlerCallback<T> = (promise) => {
     setInProgress(true);
     return promise
-      .then(() => setErrorMessage(''))
-      .catch((reason) => setErrorMessage(reason || 'An error occurred. Please try again.'))
+      .then((res) => {
+        setErrorMessage('');
+        return res;
+      })
+      .catch((reason) => {
+        const error = reason || 'An error occurred. Please try again.';
+        setErrorMessage(error);
+        return Promise.reject(error);
+      })
       .finally(() => setInProgress(false));
   };
   return [handlePromise, inProgress, errorMessage];
 };
 
 type PromiseHandlerCallback<T> = (promise: Promise<T>) => Promise<T>;
-type PromisHandlerHook = <T = any>() => [PromiseHandlerCallback<T>, boolean, string];
+type PromisHandlerHook = <T>() => [PromiseHandlerCallback<T>, boolean, string];

--- a/frontend/packages/console-shared/src/hooks/promise-handler.ts
+++ b/frontend/packages/console-shared/src/hooks/promise-handler.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+export const usePromiseHandler: PromisHandlerHook = () => {
+  const [inProgress, setInProgress] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState('');
+  const handlePromise = (promise) => {
+    setInProgress(true);
+    return promise
+      .then(() => setErrorMessage(''))
+      .catch((reason) => setErrorMessage(reason || 'An error occurred. Please try again.'))
+      .finally(() => setInProgress(false));
+  };
+  return [handlePromise, inProgress, errorMessage];
+};
+
+type PromiseHandlerCallback<T> = (promise: Promise<T>) => Promise<T>;
+type PromisHandlerHook = <T = any>() => [PromiseHandlerCallback<T>, boolean, string];

--- a/frontend/packages/console-shared/src/hooks/redux-selectors.ts
+++ b/frontend/packages/console-shared/src/hooks/redux-selectors.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+
+export const useActiveNamespace = () => {
+  return useSelector(({ UI }) => UI.get('activeNamespace'));
+};

--- a/frontend/public/components/modals/delete-namespace-modal.jsx
+++ b/frontend/public/components/modals/delete-namespace-modal.jsx
@@ -1,76 +1,73 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { k8sKill } from '@console/internal/module/k8s';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import { history } from '@console/internal/components/utils';
+import { setActiveNamespace } from '@console/internal/actions/ui';
+import { ALL_NAMESPACES_KEY, YellowExclamationTriangleIcon } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks/redux-selectors';
+import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
 
-import { k8sKill } from '../../module/k8s';
-import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
-import { history, PromiseComponent } from '../utils';
-import { YellowExclamationTriangleIcon } from '@console/shared';
+export const DeleteNamespaceModal = ({ cancel, close, kind, resource }) => {
+  const activeNamespace = useActiveNamespace();
+  const dispatch = useDispatch();
+  const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
+  const [confirmed, setConfirmed] = React.useState(false);
 
-class DeleteNamespaceModal extends PromiseComponent {
-  constructor(props) {
-    super(props);
-    this.state = Object.assign(this.state, { isTypedNsMatching: false });
-    this._submit = this._submit.bind(this);
-    this._close = props.close.bind(this);
-    this._cancel = props.cancel.bind(this);
-    this._matchTypedNamespace = this._matchTypedNamespace.bind(this);
-  }
-
-  _matchTypedNamespace(e) {
-    this.setState({ isTypedNsMatching: e.target.value === this.props.resource.metadata.name });
-  }
-
-  _submit(event) {
+  const onSubmit = (event) => {
     event.preventDefault();
-    this.handlePromise(k8sKill(this.props.kind, this.props.resource)).then(() => {
-      this._close();
-      history.push(`/k8s/cluster/${this.props.kind.plural}`);
+    handlePromise(k8sKill(kind, resource)).then(() => {
+      if (resource.metadata.name === activeNamespace) {
+        dispatch(setActiveNamespace(ALL_NAMESPACES_KEY));
+      }
+      close?.();
+      history.push(`/k8s/cluster/${kind.plural}`);
     });
-  }
+  };
 
-  render() {
-    return (
-      <form onSubmit={this._submit} name="form" className="modal-content ">
-        <ModalTitle className="modal-header">
-          <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete{' '}
-          {this.props.kind.label}?
-        </ModalTitle>
-        <ModalBody>
-          <p>
-            This action cannot be undone. It will destroy all pods, services and other objects in
-            the namespace{' '}
-            <strong className="co-break-word">{this.props.resource.metadata.name}</strong>.
-          </p>
-          <p>
-            Confirm deletion by typing{' '}
-            <strong className="co-break-word">{this.props.resource.metadata.name}</strong> below:
-          </p>
-          <input
-            type="text"
-            data-test="project-name-input"
-            className="pf-c-form-control"
-            onKeyUp={this._matchTypedNamespace}
-            placeholder="Enter name"
-            aria-label={`Enter the name of the ${this.props.kind.label} to delete`}
-            autoFocus={true}
-          />
-        </ModalBody>
-        <ModalSubmitFooter
-          submitText="Delete"
-          submitDisabled={!this.state.isTypedNsMatching}
-          cancel={this._cancel}
-          errorMessage={this.state.errorMessage}
-          inProgress={this.state.inProgress}
-          submitDanger
+  const onKeyUp = (e) => {
+    setConfirmed(e.currentTarget.value === resource.metadata.name);
+  };
+
+  return (
+    <form onSubmit={onSubmit} name="form" className="modal-content ">
+      <ModalTitle className="modal-header">
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete {kind.label}?
+      </ModalTitle>
+      <ModalBody>
+        <p>
+          This action cannot be undone. It will destroy all pods, services and other objects in the
+          namespace <strong className="co-break-word">{resource.metadata.name}</strong>.
+        </p>
+        <p>
+          Confirm deletion by typing{' '}
+          <strong className="co-break-word">{resource.metadata.name}</strong> below:
+        </p>
+        <input
+          type="text"
+          data-test="project-name-input"
+          className="pf-c-form-control"
+          onKeyUp={onKeyUp}
+          placeholder="Enter name"
+          aria-label={`Enter the name of the ${kind.label} to delete`}
+          autoFocus={true}
         />
-      </form>
-    );
-  }
-}
-
-DeleteNamespaceModal.propTypes = {
-  kind: PropTypes.object,
-  resource: PropTypes.object,
+      </ModalBody>
+      <ModalSubmitFooter
+        submitText="Delete"
+        submitDisabled={!confirmed}
+        cancel={() => cancel?.()}
+        errorMessage={errorMessage}
+        inProgress={inProgress}
+        submitDanger
+      />
+    </form>
+  );
 };
 
 export const deleteNamespaceModal = createModalLauncher(DeleteNamespaceModal);

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
-import { k8sKill } from '@console/internal/module/k8s';
+import { k8sKill, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import {
   createModalLauncher,
   ModalTitle,
   ModalBody,
   ModalSubmitFooter,
+  ModalComponentProps,
 } from '@console/internal/components/factory/modal';
 import { history } from '@console/internal/components/utils';
 import { setActiveNamespace } from '@console/internal/actions/ui';
@@ -13,7 +16,12 @@ import { ALL_NAMESPACES_KEY, YellowExclamationTriangleIcon } from '@console/shar
 import { useActiveNamespace } from '@console/shared/src/hooks/redux-selectors';
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
 
-export const DeleteNamespaceModal = ({ cancel, close, kind, resource }) => {
+export const DeleteNamespaceModal: React.FC<DeleteNamespaceModalProps> = ({
+  cancel,
+  close,
+  kind,
+  resource,
+}) => {
   const activeNamespace = useActiveNamespace();
   const dispatch = useDispatch();
   const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
@@ -21,13 +29,17 @@ export const DeleteNamespaceModal = ({ cancel, close, kind, resource }) => {
 
   const onSubmit = (event) => {
     event.preventDefault();
-    handlePromise(k8sKill(kind, resource)).then(() => {
-      if (resource.metadata.name === activeNamespace) {
-        dispatch(setActiveNamespace(ALL_NAMESPACES_KEY));
-      }
-      close?.();
-      history.push(`/k8s/cluster/${kind.plural}`);
-    });
+    handlePromise(k8sKill(kind, resource))
+      .then(() => {
+        if (resource.metadata.name === activeNamespace) {
+          dispatch(setActiveNamespace(ALL_NAMESPACES_KEY));
+        }
+        close?.();
+        history.push(`/k8s/cluster/${kind.plural}`);
+      })
+      .catch(() => {
+        /* do nothing */
+      });
   };
 
   const onKeyUp = (e) => {
@@ -71,3 +83,8 @@ export const DeleteNamespaceModal = ({ cancel, close, kind, resource }) => {
 };
 
 export const deleteNamespaceModal = createModalLauncher(DeleteNamespaceModal);
+
+type DeleteNamespaceModalProps = {
+  resource: K8sResourceKind;
+  kind: K8sKind;
+} & ModalComponentProps;


### PR DESCRIPTION
If a user deletes their currently active namespace from the UI, fall back to selecting
"all namespaces" as the active namespace. Only effects active namespace within the browser
session where the project was deleted. Update to typescript and function component using hooks to simplify the logic needed for this fix.

- create promise handler hook
- create active namespace selector hook
- migrate DeleteNamepsaceModal to TypeScript and FunctionComponent
- Add logic in DeleteNamespaceModal to change active namespace state when current namespace is deleted