### PR TITLE
Bug 1887651: Add support for phase values of CephObjectStoreKind CRD used in OCS 4.5

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/statuses.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/statuses.tsx
@@ -54,6 +54,9 @@ export const getRGWHealthState = (cr: K8sResourceKind): SubsystemHealth => {
   switch (health) {
     case Phase.CONNECTED:
       return { state: HealthState.OK };
+    // Applicable only for OCS 4.5
+    case Phase.READY:
+      return { state: HealthState.OK };
     case Phase.PROGRESSING:
       return { state: HealthState.PROGRESS };
     case Phase.FAILURE:

--- a/frontend/packages/noobaa-storage-plugin/src/constants/status.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/status.ts
@@ -7,6 +7,7 @@ export enum Phase {
   CONNECTED = 'Connected',
   PROGRESSING = 'Progressing',
   FAILURE = 'Failure',
+  READY = 'Ready',
 }
 
 export const healthString = 'The object service includes 2 services.';


### PR DESCRIPTION
- OCS 4.5 status.phase values for CephObjectStore is "Ready"
- OCS 4.6 status.phase values for CephObjectStore is "Connected" 

Need to add support for both. 
Before:
![Screenshot from 2020-10-22 09-43-31](https://user-images.githubusercontent.com/54092533/96824046-7dc38380-144b-11eb-9a61-99d3d6eda6a4.png)
After:
![Screenshot from 2020-10-22 09-43-47](https://user-images.githubusercontent.com/54092533/96824052-81570a80-144b-11eb-8140-42cfdf3530a4.png)
