### PR TITLE
Monitoring: Add legend to alerting rule details page graph

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -116,9 +116,20 @@ $tooltip-background-color: #151515;
 .monitoring-dashboards__legend-wrap {
   height: 75px;
   overflow-x: auto;
+  padding-right: var(--pf-global--spacer--lg);
   padding-top: 1px;
   svg {
     max-height: 50px; // Required for Chrome. legend-wrap - scrollbar height
+  }
+  &:after {
+    background: linear-gradient(to left, var(--pf-global--BackgroundColor--100), rgba(255, 255, 255, 0));
+    content: '';
+    height: calc(100% - 10px); // Leave gap for the horizontal scrollbar
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: var(--pf-global--spacer--lg);
   }
 }
 

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -34,6 +34,10 @@ $tooltip-background-color: #151515;
 .graph-wrapper--query-browser {
   padding-left: 50px;
   padding-right: 10px;
+
+  &--with-legend {
+    min-height: 305px;
+  }
 }
 
 .monitoring-dashboards__card {
@@ -52,10 +56,6 @@ $tooltip-background-color: #151515;
     &:after {
       width: calc(100% - 10px);
     }
-  }
-
-  .graph-wrapper--query-browser {
-    min-height: 305px; // Allow for chart legend
   }
 
   // Move tooltip above cursor to work around bug where the legend is visible through the tooltip

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -50,7 +50,7 @@ import { AlertmanagerYAMLEditorWrapper } from '../monitoring/alert-manager-yaml-
 import { AlertmanagerConfigWrapper } from '../monitoring/alert-manager-config';
 import MonitoringDashboardsPage from '../monitoring/dashboards';
 import { QueryBrowserPage, ToggleGraph } from '../monitoring/metrics';
-import { QueryBrowser, QueryObj } from '../monitoring/query-browser';
+import { FormatLegendLabel, QueryBrowser, QueryObj } from '../monitoring/query-browser';
 import { CreateSilence, EditSilence } from '../monitoring/silence-form';
 import {
   Alert,
@@ -381,6 +381,7 @@ const queryBrowserURL = (query: string, namespace: string) =>
 const Graph_: React.FC<GraphProps> = ({
   deleteAll,
   filterLabels = undefined,
+  formatLegendLabel,
   patchQuery,
   rule,
   namespace,
@@ -407,6 +408,7 @@ const Graph_: React.FC<GraphProps> = ({
     <QueryBrowser
       defaultTimespan={timespan}
       filterLabels={filterLabels}
+      formatLegendLabel={formatLegendLabel}
       GraphLink={GraphLink}
       queries={queries}
     />
@@ -814,6 +816,13 @@ export const AlertRulesDetailsPage = withFallback(
     const { loaded, loadError, namespace, rule } = props;
     const { alerts = [], annotations, duration, labels, name = '', query = '' } = rule || {};
     const severity = labels?.severity;
+
+    const formatLegendLabel = (alertLabels) => {
+      const nameLabel = alertLabels.__name__ ?? '';
+      const otherLabels = _.omit(alertLabels, '__name__');
+      return `${nameLabel}{${_.map(otherLabels, (v, k) => `${k}="${v}"`).join(',')}}`;
+    };
+
     return (
       <>
         <Helmet>
@@ -911,7 +920,7 @@ export const AlertRulesDetailsPage = withFallback(
               <SectionHeading text="Active Alerts" />
               <div className="row">
                 <div className="col-sm-12">
-                  <Graph namespace={namespace} rule={rule} />
+                  <Graph formatLegendLabel={formatLegendLabel} namespace={namespace} rule={rule} />
                 </div>
               </div>
               <div className="row">
@@ -1645,6 +1654,7 @@ type AlertingPageProps = {
 type GraphProps = {
   deleteAll: () => never;
   filterLabels?: PrometheusLabels;
+  formatLegendLabel?: FormatLegendLabel;
   namespace?: string;
   patchQuery: (index: number, patch: QueryObj) => any;
   rule: Rule;

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -763,7 +763,11 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
               variant="info"
             />
           )}
-          <div className="graph-wrapper graph-wrapper--query-browser">
+          <div
+            className={classNames('graph-wrapper graph-wrapper--query-browser', {
+              'graph-wrapper--query-browser--with-legend': !!formatLegendLabel,
+            })}
+          >
             <div ref={containerRef} style={{ width: '100%' }}>
               {width > 0 && (
                 <>


### PR DESCRIPTION
Use the same legend style as the Monitoring > Dashboards page.

Also adds a gradient to the graph legend (monitoring dashboards and alerting rule details graph) to give a visual hint that the legend is scrollable.

![screenshot](https://user-images.githubusercontent.com/460802/96876348-4b4d7100-14b3-11eb-9c35-5c412a466ab9.png)

FYI @cshinn 