### PR TITLE
Bug 1889724: When LocalVolumeDiscovery CR is created form the LSO page , user must Disk tab

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-disks-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/attached-devices-mode/lso-disk-inventory/ocs-disks-list.tsx
@@ -259,6 +259,7 @@ const OCSDisksList: React.FC<TableProps> = React.memo((props) => {
       Header={diskHeader}
       Row={diskRow}
       customData={{ ocsState, dispatch }}
+      NoDataEmptyMsg={props.customData.EmptyMsg}
       virtualize
     />
   );

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -38,6 +38,7 @@ import {
   getHostNames,
 } from '@console/local-storage-operator-plugin/src/utils';
 import { DiskType } from '@console/local-storage-operator-plugin/src/components/local-volume-set/types';
+import { OCS_ATTACHED_DEVICES_FLAG } from '@console/local-storage-operator-plugin/src/features';
 import { initialState, reducer, State, Action, Discoveries, OnNextClick } from './state';
 import { AutoDetectVolume } from './wizard-pages/auto-detect-volume';
 import { CreateLocalVolumeSet } from './wizard-pages/create-local-volume-set';
@@ -56,12 +57,7 @@ import { getName } from '@console/shared';
 import { StorageClusterKind } from '../../../../types';
 import { getOCSRequestData, labelNodes } from '../../ocs-request-data';
 import { OCSServiceModel } from '../../../../models';
-import {
-  OCS_ATTACHED_DEVICES_FLAG,
-  OCS_CONVERGED_FLAG,
-  OCS_INDEPENDENT_FLAG,
-  OCS_FLAG,
-} from '../../../../features';
+import { OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG, OCS_FLAG } from '../../../../features';
 import { ReviewAndCreate } from './wizard-pages/review-and-create-step';
 import { Configure } from './wizard-pages/configure-step';
 import '../../install-wizard/install-wizard.scss';

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
@@ -20,6 +20,7 @@ import {
 import { setFlag } from '@console/internal/actions/features';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { getName } from '@console/shared';
+import { OCS_ATTACHED_DEVICES_FLAG } from '@console/local-storage-operator-plugin/src/features';
 import {
   MINIMUM_NODES,
   defaultRequestSize,
@@ -30,12 +31,7 @@ import {
 import { OCSServiceModel } from '../../../models';
 import AttachedDevicesNodeTable from './sc-node-list';
 import { PVsAvailableCapacity } from '../pvs-available-capacity';
-import {
-  OCS_CONVERGED_FLAG,
-  OCS_FLAG,
-  OCS_ATTACHED_DEVICES_FLAG,
-  OCS_INDEPENDENT_FLAG,
-} from '../../../features';
+import { OCS_CONVERGED_FLAG, OCS_FLAG, OCS_INDEPENDENT_FLAG } from '../../../features';
 import { scResource, pvResource } from '../../../constants/resources';
 import { labelNodes, getOCSRequestData } from '../ocs-request-data';
 import {

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -14,7 +14,6 @@ import { OCSServiceModel } from './models';
 import {
   CEPH_STORAGE_NAMESPACE,
   OCS_SUPPORT_ANNOTATION,
-  ATTACHED_DEVICES_ANNOTATION,
   RGW_PROVISIONER,
   SECOND,
   OCS_OPERATOR,
@@ -23,8 +22,7 @@ import { StorageClusterKind } from './types';
 
 export const OCS_INDEPENDENT_FLAG = 'OCS_INDEPENDENT';
 export const OCS_CONVERGED_FLAG = 'OCS_CONVERGED';
-/* INFO: Flag OCS_ATTACHED_DEVICES_FLAG used in local-storage-plugin without import */
-export const OCS_ATTACHED_DEVICES_FLAG = 'OCS_ATTACHED_DEVICES';
+
 // Used to activate NooBaa dashboard
 export const OCS_FLAG = 'OCS';
 // Todo(bipuladh): Remove this completely in 4.6
@@ -79,24 +77,15 @@ export const detectOCS: FeatureDetector = async (dispatch) => {
       (sc: StorageClusterKind) => sc.status.phase !== 'Ignored',
     );
     const isInternal = _.isEmpty(storageCluster.spec.externalStorage);
-    const isAttachedDevicesCluster =
-      getAnnotations(storageCluster)?.[ATTACHED_DEVICES_ANNOTATION] === 'true';
     dispatch(setFlag(OCS_FLAG, true));
-    dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, isAttachedDevicesCluster));
     dispatch(setFlag(OCS_CONVERGED_FLAG, isInternal));
     dispatch(setFlag(OCS_INDEPENDENT_FLAG, !isInternal));
   } catch (e) {
     if (e?.response?.status !== 404)
-      handleError(
-        e,
-        [OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG, OCS_ATTACHED_DEVICES_FLAG],
-        dispatch,
-        detectOCS,
-      );
+      handleError(e, [OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG], dispatch, detectOCS);
     else {
       dispatch(setFlag(OCS_CONVERGED_FLAG, false));
       dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
-      dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, false));
     }
   }
 };

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import * as models from './models';
 import {
+  AlertAction,
   ClusterServiceVersionAction,
   DashboardsCard,
   DashboardsOverviewHealthResourceSubsystem,
@@ -23,6 +24,7 @@ import { GridPosition } from '@console/shared/src/components/dashboard/Dashboard
 import { referenceForModel } from '@console/internal/module/k8s';
 import { NodeModel } from '@console/internal/models';
 import { LSO_DEVICE_DISCOVERY } from '@console/local-storage-operator-plugin/src/plugin';
+import { OCS_ATTACHED_DEVICES_FLAG } from '@console/local-storage-operator-plugin/src/features';
 import { getCephHealthState } from './components/dashboard-page/storage-dashboard/status-card/utils';
 import { isClusterExpandActivity } from './components/dashboard-page/storage-dashboard/activity-card/cluster-expand-activity';
 import { StorageClassFormProvisoners } from './utils/ocs-storage-class-params';
@@ -34,10 +36,12 @@ import {
   CEPH_FLAG,
   OCS_INDEPENDENT_FLAG,
   OCS_CONVERGED_FLAG,
-  OCS_ATTACHED_DEVICES_FLAG,
 } from './features';
+import { getAlertActionPath } from './utils/alert-action-path';
+import { OSD_DOWN_ALERT, OSD_DOWN_AND_OUT_ALERT } from './constants';
 
 type ConsumedExtensions =
+  | AlertAction
   | ModelFeatureFlag
   | HorizontalNavTab
   | ModelDefinition
@@ -401,6 +405,28 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [OCS_ATTACHED_DEVICES_FLAG, LSO_DEVICE_DISCOVERY],
+    },
+  },
+  {
+    type: 'AlertAction',
+    properties: {
+      alert: OSD_DOWN_ALERT,
+      text: 'Troubleshoot',
+      path: getAlertActionPath,
+    },
+    flags: {
+      required: [LSO_DEVICE_DISCOVERY, OCS_ATTACHED_DEVICES_FLAG],
+    },
+  },
+  {
+    type: 'AlertAction',
+    properties: {
+      alert: OSD_DOWN_AND_OUT_ALERT,
+      text: 'Troubleshoot',
+      path: getAlertActionPath,
+    },
+    flags: {
+      required: [LSO_DEVICE_DISCOVERY, OCS_ATTACHED_DEVICES_FLAG],
     },
   },
 ];

--- a/frontend/packages/ceph-storage-plugin/src/utils/alert-action-path.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/alert-action-path.tsx
@@ -1,0 +1,4 @@
+import { Alert } from '@console/internal/components/monitoring/types';
+
+export const getAlertActionPath = (alertData: Alert) =>
+  `/k8s/cluster/nodes/${alertData.labels.host}/disks?node-disk-name=${alertData.labels.device}`;

--- a/frontend/packages/local-storage-operator-plugin/src/features.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/features.ts
@@ -1,0 +1,33 @@
+import { FeatureDetector } from '@console/plugin-sdk';
+import { K8sKind, k8sList } from '@console/internal/module/k8s';
+import { getAnnotations } from '@console/shared/src/selectors/common';
+import { setFlag, handleError } from '@console/internal/actions/features';
+
+export const OCSServiceModel: K8sKind = {
+  label: 'Storage Cluster',
+  labelPlural: 'Storage Clusters',
+  apiVersion: 'v1',
+  apiGroup: 'ocs.openshift.io',
+  plural: 'storageclusters',
+  abbr: 'OCS',
+  namespaced: true,
+  kind: 'StorageCluster',
+  id: 'ocscluster',
+  crd: true,
+};
+const ATTACHED_DEVICES_ANNOTATION = 'cluster.ocs.openshift.io/local-devices';
+export const OCS_ATTACHED_DEVICES_FLAG = 'OCS_ATTACHED_DEVICES';
+
+export const detectOCSAttachedDeviceMode: FeatureDetector = async (dispatch) => {
+  try {
+    const storageClusters = await k8sList(OCSServiceModel, { ns: 'openshift-storage' });
+    const storageCluster = storageClusters.find((sc) => sc.status.phase !== 'Ignored');
+    const isAttachedDevicesCluster =
+      getAnnotations(storageCluster)?.[ATTACHED_DEVICES_ANNOTATION] === 'true';
+    dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, isAttachedDevicesCluster));
+  } catch (err) {
+    err?.response?.status === 404
+      ? dispatch(setFlag(OCS_ATTACHED_DEVICES_FLAG, false))
+      : handleError(err, OCS_ATTACHED_DEVICES_FLAG, dispatch, detectOCSAttachedDeviceMode);
+  }
+};

--- a/frontend/packages/local-storage-operator-plugin/src/plugin.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/plugin.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import {
   AlertAction,
+  CustomFeatureFlag,
   ModelDefinition,
   ModelFeatureFlag,
   Plugin,
@@ -10,11 +11,12 @@ import {
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { NodeModel } from '@console/internal/models';
-import { getAlertActionPath } from './utils/alert-actions-path';
+import { detectOCSAttachedDeviceMode, OCS_ATTACHED_DEVICES_FLAG } from './features';
 import * as models from './models';
 
 type ConsumedExtensions =
   | AlertAction
+  | CustomFeatureFlag
   | HorizontalNavTab
   | ModelFeatureFlag
   | ModelDefinition
@@ -22,8 +24,6 @@ type ConsumedExtensions =
 
 const LSO_FLAG = 'LSO';
 export const LSO_DEVICE_DISCOVERY = 'LSO_DEVICE_DISCOVERY';
-const OCS_ATTACHED_DEVICES_FLAG =
-  'OCS_ATTACHED_DEVICES'; /* Inline with OCS_ATTACHED_DEVICES_FLAG flag of `@console/ceph-storage-plugin/src/fetaures` */
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -42,8 +42,14 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'FeatureFlag/Model',
     properties: {
-      model: models.LocalVolumeDiscoveryResult,
+      model: models.LocalVolumeDiscovery,
       flag: LSO_DEVICE_DISCOVERY,
+    },
+  },
+  {
+    type: 'FeatureFlag/Custom',
+    properties: {
+      detect: detectOCSAttachedDeviceMode,
     },
   },
   {
@@ -78,28 +84,6 @@ const plugin: Plugin<ConsumedExtensions> = [
     flags: {
       required: [LSO_DEVICE_DISCOVERY],
       disallowed: [OCS_ATTACHED_DEVICES_FLAG],
-    },
-  },
-  {
-    type: 'AlertAction',
-    properties: {
-      alert: 'CephOSDDiskNotResponding',
-      text: 'Troubleshoot',
-      path: getAlertActionPath,
-    },
-    flags: {
-      required: [LSO_DEVICE_DISCOVERY],
-    },
-  },
-  {
-    type: 'AlertAction',
-    properties: {
-      alert: 'CephOSDDiskUnavailable',
-      text: 'Troubleshoot',
-      path: getAlertActionPath,
-    },
-    flags: {
-      required: [LSO_DEVICE_DISCOVERY],
     },
   },
   {


### PR DESCRIPTION
- The flag  is set only by OCS and gets undefined when OCS is not installed. The flag must be set by LSO plugin and imported in OCS.
- Created an action flag in LSO package to be set
- Looking for discovery CR rather than discoveryresult CR
- minor fix for empty state too