### PR TITLE
Bug 1891376: Remove title passed to the PrometheusGraph component in the AreaChart

### DIFF
--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -119,7 +119,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
   }, [formatDate, getLabel, multiLine, processedData, showAllTooltip]);
 
   return (
-    <PrometheusGraph className={className} ref={containerRef} title={title}>
+    <PrometheusGraph className={className} ref={containerRef}>
       {processedData?.length ? (
         <PrometheusGraphLink query={query} title={title}>
           <Chart


### PR DESCRIPTION
Was introduced in https://github.com/openshift/console/pull/6878/files

/assign @spadgett 
cc'ing @dtaylor113 