### PR TITLE
Bug 1891376: Extra text in Cluster Utilization charts

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -67,6 +67,7 @@ export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> =
         height={70}
         byteDataType={byteDataType}
         showAllTooltip
+        ariaChartLabel={`View ${title || ''} Graph in Query Browser`}
       />
     );
 
@@ -138,7 +139,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
 
     const chart = (
       <AreaChart
-        title={title}
+        ariaChartLabel={`View ${title || ''} Graph in Query Browser`}
         data={data}
         loading={!error && isLoading}
         query={query}

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -51,6 +51,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
   query,
   tickCount = DEFAULT_TICK_COUNT,
   title,
+  ariaChartLabel,
   xAxis = true,
   yAxis = true,
   chartStyle,
@@ -121,7 +122,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
   return (
     <PrometheusGraph className={className} ref={containerRef} title={title}>
       {processedData?.length ? (
-        <PrometheusGraphLink query={query} title={title}>
+        <PrometheusGraphLink query={query} ariaChartLabel={ariaChartLabel}>
           <Chart
             containerComponent={container}
             domainPadding={{ y: 20 }}
@@ -207,6 +208,7 @@ export type AreaChartProps = {
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
   tickCount?: number;
   title?: string;
+  ariaChartLabel?: string;
   data?: DataPoint[][];
   xAxis?: boolean;
   yAxis?: boolean;

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -35,7 +35,7 @@ export const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
   perspective,
   query,
   namespace,
-  title,
+  ariaChartLabel,
 }) => {
   if (!query) {
     return <>{children}</>;
@@ -50,11 +50,7 @@ export const PrometheusGraphLink_: React.FC<PrometheusGraphLinkProps> = ({
       : `/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`;
 
   return (
-    <Link
-      to={url}
-      aria-label={`View ${title ? title : ''} Graph in Query Browser`}
-      style={{ color: 'inherit', textDecoration: 'none' }}
-    >
+    <Link to={url} aria-label={ariaChartLabel} style={{ color: 'inherit', textDecoration: 'none' }}>
       {children}
     </Link>
   );
@@ -75,7 +71,7 @@ type PrometheusGraphLinkProps = {
   perspective: string;
   query: string;
   namespace?: string;
-  title?: string;
+  ariaChartLabel?: string;
 };
 
 type PrometheusGraphProps = {


### PR DESCRIPTION
This is an extension of merged #6878 which did fixed accesibility issues, but also introduced extra titles/text in the Home -> Overview Cluster Utilization graphs.

**BEFORE**
![image](https://user-images.githubusercontent.com/12733153/97224036-f3f71b80-17a6-11eb-8bf8-3357a832704c.png)

**AFTER**
![image](https://user-images.githubusercontent.com/12733153/97224060-fbb6c000-17a6-11eb-8df7-b46a7b32311f.png)

**_* No accesibility violations detected for Home -> Overview dashboard page._**