### PR TITLE
Bug 1812412: Monitoring: Increase Prometheus query_range timeouts to 30s

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -131,7 +131,7 @@ const SingleVariableDropdown_: React.FC<SingleVariableDropdownProps> = ({
         endpoint: PrometheusEndpoint.QUERY_RANGE,
         query: prometheusQuery,
         samples: NUM_SAMPLES,
-        timeout: '5s',
+        timeout: '30s',
         timespan,
       });
 

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -605,7 +605,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
               namespace,
               query,
               samples,
-              timeout: '5s',
+              timeout: '30s',
               timespan: span,
             }),
           ),


### PR DESCRIPTION
The current timeout of 5 seconds is probably much too strict.

Prometheus has a maximum concurrent queries limit, which is currently
set to 20. This should protect against overloading Prometheus, even if
we increase the timeout significantly.

Also, if there are more than 20 queries, some will be queued and the
time they spend in the queue will count towards the time limit, which is
another reason to make the timeout less strict.