### PR TITLE
check for taskRef kind in the TR spec

### DIFF
--- a/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/dev-console/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { ResourceLink, Timestamp, Kebab, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { TaskRunKind } from '../../../utils/pipeline-augment';
-import { TaskRunModel, PipelineModel, TaskModel } from '../../../models';
+import { TaskRunKind, getModelReferenceFromTaskKind } from '../../../utils/pipeline-augment';
+import { TaskRunModel, PipelineModel } from '../../../models';
 import { tableColumnClasses } from './taskruns-table';
 import { Status } from '@console/shared';
 import { pipelineRunFilterReducer as taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
 
 const taskRunsReference = referenceForModel(TaskRunModel);
-const taskReference = referenceForModel(TaskModel);
 const pipelineReference = referenceForModel(PipelineModel);
 
 const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...props }) => (
@@ -42,7 +41,7 @@ const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...prop
     <TableData className={tableColumnClasses[3]}>
       {obj.spec.taskRef?.name ? (
         <ResourceLink
-          kind={taskReference}
+          kind={getModelReferenceFromTaskKind(obj.spec.taskRef?.kind)}
           name={obj.spec.taskRef.name}
           namespace={obj.metadata.namespace}
         />

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -11,6 +11,7 @@ import {
   K8sResourceKind,
   PersistentVolumeClaimKind,
   referenceForModel,
+  GroupVersionKind,
 } from '@console/internal/module/k8s';
 import {
   ClusterTaskModel,
@@ -491,3 +492,8 @@ export const getResourceModelFromTask = (task: PipelineTask): K8sKind => {
 
 export const pipelineRefExists = (pipelineRun: PipelineRun): boolean =>
   !!pipelineRun.spec.pipelineRef?.name;
+
+export const getModelReferenceFromTaskKind = (kind: string): GroupVersionKind => {
+  const model = getResourceModelFromTaskKind(kind);
+  return referenceForModel(model);
+};


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5031

**Root Analysis:**
The Task col in the TaskRun list is always considering the taskRef to be of kind `Task`. So, in a scenario where TaskRun references ClusterTask, the linked task name gives a 404 error

**Solution Description:**
added a check for the taskRef kind

**GIF:**
![clkind](https://user-images.githubusercontent.com/22490998/96682125-04b62480-1396-11eb-9d2a-e578790c907a.gif)
