### PR TITLE
Bug 1891314: Return helm charts based on the installed kubernetes version

### DIFF
--- a/docs/helm/endpoints_api.md
+++ b/docs/helm/endpoints_api.md
@@ -335,6 +335,10 @@ _Returns repository index file containing all entries from all configured reposi
 
   `GET`
 
+* **Supported URL Query Parameter:**
+    *  `onlyCompatible` - `true`/`false` Setting true would return helm charts which are supported in the provided cluster.
+    Default value is set to true if not provided.
+
 * **Success Response:**
 
   * **Code:** 200 <br />

--- a/pkg/helm/actions/kube_version.go
+++ b/pkg/helm/actions/kube_version.go
@@ -1,0 +1,24 @@
+package actions
+
+import (
+	"errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+func GetKubeVersion(config *rest.Config) (string, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return "", err
+	}
+
+	kubeVersion, err := client.ServerVersion()
+	if err != nil {
+		return "", err
+	}
+
+	if kubeVersion != nil {
+		return kubeVersion.String(), nil
+	}
+	return "", errors.New("failed to get kubernetes version")
+}

--- a/pkg/helm/chartproxy/repos_test.go
+++ b/pkg/helm/chartproxy/repos_test.go
@@ -3,17 +3,18 @@ package chartproxy
 import (
 	"errors"
 	"fmt"
-	helmrepo "helm.sh/helm/v3/pkg/repo"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	helmrepo "helm.sh/helm/v3/pkg/repo"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeclient "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	fakeclienttest "k8s.io/client-go/testing"
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"testing"
 
 	"github.com/openshift/console/pkg/helm/actions/fake"
 )

--- a/pkg/helm/chartproxy/testdata/RepoIndexPreRelease.yaml
+++ b/pkg/helm/chartproxy/testdata/RepoIndexPreRelease.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+entries:
+  ibm-cpq-prod:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.20.0-alpha.2'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+  ibm-operator-catalog-enablement:
+    - apiVersion: v2
+      appVersion: 1.0.0
+      created: "2020-07-15T16:32:34.697730479+05:30"
+      description: |
+        IBM Operator Catalog enablement deploys custom CatalogSources for operators
+        available to deploy and maintain IBM products.  The operators are publically
+        available, but products they install may require purchase and entitlement keys.
+
+        Documentation
+        For additional details regarding installation see https://ibm.biz/operator-catalog-readme
+
+        License
+        By installing this catalog you accept the license terms https://www.apache.org/licenses/LICENSE-2.0
+      digest: 5a765d2f3f36f1b35c403a546df3590e3d6014cbf86bd36775f8febb54baa58c
+      home: http://ibm.biz/oprcatalog
+      icon: data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxITEhUQEhAVEhEVFRUQFxgVGBUQEBgSFREXFhcXFxUYHiggGBolHRUWITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGxAQGi0mHyYtLS0wLy4tKy8tMistLS0tLS8vLS0tLS0rLS0uLS0tLS0tLS0vLS0tLS0tLS0tLS0tLf/AABEIANMA7wMBEQACEQEDEQH/xAAbAAEAAgMBAQAAAAAAAAAAAAAABQYCAwQBB//EAEYQAAIBAQQFBwgHBgUFAAAAAAABAgMEBREhBhIxQVEiYXGBkaGxEyMyUlSjwdIzQmJygsLRFBaisuHwB0NTc5IVJDREs//EABoBAQACAwEAAAAAAAAAAAAAAAAEBQECAwb/xAA5EQACAQICBwYFAwMFAQEAAAAAAQIDBBEhBRIxQVGh0RMVUnGBsSIyYeHwQpHBFCMzNENygvHCYv/aAAwDAQACEQMRAD8A+4gAAAAAAAAAAAAAAAAAAAArmk1eWvGnjhHV1sOLcms+Ow70lliea03Wn2ipp5YY830OjRmvKSnFvFR1Wsc8MccujIxVSWDJGhK05xnCTxSww9cehNnEvQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVbSh+eX+2v5pEqj8p5XTf+oX/Fe7OnRR/Sfg/OaV9xJ0Dtqf8AX+SwHA9CAAAAAAAAAAAAAAAAAAAAAAAAAAAACD0sttSnTioNx1pNOSyeSxwT3Y/AlWsIyk8Sp0tcVKVNKDwxe0jdGb5lr+SqTcoyyi5NyaluWLzwf6HW4orV1oog6Mv5qp2VSWKezHj5/UtxAPSAAAAAAAAqmlT88v8Abj/PMl0Pl9Ty2m/9Qv8AivdnTok/pfwfnNbjcSNA7an/AF/+ixEY9CAAAAAAACs3neUpTahNxgslqtrHnxR2jHBHkr/SNSpVapyaitmDwx+pMXPXlOmnLN4tY8UjnNYMvdGV51rdSntzWPE7jUsAAAAAAAAAAAAAAAAAct5WJVqcqb3rJ8JLYzenNwkpI4XNBV6Tpvf7nzqpCUJOMspReD4pplwmpLFHipwlCTi8mi/XDePlqSk/TjyZdK39e0qq9Ps5Ybj19hdf1FFSe1ZPz+5InEmgAAAAAFU0sXnovc6aXWpSx8V2ky3+U8vptPt4v/8AP8s6dEF9K93IXWtbHxRpcbiRoJP+4/L+SxEY9AAAAAAARd/W3UhqJ8qeXRHe/gdKccXiVOlrvsaWpH5pe2/p/wCEBZKLnJQW19y3s6vJYnmbehKtUVOO8uFGkoxUVsSwI7eJ7mnTjTgoR2IzMG4AAAAAAAAAAAAAAAAABVNMrt2WiK4Rn4Rl8Own2dX9D9Cg0xa/78fJ/wAP+P2IjR+8vI1U2+RLkz6N0urwxJFelrxy2ldYXX9PVxfyvJ9fQ+hIqD2AAAAAABptVlhUWE4qS59q6HuNoycdhxrUKdZYVFiZUKEYLVhFRjwRhybeLNqdKFOOrBYI2GDoAAAADGpNRTk3gksX0IyliazmoRcpbEUu22p1Jub37FwjuRKjHBYHiLq4dxVdR+nkT+j1j1Y+Ua5UtnNH+u3sONSWeB6DQ9p2dPtZbZe332/sS5yLkAAAAAAAAAAAAAAAAAAAGFekpxcJLGMk4tczMxbi8UazgpxcZbGfPbbctaFR01SnNY8mUYtxa3PFZJ8cdhcQrwlHHFI8hWsa1Oo4KLfBpbfzeXu7KMoUqcJvGUYRi9+aWzHeVNSSlNtHqraEqdGMZbUkdRodwAAAAAAAAAAAAAcN9UJToyjDN5PDik8cDpTaUsyDpGjOrbyjDbl65leuy7JzmlKEowWcnJOPUsTvOaSyPO2Wj6lWqlOLUVtxWHpmW5IiHsD0AAAAAAAAAAAAAAAAAAAAAAAAA8bAIm26R2enlr+Ulwhyl/y2d5Iha1JbsPMrq2lLenlji/pnz2EPaNLpv0KcYrjJuT7FgSI2cVtZW1NNVH8kUvPPocFXSC0y/wA3D7qivhidVbU1uIc9J3Uv14eSRhTvavj9NPtDow4Gsb24b+dnbQvGt/qy7TnKlDgSY3dfxskaF51d8selI4ulHgTKd5WW8kKN5v60V1ZdxydLgTIXj/UjtpWqMt+D58jm4tEuFaEjcanUAAAAAAAAAAAAAAAAHPZ7fSm3GFWE5LaoyjJrpSZ0lSnFYyi16HKFanNtRkm1wZ0HM6gAAAAAAAAELfGkdKjjBecqr6qeSf2nu6NpKo2s6mbyRXXekqdD4VnLhw82U68b4rVny58n1VyYdm/rLKnQhT2I87cXlav87y4bvzzNdisVWq8KdOU92K9FdMnkjM5xh8zOdKhUqvCnFv8AOOwnbJojUedSpGHNFOb7cku8iTvY/pRZ0tC1H/kkl5Z9P5JSjopQXpSnLpaS7kR3dzezAnQ0NQXzNv16HVDR6zL/AC+2U38TR3NR7zvHRltH9PN9TZ/0Whuhh0OX6mvbz4m3d9Dw82Yu54bnJdjRntnvMOwp7mzB3bJbGn3Mz2iZo7SUdjxMVTayawGOJjUayZ1UajXQaNJkiEmjqhUTNGsCRGSZmYNgAAAAAAAADU7TBS1HOOtwxWt2GcHtOTr0lPUclrcMVj+xtMHUjtIaFSdmqwpem4tLDJvil0rFdZ3tpRjVi5bMSNdwnOhKMNuB8njKUJfWhOL54Ti/FM9M0pLimeQWtCXBr0aLbcumso4QtC147NeK5a+9H63Vn0lZcaNTzp5fQuLbS0o/DWzXFbfVdP2LrY7XTqxU6c1OL3rwfB8zKidOUHqyWDLynVhUjrQeKN5odAAADyTSWLeCWfNgA3gUrSHSlyxpWd4Q2Oayk+aPBc/9u1t7LV+Kpt4Hnb7SjnjCi8uPHy6/sV2yWedSShTi5Se5eLe5c7Js5RgsZPIqadKdSWrBYsuV0aJwjhKu/KS9VfRr4y8OYq617KWUMlzL+10RCPxVs3w3ff8AMiyQgkkkkksklkl1EJtvNlxGKisEsjIwZAAAAAAAB41jtBhpPaaZ0OBspcTm6fAwijYwkb4SNGjomZmDYAAAAGi12uFNa05JcOL6FvNoxcthwr3FOhHWqPAr1vv2c8qfIjx+u/0O8aSW087d6YqVPhpfCuf2/MyMpwcnhFOUnwzZu8tpUwhOpLVisWy8UU1GKk8ZJJN8+GZEe095TUlBKW3BY+ZmYNyNvi46NoXnI8rYpxymuveuZ5EihdVKL+F5cNxFuLSlXXxrPjvKFfei1ehjJLytL1orlJfajtXSsV0F1b31Ork8n+bGefudHVaOazjxX8oi7Bb6lGWvSm4S5tjXBrY0SalKNRas1iRKVadKWtTeB9E0V0g/aVKM4qNSCTeHoyT3pbtmwoby07Bpp5M9JYX39QmpLCSJ8hFiACg6WaReVboUn5pPCUl9drcvsrv6NtzZ2motee32+55vSV/2rdKn8u98ft7+W2Jua66lonqQySzlJ+jFfF8ESa9aNKOLINrazuJ6sfV8D6PdV2U6ENSmumT9KT4t/AoqtaVWWMj1VtbU7eOrBeu9naciQAAAAAAAAAAAAADyUcTOJhoxwBgyRgyegyACFvy+XSfk4LlYYtvNLHgt7O9KlrZsp9I6SlQl2dNZ4beBWataUnrSk5Se95slKKWw8zUqTqS1pvFkrd1xznyp+bj/ABvq3dZxnVS2FnaaJq1fiqfCuf29f2LJZLHCmsIRw4vbJ9LI0pOW09Jb21KhHCmsPc3mp3AAAABXr60SoV25x8zUeeMVjFv7UN/SsCdQv6lLJ5r83ldc6NpVviXwv6fyjo0c0fjZVLluc5YYyw1VgtiSzw28TS6u3XaywSOlnZRtk88W95MkQmlV03vvycf2em/OTWMmtsYPd0vwx5iysLbXfaS2L3+xUaUvOzj2UNr2/Rfcpl12GdepGlDa9r3Ritsn/fAta1SNKDlIoaFCVaahD/xcT6ldl3woU1Sgslte+Ut8nznnKtWVWWtI9fb0IUIKEDrOZ2AAAAAAAAAAAAAAAAB45LiDDaPNdcUZwGsuJkYMgAir2uVVpKanqSwweWsmujFZnanWcFgVl9o2NzJTUsH5Y9Dbd10U6WaWtP1nt6luNZ1ZSOlro6jb5pYy4v8AjgSBzJ4AAAAAAAAAAOe32uNKnKrL0Ypy6eCXO3l1m9Om6klFbznVqKnBzlsR8kttolUnKrN4yk3J/BdCWC6j1FOChFRjsR46rOVSbnLaz6Nojc/kKOtJedqYSlxS+rDq387ZQ3tx2s8FsX5iel0da9hTxl8z29PzeTpCLAAAAAAAAAAAAAAGMppGUsTDeBplWe7I21TnKb3GmcnxNkcZNs0yNjkzVIyjmzHWa2NroyM4Gus1sNkLdNb8en9TV00zeNzOP1OyheEJZPkvn2dppKm0Sqd1CWTyZ1nMkgAAAAAAAAAAAFS08tb1YUFv85LoWUV24vqRaaNp5uo/IqdKVMlTXm/4IPRS6/K2hOS5FPzj4Np8ldufUyZe1uzpZbXkQLC37Ssm9iz6H0k8+elAAAAAAAAAAAAABjJmTDZqaNjQKjxDkNQ2KkuBrizKhEyUVwMYm2CDiuAxGCNU7NB7Yrqy8DZSaNJUYPajlrXb6sup/qbqrxI07PwsjLRSlF4SWHgdotPYQKkJQeEkbLJeMoZPlR4b10GJU1I3o3UqeTzRN0K0ZrWi8URmmngy2p1IzjrRNhg3AAAAAAAAAKDfkvKVpy3Y6q6I5fDHrLy3WpTSKC5evVb/ADIsOiFk1KLnvnJv8Mcl349pAvqmtUw4FjYU9WnjxJ0hE4AAAAAAAAAAAA8ZkwzzAGD1IwbHoAAAAAAAAMalNSWDWKMptbDWUVJYNEDeV3uHKjnDvXTzc5Jp1NbJ7SourV0/ijs9jksdtdOWKzW9cV+pvOCkiNQuJUZYrZvRZ6FVTipReKZDaaeDL+nOM4qUdhsMG4AAB42DGITMgxrTwi5cE32IRWLSEngsSjypF1iUrgXWx0dSEYerFLrwzKepLWk2XFOOrFI3GhuAAAAAAAAAAAAAAAAAAAAAAAAAAAeNbgGsSsXxYfJyxXoS2cz4E2lPWWe0oL227GWK+V/mBlcVv1J6knyZPDolu7dnYYrU8VijNhc9nPUex+5ZiGXwANVWrhlvNlHE1lLAxhIyzVM3JGhvgarb9HL7r8Den8yNanysr1Oz4tLnXiT3PIhKOZZytLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA02uzqpBwexrse5m0ZOLxRzrUlVg4PeUivFxk4vJptPpRZRzWKPKTi4ScXtRcLntflaUZP0lyZdK/XJ9ZX1YaksD0tnX7akpPbsfmdNeqoxcnu8TWMdZ4EiUtVYkUq7bxe1kpxwI+tiSlCGCz2kWTxZIisDaamxrtK5Mug2h8yNZbGRlKnmuleJJlLIjpZkuRCUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACqaV2fVqRqLZNYP70f6NdhPtZYxw4Hn9K0tWoprf7oz0RtPLnT4rXXSng/Fdhi6jkpG+iauE5Q45nbftq5Spp7FrPpez++cxbU8nIsbieeqeXNHXlrPZHPrewXD1VhxFBazxJwhEwAGM1kzK2mHsOdQN8TngdRzOoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITS6njQUvVmn1PFfFEq0fx4FZpaONDHg10K5cNfVrwe7lJ9Go/6EyvHGmynsZuFeL8/Zi9LbrVqjx+u49UeSvAk0KWFKK+haVZ4zbLVo5DChGW+Tcu/BdyKq8f91rgT7ZYU8eJKEUkAAAGvVNsTXAzRqbHoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFaUf+NU/B/8ASJItf8q9fYg6S/00vT3RRaVRpprb/QtWsUeXi2nijjqV223xbfa8SxUElgWzli8T6dci/wC3o/7UH2wTPL3P+afm/cu6P+OPkjtOJ1AAAPMAYPQZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCaX1cLM160ox79b8pKs1jVK7SssLdri11/gqNz0tetCGGOOt3Qk/gWVZ6sGygtIa9aMfP2ZFWxatScfVnKPZJr4FnT+KCfFInzyk0fTdHaqlZqLX+nGPXFar8DzF3HVrzX1fMu7d40o+RIkc7AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqGnVrzp0VuxqP+WP5iysIZOXoUWmKucafr/C/k5tCaGtXc90IfxSyXcpHS+lhTS4nHRNPWrOXBe/4yE0vs3k7XUW6bVVfjzf8WsWmj6mvbx+mX7fbA73UNWq/rmWn/D23a1CVJvOnLFfcnmu/WKrS1LVqqfFc1+InWFTGDjwLUVROAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMatRRTlJ4RScm3sSSxbMpNvBGJSUVi9h8uvS3+Wqzq7pPJcIrJLsPQUqXZwUTx9xWdao58fbcXbQ+xeToKT9Ko9f8OyPdn1lTe1Napgt2R6DRlHs6Os9ss/TcRv+Id261ONois6fJl9yT29T8WTdEV9Wbpvfs8zN/Sxiprd7FQ0bvf8AZq8aj9B8if3Hvw4p4Pq5y4vLbt6Tjv2rzK+3rdlNS3bz65CaaTTTTWKazTT2NM8g008GX6eOaMjBkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFL03vv/1ab56jXdD4vqXEtrC2/wB2Xp1KLSt5/sw9enUgtHrtdorKH1FypvhBbul7O17iZc1lShjv3FdZ27r1VHdtfl9z6hFYZLJLI86euSwMa1KM4uEljGScWnsaawaMxk4tSW1GGk1gz5BpHdErLWdN4uD5VOXGH6rY+3eexs7mNxT1lt3r6/mw8/cUXSnqvZuJ3QjSpU8LNXlhT2U5vZHH6sn6vB7ujZA0lo9z/u01nvXH6+ZKs7vV/tz2bmfRTzhbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFS0p0rVPGjQknV2Sms4w5lxl4FnZ2Ln8dTZw4/Yp7/SKp406T+Le+H39ij2WjOpNQgnOcngltbbzbb72y4nKMI60skihhCVSSjHNs+pXBdEbNSUFnN8qcuMubmW485c13Wnju3HrLO1VvT1d+9/UkyOSgAR9+XRTtVJ0qmW+Ml6UZbmv03ki2uZ289ePquKOVajGrHVkfIb6umrZqjp1Y/dkvQmuMX8NqPYW1zTuIa0H6b0efrUZUpasiV0b0zq2ZKnUTrUFklj5yC+y3tX2X1NES80XTr/ABRylyfn19zvb3s6XwvNcz6LdOkFmtC81VTl6j5NRfhefWsjzlxZVqHzxy47v3LelcU6vyvqShFO4AAAAAAAAAAAAAAAAAAAAAAAAAABE3npHZqGU6qcvUhy59i2deBKo2dar8scuLyRFr3tGj80s+CzZSL80xrV8YU/M0nlk/OSXPLcuZdrLi30dTpZyzfIo7rSdSr8MPhXP9+n7kLd1hqVpqnSg5S7Elxk9yJdWpCnHWmyBRozqy1ILFn03RzR+Fljj6daS5U/yx4Lx8PO3V3Ku+C4HqLOyjbx4ye19PoTREJoAAAAOW8bvpV4OlVgpwe57U+Ke1PnR1o1p0Za8HgzSpTjUjqyWKPnV/aAVqeM7O/LQ26rwjWS8Jdz5j0drpmnP4avwvju+xT19HzjnDNc/uUu00pQlqzjKE1uknGS6nmXcJRmsYvFFdJOLweTO2y6SWyllC1VEuDl5Rdk8ThOxtqnzQXt7HWNzWjsk/zzOp6dXj7T7uj8hy7os/Bzl1N/6+48XJdB+/l4+0+7o/IO57Pwc5dTHeFx4uS6D9/Lx9p93R+Qd0Wfg5y6jvC48XJdB+/l4+0+7o/IY7os/Bzl1Md4XHi5LoFp3eHtPu6PyDuiz8HOXUx3hc+LkuhktOrw9p93R+Qx3RZ+DnLqO8Lnxcl0Pf36vD2n3dH5DHdNp4Ocuo7wufFyXQ9WnN4e0+7pfKY7ptPBzfUx3hc+LkuhktOLw9o93S+Ux3TaeDm+o7xufFyXQ9/fi3+0e7pfKY7qtPBzfUd43Pi5LoerTe3+0e7pfKY7qtfBzfUd43Pi5LoZLTa3+0e7pfKY7rtfBzfUd43Pi5LoerTW3+0e7pfKY7rtfBzfUd43Pi5LoZLTW3+0e7pfKY7rtfBzfUx3jc+Lkuh6tNLd7R7ul8pjuy18PN9R3jc+Lkuh6tM7d7R/BS+Ux3ZbeHm+o7xufFyXQS0wtzy/aH1Qpr8oWjbZfo5vqYekbl/r5LocNqve0VPpK9SS4OTUf+KyO0LalD5YpehwncVZ/NJv1NFks06j1acJTlwinJ9eGw2nOMFjN4eZyhTlN4QWPkW65tBas8JWiXko+rHCVR9fox7yrr6UhHKmsXx3dXyLW30TOWdV4LgtvRcy9Xdd1KhDUpQUI78NrfFva30lJVrTqy1pvEvKNGFKOrBYI6jmdQAAAAAAAADntlipVVq1aUKkeE4qa7zpTqzpvGEmvJms4RmsJLEp+kWiVigtaFDVbx2TqJZLhrYIuLPSVzJ4Slj6LoV9ezorNR9z5fb6ajNpLBJvn8T1NKTlFNlJUSUsEczOpzBgwegwAD1GGDJGpg9RgGaMMHqMGDJGoPUYBkjBgyRhgyRqDJGATFwWKFSSU44rPe1sx4Mh3VWUFjFkq1pRqSwkj6BdGi1j1FN2eMpfac5r/jJtFDXv7jWw1v2wXsXlGwt8MdX98X7lhoUIwWrCMYRW6KUV2IgSlKTxk8SdGKisIrA2GpsAAAAAAf/Z
+      keywords:
+        - amd64
+        - deploy
+        - Catalog
+        - Commercial
+        - Limited
+        - Other
+        - RHOCP
+      kubeVersion: '>=1.20.0-beta.2'
+      maintainers:
+        - name: IBM
+      name: ibm-operator-catalog-enablement
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
+      version: 1.0.0
+generated: "2020-03-30T16:27:13.4275217-05:00"

--- a/pkg/helm/chartproxy/testdata/incompatibleRepoIndex.yaml
+++ b/pkg/helm/chartproxy/testdata/incompatibleRepoIndex.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+entries:
+  ibm-cpq-prod:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.17.0'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+  ibm-object-storage-plugin:
+    - apiVersion: v2
+      appVersion: 2.0.0
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      kubeVersion: '>=1.17.0'
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+      version: 2.0.0
+    - apiVersion: v2
+      appVersion: 2.0.1
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      kubeVersion: '>=1.17.0'
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.1.tgz
+      version: 2.0.0
+  ibm-oms-ent-prod:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.17.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/mergedRepoIndexPreReleaseV1-20-0-0.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedRepoIndexPreReleaseV1-20-0-0.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+entries:
+  ibm-oms-ent-prod-5--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.20.0-0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-03-30T16:27:13.4275217-05:00"

--- a/pkg/helm/chartproxy/testdata/mergedRepoIndexPreReleaseV1-20-0-alpha2.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedRepoIndexPreReleaseV1-20-0-alpha2.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+entries:
+  ibm-cpq-prod--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.20.0-alpha.2'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+generated: "2020-03-30T16:27:13.4275217-05:00"

--- a/pkg/helm/chartproxy/testdata/mergedRepoIndexPreReleaseV1-20-0-beta2.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedRepoIndexPreReleaseV1-20-0-beta2.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+entries:
+  ibm-cpq-prod--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.20.0-alpha.2'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+  ibm-operator-catalog-enablement--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 1.0.0
+      created: "2020-07-15T16:32:34.697730479+05:30"
+      description: |
+        IBM Operator Catalog enablement deploys custom CatalogSources for operators
+        available to deploy and maintain IBM products.  The operators are publically
+        available, but products they install may require purchase and entitlement keys.
+
+        Documentation
+        For additional details regarding installation see https://ibm.biz/operator-catalog-readme
+
+        License
+        By installing this catalog you accept the license terms https://www.apache.org/licenses/LICENSE-2.0
+      digest: 5a765d2f3f36f1b35c403a546df3590e3d6014cbf86bd36775f8febb54baa58c
+      home: http://ibm.biz/oprcatalog
+      icon: data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxITEhUQEhAVEhEVFRUQFxgVGBUQEBgSFREXFhcXFxUYHiggGBolHRUWITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGxAQGi0mHyYtLS0wLy4tKy8tMistLS0tLS8vLS0tLS0rLS0uLS0tLS0tLS0vLS0tLS0tLS0tLS0tLf/AABEIANMA7wMBEQACEQEDEQH/xAAbAAEAAgMBAQAAAAAAAAAAAAAABQYCAwQBB//EAEYQAAIBAQQFBwgHBgUFAAAAAAABAgMEBREhBhIxQVEiYXGBkaGxEyMyUlSjwdIzQmJygsLRFBaisuHwB0NTc5IVJDREs//EABoBAQACAwEAAAAAAAAAAAAAAAAEBQECAwb/xAA5EQACAQICBwYFAwMFAQEAAAAAAQIDBBEhBRIxQVGh0RMVUnGBsSIyYeHwQpHBFCMzNENygvHCYv/aAAwDAQACEQMRAD8A+4gAAAAAAAAAAAAAAAAAAAArmk1eWvGnjhHV1sOLcms+Ow70lliea03Wn2ipp5YY830OjRmvKSnFvFR1Wsc8MccujIxVSWDJGhK05xnCTxSww9cehNnEvQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVbSh+eX+2v5pEqj8p5XTf+oX/Fe7OnRR/Sfg/OaV9xJ0Dtqf8AX+SwHA9CAAAAAAAAAAAAAAAAAAAAAAAAAAAACD0sttSnTioNx1pNOSyeSxwT3Y/AlWsIyk8Sp0tcVKVNKDwxe0jdGb5lr+SqTcoyyi5NyaluWLzwf6HW4orV1oog6Mv5qp2VSWKezHj5/UtxAPSAAAAAAAAqmlT88v8Abj/PMl0Pl9Ty2m/9Qv8AivdnTok/pfwfnNbjcSNA7an/AF/+ixEY9CAAAAAAACs3neUpTahNxgslqtrHnxR2jHBHkr/SNSpVapyaitmDwx+pMXPXlOmnLN4tY8UjnNYMvdGV51rdSntzWPE7jUsAAAAAAAAAAAAAAAAAct5WJVqcqb3rJ8JLYzenNwkpI4XNBV6Tpvf7nzqpCUJOMspReD4pplwmpLFHipwlCTi8mi/XDePlqSk/TjyZdK39e0qq9Ps5Ybj19hdf1FFSe1ZPz+5InEmgAAAAAFU0sXnovc6aXWpSx8V2ky3+U8vptPt4v/8AP8s6dEF9K93IXWtbHxRpcbiRoJP+4/L+SxEY9AAAAAAARd/W3UhqJ8qeXRHe/gdKccXiVOlrvsaWpH5pe2/p/wCEBZKLnJQW19y3s6vJYnmbehKtUVOO8uFGkoxUVsSwI7eJ7mnTjTgoR2IzMG4AAAAAAAAAAAAAAAAABVNMrt2WiK4Rn4Rl8Own2dX9D9Cg0xa/78fJ/wAP+P2IjR+8vI1U2+RLkz6N0urwxJFelrxy2ldYXX9PVxfyvJ9fQ+hIqD2AAAAAABptVlhUWE4qS59q6HuNoycdhxrUKdZYVFiZUKEYLVhFRjwRhybeLNqdKFOOrBYI2GDoAAAADGpNRTk3gksX0IyliazmoRcpbEUu22p1Jub37FwjuRKjHBYHiLq4dxVdR+nkT+j1j1Y+Ua5UtnNH+u3sONSWeB6DQ9p2dPtZbZe332/sS5yLkAAAAAAAAAAAAAAAAAAAGFekpxcJLGMk4tczMxbi8UazgpxcZbGfPbbctaFR01SnNY8mUYtxa3PFZJ8cdhcQrwlHHFI8hWsa1Oo4KLfBpbfzeXu7KMoUqcJvGUYRi9+aWzHeVNSSlNtHqraEqdGMZbUkdRodwAAAAAAAAAAAAAcN9UJToyjDN5PDik8cDpTaUsyDpGjOrbyjDbl65leuy7JzmlKEowWcnJOPUsTvOaSyPO2Wj6lWqlOLUVtxWHpmW5IiHsD0AAAAAAAAAAAAAAAAAAAAAAAAA8bAIm26R2enlr+Ulwhyl/y2d5Iha1JbsPMrq2lLenlji/pnz2EPaNLpv0KcYrjJuT7FgSI2cVtZW1NNVH8kUvPPocFXSC0y/wA3D7qivhidVbU1uIc9J3Uv14eSRhTvavj9NPtDow4Gsb24b+dnbQvGt/qy7TnKlDgSY3dfxskaF51d8selI4ulHgTKd5WW8kKN5v60V1ZdxydLgTIXj/UjtpWqMt+D58jm4tEuFaEjcanUAAAAAAAAAAAAAAAAHPZ7fSm3GFWE5LaoyjJrpSZ0lSnFYyi16HKFanNtRkm1wZ0HM6gAAAAAAAAELfGkdKjjBecqr6qeSf2nu6NpKo2s6mbyRXXekqdD4VnLhw82U68b4rVny58n1VyYdm/rLKnQhT2I87cXlav87y4bvzzNdisVWq8KdOU92K9FdMnkjM5xh8zOdKhUqvCnFv8AOOwnbJojUedSpGHNFOb7cku8iTvY/pRZ0tC1H/kkl5Z9P5JSjopQXpSnLpaS7kR3dzezAnQ0NQXzNv16HVDR6zL/AC+2U38TR3NR7zvHRltH9PN9TZ/0Whuhh0OX6mvbz4m3d9Dw82Yu54bnJdjRntnvMOwp7mzB3bJbGn3Mz2iZo7SUdjxMVTayawGOJjUayZ1UajXQaNJkiEmjqhUTNGsCRGSZmYNgAAAAAAAADU7TBS1HOOtwxWt2GcHtOTr0lPUclrcMVj+xtMHUjtIaFSdmqwpem4tLDJvil0rFdZ3tpRjVi5bMSNdwnOhKMNuB8njKUJfWhOL54Ti/FM9M0pLimeQWtCXBr0aLbcumso4QtC147NeK5a+9H63Vn0lZcaNTzp5fQuLbS0o/DWzXFbfVdP2LrY7XTqxU6c1OL3rwfB8zKidOUHqyWDLynVhUjrQeKN5odAAADyTSWLeCWfNgA3gUrSHSlyxpWd4Q2Oayk+aPBc/9u1t7LV+Kpt4Hnb7SjnjCi8uPHy6/sV2yWedSShTi5Se5eLe5c7Js5RgsZPIqadKdSWrBYsuV0aJwjhKu/KS9VfRr4y8OYq617KWUMlzL+10RCPxVs3w3ff8AMiyQgkkkkksklkl1EJtvNlxGKisEsjIwZAAAAAAAB41jtBhpPaaZ0OBspcTm6fAwijYwkb4SNGjomZmDYAAAAGi12uFNa05JcOL6FvNoxcthwr3FOhHWqPAr1vv2c8qfIjx+u/0O8aSW087d6YqVPhpfCuf2/MyMpwcnhFOUnwzZu8tpUwhOpLVisWy8UU1GKk8ZJJN8+GZEe095TUlBKW3BY+ZmYNyNvi46NoXnI8rYpxymuveuZ5EihdVKL+F5cNxFuLSlXXxrPjvKFfei1ehjJLytL1orlJfajtXSsV0F1b31Ork8n+bGefudHVaOazjxX8oi7Bb6lGWvSm4S5tjXBrY0SalKNRas1iRKVadKWtTeB9E0V0g/aVKM4qNSCTeHoyT3pbtmwoby07Bpp5M9JYX39QmpLCSJ8hFiACg6WaReVboUn5pPCUl9drcvsrv6NtzZ2motee32+55vSV/2rdKn8u98ft7+W2Jua66lonqQySzlJ+jFfF8ESa9aNKOLINrazuJ6sfV8D6PdV2U6ENSmumT9KT4t/AoqtaVWWMj1VtbU7eOrBeu9naciQAAAAAAAAAAAAADyUcTOJhoxwBgyRgyegyACFvy+XSfk4LlYYtvNLHgt7O9KlrZsp9I6SlQl2dNZ4beBWataUnrSk5Se95slKKWw8zUqTqS1pvFkrd1xznyp+bj/ABvq3dZxnVS2FnaaJq1fiqfCuf29f2LJZLHCmsIRw4vbJ9LI0pOW09Jb21KhHCmsPc3mp3AAAABXr60SoV25x8zUeeMVjFv7UN/SsCdQv6lLJ5r83ldc6NpVviXwv6fyjo0c0fjZVLluc5YYyw1VgtiSzw28TS6u3XaywSOlnZRtk88W95MkQmlV03vvycf2em/OTWMmtsYPd0vwx5iysLbXfaS2L3+xUaUvOzj2UNr2/Rfcpl12GdepGlDa9r3Ritsn/fAta1SNKDlIoaFCVaahD/xcT6ldl3woU1Sgslte+Ut8nznnKtWVWWtI9fb0IUIKEDrOZ2AAAAAAAAAAAAAAAAB45LiDDaPNdcUZwGsuJkYMgAir2uVVpKanqSwweWsmujFZnanWcFgVl9o2NzJTUsH5Y9Dbd10U6WaWtP1nt6luNZ1ZSOlro6jb5pYy4v8AjgSBzJ4AAAAAAAAAAOe32uNKnKrL0Ypy6eCXO3l1m9Om6klFbznVqKnBzlsR8kttolUnKrN4yk3J/BdCWC6j1FOChFRjsR46rOVSbnLaz6Nojc/kKOtJedqYSlxS+rDq387ZQ3tx2s8FsX5iel0da9hTxl8z29PzeTpCLAAAAAAAAAAAAAAGMppGUsTDeBplWe7I21TnKb3GmcnxNkcZNs0yNjkzVIyjmzHWa2NroyM4Gus1sNkLdNb8en9TV00zeNzOP1OyheEJZPkvn2dppKm0Sqd1CWTyZ1nMkgAAAAAAAAAAAFS08tb1YUFv85LoWUV24vqRaaNp5uo/IqdKVMlTXm/4IPRS6/K2hOS5FPzj4Np8ldufUyZe1uzpZbXkQLC37Ssm9iz6H0k8+elAAAAAAAAAAAAABjJmTDZqaNjQKjxDkNQ2KkuBrizKhEyUVwMYm2CDiuAxGCNU7NB7Yrqy8DZSaNJUYPajlrXb6sup/qbqrxI07PwsjLRSlF4SWHgdotPYQKkJQeEkbLJeMoZPlR4b10GJU1I3o3UqeTzRN0K0ZrWi8URmmngy2p1IzjrRNhg3AAAAAAAAAKDfkvKVpy3Y6q6I5fDHrLy3WpTSKC5evVb/ADIsOiFk1KLnvnJv8Mcl349pAvqmtUw4FjYU9WnjxJ0hE4AAAAAAAAAAAA8ZkwzzAGD1IwbHoAAAAAAAAMalNSWDWKMptbDWUVJYNEDeV3uHKjnDvXTzc5Jp1NbJ7SourV0/ijs9jksdtdOWKzW9cV+pvOCkiNQuJUZYrZvRZ6FVTipReKZDaaeDL+nOM4qUdhsMG4AAB42DGITMgxrTwi5cE32IRWLSEngsSjypF1iUrgXWx0dSEYerFLrwzKepLWk2XFOOrFI3GhuAAAAAAAAAAAAAAAAAAAAAAAAAAAeNbgGsSsXxYfJyxXoS2cz4E2lPWWe0oL227GWK+V/mBlcVv1J6knyZPDolu7dnYYrU8VijNhc9nPUex+5ZiGXwANVWrhlvNlHE1lLAxhIyzVM3JGhvgarb9HL7r8Den8yNanysr1Oz4tLnXiT3PIhKOZZytLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA02uzqpBwexrse5m0ZOLxRzrUlVg4PeUivFxk4vJptPpRZRzWKPKTi4ScXtRcLntflaUZP0lyZdK/XJ9ZX1YaksD0tnX7akpPbsfmdNeqoxcnu8TWMdZ4EiUtVYkUq7bxe1kpxwI+tiSlCGCz2kWTxZIisDaamxrtK5Mug2h8yNZbGRlKnmuleJJlLIjpZkuRCUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACqaV2fVqRqLZNYP70f6NdhPtZYxw4Hn9K0tWoprf7oz0RtPLnT4rXXSng/Fdhi6jkpG+iauE5Q45nbftq5Spp7FrPpez++cxbU8nIsbieeqeXNHXlrPZHPrewXD1VhxFBazxJwhEwAGM1kzK2mHsOdQN8TngdRzOoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITS6njQUvVmn1PFfFEq0fx4FZpaONDHg10K5cNfVrwe7lJ9Go/6EyvHGmynsZuFeL8/Zi9LbrVqjx+u49UeSvAk0KWFKK+haVZ4zbLVo5DChGW+Tcu/BdyKq8f91rgT7ZYU8eJKEUkAAAGvVNsTXAzRqbHoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABFaUf+NU/B/8ASJItf8q9fYg6S/00vT3RRaVRpprb/QtWsUeXi2nijjqV223xbfa8SxUElgWzli8T6dci/wC3o/7UH2wTPL3P+afm/cu6P+OPkjtOJ1AAAPMAYPQZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCaX1cLM160ox79b8pKs1jVK7SssLdri11/gqNz0tetCGGOOt3Qk/gWVZ6sGygtIa9aMfP2ZFWxatScfVnKPZJr4FnT+KCfFInzyk0fTdHaqlZqLX+nGPXFar8DzF3HVrzX1fMu7d40o+RIkc7AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqGnVrzp0VuxqP+WP5iysIZOXoUWmKucafr/C/k5tCaGtXc90IfxSyXcpHS+lhTS4nHRNPWrOXBe/4yE0vs3k7XUW6bVVfjzf8WsWmj6mvbx+mX7fbA73UNWq/rmWn/D23a1CVJvOnLFfcnmu/WKrS1LVqqfFc1+InWFTGDjwLUVROAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMatRRTlJ4RScm3sSSxbMpNvBGJSUVi9h8uvS3+Wqzq7pPJcIrJLsPQUqXZwUTx9xWdao58fbcXbQ+xeToKT9Ko9f8OyPdn1lTe1Napgt2R6DRlHs6Os9ss/TcRv+Id261ONois6fJl9yT29T8WTdEV9Wbpvfs8zN/Sxiprd7FQ0bvf8AZq8aj9B8if3Hvw4p4Pq5y4vLbt6Tjv2rzK+3rdlNS3bz65CaaTTTTWKazTT2NM8g008GX6eOaMjBkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFL03vv/1ab56jXdD4vqXEtrC2/wB2Xp1KLSt5/sw9enUgtHrtdorKH1FypvhBbul7O17iZc1lShjv3FdZ27r1VHdtfl9z6hFYZLJLI86euSwMa1KM4uEljGScWnsaawaMxk4tSW1GGk1gz5BpHdErLWdN4uD5VOXGH6rY+3eexs7mNxT1lt3r6/mw8/cUXSnqvZuJ3QjSpU8LNXlhT2U5vZHH6sn6vB7ujZA0lo9z/u01nvXH6+ZKs7vV/tz2bmfRTzhbgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFS0p0rVPGjQknV2Sms4w5lxl4FnZ2Ln8dTZw4/Yp7/SKp406T+Le+H39ij2WjOpNQgnOcngltbbzbb72y4nKMI60skihhCVSSjHNs+pXBdEbNSUFnN8qcuMubmW485c13Wnju3HrLO1VvT1d+9/UkyOSgAR9+XRTtVJ0qmW+Ml6UZbmv03ki2uZ289ePquKOVajGrHVkfIb6umrZqjp1Y/dkvQmuMX8NqPYW1zTuIa0H6b0efrUZUpasiV0b0zq2ZKnUTrUFklj5yC+y3tX2X1NES80XTr/ABRylyfn19zvb3s6XwvNcz6LdOkFmtC81VTl6j5NRfhefWsjzlxZVqHzxy47v3LelcU6vyvqShFO4AAAAAAAAAAAAAAAAAAAAAAAAAABE3npHZqGU6qcvUhy59i2deBKo2dar8scuLyRFr3tGj80s+CzZSL80xrV8YU/M0nlk/OSXPLcuZdrLi30dTpZyzfIo7rSdSr8MPhXP9+n7kLd1hqVpqnSg5S7Elxk9yJdWpCnHWmyBRozqy1ILFn03RzR+Fljj6daS5U/yx4Lx8PO3V3Ku+C4HqLOyjbx4ye19PoTREJoAAAAOW8bvpV4OlVgpwe57U+Ke1PnR1o1p0Za8HgzSpTjUjqyWKPnV/aAVqeM7O/LQ26rwjWS8Jdz5j0drpmnP4avwvju+xT19HzjnDNc/uUu00pQlqzjKE1uknGS6nmXcJRmsYvFFdJOLweTO2y6SWyllC1VEuDl5Rdk8ThOxtqnzQXt7HWNzWjsk/zzOp6dXj7T7uj8hy7os/Bzl1N/6+48XJdB+/l4+0+7o/IO57Pwc5dTHeFx4uS6D9/Lx9p93R+Qd0Wfg5y6jvC48XJdB+/l4+0+7o/IY7os/Bzl1Md4XHi5LoFp3eHtPu6PyDuiz8HOXUx3hc+LkuhktOrw9p93R+Qx3RZ+DnLqO8Lnxcl0Pf36vD2n3dH5DHdNp4Ocuo7wufFyXQ9WnN4e0+7pfKY7ptPBzfUx3hc+LkuhktOLw9o93S+Ux3TaeDm+o7xufFyXQ9/fi3+0e7pfKY7qtPBzfUd43Pi5LoerTe3+0e7pfKY7qtfBzfUd43Pi5LoZLTa3+0e7pfKY7rtfBzfUd43Pi5LoerTW3+0e7pfKY7rtfBzfUd43Pi5LoZLTW3+0e7pfKY7rtfBzfUx3jc+Lkuh6tNLd7R7ul8pjuy18PN9R3jc+Lkuh6tM7d7R/BS+Ux3ZbeHm+o7xufFyXQS0wtzy/aH1Qpr8oWjbZfo5vqYekbl/r5LocNqve0VPpK9SS4OTUf+KyO0LalD5YpehwncVZ/NJv1NFks06j1acJTlwinJ9eGw2nOMFjN4eZyhTlN4QWPkW65tBas8JWiXko+rHCVR9fox7yrr6UhHKmsXx3dXyLW30TOWdV4LgtvRcy9Xdd1KhDUpQUI78NrfFva30lJVrTqy1pvEvKNGFKOrBYI6jmdQAAAAAAAADntlipVVq1aUKkeE4qa7zpTqzpvGEmvJms4RmsJLEp+kWiVigtaFDVbx2TqJZLhrYIuLPSVzJ4Slj6LoV9ezorNR9z5fb6ajNpLBJvn8T1NKTlFNlJUSUsEczOpzBgwegwAD1GGDJGpg9RgGaMMHqMGDJGoPUYBkjBgyRhgyRqDJGATFwWKFSSU44rPe1sx4Mh3VWUFjFkq1pRqSwkj6BdGi1j1FN2eMpfac5r/jJtFDXv7jWw1v2wXsXlGwt8MdX98X7lhoUIwWrCMYRW6KUV2IgSlKTxk8SdGKisIrA2GpsAAAAAAf/Z
+      keywords:
+        - amd64
+        - deploy
+        - Catalog
+        - Commercial
+        - Limited
+        - Other
+        - RHOCP
+      kubeVersion: '>=1.20.0-beta.2'
+      maintainers:
+        - name: IBM
+      name: ibm-operator-catalog-enablement
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
+      version: 1.0.0
+generated: "2020-03-30T16:27:13.4275217-05:00"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndex3.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndex3.yaml
@@ -1,0 +1,306 @@
+apiVersion: v1
+entries:
+  ibm-cpq-prod:
+    - apiVersion: v2
+      appVersion: 10.0.0.6
+      created: "2020-07-15T16:32:34.607411698+05:30"
+      description: |-
+        IBM Sterling Configure, Price, Quote (CPQ) solution enables you to quickly configure, price, quote and order the right products and services.\n
+        To sell competitively in todayâ€™s multichannel environment, organizations need a way to easily manage product and service configuration and pricing rules that allow prospects, customers, sales staff, call center representatives and Business Partners to quickly find, configure and order the right products and services.\n
+        IBMÂ® Sterling Configure, Price, Quote solution automates every step of the configure, price and quote process to help organizations easily create Web storefronts, offer dynamic catalog and pricing information,  and direct customers and partners to find, configure and order the right products and services.\n
+        This enables you to transform how you sell complex products and services by removing the internal complexity of multi-tiered selling within your organization and with your partners.\n
+
+        Documentation\n
+        Additional information about installation can be found at https://ibm.biz/BdqqUS.
+
+        License\n
+        Sterling Configure Price Quote Software is licensed under https://ibm.biz/Bdqqgd which must be accepted during the install of the Product.
+      digest: 2d93c570ff47b27858901dacafc22fe64d868e9a8ecb4742867396f2912eded8
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - cpq
+        - ifs
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - framework
+        - Commercial
+        - RHOCP
+        - All items
+        - Languages
+        - Databases
+        - Middleware
+        - CI/CD
+        - Other
+      kubeVersion: '>=1.17.0'
+      maintainers:
+        - name: IBM
+      name: ibm-cpq-prod
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+      version: 2.0.0
+  ibm-object-storage-plugin:
+    - apiVersion: v2
+      appVersion: 2.0.0
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      kubeVersion: '>=1.17.0'
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+      version: 2.0.0
+    - apiVersion: v2
+      appVersion: 2.0.1
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      kubeVersion: '>=1.15.0'
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.1.tgz
+      version: 2.0.0
+  ibm-oms-ent-prod:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+  ibm-oms-ent-prod-2:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>= 1.13.0 < 1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+  ibm-oms-ent-prod-3:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>= 1.13.0 <= 1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+  ibm-oms-ent-prod-4:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>= 1.13.0 < 1.14.0 || >= 1.14.1 < 1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+  ibm-oms-ent-prod-5:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.20.0-0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndex3FilteredKube1-16-0.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndex3FilteredKube1-16-0.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+entries:
+  ibm-object-storage-plugin--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 2.0.1
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      kubeVersion: '>=1.15.0'
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.1.tgz
+      version: 2.0.0
+  ibm-oms-ent-prod--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndexFilteredKube1-14-0.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndexFilteredKube1-14-0.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+entries:
+  ibm-oms-ent-prod-3--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>= 1.13.0 <= 1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+  ibm-oms-ent-prod-2--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>= 1.13.0 < 1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndexFilteredKube1-15-0.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndexFilteredKube1-15-0.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+entries:
+  ibm-object-storage-plugin--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 2.0.1
+      created: "2020-07-15T16:32:34.612556197+05:30"
+      description: |
+        Chart for deploying ibmcloud object storage plugin.
+        IBM Cloud Object Storage is persistent, highly available storage
+        that you can mount to apps that run in a Kubernetes cluster by using
+        the IBM Cloud Object Storage plug-in. The plug-in is a Kubernetes Flex-Volume plug-in
+        that connects Cloud Object Storage buckets to pods in your cluster.
+
+        Documentation
+        For additional details regarding install parameters see here
+        ibm.biz/BdqPR6
+
+        License
+        By installing this product you accept the license terms.
+        https://www.apache.org/licenses/LICENSE-2.0
+      digest: 469e5e4093386c9b2a2f50cf55197db1c2489832bd3bc72018a17f0df9553474
+      icon: https://cache.globalcatalog.cloud.ibm.com/static/cache/2461-acb0d10a1725d783/images/uploaded/icons/object-storage.png
+      keywords:
+        - IKS
+        - amd64
+        - Storage
+        - Commercial
+        - Limited
+        - Other
+        - ROKS
+      maintainers:
+        - email: contsto2@in.ibm.com
+          name: IBM
+      name: ibm-object-storage-plugin
+      kubeVersion: '>=1.15.0'
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.1.tgz
+      version: 2.0.0
+  ibm-oms-ent-prod--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>=1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+  ibm-oms-ent-prod-3--sample-repo-1:
+    - apiVersion: v2
+      appVersion: 10.0.0
+      created: "2020-07-15T16:32:34.663118186+05:30"
+      dependencies:
+        - alias: sch
+          name: ibm-sch
+          repository: '@sch'
+          version: 1.2.15
+      description: |-
+        IBM Order management Software Enterprise Edition v10 provides cross-channel order orchestration capabilities to enable intelligent brokering of orders across many disparate systems. It also provides a global view of inventory across the supply chain and enables business users to make changes to order process.
+
+        For additional details regarding install parameters check: http://ibm.biz/oms-helm-readme.
+
+        By installing this product you accept the license terms http://ibm.biz/oms-license and http://ibm.biz/oms-apps-license.
+      digest: f01226a974704ea84685d95ad48feae8666ea154254cdca888859430d5517961
+      icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ibm-oms-logo.png
+      keywords:
+        - oms
+        - sterling
+        - yantra
+        - order
+        - fulfillment
+        - om
+        - amd64
+        - ppc64le
+        - framework
+        - Commercial
+        - RHOCP
+        - Other
+      kubeVersion: '>= 1.13.0 <= 1.15.0'
+      maintainers:
+        - name: IBM
+      name: ibm-oms-ent-prod
+      type: application
+      response:
+        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+      version: 5.0.0
+generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -412,7 +412,8 @@ func (s *Server) HTTPHandler() http.Handler {
 	}
 	kubeVersion, err := actions.GetKubeVersion(config)
 	if err != nil {
-		klog.Warningf("Failed to get cluster k8s version %s", err.Error())
+		kubeVersion = os.Getenv("KUBE_GIT_VERSION")
+		klog.Warningf("Failed to get cluster k8s version from api server %s, falling back to env var KUBE_GIT_VERSION", err.Error())
 	}
 
 	helmHandlers := helmhandlerspkg.New(s.K8sProxyConfig.Endpoint.String(), s.K8sClient.Transport, kubeVersion)


### PR DESCRIPTION
- This PR enables support to filter charts based on the kubernetes version. 
- `onlyCompatible` flag is provided to `/api/helm/charts/index.yaml` API which drops the unsupported charts from the response.

Ref: https://issues.redhat.com/browse/HELM-12