### PR TITLE
Fix po-to-i18n script

### DIFF
--- a/frontend/i18n-scripts/.eslintrc.js
+++ b/frontend/i18n-scripts/.eslintrc.js
@@ -1,0 +1,68 @@
+var fs = require('fs');
+
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es6: true,
+    jasmine: true,
+    jest: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:import/errors',
+    'plugin:import/warnings',
+    'plugin:console/prettier',
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+    comment: true,
+    ecmaVersion: 2017,
+    sourceType: 'module',
+    tsconfigRootDir: './',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    camelcase: [
+      'error',
+      { allow: [] },
+    ],
+    'consistent-return': 0,
+    'consistent-this': [1, 'that'],
+    curly: [2, 'all'],
+    'default-case': [2],
+    'dot-notation': [2],
+    'no-multiple-empty-lines': [2, { max: 2, maxEOF: 0 }],
+    eqeqeq: [2, 'allow-null'],
+    'guard-for-in': 2,
+    'import/no-unresolved': ['error'],
+    'import/no-duplicates': ['error'],
+    'max-nested-callbacks': [1, 4],
+    'no-alert': 2,
+    'no-caller': 2,
+    'no-console': 0,
+    'no-constant-condition': 2,
+    'no-debugger': 2,
+    'no-else-return': ['error'],
+    'no-global-strict': 0,
+    'no-irregular-whitespace': ['error'],
+    'no-prototype-builtins': 0, // Disable with exlint v6 update.
+    'no-shadow': ['error'],
+    'no-undef': 0,
+    'no-underscore-dangle': 0,
+    'no-var': 2,
+    'object-shorthand': ['error', 'properties'],
+    'prefer-const': ['error', { destructuring: 'all' }],
+    'prefer-template': 2,
+    radix: 2,
+    'require-atomic-updates': 0,
+  },
+  settings: {
+    'import/extensions': ['.js'],
+    'import/resolver': { node: { extensions: ['.js'] } },
+  },
+  globals: {
+    process: 'readonly',
+  },
+};

--- a/frontend/i18n-scripts/common.js
+++ b/frontend/i18n-scripts/common.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 
-// eslint-disable-next-line no-undef
 module.exports = {
   isDirectory: function(filePath) {
     try {
@@ -27,7 +26,6 @@ module.exports = {
           argFunction(filePath, package);
         }
       } catch (e) {
-        // eslint-disable-next-line no-console
         console.error(e);
       }
     })();
@@ -36,7 +34,6 @@ module.exports = {
     try {
       fs.unlinkSync(filePath);
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error(e);
     }
   },

--- a/frontend/i18n-scripts/consolidate-public-folders.js
+++ b/frontend/i18n-scripts/consolidate-public-folders.js
@@ -2,9 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const common = require('./common.js');
 
-// eslint-disable-next-line no-undef
 const public = path.join(__dirname, './../public/locales/');
-// eslint-disable-next-line no-undef
 const packages = path.join(__dirname, './../packages');
 
 const publicFileNames = {};
@@ -12,15 +10,12 @@ const publicFileNames = {};
 function processFile(fileName) {
   const language = path.basename(path.dirname(fileName));
   if (publicFileNames[language].includes(path.basename(fileName))) {
-    // eslint-disable-next-line no-console
     console.log(`Merging ${fileName} with matching public namespace.`);
     const file = require(fileName);
-    /* eslint-disable no-undef, no-console */
     const publicFile = path.join(
       __dirname,
       `./../public/locales/${language}/${path.basename(fileName)}`,
     );
-    /* eslint-enable */
     const keys = Object.keys(file);
 
     const data = fs.readFileSync(publicFile);
@@ -31,7 +26,6 @@ function processFile(fileName) {
       if (!json.hasOwnProperty(keys[i])) {
         json[keys[i]] = file[keys[i]];
       } else {
-        // eslint-disable-next-line no-console
         console.log(
           `Conflict: Key "${keys[i]}" in ${publicFile} already exists. Skipping merge for "${keys[i]}."`,
         );

--- a/frontend/i18n-scripts/i18n-to-pot.js
+++ b/frontend/i18n-scripts/i18n-to-pot.js
@@ -25,14 +25,12 @@ function removeValues(i18nFile, filePath) {
 
   fs.writeFile(tmpFile, JSON.stringify(updatedFile, null, 2), function writeJSON(e) {
     if (e) {
-      // eslint-disable-next-line no-console
       return console.error(e);
     }
   });
 }
 
 function processFile(fileName, package, language) {
-  /* eslint-disable no-undef, no-console */
   if (package) {
     const i18nFile = path.join(__dirname, `./../packages/${package}/locales/en/${fileName}.json`);
 
@@ -74,7 +72,6 @@ function processFile(fileName, package, language) {
     common.deleteFile(tmpFile);
     console.log(`Processed ${fileName}`);
   }
-  /* eslint-enable */
 }
 
 const options = {
@@ -97,7 +94,6 @@ const options = {
 const args = minimist(process.argv.slice(2), options);
 
 if (args.help) {
-  // eslint-disable-next-line no-console
   return console.log(
     "-h: help\n-l: language (defaults to 'ja')\n-p: package (i.e. 'dev-console'; defaults to undefined)\n-f: file name to convert (i.e. 'nav')",
   );

--- a/frontend/i18n-scripts/po-to-i18n.js
+++ b/frontend/i18n-scripts/po-to-i18n.js
@@ -3,9 +3,7 @@ const path = require('path');
 const common = require('./common.js');
 const { gettextToI18next } = require('i18next-conv');
 
-// eslint-disable-next-line no-undef
 const public = path.join(__dirname, './../public/locales/pos');
-// eslint-disable-next-line no-undef
 const packages = path.join(__dirname, './../packages');
 
 function save(target) {
@@ -24,16 +22,37 @@ function processFile(fileName, package) {
   if (fileName.includes('ja_JP')) {
     language = 'ja';
     remainingPath = fileName.split(/-ja_JP\.po+/g)[0];
+  } else {
+    console.error(
+      "You must provide a PO name that includes the language in the following format: 'ja_JP' or 'zh_CN'",
+    );
+    return;
   }
   const newFileName = remainingPath.split('/');
 
   let newFilePath;
   if (package) {
-    newFilePath = `./../packages/${package}/locales/${language}/${
-      newFileName[newFileName.length - 1]
-    }.json`;
+    if (!fs.existsSync(path.join(__dirname, `./../packages/${package}/locales/${language}`))) {
+      fs.mkdirSync(path.join(__dirname, `./../packages/${package}/locales/${language}`), {
+        recursive: true,
+      });
+    }
+    newFilePath = path.join(
+      __dirname,
+      `./../packages/${package}/locales/${language}/${newFileName[newFileName.length - 1]}.json`,
+    );
+    console.log(
+      `Saving packages/${package}/locales/${language}/${newFileName[newFileName.length - 1]}.json`,
+    );
   } else {
-    newFilePath = `./../public/locales/${language}/${newFileName[newFileName.length - 1]}.json`;
+    if (!fs.existsSync(path.join(__dirname, `../public/locales/${language}/`))) {
+      fs.mkdirSync(path.join(__dirname, `../public/locales/${language}/`), { recursive: true });
+    }
+    newFilePath = path.join(
+      __dirname,
+      `../public/locales/${language}/${newFileName[newFileName.length - 1]}.json`,
+    );
+    console.log(`Saving public/locales/${language}/${newFileName[newFileName.length - 1]}.json`);
   }
   gettextToI18next(language, fs.readFileSync(fileName)).then(save(newFilePath));
 }
@@ -51,7 +70,6 @@ function processPackages(filePath) {
   }
 }
 
-// eslint-disable-next-line no-console
 console.log('You must save PO files to locales/pos in order to use this tool.');
 
 if (fs.existsSync(public)) {

--- a/frontend/i18n-scripts/set-english-defaults.js
+++ b/frontend/i18n-scripts/set-english-defaults.js
@@ -3,9 +3,7 @@ const path = require('path');
 const pluralize = require('pluralize');
 const common = require('./common.js');
 
-// eslint-disable-next-line no-undef
 const public = path.join(__dirname, './../public/locales/');
-// eslint-disable-next-line no-undef
 const packages = path.join(__dirname, './../packages');
 
 function determineRule(key) {
@@ -59,7 +57,6 @@ function updateFile(fileName) {
 
   fs.writeFile(fileName, JSON.stringify(updatedFile, null, 2), function writeJSON(e) {
     if (e) {
-      // eslint-disable-next-line no-console
       return console.error(e);
     }
   });


### PR DESCRIPTION
I didn't realize recent file structure changes broke the script. I fixed that and added better handling for nonexistent directories and bad file names. I also updated .eslintignore so we could remove "ignore me linter!" comments.