### PR TITLE
Bug 1890235: update Protractor's checkErrors logging

### DIFF
--- a/frontend/@types/console/declarations.d.ts
+++ b/frontend/@types/console/declarations.d.ts
@@ -41,7 +41,7 @@ declare interface Window {
     GOOS: string;
     graphqlBaseURL: string;
   };
-  windowError?: Error | PromiseRejectionEvent;
+  windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
   store?: {}; // Redux store
   pluginStore?: {}; // Console plugin store

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -270,7 +270,7 @@ function hasError() {
 export const checkErrors = async () =>
   await browser.executeScript(hasError).then((err) => {
     if (err) {
-      fail(`omg js error: ${err}`);
+      fail(err);
     }
   });
 

--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -39,22 +39,9 @@ after(() => {
   });
 });
 
-const formatWindowError = (windowError: Error | PromiseRejectionEvent) => {
-  if (!windowError) {
-    return 'no window error detected';
-  }
-  const { reason } = windowError as PromiseRejectionEvent;
-  if (reason) {
-    return reason;
-  }
-  const { message, stack } = windowError as Error;
-  const formattedStack = stack?.replace(/\\n/g, '\n');
-  return `window error detected: ${message} ${formattedStack}`;
-};
-
 export const checkErrors = () =>
   cy.window().then((win) => {
-    assert.isTrue(!win.windowError, formatWindowError(win.windowError));
+    assert.isTrue(!win.windowError, win.windowError);
   });
 
 export const testName = `test-${Math.random()

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -230,14 +230,17 @@ graphQLReady.onReady(() => {
   // Used by GUI tests to check for unhandled exceptions
   window.windowError = null;
   window.onerror = (message, source, lineno, colno, error) => {
+    const { stack } = error;
+    const formattedStack = stack?.replace(/\\n/g, '\n');
+    window.windowError = `unhandled error: ${message} ${formattedStack || ''}`;
     // eslint-disable-next-line no-console
-    console.error('Uncaught error', error);
-    window.windowError = error;
+    console.error(window.windowError);
   };
   window.onunhandledrejection = (promiseRejectionEvent) => {
+    const { reason } = promiseRejectionEvent;
+    window.windowError = `unhandled promise rejection: ${reason}`;
     // eslint-disable-next-line no-console
-    console.error('Unhandled promise rejection', promiseRejectionEvent);
-    window.windowError = promiseRejectionEvent;
+    console.error(window.windowError);
   };
 
   if ('serviceWorker' in navigator) {

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -137,11 +137,9 @@ i18n
       },
       saveMissing: true,
       missingKeyHandler: function(lng, ns, key) {
-        window.windowError = new Error(
-          `Missing i18n key "${key}" in namespace "${ns}" and language "${lng}."`,
-        );
+        window.windowError = `Missing i18n key "${key}" in namespace "${ns}" and language "${lng}."`;
         // eslint-disable-next-line no-console
-        console.error(`Missing i18n key "${key}" in namespace "${ns}" and language "${lng}."`);
+        console.error(window.windowError);
       },
     },
     () => {


### PR DESCRIPTION
Want to display better info than `omg js error: [object Object]`:

**Before:**
```
Failed Specs:
1) Alertmanager: Configuration : launches Alert Routing modal, edits and saves correctly
   Error: Failed: omg js error: [object Object]
```
**After:**
```
Protractor:

yarn run test-protractor-suite --suite dashboards --params.openshift true

Failed Specs:

1) Cluster Dashboard Details Card : has all fields populated
   Error: Failed: Missing i18n key "Activity" in namespace "dashboard" and language "en."
       at protractor_1.browser.executeScript.then /home/dtaylor/repos/openshift/origin/src/github.com/openshift/console/frontend/integration-tests/protractor.conf.ts:261:13
       ...
       ...

Cypress

./test-cypress.sh -p console -s 'tests/crud/other*' -h true

 1) Visiting other routes
       "after each" hook for "successfully displays view for route: /":
     AssertionError: Missing i18n key "Activity" in namespace "dashboard" and language "en.": expected false to be true


```