### PR TITLE
Show custom builder image in edit flows BuilderImage section

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
@@ -6,6 +6,8 @@ import { getActivePerspective } from '@console/internal/reducers/ui';
 import { RootState } from '@console/internal/redux';
 import { history } from '@console/internal/components/utils';
 import { useExtensions, Perspective, isPerspective } from '@console/plugin-sdk';
+import { k8sGet, K8sResourceKind } from '@console/internal/module/k8s';
+import { ImageStreamModel } from '@console/internal/models';
 import { NormalizedBuilderImages, normalizeBuilderImages } from '../../utils/imagestream-utils';
 import {
   createOrUpdateResources as createOrUpdateGitResources,
@@ -16,7 +18,7 @@ import { createOrUpdateDeployImageResources } from '../import/deployImage-submit
 import { deployValidationSchema } from '../import/deployImage-validation-utils';
 import EditApplicationForm from './EditApplicationForm';
 import { EditApplicationProps } from './edit-application-types';
-import { getPageHeading, getInitialValues } from './edit-application-utils';
+import { getPageHeading, getInitialValues, CreateApplicationFlow } from './edit-application-utils';
 
 export interface StateProps {
   perspective: string;
@@ -29,16 +31,14 @@ const EditApplication: React.FC<EditApplicationProps & StateProps> = ({
   resources: appResources,
 }) => {
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
+  const initialValues = getInitialValues(appResources, appName, namespace);
+  const pageHeading = getPageHeading(_.get(initialValues, 'build.strategy', ''));
   const imageStreamsData =
     appResources.imageStreams && appResources.imageStreams.loaded
       ? appResources.imageStreams.data
       : [];
-  const builderImages: NormalizedBuilderImages = !_.isEmpty(imageStreamsData)
-    ? normalizeBuilderImages(imageStreamsData)
-    : null;
 
-  const initialValues = getInitialValues(appResources, appName, namespace);
-  const pageHeading = getPageHeading(_.get(initialValues, 'build.strategy', ''));
+  const [builderImages, setBuilderImages] = React.useState<NormalizedBuilderImages>(null);
 
   const updateResources = (values) => {
     if (values.build.strategy) {
@@ -71,6 +71,43 @@ const EditApplication: React.FC<EditApplicationProps & StateProps> = ({
       />
     );
   };
+
+  React.useEffect(() => {
+    let ignore = false;
+
+    const getBuilderImages = async () => {
+      let allBuilderImages: NormalizedBuilderImages = !_.isEmpty(imageStreamsData)
+        ? normalizeBuilderImages(imageStreamsData)
+        : {};
+      const {
+        name: imageName,
+        namespace: imageNs,
+      } = appResources.buildConfig.data.spec?.strategy.sourceStrategy.from;
+      const selectedImage = imageName?.split(':')[0];
+      const builderImageExists = imageNs === 'openshift' && allBuilderImages?.[selectedImage];
+      if (!builderImageExists) {
+        let newImageStream: K8sResourceKind;
+        try {
+          newImageStream = await k8sGet(ImageStreamModel, selectedImage, imageNs);
+          // eslint-disable-next-line no-empty
+        } catch {}
+        if (ignore) return;
+        allBuilderImages = {
+          ...allBuilderImages,
+          ...(newImageStream ? normalizeBuilderImages(newImageStream) : {}),
+        };
+      }
+      setBuilderImages(!_.isEmpty(allBuilderImages) ? allBuilderImages : null);
+    };
+
+    if (pageHeading === CreateApplicationFlow.Git) {
+      getBuilderImages();
+    }
+
+    return () => {
+      ignore = true;
+    };
+  }, [appResources.buildConfig.data.spec, imageStreamsData, pageHeading]);
 
   return (
     <Formik

--- a/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
@@ -16,15 +16,15 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
   loadingImageStream,
   builderImages,
 }) => {
-  const { values, setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
-  const { selected, recommended, isRecommending, couldNotRecommend } = values.image;
+  const { values, setFieldValue, setFieldTouched, validateForm } = useFormikContext<FormikValues>();
+  const { selected, recommended, isRecommending, couldNotRecommend, tag } = values.image;
 
   React.useEffect(() => {
-    if (selected) {
-      setFieldValue('image.tag', _.get(builderImages, `${selected}.recentTag.name`, ''));
+    if (selected && !tag) {
+      setFieldValue('image.tag', builderImages?.[selected]?.recentTag?.name ?? '');
       setFieldTouched('image.tag', true);
     }
-  }, [selected, setFieldValue, setFieldTouched, builderImages]);
+  }, [selected, setFieldValue, setFieldTouched, builderImages, tag]);
 
   const fieldId = getFieldId('image.name', 'selector');
 
@@ -41,7 +41,7 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
 
   return (
     <FormGroup fieldId={fieldId} label="Builder Image">
-      {isRecommending && (
+      {isRecommending && !recommended && (
         <>
           <LoadingInline /> Detecting recommended builder images...
         </>
@@ -68,6 +68,11 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
         name="image.selected"
         loadingItems={loadingImageStream}
         recommended={values.image.recommended}
+        onSelect={() => {
+          setFieldValue('image.tag', '', false);
+          setFieldTouched('image.tag', true);
+          validateForm();
+        }}
       />
     </FormGroup>
   );

--- a/frontend/packages/dev-console/src/components/import/builder/BuilderSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderSection.tsx
@@ -20,7 +20,7 @@ const BuilderSection: React.FC<ImageSectionProps> = ({ image, builderImages }) =
       <FormSection title="Builder" fullWidth>
         <BuilderImageSelector loadingImageStream={!builderImages} builderImages={builderImages} />
       </FormSection>
-      {image.tag && (
+      {builderImages[image.selected] && image.tag && (
         <FormSection>
           <BuilderImageTagSelector
             selectedBuilderImage={builderImages[image.selected]}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5015

**Analysis / Root cause**: 
Application is not editable if a custom builder image is used

**Solution Description**: 
Show a new tile for the custom builder image in builder section of edit flows

**Screen shots / Gifs for design review**: 
![Peek 2020-10-29 19-20](https://user-images.githubusercontent.com/20724543/97582015-43458200-1a1b-11eb-8c64-69fbd7e8be18.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge