### PR TITLE
Add YAML switcher to pipeline builder form

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -14,6 +14,7 @@ type EditorContext = {
   editor: React.ReactNode;
   isDisabled?: boolean;
   sanitizeTo?: (preFormData: any) => any;
+  label?: string;
 };
 
 type SyncedEditorFieldProps = {
@@ -58,7 +59,7 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
     const newYAML = safeJSToYAML(formData, yamlData, { skipInvalid: true });
     setFieldValue(
       yamlContext.name,
-      yamlContext.sanitizeTo ? formContext.sanitizeTo(newYAML) : newYAML,
+      yamlContext.sanitizeTo ? yamlContext.sanitizeTo(newYAML) : newYAML,
     );
     changeEditorType(EditorType.YAML);
   };
@@ -97,12 +98,12 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
           name={name}
           options={[
             {
-              label: t('console-shared~Form View'),
+              label: formContext.label || t('console-shared~Form View'),
               value: EditorType.Form,
               isDisabled: formContext.isDisabled,
             },
             {
-              label: t('console-shared~YAML View'),
+              label: yamlContext.label || t('console-shared~YAML View'),
               value: EditorType.YAML,
               isDisabled: yamlContext.isDisabled,
             },

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
@@ -19,7 +19,7 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
 }) => {
   const { nodes, edges } = getTopologyNodesEdges(pipeline, pipelineRun);
   let content: React.ReactElement;
-  if (hasInlineTaskSpec(pipeline)) {
+  if (hasInlineTaskSpec(pipeline.spec.tasks)) {
     // TODO: Inline taskSpec is not yet supported feature
     content = (
       <Alert

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
@@ -1,11 +1,9 @@
 .odc-pipeline-builder-form {
+  overflow: auto;
+
   &__grid {
     grid-template-columns: minmax(0, 1fr);
-  }
-
-  &__content {
-    overflow: auto;
-    padding: 30px 30px 0 30px;
+    padding: 0 30px;
   }
 
   &__short-section {

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderFormEditor.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderFormEditor.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { useFormikContext } from 'formik';
+import { TextInputTypes } from '@patternfly/react-core';
+import { InputField } from '@console/shared';
+import { PipelineParameters, PipelineResources } from '../detail-page-tabs';
+import PipelineBuilderVisualization from './PipelineBuilderVisualization';
+import {
+  PipelineBuilderFormikValues,
+  PipelineBuilderTaskGroup,
+  SelectTaskCallback,
+  UpdateTasksCallback,
+} from './types';
+
+import './PipelineBuilderForm.scss';
+
+type PipelineBuilderFormEditorProps = {
+  namespace: string;
+  hasExistingPipeline: boolean;
+  taskGroup: PipelineBuilderTaskGroup;
+  onTaskSelection: SelectTaskCallback;
+  onUpdateTasks: UpdateTasksCallback;
+};
+
+const PipelineBuilderFormEditor: React.FC<PipelineBuilderFormEditorProps> = (props) => {
+  const { namespace, hasExistingPipeline, taskGroup, onTaskSelection, onUpdateTasks } = props;
+  const { status } = useFormikContext<PipelineBuilderFormikValues>();
+
+  return (
+    <>
+      <div className="odc-pipeline-builder-form__short-section">
+        <InputField
+          label="Name"
+          name="formData.name"
+          type={TextInputTypes.text}
+          isDisabled={hasExistingPipeline}
+          required
+        />
+      </div>
+
+      <div>
+        <h2>Tasks</h2>
+        <PipelineBuilderVisualization
+          namespace={namespace}
+          tasksInError={status?.tasks || {}}
+          onTaskSelection={onTaskSelection}
+          onUpdateTasks={onUpdateTasks}
+          taskGroup={taskGroup}
+        />
+      </div>
+
+      <div>
+        <h2>Parameters</h2>
+        <PipelineParameters addLabel="Add Parameters" fieldName="formData.params" />
+      </div>
+
+      <div>
+        <h2>Resources</h2>
+        <PipelineResources addLabel="Add Resources" fieldName="formData.resources" />
+      </div>
+    </>
+  );
+};
+
+export default PipelineBuilderFormEditor;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.scss
@@ -6,8 +6,4 @@
   &__title {
     margin: var(--pf-global--spacer--xs) 0 0 0;
   }
-
-  hr {
-    margin: 0;
-  }
 }

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
@@ -1,43 +1,20 @@
 import * as React from 'react';
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
-import { warnYAML } from './modals';
+import { Flex, FlexItem } from '@patternfly/react-core';
 import { TechPreviewBadge } from '@console/shared';
-import { Pipeline } from '../../../utils/pipeline-augment';
-import { goToYAML } from './utils';
 
 import './PipelineBuilderHeader.scss';
 
-type PipelineBuilderHeaderProps = {
-  existingPipeline: Pipeline;
-  namespace: string;
-};
-
-const PipelineBuilderHeader: React.FC<PipelineBuilderHeaderProps> = (props) => {
-  const { existingPipeline, namespace } = props;
-
-  return (
-    <div className="odc-pipeline-builder-header">
-      <Flex className="odc-pipeline-builder-header__content">
-        <FlexItem grow={{ default: 'grow' }}>
-          <h1 className="odc-pipeline-builder-header__title">Pipeline Builder</h1>
-        </FlexItem>
-        <FlexItem>
-          <Button
-            variant="link"
-            onClick={() => {
-              warnYAML(() => goToYAML(existingPipeline, namespace));
-            }}
-          >
-            Edit YAML
-          </Button>
-        </FlexItem>
-        <FlexItem>
-          <TechPreviewBadge />
-        </FlexItem>
-      </Flex>
-      <hr />
-    </div>
-  );
-};
+const PipelineBuilderHeader: React.FC = () => (
+  <div className="odc-pipeline-builder-header">
+    <Flex className="odc-pipeline-builder-header__content">
+      <FlexItem grow={{ default: 'grow' }}>
+        <h1 className="odc-pipeline-builder-header__title">Pipeline Builder</h1>
+      </FlexItem>
+      <FlexItem>
+        <TechPreviewBadge />
+      </FlexItem>
+    </Flex>
+  </div>
+);
 
 export default PipelineBuilderHeader;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
 import { LoadingBox } from '@console/internal/components/utils';
+import { hasInlineTaskSpec } from '../../../utils/pipeline-utils';
 import { PipelineLayout } from '../pipeline-topology/const';
 import PipelineTopologyGraph from '../pipeline-topology/PipelineTopologyGraph';
 import { getEdgesFromNodes } from '../pipeline-topology/utils';
@@ -48,6 +49,16 @@ const PipelineBuilderVisualization: React.FC<PipelineBuilderVisualizationProps> 
   if (tasksCount === 0 && taskGroup.tasks.length === 0) {
     // No tasks, nothing we can do here...
     return <Alert variant="danger" isInline title="Unable to locate any tasks." />;
+  }
+
+  if (hasInlineTaskSpec(taskGroup.tasks)) {
+    return (
+      <Alert
+        variant="info"
+        isInline
+        title="This Pipeline cannot be visualized. Pipeline taskSpec is not supported."
+      />
+    );
   }
 
   return (

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/const.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-cycle
+import { PipelineBuilderFormValues } from './types';
+
 export const TASK_INCOMPLETE_ERROR_MESSAGE = 'Incomplete Task';
 
 export enum UpdateOperationType {
@@ -25,3 +28,11 @@ export const nodeTaskErrors = [
   TaskErrorType.MISSING_REQUIRED_PARAMS,
   TaskErrorType.MISSING_RESOURCES,
 ];
+
+export const initialPipelineFormData: PipelineBuilderFormValues = {
+  name: 'new-pipeline',
+  params: [],
+  resources: [],
+  tasks: [],
+  listTasks: [],
+};

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/modals/index.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/modals/index.tsx
@@ -24,22 +24,3 @@ export const removeTaskModal = (taskName: string, onRemove: ModalCallback) => {
     submitDanger: true,
   });
 };
-
-export const warnYAML = (onAccept: ModalCallback) => {
-  confirmModal({
-    message: (
-      <ModalContent
-        icon={<ExclamationTriangleIcon size="lg" color={warningColor.value} />}
-        title="Switch to YAML Editor?"
-        message="Switching to YAML will lose any unsaved changes in this pipeline builder and allow you to build your pipeline in YAML.
-        Are you sure you want to switch?"
-      />
-    ),
-    submitDanger: true,
-    btnText: 'Continue',
-    executeFn: () => {
-      onAccept();
-      return Promise.resolve();
-    },
-  });
-};

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -36,7 +36,7 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
     selectedPipelineTaskIndex,
     taskResource,
   } = props;
-  const formikTaskReference = `tasks.${selectedPipelineTaskIndex}`;
+  const formikTaskReference = `formData.tasks.${selectedPipelineTaskIndex}`;
   const [taskField] = useField<PipelineTask>(formikTaskReference);
 
   const updateTask = (newData: Partial<UpdateOperationUpdateTaskData>) => {

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/types.ts
@@ -1,4 +1,5 @@
 import { FormikValues } from 'formik';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import {
   PipelineParam,
   PipelineResource,
@@ -7,6 +8,7 @@ import {
 } from '../../../utils/pipeline-augment';
 import { PipelineVisualizationTaskItem } from '../../../utils/pipeline-utils';
 import { AddNodeDirection } from '../pipeline-topology/const';
+// eslint-disable-next-line import/no-cycle
 import { TaskErrorType, UpdateOperationType } from './const';
 
 export type UpdateErrors = (errors?: TaskErrorMap) => void;
@@ -30,7 +32,13 @@ export type PipelineBuilderFormValues = PipelineBuilderTaskGrouping & {
   resources: PipelineResource[];
 };
 
-export type PipelineBuilderFormikValues = FormikValues & PipelineBuilderFormValues;
+export type PipelineBuilderFormYamlValues = {
+  editorType: EditorType;
+  yamlData: string;
+  formData: PipelineBuilderFormValues;
+};
+
+export type PipelineBuilderFormikValues = FormikValues & PipelineBuilderFormYamlValues;
 
 export type SelectedBuilderTask = {
   resource: PipelineResourceTask;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/validation-utils.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 
-export const validationSchema = yup.object({
+const pipelineBuilderFormSchema = yup.object({
   name: yup.string().required('Required'),
   params: yup.array().of(
     yup.object({
@@ -37,4 +38,16 @@ export const validationSchema = yup.object({
       runAfter: yup.string(),
     }),
   ),
+});
+
+export const validationSchema = yup.object({
+  editorType: yup.string(),
+  yamlData: yup.string().when('editorType', {
+    is: EditorType.YAML,
+    then: yup.string().required(),
+  }),
+  formData: yup.object().when('editorType', {
+    is: EditorType.Form,
+    then: pipelineBuilderFormSchema,
+  }),
 });

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
@@ -153,12 +153,12 @@ describe('pipeline-utils ', () => {
   });
 
   it('expect pipeline with inline task spec to return true', () => {
-    const hasSpec = hasInlineTaskSpec(mockPipelinesJSON[2]);
+    const hasSpec = hasInlineTaskSpec(mockPipelinesJSON[2].spec.tasks);
     expect(hasSpec).toBe(true);
   });
 
   it('expect pipeline without inline task spec to return false', () => {
-    const hasSpec = hasInlineTaskSpec(mockPipelinesJSON[0]);
+    const hasSpec = hasInlineTaskSpec(mockPipelinesJSON[0].spec.tasks);
     expect(hasSpec).toBe(false);
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -60,7 +60,7 @@ export const reRunPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipeli
 
 export const editPipeline: KebabAction = (kind: K8sKind, pipeline: Pipeline) => ({
   label: 'Edit Pipeline',
-  hidden: hasInlineTaskSpec(pipeline),
+  hidden: hasInlineTaskSpec(pipeline.spec.tasks),
   callback: () => {
     const {
       metadata: { name, namespace },

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -28,6 +28,7 @@ import {
   PipelineTaskRef,
   PipelineRunWorkspace,
   TaskRunKind,
+  PipelineTask,
 } from './pipeline-augment';
 import { pipelineRunFilterReducer, pipelineRunStatus } from './pipeline-filter-reducer';
 import {
@@ -180,10 +181,9 @@ const appendPipelineRunStatus = (pipeline, pipelineRun) => {
     return mTask;
   });
 };
-export const hasInlineTaskSpec = (pipeline: K8sResourceKind) => {
-  const tasks = pipeline?.spec.tasks ?? [];
-  return tasks.some((task) => !!(task.taskSpec && !task.taskRef));
-};
+export const hasInlineTaskSpec = (tasks: PipelineTask[] = []): boolean =>
+  tasks.some((task) => !!(task.taskSpec && !task.taskRef));
+
 export const getPipelineTasks = (
   pipeline: K8sResourceKind,
   pipelineRun: K8sResourceKind = {


### PR DESCRIPTION
**Story**: 
https://issues.redhat.com/browse/ODC-3662
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
Add a YAML switcher allowing the ability to dynamically switch between YAML view and form view, including persisting form data including errors in both views.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp0](https://user-images.githubusercontent.com/20013884/97590866-16966800-1a25-11eb-98e6-7d134fb04dfe.png)
![tmp1](https://user-images.githubusercontent.com/20013884/97590894-1b5b1c00-1a25-11eb-8f50-4aaaee11112c.png)
![tmp](https://user-images.githubusercontent.com/20013884/97842463-a7af5c80-1d0d-11eb-85d9-4e206f691dc5.png)
![tmp2](https://user-images.githubusercontent.com/20013884/97590936-20b86680-1a25-11eb-8fa0-0d0a9692d55e.png)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @openshift/team-devconsole-ux @andrewballantyne @karthikjeeyar 