### PR TITLE
Fix to warn user when creating an application grouping that exists

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -1,0 +1,8 @@
+{
+  "Select application": "Select application",
+  "Application": "Application",
+  "Application Name": "Application Name",
+  "Warning: the application grouping already exists.": "Warning: the application grouping already exists.",
+  "A unique name given to the application grouping to label your resources.": "A unique name given to the application grouping to label your resources.",
+  "Select an application for your grouping or {{UNASSIGNED_LABEL}} to not use an application grouping.": "Select an application for your grouping or {{UNASSIGNED_LABEL}} to not use an application grouping."
+}

--- a/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Firehose } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ServiceModel } from '@console/knative-plugin';
@@ -42,6 +43,7 @@ interface ApplicationDropdownProps {
 }
 
 const ApplicationDropdown: React.FC<ApplicationDropdownProps> = ({ namespace, ...props }) => {
+  const { t } = useTranslation();
   const resources = [
     {
       isList: true,
@@ -116,7 +118,7 @@ const ApplicationDropdown: React.FC<ApplicationDropdownProps> = ({ namespace, ..
     <Firehose resources={resources}>
       <ResourceDropdown
         {...props}
-        placeholder="Select an Application"
+        placeholder={t('devconsole~Select application')}
         dataSelector={['metadata', 'labels', 'app.kubernetes.io/part-of']}
       />
     </Firehose>

--- a/frontend/packages/dev-console/src/components/import/app/__tests__/ApplicationSelector.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/__tests__/ApplicationSelector.spec.tsx
@@ -10,6 +10,14 @@ type ApplicationSelectorProps = React.ComponentProps<typeof ApplicationSelector>
 
 let applicationSelectorProps: ApplicationSelectorProps;
 
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
 describe('ApplicationSelector', () => {
   let wrapper: ShallowWrapper<ApplicationSelectorProps>;
   const spyUseFormikContext = jest.spyOn(formik, 'useFormikContext');

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -16,5 +16,5 @@ export const RESOURCE_NAME_TRUNCATE_LENGTH = 13;
 export const CREATE_APPLICATION_KEY = '#CREATE_APPLICATION_KEY#';
 export const UNASSIGNED_KEY = '#UNASSIGNED_APP#';
 
-export const CREATE_APPLICATION_LABEL = 'Create Application';
+export const CREATE_APPLICATION_LABEL = 'Create application';
 export const UNASSIGNED_LABEL = 'no application group';

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -95,6 +95,7 @@ i18n
         'ingress',
         'console-shared',
         'workload',
+        'devconsole',
       ],
       defaultNS: 'public',
       nsSeparator: '~',

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -203,6 +203,7 @@ const config: Configuration = {
     new CopyWebpackPlugin([
       { from: './packages/operator-lifecycle-manager/locales', to: 'locales' },
     ]),
+    new CopyWebpackPlugin([{ from: './packages/dev-console/locales', to: 'locales' }]),
     new MomentLocalesPlugin({
       localesToKeep: Object.keys(SUPPORTED_LOCALES).map((key) => (key === 'zh' ? 'zh-cn' : key)),
     }),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-1310
https://issues.redhat.com/browse/ODC-3206

**Solution Description**: 
On text change, determine if the application grouping already exists. If it exists update the input field to show a warning message but allow the user to continue.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/97604363-c64ae600-19e3-11eb-8cc4-e5bfb3c614d2.png)

![image](https://user-images.githubusercontent.com/11633780/97603487-df9f6280-19e2-11eb-9471-63a137a11edc.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge