### PR TITLE
[release-4.6] Bug 1886541: Update trigger limit for Minimal Deployment

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install-lso-sc.tsx
@@ -100,7 +100,7 @@ export const CreateOCS = withHandlePromise<CreateOCSProps & HandlePromiseProps>(
   const isMinimalSupported = useFlag(OCS_SUPPORT_FLAGS.MINIMAL_DEPLOYMENT);
   const isEncryptionSupported = useFlag(OCS_SUPPORT_FLAGS.ENCRYPTION);
 
-  const isMinimal = nodes.length > minSelectedNode ? shouldDeployAsMinimal(nodes) : false;
+  const isMinimal = nodes.length >= minSelectedNode ? shouldDeployAsMinimal(nodes) : false;
 
   React.useEffect(() => {
     // this is needed to ensure that the useEffect should be called only when setHasNoProvSC is defined

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-request-data.ts
@@ -71,6 +71,28 @@ export const getOCSRequestData = (
             memory: '8Gi',
           },
         },
+        rgw: {
+          limits: {
+            cpu: '2',
+            memory: '4Gi',
+          },
+          requests: {
+            cpu: '1',
+            memory: '4Gi',
+          },
+        },
+      },
+    });
+    requestData.spec.storageDeviceSets[0] = Object.assign(requestData.spec.storageDeviceSets[0], {
+      resources: {
+        limits: {
+          cpu: '2',
+          memory: '5Gi',
+        },
+        requests: {
+          cpu: '1',
+          memory: '5Gi',
+        },
       },
     });
   }

--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -31,7 +31,7 @@ export const MinimalDeploymentAlert = () => (
     isInline
   >
     The selected nodes do not match the OCS storage cluster recommended requirements of an
-    aggregated 42 CPUs and 102 GiB of RAM. If the selection won’t be modified, a minimal cluster
+    aggregated 42 CPUs and 102 GiB of RAM. If the selection cannot be modified, a minimal cluster
     will be deployed.
   </Alert>
 );

--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -30,9 +30,8 @@ export const MinimalDeploymentAlert = () => (
     }
     isInline
   >
-    The selected nodes do not match the OCS storage cluster recommended requirements of an
-    aggregated 42 CPUs and 102 GiB of RAM. If the selection cannot be modified, a minimal cluster
-    will be deployed.
+    The selected nodes do not match the OCS storage cluster requirement of an aggregated 30 CPUs and
+    72 GiB of RAM. If the selection cannot be modified, a minimal cluster will be deployed.
   </Alert>
 );
 

--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -60,7 +60,7 @@ export const getAssociatedNodes = (pvs: K8sResourceKind[]): string[] => {
 export const shouldDeployAsMinimal = (nodes: NodeKind[]) => {
   const { totalCPU, totalMemory } = nodes.reduce(
     (acc, curr) => {
-      const cpus = humanizeCpuCores(getNodeCPUCapacity(curr)).value;
+      const cpus = humanizeCpuCores(Number(getNodeCPUCapacity(curr))).value;
       const memoryRaw = getNodeAllocatableMemory(curr);
       const memory = humanizeBinaryBytes(convertToBaseValue(memoryRaw)).value;
       acc.totalCPU += cpus;
@@ -72,5 +72,5 @@ export const shouldDeployAsMinimal = (nodes: NodeKind[]) => {
       totalMemory: 0,
     },
   );
-  return totalCPU < 42 || totalMemory < 96;
+  return totalCPU < 30 || totalMemory < 72;
 };


### PR DESCRIPTION
The minimal deployment warning message is also corrected. 

Doing a manual cherry-pick since the original bug fix produced a regression hence need to pick two commits from two PRs.
https://github.com/openshift/console/pull/7011
https://github.com/openshift/console/pull/6845

