### PR TITLE
Bug 1896529: Updates to the serverless quicks starts content to fix errors and update areas that have changed based on the new operator release.

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/data/explore-serverless-quickstart.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/data/explore-serverless-quickstart.ts
@@ -25,11 +25,11 @@ Adding OpenShift Serverless to your OpenShift Container Platform cluster is quic
         title: `Install the OpenShift Serverless Operator`,
         description: `### To install the Serverless Operator:
 1. From the **Administrator** perspective, go to the **OperatorHub** from the **Operators** section of the navigation.
-2. In the **Filter by keyword** field at the top of the page, type the keyword \`Serverless\`.
+2. In the **Filter by keyword** field, type \`Serverless\`.
 3. If the tile has an **Installed** label on it, the Operator is already installed. Proceed to task two.
 4. Click the **OpenShift Serverless Operator** tile.
 5. At the top of the OpenShift Serverless Operator panel, click **Install**.
-6. Verify that the OpenShift Serverless Operator Update Channel is 4.5 and click **Install** again.
+6. Verify that the **OpenShift Serverless Operator Update Channel** is set to the latest version, then click **Install**.
 7. Wait for the OpenShift Serverless Operator's status to change from **Installing operator** to **Operator installed - Ready for use**.
 `,
 
@@ -52,11 +52,11 @@ In the Status column of the **Installed Operators** page, is the OpenShift Serve
 **To create the Knative Serving and Knative Eventing APIs:**
 1. Go to the **Installed Operators** page.
 2. Click **OpenShift Serverless Operator**.
-3. If it does not already exist, create a project called “knative_serving” under the Project list at the top of the page. If it does exist, select the project from the list.
-4. Click on the Knative Serving link under Provided APIs or, from Knative Serving tile, click **Create Instance**.
+3. If it does not already exist, create a project called “knative-serving” under the Project list at the top of the page. If it does exist, select the project from the list.
+4. Click the Knative Serving link under Provided APIs or, from Knative Serving tile, click **Create Instance**.
 5. Click **Create** to create the custom resource.
-6. Now, if it does not already exist, create a project called “knative_eventing” under the Project list at the top of the page. If it does exist, select the project from the list.
-7. Click on the Knative Eventing link under Provided APIs or, from Knative Eventing tile, click **Create Instance**.
+6. If it does not already exist, create a project called “knative-eventing” under the Project list at the top of the page. If it does exist, select the project from the list.
+7. Click the Knative Eventing link under Provided APIs or, from Knative Eventing tile, click **Create Instance**.
 8. Click **Create** to create the custom resource.
 `,
         review: {
@@ -73,7 +73,7 @@ Are the Knative Serving and Knative Eventing resources in the list of instances?
         },
       },
     ],
-    conclusion: `Your Serverless Operator is ready! If you want to learn how to deploy a serverless application, take the **Creating a Serverless application** quick start.`,
+    conclusion: `Your Serverless Operator is ready! If you want to learn how to deploy a serverless application, take the **Exploring Serverless applications** quick start.`,
     nextQuickStart: `serverless-application`,
     accessReviewResources: [
       {

--- a/frontend/packages/console-app/src/components/quick-starts/data/serverless-application-quickstart.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/data/serverless-application-quickstart.ts
@@ -47,7 +47,7 @@ Do you see the completed application and build?`,
         description: `### To see your application scale:
 1. From the **Display Options** list at the top of the **Topology** view, click **Pod Count**.
 2. Wait for the Pod count to scale down to zero Pods. Scaling down may take a few minutes.
-3. Click the **Route URL** icon in the upper-right corner of the Knative Service panel. The application opens in a new tab.
+3. Click the **Open URL** icon in the upper-right corner of the Knative Service panel. The application opens in a new tab.
 4. Close the new browser tab and return to the **Topology** view.
 
 In the **Topology** view, you can see that your application scaled up to one Pod to accommodate your request.  After a few minutes, your application scales back down to zero Pods.
@@ -74,8 +74,7 @@ Is the Pod ring autoscaled to zero?`,
 4. Under the **Type** field, click **PingSource**.
 5. In the **Data** field, type \`This message is from PingSource\`. This message is posted when the service is called.
 6. In the **Schedule** field, type \`* * * * *\`.  This means that the PingSource will make a call every minute.
-7. In the **Application** field, select **Sample Serverless App**.
-8. Click **Create**.`,
+7. Click **Create**.`,
         review: {
           instructions: `#### To verify that the event connected to your Knative service:
 
@@ -94,15 +93,15 @@ Do you see a PingSource connected by a gray line to the side of your application
         title: `Forcing a new revision and set traffic distribution`,
         description: `### To force a revision and set traffic distribution:
 
-1. In **Topology**, click on the revision inside your service to view its details. The badges under the Pod ring and at the top of the detail panel should be (REV).
-2. In the side panel, click on the **Resources** tab.
-3. Scroll down and click on the configuration associated with your service.
+1. In **Topology**, click the revision inside your service to view its details. The badges under the Pod ring and at the top of the detail panel should be (REV).
+2. In the side panel, click the **Resources** tab.
+3. Scroll down and click the configuration associated with your service.
 4. Go to the resource’s **YAML** tab.
 5. Scroll all the way down until you see \`timeoutSeconds\`.
 6. Change the value from \`300\` to \`30\` and click **Save**.
 7. Go back to the **Topology** view.
-8. Click on your service. The badge at the top of the side panel should be (KSVC).
-9. In the side panel, click on the **Resources** tab.
+8. Click your service. The badge at the top of the side panel should be (KSVC).
+9. In the side panel, click the **Resources** tab.
 10. Next to **Revisions**, click **Set Traffic Distribution**.
 11. Click **Add Revision**.
 12. In the **Revision** dropdown, select the new revision.
@@ -129,7 +128,7 @@ Do you see two revisions in your Knative Service?`,
         description: `### To delete the application you just created:
 
 1. Click your application’s name. The badge at the top of the side panel should be (A).
-2. At the top of the resource details panel, click on the **Actions** list.
+2. At the top of the resource details panel, click the **Actions** list.
 3. Click **Delete application**.
 4. To confirm deletion, type the application’s name in the **Name** field, and then click **Delete**.`,
         review: {


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1896529

Design: https://issues.redhat.com/browse/ODC-5059

Updates to the serverless quicks starts content to fix errors and update areas that have changed based on the new operator release.