### PR TITLE
Fix application dropdown to fetch resources based on extensions.

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/DeployImage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/__tests__/DeployImage.spec.tsx
@@ -17,6 +17,10 @@ jest.mock('react-i18next', () => {
   return {
     ...reactI18next,
     useTranslation: () => ({ t: (key) => key }),
+    withTranslation: () => (Component) => {
+      Component.defaultProps = { ...Component.defaultProps, t: (s) => s };
+      return Component;
+    },
   };
 });
 

--- a/frontend/packages/dev-console/src/extensions/topology.ts
+++ b/frontend/packages/dev-console/src/extensions/topology.ts
@@ -8,7 +8,7 @@ import {
   CreateConnectionGetter,
   ViewComponentFactory,
   TopologyDataModelReconciler,
-} from '../components/topology';
+} from '../components/topology/topology-types';
 
 namespace ExtensionProperties {
   export interface TopologyComponentFactory {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3613

**Solution Description**: 
Use the topology plugin extensions to determine which resource kinds to fetch to then search for existing application groupings.

**Browser conformance**: 
- [x ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge