### PR TITLE
feature flag Helm based on HelmRepository CRs

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/catalog-plugin.ts
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-plugin.ts
@@ -1,5 +1,6 @@
 import { CatalogItemProvider, CatalogItemType, Plugin } from '@console/plugin-sdk';
 import { builderImageProvider, helmChartProvider, templateProvider } from './providers';
+import { FLAG_OPENSHIFT_HELM } from '../../const';
 
 export type CatalogConsumedExtensions = CatalogItemProvider | CatalogItemType;
 
@@ -77,12 +78,18 @@ export const catalogPlugin: Plugin<CatalogConsumedExtensions> = [
         },
       ],
     },
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
+    },
   },
   {
     type: 'Catalog/ItemProvider',
     properties: {
       type: 'HelmChart',
       provider: helmChartProvider,
+    },
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
     },
   },
 ];

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -1,4 +1,5 @@
 export const FLAG_OPENSHIFT_GITOPS = 'OPENSHIFT_GITOPS';
+export const FLAG_OPENSHIFT_HELM = 'OPENSHIFT_HELM';
 
 /** URL query params that adjust scope / purpose of the page */
 export enum QUERY_PROPERTIES {

--- a/frontend/packages/dev-console/src/models/helm.ts
+++ b/frontend/packages/dev-console/src/models/helm.ts
@@ -1,0 +1,14 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+export const HelmChartRepositoryModel: K8sKind = {
+  apiGroup: 'helm.openshift.io',
+  apiVersion: 'v1beta1',
+  kind: 'HelmChartRepository',
+  id: 'helmchartrepository',
+  plural: 'helmchartrepositories',
+  label: 'Helm Chart Repository',
+  labelPlural: 'Helm Chart Repositories',
+  abbr: 'HCR',
+  namespaced: false,
+  crd: true,
+};

--- a/frontend/packages/dev-console/src/models/index.ts
+++ b/frontend/packages/dev-console/src/models/index.ts
@@ -1,1 +1,2 @@
 export * from './gitops';
+export * from './helm';

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -25,6 +25,7 @@ import {
   OverviewTabSection,
   GuidedTour,
   PostFormSubmissionAction,
+  CustomFeatureFlag,
 } from '@console/plugin-sdk';
 import { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';
 import { FLAGS } from '@console/shared/src/constants';
@@ -42,7 +43,7 @@ import {
 import { doConnectsToBinding } from '@console/topology/src/utils/connector-utils';
 import * as models from './models';
 import { getKebabActionsForKind } from './utils/kebab-actions';
-import { FLAG_OPENSHIFT_GITOPS, INCONTEXT_ACTIONS_CONNECTS_TO } from './const';
+import { FLAG_OPENSHIFT_GITOPS, INCONTEXT_ACTIONS_CONNECTS_TO, FLAG_OPENSHIFT_HELM } from './const';
 import { AddAction } from './extensions/add-actions';
 import * as yamlIcon from './images/yaml.svg';
 import * as importGitIcon from './images/from-git.svg';
@@ -50,11 +51,13 @@ import * as dockerfileIcon from './images/dockerfile.svg';
 import { usePerspectiveDetection } from './utils/usePerspectiveDetection';
 import { getGuidedTour } from './components/guided-tour';
 import { CatalogConsumedExtensions, catalogPlugin } from './components/catalog/catalog-plugin';
+import { detectHelmChartRepositories } from './utils/helm-plugin-utils';
 
 type ConsumedExtensions =
   | ModelDefinition
   | ModelFeatureFlag
   | NavSection
+  | CustomFeatureFlag
   | HrefNavItem
   | ResourceClusterNavItem
   | ResourceNSNavItem
@@ -97,6 +100,12 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'resources',
       perspective: 'dev',
+    },
+  },
+  {
+    type: 'FeatureFlag/Custom',
+    properties: {
+      detect: detectHelmChartRepositories,
     },
   },
   {
@@ -211,7 +220,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       },
     },
     flags: {
-      required: [FLAGS.OPENSHIFT],
+      required: [FLAG_OPENSHIFT_HELM],
     },
   },
   {
@@ -448,6 +457,9 @@ const plugin: Plugin<ConsumedExtensions> = [
           )
         ).default,
     },
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
+    },
   },
   {
     type: 'Page/Route',
@@ -460,6 +472,9 @@ const plugin: Plugin<ConsumedExtensions> = [
             './components/helm/HelmInstallUpgradePage' /* webpackChunkName: "dev-console-helm-install-upgrade" */
           )
         ).default,
+    },
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
     },
   },
   {
@@ -474,6 +489,9 @@ const plugin: Plugin<ConsumedExtensions> = [
           )
         ).default,
     },
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
+    },
   },
   {
     type: 'Page/Route',
@@ -487,6 +505,9 @@ const plugin: Plugin<ConsumedExtensions> = [
           )
         ).default,
     },
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
+    },
   },
   {
     type: 'Page/Route',
@@ -499,6 +520,9 @@ const plugin: Plugin<ConsumedExtensions> = [
             './components/helm/HelmReleaseDetailsPage' /* webpackChunkName: "dev-console-helm-release-details" */
           )
         ).default,
+    },
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
     },
   },
   {
@@ -762,6 +786,9 @@ const plugin: Plugin<ConsumedExtensions> = [
   },
   {
     type: 'AddAction',
+    flags: {
+      required: [FLAG_OPENSHIFT_HELM],
+    },
     properties: {
       id: 'helm',
       url: '/catalog?catalogType=HelmChart',

--- a/frontend/packages/dev-console/src/utils/helm-plugin-utils.ts
+++ b/frontend/packages/dev-console/src/utils/helm-plugin-utils.ts
@@ -1,0 +1,31 @@
+import { Dispatch } from 'react-redux';
+import { K8sResourceKind, ListKind } from '@console/internal/module/k8s';
+import { fetchK8s } from '@console/internal/graphql/client';
+import { FeatureDetector } from '@console/plugin-sdk';
+import { setFlag, handleError } from '@console/internal/actions/features';
+import { HelmChartRepositoryModel } from '../models';
+import { FLAG_OPENSHIFT_HELM } from '../const';
+
+const checkDisabledHelmCharts = (helmChartRepositories: K8sResourceKind[]): boolean => {
+  let isDisabled = true;
+  helmChartRepositories.forEach((hcr) => {
+    isDisabled = isDisabled && (hcr.spec.disabled || false);
+  });
+  return isDisabled;
+};
+
+export const detectHelmChartRepositories: FeatureDetector = async (dispatch: Dispatch) => {
+  let id = null;
+  const fetchHelmChartRepositories = () =>
+    fetchK8s<ListKind<K8sResourceKind>>(HelmChartRepositoryModel)
+      .then((list) => {
+        dispatch(setFlag(FLAG_OPENSHIFT_HELM, !checkDisabledHelmCharts(list?.items)));
+      })
+      .catch((error) => {
+        error?.response?.status === 404
+          ? dispatch(setFlag(FLAG_OPENSHIFT_HELM, false))
+          : handleError(error, FLAG_OPENSHIFT_HELM, dispatch, detectHelmChartRepositories);
+        clearInterval(id);
+      });
+  id = setInterval(fetchHelmChartRepositories, 10 * 1000);
+};


### PR DESCRIPTION
**JIRA Story:**
https://issues.redhat.com/browse/ODC-5024

**Root Analysis:**
Need a way to enable/disable helm specific navigation items from the console if there are no helm repositories configured 

**Solution Description:**
- disables the FLAG_OPENSHIFT_HELM flag when there are no HelmChartRepository configured &
- hides the Helm nav item
- hides the Helm catalog item from the Add page
- the helm URLs shows 404

**GIF/Sceenshot:**
![helm_ff](https://user-images.githubusercontent.com/22490998/97696360-76474e80-1acb-11eb-89df-021879a441bb.gif)