### PR TITLE
add pipelinerun watcher to add or remove the last run menu item

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/__tests__/hooks.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/__tests__/hooks.spec.ts
@@ -1,0 +1,52 @@
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { testHook } from '@console/shared/src/test-utils/hooks-utils';
+import { pipelineTestData, PipelineExampleNames } from '../../../test/pipeline-data';
+import { PipelineRun } from '../../../utils/pipeline-augment';
+import * as hooks from '../hooks';
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+const mockData = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
+const pipelineRuns: PipelineRun[] = Object.values(mockData.pipelineRuns);
+const {
+  metadata: { name: pipelineName, namespace },
+} = mockData.pipeline;
+
+describe('useLatestPipelineRun:', () => {
+  beforeEach(() => {
+    (useK8sWatchResource as jest.Mock).mockReturnValue([pipelineRuns, true, null]);
+  });
+  it('should return the latest pipeline run from the list', () => {
+    testHook(() => {
+      const latestPipelineRun = hooks.useLatestPipelineRun(pipelineName, namespace);
+      expect(latestPipelineRun).toEqual(pipelineRuns[1]);
+    });
+  });
+  it('should return null if there are no pipeline runs available', () => {
+    testHook(() => {
+      (useK8sWatchResource as jest.Mock).mockReturnValue([[], true, null]);
+      const latestPipelineRun = hooks.useLatestPipelineRun(pipelineName, namespace);
+      expect(latestPipelineRun).toBe(null);
+    });
+  });
+  it('should return null if the pipeline runs are still loading', () => {
+    testHook(() => {
+      (useK8sWatchResource as jest.Mock).mockReturnValue([[], false, null]);
+      const latestPipelineRun = hooks.useLatestPipelineRun(pipelineName, namespace);
+      expect(latestPipelineRun).toBe(null);
+    });
+  });
+  it('should return null if the pipeline run call results in error', () => {
+    testHook(() => {
+      (useK8sWatchResource as jest.Mock).mockReturnValue([
+        pipelineRuns,
+        true,
+        { response: { status: 404 } },
+      ]);
+      const latestPipelineRun = hooks.useLatestPipelineRun(pipelineName, namespace);
+      expect(latestPipelineRun).toBe(null);
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/__tests__/pipelineDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/__tests__/pipelineDetailsPage.spec.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import { DetailsPage } from '@console/internal/components/factory/';
+import { LoadingBox } from '@console/internal/components/utils';
+import { ErrorPage404 } from '@console/internal/components/error';
+import { pipelineTestData, PipelineExampleNames } from '../../../test/pipeline-data';
+import { getPipelineKebabActions } from '../../../utils/pipeline-actions';
+import { PipelineRun } from '../../../utils/pipeline-augment';
+import { PipelineModel } from '../../../models';
+import * as utils from '../../pipelineruns/triggered-by';
+import * as hookUtils from '../hooks';
+import PipelineDetailsPage from '../PipelineDetailsPage';
+import * as triggerUtils from '../utils/triggers';
+
+const menuActions = jest.spyOn(utils, 'useMenuActionsWithUserAnnotation');
+const breadCrumbs = jest.spyOn(hookUtils, 'usePipelinesBreadcrumbsFor');
+const templateNames = jest.spyOn(triggerUtils, 'usePipelineTriggerTemplateNames');
+const latestPipelineRun = jest.spyOn(hookUtils, 'useLatestPipelineRun');
+
+jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
+  useK8sGet: jest.fn(),
+}));
+type PipelineDetailsPageProps = React.ComponentProps<typeof PipelineDetailsPage>;
+const mockData = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
+const pipelineRuns: PipelineRun[] = Object.values(mockData.pipelineRuns);
+const {
+  metadata: { name: pipelineName, namespace },
+} = mockData.pipeline;
+
+describe('PipelineDetailsPage:', () => {
+  let PipelineDetailsPageProps: PipelineDetailsPageProps;
+  beforeEach(() => {
+    PipelineDetailsPageProps = {
+      kind: PipelineModel.kind,
+      kindObj: PipelineModel,
+      match: {
+        isExact: true,
+        path: `/k8s/ns/${namespace}/${referenceForModel(PipelineModel)}/${pipelineName}`,
+        url: `k8s/ns/${namespace}/${referenceForModel(PipelineModel)}/${pipelineName}`,
+        params: {
+          ns: namespace,
+        },
+      },
+    };
+    menuActions.mockReturnValue(getPipelineKebabActions(pipelineRuns[0], true));
+    breadCrumbs.mockReturnValue([{ label: 'Pipelines' }, { label: 'Pipeline Details' }]);
+    templateNames.mockReturnValue([]);
+    latestPipelineRun.mockReturnValue(null);
+    (useK8sGet as jest.Mock).mockReturnValue([mockData.pipeline, true, null]);
+  });
+
+  it('should render the Details Page if the pipeline is loaded and available', () => {
+    (useK8sGet as jest.Mock).mockReturnValue([mockData.pipeline, true, null]);
+    const wrapper = shallow(<PipelineDetailsPage {...PipelineDetailsPageProps} />);
+    expect(wrapper.find(DetailsPage).exists()).toBe(true);
+  });
+
+  it('should render the loading box if the pipeline is not loaded yet', () => {
+    (useK8sGet as jest.Mock).mockReturnValue([[], false, null]);
+    const wrapper = shallow(<PipelineDetailsPage {...PipelineDetailsPageProps} />);
+    expect(wrapper.find(LoadingBox).exists()).toBe(true);
+  });
+
+  it('should render the ErrorPage404 if the pipeline is not found', () => {
+    (useK8sGet as jest.Mock).mockReturnValue([[], true, { response: { status: 404 } }]);
+    const wrapper = shallow(<PipelineDetailsPage {...PipelineDetailsPageProps} />);
+    expect(wrapper.find(ErrorPage404).exists()).toBe(true);
+  });
+
+  it('should not contain Start last run menu item if the pipeline run is not present', () => {
+    menuActions.mockReturnValue(getPipelineKebabActions(null, false));
+    const wrapper = shallow(<PipelineDetailsPage {...PipelineDetailsPageProps} />);
+    const menuItems = wrapper.props().menuActions;
+    const startLastRun = menuItems.find(
+      (menu) => menu(PipelineModel, mockData.pipeline).label === 'Start Last Run',
+    );
+    expect(startLastRun).toBeUndefined();
+  });
+
+  it('should contain Start last run menu item if the pipeline run is present', () => {
+    menuActions.mockReturnValue(getPipelineKebabActions(pipelineRuns[0], false));
+    const wrapper = shallow(<PipelineDetailsPage {...PipelineDetailsPageProps} />);
+    const menuItems = wrapper.props().menuActions;
+    const startLastRun = menuItems.find(
+      (menu) => menu(PipelineModel, mockData.pipeline).label === 'Start Last Run',
+    );
+    expect(startLastRun).toBeDefined();
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/const.ts
@@ -6,6 +6,7 @@ export enum StartedByAnnotation {
 }
 
 export enum TektonResourceLabel {
+  pipeline = 'tekton.dev/pipeline',
   pipelinerun = 'tekton.dev/pipelineRun',
   taskrun = 'tekton.dev/taskRun',
 }

--- a/frontend/packages/dev-console/src/components/pipelines/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/hooks.ts
@@ -1,7 +1,14 @@
 import { match as RMatch } from 'react-router-dom';
 import { useTabbedTableBreadcrumbsFor } from '@console/shared';
-import { K8sKind } from '@console/internal/module/k8s';
+import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
+import {
+  useK8sWatchResource,
+  WatchK8sResource,
+} from '@console/internal/components/utils/k8s-watch-hook';
 import { pipelinesTab } from '../../utils/pipeline-utils';
+import { PipelineRun, getLatestRun } from '../../utils/pipeline-augment';
+import { TektonResourceLabel } from './const';
+import { PipelineRunModel } from '../../models';
 
 type Match = RMatch<{ url: string }>;
 
@@ -13,3 +20,20 @@ export const useTasksBreadcrumbsFor = (kindObj: K8sKind, match: Match) =>
 
 export const useTriggersBreadcrumbsFor = (kindObj: K8sKind, match: Match) =>
   useTabbedTableBreadcrumbsFor(kindObj, match, 'triggers', pipelinesTab(kindObj));
+
+export const useLatestPipelineRun = (pipelineName: string, namespace: string): PipelineRun => {
+  const pipelineRunResource: WatchK8sResource = {
+    kind: referenceForModel(PipelineRunModel),
+    namespace,
+    selector: {
+      matchLabels: { [TektonResourceLabel.pipeline]: pipelineName },
+    },
+    optional: true,
+    isList: true,
+  };
+  const [pipelineRun, pipelineRunLoaded, pipelineRunError] = useK8sWatchResource<PipelineRun[]>(
+    pipelineRunResource,
+  );
+  const latestRun = getLatestRun({ data: pipelineRun }, 'creationTimestamp');
+  return pipelineRunLoaded && !pipelineRunError ? latestRun : null;
+};

--- a/frontend/packages/dev-console/src/test/pipeline-data.ts
+++ b/frontend/packages/dev-console/src/test/pipeline-data.ts
@@ -66,6 +66,7 @@ export const pipelineTestData: PipelineTestData = {
         metadata: {
           name: 'simple-pipeline-br8cxv',
           namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T06:11:46Z',
         },
         spec: {
           pipelineRef: { name: 'simple-pipeline' },
@@ -112,6 +113,7 @@ export const pipelineTestData: PipelineTestData = {
         metadata: {
           name: 'simple-pipeline-p1bun0',
           namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T09:58:19Z',
         },
         spec: {
           pipelineRef: { name: 'simple-pipeline' },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4897

**Analysis / Root cause**: 
Pipeline run object was not updating  real-time, causing the kebab menu to show `start last run` option even if all the existing pipelineruns are deleted.

**Solution Description**: 
Added watcher to the pipeline run resource to get the latest changes and based on the availability of the resource, the menu item is now updated.

**Screen shots / Gifs for design review**: 
![start_last_run](https://user-images.githubusercontent.com/9964343/97622335-207e9200-1a4a-11eb-9da5-ad264febfceb.gif)

**Unit test coverage report**: 

**hook.spec.ts**
![image](https://user-images.githubusercontent.com/9964343/97622593-7eab7500-1a4a-11eb-87ae-e9f7a204a4ae.png)

**pipelineDetailsPage.spec.tsx**
![image](https://user-images.githubusercontent.com/9964343/97622535-69cee180-1a4a-11eb-94d9-e61b359983b7.png)

**Test setup:**
1. Install Openshift Pipelines operator
2. Create a pipeline and start the pipeline
3. In pipeline details page, go to pipelinerun tab and delete all the pipelineruns 
4. Check the Action menu, the `start last run` option should not be available

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge