### PR TITLE
Fix status icon size in topology and alignments

### DIFF
--- a/frontend/packages/console-shared/src/components/status/GenericStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/GenericStatus.tsx
@@ -4,23 +4,30 @@ import PopoverStatus from './PopoverStatus';
 import StatusIconAndText from './StatusIconAndText';
 
 const GenericStatus: React.FC<GenericStatusProps> = (props) => {
-  const { Icon, children, popoverTitle, title, ...restProps } = props;
-  return React.Children.toArray(children).length ? (
-    <PopoverStatus
-      title={popoverTitle || title}
+  const { Icon, children, popoverTitle, title, noTooltip, iconOnly, ...restProps } = props;
+  const renderIcon = iconOnly && !noTooltip ? <Icon title={title} /> : <Icon />;
+  const statusBody = (
+    <StatusIconAndText
       {...restProps}
-      statusBody={<StatusIconAndText {...restProps} title={title} icon={<Icon />} />}
-    >
+      noTooltip={noTooltip}
+      title={title}
+      iconOnly={iconOnly}
+      icon={renderIcon}
+    />
+  );
+  return React.Children.toArray(children).length ? (
+    <PopoverStatus title={popoverTitle || title} {...restProps} statusBody={statusBody}>
       {children}
     </PopoverStatus>
   ) : (
-    <StatusIconAndText {...restProps} title={title} icon={<Icon />} />
+    statusBody
   );
 };
 
 type GenericStatusProps = StatusComponentProps & {
-  Icon: React.ComponentType<{}>;
+  Icon: React.ComponentType<{ title?: string }>;
   popoverTitle?: string;
+  noTooltip?: boolean;
 };
 
 export default GenericStatus;

--- a/frontend/packages/console-shared/src/components/status/statuses.tsx
+++ b/frontend/packages/console-shared/src/components/status/statuses.tsx
@@ -10,51 +10,31 @@ import GenericStatus from './GenericStatus';
 import { StatusComponentProps } from './types';
 
 export const ErrorStatus: React.FC<StatusComponentProps> = (props) => (
-  <GenericStatus
-    {...props}
-    Icon={() => <RedExclamationCircleIcon className="co-icon-and-text__icon" title="Error" />}
-  />
+  <GenericStatus {...props} Icon={RedExclamationCircleIcon} title={props.title || 'Error'} />
 );
 ErrorStatus.displayName = 'ErrorStatus';
 
 export const InfoStatus: React.FC<StatusComponentProps> = (props) => (
-  <GenericStatus
-    {...props}
-    Icon={() => <BlueInfoCircleIcon className="co-icon-and-text__icon" title="Information" />}
-  />
+  <GenericStatus {...props} Icon={BlueInfoCircleIcon} title={props.title || 'Information'} />
 );
 InfoStatus.displayName = 'InfoStatus';
 
 export const PendingStatus: React.FC<StatusComponentProps> = (props) => (
-  <GenericStatus
-    {...props}
-    Icon={() => <HourglassHalfIcon className="co-icon-and-text__icon" title="Pending" />}
-  />
+  <GenericStatus {...props} Icon={HourglassHalfIcon} title={props.title || 'Pending'} />
 );
 PendingStatus.displayName = 'PendingStatus';
 
 export const ProgressStatus: React.FC<StatusComponentProps> = (props) => (
-  <GenericStatus
-    {...props}
-    Icon={() => <InProgressIcon className="co-icon-and-text__icon" title="In progress" />}
-  />
+  <GenericStatus {...props} Icon={InProgressIcon} title={props.title || 'In progress'} />
 );
 ProgressStatus.displayName = 'ProgressStatus';
 
 export const SuccessStatus: React.FC<StatusComponentProps> = (props) => (
-  <GenericStatus
-    {...props}
-    Icon={() => <GreenCheckCircleIcon className="co-icon-and-text__icon" title="Healthy" />}
-  />
+  <GenericStatus {...props} Icon={GreenCheckCircleIcon} title={props.title || 'Healthy'} />
 );
 SuccessStatus.displayName = 'SuccessStatus';
 
 export const WarningStatus: React.FC<StatusComponentProps> = (props) => (
-  <GenericStatus
-    {...props}
-    Icon={() => (
-      <YellowExclamationTriangleIcon className="co-icon-and-text__icon" title="Warning" />
-    )}
-  />
+  <GenericStatus {...props} Icon={YellowExclamationTriangleIcon} title={props.title || 'Warning'} />
 );
 WarningStatus.displayName = 'WarningStatus';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5058

**Analysis / Root cause**: 
Changes made in https://github.com/openshift/console/pull/6971 caused the necessary classNames not to be added since the icon passed was changed to a function rather than a component.

**Solution Description**: 
Change the icon parameters back to a component and add an sr-only span for the title.

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/11633780/97627958-7af40000-1a02-11eb-9418-099fb350839d.png)

![image](https://user-images.githubusercontent.com/11633780/97628025-9101c080-1a02-11eb-8f07-4ac010b6b57b.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge