### PR TITLE
Bug 1893022: Fix git validation on selecting git type

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -43,9 +43,9 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) =>
       setFieldValue('git.isUrlValidating', true);
       setValidated(ValidatedOptions.default);
 
-      const gitType = detectGitType(url);
+      const gitType = gitTypeTouched ? values.git.type : detectGitType(url);
       const gitRepoName = detectGitRepoName(url);
-      const showGitType = gitType === GitTypes.unsure;
+      const showGitType = gitType === GitTypes.unsure || gitTypeTouched;
 
       setFieldValue('git.type', gitType);
       setFieldValue('git.showGitType', showGitType);
@@ -82,10 +82,12 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) =>
     },
     [
       builderImages,
+      gitTypeTouched,
       setFieldTouched,
       setFieldValue,
       values.application.name,
       values.application.selectedKey,
+      values.git.type,
       values.name,
     ],
   );
@@ -138,8 +140,8 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) =>
 
   React.useEffect(() => {
     const { url, ref } = values.git;
-    !dirty && url && handleGitUrlChange(url, ref);
-  }, [dirty, handleGitUrlChange, values.git]);
+    (!dirty || gitTypeTouched) && values.git.url && handleGitUrlChange(url, ref);
+  }, [dirty, gitTypeTouched, handleGitUrlChange, values.git]);
 
   const getHelpText = () => {
     if (values.git.isUrlValidating) {
@@ -204,7 +206,7 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample, builderImages }) =>
             fullWidth
             required
           />
-          {!gitTypeTouched && (
+          {!gitTypeTouched && values.git.type === GitTypes.unsure && (
             <Alert isInline variant="info" title="Defaulting Git Type to Other">
               We failed to detect the git type.
             </Alert>

--- a/frontend/packages/git-service/src/services/__tests__/__nock-fixtures__/gitlab/custom-domain-with-subdomain.json
+++ b/frontend/packages/git-service/src/services/__tests__/__nock-fixtures__/gitlab/custom-domain-with-subdomain.json
@@ -1,0 +1,56 @@
+[
+  {
+    "scope": "https://version.helsinki.fi:443",
+    "method": "GET",
+    "path": "/api/v4/projects/random-user%2Fpublic-project",
+    "body": "",
+    "status": 200,
+    "response": {
+      "id": 123456,
+      "description": "",
+      "name": "public-project",
+      "name_with_namespace": "random-user / public-project",
+      "path": "public-project",
+      "path_with_namespace": "random-user/public-project",
+      "created_at": "2020-05-25T14:25:31.214Z",
+      "default_branch": "master",
+      "tag_list": [],
+      "ssh_url_to_repo": "git@version.helsinki.fi:random-user/public-project.git",
+      "http_url_to_repo": "https://version.helsinki.fi/random-user/public-project.git",
+      "web_url": "https://version.helsinki.fi/random-user/public-project",
+      "readme_url": "https://version.helsinki.fi/random-user/public-project/-/blob/master/README.md",
+      "avatar_url": null,
+      "star_count": 0,
+      "forks_count": 0,
+      "last_activity_at": "2020-06-02T13:09:17.863Z",
+      "namespace": {
+        "id": 123456,
+        "name": "A Random user",
+        "path": "random-user",
+        "kind": "user",
+        "full_path": "random-user",
+        "parent_id": null
+      }
+    },
+    "rawHeaders": [
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "Content-Type",
+      "application/json",
+      "Date",
+      "Tue, 16 Jun 2020 21:59:55 GMT",
+      "Server",
+      "Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips PHP/5.4.16",
+      "Vary",
+      "Origin",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-Request-Id",
+      "PBgWs7TOO62",
+      "X-Runtime",
+      0.088692
+    ]
+  }
+]

--- a/frontend/packages/git-service/src/services/__tests__/gitlab-service.spec.ts
+++ b/frontend/packages/git-service/src/services/__tests__/gitlab-service.spec.ts
@@ -14,6 +14,15 @@ describe('Gitlab Service', () => {
 
     const gitService = new GitlabService(gitSource);
 
+    const metaData = gitService.getRepoMetadata();
+    expect(metaData).toEqual({
+      repoName: 'devconsole-git',
+      owner: 'jpratik999',
+      host: 'https://gitlab.com',
+      defaultBranch: 'master',
+      fullName: 'jpratik999/devconsole-git',
+    });
+
     return nockBack('repo.json').then(async ({ nockDone, context }) => {
       const isReachable = await gitService.isRepoReachable();
       expect(isReachable).toEqual(true);
@@ -27,9 +36,40 @@ describe('Gitlab Service', () => {
 
     const gitService = new GitlabService(gitSource);
 
+    const metaData = gitService.getRepoMetadata();
+    expect(metaData).toEqual({
+      repoName: 'devconsole-git',
+      owner: 'jpratik99',
+      host: 'https://gitlab.com',
+      defaultBranch: 'master',
+      fullName: 'jpratik99/devconsole-git',
+    });
+
     return nockBack('repo-not-reachable.json').then(async ({ nockDone, context }) => {
       const isReachable = await gitService.isRepoReachable();
       expect(isReachable).toEqual(false);
+      context.assertScopesFinished();
+      nockDone();
+    });
+  });
+
+  it('should return ok on public custom domain with subdomain', async () => {
+    const gitSource: GitSource = { url: 'https://version.helsinki.fi/random-user/public-project' };
+
+    const gitService = new GitlabService(gitSource);
+
+    const metaData = gitService.getRepoMetadata();
+    expect(metaData).toEqual({
+      repoName: 'public-project',
+      owner: 'random-user',
+      host: 'https://version.helsinki.fi',
+      defaultBranch: 'master',
+      fullName: 'random-user/public-project',
+    });
+
+    return nockBack('custom-domain-with-subdomain.json').then(async ({ nockDone, context }) => {
+      const isReachable = await gitService.isRepoReachable();
+      expect(isReachable).toEqual(true);
       context.assertScopesFinished();
       nockDone();
     });

--- a/frontend/packages/git-service/src/services/gitlab-service.ts
+++ b/frontend/packages/git-service/src/services/gitlab-service.ts
@@ -38,8 +38,12 @@ export class GitlabService extends BaseService {
       return Promise.resolve(this.repo);
     }
     const repo: GitlabRepo = await this.client.Projects.show(this.metadata.fullName);
-    if (!repo || repo.path_with_namespace !== this.metadata.fullName) {
-      throw new Error('Unable to find repo');
+    if (!repo) {
+      throw new Error('Unable to find any repo');
+    } else if (repo.path_with_namespace !== this.metadata.fullName) {
+      throw new Error(
+        `Repository path ${repo.path_with_namespace} does not match expected name ${this.metadata.fullName}`,
+      );
     }
 
     this.repo = repo;
@@ -47,8 +51,10 @@ export class GitlabService extends BaseService {
   };
 
   getRepoMetadata(): RepoMetadata {
-    const { name, owner, protocol, source, full_name: fullName } = GitUrlParse(this.gitsource.url);
-    const host = `${protocol}://${source}`;
+    const { name, owner, protocol, resource, full_name: fullName } = GitUrlParse(
+      this.gitsource.url,
+    );
+    const host = `${protocol}://${resource}`;
     return {
       repoName: name,
       owner,


### PR DESCRIPTION
Cherry Pick PR for https://github.com/openshift/console/pull/5706

Fixes:
https://issues.redhat.com/browse/ODC-4044

Analysis / Root cause:
when git type is not known, the git url is not validated after git type is explicitly selected from the git type dropdown

Solution Description:
validate git url after a git type is selected from the dropdown

Screens:
![git-custom-repo](https://user-images.githubusercontent.com/38663217/97641324-a3164a00-1a68-11eb-98cd-74f1b25c5d05.gif)

Test Coverage:
![Screenshot from 2020-10-30 04-35-21](https://user-images.githubusercontent.com/38663217/97641702-7f073880-1a69-11eb-8a2e-c67f40e6407f.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge