### PR TITLE
Remove Tech Preview badge from dev console monitoring

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -7,7 +7,7 @@ import {
   history,
   useAccessReview,
 } from '@console/internal/components/utils';
-import { TechPreviewBadge, ALL_NAMESPACES_KEY } from '@console/shared';
+import { ALL_NAMESPACES_KEY } from '@console/shared';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import CreateProjectListPage from '../projects/CreateProjectListPage';
@@ -66,11 +66,11 @@ export const PageContents: React.FC<MonitoringPageProps> = ({ match }) => {
   ];
   return activeNamespace ? (
     <>
-      <PageHeading badge={<TechPreviewBadge />} title="Monitoring" />
+      <PageHeading title="Monitoring" />
       <HorizontalNav pages={pages} match={match} noStatusBox />
     </>
   ) : (
-    <CreateProjectListPage badge={<TechPreviewBadge />} title="Monitoring">
+    <CreateProjectListPage title="Monitoring">
       Select a project to view monitoring metrics
     </CreateProjectListPage>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5060

**Analysis / Root cause**: 
Monitoring backend went GA in 4.6 but we have `Tech Preview` badge in dev console monitoring page.

**Solution Description**: 
Remove `Tech Preview` badge in dev console monitoring page.

**Screen shots / Gifs for design review**: 
<img width="1506" alt="Screenshot 2020-10-30 at 11 08 06 AM" src="https://user-images.githubusercontent.com/2561818/97663672-34ed7980-1aa0-11eb-9075-27838a02b154.png">
