### PR TITLE
Bug 1866087: Fix crash when helm manifest yaml contains duplicate keys

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,6 +1,6 @@
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
-import { safeDump } from 'js-yaml';
+import { loadAll, safeDump, DEFAULT_SAFE_SCHEMA } from 'js-yaml';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
@@ -231,6 +231,14 @@ export const getChartValuesYAML = (chart: HelmChart): string => {
   if (orderedValues) return orderedValues;
 
   return !_.isEmpty(chart?.values) ? safeDump(chart?.values) : '';
+};
+
+export const loadHelmManifestResources = (release: HelmRelease): K8sResourceKind[] => {
+  if (!release || !release.manifest) {
+    return [];
+  }
+  const manifests = loadAll(release.manifest, null, { schema: DEFAULT_SAFE_SCHEMA, json: true });
+  return manifests.filter(Boolean);
 };
 
 export const getChartReadme = (chart: HelmChart): string => {

--- a/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
@@ -1,4 +1,3 @@
-import { safeLoadAll } from 'js-yaml';
 import { Model, NodeModel } from '@patternfly/react-topology';
 import { apiVersionForModel, K8sResourceKind } from '@console/internal/module/k8s';
 import { SecretModel } from '@console/internal/models';
@@ -13,7 +12,7 @@ import {
   TYPE_HELM_WORKLOAD,
 } from './components/const';
 import { HelmReleaseResourcesMap } from '../../helm/helm-types';
-import { fetchHelmReleases } from '../../helm/helm-utils';
+import { fetchHelmReleases, loadHelmManifestResources } from '../../helm/helm-utils';
 import { WORKLOAD_TYPES } from '../topology-utils';
 import {
   addToTopologyDataModel,
@@ -164,8 +163,7 @@ const getHelmReleaseMap = (namespace: string) => {
     .then((releases) =>
       releases.reduce((acc, release) => {
         try {
-          let manifestResources: K8sResourceKind[] = safeLoadAll(release.manifest);
-          manifestResources = manifestResources.filter((obj) => obj);
+          const manifestResources = loadHelmManifestResources(release);
           manifestResources.forEach((resource) => {
             const resourceKindName = getHelmReleaseKey(resource);
             if (!acc.hasOwnProperty(resourceKindName)) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4947
https://bugzilla.redhat.com/show_bug.cgi?id=1866087

**Analysis / Root cause**: 
The agones helm chart creates a release yaml file which contains an invalid manifest yaml (as string).

The developer console parse this manifest resource yaml string and crashes because there are duplicated keys in the yaml file. This is also invalid in yaml.

**Solution Description**: 
This change adds an option `{ json: true }` to `yaml-js` parse call so that the duplicate key warning is ignored. (The second key overrides the first one.)

**Screen shots / Gifs for design review**: 
Helm Release "Resource" tab before:
![odc-4947-release-manifest-before](https://user-images.githubusercontent.com/139310/97865045-dd524680-1d09-11eb-9dd0-ae0eb9dbf71c.png)

Helm Release "Resource" tab after:
![odc-4947-release-manifest-after](https://user-images.githubusercontent.com/139310/97865056-e0e5cd80-1d09-11eb-9e45-bcb112e49866.png)

Topology before:
![odc-4947-topology-before](https://user-images.githubusercontent.com/139310/97865063-e3482780-1d09-11eb-80f1-3cf819db06d3.png)

Topology after:
![odc-4947-topology-after](https://user-images.githubusercontent.com/139310/97865066-e511eb00-1d09-11eb-9d71-485461d8364d.png)

**Unit test coverage report**: 
Added some unit tests:
```
    loadHelmManifestResources
      ✓ should support an empty string
      ✓ should filter out empty manifest values (2ms)
      ✓ should support a single helm manifest (1ms)
      ✓ should support multiple helm manifests
      ✓ should support helm manifests with duplicated keys (invalid json) (1ms)
```

**Test setup:**
See https://issues.redhat.com/browse/ODC-4947 for steps to reproduce

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
