### PR TITLE
Bug 1893724: Use correct service account for operator monitoring

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -280,7 +280,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
       subjects: [
         {
           kind: 'ServiceAccount',
-          name: 'prometheus-operator',
+          name: 'prometheus-k8s',
           namespace: 'openshift-monitoring',
         },
       ],


### PR DESCRIPTION
The role binding should use the `prometheus-k8s` service account, not `prometheus-operator`.

/assign @jhadvig 
/cc @awgreene 