### PR TITLE
Fetch pods when displaying pods resources in overview pages

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -6,6 +6,7 @@ export * from './scroll';
 export * from './plugins-overview-tab-section';
 export * from './debounce';
 export * from './select-list';
+export * from './usePodsWatcher';
 export * from './useQueryParams';
 export * from './version';
 export * from './csv-watch-hook';

--- a/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { getPodsDataForResource, getResourcesToWatchForPods } from '../utils';
+import { PodRCData } from '../types';
+
+export const usePodsWatcher = (
+  resource: K8sResourceKind,
+  kind?: string,
+  namespace?: string,
+): { loaded: boolean; loadError: string; podData: PodRCData } => {
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>('');
+  const [podData, setPodData] = React.useState<PodRCData>();
+  const watchKind = kind || resource.kind;
+  const watchNS = namespace || resource.metadata.namespace;
+  const watchedResources = React.useMemo(() => getResourcesToWatchForPods(watchKind, watchNS), [
+    watchKind,
+    watchNS,
+  ]);
+
+  const resources = useK8sWatchResources(watchedResources);
+
+  React.useEffect(() => {
+    const errorKey = Object.keys(resources).find((key) => resources[key].loadError);
+    if (errorKey) {
+      setLoadError(resources[errorKey].loadError);
+      return;
+    }
+    setLoadError('');
+    if (
+      Object.keys(resources).length > 0 &&
+      Object.keys(resources).every((key) => resources[key].loaded)
+    ) {
+      const updatedPods = getPodsDataForResource(resource, watchKind, resources);
+      setPodData(updatedPods);
+      setLoaded(true);
+    }
+  }, [watchKind, resource, resources]);
+
+  return { loaded, loadError, podData };
+};

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-resource-utils.spec.ts
@@ -1,0 +1,273 @@
+import * as _ from 'lodash';
+import {
+  MockResources,
+  sampleCronJobs,
+  sampleDaemonSets,
+  sampleDeploymentConfigs,
+  sampleDeployments,
+  sampleStatefulSets,
+} from '@console/dev-console/src/components/topology/__tests__/topology-test-data';
+import {
+  getPodsForDeploymentConfig,
+  getPodsForDeployment,
+  getPodsForStatefulSet,
+  getPodsForDaemonSet,
+  getPodsForCronJob,
+  getPodsForDeploymentConfigs,
+  getPodsForDeployments,
+  getPodsForStatefulSets,
+  getPodsForDaemonSets,
+  getPodsForCronJobs,
+} from '../pod-resource-utils';
+
+let mockResources;
+
+describe('getPodsFor...', () => {
+  beforeEach(() => {
+    mockResources = _.cloneDeep(MockResources);
+  });
+
+  it('should return pods and replication controllers for a given DeploymentConfig', () => {
+    let podRCData = getPodsForDeploymentConfig(sampleDeploymentConfigs.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(1);
+    expect(podRCData.current).not.toBeNull();
+    expect(podRCData.previous).toBeFalsy();
+    expect(podRCData.isRollingOut).toBeFalsy();
+
+    podRCData = getPodsForDeploymentConfig(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    mockResources.replicationControllers = { loaded: false, loadError: 'error', data: [] };
+    podRCData = getPodsForDeploymentConfig(sampleDeploymentConfigs.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    delete mockResources.replicationControllers;
+    podRCData = getPodsForDeploymentConfig(sampleDeploymentConfigs.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+  });
+
+  it('should return pods for a given Deployment', () => {
+    let podRCData = getPodsForDeployment(sampleDeployments.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(3);
+    expect(podRCData.current).not.toBeNull();
+    expect(podRCData.previous).toBeFalsy();
+    expect(podRCData.isRollingOut).toBeFalsy();
+
+    podRCData = getPodsForDeployment(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    podRCData = getPodsForDeployment(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    mockResources.replicaSets = { loaded: false, loadError: 'error', data: [] };
+    podRCData = getPodsForDeployment(sampleDeployments.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    delete mockResources.replicaSets;
+    podRCData = getPodsForDeployment(sampleDeployments.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+  });
+
+  it('should return pods for a given StatefulSet', () => {
+    let podRCData = getPodsForStatefulSet(sampleStatefulSets.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(1);
+    expect(podRCData.current).not.toBeNull();
+    expect(podRCData.previous).toBeFalsy();
+    expect(podRCData.isRollingOut).toBeFalsy();
+
+    podRCData = getPodsForStatefulSet(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    podRCData = getPodsForStatefulSet(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    mockResources.statefulSets = { loaded: false, loadError: 'error', data: [] };
+    podRCData = getPodsForStatefulSet(sampleStatefulSets.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    delete mockResources.statefulSets;
+    podRCData = getPodsForStatefulSet(sampleStatefulSets.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+  });
+
+  it('should return pods for a given DaemonSet', () => {
+    let podRCData = getPodsForDaemonSet(sampleDaemonSets.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(1);
+    expect(podRCData.current).not.toBeNull();
+    expect(podRCData.previous).toBeFalsy();
+    expect(podRCData.isRollingOut).toBeFalsy();
+
+    podRCData = getPodsForDaemonSet(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    podRCData = getPodsForDaemonSet(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    mockResources.pods = { loaded: false, loadError: 'error', data: [] };
+    podRCData = getPodsForDaemonSet(sampleDaemonSets.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    delete mockResources.pods;
+    podRCData = getPodsForDaemonSet(sampleDaemonSets.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+  });
+
+  it('should return pods for a given CronJob', () => {
+    let podRCData = getPodsForCronJob(sampleCronJobs.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(2);
+    expect(podRCData.current).not.toBeNull();
+    expect(podRCData.previous).toBeFalsy();
+    expect(podRCData.isRollingOut).toBeFalsy();
+
+    podRCData = getPodsForCronJob(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    podRCData = getPodsForCronJob(null, mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    mockResources.jobs = { loaded: false, loadError: 'error', data: [] };
+    podRCData = getPodsForCronJob(sampleCronJobs.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+
+    delete mockResources.jobs;
+    podRCData = getPodsForCronJob(sampleCronJobs.data[0], mockResources);
+    expect(podRCData.pods).toHaveLength(0);
+  });
+
+  it('should return pods and replication controllers for a set of DeploymentConfigs', () => {
+    let podRCDataArray = getPodsForDeploymentConfigs(sampleDeploymentConfigs.data, mockResources);
+    expect(podRCDataArray).toHaveLength(2);
+    expect(podRCDataArray[0].pods).toHaveLength(1);
+    expect(podRCDataArray[0].current).not.toBeNull();
+    expect(podRCDataArray[0].previous).toBeFalsy();
+    expect(podRCDataArray[0].isRollingOut).toBeFalsy();
+    expect(podRCDataArray[1].pods).toHaveLength(0);
+
+    podRCDataArray = getPodsForDeploymentConfigs([], mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    podRCDataArray = getPodsForDeploymentConfigs(null, mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    mockResources.replicationControllers = { loaded: false, loadError: 'error', data: [] };
+    podRCDataArray = getPodsForDeploymentConfigs(sampleDeploymentConfigs.data, mockResources);
+    expect(podRCDataArray).toHaveLength(2);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+    expect(podRCDataArray[1].pods).toHaveLength(0);
+
+    delete mockResources.replicationControllers;
+    podRCDataArray = getPodsForDeploymentConfigs(sampleDeploymentConfigs.data, mockResources);
+    expect(podRCDataArray).toHaveLength(2);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+    expect(podRCDataArray[1].pods).toHaveLength(0);
+  });
+
+  it('should return pods for a given Deployment', () => {
+    let podRCDataArray = getPodsForDeployments(sampleDeployments.data, mockResources);
+    expect(podRCDataArray).toHaveLength(3);
+    expect(podRCDataArray[0].pods).toHaveLength(3);
+    expect(podRCDataArray[0].current).not.toBeNull();
+    expect(podRCDataArray[0].previous).toBeFalsy();
+    expect(podRCDataArray[0].isRollingOut).toBeFalsy();
+    expect(podRCDataArray[1].pods).toHaveLength(3);
+    expect(podRCDataArray[1].current).not.toBeNull();
+    expect(podRCDataArray[1].previous).toBeFalsy();
+    expect(podRCDataArray[1].isRollingOut).toBeFalsy();
+    expect(podRCDataArray[2].pods).toHaveLength(0);
+
+    podRCDataArray = getPodsForDeployments([], mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    podRCDataArray = getPodsForDeployments(null, mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    mockResources.replicaSets = { loaded: false, loadError: 'error', data: [] };
+    podRCDataArray = getPodsForDeployments(sampleDeployments.data, mockResources);
+    expect(podRCDataArray).toHaveLength(3);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+    expect(podRCDataArray[1].pods).toHaveLength(0);
+    expect(podRCDataArray[2].pods).toHaveLength(0);
+
+    delete mockResources.replicaSets;
+    podRCDataArray = getPodsForDeployments(sampleDeployments.data, mockResources);
+    expect(podRCDataArray).toHaveLength(3);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+    expect(podRCDataArray[1].pods).toHaveLength(0);
+    expect(podRCDataArray[2].pods).toHaveLength(0);
+  });
+
+  it('should return pods for a set of StatefulSets', () => {
+    let podRCDataArray = getPodsForStatefulSets(sampleStatefulSets.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(1);
+    expect(podRCDataArray[0].current).not.toBeNull();
+    expect(podRCDataArray[0].previous).toBeFalsy();
+    expect(podRCDataArray[0].isRollingOut).toBeFalsy();
+
+    podRCDataArray = getPodsForStatefulSets([], mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    podRCDataArray = getPodsForStatefulSets(null, mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    mockResources.statefulSets = { loaded: false, loadError: 'error', data: [] };
+    podRCDataArray = getPodsForStatefulSets(sampleStatefulSets.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+
+    delete mockResources.statefulSets;
+    podRCDataArray = getPodsForStatefulSets(sampleStatefulSets.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+  });
+
+  it('should return pods for a set of DaemonSets', () => {
+    let podRCDataArray = getPodsForDaemonSets(sampleDaemonSets.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(1);
+    expect(podRCDataArray[0].current).not.toBeNull();
+    expect(podRCDataArray[0].previous).toBeFalsy();
+    expect(podRCDataArray[0].isRollingOut).toBeFalsy();
+
+    podRCDataArray = getPodsForDaemonSets([], mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    podRCDataArray = getPodsForDaemonSets(null, mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    mockResources.pods = { loaded: false, loadError: 'error', data: [] };
+    podRCDataArray = getPodsForDaemonSets(sampleDaemonSets.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+
+    delete mockResources.pods;
+    podRCDataArray = getPodsForDaemonSets(sampleDaemonSets.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+  });
+
+  it('should return pods for a set of CronJobs', () => {
+    let podRCDataArray = getPodsForCronJobs(sampleCronJobs.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(2);
+    expect(podRCDataArray[0].current).not.toBeNull();
+    expect(podRCDataArray[0].previous).toBeFalsy();
+    expect(podRCDataArray[0].isRollingOut).toBeFalsy();
+
+    podRCDataArray = getPodsForCronJobs([], mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    podRCDataArray = getPodsForCronJobs(null, mockResources);
+    expect(podRCDataArray).toHaveLength(0);
+
+    mockResources.jobs = { loaded: false, loadError: 'error', data: [] };
+    podRCDataArray = getPodsForCronJobs(sampleCronJobs.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+
+    delete mockResources.jobs;
+    podRCDataArray = getPodsForCronJobs(sampleCronJobs.data, mockResources);
+    expect(podRCDataArray).toHaveLength(1);
+    expect(podRCDataArray[0].pods).toHaveLength(0);
+  });
+});

--- a/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
@@ -25,8 +25,6 @@ import {
   createOverviewItemsForType,
   createPodItems,
   createWorkloadItems,
-  getPodsForDeploymentConfigs,
-  getPodsForDeployments,
   getWorkloadMonitoringAlerts,
 } from '../resource-utils';
 import { mockAlerts } from '../__mocks__/alerts-and-rules-data';
@@ -91,7 +89,6 @@ const podKeys = [Keys.ALERTS, Keys.OBJ, Keys.ROUTES, Keys.SERVICE, Keys.STATUS];
 const dsAndSSKeys = [...podKeys, Keys.BC, Keys.PODS];
 const dcKeys = [...dsAndSSKeys, Keys.CURRENT, Keys.ROLLINGOUT, Keys.PREVIOUS];
 const knativeKeys = [...dcKeys, Keys.REVISIONS, Keys.KNATIVECONFIGS, Keys.KSROUTES];
-const podRCKeys = [Keys.OBJ, Keys.CURRENT, Keys.PREVIOUS, Keys.PODS, Keys.ROLLINGOUT];
 
 describe('TransformResourceData', () => {
   it('should create Deployment config Items for a provided dc', () => {
@@ -193,22 +190,6 @@ describe('TransformResourceData', () => {
     expect(transformedData[0][Keys.PREVIOUS]).toBeUndefined();
     expect(transformedData[0][Keys.ROLLINGOUT]).toBeUndefined();
     expect(transformedData[0][Keys.BC]).toHaveLength(0);
-  });
-
-  it('should return pods and replication controllers for a given DeploymentConfig', () => {
-    const transformedData = getPodsForDeploymentConfigs(
-      sampleDeploymentConfigs.data,
-      MockResources,
-    );
-    expect(transformedData).toHaveLength(2);
-    expect(transformedData[0]).toHaveProperties(podRCKeys);
-  });
-
-  it('should return pods and replication controllers for a given DeploymentConfig', () => {
-    const transformedData = getPodsForDeployments(sampleDeployments.data, MockResources);
-    expect(transformedData).toHaveLength(3);
-    expect(transformedData[0]).toHaveProperties(podRCKeys);
-    expect(transformedData[1]).toHaveProperties(podRCKeys);
   });
 
   it('should return only pods and not replication controllers for a given resource', () => {

--- a/frontend/packages/console-shared/src/utils/index.ts
+++ b/frontend/packages/console-shared/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './grammar';
 export * from './utils';
 export * from './pod-utils';
 export * from './pod-ring-utils';
+export * from './pod-resource-utils';
 export * from './resource-utils';
 export * from './validation';
 export * from './table-utils';

--- a/frontend/packages/console-shared/src/utils/pod-resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-resource-utils.ts
@@ -1,0 +1,229 @@
+import { apiVersionForModel, K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { PodRCData } from '../types';
+import {
+  CronJobModel,
+  DeploymentConfigModel,
+  DeploymentModel,
+  StatefulSetModel,
+} from '@console/internal/models';
+import {
+  getJobsForCronJob,
+  getPodsForResource,
+  getReplicaSetsForResource,
+  getReplicationControllersForResource,
+  getRolloutStatus,
+  getStatefulSetsResource,
+} from './resource-utils';
+
+export const getPodsForDeploymentConfig = (
+  deploymentConfig: K8sResourceKind,
+  resources: any,
+): PodRCData => {
+  const obj: K8sResourceKind = {
+    ...deploymentConfig,
+    apiVersion: apiVersionForModel(DeploymentConfigModel),
+    kind: DeploymentConfigModel.kind,
+  };
+  const { visibleReplicationControllers } = getReplicationControllersForResource(obj, resources);
+  const [current, previous] = visibleReplicationControllers;
+  const isRollingOut = getRolloutStatus(obj, current, previous);
+  return {
+    obj,
+    current,
+    previous,
+    pods: [...(current?.pods || []), ...(previous?.pods || [])],
+    isRollingOut,
+  };
+};
+
+export const getPodsForDeploymentConfigs = (
+  deploymentConfigs: K8sResourceKind[],
+  resources: any,
+): PodRCData[] =>
+  deploymentConfigs ? deploymentConfigs.map((dc) => getPodsForDeploymentConfig(dc, resources)) : [];
+
+export const getPodsForDeployment = (deployment: K8sResourceKind, resources: any): PodRCData => {
+  const obj: K8sResourceKind = {
+    ...deployment,
+    apiVersion: apiVersionForModel(DeploymentModel),
+    kind: DeploymentModel.kind,
+  };
+  const replicaSets = getReplicaSetsForResource(obj, resources);
+  const [current, previous] = replicaSets;
+  const isRollingOut = !!current && !!previous;
+
+  return {
+    obj,
+    current,
+    previous,
+    isRollingOut,
+    pods: [...(current?.pods || []), ...(previous?.pods || [])],
+  };
+};
+
+export const getPodsForDeployments = (
+  deployments: K8sResourceKind[],
+  resources: any,
+): PodRCData[] => (deployments ? deployments.map((d) => getPodsForDeployment(d, resources)) : []);
+
+export const getPodsForStatefulSet = (ss: K8sResourceKind, resources: any): PodRCData => {
+  const obj: K8sResourceKind = {
+    ...ss,
+    apiVersion: apiVersionForModel(StatefulSetModel),
+    kind: StatefulSetModel.kind,
+  };
+  const statefulSets = getStatefulSetsResource(obj, resources);
+  const [current, previous] = statefulSets;
+  const isRollingOut = !!current && !!previous;
+
+  return {
+    obj,
+    current,
+    previous,
+    isRollingOut,
+    pods: [...(current?.pods || []), ...(previous?.pods || [])],
+  };
+};
+
+export const getPodsForStatefulSets = (ss: K8sResourceKind[], resources: any): PodRCData[] =>
+  ss ? ss.map((s) => getPodsForStatefulSet(s, resources)) : [];
+
+export const getPodsForDaemonSet = (ds: K8sResourceKind, resources: any): PodRCData => {
+  const obj: K8sResourceKind = {
+    ...ds,
+    apiVersion: apiVersionForModel(StatefulSetModel),
+    kind: StatefulSetModel.kind,
+  };
+  return {
+    obj,
+    current: undefined,
+    previous: undefined,
+    isRollingOut: undefined,
+    pods: getPodsForResource(ds, resources),
+  };
+};
+
+export const getPodsForDaemonSets = (ds: K8sResourceKind[], resources: any): PodRCData[] =>
+  ds ? ds.map((d) => getPodsForDaemonSet(d, resources)) : [];
+
+export const getPodsForCronJob = (cronJob: K8sResourceKind, resources: any): PodRCData => {
+  const obj: K8sResourceKind = {
+    ...cronJob,
+    apiVersion: apiVersionForModel(CronJobModel),
+    kind: CronJobModel.kind,
+  };
+  const jobs = getJobsForCronJob(cronJob, resources);
+  return {
+    obj,
+    current: undefined,
+    previous: undefined,
+    isRollingOut: undefined,
+    pods: jobs?.reduce((acc, job) => {
+      acc.push(...getPodsForResource(job, resources));
+      return acc;
+    }, []),
+  };
+};
+
+export const getPodsForCronJobs = (cronJobs: K8sResourceKind[], resources: any): PodRCData[] =>
+  cronJobs ? cronJobs.map((cronJob) => getPodsForCronJob(cronJob, resources)) : [];
+
+export const getPodsDataForResource = (
+  resource: K8sResourceKind,
+  kind: string,
+  resources: any,
+): PodRCData => {
+  switch (kind) {
+    case 'DeploymentConfig':
+      return getPodsForDeploymentConfig(resource, resources);
+    case 'Deployment':
+      return getPodsForDeployment(resource, resources);
+    case 'StatefulSet':
+      return getPodsForStatefulSet(resource, resources);
+    case 'DaemonSet':
+      return getPodsForDaemonSet(resource, resources);
+    case 'CronJob':
+      return getPodsForCronJob(resource, resources);
+    case 'Pod':
+      return {
+        obj: resource,
+        current: undefined,
+        previous: undefined,
+        isRollingOut: undefined,
+        pods: [resource as PodKind],
+      };
+    default:
+      return {
+        obj: resource,
+        current: undefined,
+        previous: undefined,
+        isRollingOut: undefined,
+        pods: getPodsForResource(resource, resources),
+      };
+  }
+};
+
+export const getResourcesToWatchForPods = (kind: string, namespace: string) => {
+  switch (kind) {
+    case 'DeploymentConfig':
+      return {
+        pods: {
+          isList: true,
+          kind: 'Pod',
+          namespace,
+        },
+        replicationControllers: {
+          isList: true,
+          kind: 'ReplicationController',
+          namespace,
+        },
+      };
+    case 'Deployment':
+      return {
+        pods: {
+          isList: true,
+          kind: 'Pod',
+          namespace,
+        },
+        replicaSets: {
+          isList: true,
+          kind: 'ReplicaSet',
+          namespace,
+        },
+      };
+    case 'StatefulSet':
+      return {
+        pods: {
+          isList: true,
+          kind: 'Pod',
+          namespace,
+        },
+        statefulSets: {
+          isList: true,
+          kind: 'StatefulSet',
+          namespace,
+        },
+      };
+    case 'CronJob':
+      return {
+        pods: {
+          isList: true,
+          kind: 'Pod',
+          namespace,
+        },
+        jobs: {
+          isList: true,
+          kind: 'Job',
+          namespace,
+        },
+      };
+    default:
+      return {
+        pods: {
+          isList: true,
+          kind: 'Pod',
+          namespace,
+        },
+      };
+  }
+};

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -29,7 +29,7 @@ import {
   getPodsForDeployments,
   getPodsForStatefulSets,
   getPodsForDaemonSets,
-} from './resource-utils';
+} from './pod-resource-utils';
 import { AllPodStatus } from '../constants';
 
 import './pod-ring-text.scss';

--- a/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
@@ -24,7 +24,6 @@ export type EventSinkServicesOverviewListProps = {
 
 const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps> = ({
   obj,
-  pods,
   current,
 }) => {
   const { t } = useTranslation();
@@ -73,7 +72,7 @@ const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps
       ) : (
         <span className="text-muted">{t('knative-plugin~No sink found for this resource.')}</span>
       )}
-      {pods?.length > 0 && <PodsOverview pods={pods} obj={obj} allPodsLink={linkUrl} />}
+      {<PodsOverview hideIfEmpty obj={obj} allPodsLink={linkUrl} />}
       {deploymentData?.name && (
         <>
           <SidebarSectionHeading text="Deployment" />

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeRevisionResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeRevisionResources.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { K8sResourceKind, PodKind, podPhase } from '@console/internal/module/k8s';
 import { PodControllerOverviewItem } from '@console/shared';
-import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import { PodsOverviewContent } from '@console/internal/components/overview/pods-overview';
 import ConfigurationsOverviewList from './ConfigurationsOverviewList';
 import KSRoutesOverviewList from './RoutesOverviewList';
 import DeploymentOverviewList from './DeploymentOverviewList';
@@ -35,9 +35,11 @@ const KnativeRevisionResources: React.FC<KnativeRevisionResourceProps> = ({
   )}`;
   return (
     <>
-      <PodsOverview
-        pods={activePods}
+      <PodsOverviewContent
         obj={obj}
+        pods={activePods}
+        loaded
+        loadError={null}
         emptyText={t('knative-plugin~Autoscaled to 0')}
         allPodsLink={linkUrl}
       />

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
@@ -5,7 +5,7 @@ import { podPhase } from '@console/internal/module/k8s';
 import { BuildOverview } from '@console/internal/components/overview/build-overview';
 import { PodModel } from '@console/internal/models';
 import { AllPodStatus, OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
-import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import { PodsOverviewContent } from '@console/internal/components/overview/pods-overview';
 import { Subscriber } from '../../topology/topology-types';
 import { getSubscriberByType } from '../../topology/knative-topology-utils';
 import RevisionsOverviewList from './RevisionsOverviewList';
@@ -44,9 +44,11 @@ const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({ item }
   const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <>
-      <PodsOverview
+      <PodsOverviewContent
         pods={activePods}
         obj={obj}
+        loaded
+        loadError={null}
         emptyText={REVISIONS_AUTOSCALED}
         allPodsLink={linkUrl}
       />

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import * as _ from 'lodash';
 import { referenceForModel, PodKind } from '@console/internal/module/k8s';
 import { PodControllerOverviewItem } from '@console/shared';
-import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import {
+  PodsOverview,
+  PodsOverviewContent,
+} from '@console/internal/components/overview/pods-overview';
 import {
   ResourceLink,
   ExternalLink,
   SidebarSectionHeading,
+  history,
 } from '@console/internal/components/utils';
 import { getEventSourceResponse } from '../../../topology/__tests__/topology-knative-test-data';
 import {
@@ -17,6 +21,9 @@ import {
   EventingIMCModel,
 } from '../../../models';
 import EventSinkServicesOverviewList from '../EventSinkServicesOverviewList';
+import { Provider } from 'react-redux';
+import store from '@console/internal/redux';
+import { Router } from 'react-router';
 
 jest.mock('react-i18next', () => {
   const reactI18next = require.requireActual('react-i18next');
@@ -175,12 +182,19 @@ describe('EventSinkServicesOverviewList', () => {
   });
 
   it('should not show pods if not present', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <EventSinkServicesOverviewList
         obj={getEventSourceResponse(EventSourceApiServerModel).data[0]}
         current={current}
       />,
+      {
+        wrappingComponent: ({ children }) => (
+          <Router history={history}>
+            <Provider store={store}>{children}</Provider>
+          </Router>
+        ),
+      },
     );
-    expect(wrapper.find(PodsOverview)).toHaveLength(0);
+    expect(wrapper.find(PodsOverviewContent)).toHaveLength(0);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeRevisionResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeRevisionResources.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import { PodsOverviewContent } from '@console/internal/components/overview/pods-overview';
 import {
   sampleKnativeConfigurations,
   sampleKnativePods,
@@ -30,7 +30,7 @@ describe('KnativeRevisionResources', () => {
         pods={sampleKnativePods.data}
       />,
     );
-    expect(wrapper.find(PodsOverview)).toHaveLength(1);
+    expect(wrapper.find(PodsOverviewContent)).toHaveLength(1);
     expect(wrapper.find(ConfigurationsOverviewList)).toHaveLength(1);
     expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
     expect(wrapper.find(DeploymentOverviewList)).toHaveLength(1);

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { useExtensions } from '@console/plugin-sdk';
-import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import { PodsOverviewContent } from '@console/internal/components/overview/pods-overview';
 import {
   sampleKnativePods,
   sampleKnativeRoutes,
@@ -40,7 +40,7 @@ describe('KnativeServiceResources', () => {
       buildConfigs: [],
     } as OverviewItem;
     const wrapper = shallow(<KnativeServiceResources item={item} />);
-    expect(wrapper.find(PodsOverview)).toHaveLength(1);
+    expect(wrapper.find(PodsOverviewContent)).toHaveLength(1);
     expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
     expect(wrapper.find(RevisionsOverviewList)).toHaveLength(1);
     expect(wrapper.find(BuildOverview)).toHaveLength(0);

--- a/frontend/packages/kubevirt-plugin/src/topology/TopologyVmResourcesPanel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/TopologyVmResourcesPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from '@patternfly/react-topology';
-import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import { PodsOverviewContent } from '@console/internal/components/overview/pods-overview';
 import { NetworkingOverview } from '@console/internal/components/overview/networking-overview';
 import { VMNode } from './types';
 
@@ -15,7 +15,7 @@ export const TopologyVmResourcesPanel: React.FC<TopologyVmResourcePanelProps> = 
 
     return (
       <div className="overview__sidebar-pane-body">
-        <PodsOverview pods={pods} obj={vm} />
+        <PodsOverviewContent obj={vm} pods={pods} loaded loadError={null} />
         <NetworkingOverview services={services} routes={routes} />
       </div>
     );

--- a/frontend/public/components/overview/cron-job-overview.tsx
+++ b/frontend/public/components/overview/cron-job-overview.tsx
@@ -6,7 +6,7 @@ import { CronJobKind } from '../../module/k8s';
 import { menuActions } from '../cron-job';
 import { DetailsItem, KebabAction, pluralize, ResourceSummary, Timestamp } from '../utils';
 import { ResourceOverviewDetails } from './resource-overview-details';
-import { PodsOverview } from './pods-overview';
+import { PodsOverviewMultiple } from './pods-overview';
 import { BuildOverview } from './build-overview';
 import { JobsOverview } from './jobs-overview';
 
@@ -52,7 +52,7 @@ const CronJobResourcesTab: React.SFC<CronJobResourcesTabProps> = ({ item }) => {
   const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <div className="overview__sidebar-pane-body">
-      <PodsOverview pods={pods} obj={obj} />
+      <PodsOverviewMultiple obj={obj} podResources={jobs} />
       <JobsOverview jobs={jobs} pods={pods} obj={obj} />
       <BuildOverview buildConfigs={buildConfigs} />
       {pluginComponents.map(({ Component, key }) => (

--- a/frontend/public/components/overview/job-overview.tsx
+++ b/frontend/public/components/overview/job-overview.tsx
@@ -39,11 +39,11 @@ const JobOverviewDetails: React.FC<JobOverviewDetailsProps> = ({
 );
 
 export const JobResourcesTab: React.SFC<JobResourcesTabProps> = ({ item }) => {
-  const { obj, pods } = item;
+  const { obj } = item;
   const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <div className="overview__sidebar-pane-body">
-      <PodsOverview pods={pods} obj={obj} />
+      <PodsOverview obj={obj} />
       {pluginComponents.map(({ Component, key }) => (
         <Component key={key} item={item} />
       ))}

--- a/frontend/public/components/overview/pod-overview.tsx
+++ b/frontend/public/components/overview/pod-overview.tsx
@@ -38,7 +38,7 @@ const PodOverviewDetails: React.SFC<PodOverviewDetailsProps> = ({ item: { obj: p
 
 const PodResourcesTab: React.SFC<PodResourcesTabProps> = ({ item: { obj, routes, services } }) => (
   <div className="overview__sidebar-pane-body">
-    <PodsOverview pods={[obj]} obj={obj} />
+    <PodsOverview obj={obj} />
     <NetworkingOverview services={services} routes={routes} />
   </div>
 );

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -17,13 +17,13 @@ const { common } = Kebab.factory;
 export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabProps> = ({
   item,
 }) => {
-  const { buildConfigs, hpas, routes, services, pods, obj } = item;
+  const { buildConfigs, hpas, routes, services, obj } = item;
   const hasBuildConfig = buildConfigs?.length > 0;
   const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <div className="overview__sidebar-pane-body">
       <ManagedByOperatorLink obj={item.obj} />
-      <PodsOverview pods={pods} obj={obj} hasBuildConfig={hasBuildConfig} />
+      <PodsOverview obj={obj} hasBuildConfig={hasBuildConfig} />
       <BuildOverview buildConfigs={buildConfigs} />
       <HPAOverview hpas={hpas} />
       {pluginComponents.map(({ Component, key }) => (


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4966 (portions of it)

**Description**
Update the pod resources section of overview pages to retrieve pods for display rather than depending upon the passed in item's resources to be kept up to date.

Non-functional change

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup