### PR TITLE
Determine metrics status in list view nodes

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/TopologyListViewNode.tsx
@@ -42,8 +42,13 @@ interface TopologyListViewNodeProps {
   onSelect: (ids: string[]) => void;
   badgeCell?: React.ReactNode;
   labelCell?: React.ReactNode;
+  alertsCell?: React.ReactNode;
+  memoryCell?: React.ReactNode;
+  cpuCell?: React.ReactNode;
+  statusCell?: React.ReactNode;
   groupResourcesCell?: React.ReactNode;
-  additionalCells?: React.ReactNode[];
+  hideAlerts?: boolean;
+  noPods?: boolean;
 }
 
 const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & DispatchProps> = ({
@@ -53,8 +58,13 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
   onSelectTab,
   badgeCell,
   labelCell,
+  alertsCell,
+  memoryCell,
+  cpuCell,
+  statusCell,
   groupResourcesCell,
-  additionalCells,
+  hideAlerts = false,
+  noPods = false,
   children,
 }) => {
   const [filtered] = useSearchFilter(item.getLabel());
@@ -102,15 +112,17 @@ const ObservedTopologyListViewNode: React.FC<TopologyListViewNodeProps & Dispatc
     if (item.isCollapsed()) {
       cells.push(groupResourcesCell || <GroupResourcesCell key="resources" group={item} />);
     }
-  } else if (additionalCells) {
-    cells.push(...additionalCells);
   } else {
-    cells.push(<AlertsCell key="alerts" item={item} />);
-    if (!selectedIds[0]) {
-      cells.push(<MemoryCell key="memory" item={item} />);
-      cells.push(<CpuCell key="cpu" item={item} />);
+    if (!hideAlerts) {
+      cells.push(alertsCell || <AlertsCell key="alerts" item={item} />);
     }
-    cells.push(<StatusCell key="status" item={item} />);
+    if (!noPods) {
+      if (!selectedIds[0]) {
+        cells.push(memoryCell || <MemoryCell key="memory" item={item} />);
+        cells.push(cpuCell || <CpuCell key="cpu" item={item} />);
+      }
+      cells.push(statusCell || <StatusCell key="status" item={item} />);
+    }
   }
 
   const className = classNames('odc-topology-list-view__item-row', { 'is-filtered': filtered });

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/CpuCell.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/CpuCell.tsx
@@ -1,63 +1,46 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { Node } from '@patternfly/react-topology';
 import { DataListCell } from '@patternfly/react-core';
-import { K8sResourceKind } from '@console/internal/module/k8s';
-import { formatBytesAsMiB, formatCores } from '@console/internal/components/utils';
-import { useOverviewMetrics } from '../../../../utils/useOverviewMetrics';
+import { formatCores } from '@console/internal/components/utils';
+import { getTopologyResourceObject } from '../../topology-utils';
 import { MetricsTooltip } from './MetricsTooltip';
+import { useMetricStats } from '../useMetricStats';
 
 import './MetricsCell.scss';
+
+interface CpuCellComponentProps {
+  cpuByPod: any;
+  totalCores: number;
+}
+
+export const CpuCellComponent: React.FC<CpuCellComponentProps> = React.memo(
+  ({ cpuByPod, totalCores }) => (
+    <div className="odc-topology-list-view__metrics-cell__detail--cpu">
+      <MetricsTooltip metricLabel="CPU" byPod={cpuByPod}>
+        <span>
+          <span className="odc-topology-list-view__metrics-cell__metric-value">
+            {formatCores(totalCores)}
+          </span>
+          &nbsp;
+          <span className="odc-topology-list-view__metrics-cell__metric-unit">cores</span>
+        </span>
+      </MetricsTooltip>
+    </div>
+  ),
+);
 
 type CpuCellProps = {
   item: Node;
 };
 
 export const CpuCell: React.FC<CpuCellProps> = ({ item }) => {
-  const { resources } = item.getData();
-  const metrics = useOverviewMetrics();
-  const getPods = () => {
-    if (resources.obj.kind === 'Pod') {
-      return [resources.obj];
-    }
-    return resources.current ? resources.current.pods : resources.pods;
-  };
-
-  let totalBytes = 0;
-  let totalCores = 0;
-  const memoryByPod = [];
-  const cpuByPod = [];
-  _.each(getPods(), ({ metadata: { name } }: K8sResourceKind) => {
-    const bytes = _.get(metrics, ['memory', name]);
-    if (_.isFinite(bytes)) {
-      totalBytes += bytes;
-      const formattedValue = `${formatBytesAsMiB(bytes)} MiB`;
-      memoryByPod.push({ name, value: bytes, formattedValue });
-    }
-
-    const cores = _.get(metrics, ['cpu', name]);
-    if (_.isFinite(cores)) {
-      totalCores += cores;
-      cpuByPod[name] = `${formatCores(cores)} cores`;
-      const formattedValue = `${formatCores(cores)} cores`;
-      cpuByPod.push({ name, value: cores, formattedValue });
-    }
-  });
+  const resource = getTopologyResourceObject(item.getData());
+  const memoryStats = useMetricStats(resource);
 
   return (
     <DataListCell id={`${item.getId()}_metrics`}>
-      {_.isEmpty(metrics) || !totalBytes || !totalCores ? null : (
-        <div className="odc-topology-list-view__metrics-cell__detail--cpu">
-          <MetricsTooltip metricLabel="CPU" byPod={cpuByPod}>
-            <span>
-              <span className="odc-topology-list-view__metrics-cell__metric-value">
-                {formatCores(totalCores)}
-              </span>
-              &nbsp;
-              <span className="odc-topology-list-view__metrics-cell__metric-unit">cores</span>
-            </span>
-          </MetricsTooltip>
-        </div>
+      {!memoryStats || !memoryStats.totalBytes || !memoryStats.totalCores ? null : (
+        <CpuCellComponent cpuByPod={memoryStats.cpuByPod} totalCores={memoryStats.totalCores} />
       )}
     </DataListCell>
   );

--- a/frontend/packages/dev-console/src/components/topology/list-view/cells/StatusCell.tsx
+++ b/frontend/packages/dev-console/src/components/topology/list-view/cells/StatusCell.tsx
@@ -1,18 +1,84 @@
 import { Node } from '@patternfly/react-topology';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { DataListCell } from '@patternfly/react-core';
+import { usePodsWatcher, PodRCData } from '@console/shared';
+import { resourceObjPath } from '@console/internal/components/utils';
+import { K8sResourceKind, PodKind, podPhase } from '@console/internal/module/k8s';
+import { DaemonSetModel } from '@console/internal/models';
+import { getTopologyResourceObject } from '../../topology-utils';
 
 import './StatusCell.scss';
+
+type StatusCellResourceLinkProps = {
+  desired: number;
+  ready: number;
+  resource: K8sResourceKind;
+};
+
+export const StatusCellResourceLink: React.FC<StatusCellResourceLinkProps> = ({
+  desired = 0,
+  ready = 0,
+  resource,
+}) => {
+  const href = `${resourceObjPath(resource, resource.kind)}/pods`;
+  return (
+    <Link to={href}>
+      {ready} of {desired} pods
+    </Link>
+  );
+};
+
+interface StatusCellResourceStatus {
+  obj: K8sResourceKind;
+  podData: PodRCData;
+}
+
+export const StatusCellResourceStatus: React.FC<StatusCellResourceStatus> = ({ obj, podData }) => {
+  if (obj.kind === DaemonSetModel.kind) {
+    return (
+      <StatusCellResourceLink
+        desired={obj?.status?.desiredNumberScheduled}
+        ready={obj?.status?.currentNumberScheduled}
+        resource={obj}
+      />
+    );
+  }
+  if (obj.spec?.replicas === undefined) {
+    const href = `${resourceObjPath(obj, obj.kind)}/pods`;
+    const filteredPods = podData.pods?.filter((p) => podPhase(p as PodKind) !== 'Completed') ?? [];
+    if (!filteredPods.length) {
+      return null;
+    }
+    return <Link to={href}>{filteredPods.length} pods</Link>;
+  }
+
+  return podData.isRollingOut ? (
+    <span className="text-muted">Rollout in progress...</span>
+  ) : (
+    <StatusCellResourceLink
+      desired={obj.spec.replicas}
+      ready={obj.status.replicas}
+      resource={podData.current ? podData.current.obj : obj}
+    />
+  );
+};
 
 type StatusProps = {
   item: Node;
 };
 
 export const StatusCell: React.FC<StatusProps> = ({ item }) => {
-  const { status } = item.getData().resources;
+  const resource = getTopologyResourceObject(item.getData());
+  const { podData, loaded, loadError } = usePodsWatcher(resource);
+
   return (
     <DataListCell id={`${item.getId()}_status`}>
-      {status ? <div className="odc-topology-list-view__detail--status">{status}</div> : null}
+      <div className="odc-topology-list-view__detail--status">
+        {loaded && !loadError ? (
+          <StatusCellResourceStatus obj={resource} podData={podData} />
+        ) : null}
+      </div>
     </DataListCell>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/list-view/listViewComponentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/list-view/listViewComponentFactory.ts
@@ -1,9 +1,8 @@
 /* eslint-disable import/no-cycle */
 import * as React from 'react';
 import { Node } from '@patternfly/react-topology';
-import { TYPE_KNATIVE_SERVICE, TYPE_SINK_URI } from '@console/knative-plugin/src/topology/const';
-import { KnativeServiceListViewNode } from '@console/knative-plugin/src/topology/listView/KnativeServiceListViewNode';
-import { SinkUriListViewNode } from '@console/knative-plugin/src/topology/listView/SinkUriListViewNode';
+import { knativeListViewNodeComponentFactory } from '@console/knative-plugin/src/topology/listView/knativeListViewComponentFactory';
+import { kubevirtListViewNodeComponentFactory } from '@console/kubevirt-plugin/src/topology/listView/kubevirtListViewComponentFactory';
 import { TYPE_WORKLOAD } from '../components/const';
 import { TopologyListViewNode } from './TopologyListViewNode';
 import { TYPE_OPERATOR_BACKED_SERVICE } from '../operators/components/const';
@@ -20,6 +19,16 @@ export const listViewNodeComponentFactory = (
       onSelect: (ids: string[]) => void;
     }>
   | undefined => {
+  // TODO: Move to plugins
+  const knativeComponent = knativeListViewNodeComponentFactory(type);
+  if (knativeComponent) {
+    return knativeComponent;
+  }
+  const kubevirtComponent = kubevirtListViewNodeComponentFactory(type);
+  if (kubevirtComponent) {
+    return kubevirtComponent;
+  }
+
   switch (type) {
     case TYPE_WORKLOAD:
       return TopologyListViewNode;
@@ -27,10 +36,6 @@ export const listViewNodeComponentFactory = (
       return OperatorGroupListViewNode;
     case TYPE_HELM_RELEASE:
       return HelmReleaseListViewNode;
-    case TYPE_KNATIVE_SERVICE:
-      return KnativeServiceListViewNode;
-    case TYPE_SINK_URI:
-      return SinkUriListViewNode;
     default:
       return TopologyListViewNode;
   }

--- a/frontend/packages/dev-console/src/components/topology/list-view/metricStats.ts
+++ b/frontend/packages/dev-console/src/components/topology/list-view/metricStats.ts
@@ -1,0 +1,44 @@
+import { PodRCData } from '@console/shared/src';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { formatBytesAsMiB, formatCores } from '@console/internal/components/utils';
+import { NamespaceMetrics } from '@console/internal/actions/ui';
+
+export type PodStats = {
+  name: string;
+  value: number;
+  formattedValue: string;
+};
+
+export type MetricStats = {
+  totalBytes?: number;
+  totalCores?: number;
+  memoryByPod?: PodStats[];
+  cpuByPod?: PodStats[];
+};
+
+export const getPodMetricStats = (metrics: NamespaceMetrics, podData: PodRCData): MetricStats => {
+  const currentPods = podData.current ? podData.current.pods : podData.pods;
+  let totalBytes = 0;
+  let totalCores = 0;
+  const memoryByPod = [];
+  const cpuByPod = [];
+  if (currentPods?.length) {
+    currentPods.forEach(({ metadata: { name } }: K8sResourceKind) => {
+      const bytes = metrics?.memory?.[name];
+      if (Number.isFinite(bytes)) {
+        totalBytes += bytes;
+        const formattedValue = `${formatBytesAsMiB(bytes)} MiB`;
+        memoryByPod.push({ name, value: bytes, formattedValue });
+      }
+
+      const cores = metrics?.cpu?.[name];
+      if (Number.isFinite(cores)) {
+        totalCores += cores;
+        cpuByPod[name] = `${formatCores(cores)} cores`;
+        const formattedValue = `${formatCores(cores)} cores`;
+        cpuByPod.push({ name, value: cores, formattedValue });
+      }
+    });
+  }
+  return { totalBytes, totalCores, memoryByPod, cpuByPod };
+};

--- a/frontend/packages/dev-console/src/components/topology/list-view/useMetricStats.ts
+++ b/frontend/packages/dev-console/src/components/topology/list-view/useMetricStats.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { usePodsWatcher } from '@console/shared/src';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useOverviewMetrics } from '../../../utils/useOverviewMetrics';
+import { MetricStats, getPodMetricStats } from './metricStats';
+
+export const useMetricStats = (resource: K8sResourceKind): MetricStats => {
+  const metrics = useOverviewMetrics();
+  const { podData, loaded } = usePodsWatcher(resource, resource.kind, resource.metadata.namespace);
+  const memoryStats = React.useMemo(() => {
+    if (_.isEmpty(metrics) || !loaded) {
+      return null;
+    }
+    return getPodMetricStats(metrics, podData);
+  }, [loaded, metrics, podData]);
+
+  return memoryStats;
+};

--- a/frontend/packages/knative-plugin/src/topology/listView/KnativeRevisionListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/KnativeRevisionListViewNode.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Node, observer } from '@patternfly/react-topology';
+import { DataListCell } from '@patternfly/react-core';
+import {
+  CpuCellComponent,
+  getTopologyResourceObject,
+  MemoryCellComponent,
+  StatusCellResourceStatus,
+  TopologyListViewNode,
+} from '@console/dev-console/src/components/topology';
+import { useOverviewMetrics } from '@console/dev-console/src/utils/useOverviewMetrics';
+import { getPodMetricStats } from '@console/dev-console/src/components/topology/list-view/metricStats';
+import { usePodsForRevisions } from '../../utils/usePodsForRevisions';
+
+interface KnativeRevisionListViewNodeProps {
+  item: Node;
+  selectedIds: string[];
+  onSelect: (ids: string[]) => void;
+}
+
+const ObservedKnativeRevisionListViewNode: React.FC<KnativeRevisionListViewNodeProps> = ({
+  item,
+  selectedIds,
+  onSelect,
+  children,
+}) => {
+  const resource = getTopologyResourceObject(item.getData());
+  const metrics = useOverviewMetrics();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const revisions = React.useMemo(() => [resource], [resource.metadata.uid]);
+  const { loaded, pods } = usePodsForRevisions(revisions, resource.metadata.namespace);
+  const podData = React.useMemo(() => {
+    if (!loaded) {
+      return null;
+    }
+    const [current, previous] = pods;
+    const isRollingOut = !!current && !!previous;
+    return {
+      current,
+      previous,
+      obj: current?.obj || resource,
+      isRollingOut,
+      pods: [...(current?.pods || []), ...(previous?.pods || [])],
+    };
+  }, [loaded, pods, resource]);
+
+  const metricStats = React.useMemo(() => {
+    if (!podData) {
+      return null;
+    }
+    return getPodMetricStats(metrics, podData);
+  }, [metrics, podData]);
+
+  const memoryCell = (
+    <DataListCell key="memory" id={`${item.getId()}_memory`}>
+      {!metricStats || !metricStats.totalBytes || !metricStats.totalCores ? null : (
+        <MemoryCellComponent
+          totalBytes={metricStats.totalBytes}
+          memoryByPod={metricStats.memoryByPod}
+        />
+      )}
+    </DataListCell>
+  );
+  const cpuCell = (
+    <DataListCell key="cpu" id={`${item.getId()}_metrics`}>
+      {!metricStats || !metricStats.totalBytes || !metricStats.totalCores ? null : (
+        <CpuCellComponent cpuByPod={metricStats.cpuByPod} totalCores={metricStats.totalCores} />
+      )}
+    </DataListCell>
+  );
+
+  const statusCell = (
+    <DataListCell key="status" id={`${item.getId()}_status`}>
+      <div className="odc-topology-list-view__detail--status">
+        {podData ? <StatusCellResourceStatus obj={podData.obj} podData={podData} /> : null}
+      </div>
+    </DataListCell>
+  );
+
+  return (
+    <TopologyListViewNode
+      item={item}
+      selectedIds={selectedIds}
+      onSelect={onSelect}
+      memoryCell={memoryCell}
+      cpuCell={cpuCell}
+      statusCell={statusCell}
+    >
+      {children}
+    </TopologyListViewNode>
+  );
+};
+
+const KnativeRevisionListViewNode = observer(ObservedKnativeRevisionListViewNode);
+export { KnativeRevisionListViewNode };

--- a/frontend/packages/knative-plugin/src/topology/listView/NoStatusListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/NoStatusListViewNode.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { OdcBaseNode, TopologyListViewNode } from '@console/dev-console/src/components/topology';
+
+interface NoStatusListViewNodeProps {
+  item: OdcBaseNode;
+  selectedIds: string[];
+  onSelect: (ids: string[]) => void;
+}
+
+const NoStatusListViewNode: React.FC<NoStatusListViewNodeProps> = (props) => (
+  <TopologyListViewNode noPods {...props} />
+);
+
+export { NoStatusListViewNode };

--- a/frontend/packages/knative-plugin/src/topology/listView/SinkUriListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/SinkUriListViewNode.tsx
@@ -7,18 +7,13 @@ import {
 } from '@console/dev-console/src/components/topology';
 import { DataListCell } from '@patternfly/react-core';
 
-interface KnativeServiceListViewNodeProps {
+interface SinkUriListViewNodeProps {
   item: OdcBaseNode;
   selectedIds: string[];
   onSelect: (ids: string[]) => void;
 }
 
-const ObservedSinkUriListViewNode: React.FC<KnativeServiceListViewNodeProps> = ({
-  item,
-  selectedIds,
-  onSelect,
-  children,
-}) => {
+const ObservedSinkUriListViewNode: React.FC<SinkUriListViewNodeProps> = ({ item, ...rest }) => {
   const sinkUri = item.getResource()?.spec?.sinkUri;
 
   const labelCell = (
@@ -28,16 +23,7 @@ const ObservedSinkUriListViewNode: React.FC<KnativeServiceListViewNodeProps> = (
     </DataListCell>
   );
 
-  return (
-    <TopologyListViewNode
-      item={item}
-      selectedIds={selectedIds}
-      onSelect={onSelect}
-      labelCell={labelCell}
-    >
-      {children}
-    </TopologyListViewNode>
-  );
+  return <TopologyListViewNode item={item} labelCell={labelCell} noPods {...rest} />;
 };
 
 const SinkUriListViewNode = observer(ObservedSinkUriListViewNode);

--- a/frontend/packages/knative-plugin/src/topology/listView/knativeListViewComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/listView/knativeListViewComponentFactory.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Node } from '@patternfly/react-topology';
+import {
+  TYPE_KNATIVE_SERVICE,
+  TYPE_SINK_URI,
+  TYPE_EVENT_SOURCE,
+  TYPE_EVENT_SOURCE_LINK,
+  TYPE_EVENT_PUB_SUB,
+  TYPE_EVENT_PUB_SUB_LINK,
+  TYPE_KNATIVE_REVISION,
+} from '../const';
+import { KnativeServiceListViewNode } from './KnativeServiceListViewNode';
+import { SinkUriListViewNode } from './SinkUriListViewNode';
+import { NoStatusListViewNode } from './NoStatusListViewNode';
+import { KnativeRevisionListViewNode } from './KnativeRevisionListViewNode';
+
+export const knativeListViewNodeComponentFactory = (
+  type,
+):
+  | React.ComponentType<{
+      item: Node;
+      selectedIds: string[];
+      onSelect: (ids: string[]) => void;
+    }>
+  | undefined => {
+  switch (type) {
+    case TYPE_KNATIVE_SERVICE:
+      return KnativeServiceListViewNode;
+    case TYPE_KNATIVE_REVISION:
+      return KnativeRevisionListViewNode;
+    case TYPE_SINK_URI:
+      return SinkUriListViewNode;
+    case TYPE_EVENT_PUB_SUB_LINK:
+    case TYPE_EVENT_SOURCE:
+    case TYPE_EVENT_SOURCE_LINK:
+    case TYPE_EVENT_PUB_SUB:
+      return NoStatusListViewNode;
+    default:
+      return null;
+  }
+};

--- a/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
+++ b/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import {
+  apiVersionForModel,
+  K8sResourceCommon,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import {
+  getOwnedResources,
+  getReplicaSetsForResource,
+  PodControllerOverviewItem,
+} from '@console/shared/src';
+import { DeploymentModel } from '@console/internal/models';
+
+export const usePodsForRevisions = (
+  revisionResources: K8sResourceKind[],
+  namespace: string,
+): { loaded: boolean; loadError: string; pods: PodControllerOverviewItem[] } => {
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>('');
+  const [pods, setPods] = React.useState<PodControllerOverviewItem[]>();
+  const watchedResources = React.useMemo(
+    () => ({
+      deployments: {
+        isList: true,
+        kind: 'Deployment',
+        namespace,
+      },
+      replicaSets: {
+        isList: true,
+        kind: 'ReplicaSet',
+        namespace,
+      },
+      pods: {
+        isList: true,
+        kind: 'Pod',
+        namespace,
+      },
+    }),
+    [namespace],
+  );
+
+  const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
+
+  React.useEffect(() => {
+    const errorKey = Object.keys(resources).find((key) => resources[key].loadError);
+    if (errorKey) {
+      setLoadError(resources[errorKey].loadError);
+      return;
+    }
+    if (
+      Object.keys(resources).length > 0 &&
+      Object.keys(resources).every((key) => resources[key].loaded)
+    ) {
+      const revisionsPods = [];
+      revisionResources.forEach((revision) => {
+        const associatedDeployment = getOwnedResources(revision, resources.deployments.data);
+        if (associatedDeployment?.[0]) {
+          const depObj: K8sResourceKind = {
+            ...associatedDeployment[0],
+            apiVersion: apiVersionForModel(DeploymentModel),
+            kind: DeploymentModel.kind,
+          };
+          revisionsPods.push(...getReplicaSetsForResource(depObj, resources));
+        }
+      });
+      setLoaded(true);
+      setLoadError(null);
+      setPods(revisionsPods);
+    }
+  }, [revisionResources, resources]);
+
+  return { loaded, loadError, pods };
+};

--- a/frontend/packages/kubevirt-plugin/src/topology/listView/VmListViewNode.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/listView/VmListViewNode.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { Node, observer } from '@patternfly/react-topology';
+import { DataListCell } from '@patternfly/react-core';
+import {
+  CpuCellComponent,
+  getTopologyResourceObject,
+  MemoryCellComponent,
+  TopologyListViewNode,
+} from '@console/dev-console/src/components/topology';
+import { useOverviewMetrics } from '@console/dev-console/src/utils/useOverviewMetrics';
+import { getPodMetricStats } from '@console/dev-console/src/components/topology/list-view/metricStats';
+import { usePodsForVm } from '../../utils/usePodsForVm';
+
+interface VmListViewNodeProps {
+  item: Node;
+  selectedIds: string[];
+  onSelect: (ids: string[]) => void;
+}
+
+const VmListViewNode: React.FC<VmListViewNodeProps> = observer(({ item, ...rest }) => {
+  const vm = getTopologyResourceObject(item.getData());
+  const metrics = useOverviewMetrics();
+  const { podData } = usePodsForVm(vm);
+
+  const metricStats = React.useMemo(() => {
+    if (!podData) {
+      return null;
+    }
+    return getPodMetricStats(metrics, podData);
+  }, [metrics, podData]);
+
+  const memoryCell = (
+    <DataListCell key="memory" id={`${item.getId()}_memory`}>
+      {!metricStats || !metricStats.totalBytes || !metricStats.totalCores ? null : (
+        <MemoryCellComponent
+          totalBytes={metricStats.totalBytes}
+          memoryByPod={metricStats.memoryByPod}
+        />
+      )}
+    </DataListCell>
+  );
+  const cpuCell = (
+    <DataListCell key="cpu" id={`${item.getId()}_metrics`}>
+      {!metricStats || !metricStats.totalBytes || !metricStats.totalCores ? null : (
+        <CpuCellComponent cpuByPod={metricStats.cpuByPod} totalCores={metricStats.totalCores} />
+      )}
+    </DataListCell>
+  );
+
+  // No status cell
+  const statusCell = <DataListCell key="status" id={`${item.getId()}_status`} />;
+
+  return (
+    <TopologyListViewNode
+      item={item}
+      memoryCell={memoryCell}
+      cpuCell={cpuCell}
+      statusCell={statusCell}
+      {...rest}
+    />
+  );
+});
+
+export { VmListViewNode };

--- a/frontend/packages/kubevirt-plugin/src/topology/listView/kubevirtListViewComponentFactory.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/listView/kubevirtListViewComponentFactory.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { Node } from '@patternfly/react-topology';
+import { VmListViewNode } from './VmListViewNode';
+import { TYPE_VIRTUAL_MACHINE } from '../components/const';
+
+export const kubevirtListViewNodeComponentFactory = (
+  type,
+):
+  | React.ComponentType<{
+      item: Node;
+      selectedIds: string[];
+      onSelect: (ids: string[]) => void;
+    }>
+  | undefined => {
+  switch (type) {
+    case TYPE_VIRTUAL_MACHINE:
+      return VmListViewNode;
+    default:
+      return null;
+  }
+};

--- a/frontend/packages/kubevirt-plugin/src/utils/usePodsForVm.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/usePodsForVm.ts
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { K8sResourceCommon, K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { getReplicationControllersForResource, PodRCData } from '@console/shared/src';
+import { VMIKind } from '../types/vm';
+import { findVMIPod } from '../selectors/pod/selectors';
+import * as models from '../models';
+
+export const usePodsForVm = (
+  vm: K8sResourceKind,
+): { loaded: boolean; loadError: string; podData: PodRCData } => {
+  const { namespace } = vm.metadata;
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>('');
+  const [podData, setPodData] = React.useState<PodRCData>();
+
+  const watchedResources = React.useMemo(
+    () => ({
+      replicationControllers: {
+        isList: true,
+        kind: 'ReplicationController',
+        namespace,
+      },
+      pods: {
+        isList: true,
+        kind: 'Pod',
+        namespace,
+      },
+      virtualmachineinstances: {
+        isList: true,
+        kind: models.VirtualMachineInstanceModel.kind,
+        namespace,
+        optional: true,
+      },
+    }),
+    [namespace],
+  );
+
+  const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
+
+  React.useEffect(() => {
+    const errorKey = Object.keys(resources).find((key) => resources[key].loadError);
+    if (errorKey) {
+      setLoadError(resources[errorKey].loadError);
+      return;
+    }
+    if (
+      Object.keys(resources).length > 0 &&
+      Object.keys(resources).every((key) => resources[key].loaded)
+    ) {
+      const { name } = vm.metadata;
+      const vmis = resources.virtualmachineinstances.data;
+      const vmi = vmis.find((instance) => instance.metadata.name === name) as VMIKind;
+      const { visibleReplicationControllers } = getReplicationControllersForResource(vm, resources);
+      const [current, previous] = visibleReplicationControllers;
+      const launcherPod = findVMIPod(vmi, resources.pods.data as PodKind[]);
+      const podRCData: PodRCData = {
+        current,
+        previous,
+        isRollingOut: false,
+        pods: launcherPod ? [launcherPod] : [],
+        obj: vm,
+      };
+      setLoaded(true);
+      setLoadError(null);
+      setPodData(podRCData);
+    }
+  }, [resources, vm]);
+
+  return { loaded, loadError, podData };
+};


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4966 (portions of it)

**Description**
Determine metric stats shown in the topology list view when rendered rather than depending on stats to be determined at topology graph load time. 
Also fixes pod counts in the list view for knative revisions.
Only shows stats columns for items that should have stats.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup
