### PR TITLE
E2E test: Use KUBEADM_PASSWORD_FILE by default

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -17,7 +17,7 @@ trap copyArtifacts EXIT
 
 # don't log kubeadmin-password
 set +x
-BRIDGE_KUBEADMIN_PASSWORD="$(cat "${INSTALLER_DIR}/auth/kubeadmin-password")"
+BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
 export BRIDGE_KUBEADMIN_PASSWORD
 set -x
 BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"


### PR DESCRIPTION
We want to move the current template-based tests to the more modern
step-registry based tests, which provide the kubeadm password file
location via an env var.