### PR TITLE
Bug 1893963: Dont use lookbehinds regexp

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -82,9 +82,8 @@ const VMConsoles: React.FC<VMConsolesProps> = ({
   const cloudInitVolume = getCloudInitVolume(vm);
   const data = new VolumeWrapper(cloudInitVolume).getCloudInitNoCloud();
   const cloudInitHelper = new CloudInitDataHelper(data);
-  const cloudInitUserData = cloudInitHelper.getUserData();
-  const cloudInitUsername = cloudInitUserData?.match(/(?<=user:\s+).*/);
-  const cloudInitPassword = cloudInitUserData?.match(/(?<=password:\s+).*/);
+  const cloudInitUsername = cloudInitHelper.get('user');
+  const cloudInitPassword = cloudInitHelper.get('password');
 
   if (!isVMIRunning(vmi)) {
     if (vmStatusBundle?.status?.isImporting() || vmStatusBundle?.status?.isMigrating()) {


### PR DESCRIPTION
On Firefox 68.12.0esr (64-bit) and  66.0.2 (64-bit) when going to the Virtualization tab in the UI nothing is loading on the right side 
FireFox 68 does not support lookbehinds regular expresions [1], this PR introduce a workaround supported by older browsers.

[1] https://kangax.github.io/compat-table/es2016plus/#test-RegExp_Lookbehind_Assertions