### PR TITLE
[release-4.6] Bug 1893626: Fix Encryption request for OCS

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -131,16 +131,19 @@ export const CreateInternalCluster = withHandlePromise<
   const submit = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     // eslint-disable-next-line promise/catch-or-return
-    handlePromise(makeOCSRequest(nodes, storageClass, osdSize, isEncrypted, isMinimal), () => {
-      dispatch(setFlag(OCS_CONVERGED_FLAG, true));
-      dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
-      dispatch(setFlag(OCS_FLAG, true));
-      history.push(
-        `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(
-          OCSServiceModel,
-        )}/${OCS_INTERNAL_CR_NAME}`,
-      );
-    });
+    handlePromise(
+      makeOCSRequest(nodes, storageClass, osdSize, isEncrypted, isMinimal, isEncryptionSupported),
+      () => {
+        dispatch(setFlag(OCS_CONVERGED_FLAG, true));
+        dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
+        dispatch(setFlag(OCS_FLAG, true));
+        history.push(
+          `/k8s/ns/${ns}/clusterserviceversions/${appName}/${referenceForModel(
+            OCSServiceModel,
+          )}/${OCS_INTERNAL_CR_NAME}`,
+        );
+      },
+    );
   };
 
   const handleStorageClass = (sc: StorageClassResourceKind) => {


### PR DESCRIPTION
- Argument `isEncryptionSupported` was missing for `makeOCSRequest` function. 
Correct CR is getting created: 
```
      manager: ocs-operator
      operation: Update
      time: '2020-11-03T18:26:37Z'
  namespace: openshift-storage
  finalizers:
    - storagecluster.ocs.openshift.io
spec:
  encryption:
    enable: true
  externalStorage: {}
```