### PR TITLE
[release-4.6] Bug 1894235: Fix to allow shift-drag to regroup knative services in topology

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,7 @@
     "@patternfly/react-core": "4.40.2",
     "@patternfly/react-table": "4.15.3",
     "@patternfly/react-tokens": "4.9.2",
-    "@patternfly/react-topology": "4.5.15",
+    "@patternfly/react-topology": "4.5.15-1",
     "@patternfly/react-virtualized-extension": "4.5.49",
     "abort-controller": "3.0.0",
     "ajv": "^6.12.3",

--- a/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/componentUtils.ts
@@ -155,6 +155,21 @@ const nodeDragSourceSpec = (
   }),
 });
 
+const noRegroupDragSourceSpec: DragSourceSpec<
+  DragObjectWithType,
+  DragSpecOperationType<EditableDragOperationType>,
+  Node,
+  {
+    dragging?: boolean;
+  },
+  NodeComponentProps
+> = {
+  item: { type: NODE_DRAG_TYPE },
+  collect: (monitor) => ({
+    dragging: monitor.isDragging(),
+  }),
+};
+
 const nodesEdgeIsDragging = (monitor, props) => {
   if (!monitor.isDragging()) {
     return false;
@@ -354,6 +369,7 @@ export {
   EditableDragOperationType,
   DragNodeObject,
   nodesEdgeIsDragging,
+  noRegroupDragSourceSpec,
   nodeDragSourceSpec,
   nodeDropTargetSpec,
   graphDropTargetSpec,

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
@@ -24,8 +24,7 @@ import {
   useSearchFilter,
   SHOW_LABELS_FILTER_ID,
 } from '../../filters';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_HELM_RELEASE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 
 export type HelmReleaseGroupProps = {
   element: Node;
@@ -45,13 +44,8 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const dragSpec = nodeDragSourceSpec(TYPE_HELM_RELEASE, false);
-  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(dragSpec, { element });
-  const [
-    { dragging: labelDragging, regrouping: labelRegrouping },
-    dragLabelRef,
-  ] = useDragNode(dragSpec, { element });
-
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
+  const [{ dragging: labelDragging }, dragLabelRef] = useDragNode(noRegroupDragSourceSpec);
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const displayFilters = useDisplayFilters();
@@ -71,9 +65,7 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
       })}
     >
       <NodeShadows />
-      <Layer
-        id={(dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'}
-      >
+      <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
         <g
           ref={nodeRefs}
           className={classNames('odc-helm-release', {

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -21,8 +21,7 @@ import {
 import { useSearchFilter } from '../../filters/useSearchFilter';
 import { GroupNode } from '../../components/groups/GroupNode';
 import { GroupNodeAnchor } from '../../components/groups/GroupNodeAnchor';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_HELM_RELEASE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 
 export type HelmReleaseNodeProps = {
   element: Node;
@@ -41,9 +40,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
   dndDropRef,
 }) => {
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(nodeDragSourceSpec(TYPE_HELM_RELEASE, false), {
-    element,
-  });
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDropRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const { groupResources } = element.getData();

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
@@ -15,8 +15,7 @@ import {
   RectAnchor,
 } from '@patternfly/react-topology';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_OPERATOR_BACKED_SERVICE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 import {
   getFilterById,
   useDisplayFilters,
@@ -49,19 +48,8 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
-  const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
-
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
+  const [{ dragging: labelDragging }, dragLabelRef] = useDragNode(noRegroupDragSourceSpec);
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();
@@ -84,9 +72,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
       })}
     >
       <NodeShadows />
-      <Layer
-        id={(dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'}
-      >
+      <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
         <Tooltip
           content="Create a binding connector"
           trigger="manual"

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
@@ -14,8 +14,7 @@ import {
   useSize,
 } from '@patternfly/react-topology';
 import { useSearchFilter } from '../../filters/useSearchFilter';
-import { nodeDragSourceSpec } from '../../components/componentUtils';
-import { TYPE_OPERATOR_BACKED_SERVICE } from './const';
+import { noRegroupDragSourceSpec } from '../../components/componentUtils';
 import {
   NodeShadows,
   NODE_SHADOW_FILTER_ID,
@@ -41,12 +40,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   dropTarget,
 }) => {
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
+  const [{ dragging }, dragNodeRef] = useDragNode(noRegroupDragSourceSpec);
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef, dndDropRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const kind = 'Operator';

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -66,19 +66,15 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),
-    {
-      element,
-    },
-  );
+  const dragSpec = React.useMemo(() => nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess), [
+    editAccess,
+  ]);
+  const dragProps = React.useMemo(() => ({ element }), [element]);
+  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(dragSpec, dragProps);
   const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),
-    {
-      element,
-    },
+    dragSpec,
+    dragProps,
   );
-
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
@@ -53,12 +53,11 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
   onShowCreateConnector,
 }) => {
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),
-    {
-      element,
-    },
-  );
+  const dragSpec = React.useMemo(() => nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess), [
+    editAccess,
+  ]);
+  const dragProps = React.useMemo(() => ({ element }), [element]);
+  const [{ dragging }, dragNodeRef] = useDragNode(dragSpec, dragProps);
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const allowEdgeCreation = useAllowEdgeCreation();

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2131,10 +2131,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.8.tgz#260079b01359bcaf23875890e412f3c6e87e0202"
   integrity sha512-HBbtQHlWl3/B9KrS1fI3/k6sXDowfTsmw0zKuHXWjG552l0ApOrDmzh120Q7m6cvvkFv/Cw6XRwtJIDZBCEiyg==
 
-"@patternfly/react-topology@4.5.15":
-  version "4.5.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.5.15.tgz#5a4fc25e76eae62ac21e262718fd38d96975da79"
-  integrity sha512-+AzT4sTSSKo8LyfAV/tm7dp4Bv5eVUjXppY9jHdwkYIK1aE4k2a3aWW5cH7s5zShfdE4VbWbKy7Tmktxg3OHfA==
+"@patternfly/react-topology@4.5.15-1":
+  version "4.5.15-1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.5.15-1.tgz#6e24cb18c49d2ef1c5e68a436b4fdb3b65a29e77"
+  integrity sha512-DEpwdeAUYp2XZpSTHVR9LSBfre9UoA6VBT0aRvbTDLsblZyOhuobZHe9AiMEJTaZ77WHerXRGDliANadiklVUw==
   dependencies:
     "@patternfly/react-core" "^4.50.2"
     "@patternfly/react-icons" "^4.7.6"


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/6909

**Fixes**
https://issues.redhat.com/browse/ODC-4979

**Description**
Update @patternfly/react-topology to gain a fix for maintaining drag regrouping on component updates and update group nodes to no re-create drag specs every time.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
