### PR TITLE
Fix to maintain data on the graph element on a settings restoral

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -203,6 +203,7 @@ const Topology: React.FC<TopologyProps & StateProps & DispatchProps> = ({
             y: storedGraphModel.y,
             scale: storedGraphModel.scale,
             scaleExtent: storedGraphModel.scaleExtent,
+            data: visualization.getGraph()?.getData(),
           };
         }
         const storedLayout = getTopologyLayout(namespace);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5075

**Analysis / Root cause**: 
When adding code to restore graph settings from previous visits, the code did not add the graph data to the updated model. The model update overwrites the current graph including its data.

**Solution Description**: 
Get the current graph data and add it to the graph model being updated.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge