### PR TITLE
CONSOLE-2395: Add language switcher

### DIFF
--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -3,10 +3,8 @@
 }
 
 .co-username {
-  font-size: $pf-header-icon-fontsize; // for cases where there is no user menu
   max-width: 140px !important; // PF4 does not limit username length (upstream bug)
   overflow-x: hidden;
-  padding: 0 8px; // so sizing is consistent with .pf-c-dropdown__toggle
   text-overflow: ellipsis;
   @media(min-width: 855px) {
     max-width: 225px !important;

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -36,6 +36,7 @@ import { clusterVersionReference, getReportBugLink } from '../module/k8s/cluster
 import * as redhatLogoImg from '../imgs/logos/redhat.svg';
 import { GuidedTourMastheadTrigger } from '@console/app/src/components/tour';
 import { ConsoleLinkModel } from '../models';
+import { languagePreferencesModal } from './modals';
 
 const SystemStatusButton = ({ statuspageData, className }) => {
   const { t } = useTranslation();
@@ -434,9 +435,16 @@ class MastheadToolbarContents_ extends React.Component {
     }
 
     const actions = [];
-    if (flags[FLAGS.AUTH_ENABLED]) {
-      const userActions = [];
+    const userActions = [
+      {
+        label: t('masthead~Language preferences'),
+        callback: () => languagePreferencesModal({}),
+        component: 'button',
+        dataTest: 'language',
+      },
+    ];
 
+    if (flags[FLAGS.AUTH_ENABLED]) {
       const logout = (e) => {
         e.preventDefault();
         if (flags[FLAGS.OPENSHIFT]) {
@@ -447,7 +455,7 @@ class MastheadToolbarContents_ extends React.Component {
       };
 
       if (window.SERVER_FLAGS.requestTokenURL) {
-        userActions.push({
+        userActions.unshift({
           label: t('masthead~Copy login command'),
           href: window.SERVER_FLAGS.requestTokenURL,
           externalLink: true,
@@ -460,13 +468,13 @@ class MastheadToolbarContents_ extends React.Component {
         component: 'button',
         dataTest: 'log-out',
       });
-
-      actions.push({
-        name: '',
-        isSection: true,
-        actions: userActions,
-      });
     }
+
+    actions.push({
+      name: '',
+      isSection: true,
+      actions: userActions,
+    });
 
     if (!_.isEmpty(additionalUserActions.actions)) {
       actions.unshift(additionalUserActions);
@@ -504,17 +512,11 @@ class MastheadToolbarContents_ extends React.Component {
       );
     }
 
-    if (_.isEmpty(actions)) {
-      return (
-        <div data-test="username" className="co-username">
-          {username}
-        </div>
-      );
-    }
-
     const userToggle = (
       <span className="pf-c-dropdown__toggle">
-        <span className="co-username">{username}</span>
+        <span className="co-username" data-test="username">
+          {username}
+        </span>
         <CaretDownIcon className="pf-c-dropdown__toggle-icon" />
       </span>
     );

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -138,3 +138,8 @@ export const managedResourceSaveModal = (props) =>
   import(
     './managed-resource-save-modal' /* webpackChunkName: "managed-resource-save-modal" */
   ).then((m) => m.managedResourceSaveModal(props));
+
+export const languagePreferencesModal = (props) =>
+  import(
+    './language-preferences-modal' /* webpackChunkName: "language-preferences-modal" */
+  ).then((m) => m.languagePreferencesModal(props));

--- a/frontend/public/components/modals/language-preferences-modal.tsx
+++ b/frontend/public/components/modals/language-preferences-modal.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
+
+import { Dropdown } from '../utils';
+import {
+  createModalLauncher,
+  ModalBody,
+  ModalComponentProps,
+  ModalSubmitFooter,
+  ModalTitle,
+} from '../factory/modal';
+import { FALLBACK_LOCALE, SUPPORTED_LOCALES } from '../../i18next-parser.config';
+
+const LanguagePreferencesModal = (props: LanguagePreferencesModalProps) => {
+  const { i18n, t } = useTranslation();
+  const langOptions = Object.keys(SUPPORTED_LOCALES).map((lang) => ({
+    lang,
+    value: SUPPORTED_LOCALES[lang],
+  }));
+  const initLang =
+    localStorage.getItem('bridge/language') ||
+    langOptions.find((lang) => lang.lang === i18n.language)?.lang;
+  const [language, setLanguage] = React.useState(initLang);
+  const { close } = props;
+  const submit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    i18n.changeLanguage(language ? language : FALLBACK_LOCALE);
+    localStorage.setItem('bridge/language', language);
+    close();
+  };
+
+  return (
+    <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+      <ModalTitle>{t('language-preferences-modal~Edit language preferences')}</ModalTitle>
+      <ModalBody>
+        <p>
+          {t(
+            'language-preferences-modal~All interface content will appear in your selected language.',
+          )}
+        </p>
+        <div className="form-group">
+          <label htmlFor="language_dropdown">{t('language-preferences-modal~Language')}</label>
+          <Dropdown
+            id="language_dropdown"
+            items={SUPPORTED_LOCALES}
+            onChange={(newLanguage: string) => setLanguage(newLanguage)}
+            selectedKey={language}
+            title={t('language-preferences-modal~Select language')}
+          />
+        </div>
+      </ModalBody>
+      <ModalSubmitFooter
+        submitText={t('public~Save')}
+        cancelText={t('public~Cancel')}
+        cancel={close}
+        inProgress={false}
+      />
+    </form>
+  );
+};
+
+export const languagePreferencesModal = createModalLauncher(LanguagePreferencesModal);
+
+type LanguagePreferencesModalProps = {
+  t: TFunction;
+} & ModalComponentProps;

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -31,6 +31,7 @@ i18n
       backend: {
         loadPath: 'static/locales/{{lng}}/{{ns}}.json',
       },
+      lng: localStorage.getItem('bridge/language'),
       fallbackLng: FALLBACK_LOCALE,
       load: 'all',
       debug: process.env.NODE_ENV === 'development',
@@ -65,6 +66,7 @@ i18n
         'idp-cafile-input',
         'idp-name-input',
         'keystone-idp-form',
+        'language-preferences-modal',
         'ldap-idp-form',
         'limit-range',
         'logs',

--- a/frontend/public/locales/en/language-preferences-modal.json
+++ b/frontend/public/locales/en/language-preferences-modal.json
@@ -1,0 +1,6 @@
+{
+  "Edit language preferences": "Edit language preferences",
+  "All interface content will appear in your selected language.": "All interface content will appear in your selected language.",
+  "Language": "Language",
+  "Select language": "Select language"
+}

--- a/frontend/public/locales/en/masthead.json
+++ b/frontend/public/locales/en/masthead.json
@@ -6,6 +6,7 @@
   "Documentation": "Documentation",
   "Command line tools": "Command line tools",
   "About": "About",
+  "Language preferences": "Language preferences",
   "Copy login command": "Copy login command",
   "Log out": "Log out",
   "Import YAML": "Import YAML",


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/CONSOLE-2395

<img width="391" alt="Screen Shot 2020-11-04 at 8 32 34 AM" src="https://user-images.githubusercontent.com/895728/98118347-19f08000-1e79-11eb-9a47-5a38b67a9c28.png">
<img width="639" alt="Screen Shot 2020-11-04 at 8 34 09 AM" src="https://user-images.githubusercontent.com/895728/98118348-19f08000-1e79-11eb-88b2-c3078816ab01.png">

Demo to show reactive change (but missing all Japanese translation files except for cluster-settings, so empty strings load for the site chrome when language is changed to Japanese)
![UUzthuJBie](https://user-images.githubusercontent.com/895728/98119051-14e00080-1e7a-11eb-9659-057667297906.gif)
