### PR TITLE
Add API to create user settings

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -543,29 +543,28 @@ func main() {
 		bridge.FlagFatalf("user-auth", "must be one of: oidc, openshift, disabled")
 	}
 
-	var resourceListerToken string
 	switch *fK8sAuth {
 	case "service-account":
 		bridge.ValidateFlagIs("k8s-mode", *fK8sMode, "in-cluster")
 		srv.StaticUser = &auth.User{
 			Token: k8sAuthServiceAccountBearerToken,
 		}
-		resourceListerToken = k8sAuthServiceAccountBearerToken
+		srv.ServiceAccountToken = k8sAuthServiceAccountBearerToken
 	case "bearer-token":
 		bridge.ValidateFlagNotEmpty("k8s-auth-bearer-token", *fK8sAuthBearerToken)
 		srv.StaticUser = &auth.User{
 			Token: *fK8sAuthBearerToken,
 		}
-		resourceListerToken = *fK8sAuthBearerToken
+		srv.ServiceAccountToken = *fK8sAuthBearerToken
 	case "oidc", "openshift":
 		bridge.ValidateFlagIs("user-auth", *fUserAuth, "oidc", "openshift")
-		resourceListerToken = k8sAuthServiceAccountBearerToken
+		srv.ServiceAccountToken = k8sAuthServiceAccountBearerToken
 	default:
 		bridge.FlagFatalf("k8s-mode", "must be one of: service-account, bearer-token, oidc, openshift")
 	}
 
 	srv.MonitoringDashboardConfigMapLister = server.NewResourceLister(
-		resourceListerToken,
+		srv.ServiceAccountToken,
 		&url.URL{
 			Scheme: k8sEndpoint.Scheme,
 			Host:   k8sEndpoint.Host,
@@ -583,7 +582,7 @@ func main() {
 	)
 
 	srv.KnativeEventSourceCRDLister = server.NewResourceLister(
-		resourceListerToken,
+		srv.ServiceAccountToken,
 		&url.URL{
 			Scheme: k8sEndpoint.Scheme,
 			Host:   k8sEndpoint.Host,
@@ -601,7 +600,7 @@ func main() {
 	)
 
 	srv.KnativeChannelCRDLister = server.NewResourceLister(
-		resourceListerToken,
+		srv.ServiceAccountToken,
 		&url.URL{
 			Scheme: k8sEndpoint.Scheme,
 			Host:   k8sEndpoint.Host,

--- a/pkg/usersettings/handlers.go
+++ b/pkg/usersettings/handlers.go
@@ -1,0 +1,178 @@
+package usersettings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	core "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+
+	"github.com/openshift/console/pkg/auth"
+	"github.com/openshift/console/pkg/proxy"
+	"github.com/openshift/console/pkg/serverutils"
+)
+
+const namespace = "openshift-console-user-settings"
+
+var USER_RESOURCE = schema.GroupVersionResource{
+	Group:    "user.openshift.io",
+	Version:  "v1",
+	Resource: "users",
+}
+
+type UserSettingsHandler struct {
+	K8sProxyConfig      *proxy.Config
+	Client              *http.Client
+	Endpoint            string
+	ServiceAccountToken string
+}
+
+func (h *UserSettingsHandler) HandleUserSettings(user *auth.User, w http.ResponseWriter, r *http.Request) {
+	context := context.TODO()
+
+	serviceAccountClient, err := h.createServiceAccountClient()
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to create service account to handle user setting request: %v", err)
+		klog.Errorf(errMsg)
+		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: errMsg})
+		return
+	}
+
+	userSettingMeta, err := h.getUserSettingMeta(context, user)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to get user data to handle user setting request: %v", err)
+		klog.Errorf(errMsg)
+		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: errMsg})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		configMap, err := h.getUserSettings(context, serviceAccountClient, userSettingMeta)
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to get user settings: %v", err)
+			klog.Errorf(errMsg)
+			serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: errMsg})
+			return
+		}
+		serverutils.SendResponse(w, http.StatusOK, configMap)
+	case http.MethodPost:
+		configMap, err := h.createUserSettings(context, serviceAccountClient, userSettingMeta)
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to create user settings: %v", err)
+			klog.Errorf(errMsg)
+			serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: errMsg})
+			return
+		}
+		serverutils.SendResponse(w, http.StatusOK, configMap)
+	case http.MethodDelete:
+		err := h.deleteUserSettings(context, serviceAccountClient, userSettingMeta)
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to delete user settings: %v", err)
+			klog.Errorf(errMsg)
+			serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: errMsg})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.Header().Set("Allow", "GET, POST, DELETE")
+		serverutils.SendResponse(w, http.StatusMethodNotAllowed, serverutils.ApiError{Err: "Unsupported method, supported methods are GET POST DELETE"})
+	}
+}
+
+// Fetch the user-setting ConfigMap of the current user, by using his token.
+func (h *UserSettingsHandler) getUserSettings(ctx context.Context, client *kubernetes.Clientset, userSettingMeta *UserSettingMeta) (*core.ConfigMap, error) {
+	return client.CoreV1().ConfigMaps(namespace).Get(ctx, userSettingMeta.getConfigMapName(), meta.GetOptions{})
+}
+
+// Create a new user-setting ConfigMap, incl. Role and RoleBinding for the current user.
+// Returns the existing ConfigMap if it is already exist.
+func (h *UserSettingsHandler) createUserSettings(ctx context.Context, client *kubernetes.Clientset, userSettingMeta *UserSettingMeta) (*core.ConfigMap, error) {
+	role := createRole(userSettingMeta)
+	roleBinding := createRoleBinding(userSettingMeta)
+	configMap := createConfigMap(userSettingMeta)
+
+	_, err := client.RbacV1().Roles(namespace).Create(ctx, role, meta.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		h.deleteUserSettings(ctx, client, userSettingMeta)
+		return nil, err
+	}
+
+	_, err = client.RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, meta.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		h.deleteUserSettings(ctx, client, userSettingMeta)
+		return nil, err
+	}
+
+	configMap, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, meta.CreateOptions{})
+	if err != nil {
+		// Return actual ConfigMap if it is already created
+		if apierrors.IsAlreadyExists(err) {
+			klog.Infof("User settings ConfigMap \"%s\" already exist, will return existing data.", userSettingMeta.getConfigMapName())
+			return client.CoreV1().ConfigMaps(namespace).Get(ctx, userSettingMeta.getConfigMapName(), meta.GetOptions{})
+		}
+		h.deleteUserSettings(ctx, client, userSettingMeta)
+		return nil, err
+	}
+	return configMap, nil
+}
+
+// Deletes the user-setting ConfigMap, Role and RoleBinding of the current user.
+// It handles not found responses, so that it does not fail on multiple calls.
+func (h *UserSettingsHandler) deleteUserSettings(ctx context.Context, client *kubernetes.Clientset, userSettingMeta *UserSettingMeta) error {
+	err := client.RbacV1().RoleBindings(namespace).Delete(ctx, userSettingMeta.getRoleBindingName(), meta.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	err = client.RbacV1().Roles(namespace).Delete(ctx, userSettingMeta.getRoleName(), meta.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	err = client.CoreV1().ConfigMaps(namespace).Delete(ctx, userSettingMeta.getConfigMapName(), meta.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (h *UserSettingsHandler) createServiceAccountClient() (*kubernetes.Clientset, error) {
+	config := &rest.Config{
+		Host:        h.Endpoint,
+		BearerToken: h.ServiceAccountToken,
+		Transport:   h.Client.Transport,
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+func (h *UserSettingsHandler) createUserProxyClient(user *auth.User) (dynamic.Interface, error) {
+	config := &rest.Config{
+		Host:        h.Endpoint,
+		BearerToken: user.Token,
+		Transport:   h.Client.Transport,
+	}
+	return dynamic.NewForConfig(config)
+}
+
+func (h *UserSettingsHandler) getUserSettingMeta(context context.Context, user *auth.User) (*UserSettingMeta, error) {
+	client, err := h.createUserProxyClient(user)
+	if err != nil {
+		return nil, err
+	}
+
+	userInfo, err := client.Resource(USER_RESOURCE).Get(context, "~", meta.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return newUserSettingMeta(userInfo.GetName(), string(userInfo.GetUID()))
+}

--- a/pkg/usersettings/helpers.go
+++ b/pkg/usersettings/helpers.go
@@ -1,0 +1,95 @@
+package usersettings
+
+import (
+	"errors"
+
+	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newUserSettingMeta(name string, uid string) (*UserSettingMeta, error) {
+	resourceIdentifier := ""
+
+	if uid != "" {
+		resourceIdentifier = uid
+	} else if name == "kube:admin" {
+		resourceIdentifier = "kubeadmin"
+	} else {
+		return nil, errors.New("User must have UID to get required resource data for user-settings")
+	}
+
+	return &UserSettingMeta{
+		Username:           name,
+		UID:                uid,
+		ResourceIdentifier: resourceIdentifier,
+	}, nil
+}
+
+func createRole(userSettingMeta *UserSettingMeta) *rbac.Role {
+	return &rbac.Role{
+		TypeMeta: meta.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name: userSettingMeta.getRoleName(),
+		},
+		Rules: []rbac.PolicyRule{
+			rbac.PolicyRule{
+				APIGroups: []string{
+					"", // Core group, not "v1"
+				},
+				Resources: []string{
+					"configmaps", // Not "ConfigMap"
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+				ResourceNames: []string{
+					userSettingMeta.getConfigMapName(),
+				},
+			},
+		},
+	}
+}
+
+func createRoleBinding(userSettingMeta *UserSettingMeta) *rbac.RoleBinding {
+	return &rbac.RoleBinding{
+		TypeMeta: meta.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name: userSettingMeta.getRoleBindingName(),
+		},
+		Subjects: []rbac.Subject{
+			rbac.Subject{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "User",
+				Name:     userSettingMeta.Username,
+			},
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     userSettingMeta.getRoleName(),
+		},
+	}
+}
+
+func createConfigMap(userSettingMeta *UserSettingMeta) *core.ConfigMap {
+	return &core.ConfigMap{
+		TypeMeta: meta.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name: userSettingMeta.getConfigMapName(),
+		},
+	}
+}

--- a/pkg/usersettings/helpers_test.go
+++ b/pkg/usersettings/helpers_test.go
@@ -1,0 +1,144 @@
+package usersettings
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestNewUserSettingsMeta(t *testing.T) {
+	tests := []struct {
+		testcase      string
+		username      string
+		uid           string
+		mergedFile    string
+		expectedError error
+		expectedData  *UserSettingMeta
+	}{
+		{
+			testcase:      "returns -kubeadmin for kube:admin",
+			username:      "kube:admin",
+			uid:           "",
+			expectedError: nil,
+			expectedData: &UserSettingMeta{
+				Username:           "kube:admin",
+				UID:                "",
+				ResourceIdentifier: "kubeadmin",
+			},
+		},
+		{
+			testcase:      "returns -kubeadmin for fake kube:admin with uid",
+			username:      "kube:admin",
+			uid:           "1234",
+			expectedError: nil,
+			expectedData: &UserSettingMeta{
+				Username:           "kube:admin",
+				UID:                "1234",
+				ResourceIdentifier: "1234",
+			},
+		},
+		{
+			testcase:      "returns uid for non kube:admin users",
+			username:      "developer",
+			uid:           "1234",
+			expectedError: nil,
+			expectedData: &UserSettingMeta{
+				Username:           "developer",
+				UID:                "1234",
+				ResourceIdentifier: "1234",
+			},
+		},
+		{
+			testcase:      "returns error for non kube:admin users without uid",
+			username:      "developer",
+			uid:           "",
+			expectedError: errors.New("User must have UID to get required resource data for user-settings"),
+			expectedData:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testcase, func(t *testing.T) {
+			data, err := newUserSettingMeta(tt.username, tt.uid)
+			if !reflect.DeepEqual(tt.expectedError, err) {
+				t.Errorf("Error does not match expectation:\n%v\nbut got\n%v", tt.expectedError, err)
+			}
+			if !reflect.DeepEqual(tt.expectedData, data) {
+				t.Errorf("Content does not match expectation:\n%v\nbut got\n%v", tt.expectedData, data)
+			}
+		})
+	}
+}
+
+func TestCreateUserSettingsResources(t *testing.T) {
+	tests := []struct {
+		testcase                string
+		username                string
+		uid                     string
+		expectedRoleName        string
+		expectedRoleBindingName string
+		expectedConfigMapName   string
+	}{
+		{
+			testcase:                "for kubeadmin",
+			username:                "kube:admin",
+			uid:                     "",
+			expectedConfigMapName:   "user-settings-kubeadmin",
+			expectedRoleName:        "user-settings-kubeadmin-role",
+			expectedRoleBindingName: "user-settings-kubeadmin-rolebinding",
+		},
+		{
+			testcase:                "for fake kubeadmin we use uid",
+			username:                "kube:admin",
+			uid:                     "1234",
+			expectedConfigMapName:   "user-settings-1234",
+			expectedRoleName:        "user-settings-1234-role",
+			expectedRoleBindingName: "user-settings-1234-rolebinding",
+		},
+		{
+			testcase:                "for non kubeadmin",
+			username:                "developer",
+			uid:                     "1234",
+			expectedConfigMapName:   "user-settings-1234",
+			expectedRoleName:        "user-settings-1234-role",
+			expectedRoleBindingName: "user-settings-1234-rolebinding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testcase, func(t *testing.T) {
+			userSettingMeta, err := newUserSettingMeta(tt.username, tt.uid)
+			if err != nil {
+				t.Error(err)
+			}
+
+			role := createRole(userSettingMeta)
+			roleBinding := createRoleBinding(userSettingMeta)
+			configMap := createConfigMap(userSettingMeta)
+
+			// Role
+			if role.ObjectMeta.Name != tt.expectedRoleName {
+				t.Errorf("Role name does not match:\n%v\nbut got\n%v", tt.expectedRoleName, role.ObjectMeta.Name)
+			}
+			if role.Rules[0].ResourceNames[0] != tt.expectedConfigMapName {
+				t.Errorf("Role configmap ref does not match:\n%v\nbut got\n%v", tt.expectedConfigMapName, role.Rules[0].ResourceNames[0])
+			}
+
+			// RoleBinding
+			if roleBinding.ObjectMeta.Name != tt.expectedRoleBindingName {
+				t.Errorf("RoleBinding name does not match:\n%v\nbut got\n%v", tt.expectedRoleBindingName, roleBinding.ObjectMeta.Name)
+			}
+			if roleBinding.Subjects[0].Name != tt.username {
+				t.Errorf("RoleBinding username ref does not match:\n%v\nbut got\n%v", tt.username, roleBinding.Subjects[0].Name)
+			}
+			if roleBinding.RoleRef.Name != tt.expectedRoleName {
+				t.Errorf("RoleBinding role ref does not match:\n%v\nbut got\n%v", tt.expectedRoleName, roleBinding.RoleRef.Name)
+			}
+
+			// ConfigMap
+			if configMap.ObjectMeta.Name != tt.expectedConfigMapName {
+				t.Errorf("ConfigMap name does not match:\n%v\nbut got\n%v", tt.expectedConfigMapName, configMap.ObjectMeta.Name)
+			}
+		})
+	}
+}

--- a/pkg/usersettings/types.go
+++ b/pkg/usersettings/types.go
@@ -1,0 +1,20 @@
+package usersettings
+
+type UserSettingMeta struct {
+	Username string
+	UID      string
+	// The resource identifier contains "kubeadmin" for the kubeadmin and the user uid otherwise.
+	ResourceIdentifier string
+}
+
+func (r *UserSettingMeta) getConfigMapName() string {
+	return "user-settings-" + r.ResourceIdentifier
+}
+
+func (r *UserSettingMeta) getRoleName() string {
+	return "user-settings-" + r.ResourceIdentifier + "-role"
+}
+
+func (r *UserSettingMeta) getRoleBindingName() string {
+	return "user-settings-" + r.ResourceIdentifier + "-rolebinding"
+}

--- a/pkg/usersettings/types_test.go
+++ b/pkg/usersettings/types_test.go
@@ -1,0 +1,55 @@
+package usersettings
+
+import (
+	"testing"
+)
+
+func TestUserSettingMetaNameHelpers(t *testing.T) {
+	tests := []struct {
+		testcase                string
+		userSettingMeta         UserSettingMeta
+		expectedConfigMapName   string
+		expectedRoleName        string
+		expectedRoleBindingName string
+	}{
+		{
+			testcase: "for kubeadmin",
+			userSettingMeta: UserSettingMeta{
+				Username:           "kube:admin",
+				UID:                "",
+				ResourceIdentifier: "kubeadmin",
+			},
+			expectedConfigMapName:   "user-settings-kubeadmin",
+			expectedRoleName:        "user-settings-kubeadmin-role",
+			expectedRoleBindingName: "user-settings-kubeadmin-rolebinding",
+		},
+		{
+			testcase: "for non kubeadmin",
+			userSettingMeta: UserSettingMeta{
+				Username:           "developer",
+				UID:                "1234",
+				ResourceIdentifier: "1234",
+			},
+			expectedConfigMapName:   "user-settings-1234",
+			expectedRoleName:        "user-settings-1234-role",
+			expectedRoleBindingName: "user-settings-1234-rolebinding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testcase, func(t *testing.T) {
+			got := tt.userSettingMeta.getConfigMapName()
+			if got != tt.expectedConfigMapName {
+				t.Errorf("ConfigMap name does not match:\n%v\nbut got\n%v", tt.expectedConfigMapName, got)
+			}
+			got = tt.userSettingMeta.getRoleName()
+			if got != tt.expectedRoleName {
+				t.Errorf("Role name does not match:\n%v\nbut got\n%v", tt.expectedRoleName, got)
+			}
+			got = tt.userSettingMeta.getRoleBindingName()
+			if got != tt.expectedRoleBindingName {
+				t.Errorf("RoleBinding name does not match:\n%v\nbut got\n%v", tt.expectedRoleBindingName, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4755

**Analysis / Root cause**:
Based on the [User Settings for OpenShift Console enhancement proposal](https://github.com/openshift/enhancements/blob/master/enhancements/console/user-settings.md) we want to create a `ConfigMap` for each individual user in the namespace `openshift-console-user-settings`

Currently you need create this namespace yourself, **see Test Setup below**. This namespace will be automatically created by the console-operator, see PR https://github.com/openshift/console-operator/pull/479

**Solution Description**: 
Because the user could not create a ConfigMap here, we create a new `ConfigMap`, `Role` and `RoleBinding` with the service account role over the bridge. This code provides 3 new endpoints to create, get and delete the user settings. (The second and third API calls primary for debugging / development.) The console will fetch the ConfigMap over the known k8sWatch API.

**API**
`GET /api/console/user-settings`
Get the current user settings (returns a ConfigMap or 404)

`POST /api/console/user-settings`
Create a user setting ConfigMap for the current user. It returns the existing ConfigMap if it is already exist. This method does not accept an initial content for the ConfigMap.

`DELETE /api/console/user-settings`
Delete the user setting ConfigMap for the current user. Returns `204 No Content` if the ConfigMap was deleted, also if it was not created yet.

**Screen shots / Gifs for design review**: 
Irrelevant

**Unit test coverage report**: 
```bash
➜  console git:([odc-4755](https://issues.redhat.com/browse/odc-4755)) go test -coverprofile=coverage.out github.com/openshift/console/pkg/usersettings  
ok  	github.com/openshift/console/pkg/usersettings	0.006s	coverage: 16.2% of statements

➜  console git:([odc-4755](https://issues.redhat.com/browse/odc-4755)) ✗ go tool cover -func=coverage.out
github.com/openshift/console/pkg/usersettings/handlers.go:37:	HandleUserSettings		0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:86:	getUserSettings			0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:92:	createUserSettings		0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:121:	deleteUserSettings		0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:140:	createServiceAccountClient	0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:149:	createUserProxyClient		0.0%
github.com/openshift/console/pkg/usersettings/handlers.go:158:	getUserSettingMeta		0.0%
github.com/openshift/console/pkg/usersettings/helpers.go:11:	getUserSettingMeta		100.0%
github.com/openshift/console/pkg/usersettings/helpers.go:29:	createRole			100.0%
github.com/openshift/console/pkg/usersettings/helpers.go:61:	createRoleBinding		100.0%
github.com/openshift/console/pkg/usersettings/helpers.go:85:	createConfigMap			100.0%
github.com/openshift/console/pkg/usersettings/types.go:10:	getConfigMapName		100.0%
github.com/openshift/console/pkg/usersettings/types.go:14:	getRoleName			100.0%
github.com/openshift/console/pkg/usersettings/types.go:18:	getRoleBindingName		100.0%
total:								(statements)			16.2%
```

**Test setup:**
This PR require some additional RBAC rules.

1. If PR https://github.com/openshift/console-operator/pull/479 is not part of your cluster you need to create a namespace:

1a Create namespace:
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: openshift-console-user-settings
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
    openshift.io/node-selector: ""
```

Until https://github.com/openshift/console-operator/pull/486/files is merged and available on your cluster you need to add this as well:

1b Create Role:
```yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: console-user-settings-admin-fixed
  namespace: openshift-console-user-settings
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
rules:
- apiGroups:
  - rbac.authorization.k8s.io
  resources:
  - roles
  - rolebindings
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - delete
  - patch
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - delete
  - patch
```

1c Create RoleBinding:
```yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: console-user-settings-admin-fixed
  namespace: openshift-console-user-settings
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
roleRef:
  kind: Role
  name: console-user-settings-admin-fixed
  apiGroup: rbac.authorization.k8s.io
subjects:
  - kind: ServiceAccount
    name: console
    namespace: openshift-console
```

2. Because the API calls needs a authentication and CSRF token, you can test the API calls from a logged in browser session with this JavaScript snippet:

In frontend code this is automatically done by `coFetch`, see [co-fetch.js](https://github.com/openshift/console/blob/master/frontend/public/co-fetch.js#L88-L97). But to test this without additional frontend code or postman I extracted the code for you:

2a Extract crcf token:
```js
let cookiePrefix = 'csrf-token=';
let getCSRFToken = () =>
  document &&
  document.cookie &&
  document.cookie
    .split(';')
    .map((c) => c.trim())
    .filter((c) => c.startsWith(cookiePrefix))
    .map((c) => c.slice(cookiePrefix.length))
    .pop();
getCSRFToken();
```

2b Get user-settings:
```js
fetch('/api/console/user-settings', { method: 'GET', headers: { 'X-CSRFToken': getCSRFToken() } }).then(
    (res) => {
        console.log('res', res);
        res.text().then(
            (text) => {
                console.log('text', text);
            },
            (parseErr) => console.warn('parseErr', parseErr)
        );
    },
    (requestErr) => {
        console.warn('requestErr', requestErr);
    }
);
```

2c Create user-settings:
```js
fetch('/api/console/user-settings', { method: 'POST', headers: { 'X-CSRFToken': getCSRFToken() } }).then(
    (res) => {
        console.log('res', res);
        res.text().then(
            (text) => {
                console.log('text', text);
            },
            (parseErr) => console.warn('parseErr', parseErr)
        );
    },
    (requestErr) => {
        console.warn('requestErr', requestErr);
    }
);
```

**Browser conformance**: 
Irrelevant