### PR TITLE
remove tech preview badge from web terminal

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, Flex, FlexItem, Button } from '@patternfly/react-core';
 import { CloseIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { InlineTechPreviewBadge } from '@console/shared';
 import Drawer from '@console/shared/src/components/drawer/Drawer';
 import MinimizeRestoreButton from './MinimizeRestoreButton';
 
@@ -32,9 +31,6 @@ const CloudShellDrawer: React.FC<CloudShellDrawerProps> = ({ children, onClose }
     <Flex style={{ flexGrow: 1 }}>
       <FlexItem className="co-cloud-shell-drawer__heading">
         {t('cloudshell~Command line terminal')}
-      </FlexItem>
-      <FlexItem>
-        <InlineTechPreviewBadge />
       </FlexItem>
       <FlexItem align={{ default: 'alignRight' }}>
         <Tooltip content={t('cloudshell~Open terminal in new tab')}>

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { InlineTechPreviewBadge } from '@console/shared';
 import CloudShellTerminal from './CloudShellTerminal';
 import './CloudShellTab.scss';
 
@@ -12,7 +11,6 @@ const CloudShellTab: React.FC = () => {
         <div className="co-cloud-shell-tab__header-text">
           {t('cloudshell~OpenShift command line terminal')}
         </div>
-        <InlineTechPreviewBadge />
       </div>
       <div className="co-cloud-shell-tab__body">
         <CloudShellTerminal />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5049

**Analysis / Root cause**: 
Terminal is no longer tech preview

**Solution Description**: 
Removed badge from drawer and terminal page.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 

![image](https://user-images.githubusercontent.com/14068621/98159709-0c53ee00-1eab-11eb-83fa-80738dd395f9.png)

![image](https://user-images.githubusercontent.com/14068621/98159761-2261ae80-1eab-11eb-8505-684efd4c4c80.png)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
