### PR TITLE
Bug 1894810: removes techpreview badge from eventing

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { RouteComponentProps } from 'react-router';
-import { PageBody, getBadgeFromType } from '@console/shared';
+import { PageBody } from '@console/shared';
 import { PageHeading } from '@console/internal/components/utils';
 import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
 import { QUERY_PROPERTIES } from '@console/dev-console/src/const';
 import ConnectedEventSource from './EventSource';
-import { KnativeEventingModel } from '../../models';
 import EventSourceAlert from './EventSourceAlert';
 import { useEventSourceList } from '../../utils/create-eventsources-utils';
 import { useTranslation } from 'react-i18next';
@@ -25,10 +24,7 @@ const EventSourcePage: React.FC<EventSourcePageProps> = ({ match, location }) =>
       <Helmet>
         <title>{t('knative-plugin~Event Sources')}</title>
       </Helmet>
-      <PageHeading
-        badge={getBadgeFromType(KnativeEventingModel.badge)}
-        title={t('knative-plugin~Event Sources')}
-      >
+      <PageHeading title={t('knative-plugin~Event Sources')}>
         {t(
           'knative-plugin~Create an event source to register interest in a class of events from a particular system',
         )}

--- a/frontend/packages/knative-plugin/src/components/add/EventingChannelPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventingChannelPage.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { RouteComponentProps } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { PageBody, getBadgeFromType } from '@console/shared';
+import { PageBody } from '@console/shared';
 import { PageHeading } from '@console/internal/components/utils';
 import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
 import { QUERY_PROPERTIES } from '@console/dev-console/src/const';
-import { KnativeEventingModel } from '../../models';
 import { useChannelList } from '../../utils/create-channel-utils';
 import AddChannel from './channels/AddChannel';
 
@@ -24,10 +23,7 @@ const EventingChannelPage: React.FC<EventingChannelPageProps> = ({ match, locati
       <Helmet>
         <title>{t('knative-plugin~Channel')}</title>
       </Helmet>
-      <PageHeading
-        badge={getBadgeFromType(KnativeEventingModel.badge)}
-        title={t('knative-plugin~Channel')}
-      >
+      <PageHeading title={t('knative-plugin~Channel')}>
         {t(
           'knative-plugin~Create a Knative Channel to create an event forwarding and persistence layer with in-memory and reliable implementations',
         )}

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -1,7 +1,6 @@
 import { chart_color_cyan_400 as knativeServingColor } from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
 import { chart_color_red_300 as knativeEventingColor } from '@patternfly/react-tokens/dist/js/chart_color_red_300';
 import { K8sKind } from '@console/internal/module/k8s';
-import { BadgeType } from '@console/shared/src/components/badges/badge-factory';
 import {
   KNATIVE_EVENT_SOURCE_APIGROUP,
   KNATIVE_EVENT_SOURCE_APIGROUP_DEP,
@@ -52,7 +51,6 @@ export const KnativeEventingModel: K8sKind = {
   abbr: 'KE',
   namespaced: true,
   crd: true,
-  badge: BadgeType.TECH,
   color: knativeEventingColor.value,
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5045

**Analysis / Root cause**: 
Eventing is going GA, so needed to remove TP badge from 
- Add Channel
- EventSource creation
- Eventing CR creation

**Solution Description**: 
Removed TP badge from Eventing components

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

- Eventing CR:

![image](https://user-images.githubusercontent.com/5129024/98204980-3239cb00-1f5d-11eb-9c90-6694ef53de19.png)

![image](https://user-images.githubusercontent.com/5129024/98205011-41207d80-1f5d-11eb-921f-eaacbcdb161a.png)

- Add Channel

![image](https://user-images.githubusercontent.com/5129024/98205048-60b7a600-1f5d-11eb-92cb-6f9d64803401.png)


- EventSources

![image](https://user-images.githubusercontent.com/5129024/98205084-75943980-1f5d-11eb-9f71-607cec146f56.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
