### PR TITLE
Bug 1891047: Access server API via kubernetes.default.svc from Helm endpoints

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -390,7 +390,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	handle("/api/console/version", authHandler(s.versionHandler))
 
 	// Helm Endpoints
-	helmHandlers := helmhandlerspkg.New(s.KubeAPIServerURL, s.K8sClient.Transport)
+	helmHandlers := helmhandlerspkg.New(s.K8sProxyConfig.Endpoint.String(), s.K8sClient.Transport)
 	handle("/api/helm/template", authHandlerWithUser(helmHandlers.HandleHelmRenderManifests))
 	handle("/api/helm/releases", authHandlerWithUser(helmHandlers.HandleHelmList))
 	handle("/api/helm/chart", authHandlerWithUser(helmHandlers.HandleChartGet))


### PR DESCRIPTION
Previously, `Server.KubeAPIServerURL` was used and on some clusters this URL certificate might not verifiable using in-cluster CA.