### PR TITLE
Fix edit flow in case of custom template application

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -22,6 +22,7 @@ import {
   getCommonAnnotations,
   getTriggerAnnotation,
   mergeData,
+  getTemplateLabels,
 } from '../../utils/resource-label-utils';
 import { createService, createRoute, dryRunOpt } from '../../utils/shared-submit-utils';
 import { getProbesData } from '../health-checks/create-health-checks-probe-utils';
@@ -258,6 +259,7 @@ export const createOrUpdateDeployment = (
     ...getTriggerAnnotation(name, namespace, imageChange),
   };
   const podLabels = getPodLabels(name);
+  const templateLabels = getTemplateLabels(originalDeployment);
 
   const newDeployment = {
     apiVersion: 'apps/v1',
@@ -277,7 +279,7 @@ export const createOrUpdateDeployment = (
       replicas,
       template: {
         metadata: {
-          labels: { ...userLabels, ...podLabels },
+          labels: { ...templateLabels, ...userLabels, ...podLabels },
         },
         spec: {
           containers: [
@@ -337,6 +339,7 @@ export const createOrUpdateDeploymentConfig = (
   const defaultLabels = getAppLabels({ name, applicationName, imageStreamName, selectedTag });
   const defaultAnnotations = { ...getGitAnnotations(repository, ref), ...getCommonAnnotations() };
   const podLabels = getPodLabels(name);
+  const templateLabels = getTemplateLabels(originalDeploymentConfig);
 
   const newDeploymentConfig = {
     apiVersion: 'apps.openshift.io/v1',
@@ -352,7 +355,7 @@ export const createOrUpdateDeploymentConfig = (
       replicas,
       template: {
         metadata: {
-          labels: { ...userLabels, ...podLabels },
+          labels: { ...templateLabels, ...userLabels, ...podLabels },
         },
         spec: {
           containers: [

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -104,3 +104,16 @@ export const mergeData = (originalResource: K8sResourceKind, newResource: K8sRes
   }
   return mergedData;
 };
+
+export const getTemplateLabels = (deployment: K8sResourceKind) => {
+  return _.reduce(
+    deployment?.spec?.template?.metadata?.labels,
+    (acc, value, key) => {
+      if (!deployment.metadata?.labels?.hasOwnProperty(key)) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {},
+  );
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5017

**Analysis / Root cause**: 
User is not able to edit custom template application because we only add the user labels (which in this case are template specific labels) and pod labels to spec.template.metadata.label and specific spec.template.metadata.label labels are getting removed. Another reason is during edit we get the `imageStream` based on the value of `app.kubernetes.io/instance` and if the respective `imageStream` doesnt have `app.kubernetes.io/instance` label the edit flow will not get the `imageStream` to be updated. We will ask the user to add `app.kubernetes.io/instance` on the `imageStream`. For more context - https://issues.redhat.com/browse/ODC-5017?focusedCommentId=15387232&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15387232

**Solution Description**: 
Preserve specific spec.template.metadata.label labels during edit.

**Screen shots / Gifs for design review**: 
![Peek 2020-11-05 23-03](https://user-images.githubusercontent.com/20724543/98275439-9fc81480-1fba-11eb-8b46-51b0d214d600.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge