### PR TITLE
Fix to allow in context create after page reload

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
@@ -99,20 +99,21 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
     }
   }, []);
 
-  const onVisualizationChange = React.useCallback(
-    (vis: Visualization) => {
-      const graphData: GraphData = {
-        createResourceAccess,
-        namespace,
-        eventSourceEnabled,
-        createConnectorExtensions: createConnectors,
-      };
-      vis.getGraph().setData(graphData);
-
-      setVisualization(vis);
-    },
+  const graphData: GraphData = React.useMemo(
+    () => ({
+      createResourceAccess,
+      namespace,
+      eventSourceEnabled,
+      createConnectorExtensions: createConnectors,
+    }),
     [createConnectors, createResourceAccess, eventSourceEnabled, namespace],
   );
+
+  React.useEffect(() => {
+    if (visualization) {
+      visualization.getGraph().setData(graphData);
+    }
+  }, [visualization, graphData]);
 
   const createConnectorPromises = React.useMemo(
     () => createConnectorExtensions.map((creator) => creator.properties.getCreateConnector()),
@@ -224,17 +225,17 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
           namespace={namespace}
           application={applicationRef.current}
           onSelect={onSelect}
-          setVisualization={onVisualizationChange}
+          setVisualization={setVisualization}
         />
       ) : (
         <TopologyListView
           model={filteredModel}
           namespace={namespace}
           onSelect={onSelect}
-          setVisualization={onVisualizationChange}
+          setVisualization={setVisualization}
         />
       ),
-    [filteredModel, namespace, onSelect, onVisualizationChange, showGraphView],
+    [filteredModel, namespace, onSelect, showGraphView],
   );
 
   const topologyFilterBar = React.useMemo(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5075

**Analysis / Root cause**: 
On a fresh reload while on the topology graph page, the data for the project access settings is not set prior to adding it to the graph data. Without the correct settings the in context believes the user does not have permission to add items.

**Solution Description**: 
Update the graph data when the project settings are updated.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug