### PR TITLE
Bug 1878701: Filter out events from old VM with the same nam

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-activity.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-activity.tsx
@@ -25,7 +25,7 @@ import { VMILikeEntityKind } from '../../../types/vmLike';
 import './vm-activity.scss';
 
 const combinedVmFilter = (vm: VMILikeEntityKind): EventFilterFuncion => (event) =>
-  getVmEventsFilters(vm).some((filter) => filter(event.involvedObject));
+  getVmEventsFilters(vm).some((filter) => filter(event.involvedObject, event));
 
 const getEventsResource = (namespace: string): FirehoseResource => ({
   isList: true,

--- a/frontend/packages/kubevirt-plugin/src/selectors/event/filters.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/event/filters.ts
@@ -1,6 +1,6 @@
-import { getName, getNamespace } from '@console/shared';
+import { getName, getNamespace, getUID, getCreationTimestamp } from '@console/shared';
 import { PodModel } from '@console/internal/models';
-import { EventInvolvedObject } from '@console/internal/module/k8s';
+import { EventInvolvedObject, EventKind } from '@console/internal/module/k8s';
 import {
   VirtualMachineImportModel,
   VirtualMachineInstanceMigrationModel,
@@ -10,39 +10,44 @@ import {
 import { VIRT_LAUNCHER_POD_PREFIX } from '../../constants/vm';
 import { VMILikeEntityKind } from '../../types/vmLike';
 
-type EventFilterFunction = (src: EventInvolvedObject) => boolean;
+type EventFilterFunction = (src: EventInvolvedObject, event: EventKind) => boolean;
 
-const vmEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => ({
-  kind,
-  namespace,
-  name,
-}) => {
-  return (
-    kind === VirtualMachineModel.kind && name === getName(vm) && namespace === getNamespace(vm)
-  );
+const vmEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => ({ kind, uid }) => {
+  return kind === VirtualMachineModel.kind && uid === getUID(vm);
 };
 
-const vmiEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => ({
-  kind,
-  namespace,
-  name,
-}) =>
+// If a VM with a name x is created than started/migrated etc and than deleted again,
+// the associated events will keep existing in the system even though the objects which produced them are gone (e.g. the migration object/pod etc).
+// Since the event itself does not contain a reference to the VM ID and can only be associated using a VM name,
+// the events from the previous VM are mixed into the events of the new VM.
+// Since the owner reference to the VM is not present on the event but only the object which produced the event (e.g. migration pod) and this object can be gone
+// by now, the only safe way how to filter these events out is to make sure no events which have been produced before the VM was created are shown.
+const happenedBeforeVmCreation = (vm: VMILikeEntityKind, timestamp: string): boolean =>
+  new Date(timestamp) < new Date(getCreationTimestamp(vm));
+
+const vmiEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => (
+  { kind, namespace, name },
+  { firstTimestamp },
+) =>
   kind === VirtualMachineInstanceModel.kind &&
   name === getName(vm) &&
-  namespace === getNamespace(vm);
+  namespace === getNamespace(vm) &&
+  !happenedBeforeVmCreation(vm, firstTimestamp);
 
 const launcherPodEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => {
   const podNameStart = `${VIRT_LAUNCHER_POD_PREFIX}${getName(vm)}-`;
 
-  return ({ kind, namespace, name }) =>
-    kind === PodModel.kind && namespace === getNamespace(vm) && name.startsWith(podNameStart);
+  return ({ kind, namespace, name }, { firstTimestamp }) =>
+    kind === PodModel.kind &&
+    namespace === getNamespace(vm) &&
+    name.startsWith(podNameStart) &&
+    !happenedBeforeVmCreation(vm, firstTimestamp);
 };
 
-const cdiImporterPodEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => ({
-  kind,
-  namespace,
-  name,
-}) => {
+const cdiImporterPodEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => (
+  { kind, namespace, name },
+  { firstTimestamp },
+) => {
   // importer pod example importer-<vmName>-<diskName>-<generatedId>
   // note: diskName and vmname may contain '-' which means pod name should have at least 4 parts
   if (
@@ -55,37 +60,26 @@ const cdiImporterPodEventFilter = (vm: VMILikeEntityKind): EventFilterFunction =
     const lastDashIndex = name.lastIndexOf('-');
     // remove importer- and -<generatedId>
     const vmAndDiskName = name.slice(importerDashIndex + 1, lastDashIndex);
-    return vmAndDiskName.startsWith(getName(vm));
+    return vmAndDiskName.startsWith(getName(vm)) && !happenedBeforeVmCreation(vm, firstTimestamp);
   }
   return false;
 };
 
-const vmiMigrationEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => ({
-  kind,
-  namespace,
-  name,
-}) =>
+const vmiMigrationEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => (
+  { kind, namespace, name },
+  { firstTimestamp },
+) =>
   kind === VirtualMachineInstanceMigrationModel.kind &&
   namespace === getNamespace(vm) &&
-  name === `${getName(vm)}-migration`;
+  name === `${getName(vm)}-migration` &&
+  !happenedBeforeVmCreation(vm, firstTimestamp);
 
 // Conversion pod name example: kubevirt-v2v-conversion-[vmName]-<generatedId>
 const V2V_CONVERSION_POD_NAME_PREFIX = 'kubevirt-v2v-conversion-';
-const v2vConversionPodEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => ({
-  kind,
-  namespace,
-  name,
-}) => {
-  /* Idea for improvement:
-       Find the conversion pod via provided event.involvedObject.uid and check it's ownerReference to VirtualMachine vm.
-       This way, we would avoid false-positive matching which is possible when comparing just by name as implemented bellow.
-     When this can happen:
-       Conversion is started, the VM deleted and a new conversion for a VM of the same name is created again. The events will be merged together in that case.
-     Why not implemented properly now:
-       The list of pods is not available and it would be costly to fetch it just for the purpose of this comparision.
-       Please note, the conversion is one-time and occasional action and the list of events is for the last hour only.
-       If there is any other reason to fetch list of pods, fix here as described above.
-  */
+const v2vConversionPodEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => (
+  { kind, namespace, name },
+  { firstTimestamp },
+) => {
   if (
     kind === PodModel.kind &&
     namespace === getNamespace(vm) &&
@@ -94,23 +88,24 @@ const v2vConversionPodEventFilter = (vm: VMILikeEntityKind): EventFilterFunction
     const nameWithRandom = name.slice(V2V_CONVERSION_POD_NAME_PREFIX.length);
     const lastDashIndex = nameWithRandom.lastIndexOf('-');
     const vmName = nameWithRandom.slice(0, lastDashIndex);
-    return vmName === getName(vm);
+    return vmName === getName(vm) && !happenedBeforeVmCreation(vm, firstTimestamp);
   }
   return false;
 };
 
-const virtualMachineImportEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => ({
-  kind,
-  namespace,
-  name,
-}) => {
+const virtualMachineImportEventFilter = (vm: VMILikeEntityKind): EventFilterFunction => (
+  { kind, namespace, name },
+  { firstTimestamp },
+) => {
   if (kind !== VirtualMachineImportModel.kind || namespace !== getNamespace(vm)) {
     return false;
   }
 
   const lastDashIndex = name.lastIndexOf('-');
   const vmImportName = name.slice(0, lastDashIndex);
-  return vmImportName === `vm-import-${getName(vm)}`;
+  return (
+    vmImportName === `vm-import-${getName(vm)}` && happenedBeforeVmCreation(vm, firstTimestamp)
+  );
 };
 
 export const getVmEventsFilters = (vm: VMILikeEntityKind): EventFilterFunction[] => [

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -386,7 +386,7 @@ class EventStream extends React.Component {
       if (kind && !kindFilter(kind, obj)) {
         return false;
       }
-      if (filter && !filter.some((flt) => flt(obj.involvedObject))) {
+      if (filter && !filter.some((flt) => flt(obj.involvedObject, obj))) {
         return false;
       }
       if (!textMatches(obj)) {


### PR DESCRIPTION
Added 2 checks:
1: the VM object events filter now makes sure it checks the VM UID, not only the name

2: filtered out the events which happened before the VM was created.
Unfortunately, there is no way to filter them based on the UID of the VM since
the object which contains the owner reference with UID (like the migration pod)
is/might be deleted by now and all what is left is an event