### PR TITLE
CONSOLE-2464: Automatically collapse metadata.managedFields

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/YAMLEditor.tsx
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditor.tsx
@@ -32,7 +32,7 @@ const YAMLEditor = React.forwardRef<MonacoEditor, YAMLEditorProps>((props, ref) 
     (editor, monaco) => {
       editor.layout();
       editor.focus();
-      registerYAMLinMonaco(monaco);
+      registerYAMLinMonaco(editor, monaco);
       monaco.editor.getModels()[0].updateOptions({ tabSize: 2 });
       onSave && editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, onSave); // eslint-disable-line no-bitwise
     },

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -16,7 +16,7 @@ import {
 } from '@console/shared';
 import YAMLEditor from '@console/shared/src/components/editor/YAMLEditor';
 import YAMLEditorSidebar from '@console/shared/src/components/editor/YAMLEditorSidebar';
-import { downloadYaml } from '@console/shared/src/components/editor/yaml-editor-utils';
+import { downloadYaml, fold } from '@console/shared/src/components/editor/yaml-editor-utils';
 import { isYAMLTemplate, withExtensions } from '@console/plugin-sdk';
 
 import { connectToFlags } from '../reducers/features';
@@ -146,6 +146,8 @@ export const EditYAML_ = connect(stateToProps)(
 
         reload() {
           this.loadYaml(true);
+          const currentEditor = this.getEditor();
+          fold(currentEditor, currentEditor.getModel(), false);
           this.setState({
             sampleObj: null,
             error: null,


### PR DESCRIPTION
This PR makes it so that when a yaml editor opens, it checks to see if metadata.managedFields exists and if it does then collapse it. Unfortunately, the YAML language server doesn't provide folding ranges yet so the only alternative is to look through the AST manually.

It ends up looking like: https://www.youtube.com/watch?v=_FDwyjQN444

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>