### PR TITLE
[ODC-4388] Allow cluster admins to create terminals

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
@@ -3,9 +3,9 @@ import { shallow } from 'enzyme';
 import { StatusBox } from '@console/internal/components/utils/status-box';
 import { InternalCloudShellTerminal } from '../CloudShellTerminal';
 import TerminalLoadingBox from '../TerminalLoadingBox';
-import CloudShellSetup from '../setup/CloudShellSetup';
 import { user } from './cloud-shell-test-data';
 import useCloudShellWorkspace from '../useCloudShellWorkspace';
+import CloudShellDeveloperSetup from '../setup/CloudShellDeveloperSetup';
 
 jest.mock('../useCloudShellWorkspace', () => ({
   default: jest.fn(),
@@ -18,6 +18,10 @@ jest.mock('react-i18next', () => {
     useTranslation: () => ({ t: (key: string) => key }),
   };
 });
+
+jest.mock('@console/internal/components/utils/rbac', () => ({
+  useAccessReview2: () => [false, false],
+}));
 
 jest.mock('@console/shared/src/hooks/useUserSettingsCompatibility', () => {
   return {
@@ -59,6 +63,6 @@ describe('CloudShellTerminal', () => {
         setUserSettingState={jest.fn()}
       />,
     );
-    expect(wrapper.find(CloudShellSetup)).toHaveLength(1);
+    expect(wrapper.find(CloudShellDeveloperSetup)).toHaveLength(1);
   });
 });

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -32,6 +32,7 @@ export const CLOUD_SHELL_LABEL = 'console.openshift.io/terminal';
 export const CLOUD_SHELL_CREATOR_LABEL = 'controller.devfile.io/creator';
 export const CLOUD_SHELL_RESTRICTED_ANNOTATION = 'controller.devfile.io/restricted-access';
 export const CLOUD_SHELL_STOPPED_BY_ANNOTATION = 'controller.devfile.io/stopped-by';
+export const CLOUD_SHELL_PROTECTED_NAMESPACE = 'openshift-terminal';
 
 export const createCloudShellResourceName = () => `terminal-${getRandomChars(6)}`;
 

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellAdminSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellAdminSetup.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import { k8sCreate, k8sGet } from '@console/internal/module/k8s';
+import { WorkspaceModel } from '../../../models';
+import {
+  newCloudShellWorkSpace,
+  createCloudShellResourceName,
+  CLOUD_SHELL_PROTECTED_NAMESPACE,
+} from '../cloud-shell-utils';
+import { NamespaceModel } from '@console/internal/models';
+import TerminalLoadingBox from '../TerminalLoadingBox';
+import { LoadError } from '@console/internal/components/utils/status-box';
+import { useTranslation } from 'react-i18next';
+
+type Props = {
+  onInitialize: (namespace: string) => void;
+};
+
+const CloudShellAdminSetup: React.FunctionComponent<Props> = ({ onInitialize }) => {
+  const { t } = useTranslation();
+
+  const [initError, setInitError] = React.useState<string>();
+  React.useEffect(() => {
+    (async () => {
+      async function namespaceExists(): Promise<boolean> {
+        try {
+          await k8sGet(NamespaceModel, CLOUD_SHELL_PROTECTED_NAMESPACE);
+          return true;
+        } catch (error) {
+          if (error.json.code !== 404) {
+            setInitError(error);
+          }
+          return false;
+        }
+      }
+
+      try {
+        const protectedNamespaceExists = await namespaceExists();
+        if (!protectedNamespaceExists) {
+          await k8sCreate(NamespaceModel, {
+            metadata: {
+              name: CLOUD_SHELL_PROTECTED_NAMESPACE,
+            },
+          });
+        }
+        await k8sCreate(
+          WorkspaceModel,
+          newCloudShellWorkSpace(createCloudShellResourceName(), CLOUD_SHELL_PROTECTED_NAMESPACE),
+        );
+        onInitialize(CLOUD_SHELL_PROTECTED_NAMESPACE);
+      } catch (error) {
+        setInitError(error);
+      }
+    })();
+    // Don't include dependencies because if the CLOUD_SHELL_PROTECTED_NAMESPACE
+    // is not found a refresh will be triggered, creating an extra terminal
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (initError) {
+    return (
+      <LoadError message={initError} label={t('cloudshell~OpenShift command line terminal')} />
+    );
+  }
+
+  return (
+    <div className="co-cloudshell-terminal__container">
+      <TerminalLoadingBox />
+    </div>
+  );
+};
+
+export default connect()(CloudShellAdminSetup);

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
@@ -26,7 +26,7 @@ type Props = StateProps & {
   onCancel?: () => void;
 };
 
-const CloudShellSetup: React.FunctionComponent<Props> = ({
+const CloudShellDeveloperSetup: React.FunctionComponent<Props> = ({
   activeNamespace,
   onSubmit,
   onCancel,
@@ -80,4 +80,4 @@ const mapStateToProps = (state: RootState): StateProps => ({
   activeNamespace: state.UI.get('activeNamespace'),
 });
 
-export default connect<StateProps>(mapStateToProps)(CloudShellSetup);
+export default connect<StateProps>(mapStateToProps)(CloudShellDeveloperSetup);

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -11,6 +11,7 @@ import {
   CloudShellResource,
   CLOUD_SHELL_RESTRICTED_ANNOTATION,
   startWorkspace,
+  CLOUD_SHELL_PROTECTED_NAMESPACE,
 } from './cloud-shell-utils';
 import { useAccessReview2 } from '@console/internal/components/utils';
 import { ProjectModel } from '@console/internal/models';
@@ -30,6 +31,7 @@ const findWorkspace = (data?: CloudShellResource[]): CloudShellResource | undefi
 
 const useCloudShellWorkspace = (
   user: UserKind,
+  isClusterAdmin: boolean,
   defaultNamespace: string = null,
 ): WatchK8sResult<CloudShellResource> => {
   const [namespace, setNamespace] = useSafetyFirst(defaultNamespace);
@@ -67,11 +69,14 @@ const useCloudShellWorkspace = (
       },
     };
 
-    if (!canListWorkspaces) {
+    if (isClusterAdmin) {
+      result.namespace = CLOUD_SHELL_PROTECTED_NAMESPACE;
+    } else if (!canListWorkspaces) {
       result.namespace = namespace;
     }
+
     return result;
-  }, [isKubeAdmin, uid, namespace, loadingAccessReview, canListWorkspaces]);
+  }, [loadingAccessReview, canListWorkspaces, namespace, isKubeAdmin, uid, isClusterAdmin]);
 
   // call k8s api to fetch workspace
   const [data, loaded, loadError] = useK8sWatchResource<CloudShellResource[]>(resource);


### PR DESCRIPTION
This PR is part of https://issues.redhat.com/browse/ODC-4388 which is for giving privileged users access to create terminal.

Currently, the flow is:
If the user is a cluster-admin then deny them from opening a terminal.

Now, the flow is:
If the user is a cluster-admin then automatically create their terminal in a secure openshift-terminal namespace. If the openshift-terminal namespace does not exist then create it.

The backend code then checks if the current user is a cluster-admin and if they are then check that the workspace they are trying to access is in the openshift-terminal namespace.

Before: https://www.youtube.com/watch?v=TUri-TE52UA
After: https://www.youtube.com/watch?v=v6Xy7LKbYrU

You can test with: `quay.io/jpinkney/console:515`

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>