### PR TITLE
add support for customSchema in resource sidebar for helm charts

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
@@ -10,14 +10,20 @@ import { YAMLEditorFieldProps } from './field-types';
 
 import './YAMLEditorField.scss';
 
-const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name, onSave, schemaModel }) => {
+const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({
+  name,
+  onSave,
+  schema,
+  schemaModel,
+  schemaLabel,
+}) => {
   const [field] = useField(name);
   const { setFieldValue } = useFormikContext<FormikValues>();
   const { t } = useTranslation();
 
   const [sidebarOpen, setSidebarOpen] = React.useState<boolean>(true);
   const definition = schemaModel ? definitionFor(schemaModel) : { properties: [] };
-  const showSchema = definition && !isEmpty(definition.properties);
+  const showSchema = schema || (definition && !isEmpty(definition.properties));
 
   return (
     <div className="osc-yaml-editor">
@@ -49,6 +55,8 @@ const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name, onSave, schemaM
               )
             }
             kindObj={schemaModel}
+            schema={schema}
+            sidebarLabel={schemaLabel}
             showSidebar={sidebarOpen}
             toggleSidebar={() => setSidebarOpen(!sidebarOpen)}
             showSchema={showSchema}

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -87,6 +87,8 @@ export interface YAMLEditorFieldProps extends FieldProps {
   onChange?: (value: string) => void;
   onSave?: () => void;
   schemaModel?: K8sKind;
+  schemaLabel?: string;
+  schema?: any;
 }
 
 export interface NameValuePair {

--- a/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
@@ -59,7 +59,14 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
     />
   );
 
-  const yamlEditor = chartHasValues && <YAMLEditorField name="yamlData" onSave={handleSubmit} />;
+  const yamlEditor = chartHasValues && (
+    <YAMLEditorField
+      schema={formSchema}
+      name="yamlData"
+      schemaLabel="Helm Chart"
+      onSave={handleSubmit}
+    />
+  );
 
   const formSubTitle = _.isString(subTitle) ? subTitle : subTitle?.[editorType];
 

--- a/frontend/public/components/sidebars/resource-sidebar.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar.tsx
@@ -43,8 +43,8 @@ const ResourceSidebarWrapper = (props) => {
   );
 };
 
-const ResourceSchema = ({ kindObj }) => (
-  <ExploreType kindObj={kindObj} scrollTop={sidebarScrollTop} />
+const ResourceSchema = ({ kindObj, schema }) => (
+  <ExploreType kindObj={kindObj} schema={schema} scrollTop={sidebarScrollTop} />
 );
 
 const ResourceSamples = ({ samples, kindObj, downloadSampleYaml, loadSampleYaml }) => (
@@ -65,6 +65,8 @@ export const ResourceSidebar = (props) => {
   const {
     downloadSampleYaml,
     kindObj,
+    schema,
+    sidebarLabel,
     loadSampleYaml,
     insertSnippetYaml,
     isCreateMode,
@@ -74,11 +76,11 @@ export const ResourceSidebar = (props) => {
     snippets,
     showSchema,
   } = props;
-  if (!kindObj) {
+  if (!kindObj && !schema) {
     return null;
   }
 
-  const { label } = kindObj;
+  const { label = sidebarLabel } = kindObj ?? {};
 
   const showSamples = !_.isEmpty(samples) && isCreateMode;
   const showSnippets = !_.isEmpty(snippets);
@@ -114,6 +116,7 @@ export const ResourceSidebar = (props) => {
           tabProps={{
             downloadSampleYaml,
             kindObj,
+            schema,
             loadSampleYaml,
             insertSnippetYaml,
             samples,
@@ -122,7 +125,7 @@ export const ResourceSidebar = (props) => {
           additionalClassNames="co-m-horizontal-nav__menu--within-sidebar"
         />
       ) : (
-        <ResourceSchema kindObj={kindObj} />
+        <ResourceSchema schema={schema} kindObj={kindObj} />
       )}
     </ResourceSidebarWrapper>
   );


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5041
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: missing schema sidebar for Helm charts install form
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: added support for custom schema in the sidebar
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
<img width="1496" alt="Screenshot 2020-11-09 at 12 07 58 PM" src="https://user-images.githubusercontent.com/9278015/98507774-472b9c80-2284-11eb-8602-07517f695518.png">
<img width="1491" alt="Screenshot 2020-11-09 at 12 08 14 PM" src="https://user-images.githubusercontent.com/9278015/98507801-56aae580-2284-11eb-9ffe-c025c4c1aa3c.png">

**Unit test coverage report**:

<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
