### PR TITLE
Fix to use graph view for default for dev perspective topology page

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataRenderer.tsx
@@ -4,14 +4,15 @@ import { HintBlock, StatusBox } from '@console/internal/components/utils';
 import ModelContext, { ExtensibleModel } from './data-transforms/ModelContext';
 import { TopologyView } from './TopologyView';
 import EmptyState from '../EmptyState';
+import { TopologyViewType } from './topology-types';
 
 interface TopologyDataRendererProps {
-  showGraphView: boolean;
+  viewType: TopologyViewType;
   title: string;
 }
 
 export const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observer(
-  ({ showGraphView, title }) => {
+  ({ viewType, title }) => {
     const { namespace, model, loaded, loadError } = React.useContext<ExtensibleModel>(ModelContext);
     const EmptyMsg = React.useCallback(
       () => (
@@ -33,7 +34,7 @@ export const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observe
     return (
       <StatusBox
         skeleton={
-          !showGraphView && (
+          viewType === TopologyViewType.list && (
             <div className="co-m-pane__body skeleton-overview">
               <div className="skeleton-overview--head" />
               <div className="skeleton-overview--tile" />
@@ -48,7 +49,7 @@ export const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observe
         loadError={loadError}
         EmptyMsg={EmptyMsg}
       >
-        <TopologyView showGraphView={showGraphView} model={model} namespace={namespace} />
+        <TopologyView viewType={viewType} model={model} namespace={namespace} />
       </StatusBox>
     );
   },

--- a/frontend/packages/dev-console/src/components/topology/TopologyPageToolbar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPageToolbar.tsx
@@ -4,14 +4,16 @@ import { Tooltip, Popover, Button } from '@patternfly/react-core';
 import { ListIcon, TopologyIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import TopologyShortcuts from './TopologyShortcuts';
 import ModelContext, { ExtensibleModel } from './data-transforms/ModelContext';
+import { TopologyViewType } from './topology-types';
 
 interface TopologyPageToolbarProps {
-  showGraphView: boolean;
-  onViewChange: (graphView: boolean) => void;
+  viewType: TopologyViewType;
+  onViewChange: (view: TopologyViewType) => void;
 }
 
 export const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
-  ({ showGraphView, onViewChange }) => {
+  ({ viewType, onViewChange }) => {
+    const showGraphView = viewType === TopologyViewType.graph;
     const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
     const { namespace, isEmptyModel } = dataModelContext;
 
@@ -43,7 +45,9 @@ export const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
           <Button
             variant="link"
             className="pf-m-plain odc-topology__view-switcher"
-            onClick={() => onViewChange(!showGraphView)}
+            onClick={() =>
+              onViewChange(showGraphView ? TopologyViewType.list : TopologyViewType.graph)
+            }
           >
             {showGraphView ? <ListIcon size="md" /> : <TopologyIcon size="md" />}
           </Button>

--- a/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyView.tsx
@@ -16,6 +16,7 @@ import {
   GraphData,
   TopologyApplyDisplayOptions,
   TopologyDisplayFilterType,
+  TopologyViewType,
 } from './topology-types';
 import {
   isTopologyCreateConnector,
@@ -53,7 +54,7 @@ interface DispatchProps {
 interface TopologyViewProps {
   model: Model;
   namespace: string;
-  showGraphView: boolean;
+  viewType: TopologyViewType;
 }
 
 type ComponentProps = TopologyViewProps & StateProps & DispatchProps;
@@ -61,7 +62,7 @@ type ComponentProps = TopologyViewProps & StateProps & DispatchProps;
 export const ConnectedTopologyView: React.FC<ComponentProps> = ({
   model,
   namespace,
-  showGraphView,
+  viewType,
   eventSourceEnabled,
   application,
   onFiltersChange,
@@ -219,7 +220,7 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
 
   const viewContent = React.useMemo(
     () =>
-      showGraphView ? (
+      viewType === TopologyViewType.graph ? (
         <Topology
           model={filteredModel}
           namespace={namespace}
@@ -235,12 +236,12 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
           setVisualization={setVisualization}
         />
       ),
-    [filteredModel, namespace, onSelect, showGraphView],
+    [filteredModel, namespace, onSelect, viewType],
   );
 
   const topologyFilterBar = React.useMemo(
-    () => <TopologyFilterBar showGraphView={showGraphView} visualization={visualization} />,
-    [showGraphView, visualization],
+    () => <TopologyFilterBar viewType={viewType} visualization={visualization} />,
+    [viewType, visualization],
   );
 
   const topologySideBar = React.useMemo(

--- a/frontend/packages/dev-console/src/components/topology/__tests__/DataModelProvider.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/DataModelProvider.spec.tsx
@@ -6,6 +6,7 @@ import * as utils from '@console/internal/components/utils/url-poll-hook';
 import DataModelProvider from '../data-transforms/DataModelProvider';
 import { TopologyDataRetriever } from '../TopologyDataRetriever';
 import { TopologyDataRenderer } from '../TopologyDataRenderer';
+import { TopologyViewType } from '../topology-types';
 
 jest.mock('@console/plugin-sdk/src/api/useExtensions', () => ({
   useExtensions: () => [],
@@ -30,7 +31,7 @@ describe('DataModelProvider', () => {
     spyUseURLPoll.mockReturnValue([{}, null, false]);
     wrapper = mount(
       <DataModelProvider namespace="test-project">
-        <TopologyDataRenderer showGraphView title="Topology" />
+        <TopologyDataRenderer viewType={TopologyViewType.graph} title="Topology" />
       </DataModelProvider>,
       {
         wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,

--- a/frontend/packages/dev-console/src/components/topology/__tests__/Graph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/Graph.spec.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { ConnectedTopologyView } from '../TopologyView';
 import { MockGraphResources } from './graph-test-data';
 import { baseDataModelGetter } from '../data-transforms';
+import { TopologyViewType } from '../topology-types';
 
 describe('Graph', () => {
   let topologyData;
@@ -17,7 +18,7 @@ describe('Graph', () => {
       <ConnectedTopologyView
         model={topologyData}
         namespace="test"
-        showGraphView
+        viewType={TopologyViewType.graph}
         application={''}
         eventSourceEnabled
         onSelectTab={() => {}}

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import NamespacedPage from '../../NamespacedPage';
 import { TopologyPage } from '../TopologyPage';
+import { TopologyViewType } from '../topology-types';
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
   useK8sWatchResources: jest.fn(),
@@ -50,8 +51,20 @@ describe('Topology page tests', () => {
     expect(wrapper.find(NamespacedPage).exists()).toBe(true);
   });
 
-  it('should default to list view', () => {
+  it('should default to graph view', () => {
     const wrapper = shallow(<TopologyPage match={match} title="Topology" hideProjects={false} />);
+    expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(false);
+  });
+
+  it('should allow setting default to list view', () => {
+    const wrapper = shallow(
+      <TopologyPage
+        match={match}
+        title="Topology"
+        hideProjects={false}
+        defaultViewType={TopologyViewType.list}
+      />,
+    );
     expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(true);
   });
 

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPageToolbar.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPageToolbar.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { TopologyPageToolbar } from '../TopologyPageToolbar';
+import { TopologyViewType } from '../topology-types';
 
 jest.mock('react', () => {
   const ActualReact = require.requireActual('react');
@@ -35,7 +36,9 @@ describe('TopologyPageToolbar tests', () => {
       isEmptyModel: false,
       namespace: 'test-namespace',
     });
-    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    const wrapper = shallow(
+      <TopologyPageToolbar viewType={TopologyViewType.graph} onViewChange={mockViewChange} />,
+    );
     expect(wrapper.find('[data-test-id="topology-view-shortcuts"]').exists()).toBe(true);
   });
 
@@ -46,7 +49,7 @@ describe('TopologyPageToolbar tests', () => {
       namespace: 'test-namespace',
     });
     const wrapper = shallow(
-      <TopologyPageToolbar showGraphView={false} onViewChange={mockViewChange} />,
+      <TopologyPageToolbar viewType={TopologyViewType.list} onViewChange={mockViewChange} />,
     );
     expect(wrapper.find('[data-test-id="topology-view-shortcuts"]').exists()).toBe(false);
   });
@@ -58,7 +61,7 @@ describe('TopologyPageToolbar tests', () => {
       namespace: 'test-namespace',
     });
     const wrapper = shallow(
-      <TopologyPageToolbar showGraphView={false} onViewChange={mockViewChange} />,
+      <TopologyPageToolbar viewType={TopologyViewType.list} onViewChange={mockViewChange} />,
     );
     expect(wrapper.find(Tooltip).props().content).toBe('Topology View');
   });
@@ -69,7 +72,9 @@ describe('TopologyPageToolbar tests', () => {
       isEmptyModel: false,
       namespace: 'test-namespace',
     });
-    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    const wrapper = shallow(
+      <TopologyPageToolbar viewType={TopologyViewType.graph} onViewChange={mockViewChange} />,
+    );
     expect(wrapper.find(Tooltip).props().content).toBe('List View');
   });
 
@@ -79,7 +84,9 @@ describe('TopologyPageToolbar tests', () => {
       isEmptyModel: false,
       namespace: undefined,
     });
-    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    const wrapper = shallow(
+      <TopologyPageToolbar viewType={TopologyViewType.graph} onViewChange={mockViewChange} />,
+    );
     expect(wrapper.find(Button).exists()).toBe(false);
   });
 
@@ -89,7 +96,9 @@ describe('TopologyPageToolbar tests', () => {
       isEmptyModel: true,
       namespace: 'test-namespace',
     });
-    const wrapper = shallow(<TopologyPageToolbar showGraphView onViewChange={mockViewChange} />);
+    const wrapper = shallow(
+      <TopologyPageToolbar viewType={TopologyViewType.graph} onViewChange={mockViewChange} />,
+    );
     expect(wrapper.find(Button).exists()).toBe(false);
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
@@ -7,14 +7,14 @@ import {
   SelectVariant,
   Switch,
 } from '@patternfly/react-core';
-import { TopologyDisplayFilterType, DisplayFilters } from '../topology-types';
+import { DisplayFilters, TopologyDisplayFilterType, TopologyViewType } from '../topology-types';
 import { EXPAND_GROUPS_FILTER_ID, SHOW_GROUPS_FILTER_ID } from './const';
 
 import './FilterDropdown.scss';
 
 type FilterDropdownProps = {
   filters: DisplayFilters;
-  showGraphView: boolean;
+  viewType: TopologyViewType;
   supportedFilters: string[];
   onChange: (filter: DisplayFilters) => void;
   opened?: boolean; // Use only for testing
@@ -22,7 +22,7 @@ type FilterDropdownProps = {
 
 const FilterDropdown: React.FC<FilterDropdownProps> = ({
   filters,
-  showGraphView,
+  viewType,
   supportedFilters,
   onChange,
   opened = false,
@@ -123,7 +123,7 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
           </SelectGroup>
         </div>
       ) : null}
-      {showGraphView && showFilters.length ? (
+      {viewType === TopologyViewType.graph && showFilters.length ? (
         <div className="odc-topology-filter-dropdown__group">
           <SelectGroup label="Show">
             {showFilters.map((filter) => (

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
@@ -21,7 +21,7 @@ import { TextFilter } from '@console/internal/components/factory';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ConsoleLinkModel } from '@console/internal/models';
 import { setTopologyFilters } from '../redux/action';
-import { DisplayFilters } from '../topology-types';
+import { DisplayFilters, TopologyViewType } from '../topology-types';
 import {
   getSupportedTopologyFilters,
   getSupportedTopologyKinds,
@@ -48,7 +48,7 @@ type DispatchProps = {
 
 type OwnProps = {
   visualization?: Visualization;
-  showGraphView: boolean;
+  viewType: TopologyViewType;
 };
 
 type MergeProps = StateProps & DispatchProps & OwnProps;
@@ -61,7 +61,7 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
   supportedKinds,
   onFiltersChange,
   visualization,
-  showGraphView,
+  viewType,
   namespace,
 }) => {
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
@@ -88,7 +88,7 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
           <ToolbarItem>
             <FilterDropdown
               filters={filters}
-              showGraphView={showGraphView}
+              viewType={viewType}
               supportedFilters={supportedFilters}
               onChange={onFiltersChange}
             />
@@ -113,7 +113,7 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
               className="odc-topology-filter-bar__text-filter"
             />
           </ToolbarItem>
-          {showGraphView ? (
+          {viewType === TopologyViewType.graph ? (
             <ToolbarItem>
               <Popover
                 aria-label="Find by name"
@@ -168,7 +168,7 @@ const dispatchToProps = (dispatch: Dispatch): DispatchProps => ({
 const mergeProps = (
   { filters, supportedFilters, supportedKinds, namespace }: StateProps,
   { onFiltersChange }: DispatchProps,
-  { visualization, showGraphView }: OwnProps,
+  { visualization, viewType }: OwnProps,
 ): MergeProps => ({
   filters,
   supportedFilters,
@@ -176,7 +176,7 @@ const mergeProps = (
   namespace,
   onFiltersChange,
   visualization,
-  showGraphView,
+  viewType,
 });
 
 export default connect<StateProps, DispatchProps, OwnProps, MergeProps>(

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 import { Radio, SelectOption, Switch } from '@patternfly/react-core';
 import FilterDropdown from '../FilterDropdown';
-import { DisplayFilters, TopologyDisplayFilterType } from '../../topology-types';
+import { DisplayFilters, TopologyDisplayFilterType, TopologyViewType } from '../../topology-types';
 import {
   DEFAULT_TOPOLOGY_FILTERS,
   EXPAND_APPLICATION_GROUPS_FILTER_ID,
@@ -23,7 +23,7 @@ describe(FilterDropdown.displayName, () => {
     const wrapper = shallow(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
       />,
@@ -35,7 +35,7 @@ describe(FilterDropdown.displayName, () => {
     const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
         opened
@@ -48,7 +48,7 @@ describe(FilterDropdown.displayName, () => {
     const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView={false}
+        viewType={TopologyViewType.list}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
         opened
@@ -63,7 +63,7 @@ describe(FilterDropdown.displayName, () => {
     const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={[EXPAND_APPLICATION_GROUPS_FILTER_ID]}
         onChange={onChange}
         opened
@@ -76,7 +76,7 @@ describe(FilterDropdown.displayName, () => {
     let wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
         opened
@@ -92,7 +92,7 @@ describe(FilterDropdown.displayName, () => {
     wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
         opened
@@ -108,7 +108,7 @@ describe(FilterDropdown.displayName, () => {
     const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
         opened
@@ -122,7 +122,7 @@ describe(FilterDropdown.displayName, () => {
     const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
         opened
@@ -141,7 +141,7 @@ describe(FilterDropdown.displayName, () => {
     const wrapper = mount(
       <FilterDropdown
         filters={dropdownFilter}
-        showGraphView
+        viewType={TopologyViewType.graph}
         supportedFilters={dropdownFilter.map((f) => f.id)}
         onChange={onChange}
         opened

--- a/frontend/public/components/overview/OverviewListPage.tsx
+++ b/frontend/public/components/overview/OverviewListPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { match as RMatch } from 'react-router';
 import { STORAGE_PREFIX } from '@console/shared/src';
 import { TopologyPage } from '@console/dev-console/src/components/topology/TopologyPage';
+import { TopologyViewType } from '@console/dev-console/src/components/topology/topology-types';
 
 type OverviewListPageProps = {
   match: RMatch<{
@@ -18,6 +19,7 @@ export const OverviewListPage: React.FC<OverviewListPageProps> = ({ match }) => 
       hideProjects
       title=""
       activeViewStorageKey={LAST_TOPOLOGY_WORKLOADS_VIEW_LOCAL_STORAGE_KEY}
+      defaultViewType={TopologyViewType.list}
     />
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5108

**Analysis / Root cause**: 
Default was mistakenly set to list view for dev perspective topology page

**Solution Description**: 
Default set to graph view with the option to default to list view. Update workloads tab to set the default to list view.
Update code to use the enum for view type rather than passing `graph` or `list` string values.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug