### PR TITLE
Bug 1896296: Ensure correct git URL for topology edit icon

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -124,6 +124,7 @@
     "focus-trap-react": "^6.0.0",
     "formik": "2.0.3",
     "fuzzysearch": "1.0.x",
+    "git-url-parse": "^11.4.0",
     "graphql": "^14.0.0",
     "history": "4.x",
     "hoist-non-react-statics": "3.x",

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import GitUrlParse from 'git-url-parse';
 import {
   K8sResourceKind,
   K8sResourceKindReference,
@@ -32,9 +33,11 @@ export const getServiceBindingStatus = ({ FLAGS }: RootState): boolean =>
 export const getCheURL = (consoleLinks: K8sResourceKind[]) =>
   _.get(_.find(consoleLinks, ['metadata.name', 'che']), 'spec.href', '');
 
-export const getEditURL = (gitURL: string, gitBranch: string, cheURL: string) => {
+export const getEditURL = (vcsURI: string, gitBranch?: string, cheURL?: string) => {
+  const parsedURL = GitUrlParse(vcsURI);
+  const gitURL = `https://${parsedURL.source}/${parsedURL.owner}/${parsedURL.name}`;
   const fullGitURL = gitBranch ? `${gitURL}/tree/${gitBranch}` : gitURL;
-  return gitURL && cheURL ? `${cheURL}/f?url=${fullGitURL}&policies.create=peruser` : fullGitURL;
+  return cheURL ? `${cheURL}/f?url=${fullGitURL}&policies.create=peruser` : fullGitURL;
 };
 
 export const getNamespaceDashboardKialiLink = (

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8968,6 +8968,13 @@ git-url-parse@^11.1.2:
   dependencies:
     git-up "^4.0.0"
 
+git-url-parse@^11.4.0:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.4.0.tgz#f2bb1f2b00f05552540e95a62e31399a639a6aa6"
+  integrity sha512-KlIa5jvMYLjXMQXkqpFzobsyD/V2K5DRHl5OAf+6oDFPlPLxrGDVQlIdI63c4/Kt6kai4kALENSALlzTGST3GQ==
+  dependencies:
+    git-up "^4.0.0"
+
 gitlab@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/gitlab/-/gitlab-10.0.1.tgz#f1619e8d2d6c5a707d0ffec47c14219b232af143"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5040
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Git URLs with `.git` suffix do not work when branch info is appended to the URL.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Check and remove `.git` in the URL before appending branch info.
Check if url is an SSH url (ex. `git@github.com:sclorg/nodejs-ex.git`) transform it into HTTP URL.
<!-- Describe your code changes in detail and explain the solution -->

<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug