### PR TITLE
Topology, fetch service and route data when necessary

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -8,6 +8,8 @@ export * from './debounce';
 export * from './select-list';
 export * from './useBuildConfigsWatcher';
 export * from './usePodsWatcher';
+export * from './useRoutesWatcher';
+export * from './useServicesWatcher';
 export * from './useQueryParams';
 export * from './version';
 export * from './csv-watch-hook';

--- a/frontend/packages/console-shared/src/hooks/useRoutesWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useRoutesWatcher.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { K8sResourceKind, RouteKind } from '@console/internal/module/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { getRoutesForServices } from '../utils';
+import { useServicesWatcher } from './useServicesWatcher';
+
+export const useRoutesWatcher = (
+  resource: K8sResourceKind,
+): { loaded: boolean; loadError: string; routes: RouteKind[] } => {
+  const { namespace } = resource.metadata;
+  const watchedServices = useServicesWatcher(resource);
+  const [allRoutes, loaded, loadError] = useK8sWatchResource<RouteKind[]>({
+    isList: true,
+    kind: 'Route',
+    namespace,
+  });
+
+  const servicesNames = React.useMemo(
+    () =>
+      !watchedServices.loadError && watchedServices.loaded
+        ? watchedServices.services.map((s) => s.metadata.name)
+        : [],
+    [watchedServices.loadError, watchedServices.loaded, watchedServices.services],
+  );
+
+  const routes = React.useMemo(() => getRoutesForServices(servicesNames, allRoutes), [
+    servicesNames,
+    allRoutes,
+  ]);
+
+  return {
+    loaded: loaded && watchedServices.loaded,
+    loadError: loadError || watchedServices.loadError,
+    routes,
+  };
+};

--- a/frontend/packages/console-shared/src/hooks/useServicesWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useServicesWatcher.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { getServicesForResource } from '../utils';
+
+export const useServicesWatcher = (
+  resource: K8sResourceKind,
+): { loaded: boolean; loadError: string; services: K8sResourceKind[] } => {
+  const { namespace } = resource.metadata;
+  const [allServices, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>({
+    isList: true,
+    kind: 'Service',
+    namespace,
+  });
+
+  const services = React.useMemo(
+    () => (!loadError && loaded ? getServicesForResource(resource, allServices) : []),
+    [allServices, loadError, loaded, resource],
+  );
+
+  return { loaded, loadError, services };
+};

--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -3,7 +3,6 @@ import {
   JobKind,
   K8sResourceKind,
   PodKind,
-  RouteKind,
 } from '@console/internal/module/k8s';
 import { DEPLOYMENT_STRATEGY } from '../constants';
 import { PodControllerOverviewItem } from './pod';
@@ -32,8 +31,6 @@ export type OverviewItem<T = K8sResourceKind> = {
   hpas?: HorizontalPodAutoscalerKind[];
   pods?: PodKind[];
   previous?: PodControllerOverviewItem;
-  routes: RouteKind[];
-  services: K8sResourceKind[];
   jobs?: JobKind[];
   status?: React.ReactNode;
   ksroutes?: K8sResourceKind[];

--- a/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
@@ -75,15 +75,13 @@ enum Keys {
   PODS = 'pods',
   JOBS = 'jobs',
   PREVIOUS = 'previous',
-  ROUTES = 'routes',
   STATUS = 'status',
-  SERVICE = 'services',
   REVISIONS = 'revisions',
   KNATIVECONFIGS = 'configurations',
   KSROUTES = 'ksroutes',
 }
 
-const podKeys = [Keys.OBJ, Keys.ROUTES, Keys.SERVICE, Keys.STATUS];
+const podKeys = [Keys.OBJ, Keys.STATUS];
 const dsAndSSKeys = [...podKeys, Keys.PODS];
 const dcKeys = [...dsAndSSKeys, Keys.CURRENT, Keys.ROLLINGOUT, Keys.PREVIOUS];
 const knativeKeys = [...dcKeys, Keys.REVISIONS, Keys.KNATIVECONFIGS, Keys.KSROUTES];

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
@@ -23,8 +23,6 @@ describe('Monitoring Tab', () => {
           },
         },
       },
-      routes: [],
-      services: [],
     },
   };
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
@@ -11,8 +11,6 @@ describe('Pipeline sidebar overview', () => {
     props = {
       item: {
         obj: {},
-        routes: [],
-        services: [],
         pipelines: [{ metadata: { name: 'pipeline', namespace: 'test' }, spec: { tasks: [] } }],
         pipelineRuns: [],
       },

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { calculateRadius } from '@console/shared';
 import {
   Node,
   observer,
@@ -12,6 +11,7 @@ import {
 } from '@patternfly/react-topology';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { calculateRadius, useRoutesWatcher } from '@console/shared';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConsoleLinkModel } from '@console/internal/models';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
@@ -20,7 +20,12 @@ import { Decorator } from './Decorator';
 import PodSet, { podSetInnerRadius } from './PodSet';
 import BuildDecorator from './build-decorators/BuildDecorator';
 import { BaseNode } from './BaseNode';
-import { getCheURL, getEditURL, getTopologyResourceObject } from '../../topology-utils';
+import {
+  getCheURL,
+  getEditURL,
+  getRoutesURL,
+  getTopologyResourceObject,
+} from '../../topology-utils';
 import { useDisplayFilters, getFilterById, SHOW_POD_COUNT_FILTER_ID } from '../../filters';
 import MonitoringAlertsDecorator from './MonitoringAlertsDecorator';
 import './WorkloadNode.scss';
@@ -70,6 +75,9 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
   const tipContent = dropTooltip || `Create a visual connector`;
   const showPodCountFilter = getFilterById(SHOW_POD_COUNT_FILTER_ID, filters);
   const showPodCount = showPodCountFilter?.value ?? false;
+  const routeResources = useRoutesWatcher(resourceObj);
+  const routes = routeResources.loaded && !routeResources.loadError ? routeResources.routes : [];
+  const url = getRoutesURL(resourceObj, routes);
 
   return (
     <g>
@@ -105,13 +113,13 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
                 </Decorator>
               </Tooltip>
             ),
-            workloadData.url && (
+            url && (
               <Tooltip key="route" content="Open URL" position={TooltipPosition.right}>
                 <Decorator
                   x={cx + radius - decoratorRadius * 0.7}
                   y={cy + -radius + decoratorRadius * 0.7}
                   radius={decoratorRadius}
-                  href={workloadData.url}
+                  href={url}
                   external
                   circleRef={urlAnchorRef}
                 >

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/index.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/index.ts
@@ -1,3 +1,4 @@
 export * from './data-transformer';
 export * from './transform-utils';
 export * from './updateModelFromFilters';
+export * from './useRoutesURL';

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -36,7 +36,7 @@ import {
   GROUP_HEIGHT,
   GROUP_PADDING,
 } from '../components/const';
-import { getRoutesURL, WORKLOAD_TYPES } from '../topology-utils';
+import { WORKLOAD_TYPES } from '../topology-utils';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
 
 export const dataObjectFromModel = (node: OdcNodeModel): TopologyDataObject => {
@@ -84,7 +84,6 @@ export const createTopologyNodeData = (
     pods: overviewItem.pods,
     data: {
       monitoringAlerts,
-      url: getRoutesURL(resource, overviewItem),
       kind: referenceFor(resource),
       editURL: deploymentsAnnotations['app.openshift.io/edit-url'],
       vcsURI: deploymentsAnnotations['app.openshift.io/vcs-uri'],
@@ -363,18 +362,6 @@ export const getBaseWatchedResources = (namespace: string): WatchK8sResources<an
     replicationControllers: {
       isList: true,
       kind: 'ReplicationController',
-      namespace,
-      optional: true,
-    },
-    routes: {
-      isList: true,
-      kind: 'Route',
-      namespace,
-      optional: true,
-    },
-    services: {
-      isList: true,
-      kind: 'Service',
       namespace,
       optional: true,
     },

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/useRoutesURL.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/useRoutesURL.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { useRoutesWatcher } from '@console/shared';
+import { getRoutesURL } from '../topology-utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const useRoutesURL = (resource: K8sResourceKind): string => {
+  const routeResources = useRoutesWatcher(resource);
+
+  const routes = routeResources.loaded && !routeResources.loadError ? routeResources.routes : [];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const url = React.useMemo(() => getRoutesURL(resource, routes), [routes]);
+
+  return url;
+};

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -104,7 +104,6 @@ export interface ConnectedWorkloadPipeline {
 }
 
 export interface WorkloadData {
-  url?: string;
   editURL?: string;
   vcsURI?: string;
   vcsRef?: string;

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -4,10 +4,10 @@ import {
   K8sResourceKindReference,
   modelFor,
   referenceFor,
+  RouteKind,
 } from '@console/internal/module/k8s';
 import { RootState } from '@console/internal/redux';
 import { getRouteWebURL } from '@console/internal/components/routes';
-import { OverviewItem } from '@console/shared';
 import { Node, Edge, GraphElement } from '@patternfly/react-topology';
 import { updateResourceApplication, removeResourceConnection } from '../../utils/application-utils';
 import { createResourceConnection } from '../../utils/connector-utils';
@@ -63,27 +63,13 @@ export const filterBasedOnActiveApplication = (
 };
 
 /**
- * get the route data
- */
-const getRouteData = (resource: K8sResourceKind, ksroutes: K8sResourceKind[]): string => {
-  if (ksroutes && ksroutes.length > 0 && !_.isEmpty(ksroutes[0].status)) {
-    const trafficData: { [x: string]: any } = _.find(ksroutes[0].status.traffic, {
-      revisionName: resource.metadata.name,
-    });
-    return trafficData?.url;
-  }
-  return null;
-};
-
-/**
  * get routes url
  */
-export const getRoutesURL = (resource: K8sResourceKind, overviewItem: OverviewItem): string => {
-  const { routes, ksroutes } = overviewItem;
+export const getRoutesURL = (resource: K8sResourceKind, routes: RouteKind[]): string => {
   if (routes.length > 0 && !_.isEmpty(routes[0].spec)) {
     return getRouteWebURL(routes[0]);
   }
-  return getRouteData(resource, ksroutes);
+  return null;
 };
 
 export const getTopologyResourceObject = (topologyObject: TopologyDataObject): K8sResourceKind => {

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
@@ -48,8 +48,6 @@ describe('EventPubSubResources', () => {
     item: {
       obj: EventSubscriptionObj,
       eventSources: [],
-      routes: [],
-      services: [],
       subscribers: sampleSubscribers,
     },
   };

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
@@ -12,8 +12,6 @@ describe('KnativeOverview', () => {
   beforeEach(() => {
     item = {
       obj: revisionObj,
-      routes: [],
-      services: [],
     };
   });
 

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
@@ -17,8 +17,6 @@ describe('KnativeResourceOverviewPage', () => {
   beforeEach(() => {
     item = {
       obj: revisionObj,
-      routes: [],
-      services: [],
     };
   });
 

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -33,8 +33,6 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
         revisions: MockKnativeResources.revisions.data,
         ksservices: MockKnativeResources.ksservices.data,
         ksroutes: MockKnativeResources.ksroutes.data,
-        routes: [],
-        services: [],
         isOperatorBackedService: false,
       },
     };

--- a/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
@@ -104,14 +104,6 @@ describe('knative data transformer ', () => {
     expect((graphData.nodes[0].data.data as WorkloadData).isKnativeResource).toBeTruthy();
   });
 
-  it('should return knative routes for knative resource', async () => {
-    const graphData = await getTransformedTopologyData(mockResources);
-    expect(
-      (getNodeById('cea9496b-8ce0-11e9-bb7b-0ebb55b110b8', graphData).data.data as WorkloadData)
-        .url,
-    ).toEqual('http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com');
-  });
-
   it('should return revision resources for knative workloads', async () => {
     const graphData = await getTransformedTopologyData(mockResources);
     const revRes = getNodeById('cea9496b-8ce0-11e9-bb7b-0ebb55b110b8', graphData).data.resources

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/RevisionNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/RevisionNode.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
 import { useAnchor, AnchorEnd, Node, observer } from '@patternfly/react-topology';
-import { WorkloadNode } from '@console/dev-console/src/components/topology';
+import {
+  getTopologyResourceObject,
+  useRoutesURL,
+  WorkloadNode,
+} from '@console/dev-console/src/components/topology';
 import RevisionTrafficTargetAnchor from '../anchors/RevisionTrafficTargetAnchor';
 
 const DECORATOR_RADIUS = 13;
 const RevisionNode: React.FC<React.ComponentProps<typeof WorkloadNode>> = (props) => {
-  const hasDataUrl = !!props.element.getData().data.url;
+  const { element } = props;
+  const resource = getTopologyResourceObject(element.getData());
+  const url = useRoutesURL(resource);
+  const hasDataUrl = !!url;
+
   useAnchor(
     React.useCallback(
       (node: Node) => new RevisionTrafficTargetAnchor(node, hasDataUrl ? DECORATOR_RADIUS : 0),

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -12,8 +12,6 @@ import {
   getOwnedResources,
   getBuildConfigsForResource,
   getReplicaSetsForResource,
-  getRoutesForServices,
-  getServicesForResource,
 } from '@console/shared';
 import { Edge, EdgeModel, Model, Node, NodeModel, NodeShape } from '@patternfly/react-topology';
 import {
@@ -528,16 +526,12 @@ const createKnativeDeploymentItems = (
     const replicaSets = getReplicaSetsForResource(depObj, resources);
     const [current, previous] = replicaSets;
     const isRollingOut = !!current && !!previous;
-    const services = getServicesForResource(depObj, resources);
-    const routes = getRoutesForServices(services, resources);
     const overviewItem = {
       obj: resource,
       current,
       isRollingOut,
       previous,
       pods: [..._.get(current, 'pods', []), ..._.get(previous, 'pods', [])],
-      routes,
-      services,
       associatedDeployment: depObj,
     };
 
@@ -552,8 +546,6 @@ const createKnativeDeploymentItems = (
   const knResources = getKnativeServiceData(resource, resources, utils);
   return {
     obj: resource,
-    routes: [],
-    services: [],
     ...knResources,
   };
 };
@@ -631,8 +623,6 @@ export const createPubSubDataItems = (
 
   return {
     obj: resource,
-    routes: [],
-    services: [],
     ...(depChannelResources && { channels: depChannelResources }),
     eventSources,
     ...channelSubsData,

--- a/frontend/packages/kubevirt-plugin/src/topology/TopologyVmResourcesPanel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/TopologyVmResourcesPanel.tsx
@@ -11,12 +11,12 @@ type TopologyVmResourcePanelProps = {
 export const TopologyVmResourcesPanel: React.FC<TopologyVmResourcePanelProps> = observer(
   ({ vmNode }: TopologyVmResourcePanelProps) => {
     const vmData = vmNode.getData();
-    const { obj: vm, pods, services, routes } = vmData?.resources;
+    const { obj: vm, pods } = vmData?.resources;
 
     return (
       <div className="overview__sidebar-pane-body">
         <PodsOverviewContent obj={vm} pods={pods} loaded loadError={null} />
-        <NetworkingOverview services={services} routes={routes} />
+        <NetworkingOverview obj={vm} />
       </div>
     );
   },

--- a/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
@@ -5,18 +5,12 @@ import {
   PodKind,
   referenceFor,
 } from '@console/internal/module/k8s';
-import {
-  OverviewItem,
-  getRoutesForServices,
-  getReplicationControllersForResource,
-  getServicesForResource,
-} from '@console/shared';
+import { OverviewItem, getReplicationControllersForResource } from '@console/shared';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { Model } from '@patternfly/react-topology';
 import {
   TopologyDataObject,
   TopologyDataResources,
-  getRoutesURL,
   getTopologyGroupItems,
   getTopologyNodeItem,
   mergeGroup,
@@ -53,8 +47,6 @@ export const createVMOverviewItem = (vm: K8sResourceKind, resources: any): Overv
   const vmi = vmis.find((instance) => instance.metadata.name === name) as VMIKind;
   const { visibleReplicationControllers } = getReplicationControllersForResource(vm, resources);
   const [current, previous] = visibleReplicationControllers;
-  const services = getServicesForResource(vm, resources);
-  const routes = getRoutesForServices(services, resources);
   const laucherPod = findVMIPod(vmi, resources.pods.data);
   const pods = laucherPod ? [laucherPod] : [];
 
@@ -63,8 +55,6 @@ export const createVMOverviewItem = (vm: K8sResourceKind, resources: any): Overv
     obj: vm,
     previous,
     pods,
-    routes,
-    services,
     isMonitorable: false,
     isOperatorBackedService: false,
   };
@@ -101,7 +91,6 @@ const createTopologyVMNodeData = (
     resource,
     resources: vmOverview,
     data: {
-      url: getRoutesURL(resource, vmOverview),
       kind: referenceFor(resource),
       vmi,
       vmStatusBundle,

--- a/frontend/packages/kubevirt-plugin/src/topology/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/types.ts
@@ -7,7 +7,6 @@ import { VMIKind } from '../types/vm';
 import { VMStatusBundle } from '../statuses/vm/types';
 
 export interface VMNodeData {
-  url: string;
   kind: string;
   vmi: VMIKind;
   vmStatusBundle: VMStatusBundle;

--- a/frontend/public/components/overview/networking-overview.tsx
+++ b/frontend/public/components/overview/networking-overview.tsx
@@ -5,6 +5,7 @@ import { LongArrowAltRightIcon } from '@patternfly/react-icons';
 import { K8sResourceKind, RouteKind } from '../../module/k8s';
 import { RouteLocation } from '../routes';
 import { ResourceLink, SidebarSectionHeading } from '../utils';
+import { useRoutesWatcher, useServicesWatcher } from '@console/shared/src';
 
 const ServicePortList: React.SFC<ServicePortListProps> = ({ service }) => {
   const ports = _.get(service, 'spec.ports', []);
@@ -60,7 +61,13 @@ const RoutesOverviewList: React.SFC<RoutesOverviewListProps> = ({ routes }) => (
   </ul>
 );
 
-export const NetworkingOverview: React.SFC<NetworkingOverviewProps> = ({ routes, services }) => {
+export const NetworkingOverview: React.SFC<NetworkingOverviewProps> = ({ obj }) => {
+  const serviceResources = useServicesWatcher(obj);
+  const services =
+    serviceResources.loaded && !serviceResources.loadError ? serviceResources.services : [];
+  const routeResources = useRoutesWatcher(obj);
+  const routes = routeResources.loaded && !routeResources.loadError ? routeResources.routes : [];
+
   return (
     <>
       <SidebarSectionHeading text="Services" />
@@ -89,8 +96,7 @@ type RoutesOverviewListItemProps = {
 };
 
 type NetworkingOverviewProps = {
-  routes: RouteKind[];
-  services: K8sResourceKind[];
+  obj: K8sResourceKind;
 };
 
 type ServicePortListProps = {

--- a/frontend/public/components/overview/pod-overview.tsx
+++ b/frontend/public/components/overview/pod-overview.tsx
@@ -25,10 +25,10 @@ const PodOverviewDetails: React.SFC<PodOverviewDetailsProps> = ({ item: { obj: p
   );
 };
 
-const PodResourcesTab: React.SFC<PodResourcesTabProps> = ({ item: { obj, routes, services } }) => (
+const PodResourcesTab: React.SFC<PodResourcesTabProps> = ({ item: { obj } }) => (
   <div className="overview__sidebar-pane-body">
     <PodsOverview obj={obj} />
-    <NetworkingOverview services={services} routes={routes} />
+    <NetworkingOverview obj={obj} />
   </div>
 );
 

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import {
   OverviewItem,
   usePluginsOverviewTabSection,
@@ -21,7 +20,7 @@ const { common } = Kebab.factory;
 export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabProps> = ({
   item,
 }) => {
-  const { hpas, routes, services, obj } = item;
+  const { hpas, obj } = item;
   const pluginComponents = usePluginsOverviewTabSection(item);
   const { buildConfigs } = useBuildConfigsWatcher(obj);
   const hasBuildConfig = buildConfigs?.length > 0;
@@ -34,7 +33,7 @@ export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabP
       {pluginComponents.map(({ Component, key }) => (
         <Component key={key} item={item} />
       ))}
-      <NetworkingOverview services={services} routes={routes} />
+      <NetworkingOverview obj={obj} />
     </div>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5113

**Solution Description**: 
Remove routes and services fields from OverviewItem type. Add hooks to retrieve routes and services for a given resource. Update instances to use hooks rather than fields in the OverviewItem type.

Non-Functional Change

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup