### PR TITLE
add error status popover in the pipleline, pipelinerun and taskrun list

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
@@ -46,7 +46,7 @@ export const PipelineRunDetails: React.FC<PipelineRunDetailsProps> = ({ obj: pip
           </dl>
           <RunDetailsErrorLog
             logDetails={getPLRLogSnippet(pipelineRun)}
-            namespace={pipelineRun.metadata.name}
+            namespace={pipelineRun.metadata.namespace}
           />
           {pipelineRefExists(pipelineRun) && (
             <dl>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Status } from '@console/shared';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -11,6 +10,7 @@ import { PipelineRunModel } from '../../../models';
 import LinkedPipelineRunTaskStatus from '../status/LinkedPipelineRunTaskStatus';
 import { ResourceKebabWithUserLabel } from '../triggered-by';
 import { tableColumnClasses } from './pipelinerun-table';
+import PipelineRunStatus from '../status/PipelineRunStatus';
 
 const pipelinerunReference = referenceForModel(PipelineRunModel);
 
@@ -30,7 +30,7 @@ const PipelineRunRow: RowFunction<PipelineRun> = ({ obj, index, key, style }) =>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
-        <Status status={pipelineRunFilterReducer(obj)} />
+        <PipelineRunStatus status={pipelineRunFilterReducer(obj)} pipelineRun={obj} />
       </TableData>
       <TableData className={tableColumnClasses[3]}>
         <LinkedPipelineRunTaskStatus pipelineRun={obj} />

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineResourceStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineResourceStatus.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Status } from '@console/shared';
+
+type PipelineResourceStatusProps = {
+  status: string;
+  children?: React.ReactNode;
+};
+const PipelineResourceStatus: React.FC<PipelineResourceStatusProps> = ({ status, children }) => (
+  <Status status={status}>
+    {status === 'Failed' && React.Children.toArray(children).length > 0 && children}
+  </Status>
+);
+
+export default PipelineResourceStatus;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineRunStatus.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { resourcePathFromModel } from '@console/internal/components/utils';
+import { DASH } from '@console/shared';
+import { PipelineRun } from '../../../utils/pipeline-augment';
+import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
+import { PipelineRunModel } from '../../../models';
+import PipelineResourceStatus from './PipelineResourceStatus';
+import StatusPopoverContent from './StatusPopoverContent';
+
+type PipelineRunStatusProps = {
+  status: string;
+  pipelineRun: PipelineRun;
+};
+const PipelineRunStatus: React.FC<PipelineRunStatusProps> = ({ status, pipelineRun }) => {
+  return pipelineRun ? (
+    <PipelineResourceStatus status={status}>
+      <StatusPopoverContent
+        logDetails={getPLRLogSnippet(pipelineRun)}
+        namespace={pipelineRun.metadata.namespace}
+        link={
+          <Link
+            to={`${resourcePathFromModel(
+              PipelineRunModel,
+              pipelineRun.metadata.name,
+              pipelineRun.metadata.namespace,
+            )}/logs`}
+          >
+            View Logs
+          </Link>
+        }
+      />
+    </PipelineResourceStatus>
+  ) : (
+    <>{DASH}</>
+  );
+};
+
+export default PipelineRunStatus;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/StatusPopoverContent.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/StatusPopoverContent.scss
@@ -1,0 +1,8 @@
+.odc-statuspopover-content {
+  min-height: 175px;
+  display: flex;
+  flex-direction: column;
+  pre {
+    flex-grow: 1;
+  }
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/StatusPopoverContent.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/StatusPopoverContent.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import LogSnippetBlock from '../logs/LogSnippetBlock';
+import { CombinedErrorDetails } from '../logs/log-snippet-types';
+
+import './StatusPopoverContent.scss';
+
+type StatusPopoverContentProps = {
+  link?: React.ReactNode;
+  namespace: string;
+  logDetails: CombinedErrorDetails;
+};
+const StatusPopoverContent: React.FC<StatusPopoverContentProps> = ({
+  namespace,
+  logDetails,
+  link = null,
+}) => {
+  return (
+    <div className="odc-statuspopover-content">
+      <LogSnippetBlock logDetails={logDetails} namespace={namespace}>
+        {(logSnippet: string) => (
+          <>
+            <pre>{logSnippet}</pre>
+            {link}
+          </>
+        )}
+      </LogSnippetBlock>
+    </div>
+  );
+};
+
+export default StatusPopoverContent;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/__tests__/PipelineResourceStatus.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/__tests__/PipelineResourceStatus.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Status } from '@console/shared';
+import PipelineResourceStatus from '../PipelineResourceStatus';
+
+type PipelineResourceStatusWrapperProps = React.ComponentProps<typeof PipelineResourceStatus>;
+
+let componentProps: PipelineResourceStatusWrapperProps;
+
+describe('PipelineResourceStatus', () => {
+  beforeEach(() => {
+    componentProps = {
+      status: 'Failed',
+      children: <div>Test Children</div>,
+    };
+  });
+
+  it('should render Status without children', () => {
+    const wrapper = shallow(<PipelineResourceStatus status={componentProps.status} />);
+    expect(wrapper.find(Status).exists()).toBeTruthy();
+    expect(wrapper.props().children).toBeFalsy();
+  });
+
+  it('should render status component even if the null value is passed', () => {
+    const wrapper = shallow(<PipelineResourceStatus status={null} />);
+    expect(wrapper.find(Status).exists()).toBeTruthy();
+  });
+
+  it('should not render the children when the status is not Failed', () => {
+    const wrapper = shallow(<PipelineResourceStatus {...componentProps} status="Success" />);
+    expect(wrapper.props().children).toBeFalsy();
+  });
+
+  it('should render the children when the status is Failed', () => {
+    const wrapper = shallow(<PipelineResourceStatus {...componentProps} />);
+    expect(wrapper.find(Status).exists).toBeDefined();
+    expect(wrapper.props().children).toBe(componentProps.children);
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -9,6 +9,7 @@ export enum TektonResourceLabel {
   pipeline = 'tekton.dev/pipeline',
   pipelinerun = 'tekton.dev/pipelineRun',
   taskrun = 'tekton.dev/taskRun',
+  pipelineTask = 'tekton.dev/pipelineTask',
 }
 
 export enum PipelineResourceType {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Status } from '@console/shared';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { ResourceLink, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -7,6 +6,7 @@ import { pipelineFilterReducer } from '../../../utils/pipeline-filter-reducer';
 import { Pipeline } from '../../../utils/pipeline-augment';
 import { PipelineModel, PipelineRunModel } from '../../../models';
 import LinkedPipelineRunTaskStatus from '../../pipelineruns/status/LinkedPipelineRunTaskStatus';
+import PipelineRunStatus from '../../pipelineruns/status/PipelineRunStatus';
 import { tableColumnClasses } from './pipeline-table';
 import PipelineRowKebabActions from './PipelineRowKebabActions';
 
@@ -48,7 +48,7 @@ const PipelineRow: RowFunction<Pipeline> = ({ obj, index, key, style }) => {
         {obj.latestRun ? <LinkedPipelineRunTaskStatus pipelineRun={obj.latestRun} /> : '-'}
       </TableData>
       <TableData className={tableColumnClasses[4]}>
-        <Status status={pipelineFilterReducer(obj)} />
+        <PipelineRunStatus status={pipelineFilterReducer(obj)} pipelineRun={obj.latestRun} />
       </TableData>
       <TableData className={tableColumnClasses[5]}>
         {(obj.latestRun && obj.latestRun.status && obj.latestRun.status.completionTime && (

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsHeader.tsx
@@ -1,4 +1,5 @@
 import { sortable } from '@patternfly/react-table';
+import { TektonResourceLabel } from '../../pipelines/const';
 import { tableColumnClasses } from './taskruns-table';
 
 const TaskRunsHeader = (showPipelineColumn: boolean = true) => () => {
@@ -18,13 +19,13 @@ const TaskRunsHeader = (showPipelineColumn: boolean = true) => () => {
     },
     {
       title: 'Pipeline',
-      sortField: 'metadata.labels["tekton.dev/pipeline"]',
+      sortField: `metadata.labels["${TektonResourceLabel.pipeline}"]`,
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },
     {
       title: 'Task',
-      sortField: 'spec.taskRef.name',
+      sortField: `metadata.labels["${TektonResourceLabel.pipelineTask}"]`,
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -5,8 +5,9 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskRunKind, getModelReferenceFromTaskKind } from '../../../utils/pipeline-augment';
 import { TaskRunModel, PipelineModel } from '../../../models';
 import { tableColumnClasses } from './taskruns-table';
-import { Status } from '@console/shared';
 import { pipelineRunFilterReducer as taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { TektonResourceLabel } from '../../pipelines/const';
+import TaskRunStatus from '../status/TaskRunStatus';
 
 const taskRunsReference = referenceForModel(TaskRunModel);
 const pipelineReference = referenceForModel(PipelineModel);
@@ -27,10 +28,10 @@ const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...prop
     </TableData>
     {props.customData?.showPipelineColumn && (
       <TableData className={tableColumnClasses[2]}>
-        {obj.metadata.labels['tekton.dev/pipeline'] ? (
+        {obj.metadata.labels[TektonResourceLabel.pipeline] ? (
           <ResourceLink
             kind={pipelineReference}
-            name={obj.metadata.labels['tekton.dev/pipeline']}
+            name={obj.metadata.labels[TektonResourceLabel.pipeline]}
             namespace={obj.metadata.namespace}
           />
         ) : (
@@ -42,6 +43,7 @@ const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...prop
       {obj.spec.taskRef?.name ? (
         <ResourceLink
           kind={getModelReferenceFromTaskKind(obj.spec.taskRef?.kind)}
+          displayName={obj.metadata.labels[TektonResourceLabel.pipelineTask]}
           name={obj.spec.taskRef.name}
           namespace={obj.metadata.namespace}
         />
@@ -57,7 +59,7 @@ const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...prop
       )}
     </TableData>
     <TableData className={tableColumnClasses[5]}>
-      <Status status={taskRunFilterReducer(obj)} />
+      <TaskRunStatus status={taskRunFilterReducer(obj)} taskRun={obj} />
     </TableData>
     <TableData className={tableColumnClasses[6]}>
       <Timestamp timestamp={obj?.status?.startTime} />

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/status/TaskRunStatus.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/status/TaskRunStatus.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { resourcePathFromModel } from '@console/internal/components/utils';
+import { TaskRunKind } from '../../../utils/pipeline-augment';
+import { TaskRunModel } from '../../../models';
+import PipelineResourceStatus from '../../pipelineruns/status/PipelineResourceStatus';
+import { getTRLogSnippet } from '../logs/taskRunLogSnippet';
+import StatusPopoverContent from '../../pipelineruns/status/StatusPopoverContent';
+
+type TaskRunStatusProps = {
+  status: string;
+  taskRun: TaskRunKind;
+};
+const TaskRunStatus: React.FC<TaskRunStatusProps> = ({ status, taskRun }) => (
+  <PipelineResourceStatus status={status}>
+    <StatusPopoverContent
+      logDetails={getTRLogSnippet(taskRun)}
+      namespace={taskRun.metadata.namespace}
+      link={
+        <Link
+          to={`${resourcePathFromModel(
+            TaskRunModel,
+            taskRun.metadata.name,
+            taskRun.metadata.namespace,
+          )}/logs`}
+        >
+          View Logs
+        </Link>
+      }
+    />
+  </PipelineResourceStatus>
+);
+
+export default TaskRunStatus;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5061
https://issues.redhat.com/browse/ODC-5099

**Analysis**: 
1. Error status field in the Pipeline, PLR and TR list component does not have popover to view the error and link
2. Log snippet error in PLR details page ( Incorrect namespace was passed causing the snippet to show pod not found error
always)
3. Incorrect task name in taskrun list component

**Solution Description**: 
1. Add status popover  (followed the convention mentioned [here](http://openshift.github.io/openshift-origin-design/designs/administrator/4.0/status/#status-popovers))
2. Correct namespace is passed to the RunDetailsErrorLog component
3. Use correct task name from the pipeline

**Screen shots / Gifs for design review**: 

1. Failed status field to have popover:
![image](https://user-images.githubusercontent.com/9964343/98812781-15176780-2449-11eb-9d1f-221e36329c4e.png)

2. Log snippet in PLR details page
![image (2)](https://user-images.githubusercontent.com/9964343/98584734-52b2ae00-22ec-11eb-937a-b72b5baf17b6.png)

3. Correct Task name in the taskRun list Component
![image (3)](https://user-images.githubusercontent.com/9964343/98584793-6231f700-22ec-11eb-8aee-4ae615da356f.png)

![status-popover](https://user-images.githubusercontent.com/9964343/98812819-2d878200-2449-11eb-819a-814e4be4b7eb.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/9964343/98584974-94435900-22ec-11eb-9216-1fa77beb0eed.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Use Git add flow to create a pipeline and start it.
2. Click on the pipeline tab on the navigation menu

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

@andrewballantyne @bgliwa01 @openshift/team-devconsole-ux 