### PR TITLE
Topology, fetch build config data when necessary

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
@@ -18,7 +18,6 @@ describe('usePluginsOverviewTabSection', () => {
     item = {
       revisions: sampleKnativeRevisions.data,
       obj: knativeServiceObj,
-      buildConfigs: [],
     } as OverviewItem;
   });
 

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -6,6 +6,7 @@ export * from './scroll';
 export * from './plugins-overview-tab-section';
 export * from './debounce';
 export * from './select-list';
+export * from './useBuildConfigsWatcher';
 export * from './usePodsWatcher';
 export * from './useQueryParams';
 export * from './version';

--- a/frontend/packages/console-shared/src/hooks/useBuildConfigsWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useBuildConfigsWatcher.ts
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { getBuildConfigsForResource } from '../utils';
+import { BuildConfigOverviewItem } from '../types';
+
+export const useBuildConfigsWatcher = (
+  resource: K8sResourceKind,
+): { loaded: boolean; loadError: string; buildConfigs: BuildConfigOverviewItem[] } => {
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>(null);
+  const [buildConfigs, setBuildConfigs] = React.useState<BuildConfigOverviewItem[]>();
+  const { namespace } = resource.metadata;
+  const watchedResources = React.useMemo(
+    () => ({
+      buildConfigs: {
+        isList: true,
+        kind: 'BuildConfig',
+        namespace,
+      },
+      builds: {
+        isList: true,
+        kind: 'Build',
+        namespace,
+      },
+    }),
+    [namespace],
+  );
+
+  const resources = useK8sWatchResources(watchedResources);
+
+  React.useEffect(() => {
+    const resourceWithLoadError = Object.values(resources).find((r) => r.loadError);
+    if (resourceWithLoadError) {
+      setLoadError(resourceWithLoadError.loadError);
+      return;
+    }
+    setLoadError(null);
+    if (
+      Object.keys(resources).length > 0 &&
+      Object.keys(resources).every((key) => resources[key].loaded)
+    ) {
+      const resourceBuildConfigs = getBuildConfigsForResource(resource, resources);
+      setBuildConfigs(resourceBuildConfigs);
+      setLoaded(true);
+    }
+  }, [resource, resources]);
+
+  return { loaded, loadError, buildConfigs };
+};

--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -6,7 +6,7 @@ import {
   RouteKind,
 } from '@console/internal/module/k8s';
 import { DEPLOYMENT_STRATEGY } from '../constants';
-import { OverviewItemAlerts, PodControllerOverviewItem } from './pod';
+import { PodControllerOverviewItem } from './pod';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 import { Alert } from '@console/internal/components/monitoring/types';
 
@@ -26,8 +26,6 @@ export type BuildConfigOverviewItem = K8sResourceKind & {
 };
 
 export type OverviewItem<T = K8sResourceKind> = {
-  alerts?: OverviewItemAlerts;
-  buildConfigs: BuildConfigOverviewItem[];
   current?: PodControllerOverviewItem;
   isRollingOut?: boolean;
   obj: T;

--- a/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
@@ -69,8 +69,6 @@ expect.extend({
 });
 
 enum Keys {
-  ALERTS = 'alerts',
-  BC = 'buildConfigs',
   CURRENT = 'current',
   ROLLINGOUT = 'isRollingOut',
   OBJ = 'obj',
@@ -85,8 +83,8 @@ enum Keys {
   KSROUTES = 'ksroutes',
 }
 
-const podKeys = [Keys.ALERTS, Keys.OBJ, Keys.ROUTES, Keys.SERVICE, Keys.STATUS];
-const dsAndSSKeys = [...podKeys, Keys.BC, Keys.PODS];
+const podKeys = [Keys.OBJ, Keys.ROUTES, Keys.SERVICE, Keys.STATUS];
+const dsAndSSKeys = [...podKeys, Keys.PODS];
 const dcKeys = [...dsAndSSKeys, Keys.CURRENT, Keys.ROLLINGOUT, Keys.PREVIOUS];
 const knativeKeys = [...dcKeys, Keys.REVISIONS, Keys.KNATIVECONFIGS, Keys.KSROUTES];
 
@@ -164,7 +162,6 @@ describe('TransformResourceData', () => {
     expect(transformedData[0][Keys.CURRENT]).toBeUndefined();
     expect(transformedData[0][Keys.PREVIOUS]).toBeUndefined();
     expect(transformedData[0][Keys.ROLLINGOUT]).toBeUndefined();
-    expect(transformedData[0][Keys.BC]).toHaveLength(0);
   });
 
   it('should create DaemonSets Items for a provided ds', () => {
@@ -189,7 +186,6 @@ describe('TransformResourceData', () => {
     expect(transformedData[0][Keys.CURRENT]).toBeUndefined();
     expect(transformedData[0][Keys.PREVIOUS]).toBeUndefined();
     expect(transformedData[0][Keys.ROLLINGOUT]).toBeUndefined();
-    expect(transformedData[0][Keys.BC]).toHaveLength(0);
   });
 
   it('should return only pods and not replication controllers for a given resource', () => {
@@ -212,7 +208,6 @@ describe('TransformResourceData', () => {
     expect(transformedData[0][Keys.CURRENT]).toBeUndefined();
     expect(transformedData[0][Keys.PREVIOUS]).toBeUndefined();
     expect(transformedData[0][Keys.ROLLINGOUT]).toBeUndefined();
-    expect(transformedData[0][Keys.BC]).toHaveLength(0);
   });
 
   it('should create CronJob Items', () => {
@@ -221,7 +216,6 @@ describe('TransformResourceData', () => {
     expect(transformedData[0][Keys.CURRENT]).toBeUndefined();
     expect(transformedData[0][Keys.PREVIOUS]).toBeUndefined();
     expect(transformedData[0][Keys.ROLLINGOUT]).toBeUndefined();
-    expect(transformedData[0][Keys.BC]).toHaveLength(1);
     expect(transformedData[0][Keys.JOBS]).toHaveLength(2);
     expect(transformedData[0][Keys.PODS]).toHaveLength(2);
   });

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
@@ -23,7 +23,6 @@ describe('Monitoring Tab', () => {
           },
         },
       },
-      buildConfigs: [],
       routes: [],
       services: [],
     },

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
@@ -10,7 +10,6 @@ describe('Pipeline sidebar overview', () => {
   beforeEach(() => {
     props = {
       item: {
-        buildConfigs: [],
         obj: {},
         routes: [],
         services: [],

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
@@ -20,7 +20,7 @@ import { Decorator } from './Decorator';
 import PodSet, { podSetInnerRadius } from './PodSet';
 import BuildDecorator from './build-decorators/BuildDecorator';
 import { BaseNode } from './BaseNode';
-import { getCheURL, getEditURL } from '../../topology-utils';
+import { getCheURL, getEditURL, getTopologyResourceObject } from '../../topology-utils';
 import { useDisplayFilters, getFilterById, SHOW_POD_COUNT_FILTER_ID } from '../../filters';
 import MonitoringAlertsDecorator from './MonitoringAlertsDecorator';
 import './WorkloadNode.scss';
@@ -57,6 +57,7 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
   const cheURL = getCheURL(consoleLinks);
   const { width, height } = element.getDimensions();
   const workloadData = element.getData().data;
+  const resourceObj = getTopologyResourceObject(element.getData());
   const filters = useDisplayFilters();
   const size = Math.min(width, height);
   const { donutStatus, editURL, vcsURI, vcsRef } = workloadData;
@@ -121,6 +122,7 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
               </Tooltip>
             ),
             <BuildDecorator
+              resource={resourceObj}
               key="build"
               workloadData={workloadData}
               x={cx - radius + decoratorRadius * 0.7}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/BuildDecorator.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/BuildDecorator.tsx
@@ -1,19 +1,30 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { useBuildConfigsWatcher } from '@console/shared/src';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { WorkloadData } from '../../../topology-types';
 import { Decorator } from '../Decorator';
 import { getBuildDecoratorParts } from './build-decorator-utils';
 
 export interface BuildDecoratorProps {
+  resource: K8sResourceKind;
   workloadData: WorkloadData;
   radius: number;
   x: number;
   y: number;
 }
 
-const BuildDecorator: React.FC<BuildDecoratorProps> = ({ workloadData, radius, x, y }) => {
-  const { decoratorIcon, linkRef, tooltipContent } = getBuildDecoratorParts(workloadData);
+const BuildDecorator: React.FC<BuildDecoratorProps> = ({
+  resource,
+  workloadData,
+  radius,
+  x,
+  y,
+}) => {
+  const { buildConfigs } = useBuildConfigsWatcher(resource);
+  const build = buildConfigs?.[0]?.builds?.[0];
+  const { decoratorIcon, linkRef, tooltipContent } = getBuildDecoratorParts(workloadData, build);
 
   if (!decoratorIcon && !tooltipContent) {
     return null;

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/__tests__/build-decorator-utils-data.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/__tests__/build-decorator-utils-data.tsx
@@ -6,7 +6,6 @@ import {
 import { ConnectedWorkloadPipeline, WorkloadData } from '../../../../topology-types';
 
 export const bareMinimalWorkloadData: WorkloadData = {
-  build: null,
   connectedPipeline: null,
   donutStatus: null,
 };
@@ -19,7 +18,7 @@ const connectedPipelineOne: ConnectedWorkloadPipeline = {
   ],
 };
 
-const buildData = {
+export const buildData = {
   metadata: {
     annotations: {
       'openshift.io/build-config.name': 'react-web-app',
@@ -119,14 +118,12 @@ const buildData = {
   },
 };
 
-export const buildAndPipelineData: WorkloadData = {
-  build: buildData,
+export const pipelineData: WorkloadData = {
   connectedPipeline: connectedPipelineOne,
   donutStatus: null,
 };
 
-export const buildOnlyData: WorkloadData = {
-  build: buildData,
+export const noPiplelineData: WorkloadData = {
   connectedPipeline: { pipeline: null, pipelineRuns: [] },
   donutStatus: null,
 };

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/__tests__/build-decorator-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/__tests__/build-decorator-utils.spec.tsx
@@ -6,13 +6,14 @@ import { getBuildDecoratorParts } from '../build-decorator-utils';
 import PipelineBuildDecoratorTooltip from '../PipelineBuildDecoratorTooltip';
 import {
   bareMinimalWorkloadData,
-  buildAndPipelineData,
-  buildOnlyData,
+  pipelineData,
+  buildData,
+  noPiplelineData,
 } from './build-decorator-utils-data';
 
 describe('build-decorator-utils', () => {
   it('expect get build decorator parts to return nothing when giving insufficient data', () => {
-    const missingData = getBuildDecoratorParts(bareMinimalWorkloadData);
+    const missingData = getBuildDecoratorParts(bareMinimalWorkloadData, null);
 
     expect(missingData.decoratorIcon).toBeNull();
     expect(missingData.linkRef).toBeNull();
@@ -20,7 +21,7 @@ describe('build-decorator-utils', () => {
   });
 
   it('expect get build decorator parts to return pipeline-specific when providing both build and pipeline', () => {
-    const buildAndPipeline = getBuildDecoratorParts(buildAndPipelineData);
+    const buildAndPipeline = getBuildDecoratorParts(pipelineData, buildData);
 
     // Got back data
     expect(buildAndPipeline.decoratorIcon).not.toBeNull();
@@ -36,7 +37,7 @@ describe('build-decorator-utils', () => {
   });
 
   it('expect getBuildDecorator to return build-specific when not providing pipeline data', () => {
-    const buildOnly = getBuildDecoratorParts(buildOnlyData);
+    const buildOnly = getBuildDecoratorParts(noPiplelineData, buildData);
 
     // Got back data
     expect(buildOnly.decoratorIcon).not.toBeNull();

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/build-decorator-utils.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/build-decorators/build-decorator-utils.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Status } from '@console/shared';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { resourcePathFromModel } from '@console/internal/components/utils';
 import { BuildModel } from '@console/internal/models';
 import { PipelineRunModel } from '../../../../../models';
@@ -14,8 +15,11 @@ type BuildDecoratorData = {
   tooltipContent: React.ReactElement;
 };
 
-export const getBuildDecoratorParts = (workloadData: WorkloadData): BuildDecoratorData => {
-  const { build, connectedPipeline } = workloadData;
+export const getBuildDecoratorParts = (
+  workloadData: WorkloadData,
+  build: K8sResourceKind,
+): BuildDecoratorData => {
+  const { connectedPipeline } = workloadData;
 
   let tooltipContent = null;
   let decoratorIcon = null;

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -64,7 +64,6 @@ export const createTopologyNodeData = (
     current,
     previous,
     isRollingOut,
-    buildConfigs,
     pipelines = [],
     pipelineRuns = [],
     monitoringAlerts = [],
@@ -95,7 +94,6 @@ export const createTopologyNodeData = (
         type && (type === TYPE_EVENT_SOURCE || type === TYPE_KNATIVE_REVISION)
           ? true
           : isKnativeServing(resource, 'metadata.labels'),
-      build: buildConfigs?.[0]?.builds?.[0],
       connectedPipeline: {
         pipeline: pipelines[0],
         pipelineRuns,
@@ -395,18 +393,6 @@ export const getBaseWatchedResources = (namespace: string): WatchK8sResources<an
     cronJobs: {
       isList: true,
       kind: 'CronJob',
-      namespace,
-      optional: true,
-    },
-    buildConfigs: {
-      isList: true,
-      kind: 'BuildConfig',
-      namespace,
-      optional: true,
-    },
-    builds: {
-      isList: true,
-      kind: 'Build',
       namespace,
       optional: true,
     },

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -111,7 +111,6 @@ export interface WorkloadData {
   builderImage?: string;
   kind?: string;
   isKnativeResource?: boolean;
-  build: K8sResourceKind;
   donutStatus: PodRCData;
   connectedPipeline: ConnectedWorkloadPipeline;
 }

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
@@ -4,7 +4,12 @@ import { useTranslation } from 'react-i18next';
 import { podPhase } from '@console/internal/module/k8s';
 import { BuildOverview } from '@console/internal/components/overview/build-overview';
 import { PodModel } from '@console/internal/models';
-import { AllPodStatus, OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
+import {
+  AllPodStatus,
+  OverviewItem,
+  usePluginsOverviewTabSection,
+  useBuildConfigsWatcher,
+} from '@console/shared';
 import { PodsOverviewContent } from '@console/internal/components/overview/pods-overview';
 import { Subscriber } from '../../topology/topology-types';
 import { getSubscriberByType } from '../../topology/knative-topology-utils';
@@ -23,15 +28,8 @@ type KnativeServiceResourceProps = {
 
 const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({ item }) => {
   const { t } = useTranslation();
-  const {
-    revisions,
-    ksroutes,
-    obj,
-    pods,
-    buildConfigs,
-    eventSources = [],
-    subscribers = [],
-  } = item;
+  const { revisions, ksroutes, obj, pods, eventSources = [], subscribers = [] } = item;
+  const { buildConfigs } = useBuildConfigsWatcher(obj);
   const {
     kind: resKind,
     metadata: { name, namespace },

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventPubSubResources.spec.tsx
@@ -47,7 +47,6 @@ describe('EventPubSubResources', () => {
   sampleItemData = {
     item: {
       obj: EventSubscriptionObj,
-      buildConfigs: [],
       eventSources: [],
       routes: [],
       services: [],

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
@@ -11,7 +11,6 @@ describe('KnativeOverview', () => {
   let item: OverviewItem;
   beforeEach(() => {
     item = {
-      buildConfigs: [],
       obj: revisionObj,
       routes: [],
       services: [],

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
@@ -16,7 +16,6 @@ describe('KnativeResourceOverviewPage', () => {
   let item: OverviewItem;
   beforeEach(() => {
     item = {
-      buildConfigs: [],
       obj: revisionObj,
       routes: [],
       services: [],

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
@@ -7,6 +7,7 @@ import {
   sampleKnativeRoutes,
   sampleKnativeRevisions,
   knativeServiceObj,
+  MockKnativeBuildConfig,
 } from '../../../topology/__tests__/topology-knative-test-data';
 import { BuildOverview } from '@console/internal/components/overview/build-overview';
 import { OverviewItem } from '@console/shared';
@@ -26,18 +27,34 @@ jest.mock('react-i18next', () => {
   };
 });
 
+let mockBuildConfigs = [];
+
+jest.mock('@console/shared', () => {
+  const ActualShared = require.requireActual('@console/shared');
+  return {
+    ...ActualShared,
+    useBuildConfigsWatcher: () => {
+      return {
+        loaded: true,
+        loadError: '',
+        buildConfigs: mockBuildConfigs,
+      };
+    },
+  };
+});
+
 describe('KnativeServiceResources', () => {
   beforeEach(() => {
     (useExtensions as jest.Mock).mockReturnValueOnce([]);
   });
 
   it('should render KnativeServiceResources', () => {
+    mockBuildConfigs = [];
     const item = {
       revisions: sampleKnativeRevisions.data,
       ksroutes: sampleKnativeRoutes.data,
       obj: knativeServiceObj,
       pods: sampleKnativePods.data,
-      buildConfigs: [],
     } as OverviewItem;
     const wrapper = shallow(<KnativeServiceResources item={item} />);
     expect(wrapper.find(PodsOverviewContent)).toHaveLength(1);
@@ -47,12 +64,12 @@ describe('KnativeServiceResources', () => {
   });
 
   it('should render buildOverview if buildconfigs is present', () => {
+    mockBuildConfigs = [MockKnativeBuildConfig];
     const item = {
       revisions: sampleKnativeRevisions.data,
       ksroutes: sampleKnativeRoutes.data,
       obj: knativeServiceObj,
       pods: sampleKnativePods.data,
-      buildConfigs: [{}],
     } as OverviewItem;
     const wrapper = shallow(<KnativeServiceResources item={item} />);
     expect(wrapper.find(BuildOverview)).toHaveLength(1);

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -33,7 +33,6 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
         revisions: MockKnativeResources.revisions.data,
         ksservices: MockKnativeResources.ksservices.data,
         ksroutes: MockKnativeResources.ksroutes.data,
-        buildConfigs: [],
         routes: [],
         services: [],
         isOperatorBackedService: false,

--- a/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/data-transformer.spec.ts
@@ -166,8 +166,10 @@ describe('knative data transformer ', () => {
 
     const spy = spyOn(k8s, 'k8sKill');
     const checkAccessSpy = spyOn(utils, 'checkAccess');
+    const spyK8sList = spyOn(k8s, 'k8sList');
     spyAndReturn(spy)(Promise.resolve({}));
     spyAndReturn(checkAccessSpy)(Promise.resolve({ status: { allowed: true } }));
+    spyAndReturn(spyK8sList)(Promise.resolve([]));
 
     cleanUpWorkload(node)
       .then(() => {

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -1030,3 +1030,102 @@ export const MockKnativeResources: TopologyDataResources = {
   triggers: sampleTriggers,
   brokers: sampleBrokers,
 };
+export const MockKnativeBuildConfig = {
+  metadata: {
+    annotations: {
+      'openshift.io/build-config.name': 'react-web-app',
+      'openshift.io/build.number': '1',
+      'openshift.io/build.pod-name': 'react-web-app-1-build',
+    },
+    selfLink: '/apis/build.openshift.io/v1/namespaces/andrew-test/builds/react-web-app-1',
+    resourceVersion: '696608',
+    name: 'react-web-app-1',
+    uid: 'fd52472d-f752-11e9-81ae-0a580a810022',
+    creationTimestamp: '2019-10-25T18:12:22Z',
+    namespace: 'andrew-test',
+    ownerReferences: [
+      {
+        apiVersion: 'build.openshift.io/v1',
+        kind: 'BuildConfig',
+        name: 'react-web-app',
+        uid: 'fd28333b-f752-11e9-81ae-0a580a810022',
+        controller: true,
+      },
+    ],
+    labels: {
+      app: 'react-web-app',
+      'app.kubernetes.io/part-of': 'react-web-app-app',
+      'app.kubernetes.io/instance': 'react-web-app',
+      'openshift.io/build-config.name': 'react-web-app',
+      'app.kubernetes.io/component': 'react-web-app',
+      'openshift.io/build.start-policy': 'Serial',
+      buildconfig: 'react-web-app',
+      'app.openshift.io/runtime': 'modern-webapp',
+      'app.kubernetes.io/name': 'modern-webapp',
+      'app.openshift.io/runtime-version': '10.x',
+    },
+  },
+  spec: {
+    nodeSelector: null,
+    output: {
+      to: { kind: 'ImageStreamTag', name: 'react-web-app:latest' },
+      pushSecret: { name: 'builder-dockercfg-9jcf2' },
+    },
+    resources: {},
+    triggeredBy: [
+      {
+        message: 'Image change',
+        imageChangeBuild: {
+          imageID:
+            'image-registry.openshift-image-registry.svc:5000/openshift/modern-webapp@sha256:eb672caddbf6f1d2283ecc2e7f69142bd605f5a0067c951dd9b829f29343edc4',
+          fromRef: { kind: 'ImageStreamTag', namespace: 'openshift', name: 'modern-webapp:10.x' },
+        },
+      },
+    ],
+    strategy: {
+      type: 'Source',
+      sourceStrategy: {
+        from: {
+          kind: 'DockerImage',
+          name:
+            'image-registry.openshift-image-registry.svc:5000/openshift/modern-webapp@sha256:eb672caddbf6f1d2283ecc2e7f69142bd605f5a0067c951dd9b829f29343edc4',
+        },
+        pullSecret: { name: 'builder-dockercfg-9jcf2' },
+      },
+    },
+    postCommit: {},
+    serviceAccount: 'builder',
+    source: {
+      type: 'Git',
+      git: { uri: 'https://github.com/nodeshift-starters/react-web-app' },
+      contextDir: '/',
+    },
+    revision: {
+      type: 'Git',
+      git: {
+        commit: '32b53d1a23d8148077f2095226bd4e8afcd1ce4a',
+        author: { name: 'Lucas Holmquist', email: 'lholmqui@redhat.com' },
+        committer: { name: 'Lucas Holmquist', email: 'lholmqui@redhat.com' },
+        message: 'chore: text updates',
+      },
+    },
+  },
+  status: {
+    phase: 'Running',
+    startTimestamp: '2019-10-25T18:12:22Z',
+    outputDockerImageReference:
+      'image-registry.openshift-image-registry.svc:5000/andrew-test/react-web-app:latest',
+    config: { kind: 'BuildConfig', namespace: 'andrew-test', name: 'react-web-app' },
+    output: {},
+    stages: [
+      {
+        name: 'FetchInputs',
+        startTime: '2019-10-25T18:12:30Z',
+        durationMilliseconds: 479,
+        steps: [
+          { name: 'FetchGitSource', startTime: '2019-10-25T18:12:30Z', durationMilliseconds: 479 },
+        ],
+      },
+    ],
+  },
+};

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -79,7 +79,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
   );
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const hasChildren = element.getChildren()?.length > 0;
-  const { data } = element.getData();
+  const { data, resource } = element.getData();
   const hasDataUrl = !!data.url;
   useAnchor(
     React.useCallback(
@@ -172,7 +172,13 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
             </Decorator>
           </Tooltip>
         )}
-        <BuildDecorator x={x} y={y + height} radius={DECORATOR_RADIUS} workloadData={data} />
+        <BuildDecorator
+          x={x}
+          y={y + height}
+          radius={DECORATOR_RADIUS}
+          workloadData={data}
+          resource={resource}
+        />
         {showLabels && (data.kind || element.getLabel()) && (
           <SvgBoxedText
             className="odc-knative-service__label odc-base-node__label"

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -9,8 +9,6 @@ import {
   kindForReference,
 } from '@console/internal/module/k8s';
 import {
-  getResourcePausedAlert,
-  getBuildAlerts,
   getOwnedResources,
   getBuildConfigsForResource,
   getReplicaSetsForResource,
@@ -530,17 +528,10 @@ const createKnativeDeploymentItems = (
     const replicaSets = getReplicaSetsForResource(depObj, resources);
     const [current, previous] = replicaSets;
     const isRollingOut = !!current && !!previous;
-    const buildConfigs = getBuildConfigsForResource(depObj, resources);
     const services = getServicesForResource(depObj, resources);
     const routes = getRoutesForServices(services, resources);
-    const alerts = {
-      ...getResourcePausedAlert(depObj),
-      ...getBuildAlerts(buildConfigs),
-    };
-    const overviewItems = {
+    const overviewItem = {
       obj: resource,
-      alerts,
-      buildConfigs,
       current,
       isRollingOut,
       previous,
@@ -553,15 +544,14 @@ const createKnativeDeploymentItems = (
     if (utils) {
       return utils.reduce((acc, util) => {
         return { ...acc, ...util(resource, resources) };
-      }, overviewItems);
+      }, overviewItem);
     }
 
-    return overviewItems;
+    return overviewItem;
   }
   const knResources = getKnativeServiceData(resource, resources, utils);
   return {
     obj: resource,
-    buildConfigs: [],
     routes: [],
     services: [],
     ...knResources,
@@ -641,7 +631,6 @@ export const createPubSubDataItems = (
 
   return {
     obj: resource,
-    buildConfigs: [],
     routes: [],
     services: [],
     ...(depChannelResources && { channels: depChannelResources }),
@@ -928,7 +917,6 @@ export const createTopologyServiceNodeData = (
         pipeline: pipelines[0],
         pipelineRuns,
       },
-      build: svcRes.buildConfigs?.[0]?.builds?.[0],
     },
   };
 };

--- a/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/kubevirt-data-transformer.ts
@@ -8,7 +8,6 @@ import {
 import {
   OverviewItem,
   getRoutesForServices,
-  getBuildConfigsForResource,
   getReplicationControllersForResource,
   getServicesForResource,
 } from '@console/shared';
@@ -54,14 +53,12 @@ export const createVMOverviewItem = (vm: K8sResourceKind, resources: any): Overv
   const vmi = vmis.find((instance) => instance.metadata.name === name) as VMIKind;
   const { visibleReplicationControllers } = getReplicationControllersForResource(vm, resources);
   const [current, previous] = visibleReplicationControllers;
-  const buildConfigs = getBuildConfigsForResource(vm, resources);
   const services = getServicesForResource(vm, resources);
   const routes = getRoutesForServices(services, resources);
   const laucherPod = findVMIPod(vmi, resources.pods.data);
   const pods = laucherPod ? [laucherPod] : [];
 
-  const overviewItems = {
-    buildConfigs,
+  return {
     current,
     obj: vm,
     previous,
@@ -71,8 +68,6 @@ export const createVMOverviewItem = (vm: K8sResourceKind, resources: any): Overv
     isMonitorable: false,
     isOperatorBackedService: false,
   };
-
-  return overviewItems;
 };
 
 const createTopologyVMNodeData = (

--- a/frontend/public/components/overview/cron-job-overview.tsx
+++ b/frontend/public/components/overview/cron-job-overview.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
-import { OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
+import {
+  OverviewItem,
+  usePluginsOverviewTabSection,
+  useBuildConfigsWatcher,
+} from '@console/shared';
 import { CronJobModel } from '../../models';
 import { CronJobKind } from '../../module/k8s';
 import { menuActions } from '../cron-job';
@@ -37,8 +41,9 @@ const CronJobOverviewDetails: React.SFC<CronJobOverviewDetailsProps> = ({
 );
 
 const CronJobResourcesTab: React.SFC<CronJobResourcesTabProps> = ({ item }) => {
-  const { buildConfigs, pods, jobs, obj } = item;
+  const { pods, jobs, obj } = item;
   const pluginComponents = usePluginsOverviewTabSection(item);
+  const { buildConfigs } = useBuildConfigsWatcher(obj);
   return (
     <div className="overview__sidebar-pane-body">
       <PodsOverviewMultiple obj={obj} podResources={jobs} />

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
 
+import {
+  OverviewItem,
+  usePluginsOverviewTabSection,
+  useBuildConfigsWatcher,
+} from '@console/shared';
 import { connectToModel } from '../../kinds';
 import { referenceForModel } from '../../module/k8s';
 import { AsyncComponent, Kebab, ResourceOverviewHeading, ResourceSummary } from '../utils';
@@ -9,7 +14,6 @@ import { HPAOverview } from './hpa-overview';
 import { NetworkingOverview } from './networking-overview';
 import { PodsOverview } from './pods-overview';
 import { resourceOverviewPages } from './resource-overview-pages';
-import { OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
 import { ManagedByOperatorLink } from '../utils/managed-by';
 
 const { common } = Kebab.factory;
@@ -17,9 +21,10 @@ const { common } = Kebab.factory;
 export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabProps> = ({
   item,
 }) => {
-  const { buildConfigs, hpas, routes, services, obj } = item;
-  const hasBuildConfig = buildConfigs?.length > 0;
+  const { hpas, routes, services, obj } = item;
   const pluginComponents = usePluginsOverviewTabSection(item);
+  const { buildConfigs } = useBuildConfigsWatcher(obj);
+  const hasBuildConfig = buildConfigs?.length > 0;
   return (
     <div className="overview__sidebar-pane-body">
       <ManagedByOperatorLink obj={item.obj} />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5114

**Solution Description**: 
Remove build configs from OverviewItem type. Add hook to retrieve build configs for a given resource. Update instances to use hooks rather than fields in the OverviewItem type.

The alerts field for OverviewItem type is also removed as it is not being used anywhere (but required loading buildConfig resources).

Non-Functional Change

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup