### PR TITLE
CONSOLE-2405: Allow Console static plugins to use dynamic extensions

### DIFF
--- a/frontend/dynamic-demo-plugin/console-extensions.json
+++ b/frontend/dynamic-demo-plugin/console-extensions.json
@@ -4,6 +4,11 @@
  * The '$schema' property is optional but recommended, allowing code editors to validate
  * the content as well as provide additional features such as code completion and property
  * description.
+ *
+ * Depending on extension 'type', the 'properties' object may contain code references, encoded
+ * as object literals { $codeRef: string }. The '$codeRef' value should be formatted as either
+ * 'moduleName.exportName' (referring to a named export) or 'moduleName' (referring to the
+ * 'default' export). Only the plugin's exposed modules may be used in code references.
  */
 {
   "$schema": "../packages/console-dynamic-plugin-sdk/dist/schema/console-extensions.json",

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -7,11 +7,11 @@ import * as ConsoleReporter from 'jasmine-console-reporter';
 import * as failFast from 'protractor-fail-fast';
 import { createWriteStream, writeFileSync } from 'fs';
 import { format } from 'util';
+import { resolvePluginPackages } from '@console/plugin-sdk/src/codegen/plugin-resolver';
 import {
-  resolvePluginPackages,
   reducePluginTestSuites,
   mergeTestSuites,
-} from '@console/plugin-sdk/src/codegen';
+} from '@console/plugin-sdk/src/codegen/plugin-integration-tests';
 
 const tap = !!process.env.TAP;
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -290,7 +290,7 @@
     "webpack-bundle-analyzer": "^3.5.0",
     "webpack-cli": "^3.3.9",
     "webpack-dev-server": "^3.11.0",
-    "webpack-virtual-modules": "^0.1.10"
+    "webpack-virtual-modules": "0.3.x"
   },
   "engines": {
     "node": ">=10.x"

--- a/frontend/packages/console-app/src/__tests__/plugin-test-utils.ts
+++ b/frontend/packages/console-app/src/__tests__/plugin-test-utils.ts
@@ -1,9 +1,10 @@
 import * as _ from 'lodash';
 import { List as ImmutableList } from 'immutable';
 import { Extension, PluginStore } from '@console/plugin-sdk';
-import { resolvePluginPackages, loadActivePlugins } from '@console/plugin-sdk/src/codegen';
+import { resolvePluginPackages } from '@console/plugin-sdk/src/codegen/plugin-resolver';
+import { loadActivePluginsForTestPurposes } from '@console/plugin-sdk/src/codegen/active-plugins';
 
-const testedPlugins = loadActivePlugins(resolvePluginPackages());
+const testedPlugins = loadActivePluginsForTestPurposes(resolvePluginPackages());
 const testedPluginStore = new PluginStore(testedPlugins);
 
 export const testedExtensions = ImmutableList<Extension>(testedPluginStore.getAllExtensions());

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -81,11 +81,11 @@ Declares all extensions contributed by the plugin. The `$schema` property is opt
 
 Depending on extension `type`, the `properties` object may contain code references, encoded as object
 literals `{ $codeRef: string }`. When loading dynamic plugins, encoded code references are transformed
-into functions `CodeRef<T> = () => Promise<T>` which load the referenced objects.
+into functions `CodeRef<T> = () => Promise<T>` used to load the referenced objects.
 
-The `$codeRef` value should be formatted as `moduleName.exportName` (referring to a named export) or
-`moduleName` (referring to the `default` export). Only the plugin's exposed modules (i.e. the keys of
-`consolePlugin.exposedModules` object in `package.json` file) may be used as the `moduleName` value.
+The `$codeRef` value should be formatted as either `moduleName.exportName` (referring to a named export)
+or `moduleName` (referring to the `default` export). Only the plugin's exposed modules (i.e. the keys of
+`consolePlugin.exposedModules` object in `package.json` file) may be used in code references.
 
 ## Webpack config
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
@@ -4,12 +4,16 @@ import { SchemaValidator } from '../../validation/SchemaValidator';
 import { getPluginManifest } from '../../utils/test-utils';
 
 const coFetch = jest.spyOn(coFetchModule, 'coFetch');
-const validatePluginManifest = jest.spyOn(pluginManifestModule, 'validatePluginManifest');
+
+const validatePluginManifestSchema = jest.spyOn(
+  pluginManifestModule,
+  'validatePluginManifestSchema',
+);
 
 const { fetchPluginManifest } = pluginManifestModule;
 
 beforeEach(() => {
-  [coFetch, validatePluginManifest].forEach((mock) => mock.mockReset());
+  [coFetch, validatePluginManifestSchema].forEach((mock) => mock.mockReset());
 });
 
 describe('fetchPluginManifest', () => {
@@ -21,13 +25,13 @@ describe('fetchPluginManifest', () => {
     const validatorResultReport = jest.spyOn(validator.result, 'report');
 
     coFetch.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
-    validatePluginManifest.mockImplementation(() => Promise.resolve(validator.result));
+    validatePluginManifestSchema.mockImplementation(() => Promise.resolve(validator.result));
 
     const result = await fetchPluginManifest('http://example.com/test');
 
     expect(result).toBe(manifest);
     expect(coFetch).toHaveBeenCalledWith(manifestURL, { method: 'GET' });
-    expect(validatePluginManifest).toHaveBeenCalledWith(manifest, manifestURL);
+    expect(validatePluginManifestSchema).toHaveBeenCalledWith(manifest, manifestURL);
     expect(validatorResultReport).toHaveBeenCalledWith();
   });
 
@@ -39,7 +43,7 @@ describe('fetchPluginManifest', () => {
       await fetchPluginManifest('http://example.com/test');
     } catch (e) {
       expect(coFetch).toHaveBeenCalled();
-      expect(validatePluginManifest).not.toHaveBeenCalled();
+      expect(validatePluginManifestSchema).not.toHaveBeenCalled();
     }
   });
 
@@ -53,14 +57,14 @@ describe('fetchPluginManifest', () => {
     });
 
     coFetch.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
-    validatePluginManifest.mockImplementation(() => Promise.resolve(validator.result));
+    validatePluginManifestSchema.mockImplementation(() => Promise.resolve(validator.result));
 
     expect.assertions(2);
     try {
       await fetchPluginManifest('http://example.com/test');
     } catch (e) {
       expect(coFetch).toHaveBeenCalled();
-      expect(validatePluginManifest).toHaveBeenCalled();
+      expect(validatePluginManifestSchema).toHaveBeenCalled();
     }
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
@@ -5,7 +5,7 @@ import { pluginManifestFile } from '../constants';
 import pluginManifestSchema from '../../dist/schema/plugin-manifest';
 import { resolveURL } from '../utils/url';
 
-export const validatePluginManifest = async (
+export const validatePluginManifestSchema = async (
   manifest: ConsolePluginManifestJSON,
   manifestURL: string,
 ) => {
@@ -33,6 +33,6 @@ export const fetchPluginManifest = async (baseURL: string) => {
   const url = resolveURL(baseURL, pluginManifestFile, { trailingSlashInBaseURL: true });
   const response: Response = await coFetch(url, { method: 'GET' });
   const manifest = (await response.json()) as ConsolePluginManifestJSON;
-  (await validatePluginManifest(manifest, url)).report();
+  (await validatePluginManifestSchema(manifest, url)).report();
   return manifest;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/jsonc.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/jsonc.ts
@@ -1,0 +1,9 @@
+import * as fs from 'fs';
+import * as jsonc from 'comment-json';
+
+/**
+ * Parse the given file as JSON with comments (JSONC).
+ */
+export const parseJSONC = <T = any>(filePath: string, removeComments = true) => {
+  return jsonc.parse(fs.readFileSync(filePath, 'utf-8'), null, removeComments) as T;
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
@@ -74,7 +74,7 @@ export class ExtensionValidator {
         const [moduleName, exportName] = parseEncodedCodeRefValue(codeRefValue);
         const errorTrace = `in ${dataVar}.${extensionDataVar}[${data.index}] property '${propName}'`;
 
-        if (!moduleName) {
+        if (!moduleName || !exportName) {
           this.result.addError(`Invalid code reference '${codeRefValue}' ${errorTrace}`);
           return;
         }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
@@ -1,8 +1,9 @@
+/* eslint-disable no-empty-function */
+
 import * as semver from 'semver';
 import { ValidationResult } from './ValidationResult';
 
 export class ValidationAssertions {
-  // eslint-disable-next-line no-empty-function
   constructor(private readonly result: ValidationResult) {}
 
   nonEmptyString(obj: any, objPath: string) {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-empty-function */
-
 import * as semver from 'semver';
 import { ValidationResult } from './ValidationResult';
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationResult.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationResult.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-empty-function */
-
 import chalk from 'chalk';
 
 export class ValidationResult {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationResult.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationResult.ts
@@ -1,9 +1,10 @@
+/* eslint-disable no-empty-function */
+
 import chalk from 'chalk';
 
 export class ValidationResult {
   private readonly errors: string[] = [];
 
-  // eslint-disable-next-line no-empty-function
   constructor(private readonly description: string) {}
 
   assertThat(condition: boolean, message: string) {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -4,16 +4,16 @@ import * as readPkg from 'read-pkg';
 import * as _ from 'lodash';
 import { ConsoleAssetPlugin } from './ConsoleAssetPlugin';
 import { ConsolePackageJSON } from '../schema/plugin-package';
-import { sharedVendorModules } from '../shared-modules';
 import { SchemaValidator } from '../validation/SchemaValidator';
-import { remoteEntryFile } from '../constants';
 import consolePkgMetadataSchema from '../../dist/schema/plugin-package';
+import { sharedVendorModules } from '../shared-modules';
+import { remoteEntryFile } from '../constants';
 
-const remoteEntryLibraryType = 'jsonp';
-const remoteEntryCallback = 'window.loadPluginEntry';
-
-const validatePackageFile = (pkg: ConsolePackageJSON) => {
-  const validator = new SchemaValidator('package.json');
+export const validatePackageFileSchema = (
+  pkg: ConsolePackageJSON,
+  description = 'package.json',
+) => {
+  const validator = new SchemaValidator(description);
   validator.assert.validSemverString(pkg.version, 'pkg.version');
 
   if (pkg.consolePlugin) {
@@ -34,12 +34,15 @@ const validatePackageFile = (pkg: ConsolePackageJSON) => {
   return validator.result;
 };
 
+const remoteEntryLibraryType = 'jsonp';
+const remoteEntryCallback = 'window.loadPluginEntry';
+
 export class ConsoleRemotePlugin {
   private readonly pkg: ConsolePackageJSON;
 
   constructor() {
     this.pkg = readPkg.sync({ normalize: false }) as ConsolePackageJSON;
-    validatePackageFile(this.pkg).report();
+    validatePackageFileSchema(this.pkg).report();
   }
 
   apply(compiler: webpack.Compiler) {

--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -235,7 +235,7 @@ describe('PluginStore', () => {
   });
 
   describe('constructor', () => {
-    it('processes all plugins and stores their extensions in staticExtensions', () => {
+    it('processes all plugins and stores their extensions in staticPluginExtensions', () => {
       const store = new PluginStore([
         {
           name: 'Test',
@@ -247,12 +247,12 @@ describe('PluginStore', () => {
       ]);
 
       const {
-        staticExtensions,
-        dynamicExtensions,
+        staticPluginExtensions,
+        dynamicPluginExtensions,
         dynamicPlugins,
       } = store.getStateForTestPurposes();
 
-      expect(staticExtensions).toEqual([
+      expect(staticPluginExtensions).toEqual([
         {
           type: 'Foo',
           properties: { test: true },
@@ -271,14 +271,14 @@ describe('PluginStore', () => {
         },
       ]);
 
-      staticExtensions.forEach((e) => {
+      staticPluginExtensions.forEach((e) => {
         expect(Object.isFrozen(e)).toBe(true);
       });
 
-      expect(dynamicExtensions).toEqual([]);
+      expect(dynamicPluginExtensions).toEqual([]);
       expect(dynamicPlugins.size).toBe(0);
 
-      expect(store.getAllExtensions()).toEqual(staticExtensions);
+      expect(store.getAllExtensions()).toEqual(staticPluginExtensions);
       expect(store.getDynamicPluginMetadata()).toEqual({});
     });
   });
@@ -401,7 +401,7 @@ describe('PluginStore', () => {
       expect(store.getStateForTestPurposes().listeners).toEqual([]);
     });
 
-    it('causes the listener to be called when dynamicExtensions changes', () => {
+    it('causes the listener to be called when dynamicPluginExtensions changes', () => {
       const store = new PluginStore([]);
       const manifest = getPluginManifest('Test', '1.2.3', [{ type: 'Foo', properties: {} }]);
 
@@ -410,14 +410,14 @@ describe('PluginStore', () => {
       const listeners = [jest.fn(), jest.fn()];
       listeners.forEach((l) => store.subscribe(l));
 
-      expect(store.getStateForTestPurposes().dynamicExtensions.length).toBe(0);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions.length).toBe(0);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(0);
       });
 
       store.setDynamicPluginEnabled('Test@1.2.3', true);
 
-      expect(store.getStateForTestPurposes().dynamicExtensions.length).toBe(1);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions.length).toBe(1);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(1);
         expect(l.mock.calls[0]).toEqual([]);
@@ -460,13 +460,13 @@ describe('PluginStore', () => {
       store.addDynamicPlugin('Test@1.2.3', manifest, resolvedExtensions);
 
       const {
-        staticExtensions,
-        dynamicExtensions,
+        staticPluginExtensions,
+        dynamicPluginExtensions,
         dynamicPlugins,
       } = store.getStateForTestPurposes();
 
-      expect(staticExtensions).toEqual([]);
-      expect(dynamicExtensions).toEqual([]);
+      expect(staticPluginExtensions).toEqual([]);
+      expect(dynamicPluginExtensions).toEqual([]);
 
       expect(dynamicPlugins.size).toBe(1);
       expect(dynamicPlugins.has('Test@1.2.3')).toBe(true);
@@ -540,7 +540,7 @@ describe('PluginStore', () => {
   });
 
   describe('setDynamicPluginEnabled', () => {
-    it('recomputes dynamicExtensions and calls all registered listeners', () => {
+    it('recomputes dynamicPluginExtensions and calls all registered listeners', () => {
       const store = new PluginStore([]);
       const manifest1 = getPluginManifest('Test1', '1.2.3', [{ type: 'Foo', properties: {} }]);
       const manifest2 = getPluginManifest('Test2', '2.3.4', [{ type: 'Bar', properties: {} }]);
@@ -553,7 +553,7 @@ describe('PluginStore', () => {
 
       expect(store.isDynamicPluginEnabled('Test1@1.2.3')).toBe(false);
       expect(store.isDynamicPluginEnabled('Test2@2.3.4')).toBe(false);
-      expect(store.getStateForTestPurposes().dynamicExtensions).toEqual([]);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions).toEqual([]);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(0);
       });
@@ -562,7 +562,7 @@ describe('PluginStore', () => {
 
       expect(store.isDynamicPluginEnabled('Test1@1.2.3')).toBe(true);
       expect(store.isDynamicPluginEnabled('Test2@2.3.4')).toBe(false);
-      expect(store.getStateForTestPurposes().dynamicExtensions).toEqual([
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions).toEqual([
         {
           type: 'Foo',
           properties: {},
@@ -580,7 +580,7 @@ describe('PluginStore', () => {
 
       expect(store.isDynamicPluginEnabled('Test1@1.2.3')).toBe(true);
       expect(store.isDynamicPluginEnabled('Test2@2.3.4')).toBe(true);
-      expect(store.getStateForTestPurposes().dynamicExtensions).toEqual([
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions).toEqual([
         {
           type: 'Foo',
           properties: {},
@@ -606,7 +606,7 @@ describe('PluginStore', () => {
 
       expect(store.isDynamicPluginEnabled('Test1@1.2.3')).toBe(false);
       expect(store.isDynamicPluginEnabled('Test2@2.3.4')).toBe(true);
-      expect(store.getStateForTestPurposes().dynamicExtensions).toEqual([
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions).toEqual([
         {
           type: 'Bar',
           properties: {},
@@ -631,7 +631,7 @@ describe('PluginStore', () => {
       listeners.forEach((l) => store.subscribe(l));
 
       expect(store.isDynamicPluginEnabled('Test@1.2.3')).toBe(false);
-      expect(store.getStateForTestPurposes().dynamicExtensions.length).toBe(0);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions.length).toBe(0);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(0);
       });
@@ -639,7 +639,7 @@ describe('PluginStore', () => {
       store.setDynamicPluginEnabled('Test@1.2.3', false);
 
       expect(store.isDynamicPluginEnabled('Test@1.2.3')).toBe(false);
-      expect(store.getStateForTestPurposes().dynamicExtensions.length).toBe(0);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions.length).toBe(0);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(0);
       });
@@ -647,7 +647,7 @@ describe('PluginStore', () => {
       store.setDynamicPluginEnabled('Test@1.2.3', true);
 
       expect(store.isDynamicPluginEnabled('Test@1.2.3')).toBe(true);
-      expect(store.getStateForTestPurposes().dynamicExtensions.length).toBe(1);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions.length).toBe(1);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(1);
       });
@@ -655,7 +655,7 @@ describe('PluginStore', () => {
       store.setDynamicPluginEnabled('Test@1.2.3', true);
 
       expect(store.isDynamicPluginEnabled('Test@1.2.3')).toBe(true);
-      expect(store.getStateForTestPurposes().dynamicExtensions.length).toBe(1);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions.length).toBe(1);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(1);
       });
@@ -673,7 +673,7 @@ describe('PluginStore', () => {
       store.setDynamicPluginEnabled('Test1@1.2.3', true);
 
       expect(store.isDynamicPluginEnabled('Test@1.2.3')).toBe(false);
-      expect(store.getStateForTestPurposes().dynamicExtensions.length).toBe(0);
+      expect(store.getStateForTestPurposes().dynamicPluginExtensions.length).toBe(0);
       listeners.forEach((l) => {
         expect(l.mock.calls.length).toBe(0);
       });

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
@@ -9,12 +9,11 @@ import { PluginPackage } from '../plugin-resolver';
 import { Extension } from '../../typings';
 import * as activePluginsModule from '../active-plugins';
 import { trimStartMultiLine } from '../../utils/string';
-import * as moduleUtils from '../../utils/nodejs-modules';
 import { getTemplatePackage } from '../../utils/test-utils';
 
 const parseJSONC = jest.spyOn(jsoncModule, 'parseJSONC');
 const validateExtensionsFileSchema = jest.spyOn(assetPluginModule, 'validateExtensionsFileSchema');
-const reloadModule = jest.spyOn(moduleUtils, 'reloadModule');
+const reloadModule = jest.spyOn(activePluginsModule, 'reloadModule');
 
 const {
   getActivePluginsModule,

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
@@ -1,101 +1,477 @@
-import { Plugin, HrefNavItem } from '../../typings';
-import { loadActivePlugins, getActivePluginsModule } from '../active-plugins';
+import * as fs from 'fs';
+import * as _ from 'lodash';
+import * as jsoncModule from '@console/dynamic-plugin-sdk/src/utils/jsonc';
+import * as assetPluginModule from '@console/dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin';
+import { ValidationResult } from '@console/dynamic-plugin-sdk/src/validation/ValidationResult';
+import { EncodedCodeRef } from '@console/dynamic-plugin-sdk/src/types';
+import { extensionsFile } from '@console/dynamic-plugin-sdk/src/constants';
 import { PluginPackage } from '../plugin-resolver';
-import { getTemplatePackage } from './plugin-resolver.spec';
+import { Extension } from '../../typings';
+import * as activePluginsModule from '../active-plugins';
+import { trimStartMultiLine } from '../../utils/string';
+import * as moduleUtils from '../../utils/nodejs-modules';
+import { getTemplatePackage } from '../../utils/test-utils';
 
-describe('active-plugins', () => {
-  describe('loadActivePlugins', () => {
-    afterEach(() => {
-      jest.resetModules();
-    });
+const parseJSONC = jest.spyOn(jsoncModule, 'parseJSONC');
+const validateExtensionsFileSchema = jest.spyOn(assetPluginModule, 'validateExtensionsFileSchema');
+const reloadModule = jest.spyOn(moduleUtils, 'reloadModule');
 
-    it('loads the consolePlugin.entry module along with additional data', () => {
-      const fooPlugin: Plugin<HrefNavItem> = [
-        {
-          type: 'NavItem/Href',
-          properties: {
-            id: 'foo',
-            componentProps: {
-              name: 'Foo Link',
-              href: '/foo',
-            },
-          },
-        },
-      ];
-      const barPlugin: Plugin<HrefNavItem> = [
-        {
-          type: 'NavItem/Href',
-          properties: {
-            id: 'bar',
-            componentProps: {
-              name: 'Bar Link',
-              href: '/bar',
-            },
-          },
-        },
-      ];
+const {
+  getActivePluginsModule,
+  loadActivePluginsForTestPurposes,
+  getExecutableCodeRefSource,
+  getDynamicExtensions,
+} = activePluginsModule;
 
-      jest.doMock('foo/src/plugin.ts', () => ({ default: fooPlugin }), { virtual: true });
-      jest.doMock('bar-plugin/index.ts', () => ({ default: barPlugin }), { virtual: true });
+beforeEach(() => {
+  [parseJSONC, validateExtensionsFileSchema, reloadModule].forEach((mock) => mock.mockReset());
+});
 
-      expect(
-        loadActivePlugins([
-          {
-            ...getTemplatePackage({
-              name: 'foo',
-            }),
-            consolePlugin: { entry: 'src/plugin.ts' },
-          },
-          {
-            ...getTemplatePackage({
-              name: 'bar-plugin',
-            }),
-            consolePlugin: { entry: 'index.ts' },
-          },
-        ]),
-      ).toEqual([
-        {
-          name: 'foo',
-          extensions: fooPlugin,
-        },
-        {
-          name: 'bar-plugin',
-          extensions: barPlugin,
-        },
-      ]);
-    });
-  });
+describe('getActivePluginsModule', () => {
+  it('returns module that exports the list of plugins based on pluginPackages', () => {
+    const fooPluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'foo',
+      }),
+      consolePlugin: { entry: 'src/plugin.ts' },
+    };
 
-  describe('getActivePluginsModule', () => {
-    it('returns module source that exports the list of active plugins', () => {
-      const pluginPackages: PluginPackage[] = [
-        {
-          ...getTemplatePackage({
-            name: 'foo',
-          }),
-          consolePlugin: { entry: 'src/plugin.ts' },
-        },
-        {
-          ...getTemplatePackage({
-            name: 'bar-plugin',
-          }),
-          consolePlugin: { entry: 'index.ts' },
-        },
-      ];
+    const barPluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'bar-plugin',
+      }),
+      consolePlugin: { entry: 'index.ts' },
+    };
 
-      expect(getActivePluginsModule(pluginPackages)).toBe(
+    const fooDynamicExtensions: Extension[] = [{ type: 'Dynamic/Foo', properties: { test: true } }];
+    const barDynamicExtensions: Extension[] = [
+      { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'a.b' } } },
+    ];
+
+    const dynamicExtensionHook = (pkg: PluginPackage) => {
+      switch (pkg) {
+        case fooPluginPackage:
+          return JSON.stringify(fooDynamicExtensions);
+        case barPluginPackage:
+          return JSON.stringify(barDynamicExtensions);
+        default:
+          throw new Error('invalid arguments');
+      }
+    };
+
+    expect(getActivePluginsModule([fooPluginPackage, barPluginPackage], dynamicExtensionHook)).toBe(
+      trimStartMultiLine(
         `
         const activePlugins = [];
 
-        const plugin_0 = require('foo/src/plugin.ts').default;
-        activePlugins.push({ name: 'foo', extensions: plugin_0 });
+        activePlugins.push({
+          name: 'foo',
+          extensions: [
+            ...require('foo/src/plugin.ts').default,
+            ...${JSON.stringify(fooDynamicExtensions)},
+          ],
+        });
 
-        const plugin_1 = require('bar-plugin/index.ts').default;
-        activePlugins.push({ name: 'bar-plugin', extensions: plugin_1 });
+        activePlugins.push({
+          name: 'bar-plugin',
+          extensions: [
+            ...require('bar-plugin/index.ts').default,
+            ...${JSON.stringify(barDynamicExtensions)},
+          ],
+        });
 
         export default activePlugins;
-        `.replace(/^\s+/gm, ''),
-      );
+        `,
+      ),
+    );
+  });
+});
+
+describe('loadActivePluginsForTestPurposes', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('loads and returns the list of plugins based on pluginPackages', () => {
+    const fooPluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'foo',
+      }),
+      consolePlugin: { entry: 'src/plugin.ts' },
+    };
+
+    const barPluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'bar-plugin',
+      }),
+      consolePlugin: { entry: 'index.ts' },
+    };
+
+    const fooStaticExtensions: Extension[] = [{ type: 'Static/Foo', properties: { test: true } }];
+    const barStaticExtensions: Extension[] = [
+      { type: 'Static/Bar', properties: { baz: 1, qux: () => true } },
+    ];
+
+    const fooDynamicExtensions: Extension[] = [{ type: 'Dynamic/Foo', properties: { test: true } }];
+    const barDynamicExtensions: Extension[] = [
+      { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'a.b' } } },
+    ];
+
+    const dynamicExtensionHook = (pkg: PluginPackage) => {
+      switch (pkg) {
+        case fooPluginPackage:
+          return fooDynamicExtensions;
+        case barPluginPackage:
+          return barDynamicExtensions;
+        default:
+          throw new Error('invalid arguments');
+      }
+    };
+
+    jest.doMock('foo/src/plugin.ts', () => ({ default: fooStaticExtensions }), { virtual: true });
+    jest.doMock('bar-plugin/index.ts', () => ({ default: barStaticExtensions }), { virtual: true });
+
+    expect(
+      loadActivePluginsForTestPurposes([fooPluginPackage, barPluginPackage], dynamicExtensionHook),
+    ).toEqual([
+      {
+        name: 'foo',
+        extensions: [...fooStaticExtensions, ...fooDynamicExtensions],
+      },
+      {
+        name: 'bar-plugin',
+        extensions: [...barStaticExtensions, ...barDynamicExtensions],
+      },
+    ]);
+  });
+});
+
+describe('getExecutableCodeRefSource', () => {
+  const getPluginPackage = (
+    name: string,
+    exposedModules: { [moduleName: string]: string } = {},
+  ): PluginPackage => ({
+    ...getTemplatePackage({ name }),
+    consolePlugin: { entry: 'src/plugin.ts', exposedModules },
+  });
+
+  it('transforms encoded code reference into executable CodeRef function source', () => {
+    const validationResult = new ValidationResult('test');
+
+    reloadModule.mockImplementation((request: string) => {
+      switch (request) {
+        case 'test-plugin/src/foo.ts':
+        case '@console/test-plugin/src/foo.ts':
+          return { bar: 'value' };
+        default:
+          throw new Error('invalid mock arguments');
+      }
     });
+
+    expect(
+      getExecutableCodeRefSource(
+        { $codeRef: 'foo.bar' },
+        'qux',
+        getPluginPackage('test-plugin', { foo: 'src/foo.ts' }),
+        validationResult,
+      ),
+    ).toBe(
+      "() => import('test-plugin/src/foo.ts' /* webpackChunkName: 'test-plugin/code-refs/foo' */).then((m) => m.bar)",
+    );
+
+    expect(validationResult.hasErrors()).toBe(false);
+
+    expect(
+      getExecutableCodeRefSource(
+        { $codeRef: 'foo.bar' },
+        'qux',
+        getPluginPackage('@console/test-plugin', { foo: 'src/foo.ts' }),
+        validationResult,
+      ),
+    ).toBe(
+      "() => import('@console/test-plugin/src/foo.ts' /* webpackChunkName: 'test-plugin/code-refs/foo' */).then((m) => m.bar)",
+    );
+
+    expect(validationResult.hasErrors()).toBe(false);
+  });
+
+  it('fails on malformed code reference', () => {
+    const validationResult = new ValidationResult('test');
+
+    expect(
+      getExecutableCodeRefSource(
+        { $codeRef: '.bar' },
+        'qux',
+        getPluginPackage('test-plugin'),
+        validationResult,
+      ),
+    ).toBe('() => Promise.resolve(null)');
+
+    expect(validationResult.getErrors().length).toBe(1);
+    expect(validationResult.getErrors()[0]).toBe("Invalid code reference '.bar' in property 'qux'");
+  });
+
+  it('fails when requested module is not exposed by the plugin', () => {
+    const validationResult = new ValidationResult('test');
+
+    expect(
+      getExecutableCodeRefSource(
+        { $codeRef: 'foo.bar' },
+        'qux',
+        getPluginPackage('test-plugin'),
+        validationResult,
+      ),
+    ).toBe('() => Promise.resolve(null)');
+
+    expect(validationResult.getErrors().length).toBe(1);
+    expect(validationResult.getErrors()[0]).toBe("Module 'foo' is not exposed in property 'qux'");
+  });
+
+  it('fails when requested module resolution throws an error', () => {
+    const validationResult = new ValidationResult('test');
+
+    reloadModule.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    expect(
+      getExecutableCodeRefSource(
+        { $codeRef: 'foo.bar' },
+        'qux',
+        getPluginPackage('test-plugin', { foo: 'src/foo.ts' }),
+        validationResult,
+      ),
+    ).toBe('() => Promise.resolve(null)');
+
+    expect(validationResult.getErrors().length).toBe(1);
+    expect(validationResult.getErrors()[0]).toBe(
+      "Cannot import 'test-plugin/src/foo.ts' in property 'qux'",
+    );
+  });
+
+  it('fails on missing module export', () => {
+    const validationResult = new ValidationResult('test');
+
+    reloadModule.mockImplementation((request: string) => {
+      switch (request) {
+        case 'test-plugin/src/foo.ts':
+          return { bar: 'value' };
+        default:
+          throw new Error('invalid mock arguments');
+      }
+    });
+
+    expect(
+      getExecutableCodeRefSource(
+        { $codeRef: 'foo.baz' },
+        'qux',
+        getPluginPackage('test-plugin', { foo: 'src/foo.ts' }),
+        validationResult,
+      ),
+    ).toBe('() => Promise.resolve(null)');
+
+    expect(validationResult.getErrors().length).toBe(1);
+    expect(validationResult.getErrors()[0]).toBe("Invalid module export 'baz' in property 'qux'");
+  });
+});
+
+describe('getDynamicExtensions', () => {
+  let fsExistsSync: jest.SpyInstance<typeof fs.existsSync>;
+  let getExecutableCodeRefSourceMock: jest.SpyInstance<typeof getExecutableCodeRefSource>;
+
+  beforeEach(() => {
+    fsExistsSync = jest.spyOn(fs, 'existsSync');
+    getExecutableCodeRefSourceMock = jest.spyOn(activePluginsModule, 'getExecutableCodeRefSource');
+  });
+
+  afterEach(() => {
+    [fsExistsSync, getExecutableCodeRefSourceMock].forEach((mock) => mock.mockRestore());
+  });
+
+  it('returns an array of dynamic extensions with transformed code references', () => {
+    const pluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'test-plugin',
+      }),
+      consolePlugin: { entry: 'src/plugin.ts' },
+    };
+
+    const extensionsObject: { data: Extension[] } = {
+      data: [
+        { type: 'Dynamic/Foo', properties: { test: true, mux: { $codeRef: 'a.b' } } },
+        { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'foo.bar' } } },
+      ],
+    };
+
+    const extensionsFilePath = `${pluginPackage._path}/${extensionsFile}`;
+    const errorCallback = jest.fn();
+
+    fsExistsSync.mockImplementation(() => true);
+    parseJSONC.mockImplementation(() => extensionsObject);
+    validateExtensionsFileSchema.mockImplementation(() => new ValidationResult('test'));
+
+    getExecutableCodeRefSourceMock.mockImplementation((ref: EncodedCodeRef) => {
+      if (_.isEqual(ref, { $codeRef: 'a.b' })) {
+        return "() => import('test-plugin/src/aaa.ts').then((m) => m.b)";
+      }
+      if (_.isEqual(ref, { $codeRef: 'foo.bar' })) {
+        return "() => import('test-plugin/src/foo.ts').then((m) => m.bar)";
+      }
+      throw new Error('invalid mock arguments');
+    });
+
+    expect(getDynamicExtensions(pluginPackage, extensionsFilePath, errorCallback)).toBe(
+      trimStartMultiLine(
+        `
+        [
+          {
+            "type": "Dynamic/Foo",
+            "properties": {
+              "test": true,
+              "mux": () => import('test-plugin/src/aaa.ts').then((m) => m.b)
+            }
+          },
+          {
+            "type": "Dynamic/Bar",
+            "properties": {
+              "baz": 1,
+              "qux": () => import('test-plugin/src/foo.ts').then((m) => m.bar)
+            }
+          }
+        ]`,
+      ),
+    );
+
+    expect(errorCallback).not.toHaveBeenCalled();
+    expect(fsExistsSync).toHaveBeenCalledWith(extensionsFilePath);
+    expect(parseJSONC).toHaveBeenCalledWith(extensionsFilePath);
+    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsObject, extensionsFilePath);
+
+    expect(getExecutableCodeRefSourceMock.mock.calls.length).toBe(2);
+    expect(getExecutableCodeRefSourceMock.mock.calls[0]).toEqual([
+      { $codeRef: 'a.b' },
+      'mux',
+      pluginPackage,
+      expect.any(ValidationResult),
+    ]);
+    expect(getExecutableCodeRefSourceMock.mock.calls[1]).toEqual([
+      { $codeRef: 'foo.bar' },
+      'qux',
+      pluginPackage,
+      expect.any(ValidationResult),
+    ]);
+  });
+
+  it('returns an empty array if the extensions file is missing', () => {
+    const pluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'test-plugin',
+      }),
+      consolePlugin: { entry: 'src/plugin.ts' },
+    };
+
+    const extensionsFilePath = `${pluginPackage._path}/${extensionsFile}`;
+    const errorCallback = jest.fn();
+
+    fsExistsSync.mockImplementation(() => false);
+
+    expect(getDynamicExtensions(pluginPackage, extensionsFilePath, errorCallback)).toBe('[]');
+
+    expect(errorCallback).not.toHaveBeenCalled();
+    expect(fsExistsSync).toHaveBeenCalledWith(extensionsFilePath);
+    expect(parseJSONC).not.toHaveBeenCalled();
+    expect(validateExtensionsFileSchema).not.toHaveBeenCalled();
+    expect(getExecutableCodeRefSourceMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array if the extensions file has schema validation errors', () => {
+    const pluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'test-plugin',
+      }),
+      consolePlugin: { entry: 'src/plugin.ts' },
+    };
+
+    const extensionsObject: { data: Extension[] } = { data: [] };
+    const extensionsFilePath = `${pluginPackage._path}/${extensionsFile}`;
+    const errorCallback = jest.fn();
+
+    fsExistsSync.mockImplementation(() => true);
+    parseJSONC.mockImplementation(() => extensionsObject);
+    validateExtensionsFileSchema.mockImplementation(() => {
+      const result = new ValidationResult('test');
+      result.addError('schema validation error');
+      return result;
+    });
+
+    expect(getDynamicExtensions(pluginPackage, extensionsFilePath, errorCallback)).toBe('[]');
+
+    expect(errorCallback).toHaveBeenCalledWith(expect.any(String));
+    expect(fsExistsSync).toHaveBeenCalledWith(extensionsFilePath);
+    expect(parseJSONC).toHaveBeenCalledWith(extensionsFilePath);
+    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsObject, extensionsFilePath);
+    expect(getExecutableCodeRefSourceMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array when code reference transformation yields errors', () => {
+    const pluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'test-plugin',
+      }),
+      consolePlugin: { entry: 'src/plugin.ts' },
+    };
+
+    const extensionsObject: { data: Extension[] } = {
+      data: [
+        { type: 'Dynamic/Foo', properties: { test: true, mux: { $codeRef: 'a.b' } } },
+        { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'foo.bar' } } },
+      ],
+    };
+
+    const extensionsFilePath = `${pluginPackage._path}/${extensionsFile}`;
+    const errorCallback = jest.fn();
+
+    fsExistsSync.mockImplementation(() => true);
+    parseJSONC.mockImplementation(() => extensionsObject);
+    validateExtensionsFileSchema.mockImplementation(() => new ValidationResult('test'));
+
+    getExecutableCodeRefSourceMock.mockImplementation(
+      (
+        ref: EncodedCodeRef,
+        propName: string,
+        pkg: PluginPackage,
+        validationResult: ValidationResult,
+      ) => {
+        if (_.isEqual(ref, { $codeRef: 'a.b' })) {
+          validationResult.addError('code reference transform error');
+          return '() => Promise.resolve(null)';
+        }
+        if (_.isEqual(ref, { $codeRef: 'foo.bar' })) {
+          return "() => import('test-plugin/src/foo.ts').then((m) => m.bar)";
+        }
+        throw new Error('invalid mock arguments');
+      },
+    );
+
+    expect(getDynamicExtensions(pluginPackage, extensionsFilePath, errorCallback)).toBe('[]');
+
+    expect(errorCallback).toHaveBeenCalledWith(expect.any(String));
+    expect(fsExistsSync).toHaveBeenCalledWith(extensionsFilePath);
+    expect(parseJSONC).toHaveBeenCalledWith(extensionsFilePath);
+    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsObject, extensionsFilePath);
+
+    expect(getExecutableCodeRefSourceMock.mock.calls.length).toBe(2);
+    expect(getExecutableCodeRefSourceMock.mock.calls[0]).toEqual([
+      { $codeRef: 'a.b' },
+      'mux',
+      pluginPackage,
+      expect.any(ValidationResult),
+    ]);
+    expect(getExecutableCodeRefSourceMock.mock.calls[1]).toEqual([
+      { $codeRef: 'foo.bar' },
+      'qux',
+      pluginPackage,
+      expect.any(ValidationResult),
+    ]);
   });
 });

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-integration-tests.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-integration-tests.spec.ts
@@ -1,163 +1,161 @@
 import * as glob from 'glob';
 import { PluginPackage } from '../plugin-resolver';
 import { getTestSuitesForPluginPackage, mergeTestSuites } from '../plugin-integration-tests';
-import { getTemplatePackage } from './plugin-resolver.spec';
+import { getTemplatePackage } from '../../utils/test-utils';
 
-describe('plugin-integration-tests', () => {
-  describe('getTestSuitesForPluginPackage', () => {
-    let globMock: jest.SpyInstance<typeof glob.sync>;
+describe('getTestSuitesForPluginPackage', () => {
+  let globMock: jest.SpyInstance<typeof glob.sync>;
 
-    beforeEach(() => {
-      globMock = jest.spyOn(glob, 'sync');
-    });
+  beforeEach(() => {
+    globMock = jest.spyOn(glob, 'sync');
+  });
 
-    afterEach(() => {
-      globMock.mockRestore();
-    });
+  afterEach(() => {
+    globMock.mockRestore();
+  });
 
-    it('returns an empty object if package.consolePlugin.integrationTestSuites is missing', () => {
-      expect(
-        getTestSuitesForPluginPackage(
-          {
-            ...getTemplatePackage(),
-            consolePlugin: { entry: 'plugin.ts' },
-          },
-          '/test/packages/console-app',
-        ),
-      ).toEqual({});
-    });
-
-    it('maps package.consolePlugin.integrationTestSuites to an object with relative paths', () => {
-      const pluginPackage: PluginPackage = {
-        ...getTemplatePackage({
-          _path: '/test/packages/test-plugin',
-        }),
-        consolePlugin: {
-          entry: 'plugin.ts',
-          integrationTestSuites: {
-            'foo-bar': ['integration-tests/**/*.scenario.ts'],
-            'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-          },
+  it('returns an empty object if package.consolePlugin.integrationTestSuites is missing', () => {
+    expect(
+      getTestSuitesForPluginPackage(
+        {
+          ...getTemplatePackage(),
+          consolePlugin: { entry: 'plugin.ts' },
         },
-      };
+        '/test/packages/console-app',
+      ),
+    ).toEqual({});
+  });
 
-      globMock.mockImplementation((pattern: string) => {
-        if (pattern === 'integration-tests/**/*.scenario.ts') {
-          return [
-            '/test/packages/test-plugin/integration-tests/tests/foo.scenario.ts',
-            '/test/packages/test-plugin/integration-tests/tests/bar.scenario.ts',
-          ];
-        }
-        if (pattern === '../demo-plugin/integration-tests/tests/demo.scenario.ts') {
-          return ['/test/packages/demo-plugin/integration-tests/tests/demo.scenario.ts'];
-        }
-        throw new Error('invalid mock arguments');
-      });
+  it('maps package.consolePlugin.integrationTestSuites to an object with relative paths', () => {
+    const pluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        _path: '/test/packages/test-plugin',
+      }),
+      consolePlugin: {
+        entry: 'plugin.ts',
+        integrationTestSuites: {
+          'foo-bar': ['integration-tests/**/*.scenario.ts'],
+          'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
+        },
+      },
+    };
 
-      expect(getTestSuitesForPluginPackage(pluginPackage, '/test/packages/console-app')).toEqual({
-        'foo-bar': [
-          '../test-plugin/integration-tests/tests/foo.scenario.ts',
-          '../test-plugin/integration-tests/tests/bar.scenario.ts',
-        ],
-        'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-      });
+    globMock.mockImplementation((pattern: string) => {
+      if (pattern === 'integration-tests/**/*.scenario.ts') {
+        return [
+          '/test/packages/test-plugin/integration-tests/tests/foo.scenario.ts',
+          '/test/packages/test-plugin/integration-tests/tests/bar.scenario.ts',
+        ];
+      }
+      if (pattern === '../demo-plugin/integration-tests/tests/demo.scenario.ts') {
+        return ['/test/packages/demo-plugin/integration-tests/tests/demo.scenario.ts'];
+      }
+      throw new Error('invalid mock arguments');
+    });
 
-      expect(globMock).toHaveBeenCalledTimes(2);
-      expect(globMock).toHaveBeenCalledWith(expect.any(String), {
-        cwd: '/test/packages/test-plugin',
-        absolute: true,
-      });
+    expect(getTestSuitesForPluginPackage(pluginPackage, '/test/packages/console-app')).toEqual({
+      'foo-bar': [
+        '../test-plugin/integration-tests/tests/foo.scenario.ts',
+        '../test-plugin/integration-tests/tests/bar.scenario.ts',
+      ],
+      'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
+    });
+
+    expect(globMock).toHaveBeenCalledTimes(2);
+    expect(globMock).toHaveBeenCalledWith(expect.any(String), {
+      cwd: '/test/packages/test-plugin',
+      absolute: true,
+    });
+  });
+});
+
+describe('mergeTestSuites', () => {
+  it('merges object values as arrays', () => {
+    expect(
+      mergeTestSuites(
+        {},
+        {
+          'foo-bar': [
+            '../test-plugin/integration-tests/tests/foo.scenario.ts',
+            '../test-plugin/integration-tests/tests/bar.scenario.ts',
+          ],
+          'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
+        },
+      ),
+    ).toEqual({
+      'foo-bar': [
+        '../test-plugin/integration-tests/tests/foo.scenario.ts',
+        '../test-plugin/integration-tests/tests/bar.scenario.ts',
+      ],
+      'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
+    });
+
+    expect(
+      mergeTestSuites(
+        {
+          filter: ['integration-tests/tests/filter.scenario.ts'],
+          all: [
+            'integration-tests/tests/crud.scenario.ts',
+            'integration-tests/tests/filter.scenario.ts',
+          ],
+        },
+        {
+          'foo-bar': [
+            '../test-plugin/integration-tests/tests/foo.scenario.ts',
+            '../test-plugin/integration-tests/tests/bar.scenario.ts',
+          ],
+          'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
+          all: ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
+        },
+      ),
+    ).toEqual({
+      filter: ['integration-tests/tests/filter.scenario.ts'],
+      all: [
+        'integration-tests/tests/crud.scenario.ts',
+        'integration-tests/tests/filter.scenario.ts',
+        '../demo-plugin/integration-tests/tests/demo.scenario.ts',
+      ],
+      'foo-bar': [
+        '../test-plugin/integration-tests/tests/foo.scenario.ts',
+        '../test-plugin/integration-tests/tests/bar.scenario.ts',
+      ],
+      'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
     });
   });
 
-  describe('mergeTestSuites', () => {
-    it('merges object values as arrays', () => {
-      expect(
-        mergeTestSuites(
-          {},
-          {
-            'foo-bar': [
-              '../test-plugin/integration-tests/tests/foo.scenario.ts',
-              '../test-plugin/integration-tests/tests/bar.scenario.ts',
-            ],
-            'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-          },
-        ),
-      ).toEqual({
-        'foo-bar': [
-          '../test-plugin/integration-tests/tests/foo.scenario.ts',
-          '../test-plugin/integration-tests/tests/bar.scenario.ts',
-        ],
-        'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-      });
+  it('removes duplicate array elements', () => {
+    expect(
+      mergeTestSuites(
+        {
+          filter: [
+            'integration-tests/tests/filter.scenario.ts',
+            'integration-tests/tests/filter.scenario.ts',
+          ],
+        },
+        {
+          'foo-bar': [
+            '../test-plugin/integration-tests/tests/foo.scenario.ts',
+            '../test-plugin/integration-tests/tests/bar.scenario.ts',
+            '../test-plugin/integration-tests/tests/foo.scenario.ts',
+          ],
+        },
+      ),
+    ).toEqual({
+      filter: ['integration-tests/tests/filter.scenario.ts'],
+      'foo-bar': [
+        '../test-plugin/integration-tests/tests/foo.scenario.ts',
+        '../test-plugin/integration-tests/tests/bar.scenario.ts',
+      ],
+    });
+  });
 
-      expect(
-        mergeTestSuites(
-          {
-            filter: ['integration-tests/tests/filter.scenario.ts'],
-            all: [
-              'integration-tests/tests/crud.scenario.ts',
-              'integration-tests/tests/filter.scenario.ts',
-            ],
-          },
-          {
-            'foo-bar': [
-              '../test-plugin/integration-tests/tests/foo.scenario.ts',
-              '../test-plugin/integration-tests/tests/bar.scenario.ts',
-            ],
-            'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-            all: ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-          },
-        ),
-      ).toEqual({
-        filter: ['integration-tests/tests/filter.scenario.ts'],
-        all: [
-          'integration-tests/tests/crud.scenario.ts',
-          'integration-tests/tests/filter.scenario.ts',
-          '../demo-plugin/integration-tests/tests/demo.scenario.ts',
-        ],
-        'foo-bar': [
-          '../test-plugin/integration-tests/tests/foo.scenario.ts',
-          '../test-plugin/integration-tests/tests/bar.scenario.ts',
-        ],
-        'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-      });
+  it('does not modify the original target object', () => {
+    const target = {};
+    const result = mergeTestSuites(target, {
+      'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
     });
 
-    it('removes duplicate array elements', () => {
-      expect(
-        mergeTestSuites(
-          {
-            filter: [
-              'integration-tests/tests/filter.scenario.ts',
-              'integration-tests/tests/filter.scenario.ts',
-            ],
-          },
-          {
-            'foo-bar': [
-              '../test-plugin/integration-tests/tests/foo.scenario.ts',
-              '../test-plugin/integration-tests/tests/bar.scenario.ts',
-              '../test-plugin/integration-tests/tests/foo.scenario.ts',
-            ],
-          },
-        ),
-      ).toEqual({
-        filter: ['integration-tests/tests/filter.scenario.ts'],
-        'foo-bar': [
-          '../test-plugin/integration-tests/tests/foo.scenario.ts',
-          '../test-plugin/integration-tests/tests/bar.scenario.ts',
-        ],
-      });
-    });
-
-    it('does not modify the original target object', () => {
-      const target = {};
-      const result = mergeTestSuites(target, {
-        'demo-suite': ['../demo-plugin/integration-tests/tests/demo.scenario.ts'],
-      });
-
-      expect(target).toEqual({});
-      expect(result).not.toBe(target);
-    });
+    expect(target).toEqual({});
+    expect(result).not.toBe(target);
   });
 });

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-resolver.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/plugin-resolver.spec.ts
@@ -10,217 +10,203 @@ import {
   filterActivePluginPackages,
   getMonorepoRootDir,
 } from '../plugin-resolver';
+import { getTemplatePackage } from '../../utils/test-utils';
 
-export const getTemplatePackage = ({
-  name = 'test',
-  version = '0.0.0',
-  _path = '/test/packages/test-pkg',
-} = {}): Package =>
-  Object.freeze({
-    name,
-    version,
-    readme: '',
-    _id: `${name}@${version}`,
-    _path,
+describe('isPluginPackage', () => {
+  it('returns false if package.consolePlugin is missing', () => {
+    expect(
+      isPluginPackage({
+        ...getTemplatePackage(),
+      }),
+    ).toBe(false);
   });
 
-describe('plugin-resolver', () => {
-  describe('isPluginPackage', () => {
-    it('returns false if package.consolePlugin is missing', () => {
-      expect(
-        isPluginPackage({
-          ...getTemplatePackage(),
-        }),
-      ).toBe(false);
-    });
-
-    it('returns false if package.consolePlugin.entry is missing', () => {
-      expect(
-        isPluginPackage({
-          ...getTemplatePackage(),
-          consolePlugin: {},
-        }),
-      ).toBe(false);
-    });
-
-    it('returns false if package.consolePlugin.entry is an empty string', () => {
-      expect(
-        isPluginPackage({
-          ...getTemplatePackage(),
-          consolePlugin: { entry: '' },
-        }),
-      ).toBe(false);
-    });
-
-    it('returns true if package.consolePlugin.entry is a non-empty string', () => {
-      expect(
-        isPluginPackage({
-          ...getTemplatePackage(),
-          consolePlugin: { entry: 'plugin.ts' },
-        }),
-      ).toBe(true);
-    });
+  it('returns false if package.consolePlugin.entry is missing', () => {
+    expect(
+      isPluginPackage({
+        ...getTemplatePackage(),
+        consolePlugin: {},
+      }),
+    ).toBe(false);
   });
 
-  describe('readPackages', () => {
-    let readPkgMock: jest.SpyInstance<typeof readPkg.sync>;
+  it('returns false if package.consolePlugin.entry is an empty string', () => {
+    expect(
+      isPluginPackage({
+        ...getTemplatePackage(),
+        consolePlugin: { entry: '' },
+      }),
+    ).toBe(false);
+  });
 
-    beforeEach(() => {
-      readPkgMock = jest.spyOn(readPkg, 'sync');
+  it('returns true if package.consolePlugin.entry is a non-empty string', () => {
+    expect(
+      isPluginPackage({
+        ...getTemplatePackage(),
+        consolePlugin: { entry: 'plugin.ts' },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('readPackages', () => {
+  let readPkgMock: jest.SpyInstance<typeof readPkg.sync>;
+
+  beforeEach(() => {
+    readPkgMock = jest.spyOn(readPkg, 'sync');
+  });
+
+  afterEach(() => {
+    readPkgMock.mockRestore();
+  });
+
+  it('detects app and plugin packages by reading their metadata', () => {
+    const appPackagePath = '/test/packages/console-app';
+    const appPackage: Package = {
+      ...getTemplatePackage({
+        name: '@console/app',
+        _path: appPackagePath,
+      }),
+    };
+
+    const pluginPackagePath = '/test/packages/foo-plugin';
+    const pluginPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: '@console/foo-plugin',
+        _path: pluginPackagePath,
+      }),
+      consolePlugin: { entry: 'plugin.ts' },
+    };
+
+    const utilsPackagePath = '/test/packages/bar-utils';
+    const utilsPackage: Package = {
+      ...getTemplatePackage({
+        name: '@console/bar-utils',
+        _path: utilsPackagePath,
+      }),
+    };
+
+    readPkgMock.mockImplementation(
+      ({ cwd }): Package => {
+        if (cwd === appPackagePath) {
+          return appPackage;
+        }
+        if (cwd === pluginPackagePath) {
+          return pluginPackage;
+        }
+        if (cwd === utilsPackagePath) {
+          return utilsPackage;
+        }
+        throw new Error('invalid mock arguments');
+      },
+    );
+
+    expect(
+      readPackages([
+        `${appPackagePath}/package.json`,
+        `${pluginPackagePath}/package.json`,
+        `${utilsPackagePath}/package.json`,
+      ]),
+    ).toEqual({
+      appPackage,
+      pluginPackages: [pluginPackage],
     });
+  });
+});
 
-    afterEach(() => {
-      readPkgMock.mockRestore();
-    });
+describe('filterActivePluginPackages', () => {
+  it('returns plugin packages listed in appPackage.dependencies', () => {
+    const appPackage: Package = {
+      ...getTemplatePackage({
+        name: 'app',
+      }),
+      dependencies: {
+        foo: '0.1.2',
+        bar: '1.2.3',
+      },
+    };
 
-    it('detects app and plugin packages by reading their metadata', () => {
-      const appPackagePath = '/test/packages/console-app';
-      const appPackage: Package = {
+    const pluginPackages: PluginPackage[] = [
+      {
         ...getTemplatePackage({
-          name: '@console/app',
-          _path: appPackagePath,
-        }),
-      };
-
-      const pluginPackagePath = '/test/packages/foo-plugin';
-      const pluginPackage: PluginPackage = {
-        ...getTemplatePackage({
-          name: '@console/foo-plugin',
-          _path: pluginPackagePath,
+          name: 'bar',
+          version: '1.2.3',
         }),
         consolePlugin: { entry: 'plugin.ts' },
-      };
-
-      const utilsPackagePath = '/test/packages/bar-utils';
-      const utilsPackage: Package = {
+      },
+      {
         ...getTemplatePackage({
-          name: '@console/bar-utils',
-          _path: utilsPackagePath,
+          name: 'qux',
+          version: '2.3.4',
         }),
-      };
+        consolePlugin: { entry: 'plugin.ts' },
+      },
+    ];
 
-      readPkgMock.mockImplementation(
-        ({ cwd }): Package => {
-          if (cwd === appPackagePath) {
-            return appPackage;
-          }
-          if (cwd === pluginPackagePath) {
-            return pluginPackage;
-          }
-          if (cwd === utilsPackagePath) {
-            return utilsPackage;
-          }
-          throw new Error('invalid mock arguments');
-        },
-      );
-
-      expect(
-        readPackages([
-          `${appPackagePath}/package.json`,
-          `${pluginPackagePath}/package.json`,
-          `${utilsPackagePath}/package.json`,
-        ]),
-      ).toEqual({
-        appPackage,
-        pluginPackages: [pluginPackage],
-      });
-    });
+    expect(filterActivePluginPackages(appPackage, pluginPackages)).toEqual([pluginPackages[0]]);
   });
 
-  describe('filterActivePluginPackages', () => {
-    it('returns plugin packages listed in appPackage.dependencies', () => {
-      const appPackage: Package = {
-        ...getTemplatePackage({
-          name: 'app',
-        }),
-        dependencies: {
-          foo: '0.1.2',
-          bar: '1.2.3',
-        },
-      };
+  it('should include appPackage as a valid plugin package', () => {
+    const appPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'app',
+      }),
+      dependencies: {},
+      consolePlugin: { entry: 'plugin.ts' },
+    };
 
-      const pluginPackages: PluginPackage[] = [
-        {
-          ...getTemplatePackage({
-            name: 'bar',
-            version: '1.2.3',
-          }),
-          consolePlugin: { entry: 'plugin.ts' },
-        },
-        {
-          ...getTemplatePackage({
-            name: 'qux',
-            version: '2.3.4',
-          }),
-          consolePlugin: { entry: 'plugin.ts' },
-        },
-      ];
-
-      expect(filterActivePluginPackages(appPackage, pluginPackages)).toEqual([pluginPackages[0]]);
-    });
-
-    it('should include appPackage as a valid plugin package', () => {
-      const appPackage: PluginPackage = {
-        ...getTemplatePackage({
-          name: 'app',
-        }),
-        dependencies: {},
-        consolePlugin: { entry: 'plugin.ts' },
-      };
-
-      expect(filterActivePluginPackages(appPackage, [appPackage])).toEqual([appPackage]);
-    });
-
-    it('should return appPackage as the first plugin package', () => {
-      const appPackage: PluginPackage = {
-        ...getTemplatePackage({
-          name: 'app',
-        }),
-        dependencies: {
-          bar: '1.2.3',
-          qux: '2.3.4',
-        },
-        consolePlugin: { entry: 'plugin.ts' },
-      };
-
-      const pluginPackages: PluginPackage[] = [
-        {
-          ...getTemplatePackage({
-            name: 'bar',
-            version: '1.2.3',
-          }),
-          consolePlugin: { entry: 'plugin.ts' },
-        },
-        {
-          ...getTemplatePackage({
-            name: 'qux',
-            version: '2.3.4',
-          }),
-          consolePlugin: { entry: 'plugin.ts' },
-        },
-      ];
-
-      expect(filterActivePluginPackages(appPackage, [...pluginPackages, appPackage])).toEqual([
-        appPackage,
-        pluginPackages[0],
-        pluginPackages[1],
-      ]);
-    });
+    expect(filterActivePluginPackages(appPackage, [appPackage])).toEqual([appPackage]);
   });
 
-  describe('getMonorepoRootDir', () => {
-    it('returns the location of Console monorepo root package', () => {
-      const currentPackageFile = findUp.sync('package.json', {
-        cwd: __dirname,
-      });
-      expect(fs.existsSync(currentPackageFile)).toBe(true);
+  it('should return appPackage as the first plugin package', () => {
+    const appPackage: PluginPackage = {
+      ...getTemplatePackage({
+        name: 'app',
+      }),
+      dependencies: {
+        bar: '1.2.3',
+        qux: '2.3.4',
+      },
+      consolePlugin: { entry: 'plugin.ts' },
+    };
 
-      const parentPackageFile = findUp.sync('package.json', {
-        cwd: path.join(path.dirname(currentPackageFile), '..'),
-      });
-      expect(fs.existsSync(parentPackageFile)).toBe(true);
+    const pluginPackages: PluginPackage[] = [
+      {
+        ...getTemplatePackage({
+          name: 'bar',
+          version: '1.2.3',
+        }),
+        consolePlugin: { entry: 'plugin.ts' },
+      },
+      {
+        ...getTemplatePackage({
+          name: 'qux',
+          version: '2.3.4',
+        }),
+        consolePlugin: { entry: 'plugin.ts' },
+      },
+    ];
 
-      expect(getMonorepoRootDir()).toEqual(path.dirname(parentPackageFile));
+    expect(filterActivePluginPackages(appPackage, [...pluginPackages, appPackage])).toEqual([
+      appPackage,
+      pluginPackages[0],
+      pluginPackages[1],
+    ]);
+  });
+});
+
+describe('getMonorepoRootDir', () => {
+  it('returns the location of Console monorepo root package', () => {
+    const currentPackageFile = findUp.sync('package.json', {
+      cwd: __dirname,
     });
+    expect(fs.existsSync(currentPackageFile)).toBe(true);
+
+    const parentPackageFile = findUp.sync('package.json', {
+      cwd: path.join(path.dirname(currentPackageFile), '..'),
+    });
+    expect(fs.existsSync(parentPackageFile)).toBe(true);
+
+    expect(getMonorepoRootDir()).toEqual(path.dirname(parentPackageFile));
   });
 });

--- a/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
@@ -1,37 +1,40 @@
-import { Extension, Plugin, ActivePlugin } from '../typings';
-import { PluginPackage } from './plugin-resolver';
-
-/**
- * Dynamically load plugins for testing or reporting purposes.
- *
- * _Important: keep this in sync with `getActivePluginsModule` below._
- */
-export const loadActivePlugins = (pluginPackages: PluginPackage[]) => {
-  const activePlugins: ActivePlugin[] = [];
-
-  for (const pkg of pluginPackages) {
-    // eslint-disable-next-line
-    const plugin = require(`${pkg.name}/${pkg.consolePlugin.entry}`).default as Plugin<Extension>;
-    activePlugins.push({ name: pkg.name, extensions: plugin });
-  }
-
-  return activePlugins;
-};
+import * as fs from 'fs';
+import * as _ from 'lodash';
+import {
+  isEncodedCodeRef,
+  parseEncodedCodeRefValue,
+} from '@console/dynamic-plugin-sdk/src/coderefs/coderef-resolver';
+import { ConsoleExtensionsJSON } from '@console/dynamic-plugin-sdk/src/schema/console-extensions';
+import { ValidationResult } from '@console/dynamic-plugin-sdk/src/validation/ValidationResult';
+import { EncodedCodeRef } from '@console/dynamic-plugin-sdk/src/types';
+import { parseJSONC } from '@console/dynamic-plugin-sdk/src/utils/jsonc';
+import { validateExtensionsFileSchema } from '@console/dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin';
+import { Extension, ActivePlugin } from '../typings';
+import { trimStartMultiLine } from '../utils/string';
+import { reloadModule } from '../utils/nodejs-modules';
+import { consolePkgScope, PluginPackage } from './plugin-resolver';
 
 /**
  * Generate the `@console/active-plugins` virtual module source.
  */
-export const getActivePluginsModule = (pluginPackages: PluginPackage[]) => {
+export const getActivePluginsModule = (
+  pluginPackages: PluginPackage[],
+  dynamicExtensionHook: (pkg: PluginPackage) => string = _.constant('[]'),
+) => {
   let output = `
     const activePlugins = [];
   `;
 
   for (const pkg of pluginPackages) {
-    const pluginVar = `plugin_${pluginPackages.indexOf(pkg)}`;
     output = `
       ${output}
-      const ${pluginVar} = require('${pkg.name}/${pkg.consolePlugin.entry}').default;
-      activePlugins.push({ name: '${pkg.name}', extensions: ${pluginVar} });
+      activePlugins.push({
+        name: '${pkg.name}',
+        extensions: [
+          ...require('${pkg.name}/${pkg.consolePlugin.entry}').default,
+          ...${dynamicExtensionHook(pkg)},
+        ],
+      });
     `;
   }
 
@@ -40,5 +43,117 @@ export const getActivePluginsModule = (pluginPackages: PluginPackage[]) => {
     export default activePlugins;
   `;
 
-  return output.replace(/^\s+/gm, '');
+  return trimStartMultiLine(output);
+};
+
+/**
+ * Important: keep this in sync with `getActivePluginsModule` above.
+ */
+export const loadActivePluginsForTestPurposes = (
+  pluginPackages: PluginPackage[],
+  dynamicExtensionHook: (pkg: PluginPackage) => Extension[] = _.constant([]),
+) => {
+  const activePlugins: ActivePlugin[] = [];
+
+  for (const pkg of pluginPackages) {
+    activePlugins.push({
+      name: pkg.name,
+      extensions: [
+        // eslint-disable-next-line
+        ...require(`${pkg.name}/${pkg.consolePlugin.entry}`).default,
+        ...dynamicExtensionHook(pkg),
+      ],
+    });
+  }
+
+  return activePlugins;
+};
+
+/**
+ * Transform the `EncodedCodeRef` into `CodeRef` function source.
+ */
+export const getExecutableCodeRefSource = (
+  ref: EncodedCodeRef,
+  propName: string,
+  pkg: PluginPackage,
+  validationResult: ValidationResult,
+) => {
+  const [moduleName, exportName] = parseEncodedCodeRefValue(ref.$codeRef);
+  const exposedModules = pkg.consolePlugin.exposedModules || {};
+
+  const errorTrace = `in property '${propName}'`;
+  const emptyCodeRefSource = '() => Promise.resolve(null)';
+
+  if (!moduleName || !exportName) {
+    validationResult.addError(`Invalid code reference '${ref.$codeRef}' ${errorTrace}`);
+    return emptyCodeRefSource;
+  }
+
+  if (!exposedModules[moduleName]) {
+    validationResult.addError(`Module '${moduleName}' is not exposed ${errorTrace}`);
+    return emptyCodeRefSource;
+  }
+
+  const importPath = `${pkg.name}/${exposedModules[moduleName]}`;
+  let requestedModule: object;
+
+  try {
+    requestedModule = reloadModule(importPath);
+  } catch (error) {
+    validationResult.addError(`Cannot import '${importPath}' ${errorTrace}`);
+    return emptyCodeRefSource;
+  }
+
+  if (!requestedModule[exportName]) {
+    validationResult.addError(`Invalid module export '${exportName}' ${errorTrace}`);
+    return emptyCodeRefSource;
+  }
+
+  const pluginReference = pkg.name.replace(`${consolePkgScope}/`, '');
+  const webpackChunkName = `${pluginReference}/code-refs/${moduleName}`;
+  const webpackMagicComment = `/* webpackChunkName: '${webpackChunkName}' */`;
+
+  return `() => import('${importPath}' ${webpackMagicComment}).then((m) => m.${exportName})`;
+};
+
+/**
+ * Returns the array source containing the given plugin's dynamic extensions.
+ *
+ * If an error occurs, calls `errorCallback` and returns an empty array.
+ */
+export const getDynamicExtensions = (
+  pkg: PluginPackage,
+  extensionsFilePath: string,
+  errorCallback: (errorMessage: string) => void,
+) => {
+  const emptyArraySource = '[]';
+
+  if (!fs.existsSync(extensionsFilePath)) {
+    return emptyArraySource;
+  }
+
+  const ext = parseJSONC<ConsoleExtensionsJSON>(extensionsFilePath);
+  const schemaValidationResult = validateExtensionsFileSchema(ext, extensionsFilePath);
+
+  if (schemaValidationResult.hasErrors()) {
+    errorCallback(schemaValidationResult.formatErrors());
+    return emptyArraySource;
+  }
+
+  const codeRefValidationResult = new ValidationResult(extensionsFilePath);
+  const source = JSON.stringify(
+    ext.data,
+    (key, value) =>
+      isEncodedCodeRef(value)
+        ? `%${getExecutableCodeRefSource(value, key, pkg, codeRefValidationResult)}%`
+        : value,
+    2,
+  ).replace(/"%(.*)%"/g, '$1');
+
+  if (codeRefValidationResult.hasErrors()) {
+    errorCallback(codeRefValidationResult.formatErrors());
+    return emptyArraySource;
+  }
+
+  return trimStartMultiLine(source);
 };

--- a/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
@@ -11,8 +11,15 @@ import { parseJSONC } from '@console/dynamic-plugin-sdk/src/utils/jsonc';
 import { validateExtensionsFileSchema } from '@console/dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin';
 import { Extension, ActivePlugin } from '../typings';
 import { trimStartMultiLine } from '../utils/string';
-import { reloadModule } from '../utils/nodejs-modules';
 import { consolePkgScope, PluginPackage } from './plugin-resolver';
+
+/**
+ * Reload the requested module, bypassing `require.cache` mechanism.
+ */
+export const reloadModule = (request: string) => {
+  delete require.cache[require.resolve(request)];
+  return require(request);
+};
 
 /**
  * Generate the `@console/active-plugins` virtual module source.
@@ -59,7 +66,6 @@ export const loadActivePluginsForTestPurposes = (
     activePlugins.push({
       name: pkg.name,
       extensions: [
-        // eslint-disable-next-line
         ...require(`${pkg.name}/${pkg.consolePlugin.entry}`).default,
         ...dynamicExtensionHook(pkg),
       ],

--- a/frontend/packages/console-plugin-sdk/src/codegen/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/index.ts
@@ -1,3 +1,0 @@
-export { resolvePluginPackages } from './plugin-resolver';
-export { loadActivePlugins, getActivePluginsModule } from './active-plugins';
-export { reducePluginTestSuites, mergeTestSuites } from './plugin-integration-tests';

--- a/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
@@ -5,11 +5,13 @@ import * as glob from 'glob';
 import * as findUp from 'find-up';
 import * as readPkg from 'read-pkg';
 
-// the name of Console application package
-const consoleAppName = '@console/app';
+export const consolePkgScope = '@console';
 
 // glob that matches all the monorepo packages
 const consolePkgGlob = 'packages/*/package.json';
+
+// the name of Console application package
+const consoleAppName = `${consolePkgScope}/app`;
 
 // env. variable used to override the active plugin list
 const consolePluginOverrideEnvVar = 'CONSOLE_PLUGINS';
@@ -91,7 +93,7 @@ export const resolvePluginPackages = (
   if (_.isString(process.env[consolePluginOverrideEnvVar])) {
     const pkgNames = process.env[consolePluginOverrideEnvVar]
       .split(',')
-      .map((name) => (!name.startsWith('@') ? `@console/${name}` : name));
+      .map((name) => (!name.startsWith('@') ? `${consolePkgScope}/${name}` : name));
 
     return sortPluginPackages(
       appPackage,
@@ -113,6 +115,7 @@ export type PluginPackage = Package & {
   consolePlugin: {
     entry: string;
     integrationTestSuites?: Record<string, string[]>;
+    exposedModules?: { [moduleName: string]: string };
   };
 };
 

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -40,11 +40,11 @@ export const getGatingFlagNames = (extensions: Extension[]): string[] =>
  * In development, this object is exposed as `window.pluginStore` for easier debugging.
  */
 export class PluginStore {
-  // Extensions contributed by static plugins
-  private readonly staticExtensions: LoadedExtension[];
+  // Extensions contributed by static plugins (part of Console application itself)
+  private readonly staticPluginExtensions: LoadedExtension[];
 
-  // Extensions contributed by dynamic plugins
-  private dynamicExtensions: LoadedExtension[] = [];
+  // Extensions contributed by dynamic plugins (loaded from remote hosts at runtime)
+  private dynamicPluginExtensions: LoadedExtension[] = [];
 
   // TODO(vojtech): legacy, remove
   public readonly registry: ExtensionRegistry;
@@ -54,7 +54,7 @@ export class PluginStore {
   private readonly listeners: VoidFunction[] = [];
 
   public constructor(plugins: ActivePlugin[]) {
-    this.staticExtensions = _.flatMap(
+    this.staticPluginExtensions = _.flatMap(
       plugins.map((p) =>
         p.extensions.map((e, index) =>
           Object.freeze(augmentExtension(sanitizeExtension({ ...e }), p.name, p.name, index)),
@@ -66,11 +66,11 @@ export class PluginStore {
   }
 
   public getAllExtensions() {
-    return [...this.staticExtensions, ...this.dynamicExtensions];
+    return [...this.staticPluginExtensions, ...this.dynamicPluginExtensions];
   }
 
   private updateDynamicExtensions() {
-    this.dynamicExtensions = Array.from(this.dynamicPlugins.values()).reduce(
+    this.dynamicPluginExtensions = Array.from(this.dynamicPlugins.values()).reduce(
       (acc, plugin) => (plugin.enabled ? [...acc, ...plugin.processedExtensions] : acc),
       [],
     );
@@ -143,8 +143,8 @@ export class PluginStore {
 
   public getStateForTestPurposes() {
     return {
-      staticExtensions: this.staticExtensions,
-      dynamicExtensions: this.dynamicExtensions,
+      staticPluginExtensions: this.staticPluginExtensions,
+      dynamicPluginExtensions: this.dynamicPluginExtensions,
       dynamicPlugins: this.dynamicPlugins,
       listeners: this.listeners,
     };

--- a/frontend/packages/console-plugin-sdk/src/typings/base.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/base.ts
@@ -23,8 +23,6 @@ export type ExtensionFlags = Partial<{
  *
  * Each extension may specify `flags` referencing Console feature flags which
  * are required and/or disallowed in order to put this extension into effect.
- *
- * TODO(vojtech): write ESLint rule to guard against extension type duplicity
  */
 export type Extension<P extends {} = any> = {
   type: string;

--- a/frontend/packages/console-plugin-sdk/src/utils/nodejs-modules.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/nodejs-modules.ts
@@ -1,5 +1,0 @@
-export const reloadModule = (request: string) => {
-  delete require.cache[require.resolve(request)];
-  // eslint-disable-next-line
-  return require(request);
-};

--- a/frontend/packages/console-plugin-sdk/src/utils/nodejs-modules.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/nodejs-modules.ts
@@ -1,0 +1,5 @@
+export const reloadModule = (request: string) => {
+  delete require.cache[require.resolve(request)];
+  // eslint-disable-next-line
+  return require(request);
+};

--- a/frontend/packages/console-plugin-sdk/src/utils/string.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/string.ts
@@ -1,0 +1,4 @@
+/**
+ * Multi-line equivalent of `String.prototype.trimStart` function.
+ */
+export const trimStartMultiLine = (s: string) => s.replace(/^\s+/gm, '');

--- a/frontend/packages/console-plugin-sdk/src/utils/test-utils.ts
+++ b/frontend/packages/console-plugin-sdk/src/utils/test-utils.ts
@@ -1,0 +1,14 @@
+import { Package } from '../codegen/plugin-resolver';
+
+export const getTemplatePackage = ({
+  name = 'test',
+  version = '0.0.0',
+  _path = `/test/packages/${name}-pkg`,
+} = {}): Package =>
+  Object.freeze({
+    name,
+    version,
+    readme: '',
+    _id: `${name}@${version}`,
+    _path,
+  });

--- a/frontend/packages/console-plugin-sdk/src/webpack/.eslintrc.js
+++ b/frontend/packages/console-plugin-sdk/src/webpack/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: ['plugin:console/node-typescript-prettier'],
+  rules: {
+    'no-underscore-dangle': 'off',
+  },
+};

--- a/frontend/packages/console-plugin-sdk/src/webpack/ConsoleActivePluginsModule.ts
+++ b/frontend/packages/console-plugin-sdk/src/webpack/ConsoleActivePluginsModule.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-empty-function */
-
 import * as webpack from 'webpack';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/frontend/packages/console-plugin-sdk/src/webpack/ConsoleActivePluginsModule.ts
+++ b/frontend/packages/console-plugin-sdk/src/webpack/ConsoleActivePluginsModule.ts
@@ -1,0 +1,91 @@
+/* eslint-disable no-empty-function */
+
+import * as webpack from 'webpack';
+import * as path from 'path';
+import * as fs from 'fs';
+import { extensionsFile } from '@console/dynamic-plugin-sdk/src/constants';
+import { PluginPackage } from '../codegen/plugin-resolver';
+import { getActivePluginsModule, getDynamicExtensions } from '../codegen/active-plugins';
+
+type VirtualModulesPluginAPI = {
+  writeModule: (filePath: string, source: string) => void;
+};
+
+const getExtensionsFilePath = (pkg: PluginPackage) => path.resolve(pkg._path, extensionsFile);
+
+const getPluginFiles = (pkg: PluginPackage) => {
+  const files = new Set<string>();
+  files.add(getExtensionsFilePath(pkg));
+
+  Object.keys(pkg.consolePlugin.exposedModules || {}).forEach((moduleName) => {
+    files.add(path.resolve(pkg._path, pkg.consolePlugin.exposedModules[moduleName]));
+  });
+
+  return files;
+};
+
+const getFileLastModified = (f: string) => (fs.existsSync(f) ? fs.statSync(f).mtimeMs : -1);
+
+export class ConsoleActivePluginsModule {
+  constructor(
+    private readonly pluginPackages: PluginPackage[],
+    private readonly virtualModules: VirtualModulesPluginAPI,
+  ) {}
+
+  apply(compiler: webpack.Compiler) {
+    const lastModified = new Map<string, number>();
+    let errors: string[] = [];
+
+    const checkFilesModified = () => {
+      let filesModified = false;
+
+      this.pluginPackages.forEach((pkg) => {
+        getPluginFiles(pkg).forEach((f) => {
+          const mtime = getFileLastModified(f);
+          filesModified = filesModified || mtime !== lastModified.get(f);
+          lastModified.set(f, mtime);
+        });
+      });
+
+      return filesModified;
+    };
+
+    const writeModule = () => {
+      if (checkFilesModified()) {
+        errors = [];
+
+        this.virtualModules.writeModule(
+          'node_modules/@console/active-plugins.js',
+          getActivePluginsModule(this.pluginPackages, (pkg) =>
+            getDynamicExtensions(pkg, getExtensionsFilePath(pkg), (errorMessage) => {
+              errors.push(errorMessage);
+            }),
+          ),
+        );
+      }
+    };
+
+    const addFilesToCompilation = (compilation: webpack.compilation.Compilation) => {
+      this.pluginPackages.forEach((pkg) => {
+        getPluginFiles(pkg).forEach((f) => {
+          compilation.fileDependencies.add(f);
+        });
+      });
+    };
+
+    const addErrorsToCompilation = (compilation: webpack.compilation.Compilation) => {
+      errors.forEach((e) => {
+        compilation.errors.push(new Error(e));
+      });
+    };
+
+    compiler.hooks.afterResolvers.tap(ConsoleActivePluginsModule.name, writeModule);
+    compiler.hooks.watchRun.tap(ConsoleActivePluginsModule.name, writeModule);
+    compiler.hooks.afterCompile.tap(ConsoleActivePluginsModule.name, addFilesToCompilation);
+
+    compiler.hooks.shouldEmit.tap(ConsoleActivePluginsModule.name, (compilation) => {
+      addErrorsToCompilation(compilation);
+      return errors.length === 0;
+    });
+  }
+}

--- a/frontend/packages/eslint-plugin-console/index.js
+++ b/frontend/packages/eslint-plugin-console/index.js
@@ -53,6 +53,8 @@ module.exports = {
       rules: {
         // TODO fix for monorepo support
         'import/no-extraneous-dependencies': 'off',
+        // Allow invocation of require()
+        '@typescript-eslint/no-require-imports': 'off',
       },
     },
   },

--- a/frontend/packages/eslint-plugin-console/lib/config/json.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/json.js
@@ -1,7 +1,18 @@
 module.exports = {
   extends: ['plugin:json/recommended'],
+
   plugins: ['json'],
+
   rules: {
     'json/*': 'error',
   },
+
+  overrides: [
+    {
+      files: ['**/console-extensions.json'],
+      rules: {
+        'json/*': ['error', { allowComments: true }],
+      },
+    },
+  ],
 };

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/node.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/node.js
@@ -71,4 +71,6 @@ module.exports = {
   'node/prefer-promises/dns': 'error',
   // disallows callback API in favor of promise API for fs module
   'node/prefer-promises/fs': 'error',
+  // Disallow expressions in require()
+  'import/no-dynamic-require': 'off',
 };

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/typescript.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/typescript.js
@@ -210,6 +210,9 @@ module.exports = {
   // Covered by 'typescript/member-ordering'
   'sort-class-members/sort-class-members': 'off',
 
+  // Replaces base no-empty-function rule, handling TypeScript code that would otherwise trigger the rule
+  '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
+
   /**
    * 1. Disable things that are checked by Typescript
    */
@@ -235,13 +238,15 @@ module.exports = {
   'no-dupe-class-members': 'off',
   // This is already checked by Typescript.
   'no-redeclare': 'off',
+  // Replaced by @typescript-eslint/no-empty-function
+  'no-empty-function': 'off',
   /**
-   * 2. Enable more ideomatic code
+   * 2. Enable more idiomatic code
    */
   // Typescript allows const and let instead of var.
   'no-var': 'error',
   'prefer-const': 'error',
-  // The spread operator/rest parameters should be prefered in Typescript.
+  // The spread operator/rest parameters should be preferred in Typescript.
   'prefer-rest-params': 'error',
   'prefer-spread': 'error',
 };

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -7,10 +7,11 @@ import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import * as VirtualModulesPlugin from 'webpack-virtual-modules';
 import * as ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 
-import { resolvePluginPackages, getActivePluginsModule } from '@console/plugin-sdk/src/codegen';
 import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
-import { CircularDependencyPreset } from './webpack.circular-deps';
 import { sharedVendorModules } from '@console/dynamic-plugin-sdk/src/shared-modules';
+import { resolvePluginPackages } from '@console/plugin-sdk/src/codegen/plugin-resolver';
+import { ConsoleActivePluginsModule } from '@console/plugin-sdk/src/webpack/ConsoleActivePluginsModule';
+import { CircularDependencyPreset } from './webpack.circular-deps';
 
 interface Configuration extends webpack.Configuration {
   devServer?: WebpackDevServerConfiguration;
@@ -28,6 +29,7 @@ const WDS_PORT = 8080;
 
 /* Helpers */
 const extractCSS = new MiniCssExtractPlugin({ filename: 'app-bundle.[contenthash].css' });
+const virtualModules = new VirtualModulesPlugin();
 const overpassTest = /overpass-.*\.(woff2?|ttf|eot|otf)(\?.*$|$)/;
 const sharedVendorTest = new RegExp(`node_modules\\/(${sharedVendorModules.join('|')})\\/`);
 
@@ -218,6 +220,8 @@ const config: Configuration = {
       localesToKeep: ['en', 'ja', 'ko'],
     }),
     extractCSS,
+    virtualModules,
+    new ConsoleActivePluginsModule(resolvePluginPackages(), virtualModules),
     ...(IS_WDS
       ? [
           new ReactRefreshWebpackPlugin({
@@ -251,12 +255,5 @@ if (NODE_ENV === 'production') {
   config.optimization.concatenateModules = false;
   config.stats = 'normal';
 }
-
-/* Console plugin support */
-config.plugins.push(
-  new VirtualModulesPlugin({
-    'node_modules/@console/active-plugins.js': getActivePluginsModule(resolvePluginPackages()),
-  }),
-);
 
 export default config;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -19360,10 +19360,10 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-virtual-modules@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.1.10.tgz#2039529cbf1007e19f6e897c8d35721cc2c41f68"
-  integrity sha1-IDlSnL8QB+Gfbol8jTVyHMLEH2g=
+webpack-virtual-modules@0.3.x:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.3.2.tgz#b7baa30971a22d99451f897db053af48ec29ad2c"
+  integrity sha512-RXQXioY6MhzM4CNQwmBwKXYgBs6ulaiQ8bkNQEl2J6Z+V+s7lgl/wGvaI/I0dLnYKB8cKsxQc17QOAVIphPLDw==
   dependencies:
     debug "^3.0.0"
 


### PR DESCRIPTION
See [CONSOLE-2405](https://issues.redhat.com/browse/CONSOLE-2405)

## :memo: Summary

This PR allows the existing [static plugins](https://github.com/openshift/console/blob/master/frontend/packages/console-plugin-sdk/README.md) to use Console [dynamic plugin](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/README.md) extension declarations.

To ease the transition from static to dynamic, existing static plugins can start migrating their current extension declarations over to the new mechanism, while still being part of the Console application build.

Once a static plugin's entry module (e.g. `src/plugin.ts`) exports an empty array and the relevant Console backend/operator support is ready, the plugin's maintainers can finalize the transition process:
- move plugin source code to a separate repository
- deliver and expose dynamic plugin assets via OLM operator

## :gear: Details

Console static plugin support is now implemented via `ConsoleActivePluginsModule` webpack plugin, which re-generates the `@console/active-plugins` virtual module source as part of the webpack compilation.

Encoded code references are transformed into `CodeRef<T>` functions using the standard ES6 module [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports) API. For example, this extension declaration:

```json
{
  "type": "console.flag",
  "properties": {
    "handler": {
      "$codeRef": "foo.bar"
    }
  }
}
```

is mapped to the following source (assuming `test-plugin` exposes module `foo` as `src/foo.ts`):

```js
{
  type: "console.flag",
  properties: {
    handler: () => import('test-plugin/src/foo.ts' /* webpackChunkName: 'test-plugin/code-refs/foo' */).then((m) => m.bar)
  }
}
```

### Validation

Extension validation logic is equivalent to `ConsoleAssetPlugin` and covers the following cases:
- schema validation of `console-extensions.json` file must pass
- for each encoded code reference in `console-extensions.json` file:
  - `$codeRef` syntax must be valid
  - referenced module must be exposed by the plugin
  - referenced module must provide the given export

:bulb: Note: the "each exposed module must be referenced" check is currently not enforced.

### `webpack-dev-server`

The list of plugins to include in the Console application build, as well as the corresponding `package.json` files, are treated as immutable data. Changing these will necessitate dev-server restart.

`console-extensions.json` files, as well as any exposed module files, are treated as mutable data. Changing these will trigger a new compilation.

Extension validation errors will cause the webpack compilation to fail.