### PR TITLE
Topology, fetch jobs for cronjobs when necessary

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -7,6 +7,7 @@ export * from './plugins-overview-tab-section';
 export * from './debounce';
 export * from './select-list';
 export * from './useBuildConfigsWatcher';
+export * from './useJobsForCronJobWatcher';
 export * from './usePodsWatcher';
 export * from './useRoutesWatcher';
 export * from './useServicesWatcher';

--- a/frontend/packages/console-shared/src/hooks/useJobsForCronJobWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useJobsForCronJobWatcher.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { K8sResourceKind, JobKind } from '@console/internal/module/k8s';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { getJobsForCronJob } from '../utils';
+
+export const useJobsForCronJobWatcher = (
+  cronJob: K8sResourceKind,
+): { loaded: boolean; loadError: string; jobs: JobKind[] } => {
+  const { namespace, uid } = cronJob.metadata;
+  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>('');
+  const [jobs, setJobs] = React.useState<JobKind[]>([]);
+  const watchedResources = React.useMemo(
+    () => ({
+      jobs: {
+        isList: true,
+        kind: 'Job',
+        namespace,
+      },
+    }),
+    [namespace],
+  );
+  const resources = useK8sWatchResources(watchedResources);
+
+  React.useEffect(() => {
+    const errorKey = Object.keys(resources).find((key) => resources[key].loadError);
+    if (errorKey) {
+      setLoadError(resources[errorKey].loadError);
+      return;
+    }
+    setLoadError('');
+    if (
+      Object.keys(resources).length > 0 &&
+      Object.keys(resources).every((key) => resources[key].loaded)
+    ) {
+      const resourceJobs = getJobsForCronJob(uid, resources);
+      setJobs(resourceJobs);
+      setLoaded(true);
+    }
+  }, [uid, resources]);
+
+  return { loaded, loadError, jobs };
+};

--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -1,6 +1,5 @@
 import {
   HorizontalPodAutoscalerKind,
-  JobKind,
   K8sResourceKind,
   PodKind,
 } from '@console/internal/module/k8s';
@@ -31,7 +30,6 @@ export type OverviewItem<T = K8sResourceKind> = {
   hpas?: HorizontalPodAutoscalerKind[];
   pods?: PodKind[];
   previous?: PodControllerOverviewItem;
-  jobs?: JobKind[];
   status?: React.ReactNode;
   ksroutes?: K8sResourceKind[];
   configurations?: K8sResourceKind[];

--- a/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
@@ -73,7 +73,6 @@ enum Keys {
   ROLLINGOUT = 'isRollingOut',
   OBJ = 'obj',
   PODS = 'pods',
-  JOBS = 'jobs',
   PREVIOUS = 'previous',
   STATUS = 'status',
   REVISIONS = 'revisions',
@@ -214,7 +213,6 @@ describe('TransformResourceData', () => {
     expect(transformedData[0][Keys.CURRENT]).toBeUndefined();
     expect(transformedData[0][Keys.PREVIOUS]).toBeUndefined();
     expect(transformedData[0][Keys.ROLLINGOUT]).toBeUndefined();
-    expect(transformedData[0][Keys.JOBS]).toHaveLength(2);
     expect(transformedData[0][Keys.PODS]).toHaveLength(2);
   });
 

--- a/frontend/packages/console-shared/src/utils/pod-resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-resource-utils.ts
@@ -112,7 +112,7 @@ export const getPodsForCronJob = (cronJob: K8sResourceKind, resources: any): Pod
     apiVersion: apiVersionForModel(CronJobModel),
     kind: CronJobModel.kind,
   };
-  const jobs = getJobsForCronJob(cronJob, resources);
+  const jobs = getJobsForCronJob(cronJob?.metadata?.uid, resources);
   return {
     obj,
     current: undefined,

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -454,12 +454,12 @@ export const getReplicaSetsForResource = (
   );
 };
 
-export const getJobsForCronJob = (cronJob: K8sResourceKind, resources: any): JobKind[] => {
-  if (!cronJob || !resources?.jobs?.data?.length) {
+export const getJobsForCronJob = (cronJobUid: string, resources: any): JobKind[] => {
+  if (!resources?.jobs?.data?.length) {
     return [];
   }
   return resources.jobs.data
-    .filter((job) => job.metadata?.ownerReferences?.find((ref) => ref.uid === cronJob.metadata.uid))
+    .filter((job) => job.metadata?.ownerReferences?.find((ref) => ref.uid === cronJobUid))
     .map((job) => ({
       ...job,
       apiVersion: apiVersionForModel(JobModel),
@@ -749,7 +749,7 @@ export const createCronJobItem = (
   resources: any,
   utils?: ResourceUtil[],
 ): OverviewItem => {
-  const jobs = getJobsForCronJob(cronJob, resources);
+  const jobs = getJobsForCronJob(cronJob.metadata.uid, resources);
   const pods = jobs?.reduce((acc, job) => {
     acc.push(...getPodsForResource(job, resources));
     return acc;
@@ -762,7 +762,6 @@ export const createCronJobItem = (
   const overviewItem: OverviewItem = {
     obj: cronJob,
     pods,
-    jobs,
     status,
     isMonitorable,
     monitoringAlerts,

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/data-transformer.spec.ts
@@ -204,7 +204,6 @@ describe('data transformer ', () => {
     const graphData = getTransformedTopologyData(mockResources, ['cronJobs', 'jobs', 'pods']);
     expect(graphData.nodes).toHaveLength(3);
     const cronJobs = graphData.nodes.filter((n) => n.data.resources.obj.kind === 'CronJob');
-    expect(cronJobs[0].data.resources.jobs).toHaveLength(2);
     expect((cronJobs[0].data.data as WorkloadData).donutStatus.pods).toHaveLength(2);
   });
 

--- a/frontend/public/components/overview/cron-job-overview.tsx
+++ b/frontend/public/components/overview/cron-job-overview.tsx
@@ -4,6 +4,7 @@ import {
   OverviewItem,
   usePluginsOverviewTabSection,
   useBuildConfigsWatcher,
+  useJobsForCronJobWatcher,
 } from '@console/shared';
 import { CronJobModel } from '../../models';
 import { CronJobKind } from '../../module/k8s';
@@ -41,9 +42,10 @@ const CronJobOverviewDetails: React.SFC<CronJobOverviewDetailsProps> = ({
 );
 
 const CronJobResourcesTab: React.SFC<CronJobResourcesTabProps> = ({ item }) => {
-  const { pods, jobs, obj } = item;
+  const { pods, obj } = item;
   const pluginComponents = usePluginsOverviewTabSection(item);
   const { buildConfigs } = useBuildConfigsWatcher(obj);
+  const { jobs } = useJobsForCronJobWatcher(obj);
   return (
     <div className="overview__sidebar-pane-body">
       <PodsOverviewMultiple obj={obj} podResources={jobs} />

--- a/frontend/public/components/overview/pods-overview.tsx
+++ b/frontend/public/components/overview/pods-overview.tsx
@@ -251,10 +251,12 @@ export const PodsOverviewMultiple: React.SFC<PodsOverviewMultipleProps> = ({
       Object.keys(resources).length > 0 &&
       Object.keys(resources).every((key) => resources[key].loaded)
     ) {
-      let updatedPods = podResources.reduce((acc, resource) => {
-        acc.push(...getPodsForResource(resource, resources));
-        return acc;
-      }, []);
+      let updatedPods = podResources?.length
+        ? podResources.reduce((acc, resource) => {
+            acc.push(...getPodsForResource(resource, resources));
+            return acc;
+          }, [])
+        : [];
       if (podsFilter) {
         updatedPods = updatedPods.filter(podsFilter);
       }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5115

**Solution Description**: 
Remove jobs from OverviewItem type. Add hook to retrieve jobs for a given cronjob resource. Update instances to use hooks rather than fields in the OverviewItem type.

Non-Functional Change

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup