### PR TITLE
Consistency display resource details in a two equal column layout

### DIFF
--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -92,14 +92,18 @@ const OAuthDetails: React.FC<OAuthDetailsProps> = ({ obj }: { obj: OAuthKind }) 
     <>
       <div className="co-m-pane__body">
         <SectionHeading text={t('oauth~{{resource}} details', { resource: OAuthModel.label })} />
-        <ResourceSummary resource={obj}>
-          {tokenConfig && (
-            <>
-              <dt>{t('oauth~Access token max age')}</dt>
-              <dd>{tokenDuration(tokenConfig.accessTokenMaxAgeSeconds)}</dd>
-            </>
-          )}
-        </ResourceSummary>
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={obj}>
+              {tokenConfig && (
+                <>
+                  <dt>{t('oauth~Access token max age')}</dt>
+                  <dd>{tokenDuration(tokenConfig.accessTokenMaxAgeSeconds)}</dd>
+                </>
+              )}
+            </ResourceSummary>
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text={t('oauth~Identity providers')} />

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -112,7 +112,11 @@ const ConfigMapsDetailsPage = (props) => {
       <>
         <div className="co-m-pane__body">
           <SectionHeading text={t('workload~ConfigMap details')} />
-          <ResourceSummary resource={configMap} />
+          <div className="row">
+            <div className="col-md-6">
+              <ResourceSummary resource={configMap} />
+            </div>
+          </div>
         </div>
         <div className="co-m-pane__body">
           <SectionHeading text={t('workload~Data')} />

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -94,7 +94,15 @@ export const DetailsForKind = (kind) =>
       <>
         <div className="co-m-pane__body">
           <SectionHeading text={`${kindForReference(kind)} Details`} />
-          <ResourceSummary resource={obj} podSelector="spec.podSelector" showNodeSelector={false} />
+          <div className="row">
+            <div className="col-md-6">
+              <ResourceSummary
+                resource={obj}
+                podSelector="spec.podSelector"
+                showNodeSelector={false}
+              />
+            </div>
+          </div>
         </div>
         {_.isArray(obj?.status?.conditions) && (
           <div className="co-m-pane__body">

--- a/frontend/public/components/group.tsx
+++ b/frontend/public/components/group.tsx
@@ -150,7 +150,11 @@ const GroupDetails: React.FC<GroupDetailsProps> = ({ obj }) => {
     <>
       <div className="co-m-pane__body">
         <SectionHeading text="Group Details" />
-        <ResourceSummary resource={obj} />
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={obj} />
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text="Users" />

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -223,15 +223,19 @@ export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({ obj: 
           />
         )}
         <SectionHeading text="Image Stream Details" />
-        <ResourceSummary resource={imageStream}>
-          {imageRepository && <dt>Image Repository</dt>}
-          {imageRepository && <dd>{imageRepository}</dd>}
-          {publicImageRepository && <dt>Public Image Repository</dt>}
-          {publicImageRepository && <dd>{publicImageRepository}</dd>}
-          <dt>Image Count</dt>
-          <dd>{imageCount ? imageCount : 0}</dd>
-        </ResourceSummary>
-        <ExampleDockerCommandPopover imageStream={imageStream} />
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={imageStream}>
+              {imageRepository && <dt>Image Repository</dt>}
+              {imageRepository && <dd>{imageRepository}</dd>}
+              {publicImageRepository && <dt>Public Image Repository</dt>}
+              {publicImageRepository && <dd>{publicImageRepository}</dd>}
+              <dt>Image Count</dt>
+              <dd>{imageCount ? imageCount : 0}</dd>
+            </ResourceSummary>
+            <ExampleDockerCommandPopover imageStream={imageStream} />
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text="Tags" />

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -175,12 +175,16 @@ const Details = ({ obj: ingress }) => {
     <>
       <div className="co-m-pane__body">
         <SectionHeading text={t('ingress~Ingress details')} />
-        <ResourceSummary resource={ingress}>
-          <dt>{t('ingress~TLS certificate')}</dt>
-          <dd>
-            <TLSCert ingress={ingress} />
-          </dd>
-        </ResourceSummary>
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={ingress}>
+              <dt>{t('ingress~TLS certificate')}</dt>
+              <dd>
+                <TLSCert ingress={ingress} />
+              </dd>
+            </ResourceSummary>
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text={t('ingress~Ingress rules')} />

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -182,7 +182,11 @@ export const LimitRangeDetailsPage = (props) => {
         <SectionHeading
           text={t('limit-range~{{resource}} details', { resource: LimitRangeModel.label })}
         />
-        <ResourceSummary resource={rq} />
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={rq} />
+          </div>
+        </div>
       </div>
       <LimitRangeDetailsList resource={rq} />
     </>

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -140,16 +140,20 @@ const MachineAutoscalerDetails: React.FC<MachineAutoscalerDetailsProps> = ({ obj
     <>
       <div className="co-m-pane__body">
         <SectionHeading text={t('machine-autoscalers~MachineAutoscaler details')} />
-        <ResourceSummary resource={obj}>
-          <dt>{t('machine-autoscalers~Scale target')}</dt>
-          <dd>
-            <MachineAutoscalerTargetLink obj={obj} />
-          </dd>
-          <dt>{t('machine-autoscalers~Min replicas')}</dt>
-          <dd>{_.get(obj, 'spec.minReplicas') || '-'}</dd>
-          <dt>{t('machine-autoscalers~Max replicas')}</dt>
-          <dd>{_.get(obj, 'spec.maxReplicas') || '-'}</dd>
-        </ResourceSummary>
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={obj}>
+              <dt>{t('machine-autoscalers~Scale target')}</dt>
+              <dd>
+                <MachineAutoscalerTargetLink obj={obj} />
+              </dd>
+              <dt>{t('machine-autoscalers~Min replicas')}</dt>
+              <dd>{_.get(obj, 'spec.minReplicas') || '-'}</dd>
+              <dt>{t('machine-autoscalers~Max replicas')}</dt>
+              <dd>{_.get(obj, 'spec.maxReplicas') || '-'}</dd>
+            </ResourceSummary>
+          </div>
+        </div>
       </div>
     </>
   );

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -39,7 +39,7 @@ const MachineConfigDetails: React.SFC<MachineConfigDetailsProps> = ({ obj }) => 
     <div className="co-m-pane__body">
       <SectionHeading text={t('machine-configs~MachineConfig details')} />
       <div className="row">
-        <div className="col-xs-12">
+        <div className="col-md-6">
           <MachineConfigSummary obj={obj} t={t} />
         </div>
       </div>

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -215,34 +215,38 @@ const MachineSetDetails: React.SFC<MachineSetDetailsProps> = ({ obj }) => {
       <div className="co-m-pane__body">
         <SectionHeading text={t('machine-sets~Machine set details')} />
         <MachineCounts resourceKind={MachineSetModel} resource={obj} />
-        <ResourceSummary resource={obj}>
-          <dt>{t('machine-sets~Selector')}</dt>
-          <dd>
-            <Selector
-              kind={machineReference}
-              selector={obj.spec?.selector}
-              namespace={obj.metadata.namespace}
-            />
-          </dd>
-          {machineRole && (
-            <>
-              <dt>{t('machine-sets~Machine role')}</dt>
-              <dd>{machineRole}</dd>
-            </>
-          )}
-          {region && (
-            <>
-              <dt>{t('machine-sets~Region')}</dt>
-              <dd>{region}</dd>
-            </>
-          )}
-          {availabilityZone && (
-            <>
-              <dt>{t('machine-sets~Availability zone')}</dt>
-              <dd>{availabilityZone}</dd>
-            </>
-          )}
-        </ResourceSummary>
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={obj}>
+              <dt>{t('machine-sets~Selector')}</dt>
+              <dd>
+                <Selector
+                  kind={machineReference}
+                  selector={obj.spec?.selector}
+                  namespace={obj.metadata.namespace}
+                />
+              </dd>
+              {machineRole && (
+                <>
+                  <dt>{t('machine-sets~Machine role')}</dt>
+                  <dd>{machineRole}</dd>
+                </>
+              )}
+              {region && (
+                <>
+                  <dt>{t('machine-sets~Region')}</dt>
+                  <dd>{region}</dd>
+                </>
+              )}
+              {availabilityZone && (
+                <>
+                  <dt>{t('machine-sets~Availability zone')}</dt>
+                  <dd>{availabilityZone}</dd>
+                </>
+              )}
+            </ResourceSummary>
+          </div>
+        </div>
       </div>
     </>
   );

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -189,7 +189,11 @@ const Details_ = ({ obj: np, flags }) => {
     <>
       <div className="co-m-pane__body">
         <SectionHeading text={t('network-policy~Network policy details')} />
-        <ResourceSummary resource={np} podSelector={'spec.podSelector'} showPodSelector />
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={np} podSelector={'spec.podSelector'} showPodSelector />
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text={t('network-policy~Ingress rules')} />

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -141,7 +141,11 @@ const SecretDetails = ({ obj: secret }) => {
     <>
       <div className="co-m-pane__body">
         <SectionHeading text="Secret Details" />
-        <ResourceSummary resource={secret} />
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={secret} />
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body">
         <SecretData data={secret.data} type={secret.type} />

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -186,7 +186,11 @@ const Details = ({ obj: serviceaccount }) => {
     <>
       <div className="co-m-pane__body">
         <SectionHeading text="Service Account Details" />
-        <ResourceSummary resource={serviceaccount} />
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={serviceaccount} />
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body co-m-pane__body--section-heading">
         <SectionHeading text="Secrets" />

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -76,7 +76,11 @@ const StatefulSetDetails: React.FC<StatefulSetDetailsProps> = ({ obj: ss }) => {
             );
           }}
         />
-        <ResourceSummary resource={ss} showPodSelector showNodeSelector showTolerations />
+        <div className="row">
+          <div className="col-md-6">
+            <ResourceSummary resource={ss} showPodSelector showNodeSelector showTolerations />
+          </div>
+        </div>
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text={t('workload~Containers')} />


### PR DESCRIPTION
Currently the majority of resource detail pages use an equal two column structure to display content, though not all resources have data displayed in the rightmost column. While other pages utilize a single column structure, this has resulted in different display widths of the `label` input and edit component. [Bugzilla 1872095](https://bugzilla.redhat.com/show_bug.cgi?id=1872095) was opened for this issue.  

Since the majority of pages utilize a two column structure, I found and updated the remaining pages to be utilize a two column layout.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1872095