### PR TITLE
Bug 1888870: Remove resolveCompletionItem from yaml editor since it's not needed

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -100,12 +100,6 @@ export const registerYAMLCompletion = (
           return p2m.asCompletionResult(list);
         });
     },
-
-    resolveCompletionItem(item) {
-      return yamlService
-        .doResolve(m2p.asCompletionItem(item))
-        .then((result) => p2m.asCompletionItem(result));
-    },
   });
 };
 


### PR DESCRIPTION
This PR removes the resolveCompletionItem from the yaml editor since it's not actually needed and is causing errors.

Associated issue: https://bugzilla.redhat.com/show_bug.cgi?id=1888870

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>