### PR TITLE
Bug 1896302: Fix 4.6 test failures

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/cdi-upload.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/cdi-upload.scenario.ts
@@ -8,6 +8,7 @@ import {
   withResources,
 } from '@console/shared/src/test-utils/utils';
 import { errorMessage } from '@console/internal-integration-tests/views/crud.view';
+import { warnMessage } from '../views/pvc.view';
 import {
   CLONE_VM_TIMEOUT_SECS,
   CDI_UPLOAD_TIMEOUT_SECS,
@@ -84,7 +85,7 @@ describe('KubeVirt Auto Clone', () => {
       4 * CDI_UPLOAD_TIMEOUT_SECS,
     );
 
-    it('ID(CNV-4891) It shows an error when image format is not supported', async () => {
+    it('ID(CNV-4891) It shows a warning message when image format is not supported', async () => {
       const pvc: PVCData = {
         image: invalidImage,
         pvcName: `upload-pvc-${testName}-invalid`,
@@ -93,9 +94,10 @@ describe('KubeVirt Auto Clone', () => {
         storageClass: STORAGE_CLASS,
       };
 
-      await uploadForm.upload(pvc);
-      await browser.wait(until.presenceOf(errorMessage));
-      expect(errorMessage.getText()).toContain('not supported');
+      await uploadForm.openForm();
+      await uploadForm.fillAll(pvc);
+      await browser.wait(until.presenceOf(warnMessage));
+      expect(warnMessage.getText()).toContain('not supported');
     });
 
     it(
@@ -188,7 +190,7 @@ describe('KubeVirt Auto Clone', () => {
           },
         );
       },
-      VM_BOOTUP_TIMEOUT_SECS + CLONE_VM_TIMEOUT_SECS,
+      (VM_BOOTUP_TIMEOUT_SECS + CLONE_VM_TIMEOUT_SECS) * 2,
     );
 
     it(

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/mocks.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/mocks.ts
@@ -22,6 +22,7 @@ import {
   DISK_INTERFACE,
   DISK_SOURCE,
   DISK_DRIVE,
+  diskAccessMode,
 } from '../utils/constants/vm';
 import { ProvisionSource } from '../utils/constants/enums/provisionSource';
 
@@ -144,6 +145,18 @@ export const rootDisk: Disk = {
   bootable: true,
   interface: DISK_INTERFACE.VirtIO,
   storageClass: `${STORAGE_CLASS}`,
+};
+deepFreeze(rootDisk);
+
+export const rwxRootDisk = {
+  name: 'rootdisk',
+  size: '1',
+  drive: DISK_DRIVE.Disk,
+  interface: DISK_INTERFACE.VirtIO,
+  storageClass: `${STORAGE_CLASS}`,
+  advanced: {
+    accessMode: diskAccessMode.ReadWriteMany.value,
+  },
 };
 deepFreeze(rootDisk);
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/vmBuilderPresets.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/vmBuilderPresets.ts
@@ -121,7 +121,7 @@ export const vmPresets: { [k: string]: VirtualMachine } = {
     .setProvisionSource(ProvisionSource.PXE)
     .setDisks([rootDisk])
     .setNetworks([multusNetworkInterface])
-    .setStartOnCreation(true)
+    .setStartOnCreation(false)
     .build(),
   [ProvisionSource.DISK.getValue()]: new VMBuilder(getBasicVMBuilder())
     .setProvisionSource(ProvisionSource.DISK)

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/baseVirtualMachine.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/baseVirtualMachine.ts
@@ -23,6 +23,13 @@ export class BaseVirtualMachine extends KubevirtUIResource<VMBuilderData> {
       until.textToBePresentInElement(vmView.vmDetailStatus(this.namespace, this.name), status),
       resolveTimeout(timeout, VM_BOOTUP_TIMEOUT_SECS),
     );
+    // TODO: uncomment below once https://github.com/openshift/console/pull/7306 is merged.
+    /*
+    if (status === VM_STATUS.Running) {
+      // wait for the VM to boot up
+      execSync(`expect ${EXPECT_LOGIN_SCRIPT_PATH} ${this.name} ${this.namespace}`);
+    }
+    */
   }
 
   protected hasResource(resources, resource) {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/kubevirtUIResource.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/kubevirtUIResource.ts
@@ -10,6 +10,7 @@ import { clickNavLink } from '@console/internal-integration-tests/views/sidenav.
 import { PAGE_LOAD_TIMEOUT_SECS } from '../utils/constants/common';
 import { Disk, Network, VirtualMachineTemplateModel } from '../types/types';
 import * as kubevirtDetailView from '../../views/kubevirtUIResource.view';
+import * as disksView from '../../views/vm.disks.view';
 import {
   vmDetailFlavorEditButton,
   vmDetailBootOrderEditButton,
@@ -122,6 +123,7 @@ export class KubevirtUIResource<T extends BaseVMBuilderData> extends UIResource 
   async navigateToDisks() {
     await this.navigateToTab(TAB.Disks);
     await isLoaded();
+    await browser.wait(until.presenceOf(disksView.diskRows));
   }
 
   async navigateToNICs() {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/rhvImportWizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/rhvImportWizard.ts
@@ -6,9 +6,9 @@ import { selectOptionByText, setCheckboxState } from '../utils/utils';
 import { InstanceConfig, rhvConfig, VMImportConfig } from '../types/types';
 import {
   IMPORT_WIZARD_CONN_TO_NEW_INSTANCE,
-  RHV_WIZARD_CREATE_SUCCESS,
   PAGE_LOAD_TIMEOUT_SECS,
   IMPORT_WIZARD_CONN_NAME_PREFIX,
+  WIZARD_STARTED_IMPORT,
 } from '../utils/constants/common';
 import * as view from '../../views/importWizard.view';
 import * as rhvView from '../../views/rhvImportWizard.view';
@@ -72,7 +72,7 @@ export class RhvImportWizard extends ImportWizard {
 
   async waitForCreation() {
     await browser.wait(
-      until.textToBePresentInElement(wizardView.creationSuccessResult, RHV_WIZARD_CREATE_SUCCESS),
+      until.textToBePresentInElement(wizardView.creationSuccessResult, WIZARD_STARTED_IMPORT),
       PAGE_LOAD_TIMEOUT_SECS,
     );
   }

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
@@ -1,11 +1,7 @@
 /* eslint-disable no-await-in-loop, no-console */
 import { browser, ExpectedConditions as until } from 'protractor';
 import { cloneDeepWithEnum } from '@console/shared/src/constants/object-enum';
-import {
-  waitForStringNotInElement,
-  click,
-  waitForStringInElement,
-} from '@console/shared/src/test-utils/utils';
+import { click, waitForStringNotInElement } from '@console/shared/src/test-utils/utils';
 import { detailViewAction, listViewAction } from '@console/shared/src/test-utils/actions.view';
 import { VirtualMachineModel } from '@console/kubevirt-plugin/src/models';
 import { annotationDialogOverlay } from '@console/internal-integration-tests/views/modal-annotations.view';
@@ -182,10 +178,7 @@ export class VirtualMachine extends BaseVirtualMachine {
       );
     }
     if (this.data.startOnCreation) {
-      await browser.wait(
-        waitForStringInElement(vmView.vmDetailStatus(this.namespace, this.name), VM_STATUS.Running),
-        VM_BOOTUP_TIMEOUT_SECS,
-      );
+      await this.waitForStatus(VM_STATUS.Running, VM_BOOTUP_TIMEOUT_SECS);
     }
   }
 }

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/vmwareImportWizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/vmwareImportWizard.ts
@@ -6,7 +6,7 @@ import { selectOptionByText, setCheckboxState } from '../utils/utils';
 import {
   IMPORT_WIZARD_CONN_TO_NEW_INSTANCE,
   IMPORT_WIZARD_CONN_NAME_PREFIX,
-  WIZARD_CREATE_SUCCESS,
+  WIZARD_STARTED_IMPORT,
   PAGE_LOAD_TIMEOUT_SECS,
 } from '../utils/constants/common';
 import * as view from '../../views/importWizard.view';
@@ -63,7 +63,7 @@ export class VmwareImportWizard extends ImportWizard {
 
   async waitForCreation() {
     await browser.wait(
-      until.textToBePresentInElement(wizardView.creationSuccessResult, WIZARD_CREATE_SUCCESS),
+      until.textToBePresentInElement(wizardView.creationSuccessResult, WIZARD_STARTED_IMPORT),
       PAGE_LOAD_TIMEOUT_SECS,
     );
   }

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -26,11 +26,11 @@ import {
   SEC,
   // CHARACTERS_NOT_ALLOWED,
 } from '../utils/constants/common';
-import * as view from '../../views/wizard.view';
 import { NetworkInterfaceDialog } from '../dialogs/networkInterfaceDialog';
 import { DiskDialog } from '../dialogs/diskDialog';
 import { Flavor } from '../utils/constants/wizard';
-import { resourceHorizontalTab } from '../../views/uiResource.view';
+import * as view from '../../views/wizard.view';
+import { resourceHorizontalTab, dropDownItem, dropDownItemMain } from '../../views/uiResource.view';
 import { confirmActionButton } from '../../views/importWizard.view';
 import { virtualizationTitle } from '../../views/vms.list.view';
 import { VMBuilderData } from '../types/vm';
@@ -96,11 +96,11 @@ export class Wizard {
   }
 
   async selectOperatingSystem(operatingSystem: string) {
-    await selectItemFromDropdown(view.operatingSystemSelect, view.dropDownItem(operatingSystem));
+    await selectItemFromDropdown(view.operatingSystemSelect, dropDownItem(operatingSystem));
   }
 
   async selectFlavor(flavor: FlavorConfig) {
-    await selectItemFromDropdown(view.flavorSelect, view.dropDownItemMain(flavor.flavor));
+    await selectItemFromDropdown(view.flavorSelect, dropDownItemMain(flavor.flavor));
     if (flavor.flavor === Flavor.CUSTOM && (!flavor.memory || !flavor.cpu)) {
       throw Error('Custom Flavor requires memory and cpu values.');
     }
@@ -113,10 +113,7 @@ export class Wizard {
   }
 
   async selectWorkloadProfile(workloadProfile: string) {
-    await selectItemFromDropdown(
-      view.workloadProfileSelect,
-      view.dropDownItemMain(workloadProfile),
-    );
+    await selectItemFromDropdown(view.workloadProfileSelect, dropDownItemMain(workloadProfile));
   }
 
   async disableGoldenImageCloneCheckbox() {
@@ -136,7 +133,7 @@ export class Wizard {
   async selectProvisionSource(provisionSource: ProvisionSource) {
     await selectItemFromDropdown(
       view.provisionSourceSelect,
-      view.dropDownItemMain(provisionSource.getDescription()),
+      dropDownItemMain(provisionSource.getDescription()),
     );
     if (provisionSource.getSource()) {
       await fillInput(

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/common.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/common.ts
@@ -29,7 +29,7 @@ export const TEMPLATE_ACTIONS_TIMEOUT_SECS = 90 * SEC;
 export const VM_ACTIONS_TIMEOUT_SECS = 250 * SEC;
 export const VM_BOOTUP_TIMEOUT_SECS = 230 * SEC;
 export const VM_MIGRATION_TIMEOUT_SECS = 260 * SEC;
-export const VM_STOP_TIMEOUT_SECS = 60 * SEC;
+export const VM_STOP_TIMEOUT_SECS = 220 * SEC;
 export const VM_DELETE_TIMEOUT_SECS = 30 * SEC;
 export const VM_IP_ASSIGNMENT_TIMEOUT_SECS = 180 * SEC;
 export const VM_IMPORT_TIMEOUT_SECS = 160 * SEC;
@@ -63,9 +63,8 @@ export const RHV_PROVIDER = 'Red Hat Virtualization (RHV)';
 export const VMWARE_PROVIDER = 'VMware';
 
 // Web-UI Exceptions
-export const RHV_WIZARD_CREATE_SUCCESS = 'Started import of virtual machine';
-export const WIZARD_CREATE_SUCCESS = 'Started import of virtual machine';
-// export const WIZARD_CREATE_SUCCESS = 'Successfully created virtual machine';
+export const WIZARD_STARTED_IMPORT = 'Started import of virtual machine';
+export const WIZARD_CREATE_SUCCESS = 'Successfully created virtual machine';
 
 // Framework Exception
 export const UNEXPECTED_ACTION_ERROR = 'Received unexpected action.';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/enums/provisionSource.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/enums/provisionSource.ts
@@ -10,7 +10,7 @@ export class ProvisionSource extends ObjectEnum<string> {
   static readonly CONTAINER = new ProvisionSource(
     'Container',
     'Container',
-    'kubevirt/fedora-cloud-container-disk-demo',
+    'kubevirt/fedora-cloud-container-disk-demo:latest',
   );
 
   static readonly PXE = new ProvisionSource('PXE', 'PXE (network boot - adds network interface)');

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-login.sh
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/scripts/expect-login.sh
@@ -2,7 +2,7 @@
 # usage ./expect-login.sh <vm name> <vm namespace>
 set vm_name [lindex $argv 0]
 set vm_namespace [lindex $argv 1]
-set login_prompt "*login: "
+set login_prompt " login: "
 
 spawn virtctl console $vm_name -n $vm_namespace --timeout 7
 
@@ -12,6 +12,9 @@ send "\n"
 
 set timeout 300
 
-expect $login_prompt
+expect {
+    -re $login_prompt {}
+    timeout { puts "timeout!"; exit 1 }
+}
 
 send \003]

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/templates/windowsVMForRDPL2.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/templates/windowsVMForRDPL2.ts
@@ -95,7 +95,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: 'kubevirt/fedora-cloud-registry-disk-demo:latest'
+            image: 'kubevirt/fedora-cloud-container-disk-demo:latest'
           name: rootdisk
         - containerDisk:
             image: kubevirt/virtio-container-disk
@@ -106,9 +106,9 @@ spec:
               password: fedora
               chpasswd: { expire: False }
               runcmd:
-              - ifconfig eth1 ${vmIP} netmask 255.255.255.0 up
               - dnf install -y qemu-guest-agent
               - systemctl start qemu-guest-agent
+              - ifconfig eth1 ${vmIP} netmask 255.255.255.0 up
           name: cloudinitdisk
 status: {}
 `;

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
@@ -12,6 +12,7 @@ import {
   createYAMLLink,
   resourceTitle,
 } from '@console/internal-integration-tests/views/crud.view';
+import { clickNavLink } from '@console/internal-integration-tests/views/sidenav.view';
 import { click } from '@console/shared/src/test-utils/utils';
 import {
   isLoaded as yamlPageIsLoaded,
@@ -57,8 +58,9 @@ export async function createProject(name: string) {
 
 export async function createExampleVMViaYAML(getVMObj?: boolean) {
   let vm = null;
-  await browser.get(`${appHost}/k8s/ns/${testName}/virtualization`);
+  await clickNavLink(['Workloads', 'Virtualization']);
   await isLoaded();
+
   await click(createItemButton);
   await click(createYAMLLink);
   await yamlPageIsLoaded();
@@ -109,6 +111,17 @@ export async function getSelectOptions(selector: any): Promise<string[]> {
     }
   }
   return options;
+}
+
+export async function getListTexts(selector: any): Promise<string[]> {
+  const texts = [];
+  await selector.each((elem) => {
+    elem
+      .getText()
+      .then((text) => texts.push(text))
+      .catch((err) => Promise.reject(err));
+  });
+  return texts;
 }
 
 export function getRandStr(length: number) {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.base.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.base.scenario.ts
@@ -57,7 +57,7 @@ describe('Kubevirt VM details tab', () => {
       status: VM_STATUS.Off,
       description: testName,
       os: OperatingSystem.RHEL7,
-      profile: Workload.DESKTOP,
+      profile: Workload.DESKTOP.toLowerCase(),
       template: NOT_AVAILABLE,
       bootOrder: ['rootdisk (Disk)', 'nic-0 (NIC)', 'cloudinitdisk (Disk)'],
       flavorConfig: 'Tiny: 1 vCPU, 1 GiB Memory',

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
@@ -8,7 +8,7 @@ import * as virtualMachineView from '../views/virtualMachine.view';
 import { saveButton } from '../views/kubevirtUIResource.view';
 import { VM_CREATE_AND_EDIT_TIMEOUT_SECS } from './utils/constants/common';
 import * as editFlavorView from '../views/dialogs/editFlavorView';
-import { selectOptionByText, getSelectedOptionText } from './utils/utils';
+import { selectOptionByText } from './utils/utils';
 import { getCPU, getMemory } from '../../src/selectors/vm/selectors';
 import { VMBuilder } from './models/vmBuilder';
 import { getBasicVMBuilder } from './mocks/vmBuilderPresets';
@@ -31,7 +31,6 @@ describe('KubeVirt VM detail - edit flavor', () => {
       await withResource(leakedResources, vm.asResource(), async () => {
         await vm.navigateToDetail();
         await vm.modalEditFlavor();
-        expect(await getSelectedOptionText(editFlavorView.flavorDropdown)).toEqual('Tiny');
         await selectOptionByText(editFlavorView.flavorDropdown, 'Custom');
         await fillInput(editFlavorView.cpusInput(), '2');
         await fillInput(editFlavorView.memoryInput(), '3');

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.next.run.configuration.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.next.run.configuration.scenario.ts
@@ -8,7 +8,7 @@ import {
   multusNAD,
 } from './mocks/mocks';
 import { VirtualMachine } from './models/virtualMachine';
-import { getRandStr, getSelectedOptionText, selectOptionByText } from './utils/utils';
+import { getRandStr, selectOptionByText } from './utils/utils';
 import {
   fillInput,
   click,
@@ -59,10 +59,9 @@ describe('Kubevirt VM Next Run Configuration', () => {
     await vm.detailViewAction(VM_ACTION.Stop);
   }, VM_BOOTUP_TIMEOUT_SECS);
 
-  it('Change Flavor from tiny to custom while VM is running.', async () => {
+  it('ID(CNV-5326) Change Flavor from tiny to custom while VM is running.', async () => {
     await vm.navigateToDetail();
     await vm.modalEditFlavor();
-    expect(await getSelectedOptionText(editFlavorView.flavorDropdown)).toEqual(Flavor.TINY);
     expect(await isPCInfoAlertPresent()).toBeTruthy();
     await selectOptionByText(editFlavorView.flavorDropdown, Flavor.CUSTOM);
     expect(await isPCAlertPresent()).toBeTruthy();
@@ -80,10 +79,9 @@ describe('Kubevirt VM Next Run Configuration', () => {
     expect(alertTabAttrs.includes('Flavor')).toBeTruthy();
   });
 
-  it('Change Custom Flavor while VM is running.', async () => {
+  it('ID(CNV-5327) Change Custom Flavor while VM is running.', async () => {
     await vm.navigateToDetail();
     await vm.modalEditFlavor();
-    expect(await getSelectedOptionText(editFlavorView.flavorDropdown)).toEqual(Flavor.CUSTOM);
     expect(await isPCInfoAlertPresent()).toBeTruthy();
     await fillInput(editFlavorView.cpusInput(), '2');
     expect(await isPCAlertPresent()).toBeTruthy();
@@ -99,25 +97,7 @@ describe('Kubevirt VM Next Run Configuration', () => {
     expect(alertTabAttrs.includes('Flavor')).toBeTruthy();
   });
 
-  it('Change Boot-Order while VM is running.', async () => {
-    await vm.navigateToDetail();
-    await vm.modalEditBootOrder();
-    expect(await isPCInfoAlertPresent()).toBeTruthy();
-    await click(bootOrderView.deleteDeviceButton(1));
-    expect(await isPCAlertPresent()).toBeTruthy();
-    await click(saveButton);
-
-    await isLoaded();
-    expect(await isPCAlertPresent()).toBeTruthy();
-
-    const alertTabs = await alertHeadings();
-    const alertTabAttrs = await alertValues();
-
-    expect(alertTabs.includes('Details')).toBeTruthy();
-    expect(alertTabAttrs.includes('Boot Order')).toBeTruthy();
-  });
-
-  it('Add Environment variable while VM is running.', async () => {
+  it('ID(CNV-5329) Add Environment variable while VM is running.', async () => {
     await vm.navigateToEnvironment();
     await vmEnv.addSource(configmapName);
     await isLoaded();
@@ -135,7 +115,7 @@ describe('Kubevirt VM Next Run Configuration', () => {
     expect(!!alertTabAttrs.find((val: string) => val.match(`${configmapName}-[a-z0-9]*-disk`)));
   });
 
-  it('Add Disk while VM is Running', async () => {
+  it('ID(CNV-5330) Add Disk while VM is Running', async () => {
     await vm.addDisk(hddDisk);
     expect(await vm.hasDisk(hddDisk)).toBeTruthy();
 
@@ -153,7 +133,7 @@ describe('Kubevirt VM Next Run Configuration', () => {
     ).toBeTruthy();
   });
 
-  it('Add NIC while VM is Running', async () => {
+  it('ID(CNV-5332) Add NIC while VM is Running', async () => {
     await vm.addNIC(multusNetworkInterface);
     expect(await vm.hasNIC(multusNetworkInterface)).toBeTruthy();
 
@@ -172,5 +152,23 @@ describe('Kubevirt VM Next Run Configuration', () => {
           row.includes(`${multusNetworkInterface.name}`) && row.includes('(pending restart)'),
       ),
     ).toBeTruthy();
+  });
+
+  it('ID(CNV-5328) Change Boot-Order while VM is running.', async () => {
+    await vm.navigateToDetail();
+    await vm.modalEditBootOrder();
+    expect(await isPCInfoAlertPresent()).toBeTruthy();
+    await click(bootOrderView.deleteDeviceButton(1));
+    expect(await isPCAlertPresent()).toBeTruthy();
+    await click(saveButton);
+
+    await isLoaded();
+    expect(await isPCAlertPresent()).toBeTruthy();
+
+    const alertTabs = await alertHeadings();
+    const alertTabAttrs = await alertValues();
+
+    expect(alertTabs.includes('Details')).toBeTruthy();
+    expect(alertTabAttrs.includes('Boot Order')).toBeTruthy();
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.tab.yaml.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.tab.yaml.scenario.ts
@@ -1,4 +1,5 @@
 import { browser, ExpectedConditions as until } from 'protractor';
+import { testName } from '@console/internal-integration-tests/protractor.conf';
 import {
   isLoaded,
   createItemButton,
@@ -6,13 +7,13 @@ import {
   resourceTitle,
   errorMessage,
 } from '@console/internal-integration-tests/views/crud.view';
+import { clickNavLink } from '@console/internal-integration-tests/views/sidenav.view';
 import {
   isLoaded as yamlPageIsLoaded,
   saveButton,
   cancelButton,
   setEditorContent,
 } from '@console/internal-integration-tests/views/yaml.view';
-import { appHost, testName } from '@console/internal-integration-tests/protractor.conf';
 import {
   click,
   withResource,
@@ -44,7 +45,7 @@ describe('Test VM creation from YAML', () => {
   });
 
   beforeEach(async () => {
-    await browser.get(`${appHost}/k8s/ns/${testName}/virtualization`);
+    await clickNavLink(['Workloads', 'Virtualization']);
     await isLoaded();
     await click(createItemButton);
     await click(createYAMLLink);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
@@ -127,7 +127,7 @@ describe('Kubevirt create VM using wizard', () => {
           [`name.os.template.kubevirt.io/${osID}`]: OperatingSystem.WINDOWS_10,
         };
         const requiredLabels = {
-          [`workload.template.kubevirt.io/${vm.getData().workload}`]: 'true',
+          [`workload.template.kubevirt.io/${vm.getData().workload.toLowerCase()}`]: 'true',
           [`os.template.kubevirt.io/${osID}`]: 'true',
           'vm.kubevirt.io/template': `windows10-${vm
             .getData()
@@ -234,7 +234,7 @@ describe('Kubevirt create VM using wizard', () => {
     CLONE_VM_TIMEOUT_SECS,
   );
 
-  it('ICNV-5045 - dont let the user continue If PXE provision source is selected on a cluster without a NAD available', async () => {
+  it('ID(CNV-5045) - dont let the user continue If PXE provision source is selected on a cluster without a NAD available', async () => {
     deleteResources([multusNAD]);
 
     const vm = new VMBuilder(getBasicVMBuilder())
@@ -256,5 +256,6 @@ describe('Kubevirt create VM using wizard', () => {
       waitForStringInElement(view.footerError, 'Please correct the following field: Boot Source.'),
       1000,
     );
+    await wizard.closeWizard();
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.validation.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.validation.scenario.ts
@@ -74,10 +74,6 @@ describe('Wizard validation', () => {
     // Network tab
     await wizard.next();
     // Storage tab
-    // TODO: When BZ 1803132 is fixed, we should also verify that a warning is displayed
-    // Right away when user navigates to Storace section because Windows CTs use rootdisk
-    // with sata interface, which is not on the recommended list
-
     await clickKebabAction('rootdisk', KEBAP_ACTION.Edit); // Open dialog
     await diskDialog.selectInterface(WINDOWS_NOT_RECOMMENDED_INTERFACE);
     await browser.wait(

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.overview.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.overview.scenario.ts
@@ -61,7 +61,7 @@ describe('Test VMI Details', () => {
       status: VM_STATUS.Running,
       description: testName,
       os: OperatingSystem.RHEL7,
-      profile: Workload.DESKTOP,
+      profile: Workload.DESKTOP.toLowerCase(),
       bootOrderTexts: ['rootdisk (Disk)', 'nic-0 (NIC)', 'cloudinitdisk (Disk)'],
       flavorText: 'Tiny: 1 vCPU, 1 GiB Memory',
     };

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmtemplate.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmtemplate.wizard.scenario.ts
@@ -82,7 +82,7 @@ describe('Create VM from Template using wizard', () => {
         name: vmtData.name,
         description: vmtData.description,
         os: vmtData.os,
-        profile: vmtData.workload,
+        profile: vmtData.workload.toLowerCase(),
         bootOrder: ['rootdisk (Disk)'],
         flavor: `${vmtData.flavor.flavor}: 1 vCPU, 1 GiB Memory`,
       };

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/pvc.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/pvc.view.ts
@@ -13,3 +13,4 @@ export const pvcKebabButton = $('[data-test-id="kebab-button"]');
 export const pvcDeleteButton = element(by.buttonText('Delete Persistent Volume Claim'));
 export const errorUploading = $('.pf-c-empty-state__body');
 export const disabled = $('.pf-c-dropdown__menu-item.pf-m-disabled');
+export const warnMessage = $('.pf-c-alert.pf-m-inline.pf-m-warning');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/uiResource.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/uiResource.view.ts
@@ -1,4 +1,4 @@
-import { $, by } from 'protractor';
+import { $, $$, by, element } from 'protractor';
 import { K8sKind } from '@console/internal/module/k8s/types';
 import { click } from '@console/shared/src/test-utils/utils';
 
@@ -20,3 +20,9 @@ export const switchClusterNamespace = async (namespace: string): Promise<void> =
   await click(namespaceDropdownButton);
   await click(namespaceButton(namespace));
 };
+
+export const dropDownItem = (text) =>
+  element(by.cssContainingText('.pf-c-select__menu-item', text));
+export const dropDownItemMain = (text) =>
+  element(by.cssContainingText('.pf-c-select__menu-item-main', text));
+export const dropDownList = $$('.pf-c-select__menu-item-main');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/vm.disks.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/vm.disks.view.ts
@@ -1,7 +1,8 @@
-import { $ } from 'protractor';
+import { $, $$ } from 'protractor';
 
 export const fileSystemsTableHeader = $('#file-systems-header');
 export const fileSystemsTable = $(`[aria-label="FileSystems"]`)
   .$('div')
   .$('table')
   .$('tbody');
+export const diskRows = $$('[data-test-rows="resource-row"]');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/vm.environment.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/vm.environment.view.ts
@@ -9,7 +9,7 @@ export const successAlert = $('.pf-c-alert.pf-m-inline.pf-m-success.co-alert');
 export const errorAlert = $('.pf-c-alert.pf-m-inline.pf-m-danger.co-alert.co-alert--scrollable');
 
 export const dropDownBtn = $$('.value-from');
-export const textFilter = $('[placeholder="Config Map or Secret"]');
+export const textFilter = $('[placeholder="ConfigMap or Secret"]');
 export const option = $$('[role="option"]');
 export const deleteButton = $$('.pf-c-button.pf-m-plain.pairs-list__span-btns');
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
@@ -48,7 +48,7 @@ export const pxeBootSourceSelect = $('#pxe-bootsource');
 export const addDiskButton = $('#add-disk');
 export const storageBootSourceSelect = $('#storage-bootsource');
 export const diskWarning = (resourceName) =>
-  $(`[data-id="${resourceName}"]`).$('.kubevirt-validation-cell__cell--warning');
+  $(`[data-id="${resourceName}"]`).$('.kv-validation-cell__cell--warning');
 
 // Advanced -- Cloud-init
 export const cloudInitFormCheckbox = $('#cloud-init-edit-mode-first-option');
@@ -89,8 +89,5 @@ export const tableRowAttribute = async (name: string, columnIndex: number): Prom
     .get(columnIndex)
     .getText();
 };
-export const dropDownItem = (text) =>
-  element(by.cssContainingText('.pf-c-select__menu-item', text));
-export const dropDownItemMain = (text) =>
-  element(by.cssContainingText('.pf-c-select__menu-item-main', text));
+
 export const uploadLink = element(by.linkText('upload a new disk image'));


### PR DESCRIPTION
This will fix/improve below test failures:
1. fix migration tests as it require rootdisk's accessMode is RXW.
2. fix cloud-init test as the wizard procedure to custom script instead of form.
3. increase vm stop timeout to 220 which is larger than vm's termination grace period 210s.
4. add checking to look for VM login prompt when starts a VM.
5. change container image from 'fedora-cloud-registry-disk-demo' to 'fedora-cloud-container-disk-demo'
6. fix network dialog test failures due to new UI changes.
7. add test ID for guest data test.
8. move boot-order test to bottom in next-run-configuration test as it has side effects.
9. add a check for loading vm disk page.

TODO: add test ID for test `vm.next.run.configuration.scenario.ts`.