### PR TITLE
Bug 1895372: Tolerate missing `status` on OperatorGroups

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -138,7 +138,7 @@ export const subscriptionFor = (allSubscriptions: SubscriptionKind[] = []) => (
       allGroups.some(
         (og) =>
           og.metadata.namespace === sub.metadata.namespace &&
-          (isGlobal(og) || _.get(og.status, 'namespaces', [] as string[]).includes(ns)),
+          (isGlobal(og) || og.status?.namespaces?.includes(ns)),
       ),
     );
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -223,7 +223,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   };
   const conflictingProvidedAPIs = (ns: string) => {
     const operatorGroups = props.operatorGroup.data.filter(
-      (og) => og.status.namespaces.includes(ns) || isGlobal(og),
+      (og) => og.status?.namespaces?.includes(ns) || isGlobal(og),
     );
     if (_.isEmpty(operatorGroups)) {
       return [];


### PR DESCRIPTION
Use optional chaining to avoid runtime errors during OperatorHub subscribe when an OperatorGroup doesn't have a `status` stanza.

/assign @rhamilto 