### PR TITLE
Bug 1896229: Hide empty cards

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -356,7 +356,12 @@ const Card: React.FC<CardProps> = ({ panel }) => {
     );
   }
 
+  if (!['grafana-piechart-panel', 'graph', 'singlestat', 'table'].includes(panel.type)) {
+    return null;
+  }
+
   const panelClassModifier = getPanelClassModifier(panel);
+
   return (
     <div
       className={`monitoring-dashboards__panel monitoring-dashboards__panel--${panelClassModifier}`}


### PR DESCRIPTION
We currently don't have code to handle gauge panels. (Both of the Current Rate of Bytes Received and Current Rate of Bytes Transmitted cards call for them.) Sam suggested hiding these cards for now and creating a story to support gauge panels. (See https://issues.redhat.com/browse/CONSOLE-2473 for the story.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1896229.