### PR TITLE
[release-4.6.z] Bug 1896625: update apiVersion for eventing resources wrt serverless 1.10

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
@@ -34,7 +34,7 @@ const ApiServerSection: React.FC<ApiServerSectionProps> = ({ title }) => {
     [setFieldValue],
   );
   const modeItems = {
-    Ref: 'Ref',
+    Reference: 'Reference',
     Resource: 'Resource',
   };
   const fieldId = getFieldId(values.type, 'res-input');
@@ -65,7 +65,7 @@ const ApiServerSection: React.FC<ApiServerSectionProps> = ({ title }) => {
         name="data.apiserversource.mode"
         label="Mode"
         items={modeItems}
-        title={modeItems.Ref}
+        title={modeItems.Reference}
         helpText="The mode the receive adapter controller runs under"
         fullWidth
       />

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -127,8 +127,8 @@ export const EventSourcePingModel: K8sKind = {
 };
 
 export const EventSourceContainerModel: K8sKind = {
-  apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP_DEP,
-  apiVersion: 'v1alpha1',
+  apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
+  apiVersion: 'v1alpha2',
   kind: 'ContainerSource',
   label: 'Container Source',
   labelPlural: 'Container Sources',
@@ -142,7 +142,7 @@ export const EventSourceContainerModel: K8sKind = {
 
 export const EventSourceApiServerModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   kind: 'ApiServerSource',
   label: 'ApiServerSource',
   labelPlural: 'ApiServerSources',
@@ -198,7 +198,7 @@ export const EventSourceSinkBindingModel: K8sKind = {
 
 export const EventingSubscriptionModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_MESSAGE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'Subscription',
   label: 'Subscription',
   labelPlural: 'Subscriptions',
@@ -212,7 +212,7 @@ export const EventingSubscriptionModel: K8sKind = {
 
 export const EventingIMCModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_MESSAGE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'InMemoryChannel',
   label: 'InMemoryChannel',
   labelPlural: 'inmemorychannels',
@@ -226,7 +226,7 @@ export const EventingIMCModel: K8sKind = {
 
 export const EventingChannelModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_MESSAGE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'Channel',
   label: 'Channel',
   labelPlural: 'channels',
@@ -254,7 +254,7 @@ export const EventingKafkaChannelModel: K8sKind = {
 
 export const EventingBrokerModel: K8sKind = {
   apiGroup: KNATIVE_EVENTING_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'Broker',
   label: 'Broker',
   labelPlural: 'Brokers',
@@ -268,7 +268,7 @@ export const EventingBrokerModel: K8sKind = {
 
 export const EventingTriggerModel: K8sKind = {
   apiGroup: KNATIVE_EVENTING_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'Trigger',
   label: 'Trigger',
   labelPlural: 'Triggers',
@@ -282,7 +282,7 @@ export const EventingTriggerModel: K8sKind = {
 
 export const CamelIntegrationModel: K8sKind = {
   apiGroup: 'camel.apache.org',
-  apiVersion: 'v1',
+  apiVersion,
   kind: 'Integration',
   label: 'Integration',
   labelPlural: 'Integrations',

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -175,9 +175,7 @@ const isSubscriber = (
   const channelRef = relatedResource?.spec?.channel;
   if (
     channelRef &&
-    (mainResource.metadata.name !== channelRef.name ||
-      mainResource.kind !== channelRef.kind ||
-      mainResource.apiVersion !== channelRef.apiVersion)
+    (mainResource.metadata.name !== channelRef.name || mainResource.kind !== channelRef.kind)
   ) {
     return false;
   }
@@ -193,12 +191,8 @@ const isPublisher = (
   relationshipResource: K8sResourceKind,
   mainResource: K8sResourceKind,
 ): boolean => {
-  const { name, kind, apiVersion } = relationshipResource.spec?.subscriber?.ref || {};
-  if (
-    mainResource.metadata.name !== name ||
-    mainResource.kind !== kind ||
-    mainResource.apiVersion !== apiVersion
-  ) {
+  const { name, kind } = relationshipResource.spec?.subscriber?.ref || {};
+  if (mainResource.metadata.name !== name || mainResource.kind !== kind) {
     return false;
   }
   if (relationshipResource.kind === EventingTriggerModel.kind) {

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-channels-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-channels-crd-mock.ts
@@ -3,7 +3,7 @@ export const mockChannelCRDData = {
   apiVersion: 'apiextensions.k8s.io/v1',
   metadata: {
     selfLink: '/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-    resourceVersion: '157889',
+    resourceVersion: '300390',
   },
   items: [
     {
@@ -11,7 +11,7 @@ export const mockChannelCRDData = {
         name: 'channels.messaging.knative.dev',
         labels: {
           'duck.knative.dev/addressable': 'true',
-          'eventing.knative.dev/release': 'v0.14.2',
+          'eventing.knative.dev/release': 'v0.16.1',
           'knative.dev/crd-install': 'true',
           'messaging.knative.dev/subscribable': 'true',
         },
@@ -27,8 +27,9 @@ export const mockChannelCRDData = {
           categories: ['all', 'knative', 'messaging', 'channel'],
         },
         versions: [
-          { name: 'v1alpha1', served: true, storage: true },
-          { name: 'v1beta1', served: true, storage: false },
+          { name: 'v1alpha1', served: false, storage: false },
+          { name: 'v1beta1', served: true, storage: true },
+          { name: 'v1', served: true, storage: false },
         ],
       },
     },
@@ -37,7 +38,7 @@ export const mockChannelCRDData = {
         name: 'inmemorychannels.messaging.knative.dev',
         labels: {
           'duck.knative.dev/addressable': 'true',
-          'eventing.knative.dev/release': 'v0.14.2',
+          'eventing.knative.dev/release': 'v0.16.1',
           'knative.dev/crd-install': 'true',
           'messaging.knative.dev/subscribable': 'true',
         },
@@ -50,6 +51,33 @@ export const mockChannelCRDData = {
           shortNames: ['imc'],
           kind: 'InMemoryChannel',
           listKind: 'InMemoryChannelList',
+          categories: ['all', 'knative', 'messaging', 'channel'],
+        },
+        versions: [
+          { name: 'v1alpha1', served: false, storage: false },
+          { name: 'v1beta1', served: true, storage: true },
+          { name: 'v1', served: true, storage: false },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'kafkachannels.messaging.knative.dev',
+        labels: {
+          'contrib.eventing.knative.dev/release': 'devel',
+          'duck.knative.dev/addressable': 'true',
+          'knative.dev/crd-install': 'true',
+          'messaging.knative.dev/subscribable': 'true',
+        },
+      },
+      spec: {
+        group: 'messaging.knative.dev',
+        names: {
+          plural: 'kafkachannels',
+          singular: 'kafkachannel',
+          shortNames: ['kc'],
+          kind: 'KafkaChannel',
+          listKind: 'KafkaChannelList',
           categories: ['all', 'knative', 'messaging', 'channel'],
         },
         versions: [

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
@@ -3,34 +3,18 @@ export const mockEventSourcCRDData = {
   apiVersion: 'apiextensions.k8s.io/v1',
   metadata: {
     selfLink: '/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-    resourceVersion: '318530',
+    resourceVersion: '300390',
   },
   items: [
     {
       metadata: {
-        name: 'apiserversources.sources.eventing.knative.dev',
-      },
-      spec: {
-        group: 'sources.eventing.knative.dev',
-        names: {
-          plural: 'apiserversources',
-          singular: 'apiserversource',
-          kind: 'ApiServerSource',
-          listKind: 'ApiServerSourceList',
-          categories: ['all', 'knative', 'eventing', 'sources'],
-        },
-        versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
-        ],
-      },
-    },
-    {
-      metadata: {
         name: 'apiserversources.sources.knative.dev',
+        labels: {
+          'duck.knative.dev/source': 'true',
+          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/source': 'true',
+          'knative.dev/crd-install': 'true',
+        },
       },
       spec: {
         group: 'sources.knative.dev',
@@ -42,17 +26,21 @@ export const mockEventSourcCRDData = {
           categories: ['all', 'knative', 'eventing', 'sources'],
         },
         versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
+          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1alpha2', served: true, storage: false },
         ],
       },
     },
     {
       metadata: {
         name: 'camelsources.sources.knative.dev',
+        labels: {
+          'contrib.eventing.knative.dev/release': 'v0.15.1',
+          'duck.knative.dev/source': 'true',
+          'eventing.knative.dev/source': 'true',
+          'knative.dev/crd-install': 'true',
+          'operators.coreos.com/knative-camel-operator.openshift-operators': '',
+        },
       },
       spec: {
         group: 'sources.knative.dev',
@@ -63,21 +51,21 @@ export const mockEventSourcCRDData = {
           listKind: 'CamelSourceList',
           categories: ['all', 'knative', 'eventing', 'sources'],
         },
-        versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
-        ],
+        versions: [{ name: 'v1alpha1', served: true, storage: true }],
       },
     },
     {
       metadata: {
-        name: 'containersources.sources.eventing.knative.dev',
+        name: 'containersources.sources.knative.dev',
+        labels: {
+          'duck.knative.dev/source': 'true',
+          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/source': 'true',
+          'knative.dev/crd-install': 'true',
+        },
       },
       spec: {
-        group: 'sources.eventing.knative.dev',
+        group: 'sources.knative.dev',
         names: {
           plural: 'containersources',
           singular: 'containersource',
@@ -85,62 +73,43 @@ export const mockEventSourcCRDData = {
           listKind: 'ContainerSourceList',
           categories: ['all', 'knative', 'eventing', 'sources'],
         },
-        versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
-        ],
+        versions: [{ name: 'v1alpha2', served: true, storage: true }],
       },
     },
     {
       metadata: {
-        name: 'cronjobsources.sources.eventing.knative.dev',
-      },
-      spec: {
-        group: 'sources.eventing.knative.dev',
-        names: {
-          plural: 'cronjobsources',
-          singular: 'cronjobsource',
-          kind: 'CronJobSource',
-          listKind: 'CronJobSourceList',
-          categories: ['all', 'knative', 'eventing', 'sources'],
+        name: 'kafkasources.sources.knative.dev',
+        labels: {
+          'contrib.eventing.knative.dev/release': 'devel',
+          'duck.knative.dev/source': 'true',
+          'eventing.knative.dev/source': 'true',
+          'knative.dev/crd-install': 'true',
         },
-        versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
-        ],
-      },
-    },
-    {
-      metadata: {
-        name: 'githubsources.sources.knative.dev',
       },
       spec: {
         group: 'sources.knative.dev',
         names: {
-          plural: 'githubsources',
-          singular: 'githubsource',
-          kind: 'GitHubSource',
-          listKind: 'GitHubSourceList',
+          plural: 'kafkasources',
+          singular: 'kafkasource',
+          kind: 'KafkaSource',
+          listKind: 'KafkaSourceList',
           categories: ['all', 'knative', 'eventing', 'sources'],
         },
         versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
+          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1beta1', served: true, storage: false },
         ],
       },
     },
     {
       metadata: {
         name: 'pingsources.sources.knative.dev',
+        labels: {
+          'duck.knative.dev/source': 'true',
+          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/source': 'true',
+          'knative.dev/crd-install': 'true',
+        },
       },
       spec: {
         group: 'sources.knative.dev',
@@ -152,44 +121,21 @@ export const mockEventSourcCRDData = {
           categories: ['all', 'knative', 'eventing', 'sources'],
         },
         versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
-          {
-            name: 'v1alpha2',
-            served: true,
-            storage: false,
-          },
-        ],
-      },
-    },
-    {
-      metadata: {
-        name: 'sinkbindings.sources.eventing.knative.dev',
-      },
-      spec: {
-        group: 'sources.eventing.knative.dev',
-        names: {
-          plural: 'sinkbindings',
-          singular: 'sinkbinding',
-          kind: 'SinkBinding',
-          listKind: 'SinkBindingList',
-          categories: ['all', 'knative', 'eventing', 'sources', 'bindings'],
-        },
-        versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
+          { name: 'v1alpha1', served: false, storage: false },
+          { name: 'v1alpha2', served: true, storage: true },
         ],
       },
     },
     {
       metadata: {
         name: 'sinkbindings.sources.knative.dev',
+        labels: {
+          'duck.knative.dev/binding': 'true',
+          'duck.knative.dev/source': 'true',
+          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/source': 'true',
+          'knative.dev/crd-install': 'true',
+        },
       },
       spec: {
         group: 'sources.knative.dev',
@@ -201,16 +147,8 @@ export const mockEventSourcCRDData = {
           categories: ['all', 'knative', 'eventing', 'sources', 'bindings'],
         },
         versions: [
-          {
-            name: 'v1alpha1',
-            served: true,
-            storage: true,
-          },
-          {
-            name: 'v1alpha2',
-            served: true,
-            storage: false,
-          },
+          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1alpha2', served: true, storage: false },
         ],
       },
     },

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -149,7 +149,7 @@ export const getEventSourceData = (source: string) => {
       },
     },
     apiserversource: {
-      mode: 'Ref',
+      mode: 'Reference',
       serviceAccountName: '',
       resources: [
         {


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/console/pull/7134