### PR TITLE
Bug 1896732: disable os upload if no os avaliable

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -112,6 +112,9 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
   ...props
 }) => {
   const operatingSystems = getTemplateOperatingSystems(commonTemplates);
+  const operatingSystemHaveDV = operatingSystems.find(
+    (os) => os?.dataVolumeName && os?.dataVolumeNamespace,
+  );
   const [accessModeHelp, setAccessModeHelp] = React.useState('Permissions to the mounted drive.');
   const [allowedAccessModes, setAllowedAccessModes] = React.useState(initialAccessModes);
   const [storageClass, setStorageClass] = React.useState('');
@@ -280,14 +283,16 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
             onDropAccepted: () => setIsFileRejected(false),
           }}
         />
-        <Checkbox
-          id="golden-os-switch"
-          className="kv--create-upload__golden-switch"
-          label="Attach this data to a Virtual Machine operating system"
-          isChecked={isGolden}
-          onChange={handleGoldenCheckbox}
-          isDisabled={isLoading}
-        />
+        {operatingSystemHaveDV && (
+          <Checkbox
+            id="golden-os-switch"
+            className="kv--create-upload__golden-switch"
+            label="Attach this data to a Virtual Machine operating system"
+            isChecked={isGolden}
+            onChange={handleGoldenCheckbox}
+            isDisabled={isLoading}
+          />
+        )}
       </div>
       {isGolden && (
         <>


### PR DESCRIPTION
OCP 4.6 with CNV 2.4 - golden images is not supported in CNV templates but th option to attach a PVC to a template is available in the UI.

This PR removes the checkbox if golden images is not supported in the templates.

Screenshot:
before:
![screenshot-localhost_9000-2020 11 11-17_47_37](https://user-images.githubusercontent.com/2181522/98832860-067b8100-2446-11eb-8a93-7ddb83ce4594.png)


after:
![screenshot-localhost_9000-2020 11 11-17_46_27](https://user-images.githubusercontent.com/2181522/98832799-ef3c9380-2445-11eb-898e-93bb36f385f2.png)
