### PR TITLE
Bug 1895263: Allow creating storage cluster irrespective of LSO namespace

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests/tests/1-install/installFlow.scenario.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests/tests/1-install/installFlow.scenario.ts
@@ -4,10 +4,7 @@ import * as _ from 'lodash';
 import { Base64 } from 'js-base64';
 import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import { click } from '@console/shared/src/test-utils/utils';
-import {
-  LOCAL_STORAGE_NAMESPACE,
-  DISCOVERY_CR_NAME,
-} from '@console/local-storage-operator-plugin/src/constants';
+import { DISCOVERY_CR_NAME } from '@console/local-storage-operator-plugin/src/constants';
 import {
   MINUTE,
   OCS_NODE_LABEL,
@@ -219,9 +216,7 @@ if (TEST_PLATFORM === Platform.OCS && MODE === Mode.ATTACHED_DEVICES) {
 
         // verify dicovery CR got created
         const discoveryCR = JSON.parse(
-          execSync(
-            `kubectl get LocalVolumeDiscovery ${DISCOVERY_CR_NAME} -n ${LOCAL_STORAGE_NAMESPACE} -o json`,
-          ).toString(),
+          execSync(`kubectl get LocalVolumeDiscovery ${DISCOVERY_CR_NAME} -A -o json`).toString(),
         );
         const numOfNodes =
           discoveryCR?.spec?.nodeSelector?.nodeSelectorTerms?.[0]?.matchExpressions?.[0]?.values

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -27,7 +27,6 @@ import { fetchK8s } from '@console/internal/graphql/client';
 import { LocalVolumeDiscovery } from '@console/local-storage-operator-plugin/src/models';
 import { getDiscoveryRequestData } from '@console/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data';
 import {
-  LOCAL_STORAGE_NAMESPACE,
   DISCOVERY_CR_NAME,
   HOSTNAME_LABEL_KEY,
   LABEL_OPERATOR,
@@ -74,6 +73,7 @@ const makeAutoDiscoveryCall = (
   onNext: OnNextClick,
   state: State,
   dispatch: React.Dispatch<Action>,
+  ns: string,
 ) => {
   dispatch({ type: 'setIsLoading', value: true });
   const selectedNodes = getNodes(
@@ -82,7 +82,7 @@ const makeAutoDiscoveryCall = (
     state.nodeNamesForLVS,
   );
 
-  fetchK8s(LocalVolumeDiscovery, DISCOVERY_CR_NAME, LOCAL_STORAGE_NAMESPACE)
+  fetchK8s(LocalVolumeDiscovery, DISCOVERY_CR_NAME, ns)
     .then((discoveryRes: K8sResourceKind) => {
       const nodeSelectorTerms = discoveryRes?.spec?.nodeSelector?.nodeSelectorTerms;
       const [selectorIndex, expIndex] = nodeSelectorTerms
@@ -112,7 +112,7 @@ const makeAutoDiscoveryCall = (
       if (err.message === AUTO_DISCOVER_ERR_MSG) {
         throw err;
       }
-      const requestData = getDiscoveryRequestData(state);
+      const requestData = getDiscoveryRequestData({ ...state, ns });
       return k8sCreate(LocalVolumeDiscovery, requestData);
     })
     .then(() => {
@@ -126,7 +126,7 @@ const makeAutoDiscoveryCall = (
     });
 };
 
-const CreateSC: React.FC<CreateSCProps> = ({ match, hasNoProvSC, mode }) => {
+const CreateSC: React.FC<CreateSCProps> = ({ match, hasNoProvSC, mode, lsoNs }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const [discoveriesData, discoveriesLoaded, discoveriesLoadError] = useK8sWatchResource<
     K8sResourceKind[]
@@ -192,7 +192,7 @@ const CreateSC: React.FC<CreateSCProps> = ({ match, hasNoProvSC, mode }) => {
     {
       id: CreateStepsSC.STORAGECLASS,
       name: 'Create Storage Class',
-      component: <CreateLocalVolumeSet dispatch={dispatch} state={state} />,
+      component: <CreateLocalVolumeSet dispatch={dispatch} state={state} ns={lsoNs} />,
     },
     {
       id: CreateStepsSC.STORAGEANDNODES,
@@ -269,7 +269,7 @@ const CreateSC: React.FC<CreateSCProps> = ({ match, hasNoProvSC, mode }) => {
     // TODO: Need to think of a way to remove this
     dispatch({ type: 'setOnNextClick', value: onNext });
     if (activeStep.id === CreateStepsSC.DISCOVER) {
-      makeAutoDiscoveryCall(onNext, state, dispatch);
+      makeAutoDiscoveryCall(onNext, state, dispatch, lsoNs);
     } else if (activeStep.id === CreateStepsSC.STORAGECLASS) {
       dispatch({ type: 'setShowConfirmModal', value: true });
     } else if (activeStep.id === CreateStepsSC.REVIEWANDCREATE) {
@@ -343,6 +343,7 @@ type CreateSCProps = {
   hasNoProvSC: boolean;
   setHasNoProvSC: React.Dispatch<React.SetStateAction<boolean>>;
   mode: string;
+  lsoNs: string;
 };
 
 export default CreateSC;

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
@@ -22,11 +22,12 @@ import { RequestErrors } from '../../../install-wizard/review-and-create';
 const makeLocalVolumeSetCall = (
   state: State,
   dispatch: React.Dispatch<Action>,
-  setInProgress,
-  setErrorMessage,
+  setInProgress: React.Dispatch<React.SetStateAction<boolean>>,
+  setErrorMessage: React.Dispatch<React.SetStateAction<string>>,
+  ns: string,
 ) => {
   setInProgress(true);
-  const requestData = getLocalVolumeSetRequestData(state);
+  const requestData = getLocalVolumeSetRequestData(state, ns);
   k8sCreate(LocalVolumeSetModel, requestData)
     .then(() => {
       state.onNextClick();
@@ -39,7 +40,11 @@ const makeLocalVolumeSetCall = (
     });
 };
 
-export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({ state, dispatch }) => {
+export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({
+  state,
+  dispatch,
+  ns,
+}) => {
   const [inProgress, setInProgress] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
   return (
@@ -58,6 +63,7 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({ stat
         <DiscoveryDonutChart state={state} dispatch={dispatch} />
       </div>
       <ConfirmationModal
+        ns={ns}
         state={state}
         dispatch={dispatch}
         setInProgress={setInProgress}
@@ -83,12 +89,13 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({ stat
 type CreateLocalVolumeSetProps = {
   state: State;
   dispatch: React.Dispatch<Action>;
+  ns: string;
 };
 
-const ConfirmationModal = ({ state, dispatch, setInProgress, setErrorMessage }) => {
+const ConfirmationModal = ({ state, dispatch, setInProgress, setErrorMessage, ns }) => {
   const makeLVSCall = () => {
     dispatch({ type: 'setShowConfirmModal', value: false });
-    makeLocalVolumeSetCall(state, dispatch, setInProgress, setErrorMessage);
+    makeLocalVolumeSetCall(state, dispatch, setInProgress, setErrorMessage, ns);
   };
 
   const cancel = () => {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/install.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { match as RouterMatch } from 'react-router';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
@@ -9,11 +10,16 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { StorageClassModel } from '@console/internal/models';
 import { fetchK8s } from '@console/internal/graphql/client';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
-import { LOCAL_STORAGE_NAMESPACE } from '@console/local-storage-operator-plugin/src/constants';
 import { LSOSubscriptionResource } from '../../../constants/resources';
 import { filterSCWithNoProv } from '../../../utils/install';
 import CreateSC from './create-sc/create-sc';
 import './attached-devices.scss';
+
+const goToLSOInstallationPage = () => {
+  history.push(
+    '/operatorhub/all-namespaces?details-item=local-storage-operator-redhat-operators-openshift-marketplace',
+  );
+};
 
 export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesClusterProps> = ({
   match,
@@ -21,28 +27,34 @@ export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesCluster
 }) => {
   const { appName, ns } = match.params;
   const [hasNoProvSC, setHasNoProvSC] = React.useState(false);
-  const [LSOEnabled, setLSOEnabled] = React.useState(false);
-  const [LSODataLoaded, setLSODataLoaded] = React.useState(false);
-  const [LSOData, LSOLoaded, LSOLoadError] = useK8sWatchResource<K8sResourceKind>(
-    LSOSubscriptionResource,
-  );
+  const [isLsoPresent, setIsLsoPresent] = React.useState(false);
+  const [allDataLoaded, setAllDataLoaded] = React.useState(false);
+  const [lsoNs, setLsoNs] = React.useState('');
+  const [subscription, subscriptionLoaded, subscriptionLoadError] = useK8sWatchResource<
+    K8sResourceKind[]
+  >(LSOSubscriptionResource);
 
   React.useEffect(() => {
-    if (LSOLoadError || (!LSOData && LSOLoaded)) {
-      setLSOEnabled(false);
-    } else if (LSOLoaded) {
-      // checking for availability of LSO CSV
-      fetchK8s(ClusterServiceVersionModel, LSOData?.status?.currentCSV, LOCAL_STORAGE_NAMESPACE)
+    if (subscriptionLoadError || (!subscription.length && subscriptionLoaded)) {
+      setIsLsoPresent(false);
+      setAllDataLoaded(true);
+    } else if (subscriptionLoaded && !_.isEmpty(subscription[0])) {
+      fetchK8s(
+        ClusterServiceVersionModel,
+        subscription[0]?.status?.installedCSV,
+        subscription[0]?.metadata?.namespace,
+      )
         .then(() => {
-          setLSOEnabled(true);
-          setLSODataLoaded(true);
+          setIsLsoPresent(true);
+          setLsoNs(subscription[0]?.metadata?.namespace);
+          setAllDataLoaded(true);
         })
         .catch(() => {
-          setLSOEnabled(false);
-          setLSODataLoaded(true);
+          setIsLsoPresent(false);
+          setAllDataLoaded(true);
         });
     }
-  }, [LSOData, LSOLoaded, LSOLoadError]);
+  }, [subscription, subscriptionLoaded, subscriptionLoadError]);
 
   React.useEffect(() => {
     /* this call can't be watched here as watching will take the user back to this view 
@@ -57,24 +69,17 @@ export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesCluster
       .catch(() => setHasNoProvSC(false));
   }, [appName, ns]);
 
-  const goToLSOInstallationPage = () => {
-    history.push(
-      '/operatorhub/all-namespaces?details-item=local-storage-operator-redhat-operators-openshift-marketplace',
-    );
-  };
-
-  return !LSODataLoaded && !LSOLoadError ? (
+  return !allDataLoaded && !subscriptionLoadError ? (
     <LoadingBox />
-  ) : LSOLoadError || (!LSOEnabled && LSODataLoaded) ? (
+  ) : subscriptionLoadError || !isLsoPresent ? (
     <Alert
       className="co-alert ceph-ocs-install__lso-install-alert"
       variant="info"
       title="Local Storage Operator Not Installed"
       isInline
     >
-      Before we can create a storage cluster, the local storage operator needs to be installed in
-      the <strong>{LOCAL_STORAGE_NAMESPACE}</strong>. When installation is finished come back to
-      OpenShift Container Storage to create a storage cluster.
+      Before we can create a storage cluster, the local storage operator needs to be installed. When
+      installation is finished come back to OpenShift Container Storage to create a storage cluster.
       <div className="ceph-ocs-install__lso-alert__button">
         <Button type="button" variant="primary" onClick={goToLSOInstallationPage}>
           Install
@@ -82,7 +87,13 @@ export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesCluster
       </div>
     </Alert>
   ) : (
-    <CreateSC hasNoProvSC={hasNoProvSC} setHasNoProvSC={setHasNoProvSC} match={match} mode={mode} />
+    <CreateSC
+      hasNoProvSC={hasNoProvSC}
+      setHasNoProvSC={setHasNoProvSC}
+      match={match}
+      lsoNs={lsoNs}
+      mode={mode}
+    />
   );
 };
 

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -5,7 +5,6 @@ import { PersistentVolumeModel, StorageClassModel, NodeModel } from '@console/in
 import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { SubscriptionModel } from '@console/operator-lifecycle-manager';
 import { LocalVolumeDiscoveryResult } from '@console/local-storage-operator-plugin/src/models';
-import { LOCAL_STORAGE_NAMESPACE } from '@console/local-storage-operator-plugin/src/constants';
 import { CephClusterModel, CephBlockPoolModel } from '../models';
 import { CEPH_STORAGE_NAMESPACE } from '.';
 import { CAPACITY_USAGE_QUERIES, StorageDashboardQuery } from './queries';
@@ -31,9 +30,8 @@ export const scResource: WatchK8sResource = {
 
 export const LSOSubscriptionResource: WatchK8sResource = {
   kind: referenceForModel(SubscriptionModel),
-  namespace: LOCAL_STORAGE_NAMESPACE,
-  isList: false,
-  name: 'local-storage-operator',
+  fieldSelector: 'metadata.name=local-storage-operator',
+  isList: true,
 };
 
 export const cephBlockPoolResource: WatchK8sResource = {

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
@@ -15,7 +15,7 @@ export const getDiscoveryRequestData = ({
   allNodeNamesOnADV: string[];
   showNodesListOnADV: boolean;
   hostNamesMapForADV: HostNamesMap;
-  ns?: string;
+  ns: string;
 }): AutoDetectVolumeKind => {
   const nodes = getNodes(showNodesListOnADV, allNodeNamesOnADV, nodeNamesForLVS);
   return {

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -5,7 +5,7 @@ import { State } from './state';
 import { HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
 
-export const getLocalVolumeSetRequestData = (state: State, ns?: string): LocalVolumeSetKind => {
+export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVolumeSetKind => {
   const nodes = getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames);
   const requestData = {
     apiVersion: apiVersionForModel(LocalVolumeSetModel),


### PR DESCRIPTION
- removes the hard-coded value of `openshift-local-storage` for fetching the LSO subscription
- if a single instance of LSO is not found, shows a dropdown to select one

