### PR TITLE
Add Japanese to language switcher

### DIFF
--- a/frontend/public/i18next-parser.config.js
+++ b/frontend/public/i18next-parser.config.js
@@ -1,5 +1,6 @@
 const SUPPORTED_LOCALES = {
   en: 'English',
+  ja: '日本語',
 };
 
 const FALLBACK_LOCALE = 'en';


### PR DESCRIPTION
We now have some translations for Japanese. Add the option to the language switcher.

/assign @rhamilto @rebeccaalpert 