### PR TITLE
Get customized catalog categories in dev catalog from server flags

### DIFF
--- a/frontend/@types/console/declarations.d.ts
+++ b/frontend/@types/console/declarations.d.ts
@@ -40,6 +40,7 @@ declare interface Window {
     GOARCH: string;
     GOOS: string;
     graphqlBaseURL: string;
+    developerCatalogCategories: string;
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogCategories.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogCategories.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import * as cx from 'classnames';
 import { VerticalTabs, VerticalTabsTab } from '@patternfly/react-catalog-view-extension';
-import { CatalogCategories } from '../utils/types';
+import { CatalogCategory } from '../utils/types';
 import { hasActiveDescendant, isActiveTab } from '../utils/category-utils';
 
 type CatalogCategoriesProp = {
-  categories: CatalogCategories;
+  categories: CatalogCategory[];
   categorizedIds: Record<string, string[]>;
   selectedCategory: string;
   onSelectCategory: (category: string) => void;
@@ -20,12 +20,15 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
 }) => {
   const activeTab = _.has(categories, selectedCategory);
 
-  const renderTabs = (category, selectedCategoryId) => {
+  const renderTabs = (
+    category: CatalogCategory & { numItems?: number },
+    selectedCategoryID: string,
+    toplevelCategory: boolean,
+  ) => {
     if (!categorizedIds[category.id]) return null;
 
     const { id, label, subcategories, numItems } = category;
     const active = id === selectedCategory;
-    const shown = _.has(categories, id);
 
     const tabClasses = cx('text-capitalize', { 'co-catalog-tab__empty': !numItems });
 
@@ -37,11 +40,13 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
         className={tabClasses}
         onActivate={() => onSelectCategory(id)}
         hasActiveDescendant={hasActiveDescendant(selectedCategory, category)}
-        shown={shown}
+        shown={toplevelCategory}
       >
         {subcategories && (
-          <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryId, category)}>
-            {_.map(subcategories, (subcategory) => renderTabs(subcategory, selectedCategoryId))}
+          <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryID, category)}>
+            {_.map(subcategories, (subcategory) =>
+              renderTabs(subcategory, selectedCategoryID, false),
+            )}
           </VerticalTabs>
         )}
       </VerticalTabsTab>
@@ -50,7 +55,7 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
 
   return (
     <VerticalTabs restrictTabs activeTab={activeTab}>
-      {_.map(categories, (category) => renderTabs(category, selectedCategory))}
+      {_.map(categories, (category) => renderTabs(category, selectedCategory, true))}
     </VerticalTabs>
   );
 };

--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogToolbar.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogToolbar.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { SearchInput } from '@patternfly/react-core';
 import { Dropdown } from '@console/internal/components/utils';
 import { CatalogSortOrder, CatalogStringMap } from '../utils/types';
-import { NO_GROUPING } from '../utils/catalog-utils';
+import { NO_GROUPING } from '../utils/category-utils';
 
 type CatalogToolbarProps = {
   title: string;

--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogView.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogView.tsx
@@ -6,15 +6,14 @@ import { CatalogItem } from '@console/plugin-sdk';
 import { isModalOpen } from '@console/internal/components/modals';
 import { useQueryParams } from '@console/shared';
 
-import { categorize, findActiveCategory } from '../utils/category-utils';
 import {
-  setURLParams,
-  updateURLParams,
-  NO_GROUPING,
-  getCatalogTypeCounts,
-  DEFAULT_CATEGORY,
+  categorize,
+  findActiveCategory,
+  ALL_CATEGORY,
   OTHER_CATEGORY,
-} from '../utils/catalog-utils';
+  NO_GROUPING,
+} from '../utils/category-utils';
+import { setURLParams, updateURLParams, getCatalogTypeCounts } from '../utils/catalog-utils';
 import {
   filterByAttributes,
   filterByCategory,
@@ -25,7 +24,7 @@ import {
 } from '../utils/filter-utils';
 
 import {
-  CatalogCategories as CategoriesType,
+  CatalogCategory,
   CatalogFilterCounts,
   CatalogFilters as FiltersType,
   CatalogQueryParams,
@@ -46,7 +45,7 @@ type CatalogViewProps = {
   items: CatalogItem[];
   catalogType: string;
   catalogTypes: CatalogType[];
-  categories: CategoriesType;
+  categories: CatalogCategory[];
   filters: FiltersType;
   filterGroups: string[];
   filterGroupNameMap: CatalogStringMap;
@@ -67,7 +66,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const queryParams = useQueryParams();
-  const activeCategoryId = queryParams.get(CatalogQueryParams.CATEGORY) ?? DEFAULT_CATEGORY;
+  const activeCategoryId = queryParams.get(CatalogQueryParams.CATEGORY) ?? ALL_CATEGORY;
   const activeSearchKeyword = queryParams.get(CatalogQueryParams.KEYWORD) ?? '';
   const activeGrouping = queryParams.get(CatalogQueryParams.GROUPING) ?? NO_GROUPING;
   const sortOrder =
@@ -145,15 +144,10 @@ const CatalogView: React.FC<CatalogViewProps> = ({
     });
   }, []);
 
-  const catalogCategories = React.useMemo(() => {
-    const allCategory = { id: DEFAULT_CATEGORY, label: t('devconsole~All items') };
+  const catalogCategories = React.useMemo<CatalogCategory[]>(() => {
+    const allCategory = { id: ALL_CATEGORY, label: t('devconsole~All items') };
     const otherCategory = { id: OTHER_CATEGORY, label: t('devconsole~Other') };
-
-    return {
-      all: allCategory,
-      ...categories,
-      other: otherCategory,
-    };
+    return [allCategory, ...categories, otherCategory];
   }, [categories, t]);
 
   const categorizedIds = React.useMemo(() => categorize(items, catalogCategories), [
@@ -164,7 +158,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({
   const activeCategory = React.useMemo(
     () =>
       findActiveCategory(activeCategoryId, catalogCategories) ||
-      findActiveCategory(DEFAULT_CATEGORY, catalogCategories),
+      findActiveCategory(ALL_CATEGORY, catalogCategories),
     [activeCategoryId, catalogCategories],
   );
 

--- a/frontend/packages/dev-console/src/components/catalog/hooks/useCatalogCategories.ts
+++ b/frontend/packages/dev-console/src/components/catalog/hooks/useCatalogCategories.ts
@@ -1,6 +1,36 @@
-import { defaultCatalogCategories } from '../utils/default-categories';
-import { CatalogCategories } from '../utils/types';
+import * as React from 'react';
 
-const useCatalogCategories = (): CatalogCategories => defaultCatalogCategories;
+import { defaultCatalogCategories } from '../utils/default-categories';
+import { CatalogCategory } from '../utils/types';
+
+const useCatalogCategories = (): CatalogCategory[] => {
+  const categories = React.useMemo<CatalogCategory[]>(() => {
+    try {
+      const categoriesString = window.SERVER_FLAGS.developerCatalogCategories;
+      if (!categoriesString) {
+        return defaultCatalogCategories;
+      }
+
+      const categoriesArray: CatalogCategory[] = JSON.parse(categoriesString);
+
+      if (!Array.isArray(categoriesArray)) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `Unexpected server flag "developerCatalogCategories" format. Expected array, got ${typeof categoriesArray}:`,
+          categoriesArray,
+        );
+        return defaultCatalogCategories;
+      }
+
+      return categoriesArray;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Could not parse server flag "developerCatalogCategories":', error);
+      return defaultCatalogCategories;
+    }
+  }, []);
+
+  return categories;
+};
 
 export default useCatalogCategories;

--- a/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
@@ -4,12 +4,6 @@ import { CatalogItem } from '@console/plugin-sdk';
 import * as catalogImg from '@console/internal/imgs/logos/catalog-icon.svg';
 import { CatalogType, CatalogTypeCounts } from './types';
 
-export const NO_GROUPING = 'none';
-
-export const DEFAULT_CATEGORY = 'all';
-
-export const OTHER_CATEGORY = 'other';
-
 export const keywordCompare = (filterString: string, item: CatalogItem): boolean => {
   if (!filterString) {
     return true;

--- a/frontend/packages/dev-console/src/components/catalog/utils/default-categories.ts
+++ b/frontend/packages/dev-console/src/components/catalog/utils/default-categories.ts
@@ -1,83 +1,71 @@
-import { CatalogCategories } from './types';
+import { CatalogCategory } from './types';
 
-export const defaultCatalogCategories: CatalogCategories = {
-  cicd: {
+export const defaultCatalogCategories: CatalogCategory[] = [
+  {
     id: 'cicd',
     label: 'CI/CD',
-    field: 'tags',
-    subcategories: {
-      jenkins: { id: 'jenkins', label: 'Jenkins', field: 'tags', values: ['jenkins'] },
-      pipelines: { id: 'pipelines', label: 'Pipelines', field: 'tags', values: ['pipelines'] },
-    },
+    subcategories: [
+      { id: 'jenkins', label: 'Jenkins', tags: ['jenkins'] },
+      { id: 'pipelines', label: 'Pipelines', tags: ['pipelines'] },
+    ],
   },
-  databases: {
+  {
     id: 'databases',
     label: 'Databases',
-    field: 'tags',
-    subcategories: {
-      mariadb: { id: 'mariadb', label: 'MariaDB', field: 'tags', values: ['mariadb'] },
-      mongodb: { id: 'mongodb', label: 'Mongo', field: 'tags', values: ['mongodb'] },
-      mysql: { id: 'mysql', label: 'MySQL', field: 'tags', values: ['mysql'] },
-      postgresql: { id: 'postgresql', label: 'Postgres', field: 'tags', values: ['postgresql'] },
-    },
+    subcategories: [
+      { id: 'mariadb', label: 'MariaDB', tags: ['mariadb'] },
+      { id: 'mongodb', label: 'Mongo', tags: ['mongodb'] },
+      { id: 'mysql', label: 'MySQL', tags: ['mysql'] },
+      { id: 'postgresql', label: 'Postgres', tags: ['postgresql'] },
+    ],
   },
-  languages: {
+  {
     id: 'languages',
     label: 'Languages',
-    field: 'tags',
-    subcategories: {
-      dotnet: { id: 'dotnet', label: '.NET', field: 'tags', values: ['dotnet'] },
-      golang: { id: 'golang', label: 'Go', field: 'tags', values: ['golang', 'go'] },
-      java: { id: 'java', label: 'Java', values: ['java'] },
-      javascript: {
+    subcategories: [
+      { id: 'dotnet', label: '.NET', tags: ['dotnet'] },
+      { id: 'golang', label: 'Go', tags: ['golang', 'go'] },
+      { id: 'java', label: 'Java', tags: ['java'] },
+      {
         id: 'javascript',
         label: 'JavaScript',
-        field: 'tags',
-        values: ['javascript', 'nodejs', 'js'],
+        tags: ['javascript', 'nodejs', 'js'],
       },
-      perl: { id: 'perl', label: 'Perl', field: 'tags', values: ['perl'] },
-      php: { id: 'php', label: 'PHP', field: 'tags', values: ['php'] },
-      python: { id: 'python', label: 'Python', field: 'tags', values: ['python'] },
-      ruby: { id: 'ruby', label: 'Ruby', field: 'tags', values: ['ruby'] },
-    },
+      { id: 'perl', label: 'Perl', tags: ['perl'] },
+      { id: 'php', label: 'PHP', tags: ['php'] },
+      { id: 'python', label: 'Python', tags: ['python'] },
+      { id: 'ruby', label: 'Ruby', tags: ['ruby'] },
+    ],
   },
-  middleware: {
+  {
     id: 'middleware',
     label: 'Middleware',
-    field: 'tags',
-    subcategories: {
-      analyticsData: {
+    subcategories: [
+      {
         id: 'analyticsData',
         label: 'Analytics & Data',
-        field: 'tags',
-        values: ['datagrid', 'datavirt'],
+        tags: ['datagrid', 'datavirt'],
       },
-      integration: {
+      {
         id: 'integration',
         label: 'Integration',
-        field: 'tags',
-        values: ['amq', 'fuse', 'jboss-fuse', 'sso', '3scale'],
+        tags: ['amq', 'fuse', 'jboss-fuse', 'sso', '3scale'],
       },
-      processAutomation: {
+      {
         id: 'processAutomation',
         label: 'Process Automation',
-        field: 'tags',
-        values: ['decisionserver', 'processserver'],
+        tags: ['decisionserver', 'processserver'],
       },
-      runtimes: {
+      {
         id: 'runtimes',
         label: 'Runtimes & Frameworks',
-        field: 'tags',
-        values: ['eap', 'httpd', 'tomcat'],
+        tags: ['eap', 'httpd', 'tomcat'],
       },
-    },
+    ],
   },
-  virtualization: {
+  {
     id: 'virtualization',
     label: 'Virtualization',
-    field: 'tags',
-    subcategories: {
-      vms: { id: 'vms', label: 'Virtual Machines', field: 'tags', values: ['virtualmachine'] },
-    },
+    subcategories: [{ id: 'vms', label: 'Virtual Machines', tags: ['virtualmachine'] }],
   },
-};
+];

--- a/frontend/packages/dev-console/src/components/catalog/utils/types.ts
+++ b/frontend/packages/dev-console/src/components/catalog/utils/types.ts
@@ -37,16 +37,12 @@ export type CatalogType = {
 export type CatalogCategory = {
   id: string;
   label: string;
-  field?: string;
-  values?: string[];
-  subcategories?: Record<string, CatalogSubcategory>;
+  tags?: string[];
+  subcategories?: CatalogSubcategory[];
 };
 
 export type CatalogSubcategory = {
   id: string;
   label: string;
-  field?: string;
-  values?: string[];
+  tags?: string[];
 };
-
-export type CatalogCategories = Record<string, CatalogCategory>;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -93,6 +93,7 @@ type jsGlobals struct {
 	GOARCH                   string `json:"GOARCH"`
 	GOOS                     string `json:"GOOS"`
 	GraphQLBaseURL           string `json:"graphqlBaseURL"`
+	DevCatalogCategories     string `json:"developerCatalogCategories"`
 }
 
 type Server struct {
@@ -135,6 +136,7 @@ type Server struct {
 	GrafanaPublicURL      *url.URL
 	PrometheusPublicURL   *url.URL
 	ThanosPublicURL       *url.URL
+	DevCatalogCategories  string
 }
 
 func (s *Server) authDisabled() bool {
@@ -500,6 +502,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		GOOS:                  s.GOOS,
 		LoadTestFactor:        s.LoadTestFactor,
 		GraphQLBaseURL:        proxy.SingleJoiningSlash(s.BaseURL.Path, graphQLEndpoint),
+		DevCatalogCategories:  s.DevCatalogCategories,
 	}
 
 	if !s.authDisabled() {

--- a/pkg/serverconfig/config_test.go
+++ b/pkg/serverconfig/config_test.go
@@ -1,0 +1,172 @@
+package serverconfig
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+)
+
+func TestDefaultValue(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+
+	args := []string{}
+	Parse(fs, args, prefix)
+
+	if *userAuth != "default value" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "default value")
+	}
+}
+
+func TestCliArgument(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+
+	args := []string{"-user-auth", "openshift"}
+	Parse(fs, args, prefix)
+
+	if *userAuth != "openshift" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift")
+	}
+}
+
+func TestEnvVariable(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+
+	args := []string{}
+	os.Setenv(fmt.Sprintf("%s_USER_AUTH", prefix), "openshift")
+	Parse(fs, args, prefix)
+
+	if *userAuth != "openshift" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift")
+	}
+}
+
+func TestCliArgumentOverridesEnvVariable(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+
+	args := []string{"-user-auth", "openshift-cli"}
+	os.Setenv(fmt.Sprintf("%s_USER_AUTH", prefix), "openshift-env")
+	Parse(fs, args, prefix)
+
+	if *userAuth != "openshift-cli" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift-cli")
+	}
+}
+
+func TestCliArgumentToParseConfig(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+	listen := fs.String("listen", "http://0.0.0.0:9000", "")
+
+	args := []string{"-config", "test/bind-address-config.yaml"}
+	Parse(fs, args, prefix)
+
+	// Parsing a configfile automatically switches to 'openshift' user auth
+	if *userAuth != "openshift" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift")
+	}
+	// Value from config file
+	if *listen != "http://localhost:9000" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *listen, "http://localhost:9000")
+	}
+}
+
+func TestCliArgumentOverridesParsedConfig(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+	listen := fs.String("listen", "http://0.0.0.0:9000", "")
+
+	args := []string{"-config", "test/bind-address-config.yaml", "-user-auth", "openshift-cli"}
+	Parse(fs, args, prefix)
+
+	// Note: Parsing a configfile automatically switches to 'openshift' user auth
+	if *userAuth != "openshift-cli" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift-cli")
+	}
+	// Value from config file
+	if *listen != "http://localhost:9000" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *listen, "http://localhost:9000")
+	}
+}
+
+func TestEnvVariableToParseConfig(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+	listen := fs.String("listen", "http://0.0.0.0:9000", "")
+
+	args := []string{}
+	os.Setenv(fmt.Sprintf("%s_CONFIG", prefix), "test/bind-address-config.yaml")
+	Parse(fs, args, prefix)
+
+	// Parsing a configfile automatically switches to 'openshift' user auth
+	if *userAuth != "openshift" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift")
+	}
+	// Value from config file
+	if *listen != "http://localhost:9000" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *listen, "http://localhost:9000")
+	}
+}
+
+func TestEnvVariableOverridesParsedConfig(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+	listen := fs.String("listen", "http://0.0.0.0:9000", "")
+
+	args := []string{}
+	os.Setenv(fmt.Sprintf("%s_CONFIG", prefix), "test/bind-address-config.yaml")
+	os.Setenv(fmt.Sprintf("%s_USER_AUTH", prefix), "openshift-env")
+	Parse(fs, args, prefix)
+
+	// Note: Parsing a configfile automatically switches to 'openshift' user auth
+	if *userAuth != "openshift-env" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift-env")
+	}
+	// Value from config file
+	if *listen != "http://localhost:9000" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *listen, "http://localhost:9000")
+	}
+}
+
+func TestCliArgumentsOverridesEnvVariablesAndParsedConfig(t *testing.T) {
+	prefix := fmt.Sprintf("TEST_PREFIX_%d", rand.Int())
+	fs := flag.NewFlagSet(prefix, flag.ContinueOnError)
+	fs.String("config", "", "The config file.")
+	userAuth := fs.String("user-auth", "default value", "")
+	listen := fs.String("listen", "http://0.0.0.0:9000", "")
+
+	args := []string{"-config", "test/bind-address-config.yaml", "-user-auth", "openshift-cli"}
+	os.Setenv(fmt.Sprintf("%s_CONFIG", prefix), "test/does-not-exist.yaml")
+	os.Setenv(fmt.Sprintf("%s_USER_AUTH", prefix), "openshift-env")
+	Parse(fs, args, prefix)
+
+	// Note: Parsing a configfile automatically switches to 'openshift' user auth
+	if *userAuth != "openshift-cli" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *userAuth, "openshift-cli")
+	}
+	// Value from config file
+	if *listen != "http://localhost:9000" {
+		t.Errorf("Unexpected value: actual %s, expected %s", *listen, "http://localhost:9000")
+	}
+}

--- a/pkg/serverconfig/test/bind-address-config.yaml
+++ b/pkg/serverconfig/test/bind-address-config.yaml
@@ -1,0 +1,4 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: http://localhost:9000

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -65,6 +65,34 @@ type Customization struct {
 	DocumentationBaseURL string `yaml:"documentationBaseURL,omitempty"`
 	CustomProductName    string `yaml:"customProductName,omitempty"`
 	CustomLogoFile       string `yaml:"customLogoFile,omitempty"`
+	// developerCatalog allows to configure the shown developer catalog categories.
+	DeveloperCatalog DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
+}
+
+// DeveloperConsoleCatalogCustomization allow cluster admin to configure developer catalog.
+type DeveloperConsoleCatalogCustomization struct {
+	// categories which are shown the in developer catalog.
+	Categories []DeveloperConsoleCatalogCategory `json:"categories,omitempty" yaml:"categories,omitempty"`
+}
+
+// DeveloperConsoleCatalogCategoryMeta are the key identifiers of a developer catalog category.
+type DeveloperConsoleCatalogCategoryMeta struct {
+	// ID is an identifier used in the URL to enable deep linking in console.
+	// ID is required and must have 1-32 URL safe (A-Z, a-z, 0-9, - and _) characters.
+	ID string `json:"id" yaml:"id"`
+	// label defines a category display label. It is required and must have 1-64 characters.
+	Label string `json:"label" yaml:"label"`
+	// tags is a list of strings that will match the category. A selected category
+	// show all items which has at least one overlapping tag between category and item.
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// DeveloperConsoleCatalogCategory for the developer console catalog.
+type DeveloperConsoleCatalogCategory struct {
+	// defines top level category ID, label and filter tags.
+	DeveloperConsoleCatalogCategoryMeta `json:",inline" yaml:",inline"`
+	// subcategories defines a list of child categories.
+	Subcategories []DeveloperConsoleCatalogCategoryMeta `json:"subcategories,omitempty" yaml:"subcategories,omitempty"`
 }
 
 type Providers struct {

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -1,0 +1,41 @@
+package serverconfig
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strings"
+)
+
+func Validate(fs *flag.FlagSet) error {
+	if _, err := validateDeveloperCatalogCategories(fs.Lookup("developer-catalog-categories").Value.String()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateDeveloperCatalogCategories(value string) ([]DeveloperConsoleCatalogCategory, error) {
+	if value == "" {
+		return nil, nil
+	}
+	var categories []DeveloperConsoleCatalogCategory
+
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&categories); err != nil {
+		return nil, err
+	}
+
+	for categoryIndex, category := range categories {
+		if category.ID == "" || category.Label == "" {
+			return categories, fmt.Errorf("Developer catalog category at index %d must have at least id and label properties.", categoryIndex)
+		}
+		for subcategoryIndex, subcategory := range category.Subcategories {
+			if subcategory.ID == "" || subcategory.Label == "" {
+				return categories, fmt.Errorf("Developer catalog subcategory at index %d of category \"%s\" must have at least id and label properties.", subcategoryIndex, category.ID)
+			}
+		}
+	}
+
+	return categories, nil
+}

--- a/pkg/serverconfig/validate_test.go
+++ b/pkg/serverconfig/validate_test.go
@@ -1,0 +1,84 @@
+package serverconfig
+
+import (
+	"testing"
+)
+
+func TestValidEmptyDeveloperCatalogCategories(t *testing.T) {
+	actualCategories, err := validateDeveloperCatalogCategories("")
+	if err != nil {
+		t.Error("Unexpected error when parsing an empty string.", err)
+	}
+	if actualCategories != nil {
+		t.Errorf("Unexpected value: actual %v, expected %v", actualCategories, nil)
+	}
+}
+
+func TestValidEmptyArrayForDeveloperCatalogCategories(t *testing.T) {
+	actualCategories, err := validateDeveloperCatalogCategories("[]")
+	if err != nil {
+		t.Error("Unexpected error when parsing an empty array.", err)
+	}
+	if actualCategories == nil {
+		t.Errorf("Unexpected value: actual %v, expected %v", actualCategories, nil)
+	}
+	if len(actualCategories) != 0 {
+		t.Errorf("Unexpected value: actual %v, expected %v", len(actualCategories), 0)
+	}
+}
+
+func TestValidDeveloperCatalogCategories(t *testing.T) {
+	actualCategories, err := validateDeveloperCatalogCategories("[{ \"id\": \"java\", \"label\": \"Java\", \"tags\": [ \"jvm\", \"java\", \"quarkus\" ] }]")
+	if err != nil {
+		t.Error("Unexpected error when parsing an empty array.", err)
+	}
+	if actualCategories == nil {
+		t.Errorf("Unexpected value: actual %v, expected %v", actualCategories, nil)
+	}
+	if len(actualCategories) != 1 {
+		t.Errorf("Unexpected value: actual %v, expected %v", len(actualCategories), 1)
+	}
+	if actualCategories[0].ID != "java" {
+		t.Errorf("Unexpected value: actual %v, expected %v", actualCategories[0].ID, "java")
+	}
+	if actualCategories[0].Label != "Java" {
+		t.Errorf("Unexpected value: actual %v, expected %v", actualCategories[0].Label, "Java")
+	}
+	if len(actualCategories[0].Tags) != 3 {
+		t.Errorf("Unexpected value: actual %v, expected %v", len(actualCategories[0].Tags), 3)
+	}
+}
+
+func TestInvalidObjectForDeveloperCatalogCategories(t *testing.T) {
+	_, err := validateDeveloperCatalogCategories("{}")
+	if err == nil {
+		t.Error("Expected an error when parsing an object.")
+	}
+}
+
+func TestIncompleteDeveloperCatalogCategory(t *testing.T) {
+	_, err := validateDeveloperCatalogCategories("[{}]")
+	actualMsg := err.Error()
+	expectedMsg := "Developer catalog category at index 0 must have at least id and label properties."
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}
+
+func TestIncompleteDeveloperCatalogSubcategory(t *testing.T) {
+	_, err := validateDeveloperCatalogCategories("[{ \"id\": \"java\", \"label\": \"Java\", \"tags\": [ \"jvm\", \"java\", \"quarkus\" ], \"subcategories\": [ {} ] }]")
+	actualMsg := err.Error()
+	expectedMsg := "Developer catalog subcategory at index 0 of category \"java\" must have at least id and label properties."
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}
+
+func TestUnknownPropertyInDeveloperCatalogCategory(t *testing.T) {
+	_, err := validateDeveloperCatalogCategories("[{ \"unknown key\": \"ignored value\" }]")
+	actualMsg := err.Error()
+	expectedMsg := "json: unknown field \"unknown key\""
+	if actualMsg != expectedMsg {
+		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
+	}
+}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5019

**Analysis / Root cause**: 
Catalog categories are hard coded before. Based on the [Customize Developer Catalog Categories enhancement](https://github.com/openshift/enhancements/pull/508) we need to load them and fallback to the default categories.

**Solution Description**: 
Created a `useCatalogCategories` hook and refactored `CatalogFileViewPage` to a function component to use this hook. Also extracted the default categories and use a naming in sync with @rohitkrai03 upcoming catalog extensibility changes, see PR #7233.

Because of some security concerns / best practices the frontend could not read the ConfigMap directly. Instead of that the hook reads the customized developer catalog categories from `SERVER_FLAGS`. To add the categories to the server flags requires some changes in the `bridge` code. The bridge code now automatically 'add' a new `developerCatalogCategories` flag with an JSON encoded string for all categories.

All SERVER_FLAGS are rendered automatically to the `index.html` and are available as global `window.SERVERFLAGS....`.

When an admin changes the `Console` "cluster" resource, a `ConfigMap` "cluster" was automatically created. It contains a `ConsoleConfig.yaml` entry which was then provided as file to a new console Pod. Each change to the Console resource triggers a new console instance.

**Screen shots / Gifs for design review**:
Catalog looks like before, but has now customized categories:
![image](https://user-images.githubusercontent.com/139310/100008057-3a9f5c00-2dcd-11eb-996f-f0ebdf57dfda.png)

**Unit test coverage report**: 
Updated existing tests, no update for the code coverage here.

**Test setup, with a cluster-bot cluster**
1. Launch a new cluster with cluster-bot `launch openshift/console#7196`
2. WIP... ;)

**Test setup, with a local running bridge and a remote cluster:**
1. Checkout this branch
2. `./build-backend.sh`
3. Login to your cluster as always (`oc login...`)
4. Setup the local bridge environment variables `source ./contrib/oc-environment.sh`
5. **New: Define the Developer Catalog Categories**

**a.) Configure your remote cluster and fetch the cluster customization config for local testing:**

Run the script `source ./contrib/oc-get-customization.sh` similar to oc-env. This new script needs to be called with kube:admin or service account permissions and it requires the yq command. It automatically fetches the customization config and sets the environment variable `BRIDGE_CONFIG`.

You can switch the user after this call or just run `bin/bridge`

**b.) Alternative you can create your own `cluster-consoleconfig-customization.yaml` and insert for example:**

```yaml
apiVersion: console.openshift.io/v1
kind: ConsoleConfig
customization:
  branding: ocp
  documentationBaseURL: https://docs.openshift.com/container-platform/4.6/
```

Export the config filename in your shell (see 5a) or just add the config file to your `bin/bridge` call:
```bash
bin/bridge -config cluster-consoleconfig-customization.yaml
```

**c.) Set the developer catalog categories directly as command line argument:**

```bash
bin/bridge -developer-catalog-categories '[ { "id": "java", "label": "Java", "tags": [ "java" ] } ]'
```

Please note that categories which doesn't match any item are not displayed by the catalog. ;)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
