### PR TITLE
[ODC-5071]: Update web terminal to explain the reason why the workspace was stopped

### DIFF
--- a/frontend/packages/console-app/locales/en/cloudshell.json
+++ b/frontend/packages/console-app/locales/en/cloudshell.json
@@ -9,6 +9,7 @@
   "Restore terminal": "Restore terminal",
   "Close terminal": "Close terminal",
   "The terminal connection has closed.": "The terminal connection has closed.",
+  "The terminal connection has closed due to {{reason}}.": "The terminal connection has closed due to {{reason}}.",
   "connecting to {{container}}": "connecting to {{container}}",
   "OpenShift command line terminal": "OpenShift command line terminal",
   "Close command line terminal": "Close command line terminal",

--- a/frontend/packages/console-app/locales/en/cloudshell.json
+++ b/frontend/packages/console-app/locales/en/cloudshell.json
@@ -23,5 +23,7 @@
   "Create Project": "Create Project",
   "This project will be used to initialize your command line terminal": "This project will be used to initialize your command line terminal",
   "Project Name": "Project Name",
-  "Connecting to your OpenShift command line terminal ...": "Connecting to your OpenShift command line terminal ..."
+  "Connecting to your OpenShift command line terminal ...": "Connecting to your OpenShift command line terminal ...",
+  "Reconnect to terminal": "Reconnect to terminal",
+  "Restart Terminal": "Restart Terminal"
 }

--- a/frontend/packages/console-app/locales/en/cloudshell.json
+++ b/frontend/packages/console-app/locales/en/cloudshell.json
@@ -8,12 +8,14 @@
   "Minimize terminal": "Minimize terminal",
   "Restore terminal": "Restore terminal",
   "Close terminal": "Close terminal",
-  "The terminal connection has closed.": "The terminal connection has closed.",
   "The terminal connection has closed due to {{reason}}.": "The terminal connection has closed due to {{reason}}.",
+  "The terminal connection has closed.": "The terminal connection has closed.",
   "connecting to {{container}}": "connecting to {{container}}",
-  "OpenShift command line terminal": "OpenShift command line terminal",
+  "Reconnect to terminal": "Reconnect to terminal",
+  "Restart terminal": "Restart terminal",
   "Close command line terminal": "Close command line terminal",
   "Open command line terminal": "Open command line terminal",
+  "OpenShift command line terminal": "OpenShift command line terminal",
   "Failed to connect to your OpenShift command line terminal": "Failed to connect to your OpenShift command line terminal",
   "Initialize Terminal": "Initialize Terminal",
   "Start": "Start",
@@ -23,7 +25,5 @@
   "Create Project": "Create Project",
   "This project will be used to initialize your command line terminal": "This project will be used to initialize your command line terminal",
   "Project Name": "Project Name",
-  "Connecting to your OpenShift command line terminal ...": "Connecting to your OpenShift command line terminal ...",
-  "Reconnect to terminal": "Reconnect to terminal",
-  "Restart terminal": "Restart terminal"
+  "Connecting to your OpenShift command line terminal ...": "Connecting to your OpenShift command line terminal ..."
 }

--- a/frontend/packages/console-app/locales/en/cloudshell.json
+++ b/frontend/packages/console-app/locales/en/cloudshell.json
@@ -25,5 +25,5 @@
   "Project Name": "Project Name",
   "Connecting to your OpenShift command line terminal ...": "Connecting to your OpenShift command line terminal ...",
   "Reconnect to terminal": "Reconnect to terminal",
-  "Restart Terminal": "Restart Terminal"
+  "Restart terminal": "Restart terminal"
 }

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.scss
@@ -1,0 +1,12 @@
+@import '~patternfly/dist/sass/patternfly/color-variables';
+
+.co-cloudshell-exec {
+  &__container-error {
+    background-color: #fff;
+    height: 100%;
+  }
+
+  &__error-msg {
+    color: $color-pf-red !important;
+  }
+}

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
@@ -55,6 +55,7 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
 }) => {
   const [wsOpen, setWsOpen] = React.useState<boolean>(false);
   const [wsError, setWsError] = React.useState<string>();
+  const [wsReopening, setWsReopening] = React.useState<boolean>(false);
   const [customResource, setCustomResource] = React.useState<CloudShellResource>();
   const ws = React.useRef<WSFactory>();
   const terminal = React.useRef<ImperativeTerminalType>();
@@ -176,11 +177,24 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
         );
     }
 
+    setWsReopening(false);
+
     return () => {
       unmounted = true;
       websocket.destroy();
     };
-  }, [tick, container, flags, impersonate, namespace, podname, shcommand, t, workspaceName]);
+  }, [
+    tick,
+    container,
+    flags,
+    impersonate,
+    namespace,
+    podname,
+    shcommand,
+    t,
+    workspaceName,
+    wsReopening,
+  ]);
 
   if (wsError) {
     return (
@@ -190,10 +204,12 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
           <Button
             variant="primary"
             onClick={() => {
-              if (customResource) {
+              if (customResource && customResource.status.phase !== 'Running') {
                 startWorkspace(customResource);
-                setWsError(undefined);
+              } else if (!wsReopening) {
+                setWsReopening(true);
               }
+              setWsError(undefined);
             }}
           >
             Restart Terminal

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
@@ -18,6 +18,7 @@ import {
   CloudShellResource,
 } from './cloud-shell-utils';
 import { Button, EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import './CloudShellExec.scss';
 
 // pod exec WS protocol is FD prefixed, base64 encoded data (sometimes json stringified)
 
@@ -198,9 +199,9 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
 
   if (wsError) {
     return (
-      <div className="co-cloudshell-terminal__container-error">
+      <div className="co-cloudshell-exec__container-error">
         <EmptyState>
-          <EmptyStateBody className="cloudshell-error">{wsError}</EmptyStateBody>
+          <EmptyStateBody className="co-cloudshell-exec__error-msg">{wsError}</EmptyStateBody>
           <Button
             variant="primary"
             onClick={() => {
@@ -213,8 +214,8 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
             }}
           >
             {customResource.status.phase === 'Running'
-              ? t('Reconnect to terminal')
-              : t('Restart Terminal')}
+              ? t('cloudshell~Reconnect to terminal')
+              : t('cloudshell~Restart terminal')}
           </Button>
         </EmptyState>
       </div>

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellExec.tsx
@@ -212,7 +212,9 @@ const CloudShellExec: React.FC<CloudShellExecProps> = ({
               setWsError(undefined);
             }}
           >
-            Restart Terminal
+            {customResource.status.phase === 'Running'
+              ? t('Reconnect to terminal')
+              : t('Restart Terminal')}
           </Button>
         </EmptyState>
       </div>

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
@@ -1,18 +1,7 @@
-@import '~patternfly/dist/sass/patternfly/color-variables';
-
 .co-cloudshell-terminal {
   &__container {
     background-color: #000;
     color: var(--pf-global--Color--light-100);
     height: 100%;
-  }
-
-  &__container-error {
-    background-color: #fff;
-    height: 100%;
-
-    .cloudshell-error {
-      color: $color-pf-red !important;
-    }
   }
 }

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.scss
@@ -1,7 +1,18 @@
+@import '~patternfly/dist/sass/patternfly/color-variables';
+
 .co-cloudshell-terminal {
   &__container {
     background-color: #000;
     color: var(--pf-global--Color--light-100);
     height: 100%;
+  }
+
+  &__container-error {
+    background-color: #fff;
+    height: 100%;
+
+    .cloudshell-error {
+      color: $color-pf-red !important;
+    }
   }
 }

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
@@ -126,15 +126,13 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps> = ({ user, onCancel 
 
   if (initData && workspaceNamespace) {
     return (
-      <div className="co-cloudshell-terminal__container">
-        <CloudshellExec
-          workspaceName={workspaceName}
-          namespace={workspaceNamespace}
-          container={initData.container}
-          podname={initData.pod}
-          shcommand={initData.cmd || []}
-        />
-      </div>
+      <CloudshellExec
+        workspaceName={workspaceName}
+        namespace={workspaceNamespace}
+        container={initData.container}
+        podname={initData.pod}
+        shcommand={initData.cmd || []}
+      />
     );
   }
 

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind, k8sPatch } from '@console/internal/module/k8s';
+import { K8sResourceKind, k8sPatch, k8sGet } from '@console/internal/module/k8s';
 import { STORAGE_PREFIX, getRandomChars } from '@console/shared';
 import { coFetchJSON, coFetch } from '@console/internal/co-fetch';
 import { WorkspaceModel } from '../../models';
@@ -33,6 +33,7 @@ export type TerminalInitData = { pod: string; container: string; cmd: string[] }
 export const CLOUD_SHELL_LABEL = 'console.openshift.io/terminal';
 export const CLOUD_SHELL_CREATOR_LABEL = 'controller.devfile.io/creator';
 export const CLOUD_SHELL_RESTRICTED_ANNOTATION = 'controller.devfile.io/restricted-access';
+export const CLOUD_SHELL_STOPPED_BY_ANNOTATION = 'controller.devfile.io/stopped-by';
 
 export const createCloudShellResourceName = () => `terminal-${getRandomChars(6)}`;
 
@@ -103,4 +104,8 @@ export const setCloudShellNamespace = (namespace: string) => {
   } else {
     localStorage.setItem(CLOUD_SHELL_NAMESPACE, namespace);
   }
+};
+
+export const getCloudShellCR = (name: string, ns: string) => {
+  return k8sGet(WorkspaceModel, name, ns);
 };


### PR DESCRIPTION
This PR updates the web terminal to look into the custom resource annotation ```controller.devfile.io/stopped-by``` to determine why the workspace has stopped. Additionally, when that error is thrown it shows a button that allows you to restart your web terminal.

If WTO 1.1 is installed it just defaults to the old error "The terminal connection has closed" since the `controller.devfile.io/stopped-by` annotation does not exist in the CR.

Before: https://www.youtube.com/watch?v=2S4inkX5sKc
After: https://www.youtube.com/watch?v=YUld4YKFeoU

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>