### PR TITLE
Bug 1893601: fix filesystem queries

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -431,12 +431,11 @@ const fetchNodeMetrics = (): Promise<NodeMetrics> => {
     {
       key: 'usedStorage',
       query:
-        'sum by (instance) (node_filesystem_size_bytes{fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"} - node_filesystem_free_bytes{fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"})',
+        'sum by (instance) (node_filesystem_size_bytes{mountpoint="/var"} - node_filesystem_free_bytes{mountpoint="/var"})',
     },
     {
       key: 'totalStorage',
-      query:
-        'sum by (instance) (node_filesystem_size_bytes{fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"})',
+      query: 'sum by (instance) (node_filesystem_size_bytes{mountpoint="/var"})',
     },
     {
       key: 'cpu',

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
@@ -37,10 +37,10 @@ const queries = {
   [NodeQueries.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance='<%= node %>'}`),
   [NodeQueries.POD_COUNT]: _.template(`kubelet_running_pods{instance=~'<%= ipAddress %>:.*'}`),
   [NodeQueries.FILESYSTEM_USAGE]: _.template(
-    `sum(node_filesystem_size_bytes{instance="<%= node %>",fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"} - node_filesystem_avail_bytes{instance="<%= node %>",fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"})`,
+    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/var"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/var"})`,
   ),
   [NodeQueries.FILESYSTEM_TOTAL]: _.template(
-    `sum(node_filesystem_size_bytes{instance='<%= node %>',fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"})`,
+    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/var"})`,
   ),
   [NodeQueries.NETWORK_IN_UTILIZATION]: _.template(
     `instance:node_network_receive_bytes:rate:sum{instance='<%= node %>'}`,

--- a/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
@@ -44,7 +44,7 @@ const top25Queries = {
   [OverviewQuery.NODES_BY_MEMORY]:
     'topk(25, sort_desc(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes))',
   [OverviewQuery.NODES_BY_STORAGE]:
-    'topk(25, sort_desc(sum(node_filesystem_size_bytes{fstype!="tmpfs",mountpoint!="/boot|/boot/efi"} - node_filesystem_avail_bytes{instance=~".*",fstype!="tmpfs",mountpoint!="/boot|/boot/efi"}) BY (instance)))',
+    'topk(25, sort_desc(sum(node_filesystem_size_bytes{mountpoint="/var"} - node_filesystem_avail_bytes{instance=~".*",mountpoint="/var"}) BY (instance)))',
   [OverviewQuery.NODES_BY_PODS]:
     'topk(25, sort_desc(sum(avg_over_time(kubelet_running_pods[5m])) BY (node)))',
   [OverviewQuery.NODES_BY_NETWORK_IN]:
@@ -74,8 +74,8 @@ const overviewQueries = {
   [OverviewQuery.CPU_UTILIZATION]: 'cluster:cpu_usage_cores:sum',
   [OverviewQuery.CPU_TOTAL]: 'sum(cluster:capacity_cpu_cores:sum)',
   [OverviewQuery.STORAGE_UTILIZATION]:
-    '(sum(node_filesystem_size_bytes) - sum(node_filesystem_free_bytes))',
-  [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes)',
+    '(sum(node_filesystem_size_bytes{mountpoint="/var"}) - sum(node_filesystem_free_bytes{mountpoint="/var"}))',
+  [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes{mountpoint="/var"})',
   [OverviewQuery.POD_UTILIZATION]: 'count(kube_pod_info)',
   [OverviewQuery.NETWORK_IN_UTILIZATION]:
     'sum(instance:node_network_receive_bytes_excluding_lo:rate1m)',

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/queries.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/queries.ts
@@ -28,10 +28,10 @@ const nodeQueriesByNodeName = {
   [HostQuery.MEMORY_UTILIZATION]: _.template(`node_memory_Active_bytes{instance=~'<%= node %>'}`),
   [HostQuery.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance=~'<%= node %>'}`),
   [HostQuery.STORAGE_UTILIZATION]: _.template(
-    `sum(node_filesystem_size_bytes{instance="<%= node %>",fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"} - node_filesystem_avail_bytes{instance="<%= node %>",fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"})`,
+    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/var"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/var"})`,
   ),
   [HostQuery.STORAGE_TOTAL]: _.template(
-    `sum(node_filesystem_size_bytes{instance='<%= node %>',fstype!~"tmpfs|squashfs",mountpoint!~"/usr|/var"})`,
+    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/var"})`,
   ),
   [HostQuery.NETWORK_IN_UTILIZATION]: _.template(
     `instance:node_network_receive_bytes:rate:sum{instance=~'<%= node %>'}`,


### PR DESCRIPTION
In RHCOS, the only part of the filesystem that is usable by OpenShift is `/var`.
- `/var/lib/kubelet` holds pod volumes
- `/var/lib/containers` holds the container writeable layers and images.
- `/var/log` contains system logs.

```
# lsblk
NAME                         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
sda                            8:0    0   120G  0 disk 
|-sda1                         8:1    0   384M  0 part /boot
|-sda2                         8:2    0   127M  0 part /boot/efi
|-sda3                         8:3    0     1M  0 part 
`-sda4                         8:4    0 119.5G  0 part 
  `-coreos-luks-root-nocrypt 253:0    0 119.5G  0 dm   /sysroot

# df -h /sysroot
Filesystem                            Size  Used Avail Use% Mounted on
/dev/mapper/coreos-luks-root-nocrypt  120G   17G  104G  14% /sysroot

# df -h /var
Filesystem                            Size  Used Avail Use% Mounted on
/dev/mapper/coreos-luks-root-nocrypt  120G   17G  104G  14% /var
```
Thus it is the only mountpoint whose capacity and utilization we care about.

/cc @rawagner 

Also see previous attempt to fix this:
https://bugzilla.redhat.com/show_bug.cgi?id=1874028
https://github.com/openshift/console/pull/6571