### PR TITLE
Fix continual poll for pod graph data in pod details page

### DIFF
--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -169,7 +169,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
 };
 
 export const Area: React.FC<AreaProps> = ({
-  endTime = Date.now(),
+  endTime,
   namespace,
   query,
   limitQuery,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5137

**Analysis / Root cause**: 
Area charts were updated to use generic prometheus poll props and set the endTime property to `Date.now()` by default. This causes the component to constantly change the URL since the endTime is changed every time.

**Solution Description**: 
Remove the default setting for endTime so that it is only set if the caller provides one.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug