### PR TITLE
Hide edit icon for nodes without vcs URI

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -33,7 +33,10 @@ export const getServiceBindingStatus = ({ FLAGS }: RootState): boolean =>
 export const getCheURL = (consoleLinks: K8sResourceKind[]) =>
   _.get(_.find(consoleLinks, ['metadata.name', 'che']), 'spec.href', '');
 
-export const getEditURL = (vcsURI: string, gitBranch?: string, cheURL?: string) => {
+export const getEditURL = (vcsURI?: string, gitBranch?: string, cheURL?: string) => {
+  if (!vcsURI) {
+    return null;
+  }
   const parsedURL = GitUrlParse(vcsURI);
   const gitURL = `https://${parsedURL.source}/${parsedURL.owner}/${parsedURL.name}`;
   const fullGitURL = gitBranch ? `${gitURL}/tree/${gitBranch}` : gitURL;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5139
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Topology page crashes if application created using Git do not have vcsURI provided.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Do not show edit icon if `vcsURI` is not provided.
<!-- Describe your code changes in detail and explain the solution -->

**Test setup:**
Create an application using git flow and remove the git URL from it's annotations.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge