### PR TITLE
Bug 1879140: Set proper loglevel for auth errors

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -369,13 +369,13 @@ func (a *Authenticator) CallbackFunc(fn func(loginInfo LoginJSON, successURL str
 		}
 
 		if code == "" {
-			klog.Info("missing auth code in query param")
+			klog.Error("missing auth code in query param")
 			a.redirectAuthError(w, errorMissingCode)
 			return
 		}
 
 		if urlState != cookieState.Value {
-			klog.Error("State in url does not match State cookie")
+			klog.Error("state in url does not match State cookie")
 			a.redirectAuthError(w, errorInvalidState)
 			return
 		}
@@ -383,7 +383,7 @@ func (a *Authenticator) CallbackFunc(fn func(loginInfo LoginJSON, successURL str
 		oauthConfig, lm := a.authFunc()
 		token, err := oauthConfig.Exchange(ctx, code)
 		if err != nil {
-			klog.Infof("unable to verify auth code with issuer: %v", err)
+			klog.Errorf("unable to verify auth code with issuer: %v", err)
 			a.redirectAuthError(w, errorInvalidCode)
 			return
 		}

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -25,7 +25,7 @@ func authMiddlewareWithUser(a *auth.Authenticator, handlerFunc func(user *auth.U
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user, err := a.Authenticate(r)
 		if err != nil {
-			klog.Infof("authentication failed: %v", err)
+			klog.V(4).Infof("authentication failed: %v", err)
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -43,13 +43,13 @@ func authMiddlewareWithUser(a *auth.Authenticator, handlerFunc func(user *auth.U
 		}
 		if !safe {
 			if err := a.VerifySourceOrigin(r); err != nil {
-				klog.Infof("invalid source origin: %v", err)
+				klog.Errorf("invalid source origin: %v", err)
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
 
 			if err := a.VerifyCSRFToken(r); err != nil {
-				klog.Infof("invalid CSRFToken: %v", err)
+				klog.Errorf("invalid CSRFToken: %v", err)
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}


### PR DESCRIPTION
Print the authentication failures that indicate that the user is not logged in on a `Debug` loglevel
```
  2020-07-01T17:39:31.533556276Z 2020/07/1 17:39:31 server: authentication failed: http: named cookie not present
  2020-07-01T17:39:34.888946631Z 2020/07/1 17:39:34 server: authentication failed: unauthenticated, no value for cookie openshift-session-token
```

Also updated the `klog` methods upon calling `redirectAuthError()` 

/assign @spadgett 