### PR TITLE
Correct the order of dev perspective nav for pipelines

### DIFF
--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -230,6 +230,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceCluster',
     properties: {
+      id: 'storage',
       section: 'Storage',
       componentProps: {
         name: 'Volume Snapshot Contents',

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -75,6 +75,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'home',
       section: 'Home',
       componentProps: {
         name: 'Test Href Link',
@@ -88,6 +89,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'testresourcens',
       section: 'Home',
       componentProps: {
         name: 'Test ResourceNS Link',
@@ -101,6 +103,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceCluster',
     properties: {
+      id: 'testresourcecluster',
       section: 'Home',
       componentProps: {
         name: 'Test ResourceCluster Link',
@@ -180,6 +183,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'testhome',
       perspective: 'test',
       componentProps: {
         name: 'Test Home',
@@ -190,6 +194,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceCluster',
     properties: {
+      id: 'testprojects',
       perspective: 'test',
       section: 'Advanced',
       componentProps: {

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
@@ -14,6 +14,7 @@ describe('active-plugins', () => {
         {
           type: 'NavItem/Href',
           properties: {
+            id: 'foo',
             componentProps: {
               name: 'Foo Link',
               href: '/foo',
@@ -25,6 +26,7 @@ describe('active-plugins', () => {
         {
           type: 'NavItem/Href',
           properties: {
+            id: 'bar',
             componentProps: {
               name: 'Bar Link',
               href: '/bar',

--- a/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
@@ -8,16 +8,26 @@ import { Extension } from './base';
 
 namespace ExtensionProperties {
   interface NavItem {
+    /** Item id, should be unique for all items and sections */
+    id: string;
     /** Perspective id to which this item belongs to. If not specified, use the default perspective. */
     perspective?: string;
-    /** Nav section to which this item belongs to. If not specified, render item as top-level link. */
+    /** Nav section to which this item belongs to.If not specified, render item as top-level link. */
     section?: string;
     /** Nav group to which this item belongs to. Add items to a grouping with a separator above */
     group?: string;
     /** Props to pass to the corresponding `NavLink` component. */
     componentProps: Pick<NavLinkProps, 'name' | 'startsWith' | 'testID' | 'data-tour-id'>;
-    /** Nav item before which this item should be placed. */
-    mergeBefore?: string;
+    /*
+     * TODO: Resolve issue of extensions adding optional sections
+     * Providing insertBefore and mergeAfter capability to handles simple cases where extensions
+     * could add optional sections. This only handles cases where either the prev or next nav
+     * item is always there.
+     */
+    /** Nav item before which this item should be placed. For arrays, first one found in order is used */
+    insertBefore?: string | string[];
+    /** Nav item after which this item should be placed (before takes precedence). For arrays, first one found in order is used */
+    insertAfter?: string | string[];
   }
 
   export interface SeparatorNavItem extends Omit<NavItem, 'componentProps'> {

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -118,9 +118,10 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'imagevulnerabilities',
       perspective: 'admin',
       section: 'Administration',
-      mergeBefore: 'Custom Resource Definitions',
+      insertBefore: 'customresourcedefinitions',
       componentProps: {
         name: 'Image Vulnerabilities',
         resource: referenceForModel(ImageManifestVulnModel),

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -110,6 +110,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'add',
       perspective: 'dev',
       group: 'top',
       componentProps: {
@@ -122,6 +123,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'topology',
       perspective: 'dev',
       group: 'top',
       componentProps: {
@@ -137,6 +139,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'monitoring',
       perspective: 'dev',
       group: 'top',
       componentProps: {
@@ -153,6 +156,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'search',
       perspective: 'dev',
       group: 'top',
       componentProps: {
@@ -166,6 +170,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'builds',
       perspective: 'dev',
       group: 'resources',
       componentProps: {
@@ -181,6 +186,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'applicationstages',
       perspective: 'dev',
       group: 'resources',
       componentProps: {
@@ -196,6 +202,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'helm',
       perspective: 'dev',
       group: 'resources',
       componentProps: {
@@ -211,6 +218,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'project',
       perspective: 'dev',
       group: 'resources',
       componentProps: {

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -126,6 +126,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'serverlessserving',
       perspective: 'admin',
       section: 'Serverless',
       componentProps: {
@@ -144,6 +145,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'serverlesseventing',
       perspective: 'admin',
       section: 'Serverless',
       componentProps: {

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -84,12 +84,13 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'virtualization',
       section: 'Workloads',
       componentProps: {
         name: 'Virtualization',
         resource: 'virtualization',
       },
-      mergeBefore: 'Deployments',
+      insertBefore: 'deployments',
     },
     flags: {
       required: [FLAG_KUBEVIRT],

--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -92,6 +92,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'baremetal',
       section: 'Compute',
       componentProps: {
         name: 'Bare Metal Hosts',
@@ -100,7 +101,7 @@ const plugin: Plugin<ConsumedExtensions> = [
           'openshift-machine-api',
         ),
       },
-      mergeBefore: 'ComputeSeparator',
+      insertBefore: 'computeseparator',
     },
     flags: {
       required: [BAREMETAL_FLAG, METAL3_FLAG],

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -42,6 +42,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'networkattachmentdefinitions',
       section: 'Networking',
       componentProps: {
         name: 'Network Attachment Definitions',

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -224,6 +224,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceCluster',
     properties: {
+      id: 'objectbuckets',
       section: 'Storage',
       componentProps: {
         name: 'Object Buckets',
@@ -257,6 +258,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'objectbucketclaims',
       section: 'Storage',
       componentProps: {
         name: 'Object Bucket Claims',

--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -100,6 +100,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'operatorhub',
       section: 'Operators',
       componentProps: {
         name: 'OperatorHub',
@@ -113,6 +114,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'operators',
       section: 'Operators',
       componentProps: {
         name: 'Installed Operators',

--- a/frontend/packages/pipelines-plugin/src/plugin.tsx
+++ b/frontend/packages/pipelines-plugin/src/plugin.tsx
@@ -78,8 +78,10 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
+      id: 'pipelines',
       perspective: 'dev',
       group: 'resources',
+      insertAfter: 'builds',
       componentProps: {
         name: PipelineModel.labelPlural,
         resource: referenceForModel(PipelineModel),
@@ -93,6 +95,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'pipelines',
       perspective: 'admin',
       section: 'Pipelines',
       componentProps: {
@@ -107,6 +110,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'pipelinetasks',
       perspective: 'admin',
       section: 'Pipelines',
       componentProps: {
@@ -121,6 +125,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      id: 'pipelinetriggers',
       perspective: 'admin',
       section: 'Pipelines',
       componentProps: {

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -29,11 +29,14 @@ import { NavSection } from './section';
 
 type SeparatorProps = {
   name: string;
+  id?: string;
   required?: string;
 };
 
 // Wrap `NavItemSeparator` so we can use `required` without prop type errors.
-const Separator: React.FC<SeparatorProps> = ({ name }) => <NavItemSeparator name={name} />;
+const Separator: React.FC<SeparatorProps> = ({ name, id }) => (
+  <NavItemSeparator name={name} id={id} />
+);
 
 const searchStartsWith = ['search'];
 const provisionedServicesStartsWith = ['serviceinstances', 'servicebindings'];
@@ -69,6 +72,7 @@ const MonitoringNavSection_ = ({ canAccess }) => {
     <NavSection title={t('nav~Monitoring')}>
       {canAccessPrometheus && (
         <HrefLink
+          id="monitoringalerts"
           href="/monitoring/alerts"
           name={t('nav~Alerting')}
           startsWith={monitoringAlertsStartsWith}
@@ -76,12 +80,19 @@ const MonitoringNavSection_ = ({ canAccess }) => {
       )}
       {canAccessPrometheus && (
         <HrefLink
+          id="monitoringmetrics"
           href="/monitoring/query-browser?query0="
           name={t('nav~Metrics')}
           startsWith={['monitoring/query-browser']}
         />
       )}
-      {canAccessPrometheus && <HrefLink href="/monitoring/dashboards" name={t('nav~Dashboards')} />}
+      {canAccessPrometheus && (
+        <HrefLink
+          id="monitoringdashboards"
+          href="/monitoring/dashboards"
+          name={t('nav~Dashboards')}
+        />
+      )}
     </NavSection>
   ) : null;
 };
@@ -98,41 +109,54 @@ const AdminNav = () => {
     <>
       <NavSection title={t('nav~Home')}>
         <HrefLink
+          id="dashboards"
           href="/dashboards"
           activePath="/dashboards/"
           name={t('nav~Overview')}
           required={[FLAGS.CAN_GET_NS, FLAGS.OPENSHIFT]}
         />
         <ResourceClusterLink
+          id="projects"
           resource="projects"
           name={t('nav~Projects')}
           required={FLAGS.OPENSHIFT}
         />
-        <HrefLink href="/search" name={t('nav~Search')} startsWith={searchStartsWith} />
-        <HrefLink href="/api-explorer" name={t('nav~Explore')} startsWith={apiExplorerStartsWith} />
-        <ResourceNSLink resource="events" name={t('nav~Events')} />
+        <HrefLink id="search" href="/search" name={t('nav~Search')} startsWith={searchStartsWith} />
+        <HrefLink
+          id="explore"
+          href="/api-explorer"
+          name={t('nav~Explore')}
+          startsWith={apiExplorerStartsWith}
+        />
+        <ResourceNSLink id="events" resource="events" name={t('nav~Events')} />
       </NavSection>
 
       <NavSection title={t('nav~Operators')} />
 
       <NavSection title={t('nav~Workloads')}>
-        <ResourceNSLink resource="pods" name={t('nav~Pods')} />
-        <ResourceNSLink resource="deployments" name={t('nav~Deployments')} />
+        <ResourceNSLink id="pods" resource="pods" name={t('nav~Pods')} />
+        <ResourceNSLink id="deployments" resource="deployments" name={t('nav~Deployments')} />
         <ResourceNSLink
+          id="deploymentconfigs"
           resource="deploymentconfigs"
           name={t('nav~Deployment Configs')}
           required={FLAGS.OPENSHIFT}
         />
-        <ResourceNSLink resource="statefulsets" name={t('nav~Stateful Sets')} />
-        <ResourceNSLink resource="secrets" name={t('nav~Secrets')} />
-        <ResourceNSLink resource="configmaps" name={t('nav~Config Maps')} />
-        <Separator name={t('nav~WorkloadsSeparator')} />
-        <ResourceNSLink resource="cronjobs" name={t('nav~Cron Jobs')} />
-        <ResourceNSLink resource="jobs" name={t('nav~Jobs')} />
-        <ResourceNSLink resource="daemonsets" name={t('nav~Daemon Sets')} />
-        <ResourceNSLink resource="replicasets" name={t('nav~Replica Sets')} />
-        <ResourceNSLink resource="replicationcontrollers" name={t('nav~Replication Controllers')} />
+        <ResourceNSLink id="statefulsets" resource="statefulsets" name={t('nav~Stateful Sets')} />
+        <ResourceNSLink id="secrets" resource="secrets" name={t('nav~Secrets')} />
+        <ResourceNSLink id="configmaps" resource="configmaps" name={t('nav~Config Maps')} />
+        <Separator id="WorkloadsSeparator" name={t('nav~WorkloadsSeparator')} />
+        <ResourceNSLink id="cronjobs" resource="cronjobs" name={t('nav~Cron Jobs')} />
+        <ResourceNSLink id="jobs" resource="jobs" name={t('nav~Jobs')} />
+        <ResourceNSLink id="daemonsets" resource="daemonsets" name={t('nav~Daemon Sets')} />
+        <ResourceNSLink id="replicasets" resource="replicasets" name={t('nav~Replica Sets')} />
         <ResourceNSLink
+          id="replicationcontrollers"
+          resource="replicationcontrollers"
+          name={t('nav~Replication Controllers')}
+        />
+        <ResourceNSLink
+          id="horizontalpodautoscalers"
           resource="horizontalpodautoscalers"
           name={t('nav~Horizontal Pod Autoscalers')}
         />
@@ -143,37 +167,55 @@ const AdminNav = () => {
       <NavSection title={t('nav~Serverless')} />
 
       <NavSection title={t('nav~Networking')}>
-        <ResourceNSLink resource="services" name={t('nav~Services')} />
-        <ResourceNSLink resource="routes" name={t('nav~Routes')} required={FLAGS.OPENSHIFT} />
-        <ResourceNSLink resource="ingresses" name={t('nav~Ingresses')} />
-        <ResourceNSLink resource="networkpolicies" name={t('nav~Network Policies')} />
+        <ResourceNSLink id="services" resource="services" name={t('nav~Services')} />
+        <ResourceNSLink
+          id="routes"
+          resource="routes"
+          name={t('nav~Routes')}
+          required={FLAGS.OPENSHIFT}
+        />
+        <ResourceNSLink id="ingresses" resource="ingresses" name={t('nav~Ingresses')} />
+        <ResourceNSLink
+          id="networkpolicies"
+          resource="networkpolicies"
+          name={t('nav~Network Policies')}
+        />
       </NavSection>
 
       <NavSection title={t('nav~Storage')}>
         <ResourceClusterLink
+          id="networkpolicies"
           resource="persistentvolumes"
           name={t('nav~Persistent Volumes')}
           required={FLAGS.CAN_LIST_PV}
         />
         <ResourceNSLink
+          id="persistentvolumeclaims"
           resource="persistentvolumeclaims"
           name={t('nav~Persistent Volume Claims')}
         />
-        <ResourceClusterLink resource="storageclasses" name={t('nav~Storage Classes')} />
+        <ResourceClusterLink
+          id="storageclasses"
+          resource="storageclasses"
+          name={t('nav~Storage Classes')}
+        />
         <ResourceNSLink
+          id="volumesnapshots"
           resource={referenceForModel(VolumeSnapshotModel)}
           name={t('nav~Volume Snapshots')}
         />
         <ResourceClusterLink
+          id="volumesnapshotclasses"
           resource={referenceForModel(VolumeSnapshotClassModel)}
           name={t('nav~Volume Snapshot Classes')}
         />
       </NavSection>
 
       <NavSection title={t('nav~Builds')} required={FLAGS.OPENSHIFT}>
-        <ResourceNSLink resource="buildconfigs" name={t('nav~Build Configs')} />
-        <ResourceNSLink resource="builds" name={t('nav~Builds')} />
+        <ResourceNSLink id="buildconfigs" resource="buildconfigs" name={t('nav~Build Configs')} />
+        <ResourceNSLink id="builds" resource="builds" name={t('nav~Builds')} />
         <ResourceNSLink
+          id="imagestreams"
           resource="imagestreams"
           name={t('nav~Image Streams')}
           startsWith={imagestreamsStartsWith}
@@ -186,12 +228,14 @@ const AdminNav = () => {
 
       <NavSection title={t('nav~Service Catalog')} required={FLAGS.SERVICE_CATALOG}>
         <HrefLink
+          id="provisionedservices"
           href="/provisionedservices"
           name={t('nav~Provisioned Services')}
           activePath="/provisionedservices/"
           startsWith={provisionedServicesStartsWith}
         />
         <HrefLink
+          id="brokermanagement"
           href="/brokermanagement"
           name={t('nav~Broker Management')}
           activePath="/brokermanagement/"
@@ -202,18 +246,21 @@ const AdminNav = () => {
       <MonitoringNavSection />
 
       <NavSection title={t('nav~Compute')} required={FLAGS.CAN_LIST_NODE}>
-        <ResourceClusterLink resource="nodes" name={t('nav~Nodes')} />
+        <ResourceClusterLink id="nodes" resource="nodes" name={t('nav~Nodes')} />
         <HrefLink
+          id="machines"
           href={formatNamespacedRouteForResource(referenceForModel(MachineModel), machineNS)}
           name={t('nav~Machines')}
           required={FLAGS.CLUSTER_API}
         />
         <HrefLink
+          id="machinesets"
           href={formatNamespacedRouteForResource(referenceForModel(MachineSetModel), machineNS)}
           name={t('nav~Machine Sets')}
           required={FLAGS.CLUSTER_API}
         />
         <HrefLink
+          id="machineautoscaler"
           href={formatNamespacedRouteForResource(
             referenceForModel(MachineAutoscalerModel),
             machineNS,
@@ -222,6 +269,7 @@ const AdminNav = () => {
           required={FLAGS.MACHINE_AUTOSCALER}
         />
         <HrefLink
+          id="machinehealthchecks"
           href={formatNamespacedRouteForResource(
             referenceForModel(MachineHealthCheckModel),
             machineNS,
@@ -229,13 +277,19 @@ const AdminNav = () => {
           name={t('nav~Machine Health Checks')}
           required={FLAGS.MACHINE_HEALTH_CHECK}
         />
-        <Separator required={FLAGS.MACHINE_CONFIG} name={t('nav~ComputeSeparator')} />
+        <Separator
+          id="computeseparator"
+          required={FLAGS.MACHINE_CONFIG}
+          name={t('nav~ComputeSeparator')}
+        />
         <ResourceClusterLink
+          id="machineconfigs"
           resource={referenceForModel(MachineConfigModel)}
           name={t('nav~Machine Configs')}
           required={FLAGS.MACHINE_CONFIG}
         />
         <ResourceClusterLink
+          id="machineconfigpools"
           resource={referenceForModel(MachineConfigPoolModel)}
           name={t('nav~Machine Config Pools')}
           required={FLAGS.MACHINE_CONFIG}
@@ -244,18 +298,30 @@ const AdminNav = () => {
 
       <NavSection title={t('nav~User Management')}>
         <ResourceClusterLink
+          id="users"
           resource={referenceForModel(UserModel)}
           name={t('nav~Users')}
           required={[FLAGS.OPENSHIFT, FLAGS.CAN_LIST_USERS]}
         />
         <ResourceClusterLink
+          id="groups"
           resource={referenceForModel(GroupModel)}
           name={t('nav~Groups')}
           required={[FLAGS.OPENSHIFT, FLAGS.CAN_LIST_GROUPS]}
         />
-        <ResourceNSLink resource="serviceaccounts" name={t('nav~Service Accounts')} />
-        <ResourceNSLink resource="roles" name={t('nav~Roles')} startsWith={rolesStartsWith} />
         <ResourceNSLink
+          id="serviceaccounts"
+          resource="serviceaccounts"
+          name={t('nav~Service Accounts')}
+        />
+        <ResourceNSLink
+          id="roles"
+          resource="roles"
+          name={t('nav~Roles')}
+          startsWith={rolesStartsWith}
+        />
+        <ResourceNSLink
+          id="rolebindings"
           resource="rolebindings"
           name={t('nav~Role Bindings')}
           startsWith={rolebindingsStartsWith}
@@ -264,6 +330,7 @@ const AdminNav = () => {
 
       <NavSection title={t('nav~Administration')}>
         <HrefLink
+          id="clustersettings"
           href="/settings/cluster"
           activePath="/settings/cluster/"
           name={t('nav~Cluster Settings')}
@@ -271,17 +338,20 @@ const AdminNav = () => {
           startsWith={clusterSettingsStartsWith}
         />
         <ResourceClusterLink
+          id="namespaces"
           resource="namespaces"
           name={t('nav~Namespaces')}
           required={FLAGS.CAN_LIST_NS}
         />
         <ResourceNSLink
+          id="resourcequotas"
           resource="resourcequotas"
           name={t('nav~Resource Quotas')}
           startsWith={quotaStartsWith}
         />
-        <ResourceNSLink resource="limitranges" name={t('nav~Limit Ranges')} />
+        <ResourceNSLink id="roles" resource="limitranges" name={t('nav~Limit Ranges')} />
         <HrefLink
+          id="metering"
           href={formatNamespacedRouteForResource(
             referenceForModel(ChargebackReportModel),
             'openshift-metering',
@@ -291,6 +361,7 @@ const AdminNav = () => {
           startsWith={meteringStartsWith}
         />
         <ResourceClusterLink
+          id="customresourcedefinitions"
           resource="customresourcedefinitions"
           name={t('nav~Custom Resource Definitions')}
           required={FLAGS.CAN_LIST_CRD}

--- a/frontend/public/components/nav/items.tsx
+++ b/frontend/public/components/nav/items.tsx
@@ -70,7 +70,6 @@ class NavLink<P extends NavLinkProps> extends React.PureComponent<P> {
   render() {
     const {
       isActive,
-      id,
       name,
       tipText,
       onClick,
@@ -89,7 +88,6 @@ class NavLink<P extends NavLinkProps> extends React.PureComponent<P> {
       <NavItem className={itemClasses} isActive={isActive}>
         <Link
           className={linkClasses}
-          id={id}
           data-test-id={testID}
           to={this.to}
           onClick={onClick}
@@ -193,12 +191,13 @@ export const createLink = (item: PluginNavItem, rootNavLink = false): React.Reac
       Component = ResourceClusterLink;
     }
     if (Component) {
+      const { id } = item.properties;
       const key = item.properties.componentProps.name;
       const props = item.properties.componentProps;
       if (rootNavLink) {
-        return <RootNavLink {...props} key={key} component={Component} />;
+        return <RootNavLink id={id} {...props} key={key} component={Component} />;
       }
-      return <Component {...props} key={key} />;
+      return <Component id={id} {...props} key={key} />;
     }
   }
   return undefined;

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -32,12 +32,30 @@ const navSectionStateToProps = (
   };
 };
 
+const findChildIndex = (id: string, Children: React.ReactElement[]) =>
+  Children.findIndex((c) => c.props.id === id);
+
 const mergePluginChild = (
   Children: React.ReactElement[],
   pluginChild: React.ReactElement,
-  mergeBefore?: string,
+  insertBefore?: string | string[],
+  insertAfter?: string | string[],
 ) => {
-  const index = Children.findIndex((c) => c.props.name === mergeBefore);
+  let index = -1;
+  const before = Array.isArray(insertBefore) ? insertBefore : [insertBefore];
+  const after = Array.isArray(insertAfter) ? insertAfter : [insertAfter];
+  let count = 0;
+  while (count < before.length && index < 0) {
+    index = findChildIndex(before[count++], Children);
+  }
+  count = 0;
+  while (count < after.length && index < 0) {
+    index = findChildIndex(after[count++], Children);
+    if (index >= 0) {
+      index += 1;
+    }
+  }
+
   if (index >= 0) {
     Children.splice(index, 0, pluginChild);
   } else {
@@ -174,7 +192,12 @@ export const NavSection = connect(navSectionStateToProps)(
         this.getNavItemExtensions(perspective, title).forEach((item) => {
           const pluginChild = this.mapChild(createLink(item));
           if (pluginChild) {
-            mergePluginChild(Children, pluginChild, item.properties.mergeBefore);
+            mergePluginChild(
+              Children,
+              pluginChild,
+              item.properties.insertBefore,
+              item.properties.insertAfter,
+            );
           }
         });
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5138

**Analysis / Root cause**: 
Pipelines was moved to a separate package and adds the `Pipelines` navigation item. I attempts to add it before an item that may or may not exist so simply adding `mergeBefore` is not acceptable.

**Solution Description**: 
Adds the ability for plugins to add items before or after other items by Id or an order of ids to look for.
Changed `mergeBefore` to `insertBefore`
Added `insertAfter`
Allow for arrays of items rather than a single item.
Use ids rather than names since names will not be consistent with i18n.
Add Ids to current nav items to allow plugins to use those Ids for insertion points.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
/kind feature
