### PR TITLE
Convert Guided tour data from local storage to user settings

### DIFF
--- a/frontend/packages/console-app/src/components/tour/utils.ts
+++ b/frontend/packages/console-app/src/components/tour/utils.ts
@@ -1,56 +1,5 @@
 import { FeatureState } from '@console/internal/reducers/features';
-import { TOUR_LOCAL_STORAGE_KEY } from './const';
 import { Step } from './type';
-
-/**
- * Local Storage utils
- */
-
-type TourLocalStorageType = {
-  completed: boolean;
-};
-
-type TourLocalStorageData = {
-  [key: string]: TourLocalStorageType;
-};
-
-const getTourLocalStorageData = (): TourLocalStorageData =>
-  JSON.parse(localStorage.getItem(TOUR_LOCAL_STORAGE_KEY));
-
-const setTourLocalStorageData = (data: TourLocalStorageData) =>
-  localStorage.setItem(TOUR_LOCAL_STORAGE_KEY, JSON.stringify(data));
-
-const hasLocalStorageKey = (key: string): boolean => localStorage.getItem(key) !== null;
-
-const initializeTourLocalStorage = (perspective: string): TourLocalStorageType => {
-  const data = { completed: false };
-  setTourLocalStorageData({ [perspective]: data });
-  return data;
-};
-
-const initializeTourLocalStorageForPerspective = (perspective: string): TourLocalStorageType => {
-  const data = getTourLocalStorageData();
-  data[perspective] = { completed: false };
-  setTourLocalStorageData(data);
-  return data[perspective];
-};
-
-export const getTourLocalStorageForPerspective = (perspective: string): TourLocalStorageType => {
-  if (!hasLocalStorageKey(TOUR_LOCAL_STORAGE_KEY)) return initializeTourLocalStorage(perspective);
-  const data = getTourLocalStorageData();
-  if (data.hasOwnProperty(perspective)) {
-    return data[perspective];
-  }
-  return initializeTourLocalStorageForPerspective(perspective);
-};
-
-export const setTourCompletionLocalStorageDataForPerspective = (
-  perspective: string,
-  completed: boolean,
-): void => {
-  const data = getTourLocalStorageData();
-  setTourLocalStorageData({ ...data, [perspective]: { ...data[perspective], completed } });
-};
 
 /**
  * filter utils


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5083
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: convert the local storage to user settings
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: use `useUserSettings` hook to store the local storage data into a config map.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No UI changes
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: Added
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
