### PR TITLE
CONSOLE-2461: Add infrastructure for Korean

### DIFF
--- a/frontend/i18n-scripts/consolidate-public-folders.js
+++ b/frontend/i18n-scripts/consolidate-public-folders.js
@@ -39,13 +39,7 @@ function processFile(fileName) {
 }
 
 function processLocalesFolder(filePath) {
-  if (path.basename(filePath) === 'en') {
-    common.parseFolder(filePath, processFile);
-  }
-  if (path.basename(filePath) === 'zh') {
-    common.parseFolder(filePath, processFile);
-  }
-  if (path.basename(filePath) === 'ja') {
+  if (common.isDirectory(filePath)) {
     common.parseFolder(filePath, processFile);
   }
 }
@@ -74,13 +68,7 @@ function logFiles(filePath) {
 }
 
 function processPublic(filePath) {
-  if (path.basename(filePath) === 'en') {
-    common.parseFolder(filePath, logFiles);
-  }
-  if (path.basename(filePath) === 'zh') {
-    common.parseFolder(filePath, logFiles);
-  }
-  if (path.basename(filePath) === 'ja') {
+  if (common.isDirectory(filePath)) {
     common.parseFolder(filePath, logFiles);
   }
 }

--- a/frontend/i18n-scripts/export-pos.sh
+++ b/frontend/i18n-scripts/export-pos.sh
@@ -5,6 +5,7 @@ set -exuo pipefail
 for f in public/locales/en/* ; do
   yarn i18n-to-po -f $(basename "$f" .json) -l zh
   yarn i18n-to-po -f $(basename "$f" .json) -l ja
+  yarn i18n-to-po -f $(basename "#f" .json) -l ko
 done
 
 cd packages
@@ -14,6 +15,7 @@ for d in */ ; do
     for f in $d/locales/en/* ; do
       yarn i18n-to-po -p "$d" -f $(basename "$f" .json) -l zh
       yarn i18n-to-po -p "$d" -f $(basename "$f" .json) -l ja
+      yarn i18n-to-po -p "$d" -f $(basename "$f" .json) -l ko
     done
   fi
 done

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -8,6 +8,7 @@ import Pseudo from 'i18next-pseudo';
 import 'moment/locale/zh-cn';
 import 'moment/locale/ja';
 import 'moment/locale/en-gb';
+import 'moment/locale/ko';
 import moment from 'moment';
 
 const params = new URLSearchParams(window.location.search);

--- a/frontend/public/locales/ko/public.json
+++ b/frontend/public/locales/ko/public.json
@@ -1,0 +1,3 @@
+{
+  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}"
+}

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -207,7 +207,7 @@ const config: Configuration = {
     new CopyWebpackPlugin([{ from: './packages/container-security/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/pipelines-plugin/locales', to: 'locales' }]),
     new MomentLocalesPlugin({
-      localesToKeep: ['en', 'ja'],
+      localesToKeep: ['en', 'ja', 'ko'],
     }),
     new webpack.IgnorePlugin(/prettier/),
     extractCSS,


### PR DESCRIPTION
Added moment.js locale for Korean, removed last language reference in script, updated bash script from https://github.com/openshift/console/pull/7030 to export Korean po files, and added timestamp in ko folder in public/locales.

Blocked by https://github.com/openshift/console/pull/7187; need to add "ko" to list of supported locales in https://github.com/openshift/console/pull/7187/files#diff-a7def86cc36a2178b4ee07b000c53d49e04068db4bc85967c0758578a2f37700R210.

Fixes https://issues.redhat.com/browse/CONSOLE-2461.