### PR TITLE
Bug:1898357 Address operatorhub image name overlap bug. Enable overflow-wrap on string.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -110,6 +110,8 @@ $co-affinity-row-margin: 15px;
 
 .co-operand-details__section--info dd {
   margin-bottom: 20px !important;
+  min-width: 0; // enable word-break
+  overflow-wrap: break-word;
 }
 
 .co-catalog-install-modal .modal-header .co-clusterserviceversion-logo__icon {


### PR DESCRIPTION
<img width="1307" alt="Screen Shot 2020-11-16 at 3 30 44 PM" src="https://user-images.githubusercontent.com/1874151/99306453-3c907a80-2823-11eb-9b1f-7ffe1d1ca09c.png">

<img width="652" alt="Screen Shot 2020-11-16 at 3 36 01 PM" src="https://user-images.githubusercontent.com/1874151/99306449-3b5f4d80-2823-11eb-9657-002c26aedf4c.png">



Fix Bug 1898357