### PR TITLE
Use console.flag/model extension in console-app package

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -15,6 +15,9 @@
   "[json]": {
     "editor.formatOnSave": true
   },
+  "[jsonc]": {
+    "editor.formatOnSave": true
+  },
   "[graphql]": {
     "editor.formatOnSave": true
   },

--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@console/dynamic-demo-plugin",
-  "version": "0.0.0-fixed",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "clean": "rm -rf ./dist",

--- a/frontend/packages/ceph-storage-plugin/console-extensions.json
+++ b/frontend/packages/ceph-storage-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": [
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "DEVWORKSPACE",
+        "model": {
+          "group": "workspace.devfile.io",
+          "version": "v1alpha1",
+          "kind": "DevWorkspace"
+        }
+      }
+    }
+  ]
+}

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { CogsIcon } from '@patternfly/react-icons';
 import { FLAGS } from '@console/shared/src/constants';
-import { FLAG_DEVWORKSPACE } from './consts';
 import {
   Plugin,
   Perspective,
-  ModelFeatureFlag,
   ModelDefinition,
   RoutePage,
   DashboardsOverviewResourceActivity,
@@ -55,7 +53,6 @@ import '@console/internal/i18n.js';
 type ConsumedExtensions =
   | Perspective
   | ModelDefinition
-  | ModelFeatureFlag
   | RoutePage
   | DashboardsOverviewResourceActivity
   | DashboardsOverviewHealthURLSubsystem<any>
@@ -74,13 +71,6 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'ModelDefinition',
     properties: {
       models: _.values(models),
-    },
-  },
-  {
-    type: 'FeatureFlag/Model',
-    properties: {
-      model: models.WorkspaceModel,
-      flag: FLAG_DEVWORKSPACE,
     },
   },
   {

--- a/frontend/packages/console-demo-plugin/console-extensions.json
+++ b/frontend/packages/console-demo-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -28,7 +28,7 @@ declared via the `consolePlugin` object.
 ```jsonc
 {
   "name": "@console/dynamic-demo-plugin",
-  "version": "0.0.0-fixed",
+  "version": "0.0.0",
   "private": true,
   // scripts, dependencies, devDependencies, ...
   "consolePlugin": {
@@ -46,7 +46,7 @@ declared via the `consolePlugin` object.
 
 Dynamic plugins can expose modules representing additional code to be referenced, loaded and executed
 at runtime. A separate [webpack chunk](https://webpack.js.org/guides/code-splitting/) is generated for
-each exposed module.
+each exposed module. Exposed modules are resolved relative to webpack `context` option.
 
 ## `console-extensions.json`
 
@@ -133,9 +133,10 @@ Provides asynchronous access to specific modules exposed by the plugin.
 
 ## Runtime constraints and specifics
 
-- Loading two or more plugins with the same `name` is not allowed.
+- Loading multiple plugins with the same `name` is not allowed.
 - Console will [override](https://webpack.js.org/concepts/module-federation/#overriding) certain modules
   to ensure a single version of React etc. is loaded and used by the application.
 - Enabling a plugin makes all of its extensions available for consumption. Individual extensions cannot
   be enabled or disabled separately.
-- Failure to resolve a code reference (unable to load module or missing export) will disable the plugin.
+- Failure to resolve a code reference (unable to load module, missing module export etc.) will disable
+  the plugin.

--- a/frontend/packages/container-security/console-extensions.json
+++ b/frontend/packages/container-security/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/insights-plugin/console-extensions.json
+++ b/frontend/packages/insights-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/local-storage-operator-plugin/console-extensions.json
+++ b/frontend/packages/local-storage-operator-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/metal3-plugin/console-extensions.json
+++ b/frontend/packages/metal3-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/network-attachment-definition-plugin/console-extensions.json
+++ b/frontend/packages/network-attachment-definition-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/noobaa-storage-plugin/console-extensions.json
+++ b/frontend/packages/noobaa-storage-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/operator-lifecycle-manager/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}

--- a/frontend/packages/topology/console-extensions.json
+++ b/frontend/packages/topology/console-extensions.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
+  "data": []
+}


### PR DESCRIPTION
- [x] Add empty `console-extensions.json` to all static plugins.
- [x] Use dynamic `console.flag/model` extension in `@console/app` package.
- [x] Update static and dynamic plugin README files.