### PR TITLE
Bug 1898320: - Incorrect Apostrophe Translation of "it's" in Scheduling Disabled Popover

### DIFF
--- a/frontend/packages/console-app/locales/en/nodes.json
+++ b/frontend/packages/console-app/locales/en/nodes.json
@@ -79,6 +79,6 @@
   "The debug pod failed. ": "The debug pod failed. ",
   "An error occurred. Please try again": "An error occurred. Please try again",
   "Scheduling disabled": "Scheduling disabled",
-  "No new Pods or workloads will be placed on this Node until it&apos;s marked as schedulable.": "No new Pods or workloads will be placed on this Node until it&apos;s marked as schedulable.",
+  "No new Pods or workloads will be placed on this Node until it's marked as schedulable.": "No new Pods or workloads will be placed on this Node until it's marked as schedulable.",
   "Mark as schedulable": "Mark as schedulable"
 }

--- a/frontend/packages/console-app/src/components/nodes/popovers/MarkAsSchedulablePopover.tsx
+++ b/frontend/packages/console-app/src/components/nodes/popovers/MarkAsSchedulablePopover.tsx
@@ -32,7 +32,7 @@ const MarkAsSchedulablePopover: React.FC<MarkAsSchedulablePopoverProps> = ({ nod
     >
       <p>
         {t(
-          'nodes~No new Pods or workloads will be placed on this Node until it&apos;s marked as schedulable.',
+          "nodes~No new Pods or workloads will be placed on this Node until it's marked as schedulable.",
         )}
       </p>
       <Button isInline variant="link" onClick={onClickMarkAsSchedulable}>


### PR DESCRIPTION
/assign @spadgett 

![Screen Shot 2020-11-16 at 4 08 34 PM](https://user-images.githubusercontent.com/15249132/99308569-23d59400-2826-11eb-9d4c-e9ccf5baf7af.png)


