### PR TITLE
Query Browser: Remove Y-axis ticks

### DIFF
--- a/frontend/public/components/graphs/themes.ts
+++ b/frontend/public/components/graphs/themes.ts
@@ -87,7 +87,6 @@ export const queryBrowserTheme = {
       grid: {
         stroke: '#EDEDED',
       },
-      ticks: axisTicks,
       tickLabels: pfDependentAxisTickLabels,
     },
   },

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -265,6 +265,9 @@ const LegendContainer = ({ children }: { children?: React.ReactNode }) => {
   );
 };
 
+const Null = () => null;
+const nullComponent = <Null />;
+
 type GraphSeries = GraphDataPoint[] | null;
 
 const Graph: React.FC<GraphProps> = React.memo(
@@ -340,7 +343,13 @@ const Graph: React.FC<GraphProps> = React.memo(
         width={width}
       >
         <ChartAxis style={xAxisStyle} tickCount={5} tickFormat={xTickFormat} />
-        <ChartAxis crossAxis={false} dependentAxis tickCount={6} tickFormat={yTickFormat} />
+        <ChartAxis
+          crossAxis={false}
+          dependentAxis
+          tickComponent={nullComponent}
+          tickCount={6}
+          tickFormat={yTickFormat}
+        />
         {isStack ? (
           <ChartStack>
             {data.map((values, i) => (


### PR DESCRIPTION
We have Y-axis strokes running the width of the graph, so the ticks seem
redundant.

Before | After
-|-
![before](https://user-images.githubusercontent.com/460802/99348728-981f3e80-28dd-11eb-9ae3-884cdb9d1322.png) | ![after](https://user-images.githubusercontent.com/460802/99348720-95bce480-28dd-11eb-9e33-af77cfcecd36.png)

FYI @cshinn 