### PR TITLE
add default workspace when auto starting pipeline from Add flow

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
@@ -1,10 +1,13 @@
 import * as _ from 'lodash';
 import { k8sCreate } from '@console/internal/module/k8s';
 import { PipelineData } from '../import-types';
-import { Pipeline, PipelineRun } from '../../../utils/pipeline-augment';
+import { Pipeline, PipelineRun, PipelineWorkspace } from '../../../utils/pipeline-augment';
 import { PipelineModel } from '../../../models';
 import { createPipelineResource } from '../../pipelines/pipeline-resource/pipelineResource-utils';
-import { convertPipelineToModalData } from '../../pipelines/modals/common/utils';
+import {
+  convertPipelineToModalData,
+  getDefaultVolumeClaimTemplate,
+} from '../../pipelines/modals/common/utils';
 import { submitStartPipeline } from '../../pipelines/modals/start-pipeline/submit-utils';
 import { StartPipelineFormValues } from '../../pipelines/modals/start-pipeline/types';
 
@@ -67,6 +70,11 @@ export const createPipelineForImportFlow = async (
 export const createPipelineRunForImportFlow = async (pipeline: Pipeline): Promise<PipelineRun> => {
   const pipelineInitialValues: StartPipelineFormValues = {
     ...convertPipelineToModalData(pipeline),
+    workspaces: (pipeline.spec.workspaces || []).map((workspace: PipelineWorkspace) => ({
+      ...workspace,
+      type: 'volumeClaimTemplate',
+      data: getDefaultVolumeClaimTemplate(pipeline?.metadata?.name),
+    })),
     secretOpen: false,
   };
   return submitStartPipeline(pipelineInitialValues, pipeline);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
@@ -1,10 +1,15 @@
 import { match as RMatch } from 'react-router-dom';
 import { useTabbedTableBreadcrumbsFor } from '@console/shared';
-import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
+import {
+  K8sKind,
+  PersistentVolumeClaimKind,
+  referenceForModel,
+} from '@console/internal/module/k8s';
 import {
   useK8sWatchResource,
   WatchK8sResource,
 } from '@console/internal/components/utils/k8s-watch-hook';
+import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { pipelinesTab } from '../../utils/pipeline-utils';
 import { PipelineRun, getLatestRun } from '../../utils/pipeline-augment';
 import { TektonResourceLabel } from './const';
@@ -36,4 +41,21 @@ export const useLatestPipelineRun = (pipelineName: string, namespace: string): P
   );
   const latestRun = getLatestRun({ data: pipelineRun }, 'creationTimestamp');
   return pipelineRunLoaded && !pipelineRunError ? latestRun : null;
+};
+
+export const usePipelinePVC = (
+  pipelineName: string,
+  namespace: string,
+): [PersistentVolumeClaimKind, boolean] => {
+  const pvcResource: WatchK8sResource = {
+    kind: PersistentVolumeClaimModel.kind,
+    namespace,
+    selector: {
+      matchLabels: { [TektonResourceLabel.pipeline]: pipelineName },
+    },
+    optional: true,
+    isList: true,
+  };
+  const [PVC, PVCLoaded, PVCError] = useK8sWatchResource<PersistentVolumeClaimKind[]>(pvcResource);
+  return [!PVCError && PVC.length > 0 ? PVC[0] : null, PVCLoaded];
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
@@ -5,7 +5,12 @@ import {
   PipelineExampleNames,
   DataState,
 } from '../../../../../test-data/pipeline-data';
-import { getPipelineRunData, getPipelineRunFromForm, migratePipelineRun } from '../utils';
+import {
+  convertPipelineToModalData,
+  getPipelineRunData,
+  getPipelineRunFromForm,
+  migratePipelineRun,
+} from '../utils';
 import { CommonPipelineModalFormikValues } from '../types';
 
 const samplePipeline = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipeline;
@@ -214,5 +219,23 @@ describe('PipelineAction testing migratePipelineRun', () => {
 
     // Should still have other spec properties
     expect(result.spec.pipelineRef).toEqual(samplePipelineRun.spec.pipelineRef);
+  });
+});
+
+describe('convertPipelineToModalData', () => {
+  const workspacePipeline = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE].pipeline;
+  it('expect to return workspaces', () => {
+    expect(convertPipelineToModalData(workspacePipeline).workspaces).toHaveLength(3);
+  });
+
+  it('expect to return workspaces with type EmptyDirectory, if preselect PVC argument is not passed', () => {
+    const { workspaces } = convertPipelineToModalData(workspacePipeline);
+    expect(workspaces.filter((workspace) => workspace.type === 'EmptyDirectory')).toHaveLength(3);
+  });
+
+  it('expect to return workspaces with type PVC, if preselect PVC argument is passed', () => {
+    const { workspaces } = convertPipelineToModalData(workspacePipeline, false, 'test-pvc');
+    expect(workspaces.filter((workspace) => workspace.type === 'EmptyDirectory')).toHaveLength(0);
+    expect(workspaces.filter((workspace) => workspace.type === 'PVC')).toHaveLength(3);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/types.ts
@@ -1,6 +1,7 @@
 import { FormikValues } from 'formik';
 import {
   PipelineParam,
+  VolumeTypeClaim,
   VolumeTypeConfigMaps,
   VolumeTypePVC,
   VolumeTypeSecret,
@@ -31,6 +32,9 @@ export type PipelineModalFormWorkspace = {
       }
     | {
         persistentVolumeClaim: VolumeTypePVC;
+      }
+    | {
+        volumeClaimTemplate: VolumeTypeClaim;
       };
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -6,6 +6,7 @@ import {
   ModalComponentProps,
 } from '@console/internal/components/factory/modal';
 import { errorModal } from '@console/internal/components/modals';
+import { LoadingBox } from '@console/internal/components/utils';
 import { Pipeline, PipelineRun } from '../../../../utils/pipeline-augment';
 import { useUserAnnotationForManualStart } from '../../../pipelineruns/triggered-by';
 import ModalStructure from '../common/ModalStructure';
@@ -14,6 +15,7 @@ import { startPipelineSchema } from '../common/validation-utils';
 import StartPipelineForm from './StartPipelineForm';
 import { submitStartPipeline } from './submit-utils';
 import { StartPipelineFormValues } from './types';
+import { usePipelinePVC } from '../../hooks';
 
 export interface StartPipelineModalProps {
   pipeline: Pipeline;
@@ -26,9 +28,17 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
 }) => {
   const { t } = useTranslation();
   const userStartedAnnotation = useUserAnnotationForManualStart();
+  const [pipelinePVC, pipelinePVCLoaded] = usePipelinePVC(
+    pipeline.metadata?.name,
+    pipeline.metadata?.namespace,
+  );
+
+  if (!pipelinePVCLoaded) {
+    return <LoadingBox />;
+  }
 
   const initialValues: StartPipelineFormValues = {
-    ...convertPipelineToModalData(pipeline),
+    ...convertPipelineToModalData(pipeline, false, pipelinePVC?.metadata?.name),
     secretOpen: false,
   };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
@@ -5,6 +5,7 @@ import {
   createModalLauncher,
   ModalComponentProps,
 } from '@console/internal/components/factory/modal';
+import { LoadingBox } from '@console/internal/components/utils';
 import { Pipeline } from '../../../../utils/pipeline-augment';
 import ModalStructure from '../common/ModalStructure';
 import { convertPipelineToModalData } from '../common/utils';
@@ -13,6 +14,7 @@ import AddTriggerForm from './AddTriggerForm';
 import { TRIGGER_BINDING_EMPTY } from './const';
 import { submitTrigger } from './submit-utils';
 import { AddTriggerFormValues } from './types';
+import { usePipelinePVC } from '../../hooks';
 
 type AddTriggerModalProps = ModalComponentProps & {
   pipeline: Pipeline;
@@ -20,8 +22,16 @@ type AddTriggerModalProps = ModalComponentProps & {
 
 const AddTriggerModal: React.FC<AddTriggerModalProps> = ({ pipeline, close }) => {
   const { t } = useTranslation();
+  const [pipelinePVC, pipelinePVCLoaded] = usePipelinePVC(
+    pipeline.metadata?.name,
+    pipeline.metadata?.namespace,
+  );
+
+  if (!pipelinePVCLoaded) {
+    return <LoadingBox />;
+  }
   const initialValues: AddTriggerFormValues = {
-    ...convertPipelineToModalData(pipeline, true),
+    ...convertPipelineToModalData(pipeline, true, pipelinePVC?.metadata?.name),
     triggerBinding: {
       name: TRIGGER_BINDING_EMPTY,
       resource: null,

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -13,6 +13,7 @@ import {
   referenceForModel,
   GroupVersionKind,
   apiVersionForModel,
+  ObjectMetadata,
 } from '@console/internal/module/k8s';
 import {
   ClusterTaskModel,
@@ -298,8 +299,32 @@ export type VolumeTypePVC = {
   claimName: string;
 };
 
+export type PersistentVolumeClaimType = {
+  persistentVolumeClaim: VolumeTypePVC;
+};
+
+export type VolumeClaimTemplateType = {
+  volumeClaimTemplate: VolumeTypeClaim;
+};
+export type VolumeTypeClaim = {
+  metadata: ObjectMetadata;
+  spec: {
+    accessModes: string[];
+    resources: {
+      requests: {
+        storage: string;
+      };
+    };
+  };
+};
+
 export interface PipelineRunWorkspace extends Param {
-  [volumeType: string]: VolumeTypeSecret | VolumeTypeConfigMaps | VolumeTypePVC | {};
+  [volumeType: string]:
+    | VolumeTypeSecret
+    | VolumeTypeConfigMaps
+    | VolumeTypePVC
+    | VolumeTypeClaim
+    | {};
 }
 
 interface FirehoseResource {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5118

**Analysis / Root cause**: 
As a user, when I'm getting my Pipeline Run auto-started off the add flow, I need a PVC volumeClaimTemplate otherwise my Pipeline Run doesn't successfully run.

**Solution Description**: 
1. Attach a default volumeClaimTemplate to the pipelineRun when auto starting a pipeline through the +Add flow with pipeline metadata label attached to it.
2. Use the pipeline metadata label pre select the `PVC` in the Start pipeline modal and Add Trigger modal or fallback to select the `EmptyDirectory` option

**Screen shots / Gifs for design review**: 
1. PVC getting created through the add flow pipeline auto start feature (via `volumeclaimTemplate` in the pipelinerun).

![pvc](https://user-images.githubusercontent.com/9964343/99375083-52687300-28e9-11eb-965f-a1957b787493.gif)
2. In Start Modal, PVC getting auto selected using the pipeline label attached to it.
![auto-selecting-pvc](https://user-images.githubusercontent.com/9964343/99376474-01f21500-28eb-11eb-9bf3-002ff88eddb5.gif)
3. In Add trigger, PVC getting auto selected
![trigger](https://user-images.githubusercontent.com/9964343/99376635-3239b380-28eb-11eb-9188-418abc25c758.gif)

4. Pipelines are now getting executed successfully
![image](https://user-images.githubusercontent.com/9964343/99383225-92345800-28f3-11eb-9e23-592e381ac1b0.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/9964343/99377114-d6bbf580-28eb-11eb-9dd1-191759e9f0be.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @andrewballantyne @jerolimov  @vdemeester @openshift/team-devconsole-ux 