### PR TITLE
add non blocking pipeline creation flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -19,6 +19,8 @@ import {
   createPipelineForImportFlow,
   createPipelineRunForImportFlow,
 } from '@console/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils';
+import { Perspective } from '@console/plugin-sdk';
+import { setPipelineNotStarted } from '@console/pipelines-plugin/src/components/pipelines/pipeline-overview/pipeline-overview-utils';
 import {
   getAppLabels,
   getPodLabels,
@@ -38,7 +40,6 @@ import {
   GitReadableTypes,
   Resources,
 } from './import-types';
-import { Perspective } from '@console/plugin-sdk';
 
 export const generateSecret = () => {
   // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
@@ -477,7 +478,13 @@ export const createOrUpdateResources = async (
       formData.pipeline,
       formData.docker.dockerfilePath,
     );
-    requests.push(createPipelineRunForImportFlow(newPipeline));
+    try {
+      await createPipelineRunForImportFlow(newPipeline);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+      setPipelineNotStarted(newPipeline.metadata.name, newPipeline.metadata.namespace);
+    }
   }
 
   verb === 'create' && requests.push(createWebhookSecret(formData, 'generic', dryRun));

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -124,6 +124,7 @@
   "Select {{resourceType}} resource...": "Select {{resourceType}} resource...",
   "Add another value": "Add another value",
   "Must define at least one task": "Must define at least one task",
+  "Pipeline could not be started automatically": "Pipeline could not be started automatically",
   "View all {{pipelineRunsLength}}": "View all {{pipelineRunsLength}}",
   "View logs": "View logs",
   "Name of the cluster.": "Name of the cluster.",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -45,3 +45,4 @@ export const SecretAnnotationType = {
 };
 
 export const PIPELINE_SERVICE_ACCOUNT = 'pipeline';
+export const PIPELINE_RUN_AUTO_START_FAILED = `bridge/pipeline-run-auto-start-failed`;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.spec.tsx
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme';
 import PipelineOverview from './PipelineOverview';
 import PipelineStartButton from './PipelineStartButton';
 import TriggerLastRunButton from './TriggerLastRunButton';
+import { setPipelineNotStarted } from './pipeline-overview-utils';
+import PipelineOverviewAlert from './PipelineOverviewAlert';
 
 jest.mock('react-i18next', () => {
   const reactI18next = require.requireActual('react-i18next');
@@ -50,5 +52,19 @@ describe('Pipeline sidebar overview', () => {
     props.item.pipelineRuns = [{ metadata: { name: 'pipelinerun', namespace: 'test' } }];
     const wrapper = shallow(<PipelineOverview {...props} />);
     expect(wrapper.find(TriggerLastRunButton)).toHaveLength(1);
+  });
+
+  it('should show the pipeline not started Alert', () => {
+    const { name, namespace } = props.item.pipelines[0].metadata;
+    setPipelineNotStarted(name, namespace);
+    const wrapper = shallow(<PipelineOverview {...props} />);
+    expect(wrapper.find(PipelineOverviewAlert)).toHaveLength(1);
+    sessionStorage.clear();
+  });
+
+  it('should not show the pipeline not started Alert', () => {
+    sessionStorage.clear();
+    const wrapper = shallow(<PipelineOverview {...props} />);
+    expect(wrapper.find(PipelineOverviewAlert)).toHaveLength(0);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
@@ -14,6 +14,8 @@ import { PipelineRunModel, PipelineModel } from '../../../models';
 import TriggerLastRunButton from './TriggerLastRunButton';
 import PipelineRunItem from './PipelineRunItem';
 import PipelineStartButton from './PipelineStartButton';
+import { isPipelineNotStarted, removePipelineNotStarted } from './pipeline-overview-utils';
+import PipelineOverviewAlert from './PipelineOverviewAlert';
 
 const MAX_VISIBLE = 3;
 
@@ -31,9 +33,24 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
   const {
     metadata: { name, namespace },
   } = pipeline;
+  const [showAlert, setShowAlert] = React.useState(isPipelineNotStarted(name, namespace));
+
+  React.useEffect(() => {
+    setShowAlert(isPipelineNotStarted(name, namespace));
+  }, [name, namespace]);
+
   return (
     <>
       <SidebarSectionHeading text={PipelineRunModel.labelPlural}>
+        {showAlert && pipelineRuns.length === 0 && (
+          <PipelineOverviewAlert
+            title={t('pipelines-plugin~Pipeline could not be started automatically')}
+            onClose={() => {
+              setShowAlert(false);
+              removePipelineNotStarted(name, namespace);
+            }}
+          />
+        )}
         {pipelineRuns.length > MAX_VISIBLE && (
           <Link
             className="sidebar__section-view-all"

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverviewAlert.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverviewAlert.scss
@@ -1,0 +1,3 @@
+.pipeline-overview-alert {
+  margin-top: var(--pf-global--spacer--md);
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverviewAlert.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverviewAlert.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Alert, AlertActionCloseButton, AlertProps } from '@patternfly/react-core';
+
+import './PipelineOverviewAlert.scss';
+
+type PipelineOverviewAlertProps = {
+  title: string;
+  onClose?: () => void;
+};
+
+const PipelineOverviewAlert: React.FC<PipelineOverviewAlertProps & AlertProps> = ({
+  title,
+  onClose,
+}) => {
+  return (
+    <Alert
+      className="pipeline-overview-alert"
+      variant="default"
+      isInline
+      title={title}
+      actionClose={<AlertActionCloseButton onClose={onClose} />}
+    />
+  );
+};
+
+export default PipelineOverviewAlert;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/__tests__/pipeline-overview-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/__tests__/pipeline-overview-utils.spec.ts
@@ -1,0 +1,54 @@
+import * as overviewUtils from '../pipeline-overview-utils';
+
+describe('pipeline-overview-utils', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('should properly set the failed pipeline names in the session storage', () => {
+    overviewUtils.setPipelineNotStarted('pipeline-one', 'ns-1');
+    overviewUtils.setPipelineNotStarted('pipeline-two', 'ns-1');
+    overviewUtils.setPipelineNotStarted('pipeline-three', 'ns-1');
+
+    expect(overviewUtils.getNotStartedPipelines('ns-1')).toHaveLength(3);
+  });
+
+  it('should not set the session storage if empty string or null is passed', () => {
+    overviewUtils.setPipelineNotStarted('', '');
+    overviewUtils.setPipelineNotStarted(null, '');
+    overviewUtils.setPipelineNotStarted(undefined, '');
+
+    expect(overviewUtils.getNotStartedPipelines('ns-1')).toHaveLength(0);
+  });
+
+  it('should remove the pipeline names from the session storage', () => {
+    overviewUtils.setPipelineNotStarted('pipeline-one', 'ns-1');
+    overviewUtils.setPipelineNotStarted('pipeline-two', 'ns-1');
+    overviewUtils.setPipelineNotStarted('pipeline-three', 'ns-1');
+
+    overviewUtils.removePipelineNotStarted('pipeline-three', 'ns-1');
+    overviewUtils.removePipelineNotStarted('pipeline-two', 'ns-1');
+    const failedPipelines = overviewUtils.getNotStartedPipelines('ns-1');
+
+    expect(failedPipelines).toHaveLength(1);
+    expect(failedPipelines[0]).toBe('pipeline-one');
+  });
+
+  it('should not affect existing values if we pass null or undefined values to remove operation', () => {
+    overviewUtils.setPipelineNotStarted('pipeline-one', 'ns-1');
+
+    overviewUtils.removePipelineNotStarted(null, 'ns-1');
+    overviewUtils.removePipelineNotStarted(undefined, 'ns-1');
+
+    expect(overviewUtils.getNotStartedPipelines('ns-1')).toHaveLength(1);
+  });
+
+  it('should return true or false based on pipeline name availability in the session storage', () => {
+    overviewUtils.setPipelineNotStarted('pipeline-one', 'ns-1');
+    overviewUtils.setPipelineNotStarted('pipeline-two', 'ns-1');
+
+    expect(overviewUtils.isPipelineNotStarted('pipeline-one', 'ns-1')).toBeTruthy();
+    expect(overviewUtils.isPipelineNotStarted('pipeline-two', 'ns-1')).toBeTruthy();
+    expect(overviewUtils.isPipelineNotStarted('pipeline-three', 'ns-1')).toBeFalsy();
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/pipeline-overview-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/pipeline-overview-utils.ts
@@ -1,0 +1,40 @@
+import { PIPELINE_RUN_AUTO_START_FAILED } from '../const';
+
+export const getAllNotStartedPipelines = (): { [ns: string]: string[] } => {
+  try {
+    return JSON.parse(sessionStorage.getItem(PIPELINE_RUN_AUTO_START_FAILED) ?? '{}');
+  } catch (e) {
+    return {};
+  }
+};
+
+export const getNotStartedPipelines = (namespace: string): string[] => {
+  return getAllNotStartedPipelines()[namespace] ?? [];
+};
+export const isPipelineNotStarted = (pipelineName: string, namespace: string): boolean => {
+  return getNotStartedPipelines(namespace).includes(pipelineName);
+};
+
+export const removePipelineNotStarted = (pipelineName: string, namespace: string): void => {
+  if (!pipelineName || !namespace) return;
+
+  const newList = getNotStartedPipelines(namespace).filter((pName) => pName !== pipelineName);
+
+  sessionStorage.setItem(
+    PIPELINE_RUN_AUTO_START_FAILED,
+    JSON.stringify({ ...getAllNotStartedPipelines(), [namespace]: newList }),
+  );
+};
+
+export const setPipelineNotStarted = (pipelineName: string, namespace: string): void => {
+  if (!pipelineName || !namespace) return;
+  const pipelineData = getAllNotStartedPipelines();
+
+  if (!pipelineData[namespace]) {
+    pipelineData[namespace] = [];
+  }
+  if (!pipelineData[namespace].includes(pipelineName)) {
+    pipelineData[namespace].push(pipelineName);
+    sessionStorage.setItem(PIPELINE_RUN_AUTO_START_FAILED, JSON.stringify(pipelineData));
+  }
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5048

**Analysis / Root cause**: 
As a user, I'd like to still be able to finish my add flow even if the Pipeline Run cannot be created for the added Pipeline.

**Solution Description**: 
Removed the pipelinerun creation request from the promise collection and added it in a try/catch block seperately.

**Screen shots / Gifs for design review**: 

**Before**:
Blocks the add flow redirection and shows the error.
![image](https://user-images.githubusercontent.com/9964343/99397283-daaa4080-2908-11eb-9376-827c92af8783.png)

**After**:
Does not block the add flow redirection and suppresses the pipelinerun creation error
![non-blocking-flow](https://user-images.githubusercontent.com/9964343/99399305-7ccb2800-290b-11eb-8300-94a5eb226430.gif)
**Topology Sidebar**
![image](https://user-images.githubusercontent.com/9964343/99662727-a612c200-2a8b-11eb-9986-17a211bdc6ff.png)


**Unit test coverage report**:
import-submit-utils.spec.ts 
![image](https://user-images.githubusercontent.com/9964343/99397569-3c6aaa80-2909-11eb-8d5a-7bb6805f8bec.png)
PipelineOverview.spec.tsx
![image](https://user-images.githubusercontent.com/9964343/99662513-5e8c3600-2a8b-11eb-8115-3d445232dd40.png)
pipeline-overview-utils.spec.ts
![image](https://user-images.githubusercontent.com/9964343/99662645-8aa7b700-2a8b-11eb-8095-cca738be26f6.png)

**Test setup:**
1. Install Openshift pipeilnes operator with `preview` channel to get 1.2 operator
2. Go to add from git flow
3. Use dotnet image `https://github.com/redhat-developer/s2i-dotnetcore-ex.git` and choose dotnet builder image
4. Add Pipeline option
5. click on create button

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @andrewballantyne @bgliwa01  @openshift/team-devconsole-ux 