### PR TITLE
adds useUserSettings hook and associated HOC

### DIFF
--- a/frontend/packages/console-shared/src/hoc/index.ts
+++ b/frontend/packages/console-shared/src/hoc/index.ts
@@ -1,1 +1,3 @@
 export * from './withPostFormSubmissionCallback';
+export * from './withUserSettingsCompatibility';
+export * from './withUserSettings';

--- a/frontend/packages/console-shared/src/hoc/withUserSettings.tsx
+++ b/frontend/packages/console-shared/src/hoc/withUserSettings.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { useUserSettings } from '../hooks';
+
+export type WithUserSettingsProps<T> = {
+  userSettingState: T;
+  setUserSettingState: (v: T) => void;
+};
+
+export const withUserSettings = <Props extends WithUserSettingsProps<T>, T = string>(
+  configStorageKey: string,
+  defaultvalue?: T,
+) => (
+  WrappedComponent: React.ComponentType<Props>,
+): React.FC<Omit<Props, keyof WithUserSettingsProps<T>>> => (props: Props) => {
+  const [state, setState, loaded] = useUserSettings(configStorageKey, defaultvalue);
+  return loaded ? (
+    <WrappedComponent {...props} userSettingState={state} setUserSettingState={setState} />
+  ) : null;
+};

--- a/frontend/packages/console-shared/src/hoc/withUserSettingsCompatibility.tsx
+++ b/frontend/packages/console-shared/src/hoc/withUserSettingsCompatibility.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { useUserSettingsCompatibility } from '../hooks';
+
+export type WithUserSettingsCompatibilityProps<T> = {
+  userSettingState: T;
+  setUserSettingState: (v: T) => void;
+};
+
+export const withUserSettingsCompatibility = <
+  Props extends WithUserSettingsCompatibilityProps<T>,
+  T = string
+>(
+  configStorageKey: string,
+  localStoragekey: string,
+  defaultvalue?: T,
+) => (
+  WrappedComponent: React.ComponentType<Props>,
+): React.FC<Omit<Props, keyof WithUserSettingsCompatibilityProps<T>>> => (props: Props) => {
+  const [state, setState, loaded] = useUserSettingsCompatibility(
+    configStorageKey,
+    localStoragekey,
+    defaultvalue,
+  );
+  return loaded ? (
+    <WrappedComponent {...props} userSettingState={state} setUserSettingState={setState} />
+  ) : null;
+};

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -1,0 +1,85 @@
+import * as redux from 'react-redux';
+import * as k8s from '@console/internal/module/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { testHook } from '../../../../../__tests__/utils/hooks-utils';
+import { useUserSettings } from '../useUserSettings';
+
+import Spy = jasmine.Spy;
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+const spyAndReturn = (spy: Spy) => (returnValue: any) =>
+  new Promise((resolve) =>
+    spy.and.callFake((...args) => {
+      resolve(args);
+      return returnValue;
+    }),
+  );
+
+const waitAndExpect = (callback) => {
+  setTimeout(() => {
+    callback();
+  }, 0);
+};
+
+describe('useUserSettings', () => {
+  let spyK8sGet: Spy;
+  let spyK8sPatch: Spy;
+  let spyK8sCreate: Spy;
+  beforeEach(() => {
+    spyK8sGet = spyOn(k8s, 'k8sGet');
+    spyK8sPatch = spyOn(k8s, 'k8sPatch');
+    spyK8sCreate = spyOn(k8s, 'k8sCreate');
+    spyAndReturn(spyK8sGet)(Promise.resolve({}));
+    spyAndReturn(spyK8sPatch)(Promise.resolve({}));
+    spyAndReturn(spyK8sCreate)(Promise.resolve({}));
+    spyOn(redux, 'useSelector').and.returnValues({ user: {} });
+  });
+
+  it('should return empty state', (done) => {
+    (useK8sWatchResource as jest.Mock).mockReturnValue([
+      { data: { 'devconsole.topology.key': '' } },
+      true,
+    ]);
+    testHook(() => {
+      const [settings, setSettings, loaded] = useUserSettings('devconsole.topology.key');
+      expect(setSettings).toBeDefined();
+      waitAndExpect(() => {
+        expect(settings).toEqual('');
+        expect(loaded).toEqual(true);
+        done();
+      });
+    });
+  });
+
+  it('should return value from default and run patch to update configMap', (done) => {
+    (useK8sWatchResource as jest.Mock).mockReturnValue([
+      { data: { 'devconsole.topology.key1': true } },
+      true,
+    ]);
+    testHook(() => {
+      const [settings, setSettings] = useUserSettings('devconsole.topology.key', 'list');
+      expect(setSettings).toBeDefined();
+      waitAndExpect(() => {
+        expect(settings).toEqual('list');
+        expect(spyK8sPatch).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it('should call side effects if configmap not loaded', (done) => {
+    (useK8sWatchResource as jest.Mock).mockReturnValue([null, true, true]);
+    testHook(() => {
+      const [, setSettings] = useUserSettings('devconsole.topology.key');
+      expect(setSettings).toBeDefined();
+      waitAndExpect(() => {
+        expect(spyK8sGet).toHaveBeenCalledTimes(1);
+        expect(spyK8sCreate).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+});

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -17,3 +17,5 @@ export * from './csv-watch-hook';
 export * from './useTabbedTableBreadcrumb';
 export * from './post-form-submit-action';
 export * from './flag';
+export * from './useUserSettings';
+export * from './useUserSettingsCompatibility';

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -1,0 +1,149 @@
+import * as React from 'react';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useSelector } from 'react-redux';
+import { RootState } from '@console/internal/redux';
+import { ConfigMapModel, ProjectRequestModel, ProjectModel } from '@console/internal/models';
+import {
+  K8sResourceKind,
+  k8sGet,
+  k8sCreate,
+  k8sPatch,
+  ConfigMapKind,
+} from '@console/internal/module/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+
+// can't create project with name prefix with 'openshift-*', once we have proxy need to update
+const USER_SETTING_CONFIGMAP_NAMESPACE = 'console-user-settings';
+
+// This won't be needed once we have proxy api
+const getProject = async () => {
+  try {
+    await k8sGet(ProjectModel, USER_SETTING_CONFIGMAP_NAMESPACE);
+  } catch {
+    await k8sCreate(ProjectRequestModel, {
+      metadata: {
+        name: USER_SETTING_CONFIGMAP_NAMESPACE,
+      },
+    });
+  }
+};
+
+const createConfigMap = async (configMapData: K8sResourceKind): Promise<boolean> => {
+  try {
+    await k8sCreate(ConfigMapModel, configMapData);
+    return true;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    return false;
+  }
+};
+
+const updateConfigMap = async (configMap: ConfigMapKind, key: string, value: string) => {
+  if (value !== configMap.data?.[key]) {
+    const patch = [
+      {
+        op: 'replace',
+        path: `/data/${key}`,
+        value,
+      },
+    ];
+    try {
+      await k8sPatch(ConfigMapModel, configMap, patch);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  }
+};
+
+const deseralizeData = <T>(data: T) => {
+  if (typeof data !== 'string') {
+    return data;
+  }
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+};
+
+const seralizeData = <T>(data: T) => {
+  if (typeof data === 'string') {
+    return data;
+  }
+  return JSON.stringify(data);
+};
+
+export const useUserSettings = <T>(
+  key: string,
+  defaultValue?: T,
+): [T, React.Dispatch<React.SetStateAction<T>>, boolean] => {
+  const defaultValueRef = React.useRef<T>(defaultValue);
+  const keyRef = React.useRef<string>(key);
+  const userUid = useSelector(
+    (state: RootState) => state.UI.get('user')?.metadata?.uid ?? 'kubeadmin',
+  );
+  const configMapResource = React.useMemo(
+    () => ({
+      kind: ConfigMapModel.kind,
+      namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
+      isList: false,
+      name: `user-settings-${userUid}`,
+    }),
+    [userUid],
+  );
+  const [cfData, cfLoaded, cfLoadError] = useK8sWatchResource<K8sResourceKind>(configMapResource);
+  const [settings, setSettings] = React.useState<T>();
+  const [loaded, setLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    if (cfLoadError || (!cfData && cfLoaded)) {
+      (async () => {
+        await getProject();
+        const cmCreated = await createConfigMap({
+          apiVersion: ConfigMapModel.apiVersion,
+          kind: ConfigMapModel.kind,
+          metadata: {
+            name: `user-settings-${userUid}`,
+            namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
+          },
+          data: {
+            ...(defaultValueRef.current !== undefined && {
+              [keyRef.current]: seralizeData(defaultValueRef.current),
+            }),
+          },
+        });
+        if (!cmCreated) {
+          setSettings(deseralizeData(defaultValueRef.current));
+          setLoaded(true);
+        }
+      })();
+    } else if (
+      cfData &&
+      cfLoaded &&
+      (!cfData.data?.hasOwnProperty(keyRef.current) ||
+        seralizeData(settings) !== cfData.data?.[keyRef.current])
+    ) {
+      setSettings(deseralizeData(cfData.data?.[keyRef.current]) ?? defaultValueRef.current);
+      setLoaded(true);
+    } else if (cfLoaded) {
+      setSettings(deseralizeData(defaultValueRef.current));
+      setLoaded(true);
+    }
+    // This effect should only be run on change of configmap data, status.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cfLoaded, cfLoadError]);
+
+  React.useEffect(() => {
+    if (cfData && cfLoaded && settings !== undefined) {
+      updateConfigMap(cfData, keyRef.current, seralizeData(settings));
+    }
+    // This effect should only be run on change of settings state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings]);
+
+  return [settings, setSettings, loaded];
+};

--- a/frontend/packages/console-shared/src/hooks/useUserSettingsCompatibility.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettingsCompatibility.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { useUserSettings } from './useUserSettings';
+
+export const useUserSettingsCompatibility = <T>(
+  key: string,
+  storageKey: string,
+  defaultValue?: T,
+): [T | string, React.Dispatch<React.SetStateAction<T>>, boolean] => {
+  const [settings, setSettings, loaded] = useUserSettings<T | string>(
+    key,
+    localStorage.getItem(storageKey) || defaultValue,
+  );
+
+  React.useEffect(
+    () => () => {
+      if (loaded) {
+        localStorage.removeItem(storageKey);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [loaded],
+  );
+
+  return [settings, setSettings, loaded];
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4753

**Analysis / Root cause**: 
User preferences were saved in localStorage so not persisted across browsers 

**Solution Description**: 
Added a hook with support for localStorage as fallback

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
NA

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/5129024/97963356-f841bb00-1ddc-11eb-8cce-1aa6b5487c43.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
