### PR TITLE
Update po export script

### DIFF
--- a/frontend/i18n-scripts/export-pos.sh
+++ b/frontend/i18n-scripts/export-pos.sh
@@ -17,3 +17,8 @@ for d in */ ; do
     done
   fi
 done
+
+cd ..
+# remove po files that don't contain untranslated strings
+# so we only send the translation team what's necessary
+grep -r -L -Z 'msgstr ""' po-files | xargs rm


### PR DESCRIPTION
I added a line to the po export script to remove po files that don't contain untranslated strings. This way we don't accidentally send them to the translation team. It seems like it would be a waste of time for translation folks to import files they don't need to touch.

I used this to generate the latest round of po files for Terry today. It's not the best approach since we're deleting files we just generated, but it's the least-additional-coding-involved approach.