### PR TITLE
Bug 1872166: Fix Silences link redirection from developer perspective

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -21,6 +21,7 @@ import {
   RedExclamationCircleIcon,
   YellowExclamationTriangleIcon,
 } from '@console/shared';
+import { useActivePerspective } from '@console/shared/src/hooks/useActivePerspective';
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
 import * as UIActions from '../../actions/ui';
 import { coFetchJSON } from '../../co-fetch';
@@ -1011,6 +1012,7 @@ const SilencesDetailsPage = withFallback(
       startsAt = '',
       updatedAt = '',
     } = silence || {};
+    const [activePerspective] = useActivePerspective();
     const { t } = useTranslation();
 
     return (
@@ -1028,10 +1030,12 @@ const SilencesDetailsPage = withFallback(
             <BreadCrumbs
               breadcrumbs={[
                 {
-                  name: t('monitoring~Silences'),
-                  path: namespace
-                    ? `/dev-monitoring/ns/${namespace}/silences`
-                    : '/monitoring/silences',
+                  name:
+                    activePerspective === 'dev' ? t('monitoring~Alerts') : t('monitoring~Silences'),
+                  path:
+                    activePerspective === 'dev'
+                      ? `/dev-monitoring/ns/${namespace}/alerts`
+                      : '/monitoring/silences',
                 },
                 { name: t('monitoring~Silence details'), path: undefined },
               ]}

--- a/frontend/public/components/monitoring/utils.ts
+++ b/frontend/public/components/monitoring/utils.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
 import { murmur3 } from 'murmurhash-js';
+import { getActiveNamespace } from '../../reducers/ui';
 
 import { RootState } from '../../redux';
 import { PrometheusLabels } from '../graphs';
@@ -80,7 +81,7 @@ export const rulesToProps = (state: RootState, perspective?: string) => {
 export const silencesToProps = ({ UI }) => UI.getIn(['monitoring', 'silences']) || {};
 
 export const silenceParamToProps = (state: RootState, { match }) => {
-  const namespace = match.params?.ns;
+  const namespace = getActiveNamespace(state);
   const { data: silences, loaded, loadError }: Silences = silencesToProps(state);
   const { loaded: alertsLoaded }: Alerts = alertsToProps(state);
   const silence = _.find(silences, { id: _.get(match, 'params.id') });


### PR DESCRIPTION
**Fixes**: 
 https://issues.redhat.com/browse/ODC-4901

**Analysis / Root cause**: 
In the Developer perspective, a Silences link redirects to an unexpected 'Alerts' page after creating a silence.

The page that is shown includes Alerts, Silences, and Alerting Rules tabs, which I believe should only be accessible from the Administrator's perspective.

**Solution Description**: 
Users are taken back to the alerts list from the silence details page where they can see that the alert has been silenced.

**Screen shots / Gifs for design review**: 
![Kapture 2020-12-07 at 21 14 31](https://user-images.githubusercontent.com/2561818/101371983-66dcd180-38d1-11eb-8309-a784e076073a.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge