### PR TITLE
Fix redirect loop when running local bridge without valid auth token

### DIFF
--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -118,6 +118,13 @@ export const authSvc = {
   },
 
   login: () => {
-    window.location = window.SERVER_FLAGS.loginURL;
+    // Ensure that we don't redirect to the current URL in a loop
+    // when using local bridge in development mode without authorization.
+    if (
+      window.location.href !== window.SERVER_FLAGS.loginURL &&
+      window.location.pathname !== window.SERVER_FLAGS.loginURL
+    ) {
+      window.location = window.SERVER_FLAGS.loginURL;
+    }
   },
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5167

**Analysis / Root cause**: 
When the `oc login` token expires the console triggers a login() call which redirects the user to `/auth/login`, which returns a 404 Page Not Found screen which redirects then again to `/auth/login`.

**Solution Description**: 
Do not redirect the user if the current URL is similar to the target URL.

**Screen shots / Gifs for design review**: 
Only affects local development

**Unit test coverage report**: 
Only affects local development

**Test setup:**
```
oc login ....
source ./contrib/oc-environment.sh
export BRIDGE_K8S_AUTH_BEARER_TOKEN=sha256~DISABLEDTOKEN
bin/bridge
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge