### PR TITLE
Cypress: test for existance of 'cypress-a11y-report.json' before running 'yarn cypress-a11y-report'

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "cypress-merge": "mochawesome-merge ./gui_test_screenshots/cypress_report*.json > ./gui_test_screenshots/cypress.json",
     "cypress-generate": "marge -o ./gui_test_screenshots/ -f cypress-report -t 'OpenShift Console Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ./gui_test_screenshots/cypress/assets ./gui_test_screenshots/cypress.json",
     "cypress-a11y-report": "echo '\nA11y Test Results:' && mv packages/integration-tests-cypress/cypress-a11y-report.json ./gui_test_screenshots/ && node -e \"console.table(JSON.parse(require('fs').readFileSync(process.argv[1])));\" ./gui_test_screenshots/cypress-a11y-report.json",
-    "cypress-postreport": "yarn cypress-merge && yarn cypress-generate && yarn cypress-a11y-report",
+    "cypress-postreport": "yarn cypress-merge && yarn cypress-generate",
     "analyze": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 yarn ts-node ./node_modules/.bin/webpack --mode=production --profile --json | sed '0,/^{/s/^[^{].*//g' > public/dist/stats.json && yarn ts-node ./node_modules/.bin/webpack-bundle-analyzer --mode static -r public/dist/report.html public/dist/stats.json",
     "prettier-all": "prettier --write '**/*.{js,jsx,ts,tsx,json}'",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -5,6 +5,9 @@ yarn install
 
 function generateReport {
   yarn run cypress-postreport
+  if test -f ./packages/integration-tests-cypress/cypress-a11y-report.json; then
+    yarn cypress-a11y-report
+  fi
 }
 trap generateReport EXIT
 


### PR DESCRIPTION
This PR unblocks OLM queue!

It appears that our a11y reporting doesn't scale.  A `cypress-a11y-report.json` is created in each package separately and the a11y script is only looking in `packages/integration-tests-cypress`.  This PR checks for the existance of `packages/integration-tests-cypress/cypress-a11y-report.json` first before executing `yarn cypress-a11y-report`  -so a11y results will only output for `console` tests.

A longer term solution is needed to figure out how to merge all the `cypress-a11y-report.json` files which maybe created in each package dir into a single json file.  Should be straight forward as we already do  `mochawesome-merge` for the cypress-unit json files.