### PR TITLE
[release-4.6] Bug 1899512: Allow creating storage cluster irrespective of LSO namespace

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests/tests/1-install/installFlow.scenario.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests/tests/1-install/installFlow.scenario.ts
@@ -4,10 +4,7 @@ import * as _ from 'lodash';
 import { Base64 } from 'js-base64';
 import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import { click } from '@console/shared/src/test-utils/utils';
-import {
-  LOCAL_STORAGE_NAMESPACE,
-  DISCOVERY_CR_NAME,
-} from '@console/local-storage-operator-plugin/src/constants';
+import { DISCOVERY_CR_NAME } from '@console/local-storage-operator-plugin/src/constants';
 import {
   MINUTE,
   OCS_NODE_LABEL,
@@ -219,9 +216,7 @@ if (TEST_PLATFORM === Platform.OCS && MODE === Mode.ATTACHED_DEVICES) {
 
         // verify dicovery CR got created
         const discoveryCR = JSON.parse(
-          execSync(
-            `kubectl get LocalVolumeDiscovery ${DISCOVERY_CR_NAME} -n ${LOCAL_STORAGE_NAMESPACE} -o json`,
-          ).toString(),
+          execSync(`kubectl get LocalVolumeDiscovery ${DISCOVERY_CR_NAME} -A -o json`).toString(),
         );
         const numOfNodes =
           discoveryCR?.spec?.nodeSelector?.nodeSelectorTerms?.[0]?.matchExpressions?.[0]?.values

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
@@ -18,9 +18,9 @@ import {
 } from '../../../../../constants';
 import '../../attached-devices.scss';
 
-const makeLocalVolumeSetCall = (state: State, dispatch: React.Dispatch<Action>) => {
+const makeLocalVolumeSetCall = (state: State, dispatch: React.Dispatch<Action>, ns: string) => {
   dispatch({ type: 'setIsLoading', value: true });
-  const requestData = getLocalVolumeSetRequestData(state);
+  const requestData = getLocalVolumeSetRequestData(state, ns);
   k8sCreate(LocalVolumeSetModel, requestData)
     .then(() => {
       state.onNextClick();
@@ -33,7 +33,11 @@ const makeLocalVolumeSetCall = (state: State, dispatch: React.Dispatch<Action>) 
     });
 };
 
-export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({ state, dispatch }) => {
+export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({
+  state,
+  dispatch,
+  ns,
+}) => {
   return (
     <>
       <LocalVolumeSetHeader />
@@ -49,7 +53,7 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({ stat
         </Form>
         <DiscoveryDonutChart state={state} dispatch={dispatch} />
       </div>
-      <ConfirmationModal state={state} dispatch={dispatch} />
+      <ConfirmationModal state={state} dispatch={dispatch} ns={ns} />
       {state.filteredNodes.length < minSelectedNode && (
         <Alert
           className="co-alert ceph-ocs-install__wizard-alert"
@@ -69,12 +73,13 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({ stat
 type CreateLocalVolumeSetProps = {
   state: State;
   dispatch: React.Dispatch<Action>;
+  ns: string;
 };
 
-const ConfirmationModal = ({ state, dispatch }) => {
+const ConfirmationModal = ({ state, dispatch, ns }) => {
   const makeLVSCall = () => {
     dispatch({ type: 'setShowConfirmModal', value: false });
-    makeLocalVolumeSetCall(state, dispatch);
+    makeLocalVolumeSetCall(state, dispatch, ns);
   };
 
   const cancel = () => {

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -5,7 +5,6 @@ import { PersistentVolumeModel, StorageClassModel, NodeModel } from '@console/in
 import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { SubscriptionModel } from '@console/operator-lifecycle-manager';
 import { LocalVolumeDiscoveryResult } from '@console/local-storage-operator-plugin/src/models';
-import { LOCAL_STORAGE_NAMESPACE } from '@console/local-storage-operator-plugin/src/constants';
 import { CephClusterModel, CephBlockPoolModel } from '../models';
 import { CEPH_STORAGE_NAMESPACE } from '.';
 import { CAPACITY_USAGE_QUERIES, StorageDashboardQuery } from './queries';
@@ -31,9 +30,8 @@ export const scResource: WatchK8sResource = {
 
 export const LSOSubscriptionResource: WatchK8sResource = {
   kind: referenceForModel(SubscriptionModel),
-  namespace: LOCAL_STORAGE_NAMESPACE,
-  isList: false,
-  name: 'local-storage-operator',
+  fieldSelector: 'metadata.name=local-storage-operator',
+  isList: true,
 };
 
 export const cephBlockPoolResource: WatchK8sResource = {

--- a/frontend/packages/local-storage-operator-plugin/integration-tests/tests/disks-list-page.scenario.ts
+++ b/frontend/packages/local-storage-operator-plugin/integration-tests/tests/disks-list-page.scenario.ts
@@ -10,7 +10,6 @@ import {
   checkDiskFilter,
   clearDiskFilter,
 } from '../views/disks-list-page.views';
-import { LOCAL_STORAGE_NAMESPACE } from '../../src/constants';
 import {
   LocalVolumeDiscoveryResultKind,
   DiskMetadata,
@@ -22,9 +21,7 @@ describe('Disk list is accessible from Nodes view', () => {
   let discoveredDevices: DiskMetadata[];
   beforeAll(async () => {
     const lvdrJson = JSON.parse(
-      execSync(
-        `kubectl get localvolumediscoveryresults -n ${LOCAL_STORAGE_NAMESPACE} -o json`,
-      ).toString(),
+      execSync(`kubectl get localvolumediscoveryresults -A -o json`).toString(),
     );
     const lvdr: LocalVolumeDiscoveryResultKind = lvdrJson.items[0];
     const { nodeName } = lvdr.spec;

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
@@ -24,7 +24,6 @@ import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
 import { initialState, reducer } from './state';
 import {
   DISCOVERY_CR_NAME,
-  LOCAL_STORAGE_NAMESPACE,
   HOSTNAME_LABEL_KEY,
   AUTO_DISCOVER_ERR_MSG,
   LABEL_OPERATOR,
@@ -42,7 +41,7 @@ const AutoDetectVolume: React.FC = withHandlePromise<AutoDetectVolumeProps & Han
       event.preventDefault();
 
       handlePromise(
-        fetchK8s(AutoDetectVolumeModel, DISCOVERY_CR_NAME, LOCAL_STORAGE_NAMESPACE)
+        fetchK8s(AutoDetectVolumeModel, DISCOVERY_CR_NAME, ns)
           .then((discoveryRes: K8sResourceKind) => {
             const nodeSelectorTerms = discoveryRes?.spec?.nodeSelector?.nodeSelectorTerms;
             const [selectorIndex, expIndex] = nodeSelectorTerms
@@ -77,7 +76,7 @@ const AutoDetectVolume: React.FC = withHandlePromise<AutoDetectVolumeProps & Han
             if (err.message === AUTO_DISCOVER_ERR_MSG) {
               throw err;
             }
-            const requestData = getDiscoveryRequestData(state);
+            const requestData = getDiscoveryRequestData({ ...state, ns });
             return k8sCreate(AutoDetectVolumeModel, requestData);
           })
           // eslint-disable-next-line promise/catch-or-return

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
@@ -1,11 +1,6 @@
 import { apiVersionForModel, K8sResourceCommon } from '@console/internal/module/k8s';
 import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
-import {
-  DISCOVERY_CR_NAME,
-  LOCAL_STORAGE_NAMESPACE,
-  HOSTNAME_LABEL_KEY,
-  LABEL_OPERATOR,
-} from '../../constants';
+import { DISCOVERY_CR_NAME, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
 import { HostNamesMap } from './types';
 
@@ -14,17 +9,19 @@ export const getDiscoveryRequestData = ({
   allNodeNamesOnADV,
   showNodesListOnADV,
   hostNamesMapForADV,
+  ns,
 }: {
   nodeNamesForLVS: string[];
   allNodeNamesOnADV: string[];
   showNodesListOnADV: boolean;
   hostNamesMapForADV: HostNamesMap;
+  ns: string;
 }): AutoDetectVolumeKind => {
   const nodes = getNodes(showNodesListOnADV, allNodeNamesOnADV, nodeNamesForLVS);
   return {
     apiVersion: apiVersionForModel(AutoDetectVolumeModel),
     kind: AutoDetectVolumeModel.kind,
-    metadata: { name: DISCOVERY_CR_NAME, namespace: LOCAL_STORAGE_NAMESPACE },
+    metadata: { name: DISCOVERY_CR_NAME, namespace: ns },
     spec: {
       nodeSelector: {
         nodeSelectorTerms: [

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.tsx
@@ -46,7 +46,7 @@ const CreateLocalVolumeSet: React.FC = withHandlePromise<
   const onSubmit = (event: React.FormEvent<EventTarget>) => {
     event.preventDefault();
 
-    const requestData = getLocalVolumeSetRequestData(state);
+    const requestData = getLocalVolumeSetRequestData(state, ns);
 
     handlePromise(k8sCreate(LocalVolumeSetModel, requestData), () =>
       history.push(

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -2,15 +2,15 @@ import { apiVersionForModel } from '@console/internal/module/k8s';
 import { LocalVolumeSetModel } from '../../models';
 import { LocalVolumeSetKind, DiskType, DiskMechanicalProperties } from './types';
 import { State } from './state';
-import { LOCAL_STORAGE_NAMESPACE, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
+import { HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
 
-export const getLocalVolumeSetRequestData = (state: State): LocalVolumeSetKind => {
+export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVolumeSetKind => {
   const nodes = getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames);
   const requestData = {
     apiVersion: apiVersionForModel(LocalVolumeSetModel),
     kind: LocalVolumeSetModel.kind,
-    metadata: { name: state.volumeSetName, namespace: LOCAL_STORAGE_NAMESPACE },
+    metadata: { name: state.volumeSetName, namespace: ns },
     spec: {
       storageClassName: state.storageClassName || state.volumeSetName,
       volumeMode: state.diskMode,


### PR DESCRIPTION
Automatic cherry pick not possible, due to [conflicts](https://github.com/openshift/console/pull/7184#issuecomment-730359003).
Hence, creating a manual cherry-pick, after resolving conflicts.

- removes the hard-coded value of `openshift-local-storage` for fetching the LSO subscription

Signed-off-by: Afreen Rahman <afrahman@redhat.com>
(cherry picked from commit e7ce92080ef8c322634ce9794a32ae97ef24cf63)