### PR TITLE
Add ability to specify nav section ordering by plugins

### DIFF
--- a/frontend/__tests__/components/nav/perspective-nav.spec.ts
+++ b/frontend/__tests__/components/nav/perspective-nav.spec.ts
@@ -1,0 +1,122 @@
+import { getSortedNavItems } from '@console/internal/components/nav/perspective-nav';
+import { LoadedExtension, NavItem, NavSection, SeparatorNavItem } from '@console/plugin-sdk/src';
+
+const mockNavItems: LoadedExtension<NavSection | NavItem | SeparatorNavItem>[] = [
+  {
+    type: 'Nav/Section',
+    properties: {
+      id: 'test1',
+    },
+    pluginID: 'test-plugin-id',
+    pluginName: 'test-plugin-name',
+    uid: 'test-plugin-uid',
+  },
+  {
+    type: 'Nav/Section',
+    properties: {
+      id: 'test2',
+    },
+    pluginID: 'test-plugin-id',
+    pluginName: 'test-plugin-name',
+    uid: 'test-plugin-uid',
+  },
+  {
+    type: 'Nav/Section',
+    properties: {
+      id: 'test3',
+    },
+    pluginID: 'test-plugin-id',
+    pluginName: 'test-plugin-name',
+    uid: 'test-plugin-uid',
+  },
+  {
+    type: 'Nav/Section',
+    properties: {
+      id: 'test4',
+    },
+    pluginID: 'test-plugin-id',
+    pluginName: 'test-plugin-name',
+    uid: 'test-plugin-uid',
+  },
+  {
+    type: 'Nav/Section',
+    properties: {
+      id: 'test5',
+    },
+    pluginID: 'test-plugin-id',
+    pluginName: 'test-plugin-name',
+    uid: 'test-plugin-uid',
+  },
+  {
+    type: 'Nav/Section',
+    properties: {
+      id: 'test6',
+    },
+    pluginID: 'test-plugin-id',
+    pluginName: 'test-plugin-name',
+    uid: 'test-plugin-uid',
+  },
+  {
+    type: 'NavItem/Separator',
+    properties: {
+      id: 'test7',
+      componentProps: {
+        testID: 'test-sep',
+      },
+    },
+    pluginID: 'test-plugin-id',
+    pluginName: 'test-plugin-name',
+    uid: 'test-plugin-uid',
+  },
+];
+
+describe('perspective-nav insertPositionedItems', () => {
+  it('should order items that are not positioned', () => {
+    const sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id)).toEqual(
+      mockNavItems.map((i) => i.properties.id),
+    );
+  });
+
+  it('should order items that are positioned', () => {
+    mockNavItems[0].properties.insertAfter = 'test2';
+    let sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(1);
+
+    delete mockNavItems[0].properties.insertAfter;
+    mockNavItems[0].properties.insertBefore = 'test5';
+    sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(3);
+
+    delete mockNavItems[0].properties.insertBefore;
+    mockNavItems[0].properties.insertAfter = ['x', 'y', 'test3', 'z'];
+    sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(2);
+
+    delete mockNavItems[0].properties.insertAfter;
+    mockNavItems[0].properties.insertBefore = ['x', 'y', 'test3', 'z'];
+    sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(1);
+
+    // Before takes precedence
+    mockNavItems[0].properties.insertAfter = 'test6';
+    sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(1);
+  });
+
+  it('should order items that are positioned on positioned items', () => {
+    delete mockNavItems[0].properties.insertBefore;
+    mockNavItems[0].properties.insertAfter = 'test6';
+    mockNavItems[5].properties.insertAfter = 'test4';
+    let sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test6')).toBe(3);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(4);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test7')).toBe(6);
+
+    mockNavItems[6].properties.insertBefore = 'test1';
+    sortedItems = getSortedNavItems(mockNavItems);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test6')).toBe(3);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(5);
+    expect(sortedItems.map((i) => i.properties.id).indexOf('test7')).toBe(4);
+  });
+});

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -230,8 +230,8 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceCluster',
     properties: {
-      id: 'storage',
-      section: 'Storage',
+      id: 'volumesnapshots',
+      section: 'storage',
       componentProps: {
         name: 'Volume Snapshot Contents',
         resource: referenceForModel(VolumeSnapshotContentModel),

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -10,6 +10,7 @@ import {
   ResourceListPage,
   ResourceDetailsPage,
   Perspective,
+  NavSection,
   YAMLTemplate,
   RoutePage,
   DashboardsOverviewHealthPrometheusSubsystem,
@@ -43,6 +44,7 @@ type ConsumedExtensions =
   | ResourceListPage
   | ResourceDetailsPage
   | Perspective
+  | NavSection
   | YAMLTemplate
   | RoutePage
   | DashboardsOverviewHealthPrometheusSubsystem
@@ -73,10 +75,17 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'NavItem/Href',
+    type: 'Nav/Section',
     properties: {
       id: 'home',
-      section: 'Home',
+      name: 'Home',
+    },
+  },
+  {
+    type: 'NavItem/Href',
+    properties: {
+      id: 'testhreflink',
+      section: 'home',
       componentProps: {
         name: 'Test Href Link',
         href: '/test',
@@ -90,7 +99,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       id: 'testresourcens',
-      section: 'Home',
+      section: 'home',
       componentProps: {
         name: 'Test ResourceNS Link',
         resource: 'pods',
@@ -104,7 +113,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceCluster',
     properties: {
       id: 'testresourcecluster',
-      section: 'Home',
+      section: 'home',
       componentProps: {
         name: 'Test ResourceCluster Link',
         resource: 'projects',
@@ -192,11 +201,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Nav/Section',
+    properties: {
+      id: 'advanced',
+      name: 'Advanced',
+    },
+  },
+  {
     type: 'NavItem/ResourceCluster',
     properties: {
       id: 'testprojects',
       perspective: 'test',
-      section: 'Advanced',
+      section: 'advanced',
       componentProps: {
         name: 'Test Projects',
         resource: 'projects',

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -6,6 +6,7 @@ export * from './features';
 export * from './kebab-actions';
 export * from './models';
 export * from './nav-items';
+export * from './nav-section';
 export * from './overview';
 export * from './pages';
 export * from './perspectives';

--- a/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
@@ -12,10 +12,8 @@ namespace ExtensionProperties {
     id: string;
     /** Perspective id to which this item belongs to. If not specified, use the default perspective. */
     perspective?: string;
-    /** Nav section to which this item belongs to.If not specified, render item as top-level link. */
+    /** Nav section to which this item belongs to. If not specified, render item as top-level link. */
     section?: string;
-    /** Nav group to which this item belongs to. Add items to a grouping with a separator above */
-    group?: string;
     /** Props to pass to the corresponding `NavLink` component. */
     componentProps: Pick<NavLinkProps, 'name' | 'startsWith' | 'testID' | 'data-tour-id'>;
     /*

--- a/frontend/packages/console-plugin-sdk/src/typings/nav-section.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav-section.ts
@@ -1,0 +1,24 @@
+import { Extension } from './base';
+
+namespace ExtensionProperties {
+  export interface NavSection {
+    /** Section id, should be unique for all sections (and top level items) */
+    id: string;
+    /** Perspective id to which this section belongs to. If not specified, use the default perspective. */
+    perspective?: string;
+    /** Title for the section, if none only a separator will be shown above the section */
+    name?: string;
+    /** Nav section before which this section should be placed. For arrays, first one found in order is used */
+    insertBefore?: string | string[];
+    /** Nav section after which this section should be placed (before takes precedence). For arrays, first one found in order is used */
+    insertAfter?: string | string[];
+  }
+}
+
+export interface NavSection extends Extension<ExtensionProperties.NavSection> {
+  type: 'Nav/Section';
+}
+
+export const isNavSection = (e: Extension): e is NavSection => {
+  return e.type === 'Nav/Section';
+};

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -120,7 +120,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'imagevulnerabilities',
       perspective: 'admin',
-      section: 'Administration',
+      section: 'administration',
       insertBefore: 'customresourcedefinitions',
       componentProps: {
         name: 'Image Vulnerabilities',

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -12,6 +12,7 @@ import {
   ModelDefinition,
   ModelFeatureFlag,
   KebabActions,
+  NavSection,
   HrefNavItem,
   ResourceNSNavItem,
   ResourceClusterNavItem,
@@ -67,6 +68,7 @@ import { CatalogConsumedExtensions, catalogPlugin } from './components/catalog/c
 type ConsumedExtensions =
   | ModelDefinition
   | ModelFeatureFlag
+  | NavSection
   | HrefNavItem
   | ResourceClusterNavItem
   | ResourceNSNavItem
@@ -108,11 +110,25 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Nav/Section',
+    properties: {
+      id: 'top',
+      perspective: 'dev',
+    },
+  },
+  {
+    type: 'Nav/Section',
+    properties: {
+      id: 'resources',
+      perspective: 'dev',
+    },
+  },
+  {
     type: 'NavItem/Href',
     properties: {
       id: 'add',
       perspective: 'dev',
-      group: 'top',
+      section: 'top',
       componentProps: {
         name: '+Add',
         href: '/add',
@@ -125,7 +141,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'topology',
       perspective: 'dev',
-      group: 'top',
+      section: 'top',
       componentProps: {
         name: 'Topology',
         href: '/topology',
@@ -141,7 +157,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'monitoring',
       perspective: 'dev',
-      group: 'top',
+      section: 'top',
       componentProps: {
         name: 'Monitoring',
         href: '/dev-monitoring',
@@ -158,7 +174,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'search',
       perspective: 'dev',
-      group: 'top',
+      section: 'top',
       componentProps: {
         name: 'Search',
         href: '/search',
@@ -172,7 +188,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'builds',
       perspective: 'dev',
-      group: 'resources',
+      section: 'resources',
       componentProps: {
         name: 'Builds',
         resource: 'buildconfigs',
@@ -188,7 +204,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'applicationstages',
       perspective: 'dev',
-      group: 'resources',
+      section: 'resources',
       componentProps: {
         name: 'Application Stages',
         href: '/applicationstages',
@@ -204,7 +220,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'helm',
       perspective: 'dev',
-      group: 'resources',
+      section: 'resources',
       componentProps: {
         name: 'Helm',
         href: '/helm-releases',
@@ -220,7 +236,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'project',
       perspective: 'dev',
-      group: 'resources',
+      section: 'resources',
       componentProps: {
         name: 'Project',
         href: '/project-details',

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import {
   Plugin,
+  NavSection,
   ResourceNSNavItem,
   ModelFeatureFlag,
   ModelDefinition,
@@ -34,6 +35,7 @@ import * as eventSourceIcon from './imgs/event-source.svg';
 import * as channelIcon from './imgs/channel.svg';
 
 type ConsumedExtensions =
+  | NavSection
   | ResourceNSNavItem
   | ModelFeatureFlag
   | ModelDefinition
@@ -126,11 +128,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Nav/Section',
+    properties: {
+      id: 'serverless',
+      name: 'Serverless',
+    },
+  },
+  {
     type: 'NavItem/Href',
     properties: {
       id: 'serverlessserving',
       perspective: 'admin',
-      section: 'Serverless',
+      section: 'serverless',
       componentProps: {
         name: 'Serving',
         href: '/serving',
@@ -149,7 +158,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'serverlesseventing',
       perspective: 'admin',
-      section: 'Serverless',
+      section: 'serverless',
       componentProps: {
         name: 'Eventing',
         href: '/eventing',

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -85,7 +85,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       id: 'virtualization',
-      section: 'Workloads',
+      section: 'workloads',
       componentProps: {
         name: 'Virtualization',
         resource: 'virtualization',

--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -93,7 +93,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       id: 'baremetal',
-      section: 'Compute',
+      section: 'compute',
       componentProps: {
         name: 'Bare Metal Hosts',
         href: formatNamespacedRouteForResource(

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -43,7 +43,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       id: 'networkattachmentdefinitions',
-      section: 'Networking',
+      section: 'networking',
       componentProps: {
         name: 'Network Attachment Definitions',
         resource: referenceForModel(models.NetworkAttachmentDefinitionModel),

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -225,7 +225,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceCluster',
     properties: {
       id: 'objectbuckets',
-      section: 'Storage',
+      section: 'storage',
       componentProps: {
         name: 'Object Buckets',
         resource: models.NooBaaObjectBucketModel.plural,
@@ -259,7 +259,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       id: 'objectbucketclaims',
-      section: 'Storage',
+      section: 'storage',
       componentProps: {
         name: 'Object Bucket Claims',
         resource: models.NooBaaObjectBucketClaimModel.plural,

--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -101,7 +101,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/Href',
     properties: {
       id: 'operatorhub',
-      section: 'Operators',
+      section: 'operators',
       componentProps: {
         name: 'OperatorHub',
         href: '/operatorhub',
@@ -115,7 +115,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       id: 'operators',
-      section: 'Operators',
+      section: 'operators',
       componentProps: {
         name: 'Installed Operators',
         resource: referenceForModel(models.ClusterServiceVersionModel),

--- a/frontend/packages/pipelines-plugin/src/plugin.tsx
+++ b/frontend/packages/pipelines-plugin/src/plugin.tsx
@@ -4,6 +4,7 @@ import {
   ModelDefinition,
   ModelFeatureFlag,
   KebabActions,
+  NavSection,
   HrefNavItem,
   ResourceNSNavItem,
   ResourceClusterNavItem,
@@ -47,6 +48,7 @@ const {
 type ConsumedExtensions =
   | ModelDefinition
   | ModelFeatureFlag
+  | NavSection
   | HrefNavItem
   | ResourceClusterNavItem
   | ResourceNSNavItem
@@ -80,7 +82,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'pipelines',
       perspective: 'dev',
-      group: 'resources',
+      section: 'resources',
       insertAfter: 'builds',
       componentProps: {
         name: PipelineModel.labelPlural,
@@ -97,7 +99,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'pipelines',
       perspective: 'admin',
-      section: 'Pipelines',
+      section: 'pipelines',
       componentProps: {
         name: PipelineModel.labelPlural,
         href: '/pipelines',
@@ -112,7 +114,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'pipelinetasks',
       perspective: 'admin',
-      section: 'Pipelines',
+      section: 'pipelines',
       componentProps: {
         name: TaskModel.labelPlural,
         href: '/tasks',
@@ -127,7 +129,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'pipelinetriggers',
       perspective: 'admin',
-      section: 'Pipelines',
+      section: 'pipelines',
       componentProps: {
         name: 'Triggers',
         href: '/triggers',

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -69,7 +69,7 @@ const MonitoringNavSection_ = ({ canAccess }) => {
   const canAccessPrometheus = canAccess && !!window.SERVER_FLAGS.prometheusBaseURL;
   const showSilences = canAccess && !!window.SERVER_FLAGS.alertManagerBaseURL;
   return canAccessPrometheus || showSilences ? (
-    <NavSection title={t('nav~Monitoring')}>
+    <NavSection id="monitoring" title={t('nav~Monitoring')}>
       {canAccessPrometheus && (
         <HrefLink
           id="monitoringalerts"
@@ -107,7 +107,7 @@ const AdminNav = () => {
   const { t } = useTranslation();
   return (
     <>
-      <NavSection title={t('nav~Home')}>
+      <NavSection id="home" title={t('nav~Home')}>
         <HrefLink
           id="dashboards"
           href="/dashboards"
@@ -131,9 +131,9 @@ const AdminNav = () => {
         <ResourceNSLink id="events" resource="events" name={t('nav~Events')} />
       </NavSection>
 
-      <NavSection title={t('nav~Operators')} />
+      <NavSection id="operators" title={t('nav~Operators')} />
 
-      <NavSection title={t('nav~Workloads')}>
+      <NavSection id="workloads" title={t('nav~Workloads')}>
         <ResourceNSLink id="pods" resource="pods" name={t('nav~Pods')} />
         <ResourceNSLink id="deployments" resource="deployments" name={t('nav~Deployments')} />
         <ResourceNSLink
@@ -164,9 +164,9 @@ const AdminNav = () => {
 
       {/* Temporary addition of Knative Serverless section until extensibility allows for section ordering
           and admin-nav gets contributed through extensions. */}
-      <NavSection title={t('nav~Serverless')} />
+      <NavSection id="serverless" title={t('nav~Serverless')} />
 
-      <NavSection title={t('nav~Networking')}>
+      <NavSection id="networking" title={t('nav~Networking')}>
         <ResourceNSLink id="services" resource="services" name={t('nav~Services')} />
         <ResourceNSLink
           id="routes"
@@ -182,7 +182,7 @@ const AdminNav = () => {
         />
       </NavSection>
 
-      <NavSection title={t('nav~Storage')}>
+      <NavSection id="storage" title={t('nav~Storage')}>
         <ResourceClusterLink
           id="networkpolicies"
           resource="persistentvolumes"
@@ -211,7 +211,7 @@ const AdminNav = () => {
         />
       </NavSection>
 
-      <NavSection title={t('nav~Builds')} required={FLAGS.OPENSHIFT}>
+      <NavSection id="builds" title={t('nav~Builds')} required={FLAGS.OPENSHIFT}>
         <ResourceNSLink id="buildconfigs" resource="buildconfigs" name={t('nav~Build Configs')} />
         <ResourceNSLink id="builds" resource="builds" name={t('nav~Builds')} />
         <ResourceNSLink
@@ -224,9 +224,13 @@ const AdminNav = () => {
 
       {/* Temporary addition of Tekton Pipelines section until extensibility allows for section ordering
           and admin-nav gets contributed through extensions. */}
-      <NavSection title={t('nav~Pipelines')} />
+      <NavSection id="pipelines" title={t('nav~Pipelines')} />
 
-      <NavSection title={t('nav~Service Catalog')} required={FLAGS.SERVICE_CATALOG}>
+      <NavSection
+        id="servicecatalog"
+        title={t('nav~Service Catalog')}
+        required={FLAGS.SERVICE_CATALOG}
+      >
         <HrefLink
           id="provisionedservices"
           href="/provisionedservices"
@@ -245,7 +249,7 @@ const AdminNav = () => {
 
       <MonitoringNavSection />
 
-      <NavSection title={t('nav~Compute')} required={FLAGS.CAN_LIST_NODE}>
+      <NavSection id="compute" title={t('nav~Compute')} required={FLAGS.CAN_LIST_NODE}>
         <ResourceClusterLink id="nodes" resource="nodes" name={t('nav~Nodes')} />
         <HrefLink
           id="machines"
@@ -296,7 +300,7 @@ const AdminNav = () => {
         />
       </NavSection>
 
-      <NavSection title={t('nav~User Management')}>
+      <NavSection id="usermanagement" title={t('nav~User Management')}>
         <ResourceClusterLink
           id="users"
           resource={referenceForModel(UserModel)}
@@ -328,7 +332,7 @@ const AdminNav = () => {
         />
       </NavSection>
 
-      <NavSection title={t('nav~Administration')}>
+      <NavSection id="administration" title={t('nav~Administration')}>
         <HrefLink
           id="clustersettings"
           href="/settings/cluster"

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -139,7 +139,7 @@ export const NavSection = connect(navSectionStateToProps)(
         this.setState({ isOpen: expandState });
       };
 
-      getNavItemExtensions = (perspective: string, title: string) => {
+      getNavItemExtensions = (perspective: string, title: string, id: string) => {
         const { navItemExtensions, perspectiveExtensions } = this.props;
 
         const defaultPerspective = _.find(perspectiveExtensions, (p) => p.properties.default);
@@ -152,7 +152,7 @@ export const NavSection = connect(navSectionStateToProps)(
             // or if no perspective specified, are we in the default perspective
             (item.properties.perspective === perspective ||
               (!item.properties.perspective && isDefaultPerspective)) &&
-            (item.properties.section === title || item.properties.group === title),
+            item.properties.section === id,
         );
       };
 
@@ -186,10 +186,10 @@ export const NavSection = connect(navSectionStateToProps)(
       };
 
       getChildren() {
-        const { title, children, perspective } = this.props;
+        const { id, title, children, perspective } = this.props;
         const Children = React.Children.map(children, this.mapChild) || [];
 
-        this.getNavItemExtensions(perspective, title).forEach((item) => {
+        this.getNavItemExtensions(perspective, title, id).forEach((item) => {
           const pluginChild = this.mapChild(createLink(item));
           if (pluginChild) {
             mergePluginChild(
@@ -269,6 +269,7 @@ type NavSectionExtensionProps = {
 };
 
 type NavSectionProps = {
+  id: string;
   title: NavSectionTitle | string;
   isGrouped?: boolean;
   required?: string;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5153

**Solution Description**: 
Update the extension definition for `NavItem` to change sections to contain an id as well as a name.
Remove groups option, use section w/o a name to specify a title-less section.
Allow specifications of `insertBefore` and `insertAfter` fields for sections.
Update existing definitions.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind feature