### PR TITLE
Enable quickstart hints in quickstart sidepanel

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartMarkdownView.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartMarkdownView.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { extension } from 'showdown';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import { MarkdownHighlightExtension } from '@console/shared';
+import { HIGHLIGHT_REGEXP } from '@console/shared/src/components/markdown-highlight-extension/highlight-consts';
+
+const EXTENSION_NAME = 'quickstart';
+extension(EXTENSION_NAME, () => {
+  return [
+    {
+      type: 'lang',
+      regex: HIGHLIGHT_REGEXP,
+      replace: (text: string, linkLabel: string, linkType: string, linkId: string): string => {
+        if (!linkLabel || !linkType || !linkId) return text;
+        return `<button class="pf-c-button pf-m-inline pf-m-link" data-highlight="${linkId}">${linkLabel}</button>`;
+      },
+    },
+  ];
+});
+
+type QuickStartMarkdownViewProps = {
+  content: string;
+};
+
+const QuickStartMarkdownView: React.FC<QuickStartMarkdownViewProps> = ({ content }) => {
+  return (
+    <SyncMarkdownView
+      content={content}
+      extensions={[EXTENSION_NAME]}
+      renderExtension={(docContext) => (
+        <MarkdownHighlightExtension key={content} docContext={docContext} />
+      )}
+    />
+  );
+};
+export default QuickStartMarkdownView;

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartConclusion.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartConclusion.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
-import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import QuickStartMarkdownView from '../QuickStartMarkdownView';
 import { QuickStartTask, QuickStartTaskStatus } from '../utils/quick-start-types';
 import TaskHeader from './QuickStartTaskHeader';
 
@@ -37,7 +37,7 @@ const QuickStartConclusion: React.FC<QuickStartConclusionProps> = ({
           onTaskSelect={onTaskSelect}
         />
       ))}
-      <SyncMarkdownView
+      <QuickStartMarkdownView
         content={
           hasFailedTask
             ? t(

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartIntroduction.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartIntroduction.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import QuickStartMarkdownView from '../QuickStartMarkdownView';
 import { QuickStartTask, QuickStartTaskStatus } from '../utils/quick-start-types';
 import TaskHeader from './QuickStartTaskHeader';
 
@@ -20,7 +20,7 @@ const QuickStartIntroduction: React.FC<QuickStartIntroductionProps> = ({
   const { t } = useTranslation();
   return (
     <>
-      <SyncMarkdownView content={introduction} />
+      <QuickStartMarkdownView content={introduction} />
       <p style={{ marginBottom: 'var(--pf-global--spacer--md)' }}>
         {t('quickstart~In this quick start, you will complete {{count, number}} task', {
           count: tasks.length,

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Alert, Radio } from '@patternfly/react-core';
-import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import QuickStartMarkdownView from '../QuickStartMarkdownView';
 import { QuickStartTaskStatus, QuickStartTaskReview } from '../utils/quick-start-types';
 
 import './QuickStartTaskReview.scss';
@@ -41,7 +41,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
 
   return (
     <Alert variant={getAlertVariant(taskStatus)} title={title} isInline>
-      <SyncMarkdownView content={instructions} />
+      <QuickStartMarkdownView content={instructions} />
       <span className="co-quick-start-task-review__actions">
         <Radio
           id="review-success"
@@ -61,7 +61,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
         />
       </span>
       {taskStatus === QuickStartTaskStatus.FAILED && taskHelp && (
-        <SyncMarkdownView content={taskHelp} />
+        <QuickStartMarkdownView content={taskHelp} />
       )}
     </Alert>
   );

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTasks.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTasks.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import QuickStartMarkdownView from '../QuickStartMarkdownView';
 import { QuickStartTask, QuickStartTaskStatus } from '../utils/quick-start-types';
 import TaskHeader from './QuickStartTaskHeader';
 import QuickStartTaskReview from './QuickStartTaskReview';
@@ -47,7 +47,7 @@ const QuickStartTasks: React.FC<QuickStartTaskProps> = ({
                 isActiveTask={isActiveTask}
                 onTaskSelect={onTaskSelect}
               />
-              <SyncMarkdownView content={taskInstructions} />
+              <QuickStartMarkdownView content={taskInstructions} />
               {isActiveTask && taskStatus !== QuickStartTaskStatus.INIT && review && (
                 <QuickStartTaskReview
                   review={review}

--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartConclusion.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartConclusion.spec.tsx
@@ -4,7 +4,7 @@ import { Button } from '@patternfly/react-core';
 import { getQuickStartByName } from '../../utils/quick-start-utils';
 import { QuickStartTaskStatus } from '../../utils/quick-start-types';
 import QuickStartConclusion from '../QuickStartConclusion';
-import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import QuickStartMarkdownView from '../../QuickStartMarkdownView';
 
 jest.mock('react-i18next', () => {
   const reactI18next = require.requireActual('react-i18next');
@@ -38,7 +38,7 @@ describe('QuickStartConclusion', () => {
   it('should render conclusion if there are no failed tasks', () => {
     expect(
       wrapper
-        .find(SyncMarkdownView)
+        .find(QuickStartMarkdownView)
         .first()
         .props().content,
     ).toEqual('conclusion');
@@ -72,7 +72,7 @@ describe('QuickStartConclusion', () => {
     );
     expect(
       wrapper
-        .find(SyncMarkdownView)
+        .find(QuickStartMarkdownView)
         .first()
         .props().content,
     ).toEqual(

--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTaskReview.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTaskReview.spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Alert } from '@patternfly/react-core';
-import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 import { getQuickStartByName } from '../../utils/quick-start-utils';
 import { QuickStartTaskStatus } from '../../utils/quick-start-types';
 import QuickStartTaskReview from '../QuickStartTaskReview';
+import QuickStartMarkdownView from '../../QuickStartMarkdownView';
 
 type QuickStartTaskReviewProps = React.ComponentProps<typeof QuickStartTaskReview>;
 let wrapper: ShallowWrapper<QuickStartTaskReviewProps>;
@@ -44,7 +44,7 @@ describe('QuickStartTaskReview', () => {
     wrapper = shallow(<QuickStartTaskReview {...props} />);
     expect(
       wrapper
-        .find(SyncMarkdownView)
+        .find(QuickStartMarkdownView)
         .at(1)
         .props().content,
     ).toEqual(props.review.failedTaskHelp);

--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTasks.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTasks.spec.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { SyncMarkdownView } from '@console/internal/components/markdown-view';
 import { getQuickStartByName } from '../../utils/quick-start-utils';
 import { QuickStartTaskStatus } from '../../utils/quick-start-types';
 import QuickStartTask from '../QuickStartTasks';
 import TaskHeader from '../QuickStartTaskHeader';
 import QuickStartTaskReview from '../QuickStartTaskReview';
+import QuickStartMarkdownView from '../../QuickStartMarkdownView';
 
 type QuickStartTaskProps = React.ComponentProps<typeof QuickStartTask>;
 let wrapper: ShallowWrapper<QuickStartTaskProps>;
@@ -53,21 +53,21 @@ describe('QuickStartTasks', () => {
 
     expect(
       wrapper
-        .find(SyncMarkdownView)
+        .find(QuickStartMarkdownView)
         .at(0)
         .props().content,
     ).toEqual(props.tasks[0].summary.success);
 
     expect(
       wrapper
-        .find(SyncMarkdownView)
+        .find(QuickStartMarkdownView)
         .at(1)
         .props().content,
     ).toEqual(props.tasks[1].summary.failed);
 
     expect(
       wrapper
-        .find(SyncMarkdownView)
+        .find(QuickStartMarkdownView)
         .at(2)
         .props().content,
     ).toEqual(props.tasks[2].description);

--- a/frontend/packages/console-shared/src/components/index.ts
+++ b/frontend/packages/console-shared/src/components/index.ts
@@ -22,3 +22,4 @@ export * from './modals';
 export * from './hpa';
 export * from './multi-tab-list';
 export * from './spotlight';
+export * from './markdown-highlight-extension';

--- a/frontend/packages/console-shared/src/components/markdown-highlight-extension/MarkdownHighlightExtension.tsx
+++ b/frontend/packages/console-shared/src/components/markdown-highlight-extension/MarkdownHighlightExtension.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Spotlight } from '../spotlight';
+
+type MarkdownHighlightExtensionProps = {
+  docContext: HTMLDocument;
+};
+const MarkdownHighlightExtension: React.FC<MarkdownHighlightExtensionProps> = ({ docContext }) => {
+  const [selector, setSelector] = React.useState<string>(null);
+  React.useEffect(() => {
+    const elements = docContext.querySelectorAll('[data-highlight]');
+    let timeoutId: NodeJS.Timeout;
+    function startHighlight(e) {
+      const highlightId = e.target.getAttribute('data-highlight');
+      if (!highlightId) {
+        return;
+      }
+      setSelector(null);
+      timeoutId = setTimeout(() => {
+        setSelector(`[data-tour-id="${highlightId}"]`);
+      }, 0);
+    }
+    elements && elements.forEach((elm) => elm.addEventListener('click', startHighlight));
+    return () => {
+      clearTimeout(timeoutId);
+      elements && elements.forEach((elm) => elm.removeEventListener('click', startHighlight));
+    };
+  }, [docContext]);
+  if (!selector) {
+    return null;
+  }
+  return <Spotlight selector={selector} interactive />;
+};
+export default MarkdownHighlightExtension;

--- a/frontend/packages/console-shared/src/components/markdown-highlight-extension/__tests__/highlight-consts.spec.ts
+++ b/frontend/packages/console-shared/src/components/markdown-highlight-extension/__tests__/highlight-consts.spec.ts
@@ -1,0 +1,50 @@
+import {
+  INVALID_HIGHLIGHT_LABELS,
+  INVALID_HIGHLIGHT_LINKS,
+  INVALID_IDS,
+  VALID_HIGHLIGHT_LABELS,
+  VALID_HIGHLIGHT_LINKS,
+  VALID_IDS,
+} from './test-data';
+import { HIGHLIGHT_REGEXP, LINK_LABEL, SELECTOR_ID } from '../highlight-consts';
+
+const createTestLoop = (
+  shouldPass: boolean,
+  label: string,
+  values: string[],
+  regExpString: string,
+) => {
+  const regExp = new RegExp(`^${regExpString}$`);
+  describe(`${label} - ${shouldPass ? '' : 'not '}${regExpString}`, () => {
+    values.forEach((value: string) => {
+      it(`expect to successfully ${shouldPass ? '' : 'not '}match against "${value}"`, () => {
+        expect(regExp.test(value)).toBe(shouldPass);
+      });
+    });
+  });
+};
+
+const successfullyTestValues = (label: string, values: string[], regExpString: string) =>
+  createTestLoop(true, label, values, regExpString);
+const failTestValuesSuccessfully = (label: string, values: string[], regExpString: string) =>
+  createTestLoop(false, label, values, regExpString);
+
+describe('Convert Markdown To Highlight RegExp Tests', () => {
+  successfullyTestValues('Valid Labels', VALID_HIGHLIGHT_LABELS, LINK_LABEL);
+  successfullyTestValues('Valid Ids', VALID_IDS, SELECTOR_ID);
+  successfullyTestValues('Valid Links', VALID_HIGHLIGHT_LINKS, HIGHLIGHT_REGEXP.source);
+
+  failTestValuesSuccessfully('Invalid Labels', INVALID_HIGHLIGHT_LABELS, LINK_LABEL);
+  failTestValuesSuccessfully('Invalid Ids', INVALID_IDS, SELECTOR_ID);
+  failTestValuesSuccessfully('Invalid Links', INVALID_HIGHLIGHT_LINKS, HIGHLIGHT_REGEXP.source);
+
+  it('should get back 3 matches from the HIGHLIGHT_REGEXP for label, highlight and Id', () => {
+    const matches = HIGHLIGHT_REGEXP.exec('[label]{{highlight tour-perspective-switcher}}');
+    expect(matches).not.toBe(null);
+    expect(matches.length).toBe(4);
+    // index 0 is the whole string
+    expect(matches[1]).toBe('label');
+    expect(matches[2]).toBe('highlight');
+    expect(matches[3]).toBe('tour-perspective-switcher');
+  });
+});

--- a/frontend/packages/console-shared/src/components/markdown-highlight-extension/__tests__/test-data.ts
+++ b/frontend/packages/console-shared/src/components/markdown-highlight-extension/__tests__/test-data.ts
@@ -1,0 +1,61 @@
+export const VALID_HIGHLIGHT_LABELS = [
+  'Perspective Switcher',
+  'Kubernetes',
+  'Topology',
+  'K8s',
+  'CaPiTaLs',
+  'ALLCAPS',
+  'search',
+  'help icon',
+  'label(s)',
+  'with $pecial character$',
+  'with great emphasis!',
+  'my long link with spaces and _under_scores_',
+  'allow-dashes',
+];
+
+export const INVALID_HIGHLIGHT_LABELS = [
+  '[[]]]',
+  '{{}}',
+  '',
+  ']{',
+  'valid characters that should work but an extra ]',
+  '[]',
+  '{}',
+];
+
+export const VALID_IDS = [
+  'tour-perspective-dropdown',
+  'tour-help-button',
+  'tour-search-nav',
+  'qs-perspective-switcher',
+  'qs-nav-topology',
+  'qs-nav-search',
+  'some-random-unbroken-text',
+];
+
+export const INVALID_IDS = [
+  'something with spaces',
+  'symbols~!@#$%^&*()`:;"\'<,>.?/|\\',
+  '#id',
+  '.class',
+  '[data-attr]',
+  '',
+  '[]',
+  '()',
+  '{}',
+];
+
+export const VALID_HIGHLIGHT_LINKS = [
+  '[Perspective Switcher]{{highlight qs-perspective-switcher}}',
+  '[Topology]{{highlight qs-nav-topology}}',
+  '[Search]{{highlight qs-nav-search}}',
+  '[Help]{{highlight qs-masthead-help}}',
+  '[Help]{{highlight some-random-id}}',
+];
+
+export const INVALID_HIGHLIGHT_LINKS = [
+  '[[link]{{highlight qs-perspective-switcher}}',
+  '[link]{{highight qs-perspective-switcher}}',
+  '[link]{{highlight perspective switcher}}',
+];

--- a/frontend/packages/console-shared/src/components/markdown-highlight-extension/highlight-consts.ts
+++ b/frontend/packages/console-shared/src/components/markdown-highlight-extension/highlight-consts.ts
@@ -1,0 +1,9 @@
+export const LINK_LABEL = '[\\d\\w\\s-()$!]+';
+export const HIGHLIGHT_ACTIONS = ['highlight'];
+export const SELECTOR_ID = `[\\w-]+`;
+
+// [linkLabel]{{action id}}
+export const HIGHLIGHT_REGEXP = new RegExp(
+  `\\[(${LINK_LABEL})]{{(${HIGHLIGHT_ACTIONS.join('|')}) (${SELECTOR_ID})}}`,
+  'g',
+);

--- a/frontend/packages/console-shared/src/components/markdown-highlight-extension/index.ts
+++ b/frontend/packages/console-shared/src/components/markdown-highlight-extension/index.ts
@@ -1,0 +1,1 @@
+export { default as MarkdownHighlightExtension } from './MarkdownHighlightExtension';

--- a/frontend/packages/console-shared/src/components/spotlight/InteractiveSpotlight.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/InteractiveSpotlight.tsx
@@ -34,15 +34,18 @@ const InteractiveSpotlight: React.FC<InteractiveSpotlightProps> = ({ element }) 
   const [clicked, setClicked] = React.useState(false);
 
   React.useEffect(() => {
-    if (!isInViewport(element)) {
-      element.scrollIntoView();
+    if (!clicked) {
+      if (!isInViewport(element)) {
+        element.scrollIntoView();
+      }
+      const handleClick = () => setClicked(true);
+      document.addEventListener('click', handleClick);
+      return () => {
+        document.removeEventListener('click', handleClick);
+      };
     }
-    const handleClick = () => setClicked(true);
-    document.addEventListener('click', handleClick);
-    return () => {
-      document.removeEventListener('click', handleClick);
-    };
-  }, [element]);
+    return () => {};
+  }, [element, clicked]);
 
   if (clicked) return null;
 

--- a/frontend/packages/console-shared/src/components/spotlight/Spotlight.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/Spotlight.tsx
@@ -9,6 +9,7 @@ type SpotlightProps = {
 
 const Spotlight: React.FC<SpotlightProps> = ({ selector, interactive }) => {
   const element = React.useMemo(() => document.querySelector(selector), [selector]);
+  if (!element) return null;
   return interactive ? (
     <InteractiveSpotlight element={element} />
   ) : (

--- a/frontend/packages/dev-console/src/components/helm/details/__tests__/HelmReleaseNotes.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/__tests__/HelmReleaseNotes.spec.tsx
@@ -5,6 +5,14 @@ import { mockHelmReleases } from '../../__tests__/helm-release-mock-data';
 import HelmReleaseNotes from '../notes/HelmReleaseNotes';
 import HelmReleaseNotesEmptyState from '../notes/HelmReleaseNotesEmptyState';
 
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
 describe('HelmReleaseNotes', () => {
   it('should render the SyncMarkdownView component when notes are available', () => {
     const helmReleaseResources = mount(<HelmReleaseNotes customData={mockHelmReleases[0]} />);


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-4964

**Description:**
- define a markdown syntax for links that trigger hints in the UI.
- enable the Spotlight component in the QuickStart side panel using the syntax

**Screens:**
![enable-tour-highlight](https://user-images.githubusercontent.com/38663217/100868074-1aecef80-34c1-11eb-8c1c-cad683bbcc3e.gif)

**Test Coverage:**
![Screenshot from 2020-12-02 17-18-43](https://user-images.githubusercontent.com/38663217/100869036-779cda00-34c2-11eb-8f93-74fe100b71f2.png)

**Browser Conformance:**
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge