### PR TITLE
Convert Hide Alert Checks from localStorage to user settings

### DIFF
--- a/frontend/packages/console-shared/src/components/health-checks/__tests__/HealthChecksAlert.spec.tsx
+++ b/frontend/packages/console-shared/src/components/health-checks/__tests__/HealthChecksAlert.spec.tsx
@@ -13,6 +13,10 @@ jest.mock('react-i18next', () => {
   };
 });
 
+jest.mock('@console/shared/src/hooks/useUserSettingsCompatibility', () => ({
+  useUserSettingsCompatibility: () => [[], jest.fn(), true],
+}));
+
 describe('HealthChecksAlert', () => {
   const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
   it('should show alert when health check probes not present', () => {

--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -30,6 +30,8 @@ export const UNASSIGNED_APPLICATIONS_KEY = '#UNASSIGNED_APP#';
 // Prefix our localStorage items to avoid conflicts if another app ever runs on the same domain.
 export const STORAGE_PREFIX = 'bridge';
 
+export const USERSETTINGS_PREFIX = 'console';
+
 // This localStorage key predates the storage prefix.
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const APPLICATION_LOCAL_STORAGE_KEY = 'dropdown-storage-applications';


### PR DESCRIPTION
**Story**: 
https://issues.redhat.com/browse/ODC-5106
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
Use `useUserSettings` hook to store the local storage data into a config map.
<!-- Describe your code changes in detail and explain the solution -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge