### PR TITLE
Add ArgoCD application links to GitOpsDetailsPage cards

### DIFF
--- a/frontend/packages/dev-console/src/components/gitops/GitOpsDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/GitOpsDetailsPage.tsx
@@ -89,7 +89,11 @@ const GitOpsDetailsPage: React.FC<GitOpsDetailsPageProps> = ({ match, location }
       {!envsData && !emptyStateMsg ? (
         <LoadingBox />
       ) : (
-        <GitOpsDetailsController envsData={envsData} emptyStateMsg={emptyStateMsg} />
+        <GitOpsDetailsController
+          envsData={envsData}
+          emptyStateMsg={emptyStateMsg}
+          appName={appName}
+        />
       )}
     </>
   );

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.scss
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.scss
@@ -7,6 +7,12 @@
     margin-right: 35px;
     min-width: 285px;
     max-width: 285px;
+    &__argocd-link {
+      margin-top: var(--pf-global--spacer--md)
+    }
+    &__co-resource-item {
+      margin-top: var(--pf-global--spacer--sm)
+    }
     &__header {
       display: flex;
       flex-direction: column;

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetails.tsx
@@ -1,18 +1,41 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Stack, StackItem, Card, CardTitle, SplitItem, Split, Label } from '@patternfly/react-core';
+import {
+  Stack,
+  StackItem,
+  Card,
+  CardTitle,
+  CardBody,
+  SplitItem,
+  Split,
+  Label,
+} from '@patternfly/react-core';
 import { ExternalLink, ResourceIcon } from '@console/internal/components/utils';
+import { ConsoleLinkModel } from '@console/internal/models';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import GitOpsServiceDetailsSection from './GitOpsServiceDetailsSection';
 import { GitOpsEnvironment } from '../utils/gitops-types';
 import './GitOpsDetails.scss';
 
 interface GitOpsDetailsProps {
   envs: GitOpsEnvironment[];
+  appName: string;
 }
 
-const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs }) => {
+const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs, appName }) => {
   const { t } = useTranslation();
+  const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
+    isList: true,
+    kind: referenceForModel(ConsoleLinkModel),
+    optional: true,
+  });
+  const argocdLink = _.find(
+    consoleLinks,
+    (link: K8sResourceKind) =>
+      link.metadata?.name === 'argocd' && link.spec?.location === 'ApplicationMenu',
+  );
   return (
     <div className="odc-gitops-details">
       {_.map(
@@ -23,27 +46,24 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs }) => {
               <StackItem>
                 <Card>
                   <CardTitle className="odc-gitops-details__env-section__header">
-                    <Stack hasGutter>
-                      <StackItem>
-                        <Split style={{ alignItems: 'center' }} hasGutter>
-                          <SplitItem
-                            className="odc-gitops-details__env-section__title co-truncate co-nowrap"
-                            isFilled
-                          >
-                            {env.environment}
-                          </SplitItem>
-                          <SplitItem>
-                            <Label
-                              className="odc-gitops-details__env-section__timestamp"
-                              color="grey"
-                            >
-                              <span style={{ color: 'var(--pf-global--palette--black-600)' }}>
-                                {env.timestamp}
-                              </span>
-                            </Label>
-                          </SplitItem>
-                        </Split>
-                      </StackItem>
+                    <Split style={{ alignItems: 'center' }} hasGutter>
+                      <SplitItem
+                        className="odc-gitops-details__env-section__title co-truncate co-nowrap"
+                        isFilled
+                      >
+                        {env.environment}
+                      </SplitItem>
+                      <SplitItem>
+                        <Label className="odc-gitops-details__env-section__timestamp" color="grey">
+                          <span style={{ color: 'var(--pf-global--palette--black-600)' }}>
+                            {env.timestamp}
+                          </span>
+                        </Label>
+                      </SplitItem>
+                    </Split>
+                  </CardTitle>
+                  <CardBody>
+                    <Stack>
                       <StackItem className="co-truncate co-nowrap">
                         {env.cluster ? (
                           <ExternalLink
@@ -58,13 +78,22 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs }) => {
                         )}
                       </StackItem>
                       <StackItem className="co-truncate co-nowrap">
-                        <span className="co-resource-item">
+                        <span className="co-resource-item odc-gitops-details__env-section__co-resource-item">
                           <ResourceIcon kind="Project" />
                           <span className="co-resource-item__resource-name">{env.environment}</span>
                         </span>
                       </StackItem>
+                      {env.environment && argocdLink && (
+                        <StackItem className="co-truncate co-nowrap">
+                          <ExternalLink
+                            href={`${argocdLink.spec.href}/applications/${env.environment}-${appName}`}
+                            text="Argo CD"
+                            additionalClassName="odc-gitops-details__env-section__argocd-link"
+                          />
+                        </StackItem>
+                      )}
                     </Stack>
-                  </CardTitle>
+                  </CardBody>
                 </Card>
               </StackItem>
               <GitOpsServiceDetailsSection services={env.services} />

--- a/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsController.tsx
+++ b/frontend/packages/dev-console/src/components/gitops/details/GitOpsDetailsController.tsx
@@ -13,6 +13,7 @@ import GitOpsEmptyState from '../GitOpsEmptyState';
 interface GitOpsDetailsControllerProps {
   envsData: GitOpsEnvironment[];
   emptyStateMsg: string;
+  appName: string;
 }
 
 const getWorkLoad = (resources: GitOpsResource[]) => {
@@ -59,6 +60,7 @@ const getTransformedEnvsData = (originalEnvsData: GitOpsEnvironment[], t: TFunct
 const GitOpsDetailsController: React.FC<GitOpsDetailsControllerProps> = ({
   envsData,
   emptyStateMsg,
+  appName,
 }) => {
   const { t } = useTranslation();
   const envs = React.useMemo(() => getTransformedEnvsData(envsData, t), [envsData, t]);
@@ -66,7 +68,7 @@ const GitOpsDetailsController: React.FC<GitOpsDetailsControllerProps> = ({
   return emptyStateMsg ? (
     <GitOpsEmptyState emptyStateMsg={emptyStateMsg} />
   ) : (
-    <GitOpsDetails envs={envs} />
+    <GitOpsDetails envs={envs} appName={appName} />
   );
 };
 


### PR DESCRIPTION
This PR is for Jira issues [ODC-4504](https://issues.redhat.com/browse/ODC-4504) / [GITOPS-451](https://issues.redhat.com/browse/GITOPS-451). It will add ArgoCD application-specific links to each of the environment cards on the gitops details page.

![GitOpsDetailsPage-argocdLink](https://user-images.githubusercontent.com/50851526/99838453-28a48b80-2b37-11eb-81d1-095f12f0087d.png)

@serenamarie125 @lwrigh 