### PR TITLE
Bug 1899949: Remove restriction on disk type selection for LocalVolume Set

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -37,10 +37,7 @@ import {
   getLabelIndex,
   getHostNames,
 } from '@console/local-storage-operator-plugin/src/utils';
-import {
-  DiskMechanicalProperties,
-  DiskType,
-} from '@console/local-storage-operator-plugin/src/components/local-volume-set/types';
+import { DiskType } from '@console/local-storage-operator-plugin/src/components/local-volume-set/types';
 import { initialState, reducer, State, Action, Discoveries, OnNextClick } from './state';
 import { AutoDetectVolume } from './wizard-pages/auto-detect-volume';
 import { CreateLocalVolumeSet } from './wizard-pages/create-local-volume-set';
@@ -153,7 +150,6 @@ const CreateSC: React.FC<CreateSCProps> = ({ match, hasNoProvSC, mode, lsoNs }) 
             // filter out non supported disks
             if (
               discovery?.status?.state === AVAILABLE &&
-              discovery.property === DiskMechanicalProperties.SSD &&
               (discovery.type === DiskType.RawDisk || discovery.type === DiskType.Partition)
             ) {
               discovery.node = name;

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
@@ -1,5 +1,6 @@
 import { HostNamesMap } from '@console/local-storage-operator-plugin/src/components/auto-detect-volume/types';
-import { diskTypeDropdownItems, diskModeDropdownItems } from '../../../../constants';
+import { diskTypeDropdownItems } from '@console/local-storage-operator-plugin/src/constants';
+import { diskModeDropdownItems } from '../../../../constants';
 import { StorageClassResourceKind, NodeKind } from '@console/internal/module/k8s';
 import { EncryptionType, KMSConfig } from '../../types';
 
@@ -14,7 +15,7 @@ export const initialState: State = {
   volumeSetName: '',
   storageClassName: '',
   showNodesListOnLVS: false,
-  diskType: diskTypeDropdownItems.SSD,
+  diskType: diskTypeDropdownItems.All,
   diskMode: diskModeDropdownItems.BLOCK,
   maxDiskLimit: '',
   nodeNames: [], // nodes selected on the LVS step

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
@@ -12,7 +12,6 @@ import { State, Action } from '../state';
 import { DiscoveryDonutChart } from './donut-chart';
 import {
   MINIMUM_NODES,
-  diskTypeDropdownItems,
   diskModeDropdownItems,
   allNodesSelectorTxt,
 } from '../../../../../constants';
@@ -55,7 +54,6 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({
           <LocalVolumeSetInner
             state={state}
             dispatch={dispatch}
-            diskTypeOptions={diskTypeDropdownItems}
             diskModeOptions={diskModeDropdownItems}
             allNodesHelpTxt={allNodesSelectorTxt}
           />

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -33,10 +33,6 @@ export const diskModeDropdownItems = Object.freeze({
   BLOCK: 'Block',
 });
 
-export const diskTypeDropdownItems = Object.freeze({
-  SSD: 'SSD / NVMe',
-});
-
 export const allNodesSelectorTxt =
   'Selecting all nodes will use the available disks that match the selected filters on all nodes selected on previous step.';
 

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -21,6 +21,7 @@ import {
   diskTypeDropdownItems,
   diskSizeUnitOptions,
   allNodesSelectorTxt,
+  DISK_TYPES,
 } from '../../constants';
 import './create-local-volume-set.scss';
 
@@ -122,11 +123,9 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
           id="create-lvs-disk-type-dropdown"
           dropDownClassName="dropdown--full-width"
           items={diskTypeOptions}
-          title={state.diskType}
+          title={DISK_TYPES[state.diskType]?.title}
           selectedKey={state.diskType}
-          onChange={(type: string) =>
-            dispatch({ type: 'setDiskType', value: diskTypeDropdownItems[type] })
-          }
+          onChange={(type: string) => dispatch({ type: 'setDiskType', value: type })}
         />
       </FormGroup>
       <ExpandableSection toggleText="Advanced" data-test-id="create-lvs-form-advanced">

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -1,8 +1,8 @@
 import { apiVersionForModel } from '@console/internal/module/k8s';
 import { LocalVolumeSetModel } from '../../models';
-import { LocalVolumeSetKind, DiskType, DiskMechanicalProperties } from './types';
+import { LocalVolumeSetKind, DiskType } from './types';
 import { State } from './state';
-import { HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
+import { DISK_TYPES, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
 
 export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVolumeSetKind => {
@@ -16,10 +16,6 @@ export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVol
       volumeMode: state.diskMode,
       deviceInclusionSpec: {
         deviceTypes: [DiskType.RawDisk, DiskType.Partition],
-        deviceMechanicalProperties:
-          state.diskType === 'HDD'
-            ? [DiskMechanicalProperties[state.diskType]]
-            : [DiskMechanicalProperties.SSD],
       },
       nodeSelector: {
         nodeSelectorTerms: [
@@ -42,6 +38,11 @@ export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVol
     requestData.spec.deviceInclusionSpec.minSize = `${state.minDiskSize}${state.diskSizeUnit}`;
   if (state.maxDiskSize)
     requestData.spec.deviceInclusionSpec.maxSize = `${state.maxDiskSize}${state.diskSizeUnit}`;
+  if (DISK_TYPES[state.diskType]?.property) {
+    requestData.spec.deviceInclusionSpec.deviceMechanicalProperties = [
+      DISK_TYPES[state.diskType].property,
+    ];
+  }
 
   return requestData;
 };

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -5,7 +5,7 @@ export const initialState = {
   volumeSetName: '',
   storageClassName: '',
   showNodesListOnLVS: false,
-  diskType: diskTypeDropdownItems.SSD,
+  diskType: diskTypeDropdownItems.All,
   diskMode: diskModeDropdownItems.BLOCK,
   maxDiskLimit: '',
   nodeNames: [],

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
@@ -15,8 +15,8 @@ export enum DiskType {
 }
 
 export enum DiskMechanicalProperties {
-  SSD = 'NonRotational',
-  HDD = 'Rotational',
+  'NonRotational' = 'NonRotational',
+  'Rotational' = 'Rotational',
 }
 
 export type LocalVolumeSetKind = K8sResourceCommon & {
@@ -25,7 +25,7 @@ export type LocalVolumeSetKind = K8sResourceCommon & {
     volumeMode: string;
     deviceInclusionSpec: {
       deviceTypes?: DiskType[];
-      deviceMechanicalProperties: DiskMechanicalProperties[];
+      deviceMechanicalProperties: [keyof typeof DiskMechanicalProperties];
       minSize?: string;
       maxSize?: string;
     };

--- a/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
@@ -1,8 +1,31 @@
+import { DiskMechanicalProperties } from '../components/local-volume-set/types';
+
 export const diskModeDropdownItems = Object.freeze({
   BLOCK: 'Block',
   FILESYSTEM: 'Filesystem',
 });
+
+export const DISK_TYPES: {
+  [key: string]: {
+    property?: keyof typeof DiskMechanicalProperties;
+    title: string;
+  };
+} = {
+  SSD: {
+    property: 'NonRotational',
+    title: 'SSD / NVMe',
+  },
+  HDD: {
+    property: 'Rotational',
+    title: 'HDD',
+  },
+  All: {
+    title: 'All',
+  },
+};
+
 export const diskTypeDropdownItems = Object.freeze({
+  All: 'All',
   SSD: 'SSD / NVMe',
   HDD: 'HDD',
 });


### PR DESCRIPTION
- allow filtering hdd disks for creating storage class

![Screenshot from 2020-11-23 14-09-06](https://user-images.githubusercontent.com/25664409/99942522-ceedcc80-2d95-11eb-9f2c-be2825a48fbd.png)
![Screenshot from 2020-11-23 14-12-38](https://user-images.githubusercontent.com/25664409/99942727-255b0b00-2d96-11eb-9f80-d900c1643021.png)



