### PR TITLE
Provide code snippet for default console catalog categories

### DIFF
--- a/frontend/packages/console-shared/src/utils/sample-utils.ts
+++ b/frontend/packages/console-shared/src/utils/sample-utils.ts
@@ -1,7 +1,13 @@
 import { Map as ImmutableMap } from 'immutable';
+import * as _ from 'lodash';
+import YAML from 'js-yaml';
+
+import { defaultCatalogCategories } from '@console/dev-console/src/components/catalog/utils/default-categories';
+
 import {
   BuildConfigModel,
   ClusterRoleModel,
+  ConsoleModel,
   ConsoleLinkModel,
   NetworkPolicyModel,
   ResourceQuotaModel,
@@ -23,7 +29,6 @@ import * as webAllowExternalImg from '@console/internal/imgs/network-policy-samp
 import * as webDbAllowAllNsImg from '@console/internal/imgs/network-policy-samples/6-web-db-allow-all-ns.svg';
 import * as webAllowProductionImg from '@console/internal/imgs/network-policy-samples/7-web-allow-production.svg';
 import { FirehoseResult } from '@console/internal/components/utils';
-import * as _ from 'lodash';
 
 export type Sample = {
   highlightText?: string;
@@ -32,6 +37,7 @@ export type Sample = {
   description: string;
   id: string;
   yaml?: string;
+  lazyYaml?: () => string;
   snippet?: boolean;
   targetResource: {
     apiVersion: string;
@@ -227,16 +233,30 @@ const defaultSamples = ImmutableMap<GroupVersionKind, Sample[]>()
       {
         title: 'Add a link to the application menu',
         description:
-          'The application menu appears in the masthead below the 9x9 grid icon.  Application menu links can include an optional image and section heading.',
+          'The application menu appears in the masthead below the 9x9 grid icon. Application menu links can include an optional image and section heading.',
         id: 'cl-application-menu',
         targetResource: getTargetResource(ConsoleLinkModel),
       },
       {
         title: 'Add a link to the namespace dashboard',
         description:
-          'Namespace dashboard links appear on the project dashboard and namespace details pages in a section called "Launcher".  Namespace dashboard links can optionally be restricted to a specific namespace or namespaces.',
+          'Namespace dashboard links appear on the project dashboard and namespace details pages in a section called "Launcher". Namespace dashboard links can optionally be restricted to a specific namespace or namespaces.',
         id: 'cl-namespace-dashboard',
         targetResource: getTargetResource(ConsoleLinkModel),
+      },
+    ],
+  )
+  .setIn(
+    [referenceForModel(ConsoleModel)],
+    [
+      {
+        title: 'Add catalog categories',
+        description:
+          'Provides a list of default categories which are shown in the Developer Catalog. The categories must be added below customization developerCatalog.',
+        id: 'devcatalog-categories',
+        snippet: true,
+        lazyYaml: () => YAML.dump(defaultCatalogCategories),
+        targetResource: getTargetResource(ConsoleModel),
       },
     ],
   );

--- a/frontend/public/components/sidebars/resource-sidebar-samples.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar-samples.tsx
@@ -70,24 +70,32 @@ const PreviewYAML = ({ maxPreviewLines = 20, yaml }) => {
   );
 };
 
-const ResourceSidebarSnippet: React.FC<any> = ({ snippet, insertSnippetYaml }) => {
+interface ResourceSidebarSnippetProps {
+  snippet: Sample;
+  insertSnippetYaml(id: string, yaml: string, reference: string);
+}
+
+const ResourceSidebarSnippet: React.FC<ResourceSidebarSnippetProps> = ({
+  snippet,
+  insertSnippetYaml,
+}) => {
   const [yamlPreviewOpen, setYamlPreviewOpen] = React.useState(false);
   const toggleYamlPreview = () => setYamlPreviewOpen(!yamlPreviewOpen);
 
-  const { highlightText, title, id, yaml, targetResource, description } = snippet;
-  const reference = referenceFor(targetResource);
+  const { highlightText, title, id, yaml, lazyYaml, targetResource, description } = snippet;
+
+  const insertSnippet = () => {
+    const reference = referenceFor(targetResource);
+    insertSnippetYaml(id, typeof lazyYaml === 'function' ? lazyYaml() : yaml, reference);
+  };
+
   return (
     <li className="co-resource-sidebar-item">
       <h3 className="h4">
         <span className="text-uppercase">{highlightText}</span> {title}
       </h3>
       <p>{description}</p>
-      <Button
-        type="button"
-        variant="link"
-        isInline
-        onClick={() => insertSnippetYaml(id, yaml, reference)}
-      >
+      <Button type="button" variant="link" isInline onClick={insertSnippet}>
         <PasteIcon className="co-icon-space-r" />
         Insert Snippet
       </Button>
@@ -110,12 +118,20 @@ const ResourceSidebarSnippet: React.FC<any> = ({ snippet, insertSnippetYaml }) =
           </>
         )}
       </Button>
-      {yamlPreviewOpen && <PreviewYAML yaml={yaml} />}
+      {yamlPreviewOpen && <PreviewYAML yaml={typeof lazyYaml === 'function' ? lazyYaml() : yaml} />}
     </li>
   );
 };
 
-export const ResourceSidebarSnippets = ({ snippets, insertSnippetYaml }) => {
+interface ResourceSidebarSnippetsProps {
+  snippets: Sample[];
+  insertSnippetYaml(id: string, yaml: string, reference: string);
+}
+
+export const ResourceSidebarSnippets: React.FC<ResourceSidebarSnippetsProps> = ({
+  snippets,
+  insertSnippetYaml,
+}) => {
   return (
     <ul className="co-resource-sidebar-list" style={{ listStyle: 'none', paddingLeft: 0 }}>
       {_.map(snippets, (snippet) => (

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -892,6 +892,19 @@ export const InfrastructureModel: K8sKind = {
   crd: true,
 };
 
+export const ConsoleModel: K8sKind = {
+  label: 'Console',
+  labelPlural: 'Consoles',
+  apiVersion: 'v1',
+  apiGroup: 'operator.openshift.io',
+  plural: 'consoles',
+  abbr: 'C',
+  namespaced: false,
+  kind: 'Console',
+  id: 'console',
+  crd: true,
+};
+
 export const ConsoleLinkModel: K8sKind = {
   label: 'Console Link',
   labelPlural: 'Console Links',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5080

**Analysis / Root cause**: 
To enable the admin to customize the categories in Developer Catalog in the `Console` CRD (group operator.openshift.io), we need a way to provide the default catalog categories.

**Solution Description**:
PR is based on #7196, you can focus on the second commit in this commit.

This PR adds a new snippet to the `Console` resources which provides a list of the default catalog categories.

To save the customized Developer Catalog you need to extend the CRD as well. See Test setup below.

This PR converts the internally saved "default categories" into the "simplified" CRD format. Instead of a map where the id matches the map key, and an entry with `field: 'tags'` and `values: <array of tags>`:

```yaml
spec:
  customization:
    developerCatalog:
      categories:
      - java:
        - id: java
          label: 'Java',
          field: 'tags'
          values: ['java']
```

the CRD defines the categories as arrays with just an array of `tags`:

```yaml
spec:
  customization:
    developerCatalog:
      categories:
        - id: java
          label: 'Java'
          tags: ['java']
```

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 
This adds a new snippet for `Console` CRD (group operator.openshift.io) in the sidebar of the `cluster` configuration.

It adds the snippet incl. the complete "yaml path", "spec.customization.developerCatalog.categories" which makes it hopefully easier for the admin to keep the correct indentation.

![image](https://user-images.githubusercontent.com/139310/99953486-9643f800-2d81-11eb-971e-c688eccb931f.png)

![image](https://user-images.githubusercontent.com/139310/99953554-b2479980-2d81-11eb-948b-7542cf508884.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. The PR https://github.com/openshift/api/pull/763/files extends the `Console` CRD (group operator.openshift.io) with a new `developerCatalog.categories` area. To save the snippet you need add these fields to the CRD before saving it:

CRD URL example: http://localhost:9000/k8s/cluster/customresourcedefinitions/consoles.operator.openshift.io

Search for `customProductName`, add this yaml between `customProductName` and `documentationBaseURL`.

```yaml
                    developerCatalog:
                      description: >-
                        console allow the cluster admin to configure the shown
                        categories.
                      type: object
                      properties:
                        categories:
                          description: categories which are shown the in the devconsole.
                          type: array
                          items:
                            type: object
                            properties:
                              id:
                                description: >-
                                  identifier used in the URL to enable
                                  deeplinking in console
                                type: string
                              label:
                                description: category display label
                                type: string
                              subcategories:
                                description: a list of child categories
                                type: array
                                items:
                                  type: object
                                  properties:
                                    id:
                                      description: >-
                                        identifier used in the URL to enable
                                        deeplinking in console
                                      type: string
                                    label:
                                      description: category display label
                                      type: string
                                    tags:
                                      description: >-
                                        the list of item tags this category will
                                        match
                                      type: array
                                      items:
                                        type: string
                              tags:
                                description: the list of item tags this category will match
                                type: array
                                items:
                                  type: string
```

2. Open the `cluster` resource of the YAML and open the sidebar.

Cluster config example: http://localhost:9000/k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml

3. Insert the default snippet and save the resource.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
