### PR TITLE
adds fallback to localstorage for usersettings if 403 for configmap

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useUserSettingsCompatibility.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettingsCompatibility.ts
@@ -1,14 +1,17 @@
 import * as React from 'react';
+import { deseralizeData } from '../utils/user-settings';
 import { useUserSettings } from './useUserSettings';
 
 export const useUserSettingsCompatibility = <T>(
   key: string,
   storageKey: string,
   defaultValue?: T,
-): [T | string, React.Dispatch<React.SetStateAction<T>>, boolean] => {
-  const [settings, setSettings, loaded] = useUserSettings<T | string>(
+): [T, React.Dispatch<React.SetStateAction<T>>, boolean] => {
+  const [settings, setSettings, loaded] = useUserSettings<T>(
     key,
-    localStorage.getItem(storageKey) || defaultValue,
+    localStorage.getItem(storageKey) !== null
+      ? deseralizeData(localStorage.getItem(storageKey))
+      : defaultValue,
   );
 
   React.useEffect(

--- a/frontend/packages/console-shared/src/hooks/useUserSettingsLocalStorage.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettingsLocalStorage.ts
@@ -1,0 +1,85 @@
+import * as React from 'react';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useSelector } from 'react-redux';
+import { RootState } from '@console/internal/redux';
+import { deseralizeData, seralizeData } from '../utils/user-settings';
+
+const CONFIGMAP_LS_KEY = 'console-user-settings';
+
+export const useUserSettingsLocalStorage = <T>(
+  key: string,
+  defaultValue: T,
+  watch: boolean = true,
+): [T, React.Dispatch<React.SetStateAction<T>>] => {
+  const keyRef = React.useRef(key);
+  const defaultValueRef = React.useRef(defaultValue);
+  const userUid = useSelector(
+    (state: RootState) => state.UI.get('user')?.metadata?.uid ?? 'kubeadmin',
+  );
+  const storageConfigNameRef = React.useRef(`${CONFIGMAP_LS_KEY}-${userUid}`);
+  const [lsData, setLsData] = React.useState(() => {
+    const valueInLocalStorage =
+      localStorage.getItem(storageConfigNameRef.current) !== null &&
+      deseralizeData(localStorage.getItem(storageConfigNameRef.current));
+    return valueInLocalStorage?.hasOwnProperty(keyRef.current) &&
+      valueInLocalStorage[keyRef.current]
+      ? valueInLocalStorage[keyRef.current]
+      : defaultValueRef.current;
+  });
+  const lsDataRef = React.useRef<T>(lsData);
+  lsDataRef.current = lsData;
+
+  const localStorageUpdated = React.useCallback(
+    (ev: StorageEvent) => {
+      if (ev.key === storageConfigNameRef.current) {
+        const lsConfigMapData = deseralizeData(localStorage.getItem(storageConfigNameRef.current));
+        if (
+          lsData !== undefined &&
+          lsConfigMapData?.[keyRef.current] &&
+          seralizeData(lsConfigMapData[keyRef.current]) !== seralizeData(lsData)
+        ) {
+          setLsData(lsConfigMapData[keyRef.current]);
+        }
+      }
+    },
+    [lsData],
+  );
+  React.useEffect(() => {
+    if (watch) {
+      window.addEventListener('storage', localStorageUpdated);
+    }
+    return () => {
+      if (watch) {
+        window.removeEventListener('storage', localStorageUpdated);
+      }
+    };
+  }, [localStorageUpdated, watch]);
+
+  const updateLsData = React.useCallback<React.Dispatch<React.SetStateAction<T>>>(
+    (action: React.SetStateAction<T>) => {
+      const previousData = lsDataRef.current;
+      const data =
+        typeof action === 'function' ? (action as (prevState: T) => T)(previousData) : action;
+      const lsConfigMapData =
+        deseralizeData(localStorage.getItem(storageConfigNameRef.current)) ?? {};
+      if (
+        data !== undefined &&
+        seralizeData(data) !== seralizeData(lsConfigMapData?.[keyRef.current])
+      ) {
+        setLsData(data);
+        const dataToUpdate = {
+          ...lsConfigMapData,
+          ...{
+            [keyRef.current]: data,
+          },
+        };
+        localStorage.setItem(storageConfigNameRef.current, seralizeData(dataToUpdate));
+      }
+    },
+    [],
+  );
+
+  return [lsData, updateLsData];
+};

--- a/frontend/packages/console-shared/src/utils/user-settings.ts
+++ b/frontend/packages/console-shared/src/utils/user-settings.ts
@@ -1,0 +1,84 @@
+import { ConfigMapModel, ProjectRequestModel, ProjectModel } from '@console/internal/models';
+import {
+  K8sResourceKind,
+  k8sGet,
+  k8sCreate,
+  k8sPatch,
+  ConfigMapKind,
+} from '@console/internal/module/k8s';
+
+// can't create project with name prefix with 'openshift-*', once we have proxy need to update
+export const USER_SETTING_CONFIGMAP_NAMESPACE = 'console-user-settings';
+
+export const getProject = async (): Promise<boolean> => {
+  try {
+    await k8sGet(ProjectModel, USER_SETTING_CONFIGMAP_NAMESPACE);
+    return true;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    return false;
+  }
+};
+
+export const createProject = async () => {
+  try {
+    await k8sCreate(ProjectRequestModel, {
+      metadata: {
+        name: USER_SETTING_CONFIGMAP_NAMESPACE,
+      },
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+};
+
+export const createConfigMap = async (configMapData: K8sResourceKind): Promise<K8sResourceKind> => {
+  try {
+    const configMapDataResp = await k8sCreate(ConfigMapModel, configMapData);
+    return configMapDataResp;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    const error: Error & { response?: object } = new Error(err.message);
+    error.response = err.response;
+    throw error;
+  }
+};
+
+export const updateConfigMap = async (configMap: ConfigMapKind, key: string, value: string) => {
+  if (value !== configMap.data?.[key]) {
+    const patch = [
+      {
+        op: 'replace',
+        path: `/data/${key}`,
+        value,
+      },
+    ];
+    try {
+      await k8sPatch(ConfigMapModel, configMap, patch);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  }
+};
+
+export const deseralizeData = (data: string | null) => {
+  if (typeof data !== 'string') {
+    return data;
+  }
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+};
+
+export const seralizeData = <T>(data: T) => {
+  if (typeof data === 'string') {
+    return data;
+  }
+  return JSON.stringify(data);
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5082

**Analysis / Root cause**: 
useUserSettings doesn't support fallback to localStorage

**Solution Description**: 
adds support fallback for support for `useUserSettings`

Implementation can be tested with https://github.com/openshift/console/pull/7051

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
NA

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
