### PR TITLE
CONSOLE-2024: Add popover for Unschedulable Pending, CrashLoopBackoff, ErrImagePull, ImagePullBackOff statuses

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -29,7 +29,7 @@ export const Status: React.FC<StatusProps> = ({
       return <StatusIconAndText {...statusProps} icon={<HourglassStartIcon />} />;
 
     case 'Pending':
-      return <StatusIconAndText {...statusProps} icon={<HourglassHalfIcon />} />;
+      return <StatusIconAndText {...statusProps} icon={<HourglassHalfIcon color="inherit" />} />;
 
     case 'Planning':
       return <StatusIconAndText {...statusProps} icon={<ClipboardListIcon />} />;

--- a/frontend/public/locales/en/workload.json
+++ b/frontend/public/locales/en/workload.json
@@ -102,6 +102,7 @@
   "Filesystem": "Filesystem",
   "Network in": "Network in",
   "Network out": "Network out",
+  "Pod unschedulable": "Pod unschedulable",
   "Restart policy": "Restart policy",
   "Pod IP": "Pod IP",
   "Pod details": "Pod details",


### PR DESCRIPTION
* If pod is `Unschedulable`, add a popover to `Pending` status that includes the reason the pod is unschedulable on the pod list and pod details pages.
  <img width="778" alt="Screen Shot 2020-11-23 at 11 34 49 AM" src="https://user-images.githubusercontent.com/895728/99988987-1cf7d580-2d80-11eb-94b8-70f8f2182b1d.png">
  <img width="1623" alt="Screen Shot 2020-11-23 at 11 40 10 AM" src="https://user-images.githubusercontent.com/895728/99989477-ac04ed80-2d80-11eb-8e13-57a2fa920269.png">
* If pod status is `CrashLoopBackoff`, add a popover to the `CrashLoopBackoff` status that includes the reason for the error on the pod list and pod details pages.
  <img width="741" alt="Screen Shot 2020-12-08 at 11 09 29 AM" src="https://user-images.githubusercontent.com/895728/101514355-2ae65280-394b-11eb-9505-8600e75937f8.png">
  <img width="1537" alt="Screen Shot 2020-12-08 at 11 09 36 AM" src="https://user-images.githubusercontent.com/895728/101514357-2b7ee900-394b-11eb-8810-c809ab623300.png">
* If pod status is `ErrImagePull`, add a popover to the `ErrImagePull` status that includes the reason for the error on the pod list and pod details pages.
  <img width="1715" alt="Screen Shot 2020-11-24 at 11 12 52 AM" src="https://user-images.githubusercontent.com/895728/100120585-17fd5980-2e46-11eb-81e5-cddc314f6a07.png">
  <img width="1647" alt="Screen Shot 2020-11-24 at 11 12 58 AM" src="https://user-images.githubusercontent.com/895728/100120586-1895f000-2e46-11eb-951b-858accefca42.png">
* If pod status is `ImagePullBackOff`, add a popover to the `ImagePullBackOff` status that includes the reason for the error on the pod list and pod details pages.
  <img width="2200" alt="Screen Shot 2020-11-24 at 8 54 41 AM" src="https://user-images.githubusercontent.com/895728/100103394-d57e5180-2e32-11eb-985e-c7fd289bab40.png">
  <img width="2206" alt="Screen Shot 2020-11-24 at 8 54 52 AM" src="https://user-images.githubusercontent.com/895728/100103395-d616e800-2e32-11eb-8da1-a21e2e3dee9a.png">

