### PR TITLE
Bug 1888036: Only show latest version for each CSV and PackageManifest provided API.

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useK8sModels.ts
+++ b/frontend/packages/console-shared/src/hooks/useK8sModels.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+import { K8sKind } from 'public/module/k8s';
+
+// Hook to retrieve all current k8s models from redux.
+export const useK8sModels = (): [{ [key: string]: K8sKind }, boolean] => [
+  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'models']))?.toJS() ?? {},
+  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight'])) ?? false,
+];

--- a/frontend/packages/console-shared/src/utils/annotations.ts
+++ b/frontend/packages/console-shared/src/utils/annotations.ts
@@ -1,0 +1,17 @@
+import { ObjectMetadata } from '@console/internal/module/k8s';
+
+export const parseJSONAnnotation = (
+  annotations: ObjectMetadata['annotations'],
+  annotationKey: string,
+  onError?: (err: Error) => void,
+  defaultReturn?: any,
+): any => {
+  try {
+    return annotations?.[annotationKey] ? JSON.parse(annotations?.[annotationKey]) : defaultReturn;
+  } catch (e) {
+    onError?.(e);
+    // eslint-disable-next-line no-console
+    console.warn(`Could not parse annotation ${annotationKey} as JSON: `, e);
+    return defaultReturn;
+  }
+};

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -8,7 +8,6 @@ import {
   RouteKind,
   apiVersionForModel,
   K8sKind,
-  ObjectMetadata,
   JobKind,
 } from '@console/internal/module/k8s';
 import {
@@ -164,22 +163,6 @@ const getAnnotation = (obj: K8sResourceKind, annotation: string): string => {
   return _.get(obj, ['metadata', 'annotations', annotation]);
 };
 
-export const parseJSONAnnotation = (
-  annotations: ObjectMetadata['annotations'],
-  annotationKey: string,
-  onError?: (err: Error) => void,
-  defaultReturn?: any,
-): any => {
-  try {
-    return annotations?.[annotationKey] ? JSON.parse(annotations?.[annotationKey]) : defaultReturn;
-  } catch (e) {
-    onError && onError(e);
-    // eslint-disable-next-line no-console
-    console.warn(`Could not parse annotation ${annotationKey} as JSON: `, e);
-    return defaultReturn;
-  }
-};
-
 const getDeploymentRevision = (obj: K8sResourceKind): number => {
   const revision = getAnnotation(obj, DEPLOYMENT_REVISION_ANNOTATION);
   return revision && parseInt(revision, 10);
@@ -264,7 +247,7 @@ const getPodAlerts = (pod: K8sResourceKind): OverviewItemAlerts => {
     const { type, status, reason, message } = condition;
     if (type === 'PodScheduled' && status === 'False' && reason === 'Unschedulable') {
       // eslint-disable-next-line
-      const key = podAlertKey(reason, pod, name);
+      const key = podAlertKey(reason, pod);
       alerts[key] = {
         severity: 'error',
         message: `${reason}: ${message}`,

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
@@ -28,9 +28,6 @@ module.exports = {
   // When there is only a single export from a module, prefer using default export over named export.
   'import/prefer-default-export': 'off',
 
-  // Disallow Unused Expressions
-  'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
-
   // Disallow console statements
   'no-console': 'error',
 

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/typescript.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/typescript.js
@@ -149,6 +149,13 @@ module.exports = {
   // Warns if a type assertion does not change the type of an expression
   '@typescript-eslint/no-unnecessary-type-assertion': 'error',
 
+  // Disallow Unused Expressions,
+  'no-unused-expressions': 'off',
+  '@typescript-eslint/no-unused-expressions': [
+    'error',
+    { allowShortCircuit: true, allowTernary: true },
+  ],
+
   // Disallow unused variables
   'no-unused-vars': 'off',
   '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],

--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -431,6 +431,7 @@ export const testModel: K8sKind = {
   labelPlural: 'Test Resources',
   namespaced: true,
   plural: 'testresources',
+  verbs: ['create'],
 };
 
 const amqPackageManifest = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -27,6 +27,7 @@ import {
   testPackageManifest,
   testCatalogSource,
   testInstallPlan,
+  testModel,
 } from '../../mocks';
 import { ClusterServiceVersionModel } from '../models';
 import { ClusterServiceVersionKind, ClusterServiceVersionPhase } from '../types';
@@ -54,6 +55,10 @@ import {
 } from '.';
 
 const i18nNS = 'details-page';
+
+jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
+  useK8sModel: () => [testModel],
+}));
 
 describe('SingleProjectTableHeader.displayName', () => {
   it('returns single project column header definition for cluster service version table header', () => {
@@ -195,8 +200,7 @@ describe(ClusterServiceVersionLogo.displayName, () => {
   });
 
   it('renders logo image from given base64 encoded image string', () => {
-    const image: ReactWrapper<React.ImgHTMLAttributes<any>> = wrapper.find('img');
-
+    const image = wrapper.find('img');
     expect(image.props().src).toEqual(
       `data:${testClusterServiceVersion.spec.icon[0].mediatype};base64,${testClusterServiceVersion.spec.icon[0].base64data}`,
     );
@@ -204,8 +208,7 @@ describe(ClusterServiceVersionLogo.displayName, () => {
 
   it('renders fallback image if given icon is invalid', () => {
     wrapper.setProps({ icon: null });
-    const fallbackImg: ReactWrapper<React.ImgHTMLAttributes<any>> = wrapper.find('img');
-
+    const fallbackImg = wrapper.find('img');
     expect(fallbackImg.props().src).toEqual(operatorLogo);
   });
 
@@ -286,7 +289,7 @@ describe(ClusterServiceVersionDetails.displayName, () => {
 
   it('renders row of cards for each "owned" CRD for the given `ClusterServiceVersion`', () => {
     expect(wrapper.find(CRDCardRow).props().csv).toEqual(testClusterServiceVersion);
-    expect(wrapper.find(CRDCardRow).props().crdDescs).toEqual(
+    expect(wrapper.find(CRDCardRow).props().providedAPIs).toEqual(
       testClusterServiceVersion.spec.customresourcedefinitions.owned,
     );
   });
@@ -526,7 +529,7 @@ describe(ClusterServiceVersionsDetailsPage.displayName, () => {
 
     const csv = _.cloneDeep(testClusterServiceVersion);
     csv.spec.customresourcedefinitions.owned = csv.spec.customresourcedefinitions.owned.concat([
-      { name: 'e.example.com', kind: 'E', version: 'v1', displayName: 'E' },
+      { name: 'e.example.com', kind: 'E', version: 'v1alpha1', displayName: 'E' },
     ]);
 
     expect(detailsPage.props().pagesFor(csv)[4].name).toEqual('All Instances');

--- a/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
@@ -9,6 +9,7 @@ import {
   referenceForModel,
   K8sKind,
   K8sResourceKind,
+  apiVersionCompare,
 } from '@console/internal/module/k8s';
 import { PackageManifestModel } from '../models';
 import {
@@ -24,14 +25,36 @@ import {
   SubscriptionKind,
 } from '../types';
 import * as operatorLogo from '../operator.svg';
+import { getInternalObjects } from '../utils';
 
 export const visibilityLabel = 'olm-visibility';
 
-type ProvidedAPIsFor = (csv: ClusterServiceVersionKind) => ProvidedAPI[];
-export const providedAPIsFor: ProvidedAPIsFor = (csv) =>
-  _.get(csv, 'spec.customresourcedefinitions.owned', []).concat(
-    _.get(csv, 'spec.apiservicedefinitions.owned', []),
-  );
+const filteredAPIs = (providedAPIs: ProvidedAPI[], internalObjects: string[]): ProvidedAPI[] => {
+  const filteredAndSorted = providedAPIs
+    .filter((api) => !internalObjects.includes(api.name))
+    .sort((a, b) => apiVersionCompare(a.version, b.version));
+  return _.uniqBy(filteredAndSorted, 'name');
+};
+
+// Returns provided apis for a given csv, excluding internal objects and duplicate
+export const providedAPIsForCSV = (csv: ClusterServiceVersionKind): ProvidedAPI[] => {
+  const allProvidedAPIs: ProvidedAPI[] = [
+    ...(csv?.spec?.apiservicedefinitions?.owned ?? []),
+    ...(csv?.spec?.customresourcedefinitions?.owned ?? []),
+  ];
+  const internalObjects = getInternalObjects(csv?.metadata?.annotations);
+  return filteredAPIs(allProvidedAPIs, internalObjects);
+};
+
+export const providedAPIsForChannel = (pkg: PackageManifestKind) => (channel: string) => {
+  const { currentCSVDesc } = pkg.status.channels.find((ch) => ch.name === channel);
+  const allProvidedAPIs: ProvidedAPI[] = [
+    ...(currentCSVDesc?.customresourcedefinitions?.owned ?? []),
+    ...(currentCSVDesc?.apiservicedefinitions?.owned ?? []),
+  ];
+  const internalObjects = getInternalObjects(currentCSVDesc?.annotations);
+  return filteredAPIs(allProvidedAPIs, internalObjects);
+};
 
 export const referenceForProvidedAPI = (
   desc: CRDDescription | APIServiceDefinition,
@@ -58,15 +81,6 @@ export const installModesFor = (pkg: PackageManifestKind) => (channel: string) =
   pkg.status.channels.find((ch) => ch.name === channel)?.currentCSVDesc?.installModes || [];
 export const supportedInstallModesFor = (pkg: PackageManifestKind) => (channel: string) =>
   installModesFor(pkg)(channel).filter(({ supported }) => supported);
-export const providedAPIsForChannel = (pkg: PackageManifestKind) => (channel: string) =>
-  _.compact(
-    _.flatten([
-      pkg.status.channels.find((ch) => ch.name === channel).currentCSVDesc.customresourcedefinitions
-        .owned,
-      pkg.status.channels.find((ch) => ch.name === channel).currentCSVDesc.apiservicedefinitions
-        .owned,
-    ]),
-  );
 
 export const iconFor = (pkg: PackageManifestKind) => {
   const defaultChannel = pkg?.status?.defaultChannel
@@ -118,11 +132,13 @@ export const ClusterServiceVersionLogo: React.SFC<ClusterServiceVersionLogoProps
   );
 };
 
+export const providedAPIForReference = (csv, reference) => {
+  const providedAPIs = providedAPIsForCSV(csv) ?? [];
+  return providedAPIs.find((api) => referenceForProvidedAPI(api) === reference);
+};
+
 export const providedAPIForModel = (csv: ClusterServiceVersionKind, model: K8sKind): ProvidedAPI =>
-  _.find<ProvidedAPI>(
-    providedAPIsFor(csv),
-    (crd) => referenceForProvidedAPI(crd) === referenceForModel(model),
-  );
+  providedAPIForReference(csv, referenceForModel(model));
 
 export const parseALMExamples = (
   csv: ClusterServiceVersionKind,

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -25,7 +25,7 @@ import {
   referenceForGroupVersionKind,
 } from '@console/internal/module/k8s';
 import { CRDDescription, ClusterServiceVersionKind, ProvidedAPI } from '../types';
-import { referenceForProvidedAPI, providedAPIsFor } from './index';
+import { providedAPIForReference } from './index';
 import { OperandLink } from './operand/operand-link';
 
 const tableColumnClasses = [
@@ -133,8 +133,9 @@ export const linkForCsvResource = (
   );
 
 export const Resources: React.FC<ResourcesProps> = (props) => {
-  const providedAPI = providedAPIsFor(props.clusterServiceVersion).find(
-    (desc) => referenceForProvidedAPI(desc) === props.match.params.plural,
+  const providedAPI = providedAPIForReference(
+    props.clusterServiceVersion,
+    props.match.params.plural,
   );
 
   const defaultResources = ['Deployment', 'Service', 'ReplicaSet', 'Pod', 'Secret', 'ConfigMap'];

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -54,6 +54,27 @@ jest.mock('react-i18next', () => {
   };
 });
 
+jest.mock('@console/shared/src/hooks/useK8sModels', () => ({
+  useK8sModels: () => [
+    {
+      'testapp.coreos.com~v1alpha1~TestResource': {
+        abbr: 'TR',
+        apiGroup: 'testapp.coreos.com',
+        apiVersion: 'v1alpha1',
+        crd: true,
+        kind: 'TestResource',
+        label: 'Test Resource',
+        labelPlural: 'Test Resources',
+        namespaced: true,
+        plural: 'testresources',
+        verbs: ['create'],
+      },
+    },
+    false,
+    null,
+  ],
+}));
+
 const i18nNS = 'details-page';
 
 describe(OperandTableHeader.displayName, () => {
@@ -415,7 +436,7 @@ describe(ProvidedAPIsPage.displayName, () => {
   });
 
   beforeEach(() => {
-    wrapper = shallow(<ProvidedAPIsPage.WrappedComponent obj={testClusterServiceVersion} />);
+    wrapper = shallow(<ProvidedAPIsPage obj={testClusterServiceVersion} />);
   });
 
   it('renders a `StatusBox` if given app has no owned or required custom resources', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -149,7 +149,7 @@ export const installedFor = (allSubscriptions: SubscriptionKind[] = []) => (
   return !_.isNil(subscriptionFor(allSubscriptions)(allGroups)(pkgName)(ns));
 };
 
-export const providedAPIsFor = (og: OperatorGroupKind) =>
+export const providedAPIsForOperatorGroup = (og: OperatorGroupKind) =>
   _.get(og.metadata.annotations, 'olm.providedAPIs', '')
     .split(',')
     .map((api) => ({

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -17,7 +17,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { fromRequirements } from '@console/internal/module/k8s/selector';
 import { PackageManifestModel, OperatorGroupModel, SubscriptionModel } from '../../models';
 import { PackageManifestKind, OperatorGroupKind, SubscriptionKind } from '../../types';
-import { operatorTypeAnnotation, nonStandaloneAnnotationValue } from '../../const';
+import { OPERATOR_TYPE_ANNOTATION, NON_STANDALONE_ANNOTATION_VALUE } from '../../const';
 import { iconFor } from '..';
 import { installedFor, subscriptionFor } from '../operator-group';
 import { getOperatorProviderType } from './operator-hub-utils';
@@ -28,7 +28,7 @@ import {
   InstalledState,
   OperatorHubCSVAnnotationKey,
 } from './index';
-import { parseJSONAnnotation } from '@console/shared';
+import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
 
 const ANNOTATIONS_WITH_JSON = [
   OperatorHubCSVAnnotationKey.infrastructureFeatures,
@@ -64,7 +64,7 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
         const { currentCSVDesc } = channels.find((ch) => ch.name === defaultChannel);
         // if CSV contains annotation for a non-standalone operator, filter it out
         return !(
-          currentCSVDesc.annotations?.[operatorTypeAnnotation] === nonStandaloneAnnotationValue
+          currentCSVDesc.annotations?.[OPERATOR_TYPE_ANNOTATION] === NON_STANDALONE_ANNOTATION_VALUE
         );
       })
       .map(

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -49,9 +49,8 @@ import {
   referenceForProvidedAPI,
   supportedInstallModesFor,
 } from '../index';
-import { installedFor, supports, providedAPIsFor, isGlobal } from '../operator-group';
+import { installedFor, supports, providedAPIsForOperatorGroup, isGlobal } from '../operator-group';
 import { CRDCard } from '../clusterserviceversion';
-import { getInternalObjects, isInternalObject } from '../../utils';
 import { OperatorInstallStatusPage } from '../operator-install-page';
 
 export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> = (props) => {
@@ -122,8 +121,6 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
       ? referenceFor(initializationResource)
       : null;
   }
-
-  const internalObjects = getInternalObjects(currentCSVDesc, 'annotations');
 
   const globalNS =
     (props.operatorGroup?.data || ([] as OperatorGroupKind[])).find(
@@ -229,7 +226,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     if (_.isEmpty(operatorGroups)) {
       return [];
     }
-    const existingAPIs = _.flatMap(operatorGroups, providedAPIsFor);
+    const existingAPIs = _.flatMap(operatorGroups, providedAPIsForOperatorGroup);
     const providedAPIs = providedAPIsForChannel(props.packageManifest.data[0])(
       selectedUpdateChannel,
     ).map((desc) => referenceForProvidedAPI(desc));
@@ -551,9 +548,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     </div>
   );
 
-  const providedAPIs = providedAPIsForChannel(props.packageManifest.data[0])(
-    selectedUpdateChannel,
-  ).filter((item) => !isInternalObject(internalObjects, item.name));
+  const providedAPIs = providedAPIsForChannel(props.packageManifest.data[0])(selectedUpdateChannel);
 
   if (showInstallStatusPage) {
     return (

--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -4,5 +4,6 @@ export enum Flags {
 
 export const GLOBAL_OPERATOR_NAMESPACE = 'openshift-operators';
 export const OPERATOR_UNINSTALL_MESSAGE_ANNOTATION = 'operator.openshift.io/uninstall-message';
-export const operatorTypeAnnotation = 'operators.operatorframework.io/operator-type';
-export const nonStandaloneAnnotationValue = 'non-standalone';
+export const OPERATOR_TYPE_ANNOTATION = 'operators.operatorframework.io/operator-type';
+export const NON_STANDALONE_ANNOTATION_VALUE = 'non-standalone';
+export const INTERNAL_OBJECTS_ANNOTATION = 'operators.operatorframework.io/internal-objects';

--- a/frontend/packages/operator-lifecycle-manager/src/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/utils.ts
@@ -1,33 +1,6 @@
-import * as _ from 'lodash';
-import { ClusterServiceVersionKind, CRDDescription } from './types';
-import { referenceForProvidedAPI } from './components';
+import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
+import { ObjectMetadata } from '@console/internal/module/k8s';
+import { INTERNAL_OBJECTS_ANNOTATION } from './const';
 
-export const getInternalObjects = (csv: any, path: string = 'metadata.annotations') => {
-  const internals: string = _.get(csv, [
-    ..._.toPath(path),
-    'operators.operatorframework.io/internal-objects',
-  ]);
-  if (!internals) {
-    return [];
-  }
-  try {
-    return JSON.parse(internals);
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Error parsing internal object annotation.', e);
-    return [];
-  }
-};
-
-export const isInternalObject = (internalObjects: string[], objectName: string): boolean =>
-  internalObjects.some((obj) => obj === objectName);
-
-export const getInternalAPIReferences = (csv: ClusterServiceVersionKind): string[] => {
-  const owned: CRDDescription[] = csv?.spec?.customresourcedefinitions?.owned || [];
-  const internalObjects = getInternalObjects(csv);
-  return owned.reduce(
-    (acc, obj) =>
-      isInternalObject(internalObjects, obj.name) ? [referenceForProvidedAPI(obj), ...acc] : acc,
-    [],
-  );
-};
+export const getInternalObjects = (annotations: ObjectMetadata['annotations']): string[] =>
+  parseJSONAnnotation(annotations, INTERNAL_OBJECTS_ANNOTATION) ?? [];

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
@@ -10,8 +10,7 @@ import { ExpandCollapse } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ClusterServiceVersionModel } from '../models';
 import { ClusterServiceVersionKind } from '../types';
-import { providedAPIsFor, referenceForProvidedAPI } from '../components';
-import { isInternal } from '../dev-catalog';
+import { providedAPIsForCSV, referenceForProvidedAPI } from '../components';
 
 type ExpandCollapseDescriptionProps = {
   children: React.ReactNode;
@@ -45,7 +44,7 @@ const normalizeClusterServiceVersions = (
     t('operator-lifecycle-manager~## Operator Description\n{{csvDescription}}', { csvDescription });
 
   const operatorProvidedAPIs: CatalogItem[] = _.flatten(
-    clusterServiceVersions.map((csv) => providedAPIsFor(csv).map((desc) => ({ ...desc, csv }))),
+    clusterServiceVersions.map((csv) => providedAPIsForCSV(csv).map((desc) => ({ ...desc, csv }))),
   )
     .reduce(
       (all, cur) =>
@@ -54,8 +53,6 @@ const normalizeClusterServiceVersions = (
           : all.concat([cur]),
       [],
     )
-    // remove internal CRDs
-    .filter((crd) => !isInternal(crd))
     .map((desc) => {
       const { creationTimestamp } = desc.csv.metadata;
       const uid = `${desc.csv.metadata.uid}-${desc.displayName}`;

--- a/frontend/packages/topology/src/operators/TopologyOperatorBackedResources.tsx
+++ b/frontend/packages/topology/src/operators/TopologyOperatorBackedResources.tsx
@@ -13,8 +13,7 @@ import {
   ClusterServiceVersionKind,
   ClusterServiceVersionModel,
   CRDDescription,
-  providedAPIsFor,
-  referenceForProvidedAPI,
+  providedAPIForReference,
 } from '@console/operator-lifecycle-manager/src';
 import {
   flattenCsvResources,
@@ -74,9 +73,7 @@ const OperatorResourcesGetter: React.FC<OperatorResourcesGetterProps> = ({
   namespace,
   flatten,
 }) => {
-  const providedAPI = providedAPIsFor(csv).find(
-    (desc) => referenceForProvidedAPI(desc) === modelReference,
-  );
+  const providedAPI = providedAPIForReference(csv, modelReference);
   const linkForResource = (obj: K8sResourceKind) => {
     return linkForCsvResource(obj, providedAPI, csv.metadata.name);
   };


### PR DESCRIPTION
- Add useK8sModels hook so that we can easily filter out APIs without a model. We need this for the
  "All Instances" page so that we can filter before we run a API requests.
- Update provideAPIsFor into providedAPIsForCSV and break out a shared filter
  function to share betweeen providedAPIsForCSV and providedAPIsForChannel
- Update providedAPIsForChannel function to use new filter function.
- Replace usage of providedAPIsFor().find() chains with helper functions to find a specific API by
  model or reference.
- Add new util function `providedAPIForReference` for consistency with `providedAPIForModel`
- Define constant for internal object annotation key and replace string literals throughout the olm
  package. Also update existing constants to match our UPPERCASE_CONSTANT convention
- Remove redundant util functions in ./packages/operator-lifecycle-manager/src/utils.ts so that the
  logic for filtering internal objects could be centralized in the 'providedAPIsForCSV' function.
- Update `getInternalObjects` function args. Now accepts an `annotations` argument, and uses shared
  `parseJSONAnnotation` util function.
- Update ProvidedAPIs page to account for built in filtering in providedAPIsForCSV function. Also,
  remove usage of 'modelFor' function since it only checks statically defined models. We need to use
  the new useK8sModels hook to make sure we get any models that have been added by operators or
  crds.
- Fix unit tests