### PR TITLE
Convert OperatorHub from localStorage to user settings

### DIFF
--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -30,6 +30,8 @@ export const UNASSIGNED_APPLICATIONS_KEY = '#UNASSIGNED_APP#';
 // Prefix our localStorage items to avoid conflicts if another app ever runs on the same domain.
 export const STORAGE_PREFIX = 'bridge';
 
+export const USERSETTINGS_PREFIX = 'console';
+
 // This localStorage key predates the storage prefix.
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const APPLICATION_LOCAL_STORAGE_KEY = 'dropdown-storage-applications';
@@ -37,6 +39,7 @@ export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-nam
 export const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-perspective`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;
+export const COMMUNITY_PROVIDERS_WARNING_USERSETTINGS_KEY = `${USERSETTINGS_PREFIX}.communityProvidersWarning`;
 export const DEV_CATALOG_FILTER_KEY = `${STORAGE_PREFIX}/dev-catalog-filters`;
 export const PINNED_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/pinned-resources`;
 export const COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/table-columns`;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -13,9 +13,11 @@ import {
   Title,
 } from '@patternfly/react-core';
 import {
-  COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY,
+  COMMUNITY_PROVIDERS_WARNING_USERSETTINGS_KEY as userSettingsKey,
+  COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY as storeKey,
   GreenCheckCircleIcon,
   Modal,
+  useUserSettingsCompatibility,
 } from '@console/shared';
 import { history } from '@console/internal/components/utils/router';
 import { TileViewPage } from '@console/internal/components/utils/tile-view-page';
@@ -326,6 +328,9 @@ const setURLParams = (params) => {
 export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) => {
   const [detailsItem, setDetailsItem] = React.useState(null);
   const [showDetails, setShowDetails] = React.useState(false);
+  const [ignoreOperatorWarning, setIgnoreOperatorWarning, loaded] = useUserSettingsCompatibility<
+    boolean
+  >(userSettingsKey, storeKey, false);
 
   const filteredItems = filterByArchAndOS(props.items);
 
@@ -343,16 +348,13 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
     setDetailsItem(item);
     setShowDetails(true);
 
-    if (ignoreWarning) {
-      localStorage.setItem(COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY, 'true');
+    if (loaded && ignoreWarning) {
+      setIgnoreOperatorWarning(true);
     }
   };
 
   const openOverlay = (item: OperatorHubItem) => {
-    const ignoreWarning =
-      localStorage.getItem(COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY) === 'true';
-
-    if (!ignoreWarning && item.providerType === COMMUNITY_PROVIDER_TYPE) {
+    if (!ignoreOperatorWarning && item.providerType === COMMUNITY_PROVIDER_TYPE) {
       communityOperatorWarningModal({
         showCommunityOperators: (ignore) => showCommunityOperator(item)(ignore),
       });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5107
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
Use `useUserSettings` hook to store the local storage data into a config map.
<!-- Describe your code changes in detail and explain the solution -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
