### PR TITLE
Bug 1900022: Search Page - Top Name/Label filter is not applied to selected Pipeline resources

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
@@ -14,7 +14,7 @@ interface PipelinesResourceListProps extends React.ComponentProps<typeof FireMan
 
 const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
   const { t } = useTranslation();
-  const { namespace, showTitle = true } = props;
+  const { namespace, showTitle = true, selector, name } = props;
 
   const resources = [
     {
@@ -23,6 +23,8 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       namespace,
       prop: PipelineModel.id,
       filters: { ...filters },
+      selector,
+      name,
     },
   ];
 
@@ -46,7 +48,7 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       badge={getBadgeFromType(PipelineModel.badge)}
     >
       <Firehose resources={resources}>
-        <PipelineAugmentRunsWrapper />
+        <PipelineAugmentRunsWrapper hideNameLabelFilters={props.hideNameLabelFilters} />
       </Firehose>
     </FireMan>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
@@ -10,6 +10,7 @@ import PipelineList from './PipelineList';
 interface PipelineAugmentRunsWrapperProps {
   pipeline?: any;
   reduxIDs?: string[];
+  hideNameLabelFilters?: boolean;
 }
 
 const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (props) => {
@@ -29,10 +30,12 @@ const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (p
         propsReferenceForRuns={firehoseResources.propsReferenceForRuns}
       >
         <ListPageWrapper
+          {...props}
           flatten={(_resources) => _.get(_resources, ['pipeline', 'data'], {})}
           kinds={['Pipeline']}
           ListComponent={PipelineList}
           rowFilters={filters}
+          hideNameLabelFilters={props.hideNameLabelFilters}
         />
       </PipelineAugmentRuns>
     </Firehose>


### PR DESCRIPTION
This PR fixes two issue with how the Pipeline plugin interacts with the console's search page:

1. Search page top Name/Label filter not being applied to Pipelines resource section
2. Pipeline resource section shows 2nd Name/Label filter.

## Before

![image](https://user-images.githubusercontent.com/12733153/100133166-687bb380-2e54-11eb-81f1-ae8ad8d84f0e.png)

## After

![image](https://user-images.githubusercontent.com/12733153/100133245-821cfb00-2e54-11eb-8ca0-22ee6bba4db6.png)
### ** Note: there is a remaining refresh bug using the Name filter & pipelines resource section/table.  Follow Up [Bug 1901207: Search Page - Pipeline resources table not immediately updated after Name filter applied or removed](https://bugzilla.redhat.com/show_bug.cgi?id=1901207) 
