### PR TITLE
tests: Don't run Protractor for olmFull suite

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -34,7 +34,7 @@ export DBUS_SESSION_BUS_ADDRESS
 
 SCENARIO="${1:-e2e}"
 
-if [ "$SCENARIO" != "login" ]; then
+if [ "$SCENARIO" != "login" ] && [ "$SCENARIO" != "olmFull" ]; then
   CHROME_VERSION=$(google-chrome --version) ./test-protractor.sh "$SCENARIO"
 fi
 


### PR DESCRIPTION
The suite is fully converted to Cypress.

/assign @rhamilto @dtaylor113 