### PR TITLE
Removing Protractor annotations test from e2e, crud, and all test suites due to flakyness

### DIFF
--- a/frontend/integration-tests/tests/modal-annotations.scenario.ts
+++ b/frontend/integration-tests/tests/modal-annotations.scenario.ts
@@ -15,7 +15,7 @@ const Actions = {
   delete: 'delete',
 };
 
-describe('Modal Annotations', () => {
+xdescribe('Modal Annotations', () => {
   beforeAll(async () => {
     await browser.get(`${appHost}/k8s/ns/${testName}/configmaps`);
     await crudView.isLoaded();


### PR DESCRIPTION
We are currently porting over annotation tests to Cypress:  https://issues.redhat.com/browse/CONSOLE-2478