### PR TITLE
UI crashes on opening topology

### DIFF
--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -185,8 +185,9 @@ export const Firehose = connect(
       const discoveryComplete =
         !this.props.inFlight && !this.props.loaded && this.state.firehoses.length === 0;
       const resourcesChanged =
+        prevProps.resources !== this.props.resources &&
         _.intersectionWith(prevProps.resources, this.props.resources, _.isEqual).length !==
-        this.props.resources.length;
+          this.props.resources.length;
 
       if (discoveryComplete || resourcesChanged) {
         this.clear();


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5173

**Analysis / Root cause**: 
Duplicate resource requests were sent to firehose. Firehose uses lodash `intersection` to check for changes to the resource list. Since there were duplicates, the intersection resulted in a different length of in compared to the original resource length. Even though the two resource lists (previous and current) were the same. 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added `===` comparison to firehose to speed up the check and overcome the intersection comparison issue. 

De-duped the resource list in ApplicationDropdown since multiple providers were interested in the same resources with the same prop key.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

_note: there seems to be an unrelated issue where on page refresh, the application selector isn't being populated right away_