### PR TITLE
convert Topology filters localStorage to userSettings

### DIFF
--- a/frontend/packages/topology/src/__tests__/Graph.spec.tsx
+++ b/frontend/packages/topology/src/__tests__/Graph.spec.tsx
@@ -22,7 +22,6 @@ describe('Graph', () => {
         application={''}
         eventSourceEnabled
         onSelectTab={() => {}}
-        onFiltersChange={() => {}}
         onSupportedFiltersChange={() => {}}
         onSupportedKindsChange={() => {}}
       />,

--- a/frontend/packages/topology/src/components/page/TopologyDataRenderer.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyDataRenderer.tsx
@@ -5,6 +5,7 @@ import EmptyState from '@console/dev-console/src/components/EmptyState';
 import { ModelContext, ExtensibleModel } from '../../data-transforms/ModelContext';
 import TopologyView from './TopologyView';
 import { TopologyViewType } from '../../topology-types';
+import { FilterProvider } from '../../filters/FilterProvider';
 
 interface TopologyDataRendererProps {
   viewType: TopologyViewType;
@@ -49,7 +50,9 @@ const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observer(
         loadError={loadError}
         EmptyMsg={EmptyMsg}
       >
-        <TopologyView viewType={viewType} model={model} namespace={namespace} />
+        <FilterProvider>
+          <TopologyView viewType={viewType} model={model} namespace={namespace} />
+        </FilterProvider>
       </StatusBox>
     );
   },

--- a/frontend/packages/topology/src/components/page/TopologyView.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyView.tsx
@@ -13,7 +13,6 @@ import { useAddToProjectAccess } from '@console/dev-console/src/utils/useAddToPr
 import { getEventSourceStatus } from '@console/knative-plugin/src/topology/knative-topology-utils';
 import {
   CreateConnectionGetter,
-  DisplayFilters,
   GraphData,
   TopologyApplyDisplayOptions,
   TopologyDisplayFilterType,
@@ -27,16 +26,12 @@ import {
 } from '../../extensions/topology';
 import { getTopologySearchQuery, useAppliedDisplayFilters, useDisplayFilters } from '../../filters';
 import { updateModelFromFilters } from '../../data-transforms/updateModelFromFilters';
-import {
-  setSupportedTopologyFilters,
-  setSupportedTopologyKinds,
-  setTopologyFilters,
-} from '../../redux/action';
+import { setSupportedTopologyFilters, setSupportedTopologyKinds } from '../../redux/action';
 import Topology from '../graph-view/Topology';
 import TopologyListView from '../list-view/TopologyListView';
 import TopologyFilterBar from '../../filters/TopologyFilterBar';
 import { getTopologySideBar } from '../side-bar/TopologySideBar';
-
+import { FilterContext } from '../../filters/FilterProvider';
 import './TopologyView.scss';
 
 const FILTER_ACTIVE_CLASS = 'odc-m-filter-active';
@@ -48,7 +43,6 @@ interface StateProps {
 
 interface DispatchProps {
   onSelectTab?: (name: string) => void;
-  onFiltersChange: (filters: DisplayFilters) => void;
   onSupportedFiltersChange: (supportedFilterIds: string[]) => void;
   onSupportedKindsChange: (supportedKinds: { [key: string]: number }) => void;
 }
@@ -67,10 +61,10 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
   viewType,
   eventSourceEnabled,
   application,
-  onFiltersChange,
   onSupportedFiltersChange,
   onSupportedKindsChange,
 }) => {
+  const { setTopologyFilters: onFiltersChange } = React.useContext(FilterContext);
   const [filteredModel, setFilteredModel] = React.useState<Model>();
   const [selectedEntity, setSelectedEntity] = React.useState<GraphElement>(null);
   const [visualization, setVisualization] = React.useState<Visualization>();
@@ -282,9 +276,6 @@ const TopologyStateToProps = (state: RootState): StateProps => {
 
 const TopologyDispatchToProps = (dispatch): DispatchProps => ({
   onSelectTab: (name) => dispatch(selectOverviewDetailsTab(name)),
-  onFiltersChange: (filters: DisplayFilters) => {
-    dispatch(setTopologyFilters(filters));
-  },
   onSupportedFiltersChange: (supportedFilterIds: string[]) => {
     dispatch(setSupportedTopologyFilters(supportedFilterIds));
   },

--- a/frontend/packages/topology/src/filters/FilterProvider.tsx
+++ b/frontend/packages/topology/src/filters/FilterProvider.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { useUserSettingsCompatibility } from '@console/shared';
+import { DEFAULT_TOPOLOGY_FILTERS } from './const';
+import { DisplayFilters } from '../topology-types';
+import { TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY } from '../redux/const';
+
+const TOPOLOGY_DISPLAY_FILTERS_USER_SETTINGS_KEY = `devconsole.topology.filters`;
+
+const getTopologyFilters = (appliedFilters: AppliedFilters) => {
+  const filters = [...DEFAULT_TOPOLOGY_FILTERS];
+  filters.forEach((filter) => {
+    if (appliedFilters[filter.id] !== undefined) {
+      filter.value = appliedFilters[filter.id];
+    }
+  });
+
+  return filters;
+};
+
+const getAppliedFilters = (filters: DisplayFilters): { [id: string]: boolean } => {
+  if (!filters?.length) {
+    return {};
+  }
+
+  return filters.reduce((acc, filter) => {
+    acc[filter.id] = filter.value;
+    return acc;
+  }, {});
+};
+
+type AppliedFilters = { [filterKey: string]: boolean };
+type SetTopologyFilters = (filters: DisplayFilters) => void;
+
+const useFilterContextValues = (): [
+  DisplayFilters,
+  AppliedFilters,
+  boolean,
+  SetTopologyFilters,
+] => {
+  const [appliedFilters, setAppliedFilters, appliedFiltersLoaded] = useUserSettingsCompatibility(
+    TOPOLOGY_DISPLAY_FILTERS_USER_SETTINGS_KEY,
+    TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY,
+    getAppliedFilters(DEFAULT_TOPOLOGY_FILTERS),
+  );
+  const [filtersLoaded, setFiltersLoaded] = React.useState<boolean>(false);
+  const [filters, setFilters] = React.useState<DisplayFilters>([]);
+
+  React.useEffect(() => {
+    if (appliedFiltersLoaded && !filtersLoaded) {
+      setFilters(getTopologyFilters(appliedFilters));
+      setFiltersLoaded(true);
+    }
+  }, [appliedFilters, appliedFiltersLoaded, filtersLoaded]);
+
+  const setTopologyFilters = React.useCallback(
+    (displayFilters: DisplayFilters) => {
+      setFilters(displayFilters);
+      setAppliedFilters(getAppliedFilters(displayFilters));
+    },
+    [setAppliedFilters],
+  );
+
+  return [filters, appliedFilters, appliedFilters && filtersLoaded, setTopologyFilters];
+};
+
+type FilterContextType = {
+  filters?: DisplayFilters;
+  appliedFilters?: AppliedFilters;
+  setTopologyFilters?: SetTopologyFilters;
+};
+
+export const FilterContext = React.createContext<FilterContextType>({});
+
+export const FilterProvider: React.FC = ({ children }) => {
+  const [filters, appliedFilters, loaded, setTopologyFilters] = useFilterContextValues();
+  return (
+    <FilterContext.Provider value={{ filters, appliedFilters, setTopologyFilters }}>
+      {loaded ? children : null}
+    </FilterContext.Provider>
+  );
+};

--- a/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import {
   Toolbar,
@@ -20,30 +19,24 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { TextFilter } from '@console/internal/components/factory';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ConsoleLinkModel } from '@console/internal/models';
-import { setTopologyFilters } from '../redux/action';
-import { DisplayFilters, TopologyViewType } from '../topology-types';
+import { TopologyViewType } from '../topology-types';
 import {
   getSupportedTopologyFilters,
   getSupportedTopologyKinds,
-  getTopologyFilters,
   onSearchChange,
 } from './filter-utils';
 import FilterDropdown from './FilterDropdown';
 import KindFilterDropdown from './KindFilterDropdown';
 import QuickSearchButton from './quick-search/QuickSearchButton';
 import { getNamespaceDashboardKialiLink } from '../utils/topology-utils';
+import { FilterContext } from './FilterProvider';
 
 import './TopologyFilterBar.scss';
 
 type StateProps = {
-  filters: DisplayFilters;
   supportedFilters: string[];
   supportedKinds: { [key: string]: number };
   namespace: string;
-};
-
-type DispatchProps = {
-  onFiltersChange: (filters: DisplayFilters) => void;
 };
 
 type OwnProps = {
@@ -51,19 +44,16 @@ type OwnProps = {
   viewType: TopologyViewType;
 };
 
-type MergeProps = StateProps & DispatchProps & OwnProps;
-
-type TopologyFilterBarProps = MergeProps;
+type TopologyFilterBarProps = StateProps & OwnProps;
 
 const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
-  filters,
   supportedFilters,
   supportedKinds,
-  onFiltersChange,
   visualization,
   viewType,
   namespace,
 }) => {
+  const { filters, setTopologyFilters: onFiltersChange } = React.useContext(FilterContext);
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     kind: referenceForModel(ConsoleLinkModel),
@@ -151,7 +141,6 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
 
 const mapStateToProps = (state: RootState): StateProps => {
   const states = {
-    filters: getTopologyFilters(state),
     supportedFilters: getSupportedTopologyFilters(state),
     supportedKinds: getSupportedTopologyKinds(state),
     namespace: getActiveNamespace(state),
@@ -159,28 +148,4 @@ const mapStateToProps = (state: RootState): StateProps => {
   return states;
 };
 
-const dispatchToProps = (dispatch: Dispatch): DispatchProps => ({
-  onFiltersChange: (filters: DisplayFilters) => {
-    dispatch(setTopologyFilters(filters));
-  },
-});
-
-const mergeProps = (
-  { filters, supportedFilters, supportedKinds, namespace }: StateProps,
-  { onFiltersChange }: DispatchProps,
-  { visualization, viewType }: OwnProps,
-): MergeProps => ({
-  filters,
-  supportedFilters,
-  supportedKinds,
-  namespace,
-  onFiltersChange,
-  visualization,
-  viewType,
-});
-
-export default connect<StateProps, DispatchProps, OwnProps, MergeProps>(
-  mapStateToProps,
-  dispatchToProps,
-  mergeProps,
-)(TopologyFilterBar);
+export default connect<StateProps>(mapStateToProps)(TopologyFilterBar);

--- a/frontend/packages/topology/src/filters/filter-utils.ts
+++ b/frontend/packages/topology/src/filters/filter-utils.ts
@@ -4,8 +4,6 @@ import {
   removeQueryArgument,
   setQueryArgument,
 } from '@console/internal/components/utils';
-import { getDefaultTopologyFilters } from '../redux/reducer';
-import { getAppliedFilters } from '../redux/action';
 import {
   DisplayFilters,
   TopologyDisplayFilterType,
@@ -24,11 +22,6 @@ export const onSearchChange = (searchQuery: string): void => {
   }
 };
 
-export const getTopologyFilters = (state: RootState): DisplayFilters => {
-  const topology = state?.plugins?.devconsole?.topology;
-  return topology ? topology.get('filters') : getDefaultTopologyFilters();
-};
-
 export const getSupportedTopologyFilters = (state: RootState): string[] => {
   const topology = state?.plugins?.devconsole?.topology;
   return topology ? topology.get('supportedFilters') : DEFAULT_TOPOLOGY_FILTERS.map((f) => f.id);
@@ -37,11 +30,6 @@ export const getSupportedTopologyFilters = (state: RootState): string[] => {
 export const getSupportedTopologyKinds = (state: RootState): { [key: string]: number } => {
   const topology = state?.plugins?.devconsole?.topology;
   return topology ? topology.get('supportedKinds') : {};
-};
-
-export const getAppliedTopologyFilters = (state: RootState): string[] => {
-  const topology = state?.plugins?.devconsole?.topology;
-  return topology ? topology.get('appliedFilters') : getAppliedFilters(DEFAULT_TOPOLOGY_FILTERS);
 };
 
 export const getTopologySearchQuery = () => getQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY) ?? '';

--- a/frontend/packages/topology/src/filters/useAppliedDisplayFilters.ts
+++ b/frontend/packages/topology/src/filters/useAppliedDisplayFilters.ts
@@ -1,13 +1,8 @@
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-import { useSelector } from 'react-redux';
-import { RootState } from '@console/internal/redux';
-import { DisplayFilters } from '../topology-types';
-import { getAppliedTopologyFilters } from './filter-utils';
+import { useContext } from 'react';
+import { FilterContext } from './FilterProvider';
 
-const useAppliedDisplayFilters = (): DisplayFilters => {
-  return useSelector((state: RootState) => getAppliedTopologyFilters(state));
+const useAppliedDisplayFilters = (): { [filterKey: string]: boolean } => {
+  return useContext(FilterContext).appliedFilters;
 };
 
 export { useAppliedDisplayFilters };

--- a/frontend/packages/topology/src/filters/useDisplayFilters.ts
+++ b/frontend/packages/topology/src/filters/useDisplayFilters.ts
@@ -1,14 +1,10 @@
-// FIXME upgrading redux types is causing many errors at this time
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-import { useSelector } from 'react-redux';
-import { RootState } from '@console/internal/redux';
+import { useContext } from 'react';
+import { useDeepCompareMemoize } from '@console/shared';
 import { DisplayFilters } from '../topology-types';
-import { getTopologyFilters } from './filter-utils';
-import { useDeepCompareMemoize } from '@console/shared/src';
+import { FilterContext } from './FilterProvider';
 
 const useDisplayFilters = (): DisplayFilters => {
-  const filters = useSelector((state: RootState) => getTopologyFilters(state));
+  const { filters } = useContext(FilterContext);
   return useDeepCompareMemoize(filters);
 };
 

--- a/frontend/packages/topology/src/redux/action.ts
+++ b/frontend/packages/topology/src/redux/action.ts
@@ -1,8 +1,6 @@
+import { action, ActionType } from 'typesafe-actions';
 import { GraphModel } from '@patternfly/react-topology';
 import { RootState } from '@console/internal/redux';
-import { action, ActionType } from 'typesafe-actions';
-import { TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY } from './const';
-import { DisplayFilters } from '../topology-types';
 
 export enum Actions {
   topologyFilters = 'topologyFilters',
@@ -10,25 +8,6 @@ export enum Actions {
   supportedTopologyKinds = 'supportedTopologyKinds',
   topologyGraphModel = 'topologyGraphModel',
 }
-
-export const getAppliedFilters = (filters: DisplayFilters): { [id: string]: boolean } => {
-  if (!filters?.length) {
-    return {};
-  }
-
-  return filters.reduce((acc, filter) => {
-    acc[filter.id] = filter.value;
-    return acc;
-  }, {});
-};
-
-export const setTopologyFilters = (filters: DisplayFilters) => {
-  localStorage.setItem(
-    TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY,
-    JSON.stringify(getAppliedFilters(filters)),
-  );
-  return action(Actions.topologyFilters, { filters });
-};
 
 export const setSupportedTopologyFilters = (supportedFilters: string[]) => {
   return action(Actions.supportedTopologyFilters, { supportedFilters });
@@ -48,7 +27,6 @@ export const getTopologyGraphModel = (state: RootState, namespace: string): Grap
 };
 
 const actions = {
-  setTopologyFilters,
   setSupportedTopologyFilters,
   setSupportedTopologyKinds,
   setTopologyGraphModel,

--- a/frontend/packages/topology/src/redux/reducer.ts
+++ b/frontend/packages/topology/src/redux/reducer.ts
@@ -1,53 +1,15 @@
 import { Map } from 'immutable';
-import { TopologyAction, Actions, getAppliedFilters } from './action';
-import { TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY } from './const';
+import { TopologyAction, Actions } from './action';
 import { DEFAULT_TOPOLOGY_FILTERS } from '../filters/const';
 
 export type State = Map<string, any>;
 
-export const getDefaultAppliedFilters = () => {
-  const appliedFilters = localStorage.getItem(TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY);
-
-  let defaultAppliedFilters;
-  if (appliedFilters) {
-    defaultAppliedFilters = JSON.parse(appliedFilters);
-  } else {
-    defaultAppliedFilters = getAppliedFilters(DEFAULT_TOPOLOGY_FILTERS);
-    localStorage.setItem(
-      TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY,
-      JSON.stringify(defaultAppliedFilters),
-    );
-  }
-  return defaultAppliedFilters;
-};
-
-export const getDefaultTopologyFilters = () => {
-  const defaultAppliedFilters = getDefaultAppliedFilters();
-
-  const filters = [...DEFAULT_TOPOLOGY_FILTERS];
-  filters.forEach((filter) => {
-    if (defaultAppliedFilters[filter.id] !== undefined) {
-      filter.value = defaultAppliedFilters[filter.id];
-    }
-  });
-
-  return filters;
-};
-
 export default (state: State, action: TopologyAction) => {
   if (!state) {
     return Map({
-      filters: getDefaultTopologyFilters(),
-      appliedFilters: getDefaultAppliedFilters(),
       supportedFilters: DEFAULT_TOPOLOGY_FILTERS.map((f) => f.id),
       supportedKinds: {},
     });
-  }
-
-  if (action.type === Actions.topologyFilters) {
-    return state
-      .set('filters', action.payload.filters)
-      .set('appliedFilters', getAppliedFilters(action.payload.filters));
   }
 
   if (action.type === Actions.supportedTopologyFilters) {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5038
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

Removed `filter` and `appliedFilters` from redux/local storage and added in userSettings.

**Screen shots / Gifs for design review**: No UI changes
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
