### PR TITLE
Update user settings hook to use bridge call to create ConfigMap

### DIFF
--- a/frontend/__tests__/utils/hooks-utils.tsx
+++ b/frontend/__tests__/utils/hooks-utils.tsx
@@ -1,11 +1,31 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 
-const TestHook: React.FC<{ callback: () => void }> = ({ callback }) => {
-  callback();
+const useRerender = () => {
+  const [, setState] = React.useState(0);
+  return () => setState((value) => value + 1);
+};
+
+type ResultRef = { current: any };
+type RerenderRef = { current?: () => void };
+
+interface TestComponentProps {
+  hook: () => void;
+  result: ResultRef;
+  rerenderRef: RerenderRef;
+}
+
+const TestHook: React.FC<TestComponentProps> = ({ hook, result, rerenderRef }) => {
+  result.current = hook();
+  rerenderRef.current = useRerender();
   return null;
 };
 
-export const testHook = (callback: () => void) => {
-  mount(<TestHook callback={callback} />);
+export const testHook = <T extends any>(hook: () => T) => {
+  // Inspired by https://github.com/testing-library/react-hooks-testing-library
+  const result = { current: undefined as T };
+  const rerenderRef: RerenderRef = {};
+  const rerender = () => rerenderRef.current();
+  mount(<TestHook hook={hook} result={result} rerenderRef={rerenderRef} />);
+  return { result, rerender };
 };

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -1,85 +1,264 @@
 import * as redux from 'react-redux';
-import * as k8s from '@console/internal/module/k8s';
+import { act } from 'react-dom/test-utils';
+import { ConfigMapKind } from '@console/internal/module/k8s';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+
 import { testHook } from '../../../../../__tests__/utils/hooks-utils';
+import {
+  createConfigMap,
+  updateConfigMap,
+  USER_SETTING_CONFIGMAP_NAMESPACE,
+} from '../../utils/user-settings';
 import { useUserSettings } from '../useUserSettings';
 
-import Spy = jasmine.Spy;
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+const createConfigMapMock = createConfigMap as jest.Mock;
+const updateConfigMapMock = updateConfigMap as jest.Mock;
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
   useK8sWatchResource: jest.fn(),
 }));
 
-const spyAndReturn = (spy: Spy) => (returnValue: any) =>
-  new Promise((resolve) =>
-    spy.and.callFake((...args) => {
-      resolve(args);
-      return returnValue;
-    }),
-  );
+jest.mock('../../utils/user-settings', () => {
+  // requireActual exist in used jest 21 and still in latest version, but was not defined well in old TS definition
+  const originalModule = (jest as any).requireActual('../../utils/user-settings');
+  return {
+    ...originalModule,
+    createConfigMap: jest.fn(),
+    updateConfigMap: jest.fn(),
+  };
+});
 
-const waitAndExpect = (callback) => {
-  setTimeout(() => {
-    callback();
-  }, 0);
+const emptyConfigMap: ConfigMapKind = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: `user-settings-1234`,
+    namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
+  },
+};
+
+const savedDataConfigMap: ConfigMapKind = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: `user-settings-1234`,
+    namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
+  },
+  data: {
+    'console.key': 'saved value',
+  },
 };
 
 describe('useUserSettings', () => {
-  let spyK8sGet: Spy;
-  let spyK8sPatch: Spy;
-  let spyK8sCreate: Spy;
   beforeEach(() => {
-    spyK8sGet = spyOn(k8s, 'k8sGet');
-    spyK8sPatch = spyOn(k8s, 'k8sPatch');
-    spyK8sCreate = spyOn(k8s, 'k8sCreate');
-    spyAndReturn(spyK8sGet)(Promise.resolve({}));
-    spyAndReturn(spyK8sPatch)(Promise.resolve({}));
-    spyAndReturn(spyK8sCreate)(Promise.resolve({}));
+    useK8sWatchResourceMock.mockClear();
+    createConfigMapMock.mockClear();
+    updateConfigMapMock.mockClear();
     spyOn(redux, 'useSelector').and.returnValues({ user: {} });
   });
 
-  it('should return empty state', (done) => {
-    (useK8sWatchResource as jest.Mock).mockReturnValue([
-      { data: { 'devconsole.topology.key': '' } },
-      true,
-    ]);
-    testHook(() => {
-      const [settings, setSettings, loaded] = useUserSettings('devconsole.topology.key');
-      expect(setSettings).toBeDefined();
-      waitAndExpect(() => {
-        expect(settings).toEqual('');
-        expect(loaded).toEqual(true);
-        done();
-      });
+  it('should create and update user settings if watcher could not find a ConfigMap', async () => {
+    // Mock loading
+    useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect loading
+    expect(result.current).toEqual([undefined, expect.any(Function), false]);
+
+    // Mock ConfigMap not found
+    await act(async () => {
+      useK8sWatchResourceMock.mockReturnValue([null, false, new Error('ConfigMap not found')]);
+      rerender();
     });
+
+    // Expect loading
+    expect(result.current).toEqual([undefined, expect.any(Function), false]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(createConfigMapMock).toHaveBeenCalledWith();
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(0);
+
+    // Mock that ConfigMap is now available
+    await act(async () => {
+      useK8sWatchResourceMock.mockReturnValue([emptyConfigMap, true, null]);
+      rerender();
+    });
+
+    // Expect default value with loaded
+    expect(result.current).toEqual(['default value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      emptyConfigMap,
+      'console.key',
+      'default value',
+    );
   });
 
-  it('should return value from default and run patch to update configMap', (done) => {
-    (useK8sWatchResource as jest.Mock).mockReturnValue([
-      { data: { 'devconsole.topology.key1': true } },
-      true,
-    ]);
-    testHook(() => {
-      const [settings, setSettings] = useUserSettings('devconsole.topology.key', 'list');
-      expect(setSettings).toBeDefined();
-      waitAndExpect(() => {
-        expect(settings).toEqual('list');
-        expect(spyK8sPatch).toHaveBeenCalledTimes(1);
-        done();
-      });
+  it('should return default value for an empty configmap after switching from loading to loaded', async () => {
+    // Mock loading
+    useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect loading
+    expect(result.current).toEqual([undefined, expect.any(Function), false]);
+
+    // Mock empty ConfigMap
+    await act(async () => {
+      useK8sWatchResourceMock.mockReturnValue([emptyConfigMap, true, null]);
+      rerender();
     });
+
+    // Expect default value with loaded
+    expect(result.current).toEqual(['default value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      emptyConfigMap,
+      'console.key',
+      'default value',
+    );
   });
 
-  it('should call side effects if configmap not loaded', (done) => {
-    (useK8sWatchResource as jest.Mock).mockReturnValue([null, true, true]);
-    testHook(() => {
-      const [, setSettings] = useUserSettings('devconsole.topology.key');
-      expect(setSettings).toBeDefined();
-      waitAndExpect(() => {
-        expect(spyK8sGet).toHaveBeenCalledTimes(1);
-        expect(spyK8sCreate).toHaveBeenCalledTimes(1);
-        done();
-      });
+  it('should return saved value for an known key after switching from loading to loaded', async () => {
+    // Mock loading
+    useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect loading
+    expect(result.current).toEqual([undefined, expect.any(Function), false]);
+
+    // Mock saved ConfigMap
+    await act(async () => {
+      useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+      rerender();
     });
+
+    // Expect default value with loaded
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return default value for an unknown key if data is already loaded (hook is used twice)', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([emptyConfigMap, true, null]);
+
+    const { result } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect default value with loaded
+    expect(result.current).toEqual(['default value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      emptyConfigMap,
+      'console.key',
+      'default value',
+    );
+  });
+
+  it('should return saved value for an known key if data is already loaded (hook is used twice)', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+
+    const { result } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return latest user settings value after switching from loading to loaded', async () => {
+    // Mock loading
+    useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect loading
+    expect(result.current).toEqual([undefined, expect.any(Function), false]);
+
+    // Mock saved ConfigMap
+    await act(async () => {
+      useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+      rerender();
+    });
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return latest user settings value in loaded state (hook is used twice)', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+
+    const { result } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should trigger update user settings when setter was called', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+
+    // Call setSettings
+    await act(async () => {
+      const [, setSettings] = result.current;
+      setSettings('new value');
+      rerender();
+    });
+
+    // Expect new value and API update
+    expect(result.current).toEqual(['new value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
+      'console.key',
+      'new value',
+    );
+  });
+
+  it('should fallback to localStorage if creation fails with 403 (must not call updateConfigMap)', async () => {
+    // Mock loading
+    useK8sWatchResourceMock.mockReturnValue([null, false, null]);
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect loading data
+    expect(result.current).toEqual([undefined, expect.any(Function), false]);
+
+    // Mock that createConfigMap is 403 Forbidden and that ConfigMap is not found.
+    await act(async () => {
+      createConfigMapMock.mockImplementation(async () => {
+        const error: Error & { response?: any } = new Error('Forbidden');
+        error.response = {
+          ok: false,
+          status: 403,
+        };
+        throw error;
+      });
+      useK8sWatchResourceMock.mockReturnValue([null, false, new Error('ConfigMap not found')]);
+      rerender();
+    });
+
+    // Should call createConfigMap, but not updateConfigMap
+    expect(result.current).toEqual(['default value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(createConfigMapMock).toHaveBeenCalledWith();
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -11,8 +11,6 @@ import { useUserSettingsLocalStorage } from './useUserSettingsLocalStorage';
 import {
   createConfigMap,
   deseralizeData,
-  getProject,
-  createProject,
   seralizeData,
   updateConfigMap,
   USER_SETTING_CONFIGMAP_NAMESPACE,
@@ -48,25 +46,10 @@ export const useUserSettings = <T>(
   );
 
   React.useEffect(() => {
-    if (cfLoadError || (!cfData && cfLoaded)) {
+    if (!fallbackLocalStorage && (cfLoadError || (!cfData && cfLoaded))) {
       (async () => {
-        // this would be replaced with proxy endpoint to create ConfigMap
         try {
-          const projectExists = await getProject();
-          if (!projectExists) await createProject();
-          await createConfigMap({
-            apiVersion: ConfigMapModel.apiVersion,
-            kind: ConfigMapModel.kind,
-            metadata: {
-              name: `user-settings-${userUid}`,
-              namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
-            },
-            data: {
-              ...(defaultValueRef.current !== undefined && {
-                [keyRef.current]: seralizeData(defaultValueRef.current),
-              }),
-            },
-          });
+          await createConfigMap();
         } catch (err) {
           if (err?.response?.status === 403) {
             setFallbackLocalStorage(true);

--- a/frontend/packages/console-shared/src/utils/__tests__/user-settings.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/user-settings.spec.ts
@@ -1,0 +1,99 @@
+import { coFetch } from '@console/internal/co-fetch';
+import { ConfigMapKind } from '@console/internal/module/k8s';
+
+import {
+  createConfigMap,
+  updateConfigMap,
+  deseralizeData,
+  seralizeData,
+  USER_SETTING_CONFIGMAP_NAMESPACE,
+} from '../user-settings';
+
+const coFetchMock = coFetch as jest.Mock;
+
+jest.mock('@console/internal/co-fetch', () => ({
+  coFetch: jest.fn(),
+}));
+
+const configMap: ConfigMapKind = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: `user-settings-1234`,
+    namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
+  },
+  data: {
+    'devconsole.topology.anotherKey': 'true',
+  },
+};
+
+beforeEach(() => {
+  coFetchMock.mockClear();
+});
+
+describe('createConfigMap', () => {
+  it('calls user settings api ', async () => {
+    coFetchMock.mockReturnValueOnce({
+      json: () => configMap,
+    });
+
+    const actual = await createConfigMap();
+
+    expect(actual).toEqual(configMap);
+    expect(coFetchMock).toHaveBeenCalledTimes(1);
+    expect(coFetchMock).lastCalledWith('/api/console/user-settings', { method: 'POST' });
+  });
+});
+
+describe('updateConfigMap', () => {
+  it('calls user settings api ', async () => {
+    coFetchMock.mockReturnValueOnce({
+      json: () => configMap,
+    });
+
+    const actual = await updateConfigMap(configMap, 'key', 'value');
+
+    expect(actual).toEqual(configMap);
+    expect(coFetchMock).toHaveBeenCalledTimes(1);
+    expect(coFetchMock).lastCalledWith(
+      '/api/kubernetes/api/v1/namespaces/openshift-console-user-settings/configmaps/user-settings-1234',
+      {
+        method: 'PATCH',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/merge-patch+json;charset=UTF-8',
+        },
+        body: '{"data":{"key":"value"}}',
+      },
+    );
+  });
+});
+
+describe('deseralizeData', () => {
+  it('does not convert null or undefined', () => {
+    expect(deseralizeData(null)).toBe(null);
+    expect(deseralizeData(undefined)).toBe(undefined);
+  });
+
+  it('converts valid json to an object', () => {
+    expect(deseralizeData('{ "key": "value" }')).toEqual({ key: 'value' });
+    expect(deseralizeData('1234')).toBe(1234);
+    expect(deseralizeData('true')).toBe(true);
+    expect(deseralizeData('false')).toBe(false);
+  });
+
+  it('return invalid json strings as string', () => {
+    expect(deseralizeData('graph')).toBe('graph');
+  });
+});
+
+describe('seralizeData', () => {
+  it('does not convert strings', () => {
+    expect(seralizeData('graph')).toBe('graph');
+    expect(seralizeData('{ "key": "value" }')).toEqual('{ "key": "value" }');
+  });
+
+  it('converts objects', () => {
+    expect(seralizeData({ key: 'value' })).toEqual('{"key":"value"}');
+  });
+});


### PR DESCRIPTION
**Fixes**: 
~~https://issues.redhat.com/browse/ODC-4755~~ https://issues.redhat.com/browse/ODC-5189

This PR is based on #7095 which must be merged first (the go part).

It keep this to make it also easier to test the frontend change. A review here should focus on the TS change.

**Analysis / Root cause**:
Based on the [User Settings for OpenShift Console enhancement proposal](https://github.com/openshift/enhancements/blob/master/enhancements/console/user-settings.md) we want to create a `ConfigMap` for each individual user in the namespace `openshift-console-user-settings`

Currently you need create this namespace yourself, **see Test Setup below**. This namespace will be automatically created by the console-operator, see PR https://github.com/openshift/console-operator/pull/479

**Solution Description**: 
Because the user could not create a ConfigMap here, we create a new `ConfigMap`, `Role` and `RoleBinding` with the service account role over the bridge. This code provides 3 new endpoints to create, get and delete the user settings. (The second and third API calls primary for debugging / development.) The console will fetch the ConfigMap over the known k8sWatch API.

**Screen shots / Gifs for design review**: 
Irrelevant

**Unit test coverage report**: 
Updated `user-settings.spec.ts` and `useUserSettings.spec.ts`:

```
 PASS  packages/console-shared/src/utils/__tests__/user-settings.spec.ts
  createConfigMap
    ✓ calls user settings api  (4ms)
  updateConfigMap
    ✓ calls user settings api  (1ms)
  deseralizeData
    ✓ does not convert null or undefined
    ✓ converts valid json to an object (1ms)
    ✓ return invalid json strings as string
  seralizeData
    ✓ does not convert strings
    ✓ converts objects

 PASS  packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
  useUserSettings
    ✓ should create and update user settings if watcher could not find a ConfigMap (297ms)
    ✓ should return default value for an empty configmap after switching from loading to loaded (4ms)
    ✓ should return saved value for an known key after switching from loading to loaded (3ms)
    ✓ should return default value for an unknown key if data is already loaded (hook is used twice) (3ms)
    ✓ should return saved value for an known key if data is already loaded (hook is used twice) (2ms)
    ✓ should return latest user settings value after switching from loading to loaded (3ms)
    ✓ should return latest user settings value in loaded state (hook is used twice) (2ms)
    ✓ should trigger update user settings when setter was called (3ms)
    ✓ should fallback to localStorage if creation fails with 403 (must not call updateConfigMap) (4ms)

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
```

**Test setup:**
This PR require some additional RBAC rules.

1. If PR https://github.com/openshift/console-operator/pull/479 is not part of your cluster you need to create a namespace:

1a Create namespace:
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: openshift-console-user-settings
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
    openshift.io/node-selector: ""
```

Until https://github.com/openshift/console-operator/pull/486/files is merged and available on your cluster you need to add this as well:

1b Create Role:
```yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: console-user-settings-admin-fixed
  namespace: openshift-console-user-settings
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
rules:
- apiGroups:
  - rbac.authorization.k8s.io
  resources:
  - roles
  - rolebindings
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - delete
  - patch
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - delete
  - patch
```

1c Create RoleBinding:
```yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: console-user-settings-admin-fixed
  namespace: openshift-console-user-settings
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
roleRef:
  kind: Role
  name: console-user-settings-admin-fixed
  apiGroup: rbac.authorization.k8s.io
subjects:
  - kind: ServiceAccount
    name: console
    namespace: openshift-console
```

2. You need the backend functions from https://github.com/openshift/console/pull/7095.

You can checkout 7095, build the backend with `./build-backend.sh` and switch back to this PR.

3. You need a hook to test PR. I used this `AddPage.tsx`:

```jsx
import * as React from 'react';
import { Helmet } from 'react-helmet';
import { useTranslation } from 'react-i18next';
import { match as RMatch } from 'react-router';
import { useUserSettings, useUserSettingsCompatibility } from '@console/shared';

import { Firehose } from '@console/internal/components/utils';
import ODCEmptyState from './EmptyState';
import NamespacedPage from './NamespacedPage';
import ProjectsExistWrapper from './ProjectsExistWrapper';
import CreateProjectListPage from './projects/CreateProjectListPage';

export interface AddPageProps {
  match: RMatch<{
    ns?: string;
  }>;
}

interface AddUserSettings {
  value: string;
}

const AddPage: React.FC<AddPageProps> = ({ match }) => {
  const { t } = useTranslation();
  const namespace = match.params.ns;

  const [userSettings, setUserSettings] = useUserSettings<AddUserSettings>('a_user_settings');
  const [userSettingsComp, setUserSettingsComp] = useUserSettingsCompatibility<string>(
    'a_user_settings_comp',
    'lskey',
  );

  return (
    <>
      <Helmet>
        <title>{`+${t('devconsole~Add')}`}</title>
      </Helmet>
      <NamespacedPage>
        <h1>
          user settings:
          <pre>{JSON.stringify(userSettings)}</pre>
          <button type="button" onClick={() => setUserSettings({ value: 'AAAAA' })}>
            AAAAA
          </button>
          <button type="button" onClick={() => setUserSettings({ value: 'BBBBB' })}>
            BBBBB
          </button>
        </h1>
        <h1>
          user settings compatibility:
          <pre>{JSON.stringify(userSettingsComp)}</pre>
          <button type="button" onClick={() => setUserSettingsComp('AAAAA')}>
            AAAAA
          </button>
          <button type="button" onClick={() => setUserSettingsComp('BBBBB')}>
            BBBBB
          </button>
        </h1>
        <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
          <ProjectsExistWrapper title={t('devconsole~Add')}>
            {namespace ? (
              <ODCEmptyState title={t('devconsole~Add')} />
            ) : (
              <CreateProjectListPage title={t('devconsole~Add')}>
                {t('devconsole~Select a project to start adding to it')}
              </CreateProjectListPage>
            )}
          </ProjectsExistWrapper>
        </Firehose>
      </NamespacedPage>
    </>
  );
};

export default AddPage;
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
