### PR TITLE
Catalog-Operator Hub: remove local storage and user filter preference

### DIFF
--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -40,7 +40,6 @@ export const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-perspe
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;
 export const COMMUNITY_PROVIDERS_WARNING_USERSETTINGS_KEY = `${USERSETTINGS_PREFIX}.communityProvidersWarning`;
-export const DEV_CATALOG_FILTER_KEY = `${STORAGE_PREFIX}/dev-catalog-filters`;
 export const PINNED_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/pinned-resources`;
 export const COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/table-columns`;
 

--- a/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
@@ -11,7 +11,7 @@ import {
   setQueryArgument,
 } from '@console/internal/components/utils';
 import { CatalogItem, CatalogItemAttribute } from '@console/plugin-sdk';
-import { DEV_CATALOG_FILTER_KEY, useQueryParams } from '@console/shared';
+import { useQueryParams } from '@console/shared';
 
 import { CatalogService } from './service/CatalogServiceProvider';
 import CatalogView from './catalog-view/CatalogView';
@@ -47,8 +47,6 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
 
   const title = typeExtension?.properties.title ?? defaultTitle;
   const description = typeExtension?.properties.catalogDescription ?? defaultDescription;
-
-  const filterPreference: string[] = [];
 
   const filterGroups: string[] = React.useMemo(() => {
     return (
@@ -173,8 +171,6 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
                 filters={availableFilters}
                 filterGroups={filterGroups}
                 filterGroupNameMap={filterGroupNameMap}
-                filterStoreKey={DEV_CATALOG_FILTER_KEY}
-                filterRetentionPreference={filterPreference}
                 groupings={groupings}
                 renderTile={renderTile}
               />

--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogView.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogView.tsx
@@ -50,8 +50,6 @@ type CatalogViewProps = {
   filters: FiltersType;
   filterGroups: string[];
   filterGroupNameMap: CatalogStringMap;
-  filterStoreKey: string;
-  filterRetentionPreference: string[];
   groupings: CatalogStringMap;
   renderTile: (item: CatalogItem) => React.ReactNode;
 };
@@ -64,8 +62,6 @@ const CatalogView: React.FC<CatalogViewProps> = ({
   filters,
   filterGroups,
   filterGroupNameMap,
-  filterStoreKey,
-  filterRetentionPreference,
   groupings,
   renderTile,
 }) => {
@@ -89,8 +85,8 @@ const CatalogView: React.FC<CatalogViewProps> = ({
       }
     });
 
-    return getActiveFilters(attributeFilters, filters, filterStoreKey, filterRetentionPreference);
-  }, [filterGroups, filterRetentionPreference, filterStoreKey, filters, queryParams]);
+    return getActiveFilters(attributeFilters, filters);
+  }, [filterGroups, filters, queryParams]);
 
   const [filterGroupsShowAll, setFilterGroupsShowAll] = React.useState<Record<string, boolean>>({});
   const [filterGroupCounts, setFilterGroupCounts] = React.useState<CatalogFilterCounts>({});
@@ -105,21 +101,6 @@ const CatalogView: React.FC<CatalogViewProps> = ({
     [sortOrder],
   );
 
-  const storeFilters = React.useCallback(
-    (currentFilters) => {
-      if (filterStoreKey && filterRetentionPreference) {
-        const filtersToStore = {};
-        _.each(filterRetentionPreference, (filterGroup) => {
-          if (currentFilters[filterGroup]) {
-            filtersToStore[filterGroup] = currentFilters[filterGroup];
-          }
-        });
-        localStorage.setItem(filterStoreKey, JSON.stringify(filtersToStore));
-      }
-    },
-    [filterRetentionPreference, filterStoreKey],
-  );
-
   const clearFilters = React.useCallback(() => {
     const params = new URLSearchParams();
     catalogType && items.length > 0 && params.set('catalogType', catalogType);
@@ -130,21 +111,18 @@ const CatalogView: React.FC<CatalogViewProps> = ({
       // this doesn't work right now because of issue with PF SearchInput
       catalogToolbarRef.current && catalogToolbarRef.current.focus({ preventScroll: true });
     }
+  }, [catalogType, items.length]);
 
-    storeFilters(activeFilters);
-  }, [activeFilters, catalogType, items.length, storeFilters]);
-
-  const handleCategoryChange = React.useCallback((categoryId) => {
+  const handleCategoryChange = (categoryId) => {
     updateURLParams(CatalogQueryParams.CATEGORY, categoryId);
-  }, []);
+  };
 
   const handleFilterChange = React.useCallback(
     (filterType, id, value) => {
       const updatedFilters = _.set(activeFilters, [filterType, id, 'active'], value);
       updateURLParams(filterType, getFilterSearchParam(updatedFilters[filterType]));
-      storeFilters(updatedFilters);
     },
-    [activeFilters, storeFilters],
+    [activeFilters],
   );
 
   const handleSearchKeywordChange = React.useCallback((searchKeyword) => {

--- a/frontend/packages/dev-console/src/components/catalog/utils/filter-utils.ts
+++ b/frontend/packages/dev-console/src/components/catalog/utils/filter-utils.ts
@@ -98,34 +98,7 @@ export const determineAvailableFilters = (
   return filters;
 };
 
-export const getActiveFilters = (
-  attributeFilters,
-  activeFilters,
-  storeFilterKey: string = null,
-  filterRetentionPreference: string[] = null,
-): CatalogFilters => {
-  const userFilters = storeFilterKey ? localStorage.getItem(storeFilterKey) : null;
-
-  if (userFilters) {
-    try {
-      const lastFilters = JSON.parse(userFilters);
-      if (lastFilters) {
-        if (filterRetentionPreference) {
-          _.each(filterRetentionPreference, (filterGroup) => {
-            if (!attributeFilters || !attributeFilters[filterGroup]) {
-              if (lastFilters[filterGroup]) {
-                activeFilters[filterGroup] = lastFilters[filterGroup];
-              }
-            }
-          });
-        }
-      }
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error('Failed parsing user filter settings.');
-    }
-  }
-
+export const getActiveFilters = (attributeFilters, activeFilters): CatalogFilters => {
   _.forOwn(attributeFilters, (filterValues, filterType) => {
     // removing default and localstore filters if Filters are present over URL
     _.each(_.keys(activeFilters[filterType]), (key) =>

--- a/frontend/public/components/catalog/catalog-items.tsx
+++ b/frontend/public/components/catalog/catalog-items.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 import { CatalogItemHeader } from '@patternfly/react-catalog-view-extension';
-import { DEV_CATALOG_FILTER_KEY as filterKey, Modal, withQueryParams } from '@console/shared';
+import { Modal, withQueryParams } from '@console/shared';
 import { history } from '../utils/router';
 import { CatalogTileDetails } from './catalog-item-details';
 import { TileViewPage } from '../utils/tile-view-page';
@@ -110,7 +110,6 @@ const pageDescription =
 // Filter property white list
 const filterGroups = ['kind'];
 
-const filterPreference = ['kind'];
 const filterGroupNameMap: Record<string, string> = {
   kind: 'Type',
 };
@@ -212,10 +211,8 @@ export const CatalogTileViewPage = withQueryParams<CatalogTileViewPageProps>(
             // TODO(alecmerdler): Dynamic filters for each Operator and its provided APIs
             getAvailableFilters={getAvailableFilters}
             filterGroups={filterGroups}
-            storeFilterKey={filterKey}
             filterGroupNameMap={filterGroupNameMap}
             keywordCompare={keywordCompare}
-            filterRetentionPreference={filterPreference}
             renderTile={this.renderTile}
             pageDescription={pageDescription}
             emptyStateInfo="No developer catalog items are being shown due to the filters being applied."


### PR DESCRIPTION
# Adresses
https://issues.redhat.com/browse/ODC-5112

# Solution
Removed usages of localStorage and filterstore + filterretention in related files.

# Screenshot
No visual changes
--------------------------------------------
![Screenshot from 2020-11-26 16-08-21](https://user-images.githubusercontent.com/24852534/100343149-00200400-3005-11eb-8467-b1ed00dd3209.png)
![Screenshot from 2020-11-26 16-08-39](https://user-images.githubusercontent.com/24852534/100343278-28a7fe00-3005-11eb-878e-99f31c2a0d5a.png)

# Tests
no changes

# Browser conformance
Chrome