### PR TITLE
Translated devconsole Getting Started text in order to pass Cypress login test

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -60,6 +60,7 @@
   "Cancel": "Cancel",
   "Edit": "Edit",
   "Select a way to create an application, component or service from one of the options.": "Select a way to create an application, component or service from one of the options.",
+  "Get started with a tour of some of the key areas in OpenShift {{version}} Developer perspective that can help you complete workflows and be more productive.": "Get started with a tour of some of the key areas in OpenShift {{version}} Developer perspective that can help you complete workflows and be more productive.",
   "Edit Health Checks": "Edit Health Checks",
   "Add Health Checks": "Add Health Checks",
   "Learn More": "Learn More",

--- a/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
+++ b/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
@@ -4,14 +4,17 @@ import { useOpenshiftVersion } from '@console/shared/src/hooks/version';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ConsoleLinkModel } from '@console/internal/models';
+import { useTranslation } from 'react-i18next';
 
 const DevPerspectiveTourText: React.FC = () => {
+  const { t } = useTranslation();
   const openshiftVersion = useOpenshiftVersion();
   return (
     <>
-      Get started with a tour of some of the key areas in OpenShift{' '}
-      {openshiftVersion ? `${openshiftVersion?.slice(0, 3)}'s` : '4.x'} Developer perspective that
-      can help you complete workflows and be more productive.
+      {t(
+        'devconsole~Get started with a tour of some of the key areas in OpenShift {{version}} Developer perspective that can help you complete workflows and be more productive.',
+        { version: openshiftVersion ? [openshiftVersion?.slice(0, 3), "'s"].join('') : '4.x' },
+      )}
     </>
   );
 };


### PR DESCRIPTION
**Cypress e2e login tests failing often due to missing i18n key in devconsole's Getting Started Guide text:**

![image](https://user-images.githubusercontent.com/12733153/100247861-ca95f080-2f08-11eb-915a-f1ef638b8de0.png)

[CI search results for 'missing i18n key' failures](https://search.ci.openshift.org/?search=Missing+i18n+key&maxAge=48h&context=1&type=build-log&name=e2e-gcp-console&maxMatches=5&maxBytes=20971520&groupBy=job)

This PR translates the Getting Started text.