### PR TITLE
Generate assets on postinstall hook

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "integration-tests"
   ],
   "scripts": {
+    "postinstall": "yarn generate",
     "clean": "rm -rf ./public/dist",
     "dev": "yarn clean && yarn generate && NODE_OPTIONS=--max-old-space-size=4096 yarn ts-node ./node_modules/.bin/webpack-dev-server",
     "dev-once": "yarn clean && yarn generate && NODE_OPTIONS=--max-old-space-size=4096 yarn ts-node ./node_modules/.bin/webpack --mode=development",


### PR DESCRIPTION
After a clean Console repo clone and `yarn install` execution, the codebase has some errors due to referencing assets which are generated via separate `yarn generate` command.

For example:
- `public/actions/features.ts` importing from `@types/gql/schema.ts`
- `ConsoleAssetPlugin` importing from `packages/console-dynamic-plugin-sdk/dist/schema/console-extensions.js`

This PR ensures that `yarn generate` is executed after each `yarn install` to ensure consistency between the (git-tracked) codebase vs. generated assets.