### PR TITLE
Added tests for Insights popup

### DIFF
--- a/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
@@ -86,15 +86,20 @@ describe('Cluster Dashboard', () => {
       it('shows correct number of hits', (done) => {
         const hitsCountUI = clusterDashboardView.insightsPopover.$$('tspan').get(5);
         expect(hitsCountUI.isDisplayed()).toBe(true);
-        const pullSecret = JSON.parse(execSync('oc get secret/pull-secret -n openshift-config -o json').toString());
-        const dockerConfigJSON = JSON.parse(Buffer.from(pullSecret.data[".dockerconfigjson"], "base64").toString());
-        const token = dockerConfigJSON["auths"]["cloud.openshift.com"]["auth"];
-        const clusterId = JSON.parse(execSync('oc get clusterversion -o json').toString()).items[0].spec.clusterID;
+        const pullSecret = JSON.parse(
+          execSync('oc get secret/pull-secret -n openshift-config -o json').toString(),
+        );
+        const dockerConfigJSON = JSON.parse(
+          Buffer.from(pullSecret.data['.dockerconfigjson'], 'base64').toString(),
+        );
+        const token = dockerConfigJSON['auths']['cloud.openshift.com']['auth'];
+        const clusterId = JSON.parse(execSync('oc get clusterversion -o json').toString()).items[0]
+          .spec.clusterID;
         const options = {
           headers: {
             'User-Agent': `insights-operator/test cluster/${clusterId}`,
-            'Authorization': `Bearer ${token}`
-          }
+            Authorization: `Bearer ${token}`,
+          },
         };
         get(
           `https://cloud.redhat.com/api/insights-results-aggregator/v1/clusters/${clusterId}/report`,
@@ -104,8 +109,9 @@ describe('Cluster Dashboard', () => {
               const hitsCountAPI = JSON.parse(d).report.meta.count.toString();
               expect(hitsCountUI.getText()).toEqual(hitsCountAPI);
               done();
-          });
-        }).on('error', (e) => {
+            });
+          },
+        ).on('error', (e) => {
           pending();
         });
       });

--- a/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
@@ -92,7 +92,7 @@ describe('Cluster Dashboard', () => {
         const dockerConfigJSON = JSON.parse(
           Buffer.from(pullSecret.data['.dockerconfigjson'], 'base64').toString(),
         );
-        const token = dockerConfigJSON['auths']['cloud.openshift.com']['auth'];
+        const token = dockerConfigJSON.auths['cloud.openshift.com'].auth;
         const clusterId = JSON.parse(execSync('oc get clusterversion -o json').toString()).items[0]
           .spec.clusterID;
         const options = {
@@ -111,7 +111,7 @@ describe('Cluster Dashboard', () => {
               done();
             });
           },
-        ).on('error', (e) => {
+        ).on('error', () => {
           pending();
         });
       });

--- a/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
@@ -60,6 +60,27 @@ describe('Cluster Dashboard', () => {
       expect(items.get(0).getText()).toEqual('Cluster');
       expect(items.get(1).getText()).toMatch('Control Plane.*');
       expect(items.get(2).getText()).toMatch('Operators.*');
+      expect(items.get(3).getText()).toMatch('Insights.*');
+    });
+    describe('Insights Popup', () => {
+      beforeAll(async () => {
+        await clusterDashboardView.insightsButton.click();
+      });
+      afterAll(async () => {
+        await clusterDashboardView.insightsCloseButton.click();
+      });
+      it('has title', () => {
+        const title = clusterDashboardView.insightsPopover.$('h6[id*="header"]');
+        expect(title.getText()).toEqual('Insights status');
+      });
+      it('has OCM UI link', () => {
+        const link = clusterDashboardView.insightsPopover.$('a.co-external-link');
+        expect(link.isDisplayed()).toBe(true);
+      })
+      it('has chart', () => {
+        const pieChart = clusterDashboardView.insightsPopover.$('div.pf-c-chart');
+        expect(pieChart.isDisplayed()).toBe(true);
+      });
     });
   });
 

--- a/frontend/integration-tests/views/dashboard.view.ts
+++ b/frontend/integration-tests/views/dashboard.view.ts
@@ -1,4 +1,4 @@
-import { $, $$ } from 'protractor';
+import { by, $, $$, element } from 'protractor';
 
 export const detailsCard = $('[data-test-id="details-card"]');
 export const detailsCardList = detailsCard.$('dl');
@@ -11,3 +11,6 @@ export const activityCard = $('[data-test-id="activity-card"]');
 export const eventsPauseButton = $('[data-test-id="events-pause-button"]');
 export const launcherCard = $('[data-test-id="launcher-card"]');
 export const resourceQuotasCard = $('[data-test-id="resource-quotas-card"]');
+export const insightsButton = element(by.xpath('.//button[normalize-space(.)="Insights"]'));
+export const insightsPopover = element(by.xpath('.//div[@role="dialog" and .//h6[normalize-space(.)="Insights status"]]'));
+export const insightsCloseButton = insightsPopover.element(by.xpath('.//button[@aria-label="Close"]'));

--- a/frontend/integration-tests/views/dashboard.view.ts
+++ b/frontend/integration-tests/views/dashboard.view.ts
@@ -12,5 +12,9 @@ export const eventsPauseButton = $('[data-test-id="events-pause-button"]');
 export const launcherCard = $('[data-test-id="launcher-card"]');
 export const resourceQuotasCard = $('[data-test-id="resource-quotas-card"]');
 export const insightsButton = element(by.xpath('.//button[normalize-space(.)="Insights"]'));
-export const insightsPopover = element(by.xpath('.//div[@role="dialog" and .//h6[normalize-space(.)="Insights status"]]'));
-export const insightsCloseButton = insightsPopover.element(by.xpath('.//button[@aria-label="Close"]'));
+export const insightsPopover = element(
+  by.xpath('.//div[@role="dialog" and .//h6[normalize-space(.)="Insights status"]]'),
+);
+export const insightsCloseButton = insightsPopover.element(
+  by.xpath('.//button[@aria-label="Close"]'),
+);


### PR DESCRIPTION
This PR adds protractor tests for Insights popup from https://github.com/openshift/console/pull/6660. Executed locally against cluster-bot's cluster:
```
root@thinkpad-t480s:/mnt/frontend# NO_HEADLESS=true BRIDGE_BASE_ADDRESS=url BRIDGE_KUBEADMIN_PASSWORD=password yarn test-protractor-suite --suite=dashboards
yarn run v1.21.0
$ yarn ts-node ./node_modules/.bin/protractor integration-tests/protractor.conf.ts --suite=dashboards
$ ts-node -O '{"module":"commonjs"}' ./node_modules/.bin/protractor integration-tests/protractor.conf.ts --suite=dashboards
Report destination:   gui_test_screenshots/protractor-report.html
[18:01:42] I/launcher - Running 1 instances of WebDriver
[18:01:42] I/hosted - Using the selenium server at http://192.168.1.6:4444/wd/hub

>> Executing 26 defined specs...

Test Suites & Specs:

1) Auth test

   2) Login test
      ✔ logs in as kubeadmin user

3) Create a test namespace
   ✔ creates test namespace if necessary

4) Cluster Dashboard

   5) Details Card
      ✔ has all fields populated
      ✔ has View settings link

   6) Status Card
      ✔ has View alerts link
      ✔ has health indicators

      7) Insights Popup
         ✔ has title
         ✔ has OCM UI link
         ✔ has chart
         ✔ shows correct number of hits

   8) Inventory Card
      ✔ has all items

   9) Utilization Card
      ✔ has all items
      ✔ has duration dropdown

   10) Activity Card
[18:02:28] W/element - more than one element found for locator By(css selector, [href="/k8s/all-namespaces/events"]) - the first result will be used
[18:02:28] W/element - more than one element found for locator By(css selector, [href="/k8s/all-namespaces/events"]) - the first result will be used
      ✔ has View events link
      ✔ has Pause events button

11) Project Dashboard
   ✔ Dashboard is default details page

   12) Details Card
      ✖ has all fields populated (2 failures)
      • has View all link

   13) Status Card
      • has health indicator

   14) Inventory Card
      • has all items

   15) Utilization Card
      • has all items
      • has duration dropdown

   16) Activity Card
      • has View events link
      • has Pause events button

   17) Launcher Card
      • is displayed when CR exists

   18) Resource Quotas Card
      • shows Resource Quotas

>> Done!
...
Summary:

Suites:  18 of 18
Specs:   17 of 26 (9 disabled)
Expects: 82 (2 failures)
Finished in 50.892 seconds
```