### PR TITLE
customize dev catalog tile descriptions

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
@@ -72,7 +72,10 @@ export type CatalogItem = {
   type: string;
   name: string;
   provider?: string;
-  description?: string;
+  // Used as the tile description. If provided as a string, the description is truncated to 3 lines.
+  // If provided as a ReactNode, the contents will not be truncated.
+  // This description will also be shown in the side panel if there are no `details.descriptions`.
+  description?: string | React.ReactNode;
   tags?: string[];
   creationTimestamp?: string;
   supportUrl?: string;

--- a/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
@@ -29,6 +29,7 @@ const CatalogTile: React.FC<CatalogTileProps> = ({ item, catalogTypes, onClick }
     </CatalogTileBadge>,
   ];
 
+  const isDescriptionReactElement = React.isValidElement(description);
   return (
     <PfCatalogTile
       className="co-catalog-tile"
@@ -36,10 +37,12 @@ const CatalogTile: React.FC<CatalogTileProps> = ({ item, catalogTypes, onClick }
       title={name}
       badges={badges}
       vendor={vendor}
-      description={description}
+      description={isDescriptionReactElement ? undefined : description}
       data-test={`${type}-${name}`}
       {...getIconProps(item)}
-    />
+    >
+      {isDescriptionReactElement ? description : undefined}
+    </PfCatalogTile>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsPanel.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsPanel.tsx
@@ -47,7 +47,7 @@ const CatalogDetailsPanel: React.FC<CatalogDetailsPanelProps> = ({ item }) => {
             </PropertiesSidePanel>
             <div className="co-catalog-page__overlay-description">
               <SectionHeading text={t('devconsole~Description')} />
-              {description && <p>{description}</p>}
+              {!details?.descriptions?.length && description && <p>{description}</p>}
               {details?.descriptions?.map((desc, index) => (
                 <React.Fragment key={index}>
                   {desc.label && <SectionHeading text={desc.label} />}

--- a/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useBuilderImages.tsx
@@ -88,6 +88,9 @@ const normalizeBuilderImages = (
 
     const detailsDescriptions = [
       {
+        value: <p>{description}</p>,
+      },
+      {
         value: imageStreamText,
       },
     ];

--- a/frontend/packages/dev-console/src/components/catalog/providers/useHelmCharts.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useHelmCharts.tsx
@@ -111,6 +111,9 @@ const normalizeHelmCharts = (
 
         const detailsDescriptions = [
           {
+            value: <p>{description}</p>,
+          },
+          {
             value: <HelmReadmeLoader chartURL={chartURL} />,
           },
         ];

--- a/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
@@ -18,10 +18,12 @@ export const keywordCompare = (filterString: string, item: CatalogItem): boolean
     return false;
   }
 
+  const filterStringLowerCase = filterString.toLowerCase();
   return (
-    item.name.toLowerCase().includes(filterString) ||
-    (item.description && item.description.toLowerCase().includes(filterString)) ||
-    (item.tags && item.tags.some((tag) => tag.includes(filterString)))
+    item.name.toLowerCase().includes(filterStringLowerCase) ||
+    (typeof item.description === 'string' &&
+      item.description.toLowerCase().includes(filterStringLowerCase)) ||
+    (item.tags && item.tags.some((tag) => tag.includes(filterStringLowerCase)))
   );
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/utils/useClusterServiceVersions.tsx
@@ -92,6 +92,9 @@ const normalizeClusterServiceVersions = (
 
       const detailsDescriptions = [
         {
+          value: <p>{description}</p>,
+        },
+        {
           value: <p>{longDescription}</p>,
         },
         {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5179

Add support for catalog tile descriptions to be a `ReactNode`. When the tile description is a `ReactNode` it will not be truncated.

With this change the tile description is no longer automatically included in the side panel if the side panel contains its own description. Therefore this change also adds the short description to the builder images, operator backed and helm side panel description to match the original behavior.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

eg card with custom description:
![image](https://user-images.githubusercontent.com/14068621/100379834-980cf600-2fe3-11eb-8be9-d48531855f39.png)

Tile description is set in side panel if there is no other description:
![image](https://user-images.githubusercontent.com/14068621/100379840-9e02d700-2fe3-11eb-8c91-eab6520f2920.png)

Operator backed description still includes the tile description:
![image](https://user-images.githubusercontent.com/14068621/100380648-3b123f80-2fe5-11eb-8ffa-e6ff2194128f.png)

Helm chart description still includes the tile description:
![image](https://user-images.githubusercontent.com/14068621/100381028-0f438980-2fe6-11eb-9739-eeca797af9bb.png)

![image](https://user-images.githubusercontent.com/14068621/100390690-496d5500-2fff-11eb-9ec4-c28232c7a19a.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

cc @rohitkrai03 @matthewcarleton @glekner 