### PR TITLE
Bug 1901594: fix item-create unstability

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -17,6 +17,7 @@ export const listPage = {
       });
   },
   clickCreateYAMLbutton: () => {
+    cy.get(`[data-test="item-create"]`).should('be.visible');
     cy.byTestID('item-create').click({ force: true });
   },
   filter: {


### PR DESCRIPTION
@jhadvig  Can we fix bug 1901594 in this way? 
[Bug 1901594 - Kubernetes resource CRUD operations.Kubernetes resource CRUD operations Pod "before all" hook for "creates the resource instance"](https://bugzilla.redhat.com/show_bug.cgi?id=1901594)