### PR TITLE
add Kamelets- schema generated forms & yaml/form switching

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
@@ -35,6 +35,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
   widgets = {},
   customUISchema,
   noActions,
+  showAlert = true,
   ...restProps
 }) => {
   const { t } = useTranslation();
@@ -56,14 +57,16 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
   }
   return (
     <>
-      <Alert
-        isInline
-        className="co-alert co-break-word"
-        variant="info"
-        title={t(
-          'console-shared~Note: Some fields may not be represented in this form view. Please select "YAML view" for full control.',
-        )}
-      />
+      {showAlert && (
+        <Alert
+          isInline
+          className="co-alert co-break-word"
+          variant="info"
+          title={t(
+            'console-shared~Note: Some fields may not be represented in this form view. Please select "YAML view" for full control.',
+          )}
+        />
+      )}
       <Accordion asDefinitionList={false} className="co-dynamic-form__accordion">
         <Form
           {...restProps}
@@ -109,6 +112,7 @@ type DynamicFormProps = FormProps<any> & {
   ErrorTemplate?: React.FC<{ errors: string[] }>;
   noActions?: boolean;
   customUISchema?: boolean;
+  showAlert?: boolean;
   onCancel?: () => void;
 };
 

--- a/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DynamicFormField.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { FormProps } from 'react-jsonschema-form';
+import cx from 'classnames';
 import { useField, useFormikContext, FormikValues } from 'formik';
 import { AsyncComponent } from '@console/internal/components/utils';
 
@@ -7,6 +8,7 @@ type DynamicFormFieldProps = FormProps<any> & {
   name: string;
   errors?: string[];
   formDescription?: React.ReactNode;
+  showAlert?: boolean;
 };
 
 const DynamicFormField: React.FC<DynamicFormFieldProps> = ({
@@ -16,20 +18,30 @@ const DynamicFormField: React.FC<DynamicFormFieldProps> = ({
   errors,
   formDescription,
   formContext,
+  showAlert,
 }) => {
   const [field] = useField(name);
   const { setFieldValue } = useFormikContext<FormikValues>();
 
   return (
-    <div className="row">
-      <div className="col-sm-12 col-md-4 col-md-push-8 col-lg-5 col-lg-push-7">
+    <div className={cx({ row: formDescription })}>
+      <div
+        className={cx({
+          'col-sm-12 col-md-4 col-md-push-8 col-lg-5 col-lg-push-7': formDescription,
+        })}
+      >
         {formDescription}
       </div>
-      <div className="col-sm-12 col-md-8 col-md-pull-4 col-lg-7 col-lg-pull-5">
+      <div
+        className={cx({
+          'col-sm-12 col-md-8 col-md-pull-4 col-lg-7 col-lg-pull-5': formDescription,
+        })}
+      >
         <AsyncComponent
           loader={() => import('../dynamic-form').then((c) => c.DynamicForm)}
           errors={errors}
           formContext={formContext}
+          showAlert={showAlert}
           uiSchema={uiSchema}
           formData={field.value}
           onChange={(data) => setFieldValue(name, data)}

--- a/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsModal.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsModal.tsx
@@ -27,7 +27,7 @@ const CatalogDetailsModal: React.FC<CatalogDetailsModalProps> = ({ item, onClose
   Object.values(CatalogQueryParams).map((q) => queryParams.delete(q)); // don't pass along catalog specific query params
 
   const to = params
-    ? `${url}?${params}&${queryParams.toString()}`
+    ? `${url}?${params}${Object.keys(queryParams).length > 0 ? `&${queryParams.toString()}` : ''}`
     : `${url}?${queryParams.toString()}`;
 
   const vendor = item.provider

--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -167,6 +167,7 @@
   "Event sources": "Event sources",
   "Event sources are objects that link to an event producer and an event sink or consumer. Cluster administrators can customize the content made available in the catalog.": "Event sources are objects that link to an event producer and an event sink or consumer. Cluster administrators can customize the content made available in the catalog.",
   "**Event sources** are objects that link to an event producer and an event sink or consumer.": "**Event sources** are objects that link to an event producer and an event sink or consumer.",
+  "Provider": "Provider",
   "No Revisions": "No Revisions",
   "Move sink to {{resourceObjKind}}": "Move sink to {{resourceObjKind}}",
   "Move sink to URI": "Move sink to URI",

--- a/frontend/packages/knative-plugin/src/components/add/EventSourceForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourceForm.tsx
@@ -25,6 +25,7 @@ interface OwnProps {
   namespace: string;
   eventSourceStatus: EventSourceListData | null;
   eventSourceMetaDescription: React.ReactNode;
+  kameletSource: K8sResourceKind;
 }
 
 const EventSourceForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
@@ -39,6 +40,7 @@ const EventSourceForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
   namespace,
   eventSourceStatus,
   eventSourceMetaDescription,
+  kameletSource,
 }) => {
   const { t } = useTranslation();
   const yamlEditor = <YAMLEditorField name="yamlData" onSave={handleSubmit} />;
@@ -73,6 +75,18 @@ const EventSourceForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
         [values.formData.type]: {
           ..._.omit(specData, 'sink'),
         },
+        ...(kameletSource && {
+          [values.formData.type]: {
+            source: {
+              ref: {
+                apiVersion: kameletSource.apiVersion,
+                kind: kameletSource.kind,
+                name: kameletSource.metadata.name,
+              },
+              properties: specData?.source?.properties,
+            },
+          },
+        }),
       },
     };
     return values.formData.type === EventSources.KafkaSource
@@ -108,7 +122,7 @@ const EventSourceForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
                 variant="info"
               />
             )}
-            <EventSourceSection namespace={namespace} catalogFlow fullWidth />{' '}
+            <EventSourceSection namespace={namespace} kameletSource={kameletSource} fullWidth />{' '}
           </div>
         </div>
       )}
@@ -116,7 +130,7 @@ const EventSourceForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
   );
   return (
     <FlexForm onSubmit={handleSubmit}>
-      {isDynamicEventSourceKind(values.formData.type) && (
+      {(isDynamicEventSourceKind(values.formData.type) || kameletSource) && (
         <SyncedEditorField
           name="editorType"
           formContext={{

--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -7,6 +7,7 @@ import {
   EventSourceSinkBindingModel,
   EventingIMCModel,
   EventingKafkaChannelModel,
+  CamelKameletBindingModel,
 } from '../../models';
 
 export const EventSources = {
@@ -16,6 +17,7 @@ export const EventSources = {
   KafkaSource: EventSourceKafkaModel.kind,
   PingSource: EventSourcePingModel.kind,
   SinkBinding: EventSourceSinkBindingModel.kind,
+  KameletBinding: CamelKameletBindingModel.kind,
 };
 export const defaultChannels = {
   InMemoryChannel: EventingIMCModel,

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -566,6 +566,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         '%knative-plugin~**Event sources** are objects that link to an event producer and an event sink or consumer.%',
       filters: [
         {
+          // t('knative-plugin~Provider')
           label: '%knative-plugin~Provider%',
           attribute: 'provider',
         },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5063

**Description**: 
when creating an source for kamelets, I should be presented with a form/yaml view and ability to switch between two

**Screen shots / Gifs for design review**: 
<img width="1788" alt="kamelet-1" src="https://user-images.githubusercontent.com/2561818/100461172-67fe4980-30ee-11eb-9247-847bdeaadfff.png">
<img width="1789" alt="kamelet-2" src="https://user-images.githubusercontent.com/2561818/100461182-6d5b9400-30ee-11eb-835e-19265d3b7012.png">


**Test setup:**
1. Install Serverless operator and create CR for KnativeServing, KnativeEventing
2. Install Red Hat Integration - Camel K 1.2.0 provided by Red Hat, If installed globally create CR for IntegrationPlatform in your namespace, where you can see the kamelets.
