### PR TITLE
Added init state to insights plugin

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { ChartDonut, ChartLegend, ChartLabel } from '@patternfly/react-charts';
-import { riskIcons, colorScale, legendColorScale, riskSorting, mapMetrics } from './mappers';
+import {
+  riskIcons,
+  colorScale,
+  legendColorScale,
+  riskSorting,
+  mapMetrics,
+  isInitState,
+} from './mappers';
 import { PrometheusHealthPopupProps } from '@console/plugin-sdk';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ExternalLink } from '@console/internal/components/utils';
@@ -19,15 +26,24 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
   );
   const numberOfIssues = Object.values(resource).reduce((acc, cur) => acc + cur, 0);
   const hasIssues = riskEntries.length > 0 && numberOfIssues > 0;
+  const isInit = isInitState(resource);
 
   return (
     <div className="co-insights__box">
+      {!isInit && (
+        <div className="co-status-popup__section">
+          Insights identifies and prioritizes risks to security, performance, availability, and
+          stability of your clusters.
+        </div>
+      )}
+      {isInit && (
+        <div className="co-status-popup__section">
+          Your cluster has been identified, and Insights analyzes your cluster. The results will be
+          displayed shortly.
+        </div>
+      )}
       <div className="co-status-popup__section">
-        Insights identifies and prioritizes risks to security, performance, availability, and
-        stability of your clusters.
-      </div>
-      <div className="co-status-popup__section">
-        {hasIssues && (
+        {hasIssues && !isInit && (
           <div>
             <ChartDonut
               data={riskEntries.map(([k, v]) => ({
@@ -66,10 +82,12 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
             />
           </div>
         )}
-        {!hasIssues && <div className="co-insights__no-rules">No Insights data to display.</div>}
+        {(!hasIssues || isInit) && (
+          <div className="co-insights__no-rules">No Insights data to display.</div>
+        )}
       </div>
       <div className="co-status-popup__section">
-        {hasIssues && (
+        {hasIssues && !isInit && (
           <>
             <h6 className="pf-c-title pf-m-md">Fixable issues</h6>
             <div>
@@ -80,7 +98,15 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
             </div>
           </>
         )}
-        {!hasIssues && (
+        {isInit && (
+          <div>
+            <ExternalLink
+              href={`https://cloud.redhat.com/openshift/details/${clusterID}`}
+              text="Go to OpenShift Cluster Manager"
+            />
+          </div>
+        )}
+        {!hasIssues && !isInit && (
           <ExternalLink
             href="https://docs.openshift.com/container-platform/latest/support/getting-support.html"
             text="More about Insights"

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/mappers.ts
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/mappers.ts
@@ -48,8 +48,13 @@ export const mapMetrics = (response: PrometheusResponse): Metrics => {
       return null;
     }
     const metricName = response.data?.result?.[i]?.metric?.metric;
-    values[metricName] = parseInt(value, 10);
+    if (values[metricName] === -1 || values[metricName] === undefined) {
+      values[metricName] = parseInt(value, 10);
+    }
   }
 
   return values;
 };
+
+export const isInitState = (values: Metrics) =>
+  Object.values(values).some((cur: number) => cur === -1);

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/status.ts
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/status.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { PrometheusHealthHandler, SubsystemHealth } from '@console/plugin-sdk';
 import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
 import { PrometheusResponse } from '@console/internal/components/graphs';
-import { mapMetrics } from './mappers';
+import { mapMetrics, isInitState } from './mappers';
 
 export const getClusterInsightsComponentStatus = (
   response: PrometheusResponse,
@@ -20,6 +20,9 @@ export const getClusterInsightsComponentStatus = (
   const values = mapMetrics(response);
   if (_.isNil(values)) {
     return { state: HealthState.UNKNOWN, message: 'Not available' };
+  }
+  if (isInitState(values)) {
+    return { state: HealthState.PROGRESS, message: 'Issues pending' };
   }
   const issuesNumber = Object.values(values).reduce((acc, cur) => acc + cur, 0);
   const issueStr = `${issuesNumber} ${issuesNumber === 1 ? 'issue' : 'issues'} found`;

--- a/frontend/packages/insights-plugin/src/plugin.tsx
+++ b/frontend/packages/insights-plugin/src/plugin.tsx
@@ -10,7 +10,10 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Dashboards/Overview/Health/Prometheus',
     properties: {
       title: 'Insights',
-      queries: ["health_statuses_insights{metric=~'low|moderate|important|critical'}"],
+      queries: [
+        "health_statuses_insights{metric=~'low|moderate|important|critical'}",
+        'insightsclient_request_send_total',
+      ],
       healthHandler: getClusterInsightsStatus,
       additionalResource: {
         kind: referenceForModel(ClusterVersionModel),


### PR DESCRIPTION
Init state appear when value of at least one insight data is `-1`. Unfortunately if reload insights-operator values of insights data are back to `-1`, thus init state appear again.

![Screenshot from 2020-11-30 10-03-16](https://user-images.githubusercontent.com/3332176/100590372-9a799380-32f4-11eb-9d8f-67a5f070ec61.png)

Please, take a look @doruskova @tisnik @spadgett @vojtechszocs 
