### PR TITLE
Import console i18n instance

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -25,6 +25,7 @@ import {
 import { DashboardsStorageCapacityDropdownItem } from '@console/ceph-storage-plugin';
 import { TemplateModel, PodModel, PersistentVolumeClaimModel } from '@console/internal/models';
 import { getName } from '@console/shared/src/selectors/common';
+import '@console/internal/i18n.js';
 import * as models from './models';
 import { VMTemplateYAMLTemplates, VirtualMachineYAMLTemplates } from './models/templates';
 import { getKubevirtHealthState } from './components/dashboards-page/overview-dashboard/health';

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -217,6 +217,7 @@ const config: Configuration = {
     new CopyWebpackPlugin([{ from: './packages/container-security/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/pipelines-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/topology/locales', to: 'locales' }]),
+    new CopyWebpackPlugin([{ from: './packages/kubevirt-plugin/locales', to: 'locales' }]),
     new MomentLocalesPlugin({
       localesToKeep: ['en', 'ja', 'ko'],
     }),


### PR DESCRIPTION
This PR imports the console i18n instance into the kubevirt-plugin and adds a directive to the frontend webpack config to copy kubevirt-plugin locales files to frontend/public/locales to make the keys discoverable.