### PR TITLE
Avoid erroneous use of python3 with old node-gyp

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -16,7 +16,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.nodejs.14 AS nodebuilder
 ADD . .
 
 USER 0
-# required for node-gyp
+# required for node-gyp; keep build-frontend.sh in sync
 RUN yum install -y python2
 # extract the yarn dependencies that must be provided in the dist-git lookaside cache
 RUN tar fx yarn-offline.tar

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -3,6 +3,8 @@
 set -e
 
 pushd frontend
+# node-sass requires old version of node-gyp which is Py2-only
+yarn config set python python2.7
 yarn install
 yarn run build
 popd


### PR DESCRIPTION
node-sass, used within console, requires an old version of node-gyp 
(specifically 3.8.0) which does not have Python 3 support.  Since the 
switch to Node.js 14, something has caused node-gyp to look only at 
python3 as a python interpreter regardless of its absence, or the 
presence of python2.

This fixes the downstream builds of console by forcing the python 
interpreter version.

/cc @spadgett
