### PR TITLE
Bug 1898532: Remove _.startCase from FieldSet title

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
@@ -88,7 +88,7 @@ export const FieldSet: React.FC<FieldSetProps> = ({
             className={classnames({ 'co-required': required })}
             htmlFor={`${idSchema.$id}_accordion-content`}
           >
-            {_.startCase(label)}
+            {label}
           </label>
         </AccordionToggle>
         {description && (


### PR DESCRIPTION
This was missed when switching to `useSchemaLabel` hook.