### PR TITLE
Cypress: disable Monitoring test suite

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -23,7 +23,7 @@ const shouldBeWatchdogSilencePage = () => {
   detailsPage.labelShouldExist('alertname=Watchdog');
 };
 
-describe('Monitoring: Alerts', () => {
+xdescribe('Monitoring: Alerts', () => {
   before(() => {
     cy.login();
     cy.createProject(testName);


### PR DESCRIPTION
Too many flakes in recent days.  Will re-evaluate after speaking with Monitoring team.

Thought this BZ was the root cause of the issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1891815

Reopened: https://bugzilla.redhat.com/show_bug.cgi?id=1870287