### PR TITLE
Bug 1902969: Added a check on the value return from getOwnerReferences

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/info-messages/VMIDetailsPageInfoMessage.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/info-messages/VMIDetailsPageInfoMessage.tsx
@@ -15,7 +15,8 @@ const VMIDetailsPageInfoMessage: React.FC<InfoMessageHintBlockProps> = ({ name, 
   });
 
   const isOwnedByVM =
-    vmi && !!getOwnerReferences<VMIKind>(vmi).find(({ kind }) => kind === VirtualMachineModel.kind);
+    vmi &&
+    !!getOwnerReferences<VMIKind>(vmi)?.find(({ kind }) => kind === VirtualMachineModel.kind);
 
   const showMessage = isLoaded && !isOwnedByVM && vmi !== null;
 


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <matanschatzman@gmail.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1902969

**Analysis / Root cause**: 
in no ownerReference found on yaml getOwnerReference return undefined

**Solution Description**: 
Added a check for undefined.