### PR TITLE
Fix sorting of nav section items

### DIFF
--- a/frontend/__tests__/components/nav/navSortUtils.spec.ts
+++ b/frontend/__tests__/components/nav/navSortUtils.spec.ts
@@ -1,4 +1,4 @@
-import { getSortedNavItems } from '@console/internal/components/nav/perspective-nav';
+import { getSortedNavItems } from '@console/internal/components/nav/navSortUtils';
 import { LoadedExtension, NavItem, NavSection, SeparatorNavItem } from '@console/plugin-sdk/src';
 
 const mockNavItems: LoadedExtension<NavSection | NavItem | SeparatorNavItem>[] = [

--- a/frontend/public/components/nav/navSortUtils.ts
+++ b/frontend/public/components/nav/navSortUtils.ts
@@ -1,0 +1,86 @@
+import { NavSection as PluginNavSection, NavItem, SeparatorNavItem } from '@console/plugin-sdk';
+
+const itemDependsOnItem = (
+  s1: PluginNavSection | NavItem | SeparatorNavItem,
+  s2: PluginNavSection | NavItem | SeparatorNavItem,
+) => {
+  if (!s1.properties.insertBefore && !s1.properties.insertAfter) {
+    return false;
+  }
+  const before = Array.isArray(s1.properties.insertBefore)
+    ? s1.properties.insertBefore
+    : [s1.properties.insertBefore];
+  const after = Array.isArray(s1.properties.insertAfter)
+    ? s1.properties.insertAfter
+    : [s1.properties.insertAfter];
+  return before.includes(s2.properties.id) || after.includes(s2.properties.id);
+};
+
+const isPositioned = (
+  item: PluginNavSection | NavItem | SeparatorNavItem,
+  allItems: (PluginNavSection | NavItem | SeparatorNavItem)[],
+) => !!allItems.find((i) => itemDependsOnItem(item, i));
+
+const findIndexForItem = (
+  item: PluginNavSection | NavItem | SeparatorNavItem,
+  currentItems: (PluginNavSection | NavItem | SeparatorNavItem)[],
+) => {
+  const { insertBefore, insertAfter } = item.properties;
+  let index = -1;
+  const before = Array.isArray(insertBefore) ? insertBefore : [insertBefore];
+  const after = Array.isArray(insertAfter) ? insertAfter : [insertAfter];
+  let count = 0;
+  while (count < before.length && index < 0) {
+    index = currentItems.findIndex((i) => i.properties.id === before[count]);
+    count++;
+  }
+  count = 0;
+  while (count < after.length && index < 0) {
+    index = currentItems.findIndex((i) => i.properties.id === after[count]);
+    if (index >= 0) {
+      index += 1;
+    }
+    count++;
+  }
+  return index;
+};
+
+const insertItem = (
+  item: PluginNavSection | NavItem | SeparatorNavItem,
+  currentItems: (PluginNavSection | NavItem | SeparatorNavItem)[],
+) => {
+  const index = findIndexForItem(item, currentItems);
+  if (index >= 0) {
+    currentItems.splice(index, 0, item);
+  } else {
+    currentItems.push(item);
+  }
+};
+
+const insertPositionedItems = (
+  insertItems: (PluginNavSection | NavItem | SeparatorNavItem)[],
+  currentItems: (PluginNavSection | NavItem | SeparatorNavItem)[],
+) => {
+  if (insertItems.length === 0) {
+    return;
+  }
+
+  const sortedItems = insertItems.filter((item) => !isPositioned(item, insertItems));
+  const positionedItems = insertItems.filter((item) => isPositioned(item, insertItems));
+
+  if (sortedItems.length === 0) {
+    // Circular dependencies
+    positionedItems.forEach((i) => insertItem(i, currentItems));
+    return;
+  }
+
+  sortedItems.forEach((i) => insertItem(i, currentItems));
+  insertPositionedItems(positionedItems, currentItems);
+};
+
+export const getSortedNavItems = (navItems: (PluginNavSection | NavItem | SeparatorNavItem)[]) => {
+  const sortedItems = navItems.filter((item) => !isPositioned(item, navItems));
+  const positionedItems = navItems.filter((item) => isPositioned(item, navItems));
+  insertPositionedItems(positionedItems, sortedItems);
+  return sortedItems;
+};

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -15,6 +15,7 @@ import { RootState } from '../../redux';
 import { featureReducerName, flagPending, FeatureState } from '../../reducers/features';
 import { stripBasePath } from '../utils';
 import { stripNS, createLink } from './items';
+import { getSortedNavItems } from './navSortUtils';
 
 const navSectionStateToProps = (
   state: RootState,
@@ -29,37 +30,6 @@ const navSectionStateToProps = (
     activeNamespace: state.UI.get('activeNamespace'),
     location: state.UI.get('location'),
   };
-};
-
-const findChildIndex = (id: string, Children: React.ReactElement[]) =>
-  Children.findIndex((c) => c.props.id === id);
-
-const mergePluginChild = (
-  Children: React.ReactElement[],
-  pluginChild: React.ReactElement,
-  insertBefore?: string | string[],
-  insertAfter?: string | string[],
-) => {
-  let index = -1;
-  const before = Array.isArray(insertBefore) ? insertBefore : [insertBefore];
-  const after = Array.isArray(insertAfter) ? insertAfter : [insertAfter];
-  let count = 0;
-  while (count < before.length && index < 0) {
-    index = findChildIndex(before[count++], Children);
-  }
-  count = 0;
-  while (count < after.length && index < 0) {
-    index = findChildIndex(after[count++], Children);
-    if (index >= 0) {
-      index += 1;
-    }
-  }
-
-  if (index >= 0) {
-    Children.splice(index, 0, pluginChild);
-  } else {
-    Children.push(pluginChild);
-  }
 };
 
 export const NavSection = connect(navSectionStateToProps)(
@@ -188,17 +158,11 @@ export const NavSection = connect(navSectionStateToProps)(
         getChildren() {
           const { id, title, children, activePerspective: perspective } = this.props;
           const Children = React.Children.map(children, this.mapChild) || [];
+          const childItems = getSortedNavItems(this.getNavItemExtensions(perspective, title, id));
 
-          this.getNavItemExtensions(perspective, title, id).forEach((item) => {
-            const pluginChild = this.mapChild(createLink(item));
-            if (pluginChild) {
-              mergePluginChild(
-                Children,
-                pluginChild,
-                item.properties.insertBefore,
-                item.properties.insertAfter,
-              );
-            }
+          childItems.forEach((item) => {
+            const pluginChild = this.mapChild(createLink(item as NavItem));
+            Children.push(pluginChild);
           });
 
           return Children;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5158

**Analysis / Root cause**: 
Items within a section were only sorted linearly so an item specifying before/after an item declared later did not get sorted based on that item.

**Solution Description**: 
Create utilities from existing sorting done for sections. Update the section nav items to use the same utilities and sort in the same manner as the sections.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug