### PR TITLE
Bug 1903054: Remove space in ReplicationControllers tab

### DIFF
--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -259,7 +259,7 @@ const pages = [
   navFactory.editYaml(),
   {
     href: 'replicationcontrollers',
-    name: 'Replication Controllers',
+    name: 'ReplicationControllers',
     component: ReplicationControllersTab,
   },
   navFactory.pods(),


### PR DESCRIPTION
Deployment Config has a Replication Controllers tab. I removed the space to bring it in line with other CamelCase efforts.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1903054.