### PR TITLE
Bug 1897008: Cypress: reenable check for 'aria-hidden-focus' rule & checkA11y test for modals

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/a11y.ts
+++ b/frontend/packages/integration-tests-cypress/support/a11y.ts
@@ -6,7 +6,7 @@ declare global {
   namespace Cypress {
     interface Chainable<Subject> {
       logA11yViolations(violations: Result[], target: string): Chainable<Element>;
-      testA11y(target: string): Chainable<Element>;
+      testA11y(target: string, selector?: string): Chainable<Element>;
     }
   }
 }
@@ -34,19 +34,18 @@ Cypress.Commands.add('logA11yViolations', (violations: Result[], target: string)
   cy.task('logTable', violationData);
 });
 
-Cypress.Commands.add('testA11y', (target: string) => {
+Cypress.Commands.add('testA11y', (target: string, selector?: string) => {
   cy.injectAxe();
   cy.configureAxe({
     rules: [
       { id: 'color-contrast', enabled: false }, // seem to be somewhat inaccurate and has difficulty always picking up the correct colors, tons of open issues for it on axe-core
       { id: 'focusable-content', enabled: false }, // recently updated and need to give the PF team time to fix issues before enabling
       { id: 'scrollable-region-focusable', enabled: false }, // recently updated and need to give the PF team time to fix issues before enabling
-      { id: 'aria-hidden-focus', enabled: false }, // disabling until we implement correct handling of Modals, see https://dequeuniversity.com/rules/axe/3.4/aria-hidden-focus?application=axeAPI
     ],
   });
   a11yTestResults.numberChecks += 1;
   cy.checkA11y(
-    null,
+    selector,
     {
       includedImpacts: ['serious', 'critical'],
     },

--- a/frontend/packages/integration-tests-cypress/support/project.ts
+++ b/frontend/packages/integration-tests-cypress/support/project.ts
@@ -22,8 +22,7 @@ Cypress.Commands.add('createProject', (name: string, devConsole: boolean = false
   listPage.clickCreateYAMLbutton();
   modal.shouldBeOpened();
   cy.byTestID('input-name').type(name);
-  // TODO: uncomment once https://bugzilla.redhat.com/show_bug.cgi?id=1897008 is fixed
-  // cy.testA11y('Create Project modal');
+  cy.testA11y('Create Project modal', '#modal-container');
   modal.submit();
   modal.shouldBeClosed();
   // TODO, switch to 'listPage.titleShouldHaveText(name)', when we switch to new test id
@@ -40,8 +39,7 @@ Cypress.Commands.add('deleteProject', (name: string) => {
   modal.submitShouldBeDisabled();
   cy.byTestID('project-name-input').type(name);
   modal.submitShouldBeEnabled();
-  // TODO: uncomment once https://bugzilla.redhat.com/show_bug.cgi?id=1897008 is fixed
-  // cy.testA11y('Delete Project modal');
+  cy.testA11y('Delete Project modal', '#modal-container');
   modal.submit();
   modal.shouldBeClosed();
   listPage.titleShouldHaveText('Projects');

--- a/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
@@ -31,7 +31,7 @@ describe('Namespace', () => {
     listPage.clickCreateYAMLbutton();
     modal.shouldBeOpened();
     cy.byTestID('input-name').type(newName);
-    cy.testA11y('Create Namespace modal');
+    cy.testA11y('Create Namespace modal', '#modal-container');
     modal.submit();
     modal.shouldBeClosed();
     cy.url().should('include', `/k8s/cluster/namespaces/${newName}`);
@@ -43,7 +43,7 @@ describe('Namespace', () => {
     listPage.rows.clickKebabAction(newName, 'Delete Namespace');
     modal.shouldBeOpened();
     cy.byTestID('project-name-input').type(newName);
-    cy.testA11y('Delete Namespace modal');
+    cy.testA11y('Delete Namespace modal', '#modal-container');
     modal.submit();
     modal.shouldBeClosed();
     cy.resourceShouldBeDeleted(testName, 'namespaces', newName);

--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -148,7 +148,7 @@ xdescribe('Monitoring: Alerts', () => {
     cy.log('expires the Silence');
     detailsPage.clickPageActionFromDropdown('Expire Silence');
     modal.shouldBeOpened();
-    cy.testA11y('Expire Silence modal');
+    cy.testA11y('Expire Silence modal', '#modal-container');
     modal.submit();
     modal.shouldBeClosed();
     cy.get(errorMessage).should('not.exist');

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -176,7 +176,7 @@ class App_ extends React.PureComponent {
           <GuidedTour />
           <ConsoleNotifier location="BannerBottom" />
         </QuickStartDrawer>
-        <div id="modal-container" />
+        <div id="modal-container" role="dialog" aria-modal="true" />
       </>
     );
 

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -147,6 +147,7 @@ export const ModalSubmitFooter: React.SFC<ModalSubmitFooterProps> = ({
           variant="secondary"
           data-test-id="modal-cancel-action"
           onClick={onCancelClick}
+          aria-label="Cancel"
         >
           {cancelText || t('public~Cancel')}
         </Button>


### PR DESCRIPTION
This PR re-enables the a11y check for 'aria-hidden-focus' rule and allows A11y testing of Modals in isolation.  Updated modal div to `<div id="modal-container" role="dialog" aria-modal="true" />`.