### PR TITLE
Add scripts to get and set user settings on a cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /frontend/@types
 /frontend/package-lock.json
 /frontend/po-files
+/user-settings.yaml

--- a/contrib/oc-get-user-settings.sh
+++ b/contrib/oc-get-user-settings.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# shellcheck shell=bash
+#
+# This file is an example of how you might set up your environment to
+# run the console against an OpenShift cluster during development. To
+# use it for running bridge, do login and run
+# ./contrib/oc-get-user-settings.sh [username] [filename]
+#
+# You'll need a working oc, and you'll need yq installed and in your
+# path for this script to work correctly. See:
+# - https://github.com/openshift/oc
+# - https://github.com/mikefarah/yq#install
+#
+# This script creates a file (see LOCAL_FILE) in your working directory
+# with the data part of the ConfigMap which saves the user settings.
+
+set -e
+
+REQUEST_USERNAME=${1:-"~"}
+LOCAL_FILE=${2:-"user-settings.yaml"}
+
+NAMESPACE="openshift-console-user-settings"
+RESOURCE="user-settings"
+
+USER_NAME=$(oc get "users.user.openshift.io/$REQUEST_USERNAME" -o 'template={{.metadata.name}}')
+USER_UID=$(oc get "users.user.openshift.io/$REQUEST_USERNAME" -o 'template={{.metadata.uid}}')
+
+if ! which yq > /dev/null; then
+    echo "yq cli not found, please checkout https://github.com/mikefarah/yq#install"
+    exit 1
+fi
+
+if [ "$USER_UID" != "<no value>" ]; then
+    RESOURCE="$RESOURCE-$USER_UID"
+elif [ "$USER_NAME" = "kube:admin" ]; then
+    RESOURCE="$RESOURCE-kubeadmin"
+else
+    echo "oc user need to be kube:admin or have a uid."
+    exit 1
+fi
+
+echo "Get ConfigMap \"$RESOURCE\" from namespace \"$NAMESPACE\" and save it to \"$LOCAL_FILE\""
+echo
+
+yaml=$(oc get -n "$NAMESPACE" configmaps "$RESOURCE" -o yaml)
+
+# Extract apiVersion, kind and customization
+(
+    echo "$yaml" | yq r - apiVersion | yq p - apiVersion
+    echo "$yaml" | yq r - kind | yq p - kind
+    echo "$yaml" | yq r - data | yq p - data
+) > "$LOCAL_FILE"
+
+# Debug output
+echo "$yaml" | yq r - data | yq p - "User settings"

--- a/contrib/oc-set-user-settings.sh
+++ b/contrib/oc-set-user-settings.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# shellcheck shell=bash
+#
+# This file is an example of how you might set up your environment to
+# run the console against an OpenShift cluster during development. To
+# use it for running bridge, do login and run
+# ./contrib/oc-set-user-settings.sh [username] [filename]
+#
+# You'll need a working oc. See:
+# - https://github.com/openshift/oc
+#
+# This script reads a file (see LOCAL_FILE) in your working directory
+# and patches the ConfigMap for the current or defined username.
+
+set -e
+
+REQUEST_USERNAME=${1:-"~"}
+LOCAL_FILE=${2:-"user-settings.yaml"}
+
+NAMESPACE="openshift-console-user-settings"
+RESOURCE="user-settings"
+
+USER_NAME=$(oc get "users.user.openshift.io/$REQUEST_USERNAME" -o 'template={{.metadata.name}}')
+USER_UID=$(oc get "users.user.openshift.io/$REQUEST_USERNAME" -o 'template={{.metadata.uid}}')
+
+if ! which yq > /dev/null; then
+    echo "yq cli not found, please checkout https://github.com/mikefarah/yq#install"
+    exit 1
+fi
+
+if [ "$USER_UID" != "<no value>" ]; then
+    RESOURCE="$RESOURCE-$USER_UID"
+elif [ "$USER_NAME" = "kube:admin" ]; then
+    RESOURCE="$RESOURCE-kubeadmin"
+else
+    echo "oc user need to be kube:admin or have a uid."
+    exit 1
+fi
+
+echo "Update ConfigMap \"$RESOURCE\" in namespace \"$NAMESPACE\" with content of \"$LOCAL_FILE\""
+
+yaml=$(cat "$LOCAL_FILE")
+
+oc patch -n "$NAMESPACE" configmaps "$RESOURCE" --patch "$yaml"


### PR DESCRIPTION
**Fixes**: 
~~https://issues.redhat.com/browse/ODC-4755~~ https://issues.redhat.com/browse/ODC-5189

Extracted this from PR #7327

**Analysis / Root cause**:
Based on the [User Settings for OpenShift Console enhancement proposal](https://github.com/openshift/enhancements/blob/master/enhancements/console/user-settings.md) we want to create a `ConfigMap` for each individual user in the namespace `openshift-console-user-settings`

Because we developers switches cluster more often then users, its could be helpful to extract the own user settings from a cluster and restore them on another cluster.

**Solution Description**: 
Created two small scripts to get and set user settings on a cluster.

Requirements:
* `oc` cli, https://github.com/openshift/oc
* `yq` cli, see https://github.com/mikefarah/yq#install

Usage:

```bash
./contrib/oc-get-user-settings.sh [username] [filename]

./contrib/oc-set-user-settings.sh [username] [filename]
```

Both commands can be called without any argument.

Default username is the current oc user (`oc whoami`)

Default filename is `user-settings.yaml`

**Test setup:**
* You need a 4.7 cluster with PRs #7095 and #7327
* `oc login`
* Use the browser to store some user settings (topology view graph switch for example)
* Call get and set scripts
