### PR TITLE
Bug 1903402: Added isVMPage boolean to choose correct links for Nics and Disks

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-inventory-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-inventory-card.tsx
@@ -30,16 +30,16 @@ import { getVmSnapshotVmName } from '../../../selectors/snapshot/snapshot';
 export const VMInventoryCard: React.FC<VMInventoryCardProps> = () => {
   const { t } = useTranslation();
   const vmDashboardContext = React.useContext(VMDashboardContext);
-  const { vm, vmi } = vmDashboardContext;
-  const vmiLike = vm || vmi;
+  const { vm, vmi, isVMPage } = vmDashboardContext;
+  const vmiLike = isVMPage ? vm : vmi;
 
   const isLoading = !vmiLike;
   const name = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
 
   // prefer vmi over vm if available (means: is running)
-  const nicCount = vm ? getNetworks(vm).length : getVMINetworks(vmi).length;
-  const disks = vm ? getDisks(vm) : getVMIDisks(vmi);
+  const nicCount = isVMPage ? getNetworks(vm).length : getVMINetworks(vmi).length;
+  const disks = isVMPage ? getDisks(vm) : getVMIDisks(vmi);
   const diskCount = disks.filter((d) => d?.disk).length;
   const cdromCount = disks.filter((d) => d?.cdrom).length;
   const lunCount = disks.filter((d) => d?.lun).length;

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard-context.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard-context.tsx
@@ -9,6 +9,6 @@ type VMDashboardContext = {
   vm?: VMKind;
   vmi?: VMIKind;
   pods?: PodKind[];
-
+  isVMPage?: boolean;
   vmStatusBundle?: VMStatusBundle;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
@@ -32,6 +32,7 @@ export const VMDashboard: React.FC<VMTabProps> = (props) => {
 
   const vm = asVM(objProp) || (isVM(vmProp) && vmProp);
   const vmi = (isVMI(objProp) && objProp) || vmisProp[0];
+  const isVMPage = isVM(objProp);
 
   const vmStatusBundle = getVMStatus({
     vm,
@@ -46,6 +47,7 @@ export const VMDashboard: React.FC<VMTabProps> = (props) => {
   const context = {
     vm,
     vmi,
+    isVMPage,
     pods,
     vmStatusBundle,
   };


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <matanschatzman@gmail.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1903402

**Analysis / Root cause**: 
There wasn't a way to tell if you are on VM page or VMI page, which in result VM page was always choose.

**Solution Description**: 
Added a boolean to check if you areo n VM or VMI page