### PR TITLE
Save dropdown bookmarks and favoriteKey in user settings

### DIFF
--- a/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
@@ -50,6 +50,7 @@ interface ResourceDropdownProps {
   title?: React.ReactNode;
   titlePrefix?: string;
   allApplicationsKey?: string;
+  userSettingsPrefix?: string;
   storageKey?: string;
   disabled?: boolean;
   allSelectorItem?: {
@@ -287,6 +288,7 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
         selectedKey={this.props.selectedKey}
         title={this.props.title || this.state.title}
         autocompletePlaceholder={this.props.placeholder}
+        userSettingsPrefix={this.props.userSettingsPrefix}
         storageKey={this.props.storageKey}
         disabled={this.props.disabled}
       />

--- a/frontend/packages/console-shared/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import ResourceDropdown from '../ResourceDropdown';
 import { mockDropdownData } from '../__mocks__/dropdown-data-mock';
 
@@ -11,6 +11,12 @@ jest.mock('react-i18next', () => {
       Component.defaultProps = { ...Component.defaultProps, t: (s) => s };
       return Component;
     },
+  };
+});
+
+jest.mock('@console/shared/src/hooks/useUserSettingsCompatibility', () => {
+  return {
+    useUserSettingsCompatibility: () => ['', () => {}],
   };
 });
 
@@ -141,7 +147,7 @@ describe('ResourceDropdown test suite', () => {
     const spy = jest.fn();
     const preventDefault = jest.fn();
     const stopPropagation = jest.fn();
-    const component = shallow(
+    const component = mount(
       componentFactory({ onChange: spy, selectedKey: 'app-group-1', id: 'dropdown1' }),
     );
     component.setProps({ resources: mockDropdownData, selectedKey: 'app-group-2' });
@@ -149,16 +155,13 @@ describe('ResourceDropdown test suite', () => {
       expect(spy).toHaveBeenCalledWith('app-group-2', 'app-group-2', mockDropdownData[0].data[1]);
     }, 0);
 
-    const dropdownComponent = component.find('Dropdown#dropdown1').shallow();
-    const dropdownBtn = dropdownComponent.find('button#dropdown1');
+    const dropdownBtn = component.find('button#dropdown1');
     dropdownBtn.simulate('click', { preventDefault });
 
-    const dropdownItem = dropdownComponent
-      .find('DropDownRow')
-      .last()
-      .shallow()
-      .find('#app-group-3-link');
+    const dropdownRows = component.find('DropDownRow');
+    const dropdownItem = dropdownRows.last().find('#app-group-3-link');
     dropdownItem.simulate('click', { preventDefault, stopPropagation });
+
     expect(component.state('title')).toEqual('app-group-3');
   });
 

--- a/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
@@ -331,7 +331,7 @@ export const DropdownField: React.FC<FieldProps> = ({
   uiSchema = {},
 }) => {
   const { t } = useTranslation();
-  const { items, title } = getUiOptions(uiSchema);
+  const { items, title } = getUiOptions(uiSchema) as { items?: object; title?: string };
   return (
     <Dropdown
       id={idSchema.$id}

--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -33,7 +33,9 @@ export const STORAGE_PREFIX = 'bridge';
 export const USERSETTINGS_PREFIX = 'console';
 
 // This localStorage key predates the storage prefix.
+export const NAMESPACE_USERSETTINGS_PREFIX = `${USERSETTINGS_PREFIX}.namespace`;
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
+export const APPLICATION_USERSETTINGS_PREFIX = `${USERSETTINGS_PREFIX}.applications`;
 export const APPLICATION_LOCAL_STORAGE_KEY = 'dropdown-storage-applications';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;

--- a/frontend/packages/topology/src/components/dropdowns/ApplicationDropdown.tsx
+++ b/frontend/packages/topology/src/components/dropdowns/ApplicationDropdown.tsx
@@ -15,6 +15,7 @@ interface ApplicationDropdownProps {
   title?: React.ReactNode;
   titlePrefix?: string;
   allApplicationsKey?: string;
+  userSettingsPrefix?: string;
   storageKey?: string;
   disabled?: boolean;
   allSelectorItem?: {

--- a/frontend/packages/topology/src/components/dropdowns/NamespaceBarApplicationSelector.tsx
+++ b/frontend/packages/topology/src/components/dropdowns/NamespaceBarApplicationSelector.tsx
@@ -5,6 +5,7 @@ import {
   ALL_NAMESPACES_KEY,
   ALL_APPLICATIONS_KEY,
   UNASSIGNED_APPLICATIONS_KEY,
+  APPLICATION_USERSETTINGS_PREFIX,
   APPLICATION_LOCAL_STORAGE_KEY,
 } from '@console/shared';
 import { setActiveApplication } from '@console/internal/actions/ui';
@@ -72,6 +73,7 @@ const NamespaceBarApplicationSelector: React.FC<Props> = ({
       }}
       selectedKey={application || ALL_APPLICATIONS_KEY}
       onChange={onApplicationChange}
+      userSettingsPrefix={APPLICATION_USERSETTINGS_PREFIX}
       storageKey={APPLICATION_LOCAL_STORAGE_KEY}
       disabled={disabled}
     />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -19,6 +19,7 @@ import {
   getDescription,
   ALL_NAMESPACES_KEY,
   KEYBOARD_SHORTCUTS,
+  NAMESPACE_USERSETTINGS_PREFIX,
   NAMESPACE_LOCAL_STORAGE_KEY,
   FLAGS,
   GreenCheckCircleIcon,
@@ -1038,8 +1039,6 @@ const RolesPage = ({ obj: { metadata } }) => (
 
 const autocompleteFilter = (text, item) => fuzzy(text, item);
 
-const defaultBookmarks = {};
-
 const namespaceBarDropdownStateToProps = (state) => {
   const activeNamespace = state.UI.get('activeNamespace');
   const canListNS = state[featureReducerName].get(FLAGS.CAN_LIST_NS);
@@ -1145,7 +1144,7 @@ class NamespaceBarDropdowns_ extends React.Component {
               ? t('dropdown~Select Project...')
               : t('dropdown~Select Namespace...')
           }
-          defaultBookmarks={defaultBookmarks}
+          userSettingsPrefix={NAMESPACE_USERSETTINGS_PREFIX}
           storageKey={NAMESPACE_LOCAL_STORAGE_KEY}
           shortCut={KEYBOARD_SHORTCUTS.focusNamespaceDropdown}
         />

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -664,7 +664,7 @@ export const AlternateServicesGroup: React.FC<AlternateServiceEntryGroupProps> =
           dropDownClassName="dropdown--full-width"
           id={`${index}-alt-service`}
           onChange={onServiceChange}
-          describedby={`${index}-alt-service-help`}
+          describedBy={`${index}-alt-service-help`}
         />
         <div className="help-block" id={`${index}-alt-service-help`}>
           <p>Alternate service to route to.</p>

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -562,13 +562,26 @@ export const Dropdown = (props) => {
     [setBookmarks],
   );
 
+  // FIXME: Remove this after latest namespace wasn't fetched from localStorage anymore.
+  const onFavorite = React.useCallback(
+    (key) => {
+      setFavoriteKey(key);
+      if (key) {
+        localStorage.setItem(favoriteStorageKey, key);
+      } else {
+        localStorage.removeItem(favoriteStorageKey);
+      }
+    },
+    [setFavoriteKey, favoriteStorageKey],
+  );
+
   return (
     <Dropdown_
       {...props}
       bookmarks={bookmarks}
       onBookmark={onBookmark}
       favoriteKey={favoriteKey}
-      onFavorite={setFavoriteKey}
+      onFavorite={onFavorite}
     />
   );
 };

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -196,7 +196,6 @@ class DropDownRow extends React.PureComponent {
   }
 }
 
-/** @augments {React.Component<any>} */
 class Dropdown_ extends DropdownMixin {
   constructor(props) {
     super(props);
@@ -600,6 +599,15 @@ Dropdown.propTypes = {
   textFilter: PropTypes.string,
   title: PropTypes.node,
   disabled: PropTypes.bool,
+  id: PropTypes.string,
+  onChange: PropTypes.func,
+  selectedKey: PropTypes.string,
+  titlePrefix: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  name: PropTypes.string,
+  autoSelect: PropTypes.bool,
+  describedBy: PropTypes.string,
+  required: PropTypes.bool,
 };
 
 class ActionsMenuDropdown_ extends DropdownMixin {

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -3,16 +3,18 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { useTranslation, withTranslation } from 'react-i18next';
 import { CaretDownIcon, MinusCircleIcon, PlusCircleIcon, StarIcon } from '@patternfly/react-icons';
+import { useUserSettingsCompatibility } from '@console/shared';
+
 import { impersonateStateToProps } from '../../reducers/ui';
 import { checkAccess } from './rbac';
 import { history } from './router';
 import { KebabItems } from './kebab';
 import { ResourceName } from './resource-icon';
 import { useSafetyFirst } from '../safety-first';
-import { useTranslation, withTranslation } from 'react-i18next';
 
-export class DropdownMixin extends React.PureComponent {
+class DropdownMixin extends React.PureComponent {
   constructor(props) {
     super(props);
     this.listener = this._onWindowClick.bind(this);
@@ -109,20 +111,20 @@ class DropDownRow extends React.PureComponent {
       itemKey,
       content,
       onclick,
-      onBookmark,
-      onUnBookmark,
       className,
       selected,
       hover,
+      autocompleteFilter,
+      isBookmarked,
+      onBookmark,
+      favoriteKey,
       canFavorite,
       onFavorite,
-      favoriteKey,
-      autocompleteFilter,
     } = this.props;
 
     let prefix;
 
-    if (!autocompleteFilter && !onBookmark && !onUnBookmark) {
+    if (!autocompleteFilter && !onBookmark) {
       //use pf4 markup if not using the autocomplete dropdown
       return (
         <li key={itemKey}>
@@ -138,37 +140,34 @@ class DropDownRow extends React.PureComponent {
         </li>
       );
     }
-    if (onUnBookmark) {
-      prefix = (
-        <a
-          href="#"
-          className={classNames('bookmarker', { hover, focus: selected })}
-          onClick={(e) => onUnBookmark(e, itemKey)}
-        >
-          <MinusCircleIcon />
-        </a>
-      );
-    }
     if (onBookmark) {
       prefix = (
         <a
           href="#"
           className={classNames('bookmarker', { hover, focus: selected })}
-          onClick={(e) => onBookmark(e, itemKey, content)}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onBookmark(itemKey, !isBookmarked);
+          }}
         >
-          <PlusCircleIcon />
+          {isBookmarked ? <MinusCircleIcon /> : <PlusCircleIcon />}
         </a>
       );
     }
 
     let suffix;
-    if (onUnBookmark && canFavorite) {
+    if (isBookmarked && canFavorite) {
       const isFavorite = favoriteKey === itemKey;
       suffix = (
         <a
           href="#"
           className={classNames('bookmarker', { hover, focus: selected })}
-          onClick={(e) => onFavorite(e, isFavorite ? undefined : itemKey)}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onFavorite(isFavorite ? null : itemKey);
+          }}
         >
           <StarIcon className={classNames({ favorite: isFavorite })} />
         </a>
@@ -198,36 +197,12 @@ class DropDownRow extends React.PureComponent {
 }
 
 /** @augments {React.Component<any>} */
-export class Dropdown extends DropdownMixin {
+class Dropdown_ extends DropdownMixin {
   constructor(props) {
     super(props);
-    this.onUnBookmark = (...args) => this.onUnBookmark_(...args);
-    this.onBookmark = (...args) => this.onBookmark_(...args);
-    this.onFavorite = (...args) => this.onFavorite_(...args);
     this.onClick = (...args) => this.onClick_(...args);
 
-    let bookmarks = props.defaultBookmarks || {};
-    let favoriteKey;
-    if (props.storageKey) {
-      try {
-        const parsedBookmarks = JSON.parse(localStorage.getItem(this.bookmarkStorageKey));
-        if (_.isPlainObject(parsedBookmarks)) {
-          bookmarks = parsedBookmarks;
-        }
-        const parsedFavorite = localStorage.getItem(props.storageKey);
-        if (props.canFavorite && _.isString(parsedFavorite)) {
-          favoriteKey = parsedFavorite;
-        }
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn(`could not load bookmarks for ${props.storageKey}: ${e}`);
-      }
-    }
-    this.state.favoriteKey = favoriteKey;
-    this.state.bookmarks = bookmarks;
-
-    this.state.items = Object.assign({}, bookmarks, props.items);
-
+    this.state.items = props.items;
     this.state.title = props.noSelection
       ? props.title
       : _.get(props.items, props.selectedKey, props.title);
@@ -260,10 +235,6 @@ export class Dropdown extends DropdownMixin {
       e.preventDefault();
       this.show(e);
     };
-  }
-
-  get bookmarkStorageKey() {
-    return `${this.props.storageKey}-bookmarks`;
   }
 
   componentDidMount() {
@@ -299,7 +270,6 @@ export class Dropdown extends DropdownMixin {
 
   applyTextFilter_(autocompleteText, items) {
     const { autocompleteFilter } = this.props;
-    items = Object.assign({}, this.state.bookmarks, items);
     if (autocompleteFilter && !_.isEmpty(autocompleteText)) {
       items = _.pickBy(items, (item, key) => autocompleteFilter(autocompleteText, item, key));
     }
@@ -313,7 +283,8 @@ export class Dropdown extends DropdownMixin {
       return;
     }
 
-    const { items, keyboardHoverKey } = this.state;
+    const { keyboardHoverKey } = this.state;
+    const { items } = this.props;
 
     if (key === 'Enter') {
       if (this.state.active && items[keyboardHoverKey]) {
@@ -345,38 +316,6 @@ export class Dropdown extends DropdownMixin {
     e.stopPropagation();
   }
 
-  onFavorite_(e, favoriteKey) {
-    e.preventDefault();
-    e.stopPropagation();
-    this.setState({ favoriteKey });
-    if (favoriteKey) {
-      localStorage.setItem(this.props.storageKey, favoriteKey);
-    } else {
-      // do not set `undefined` as a value in localstorage
-      localStorage.removeItem(this.props.storageKey, favoriteKey);
-    }
-  }
-
-  onBookmark_(e, key, value) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const bookmarks = Object.assign({}, this.state.bookmarks);
-    bookmarks[key] = value;
-    this.setState({ bookmarks });
-    localStorage.setItem(this.bookmarkStorageKey, JSON.stringify(bookmarks));
-  }
-
-  onUnBookmark_(e, key) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const bookmarks = Object.assign({}, this.state.bookmarks);
-    delete bookmarks[key];
-    this.setState({ bookmarks });
-    localStorage.setItem(this.bookmarkStorageKey, JSON.stringify(bookmarks));
-  }
-
   renderActionItem() {
     const { actionItems } = this.props;
     if (actionItems) {
@@ -402,17 +341,9 @@ export class Dropdown extends DropdownMixin {
     }
     return null;
   }
+
   render() {
-    const {
-      active,
-      autocompleteText,
-      selectedKey,
-      items,
-      title,
-      bookmarks,
-      keyboardHoverKey,
-      favoriteKey,
-    } = this.state;
+    const { active, autocompleteText, selectedKey, items, title, keyboardHoverKey } = this.state;
     const {
       ariaLabel,
       autocompleteFilter,
@@ -421,11 +352,15 @@ export class Dropdown extends DropdownMixin {
       buttonClassName,
       menuClassName,
       storageKey,
-      canFavorite,
       dropDownClassName,
       titlePrefix,
       describedBy,
       disabled,
+      bookmarks,
+      onBookmark,
+      favoriteKey,
+      canFavorite,
+      onFavorite,
     } = this.props;
     const spacerBefore = this.props.spacerBefore || new Set();
     const headerBefore = this.props.headerBefore || {};
@@ -443,13 +378,14 @@ export class Dropdown extends DropdownMixin {
             key={key}
             itemKey={key}
             content={content}
-            onUnBookmark={this.onUnBookmark}
             onclick={this.onClick}
             selected={selected}
             hover={hover}
-            canFavorite={canFavorite}
-            onFavorite={this.onFavorite}
+            isBookmarked
+            onBookmark={onBookmark}
             favoriteKey={favoriteKey}
+            canFavorite={canFavorite}
+            onFavorite={onFavorite}
           />,
         );
         return;
@@ -475,7 +411,7 @@ export class Dropdown extends DropdownMixin {
           key={key}
           itemKey={key}
           content={content}
-          onBookmark={storageKey && this.onBookmark}
+          onBookmark={storageKey && onBookmark}
           onclick={this.onClick}
           selected={selected}
           hover={hover}
@@ -600,6 +536,46 @@ export class Dropdown extends DropdownMixin {
   }
 }
 
+export const Dropdown = (props) => {
+  const { userSettingsPrefix, storageKey } = props;
+
+  // Should be undefined so that we don't save undefined-xxx.
+  const favoriteUserSettingsKey = userSettingsPrefix ? `${userSettingsPrefix}.favorite` : undefined;
+  const favoriteStorageKey = storageKey ? storageKey : undefined;
+  const bookmarkUserSettingsKey = userSettingsPrefix
+    ? `${userSettingsPrefix}.bookmarks`
+    : undefined;
+  const bookmarkStorageKey = storageKey ? `${storageKey}-bookmarks` : undefined;
+
+  const [favoriteKey, setFavoriteKey] = useUserSettingsCompatibility(
+    favoriteUserSettingsKey,
+    favoriteStorageKey,
+  );
+  const [bookmarks, setBookmarks] = useUserSettingsCompatibility(
+    bookmarkUserSettingsKey,
+    bookmarkStorageKey,
+  );
+
+  const onBookmark = React.useCallback(
+    (key, active) => {
+      setBookmarks((oldBookmarks) => ({ ...oldBookmarks, [key]: active ? true : undefined }));
+    },
+    [setBookmarks],
+  );
+
+  return (
+    <Dropdown_
+      {...props}
+      bookmarks={bookmarks}
+      onBookmark={onBookmark}
+      favoriteKey={favoriteKey}
+      onFavorite={setFavoriteKey}
+    />
+  );
+};
+
+Dropdown.displayName = 'Dropdown';
+
 Dropdown.propTypes = {
   actionItems: PropTypes.arrayOf(
     PropTypes.shape({
@@ -611,7 +587,6 @@ Dropdown.propTypes = {
   autocompletePlaceholder: PropTypes.string,
   canFavorite: PropTypes.bool,
   className: PropTypes.string,
-  defaultBookmarks: PropTypes.objectOf(PropTypes.string),
   dropDownClassName: PropTypes.string,
   enableBookmarks: PropTypes.bool,
   headerBefore: PropTypes.objectOf(PropTypes.string),
@@ -619,6 +594,7 @@ Dropdown.propTypes = {
   menuClassName: PropTypes.string,
   buttonClassName: PropTypes.string,
   noSelection: PropTypes.bool,
+  userSettingsPrefix: PropTypes.string,
   storageKey: PropTypes.string,
   spacerBefore: PropTypes.instanceOf(Set),
   textFilter: PropTypes.string,
@@ -697,6 +673,7 @@ const ActionsMenu_ = ({ actions, impersonate, title = undefined }) => {
   }, [actions, impersonate, setVisible]);
   return isVisible ? <ActionsMenuDropdown actions={actions} title={title} /> : null;
 };
+
 export const ActionsMenu = connect(impersonateStateToProps)(ActionsMenu_);
 
 ActionsMenu.propTypes = {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5198

**Analysis / Root cause**: 
As a user, I want sync my bookmarks for namespaces, applications and other dropdowns between browsers.

**Solution Description**: 
Update Dropdown component to use `useUserSettings` hook and save `booksmarks` and `favoriteKey` in user settings.

**Screen shots / Gifs for design review**: 
From user perspective nothing has changed. This video shows the migration and update of the configmap:
![Peek 2020-12-02 14-20](https://user-images.githubusercontent.com/139310/100877859-ab1f3a80-34a9-11eb-9992-ab0f40ffd1f0.gif)

**Unit test coverage report**: 
Untouched

**Test setup:**
Open developer perspective and bookmark / unbookmark / favorite namespaces and applications.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge