### PR TITLE
Bug 1902595: Fix to show alerts in topology list view

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -9,6 +9,7 @@ export * from './select-list';
 export * from './useBuildConfigsWatcher';
 export * from './useJobsForCronJobWatcher';
 export * from './usePodsWatcher';
+export * from './useReplicationControllersWatcher';
 export * from './useRoutesWatcher';
 export * from './useServicesWatcher';
 export * from './useQueryParams';

--- a/frontend/packages/console-shared/src/hooks/useReplicationControllersWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/useReplicationControllersWatcher.ts
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { getReplicationControllersForResource } from '../utils';
+import { PodControllerOverviewItem } from '../types';
+
+export const useReplicationControllersWatcher = (
+  resource: K8sResourceKind,
+): {
+  loaded: boolean;
+  loadError: string;
+  mostRecentRC: K8sResourceKind;
+  visibleReplicationControllers: PodControllerOverviewItem[];
+} => {
+  const { namespace } = resource.metadata;
+  const watchedResources = React.useMemo(
+    () => ({
+      replicationControllers: {
+        isList: true,
+        kind: 'ReplicationController',
+        namespace,
+      },
+      pods: {
+        isList: true,
+        kind: 'Pod',
+        namespace,
+      },
+    }),
+    [namespace],
+  );
+  const resources = useK8sWatchResources(watchedResources);
+
+  const { loaded, loadError, mostRecentRC, visibleReplicationControllers } = React.useMemo(() => {
+    const resourcesLoaded =
+      Object.keys(resources).length > 0 &&
+      Object.keys(resources).every((key) => resources[key].loaded);
+    const resourceWithLoadError = Object.values(resources).find((r) => r.loadError);
+    if (!resourcesLoaded || resourceWithLoadError) {
+      return {
+        loaded: resourcesLoaded,
+        loadError: resourceWithLoadError ? resourceWithLoadError.loadError : null,
+        mostRecentRC: null,
+        visibleReplicationControllers: [],
+      };
+    }
+
+    return {
+      loaded: true,
+      loadError: null,
+      ...getReplicationControllersForResource(resource, resources),
+    };
+  }, [resources, resource]);
+
+  return { loaded, loadError, mostRecentRC, visibleReplicationControllers };
+};


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1902595

**Analysis / Root cause**: 
Refactor effort removed alerts from topology data object. List view was not updated to then fetch the necessary items to determined the alerts for resources.

**Solution Description**: 
Fetch the necessary resources and determine the alerts that should be displayed for resources.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge