### PR TITLE
Bug 1897354:  make CRDCard display consistent with tabs

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -753,9 +753,6 @@ const crdCardRowStateToProps = ({ k8s }, { crdDescs }) => {
     crdDescs.map((desc) => k8s.getIn(['RESOURCES', 'models', referenceForProvidedAPI(desc)])),
   );
   return {
-    crdDescs: crdDescs.filter((desc) =>
-      models.find((m) => referenceForModel(m) === referenceForProvidedAPI(desc)),
-    ),
     createable: models
       .filter((m) => (m.verbs || []).includes('create'))
       .map((m) => referenceForModel(m)),


### PR DESCRIPTION
We were filtering out CRDs from the Provided API cards list if the model for the CRD didn't exist; this created a discrepancy between what the cards listed and what the tabs listed.  This aligns the cards with the tabs, and both now reflect what's in the CSV YAML.

Reproducer:

add a fake `spec.customresourcedefinitions.owned` to the CSV.  

```
spec:
  customresourcedefinitions:
    owned:
      - description: Foo is the Schema for the jaegers API
        displayName: Foo
        kind: Foo
        name: foo.jaegertracing.io
        version: v1
```

Before:
<img width="791" alt="Screen Shot 2020-12-03 at 5 18 25 PM" src="https://user-images.githubusercontent.com/895728/101095208-99ae5f00-358b-11eb-898c-c36a7604c26a.png">

After:
<img width="782" alt="Screen Shot 2020-12-03 at 5 17 54 PM" src="https://user-images.githubusercontent.com/895728/101095226-a03cd680-358b-11eb-8500-c321d9190627.png">
