### PR TITLE
Bug 1901531: Fix runtime error in create CR form

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
@@ -3,7 +3,7 @@ import * as classnames from 'classnames';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { JSONSchema6 } from 'json-schema';
-import { getUiOptions } from 'react-jsonschema-form/lib/utils';
+import { getUiOptions, getSchemaType } from 'react-jsonschema-form/lib/utils';
 import { FieldProps, UiSchema } from 'react-jsonschema-form';
 import SchemaField, {
   SchemaFieldProps,
@@ -21,6 +21,7 @@ import {
   PodAffinity,
 } from '@console/operator-lifecycle-manager/src/components/descriptors/spec/affinity';
 import { hasNoFields, useSchemaDescription, useSchemaLabel } from './utils';
+import { JSONSchemaType } from './types';
 
 const Description = ({ id, description }) =>
   description ? (
@@ -344,11 +345,31 @@ export const DropdownField: React.FC<FieldProps> = ({
 };
 
 export const CustomSchemaField: React.FC<SchemaFieldProps> = (props) => {
+  // TODO Remove this workaround when the issue has been fixed upstream in react-jsonschema-form and
+  // we bump our version to include that fix.
+  // Provide a fallback formData value for objects and arrays to prevent undefined
+  // references. This can occur if formData is malformed (for example, almExamples annotation
+  // explicitly sets an array value to null). This is an edge case that should be handled in the
+  // react-jsonschema-form package. An issue and fix have been opened upstream:
+  // Issue filed in @rjsf/core repo: https://github.com/rjsf-team/react-jsonschema-form/issues/2153
+  // PR opened for fix: https://github.com/rjsf-team/react-jsonschema-form/pull/2154
+  const type = getSchemaType(props.schema);
+  const fallbackFormData = React.useMemo(() => {
+    switch (type) {
+      case JSONSchemaType.array:
+        return [];
+      case JSONSchemaType.object:
+        return {};
+      default:
+        return undefined;
+    }
+  }, [type]);
+
   // If a the provided schema will not generate any form field elements, return null.
   if (hasNoFields(props.schema, props.uiSchema)) {
     return null;
   }
-  return <SchemaField {...props} />;
+  return <SchemaField {...props} formData={props.formData ?? fallbackFormData} />;
 };
 
 export const NullField = () => null;


### PR DESCRIPTION
In some cases, an uncaught exception could be thrown from dynamically generated array form fields.
This was happening when a nested array field had an explicitly set 'null' value. This is a
workaround that adds a fallback value to object and array fields to prevent this runtime error. An
issue and fix have also been opened upstream in the react-jsonschema-form repo.
https://github.com/rjsf-team/react-jsonschema-form/issues/2153
https://github.com/rjsf-team/react-jsonschema-form/pull/2154