### PR TITLE
remove vm templates from template catalog

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
@@ -31,6 +31,13 @@ namespace ExtensionProperties {
         items provided by other providers. */
     priority?: number;
   }
+
+  export interface CatalogItemFilter {
+    /** Type ID for the catalog item type. */
+    type: string;
+    /** Filters items of a specific type. Value is a function that takes CatalogItem[] and returns a subset based on the filter criteria. */
+    filter: CodeRef<<T extends CatalogItem[]>(items: T) => T>;
+  }
 }
 
 export interface DevCatalogModel extends Extension<ExtensionProperties.DevCatalogModel> {
@@ -45,6 +52,10 @@ export interface CatalogItemProvider extends Extension<ExtensionProperties.Catal
   type: 'Catalog/ItemProvider';
 }
 
+export interface CatalogItemFilter extends Extension<ExtensionProperties.CatalogItemFilter> {
+  type: 'Catalog/ItemFilter';
+}
+
 export const isDevCatalogModel = (e: Extension): e is DevCatalogModel => {
   return e.type === 'DevCatalogModel';
 };
@@ -57,6 +68,10 @@ export const isCatalogItemProvider = (e: Extension): e is CatalogItemProvider =>
   return e.type === 'Catalog/ItemProvider';
 };
 
+export const isCatalogItemFilter = (e: Extension): e is CatalogItemFilter => {
+  return e.type === 'Catalog/ItemFilter';
+};
+
 export type CatalogExtensionHookResult<T> = [T, boolean, any];
 
 export type CatalogExtensionHookOptions = {
@@ -67,7 +82,7 @@ export type CatalogExtensionHook<T> = (
   options: CatalogExtensionHookOptions,
 ) => CatalogExtensionHookResult<T>;
 
-export type CatalogItem = {
+export type CatalogItem<T extends any = any> = {
   uid: string;
   type: string;
   name: string;
@@ -95,6 +110,10 @@ export type CatalogItem = {
     properties?: CatalogItemDetailsProperty[];
     descriptions?: CatalogItemDetailsDescription[];
   };
+  // Optional data attached by the provider.
+  // May be consumed by filters.
+  // `data` for each `type` of CatalogItem should implement the same interface.
+  data?: T;
 };
 
 export type CatalogItemDetailsProperty = {

--- a/frontend/packages/dev-console/src/components/catalog/hooks/useCatalogExtensions.ts
+++ b/frontend/packages/dev-console/src/components/catalog/hooks/useCatalogExtensions.ts
@@ -1,8 +1,10 @@
 import {
   CatalogItemProvider,
   CatalogItemType,
+  CatalogItemFilter,
   isCatalogItemProvider,
   isCatalogItemType,
+  isCatalogItemFilter,
 } from '@console/plugin-sdk';
 import {
   ResolvedExtension,
@@ -11,12 +13,21 @@ import {
 
 const useCatalogExtensions = (
   catalogType: string,
-): [ResolvedExtension<CatalogItemType>[], ResolvedExtension<CatalogItemProvider>[], boolean] => {
+): [
+  ResolvedExtension<CatalogItemType>[],
+  ResolvedExtension<CatalogItemProvider>[],
+  ResolvedExtension<CatalogItemFilter>[],
+  boolean,
+] => {
   const [itemTypeExtensions, typesResolved] = useResolvedExtensions<CatalogItemType>(
     isCatalogItemType,
   );
   const [itemProviderExtensions, providersResolved] = useResolvedExtensions<CatalogItemProvider>(
     isCatalogItemProvider,
+  );
+
+  const [itemFilterExtensions, filtersResolved] = useResolvedExtensions<CatalogItemFilter>(
+    isCatalogItemFilter,
   );
 
   const catalogTypeExtensions = catalogType
@@ -33,7 +44,16 @@ const useCatalogExtensions = (
     return p1 - p2;
   });
 
-  return [catalogTypeExtensions, catalogProviderExtensions, typesResolved && providersResolved];
+  const catalogFilterExtensions = catalogType
+    ? itemFilterExtensions.filter((e) => e.properties.type === catalogType)
+    : itemFilterExtensions;
+
+  return [
+    catalogTypeExtensions,
+    catalogProviderExtensions,
+    catalogFilterExtensions,
+    typesResolved && providersResolved && filtersResolved,
+  ];
 };
 
 export default useCatalogExtensions;

--- a/frontend/packages/dev-console/src/components/catalog/providers/useTemplates.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useTemplates.tsx
@@ -3,11 +3,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import { CatalogExtensionHook, CatalogItem } from '@console/plugin-sdk';
-import {
-  k8sListPartialMetadata,
-  PartialObjectMetadata,
-  TemplateKind,
-} from '@console/internal/module/k8s';
+import { k8sListPartialMetadata, PartialObjectMetadata } from '@console/internal/module/k8s';
 import { TemplateModel } from '@console/internal/models';
 import { ANNOTATIONS, APIError } from '@console/shared';
 import {
@@ -16,11 +12,11 @@ import {
 } from '@console/internal/components/catalog/catalog-item-icon';
 
 const normalizeTemplates = (
-  templates: (TemplateKind | PartialObjectMetadata)[],
+  templates: PartialObjectMetadata[],
   activeNamespace: string = '',
   t: TFunction,
-): CatalogItem[] => {
-  const normalizedTemplates: CatalogItem[] = _.reduce(
+): CatalogItem<PartialObjectMetadata>[] => {
+  const normalizedTemplates: CatalogItem<PartialObjectMetadata>[] = _.reduce(
     templates,
     (acc, template) => {
       const { uid, name, namespace, annotations = {}, creationTimestamp } = template.metadata;
@@ -39,7 +35,7 @@ const normalizeTemplates = (
       const documentationUrl = annotations[ANNOTATIONS.documentationURL];
       const supportUrl = annotations[ANNOTATIONS.supportURL];
 
-      const normalizedTemplate: CatalogItem = {
+      const normalizedTemplate: CatalogItem<PartialObjectMetadata> = {
         uid,
         type: 'Template',
         name: displayName,
@@ -57,6 +53,7 @@ const normalizeTemplates = (
           label: t('devconsole~Instantiate Template'),
           href: `/catalog/instantiate-template?template=${name}&template-ns=${namespace}&preselected-ns=${activeNamespace}`,
         },
+        data: template,
       };
 
       acc.push(normalizedTemplate);
@@ -69,15 +66,15 @@ const normalizeTemplates = (
   return normalizedTemplates;
 };
 
-const useTemplates: CatalogExtensionHook<CatalogItem[]> = ({
+const useTemplates: CatalogExtensionHook<CatalogItem<PartialObjectMetadata>[]> = ({
   namespace,
 }): [CatalogItem[], boolean, any] => {
   const { t } = useTranslation();
-  const [templates, setTemplates] = React.useState<TemplateKind[]>([]);
+  const [templates, setTemplates] = React.useState<PartialObjectMetadata[]>([]);
   const [templatesLoaded, setTemplatesLoaded] = React.useState<boolean>(false);
   const [templatesError, setTemplatesError] = React.useState<APIError>();
 
-  const [projectTemplates, setProjectTemplates] = React.useState<TemplateKind[]>([]);
+  const [projectTemplates, setProjectTemplates] = React.useState<PartialObjectMetadata[]>([]);
   const [projectTemplatesLoaded, setProjectTemplatesLoaded] = React.useState<boolean>(false);
   const [projectTemplatesError, setProjectTemplatesError] = React.useState<APIError>();
 

--- a/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -31,6 +31,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
   const [
     catalogTypeExtensions,
     catalogProviderExtensions,
+    catalogFilterExtensions,
     extensionsResolved,
   ] = useCatalogExtensions(catalogType);
 
@@ -46,16 +47,20 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
     if (!loaded) {
       return [];
     }
-    const itemMap = _.flatten(catalogProviderExtensions.map((e) => extItemsMap[e.uid])).reduce(
-      (acc, item) => {
-        acc[item.uid] = item;
-        return acc;
-      },
-      {} as { [uid: string]: CatalogItem },
-    );
+
+    const itemMap = _.flatten(
+      catalogProviderExtensions.map((e) =>
+        catalogFilterExtensions
+          .filter((fe) => fe.properties.type === e.properties.type)
+          .reduce((acc, ext) => ext.properties.filter(acc), extItemsMap[e.uid]),
+      ),
+    ).reduce((acc, item) => {
+      acc[item.uid] = item;
+      return acc;
+    }, {} as { [uid: string]: CatalogItem });
 
     return _.sortBy(Object.values(itemMap), 'name');
-  }, [extItemsMap, loaded, catalogProviderExtensions]);
+  }, [extItemsMap, loaded, catalogProviderExtensions, catalogFilterExtensions]);
 
   const onValueResolved = React.useCallback((items, uid) => {
     setExtItemsMap((prev) => ({ ...prev, [uid]: items }));

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/dev-console/dev-catalog-vm-templates-filter.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/dev-console/dev-catalog-vm-templates-filter.ts
@@ -1,0 +1,12 @@
+import { PartialObjectMetadata } from '@console/internal/module/k8s';
+import { CatalogItem } from '@console/plugin-sdk';
+import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_VM, TEMPLATE_TYPE_LABEL } from '../../../constants';
+
+// removes all Templates identified as VM templates
+const filter = (items: CatalogItem<PartialObjectMetadata>[]) =>
+  items.filter((item) => {
+    const vmTemplateLabel = item.data?.metadata?.labels?.[TEMPLATE_TYPE_LABEL];
+    return vmTemplateLabel !== TEMPLATE_TYPE_VM && vmTemplateLabel !== TEMPLATE_TYPE_BASE;
+  });
+
+export default filter;

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -24,6 +24,7 @@ import {
   PVCDelete,
   CatalogItemProvider,
   CatalogItemType,
+  CatalogItemFilter,
 } from '@console/plugin-sdk';
 import { DashboardsStorageCapacityDropdownItem } from '@console/ceph-storage-plugin';
 import { TemplateModel, PodModel, PersistentVolumeClaimModel } from '@console/internal/models';
@@ -72,7 +73,8 @@ type ConsumedExtensions =
   | PVCDelete
   | AddAction
   | CatalogItemProvider
-  | CatalogItemType;
+  | CatalogItemType
+  | CatalogItemFilter;
 
 export const FLAG_KUBEVIRT = 'KUBEVIRT';
 
@@ -583,6 +585,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [FLAG_KUBEVIRT],
+    },
+  },
+
+  {
+    type: 'Catalog/ItemFilter',
+    properties: {
+      type: 'Template',
+      filter: getExecutableCodeRef(() =>
+        import(
+          './components/create-vm/dev-console/dev-catalog-vm-templates-filter' /* webpackChunkName: "kubevirt" */
+        ).then((m) => m.default),
+      ),
     },
   },
 ];


### PR DESCRIPTION
**Fixes**: 
fixes https://issues.redhat.com/browse/ODC-5197

**Analysis / Root cause**: 
VM templates were showing up in the standalone Templates catalog but not in the general dev catalog.

**Solution Description**: 
Add catalog filter extension allowing kubevirt plugin to filter out all Templates which have a label identifying them as vm templates.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

- install OpenShift Virtualization operator
- configure operator
- create VM template (creation via yaml is easiest)
- go to dev catalog and search for the vm template
- perform the same search in the Template and VM Template catalogs

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

cc @rohitkrai03 