### PR TITLE
Query Browser: Redesign tooltips and add stacked graph option

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
-import { QueryBrowser, QueryObj } from '@console/internal/components/monitoring/query-browser';
+import { QueryBrowser } from '@console/internal/components/monitoring/query-browser';
 import { Humanize } from '@console/internal/components/utils';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { PrometheusGraphLink } from '@console/internal/components/graphs/prometheus-graph';
-import { queryBrowserPatchQuery } from '@console/internal/actions/ui';
 import './MonitoringDashboardGraph.scss';
 
 export enum GraphTypes {
@@ -16,11 +14,7 @@ export enum GraphTypes {
   line = 'Line',
 }
 
-type DispatchProps = {
-  patchQuery: (patch: QueryObj) => void;
-};
-
-type OwnProps = {
+type MonitoringDashboardGraphProps = {
   title: string;
   query: string;
   namespace: string;
@@ -31,8 +25,6 @@ type OwnProps = {
   pollInterval?: number;
 };
 
-type MonitoringDashboardGraphProps = OwnProps & DispatchProps;
-
 const DEFAULT_TIME_SPAN = 30 * 60 * 1000;
 const DEFAULT_SAMPLES = 30;
 
@@ -40,7 +32,6 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
   query,
   namespace,
   title,
-  patchQuery,
   graphType = GraphTypes.area,
   timespan,
   pollInterval,
@@ -52,30 +43,21 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
       </DashboardCardHeader>
       <DashboardCardBody>
         <PrometheusGraphLink query={query}>
-          <div onMouseEnter={() => patchQuery({ query })}>
-            <QueryBrowser
-              hideControls
-              defaultTimespan={DEFAULT_TIME_SPAN}
-              defaultSamples={DEFAULT_SAMPLES}
-              namespace={namespace}
-              queries={[query]}
-              isStack={graphType === GraphTypes.area}
-              timespan={timespan}
-              pollInterval={pollInterval}
-              formatLegendLabel={(labels) => labels.pod}
-            />
-          </div>
+          <QueryBrowser
+            hideControls
+            defaultTimespan={DEFAULT_TIME_SPAN}
+            defaultSamples={DEFAULT_SAMPLES}
+            namespace={namespace}
+            queries={[query]}
+            isStack={graphType === GraphTypes.area}
+            timespan={timespan}
+            pollInterval={pollInterval}
+            formatLegendLabel={(labels) => labels.pod}
+          />
         </PrometheusGraphLink>
       </DashboardCardBody>
     </DashboardCard>
   );
 };
 
-const mapDispatchToProps = (dispatch): DispatchProps => ({
-  patchQuery: (v: QueryObj) => dispatch(queryBrowserPatchQuery(0, v)),
-});
-
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mapDispatchToProps,
-)(MonitoringDashboardGraph);
+export default MonitoringDashboardGraph;

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
@@ -20,7 +20,6 @@ describe('Monitoring Dashboard graph', () => {
       query: query.query({ namespace: 'test-project' }),
       humanize: query.humanize,
       byteDataType: query.byteDataType,
-      patchQuery: jest.fn(),
       timespan: 1800000,
       pollInterval: 30000,
     };

--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsChart.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsChart.tsx
@@ -50,6 +50,7 @@ export const MetricsChart: React.FC<MetricsChartProps> = ({ deleteAll, queries, 
         disabledSeries={disabledSeries}
         namespace={namespace}
         queries={queryStrings}
+        showStackedControl
       />
       <QueryTable index={0} namespace={namespace} />
     </div>

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -58,18 +58,6 @@ $tooltip-background-color: #151515;
     }
   }
 
-  // Move tooltip above cursor to work around bug where the legend is visible through the tooltip
-  .query-browser__tooltip-arrow {
-    border-bottom: none;
-    border-top: 12px solid $tooltip-background-color;
-  }
-  .query-browser__tooltip-svg-wrap {
-    transform: translate(0, -500px);
-  }
-  .query-browser__tooltip-wrap {
-    flex-direction: column-reverse;
-  }
-
   .query-browser__wrapper {
     border: 0;
     margin: 0;
@@ -294,6 +282,10 @@ $monitoring-line-height: 18px;
   justify-content: space-between;
   margin-bottom: 15px;
   width: 100%;
+
+  .pf-c-check__input {
+    margin-top: 0;
+  }
 }
 
 .query-browser__controls--left {
@@ -318,10 +310,6 @@ $monitoring-line-height: 18px;
 .query-browser__expand-icon {
   font-size: 30px;
   vertical-align: middle;
-}
-
-.query-browser__graph-container {
-  z-index: 1;
 }
 
 .query-browser__inline-control {
@@ -448,14 +436,13 @@ $monitoring-line-height: 18px;
   color: #eee;
   font-size: 12px;
   overflow-y: auto;
-  padding: 15px;
-  width: 100%;
+  padding: 10px;
 }
 
 .query-browser__tooltip-arrow {
-  border-bottom: 12px solid $tooltip-background-color;
-  border-left: 12px solid transparent;
-  border-right: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  border-right: 12px solid $tooltip-background-color;
+  border-top: 12px solid transparent;
   height: 0;
   width: 0;
 }
@@ -463,30 +450,42 @@ $monitoring-line-height: 18px;
 .query-browser__tooltip-group {
   align-items: stretch;
   display: flex;
-  margin-bottom: 15px;
+
+  .query-browser__series-btn {
+    flex: 0 0 12px;
+    height: 12px;
+    margin-top: 4px;
+    margin-right: 3px;
+  }
 }
 
-.query-browser__tooltip-label-key {
+.query-browser__tooltip-line {
+  stroke: $tooltip-background-color;
+}
+
+.query-browser__tooltip-time {
   font-weight: var(--pf-global--FontWeight--bold);
-  text-transform: uppercase;
 }
 
-.query-browser__tooltip-time,
 .query-browser__tooltip-value {
+  font-weight: var(--pf-global--FontWeight--bold);
   margin-left: auto;
-  padding-left: 15px;
-}
-
-.query-browser__tooltip-value {
-  font-weight: var(--pf-global--FontWeight--bold);
+  padding-left: 10px;
 }
 
 .query-browser__tooltip-wrap {
   align-items: center;
   display: flex;
-  flex-direction: column;
   height: 100%;
-  width: 100%;
+
+  &--left {
+    flex-direction: row-reverse;
+
+    .query-browser__tooltip-arrow {
+      border-left: 12px solid $tooltip-background-color;
+      border-right: none;
+    }
+  }
 }
 
 .query-browser__wrapper {

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -51,7 +51,7 @@ import { AlertmanagerYAMLEditorWrapper } from '../monitoring/alert-manager-yaml-
 import { AlertmanagerConfigWrapper } from '../monitoring/alert-manager-config';
 import MonitoringDashboardsPage from '../monitoring/dashboards';
 import { QueryBrowserPage, ToggleGraph } from '../monitoring/metrics';
-import { FormatLegendLabel, QueryBrowser, QueryObj } from '../monitoring/query-browser';
+import { FormatLegendLabel, QueryBrowser } from '../monitoring/query-browser';
 import { CreateSilence, EditSilence } from '../monitoring/silence-form';
 import {
   Alert,
@@ -379,24 +379,14 @@ const queryBrowserURL = (query: string, namespace: string) =>
     ? `/dev-monitoring/ns/${namespace}/metrics?query0=${encodeURIComponent(query)}`
     : `/monitoring/query-browser?query0=${encodeURIComponent(query)}`;
 
-const Graph_: React.FC<GraphProps> = ({
-  deleteAll,
+const Graph: React.FC<GraphProps> = ({
   filterLabels = undefined,
   formatLegendLabel,
   namespace,
-  patchQuery,
   query,
   ruleDuration,
 }) => {
   const { t } = useTranslation();
-
-  // Set the query in Redux so that other components like the graph tooltip can access it
-  React.useEffect(() => {
-    patchQuery(0, { query });
-  }, [patchQuery, query]);
-
-  // Clear queries on unmount
-  React.useEffect(() => deleteAll, [deleteAll]);
 
   // 3 times the rule's duration, but not less than 30 minutes
   const timespan = Math.max(3 * ruleDuration, 30 * 60) * 1000;
@@ -417,10 +407,6 @@ const Graph_: React.FC<GraphProps> = ({
     />
   );
 };
-const Graph = connect(null, {
-  deleteAll: UIActions.queryBrowserDeleteAllQueries,
-  patchQuery: UIActions.queryBrowserPatchQuery,
-})(Graph_);
 
 const tableSilenceClasses = [
   classNames('col-sm-5', 'col-xs-8'),
@@ -1696,11 +1682,9 @@ type AlertingPageProps = {
 };
 
 type GraphProps = {
-  deleteAll: () => never;
   filterLabels?: PrometheusLabels;
   formatLegendLabel?: FormatLegendLabel;
   namespace?: string;
-  patchQuery: (index: number, patch: QueryObj) => any;
   query: string;
   ruleDuration: number;
 };

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -1,35 +1,25 @@
-import * as _ from 'lodash-es';
 import * as React from 'react';
 import { connect } from 'react-redux';
 
-import * as UIActions from '../../../actions/ui';
 import { RootState } from '../../../redux';
-import { FormatLegendLabel, PatchQuery, QueryBrowser } from '../query-browser';
-
-// Set the queries in Redux so that other components like the graph tooltip can access them
-const patchAllQueries = (queries: string[], patchQuery: PatchQuery): void => {
-  _.each(queries, (query, i) => patchQuery(i, { query }));
-};
+import { FormatLegendLabel, QueryBrowser } from '../query-browser';
 
 const Graph_: React.FC<Props> = ({
   formatLegendLabel,
   isStack,
-  patchQuery,
   pollInterval,
   queries,
   timespan,
 }) => (
-  <div onMouseEnter={() => patchAllQueries(queries, patchQuery)}>
-    <QueryBrowser
-      defaultSamples={30}
-      formatLegendLabel={formatLegendLabel}
-      hideControls
-      isStack={isStack}
-      pollInterval={pollInterval}
-      queries={queries}
-      timespan={timespan}
-    />
-  </div>
+  <QueryBrowser
+    defaultSamples={30}
+    formatLegendLabel={formatLegendLabel}
+    hideControls
+    isStack={isStack}
+    pollInterval={pollInterval}
+    queries={queries}
+    timespan={timespan}
+  />
 );
 const Graph = connect(({ UI }: RootState) => ({
   timespan: UI.getIn(['monitoringDashboards', 'timespan']),
@@ -38,10 +28,9 @@ const Graph = connect(({ UI }: RootState) => ({
 type Props = {
   formatLegendLabel?: FormatLegendLabel;
   isStack: boolean;
-  patchQuery: PatchQuery;
   pollInterval: number;
   queries: string[];
   timespan: number;
 };
 
-export default connect(null, { patchQuery: UIActions.queryBrowserPatchQuery })(Graph);
+export default Graph;

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -908,6 +908,7 @@ const QueryBrowserWrapper_: React.FC<QueryBrowserWrapperProps> = ({ patchQuery, 
       defaultTimespan={30 * 60 * 1000}
       disabledSeries={disabledSeries}
       queries={queryStrings}
+      showStackedControl
     />
   );
 };

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -17,6 +17,7 @@ import {
 import {
   Alert,
   Button,
+  Checkbox,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -137,118 +138,85 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(
   },
 );
 
-const tooltipStateToProps = ({ UI }: RootState, { seriesIndex }) => {
-  let remaining = seriesIndex;
-  let props = {};
-  UI.getIn(['queryBrowser', 'queries'])
-    .filter((q) => q.get('isEnabled') && q.get('query'))
-    .forEach((q) => {
-      const series = q.get('series') || [];
-      if (series.length > remaining) {
-        props = { labels: series[remaining], query: q.get('query') };
-        return false;
-      }
-      remaining -= series.length;
-    });
-  return props;
-};
-
-const TOOLTIP_WIDTH = 240;
-const TOOLTIP_MAX_HEIGHT = 500;
-const TOOLTIP_MIN_X = -80;
-// Offset relative to the graph width
-const TOOLTIP_MAX_X_OFFSET = 40 - TOOLTIP_WIDTH;
-
-const TooltipInner_: React.FC<TooltipInnerProps> = ({
-  datumX,
-  datumY,
-  labels,
-  query,
-  seriesIndex,
-  width,
-  x,
-  y,
-}) => {
-  if (!query && !labels) {
-    return null;
-  }
-
-  // Constrain the tooltip so it doesn't stick out on the left or right side of the graph frame
-  const tooltipX = x - TOOLTIP_WIDTH / 2;
-  const constraintedX = _.clamp(tooltipX, TOOLTIP_MIN_X, width + TOOLTIP_MAX_X_OFFSET);
-  const arrowStyle =
-    tooltipX === constraintedX ? undefined : { marginLeft: 2 * (tooltipX - constraintedX) };
-
-  return (
-    <foreignObject
-      className="query-browser__tooltip-svg-wrap"
-      height={TOOLTIP_MAX_HEIGHT}
-      width={TOOLTIP_WIDTH}
-      x={constraintedX}
-      y={y}
-    >
-      <div className="query-browser__tooltip-wrap">
-        <div className="query-browser__tooltip-arrow" style={arrowStyle} />
-        <div className="query-browser__tooltip">
-          <div className="query-browser__tooltip-group">
-            <div
-              className="query-browser__series-btn"
-              style={{ backgroundColor: colors[seriesIndex % colors.length] }}
-            />
-            {datumX && (
-              <div className="query-browser__tooltip-time">{twentyFourHourTime(datumX, true)}</div>
-            )}
-          </div>
-          <div className="query-browser__tooltip-group">
-            <div className="co-nowrap co-truncate">{query}</div>
-            <div className="query-browser__tooltip-value">{formatValue(datumY)}</div>
-          </div>
-          {_.map(labels, (v, k) => (
-            <div className="co-nowrap co-truncate" key={k}>
-              <span className="query-browser__tooltip-label-key">
-                {k === '__name__' ? 'name' : k}
-              </span>{' '}
-              {v}
-            </div>
-          ))}
-        </div>
-      </div>
-    </foreignObject>
-  );
-};
-const TooltipInner = withFallback(connect(tooltipStateToProps)(TooltipInner_));
+const TOOLTIP_MAX_ENTRIES = 20;
+const TOOLTIP_MAX_WIDTH = 300;
+const TOOLTIP_MAX_HEIGHT = 400;
 
 // For performance, use this instead of PatternFly's ChartTooltip or Victory VictoryTooltip
-const Tooltip: React.FC<TooltipProps> = ({ active, datum, width, x, y }) => {
-  if (!active || !datum || !_.isFinite(datum.y) || !_.isFinite(x) || !_.isFinite(y)) {
+const Tooltip_: React.FC<TooltipProps> = ({ activePoints, center, height, style, width, x }) => {
+  const time = activePoints?.[0]?.x;
+
+  if (!_.isDate(time) || !_.isFinite(x)) {
     return null;
   }
 
+  // Don't show the tooltip if the cursor is too far from the active points (can happen when the
+  // graph's timespan includes a range with no data)
+  if (Math.abs(x - center.x) > width / 15) {
+    return null;
+  }
+
+  // Pick tooltip width and location (left or right of the cursor) to maximize its available space
+  const tooltipMaxWidth = Math.min(width / 2 + 60, TOOLTIP_MAX_WIDTH);
+  const isOnLeft = x > (width - 40) / 2;
+
+  const allSeries = activePoints
+    .map((point, i) => ({
+      color: style[i]?.fill,
+      name: style[i]?.name,
+      value: point._y1 ?? point.y,
+    }))
+    // For stacked graphs, this filters out data series that have no data for this timestamp
+    .filter(({ value }) => value !== null)
+    .sort((a, b) => b.value - a.value)
+    .slice(0, TOOLTIP_MAX_ENTRIES);
+
   return (
-    <VictoryPortal>
-      <TooltipInner
-        datumX={datum.x}
-        datumY={datum.y}
-        seriesIndex={datum._stack - 1}
-        width={width}
-        x={x}
-        y={y}
-      />
-    </VictoryPortal>
+    <>
+      <VictoryPortal>
+        <foreignObject
+          className="query-browser__tooltip-svg-wrap"
+          height={TOOLTIP_MAX_HEIGHT}
+          width={tooltipMaxWidth}
+          x={isOnLeft ? x - tooltipMaxWidth : x}
+          y={center.y - TOOLTIP_MAX_HEIGHT / 2}
+        >
+          <div
+            className={classNames('query-browser__tooltip-wrap', {
+              'query-browser__tooltip-wrap--left': isOnLeft,
+            })}
+          >
+            <div className="query-browser__tooltip-arrow" />
+            <div className="query-browser__tooltip">
+              <div className="query-browser__tooltip-group">
+                <div className="query-browser__tooltip-time">{twentyFourHourTime(time, true)}</div>
+              </div>
+              {allSeries.map((s, i) => (
+                <div className="query-browser__tooltip-group" key={i}>
+                  <div className="query-browser__series-btn" style={{ backgroundColor: s.color }} />
+                  <div className="co-nowrap co-truncate">{s.name}</div>
+                  <div className="query-browser__tooltip-value">{formatValue(s.value)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </foreignObject>
+      </VictoryPortal>
+      <line className="query-browser__tooltip-line" x1={x} x2={x} y1="0" y2={height} />
+    </>
   );
 };
-
-const tooltipComponent = <Tooltip />;
-
-// We don't use this result, but we need to return a string so that the label (tooltip) is rendered
-const tooltipLabels = () => ' ';
+const Tooltip = withFallback(Tooltip_);
 
 const graphContainer = (
   // Set activateData to false to work around VictoryVoronoiContainer crash (see
   // https://github.com/FormidableLabs/victory/issues/1314)
   <ChartVoronoiContainer
     activateData={false}
-    className="query-browser__graph-container"
+    labelComponent={<Tooltip />}
+    labels={() => ' '}
+    mouseFollowTooltips={true}
+    voronoiDimension="x"
     voronoiPadding={0}
   />
 );
@@ -268,15 +236,31 @@ const LegendContainer = ({ children }: { children?: React.ReactNode }) => {
 const Null = () => null;
 const nullComponent = <Null />;
 
+const formatLabels = (labels: PrometheusLabels) => {
+  const name = labels?.__name__ ?? '';
+  const otherLabels = _.omit(labels, '__name__');
+  return `${name}{${_.map(otherLabels, (v, k) => `${k}=${v}`).join(',')}}`;
+};
+
 type GraphSeries = GraphDataPoint[] | null;
 
 const Graph: React.FC<GraphProps> = React.memo(
   ({ allSeries, disabledSeries, formatLegendLabel, isStack, span, width, xDomain }) => {
-    // Remove any disabled series
     const data: GraphSeries[] = [];
+    const tooltipSeriesNames: string[] = [];
+    const legendData: { name: string }[] = [];
+
     _.each(allSeries, (series, i) => {
       _.each(series, ([metric, values]) => {
+        // Ignore any disabled series
         data.push(_.some(disabledSeries[i], (s) => _.isEqual(s, metric)) ? null : values);
+        if (formatLegendLabel) {
+          const name = formatLegendLabel(metric, i);
+          legendData.push({ name });
+          tooltipSeriesNames.push(name);
+        } else {
+          tooltipSeriesNames.push(formatLabels(metric));
+        }
       });
     });
 
@@ -326,11 +310,8 @@ const Graph: React.FC<GraphProps> = React.memo(
       };
     }
 
-    const legendData = formatLegendLabel
-      ? _.flatMap(allSeries, (series, i) =>
-          _.map(series, (s) => ({ name: formatLegendLabel(s[0], i) })),
-        )
-      : undefined;
+    const GroupComponent = isStack ? ChartStack : ChartGroup;
+    const ChartComponent = isStack ? ChartArea : ChartLine;
 
     return (
       <Chart
@@ -350,36 +331,20 @@ const Graph: React.FC<GraphProps> = React.memo(
           tickCount={6}
           tickFormat={yTickFormat}
         />
-        {isStack ? (
-          <ChartStack>
-            {data.map((values, i) => (
-              <ChartArea
-                key={i}
-                data={values}
-                groupComponent={<g />}
-                labelComponent={tooltipComponent}
-                labels={tooltipLabels}
-              />
-            ))}
-          </ChartStack>
-        ) : (
-          <ChartGroup>
-            {data.map((values, i) =>
-              values === null ? (
-                <ChartLine key={i} groupComponent={<g />} />
-              ) : (
-                <ChartLine
-                  key={i}
-                  data={values}
-                  groupComponent={<g />}
-                  labelComponent={tooltipComponent}
-                  labels={tooltipLabels}
-                />
-              ),
-            )}
-          </ChartGroup>
-        )}
-        {legendData && (
+        <GroupComponent>
+          {data.map((values, i) => {
+            if (values === null) {
+              return null;
+            }
+            const color = colors[i % colors.length];
+            const style = {
+              data: { [isStack ? 'fill' : 'stroke']: color },
+              labels: { fill: color, name: tooltipSeriesNames[i] },
+            };
+            return <ChartComponent data={values} groupComponent={<g />} key={i} style={style} />;
+          })}
+        </GroupComponent>
+        {!_.isEmpty(legendData) && (
           <ChartLegend
             data={legendData}
             groupComponent={<LegendContainer />}
@@ -436,7 +401,7 @@ const minSamples = 10;
 const maxSamples = 300;
 
 // Fall back to a line chart for performance if there are too many series
-const maxStacks = 20;
+const maxStacks = 50;
 
 // We don't want to refresh all the graph data for just a small adjustment in the number of samples,
 // so don't update unless the number of samples would change by at least this proportion
@@ -555,6 +520,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   namespace,
   patchQuery,
   queries,
+  showStackedControl = false,
   tickInterval,
   timespan,
 }) => {
@@ -582,7 +548,9 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
 
   const safeFetch = useSafeFetch();
 
-  const stack = isStack && _.sumBy(graphData, 'length') <= maxStacks;
+  const [isStacked, setIsStacked] = React.useState(isStack);
+
+  const canStack = _.sumBy(graphData, 'length') <= maxStacks;
 
   // If provided, `timespan` overrides any existing span setting
   React.useEffect(() => {
@@ -753,11 +721,17 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
             <SpanControls defaultSpanText={defaultSpanText} onChange={onSpanChange} span={span} />
             {updating && <Loading />}
           </div>
-          {GraphLink && (
-            <div className="query-browser__controls--right">
-              <GraphLink />
-            </div>
-          )}
+          <div className="query-browser__controls--right">
+            {GraphLink && <GraphLink />}
+            {canStack && showStackedControl && (
+              <Checkbox
+                id="stacked"
+                isChecked={isStacked}
+                label="Stacked"
+                onChange={(v) => setIsStacked(v)}
+              />
+            )}
+          </div>
         </div>
       )}
       {error && <Error error={error} />}
@@ -785,7 +759,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                       allSeries={graphData}
                       disabledSeries={disabledSeries}
                       formatLegendLabel={formatLegendLabel}
-                      isStack={stack}
+                      isStack={canStack && isStacked}
                       span={span}
                       width={width}
                       xDomain={xDomain}
@@ -795,7 +769,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                       allSeries={graphData}
                       disabledSeries={disabledSeries}
                       formatLegendLabel={formatLegendLabel}
-                      isStack={stack}
+                      isStack={canStack && isStacked}
                       onZoom={onZoom}
                       span={span}
                       width={width}
@@ -842,7 +816,7 @@ export type QueryObj = {
   text?: string;
 };
 
-export type FormatLegendLabel = (labels: PrometheusLabels, i: number) => string;
+export type FormatLegendLabel = (labels: PrometheusLabels, i?: number) => string;
 
 export type PatchQuery = (index: number, patch: QueryObj) => any;
 
@@ -883,6 +857,7 @@ export type QueryBrowserProps = {
   patchQuery: PatchQuery;
   pollInterval?: number;
   queries: string[];
+  showStackedControl?: boolean;
   tickInterval: number;
   timespan?: number;
 };
@@ -893,23 +868,11 @@ type SpanControlsProps = {
   span: number;
 };
 
-type TooltipDatum = { _stack: number; x: Date; y: number };
-
-type TooltipInnerProps = {
-  datumX: Date;
-  datumY: number;
-  labels?: PrometheusLabels;
-  query?: string;
-  seriesIndex: number;
-  width: number;
-  x: number;
-  y: number;
-};
-
 type TooltipProps = {
-  active?: boolean;
-  datum?: TooltipDatum;
+  activePoints?: { x: number; y: number; _y1?: number }[];
+  center?: { x: number; y: number };
+  height?: number;
+  style?: { fill: string };
   width?: number;
   x?: number;
-  y?: number;
 };


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/MON-787 and https://issues.redhat.com/browse/MON-1299.

Add a "Stacked" checkbox option to the Query Browser. Enabled for the
Metrics page of both the Admin and Dev Consoles.

Change the query browser graph tooltips to display all data series in
the graph at a single timestamp (instead of showing the data for just a
single data point).

If `formatLegendLabel` is provided, use that to generate the tooltip
string for the series names so that the names in the tooltip match those
in the graph legend. Otherwise generate a name using all of the data
series labels.

Removes the need to patch the query into Redux, so that code can be
removed from `graph.tsx`.

Fixes a bug with the tooltips where the vertical position of the tooltip
sometimes did not align to the corresponding data series line.

### Admin Console
![screenshot-2](https://user-images.githubusercontent.com/460802/101024110-012dd400-35b7-11eb-8e64-0538a92d8d50.png)

### Dev Console
![screenshot-3](https://user-images.githubusercontent.com/460802/101024290-3a664400-35b7-11eb-867d-60940e9c19a9.png)
![screenshot-1](https://user-images.githubusercontent.com/460802/101024093-fb37f300-35b6-11eb-9128-d6d9320d7c68.png)

FYI @cshinn 