### PR TITLE
Bug 1903172: Background shadow appears under datalist in column management modal

### DIFF
--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -28,7 +28,11 @@ const DataListRow: React.FC<DataListRowProps> = ({
   onChange,
   disableUncheckedRow,
 }) => (
-  <DataListItem aria-labelledby={`table-column-management-item-${column.id}`} key={column.id}>
+  <DataListItem
+    aria-labelledby={`table-column-management-item-${column.id}`}
+    key={column.id}
+    className="pf-c-data-list__item--transparent-bg"
+  >
     <DataListItemRow>
       <DataListCheck
         isDisabled={

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -207,6 +207,12 @@ h6 {
 .pf-c-chip-group.pf-m-toolbar {
   margin-bottom: var(--pf-global--spacer--xs);
 }
+
+//set pf datalist item background to transparent
+.pf-c-data-list__item--transparent-bg {
+  --pf-c-data-list__item--BackgroundColor: transparent;
+}
+
 // PF components that calculate their correct height based on --pf-global--FontSize--md: 1rem
 .pf-c-modal-box,
 .pf-c-switch {


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1903172

Make datalist background color transparent so the background shadow of the modal content appears when dialog is vertically shrunk.

cc: @gdoyle1 

Before:
<img width="747" alt="columnManagementBug" src="https://user-images.githubusercontent.com/35978579/101125622-ae104d00-35c7-11eb-8daa-f2b930a7bfeb.png">
After:
<img width="594" alt="Screen Shot 2020-12-04 at 12 10 57 AM" src="https://user-images.githubusercontent.com/35978579/101125639-b7011e80-35c7-11eb-96a1-5cd417541877.png">


