### PR TITLE
 Bug 1904305: add scroll for monitoring dashboard dropdown menu 

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -205,6 +205,11 @@ $screen-phone-landscape-min-width: 567px;
   overflow-x: auto;
 }
 
+.monitoring-dashboards__variable-dropdown .pf-c-dropdown__menu {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
 .monitoring-dashboards__variables {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -103,6 +103,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({
               {items[selectedKey]}
             </DropdownToggle>
           }
+          className="monitoring-dashboards__variable-dropdown"
         />
       )}
     </div>


### PR DESCRIPTION
Before fix:
<img width="749" alt="Screen Shot 2020-12-04 at 2 18 02 PM" src="https://user-images.githubusercontent.com/12692381/101129998-a095aa00-363d-11eb-8e3e-46d95bcefb36.png">

After fix: there is scroll bar for long dropdown list 
<img width="1104" alt="Screen Shot 2020-12-04 at 2 17 54 PM" src="https://user-images.githubusercontent.com/12692381/101130038-b30fe380-363d-11eb-839b-8625bb404918.png">
