### PR TITLE
Cypress: Re-enable Monitoring test suite

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -23,7 +23,7 @@ const shouldBeWatchdogSilencePage = () => {
   detailsPage.labelShouldExist('alertname=Watchdog');
 };
 
-xdescribe('Monitoring: Alerts', () => {
+describe('Monitoring: Alerts', () => {
   before(() => {
     cy.login();
     cy.createProject(testName);


### PR DESCRIPTION
Hopefully the test failures have been addressed by https://github.com/openshift/cluster-monitoring-operator/pull/997