### PR TITLE
Revert "remove tech preview badge from web terminal"

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, Flex, FlexItem, Button } from '@patternfly/react-core';
 import { CloseIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { InlineTechPreviewBadge } from '@console/shared';
 import Drawer from '@console/shared/src/components/drawer/Drawer';
 import MinimizeRestoreButton from './MinimizeRestoreButton';
 
@@ -31,6 +32,9 @@ const CloudShellDrawer: React.FC<CloudShellDrawerProps> = ({ children, onClose }
     <Flex style={{ flexGrow: 1 }}>
       <FlexItem className="co-cloud-shell-drawer__heading">
         {t('cloudshell~Command line terminal')}
+      </FlexItem>
+      <FlexItem>
+        <InlineTechPreviewBadge />
       </FlexItem>
       <FlexItem align={{ default: 'alignRight' }}>
         <Tooltip content={t('cloudshell~Open terminal in new tab')}>

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { InlineTechPreviewBadge } from '@console/shared';
 import CloudShellTerminal from './CloudShellTerminal';
 import './CloudShellTab.scss';
 
@@ -11,6 +12,7 @@ const CloudShellTab: React.FC = () => {
         <div className="co-cloud-shell-tab__header-text">
           {t('cloudshell~OpenShift command line terminal')}
         </div>
+        <InlineTechPreviewBadge />
       </div>
       <div className="co-cloud-shell-tab__body">
         <CloudShellTerminal />


### PR DESCRIPTION
This reverts commit 7ef4fcaa8670a3100136f3b7c6a29a3a5e54bd52.
Terminal remains tech preview for 4.7

Original PR: https://github.com/openshift/console/pull/7106
Related to: https://issues.redhat.com/browse/ODC-5049

![image](https://user-images.githubusercontent.com/14068621/101202536-64f7e180-3637-11eb-9511-616cf721fee1.png)

![image](https://user-images.githubusercontent.com/14068621/101202686-9670ad00-3637-11eb-9837-11d584b86ff2.png)
