### PR TITLE
Do not load topology resources when in all namespaces project is selected

### DIFF
--- a/frontend/packages/topology/src/data-transforms/DataModelProvider.tsx
+++ b/frontend/packages/topology/src/data-transforms/DataModelProvider.tsx
@@ -21,10 +21,11 @@ const DataModelProvider: React.FC<DataModelProviderProps> = ({ namespace, childr
 
   return (
     <ModelContext.Provider value={model}>
-      {modelFactories.map((factory) => (
-        <DataModelExtension key={factory.properties.id} dataModelFactory={factory} />
-      ))}
-      <TopologyDataRetriever />
+      {namespace &&
+        modelFactories.map((factory) => (
+          <DataModelExtension key={factory.properties.id} dataModelFactory={factory} />
+        ))}
+      {namespace && <TopologyDataRetriever />}
       {children}
     </ModelContext.Provider>
   );

--- a/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
+++ b/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
@@ -20,8 +20,8 @@ const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({ trafficDa
   const filters = useDisplayFilters();
   const showGroups = getFilterById(SHOW_GROUPS_FILTER_ID, filters)?.value ?? true;
   const resourcesList = React.useMemo<WatchK8sResources<any>>(
-    () => (dataModelContext.extensionsLoaded ? dataModelContext.watchedResources : {}),
-    [dataModelContext.extensionsLoaded, dataModelContext.watchedResources],
+    () => (namespace && dataModelContext.extensionsLoaded ? dataModelContext.watchedResources : {}),
+    [dataModelContext.extensionsLoaded, dataModelContext.watchedResources, namespace],
   );
 
   const resources = useK8sWatchResources<TopologyResourcesObject>(resourcesList);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5208

**Analysis / Root cause**: 
Topology context was retrieving resources when no namespace was provided resulting in all resources from all projects being retrieved.

**Solution Description**: 
Do not load resources when no namespace is selected.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug