### PR TITLE
Bug 1905610: Fix typo in export script

### DIFF
--- a/frontend/i18n-scripts/export-pos.sh
+++ b/frontend/i18n-scripts/export-pos.sh
@@ -5,7 +5,7 @@ set -exuo pipefail
 for f in public/locales/en/* ; do
   yarn i18n-to-po -f $(basename "$f" .json) -l zh
   yarn i18n-to-po -f $(basename "$f" .json) -l ja
-  yarn i18n-to-po -f $(basename "#f" .json) -l ko
+  yarn i18n-to-po -f $(basename "$f" .json) -l ko
 done
 
 cd packages


### PR DESCRIPTION
Fixed typo.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1905610.