### PR TITLE
Monitoring dashboards: Click a graph card to open the Metrics page

### DIFF
--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -256,6 +256,7 @@
   "{{count}} week_plural": "{{count}} weeks",
   "Time range": "Time range",
   "Refresh interval": "Refresh interval",
+  "Inspect": "Inspect",
   "Could not parse JSON data for dashboard \"{{dashboard}}\"": "Could not parse JSON data for dashboard \"{{dashboard}}\"",
   "Metrics dashboards": "Metrics dashboards",
   "Dashboards": "Dashboards",


### PR DESCRIPTION
On the Admin Console > Monitoring > Dashboards page, add an "Inspect"
link to all cards, which opens the card's PromQL queries in the Query
Browser (Metrics page).

FYI @cshinn 

![screenshot](https://user-images.githubusercontent.com/460802/108056517-b3dce100-7094-11eb-8cbf-43436a7816d9.png)
