### PR TITLE
Bug 1902981: Namespace is passed differently when using create vm from template.

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -42,11 +42,11 @@ const newTemplateFromCommon: MenuAction = (kind, vmTemplate, { namespace }) => (
 const vmTemplateCreateVMAction: MenuAction = (
   kind,
   obj,
-  { withSupportModal, sourceStatus, sourceLoaded, sourceLoadError, withCreate },
+  { withSupportModal, sourceStatus, sourceLoaded, sourceLoadError, withCreate, namespace },
 ) => ({
   // t('kubevirt-plugin~Create Virtual Machine')
   label: 'kubevirt-plugin~Create Virtual Machine',
-  callback: () => withSupportModal(obj, () => createVMAction(obj, sourceStatus)),
+  callback: () => withSupportModal(obj, () => createVMAction(obj, sourceStatus, namespace)),
   accessReview: asAccessReview(
     VirtualMachineModel,
     { metadata: { namespace: getNamespace(obj) } },

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/utils.ts
@@ -58,7 +58,11 @@ export const filterTemplates = (
   return [...userTemplateItems, ...Object.values(commonTemplateItems)];
 };
 
-export const createVMAction = (template: TemplateItem, sourceStatus: TemplateSourceStatus) => {
+export const createVMAction = (
+  template: TemplateItem,
+  sourceStatus: TemplateSourceStatus,
+  namespace: string,
+) => {
   if (isTemplateSourceError(sourceStatus)) {
     sourceErrorModal({ sourceStatus });
   } else if (!sourceStatus || sourceStatus.isReady) {
@@ -66,6 +70,7 @@ export const createVMAction = (template: TemplateItem, sourceStatus: TemplateSou
       getVMWizardCreateLink({
         wizardName: VMWizardName.BASIC,
         template: template.variants[0],
+        namespace,
       }),
     );
   } else {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -232,7 +232,7 @@ const VMTemplateTableRow: RowFunction<TemplateItem, VMTemplateTableRowProps> = (
           </Button>
         </Popover>
         <Button
-          onClick={() => withSupportModal(obj, () => createVMAction(obj, sourceStatus))}
+          onClick={() => withSupportModal(obj, () => createVMAction(obj, sourceStatus, namespace))}
           variant="secondary"
         >
           {t('kubevirt-plugin~Create')}


### PR DESCRIPTION
Added support for this type of url.

Signed-off-by: Matan Schatzman <matanschatzman@gmail.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1902981

**Analysis / Root cause**: 
Url format is different, should be used initData for namespace for this link.

**Solution Description**: 
Using init namespace

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/101343030-11320600-388c-11eb-89b0-e038be1419ef.png)
Before:
![image](https://user-images.githubusercontent.com/14824964/101343168-43436800-388c-11eb-99a8-2711d4ed6baa.png)
