### PR TITLE
Bug 1915220: Drop localStorage workaround after namespaces are now stored in user settings, use favorite from user settings

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -48,9 +48,13 @@ export const useValuesForNamespaceContext = () => {
   );
 
   // Keep namespace in sync with redux.
-  // Automatically sets favorited or latest namespace as soon as
-  // both informations are loaded from user settings.
   React.useEffect(() => {
+    // Url namespace overrides everything. We don't need to wait for loaded
+    if (urlNamespace && !favoriteLoaded && !lastNamespaceLoaded) {
+      dispatch(setActiveNamespace(urlNamespace));
+    }
+    // Automatically sets favorited or latest namespace as soon as
+    // both informations are loaded from user settings.
     if (!urlNamespace && favoriteLoaded && lastNamespaceLoaded) {
       dispatch(setActiveNamespace(favoritedNamespace || lastNamespace || ALL_NAMESPACES_KEY));
     }

--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -6,46 +6,63 @@ import { useLocation } from 'react-router-dom';
 import { getNamespace } from '@console/internal/components/utils/link';
 import { useUserSettingsCompatibility } from '@console/shared/src/hooks/useUserSettingsCompatibility';
 import { setActiveNamespace } from '@console/internal/actions/ui';
-import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';
+import {
+  ALL_NAMESPACES_KEY,
+  USERSETTINGS_PREFIX,
+  NAMESPACE_USERSETTINGS_PREFIX,
+  NAMESPACE_LOCAL_STORAGE_KEY,
+} from '@console/shared/src/constants';
 
 type NamespaceContextType = {
   namespace?: string;
   setNamespace?: (ns: string) => void;
 };
 
+const FAVORITE_NAMESPACE_NAME_USERSETTINGS_KEY = `${NAMESPACE_USERSETTINGS_PREFIX}.favorite`;
+const FAVORITE_NAMESPACE_NAME_LOCAL_STORAGE_KEY = NAMESPACE_LOCAL_STORAGE_KEY;
+
+const LAST_NAMESPACE_NAME_USER_SETTINGS_KEY = `${USERSETTINGS_PREFIX}.lastNamespace`;
 const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `bridge/last-namespace-name`;
-const LAST_NAMESPACE_NAME_USER_SETTINGS_KEY = 'console.lastNamespace';
 
 export const NamespaceContext = React.createContext<NamespaceContextType>({});
 
 export const useValuesForNamespaceContext = () => {
   const { pathname } = useLocation();
   const urlNamespace = getNamespace(pathname);
-  /**
-   * [TODO]: use favorite namespace here if there is any
-   *  const [favorite] = useUserSettings()
-   */
-  const [namespace, setNs, loaded] = useUserSettingsCompatibility(
-    LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
-    LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
-    urlNamespace || ALL_NAMESPACES_KEY,
+
+  const [favoritedNamespace, , favoriteLoaded] = useUserSettingsCompatibility<string>(
+    FAVORITE_NAMESPACE_NAME_USERSETTINGS_KEY,
+    FAVORITE_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
   );
-  const dispatchreduxAction = useDispatch();
+  const [lastNamespace, setLastnameNamespace, lastNamespaceLoaded] = useUserSettingsCompatibility<
+    string
+  >(LAST_NAMESPACE_NAME_USER_SETTINGS_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
+
+  const dispatch = useDispatch();
   const setNamespace = React.useCallback(
-    (ns: string) => {
-      dispatchreduxAction(setActiveNamespace(ns));
-      setNs(ns);
+    (namespace: string) => {
+      dispatch(setActiveNamespace(namespace));
+      setLastnameNamespace(namespace);
     },
-    [dispatchreduxAction, setNs],
+    [dispatch, setLastnameNamespace],
   );
 
+  // Keep namespace in sync with redux
   React.useEffect(() => {
-    if (loaded) {
-      dispatchreduxAction(setActiveNamespace(urlNamespace || namespace || ALL_NAMESPACES_KEY));
+    // Url namespace overrides everything. We don't need to wait for loaded
+    if (urlNamespace) {
+      dispatch(setActiveNamespace(urlNamespace));
+    } else if (favoriteLoaded && lastNamespaceLoaded) {
+      // Calculate namespace after loading: favorite > last used namespace > all
+      dispatch(setActiveNamespace(favoritedNamespace || lastNamespace || ALL_NAMESPACES_KEY));
     }
-    // only run this hook when namespace is loaded from user settings
+    // only run this hook when favorite and last namespace is loaded from user settings
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loaded]);
+  }, [urlNamespace, favoriteLoaded, lastNamespaceLoaded]);
 
-  return { namespace: urlNamespace || namespace || ALL_NAMESPACES_KEY, setNamespace, loaded };
+  return {
+    namespace: urlNamespace || lastNamespace || favoritedNamespace || ALL_NAMESPACES_KEY,
+    setNamespace,
+    loaded: favoriteLoaded && lastNamespaceLoaded,
+  };
 };

--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -34,7 +34,7 @@ export const useValuesForNamespaceContext = () => {
     FAVORITE_NAMESPACE_NAME_USERSETTINGS_KEY,
     FAVORITE_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
   );
-  const [lastNamespace, setLastnameNamespace, lastNamespaceLoaded] = useUserSettingsCompatibility<
+  const [lastNamespace, setLastNamespace, lastNamespaceLoaded] = useUserSettingsCompatibility<
     string
   >(LAST_NAMESPACE_NAME_USER_SETTINGS_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
 
@@ -42,26 +42,24 @@ export const useValuesForNamespaceContext = () => {
   const setNamespace = React.useCallback(
     (namespace: string) => {
       dispatch(setActiveNamespace(namespace));
-      setLastnameNamespace(namespace);
+      setLastNamespace(namespace);
     },
-    [dispatch, setLastnameNamespace],
+    [dispatch, setLastNamespace],
   );
 
-  // Keep namespace in sync with redux
+  // Keep namespace in sync with redux.
+  // Automatically sets favorited or latest namespace as soon as
+  // both informations are loaded from user settings.
   React.useEffect(() => {
-    // Url namespace overrides everything. We don't need to wait for loaded
-    if (urlNamespace) {
-      dispatch(setActiveNamespace(urlNamespace));
-    } else if (favoriteLoaded && lastNamespaceLoaded) {
-      // Calculate namespace after loading: favorite > last used namespace > all
+    if (!urlNamespace && favoriteLoaded && lastNamespaceLoaded) {
       dispatch(setActiveNamespace(favoritedNamespace || lastNamespace || ALL_NAMESPACES_KEY));
     }
-    // only run this hook when favorite and last namespace is loaded from user settings
+    // Only run this hook after favorite and last namespace are loaded.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlNamespace, favoriteLoaded, lastNamespaceLoaded]);
+  }, [favoriteLoaded, lastNamespaceLoaded]);
 
   return {
-    namespace: urlNamespace || lastNamespace || favoritedNamespace || ALL_NAMESPACES_KEY,
+    namespace: urlNamespace || favoritedNamespace || lastNamespace || ALL_NAMESPACES_KEY,
     setNamespace,
     loaded: favoriteLoaded && lastNamespaceLoaded,
   };

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -39,12 +39,7 @@ const emptyConfigMap: ConfigMapKind = {
 };
 
 const savedDataConfigMap: ConfigMapKind = {
-  apiVersion: 'v1',
-  kind: 'ConfigMap',
-  metadata: {
-    name: `user-settings-1234`,
-    namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
-  },
+  ...emptyConfigMap,
   data: {
     'console.key': 'saved value',
   },
@@ -228,6 +223,232 @@ describe('useUserSettings', () => {
     expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
     expect(updateConfigMapMock).toHaveBeenCalledWith(
       { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
+      'console.key',
+      'new value',
+    );
+  });
+
+  it('should provide the default value for user settings without sync and setter if there is no old value', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([emptyConfigMap, true, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect saved data
+    expect(result.current).toEqual(['default value', expect.any(Function), true]);
+
+    // Call setSettings
+    await act(async () => {
+      const [, setSettings] = result.current;
+      setSettings((oldValue) => {
+        expect(oldValue).toEqual('default value');
+        return 'new value';
+      });
+      rerender();
+    });
+
+    // Expect new value and API update
+    expect(result.current).toEqual(['new value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    // FIXME
+    // expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    // expect(updateConfigMapMock).toHaveBeenCalledWith(
+    //   { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
+    //   'console.key',
+    //   'new value',
+    // );
+  });
+
+  it('should provide the default value for user settings with sync and setter if there is no old value', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([emptyConfigMap, true, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
+
+    const { result, rerender } = testHook(() =>
+      useUserSettings('console.key', 'default value', true),
+    );
+
+    // Expect saved data
+    expect(result.current).toEqual(['default value', expect.any(Function), true]);
+
+    // Call setSettings
+    await act(async () => {
+      const [, setSettings] = result.current;
+      setSettings((oldValue) => {
+        expect(oldValue).toEqual('default value');
+        return 'new value';
+      });
+      rerender();
+    });
+
+    // Expect new value and API update
+    expect(result.current).toEqual(['new value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    // FIXME
+    // expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    // expect(updateConfigMapMock).toHaveBeenCalledWith(
+    //   { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
+    //   'console.key',
+    //   'new value',
+    // );
+  });
+
+  it('should provide the old value for user settings without sync and setter if there is an old value', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+
+    // Call setSettings
+    await act(async () => {
+      const [, setSettings] = result.current;
+      setSettings((oldValue) => {
+        expect(oldValue).toEqual('saved value');
+        return 'new value';
+      });
+      rerender();
+    });
+
+    // Expect new value and API update
+    expect(result.current).toEqual(['new value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
+      'console.key',
+      'new value',
+    );
+  });
+
+  it('should provide the old value for user settings with sync and setter if there is an old value', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
+
+    const { result, rerender } = testHook(() =>
+      useUserSettings('console.key', 'default value', true),
+    );
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+
+    // Call setSettings
+    await act(async () => {
+      const [, setSettings] = result.current;
+      setSettings((oldValue) => {
+        expect(oldValue).toEqual('saved value');
+        return 'new value';
+      });
+      rerender();
+    });
+
+    // Expect new value and API update
+    expect(result.current).toEqual(['new value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
+      'console.key',
+      'new value',
+    );
+  });
+
+  it('should provide an updated value for user settings wuthout sync and setter if there is was an update in the meantime', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
+
+    const { result, rerender } = testHook(() => useUserSettings('console.key', 'default value'));
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+
+    // Mock updated data (like, 'from another browser tab/window')
+    await act(async () => {
+      const updatedConfigMap = {
+        ...emptyConfigMap,
+        data: {
+          'console.key': 'magically changed value',
+        },
+      };
+      useK8sWatchResourceMock.mockReturnValue([updatedConfigMap, true, null]);
+      rerender();
+    });
+
+    // Expect that data are not changed when sync is disabled!
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+
+    // Call setSettings
+    await act(async () => {
+      const [, setSettings] = result.current;
+      setSettings((oldValue) => {
+        expect(oldValue).toEqual('saved value');
+        return 'new value';
+      });
+      rerender();
+    });
+
+    // Expect new value and API update
+    expect(result.current).toEqual(['new value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      // Old configmap must not be the old value, but it's fine.
+      { ...emptyConfigMap, data: { 'console.key': 'magically changed value' } },
+      'console.key',
+      'new value',
+    );
+  });
+
+  it('should provide an updated value for user settings with sync and setter if there is was an update in the meantime', async () => {
+    // Mock already loaded data
+    useK8sWatchResourceMock.mockReturnValue([savedDataConfigMap, true, null]);
+    updateConfigMapMock.mockReturnValue(Promise.resolve({}));
+
+    const { result, rerender } = testHook(() =>
+      useUserSettings('console.key', 'default value', true),
+    );
+
+    // Expect saved data
+    expect(result.current).toEqual(['saved value', expect.any(Function), true]);
+
+    // Mock updated data (like, 'from another browser tab/window')
+    await act(async () => {
+      const updatedConfigMap = {
+        ...emptyConfigMap,
+        data: {
+          'console.key': 'magically changed value',
+        },
+      };
+      useK8sWatchResourceMock.mockReturnValue([updatedConfigMap, true, null]);
+      rerender();
+    });
+
+    // Expect changed data if sync option is enabled
+    expect(result.current).toEqual(['magically changed value', expect.any(Function), true]);
+
+    // Call setSettings
+    await act(async () => {
+      const [, setSettings] = result.current;
+      setSettings((oldValue) => {
+        // FIXME
+        // expect(oldValue).toEqual('magically changed value');
+        return 'new value';
+      });
+      rerender();
+    });
+
+    // Expect new value and API update
+    expect(result.current).toEqual(['new value', expect.any(Function), true]);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(0);
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(updateConfigMapMock).toHaveBeenCalledWith(
+      { ...emptyConfigMap, data: { 'console.key': 'magically changed value' } },
       'console.key',
       'new value',
     );

--- a/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useUserSettings.spec.ts
@@ -251,13 +251,12 @@ describe('useUserSettings', () => {
     // Expect new value and API update
     expect(result.current).toEqual(['new value', expect.any(Function), true]);
     expect(createConfigMapMock).toHaveBeenCalledTimes(0);
-    // FIXME
-    // expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
-    // expect(updateConfigMapMock).toHaveBeenCalledWith(
-    //   { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
-    //   'console.key',
-    //   'new value',
-    // );
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(2);
+    expect(updateConfigMapMock).toHaveBeenLastCalledWith(
+      emptyConfigMap,
+      'console.key',
+      'new value',
+    );
   });
 
   it('should provide the default value for user settings with sync and setter if there is no old value', async () => {
@@ -285,13 +284,12 @@ describe('useUserSettings', () => {
     // Expect new value and API update
     expect(result.current).toEqual(['new value', expect.any(Function), true]);
     expect(createConfigMapMock).toHaveBeenCalledTimes(0);
-    // FIXME
-    // expect(updateConfigMapMock).toHaveBeenCalledTimes(1);
-    // expect(updateConfigMapMock).toHaveBeenCalledWith(
-    //   { ...emptyConfigMap, data: { 'console.key': 'saved value' } },
-    //   'console.key',
-    //   'new value',
-    // );
+    expect(updateConfigMapMock).toHaveBeenCalledTimes(2);
+    expect(updateConfigMapMock).toHaveBeenLastCalledWith(
+      emptyConfigMap,
+      'console.key',
+      'new value',
+    );
   });
 
   it('should provide the old value for user settings without sync and setter if there is an old value', async () => {
@@ -436,8 +434,7 @@ describe('useUserSettings', () => {
     await act(async () => {
       const [, setSettings] = result.current;
       setSettings((oldValue) => {
-        // FIXME
-        // expect(oldValue).toEqual('magically changed value');
+        expect(oldValue).toEqual('magically changed value');
         return 'new value';
       });
       rerender();

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -73,7 +73,10 @@ export const useUserSettings = <T>(
   );
 
   React.useEffect(() => {
-    if (!fallbackLocalStorage && (cfLoadError || (!cfData && cfLoaded))) {
+    if (fallbackLocalStorage) {
+      return;
+    }
+    if (cfLoadError || (!cfData && cfLoaded)) {
       (async () => {
         try {
           await createConfigMap();
@@ -90,7 +93,6 @@ export const useUserSettings = <T>(
       /**
        * update settings if key is present in config map but data is not equal to settings
        */
-      !fallbackLocalStorage &&
       cfData &&
       cfLoaded &&
       cfData.data?.hasOwnProperty(keyRef.current) &&
@@ -102,7 +104,6 @@ export const useUserSettings = <T>(
       /**
        * if key doesn't exist in config map send patch request to add the key with default value
        */
-      !fallbackLocalStorage &&
       defaultValueRef.current !== undefined &&
       cfData &&
       cfLoaded &&
@@ -111,7 +112,7 @@ export const useUserSettings = <T>(
       updateConfigMap(cfData, keyRef.current, seralizeData(defaultValueRef.current));
       setSettings(defaultValueRef.current);
       setLoaded(true);
-    } else if (!fallbackLocalStorage && cfLoaded) {
+    } else if (cfLoaded) {
       setSettings(defaultValueRef.current);
       setLoaded(true);
     }
@@ -141,27 +142,16 @@ export const useUserSettings = <T>(
   );
 
   const resultedSettings = React.useMemo(() => {
-    /**
-     * If key is deleted from the config map then return default value
-     */
-    if (
-      sync &&
-      cfLoaded &&
-      cfData &&
-      !cfData.data?.hasOwnProperty(keyRef.current) &&
-      settings !== undefined &&
-      !isRequestPending
-    ) {
-      return defaultValueRef.current;
-    }
-    if (
-      sync &&
-      !isRequestPending &&
-      cfLoaded &&
-      cfData &&
-      seralizeData(settingsRef.current) !== cfData?.data?.[keyRef.current]
-    ) {
-      return deseralizeData(cfData?.data?.[keyRef.current]);
+    if (sync && cfLoaded && cfData && !isRequestPending) {
+      /**
+       * If key is deleted from the config map then return default value
+       */
+      if (!cfData.data?.hasOwnProperty(keyRef.current) && settings !== undefined) {
+        return defaultValueRef.current;
+      }
+      if (seralizeData(settingsRef.current) !== cfData?.data?.[keyRef.current]) {
+        return deseralizeData(cfData?.data?.[keyRef.current]);
+      }
     }
     return settings;
   }, [sync, isRequestPending, cfData, cfLoaded, settings]);

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -155,6 +155,7 @@ export const useUserSettings = <T>(
     }
     return settings;
   }, [sync, isRequestPending, cfData, cfLoaded, settings]);
+  settingsRef.current = resultedSettings;
 
   return fallbackLocalStorage
     ? [lsData, setLsDataCallback, true]

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -565,10 +565,14 @@ export const Dropdown = (props) => {
   const [favoriteKey, setFavoriteKey] = useUserSettingsCompatibility(
     favoriteUserSettingsKey,
     favoriteStorageKey,
+    undefined,
+    true,
   );
   const [bookmarks, setBookmarks] = useUserSettingsCompatibility(
     bookmarkUserSettingsKey,
     bookmarkStorageKey,
+    undefined,
+    true,
   );
 
   const onBookmark = React.useCallback(
@@ -578,26 +582,13 @@ export const Dropdown = (props) => {
     [setBookmarks],
   );
 
-  // FIXME: Remove this after latest namespace wasn't fetched from localStorage anymore.
-  const onFavorite = React.useCallback(
-    (key) => {
-      setFavoriteKey(key);
-      if (key) {
-        localStorage.setItem(favoriteStorageKey, key);
-      } else {
-        localStorage.removeItem(favoriteStorageKey);
-      }
-    },
-    [setFavoriteKey, favoriteStorageKey],
-  );
-
   return (
     <Dropdown_
       {...props}
       bookmarks={bookmarks}
       onBookmark={onBookmark}
       favoriteKey={favoriteKey}
-      onFavorite={onFavorite}
+      onFavorite={setFavoriteKey}
     />
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5212
https://bugzilla.redhat.com/show_bug.cgi?id=1915220

**Analysis / Root cause**: 
We added this workaround to update the dropdown.js to support user settings. But for favorite project we needed this workaround until namespaces are also saved in user settings. This was merged with #7433, so we don't need this workaround anymore.

**Solution Description**: 
* Drop the workaround for localStorage.
* Enabled user settings sync function for bookmarked projects and applications and the favorite project between browser tabs.
* Integrate favorite project into 'actual' project / namespace hook so that the favorite project was automatically open.

**Screen shots / Gifs for design review**: 
![Peek 2020-12-10 20-25](https://user-images.githubusercontent.com/139310/101821316-18754000-3b28-11eb-8d38-fb4816e8b6a5.gif)

**Unit test coverage report**: 
Untouched :(

**Test setup:**
1. Favorite a namespace and open the console again with `/`, the selected project should be opened.
2. Open dev console in two browsers with the same users and add / remove namespace bookmarks

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug