### PR TITLE
Hide scale buttons of pod donut for Pod resources

### DIFF
--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { TFunction } from 'i18next';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { DeploymentConfigModel } from '@console/internal/models';
+import { DeploymentConfigModel, PodModel } from '@console/internal/models';
 import { RevisionModel } from '@console/knative-plugin';
 import * as utils from '../pod-utils';
 import { usePodScalingAccessStatus, podRingLabel, getFailedPods } from '../pod-ring-utils';
@@ -195,6 +195,14 @@ describe('usePodScalingAccessStatus', () => {
     obj.kind = 'Revision';
     testHook(() => {
       expect(usePodScalingAccessStatus(obj, RevisionModel, [], true)).toBe(false);
+      done();
+    });
+  });
+
+  it('should return false for pods', (done) => {
+    obj.kind = 'Pod';
+    testHook(() => {
+      expect(usePodScalingAccessStatus(obj, PodModel, [], true)).toBe(false);
       done();
     });
   });

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -236,22 +236,26 @@ export const usePodScalingAccessStatus = (
   enableScaling?: boolean,
   impersonate?: string,
 ) => {
-  const [editable, setEditable] = useSafetyFirst(false);
-  React.useEffect(() => {
-    checkPodEditAccess(obj, resourceKind, impersonate)
-      .then((resp: SelfSubjectAccessReviewKind) =>
-        setEditable(_.get(resp, 'status.allowed', false)),
-      )
-      .catch((error) => {
-        // console.log is used here instead of throw error
-        // throw error will break the thread and likely end-up in a white screen
-        // eslint-disable-next-line
-        console.log(error);
-        setEditable(false);
-      });
-  }, [pods, obj, resourceKind, impersonate, setEditable]);
-
   const isKnativeRevision = obj.kind === 'Revision';
-  const isScalingAllowed = !isKnativeRevision && editable && enableScaling;
-  return isScalingAllowed;
+  const isPod = obj.kind === 'Pod';
+  const isScalingAllowed = !isKnativeRevision && !isPod && enableScaling;
+  const [editable, setEditable] = useSafetyFirst(false);
+
+  React.useEffect(() => {
+    if (isScalingAllowed) {
+      checkPodEditAccess(obj, resourceKind, impersonate)
+        .then((resp: SelfSubjectAccessReviewKind) =>
+          setEditable(_.get(resp, 'status.allowed', false)),
+        )
+        .catch((error) => {
+          // console.log is used here instead of throw error
+          // throw error will break the thread and likely end-up in a white screen
+          // eslint-disable-next-line
+          console.log(error);
+          setEditable(false);
+        });
+    }
+  }, [pods, obj, resourceKind, impersonate, setEditable, isScalingAllowed]);
+
+  return editable;
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5145
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Scale up / down buttons are available for a single Pod resource and results in an error when pressed.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
The buttons are hidden if the resource is of type Pod.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp](https://user-images.githubusercontent.com/20013884/101361704-532b6e00-38c5-11eb-9711-516f547c6a72.png)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Test setup:**
- Create a single pod
- Go to Details tab in side panel of the pod node
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
