### PR TITLE
Cypress: do not test for i18n pseudo-translation of timestamps

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
@@ -137,14 +137,11 @@ describe('Kubernetes resource CRUD operations', () => {
           detailsPage.titleShouldContain(name);
           cy.testA11y(`Details page for ${kind}: ${name}`);
           if (testI18n) {
-            cy.testI18n(
-              [
-                DetailsPageSelector.horizontalNavTabs,
-                DetailsPageSelector.sectionHeadings,
-                DetailsPageSelector.itemLabels,
-              ],
-              ['timestamp'],
-            );
+            cy.testI18n([
+              DetailsPageSelector.horizontalNavTabs,
+              DetailsPageSelector.sectionHeadings,
+              DetailsPageSelector.itemLabels,
+            ]);
           }
         });
 

--- a/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
@@ -42,10 +42,4 @@ describe('Localization', () => {
     cy.visit('/dashboards?pseudolocalization=true&lng=en');
     cy.byTestID('utilization-card-item-text').isPseudoLocalized();
   });
-
-  it('pseudolocalizes timestamps', () => {
-    cy.log('test timestamps');
-    cy.visit('/k8s/all-namespaces/events?pseudolocalization=true&lng=en');
-    cy.byTestID('timestamp').isPseudoLocalized();
-  });
 });


### PR DESCRIPTION
We use `momentjs` for our timestamps which may show absolute or relative times (relative = 'a few moments ago').  Momentjs does provide [relative time translations](https://momentjs.com/docs/#/customization/relative-time/), but it doesn't work with `pseduo-translation` which we use in our cypress testing. 

This PR removes Cypress testing of pseudo-translation for timestamps.