### PR TITLE
Bug 1906766: Truncate pod ring inner labels to prevent overflow

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
@@ -10,6 +10,7 @@ import { podColor, AllPodStatus } from '../../constants';
 import './PodStatus.scss';
 
 const ANIMATION_DURATION = 350;
+const MAX_POD_TITLE_LENGTH = 14;
 
 type PodData = {
   x: string;
@@ -100,10 +101,10 @@ const PodStatus: React.FC<PodStatusProps> = ({
         data={vData}
         height={size}
         width={size}
-        title={title}
+        title={_.truncate(title, { length: MAX_POD_TITLE_LENGTH })}
         titleComponent={titleComponent}
         subTitleComponent={subTitleComponent}
-        subTitle={subTitle}
+        subTitle={_.truncate(subTitle, { length: MAX_POD_TITLE_LENGTH })}
         allowTooltip={false}
         labels={() => null}
         /*


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5039

**Analysis / Root cause**: 
Localization causes text swell and the Pod Set does not limit the text and cannot limit the width of the component.

**Solution Description**: 
Truncate the text to be shown inside the pod ring to prevent overflow.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/101377063-60256e80-387f-11eb-8efd-2cd90b99d583.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug