### PR TITLE
Bug 1898679: Fix .co-required class styling

### DIFF
--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -12,16 +12,16 @@
   flex-flow: row-reverse;
 }
 
-.co-required {
-  position: relative;
-  &:after {
-    color: $color-pf-red-200;
-    content: '*';
-    font-size: $font-size-base;
-    padding-left: 3px;
-    position: absolute;
-    top: 0;
-  }
+.co-required > * {
+  display: inline-block;
+}
+
+.co-required:after {
+  color: $color-pf-red-200;
+  content: '*';
+  font-size: $font-size-base;
+  padding-left: 3px;
+  vertical-align: top;
 }
 
 .co-form-heading__popover {


### PR DESCRIPTION
In some cases, the `position: absolute; top: 0;` styling on the `.co-required:after` pseudo-element was causing it to be rendered outside of the parent component, making it invisible.