### PR TITLE
route eventsource from Admin to catalog for source and workload on create

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
@@ -52,7 +52,7 @@ const EventSourcePage: React.FC<EventSourcePageProps> = ({ match, location }) =>
       <PageBody flexLayout>
         <EventSourceAlert
           eventSourceStatus={eventSourceStatus}
-          showSourceKindAlert={!isSourceKindPresent || kameletLoadError}
+          showSourceKindAlert={!isSourceKindPresent || (isKameletSource && kameletLoadError)}
         />
         {eventSourceStatus?.loaded ? (
           <ConnectedEventSource

--- a/frontend/packages/knative-plugin/src/components/eventing/EventingListPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/EventingListPage.tsx
@@ -23,7 +23,7 @@ const EventingListPage: React.FC<EventingListPageProps> = ({ match }) => {
   const menuActions: MenuActions = {
     eventSource: {
       label: t('knative-plugin~Event Source'),
-      onSelection: () => `/event-source/ns/${namespace}`,
+      onSelection: () => `/catalog/ns/${namespace}?catalogType=EventSource`,
     },
     channels: { label: t('knative-plugin~Channel'), onSelection: () => `/channel/ns/${namespace}` },
   };

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -311,12 +311,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: [
-        '/event-source/all-namespaces',
-        '/event-source/ns/:ns',
-        '/catalog/all-namespaces/eventsource',
-        '/catalog/ns/:ns/eventsource',
-      ],
+      path: ['/catalog/all-namespaces/eventsource', '/catalog/ns/:ns/eventsource'],
       loader: async () =>
         (
           await import(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5220

**Analysis / Root cause**: 
route on eventsource create from serverless eventing tab in Admin perspective goes to old route


**Solution Description**: 
route eventsource create from serverless eventing tab in Admin perspective to catalog for source and workload on create


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![Dec-08-2020 13-44-33](https://user-images.githubusercontent.com/5129024/101457508-a3550f80-395b-11eb-8fe5-7de82becebee.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


