### PR TITLE
WIP: fix gap above activity card

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/DashboardGrid.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/DashboardGrid.tsx
@@ -15,12 +15,16 @@ const mapCardsToGrid = (
   keyPrefix: string,
   ignoreCardSpan: boolean = false,
 ): React.ReactNode[] =>
-  cards.map(({ Card, span = 12 }, index) => (
-    // eslint-disable-next-line react/no-array-index-key
-    <GridItem key={`${keyPrefix}-${index}`} span={ignoreCardSpan ? 12 : span}>
-      <Card />
-    </GridItem>
-  ));
+  cards.map(({ Card, span = 12, loaded = true }, index) => {
+    return (
+      loaded && (
+        // eslint-disable-next-line react/no-array-index-key
+        <GridItem key={`${keyPrefix}-${index}`} span={ignoreCardSpan ? 12 : span}>
+          <Card />
+        </GridItem>
+      )
+    );
+  });
 
 const DashboardGrid: React.FC<DashboardGridProps> = ({ mainCards, leftCards, rightCards }) => {
   const [containerRef, width] = useRefWidth();
@@ -75,6 +79,7 @@ export default DashboardGrid;
 export type GridDashboardCard = {
   Card: React.ComponentType<any>;
   span?: DashboardCardSpan;
+  loaded?: boolean;
 };
 
 type DashboardGridProps = {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5221

**Analysis / Root cause**: 
Before rendering the Quick Starts catalog card it is not being checked if there are Quick Starts available in the cluster

**Solution Description**: 
- checking if Quickstarts are available
- passing sync as true to `useUserSettings` hook such that the card on the right adjusts itself when the Quickstarts catalog card is removed

**Screen shots / Gifs for design review**: 

When no Quickstarts are available
![no-quickstarts](https://user-images.githubusercontent.com/22490998/101473596-0650a180-3970-11eb-8487-4690374d3e73.png)

![qs](https://user-images.githubusercontent.com/22490998/101473618-0a7cbf00-3970-11eb-813c-a32bb0b4cb37.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge