### PR TITLE
Bug 1906872: Fix Pipeline Tech Preview badge alignment

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.scss
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.scss
@@ -1,0 +1,3 @@
+.odc-form-section-pipeline {
+  align-items: baseline;
+}

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.tsx
@@ -13,6 +13,8 @@ import { FLAG_OPENSHIFT_PIPELINE, CLUSTER_PIPELINE_NS } from '../../../const';
 import { Pipeline } from '../../../utils/pipeline-augment';
 import PipelineTemplate from './PipelineTemplate';
 
+import './PipelineSection.scss';
+
 type PipelineSectionProps = {
   flags: FlagsObject;
   builderImages: NormalizedBuilderImages;
@@ -56,7 +58,7 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
 
   if (flags[FLAG_OPENSHIFT_PIPELINE] && hasCreatePipelineAccess) {
     const title = (
-      <Split hasGutter>
+      <Split className="odc-form-section-pipeline" hasGutter>
         <SplitItem className="odc-form-section__heading">
           {t('pipelines-plugin~Pipelines')}
         </SplitItem>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4915

**Analysis / Root cause**: 
The tech preview badge is not aligned with the Pipeline title

**Solution Description**: 
Basealign Pipeline form heading with Tech Preview badge

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/101482311-8bda4e80-397c-11eb-8b39-f917fc46eeee.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
