### PR TITLE
Bug 1900377: Add selector for active users on Overview tab

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.guest.agent.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.guest.agent.scenario.ts
@@ -108,7 +108,7 @@ describe('Tests involving guest agent', () => {
       await vmLinux.navigateToOverview();
       expect(dashboardView.vmDetailsHostname.getText()).toContain(VM_LINUX_NAME);
       expect(dashboardView.vmDetailsTZ.getText()).toContain('UTC');
-      expect(vmView.vmLoggedInUsers.getText()).toEqual('1 user');
+      expect(dashboardView.vmDetailsNumActiveUsersMsg.getText()).toEqual('1 user');
     });
 
     it('ID(CNV-5320) Displays guest agent data in Disks tab', async () => {

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/dashboard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/dashboard.view.ts
@@ -9,8 +9,10 @@ export const vmDetailsNode = vmDetails.get(4);
 export const vmDetailsIPAddress = vmDetails.get(5);
 export const vmDetailsOS = vmDetails.get(6);
 export const vmDetailsTZ = vmDetails.get(7);
-export const vmDetailsLoggedInUsers = vmDetails.get(8);
+export const vmDetailsActiveUsers = vmDetails.get(8); // Exception messages only (GA not available, VM off, etc)
 export const vmDetailsViewAll = $$('.co-dashboard-card__link').get(0);
+
+export const vmDetailsNumActiveUsersMsg = $('#num-active-users-message'); // GA available and at least 1 active user
 
 export const vmStatus = $('.co-status-card__health-body > span');
 export const vmStatusAlert = $('.co-status-card__alert-item');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachine.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachine.view.ts
@@ -75,8 +75,6 @@ export const vmDetailstatusButton = (namespace, name) =>
 
 export const vmDetailService = (serviceName) => $(`[data-test-id="${serviceName}"]`);
 
-export const vmLoggedInUsers = element(by.xpath('//a[contains(@href,"logged-in-users")]'));
-
 // Scheduling view
 export const vmDetailDedicatedResources = (namespace, vmName) =>
   $(vmDetailItemId(namespace, vmName, 'dedicated-resources'));

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -140,7 +140,10 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
             errorMessage={guestAgentFieldNotAvailMsg}
           >
             {numLoggedInUsers != null && numLoggedInUsers > 0 ? (
-              <Link to={`/k8s/ns/${namespace}/virtualmachines/${name}/details#logged-in-users`}>
+              <Link
+                to={`/k8s/ns/${namespace}/virtualmachines/${name}/details#logged-in-users`}
+                id="num-active-users-message"
+              >
                 {numLoggedInUsersMsg}
               </Link>
             ) : (


### PR DESCRIPTION
This PR adds a selector to target the active users message in the Details card of the Overview tab when the guest agent is installed and at least one user is active.