### PR TITLE
Bug 1905542: Replace 'Baremetal' with 'BareMetal' in the supported platforms for I…

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -14,7 +14,7 @@ import { OCS_SUPPORT_ANNOTATION, MODES } from '../../constants';
 import { CreateAttachedDevicesCluster } from './attached-devices/install';
 import './install-page.scss';
 
-const INDEP_MODE_SUPPORTED_PLATFORMS = ['Baremetal', 'None', 'VSphere', 'OpenStack', 'oVirt'];
+const INDEP_MODE_SUPPORTED_PLATFORMS = ['BareMetal', 'None', 'VSphere', 'OpenStack', 'oVirt'];
 
 const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
   const {


### PR DESCRIPTION
Replace 'Baremetal' with 'BareMetal' in the supported platforms for Independent mode of OCS deployment.


Signed-off-by: Ashish Singh <assingh@redhat.com>