### PR TITLE
Bug 1906760: Fixes to prevent topology from unnecessary updates/renders

### DIFF
--- a/frontend/packages/console-shared/src/utils/pod-resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-resource-utils.ts
@@ -149,7 +149,7 @@ export const getPodsDataForResource = (
         obj: resource,
         current: undefined,
         previous: undefined,
-        isRollingOut: undefined,
+        isRollingOut: true,
         pods: [resource as PodKind],
       };
     default:

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/PodSet.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/PodSet.tsx
@@ -53,7 +53,7 @@ export const podSetInnerRadius = (size: number, data: PodRCData) => {
   return radius - innerStrokeWidth - podStatusInset;
 };
 
-const PodSet: React.FC<PodSetProps> = ({ size, data, x = 0, y = 0, showPodCount }) => {
+const PodSet: React.FC<PodSetProps> = React.memo(({ size, data, x = 0, y = 0, showPodCount }) => {
   const { t } = useTranslation();
   const { podStatusOuterRadius, podStatusInnerRadius, podStatusStrokeWidth } = calculateRadius(
     size,
@@ -108,6 +108,6 @@ const PodSet: React.FC<PodSetProps> = ({ size, data, x = 0, y = 0, showPodCount 
       )}
     </>
   );
-};
+});
 
 export default PodSet;

--- a/frontend/packages/topology/src/data-transforms/useMonitoringAlerts.tsx
+++ b/frontend/packages/topology/src/data-transforms/useMonitoringAlerts.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { getAlertsAndRules } from '@console/internal/components/monitoring/utils';
+import { usePrometheusRulesPoll } from '@console/internal/components/graphs/prometheus-rules-hook';
+import { Alert } from '@console/internal/components/monitoring/types';
+import { useDeepCompareMemoize } from '@console/shared';
+
+export const useMonitoringAlerts = (
+  namespace: string,
+): {
+  data: Alert[];
+  loaded: boolean;
+  loadError: string;
+} => {
+  const [alertsResponse, alertsError, alertsLoading] = usePrometheusRulesPoll({ namespace });
+  const response = React.useMemo(() => {
+    let alertData;
+    if (!alertsLoading && !alertsError) {
+      alertData = getAlertsAndRules(alertsResponse?.data).alerts;
+
+      // Don't update due to time changes
+      alertData.forEach((alert) => {
+        delete alert.activeAt;
+        if (alert.rule) {
+          delete alert.rule.evaluationTime;
+          delete alert.rule.lastEvaluation;
+          alert.rule.alerts &&
+            alert.rule.alerts.forEach((ruleAlert) => {
+              delete ruleAlert.activeAt;
+            });
+        }
+      });
+    }
+    return { data: alertData, loaded: !alertsLoading, loadError: alertsError };
+  }, [alertsError, alertsLoading, alertsResponse]);
+
+  return useDeepCompareMemoize(response);
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5169

**Analysis / Root cause**: 
Updates were occurring too frequently and when data had not changed.

**Solution Description**: 
Check for data changes before updating topology data and pod data. Throttle incoming updates to topology resource data.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge