### PR TITLE
Bug 1906718: Use chart repository spec name when available

### DIFF
--- a/frontend/packages/helm-plugin/src/catalog/helm-catalog-plugin.ts
+++ b/frontend/packages/helm-plugin/src/catalog/helm-catalog-plugin.ts
@@ -20,7 +20,7 @@ export const helmCatalogPlugin: Plugin<HelmCatalogConsumedExtensions> = [
       filters: [
         {
           label: 'Chart Repositories',
-          attribute: 'chartRepositoryName',
+          attribute: 'chartRepositoryTitle',
         },
       ],
     },

--- a/frontend/packages/helm-plugin/src/components/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/helm-plugin/src/components/__tests__/helm-release-mock-data.ts
@@ -136,7 +136,7 @@ export const mockIBMHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.3.tgz',
     ],
     version: '1.0.3',
-    repoName: 'ibm-helm-repo',
+    repoName: 'IBM Helm Repo',
   },
   {
     apiVersion: 'v1',
@@ -146,7 +146,7 @@ export const mockIBMHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.2.tgz',
     ],
     version: '1.0.2',
-    repoName: 'ibm-helm-repo',
+    repoName: 'IBM Helm Repo',
   },
   {
     appVersion: '3.10.5',
@@ -157,7 +157,7 @@ export const mockIBMHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.1.tgz',
     ],
     version: '1.0.1',
-    repoName: 'ibm-helm-repo',
+    repoName: 'IBM Helm Repo',
   },
 ];
 
@@ -170,7 +170,7 @@ export const mockRedhatHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/redhat-helm-charts/master/repo/stable/hazelcast-enterprise-1.0.2.tgz',
     ],
     version: '1.0.2',
-    repoName: 'redhat-helm-repo',
+    repoName: 'Red Hat Helm Repo',
   },
   {
     appVersion: '3.10.5',
@@ -181,7 +181,36 @@ export const mockRedhatHelmChartData: HelmChartMetaData[] = [
       'https://raw.githubusercontent.com/redhat-helm-charts/master/repo/stable/hazelcast-enterprise-1.0.1.tgz',
     ],
     version: '1.0.1',
-    repoName: 'redhat-helm-repo',
+    repoName: 'Red Hat Helm Repo',
+  },
+];
+
+export const mockHelmChartRepositories: K8sResourceKind[] = [
+  {
+    apiVersion: 'helm.openshift.io/v1beta1',
+    kind: 'HelmChartRepository',
+    metadata: {
+      name: 'ibm-helm-repo',
+    },
+    spec: {
+      connectionConfig: {
+        url: 'https://raw.githubusercontent.com/IBM/charts/master/repo/community',
+      },
+      name: 'IBM Helm Repo',
+    },
+  },
+  {
+    apiVersion: 'helm.openshift.io/v1beta1',
+    kind: 'HelmChartRepository',
+    metadata: {
+      name: 'redhat-helm-repo',
+    },
+    spec: {
+      connectionConfig: {
+        url: 'https://redhat-developer.github.io/redhat-helm-charts',
+      },
+      name: 'Red Hat Helm Repo',
+    },
   },
 ];
 

--- a/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/helm-plugin/src/utils/__tests__/helm-utils.spec.ts
@@ -19,6 +19,7 @@ import {
   flattenedMockReleaseResources,
   mockChartEntries,
   mockRedhatHelmChartData,
+  mockHelmChartRepositories,
 } from '../../components/__tests__/helm-release-mock-data';
 
 const t = (key: TFunction) => key;
@@ -56,7 +57,7 @@ describe('Helm Releases Utils', () => {
 
   it('should return the helm chart url from ibm repo', () => {
     const chartVersion = '1.0.2';
-    const chartRepoName = 'ibm-helm-repo';
+    const chartRepoName = 'IBM Helm Repo';
     const chartURL = getChartURL(mockHelmChartData, chartVersion, chartRepoName);
     expect(chartURL).toBe(
       'https://raw.githubusercontent.com/IBM/charts/master/repo/community/hazelcast-enterprise-1.0.2.tgz',
@@ -65,7 +66,7 @@ describe('Helm Releases Utils', () => {
 
   it('should return the helm chart url from redhat repo', () => {
     const chartVersion = '1.0.1';
-    const chartRepoName = 'redhat-helm-repo';
+    const chartRepoName = 'Red Hat Helm Repo';
     const chartURL = getChartURL(mockHelmChartData, chartVersion, chartRepoName);
     expect(chartURL).toBe(
       'https://raw.githubusercontent.com/redhat-helm-charts/master/repo/stable/hazelcast-enterprise-1.0.1.tgz',
@@ -75,13 +76,13 @@ describe('Helm Releases Utils', () => {
   it('should return the chart versions, concatenated with the App Version, available for the helm chart', () => {
     const chartVersions = getChartVersions(mockHelmChartData, t);
     expect(chartVersions).toEqual({
-      '1.0.1--ibm-helm-repo':
+      '1.0.1--IBM Helm Repo':
         '1.0.1helm-plugin~ / App Version {{appVersion}}helm-plugin~ (Provided by {{chartRepoName}})',
-      '1.0.1--redhat-helm-repo':
+      '1.0.1--Red Hat Helm Repo':
         '1.0.1helm-plugin~ / App Version {{appVersion}}helm-plugin~ (Provided by {{chartRepoName}})',
-      '1.0.2--ibm-helm-repo': '1.0.2helm-plugin~ (Provided by {{chartRepoName}})',
-      '1.0.2--redhat-helm-repo': '1.0.2helm-plugin~ (Provided by {{chartRepoName}})',
-      '1.0.3--ibm-helm-repo':
+      '1.0.2--IBM Helm Repo': '1.0.2helm-plugin~ (Provided by {{chartRepoName}})',
+      '1.0.2--Red Hat Helm Repo': '1.0.2helm-plugin~ (Provided by {{chartRepoName}})',
+      '1.0.3--IBM Helm Repo':
         '1.0.3helm-plugin~ / App Version {{appVersion}}helm-plugin~ (Provided by {{chartRepoName}})',
     });
   });
@@ -91,20 +92,38 @@ describe('Helm Releases Utils', () => {
       mockChartEntries,
       'hazelcast-enterprise',
       'redhat-helm-repo',
+      mockHelmChartRepositories,
     );
     expect(chartEntries).toEqual(mockRedhatHelmChartData);
   });
 
   it('should return chart entries by name from all repos if repo name not provided', () => {
-    const chartEntries = getChartEntriesByName(mockChartEntries, 'hazelcast-enterprise');
+    const chartEntries = getChartEntriesByName(
+      mockChartEntries,
+      'hazelcast-enterprise',
+      '',
+      mockHelmChartRepositories,
+    );
     expect(chartEntries).toEqual(mockHelmChartData);
   });
 
   it('should return empty array if wrong chart name or repo name provided', () => {
     expect(
-      getChartEntriesByName(mockChartEntries, 'hazelcast-enterprise', 'stable-helm-repo'),
+      getChartEntriesByName(
+        mockChartEntries,
+        'hazelcast-enterprise',
+        'stable-helm-repo',
+        mockHelmChartRepositories,
+      ),
     ).toEqual([]);
-    expect(getChartEntriesByName(mockChartEntries, 'hazelcast-enterprise-prod')).toEqual([]);
+    expect(
+      getChartEntriesByName(
+        mockChartEntries,
+        'hazelcast-enterprise-prod',
+        '',
+        mockHelmChartRepositories,
+      ),
+    ).toEqual([]);
   });
 
   it('should omit resources with no data and flatten them', () => {

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -92,16 +92,26 @@ export const getChartURL = (
   return chartData?.urls[0];
 };
 
+export const getChartRepositoryTitle = (
+  chartRepositories: K8sResourceKind[],
+  chartRepoName: string,
+) => {
+  const chartRepository = chartRepositories?.find((repo) => repo.metadata.name === chartRepoName);
+  return chartRepository?.spec?.name || toTitleCase(chartRepoName);
+};
+
 export const getChartEntriesByName = (
   chartEntries: HelmChartEntries,
   chartName: string,
   chartRepoName?: string,
+  chartRepositories?: K8sResourceKind[],
 ): HelmChartMetaData[] => {
   if (chartName && chartRepoName) {
+    const chartRepositoryTitle = getChartRepositoryTitle(chartRepositories, chartRepoName);
     return (
       chartEntries?.[`${chartName}--${chartRepoName}`]?.map((e) => ({
         ...e,
-        repoName: chartRepoName,
+        repoName: chartRepositoryTitle,
       })) ?? []
     );
   }
@@ -109,9 +119,10 @@ export const getChartEntriesByName = (
     chartEntries,
     (acc, charts, key) => {
       const repoName = key.split('--').pop();
+      const chartRepositoryTitle = getChartRepositoryTitle(chartRepositories, repoName);
       charts.forEach((chart: HelmChartMetaData) => {
         if (chart.name === chartName) {
-          acc.push({ ...chart, repoName });
+          acc.push({ ...chart, repoName: chartRepositoryTitle });
         }
       });
       return acc;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4977
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The helm catalog and install upgrade page were using chart repository name from the index file which was not actual title of the repository but the `metadata.name`.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Fetch `HelmChartRepository` CRs and look for `spec.name` to get the title of each repository.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux 
![Peek 2020-12-08 22-40](https://user-images.githubusercontent.com/6041994/101517363-b04b2080-39a6-11eb-986f-9b07c7269b5a.gif)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Add below CR - 
```yaml
apiVersion: helm.openshift.io/v1beta1
kind: HelmChartRepository
metadata:
  name: ibm-helm-repo
spec:
  name: IBM Helm Repo
  connectionConfig:
    url: https://raw.githubusercontent.com/IBM/charts/master/repo/community
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
