### PR TITLE
Bug 1905253:  update events timeline empty state and end messages

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -184,6 +184,6 @@ $color-dark-border: #ddd;
   }
 
   .co-sysevent-stream__timeline__end-message {
-    left: 45px;
+    left: 57px;
   }
 }

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -265,9 +265,7 @@ export const NoEvents = () => {
   const { t } = useTranslation();
   return (
     <Box className="co-sysevent-stream__status-box-empty">
-      <div className="text-center cos-status-box__detail">
-        {t('events~No events in the past hour')}
-      </div>
+      <div className="text-center cos-status-box__detail">{t('events~No events')}</div>
     </Box>
   );
 };
@@ -328,7 +326,6 @@ class EventStream extends React.Component {
       filteredEvents: [],
       error: null,
       loading: true,
-      oldestTimestamp: new Date(),
     };
     this.toggleStream = this.toggleStream_.bind(this);
   }
@@ -469,13 +466,8 @@ class EventStream extends React.Component {
   // update an instance variable, and throttle the actual UI update (see constructor)
   flushMessages() {
     const sorted = sortEvents(this.messages);
-    const oldestTimestamp = _.min([
-      this.state.oldestTimestamp,
-      getLastTime(new Date(_.last(sorted))),
-    ]);
     sorted.splice(maxMessages);
     this.setState({
-      oldestTimestamp,
       sortedMessages: sorted,
       filteredEvents: EventStream.filterEvents(sorted, this.props),
     });
@@ -554,9 +546,7 @@ class EventStream extends React.Component {
               className="co-sysevent-stream__timeline__btn"
             />
             <div className="co-sysevent-stream__timeline__end-message">
-              <Trans ns="events">
-                There are no events before <Timestamp timestamp={this.state.oldestTimestamp} />
-              </Trans>
+              {t('events~Older events are not stored.')}
             </div>
           </div>
           {count > 0 && <EventStreamList events={filteredEvents} EventComponent={Inner} />}

--- a/frontend/public/locales/en/events.json
+++ b/frontend/public/locales/en/events.json
@@ -11,7 +11,7 @@
   "Resource": "Resource",
   "All": "All",
   "Close": "Close",
-  "No events in the past hour": "No events in the past hour",
+  "No events": "No events",
   "No matching events": "No matching events",
   "{{allCount}}+ events exist, but none match the current filter": "{{allCount}}+ events exist, but none match the current filter",
   "{{allCount}} events exist, but none match the current filter": "{{allCount}} events exist, but none match the current filter",
@@ -27,5 +27,5 @@
   "Showing {{count}} event": "Showing {{count}} event",
   "Showing {{count}} event_plural": "Showing {{count}} events",
   "Showing {{messageCount}} of {{allCount}}+ events": "Showing {{messageCount}} of {{allCount}}+ events",
-  "There are no events before <1></1>": "There are no events before <1></1>"
+  "Older events are not stored.": "Older events are not stored."
 }


### PR DESCRIPTION
Before:
<img width="896" alt="Screen Shot 2020-12-08 at 12 06 11 PM" src="https://user-images.githubusercontent.com/895728/101517834-33408c80-394f-11eb-909b-a8f3e9ad1f3b.png">

After:
<img width="1057" alt="Screen Shot 2020-12-11 at 4 08 25 PM" src="https://user-images.githubusercontent.com/895728/101955385-b110cc00-3bcb-11eb-8465-973e5948a89b.png">

