### PR TITLE
Show type badge on every tile in all catalogs

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
@@ -137,13 +137,9 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
 
   const renderTile = React.useCallback(
     (item: CatalogItem) => (
-      <CatalogTile
-        item={item}
-        onClick={openDetailsPanel}
-        catalogTypes={!type ? catalogTypes : []}
-      />
+      <CatalogTile item={item} onClick={openDetailsPanel} catalogTypes={catalogTypes} />
     ),
-    [catalogTypes, openDetailsPanel, type],
+    [catalogTypes, openDetailsPanel],
   );
 
   return (


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5211
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Earlier designs of the catalog mentioned that the type badge should only be shown on generic catalog and be hidden from the tile when user goes to type specific catalog. The design has changed from that to show the badge on all tiles always.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Remove the check specifically added to hide the badge for type catalogs.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux @rachael-phillips 
![Peek 2020-12-08 22-49](https://user-images.githubusercontent.com/6041994/101518514-04a2d000-39a8-11eb-9200-2f578a24f259.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
