### PR TITLE
Bug 1906768: Fix to correctly sort nav items dependent on non-plugin items

### DIFF
--- a/frontend/__tests__/components/nav/navSortUtils.spec.ts
+++ b/frontend/__tests__/components/nav/navSortUtils.spec.ts
@@ -1,4 +1,7 @@
-import { getSortedNavItems } from '@console/internal/components/nav/navSortUtils';
+import {
+  getSortedNavItems,
+  sortExtensionItems,
+} from '@console/internal/components/nav/navSortUtils';
 import { LoadedExtension, NavItem, NavSection, SeparatorNavItem } from '@console/plugin-sdk/src';
 
 const mockNavItems: LoadedExtension<NavSection | NavItem | SeparatorNavItem>[] = [
@@ -70,6 +73,8 @@ const mockNavItems: LoadedExtension<NavSection | NavItem | SeparatorNavItem>[] =
   },
 ];
 
+const indexOfId = (id, sortedItems) => sortedItems.map((i) => i.properties.id).indexOf(id);
+
 describe('perspective-nav insertPositionedItems', () => {
   it('should order items that are not positioned', () => {
     const sortedItems = getSortedNavItems(mockNavItems);
@@ -81,27 +86,27 @@ describe('perspective-nav insertPositionedItems', () => {
   it('should order items that are positioned', () => {
     mockNavItems[0].properties.insertAfter = 'test2';
     let sortedItems = getSortedNavItems(mockNavItems);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(1);
+    expect(indexOfId('test1', sortedItems)).toBe(1);
 
     delete mockNavItems[0].properties.insertAfter;
     mockNavItems[0].properties.insertBefore = 'test5';
     sortedItems = getSortedNavItems(mockNavItems);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(3);
+    expect(indexOfId('test1', sortedItems)).toBe(3);
 
     delete mockNavItems[0].properties.insertBefore;
     mockNavItems[0].properties.insertAfter = ['x', 'y', 'test3', 'z'];
     sortedItems = getSortedNavItems(mockNavItems);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(2);
+    expect(indexOfId('test1', sortedItems)).toBe(2);
 
     delete mockNavItems[0].properties.insertAfter;
     mockNavItems[0].properties.insertBefore = ['x', 'y', 'test3', 'z'];
     sortedItems = getSortedNavItems(mockNavItems);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(1);
+    expect(indexOfId('test1', sortedItems)).toBe(1);
 
     // Before takes precedence
     mockNavItems[0].properties.insertAfter = 'test6';
     sortedItems = getSortedNavItems(mockNavItems);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(1);
+    expect(indexOfId('test1', sortedItems)).toBe(1);
   });
 
   it('should order items that are positioned on positioned items', () => {
@@ -109,14 +114,35 @@ describe('perspective-nav insertPositionedItems', () => {
     mockNavItems[0].properties.insertAfter = 'test6';
     mockNavItems[5].properties.insertAfter = 'test4';
     let sortedItems = getSortedNavItems(mockNavItems);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test6')).toBe(3);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(4);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test7')).toBe(6);
+    expect(indexOfId('test6', sortedItems)).toBe(3);
+    expect(indexOfId('test1', sortedItems)).toBe(4);
+    expect(indexOfId('test7', sortedItems)).toBe(6);
 
     mockNavItems[6].properties.insertBefore = 'test1';
     sortedItems = getSortedNavItems(mockNavItems);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test6')).toBe(3);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test1')).toBe(5);
-    expect(sortedItems.map((i) => i.properties.id).indexOf('test7')).toBe(4);
+    expect(indexOfId('test6', sortedItems)).toBe(3);
+    expect(indexOfId('test1', sortedItems)).toBe(5);
+    expect(indexOfId('test7', sortedItems)).toBe(4);
+  });
+
+  it('should sort dependency items correctly', () => {
+    mockNavItems.forEach((i) => {
+      delete i.properties.insertAfter;
+      delete i.properties.insertBefore;
+    });
+    mockNavItems[0].properties.insertAfter = 'test4';
+    mockNavItems[2].properties.insertAfter = 'test5';
+    mockNavItems[5].properties.insertAfter = 'test7';
+    mockNavItems[6].properties.insertBefore = 'test1';
+
+    const sortedItems = sortExtensionItems(mockNavItems);
+    // test1 depends on test4
+    expect(indexOfId('test1', sortedItems)).toBeGreaterThan(indexOfId('test4', sortedItems));
+    // test3 depends on test5
+    expect(indexOfId('test3', sortedItems)).toBeGreaterThan(indexOfId('test5', sortedItems));
+    // test6 depends on test7
+    expect(indexOfId('test6', sortedItems)).toBeGreaterThan(indexOfId('test7', sortedItems));
+    // test7 depends on test1
+    expect(indexOfId('test7', sortedItems)).toBeGreaterThan(indexOfId('test1', sortedItems));
   });
 });

--- a/frontend/public/components/nav/navSortUtils.ts
+++ b/frontend/public/components/nav/navSortUtils.ts
@@ -84,3 +84,30 @@ export const getSortedNavItems = (navItems: (PluginNavSection | NavItem | Separa
   insertPositionedItems(positionedItems, sortedItems);
   return sortedItems;
 };
+
+export const sortExtensionItems = (
+  extensionItems: (PluginNavSection | NavItem | SeparatorNavItem)[],
+) => {
+  // Mapped by item id
+  const mappedIds = extensionItems.reduce((mem, i) => {
+    mem[i.properties.id] = i;
+    return mem;
+  }, {});
+
+  // determine all dependencies for a given id
+  const dependencies = (i) => {
+    const { insertBefore, insertAfter } = mappedIds[i].properties;
+    const before = Array.isArray(insertBefore) ? insertBefore : [insertBefore];
+    const after = Array.isArray(insertAfter) ? insertAfter : [insertAfter];
+    const dependencyIds = [...before, ...after];
+    return dependencyIds.reduce((acc, index) => {
+      if (index) {
+        // Add this dependency and its dependencies
+        return [...acc, index, ...dependencies(index)];
+      }
+      return acc;
+    }, []);
+  };
+
+  return extensionItems.sort((a, b) => dependencies(b.properties.id).indexOf(a.properties.id) * -1);
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5226

**Analysis / Root cause**: 
Nav items within sections were sorted amongst themselves then added in that order

**Solution Description**: 
Sort the nav items by dependencies, then insert each in order so that they can then be placed before/after existing nav items.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge