### PR TITLE
CONSOLE-2381: Support dynamic demo plugin deployment on cluster

### DIFF
--- a/Dockerfile.plugins.demo
+++ b/Dockerfile.plugins.demo
@@ -1,0 +1,33 @@
+# This image is used for testing OpenShift Console dynamic plugin capabilities.
+#
+# See frontend/dynamic-demo-plugin/README.md for details.
+
+# Stage 0: build the demo plugin
+FROM quay.io/coreos/tectonic-console-builder:v21 AS build
+
+RUN mkdir -p /src/console
+COPY . /src/console
+
+WORKDIR /src/console/frontend
+RUN yarn install
+
+WORKDIR /src/console/frontend/dynamic-demo-plugin
+RUN yarn install && \
+    yarn build
+
+# Stage 1: build the target image
+FROM node:10
+
+COPY --from=build /src/console/frontend/dynamic-demo-plugin/dist /opt/console-demo-plugin/static
+COPY --from=build /src/console/frontend/dynamic-demo-plugin/node_modules /opt/console-demo-plugin/node_modules
+COPY --from=build /src/console/frontend/dynamic-demo-plugin/http-server.sh /opt/console-demo-plugin/http-server.sh
+
+LABEL io.k8s.display-name="OpenShift Console Demo Plugin" \
+      io.k8s.description="Sample OpenShift Console dynamic plugin used for testing purposes." \
+      io.openshift.tags="openshift" \
+      maintainer="Vojtech Szocs <vszocs@redhat.com>"
+
+USER node
+
+WORKDIR /opt/console-demo-plugin
+ENTRYPOINT [ "./http-server.sh", "./static" ]

--- a/frontend/dynamic-demo-plugin/README.md
+++ b/frontend/dynamic-demo-plugin/README.md
@@ -1,0 +1,62 @@
+# OpenShift Console Demo Plugin
+
+This project emulates a standalone repository hosting a sample
+[dynamic plugin](/frontend/packages/console-dynamic-plugin-sdk/README.md) for OpenShift Console.
+
+It is meant to serve as a reference for Console plugin developers and for testing dynamic plugin
+capabilities via end-to-end tests.
+
+## Local development
+
+1. `yarn build` to build the plugin, generating output to `dist` directory
+2. `yarn http-server` to start an HTTP server hosting the generated assets
+
+```
+Starting up http-server, serving ./dist
+Available on:
+  http://127.0.0.1:9001
+  http://192.168.1.190:9001
+  http://10.40.192.80:9001
+Hit CTRL-C to stop the server
+```
+
+The server runs on port 9001 with caching disabled and CORS enabled. Additional
+[server options](https://github.com/http-party/http-server#available-options) can be passed to
+the script, for example:
+
+```sh
+yarn http-server -a 127.0.0.1
+```
+
+## Deployment on cluster
+
+Console dynamic plugins are supposed to be deployed via [OLM operators](https://github.com/operator-framework).
+In case of demo plugin, we just apply a minimal OpenShift manifest which adds the necessary resources.
+
+```sh
+oc apply -f oc-manifest.yaml
+```
+
+Note that the `Service` exposing the HTTP server is annotated to have a signed
+[service serving certificate](https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html)
+generated and mounted into the image. This allows us to run the server with HTTP/TLS enabled, using
+a trusted CA certificate.
+
+## Docker image
+
+Following commands should be executed in Console repository root.
+
+1. Build the image:
+   ```sh
+   docker build -f Dockerfile.plugins.demo -t $USER/console-demo-plugin .
+   ```
+2. Run the image:
+   ```sh
+   docker run -it -p 9001:9001 $USER/console-demo-plugin
+   ```
+3. Push the image to Docker Hub or similar image registry:
+   ```sh
+   docker push $USER/console-demo-plugin
+   ```
+
+To test a locally built demo plugin image, simply update and re-apply `oc-manifest.yaml`.

--- a/frontend/dynamic-demo-plugin/http-server.sh
+++ b/frontend/dynamic-demo-plugin/http-server.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -u
+
+PUBLIC_PATH="$1"
+shift
+SERVER_OPTS="$@"
+
+./node_modules/.bin/http-server $PUBLIC_PATH -p 9001 -c-1 --cors $SERVER_OPTS

--- a/frontend/dynamic-demo-plugin/oc-manifest.yaml
+++ b/frontend/dynamic-demo-plugin/oc-manifest.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: console-demo-plugin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console-demo-plugin
+  namespace: console-demo-plugin
+  labels:
+    app: console-demo-plugin
+    app.kubernetes.io/component: console-demo-plugin
+    app.kubernetes.io/instance: console-demo-plugin
+    app.kubernetes.io/part-of: console-demo-plugin
+    app.openshift.io/runtime-namespace: console-demo-plugin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: console-demo-plugin
+  template:
+    metadata:
+      labels:
+        app: console-demo-plugin
+    spec:
+      containers:
+        - name: console-demo-plugin
+          image: docker.io/jhadvig/console-demo-plugin
+          ports:
+            - containerPort: 9001
+              protocol: TCP
+          imagePullPolicy: Always
+          args:
+            - '--ssl'
+            - '--cert=/var/serving-cert/tls.crt'
+            - '--key=/var/serving-cert/tls.key'
+          volumeMounts:
+            - name: console-serving-cert
+              readOnly: true
+              mountPath: /var/serving-cert
+      volumes:
+        - name: console-serving-cert
+          secret:
+            secretName: console-serving-cert
+            defaultMode: 420
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: console-serving-cert
+  name: console-demo-plugin
+  namespace: console-demo-plugin
+  labels:
+    app: console-demo-plugin
+    app.kubernetes.io/component: console-demo-plugin
+    app.kubernetes.io/instance: console-demo-plugin
+    app.kubernetes.io/part-of: console-demo-plugin
+spec:
+  ports:
+    - name: 9001-tcp
+      protocol: TCP
+      port: 9001
+      targetPort: 9001
+  selector:
+    app: console-demo-plugin
+  type: ClusterIP
+  sessionAffinity: None
+---
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: console-demo-plugin
+spec:
+  displayName: 'OpenShift Console Demo Plugin'
+  service:
+    name: console-demo-plugin
+    namespace: console-demo-plugin
+    port: 9001
+    basePath: '/'

--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rm -rf ./dist",
     "build": "yarn clean && yarn ts-node ./node_modules/.bin/webpack",
-    "http-server": "http-server ./dist -p 9001 -c-1 --cors",
+    "http-server": "./http-server.sh ./dist",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}' -I '/node_modules/(?!(@console)/)/'"
   },
   "dependencies": {


### PR DESCRIPTION
- [x] Add Dockerfile to build the demo plugin image.
- [x] Add Kubernetes manifest to deploy demo plugin on the cluster.
- [x] Add basic README for the demo plugin.

The image is based on official [Node.js image](https://hub.docker.com/_/node), using `http-server.sh` script as the entry point and running as `node` user.

@spadgett Built image size is `985MB`, is this OK or should we consider using `node:alpine` as the base image to reduce its size?

```
$ docker image ls -f "reference=node:10" -f "reference=test"
REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
test         latest    855fa54f99c3   24 hours ago   985MB
node         10        78e6fbf9befd   6 days ago     911MB
```

When building the Docker image, we need the whole Console repo as the build context. This is because `frontend/codegen.yml` is referencing GraphQL schemas at `pkg/graphql`.

The plugin HTTP server runs at port 9001 with caching disabled and CORS enabled.
