### PR TITLE
Bug 1906899: fix offset in quick start highlight bounding box

### DIFF
--- a/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/DetectPerspective.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PerspectiveDetector from './PerspectiveDetector';
-import { PerpsectiveContext, useValuesForPerspectiveContext } from './perspective-context';
+import { PerpsectiveContext } from './perspective-context';
+import { useValuesForPerspectiveContext } from './useValuesForPerspectiveContext';
 
 type DetectPerspectiveProps = {
   children: React.ReactNode;

--- a/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/__tests__/DetectPerspective.spec.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { InternalDetectPerspective } from '../DetectPerspective';
 import PerspectiveDetector from '../PerspectiveDetector';
-import { useValuesForPerspectiveContext } from '../perspective-context';
+import { useValuesForPerspectiveContext } from '../useValuesForPerspectiveContext';
 
 const MockApp = () => <h1>App</h1>;
 
-jest.mock('../perspective-context', () => ({
-  ...require.requireActual('../perspective-context'),
+jest.mock('../useValuesForPerspectiveContext', () => ({
   useValuesForPerspectiveContext: jest.fn(),
 }));
 

--- a/frontend/packages/console-app/src/components/detect-perspective/perspective-context.ts
+++ b/frontend/packages/console-app/src/components/detect-perspective/perspective-context.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { isPerspective, Perspective, useExtensions } from '@console/plugin-sdk';
-import { useUserSettingsCompatibility } from '@console/shared';
 
 export type PerspectiveType = string;
 
@@ -10,23 +8,3 @@ export type PerspectiveContextType = {
 };
 
 export const PerpsectiveContext = React.createContext<PerspectiveContextType>({});
-
-const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `bridge/last-perspective`;
-
-const LAST_PERSPECTIVE_USER_SETTINGS_KEY = 'console.lastPerspective';
-
-export const useValuesForPerspectiveContext = (): [
-  PerspectiveType,
-  React.Dispatch<React.SetStateAction<PerspectiveType>>,
-  boolean,
-] => {
-  const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
-  const [perspective, setPerspective, loaded] = useUserSettingsCompatibility<PerspectiveType>(
-    LAST_PERSPECTIVE_USER_SETTINGS_KEY,
-    LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
-    '',
-  );
-  const isValidPerspective =
-    loaded && perspectiveExtensions.some((p) => p.properties.id === perspective);
-  return [isValidPerspective ? perspective : undefined, setPerspective, loaded];
-};

--- a/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
+++ b/frontend/packages/console-app/src/components/detect-perspective/useValuesForPerspectiveContext.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { isPerspective, Perspective, useExtensions } from '@console/plugin-sdk';
+import { useUserSettingsCompatibility } from '@console/shared';
+import { PerspectiveType } from './perspective-context';
+
+const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `bridge/last-perspective`;
+
+const LAST_PERSPECTIVE_USER_SETTINGS_KEY = 'console.lastPerspective';
+
+export const useValuesForPerspectiveContext = (): [
+  PerspectiveType,
+  React.Dispatch<React.SetStateAction<PerspectiveType>>,
+  boolean,
+] => {
+  const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
+  const [perspective, setPerspective, loaded] = useUserSettingsCompatibility<PerspectiveType>(
+    LAST_PERSPECTIVE_USER_SETTINGS_KEY,
+    LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
+    '',
+  );
+  const isValidPerspective =
+    loaded && perspectiveExtensions.some((p) => p.properties.id === perspective);
+  return [isValidPerspective ? perspective : undefined, setPerspective, loaded];
+};

--- a/frontend/packages/console-app/src/components/tour/__tests__/tour-context.spec.ts
+++ b/frontend/packages/console-app/src/components/tour/__tests__/tour-context.spec.ts
@@ -6,6 +6,10 @@ import * as TourModule from '../tour-context';
 import { TourActions } from '../const';
 import { TourDataType } from '../type';
 
+jest.mock('@console/shared/src/hooks/useActivePerspective', () => ({
+  useActivePerspective: () => ['dev', jest.fn()],
+}));
+
 const { tourReducer, useTourValuesForContext, useTourStateForPerspective } = TourModule;
 
 describe('guided-tour-context', () => {
@@ -69,10 +73,13 @@ describe('guided-tour-context', () => {
     });
 
     it('should return context values from the hook', () => {
-      spyOn(redux, 'useSelector').and.returnValues('dev', { A: true, B: false }, 'dev', {
-        A: true,
-        B: false,
-      });
+      spyOn(redux, 'useSelector').and.returnValues(
+        { A: true, B: false },
+        {
+          A: true,
+          B: false,
+        },
+      );
       spyOn(plugins, 'useExtensions').and.returnValue(mockTourExtension);
       spyOn(TourModule, 'useTourStateForPerspective').and.returnValue([
         { completed: false },
@@ -96,10 +103,13 @@ describe('guided-tour-context', () => {
     });
 
     it('should return tour null from the hook', () => {
-      spyOn(redux, 'useSelector').and.returnValues('dev', { A: true, B: false }, 'dev', {
-        A: true,
-        B: false,
-      });
+      spyOn(redux, 'useSelector').and.returnValues(
+        { A: true, B: false },
+        {
+          A: true,
+          B: false,
+        },
+      );
       spyOn(plugins, 'useExtensions').and.returnValue([]);
       spyOn(TourModule, 'useTourStateForPerspective').and.returnValue([
         { completed: false },
@@ -116,10 +126,13 @@ describe('guided-tour-context', () => {
     });
 
     it('should return null from the hook if tour is available but data isnot loaded', () => {
-      spyOn(redux, 'useSelector').and.returnValues('dev', { A: true, B: false }, 'dev', {
-        A: true,
-        B: false,
-      });
+      spyOn(redux, 'useSelector').and.returnValues(
+        { A: true, B: false },
+        {
+          A: true,
+          B: false,
+        },
+      );
       spyOn(plugins, 'useExtensions').and.returnValue(mockTourExtension);
       spyOn(TourModule, 'useTourStateForPerspective').and.returnValue([
         { completed: false },

--- a/frontend/packages/console-app/src/components/tour/tour-context.ts
+++ b/frontend/packages/console-app/src/components/tour/tour-context.ts
@@ -21,6 +21,7 @@ import { useUserSettingsCompatibility } from '@console/shared/src/hooks/useUserS
 import { TourActions, TOUR_LOCAL_STORAGE_KEY } from './const';
 import { filterTourBasedonPermissionAndFlag } from './utils';
 import { TourDataType, Step } from './type';
+import { useActivePerspective } from '@console/shared/src/hooks/useActivePerspective';
 
 type TourStateAction = { type: TourActions; payload?: { completed?: boolean } };
 export const tourReducer = (state: TourState, action: TourStateAction) => {
@@ -120,7 +121,7 @@ export const useTourValuesForContext = (): TourContextType => {
   // declaring a method for the perspective instead of using getActivePerspective
   // because importing getActivePerspective in this file throws error
   // Uncaught ReferenceError: Cannot access 'allModels' before initialization and this hook is used in plugin extension for ContextProvider
-  const activePerspective = useSelector(({ UI }: RootState): string => UI.get('activePerspective'));
+  const [activePerspective] = useActivePerspective();
   const [perspective, setPerspective] = useState<string>(activePerspective);
   const tourExtension = useExtensions<GuidedTour>(isGuidedTour);
   const tour = tourExtension.find(({ properties }) => properties.perspective === perspective);

--- a/frontend/packages/console-shared/src/components/popper/Popper.tsx
+++ b/frontend/packages/console-shared/src/components/popper/Popper.tsx
@@ -217,7 +217,11 @@ const Popper: React.FC<PopperProps> = ({
 
   return isOpen ? (
     <Portal container={container}>
-      <div ref={nodeRefCallback} className={className} style={{ zIndex }}>
+      <div
+        ref={nodeRefCallback}
+        className={className}
+        style={{ zIndex, position: 'absolute', top: 0, left: 0 }}
+      >
         {children}
       </div>
     </Portal>

--- a/frontend/packages/console-shared/src/components/spotlight/InteractiveSpotlight.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/InteractiveSpotlight.tsx
@@ -22,6 +22,9 @@ const popperOptions: PopperOptions = {
     preventOverflow: {
       enabled: false,
     },
+    flip: {
+      enabled: false,
+    },
   },
 };
 
@@ -36,7 +39,7 @@ const InteractiveSpotlight: React.FC<InteractiveSpotlightProps> = ({ element }) 
   React.useEffect(() => {
     if (!clicked) {
       if (!isInViewport(element)) {
-        element.scrollIntoView();
+        element.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
       }
       const handleClick = () => setClicked(true);
       document.addEventListener('click', handleClick);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5234

**Analysis / Root cause**: 
The bounding box of the target node to highlight gets calculated immediately after the highlight is rendered to the page. However, this occurs before popper has positioned the highlight. Since the Popper component rendered the content without any positional information, it ended up rendering the content at the bottom of the page below the fold. This results in a vertical scrollbar appearing on the body and shifting the content over to the left. This only occurs the browser / os has scrollbars always visible.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
The solution here is to default the popper wrapper with `position: absolute, top: 0, left: 0` so that it begins rendering in the top left corner. Also changed the scroll behavior to be smooth as it helps guide the user to understand where the element came from it if happens to be offscreen.

To test all spotlight usage, I had to fix an issue where the guided tour menu item wasn't rendering because of a change to active perspective fetching. This fix required also addressing a circular dependency.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/14068621/101554916-90573500-3985-11eb-940f-765a1ed45ecf.png)

**Test Setup**
Install the following Quick Start:

```
apiVersion: console.openshift.io/v1
kind: ConsoleQuickStart
metadata:
  name: test-highlight
spec:
  description: test desc
  displayName: test highlight
  durationMinutes: 1
  introduction: test intro
  tasks:
    - description: |
        1. [perspective]{{highlight tour-perspective-dropdown}}
        2. [masthead]{{highlight tour-help-button}}
        3. [search]{{highlight tour-search-nav}}
      title: test highlight
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
