### PR TITLE
Bug 1906684: handles application group issue with EventSource creation

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceForm.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/EventSourceForm.spec.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { FormFooter, SyncedEditorField, FlexForm } from '@console/shared';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import { getEventSourceIcon } from '../../../utils/get-knative-icon';
+import { EventSourceContainerModel } from '../../../models';
+import EventSourceForm from '../EventSourceForm';
+import * as fetchDynamicEventsource from '../../../utils/fetch-dynamic-eventsources-utils';
+import { kameletSourceTelegram } from '../../../utils/__tests__/knative-eventing-data';
+
+let eventSourceFormProps: React.ComponentProps<typeof EventSourceForm>;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+const eventSourceStatusData = {
+  loaded: true,
+  eventSourceList: {
+    [EventSourceContainerModel.kind]: {
+      name: EventSourceContainerModel.kind,
+      title: EventSourceContainerModel.kind,
+      iconUrl: getEventSourceIcon(referenceForModel(EventSourceContainerModel)),
+      displayName: EventSourceContainerModel.kind,
+    },
+  },
+};
+
+describe('EventSourceForm', () => {
+  beforeEach(() => {
+    eventSourceFormProps = {
+      ...formikFormProps,
+      values: {
+        formData: {
+          type: 'ApiServerSource',
+        },
+      },
+      eventSourceStatus: eventSourceStatusData,
+      namespace: 'myapp',
+      eventSourceMetaDescription: 'null',
+    };
+  });
+
+  it('should render FlexForm, SyncedEditorField and FormFooter if Source is valid', () => {
+    jest
+      .spyOn(fetchDynamicEventsource, 'isDynamicEventSourceKind')
+      .mockImplementationOnce(() => true);
+    const wrapper = shallow(<EventSourceForm {...eventSourceFormProps} />);
+    expect(wrapper.find(FlexForm).exists()).toBe(true);
+    expect(wrapper.find(SyncedEditorField).exists()).toBe(true);
+    expect(wrapper.find(FormFooter).exists()).toBe(true);
+  });
+
+  it('should not render  SyncedEditorField if Source is not valid', () => {
+    jest
+      .spyOn(fetchDynamicEventsource, 'isDynamicEventSourceKind')
+      .mockImplementationOnce(() => false);
+    const wrapper = shallow(<EventSourceForm {...eventSourceFormProps} />);
+    expect(wrapper.find(FlexForm).exists()).toBe(true);
+    expect(wrapper.find(SyncedEditorField).exists()).toBe(false);
+    expect(wrapper.find(FormFooter).exists()).toBe(true);
+  });
+
+  it('should render FlexForm, SyncedEditorField and FormFooter if is a Kamelet', () => {
+    jest
+      .spyOn(fetchDynamicEventsource, 'isDynamicEventSourceKind')
+      .mockImplementationOnce(() => false);
+    const wrapper = shallow(
+      <EventSourceForm {...eventSourceFormProps} kameletSource={kameletSourceTelegram} />,
+    );
+    expect(wrapper.find(FlexForm).exists()).toBe(true);
+    expect(wrapper.find(SyncedEditorField).exists()).toBe(true);
+    expect(wrapper.find(FormFooter).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -48,7 +48,6 @@ export interface SinkResourceData {
 }
 
 export interface EventSourceFormData {
-  editorType?: string;
   project: ProjectData;
   application: ApplicationData;
   name: string;
@@ -57,7 +56,6 @@ export interface EventSourceFormData {
   sinkType: string;
   sink: SinkResourceData;
   data?: EventSourceData;
-  yamlData?: string;
 }
 
 export interface EventSourceSyncFormData {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-eventing-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-eventing-data.ts
@@ -241,3 +241,59 @@ export const triggerData: K8sResourceKind = {
     subscriberUri: 'http://broker-display.sample-app.svc.cluster.local',
   },
 };
+
+export const kameletSourceTelegram: K8sResourceKind = {
+  apiVersion: 'camel.apache.org/v1alpha1',
+  kind: 'Kamelet',
+  metadata: {
+    name: 'telegram-source',
+    annotations: {
+      'camel.apache.org/kamelet.icon':
+        'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNDAgMjQwIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImEiIHgxPSIuNjY3IiB4Mj0iLjQxNyIgeTE9Ii4xNjciIHkyPSIuNzUiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzM3YWVlMiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzFlOTZjOCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJiIiB4MT0iLjY2IiB4Mj0iLjg1MSIgeTE9Ii40MzciIHkyPSIuODAyIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNlZmY3ZmMiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNmZmYiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48Y2lyY2xlIGN4PSIxMjAiIGN5PSIxMjAiIHI9IjEyMCIgZmlsbD0idXJsKCNhKSIvPjxwYXRoIGZpbGw9IiNjOGRhZWEiIGQ9Ik05OCAxNzVjLTMuODg4IDAtMy4yMjctMS40NjgtNC41NjgtNS4xN0w4MiAxMzIuMjA3IDE3MCA4MCIvPjxwYXRoIGZpbGw9IiNhOWM5ZGQiIGQ9Ik05OCAxNzVjMyAwIDQuMzI1LTEuMzcyIDYtM2wxNi0xNS41NTgtMTkuOTU4LTEyLjAzNSIvPjxwYXRoIGZpbGw9InVybCgjYikiIGQ9Ik0xMDAuMDQgMTQ0LjQxbDQ4LjM2IDM1LjcyOWM1LjUxOSAzLjA0NSA5LjUwMSAxLjQ2OCAxMC44NzYtNS4xMjNsMTkuNjg1LTkyLjc2M2MyLjAxNS04LjA4LTMuMDgtMTEuNzQ2LTguMzYtOS4zNDlsLTExNS41OSA0NC41NzFjLTcuODkgMy4xNjUtNy44NDMgNy41NjctMS40MzggOS41MjhsMjkuNjYzIDkuMjU5IDY4LjY3My00My4zMjVjMy4yNDItMS45NjYgNi4yMTgtLjkxIDMuNzc2IDEuMjU4Ii8+PC9zdmc+',
+      'camel.apache.org/provider': 'Red Hat',
+    },
+    labels: {
+      'camel.apache.org/kamelet.type': 'source',
+    },
+  },
+  spec: {
+    definition: {
+      title: 'Telegram Source',
+      description: 'Receive all messages that people send to your telegram bot.',
+      required: ['authorizationToken'],
+      properties: {
+        authorizationToken: {
+          title: 'Token',
+          description:
+            'The token to access your bot on Telegram, that you can obtain from the Telegram "Bot Father".',
+          type: 'string',
+          'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+        },
+      },
+    },
+    types: {
+      out: {
+        mediaType: 'application/json',
+      },
+    },
+    dependencies: ['camel:jackson'],
+    flow: {
+      from: {
+        uri: 'telegram:bots',
+        parameters: {
+          authorizationToken: '{{authorizationToken}}',
+        },
+        steps: [
+          {
+            marshal: {
+              json: {},
+            },
+          },
+          {
+            to: 'kamelet:sink',
+          },
+        ],
+      },
+    },
+  },
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5239

**Analysis / Root cause**: 
Event Source creation fails if user selects no app group and switch to yaml and then to form as application name had text "no application group" as part of annotations

**Solution Description**: 
handles application group issue with EventSource creation


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/5129024/101629351-3a4ac600-3a47-11eb-866e-fb161b52c350.png)

![image](https://user-images.githubusercontent.com/5129024/101629430-564e6780-3a47-11eb-9bfe-81f77d956ecb.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
