### PR TITLE
fix quick start catalog tile icon alignment

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.scss
@@ -4,4 +4,8 @@
     display: block;
     -webkit-line-clamp: unset;
   }
+
+  & .catalog-tile-pf-icon {
+    display: flex;
+  }
 }


### PR DESCRIPTION
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When supplying a custom icon image to the PF `CatalogTile`, the vertical alignment of the image isn't correct; the image is aligned too low.

Raised an issue on PF catalog tile:
https://github.com/patternfly/patternfly-react/issues/5235

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
Before:
![image](https://user-images.githubusercontent.com/14068621/101659341-f2f71200-3a13-11eb-91ba-b5edcbf063e4.png)

After:
![image](https://user-images.githubusercontent.com/14068621/101659307-e8d51380-3a13-11eb-915a-3edd43d1f560.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
