### PR TITLE
CONSOLE-2371: [i18n] Externalize olm modal strings

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -1,0 +1,21 @@
+{
+  "Delete CatalogSource?": "Delete CatalogSource?",
+  "By deleting a CatalogSource, any Operator that has been installed from this source will no longer receive updates.": "By deleting a CatalogSource, any Operator that has been installed from this source will no longer receive updates.",
+  "Confirm deletion by typing <2>{{name}}</2> below:": "Confirm deletion by typing <2>{{name}}</2> below:",
+  "Enter name": "Enter name",
+  "Disable CatalogSource?": "Disable CatalogSource?",
+  "By disabling a default source, the operators it provides will no longer appear in OperatorHub and any operator that has been installed from this source will no longer receive updates until the source is re-enabled. Disabling the source will also remove the corresponding OperatorSource and CatalogSource resources from the cluster.": "By disabling a default source, the operators it provides will no longer appear in OperatorHub and any operator that has been installed from this source will no longer receive updates until the source is re-enabled. Disabling the source will also remove the corresponding OperatorSource and CatalogSource resources from the cluster.",
+  "Change update approval strategy": "Change update approval strategy",
+  "What strategy is used for approving updates?": "What strategy is used for approving updates?",
+  "Automatic": "Automatic",
+  "New updates will be installed as soon as they become available.": "New updates will be installed as soon as they become available.",
+  "Manual": "Manual",
+  "New updates need to be manually approved before installation begins.": "New updates need to be manually approved before installation begins.",
+  "InstallPlan Preview": "InstallPlan Preview",
+  "Change Subscription update channel": "Change Subscription update channel",
+  "Which channel is used to receive updates?": "Which channel is used to receive updates?",
+  "Uninstall Operator?": "Uninstall Operator?",
+  "This will remove Operator <1>{{name}}</1> from <4>{{namespace}}</4>. Removing the Operator will not remove any of its custom resource definitions or managed resources. If your Operator has deployed applications on the cluster or configured off-cluster resources, these will continue to run and need to be cleaned up manually.": "This will remove Operator <1>{{name}}</1> from <4>{{namespace}}</4>. Removing the Operator will not remove any of its custom resource definitions or managed resources. If your Operator has deployed applications on the cluster or configured off-cluster resources, these will continue to run and need to be cleaned up manually.",
+  "Message from Operator developer": "Message from Operator developer",
+  "Uninstall": "Uninstall"
+}

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/delete-catalog-source-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/delete-catalog-source-modal.tsx
@@ -9,6 +9,7 @@ import {
 } from '@console/internal/components/factory/modal';
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { withHandlePromise, HandlePromiseProps } from '@console/internal/components/utils';
+import { Trans, useTranslation } from 'react-i18next';
 
 const DeleteCatalogSourceModal: React.FC<DeleteCatalogSourceModalProps> = ({
   kind,
@@ -19,6 +20,7 @@ const DeleteCatalogSourceModal: React.FC<DeleteCatalogSourceModalProps> = ({
   errorMessage,
   handlePromise,
 }) => {
+  const { t } = useTranslation();
   const [confirmed, setConfirmed] = React.useState<boolean>(false);
   const isConfirmed = (e: React.KeyboardEvent<HTMLInputElement>) => {
     setConfirmed(e.currentTarget.value === resource.metadata.name);
@@ -35,27 +37,30 @@ const DeleteCatalogSourceModal: React.FC<DeleteCatalogSourceModalProps> = ({
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>
-        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete {kind.label}?
+        <YellowExclamationTriangleIcon className="co-icon-space-r" />{' '}
+        {t('olm~Delete CatalogSource?')}
       </ModalTitle>
       <ModalBody>
         <p>
-          By deleting a catlog source, any operator that has been installed from this source will no
-          longer receive updates.
+          {t(
+            'olm~By deleting a CatalogSource, any Operator that has been installed from this source will no longer receive updates.',
+          )}
         </p>
         <p>
-          Confirm deletion by typing &nbsp;
-          <strong className="co-break-word">{resource.metadata.name}</strong>
-          &nbsp; below:
+          <Trans ns="olm">
+            Confirm deletion by typing{' '}
+            <strong className="co-break-word">{{ name: resource.metadata.name }}</strong> below:
+          </Trans>
         </p>
         <input
           type="text"
           className="pf-c-form-control"
           onKeyUp={isConfirmed}
-          placeholder="Enter name"
+          placeholder={t('olm~Enter name')}
         />
       </ModalBody>
       <ModalSubmitFooter
-        submitText="Delete"
+        submitText={t('public~Delete')}
         submitDisabled={!confirmed}
         cancel={cancel}
         errorMessage={errorMessage}

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/disable-default-source-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/disable-default-source-modal.tsx
@@ -11,6 +11,7 @@ import {
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { withHandlePromise, HandlePromiseProps } from '@console/internal/components/utils';
 import { OperatorHubKind } from '../operator-hub';
+import { useTranslation } from 'react-i18next';
 
 const DisableDefaultSourceModal: React.FC<DisableSourceModalProps> = ({
   kind,
@@ -22,6 +23,7 @@ const DisableDefaultSourceModal: React.FC<DisableSourceModalProps> = ({
   errorMessage,
   handlePromise,
 }) => {
+  const { t } = useTranslation();
   const submit = React.useCallback(
     (event: React.FormEvent<EventTarget>): void => {
       event.preventDefault();
@@ -47,16 +49,16 @@ const DisableDefaultSourceModal: React.FC<DisableSourceModalProps> = ({
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>
-        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Disable Catalog Source?
+        <YellowExclamationTriangleIcon className="co-icon-space-r" />{' '}
+        {t('olm~Disable CatalogSource?')}
       </ModalTitle>
       <ModalBody>
-        By disabling a default source, the operators it provides will no longer appear in
-        OperatorHub and any operator that has been installed from this source will no longer receive
-        updates until the source is re-enabled. Disabling the source will also remove the
-        corresponding OperatorSource and CatalogSource resources from the cluster.
+        {t(
+          'olm~By disabling a default source, the operators it provides will no longer appear in OperatorHub and any operator that has been installed from this source will no longer receive updates until the source is re-enabled. Disabling the source will also remove the corresponding OperatorSource and CatalogSource resources from the cluster.',
+        )}
       </ModalBody>
       <ModalSubmitFooter
-        submitText="Disable"
+        submitText={t('public~Disable')}
         cancel={cancel}
         errorMessage={errorMessage}
         inProgress={inProgress}

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.spec.tsx
@@ -14,13 +14,20 @@ import { testSubscription, testInstallPlan } from '../../../mocks';
 import {
   InstallPlanApprovalModal,
   InstallPlanApprovalModalProps,
-  InstallPlanApprovalModalState,
 } from './installplan-approval-modal';
 
 import Spy = jasmine.Spy;
 
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
 describe(InstallPlanApprovalModal.name, () => {
-  let wrapper: ShallowWrapper<InstallPlanApprovalModalProps, InstallPlanApprovalModalState>;
+  let wrapper: ShallowWrapper<InstallPlanApprovalModalProps>;
   let k8sUpdate: Spy;
   let close: Spy;
   let cancel: Spy;
@@ -45,7 +52,7 @@ describe(InstallPlanApprovalModal.name, () => {
   it('renders a modal form', () => {
     expect(wrapper.find('form').props().name).toEqual('form');
     expect(wrapper.find(ModalTitle).exists()).toBe(true);
-    expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('Save');
+    expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('public~Save');
   });
 
   it('renders a radio button for each available approval strategy', () => {
@@ -64,7 +71,6 @@ describe(InstallPlanApprovalModal.name, () => {
 
   it('pre-selects the approval strategy option that is currently being used by an install plan', () => {
     wrapper = wrapper.setProps({ obj: _.cloneDeep(testInstallPlan) });
-
     expect(
       wrapper
         .find(ModalBody)
@@ -75,32 +81,35 @@ describe(InstallPlanApprovalModal.name, () => {
   });
 
   it('calls `props.k8sUpdate` to update the subscription when form is submitted', () => {
-    wrapper = wrapper.setState({ selectedApprovalStrategy: InstallPlanApproval.Manual });
     spyOn(k8sModels, 'modelFor').and.returnValue(SubscriptionModel);
     k8sUpdate.and.callFake((modelArg, subscriptionArg) => {
       expect(modelArg).toEqual(SubscriptionModel);
-      expect(subscriptionArg).toEqual({
-        ...subscription,
-        spec: { ...subscription.spec, installPlanApproval: InstallPlanApproval.Manual },
-      });
+      expect(subscriptionArg?.spec?.installPlanApproval).toEqual(InstallPlanApproval.Manual);
       return Promise.resolve();
     });
+    wrapper
+      .find(ModalBody)
+      .find(RadioInput)
+      .at(1)
+      .props()
+      .onChange({ target: { value: InstallPlanApproval.Manual } });
     wrapper.find('form').simulate('submit', new Event('submit'));
   });
 
   it('calls `props.k8sUpdate` to update the install plan when form is submitted', () => {
     wrapper = wrapper.setProps({ obj: _.cloneDeep(testInstallPlan) });
-    wrapper = wrapper.setState({ selectedApprovalStrategy: InstallPlanApproval.Manual });
     spyOn(k8sModels, 'modelFor').and.returnValue(InstallPlanModel);
     k8sUpdate.and.callFake((modelArg, installPlanArg) => {
       expect(modelArg).toEqual(InstallPlanModel);
-      expect(installPlanArg).toEqual({
-        ...testInstallPlan,
-        spec: { ...testInstallPlan.spec, approval: InstallPlanApproval.Manual },
-      });
+      expect(installPlanArg?.spec?.approval).toEqual(InstallPlanApproval.Manual);
       return Promise.resolve();
     });
-
+    wrapper
+      .find(ModalBody)
+      .find(RadioInput)
+      .at(1)
+      .props()
+      .onChange({ target: { value: InstallPlanApproval.Manual } });
     wrapper.find('form').simulate('submit', new Event('submit'));
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
@@ -6,7 +6,6 @@ import {
   ModalBody,
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
-import { PromiseComponent } from '@console/internal/components/utils';
 import {
   K8sKind,
   K8sResourceKind,
@@ -17,91 +16,90 @@ import {
 import { RadioInput } from '@console/internal/components/radio';
 import { SubscriptionKind, InstallPlanApproval, InstallPlanKind } from '../../types';
 import { SubscriptionModel, InstallPlanModel } from '../../models';
+import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
+import { useTranslation } from 'react-i18next';
 
-const getApprovalStrategy = (props: InstallPlanApprovalModalProps) =>
-  (referenceFor(props.obj) === referenceForModel(SubscriptionModel) &&
-    _.get(props.obj, 'spec.installPlanApproval')) ||
-  (referenceFor(props.obj) === referenceForModel(InstallPlanModel) &&
-    _.get(props.obj, 'spec.approval')) ||
+const getApprovalStrategy = (obj: InstallPlanKind | SubscriptionKind): InstallPlanApproval =>
+  (obj as SubscriptionKind)?.spec?.installPlanApproval ??
+  obj?.spec?.approval ??
   InstallPlanApproval.Automatic;
 
-export class InstallPlanApprovalModal extends PromiseComponent<
-  InstallPlanApprovalModalProps,
-  InstallPlanApprovalModalState
-> {
-  public state: InstallPlanApprovalModalState;
+export const InstallPlanApprovalModal: React.FC<InstallPlanApprovalModalProps> = ({
+  cancel,
+  close,
+  k8sUpdate,
+  obj,
+}) => {
+  const { t } = useTranslation();
+  const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
+  const [selectedApprovalStrategy, setSelectedApprovalStrategy] = React.useState(
+    getApprovalStrategy(obj),
+  );
+  const submit = React.useCallback(
+    (event: React.FormEvent<HTMLFormElement>): void => {
+      event.preventDefault();
+      const updatedObj = _.cloneDeep(obj);
+      if (referenceFor(updatedObj) === referenceForModel(SubscriptionModel)) {
+        (updatedObj as SubscriptionKind).spec.installPlanApproval = selectedApprovalStrategy;
+      } else if (referenceFor(updatedObj) === referenceForModel(InstallPlanModel)) {
+        (updatedObj as InstallPlanKind).spec.approval = selectedApprovalStrategy;
+      }
+      handlePromise(k8sUpdate(modelFor(referenceFor(obj)), updatedObj))
+        .then(() => close?.())
+        .catch(_.noop);
+    },
+    [close, handlePromise, k8sUpdate, obj, selectedApprovalStrategy],
+  );
 
-  constructor(public props: InstallPlanApprovalModalProps) {
-    super(props);
-
-    this.state.selectedApprovalStrategy = getApprovalStrategy(props);
-  }
-
-  private submit(event): void {
-    event.preventDefault();
-
-    const updatedObj = _.cloneDeep(this.props.obj);
-    if (referenceFor(updatedObj) === referenceForModel(SubscriptionModel)) {
-      (updatedObj as SubscriptionKind).spec.installPlanApproval = this.state.selectedApprovalStrategy;
-    } else if (referenceFor(updatedObj) === referenceForModel(InstallPlanModel)) {
-      (updatedObj as InstallPlanKind).spec.approval = this.state.selectedApprovalStrategy;
-    }
-    this.handlePromise(this.props.k8sUpdate(modelFor(referenceFor(this.props.obj)), updatedObj))
-      .then(() => this.props.close())
-      .catch((err) => this.setState({ errorMessage: err }));
-  }
-
-  render() {
-    return (
-      <form onSubmit={this.submit.bind(this)} name="form" className="modal-content">
-        <ModalTitle className="modal-header">Change Update Approval Strategy</ModalTitle>
-        <ModalBody>
-          <div className="co-m-form-row">
-            <p>What strategy is used for approving updates?</p>
+  return (
+    <form onSubmit={submit} name="form" className="modal-content">
+      <ModalTitle className="modal-header">{t('olm~Change update approval strategy')}</ModalTitle>
+      <ModalBody>
+        <div className="co-m-form-row">
+          <p>{t('olm~What strategy is used for approving updates?')}</p>
+        </div>
+        <div className="co-m-form-row row">
+          <div className="col-sm-12">
+            <RadioInput
+              onChange={(e) => setSelectedApprovalStrategy(e.target.value)}
+              value={InstallPlanApproval.Automatic}
+              checked={selectedApprovalStrategy === InstallPlanApproval.Automatic}
+              title={t(`olm~Automatic`)}
+              subTitle={`(${t('public~default')})`}
+            >
+              <div className="co-m-radio-desc">
+                <p className="text-muted">
+                  {t('olm~New updates will be installed as soon as they become available.')}
+                </p>
+              </div>
+            </RadioInput>
           </div>
-          <div className="co-m-form-row row">
-            <div className="col-sm-12">
-              <RadioInput
-                onChange={(e) => this.setState({ selectedApprovalStrategy: e.target.value })}
-                value={InstallPlanApproval.Automatic}
-                checked={this.state.selectedApprovalStrategy === InstallPlanApproval.Automatic}
-                title={InstallPlanApproval.Automatic}
-                subTitle="(default)"
-              >
-                <div className="co-m-radio-desc">
-                  <p className="text-muted">
-                    New updates will be installed as soon as they become available.
-                  </p>
-                </div>
-              </RadioInput>
-            </div>
-            <div className="col-sm-12">
-              <RadioInput
-                onChange={(e) => this.setState({ selectedApprovalStrategy: e.target.value })}
-                value={InstallPlanApproval.Manual}
-                checked={this.state.selectedApprovalStrategy === InstallPlanApproval.Manual}
-                title={InstallPlanApproval.Manual}
-              >
-                <div className="co-m-radio-desc">
-                  <p className="text-muted">
-                    New updates need to be manually approved before installation begins.
-                  </p>
-                </div>
-              </RadioInput>
-            </div>
+          <div className="col-sm-12">
+            <RadioInput
+              onChange={(e) => setSelectedApprovalStrategy(e.target.value)}
+              value={InstallPlanApproval.Manual}
+              checked={selectedApprovalStrategy === InstallPlanApproval.Manual}
+              title={t(`olm~Manual`)}
+            >
+              <div className="co-m-radio-desc">
+                <p className="text-muted">
+                  {t('olm~New updates need to be manually approved before installation begins.')}
+                </p>
+              </div>
+            </RadioInput>
           </div>
-        </ModalBody>
-        <ModalSubmitFooter
-          inProgress={this.state.inProgress}
-          errorMessage={this.state.errorMessage}
-          cancel={() => this.props.cancel()}
-          submitText="Save"
-          submitDisabled={getApprovalStrategy(this.props) === this.state.selectedApprovalStrategy}
-        />
-      </form>
-    );
-  }
-}
+        </div>
+      </ModalBody>
+      <ModalSubmitFooter
+        inProgress={inProgress}
+        errorMessage={errorMessage}
+        cancel={cancel}
+        submitText={t('public~Save')}
+        submitDisabled={getApprovalStrategy(obj) === selectedApprovalStrategy}
+      />
+    </form>
+  );
+};
 
 export const createInstallPlanApprovalModal = createModalLauncher<InstallPlanApprovalModalProps>(
   InstallPlanApprovalModal,
@@ -112,10 +110,4 @@ export type InstallPlanApprovalModalProps = {
   close?: () => void;
   k8sUpdate: (kind: K8sKind, newObj: K8sResourceKind) => Promise<any>;
   obj: InstallPlanKind | SubscriptionKind;
-};
-
-export type InstallPlanApprovalModalState = {
-  inProgress: boolean;
-  errorMessage: string;
-  selectedApprovalStrategy: InstallPlanApproval;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-preview-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-preview-modal.tsx
@@ -10,29 +10,33 @@ import { ActionGroup, Button } from '@patternfly/react-core';
 import { ResourceLink, CopyToClipboard } from '@console/internal/components/utils';
 import { referenceForStepResource } from '../index';
 import { StepResource } from '../../types';
+import { useTranslation } from 'react-i18next';
 
-const InstallPlanPreview: React.FC<InstallPlanPreviewModalProps> = ({ cancel, stepResource }) => (
-  <div className="modal-content">
-    <ModalTitle>
-      Install Plan Preview{' '}
-      <ResourceLink
-        linkTo={false}
-        name={stepResource.name}
-        kind={referenceForStepResource(stepResource)}
-      />
-    </ModalTitle>
-    <ModalBody>
-      <CopyToClipboard value={safeDump(JSON.parse(stepResource.manifest))} />
-    </ModalBody>
-    <ModalFooter inProgress={false}>
-      <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
-        <Button type="button" variant="secondary" onClick={() => cancel()}>
-          OK
-        </Button>
-      </ActionGroup>
-    </ModalFooter>
-  </div>
-);
+const InstallPlanPreview: React.FC<InstallPlanPreviewModalProps> = ({ cancel, stepResource }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="modal-content">
+      <ModalTitle>
+        {t('olm~InstallPlan Preview')}{' '}
+        <ResourceLink
+          linkTo={false}
+          name={stepResource.name}
+          kind={referenceForStepResource(stepResource)}
+        />
+      </ModalTitle>
+      <ModalBody>
+        <CopyToClipboard value={safeDump(JSON.parse(stepResource.manifest))} />
+      </ModalBody>
+      <ModalFooter inProgress={false}>
+        <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
+          <Button type="button" variant="secondary" onClick={() => cancel()}>
+            {t('public~OK')}
+          </Button>
+        </ActionGroup>
+      </ModalFooter>
+    </div>
+  );
+};
 
 export const installPlanPreviewModal = createModalLauncher<InstallPlanPreviewModalProps>(
   InstallPlanPreview,

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
@@ -9,6 +9,14 @@ import { UninstallOperatorModal, UninstallOperatorModalProps } from './uninstall
 
 import Spy = jasmine.Spy;
 
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
 describe(UninstallOperatorModal.name, () => {
   let wrapper: ShallowWrapper<UninstallOperatorModalProps>;
   let k8sKill: Spy;
@@ -43,13 +51,13 @@ describe(UninstallOperatorModal.name, () => {
         close={close}
         cancel={cancel}
       />,
-    ).dive();
+    );
   });
 
   it('renders a modal form', () => {
     expect(wrapper.find('form').props().name).toEqual('form');
     expect(wrapper.find(ModalTitle).exists()).toBe(true);
-    expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('Uninstall');
+    expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('olm~Uninstall');
   });
 
   it('calls `props.k8sKill` to delete the subscription when form is submitted', (done) => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/update-strategy-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/update-strategy-modal.tsx
@@ -7,26 +7,25 @@ import {
   ModalSubmitFooter,
   ModalTitle,
 } from '@console/internal/components/factory/modal';
-import { withHandlePromise } from '@console/internal/components/utils';
 import {
   ConfigureUpdateStrategy,
   getNumberOrPercent,
 } from '@console/internal/components/modals/configure-update-strategy-modal';
+import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
+import { useTranslation } from 'react-i18next';
 
-export const UpdateStrategyModal = withHandlePromise((props: UpdateStrategyModalProps) => {
-  const {
-    path,
-    resource,
-    resourceKind,
-    title,
-    handlePromise,
-    errorMessage,
-    inProgress,
-    defaultValue,
-    cancel,
-    close,
-  } = props;
+export const UpdateStrategyModal: React.FC<UpdateStrategyModalProps> = ({
+  cancel,
+  close,
+  path,
+  defaultValue,
+  resource,
+  resourceKind,
+  title,
+}) => {
+  const { t } = useTranslation();
   const getPath = path.substring(1).replace('/', '.');
+  const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
   const [strategyType, setStrategyType] = React.useState(
     _.get(resource, `${getPath}.type`) || defaultValue,
   );
@@ -37,25 +36,29 @@ export const UpdateStrategyModal = withHandlePromise((props: UpdateStrategyModal
     _.get(resource, `${getPath}.rollingUpdate.maxSurge`, '25%'),
   );
 
-  const submit = (event) => {
-    event.preventDefault();
+  const submit = React.useCallback(
+    (event: React.FormEvent<HTMLFormElement>): void => {
+      event.preventDefault();
 
-    const patch: Patch = { path: `${path}/rollingUpdate`, op: 'remove' };
-    if (strategyType === 'RollingUpdate') {
-      patch.value = {
-        maxUnavailable: getNumberOrPercent(maxUnavailable || '25%'),
-        maxSurge: getNumberOrPercent(maxSurge || '25%'),
-      };
-      patch.op = 'add';
-    }
-
-    return handlePromise(
-      k8sPatch(resourceKind, resource, [
-        patch,
-        { path: `${path}/type`, value: strategyType, op: 'replace' },
-      ]),
-    ).then(close, () => {});
-  };
+      const patch: Patch = { path: `${path}/rollingUpdate`, op: 'remove' };
+      if (strategyType === 'RollingUpdate') {
+        patch.value = {
+          maxUnavailable: getNumberOrPercent(maxUnavailable || '25%'),
+          maxSurge: getNumberOrPercent(maxSurge || '25%'),
+        };
+        patch.op = 'add';
+      }
+      handlePromise(
+        k8sPatch(resourceKind, resource, [
+          patch,
+          { path: `${path}/type`, value: strategyType, op: 'replace' },
+        ]),
+      )
+        .then(close)
+        .catch(() => {});
+    },
+    [close, handlePromise, maxSurge, maxUnavailable, path, resource, resourceKind, strategyType],
+  );
 
   return (
     <form onSubmit={submit} name="form" className="modal-content">
@@ -73,12 +76,12 @@ export const UpdateStrategyModal = withHandlePromise((props: UpdateStrategyModal
       <ModalSubmitFooter
         errorMessage={errorMessage}
         inProgress={inProgress}
-        submitText="Save"
+        submitText={t('public~Save')}
         cancel={cancel}
       />
     </form>
   );
-});
+};
 
 export const updateStrategyModal = createModalLauncher(UpdateStrategyModal);
 
@@ -90,9 +93,6 @@ export type UpdateStrategyModalProps = {
   resource: K8sResourceKind;
   resourceKind: K8sKind;
   title: string;
-  handlePromise: <T>(promise: Promise<T>) => Promise<T>;
-  inProgress: boolean;
-  errorMessage: string;
   cancel?: () => void;
   close?: () => void;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -2,5 +2,7 @@ export enum Flags {
   OPERATOR_LIFECYCLE_MANAGER = 'OPERATOR_LIFECYCLE_MANAGER',
 }
 
+export const GLOBAL_OPERATOR_NAMESPACE = 'openshift-operators';
+export const OPERATOR_UNINSTALL_MESSAGE_ANNOTATION = 'operator.openshift.io/uninstall-message';
 export const operatorTypeAnnotation = 'operators.operatorframework.io/operator-type';
 export const nonStandaloneAnnotationValue = 'non-standalone';

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -108,6 +108,7 @@ i18n
         'nodes',
         'noobaa-storage-plugin',
         'oauth',
+        'olm',
         'openid-idp-form',
         'operator-hub-details',
         'operator-hub-subscribe',

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -13,5 +13,9 @@
   "Pause": "Pause",
   "Warning": "Warning",
   "Not available": "Not available",
-  "Resource": "Resource"
+  "Resource": "Resource",
+  "Delete": "Delete",
+  "Disable": "Disable",
+  "default": "default",
+  "OK": "OK"
 }


### PR DESCRIPTION
Externalize strings in `frontend/packages/operator-lifecycle-manager/src/components/modals`