### PR TITLE
Bug 1905621: Protractor login test fails against a 4.7 (nightly) Power cluster

### DIFF
--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -12,7 +12,7 @@ const { BRIDGE_KUBEADMIN_PASSWORD } = process.env;
 describe('Auth test', () => {
   beforeAll(async () => {
     await browser.get(appHost);
-    await browser.sleep(3000); // Wait long enough for the login redirect to complete
+    await browser.sleep(6000); // Wait long enough for the login redirect to complete
   });
 
   describe('Login test', async () => {


### PR DESCRIPTION
Increased Protractor login redirect which seems to take a little longer on Power clusters.

