### PR TITLE
Bug 1906318: kubevirt: use proper term for Authorized SSH Keys

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -149,7 +149,7 @@
   "cloud-init is already configured in cloud images of Fedora and RHEL": "cloud-init is already configured in cloud images of Fedora and RHEL",
   "Learn more": "Learn more",
   "Hostname": "Hostname",
-  "Authenticated SSH Keys": "Authenticated SSH Keys",
+  "Authorized SSH Keys": "Authorized SSH Keys",
   "SSH Key {{uiIDX}}": "SSH Key {{uiIDX}}",
   "Add SSH Key": "Add SSH Key",
   "Data loss confirmation": "Data loss confirmation",

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
@@ -106,7 +106,7 @@ const CloudInitFormRows: React.FC<CloudInitFormRowsProps> = ({
         />
       </FormRow>
       <FormRow
-        title={t('kubevirt-plugin~Authenticated SSH Keys')}
+        title={t('kubevirt-plugin~Authorized SSH Keys')}
         fieldId={asId(CloudInitDataFormKeys.SSH_AUTHORIZED_KEYS)}
       >
         {authKeys.map((authKey, idx) => {


### PR DESCRIPTION
cloud-init's ssh_authorized_keys should be called that way in code and
GUI because their important function is to AUTHORIZE a user to log into
a VM, not mere authentication. I suspect that the existing term was
introduced by mistake.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>