### PR TITLE
Bug 1906689: Fix user can pin to nav configmaps and secrets multiple times

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -38,6 +38,7 @@ import {
   ConfigMapModel,
   DeploymentModel,
 } from '@console/internal/models';
+import { referenceForModel } from '@console/internal/module/k8s';
 import { doConnectsToBinding } from '@console/topology/src/utils/connector-utils';
 import { getKebabActionsForKind } from './utils/kebab-actions';
 import { INCONTEXT_ACTIONS_CONNECTS_TO } from './const';
@@ -202,7 +203,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       // t('devconsole~Developer')
       name: '%devconsole~Developer%',
       icon: <CodeIcon />,
-      defaultPins: [ConfigMapModel.kind, SecretModel.kind],
+      defaultPins: [referenceForModel(ConfigMapModel), referenceForModel(SecretModel)],
       getLandingPageURL: () => '/topology',
       getK8sLandingPageURL: () => '/add',
       getImportRedirectURL: (project) => `/topology/ns/${project}`,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5176

**Analysis / Root cause**: 
By default the developer console comes with ConfigMaps and Secrets pinned to the main navigation. and user can pin to nav configmaps and secrets multiple times.

**Solution Description**: 
Fix now can not able to pin default pin resource ConfigMaps and Secrets

**Screen shots / Gifs for design review**: 
![pinned](https://user-images.githubusercontent.com/2561818/101769165-93306200-3b0c-11eb-8ab7-a1e3e6acda6c.gif)
