### PR TITLE
Bug 1906679: Fix QuickStartPanelContent style

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
@@ -12,7 +12,7 @@ import {
 import { AsyncComponent } from '@console/internal/components/utils';
 import { useScrollDirection, ScrollDirection } from '@console/shared/';
 import { QuickStart } from './utils/quick-start-types';
-import './QuickStartDrawer.scss';
+import './QuickStartPanelContent.scss';
 
 type HandleClose = () => void;
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5190

**Analysis / Root cause**: 
quick start panel styles are not loaded

**Solution Description**: 
Fix the styles file for QuickStartPanelContent

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/101773259-90d10680-3b12-11eb-9a7a-9ba0685b6ad0.png)
![image](https://user-images.githubusercontent.com/2561818/101773313-a34b4000-3b12-11eb-910e-784f777d5273.png)
![image](https://user-images.githubusercontent.com/2561818/101773367-afcf9880-3b12-11eb-93fa-907462242108.png)
