### PR TITLE
Bug 1906769: Fix for topology load for users without access to all resources

### DIFF
--- a/frontend/packages/topology/src/data-transforms/__tests__/updateTopologyDataModel.spec.ts
+++ b/frontend/packages/topology/src/data-transforms/__tests__/updateTopologyDataModel.spec.ts
@@ -1,0 +1,124 @@
+import * as _ from 'lodash';
+import { updateTopologyDataModel } from '../updateTopologyDataModel';
+import { ExtensibleModel } from '../ModelContext';
+
+const namespace = 'test-project';
+
+const MockWatchedResources = {
+  deploymentConfigs: { isList: true, kind: 'DeploymentConfig', namespace, optional: true },
+  deployments: { isList: true, kind: 'Deployment', namespace, optional: true },
+  jobs: { isList: true, kind: 'Job', namespace, optional: true },
+  pods: { isList: true, kind: 'Pod', namespace, optional: true },
+  secrets: { isList: true, kind: 'Secret', namespace, optional: true },
+  statefulSets: { isList: true, kind: 'StatefulSet', namespace, optional: true },
+};
+
+const mockNotReadyResources = {
+  deploymentConfigs: { data: [], loaded: true, loadError: '' },
+  deployments: { data: [], loaded: true, loadError: '' },
+  jobs: { data: [], loaded: true, loadError: '' },
+  pods: { data: [], loaded: false, loadError: '' },
+  secrets: { data: [], loaded: true, loadError: '' },
+  statefulSets: { data: [], loaded: true, loadError: '' },
+};
+
+const mockReadyResources = {
+  deploymentConfigs: { data: [], loaded: true, loadError: '' },
+  deployments: { data: [], loaded: true, loadError: '' },
+  jobs: { data: [], loaded: true, loadError: '' },
+  pods: { data: [], loaded: true, loadError: '' },
+  secrets: { data: [], loaded: true, loadError: '' },
+  statefulSets: { data: [], loaded: true, loadError: '' },
+};
+
+const mockErrorResources = {
+  deploymentConfigs: { data: [], loaded: true, loadError: '' },
+  deployments: { data: [], loaded: false, loadError: 'Deployments Error' },
+  jobs: { data: [], loaded: true, loadError: 'Jobs Error' },
+  pods: { data: [], loaded: true, loadError: '' },
+  secrets: { data: [], loaded: true, loadError: '' },
+  statefulSets: { data: [], loaded: true, loadError: '' },
+};
+
+const errorResourceKeys = ['deployments', 'jobs'];
+
+describe('TopologyDataRetriever ', () => {
+  let mockWatchedResources;
+  let mockExtensibleModel;
+
+  beforeEach(() => {
+    mockWatchedResources = _.cloneDeep(MockWatchedResources);
+    mockExtensibleModel = new ExtensibleModel(namespace);
+    mockExtensibleModel.extensionsLoaded = true;
+    mockExtensibleModel.watchedResources = mockWatchedResources;
+  });
+
+  it('should proceed when all data is loaded', async () => {
+    const results = await updateTopologyDataModel(
+      mockExtensibleModel,
+      mockReadyResources,
+      true,
+      null,
+      null,
+    );
+    expect(results.loaded).toBeTruthy();
+    expect(results.loadError).toBeFalsy();
+  });
+
+  it('should wait for extensions to load', async () => {
+    mockExtensibleModel.extensionsLoaded = false;
+    const results = await updateTopologyDataModel(
+      mockExtensibleModel,
+      mockReadyResources,
+      true,
+      null,
+      null,
+    );
+    expect(results.loaded).toBeFalsy();
+    expect(results.loadError).toBeFalsy();
+  });
+
+  it('should wait for resources to be defined', async () => {
+    const results = await updateTopologyDataModel(mockExtensibleModel, undefined, true, null, null);
+    expect(results.loaded).toBeFalsy();
+    expect(results.loadError).toBeFalsy();
+  });
+
+  it('should wait for data to load', async () => {
+    const results = await updateTopologyDataModel(
+      mockExtensibleModel,
+      mockNotReadyResources,
+      true,
+      null,
+      null,
+    );
+    expect(results.loaded).toBeFalsy();
+    expect(results.loadError).toBeFalsy();
+  });
+
+  it('should proceed when optional data failed to load', async () => {
+    const results = await updateTopologyDataModel(
+      mockExtensibleModel,
+      mockErrorResources,
+      true,
+      null,
+      null,
+    );
+    expect(results.loaded).toBeTruthy();
+    expect(results.loadError).toBeFalsy();
+  });
+
+  it('should set an error when required data failed to load', async () => {
+    errorResourceKeys.forEach((key) => (mockWatchedResources[key].optional = false));
+    mockExtensibleModel.watchedResources = mockWatchedResources;
+    const results = await updateTopologyDataModel(
+      mockExtensibleModel,
+      mockErrorResources,
+      true,
+      null,
+      null,
+    );
+    expect(results.loaded).toBeFalsy();
+    expect(results.loadError).toBeTruthy();
+  });
+});

--- a/frontend/packages/topology/src/data-transforms/updateTopologyDataModel.ts
+++ b/frontend/packages/topology/src/data-transforms/updateTopologyDataModel.ts
@@ -1,0 +1,62 @@
+import { ExtensibleModel } from './ModelContext';
+import { Model } from '@patternfly/react-topology';
+import { WatchK8sResults } from '@console/internal/components/utils/k8s-watch-hook';
+import { Alerts } from '@console/internal/components/monitoring/types';
+import { TopologyResourcesObject, TrafficData } from '../topology-types';
+import { baseDataModelGetter } from './data-transformer';
+
+export const updateTopologyDataModel = (
+  dataModelContext: ExtensibleModel,
+  resources: WatchK8sResults<TopologyResourcesObject>,
+  showGroups: boolean,
+  trafficData: TrafficData,
+  monitoringAlerts: Alerts,
+): Promise<{ loaded: boolean; loadError: string; model: Model }> => {
+  const { extensionsLoaded, watchedResources } = dataModelContext;
+  if (!extensionsLoaded || !resources) {
+    return Promise.resolve({ loaded: false, loadError: '', model: null });
+  }
+
+  const getLoadError = (key) => {
+    if (resources[key].loadError && !watchedResources[key].optional) {
+      return resources[key].loadError;
+    }
+    return '';
+  };
+
+  const isLoaded = (key) => {
+    return resources[key].loaded || (resources[key].loadError && watchedResources[key].optional);
+  };
+
+  const loadErrorKey = Object.keys(resources).find((key) => getLoadError(key));
+  if (loadErrorKey) {
+    return Promise.resolve({
+      loaded: false,
+      loadError: resources[loadErrorKey].loadError,
+      model: null,
+    });
+  }
+
+  if (!Object.keys(resources).every((key) => isLoaded(key))) {
+    return Promise.resolve({ loaded: false, loadError: '', model: null });
+  }
+
+  // Get Workload objects from extensions
+  const workloadResources = dataModelContext.getWorkloadResources(resources);
+
+  // Get model from each extension
+  const depicters = dataModelContext.dataModelDepicters;
+  return dataModelContext.getExtensionModels(resources).then((extensionsModel) => {
+    const fullModel = baseDataModelGetter(
+      extensionsModel,
+      dataModelContext.namespace,
+      resources,
+      workloadResources,
+      showGroups ? depicters : [],
+      trafficData,
+      monitoringAlerts,
+    );
+    dataModelContext.reconcileModel(fullModel, resources);
+    return Promise.resolve({ loaded: true, loadError: '', model: fullModel });
+  });
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5243

**Analysis / Root cause**: 
`useK8sWatchResources` can return resources with `loaded: false, loadError: <some error>`, topology expected `loaded: false` to mean we are still waiting for data to load.

**Solution Description**: 
Update topology to continue if a resource is not loaded but has an error and that resource is `optional`.

**Test setup:**
1. login as kubeadmin
2. create a new namespace
3. create a workload
4. login as a view / self provisioner user (used consoledeveloper / developer test account)
5. go to topology

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge