### PR TITLE
Bug 1908035: Fix issue with dynamic-demo-plugin webpack build

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -75,6 +75,7 @@ export class ConsoleRemotePlugin {
     });
 
     // Skip processing config.entry option if it's missing or empty
+    // TODO(vojtech): latest webpack 5 allows `entry: {}` so use that & remove following code
     if (_.isPlainObject(compiler.options.entry) && _.isEmpty(compiler.options.entry)) {
       compiler.hooks.entryOption.tap(ConsoleRemotePlugin.name, () => {
         return true;


### PR DESCRIPTION
Console dynamic plugin SDK (and consequently `dynamic-demo-plugin`) currently uses webpack `5.0.0-beta.16` which doesn't support empty `entry` object yet. Quote from [webpack docs](https://webpack.js.org/concepts/entry-points/#object-syntax):

> You can pass empty object `{}` to `entry` when you have only entrypoints generated by plugins.

This will be fixed once we bump dynamic plugin SDK dependencies.

In the meantime, this PR fixes an issue where `dynamic-demo-plugin/dist` wasn't generated at all due to changes made in #7163 (`ConsoleAssetPlugin` not using `afterCompile` hook).

---

_Tech details:_ Dynamic plugin projects are not typical web applications with webpack-processed entry points. All dynamic plugin assets are generated via `ConsoleRemotePlugin` (which uses `ConsoleAssetPlugin` under the hood). However, webpack 4 requires us to specify at least one entry point (from which a bundle gets created). We're currently working around this issue, with webpack 5 latest this should be a non-issue.
