### PR TITLE
Bug 1906770: Hide topology shortcuts in mobile view

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -24,3 +24,4 @@ export * from './hpa-hooks';
 export * from './usePinnedResources';
 export * from './useActivePerspective';
 export * from './useActiveNamespace';
+export * from './useIsMobile';

--- a/frontend/packages/console-shared/src/hooks/useIsMobile.ts
+++ b/frontend/packages/console-shared/src/hooks/useIsMobile.ts
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+const MAX_MOBILE_WIDTH = 767;
+const MOBILE_MEDIA_QUERY = `(max-width: ${MAX_MOBILE_WIDTH}px)`;
+
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = React.useState<boolean>(window.innerWidth <= MAX_MOBILE_WIDTH);
+
+  React.useEffect(() => {
+    const mobileResolutionMatch = window.matchMedia(MOBILE_MEDIA_QUERY);
+
+    const updateIsMobile = (e) => {
+      setIsMobile(e.matches);
+    };
+
+    mobileResolutionMatch.addEventListener('change', updateIsMobile);
+
+    // Remove event listener on cleanup
+    return () => mobileResolutionMatch.removeEventListener('change', updateIsMobile);
+  }, []); // Empty array ensures that effect is only run on mount
+
+  return isMobile;
+};

--- a/frontend/packages/topology/src/components/list-view/cells/AlertsCell.tsx
+++ b/frontend/packages/topology/src/components/list-view/cells/AlertsCell.tsx
@@ -11,9 +11,9 @@ import {
   usePodsWatcher,
   useReplicationControllersWatcher,
   getReplicationControllerAlerts,
+  useIsMobile,
 } from '@console/shared';
 import { getResource } from '../../../utils';
-import { isMobile } from '../list-view-utils';
 
 import './AlertsCell.scss';
 
@@ -21,7 +21,7 @@ type AlertsProps = {
   item: Node;
 };
 
-const AlertTooltip = ({ alerts, severity }) => {
+const AlertTooltip = ({ alerts, severity, isMobile }) => {
   if (!alerts) {
     return null;
   }
@@ -37,7 +37,7 @@ const AlertTooltip = ({ alerts, severity }) => {
 
   // No tooltip on mobile since a touch also opens the sidebar, which
   // immediately covers the tooltip content.
-  if (isMobile()) {
+  if (isMobile) {
     return status;
   }
 
@@ -55,6 +55,7 @@ const AlertTooltip = ({ alerts, severity }) => {
 
 const AlertsCell: React.FC<AlertsProps> = ({ item }) => {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
   const resource = getResource(item);
   const { podData, loaded } = usePodsWatcher(resource);
   const { buildConfigs, loaded: buildConfigsLoaded } = useBuildConfigsWatcher(resource);
@@ -116,9 +117,9 @@ const AlertsCell: React.FC<AlertsProps> = ({ item }) => {
         {(error || warning || info) && (
           <div className="odc-topology-list-view__alert-cell__status">
             <span className="odc-topology-list-view__alert-cell__label">Alerts:</span>
-            <AlertTooltip severity="Error" alerts={error} />
-            <AlertTooltip severity="Warning" alerts={warning} />
-            <AlertTooltip severity="Info" alerts={info} />
+            <AlertTooltip severity="Error" alerts={error} isMobile={isMobile} />
+            <AlertTooltip severity="Warning" alerts={warning} isMobile={isMobile} />
+            <AlertTooltip severity="Info" alerts={info} isMobile={isMobile} />
           </div>
         )}
         {(buildNew || buildPending || buildRunning || buildFailed || buildError) && (
@@ -126,11 +127,11 @@ const AlertsCell: React.FC<AlertsProps> = ({ item }) => {
             <span className="odc-topology-list-view__alert-cell__label">
               {t('topology~Builds:')}
             </span>
-            <AlertTooltip severity="New" alerts={buildNew} />
-            <AlertTooltip severity="Pending" alerts={buildPending} />
-            <AlertTooltip severity="Running" alerts={buildRunning} />
-            <AlertTooltip severity="Failed" alerts={buildFailed} />
-            <AlertTooltip severity="Error" alerts={buildError} />
+            <AlertTooltip severity="New" alerts={buildNew} isMobile={isMobile} />
+            <AlertTooltip severity="Pending" alerts={buildPending} isMobile={isMobile} />
+            <AlertTooltip severity="Running" alerts={buildRunning} isMobile={isMobile} />
+            <AlertTooltip severity="Failed" alerts={buildFailed} isMobile={isMobile} />
+            <AlertTooltip severity="Error" alerts={buildError} isMobile={isMobile} />
           </div>
         )}
       </div>

--- a/frontend/packages/topology/src/components/list-view/cells/MetricsTooltip.tsx
+++ b/frontend/packages/topology/src/components/list-view/cells/MetricsTooltip.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@patternfly/react-core';
 import { truncateMiddle } from '@console/internal/components/utils';
-import { isMobile } from '../list-view-utils';
+import { useIsMobile } from '@console/shared';
 
 type MetricsTooltipProps = {
   metricLabel: string;
@@ -16,6 +16,14 @@ type MetricsTooltipProps = {
 
 const MetricsTooltip: React.FC<MetricsTooltipProps> = ({ metricLabel, byPod, children }) => {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
+
+  // Disable the tooltip on mobile since a touch also opens the sidebar, which
+  // immediately covers the tooltip content.
+  if (isMobile) {
+    return <>{children}</>;
+  }
+
   const sortedMetrics = _.orderBy(byPod, ['value', 'name'], ['desc', 'asc']);
   const content: any[] = _.isEmpty(sortedMetrics)
     ? [
@@ -51,11 +59,6 @@ const MetricsTooltip: React.FC<MetricsTooltipProps> = ({ metricLabel, byPod, chi
     );
   }
 
-  // Disable the tooltip on mobile since a touch also opens the sidebar, which
-  // immediately covers the tooltip content.
-  if (isMobile()) {
-    return <>{children}</>;
-  }
   return (
     <Tooltip content={content} distance={15}>
       <>{children}</>

--- a/frontend/packages/topology/src/components/list-view/list-view-utils.tsx
+++ b/frontend/packages/topology/src/components/list-view/list-view-utils.tsx
@@ -11,9 +11,6 @@ export const labelForNodeKind = (kindString: string) => {
   return _.startCase(kindString);
 };
 
-// Consider this mobile if the device screen width is less than 768. (This value shouldn't change.)
-export const isMobile = () => window.screen.width < 768;
-
 export const getChildKinds = (children: GraphElement[]) => {
   const childNodes = children.filter((n) => isNode(n)) as Node[];
   const kindsMap = childNodes.reduce((acc, n) => {

--- a/frontend/packages/topology/src/components/page/TopologyPageToolbar.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyPageToolbar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { observer } from '@patternfly/react-topology';
 import { Tooltip, Popover, Button } from '@patternfly/react-core';
 import { ListIcon, TopologyIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+import { useIsMobile } from '@console/shared';
 import { getTopologyShortcuts } from '../graph-view/TopologyShortcuts';
 import { ModelContext, ExtensibleModel } from '../../data-transforms/ModelContext';
 import { TopologyViewType } from '../../topology-types';
@@ -15,6 +16,7 @@ interface TopologyPageToolbarProps {
 const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
   ({ viewType, onViewChange }) => {
     const { t } = useTranslation();
+    const isMobile = useIsMobile();
     const showGraphView = viewType === TopologyViewType.graph;
     const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
     const { namespace, isEmptyModel } = dataModelContext;
@@ -25,7 +27,7 @@ const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
 
     return (
       <>
-        {showGraphView ? (
+        {showGraphView && !isMobile ? (
           <Popover
             aria-label={t('topology~Shortcuts')}
             bodyContent={getTopologyShortcuts(t)}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2382

**Analysis / Root cause**: 
Short cuts in topology view take up a log of space at mobile view

**Solution Description**: 
Add a hook to watch window size and to detect when resolution is considered mobile.
Check for mobile and when at mobile resolution do not show the shortcuts

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

/kind bug