### PR TITLE
Bug 1906685: show sinkbinding as resources in sidebar if owned by source

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/EventSourceOwnedList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventSourceOwnedList.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { SidebarSectionHeading, ResourceLink } from '@console/internal/components/utils';
+import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
+
+type EventSourceOwnedListProps = {
+  source: K8sResourceKind;
+};
+
+const EventSourceOwnedList: React.FC<EventSourceOwnedListProps> = ({ source }) => {
+  const sourceModel = modelFor(referenceFor(source));
+  return (
+    <>
+      <SidebarSectionHeading text={sourceModel?.label ?? source.kind} />
+      <ul className="list-group">
+        <li className="list-group-item">
+          <ResourceLink
+            kind={referenceFor(source)}
+            name={source.metadata?.name}
+            namespace={source.metadata?.namespace}
+          />
+        </li>
+      </ul>
+    </>
+  );
+};
+
+export default EventSourceOwnedList;

--- a/frontend/packages/knative-plugin/src/components/overview/EventSourceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventSourceResources.tsx
@@ -14,12 +14,14 @@ import {
 } from '@console/internal/components/utils';
 import { PodModel } from '@console/internal/models';
 import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import EventSourceOwnedList from './EventSourceOwnedList';
 
-export type EventSinkServicesOverviewListProps = {
+type EventSourceResourcesProps = {
   obj: K8sResourceKind;
+  ownedSources?: K8sResourceKind[];
 };
 
-const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps> = ({ obj }) => {
+const EventSourceResources: React.FC<EventSourceResourcesProps> = ({ obj, ownedSources }) => {
   const { t } = useTranslation();
   const {
     kind,
@@ -83,8 +85,12 @@ const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps
           </ul>
         </>
       )}
+      {ownedSources?.length > 0 &&
+        ownedSources.map((source) => (
+          <EventSourceOwnedList key={source.metadata.uid} source={source} />
+        ))}
     </>
   );
 };
 
-export default EventSinkServicesOverviewList;
+export default EventSourceResources;

--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -14,7 +14,7 @@ import KnativeRevisionResources from './KnativeRevisionResources';
 import RevisionsOverviewList from './RevisionsOverviewList';
 import KSRoutesOverviewList from './RoutesOverviewList';
 import ConfigurationsOverviewList from './ConfigurationsOverviewList';
-import EventSinkServicesOverviewList from './EventSinkServicesOverviewList';
+import EventSourceResources from './EventSourceResources';
 import {
   isDynamicEventResourceKind,
   isEventingChannelResourceKind,
@@ -27,9 +27,9 @@ type OverviewDetailsResourcesTabProps = {
 };
 
 const getSidebarResources = (item: KnativeServiceOverviewItem) => {
-  const { obj, ksroutes, revisions, configurations } = item;
+  const { obj, ksroutes, revisions, configurations, eventSources } = item;
   if (isDynamicEventResourceKind(referenceFor(obj))) {
-    return <EventSinkServicesOverviewList obj={obj} />;
+    return <EventSourceResources obj={obj} ownedSources={eventSources} />;
   }
   if (isEventingChannelResourceKind(referenceFor(obj))) {
     return <EventPubSubResources item={item} />;
@@ -42,7 +42,7 @@ const getSidebarResources = (item: KnativeServiceOverviewItem) => {
     case ServiceModel.kind:
       return <KnativeServiceResources item={item} />;
     case CamelKameletBindingModel.kind:
-      return <EventSinkServicesOverviewList obj={obj} />;
+      return <EventSourceResources obj={obj} ownedSources={eventSources} />;
     case EventingBrokerModel.kind:
     case EventingTriggerModel.kind:
     case EventingSubscriptionModel.kind:

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceOwnedList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSourceOwnedList.spec.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ResourceLink, SidebarSectionHeading } from '@console/internal/components/utils';
+import EventSourceOwnedList from '../EventSourceOwnedList';
+import { getEventSourceResponse } from '../../../topology/__tests__/topology-knative-test-data';
+import { EventSourceSinkBindingModel } from '../../../models';
+
+type EventSourceOwnedListProps = React.ComponentProps<typeof EventSourceOwnedList>;
+
+describe('EventSourceOwnedList', () => {
+  const mockData: K8sResourceKind = getEventSourceResponse(EventSourceSinkBindingModel).data[0];
+  let wrapper: ShallowWrapper<EventSourceOwnedListProps>;
+  beforeEach(() => {
+    wrapper = shallow(<EventSourceOwnedList source={mockData} />);
+  });
+
+  it('should render SidebarSectionHeading, ResourceLink', () => {
+    expect(wrapper.find(SidebarSectionHeading)).toHaveLength(1);
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -8,7 +8,7 @@ import KnativeRevisionResources from '../KnativeRevisionResources';
 import RevisionsOverviewList from '../RevisionsOverviewList';
 import KSRoutesOverviewList from '../RoutesOverviewList';
 import ConfigurationsOverviewList from '../ConfigurationsOverviewList';
-import EventSinkServicesOverviewList from '../EventSinkServicesOverviewList';
+import EventSourceResources from '../EventSourceResources';
 import EventPubSubResources from '../EventPubSubResources';
 import {
   MockKnativeResources,
@@ -49,7 +49,7 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
     expect(wrapper.find(KnativeRevisionResources)).toHaveLength(1);
   });
 
-  it('should render EventSinkServicesOverviewList on sidebar', () => {
+  it('should render EventSourceResources on sidebar', () => {
     jest
       .spyOn(fetchDynamicEventSources, 'isDynamicEventResourceKind')
       .mockImplementationOnce(() => true);
@@ -58,10 +58,10 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
       ...{ obj: getEventSourceResponse(EventSourceCronJobModel).data[0] },
     };
     const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
-    expect(wrapper.find(EventSinkServicesOverviewList)).toHaveLength(1);
+    expect(wrapper.find(EventSourceResources)).toHaveLength(1);
   });
 
-  it('should render EventSinkServicesOverviewList on sidebar for sinkBinding', () => {
+  it('should render EventSourceResources on sidebar for sinkBinding', () => {
     jest
       .spyOn(fetchDynamicEventSources, 'isDynamicEventResourceKind')
       .mockImplementationOnce(() => true);
@@ -70,7 +70,7 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
       ...{ obj: sampleEventSourceSinkbinding.data[0] },
     };
     const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
-    expect(wrapper.find(EventSinkServicesOverviewList)).toHaveLength(1);
+    expect(wrapper.find(EventSourceResources)).toHaveLength(1);
   });
 
   it('should render OperatorBackedOwnerReferences with proper props', () => {
@@ -116,12 +116,12 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
     expect(wrapper.find(EventPubSubResources)).toHaveLength(1);
   });
 
-  it('should render EventSinkServicesOverviewList on sidebar for KameletBinding', () => {
+  it('should render EventSourceResources on sidebar for KameletBinding', () => {
     knItem.item = {
       ...knItem.item,
       ...{ obj: sampleSourceKameletBinding.data[0] },
     };
     const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
-    expect(wrapper.find(EventSinkServicesOverviewList)).toHaveLength(1);
+    expect(wrapper.find(EventSourceResources)).toHaveLength(1);
   });
 });

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -113,7 +113,7 @@ export const EventSourceCronJobModel: K8sKind = {
 
 export const EventSourcePingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha2',
+  apiVersion: 'v1beta1',
   kind: 'PingSource',
   label: 'Ping Source',
   labelPlural: 'Ping Sources',
@@ -127,7 +127,7 @@ export const EventSourcePingModel: K8sKind = {
 
 export const EventSourceContainerModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha2',
+  apiVersion: 'v1beta1',
   kind: 'ContainerSource',
   label: 'Container Source',
   labelPlural: 'Container Sources',
@@ -141,7 +141,7 @@ export const EventSourceContainerModel: K8sKind = {
 
 export const EventSourceApiServerModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha2',
+  apiVersion: 'v1beta1',
   kind: 'ApiServerSource',
   label: 'ApiServerSource',
   labelPlural: 'ApiServerSources',
@@ -183,7 +183,7 @@ export const EventSourceKafkaModel: K8sKind = {
 
 export const EventSourceSinkBindingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1alpha2',
+  apiVersion: 'v1beta1',
   kind: 'SinkBinding',
   label: 'SinkBinding',
   labelPlural: 'SinkBindings',

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
@@ -3,7 +3,7 @@ export const mockEventSourcCRDData = {
   apiVersion: 'apiextensions.k8s.io/v1',
   metadata: {
     selfLink: '/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-    resourceVersion: '300390',
+    resourceVersion: '471070',
   },
   items: [
     {
@@ -11,7 +11,7 @@ export const mockEventSourcCRDData = {
         name: 'apiserversources.sources.knative.dev',
         labels: {
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/release': 'v0.17.2',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -23,11 +23,12 @@ export const mockEventSourcCRDData = {
           singular: 'apiserversource',
           kind: 'ApiServerSource',
           listKind: 'ApiServerSourceList',
-          categories: ['all', 'knative', 'eventing', 'sources'],
+          categories: ['all', 'knative', 'sources'],
         },
         versions: [
           { name: 'v1alpha1', served: true, storage: true },
           { name: 'v1alpha2', served: true, storage: false },
+          { name: 'v1beta1', served: true, storage: false },
         ],
       },
     },
@@ -59,7 +60,7 @@ export const mockEventSourcCRDData = {
         name: 'containersources.sources.knative.dev',
         labels: {
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/release': 'v0.17.2',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -71,32 +72,10 @@ export const mockEventSourcCRDData = {
           singular: 'containersource',
           kind: 'ContainerSource',
           listKind: 'ContainerSourceList',
-          categories: ['all', 'knative', 'eventing', 'sources'],
-        },
-        versions: [{ name: 'v1alpha2', served: true, storage: true }],
-      },
-    },
-    {
-      metadata: {
-        name: 'kafkasources.sources.knative.dev',
-        labels: {
-          'contrib.eventing.knative.dev/release': 'devel',
-          'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/source': 'true',
-          'knative.dev/crd-install': 'true',
-        },
-      },
-      spec: {
-        group: 'sources.knative.dev',
-        names: {
-          plural: 'kafkasources',
-          singular: 'kafkasource',
-          kind: 'KafkaSource',
-          listKind: 'KafkaSourceList',
-          categories: ['all', 'knative', 'eventing', 'sources'],
+          categories: ['all', 'knative', 'sources'],
         },
         versions: [
-          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1alpha2', served: true, storage: true },
           { name: 'v1beta1', served: true, storage: false },
         ],
       },
@@ -106,7 +85,7 @@ export const mockEventSourcCRDData = {
         name: 'pingsources.sources.knative.dev',
         labels: {
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/release': 'v0.17.2',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -118,11 +97,11 @@ export const mockEventSourcCRDData = {
           singular: 'pingsource',
           kind: 'PingSource',
           listKind: 'PingSourceList',
-          categories: ['all', 'knative', 'eventing', 'sources'],
+          categories: ['all', 'knative', 'sources'],
         },
         versions: [
-          { name: 'v1alpha1', served: false, storage: false },
           { name: 'v1alpha2', served: true, storage: true },
+          { name: 'v1beta1', served: true, storage: false },
         ],
       },
     },
@@ -132,7 +111,7 @@ export const mockEventSourcCRDData = {
         labels: {
           'duck.knative.dev/binding': 'true',
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.16.1',
+          'eventing.knative.dev/release': 'v0.17.2',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -144,11 +123,12 @@ export const mockEventSourcCRDData = {
           singular: 'sinkbinding',
           kind: 'SinkBinding',
           listKind: 'SinkBindingList',
-          categories: ['all', 'knative', 'eventing', 'sources', 'bindings'],
+          categories: ['all', 'knative', 'sources', 'bindings'],
         },
         versions: [
           { name: 'v1alpha1', served: true, storage: true },
           { name: 'v1alpha2', served: true, storage: false },
+          { name: 'v1beta1', served: true, storage: false },
         ],
       },
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5228

**Analysis / Root cause**: 
SinkBinding is shown in topology view along with actual source created in case of Container source and KameletBinding Creation

**Solution Description**: 
Show show only actual source created in topology view and sinkbinding in sidebar resources here (as is underlying resource here)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/5129024/101868296-0f758480-3ba3-11eb-8263-ca0be9d82911.png)




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
