### PR TITLE
Bug 1906864: Fix vertical spacing for quick start tour failed error box

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartMarkdownView.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartMarkdownView.tsx
@@ -20,12 +20,17 @@ extension(EXTENSION_NAME, () => {
 
 type QuickStartMarkdownViewProps = {
   content: string;
+  exactHeight?: boolean;
 };
 
-const QuickStartMarkdownView: React.FC<QuickStartMarkdownViewProps> = ({ content }) => {
+const QuickStartMarkdownView: React.FC<QuickStartMarkdownViewProps> = ({
+  content,
+  exactHeight,
+}) => {
   return (
     <SyncMarkdownView
       content={content}
+      exactHeight={exactHeight}
       extensions={[EXTENSION_NAME]}
       renderExtension={(docContext) => (
         <MarkdownHighlightExtension key={content} docContext={docContext} />

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.scss
@@ -5,6 +5,7 @@
   &__actions {
     display: flex;
     align-items: flex-start;
+    margin-bottom: var(--pf-global--spacer--sm);
     input[type='radio'] {
       margin-top: 0;
       margin-right: 0;

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskReview.tsx
@@ -61,7 +61,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
         />
       </span>
       {taskStatus === QuickStartTaskStatus.FAILED && taskHelp && (
-        <QuickStartMarkdownView content={taskHelp} />
+        <QuickStartMarkdownView content={taskHelp} exactHeight />
       )}
     </Alert>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4718

**Analysis / Root cause**: 
Check your work part in the Quick Starts in not equally spaced. There is too much space between radio buttons and "Is the status Succeeded?" and there isn't any space between radio buttons and "Try walking through the steps again to properly install Pipelines Operator" when user selects  "No" radio button. There is a lot space wasted after "Try walking through the steps again to properly install Pipelines Operator"

**Solution Description**: 
Fix exact height for SyncMarkdownView.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/101903220-f3d9a080-3bd9-11eb-8252-9f7a9b3574ef.png)
![image](https://user-images.githubusercontent.com/2561818/101903251-00f68f80-3bda-11eb-8c7a-50c89ea5cbea.png)


