### PR TITLE
Bug 1909067: Keep pod terminal output after connection closes

### DIFF
--- a/frontend/public/components/pod-exec.jsx
+++ b/frontend/public/components/pod-exec.jsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Base64 } from 'js-base64';
+import { withTranslation } from 'react-i18next';
 import { ExpandIcon } from '@patternfly/react-icons';
-import { Button } from '@patternfly/react-core';
+import { Button, Alert, AlertActionLink } from '@patternfly/react-core';
 
 import store from '../redux';
 import { LoadingBox, LoadingInline, Dropdown, ResourceIcon } from './utils';
@@ -31,7 +32,7 @@ const nameWithIcon = (name) => (
 const NO_SH =
   'starting container process caused "exec: \\"sh\\": executable file not found in $PATH"';
 
-export const PodExec = connectToFlags(FLAGS.OPENSHIFT)(
+const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
   class PodExec extends React.PureComponent {
     constructor(props) {
       super(props);
@@ -173,14 +174,21 @@ export const PodExec = connectToFlags(FLAGS.OPENSHIFT)(
 
     render() {
       const { containers, activeContainer, open, error } = this.state;
-      const { message } = this.props;
+      const { message, t, obj } = this.props;
 
       let contents = <LoadingBox />;
       if (error) {
-        contents = <div className="text-center cos-error-title">{error}</div>;
+        contents = <Terminal onResize={() => {}} onData={() => {}} ref={this.terminal} />;
       } else if (open) {
         contents = <Terminal onResize={this.onResize} onData={this.onData} ref={this.terminal} />;
       }
+
+      const reconnectAction =
+        obj.status.phase === 'Running' ? (
+          <AlertActionLink onClick={() => this.connect_()}>
+            {t('workload~Reconnect')}
+          </AlertActionLink>
+        ) : null;
 
       return (
         <div>
@@ -211,6 +219,9 @@ export const PodExec = connectToFlags(FLAGS.OPENSHIFT)(
               </div>
             )}
           </div>
+          {error && (
+            <Alert variant="warning" title={error} actionLinks={reconnectAction} isInline />
+          )}
           {message}
           {contents}
         </div>
@@ -218,3 +229,5 @@ export const PodExec = connectToFlags(FLAGS.OPENSHIFT)(
     }
   },
 );
+
+export const PodExec = withTranslation()(PodExec_);

--- a/frontend/public/locales/en/workload.json
+++ b/frontend/public/locales/en/workload.json
@@ -84,6 +84,7 @@
   "Active pods": "Active pods",
   "Failed pods": "Failed pods",
   "Completions": "Completions",
+  "Reconnect": "Reconnect",
   "Ready": "Ready",
   "Restarts": "Restarts",
   "Owner": "Owner",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4935
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
When open a terminal on a Pod, the terminal output disappears as soon as the user exit it or the connection was terminated. But the terminal could contain essential informations about the issue or at least infos which the user is still interessted.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Preserve the terminal output after the connection is closed.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp](https://user-images.githubusercontent.com/20013884/102348363-d0db3200-3fc7-11eb-889b-468f4ba1c148.gif)


@openshift/team-devconsole-ux 
/cc @beaumorley 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug