### PR TITLE
Bug 1907883: Fix Pipleine creation without namespace issue

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
@@ -49,6 +49,9 @@ const PipelineBuilderPage: React.FC<PipelineBuilderPageProps> = (props) => {
     if (values.editorType === EditorType.YAML) {
       try {
         pipeline = safeLoad(values.yamlData);
+        if (!pipeline.metadata?.namespace) {
+          pipeline.metadata.namespace = ns;
+        }
       } catch (err) {
         actions.setStatus({ submitError: `Invalid YAML - ${err}` });
         return null;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/PipelineBuilderPage.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/PipelineBuilderPage.spec.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Formik } from 'formik';
+import PipelineBuilderPage from '../PipelineBuilderPage';
+import { pipelineTestData, PipelineExampleNames } from '../../../../test-data/pipeline-data';
+
+type PipelineBuilderPageProps = React.ComponentProps<typeof PipelineBuilderPage>;
+type BuilderProps = React.ComponentProps<typeof Formik>;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+const { pipeline } = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
+describe('PipelineBuilderPage Form', () => {
+  let formProps: PipelineBuilderPageProps;
+  let PipelineBuilderPageWrapper: ShallowWrapper<PipelineBuilderPageProps>;
+
+  beforeEach(() => {
+    formProps = {
+      history: null,
+      location: null,
+      match: { params: { ns: 'default' }, isExact: true, path: '', url: '' },
+    };
+    PipelineBuilderPageWrapper = shallow(<PipelineBuilderPage {...formProps} />);
+  });
+
+  it('should render a Formik component', () => {
+    const PipelineBuilderForm = PipelineBuilderPageWrapper.find(Formik);
+    expect(PipelineBuilderForm).toHaveLength(1);
+  });
+
+  it('should have form view as default option and empty default values', () => {
+    const PipelineBuilderForm = PipelineBuilderPageWrapper.find(Formik);
+    const builderProps = PipelineBuilderForm.props() as BuilderProps;
+
+    expect(builderProps.initialValues.editorType).toBe('form');
+    expect(builderProps.initialValues.formData.params).toHaveLength(0);
+    expect(builderProps.initialValues.formData.tasks).toHaveLength(0);
+    expect(builderProps.initialValues.formData.resources).toHaveLength(0);
+  });
+
+  it('should contain the given pipeline values in intialValues', () => {
+    PipelineBuilderPageWrapper = shallow(
+      <PipelineBuilderPage {...formProps} existingPipeline={pipeline} />,
+    );
+    const PipelineBuilderForm = PipelineBuilderPageWrapper.find(Formik);
+    const builderProps = PipelineBuilderForm.props() as BuilderProps;
+    const { name, tasks } = builderProps.initialValues.formData;
+
+    expect(name).toBe(pipeline.metadata.name);
+    expect(tasks).toHaveLength(pipeline.spec.tasks.length);
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5251

**Analysis / Root cause**: 
In pipeline builder yaml view, adding a pipeline yaml without a namespace is failing to create the pipeline with `not found` error.

**Solution Description**: 
If a namespace is not provided in the yaml view, then adding the active namespace on the form submission.

**Screen shots / Gifs for design review**: 
![pipeline-creation-without-namespace](https://user-images.githubusercontent.com/9964343/101924913-3bbaf080-3bf7-11eb-847c-213456877fa9.gif)



**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/9964343/101925042-6dcc5280-3bf7-11eb-9741-48508bd34bfb.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Install pipelines operator -> go to pipeline builder yaml view -> add a template without the namespace and click create.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge