### PR TITLE
Update web-Terminal-adminuser.feature with actual admin flow

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/web-terminal/web-Terminal-adminuser.feature
+++ b/frontend/packages/dev-console/integration-tests/features/web-terminal/web-Terminal-adminuser.feature
@@ -12,15 +12,11 @@ Background:
 Scenario: Create new project and use Web Terminal
     Given user can see terminal icon on masthead
     When user clicks on the Web Terminal icon on the Masthead
-    And user selects Create Project from Project drop down menu
-    And user enters project name "aut-terminal-adminuser"
-    And user clicks on Submit button
-    Then user will see the terminal window for namespace "aut-terminal-adminuser"
+    Then user will see the terminal window for namespace "openshift-terminal"
 
 
 @regression, @smoke
 Scenario: Open Web Terminal for existing project
     Given user can see terminal icon on masthead
     When user clicks on the Web Terminal icon on the Masthead
-    And user selects "aut-terminal-adminuser" from Project drop down menu
-    Then user will see the terminal window for namespace "aut-terminal-adminuser"
+    Then user will see the terminal window for namespace "openshift-terminal"


### PR DESCRIPTION
After https://github.com/openshift/console/pull/7145 was merged the admin flow is a little bit different than the flow listed in web-Terminal-adminuser.feature.

Now the admin does not have a project picker, instead their terminal is created directly in the openshift-terminal namespace.

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>