### PR TITLE
Bug 1907282: fix topology page white screen, use ternary operator instead of logical operator

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
@@ -51,8 +51,8 @@ const PodStatus: React.FC<PodStatusProps> = ({
   size = 130,
   standalone = false,
   showTooltip = true,
-  title = '',
-  subTitle = '',
+  title,
+  subTitle,
   titleComponent,
   subTitleComponent,
   data,
@@ -86,7 +86,10 @@ const PodStatus: React.FC<PodStatusProps> = ({
     return prevVData.current;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
-
+  const truncTitle = title ? _.truncate(title, { length: MAX_POD_TITLE_LENGTH }) : undefined;
+  const truncSubTitle = subTitle
+    ? _.truncate(subTitle, { length: MAX_POD_TITLE_LENGTH })
+    : undefined;
   const chartDonut = React.useMemo(() => {
     return (
       <ChartDonut
@@ -101,13 +104,13 @@ const PodStatus: React.FC<PodStatusProps> = ({
         data={vData}
         height={size}
         width={size}
-        title={_.truncate(title, { length: MAX_POD_TITLE_LENGTH })}
+        title={truncTitle}
         titleComponent={titleComponent}
         subTitleComponent={subTitleComponent}
-        subTitle={_.truncate(subTitle, { length: MAX_POD_TITLE_LENGTH })}
+        subTitle={truncSubTitle}
         allowTooltip={false}
         labels={() => null}
-        /*
+        /* 
             // @ts-ignore */
         padAngle={({ datum }) => (datum.y > 0 ? 2 : 0)}
         style={{
@@ -126,9 +129,9 @@ const PodStatus: React.FC<PodStatusProps> = ({
     outerRadius,
     size,
     standalone,
-    subTitle,
+    truncSubTitle,
     subTitleComponent,
-    title,
+    truncTitle,
     titleComponent,
     updateOnEnd,
     vData,

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/PodSet.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/PodSet.tsx
@@ -92,9 +92,9 @@ const PodSet: React.FC<PodSetProps> = React.memo(({ size, data, x = 0, y = 0, sh
         outerRadius={podStatusOuterRadius}
         data={completedDeploymentData}
         size={size}
-        subTitle={showPodCount && subTitle}
-        title={showPodCount && title}
-        titleComponent={showPodCount && titleComponent}
+        subTitle={showPodCount ? subTitle : undefined}
+        title={showPodCount ? title : undefined}
+        titleComponent={showPodCount ? titleComponent : undefined}
       />
       {inProgressDeploymentData && (
         <PodStatus


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5258
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
We are using logical operator in the PodSet component which causes it to pass a boolean value to PodStatus component title/subtitle and since we started to truncate the title/subtitle using `_.truncate` in PodStatus component with PR #7447, boolean values are converted to string by lodash truncate `false => 'false'`.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: use ternary operator instead of logical operator and pass `undefined` if showPodCount is false
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
NO UI changes

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
