### PR TITLE
Bug 1892896: Disables the block radio input if the provisioner is cephfs

### DIFF
--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -2,8 +2,9 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import { ActionGroup, Button } from '@patternfly/react-core';
-import { isCephProvisioner, isObjectSC } from '@console/shared/src/utils';
+import { ActionGroup, Button, Tooltip } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { isCephProvisioner, isObjectSC, cephStorageProvisioners } from '@console/shared/src/utils';
 import { k8sCreate, K8sResourceKind, referenceFor } from '../../module/k8s';
 import { AsyncComponent, ButtonBar, RequestSizeInput, history, resourceObjPath } from '../utils';
 import { StorageClassDropdown } from '../utils/storage-class-dropdown';
@@ -20,6 +21,15 @@ import {
   dropdownUnits,
   getAccessModeForProvisioner,
 } from './shared';
+
+const InfoToolTip = () => (
+  <Tooltip
+    position="bottom"
+    content={<div>Only filesystem volume mode is available for cephfs</div>}
+  >
+    <OutlinedQuestionCircleIcon />
+  </Tooltip>
+);
 
 const NameValueEditorComponent = (props) => (
   <AsyncComponent
@@ -135,6 +145,9 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
     setAllowedAccessModes(modes);
     setStorageClass(updatedStorageClass?.metadata?.name);
     setStorageProvisioner(provisioner);
+    if (storageProvisioner.includes(cephStorageProvisioners[1])) {
+      setVolumeMode('Filesystem');
+    }
   };
 
   const handleRequestSizeInputChange = (obj) => {
@@ -266,16 +279,22 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
         Volume Mode
       </label>
       <div className="form-group">
-        {volumeModeRadios.map((radio) => (
-          <RadioInput
-            {...radio}
-            key={radio.value}
-            onChange={handleVolumeMode}
-            inline
-            checked={radio.value === volumeMode}
-            name="volumeMode"
-          />
-        ))}
+        {storageProvisioner.includes(cephStorageProvisioners[1]) ? (
+          <>
+            Filesystem <InfoToolTip />
+          </>
+        ) : (
+          volumeModeRadios.map((radio) => (
+            <RadioInput
+              {...radio}
+              key={radio.value}
+              onChange={handleVolumeMode}
+              inline
+              checked={radio.value === volumeMode}
+              name="volumeMode"
+            />
+          ))
+        )}
       </div>
     </div>
   );

--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -1,6 +1,7 @@
 import { isCephProvisioner } from '@console/shared/src/utils';
 
 export const cephRBDProvisionerSuffix = 'rbd.csi.ceph.com';
+
 //See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes for more details
 export const provisionerAccessModeMapping = {
   'kubernetes.io/no-provisioner': ['ReadWriteOnce'],


### PR DESCRIPTION
Disables the block radio input if the selected storage class provisioner is cephfs

Disabling radio input
![Screenshot from 2020-12-14 15-19-26](https://user-images.githubusercontent.com/57935785/102066431-d3028c80-3e1f-11eb-9ed7-d5ae03b7c4d8.png)

Having readonly text
![Screenshot from 2021-01-21 20-29-07](https://user-images.githubusercontent.com/57935785/105368639-c1cf4b80-5c27-11eb-99e8-3b293b37c7e1.png)


Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>