### PR TITLE
Bug 1903400: Migration cannot be when machine is off or in error

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -233,10 +233,10 @@ const menuActionMigrate = (
 
   return {
     hidden:
-      vmStatusBundle?.status?.isImporting() ||
       vmStatusBundle?.status?.isMigrating() ||
-      !isVMExpectedRunning(vm) ||
-      !isVMCreated(vm),
+      vmStatusBundle?.status?.isError() ||
+      vmStatusBundle?.status?.isInProgress() ||
+      !isVMRunningOrExpectedRunning(vm),
     // t('kubevirt-plugin~Migrate Virtual Machine')
     labelKey: 'kubevirt-plugin~Migrate Virtual Machine',
     callback: () =>


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <matanschatzman@gmail.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1903400

**Analysis / Root cause**: 
Missing checks for isError and isInProgress

**Solution Description**: 
Added checks before enabling migration 