### PR TITLE
Bug 1907399: Do not reload page on a decorator click for internal links

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/BuildDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/BuildDecorator.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Node } from '@patternfly/react-topology';
@@ -37,11 +36,9 @@ const BuildDecorator: React.FC<BuildDecoratorProps> = ({ element, radius, x, y }
       content={t('topology~Build {{status}}', { status: build.status && build.status.phase })}
       position={TooltipPosition.left}
     >
-      <Link to={link} className="odc-decorator__link">
-        <BuildDecoratorBubble x={x} y={y} radius={radius}>
-          <Status status={build.status.phase} iconOnly noTooltip />
-        </BuildDecoratorBubble>
-      </Link>
+      <BuildDecoratorBubble x={x} y={y} radius={radius} href={link}>
+        <Status status={build.status.phase} iconOnly noTooltip />
+      </BuildDecoratorBubble>
     </Tooltip>
   );
 };

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/Decorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/Decorator.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { createSvgIdUrl, useHover } from '@patternfly/react-topology';
 import SvgDropShadowFilter from '../../../../svg/SvgDropShadowFilter';
 
@@ -32,8 +33,10 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
     <g
       className="odc-decorator"
       onClick={(e) => {
-        e.stopPropagation();
-        onClick && onClick(e);
+        if (onClick) {
+          e.stopPropagation();
+          onClick(e);
+        }
       }}
       ref={hoverRef}
     >
@@ -51,13 +54,25 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
     </g>
   );
   if (href) {
-    return (
+    return external ? (
       /*
       // @ts-ignore */
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a className="odc-decorator__link" xlinkHref={href} target={external ? '_blank' : null}>
+      <a
+        className="odc-decorator__link"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
         {decorator}
       </a>
+    ) : (
+      <Link className="odc-decorator__link" to={href}>
+        {decorator}
+      </Link>
     );
   }
   return decorator;

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/__tests__/Decorator.spec.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/__tests__/Decorator.spec.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import Decorator from '../Decorator';
+import { Link } from 'react-router-dom';
+
+describe('Decorator', () => {
+  it('should show anchors for external links', () => {
+    const decorator = shallow(<Decorator x={0} y={0} radius={10} external href="http://test" />);
+    expect(decorator.find('a').exists()).toBe(true);
+    expect(decorator.find(Link).exists()).toBe(false);
+  });
+  it('should show Links for internal links', () => {
+    const decorator = shallow(<Decorator x={0} y={0} radius={10} href="/test" />);
+    expect(decorator.find('a').exists()).toBe(false);
+    expect(decorator.find(Link).exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4781

**Analysis / Root cause**: 
The Decorator component was using an anchor rather than a Link for internal links and preventing event propagation to the upper Link in the BuildDecorator.

**Solution Description**: 
Change Decorator to use a Link for internal links. Change BuildDecorator to pass the href to the Decorator rather than providing its own Link.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug