### PR TITLE
Bug 1907892: Hide edit app action for apps created using devfile flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -471,16 +471,8 @@ export const createDevfileResources = async (
   const {
     name,
     project: { name: namespace },
-    application: { name: applicationName },
-    git: { url: repository, ref = 'master' },
     devfile: { devfileSuggestedResources },
   } = formData;
-
-  const defaultLabels = getAppLabels({ name, applicationName });
-  const defaultAnnotations = {
-    ...getGitAnnotations(repository, ref),
-    isFromDevfile: 'true',
-  };
 
   const devfileResourceObjects: DevfileSuggestedResources = Object.keys(
     devfileSuggestedResources,
@@ -493,13 +485,12 @@ export const createDevfileResources = async (
         metadata: {
           ...resource.metadata,
           annotations: {
-            ...defaultAnnotations,
             ...resource.metadata?.annotations,
+            isFromDevfile: 'true',
           },
           name,
           namespace,
           labels: {
-            ...defaultLabels,
             ...resource.metadata?.labels,
           },
         },

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -81,9 +81,16 @@ export const getPodLabels = (name: string) => {
 
 export const mergeData = (originalResource: K8sResourceKind, newResource: K8sResourceKind) => {
   const mergedData = _.merge({}, originalResource || {}, newResource);
-  mergedData.metadata.labels = newResource.metadata.labels;
+  const isDevfileResource = originalResource?.metadata?.annotations?.isFromDevfile;
+  mergedData.metadata.labels = {
+    ...newResource.metadata.labels,
+    ...(isDevfileResource ? originalResource?.metadata?.labels : {}),
+  };
   if (mergedData.metadata.annotations) {
-    mergedData.metadata.annotations = newResource.metadata.annotations;
+    mergedData.metadata.annotations = {
+      ...newResource.metadata.annotations,
+      ...(isDevfileResource ? originalResource?.metadata?.annotations : {}),
+    };
   }
   if (mergedData.spec?.template?.metadata?.labels) {
     mergedData.spec.template.metadata.labels = newResource.spec?.template?.metadata?.labels;

--- a/frontend/packages/topology/src/actions/modify-application.ts
+++ b/frontend/packages/topology/src/actions/modify-application.ts
@@ -28,13 +28,16 @@ export const ModifyApplication = (kind: K8sKind, obj: K8sResourceKind): KebabOpt
 
 export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
   const annotation = obj?.metadata?.annotations?.['openshift.io/generated-by'];
+  const isFromDevfile = obj?.metadata?.annotations?.isFromDevfile;
   return {
     // t('topology~Edit {{applicationName}}')
     labelKey: 'topology~Edit {{applicationName}}',
     labelKind: {
       applicationName: truncateMiddle(obj.metadata.name, { length: RESOURCE_NAME_TRUNCATE_LENGTH }),
     },
-    hidden: obj.kind !== KnativeServiceModel.kind && annotation !== 'OpenShiftWebConsole',
+    hidden:
+      (obj.kind !== KnativeServiceModel.kind && annotation !== 'OpenShiftWebConsole') ||
+      !!isFromDevfile,
     href: `/edit/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
       model.kind}`,
     accessReview: {


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-5225

**Analysis/Root cause:**
Import from devfile is currently in `DevPreview` and edit app feature was not planned for `DevPreview` and hence is not available currently but `edit <app-name>` action is still shown clicking on which the edit flow page errors out.

**Solution:**
Add a temporary annotation `isFromDevfile` on devfile resources and hide `edit <app-name>` action on deployment based on if above annotation exists on it. We can remove this once we plan to add edit feature for apps created using devfile flow.

/kind bug