### PR TITLE
Add Chinese to webpack config

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -227,7 +227,7 @@ const config: Configuration = {
       { from: './packages/local-storage-operator-plugin/locales', to: 'locales' },
     ]),
     new MomentLocalesPlugin({
-      localesToKeep: ['en', 'ja', 'ko'],
+      localesToKeep: ['en', 'zh-cn', 'ja', 'ko'],
     }),
     extractCSS,
     virtualModules,


### PR DESCRIPTION
I was looking at our webpack config and noticed that we don't have Chinese listed, even though we should. I updated it.