### PR TITLE
Bug 1907543: Set "en" as default for Moment.js

### DIFF
--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -5,10 +5,10 @@ import httpBackend from 'i18next-http-backend';
 import Pseudo from 'i18next-pseudo';
 
 // Load moment.js locales (en is default and always loaded)
-import 'moment/locale/zh-cn';
-import 'moment/locale/ja';
 import 'moment/locale/en-gb';
+import 'moment/locale/ja';
 import 'moment/locale/ko';
+import 'moment/locale/zh-cn';
 import moment from 'moment';
 
 const params = new URLSearchParams(window.location.search);
@@ -165,11 +165,15 @@ i18n
     },
     () => {
       moment.locale(i18n.language === 'zh' ? 'zh-cn' : i18n.language);
+      // set default in case the i18n.language isn't a language we currently support -- otherwise Moment.js will default to the last region import
+      moment.locale() !== i18n.language && i18n.language !== 'zh' && moment.locale('en');
     },
   );
 
 i18n.on('languageChanged', function(lng) {
   moment.locale(lng === 'zh' ? 'zh-cn' : lng);
+  // set default in case the i18n.language isn't a language we currently support -- otherwise Moment.js will default to the last region import
+  moment.locale() !== lng && lng !== 'zh' && moment.locale('en');
 });
 
 export default i18n;


### PR DESCRIPTION
We only import the Moment.js locales we currently support in OpenShift. Moment.js didn't know how to handle locales we didn't import and seemed like it was defaulting to the last imported locale (Korean) when the language was set to German, Spanish, etc. Changing which locale was the last imported locale affected what language Moment.js set itself to.

We only support English, Japanese, Chinese, and Korean timestamps right now. I set Moment to default to English if it gets a language we don't handle.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1907543.