### PR TITLE
Bug 1907888: Fix pipeline list page loader

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
@@ -1,9 +1,9 @@
 import * as _ from 'lodash';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ListPageWrapper_ as ListPageWrapper } from '@console/internal/components/factory';
-import { Firehose } from '@console/internal/components/utils';
+import { EmptyBox, Firehose, LoadingBox } from '@console/internal/components/utils';
 import { Resource, getResources } from '../../../utils/pipeline-augment';
-import { PipelineModel } from '../../../models';
 import PipelineAugmentRuns, { filters } from './PipelineAugmentRuns';
 import PipelineList from './PipelineList';
 
@@ -14,13 +14,15 @@ interface PipelineAugmentRunsWrapperProps {
 }
 
 const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (props) => {
+  const { t } = useTranslation();
   const pipelineData = _.get(props.pipeline, 'data', []);
-  if (pipelineData.length < 1) {
-    return (
-      <div className="cos-status-box">
-        <div className="text-center">No {PipelineModel.labelPlural} Found</div>
-      </div>
-    );
+
+  if (!props.pipeline.loaded) {
+    return <LoadingBox />;
+  }
+
+  if (pipelineData.length === 0) {
+    return <EmptyBox label={t('pipelines-plugin~Pipelines')} />;
   }
   const firehoseResources: Resource = getResources(props.pipeline.data);
   return (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/__tests__/PipelineAugmentRunsWrapper.spec.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { EmptyBox, LoadingBox } from '@console/internal/components/utils';
+import { ListPageWrapper_ as ListPageWrapper } from '@console/internal/components/factory';
+import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
+import PipelineAugmentRunsWrapper from '../PipelineAugmentRunsWrapper';
+
+const mockData = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
+const { pipeline } = mockData;
+
+type PipelineAugmentRunsWrapperProps = React.ComponentProps<typeof PipelineAugmentRunsWrapper>;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+describe('Pipeline Augment Run Wrapper', () => {
+  let pipelineAugmentRunsWrapperProps: PipelineAugmentRunsWrapperProps;
+  let wrapper: ShallowWrapper;
+  beforeEach(() => {
+    pipelineAugmentRunsWrapperProps = {
+      pipeline: {
+        data: [pipeline],
+        loaded: false,
+      },
+    };
+    wrapper = shallow(<PipelineAugmentRunsWrapper {...pipelineAugmentRunsWrapperProps} />);
+  });
+
+  it('Should render loader if data not yet loaded', () => {
+    expect(wrapper.find(LoadingBox).exists()).toBeTruthy();
+  });
+
+  it('Should render the EmptyBox if the data is empty', () => {
+    wrapper.setProps({ pipeline: { data: [], loaded: true } });
+    expect(wrapper.find(EmptyBox).exists()).toBeTruthy();
+  });
+
+  it('Should render ListpageWrapper if the pipeline data is loaded and available', () => {
+    wrapper.setProps({ pipeline: { data: [pipeline], loaded: true } });
+    expect(wrapper.find(ListPageWrapper).exists()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-5264

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
"Pipelines" list page shows a message "No pipelines found" before it loads the data

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Do not render the `No pipelines found`  text before the firehose call loads the data.

Screenshots:
![pipeline-loader-text](https://user-images.githubusercontent.com/9964343/102185143-99d92380-3ed6-11eb-8c1c-8c679b495b25.gif)

**Unit test coverage report**: 

![image](https://user-images.githubusercontent.com/9964343/102329300-40442800-3fae-11eb-913e-a0d98f5c98d3.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge