### PR TITLE
Bug 1903255: Add tolerations for ocs taint in localvolumeset and localvolumediscovery

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -51,6 +51,7 @@ import {
   MINIMUM_NODES,
   defaultRequestSize,
   OCS_INTERNAL_CR_NAME,
+  OCS_TOLERATION,
 } from '../../../../constants';
 import { StorageAndNodes } from './wizard-pages/storage-and-nodes-step';
 import '../attached-devices.scss';
@@ -107,7 +108,7 @@ const makeAutoDiscoveryCall = (
       if (err.message === AUTO_DISCOVER_ERR_MSG) {
         throw err;
       }
-      const requestData = getDiscoveryRequestData({ ...state, ns });
+      const requestData = getDiscoveryRequestData({ ...state, ns, toleration: OCS_TOLERATION });
       return k8sCreate(LocalVolumeDiscovery, requestData);
     })
     .then(() => {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/auto-detect-volume.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/auto-detect-volume.tsx
@@ -4,15 +4,16 @@ import {
   AutoDetectVolumeInner,
   AutoDetectVolumeHeader,
 } from '@console/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume-inner';
-import { State, Action } from '../state';
+import { hasOCSTaint } from '../../../../../utils/install';
 import { RequestErrors } from '../../../install-wizard/review-and-create';
+import { State, Action } from '../state';
 import '../../attached-devices.scss';
 
 export const AutoDetectVolume: React.FC<AutoDetectVolumeProps> = ({ state, dispatch }) => (
   <>
     <AutoDetectVolumeHeader />
     <Form noValidate={false} className="ceph-ocs-install__auto-detect-table">
-      <AutoDetectVolumeInner state={state} dispatch={dispatch} />
+      <AutoDetectVolumeInner state={state} dispatch={dispatch} taintsFilter={hasOCSTaint} />
     </Form>
     <RequestErrors errorMessage={state.error} inProgress={state.isLoading} />
   </>

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
@@ -9,11 +9,17 @@ import {
   LocalVolumeSetHeader,
 } from '@console/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner';
 import { getLocalVolumeSetRequestData } from '@console/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data';
+import { hasOCSTaint } from '../../../../../utils/install';
+import {
+  MINIMUM_NODES,
+  diskModeDropdownItems,
+  arbiterText,
+  OCS_TOLERATION,
+} from '../../../../../constants';
+import { RequestErrors } from '../../../install-wizard/review-and-create';
+import '../../attached-devices.scss';
 import { State, Action } from '../state';
 import { DiscoveryDonutChart } from './donut-chart';
-import { MINIMUM_NODES, diskModeDropdownItems, arbiterText } from '../../../../../constants';
-import '../../attached-devices.scss';
-import { RequestErrors } from '../../../install-wizard/review-and-create';
 
 const makeLocalVolumeSetCall = (
   state: State,
@@ -23,7 +29,8 @@ const makeLocalVolumeSetCall = (
   ns: string,
 ) => {
   setInProgress(true);
-  const requestData = getLocalVolumeSetRequestData(state, ns);
+
+  const requestData = getLocalVolumeSetRequestData(state, ns, OCS_TOLERATION);
   k8sCreate(LocalVolumeSetModel, requestData)
     .then(() => {
       dispatch({
@@ -63,6 +70,7 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({
             dispatch={dispatch}
             diskModeOptions={diskModeDropdownItems}
             allNodesHelpTxt={allNodesSelectorTxt}
+            taintsFilter={hasOCSTaint}
           />
         </Form>
         <DiscoveryDonutChart state={state} dispatch={dispatch} />

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -1,4 +1,4 @@
-import { Taint } from '@console/internal/module/k8s';
+import { Taint, Toleration } from '@console/internal/module/k8s';
 import { TFunction } from 'i18next';
 import { NetworkType, KMSConfig } from '../components/ocs-install/types';
 
@@ -9,6 +9,8 @@ export const ocsTaint: Taint = {
   effect: 'NoSchedule',
 };
 Object.freeze(ocsTaint);
+
+export const OCS_TOLERATION: Toleration = { ...ocsTaint, operator: 'Equal' };
 
 export const storageClassTooltip = (t: TFunction) =>
   t(

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
@@ -1,4 +1,5 @@
-import { apiVersionForModel, K8sResourceCommon } from '@console/internal/module/k8s';
+import * as _ from 'lodash';
+import { apiVersionForModel, K8sResourceCommon, Toleration } from '@console/internal/module/k8s';
 import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
 import { DISCOVERY_CR_NAME, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
@@ -10,15 +11,17 @@ export const getDiscoveryRequestData = ({
   showNodesListOnADV,
   hostNamesMapForADV,
   ns,
+  toleration,
 }: {
   nodeNamesForLVS: string[];
   allNodeNamesOnADV: string[];
   showNodesListOnADV: boolean;
   hostNamesMapForADV: HostNamesMap;
   ns: string;
+  toleration?: Toleration;
 }): AutoDetectVolumeKind => {
   const nodes = getNodes(showNodesListOnADV, allNodeNamesOnADV, nodeNamesForLVS);
-  return {
+  const request: AutoDetectVolumeKind = {
     apiVersion: apiVersionForModel(AutoDetectVolumeModel),
     kind: AutoDetectVolumeModel.kind,
     metadata: { name: DISCOVERY_CR_NAME, namespace: ns },
@@ -38,6 +41,8 @@ export const getDiscoveryRequestData = ({
       },
     },
   };
+  if (!_.isEmpty(toleration)) request.spec.tolerations = [toleration];
+  return request;
 };
 
 type AutoDetectVolumeKind = K8sResourceCommon & {
@@ -49,5 +54,6 @@ type AutoDetectVolumeKind = K8sResourceCommon & {
         },
       ];
     };
+    tolerations?: Toleration[];
   };
 };

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -22,6 +22,7 @@ import './create-local-volume-set.scss';
 export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
   dispatch,
   state,
+  taintsFilter,
   diskModeOptions = diskModeDropdownItems,
   allNodesHelpTxt,
 }) => {
@@ -131,6 +132,7 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
             },
             filteredNodes: state.nodeNamesForLVS,
             preSelected: state.nodeNames,
+            taintsFilter,
           }}
         />
       )}
@@ -234,6 +236,7 @@ type LocalVolumeSetInnerProps = {
   dispatch: React.Dispatch<Action>;
   diskModeOptions?: { [key: string]: string };
   allNodesHelpTxt?: string;
+  taintsFilter?: (node: NodeKind) => boolean;
 };
 
 export const LocalVolumeSetHeader = () => {

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -1,11 +1,16 @@
-import { apiVersionForModel } from '@console/internal/module/k8s';
+import * as _ from 'lodash';
+import { apiVersionForModel, Toleration } from '@console/internal/module/k8s';
 import { LocalVolumeSetModel } from '../../models';
 import { LocalVolumeSetKind, DiskType } from './types';
 import { State } from './state';
 import { DISK_TYPES, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
 
-export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVolumeSetKind => {
+export const getLocalVolumeSetRequestData = (
+  state: State,
+  ns: string,
+  toleration?: Toleration,
+): LocalVolumeSetKind => {
   const nodes = getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames);
   const requestData = {
     apiVersion: apiVersionForModel(LocalVolumeSetModel),
@@ -33,6 +38,7 @@ export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVol
     },
   } as LocalVolumeSetKind;
 
+  if (!_.isEmpty(toleration)) requestData.spec.tolerations = [toleration];
   if (state.maxDiskLimit) requestData.spec.maxDeviceCount = +state.maxDiskLimit;
   if (state.minDiskSize)
     requestData.spec.deviceInclusionSpec.minSize = `${state.minDiskSize}${state.diskSizeUnit}`;

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/nodes-selection-list.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/nodes-selection-list.tsx
@@ -39,11 +39,13 @@ const getRows: GetRows = (
   setSelectedNodes,
 ) => {
   const { data } = componentProps;
-  const { filteredNodes, preSelected } = customData;
+  const { filteredNodes, preSelected, taintsFilter } = customData;
 
   const nodeList = filteredNodes?.length ? filteredNodes : data.map(getName);
-  const filteredData = data.filter(
-    (node: NodeKind) => hasNoTaints(node) && nodeList.includes(getName(node)),
+  const filteredData = data.filter((node: NodeKind) =>
+    taintsFilter
+      ? (taintsFilter(node) || hasNoTaints(node)) && nodeList.includes(getName(node))
+      : hasNoTaints(node) && nodeList.includes(getName(node)),
   );
 
   const rows = filteredData.map((node: NodeKind) => {

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
@@ -1,5 +1,5 @@
 import { IRow } from '@patternfly/react-table';
-import { NodeKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { NodeKind, K8sResourceCommon, Toleration } from '@console/internal/module/k8s';
 
 export type NodeTableRow = {
   cells: IRow['cells'];
@@ -35,6 +35,7 @@ export type LocalVolumeSetKind = K8sResourceCommon & {
       }[];
     };
     maxDeviceCount?: number;
+    tolerations?: Toleration[];
   };
 };
 
@@ -47,6 +48,7 @@ export type GetRows = (
     customData?: {
       filteredNodes: string[];
       preSelected?: string[];
+      taintsFilter?: (node: NodeKind) => boolean;
     };
   },
   visibleRows: Set<string>,


### PR DESCRIPTION
- handles displaying nodes, tainted with the taint "node.ocs.openshift.io/storage="true":NoSchedule"
- by default setting tolerations for ocs-taints in lvset and lvd yamls in OCS UI
