### PR TITLE
Bug 1908296: Fix pipeline builder form yaml switcher validation issue

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -52,9 +52,18 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
     setFieldValue,
     setStatus,
     values,
+    validateForm,
   } = props;
   const statusRef = React.useRef(status);
   statusRef.current = status;
+
+  React.useEffect(() => {
+    if (values.editorType === EditorType.Form) {
+      // Force validation against the new data that was adjusted in the YAML
+      // Formik isn't properly handling the immediate state of the form values during the cycle of the editorType
+      setTimeout(() => validateForm(), 0);
+    }
+  }, [values.editorType, validateForm]);
 
   const updateErrors: UpdateErrors = React.useCallback(
     (taskErrors) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5249

**Analysis / Root cause**: 

In pipeline builder page,  pasting the yaml file on the yaml section and switching back to form view fails to enable the create button. Formik validation is not occurring against the immediate change in form values while switch back to form view.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Add a force validation to get correct error state while switching to form view.

**Screen shots / Gifs for design review**: 
![submit-button-enabled](https://user-images.githubusercontent.com/9964343/102339445-2ceb8980-3fbb-11eb-90fd-566fe67c29e1.gif)


**Unit test coverage report**: 
No UI changes

**Test Setup**:

1. Goto pipeline builder page, switch to yaml section
2. Paste a valid pipeline yaml  from the clipboard
3. Switch back to form view (create button should be enabled)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge