### PR TITLE
Bug 1908323: Add create button for pipelinerun in devconsole search page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
@@ -18,7 +18,7 @@ const PipelineRunsResourceList: React.FC<Omit<
   return (
     <ListPage
       {...props}
-      canCreate={false}
+      canCreate
       kind={referenceForModel(PipelineRunModel)}
       ListComponent={PipelineRunsList}
       rowFilters={runFilters}

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { ListPage } from '@console/internal/components/factory';
+import PipelineRunsResourceList from '../PipelineRunsResourceList';
+
+type PipelineRunsResourceListProps = React.ComponentProps<typeof PipelineRunsResourceList>;
+
+describe('PipelineRunsResourceList:', () => {
+  let pipelineRunsResourceListProps: PipelineRunsResourceListProps;
+  let wrapper: ShallowWrapper<PipelineRunsResourceListProps>;
+
+  beforeEach(() => {
+    pipelineRunsResourceListProps = {
+      hideBadge: false,
+    };
+    wrapper = shallow(<PipelineRunsResourceList {...pipelineRunsResourceListProps} />);
+  });
+
+  it('Should set the create button prop in the list page', () => {
+    expect(wrapper.find(ListPage).props().canCreate).toBeTruthy();
+  });
+
+  it('Should render the badge in the list page', () => {
+    wrapper.setProps({ hideBadge: false });
+    expect(wrapper.find(ListPage).props().badge).not.toBeNull();
+  });
+
+  it('Should not render the badge in the list page', () => {
+    wrapper.setProps({ hideBadge: true });
+    expect(wrapper.find(ListPage).props().badge).toBeNull();
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5246

**Analysis / Root cause**: 
In dev-console search page, create button is missing for pipelinerun resource.



**Solution Description**: 
 Added create button for pipelinerun resource in the devconsole search page.


**Screen shots / Gifs for design review**: 

**Search Page:**
![image](https://user-images.githubusercontent.com/9964343/102348373-d5074f80-3fc7-11eb-91e9-ffff124d67f7.png)

**Pinned PipelineRuns List page:**
![image](https://user-images.githubusercontent.com/9964343/102488831-a7d3a380-4092-11eb-922f-a012aace40e1.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/9964343/102488946-cb96e980-4092-11eb-9806-1630cfa2b817.png)

**Test setup:**
Go to devconsole search page -> choose pipeline run in the filter.
**Browser conformance**: 

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
cc: @bgliwa01 @andrewballantyne 