### PR TITLE
Bug 1907453: Pod is now availble in Dev view , topology , machine detail

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/topology/TopologyVmDetailsPanel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/TopologyVmDetailsPanel.tsx
@@ -15,6 +15,8 @@ import { TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../constants/vm';
 import { VMDetailsList, VMResourceSummary } from '../components/vms/vm-resource';
 import { VMNode } from './types';
 import { VMKind } from '../types/vm';
+import { PodKind } from '@console/internal/module/k8s/types';
+import { usePodsForVm } from '../utils/usePodsForVm';
 
 type TopologyVmDetailsPanelProps = {
   vmNode: VMNode;
@@ -28,8 +30,8 @@ type LoadedTopologyVmDetailsPanelProps = TopologyVmDetailsPanelProps & {
 const LoadedTopologyVmDetailsPanel: React.FC<LoadedTopologyVmDetailsPanelProps> = observer(
   ({ loaded, vmNode, templates }) => {
     const vmData = vmNode.getData();
-    const { pod } = vmData.data.vmStatusBundle;
     const vmObj = vmData.resource as VMKind;
+    const { podData: { pods = [] } = {} } = usePodsForVm(vmObj);
     const { vmi, vmStatusBundle } = vmData.data;
     const canUpdate =
       useAccessReview(asAccessReview(VirtualMachineModel, vmObj || {}, 'patch')) && !!vmObj;
@@ -53,7 +55,7 @@ const LoadedTopologyVmDetailsPanel: React.FC<LoadedTopologyVmDetailsPanelProps> 
             canUpdateVM={canUpdate}
             vm={vmObj}
             vmi={vmi}
-            pods={[pod]}
+            pods={pods as PodKind[]}
             kindObj={VirtualMachineModel}
             vmStatusBundle={vmStatusBundle}
           />

--- a/frontend/packages/kubevirt-plugin/src/topology/TopologyVmResourcesPanel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/TopologyVmResourcesPanel.tsx
@@ -3,6 +3,8 @@ import { observer } from '@patternfly/react-topology';
 import { PodsOverviewContent } from '@console/internal/components/overview/pods-overview';
 import { NetworkingOverview } from '@console/internal/components/overview/networking-overview';
 import { VMNode } from './types';
+import { PodKind } from '@console/internal/module/k8s/types';
+import { usePodsForVm } from '../utils/usePodsForVm';
 
 type TopologyVmResourcePanelProps = {
   vmNode: VMNode;
@@ -12,11 +14,11 @@ export const TopologyVmResourcesPanel: React.FC<TopologyVmResourcePanelProps> = 
   ({ vmNode }: TopologyVmResourcePanelProps) => {
     const vmData = vmNode.getData();
     const vm = vmData.resource;
-    const { pod } = vmData.data.vmStatusBundle;
+    const { podData: { pods = [] } = {} } = usePodsForVm(vm);
 
     return (
       <div className="overview__sidebar-pane-body">
-        <PodsOverviewContent obj={vm} pods={pod ? [pod] : []} loaded loadError={null} />
+        <PodsOverviewContent obj={vm} pods={pods as PodKind[]} loaded loadError={null} />
         <NetworkingOverview obj={vm} />
       </div>
     );


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <matanschatzman@gmail.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1907453

**Analysis / Root cause**: 
Pods were missing on vmStatusBundle

**Solution Description**: 
Made sure pods are added to data and can be pull from vmNode.data

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/102355053-0118d580-3fb4-11eb-8aac-f5cb34066eff.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/102355156-273e7580-3fb4-11eb-9516-371349a3154d.png)
