### PR TITLE
Bug 1908715: Add fix to loop back to last quick-search list item on pressing arrow up key when on top

### DIFF
--- a/frontend/packages/topology/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchList.scss
@@ -30,7 +30,7 @@
       var(--pf-c-data-list__item--sm--BorderBottomColor) !important;
   }
   &__all-items-link {
-    padding: var(--pf-global--spacer--xs) 0px;
+    padding: var(--pf-global--spacer--sm) 0px;
     text-align: center;
     font-size: var(--pf-global--FontSize--md);
   }

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
@@ -82,7 +82,8 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   }, [selectedItem, namespace, searchTerm]);
 
   const selectPrevious = React.useCallback(() => {
-    const index = getIndexOfSelectedItem();
+    let index = getIndexOfSelectedItem();
+    if (index === 0) index = listCatalogItems?.length;
     setSelectedItemId(listCatalogItems?.[index - 1]?.uid);
     setSelectedItem(listCatalogItems?.[index - 1]);
   }, [listCatalogItems, getIndexOfSelectedItem]);
@@ -101,10 +102,12 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
           break;
         }
         case 'ArrowUp': {
+          e.preventDefault();
           selectPrevious();
           break;
         }
         case 'ArrowDown': {
+          e.preventDefault();
           selectNext();
           break;
         }


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-5281

**Analysis/Root cause:**
When on the bottom item and you press the down arrow loop backs to the top but when on the top item and you press the up arrow, it doesn't loop back to the bottom. 

**Solution:**
When topmost item is selected and arrow up key is pressed, make last item as the selectedItem.

**Gif:**
![Peek 2020-12-16 21-28](https://user-images.githubusercontent.com/20724543/102372277-0b9f9300-3fe5-11eb-92a5-25bdc68a5823.gif)


/kind bug
