### PR TITLE
Bug 1908410: Exclude Yarn from VSCode search

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -21,17 +21,22 @@
   "[graphql]": {
     "editor.formatOnSave": true
   },
-
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact", "json", "graphql"],
-  "eslint.enable": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "json",
+    "graphql"
+  ],
   "javascript.validate.enable": false,
-  "debug.node.autoAttach": "on",
   "typescript.tsdk": "node_modules/typescript/lib",
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,
     "**/.cache-loader": true,
-    "**/public/dist": true
+    "**/public/dist": true,
+    "**/.yarn/releases/**": true
   },
   "files.exclude": {
     "**/.git": true,


### PR DESCRIPTION
Searching in VSCode could result in slow/irrelevant results because the editor searches in the `yarn-x.js` file.
Also cleaned up some fields:

1. Exclude `yarn-X.js`
2. Removed `eslint.enable": true` - deprecated
3. Removed `debug.node.autoAttach": on` - unknown field
