### PR TITLE
Re-enable Protractor tests in CI

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -40,7 +40,6 @@ fi
 
 if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-console-headless
-  yarn run test-cypress-olm-headless
   yarn run test-cypress-devconsole-headless
   exit;
 fi

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -34,7 +34,7 @@ export DBUS_SESSION_BUS_ADDRESS
 
 SCENARIO="${1:-e2e}"
 
-if [ "$SCENARIO" != "login" ] && [ "$SCENARIO" != "olmFull" ] && ["$SCENARIO" != "ceph"]; then
+if [ "$SCENARIO" != "login" ] && [ "$SCENARIO" != "olmFull" ] && [ "$SCENARIO" != "ceph" ]; then
   CHROME_VERSION=$(google-chrome --version) ./test-protractor.sh "$SCENARIO"
 fi
 


### PR DESCRIPTION
This PR implements one aspect of #7446, specifically in
`test-prow-e2e.sh`:
`if [ "$SCENARIO" != "login" ] && [ "$SCENARIO" != "olmFull" ] && [ "$SCENARIO" != "ceph" ] ...`
which was why Protractor wasn't being launched in CI.

This PR also removes 'olm'(full) running during regular e2e CI tests.