### PR TITLE
Bug 1908437: Fix to show default operator icon for topology OBS group node w/o icon

### DIFF
--- a/frontend/packages/topology/src/components/svg/SvgCircledIcon.tsx
+++ b/frontend/packages/topology/src/components/svg/SvgCircledIcon.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useSize, createSvgIdUrl } from '@patternfly/react-topology';
-import { isValidUrl } from '@console/shared';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import SvgDropShadowFilter from './SvgDropShadowFilter';
 
@@ -45,7 +44,7 @@ const CircledIcon: React.FC<SvgTypedIconProps> = (
           y={y}
           width={width}
           height={height}
-          xlinkHref={isValidUrl(iconClass) ? iconClass : getImageForIconClass(iconClass)}
+          xlinkHref={getImageForIconClass(iconClass) || iconClass}
           filter={createSvgIdUrl(FILTER_ID)}
         />
       </g>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4972

**Analysis / Root cause**: 
The display of the icon expected a URL or an icon name, for default operator icons we pass an image.

**Solution Description**: 
Update the display of the icon to support passing an image.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/102384006-344e6b00-3f9a-11eb-873c-c08312bdb47e.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug