### PR TITLE
Bug 1908425: - Create Role Binding form subject type and name are undefined when All Project is selected 

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -294,7 +294,7 @@ export const RoleBindingsPage = ({
   createPath = `/k8s/${
     namespace
       ? `ns/${namespace}/rolebindings/~new?namespace=${namespace}`
-      : `cluster/rolebindings/~new?subjectName=${name}&subjectKind=${kind}`
+      : `cluster/rolebindings/~new${name && kind ? `?subjectName=${name}&subjectKind=${kind}` : ''}`
   }`,
 }) => (
   <MultiListPage


### PR DESCRIPTION
/assign @rhamilto

This PR is a follow on to https://github.com/openshift/console/pull/7546. This fix addressed the issue of subject type and name are set to undefined when All Projects is selected.

![Screen Shot 2020-12-16 at 1 17 31 PM](https://user-images.githubusercontent.com/15249132/102389434-205a3780-3fa1-11eb-8bdc-a2fd259b2174.png)
<img width="1231" alt="Screen Shot 2020-12-16 at 12 52 17 PM" src="https://user-images.githubusercontent.com/15249132/102389435-205a3780-3fa1-11eb-9d36-fe25494a7c2a.png">


