### PR TITLE
Bug 1908641: Show breadcrumb on empty state of catalog as well

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
@@ -149,7 +149,7 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
       </Helmet>
       <div className="co-m-page__body">
         <div className="co-catalog">
-          <PageHeading title={title} breadcrumbs={type && items?.length > 0 ? breadcrumbs : null} />
+          <PageHeading title={title} breadcrumbs={type ? breadcrumbs : null} />
           <p className="co-catalog-page__description">{description}</p>
           <div className="co-catalog__body">
             <StatusBox


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5280
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The breadcrumb was being hidden in when empty state was shown in catalog.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Show breadcrumb even when empty state is shown.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux @rachael-phillips 
![Peek 2020-12-17 14-11](https://user-images.githubusercontent.com/6041994/102465145-510aa180-4073-11eb-9ce1-abb73aeaf804.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
