### PR TITLE
Bug 1908716: passes loadError message and handled same in pods-overview

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
+++ b/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
@@ -49,7 +49,7 @@ export const usePodsForRevisions = (
     (updatedResources) => {
       const errorKey = Object.keys(updatedResources).find((key) => updatedResources[key].loadError);
       if (errorKey) {
-        setLoadError(updatedResources[errorKey].loadError);
+        setLoadError(updatedResources[errorKey].loadError?.message);
         return;
       }
       if (

--- a/frontend/public/components/overview/pods-overview.tsx
+++ b/frontend/public/components/overview/pods-overview.tsx
@@ -181,7 +181,7 @@ export const PodsOverviewContent: React.SFC<PodsOverviewContentProps> = ({
         </Alert>
       ) : null}
       {_.isEmpty(filteredPods) ? (
-        <span className="text-muted">{loadError || (loaded ? emptyMessage : <LoadingBox />)}</span>
+        <span className="text-muted">{loaded || !!loadError ? emptyMessage : <LoadingBox />}</span>
       ) : (
         <PodsOverviewList pods={_.take(filteredPods, podsShown)} />
       )}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5287

**Analysis / Root cause**: 
LoadError was not string which was getting to render 

**Solution Description**: 
Pass LoadError message which is string and not render loadError


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
