### PR TITLE
Bug 1908746: Fix for SVG filters in topology for Safari

### DIFF
--- a/frontend/packages/helm-plugin/src/topology/components/HelmReleaseGroup.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/HelmReleaseGroup.tsx
@@ -75,6 +75,11 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
           })}
         >
           <rect
+            key={
+              hover || innerHover || contextMenuOpen || dragging || labelDragging
+                ? 'rect-hover'
+                : 'rect'
+            }
             ref={dndDropRef}
             className="odc-helm-release__bg"
             x={x}

--- a/frontend/packages/helm-plugin/src/topology/components/HelmReleaseNode.tsx
+++ b/frontend/packages/helm-plugin/src/topology/components/HelmReleaseNode.tsx
@@ -67,6 +67,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
     >
       <NodeShadows />
       <rect
+        key={hover || contextMenuOpen || dragging ? 'rect-hover' : 'rect'}
         filter={createSvgIdUrl(
           hover || contextMenuOpen || dragging
             ? NODE_SHADOW_FILTER_ID_HOVER

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeIcon.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeIcon.tsx
@@ -34,6 +34,7 @@ const KnativeIcon: React.FC<KnativeIconProps> = ({ x, y, width, height }) => (
       </filter>
     </SVGDefs>
     <image
+      key={`image-${FILTER_ID}`}
       x={x}
       y={y}
       width={width}

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -153,6 +153,11 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
             })}
           >
             <rect
+              key={
+                hover || innerHover || dragging || labelDragging || contextMenuOpen || dropTarget
+                  ? 'rect-hover'
+                  : 'rect'
+              }
               ref={dndDropRef}
               className="odc-knative-service__bg"
               x={x}

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceNode.tsx
@@ -98,6 +98,7 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
     >
       <NodeShadows />
       <rect
+        key={hover || dragging || contextMenuOpen || dropTarget ? 'rect-hover' : 'rect'}
         ref={dndDropRef}
         className="odc-knative-service__bg"
         filter={createSvgIdUrl(

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventSource.tsx
@@ -73,6 +73,7 @@ const EventSource: React.FC<EventSourceProps> = ({
     >
       <NodeShadows />
       <polygon
+        key={hover || dragging || contextMenuOpen ? 'polygon-hover' : 'polygon'}
         className="odc-event-source__bg"
         ref={svgAnchorRef}
         filter={createSvgIdUrl(

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/EventingPubSubNode.tsx
@@ -133,6 +133,7 @@ const EventingPubSubNode: React.FC<EventingPubSubNodeProps> = ({
       >
         <NodeShadows />
         <rect
+          key={hover || dragging || contextMenuOpen || dropTarget ? 'rect-hover' : 'rect'}
           className="odc-eventing-pubsub__bg"
           x={0}
           y={0}

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/SinkUriNode.tsx
@@ -89,6 +89,7 @@ const SinkUriNode: React.FC<SinkUriNodeProps> = ({
           ref={groupRefs}
         >
           <circle
+            key={hover || dragging || contextMenuOpen ? 'circle-hover' : 'circle'}
             className="odc-sink-uri__bg"
             ref={dndDropRef}
             cx={cx}

--- a/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/nodes/VmNode.tsx
@@ -199,6 +199,11 @@ const ObservedVmNode: React.FC<VmNodeProps> = ({
             ref={refs}
           >
             <rect
+              key={
+                hover || dragging || edgeDragging || dropTarget || contextMenuOpen
+                  ? 'rect-hover'
+                  : 'rect'
+              }
               className="odc-base-node__bg"
               ref={dndDropRef}
               x={0}

--- a/frontend/packages/topology/src/components/graph-view/Topology.tsx
+++ b/frontend/packages/topology/src/components/graph-view/Topology.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { action } from 'mobx';
-import { debounce } from '@patternfly/react-core';
 import {
   ComponentFactory,
   Visualization,
@@ -147,7 +147,7 @@ const Topology: React.FC<TopologyProps &
     newVisualization.registerElementFactory(odcElementFactory);
     newVisualization.registerLayoutFactory(layoutFactory);
 
-    const onCurrentGraphModelChange = debounce(() => {
+    const onCurrentGraphModelChange = _.debounce(() => {
       const visModel = newVisualization.toModel();
       const saveGraphModel = {
         id: visModel.graph.id,
@@ -160,7 +160,7 @@ const Topology: React.FC<TopologyProps &
       onGraphModelChange(namespace, saveGraphModel);
     }, 200);
 
-    const onVisualizationLayoutChange = debounce(() => {
+    const onVisualizationLayoutChange = _.debounce(() => {
       const visModel = newVisualization.toModel();
       const updatedLayoutData = setTopologyLayout(namespace, visModel.nodes, visModel.graph.layout);
       setTopologyLayoutData((prevState) => {

--- a/frontend/packages/topology/src/components/graph-view/components/groups/ApplicationGroup.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/groups/ApplicationGroup.tsx
@@ -153,6 +153,11 @@ const ApplicationGroup: React.FC<ApplicationGroupProps> = ({
           })}
         >
           <path
+            key={
+              hover || labelHover || dragging || contextMenuOpen || dropTarget
+                ? 'group-path-hover'
+                : 'group-path'
+            }
             ref={dndDropRef}
             className="odc-application-group__bg"
             filter={createSvgIdUrl(

--- a/frontend/packages/topology/src/components/graph-view/components/groups/ApplicationNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/groups/ApplicationNode.tsx
@@ -69,6 +69,7 @@ const ApplicationNode: React.FC<ApplicationGroupProps> = ({
     >
       <NodeShadows />
       <rect
+        key={hover || dragging || contextMenuOpen || dropTarget ? 'rect-hover' : 'rect'}
         ref={dndDropRef}
         filter={createSvgIdUrl(
           hover || dragging || contextMenuOpen || dropTarget

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/BaseNode.tsx
@@ -121,6 +121,11 @@ const BaseNode: React.FC<BaseNodeProps> = ({
         ref={refs}
       >
         <circle
+          key={
+            hover || dragging || edgeDragging || dropTarget || contextMenuOpen
+              ? 'circle-hover'
+              : 'circle'
+          }
           className="odc-base-node__bg"
           ref={dndDropRef}
           cx={cx}

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/Decorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/Decorator.tsx
@@ -43,6 +43,7 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
       <SvgDropShadowFilter id={FILTER_ID} stdDeviation={1} floodOpacity={0.5} />
       <SvgDropShadowFilter id={HOVER_FILTER_ID} dy={3} stdDeviation={5} floodOpacity={0.5} />
       <circle
+        key={hover ? 'circle-hover' : 'circle'}
         ref={circleRef}
         className="odc-decorator__bg"
         cx={x}

--- a/frontend/packages/topology/src/components/svg/SvgBoxedText.tsx
+++ b/frontend/packages/topology/src/components/svg/SvgBoxedText.tsx
@@ -65,6 +65,7 @@ const SvgBoxedText: React.FC<SvgBoxedTextProps> = ({
       <SvgDropShadowFilter id={FILTER_ID} />
       {textSize && (
         <rect
+          key={`rect-${FILTER_ID}`}
           filter={createSvgIdUrl(FILTER_ID)}
           x={midX - paddingX - textSize.width / 2 - iconSpace / 2 - (typeIconClass ? 10 : 0)}
           width={textSize.width + paddingX * 2 + iconSpace + (typeIconClass ? 10 : 0)}

--- a/frontend/packages/topology/src/components/svg/SvgCircledIcon.tsx
+++ b/frontend/packages/topology/src/components/svg/SvgCircledIcon.tsx
@@ -33,6 +33,7 @@ const CircledIcon: React.FC<SvgTypedIconProps> = (
     <g className={className}>
       <SvgDropShadowFilter id={FILTER_ID} />
       <circle
+        key={`circle-${FILTER_ID}`}
         ref={circleRef}
         filter={createSvgIdUrl(FILTER_ID)}
         cx={x - iconWidth / 2}
@@ -41,6 +42,7 @@ const CircledIcon: React.FC<SvgTypedIconProps> = (
       />
       <g ref={typedIconRef}>
         <image
+          key={`image-${FILTER_ID}`}
           x={x - iconWidth}
           y={y}
           width={width}

--- a/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
+++ b/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import {
   useK8sWatchResources,
   WatchK8sResources,
@@ -42,15 +43,23 @@ const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({ trafficDa
   }, [namespace]);
 
   React.useEffect(() => {
-    updateTopologyDataModel(dataModelContext, resources, showGroups, trafficData, monitoringAlerts)
-      .then((res) => {
-        dataModelContext.loadError = res.loadError;
-        if (res.loaded) {
-          dataModelContext.loaded = true;
-          dataModelContext.model = res.model;
-        }
-      })
-      .catch(() => {});
+    if (!_.isEmpty(resources)) {
+      updateTopologyDataModel(
+        dataModelContext,
+        resources,
+        showGroups,
+        trafficData,
+        monitoringAlerts,
+      )
+        .then((res) => {
+          dataModelContext.loadError = res.loadError;
+          if (res.loaded) {
+            dataModelContext.loaded = true;
+            dataModelContext.model = res.model;
+          }
+        })
+        .catch(() => {});
+    }
   }, [resources, trafficData, dataModelContext, monitoringAlerts, showGroups]);
 
   return null;

--- a/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedServiceGroup.tsx
@@ -93,6 +93,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
             })}
           >
             <rect
+              key={hover || innerHover || dragging || labelDragging ? 'rect-hover' : 'rect'}
               ref={dndDropRef}
               className="odc-operator-backed-service__bg"
               x={x}

--- a/frontend/packages/topology/src/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/topology/src/operators/components/OperatorBackedServiceNode.tsx
@@ -78,6 +78,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
       >
         <NodeShadows />
         <rect
+          key={hover || dragging ? 'rect-hover' : 'rect'}
           className="odc-operator-backed-service__bg"
           filter={createSvgIdUrl(
             hover || dragging ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-1920

**Analysis / Root cause**: 
Safari does not render SVG elements on attribute changes. 

**Solution Description**: 
By updating the `key` on the SVG elements when we update the filter attribute, the element is remounted and then updated attributes are applied.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

/kind bug