### PR TITLE
[release-4.6 ]Bug 1908749: Fix cluster creation when using localvolume

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -4,13 +4,17 @@ import {
   Taint,
   StorageClassResourceKind,
   K8sResourceKind,
+  MatchExpression,
 } from '@console/internal/module/k8s';
 import {
   humanizeBinaryBytes,
   convertToBaseValue,
   humanizeCpuCores,
 } from '@console/internal/components/utils';
-import { HOSTNAME_LABEL_KEY } from '@console/local-storage-operator-plugin/src/constants';
+import {
+  HOSTNAME_LABEL_KEY,
+  LABEL_OPERATOR,
+} from '@console/local-storage-operator-plugin/src/constants';
 import { getNodeCPUCapacity, getNodeAllocatableMemory } from '@console/shared';
 import { ocsTaint, NO_PROVISIONER, AVAILABLE } from '../constants';
 import { Discoveries } from '../components/ocs-install/attached-devices/create-sc/state';
@@ -44,10 +48,13 @@ export const getTotalDeviceCapacity = (list: Discoveries[]): number =>
 
 export const getAssociatedNodes = (pvs: K8sResourceKind[]): string[] => {
   const nodes = pvs.reduce((res, pv) => {
-    const nodeName = pv?.metadata?.labels?.[HOSTNAME_LABEL_KEY];
-    if (nodeName) {
-      res.add(nodeName);
-    }
+    const matchExpressions: MatchExpression[] =
+      pv?.spec?.nodeAffinity?.required?.nodeSelectorTerms?.[0]?.matchExpressions;
+    matchExpressions.forEach(({ key, operator, values }) => {
+      if (key === HOSTNAME_LABEL_KEY && operator === LABEL_OPERATOR) {
+        values.forEach((value) => res.add(value));
+      }
+    });
     return res;
   }, new Set<string>());
 


### PR DESCRIPTION
- use the nodeSelector field to get the associated nodes for a PV
- drops the usage of labels

Signed-off-by: Afreen Rahman <afrahman@redhat.com>
(cherry picked from commit 1a73e76a6dd94ef63acce960251d509e7a765031)

 Conflicts resolved:
	frontend/packages/ceph-storage-plugin/src/utils/install.ts
	
Automated [cherrypick failed](https://github.com/openshift/console/pull/7552#issuecomment-747452097), hence a manual PR