### PR TITLE
Bug 1908918: Fix Pipeline builder yaml view layout

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
@@ -1,3 +1,5 @@
+@import '~@patternfly/patternfly/sass-utilities/all';
+
 .osc-yaml-editor {
   display: flex;
   flex: 1 0 auto;
@@ -12,5 +14,8 @@
     display: flex;
     flex: 1 0 0;
     margin-left: 20px;
+    @media screen and (max-width: $pf-global--breakpoint--lg) {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5245

**Analysis / Root cause**: 
Pipeline builder yaml view is not responsive.

**Solution Description**: 
Make Pipeline builder yaml view responsive

**Screen shots / Gifs for design review**: 
![Kapture 2020-12-18 at 16 17 39](https://user-images.githubusercontent.com/2561818/102606400-b2527380-414c-11eb-9a6d-fb7e65370578.gif)




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge