### PR TITLE
Bug 1908997: Add more provisioners with their accessmode mapping

### DIFF
--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -20,6 +20,8 @@ export const provisionerAccessModeMapping = {
   'manila.csi.openstack.org': ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'],
   'ebs.csi.aws.com': ['ReadWriteOnce'],
   'csi.ovirt.org': ['ReadWriteOnce'],
+  'cinder.csi.openstack.org': ['ReadWriteOnce'],
+  'pd.csi.storage.gke.io': ['ReadWriteOnce'],
 };
 export const initialAccessModes = ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'];
 export const accessModeRadios = [


### PR DESCRIPTION
Fix [Bug 1908997](https://bugzilla.redhat.com/show_bug.cgi?id=1908997) - Unsupported access mode should not be available when creating pvc by cinder-csi-driver/gcp-pd-csi-driver from web-console

@jhadvig Can you help review?