### PR TITLE
Bug 1909070: Fix logs streaming issue in multistream logs

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/MultiStreamLogs.tsx
@@ -145,7 +145,8 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
       >
         <div className="odc-multi-stream-logs__container__logs" ref={scrollPane}>
           {containers.map((container, idx) => {
-            const resourceStatus = containerToLogSourceStatus(containerStatus[idx]);
+            const statusIndex = containerStatus.findIndex((c) => c.name === container.name);
+            const resourceStatus = containerToLogSourceStatus(containerStatus[statusIndex]);
             return (
               resourceStatus !== LOG_SOURCE_WAITING && (
                 <Logs


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5269

**Analysis / Root cause**:
Logs component in PLR and TR details page, is not streaming the logs as fast as tkn logs

**Cause:**
 Logs were not streamed properly due to incorrect container status was used to render the logs component.

**Solution Description**: 
Use the correct container status to render the logs component.

**Screen shots / Gifs for design review**: 
![PLR_TR_logs](https://user-images.githubusercontent.com/9964343/102595883-5da7fc00-413e-11eb-94ac-cb7c73c39524.gif)


**Unit test coverage report**: 
No UI changes.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Start a pipeline and visit the PLR/TR logs page
2. In Parallel, run the tkn logs in terminal

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge