### PR TITLE
Bug 1909092: adds feature flag with channel CRD for add action and route

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -117,6 +117,7 @@
   "No sink found for this resource.": "No sink found for this resource.",
   "Filter": "Filter",
   "Autoscaled to 0": "Autoscaled to 0",
+  "All Revisions are autoscaled to 0": "All Revisions are autoscaled to 0",
   "Location:": "Location:",
   "Revisions": "Revisions",
   "View all ({{revLength}})": "View all ({{revLength}})",

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
@@ -17,8 +17,6 @@ import KSRoutesOverviewList from './RoutesOverviewList';
 import { PubSubResourceOverviewList } from './EventPubSubResources';
 import PubSubSubscribers from './EventPubSubSubscribers';
 
-const REVISIONS_AUTOSCALED = 'All Revisions are autoscaled to 0';
-
 type KnativeServiceResourceProps = {
   item: KnativeServiceOverviewItem;
 };
@@ -59,7 +57,7 @@ const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({ item }
         pods={servicePods}
         loaded={loaded}
         loadError={loadError}
-        emptyText={REVISIONS_AUTOSCALED}
+        emptyText={t('knative-plugin~All Revisions are autoscaled to 0')}
         allPodsLink={linkUrl}
       />
       <RevisionsOverviewList revisions={revisions} service={obj} />

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -338,7 +338,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       component: NamespaceRedirect,
     },
     flags: {
-      required: [FLAG_KNATIVE_EVENTING],
+      required: [FLAG_KNATIVE_EVENTING, FLAG_KNATIVE_EVENTING_CHANNEL],
     },
   },
   {
@@ -354,7 +354,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ).default,
     },
     flags: {
-      required: [FLAG_KNATIVE_EVENTING],
+      required: [FLAG_KNATIVE_EVENTING, FLAG_KNATIVE_EVENTING_CHANNEL],
     },
   },
   {
@@ -430,7 +430,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'AddAction',
     flags: {
-      required: [FLAG_KNATIVE_EVENTING],
+      required: [FLAG_KNATIVE_EVENTING, FLAG_KNATIVE_EVENTING_CHANNEL],
     },
     properties: {
       id: 'knative-eventing-channel',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4940

**Analysis / Root cause**: 
User was seeing invalid message if clicks on Channel Card and Eventing CR is not created

**Solution Description**: 
Feature flag on Add Action/Route for channel was only for Knative Eventing CRD added Channel CRD as well


**Test setup:**
1. Install Serverless operator
2. Don't create CR for Knative Eventing and Knative Serving

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
