### PR TITLE
Bug 1909116: fix alignment of catalog sort dropdown

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -166,7 +166,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   }
 
   &__sort {
-    display: inline-flex;
+    display: inline;
     margin-left: var(--pf-global--spacer--md);
   }
 


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5217

**Solution Description:** 
fixed the css property

**Screen shots / Gifs for design review:**
![catalog](https://user-images.githubusercontent.com/22490998/102611169-6dcad600-4154-11eb-8bb2-d3007fb921bf.png)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge