### PR TITLE
Bug 1909236: Fix for overlapping remove pin icon on long nav items

### DIFF
--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -27,6 +27,7 @@
     white-space: nowrap;
 
     &:hover, &:focus {
+      padding-right: 30px;
       .oc-nav-pinned-item__unpin-button {
         .oc-nav-pinned-item__icon {
           opacity: 1;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5205

**Analysis / Root cause**: 
The text for the nav item is truncated when it hits the end of the nav bar area.

**Solution Description**: 
On hover, truncate the text for the nav item when it hits the area where the remove icon is shown.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/102641788-a786e700-412a-11eb-8c63-914a75025317.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/bug