### PR TITLE
Bug 1899725: Reduce Quickstart side panel width when browser widths between 769 - 1600px to prevent usability display issues

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.scss
@@ -1,4 +1,9 @@
 .co-quick-start-panel-content {
+  @media (min-width: 769px) and (max-width: 1600px) {
+    &.pf-c-drawer__panel {
+      flex-basis: 275px;
+    }
+  }
   &-head {
     position: sticky;
     top: 0px;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
@@ -37,7 +37,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   });
 
   return quickStart ? (
-    <DrawerPanelContent onScroll={handleScrollCallback}>
+    <DrawerPanelContent className="co-quick-start-panel-content" onScroll={handleScrollCallback}>
       <div className={headerClasses}>
         <DrawerHead>
           <div className="co-quick-start-panel-content__title">


### PR DESCRIPTION
Fix for bug https://bugzilla.redhat.com/show_bug.cgi?id=1899725
Issue: On screens less than 1600px (14" laptops and smaller) the Quickstart side panel causes the main content area to be very compacted, in particularly with resource tables, forms and YAML editors. 
Decreasing its width to 275px (same as left nav) on screens less than 1600px prevents horizontal overlap of ui elements and improved table column display.

@christianvogt @serenamarie125 @spadgett Is this an a fair compromise?

**Before and After examples**

<img width="1462" alt="Screen Shot 2020-12-15 at 12 29 10 PM" src="https://user-images.githubusercontent.com/1874151/102633740-d6975b80-411e-11eb-8c2e-f6c6673590f8.png">
<img width="1459" alt="Screen Shot 2020-12-15 at 12 28 15 PM" src="https://user-images.githubusercontent.com/1874151/102633742-d7c88880-411e-11eb-9065-e25b7cdccd8c.png">

---
<img width="1431" alt="Screen Shot 2020-12-18 at 1 21 36 PM" src="https://user-images.githubusercontent.com/1874151/102647660-1f0d4400-4134-11eb-83dc-37759cbf5f70.png">
<img width="1429" alt="Screen Shot 2020-12-18 at 1 22 04 PM" src="https://user-images.githubusercontent.com/1874151/102647666-22a0cb00-4134-11eb-86eb-9007b917da28.png">


---

<img width="1433" alt="Screen Shot 2020-12-18 at 1 06 21 PM" src="https://user-images.githubusercontent.com/1874151/102646440-0865ed80-4132-11eb-9bc1-c0627683a269.png">
<img width="1424" alt="Screen Shot 2020-12-18 at 1 06 34 PM" src="https://user-images.githubusercontent.com/1874151/102646453-0dc33800-4132-11eb-8859-18f0de4ae6ea.png">


---

<img width="1459" alt="Screen Shot 2020-12-15 at 1 15 36 PM" src="https://user-images.githubusercontent.com/1874151/102643243-f6ce1700-412c-11eb-886c-0d88307a16bb.png">
<img width="1462" alt="Screen Shot 2020-12-15 at 1 15 51 PM" src="https://user-images.githubusercontent.com/1874151/102643256-fafa3480-412c-11eb-8cb8-fb631b9eeadb.png">

---
<img width="1461" alt="Screen Shot 2020-12-15 at 1 06 50 PM" src="https://user-images.githubusercontent.com/1874151/102643285-051c3300-412d-11eb-9088-4ca458565511.png">
<img width="1462" alt="Screen Shot 2020-12-15 at 1 07 03 PM" src="https://user-images.githubusercontent.com/1874151/102643299-0baaaa80-412d-11eb-9dcc-cb661dddc02f.png">



