### PR TITLE
Bug 1909276: Fix for a11y errors in project dropdown

### DIFF
--- a/frontend/packages/console-shared/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
@@ -158,7 +158,7 @@ describe('ResourceDropdown test suite', () => {
     const dropdownBtn = component.find('button#dropdown1');
     dropdownBtn.simulate('click', { preventDefault });
 
-    const dropdownRows = component.find('DropDownRow');
+    const dropdownRows = component.find('DropDownRowWithTranslation');
     const dropdownItem = dropdownRows.last().find('#app-group-3-link');
     dropdownItem.simulate('click', { preventDefault, stopPropagation });
 

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -105,7 +105,7 @@ class DropdownMixin extends React.PureComponent {
   }
 }
 
-class DropDownRow extends React.PureComponent {
+class DropDownRowWithTranslation extends React.PureComponent {
   render() {
     const {
       itemKey,
@@ -120,9 +120,11 @@ class DropDownRow extends React.PureComponent {
       favoriteKey,
       canFavorite,
       onFavorite,
+      t,
     } = this.props;
 
     let prefix;
+    const contentString = _.isString(content) ? content : '';
 
     if (!autocompleteFilter && !onBookmark) {
       //use pf4 markup if not using the autocomplete dropdown
@@ -150,6 +152,11 @@ class DropDownRow extends React.PureComponent {
             e.stopPropagation();
             onBookmark(itemKey, !isBookmarked);
           }}
+          aria-label={
+            isBookmarked
+              ? t('dropdown~Remove bookmark {{content}}', { content: contentString })
+              : t('dropdown~Add bookmark {{content}}', { content: contentString })
+          }
         >
           {isBookmarked ? <MinusCircleIcon /> : <PlusCircleIcon />}
         </a>
@@ -168,6 +175,11 @@ class DropDownRow extends React.PureComponent {
             e.stopPropagation();
             onFavorite(isFavorite ? null : itemKey);
           }}
+          aria-label={
+            isFavorite
+              ? t('dropdown~Remove favorite {{content}}', { content: contentString })
+              : t('dropdown~Add favorite {{content}}', { content: contentString })
+          }
         >
           <StarIcon className={classNames({ favorite: isFavorite })} />
         </a>
@@ -195,6 +207,8 @@ class DropDownRow extends React.PureComponent {
     );
   }
 }
+
+const DropDownRow = withTranslation()(DropDownRowWithTranslation);
 
 class Dropdown_ extends DropdownMixin {
   constructor(props) {

--- a/frontend/public/locales/en/dropdown.json
+++ b/frontend/public/locales/en/dropdown.json
@@ -7,6 +7,10 @@
   "Namespace": "Namespace",
   "Select Project...": "Select Project...",
   "Select Namespace...": "Select Namespace...",
+  "Remove bookmark {{content}}": "Remove bookmark {{content}}",
+  "Add bookmark {{content}}": "Add bookmark {{content}}",
+  "Remove favorite {{content}}": "Remove favorite {{content}}",
+  "Add favorite {{content}}": "Add favorite {{content}}",
   "Actions": "Actions",
   "Containers": "Containers",
   "Init containers": "Init containers"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5129

**Analysis / Root cause**: 
There are no aria attributes on the bookmark or favorite link in the dropdown.

**Solution Description**: 
Add aria-labels to the favorite and bookmark links

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/bug