### PR TITLE
Bug 1903164: fix yaml editor from remounting

### DIFF
--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -78,11 +78,11 @@ export const navFactory: NavFactory = {
     nameKey: 'details-page~Logs',
     component,
   }),
-  editYaml: (component = editYamlComponent) => ({
+  editYaml: (component) => ({
     href: 'yaml',
     // t('details-page~YAML')
     nameKey: 'details-page~YAML',
-    component,
+    component: component || editYamlComponent,
   }),
   pods: (component) => ({
     href: 'pods',


### PR DESCRIPTION
The minimized production code looks like this:
![image](https://user-images.githubusercontent.com/14068621/102655297-1589d900-4140-11eb-8c13-e05f79c6f287.png)

Every time this function uses the default value, it results in a new react FC instance which causes the previous yaml editor to unmount.

Old terser bug which requires an update to our webpack version to pick up the fix.
https://github.com/terser/terser/pull/428

Since this fix needs backporting, I have moved away from using a default parameter value as to minimize the risk instead of backporting a dependency update.

A simple way to reproduce the issue is to go to any details page -> YAML tab and toggle the left navigation using the hamburger button. Whenever the nav slides in or out, the yaml editor unmounts and remounts again. This doesn't happen with other tabs because they do not use a default value. After this change, the yaml editor no longer unmounts.

cc @rhamilto 