### PR TITLE
Bug 1908545: Clone modal fails to open

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
@@ -148,15 +148,11 @@ export const CloneVMModal = withHandlePromise<CloneVMModalProps>((props) => {
             label={t('kubevirt-plugin~Name')}
             isRequired
             fieldId={asId('name')}
-            validated={
-              !(nameError && nameError.type === ValidationErrorType.Error) ? 'default' : 'error'
-            }
-            helperTextInvalid={t(nameError.messageKey)}
+            validated={!(nameError?.type === ValidationErrorType.Error) ? 'default' : 'error'}
+            helperTextInvalid={nameError && t(nameError?.messageKey)}
           >
             <TextInput
-              validated={
-                !(nameError && nameError.type === ValidationErrorType.Error) ? 'default' : 'error'
-              }
+              validated={!(nameError?.type === ValidationErrorType.Error) ? 'default' : 'error'}
               isRequired
               type="text"
               id={asId('name')}


### PR DESCRIPTION
`nameError` can be `null` in clone modal