### PR TITLE
Cypress: Remove OLM(full) test suite from console e2e tests

### DIFF
--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -40,7 +40,6 @@ fi
 
 if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-console-headless
-  yarn run test-cypress-olm-headless
   yarn run test-cypress-devconsole-headless
   exit;
 fi


### PR DESCRIPTION
Tests in `packages/operator-lifecycle-manager/integration-tests-cypress` should not be run during normal console e2e CI tests.  Ie. via `test-prow-e2e.sh e2e`.

OLM(full) tests should only be run via `test-prow-e2e.sh olmFull`