### PR TITLE
Bug 1909792: Internationalize details page empty states

### DIFF
--- a/frontend/public/components/utils/label-list.tsx
+++ b/frontend/public/components/utils/label-list.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
+/* eslint-disable import/named */
+import { withTranslation, WithTranslation } from 'react-i18next';
+/* eslint-enable import/named */
 import { K8sResourceKindReference, kindForReference } from '../../module/k8s';
 
 export const Label: React.SFC<LabelProps> = ({ kind, name, value, expand }) => {
@@ -19,13 +22,13 @@ export const Label: React.SFC<LabelProps> = ({ kind, name, value, expand }) => {
   );
 };
 
-export class LabelList extends React.Component<LabelListProps> {
+class TranslatedLabelList extends React.Component<LabelListProps> {
   shouldComponentUpdate(nextProps) {
     return !_.isEqual(nextProps, this.props);
   }
 
   render() {
-    const { labels, kind, expand = true } = this.props;
+    const { labels, kind, t, expand = true } = this.props;
     let list = _.map(labels, (label, key) => (
       <Label key={key} kind={kind} name={key} value={label} expand={expand} />
     ));
@@ -33,7 +36,7 @@ export class LabelList extends React.Component<LabelListProps> {
     if (_.isEmpty(list)) {
       list = [
         <div className="text-muted" key="0">
-          No labels
+          {t('details-page~No labels')}
         </div>,
       ];
     }
@@ -46,6 +49,8 @@ export class LabelList extends React.Component<LabelListProps> {
   }
 }
 
+export const LabelList = withTranslation()(TranslatedLabelList);
+
 export type LabelProps = {
   kind: K8sResourceKindReference;
   name: string;
@@ -53,7 +58,7 @@ export type LabelProps = {
   expand: boolean;
 };
 
-export type LabelListProps = {
+export type LabelListProps = WithTranslation & {
   labels: { [key: string]: string };
   kind: K8sResourceKindReference;
   expand?: boolean;

--- a/frontend/public/components/utils/owner-references.tsx
+++ b/frontend/public/components/utils/owner-references.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
+import { useTranslation } from 'react-i18next';
 import { K8sResourceKind, OwnerReference, referenceForOwnerRef } from '../../module/k8s';
 import { ResourceLink } from './resource-link';
 
 export const OwnerReferences: React.FC<OwnerReferencesProps> = ({ resource }) => {
+  const { t } = useTranslation();
   const owners = (_.get(resource.metadata, 'ownerReferences') || []).map((o: OwnerReference) => (
     <ResourceLink
       key={o.uid}
@@ -12,7 +14,11 @@ export const OwnerReferences: React.FC<OwnerReferencesProps> = ({ resource }) =>
       namespace={resource.metadata.namespace}
     />
   ));
-  return owners.length ? <>{owners}</> : <span className="text-muted">No owner</span>;
+  return owners.length ? (
+    <>{owners}</>
+  ) : (
+    <span className="text-muted">{t('details-page~No owner')}</span>
+  );
 };
 
 type OwnerReferencesProps = {

--- a/frontend/public/locales/en/details-page.json
+++ b/frontend/public/locales/en/details-page.json
@@ -55,5 +55,7 @@
   "Create snapshot": "Create snapshot",
   "Clone PVC": "Clone PVC",
   "Restore as new PVC": "Restore as new PVC",
-  "Managed by": "Managed by"
+  "No labels": "No labels",
+  "Managed by": "Managed by",
+  "No owner": "No owner"
 }


### PR DESCRIPTION
No owner and no labels weren't internationalized.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1909792.