### PR TITLE
Bug 1909815: Internationalize Admin perspective in switcher

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -20,5 +20,6 @@
   "Created at": "Created at",
   "Status": "Status",
   "API version": "API version",
-  "Restore": "Restore"
+  "Restore": "Restore",
+  "Administrator": "Administrator"
 }

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { CogsIcon } from '@patternfly/react-icons';
+import i18next from 'i18next';
 import { FLAGS } from '@console/shared/src/constants';
 import {
   Plugin,
@@ -81,7 +82,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Perspective',
     properties: {
       id: 'admin',
-      name: 'Administrator',
+      name: i18next.t('console-app~Administrator'),
       icon: <CogsIcon />,
       default: true,
       getLandingPageURL: (flags) =>


### PR DESCRIPTION
The perspective switcher only had the Developer perspective label internationalized. I added the Admin perspective label.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1909815.