### PR TITLE
Disable operator-install-* Cypress tests

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -4,7 +4,7 @@ import { detailsPage } from '../../../integration-tests-cypress/views/details-pa
 
 const operatorName = 'Portworx Essentials';
 
-describe(`Interacting with a global install mode Operator (${operatorName})`, () => {
+xdescribe(`Interacting with a global install mode Operator (${operatorName})`, () => {
   before(() => {
     cy.login();
   });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -3,7 +3,7 @@ import { modal } from '../../../integration-tests-cypress/views/modal';
 
 const operatorName = '3scale Operator';
 
-describe(`Interacting with a single namespace install mode Operator (${operatorName})`, () => {
+xdescribe(`Interacting with a single namespace install mode Operator (${operatorName})`, () => {
   before(() => {
     cy.login();
     cy.createProject(testName);


### PR DESCRIPTION
operator-install-* Cypress test are failing in OLM as it depends on catalog source and operators that aren't installed in CI.  The tests need to be updated to use a mock catalog source and an operator that exists in said catalog source so as not to depend on a catalog source and operator that may not be available.  https://github.com/openshift/console/blob/f96e815b633cea26b520536b636cf031d131a3e6/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts#L42-L53 is what we used in the proceeding Protractor test it replaced.

Bug to fix test:  https://bugzilla.redhat.com/show_bug.cgi?id=1909836