### PR TITLE
Bug 1910024: fallback to localstorage for 404 on create ConfigMap

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -66,7 +66,7 @@ export const useUserSettings = <T>(
         try {
           await createConfigMap();
         } catch (err) {
-          if (err?.response?.status === 403) {
+          if (err?.response?.status === 403 || err?.response?.status === 404) {
             setFallbackLocalStorage(true);
           } else {
             setSettings(defaultValueRef.current);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5302

**Analysis / Root cause**: 
Running latest UI on 4.6 cluster locally i observe the reloads and console had warning with 404 for create userSettings

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added fallback to localstorage in case of 404 from create userSettings


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
