### PR TITLE
(bug-fix): Guard 4.7 fetaures for 4.6

### DIFF
--- a/frontend/packages/ceph-storage-plugin/README.md
+++ b/frontend/packages/ceph-storage-plugin/README.md
@@ -5,7 +5,7 @@ The OCS UI requires some annotations in the OCS Operator CSV and Storage Cluster
 Following table maps the annotation to its use case and accepted values:
 |Annotation Name|Purpose|Accepted Values |CR/CSV
 |---------------------------------------|---------------------------|--------|----------------|
-| `features.ocs.openshift.io/enabled`| Activates Optional Features | "external", "minimal_deployment", "encryption" | Operator CSV
+| `features.ocs.openshift.io/enabled`| Activates Optional Features | "multus", "flexible-scaling", "kms", "arbiter" | Operator CSV
 | `cluster.ocs.openshift.io/local-devices`| Activates disk replacement and ocs status column in disk inventory | "true" | Storage Cluster CR
 | `external.features.ocs.openshift.io/validation`| Mininum required keys to be supplied by the admin to connect to an external cluster | Array of Keys that need to be validated in UI | Operator CSV
 ||||
@@ -15,15 +15,16 @@ Following table maps the annotation to its use case and accepted values:
 UI features are activated based on the annotations. The following table maps a feature and the respective annotation key-value pair required to activate it.
 | Feature |Annotation Value| Annotation Key
 |------------------------------|--------------------------|---------|
-| External Cluster Installation|`features.ocs.openshift.io/enabled` | `external` |
-| Minimal Cluster Installation|`features.ocs.openshift.io/enabled` | `minimal_deployment` |
-| Encrypted Storage Cluster|`features.ocs.openshift.io/enabled` | `encryption` |
+| Flexible scaling |`features.ocs.openshift.io/enabled` | `flexible-scaling` |
+| KMS encryption |`features.ocs.openshift.io/enabled` | `kms` |
+| Arbiter |`features.ocs.openshift.io/enabled` | `arbiter` |
+| Multus |`features.ocs.openshift.io/enabled` | `multus` |
 | Disk Replacement Action| `cluster.ocs.openshift.io/local-devices` | `true`|
 | Disk Inventory OCS Status Column | `cluster.ocs.openshift.io/local-devices` | `true`|
 
 #### Example
 
-       "features.ocs.openshift.io/enabled": `["external"]`
+       "features.ocs.openshift.io/enabled": `["multus"]`
 
 ## JSON validation (Independent Mode)
 

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/configure-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/configure-step.tsx
@@ -4,11 +4,12 @@ import { useFlag } from '@console/shared';
 import { State, Action } from '../state';
 import { EncryptionFormGroup, NetworkFormGroup } from '../../../install-wizard/configure';
 import { NetworkType } from '../../../types';
-import { OCS_SUPPORT_FLAGS } from '../../../../../features';
+import { GUARDED_FEATURES } from '../../../../../features';
 
 export const Configure: React.FC<ConfigureProps> = ({ state, dispatch, mode }) => {
+  const isMultusSupported = useFlag(GUARDED_FEATURES.OCS_MULTUS);
+
   const { networkType: nwType, clusterNetwork, publicNetwork } = state;
-  const isMultusSupported = useFlag(OCS_SUPPORT_FLAGS.MULTUS);
 
   const setNetworkType = (networkType: NetworkType) => {
     dispatch({ type: 'setNetworkType', value: networkType });

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/review-and-create-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/review-and-create-step.tsx
@@ -18,7 +18,7 @@ import {
   RequestErrors,
 } from '../../../install-wizard/review-and-create';
 import { NetworkType } from '../../../types';
-import { OCS_SUPPORT_FLAGS } from '../../../../../features';
+import { GUARDED_FEATURES } from '../../../../../features';
 
 export const ReviewAndCreate: React.FC<ReviewAndCreateProps> = ({
   state,
@@ -42,7 +42,7 @@ export const ReviewAndCreate: React.FC<ReviewAndCreateProps> = ({
   const { cpu, memory, zones } = getNodeInfo(state.nodes);
   const scName = getName(storageClass);
   const emptyRequiredField = nodes.length < MINIMUM_NODES && !scName && !memory && !cpu;
-  const isMultusSupported = useFlag(OCS_SUPPORT_FLAGS.MULTUS);
+  const isMultusSupported = useFlag(GUARDED_FEATURES.OCS_MULTUS);
 
   return (
     <>

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormGroup, Checkbox, Radio } from '@patternfly/react-core';
 import { FieldLevelHelp, Firehose } from '@console/internal/components/utils';
-import { TechPreviewBadge, getName, ResourceDropdown } from '@console/shared';
+import { TechPreviewBadge, getName, ResourceDropdown, useFlag } from '@console/shared';
 import { NetworkAttachmentDefinitionKind } from '@console/network-attachment-definition-plugin/src/types';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -11,6 +11,7 @@ import { State, Action } from '../attached-devices/create-sc/state';
 import { KMSConfigure } from '../../kms-config/kms-config';
 import { NetworkType } from '../types';
 import { ValidationMessage, ValidationType } from '../../../utils/common-ocs-install-el';
+import { GUARDED_FEATURES } from '../../../features';
 import { setEncryptionDispatch } from '../../kms-config/utils';
 import { AdvancedSubscription } from '../subscription-icon';
 import './install-wizard.scss';
@@ -45,6 +46,8 @@ export const EncryptionFormGroup: React.FC<EncryptionFormGroupProps> = ({
   mode,
 }) => {
   const { t } = useTranslation();
+  const isKmsSupported = useFlag(GUARDED_FEATURES.OCS_KMS);
+
   const { encryption } = state;
   const [encryptionChecked, setEncryptionChecked] = React.useState(
     encryption.clusterWide || encryption.storageClass,
@@ -123,7 +126,7 @@ export const EncryptionFormGroup: React.FC<EncryptionFormGroupProps> = ({
         )}
         onChange={toggleEncryption}
       />
-      {encryptionChecked && (
+      {isKmsSupported && encryptionChecked && (
         <div className="ocs-install-encryption">
           <FormGroup
             fieldId="encryption-options"

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard-steps/configure.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard-steps/configure.tsx
@@ -4,11 +4,12 @@ import { useFlag } from '@console/shared';
 import { InternalClusterAction, InternalClusterState, ActionType } from '../reducer';
 import { EncryptionFormGroup, NetworkFormGroup } from '../../install-wizard/configure';
 import { NetworkType } from '../../types';
-import { OCS_SUPPORT_FLAGS } from '../../../../features';
+import { GUARDED_FEATURES } from '../../../../features';
 
 export const Configure: React.FC<ConfigureProps> = ({ state, dispatch, mode }) => {
+  const isMultusSupported = useFlag(GUARDED_FEATURES.OCS_MULTUS);
+
   const { networkType: nwType, publicNetwork, clusterNetwork } = state;
-  const isMultusSupported = useFlag(OCS_SUPPORT_FLAGS.MULTUS);
 
   const setNetworkType = (networkType: NetworkType) =>
     dispatch({ type: ActionType.SET_NETWORK_TYPE, payload: networkType });

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard-steps/review-and-create.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard-steps/review-and-create.tsx
@@ -19,7 +19,7 @@ import {
   RequestErrors,
 } from '../../install-wizard/review-and-create';
 import { NetworkType } from '../../types';
-import { OCS_SUPPORT_FLAGS } from '../../../../features';
+import { GUARDED_FEATURES } from '../../../../features';
 
 export const ReviewAndCreate: React.FC<ReviewAndCreateProps> = ({
   state,
@@ -43,7 +43,7 @@ export const ReviewAndCreate: React.FC<ReviewAndCreateProps> = ({
   const scName = getName(storageClass);
   const emptyRequiredField =
     nodes.length < MINIMUM_NODES && !zones.size && !scName && !memory && !cpu;
-  const isMultusSupported = useFlag(OCS_SUPPORT_FLAGS.MULTUS);
+  const isMultusSupported = useFlag(GUARDED_FEATURES.OCS_MULTUS);
 
   return (
     <>

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -33,10 +33,20 @@ export const LSO_FLAG = 'LSO';
 
 export const RGW_FLAG = 'RGW';
 
-/* Key should be same as values received from the CSV 
-  Values should be formatted as OCS_<Console-Flag-Name> */
-export const OCS_SUPPORT_FLAGS = {
-  MULTUS: 'OCS_MULTUS',
+export enum GUARDED_FEATURES {
+  // Flag names to be prefixed with "OCS_" so as to seperate from console flags
+  OCS_MULTUS = 'OCS_MULTUS',
+  OCS_ARBITER = 'OCS_ARBITER',
+  OCS_KMS = 'OCS_KMS',
+  OCS_FLEXIBLE_SCALING = 'OCS_FLEXIBLE_SCALING',
+}
+
+const OCS_FEATURE_FLAGS = {
+  // [flag name]: <value of flag in csv annotation>
+  [GUARDED_FEATURES.OCS_MULTUS]: 'multus',
+  [GUARDED_FEATURES.OCS_ARBITER]: 'arbiter',
+  [GUARDED_FEATURES.OCS_KMS]: 'kms',
+  [GUARDED_FEATURES.OCS_FLEXIBLE_SCALING]: 'flexible-scaling',
 };
 
 const handleError = (res: any, flags: string[], dispatch: Dispatch, cb: FeatureDetector) => {
@@ -121,8 +131,8 @@ export const detectOCS: FeatureDetector = async (dispatch) => {
 
 const detectFeatures = (dispatch, csv: ClusterServiceVersionKind) => {
   const support = JSON.parse(getAnnotations(csv)?.[OCS_SUPPORT_ANNOTATION]);
-  _.keys(OCS_SUPPORT_FLAGS).forEach((feature) => {
-    dispatch(setFlag(OCS_SUPPORT_FLAGS[feature], support.includes(feature.toLowerCase())));
+  _.keys(OCS_FEATURE_FLAGS).forEach((feature) => {
+    dispatch(setFlag(feature, support.includes(OCS_FEATURE_FLAGS[feature])));
   });
 };
 
@@ -141,6 +151,6 @@ export const detectOCSSupportedFeatures: FeatureDetector = async (dispatch) => {
       setTimeout(() => detectOCSSupportedFeatures(dispatch), 15 * SECOND);
     }
   } catch (error) {
-    handleError(error, _.keys(OCS_SUPPORT_FLAGS), dispatch, detectOCSSupportedFeatures);
+    handleError(error, _.keys(OCS_FEATURE_FLAGS), dispatch, detectOCSSupportedFeatures);
   }
 };


### PR DESCRIPTION
- kms, flexible-scaling, and arbiter are not present in 4.6 OCS and 4.6 OCP. Hence they need to be flagged as per the annotation coming from OCS operator CSV.
- Updated README with enabled fetaures

Implements :

https://issues.redhat.com/browse/RHSTOR-1564
https://issues.redhat.com/browse/RHSTOR-1520
https://issues.redhat.com/browse/RHSTOR-1566

Operator PR: https://github.com/openshift/ocs-operator/pull/943/