### PR TITLE
[release-4.6] Bug 1910156: Add tolerations for ocs taint in localvolumeset and localvolumediscovery

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -31,7 +31,7 @@ import { AutoDetectVolume } from './wizard-pages/auto-detect-volume';
 import { CreateLocalVolumeSet } from './wizard-pages/create-local-volume-set';
 import { nodesDiscoveriesResource } from '../../../../constants/resources';
 import { getTotalDeviceCapacity } from '../../../../utils/install';
-import { AVAILABLE, CreateStepsSC, minSelectedNode } from '../../../../constants';
+import { AVAILABLE, CreateStepsSC, minSelectedNode, OCS_TOLERATION } from '../../../../constants';
 import { CreateOCS } from '../install-lso-sc';
 import '../attached-devices.scss';
 
@@ -78,7 +78,7 @@ const makeAutoDiscoveryCall = (
       if (err.message === AUTO_DISCOVER_ERR_MSG) {
         throw err;
       }
-      const requestData = getDiscoveryRequestData({ ...state, ns });
+      const requestData = getDiscoveryRequestData({ ...state, ns, toleration: OCS_TOLERATION });
       return k8sCreate(LocalVolumeDiscovery, requestData);
     })
     .then(() => {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/auto-detect-volume.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/auto-detect-volume.tsx
@@ -4,6 +4,7 @@ import {
   AutoDetectVolumeInner,
   AutoDetectVolumeHeader,
 } from '@console/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume-inner';
+import { hasOCSTaint } from '../../../../../utils/install';
 import { State, Action } from '../state';
 import '../../attached-devices.scss';
 
@@ -11,7 +12,7 @@ export const AutoDetectVolume: React.FC<AutoDetectVolumeProps> = ({ state, dispa
   <>
     <AutoDetectVolumeHeader />
     <Form noValidate={false} className="ceph-ocs-install__auto-detect-table">
-      <AutoDetectVolumeInner state={state} dispatch={dispatch} />
+      <AutoDetectVolumeInner state={state} dispatch={dispatch} taintsFilter={hasOCSTaint} />
     </Form>
   </>
 );

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
@@ -8,18 +8,20 @@ import {
   LocalVolumeSetHeader,
 } from '@console/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner';
 import { getLocalVolumeSetRequestData } from '@console/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data';
+import { hasOCSTaint } from '../../../../../utils/install';
+import '../../attached-devices.scss';
 import { State, Action } from '../state';
 import { DiscoveryDonutChart } from './donut-chart';
 import {
   minSelectedNode,
   diskModeDropdownItems,
   allNodesSelectorTxt,
+  OCS_TOLERATION,
 } from '../../../../../constants';
-import '../../attached-devices.scss';
 
 const makeLocalVolumeSetCall = (state: State, dispatch: React.Dispatch<Action>, ns: string) => {
   dispatch({ type: 'setIsLoading', value: true });
-  const requestData = getLocalVolumeSetRequestData(state, ns);
+  const requestData = getLocalVolumeSetRequestData(state, ns, OCS_TOLERATION);
   k8sCreate(LocalVolumeSetModel, requestData)
     .then(() => {
       state.onNextClick();
@@ -47,6 +49,7 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({
             dispatch={dispatch}
             diskModeOptions={diskModeDropdownItems}
             allNodesHelpTxt={allNodesSelectorTxt}
+            taintsFilter={hasOCSTaint}
           />
         </Form>
         <DiscoveryDonutChart state={state} dispatch={dispatch} />

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -1,4 +1,4 @@
-import { Taint } from '@console/internal/module/k8s';
+import { Taint, Toleration } from '@console/internal/module/k8s';
 
 export const minSelectedNode = 3;
 export const ocsTaint: Taint = {
@@ -7,6 +7,8 @@ export const ocsTaint: Taint = {
   effect: 'NoSchedule',
 };
 Object.freeze(ocsTaint);
+
+export const OCS_TOLERATION: Toleration = { ...ocsTaint, operator: 'Equal' };
 
 export const storageClassTooltip =
   'The Storage Class will be used to request storage from the underlying infrastructure to create the backing persistent volumes that will be used to provide the OpenShift Container Storage (OCS) service.';

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/discovery-request-data.ts
@@ -1,4 +1,5 @@
-import { apiVersionForModel, K8sResourceCommon } from '@console/internal/module/k8s';
+import * as _ from 'lodash';
+import { apiVersionForModel, K8sResourceCommon, Toleration } from '@console/internal/module/k8s';
 import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
 import { DISCOVERY_CR_NAME, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
@@ -10,15 +11,17 @@ export const getDiscoveryRequestData = ({
   showNodesListOnADV,
   hostNamesMapForADV,
   ns,
+  toleration,
 }: {
   nodeNamesForLVS: string[];
   allNodeNamesOnADV: string[];
   showNodesListOnADV: boolean;
   hostNamesMapForADV: HostNamesMap;
   ns: string;
+  toleration?: Toleration;
 }): AutoDetectVolumeKind => {
   const nodes = getNodes(showNodesListOnADV, allNodeNamesOnADV, nodeNamesForLVS);
-  return {
+  const request: AutoDetectVolumeKind = {
     apiVersion: apiVersionForModel(AutoDetectVolumeModel),
     kind: AutoDetectVolumeModel.kind,
     metadata: { name: DISCOVERY_CR_NAME, namespace: ns },
@@ -38,6 +41,8 @@ export const getDiscoveryRequestData = ({
       },
     },
   };
+  if (!_.isEmpty(toleration)) request.spec.tolerations = [toleration];
+  return request;
 };
 
 type AutoDetectVolumeKind = K8sResourceCommon & {
@@ -49,5 +54,6 @@ type AutoDetectVolumeKind = K8sResourceCommon & {
         },
       ];
     };
+    tolerations?: Toleration[];
   };
 };

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -29,6 +29,7 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
   dispatch,
   state,
   diskTypeOptions = diskTypeDropdownItems,
+  taintsFilter,
   diskModeOptions = diskModeDropdownItems,
   allNodesHelpTxt = allNodesSelectorTxt,
 }) => {
@@ -115,6 +116,7 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
             },
             filteredNodes: state.nodeNamesForLVS,
             preSelected: state.nodeNames,
+            taintsFilter,
           }}
         />
       )}
@@ -215,6 +217,7 @@ type LocalVolumeSetInnerProps = {
   diskTypeOptions?: { [key: string]: string };
   diskModeOptions?: { [key: string]: string };
   allNodesHelpTxt?: string;
+  taintsFilter?: (node: NodeKind) => boolean;
 };
 
 export const LocalVolumeSetHeader = () => (

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-request-data.ts
@@ -1,11 +1,16 @@
-import { apiVersionForModel } from '@console/internal/module/k8s';
+import * as _ from 'lodash';
+import { apiVersionForModel, Toleration } from '@console/internal/module/k8s';
 import { LocalVolumeSetModel } from '../../models';
 import { LocalVolumeSetKind, DiskType } from './types';
 import { State } from './state';
 import { DISK_TYPES, HOSTNAME_LABEL_KEY, LABEL_OPERATOR } from '../../constants';
 import { getNodes, getHostNames } from '../../utils';
 
-export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVolumeSetKind => {
+export const getLocalVolumeSetRequestData = (
+  state: State,
+  ns: string,
+  toleration?: Toleration,
+): LocalVolumeSetKind => {
   const nodes = getNodes(state.showNodesListOnLVS, state.nodeNamesForLVS, state.nodeNames);
   const requestData = {
     apiVersion: apiVersionForModel(LocalVolumeSetModel),
@@ -33,6 +38,7 @@ export const getLocalVolumeSetRequestData = (state: State, ns: string): LocalVol
     },
   } as LocalVolumeSetKind;
 
+  if (!_.isEmpty(toleration)) requestData.spec.tolerations = [toleration];
   if (state.maxDiskLimit) requestData.spec.maxDeviceCount = +state.maxDiskLimit;
   if (state.minDiskSize)
     requestData.spec.deviceInclusionSpec.minSize = `${state.minDiskSize}${state.diskSizeUnit}`;

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/nodes-selection-list.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/nodes-selection-list.tsx
@@ -63,11 +63,13 @@ const getRows: GetRows = (
   setSelectedNodes,
 ) => {
   const { data } = componentProps;
-  const { filteredNodes, preSelected } = customData;
+  const { filteredNodes, preSelected, taintsFilter } = customData;
 
   const nodeList = filteredNodes?.length ? filteredNodes : data.map(getName);
-  const filteredData = data.filter(
-    (node: NodeKind) => !hasTaints(node) && nodeList.includes(getName(node)),
+  const filteredData = data.filter((node: NodeKind) =>
+    taintsFilter
+      ? (taintsFilter(node) || !hasTaints(node)) && nodeList.includes(getName(node))
+      : !hasTaints(node) && nodeList.includes(getName(node)),
   );
 
   const rows = filteredData.map((node: NodeKind) => {

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
@@ -1,5 +1,5 @@
 import { IRow } from '@patternfly/react-table';
-import { NodeKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { NodeKind, K8sResourceCommon, Toleration } from '@console/internal/module/k8s';
 
 export type NodeTableRow = {
   cells: IRow['cells'];
@@ -35,6 +35,7 @@ export type LocalVolumeSetKind = K8sResourceCommon & {
       }[];
     };
     maxDeviceCount?: number;
+    tolerations?: Toleration[];
   };
 };
 
@@ -47,6 +48,7 @@ export type GetRows = (
     customData?: {
       filteredNodes: string[];
       preSelected?: string[];
+      taintsFilter?: (node: NodeKind) => boolean;
     };
   },
   visibleRows: Set<string>,


### PR DESCRIPTION
- handles displaying nodes, tainted with the taint "node.ocs.openshift.io/storage="true":NoSchedule"
- by default seeting tolerations for ocs-taints in lvset and lvd yamls in OCS UI

Signed-off-by: Afreen Rahman <afrahman@redhat.com>
(cherry picked from commit 9da4921317511aa66fe2b445df721226c7a684ca)

Automated [cherrypick failed](https://github.com/openshift/console/pull/7551#issuecomment-749779871) 