### PR TITLE
Bug 1907989: Added support for dataVolumeTemplate in yaml

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-common-templates-updater.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-common-templates-updater.ts
@@ -8,6 +8,7 @@ import { iGetCommonData, iGetLoadedCommonData } from '../../selectors/immutable/
 import {
   iGetCommonTemplateCloudInit,
   iGetRelevantTemplate,
+  iGetCommonTemplateDiskBus,
 } from '../../../../selectors/immutable/template/combined';
 import { CLOUDINIT_DISK, DiskType, DiskBus, VolumeType } from '../../../../constants/vm';
 import { vmWizardInternalActions } from '../internal-actions';
@@ -76,7 +77,11 @@ export const commonTemplatesUpdater = ({ id, prevState, dispatch, getState }: Up
           .init({
             name: CLOUDINIT_DISK,
           })
-          .setType(DiskType.DISK, { bus: DiskBus.VIRTIO })
+          .setType(DiskType.DISK, {
+            bus:
+              DiskBus.fromString(iGetCommonTemplateDiskBus(iTemplate, 'cloudinitdisk')) ||
+              DiskBus.VIRTIO,
+          })
           .asResource(),
         volume: new VolumeWrapper()
           .init({ name: CLOUDINIT_DISK })

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
@@ -22,7 +22,7 @@ import {
   hasStepUpdateDisabled,
   isStepLocked,
 } from '../../selectors/immutable/wizard-selectors';
-import { VMWizardProps, VMWizardStorage, VMWizardTab } from '../../types';
+import { VMWizardProps, VMWizardStorage, VMWizardStorageType, VMWizardTab } from '../../types';
 import { VMDisksTable } from '../../../vm-disks/vm-disks';
 import { vmWizardActions } from '../../redux/actions';
 import { ActionType } from '../../redux/types';
@@ -89,6 +89,16 @@ const StorageTabFirehose: React.FC<StorageTabFirehoseProps> = ({
   isDeleteDisabled,
 }) => {
   const { t } = useTranslation();
+
+  React.useEffect(() => {
+    storages.forEach(({ type, id, disk }) => {
+      const isTemplateType = type === VMWizardStorageType.TEMPLATE;
+      // eslint-disable-next-line no-template-curly-in-string
+      const isMatchedDiskName = disk.name === '${NAME}';
+      isTemplateType && isMatchedDiskName && removeStorage(id);
+    });
+  }, [removeStorage, storages]);
+
   const showStorages = storages.length > 0 || isBootDiskRequired;
 
   const withProgress = wrapWithProgress(setTabLocked);

--- a/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
@@ -105,6 +105,19 @@ export const iGetCommonTemplateCloudInit = (tmp: ITemplate) => {
   return iGet(iCloudInitStorage, 'cloudInitNoCloud');
 };
 
+export const iGetCommonTemplateDiskBus = (tmp: ITemplate, diskName: string) => {
+  const cloudDisk = iGetIn(iSelectVM(tmp), [
+    'spec',
+    'template',
+    'spec',
+    'domain',
+    'devices',
+    'disks',
+  ])?.find((disk) => iGetIn(disk, ['name']) === diskName);
+
+  return iGetIn(cloudDisk, ['disk', 'bus']);
+};
+
 export const iGetDefaultTemplate = (
   iCommonTemplates: ImmutableMap<string, ITemplate>,
   os: string,


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1907989

**Analysis / Root cause**: 
DataVolumeTemplate was conflicting with wizard storage.

**Solution Description**: 
Change the behavior of wizards to work with DataVolumeTemplate by ignoring the data provided by the template and using storages created by wizards.