### PR TITLE
Bug 1766287: Fix use of hello-openshift imagestream

### DIFF
--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -8,9 +8,6 @@ import { YAMLTemplate } from '@console/plugin-sdk';
  * Sample YAML manifests for some of the statically-defined Kubernetes models.
  */
 
-const sampleContainerImage = 'registry.redhat.io/openshift4/ose-hello-openshift-rhel8';
-const sampleContainerCmd = '[ "/bin/bash", "-c", "sleep infinity" ]';
-
 export const baseTemplates = ImmutableMap<GroupVersionKind, ImmutableMap<string, string>>()
   .setIn(
     ['DEFAULT', 'default'],
@@ -256,10 +253,9 @@ spec:
     spec:
       containers:
       - name: hello-openshift
-        image: ${sampleContainerImage}
+        image: openshift/hello-openshift
         ports:
         - containerPort: 8080
-        command: ${sampleContainerCmd}
 `,
   )
   .setIn(
@@ -376,10 +372,9 @@ spec:
           ]
       containers:
       - name: hello-openshift
-        image: ${sampleContainerImage}
+        image: openshift/hello-openshift
         ports:
         - containerPort: 8080
-        command: ${sampleContainerCmd}
 `,
   )
   .setIn(
@@ -436,10 +431,9 @@ metadata:
 spec:
   containers:
     - name: hello-openshift
-      image: ${sampleContainerImage}
+      image: openshift/hello-openshift
       ports:
         - containerPort: 8080
-      command: ${sampleContainerCmd}
 `,
   )
   .setIn(
@@ -649,10 +643,9 @@ spec:
     spec:
       containers:
       - name: hello-openshift
-        image: ${sampleContainerImage}
+        image: openshift/hello-openshift
         ports:
         - containerPort: 8080
-        command: ${sampleContainerCmd}
 `,
   )
   .setIn(
@@ -806,10 +799,9 @@ spec:
     spec:
       containers:
       - name: hello-openshift
-        image: ${sampleContainerImage}
+        image: openshift/hello-openshift
         ports:
         - containerPort: 8080
-        command: ${sampleContainerCmd}
 `,
   )
   .setIn(
@@ -858,10 +850,9 @@ spec:
     spec:
       containers:
       - name: hello-openshift
-        image: ${sampleContainerImage}
+        image: openshift/hello-openshift
         ports:
         - containerPort: 8080
-        command: ${sampleContainerCmd}
 `,
   )
   .setIn(


### PR DESCRIPTION
The new imagestream was missing a lookupPolicy setting which prevented
it from being a drop-in replacement of the image on Docker Hub.  With
that fixed in the Samples operator, only the annotations are needed from
commit eee9a0cee2f766935be7fa9ed487ce015fbaeb64.

This is dependent on https://github.com/openshift/cluster-samples-operator/pull/350

/hold
/assign @cyril-ui-developer
