### PR TITLE
Bug 1911129: Fix Monitoring charts renders nothing when switching from a Deployment to "All workloads"

### DIFF
--- a/frontend/public/components/utils/router.ts
+++ b/frontend/public/components/utils/router.ts
@@ -43,6 +43,21 @@ export const setQueryArgument = (k: string, v: string) => {
   }
 };
 
+export const setQueryArguments = (newParams: { [k: string]: string }) => {
+  const params = new URLSearchParams(window.location.search);
+  let update = false;
+  _.each(newParams, (v, k) => {
+    if (params.get(k) !== v) {
+      update = true;
+      params.set(k, v);
+    }
+  });
+  if (update) {
+    const url = new URL(window.location.href);
+    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  }
+};
+
 export const setAllQueryArguments = (newParams: { [k: string]: string }) => {
   const params = new URLSearchParams();
   let update = false;
@@ -62,6 +77,21 @@ export const removeQueryArgument = (k: string) => {
   const params = new URLSearchParams(window.location.search);
   if (params.has(k)) {
     params.delete(k);
+    const url = new URL(window.location.href);
+    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  }
+};
+
+export const removeQueryArguments = (...keys: string[]) => {
+  const params = new URLSearchParams(window.location.search);
+  let update = false;
+  keys.forEach((k) => {
+    if (params.has(k)) {
+      update = true;
+      params.delete(k);
+    }
+  });
+  if (update) {
     const url = new URL(window.location.href);
     history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
   }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5294
https://bugzilla.redhat.com/show_bug.cgi?id=1911129

**Analysis / Root cause**:
When switching from a Deployment to "All workloads" a new API request is triggered via `usePoll` in `public/components/monitoring/query-browser.tsx`. The query is used in the `usePoll` tick and is calculated in `packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx`.

The `Graph` component in `query-browser.tsx` was only rendered if `width` of `const [containerRef, width] = useRefWidth();` is defined. The `containerRef` was associated to a "container" div which is rendered when the api response contain any data for the chart. Old chart data are kept until new data arrives.

When the user switch from a deployment to "All workloads", the internal state was changed multiple times. The API was requested two times, the first time it requests the "deployment chart data" for one deployment with the deployment name `"#SELECT_ALL_WORKLOADS#"` and then it requests the correct "all workload chart data".

After receiving the first response the chart was removed from the DOM because it contains no data. (Because of the wrong deployment filter `deployment = "#SELECT_ALL_WORKLOADS#"`)

When the second response was rendered the data are available, but no chart is displayed. The reason is that the `width` value (state) is not defined. It was set to null after the `containerRef` was unmounted but not set to a valid width it was mounted again.

**Solution Description**: 
~~The first commit fixes the edge case where `useRefWidth` doesn't store the latest element `width`.~~

~~This happen when the current element ref was unmounted and could be fixed manually by resizing the window. The new implementation solves this issue and is inspired by the hook faq about measuring dom elements.~~

~~See also https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node~~

~~For the user this first commit already fixes the issue that the chart wasn't displayed after switching from a deployment to "All workloads".~~

The ~~second~~ commit fixes the intermediate state which results in invalid api requests. The previous implementation sets internal states, queries and query (URL) arguments in different useEffect hooks. The result was unnecessary rerenders and api calls.

The new implementation doesn't change/fix any URL arguments on initial render. It just uses a memo hook to calculate queries based on workload name and type and update this fields together with the URL arguments in the `onSelect` callback.

**Screen shots / Gifs for design review**: 
Before (on master):
https://user-images.githubusercontent.com/139310/105850179-ad9d9c80-5fe1-11eb-816d-70c66d55f3be.mp4

After (with this PR):
https://user-images.githubusercontent.com/139310/105850189-b1312380-5fe1-11eb-8c67-cc7c20131edd.mp4

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Open developer perspective
* Import at least one Deployment to see some monitoring data (I tested it with container image `jerolimov/cpuusage-example`, which provides an endpoint `/loop/3000` to consume some CPU)
* Select "Monitoring" from the navigation
* On the "Monitoring" "Dashboard" tab switch between your Deployment workload and "All workloads"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
