### PR TITLE
Bug 1911213: VM with default flavor should not show a pending changes warning

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-like/next-run-changes.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-like/next-run-changes.ts
@@ -20,11 +20,15 @@ export const isFlavorChanged = (vm: VMWrapper, vmi: VMIWrapper): boolean => {
 
   const vmCPU = _.omit(vm.getCPU(), cpuOmitPaths);
   const vmiCPU = _.omit(vmi.getCPU(), cpuOmitPaths);
+  const vmMemory = vm.getMemory();
+  const vmiMemory = vmi.getMemory();
+  const vmFlavor = vm.getFlavor();
+  const vmiFlvor = vmi.getFlavor();
 
   return (
-    vm.getFlavor() !== vmi.getFlavor() ||
-    !_.isEqual(vm.getMemory(), vmi.getMemory()) ||
-    !_.isEqual(vmCPU, vmiCPU)
+    (vmFlavor && !_.isEqual(vmFlavor, vmiFlvor)) ||
+    (vmMemory && !_.isEqual(vmMemory, vmiMemory)) ||
+    (!_.isEmpty(vmCPU) && !_.isEqual(vmCPU, vmiCPU))
   );
 };
 


### PR DESCRIPTION
When creating a VM (using Kubevirt API or just with a simple yaml file), I see a "pending change" warning