### PR TITLE
Bug 1911381: Clone available operating system source to this Virtual Machine checkbox should hide select PVC field

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/vm-settings-tab-state-update.ts
@@ -217,6 +217,9 @@ const cloneCommonBaseDiskImageUpdater = ({ id, prevState, dispatch, getState }: 
       [VMSettingsField.IMAGE_URL]: {
         isHidden: asHidden(cloneCommonBaseDiskImage, VMSettingsField.CLONE_COMMON_BASE_DISK_IMAGE),
       },
+      [VMSettingsField.CLONE_PVC_NS]: {
+        isHidden: asHidden(cloneCommonBaseDiskImage, VMSettingsField.CLONE_COMMON_BASE_DISK_IMAGE),
+      },
     }),
   );
 };


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1911381

**Analysis / Root cause**: 
Missing setting in setting tab update.

**Solution Description**: 
Added hiding option when the checkbox is selected.

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/103294364-6af49e80-49fa-11eb-93db-13f2e7a646f1.png)
Before:
![image](https://user-images.githubusercontent.com/14824964/103294434-8790d680-49fa-11eb-831d-f735a57fd9ec.png)
