### PR TITLE
Bug 1911474: Delete Devfile Application Group without any errors

### DIFF
--- a/frontend/packages/console-shared/src/utils/__tests__/test-resource-data.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/test-resource-data.ts
@@ -1,5 +1,10 @@
 import { FirehoseResult } from '@console/internal/components/utils';
-import { DeploymentKind, PodKind, ImagePullPolicy } from '@console/internal/module/k8s';
+import {
+  DeploymentKind,
+  PodKind,
+  ImagePullPolicy,
+  K8sResourceKind,
+} from '@console/internal/module/k8s';
 
 export const sampleDeploymentConfigs: FirehoseResult = {
   loaded: true,
@@ -3305,6 +3310,57 @@ export const sampleClusterServiceVersions: FirehoseResult = {
   loadError: '',
   loaded: true,
 };
+
+export const sampleSecrets: K8sResourceKind[] = [
+  {
+    kind: 'Secret',
+    metadata: {
+      name: 'secret-1',
+      namespace: 'ns',
+      uid: '3d7aeb10-c568-4aa5-b1c6-90500a6d50a6',
+      resourceVersion: '102027',
+      creationTimestamp: '2019-04-26T10:23:41Z',
+      annotations: {
+        'kubernetes.io/service-account.name': 'builder',
+        'kubernetes.io/service-account.uid': '150b818b-2081-46a4-a563-17ee5d29035a',
+        'openshift.io/token-secret.name': 'builder-token-tnrj6',
+        'openshift.io/token-secret.value': 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjJ3enFHdFZPTlkyOElFT21K',
+      },
+    },
+  },
+  {
+    kind: 'Secret',
+    metadata: {
+      name: 'secret-2',
+      namespace: 'ns',
+      uid: '3d7aeb10-c568-4aa5-b1c6-90500a6d50a6',
+      resourceVersion: '102027',
+      creationTimestamp: '2019-04-26T10:23:41Z',
+      annotations: {
+        'kubernetes.io/service-account.name': 'builder',
+        'kubernetes.io/service-account.uid': '150b818b-2081-46a4-a563-17ee5d29035a',
+        'openshift.io/token-secret.name': 'builder-token-tnrj6',
+        'openshift.io/token-secret.value': 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjJ3enFHdFZPTlkyOElFT21K',
+      },
+    },
+  },
+  {
+    kind: 'Secret',
+    metadata: {
+      name: 'nodejs-generic-webhook-secret',
+      namespace: 'ns',
+      uid: '3d7aeb10-c568-4aa5-b1c6-90500a6d50a6',
+      resourceVersion: '102027',
+      creationTimestamp: '2019-04-26T10:23:41Z',
+      annotations: {
+        'kubernetes.io/service-account.name': 'builder',
+        'kubernetes.io/service-account.uid': '150b818b-2081-46a4-a563-17ee5d29035a',
+        'openshift.io/token-secret.name': 'builder-token-tnrj6',
+        'openshift.io/token-secret.value': 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjJ3enFHdFZPTlkyOElFT21K',
+      },
+    },
+  },
+];
 
 export const MockResources = {
   deployments: sampleDeployments,

--- a/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
+++ b/frontend/packages/topology/src/utils/__tests__/application-utils.spec.ts
@@ -13,6 +13,7 @@ import {
   MockResources,
   sampleBuildConfigs,
   sampleBuilds,
+  sampleSecrets,
 } from '@console/shared/src/utils/__tests__/test-resource-data';
 import { OdcNodeModel, TopologyDataResources } from '../../topology-types';
 import { WORKLOAD_TYPES } from '../topology-utils';
@@ -45,6 +46,7 @@ describe('ApplicationUtils ', () => {
   let spyK8sGet;
   let mockBuilds = [];
   let mockBuildConfigs = [];
+  let mockSecrets = [];
 
   beforeEach(() => {
     spy = spyOn(k8s, 'k8sKill');
@@ -60,6 +62,9 @@ describe('ApplicationUtils ', () => {
       if (model.kind === 'BuildConfig') {
         return Promise.resolve(mockBuildConfigs);
       }
+      if (model.kind === 'Secret') {
+        return Promise.resolve(mockSecrets);
+      }
       return Promise.resolve([]);
     });
   });
@@ -68,18 +73,19 @@ describe('ApplicationUtils ', () => {
     const nodeModel = await getTopologyData(MockResources, 'nodejs');
     mockBuilds = sampleBuilds.data;
     mockBuildConfigs = sampleBuildConfigs.data;
+    mockSecrets = sampleSecrets;
     cleanUpWorkload(nodeModel.resource, false)
       .then(() => {
         const allArgs = spy.calls.allArgs();
         const removedModels = allArgs.map((arg) => arg[0]);
 
-        expect(spy.calls.count()).toEqual(7);
+        expect(spy.calls.count()).toEqual(6);
         expect(removedModels).toContain(DeploymentConfigModel);
         expect(removedModels).toContain(ImageStreamModel);
         expect(removedModels).toContain(ServiceModel);
         expect(removedModels).toContain(RouteModel);
         expect(removedModels).toContain(BuildConfigModel);
-        expect(removedModels.filter((model) => model.kind === 'Secret')).toHaveLength(2);
+        expect(removedModels.filter((model) => model.kind === 'Secret')).toHaveLength(1);
         done();
       })
       .catch((err) => fail(err));


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5298

**Analysis / Root cause:** 
before deleting the webhook secret, it is not being checked if the secret exists.

**Solution Description:**
listing the available secrets in the namespace, and added a check to verify if the associated secret exists

**GIF:**
![delete-app](https://user-images.githubusercontent.com/22490998/103298650-cd609580-4a20-11eb-8304-f8e82220b3c2.gif)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge