### PR TITLE
Bug 1912434: update the guided tour modal heading

### DIFF
--- a/frontend/packages/dev-console/src/components/guided-tour/index.ts
+++ b/frontend/packages/dev-console/src/components/guided-tour/index.ts
@@ -10,7 +10,7 @@ const getSelector = (id: string): string => `[data-tour-id="${id}"]`;
 
 export const getGuidedTour = (): TourDataType => ({
   intro: {
-    heading: 'Welcome to Dev Perspective!',
+    heading: 'Welcome to the Developer Perspective!',
     content: devPerspectiveTourText,
   },
   steps: [


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5122

**Analysis / Root cause:**
Title for the initial modal screen of guided tour needs to be updated

**Solution Description:**
updated the title of the initial modal screen to "Welcome to the Developer Perspective"

**Screens:**
![Screenshot from 2021-01-04 18-54-57](https://user-images.githubusercontent.com/38663217/103539589-5f9fe800-4ebe-11eb-9584-48a8df35ca1d.png)

**Test Coverage:**
NA

**Browser Conformance:**
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge