### PR TITLE
Bug 1912558: Show pending status for taskRuns that haven't started

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -5,7 +5,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskRunKind, getModelReferenceFromTaskKind } from '../../../utils/pipeline-augment';
 import { TaskRunModel, PipelineModel } from '../../../models';
 import { tableColumnClasses } from './taskruns-table';
-import { pipelineRunFilterReducer as taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
 import { TektonResourceLabel } from '../../pipelines/const';
 import TaskRunStatus from '../status/TaskRunStatus';
 

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-filter-reducer.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-filter-reducer.spec.ts
@@ -32,8 +32,38 @@ const mockPipelineRuns = [
     },
   },
   { status: { conditions: [{ status: 'Unknown', type: 'Succeeded' }] } },
-  { status: { conditions: [{ reason: 'PipelineRunCancelled' }] } },
-  { status: { conditions: [{ reason: 'TaskRunCancelled' }] } },
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'PipelineRunCancelled' }],
+    },
+  },
+  {
+    status: { conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'TaskRunCancelled' }] },
+  },
+];
+
+const mockPipelineRunReasons = [
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'PipelineRunStopping' }],
+    },
+  },
+  { status: { conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'TaskRunStopping' }] } },
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'CreateContainerConfigError' }],
+    },
+  },
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'ExceededNodeResources' }],
+    },
+  },
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'ExceededResourceQuota' }],
+    },
+  },
 ];
 
 describe('Check PipelineRun Status | Filter Reducer applied to the following:', () => {
@@ -92,5 +122,14 @@ describe('Check PipelineRun Status | Filter Reducer applied to the following:', 
   it('Pipelinerun with first element of condition array with type as "Succeeded" & status as "Unknown"', () => {
     const reducerOutput = pipelineRunStatus(mockPipelineRuns[10]);
     expect(reducerOutput).toBe('Cancelled');
+  });
+  it('Pipelinerun with first element of condition array with type as "Succeeded" & Failing condition', () => {
+    expect(pipelineRunStatus(mockPipelineRunReasons[0])).toBe('Failed');
+    expect(pipelineRunStatus(mockPipelineRunReasons[1])).toBe('Failed');
+  });
+  it('Pipelinerun with first element of condition array with type as "Succeeded" & Pending condition', () => {
+    expect(pipelineRunStatus(mockPipelineRunReasons[2])).toBe('Pending');
+    expect(pipelineRunStatus(mockPipelineRunReasons[3])).toBe('Pending');
+    expect(pipelineRunStatus(mockPipelineRunReasons[4])).toBe('Pending');
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5222
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
TaskRun list and detail page shows that a TaskRun is "Running" if it has not yet started with the reason "ExceededNodeResources".
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Show "Pending" status for TaskRuns that have the reason "ExceededNodeResources" in the Succeeded condition.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp](https://user-images.githubusercontent.com/20013884/103567095-2df04680-4ee9-11eb-9be9-7367b0ab3be9.png)
![tmp0](https://user-images.githubusercontent.com/20013884/103567101-334d9100-4ee9-11eb-918c-2d3c163ef7ba.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Test setup:**
- Create a new namespace
- Add LimitRange and Pipeline
- Start as many PipelineRuns you need to exceed your memory limits
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
