### PR TITLE
Bug 1912730: create visual connector if service binding is not available for operator backed resource

### DIFF
--- a/frontend/packages/dev-console/src/actions/add-resources.tsx
+++ b/frontend/packages/dev-console/src/actions/add-resources.tsx
@@ -15,7 +15,6 @@ import { KebabAction, createKebabAction } from '../utils/add-resources-menu-util
 
 export const allImportResourceAccess = 'allImportResourceAccess';
 export const allCatalogImageResourceAccess = 'allCatalogImageResourceAccess';
-export const serviceBindingAvailable = 'serviceBindingAvailable';
 
 export const fromGit = createKebabAction(
   // t('devconsole~From Git')
@@ -75,7 +74,6 @@ export const fromOperatorBacked = createKebabAction(
   'devconsole~Operator Backed',
   <BoltIcon />,
   ImportOptions.OPERATORBACKED,
-  serviceBindingAvailable,
 );
 
 export const fromHelmCharts = createKebabAction(

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -16,3 +16,5 @@ export enum CONNECTOR_INCONTEXT_ACTIONS {
   /** connects to action for resources */
   connectsTo = 'connectsTo',
 }
+
+export const SERVICE_BINDING_ENABLED = 'SERVICE_BINDING_ENABLED';

--- a/frontend/packages/dev-console/src/utils/__tests__/add-resources-menu-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/add-resources-menu-utils.spec.tsx
@@ -147,6 +147,7 @@ describe('addResourceMenuUtils: ', () => {
       '',
       hasApplication,
       connectorSourceObj,
+      [],
     );
     const contextSource: string = `${referenceFor(connectorSourceObj)}/${
       connectorSourceObj?.metadata?.name
@@ -167,7 +168,7 @@ describe('addResourceMenuUtils: ', () => {
     const labelKey = 'devconsole~From Git';
 
     const kebabAction: KebabAction = createKebabAction(labelKey, icon, ImportOptions.GIT);
-    const kebabOption: KebabOption = kebabAction(primaryObj, '', hasApplication);
+    const kebabOption: KebabOption = kebabAction(primaryObj, '', hasApplication, undefined, []);
 
     expect(kebabOption.labelKey).toEqual(labelKey);
     expect(kebabOption.icon).toEqual(icon);
@@ -184,7 +185,7 @@ describe('addResourceMenuUtils: ', () => {
     const label = 'From Git';
 
     const kebabAction: KebabAction = createKebabAction(label, icon, ImportOptions.GIT);
-    const kebabOption: KebabOption = kebabAction(primaryObj, null, hasApplication);
+    const kebabOption: KebabOption = kebabAction(primaryObj, null, hasApplication, undefined, []);
 
     expect(kebabOption.accessReview).toBe(undefined);
   });

--- a/frontend/packages/dev-console/src/utils/add-resources-menu-utils.ts
+++ b/frontend/packages/dev-console/src/utils/add-resources-menu-utils.ts
@@ -7,6 +7,7 @@ import {
   QUERY_PROPERTIES,
   INCONTEXT_ACTIONS_CONNECTS_TO,
   INCONTEXT_ACTIONS_SERVICE_BINDING,
+  SERVICE_BINDING_ENABLED,
 } from '../const';
 
 const PART_OF = 'app.kubernetes.io/part-of';
@@ -17,6 +18,7 @@ export const getAddPageUrl = (
   type: string,
   hasApplication: boolean,
   contextSource?: string,
+  serviceBindingEnabled?: boolean,
 ): string => {
   let pageUrl = '';
   const params = new URLSearchParams();
@@ -74,7 +76,9 @@ export const getAddPageUrl = (
         params.append(
           QUERY_PROPERTIES.CONTEXT_ACTION,
           JSON.stringify({
-            type: INCONTEXT_ACTIONS_SERVICE_BINDING,
+            type: serviceBindingEnabled
+              ? INCONTEXT_ACTIONS_SERVICE_BINDING
+              : INCONTEXT_ACTIONS_CONNECTS_TO,
             payload: contextSource,
           }),
         );
@@ -144,6 +148,13 @@ export const createKebabAction: KebabFactory = (labelKey, icon, importType, chec
     labelKey,
     icon,
     pathKey: getMenuPath(hasApplication, connectorSourceContext),
-    href: getAddPageUrl(obj, namespace, importType, hasApplication, connectorSourceContext),
+    href: getAddPageUrl(
+      obj,
+      namespace,
+      importType,
+      hasApplication,
+      connectorSourceContext,
+      accessData.includes(SERVICE_BINDING_ENABLED),
+    ),
   };
 };

--- a/frontend/packages/dev-console/src/utils/useAddToProjectAccess.ts
+++ b/frontend/packages/dev-console/src/utils/useAddToProjectAccess.ts
@@ -12,11 +12,8 @@ import {
   ServiceModel,
 } from '@console/internal/models';
 import { ALLOW_SERVICE_BINDING_FLAG } from '@console/topology/src/const';
-import {
-  allCatalogImageResourceAccess,
-  allImportResourceAccess,
-  serviceBindingAvailable,
-} from '../actions/add-resources';
+import { allCatalogImageResourceAccess, allImportResourceAccess } from '../actions/add-resources';
+import { SERVICE_BINDING_ENABLED } from '../const';
 
 const resourceAttributes = (model: K8sKind, namespace: string): AccessReviewResourceAttributes => {
   return {
@@ -58,7 +55,7 @@ export const useAddToProjectAccess = (activeNamespace: string): string[] => {
       }
     }
     if (serviceBindingEnabled) {
-      createResourceAccess.push(serviceBindingAvailable);
+      createResourceAccess.push(SERVICE_BINDING_ENABLED);
     }
     return createResourceAccess;
   }, [

--- a/frontend/packages/topology/src/actions/__tests__/graphActions.spec.tsx
+++ b/frontend/packages/topology/src/actions/__tests__/graphActions.spec.tsx
@@ -16,7 +16,7 @@ describe('graphActions: ', () => {
       createResourceAccess: [allCatalogImageResourceAccess, allImportResourceAccess],
     };
     const actions = graphActions(graphData);
-    expect(actions).toHaveLength(8);
+    expect(actions).toHaveLength(9);
   });
 
   it('should return the correct menu items when all only import resources are allowed', () => {
@@ -26,7 +26,7 @@ describe('graphActions: ', () => {
       createResourceAccess: [allImportResourceAccess],
     };
     const actions = graphActions(graphData);
-    expect(actions).toHaveLength(7);
+    expect(actions).toHaveLength(8);
   });
 
   it('should return the correct menu items when minimal resources are allowed', () => {
@@ -36,7 +36,7 @@ describe('graphActions: ', () => {
       createResourceAccess: [],
     };
     const actions = graphActions(graphData);
-    expect(actions).toHaveLength(4);
+    expect(actions).toHaveLength(5);
   });
 
   it('should return the correct menu items when connector source is passed and event source is disabled', () => {
@@ -48,7 +48,7 @@ describe('graphActions: ', () => {
     const connectorSource = new OdcBaseNode();
     connectorSource.setData(topologyDataModel.nodes[0].data);
     const actions = graphActions(graphData, connectorSource);
-    expect(actions).toHaveLength(4);
+    expect(actions).toHaveLength(5);
   });
 
   it('should return the event source menu item when connector source is passed and event source is enabled', () => {
@@ -62,7 +62,7 @@ describe('graphActions: ', () => {
       knativeTopologyDataModel.topology['e187afa2-53b1-406d-a619-cf9ff1468031'],
     );
     const actions = graphActions(graphData, connectorSource);
-    expect(actions).toHaveLength(5);
+    expect(actions).toHaveLength(6);
     expect(
       actions.filter((action) => action.labelKey === 'knative-plugin~Event Source'),
     ).toHaveLength(1);
@@ -75,7 +75,7 @@ describe('graphActions: ', () => {
       createResourceAccess: [allCatalogImageResourceAccess, allImportResourceAccess],
     };
     const actions = graphActions(graphData);
-    expect(actions).toHaveLength(10);
+    expect(actions).toHaveLength(11);
   });
 
   it('should return the correct number of items when all permission are not allowed and eventSource is enabled', () => {
@@ -85,6 +85,6 @@ describe('graphActions: ', () => {
       createResourceAccess: [],
     };
     const actions = graphActions(graphData);
-    expect(actions).toHaveLength(6);
+    expect(actions).toHaveLength(7);
   });
 });

--- a/frontend/packages/topology/src/operators/operators-data-transformer.ts
+++ b/frontend/packages/topology/src/operators/operators-data-transformer.ts
@@ -15,6 +15,7 @@ import { isOperatorBackedKnResource } from '@console/knative-plugin/src/topology
 import { WORKLOAD_TYPES } from '../utils/topology-utils';
 import { TYPE_SERVICE_BINDING } from '../const';
 import { TopologyDataResources } from '../topology-types';
+import { getTopologyEdgeItems } from '../data-transforms/transform-utils';
 
 export const edgesFromServiceBinding = (
   source: K8sResourceKind,
@@ -148,11 +149,13 @@ export const getOperatorTopologyDataModel = (
   const obsGroups = getOperatorGroupResources(resources);
   const serviceBindingRequests = resources?.serviceBindingRequests?.data;
   const installedOperators = resources?.clusterServiceVersions?.data as ClusterServiceVersionKind[];
-
-  if (serviceBindingRequests?.length && installedOperators?.length) {
+  if (installedOperators?.length) {
     workloads.forEach((dc) => {
       operatorsDataModel.edges.push(
-        ...getServiceBindingEdges(dc, obsGroups, serviceBindingRequests, installedOperators),
+        ...[
+          ...getServiceBindingEdges(dc, obsGroups, serviceBindingRequests, installedOperators),
+          ...getTopologyEdgeItems(dc, obsGroups),
+        ],
       );
     });
   }

--- a/frontend/packages/topology/src/utils/connector-utils.ts
+++ b/frontend/packages/topology/src/utils/connector-utils.ts
@@ -259,7 +259,7 @@ const getSourceAndTargetForBinding = async (
     referenceForModel(DeploymentModel),
   ];
   let target;
-  if (serviceBindingAvailable) {
+  if (serviceBindingAvailable || !Array.isArray(resources)) {
     target = resources;
   } else {
     target = (resources as K8sResourceKind[]).find((resource) =>


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5166
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: missing support for creating visual connector for operator backed service through incontext
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: missing support for creating visual connector for operator backed service through incontext
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot 2021-01-05 at 4 30 15 PM](https://user-images.githubusercontent.com/9278015/103639334-3772c080-4f74-11eb-8d88-d1d4cadf4c7b.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
