### PR TITLE
Bug 1912523: Fix to update pod ring status for standalone pods in topology

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/WorkloadNode.tsx
@@ -10,6 +10,7 @@ import {
   WithContextMenuProps,
 } from '@patternfly/react-topology';
 import { Tooltip } from '@patternfly/react-core';
+import { PodKind } from '@console/internal/module/k8s';
 import { calculateRadius, usePodsWatcher, PodRCData } from '@console/shared';
 import PodSet, { podSetInnerRadius } from './PodSet';
 import BaseNode from './BaseNode';
@@ -83,7 +84,7 @@ const WorkloadPodsNode: React.FC<WorkloadPodsNodeProps> = observer(
   },
 );
 
-const WorkloadNode: React.FC<WorkloadNodeProps> = observer(({ element, ...rest }) => {
+const WatchedWorkloadNode: React.FC<WorkloadNodeProps> = observer(({ element, ...rest }) => {
   const resource = getTopologyResourceObject(element.getData());
   const { podData, loadError, loaded } = usePodsWatcher(
     resource,
@@ -97,6 +98,21 @@ const WorkloadNode: React.FC<WorkloadNodeProps> = observer(({ element, ...rest }
       {...rest}
     />
   );
+});
+
+const WorkloadNode: React.FC<WorkloadNodeProps> = observer(({ element, ...rest }) => {
+  const resource = getTopologyResourceObject(element.getData());
+  if (resource.kind === 'Pod') {
+    const podData = {
+      obj: resource,
+      current: undefined,
+      previous: undefined,
+      isRollingOut: true,
+      pods: [resource as PodKind],
+    };
+    return <WorkloadPodsNode element={element} donutStatus={podData} {...rest} />;
+  }
+  return <WatchedWorkloadNode element={element} {...rest} />;
 });
 
 export { WorkloadNode, WorkloadPodsNode };


### PR DESCRIPTION
**Fixes**: 
Fixes https://issues.redhat.com/browse/ODC-5308

**Analysis / Root cause**: 
Standalone pod nodes were using the pods watcher which never updated since it was only returning the given resource and not updating when that resource changes.

**Solution Description**: 
For standalone pods, do not use the pods watcher, rather build the pod data from the resource and display that.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug