### PR TITLE
Bug 1913306: quick-start-footer

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartController.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartController.tsx
@@ -6,9 +6,15 @@ import { QuickStartContext, QuickStartContextValues } from './utils/quick-start-
 
 type QuickStartControllerProps = {
   quickStart: QuickStart;
+  footerClass: string;
+  contentRef: React.Ref<HTMLDivElement>;
 };
 
-const QuickStartController: React.FC<QuickStartControllerProps> = ({ quickStart }) => {
+const QuickStartController: React.FC<QuickStartControllerProps> = ({
+  quickStart,
+  contentRef,
+  footerClass,
+}) => {
   const {
     metadata: { name },
     spec: { tasks = [] },
@@ -65,6 +71,7 @@ const QuickStartController: React.FC<QuickStartControllerProps> = ({ quickStart 
         onTaskSelect={handleTaskSelect}
         onTaskReview={handleTaskStatusChange}
         onQuickStartChange={handleQuickStartChange}
+        ref={contentRef}
       />
       <QuickStartFooter
         status={status}
@@ -72,6 +79,7 @@ const QuickStartController: React.FC<QuickStartControllerProps> = ({ quickStart 
         totalTasks={totalTasks}
         onNext={handleNext}
         onBack={handleBack}
+        footerClass={footerClass}
       />
     </>
   );

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.scss
@@ -10,6 +10,10 @@
     background: inherit;
     z-index: var(--pf-global--ZIndex--xs);
   }
+  &__body {
+    display: flex;
+    flex-direction: column;
+  }
   &__title {
     display: flex;
     align-items: center;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
@@ -10,7 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { AsyncComponent } from '@console/internal/components/utils';
-import { useScrollDirection, ScrollDirection } from '@console/shared/';
+import { useScrollShadows, Shadows } from '@console/shared';
 import { QuickStart } from './utils/quick-start-types';
 import './QuickStartPanelContent.scss';
 
@@ -27,18 +27,23 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   handleClose,
   activeQuickStartID,
 }) => {
-  const [scrollDirection, handleScrollCallback] = useScrollDirection();
   const { t } = useTranslation();
+  const [contentRef, setContentRef] = React.useState<HTMLDivElement>();
+  const shadows = useScrollShadows(contentRef);
+
   const quickStart = quickStarts.find((qs) => qs.metadata.name === activeQuickStartID);
 
-  const headerClasses = classNames('co-quick-start-panel-content-head', {
-    'pf-u-box-shadow-sm-bottom':
-      scrollDirection && scrollDirection !== ScrollDirection.scrolledToTop,
+  const headerClasses = classNames({
+    'pf-u-box-shadow-sm-bottom': shadows === Shadows.top || shadows === Shadows.both,
+  });
+
+  const footerClass = classNames({
+    'pf-u-box-shadow-sm-top': shadows === Shadows.bottom || shadows === Shadows.both,
   });
 
   return quickStart ? (
-    <DrawerPanelContent className="co-quick-start-panel-content" onScroll={handleScrollCallback}>
-      <div className={headerClasses}>
+    <DrawerPanelContent className="co-quick-start-panel-content">
+      <div className={`co-quick-start-panel-content-head ${headerClasses}`}>
         <DrawerHead>
           <div className="co-quick-start-panel-content__title">
             <Title
@@ -59,10 +64,12 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
           </DrawerActions>
         </DrawerHead>
       </div>
-      <DrawerPanelBody>
+      <DrawerPanelBody hasNoPadding className="co-quick-start-panel-content__body">
         <AsyncComponent
           loader={() => import('./QuickStartController').then((c) => c.default)}
           quickStart={quickStart}
+          footerClass={footerClass}
+          contentRef={setContentRef}
         />
       </DrawerPanelBody>
     </DrawerPanelContent>

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartContent.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartContent.scss
@@ -1,7 +1,7 @@
 @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
 
 .co-quick-start-content {
-  @media (min-width: $screen-lg-min) {
-    min-height: calc(100vh - (var(--pf-global--spacer--4xl) + var(--pf-global--spacer--3xl)));
-  }
+  flex: 1 1 0;
+  overflow: auto;
+  padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
 }

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartContent.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartContent.tsx
@@ -15,50 +15,49 @@ type QuickStartContentProps = {
   onQuickStartChange?: (quickStartId: string) => void;
 };
 
-const QuickStartContent: React.FC<QuickStartContentProps> = ({
-  quickStart,
-  taskNumber,
-  allTaskStatuses,
-  onTaskSelect,
-  onTaskReview,
-  onQuickStartChange,
-}) => {
-  const {
-    spec: { introduction, tasks, conclusion, nextQuickStart = [] },
-  } = quickStart;
-  const totalTasks = tasks.length;
-  const nextQS = nextQuickStart.length > 0 && nextQuickStart[0];
-  return (
-    <div className="co-quick-start-content">
-      {taskNumber === -1 && (
-        <QuickStartIntroduction
-          tasks={tasks}
-          allTaskStatuses={allTaskStatuses}
-          introduction={introduction}
-          onTaskSelect={onTaskSelect}
-        />
-      )}
-      {taskNumber > -1 && taskNumber < totalTasks && (
-        <QuickStartTasks
-          tasks={tasks}
-          taskNumber={taskNumber}
-          allTaskStatuses={allTaskStatuses}
-          onTaskReview={onTaskReview}
-          onTaskSelect={onTaskSelect}
-        />
-      )}
-      {taskNumber === totalTasks && (
-        <QuickStartConclusion
-          tasks={tasks}
-          conclusion={conclusion}
-          allTaskStatuses={allTaskStatuses}
-          nextQuickStart={nextQS}
-          onQuickStartChange={onQuickStartChange}
-          onTaskSelect={onTaskSelect}
-        />
-      )}
-    </div>
-  );
-};
+const QuickStartContent = React.forwardRef<HTMLDivElement, QuickStartContentProps>(
+  (
+    { quickStart, taskNumber, allTaskStatuses, onTaskSelect, onTaskReview, onQuickStartChange },
+    ref,
+  ) => {
+    const {
+      spec: { introduction, tasks, conclusion, nextQuickStart = [] },
+    } = quickStart;
+    const totalTasks = tasks.length;
+    const nextQS = nextQuickStart.length > 0 && nextQuickStart[0];
+
+    return (
+      <div className="co-quick-start-content" ref={ref}>
+        {taskNumber === -1 && (
+          <QuickStartIntroduction
+            tasks={tasks}
+            allTaskStatuses={allTaskStatuses}
+            introduction={introduction}
+            onTaskSelect={onTaskSelect}
+          />
+        )}
+        {taskNumber > -1 && taskNumber < totalTasks && (
+          <QuickStartTasks
+            tasks={tasks}
+            taskNumber={taskNumber}
+            allTaskStatuses={allTaskStatuses}
+            onTaskReview={onTaskReview}
+            onTaskSelect={onTaskSelect}
+          />
+        )}
+        {taskNumber === totalTasks && (
+          <QuickStartConclusion
+            tasks={tasks}
+            conclusion={conclusion}
+            allTaskStatuses={allTaskStatuses}
+            nextQuickStart={nextQS}
+            onQuickStartChange={onQuickStartChange}
+            onTaskSelect={onTaskSelect}
+          />
+        )}
+      </div>
+    );
+  },
+);
 
 export default QuickStartContent;

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartFooter.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartFooter.scss
@@ -1,6 +1,5 @@
 .co-quick-start-footer {
   background-color: var(--pf-global--Color--light-100);
-  bottom: 0;
-  position: sticky;
-  padding: var(--pf-global--spacer--sm) 0;
+  flex: 0 0 auto;
+  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
 }

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartFooter.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartFooter.tsx
@@ -8,6 +8,7 @@ import './QuickStartFooter.scss';
 
 type QuickStartFooterProps = {
   status: QuickStartStatus;
+  footerClass: string;
   taskNumber: number;
   totalTasks: number;
   onNext: () => void;
@@ -20,6 +21,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
   totalTasks,
   onNext,
   onBack,
+  footerClass,
 }) => {
   const location = useLocation();
   const { pathname: currentPath } = location;
@@ -47,7 +49,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
   ]);
 
   return (
-    <div className="co-quick-start-footer">
+    <div className={`co-quick-start-footer ${footerClass}`}>
       <Button
         style={{
           marginRight: 'var(--pf-global--spacer--md)',

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from './deep-compare-memoize';
 export * from './document-listener';
 export * from './fullscreen';
 export * from './scroll';
+export * from './useScrollShadows';
 export * from './plugins-overview-tab-section';
 export * from './debounce';
 export * from './select-list';

--- a/frontend/packages/console-shared/src/hooks/useScrollShadows.ts
+++ b/frontend/packages/console-shared/src/hooks/useScrollShadows.ts
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { useResizeObserver } from './useResizeObserver';
+
+export enum Shadows {
+  none = 'none',
+  both = 'both',
+  top = 'top',
+  bottom = 'bottom',
+}
+
+export const useScrollShadows = (node: HTMLElement): Shadows => {
+  const [shadows, setShadows] = React.useState(Shadows.none);
+  const computeShadows = React.useCallback(() => {
+    if (node) {
+      const { scrollTop, clientHeight, scrollHeight } = node;
+      const top = scrollTop !== 0;
+      const bottom = scrollTop + clientHeight < scrollHeight;
+      if (top && bottom) {
+        setShadows(Shadows.both);
+      } else if (top) {
+        setShadows(Shadows.top);
+      } else if (bottom) {
+        setShadows(Shadows.bottom);
+      } else {
+        setShadows(Shadows.none);
+      }
+    }
+  }, [node]);
+  // recompute when the scroll container changes in size
+  useResizeObserver(computeShadows, node);
+  React.useEffect(() => {
+    if (node) {
+      // compute initial shadows
+      computeShadows();
+      // listen for scroll events
+      node.addEventListener('scroll', computeShadows);
+    }
+    return () => {
+      if (node) {
+        node.removeEventListener('scroll', computeShadows);
+      }
+    };
+  }, [node, computeShadows]);
+  return shadows;
+};


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-4619,
https://issues.redhat.com/browse/ODC-4780/'
Fixes shadow retainment on QuickStart change
Fixes shadow update on Quickstart Load
Fixes shadow update on browser resize
Markdown area scrollbar bug -> https://issues.redhat.com/browse/ODC-5338

# Fix
**Issue**
1. Unnecessary scrollbar appears in Quick start panel - This is because some headings are two lines long and some are one line long and the height computation is made by assuming one line header.
2. No shadow for overlapping content and footer.

**Solution**
1. Converted panel into flex items
2. Added shadow to footer top onScroll

# ScreenShot
Shadow update on Quickstart change and browser resize
![footer1](https://user-images.githubusercontent.com/24852534/104728412-e1183580-575c-11eb-90c4-68129a2ff7a3.gif)
![footer2](https://user-images.githubusercontent.com/24852534/104728430-e5445300-575c-11eb-9202-5654ff2c5575.gif)

# Tests
none changed

# Browser conformance
Chrome
