### PR TITLE
tests: fix timeout loading logs in CRD extensions test

### DIFF
--- a/frontend/integration-tests/tests/crd-extensions.scenario.ts
+++ b/frontend/integration-tests/tests/crd-extensions.scenario.ts
@@ -308,7 +308,9 @@ describe('CRD extensions', () => {
 
     it(`does not display the ${crd} instance on the test pod`, async () => {
       await browser.get(`${appHost}/k8s/ns/${testName}/pods/${podName}/logs`);
-      await crudView.isLoaded();
+      // Don't use `crudView.isLoaded` here since it will block until the log
+      // content itself is loaded and sometimes time out.
+      await browser.wait(crudView.untilLoadingBoxLoaded);
       expect(cell.isPresent()).toBe(false);
     });
 


### PR DESCRIPTION
We don't need to wait for the log content itself to check if the log links are present. The log is sometimes slow to load, causing the tests to timeout.

/cc @dtaylor113 @rhamilto 