### PR TITLE
Bug 1910859: breadcrumbs and nav doesn't use last namespace

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/commands/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/app.ts
@@ -4,7 +4,6 @@ export {}; // needed in files which don't have an import to trigger ES6 module u
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
-      clickNavLink(path: [string, string]): Chainable<Element>;
       selectByDropDownText(selector: string, dropdownText: string): Chainable<Element>;
       mouseHover(selector: string): Chainable<Element>;
       selectValueFromAutoCompleteDropDown(
@@ -27,15 +26,6 @@ after(() => {
 
 afterEach(() => {
   checkErrors();
-});
-
-Cypress.Commands.add('clickNavLink', (path: [string, string]) => {
-  cy.get(`[data-component="pf-nav-expandable"]`) // this assumes all top level menu items are expandable
-    .contains(path[0])
-    .click(); // open top, expandable menu
-  cy.get('#page-sidebar')
-    .contains(path[1])
-    .click();
 });
 
 Cypress.Commands.add('selectByDropDownText', (selector: string, dropdownText: string) => {

--- a/frontend/packages/integration-tests-cypress/support/nav.ts
+++ b/frontend/packages/integration-tests-cypress/support/nav.ts
@@ -12,7 +12,11 @@ declare global {
 Cypress.Commands.add('clickNavLink', (path: string[]) => {
   cy.get('#page-sidebar')
     .contains(path[0])
-    .click();
+    .then(($navItem) => {
+      if ($navItem.attr('aria-expanded') !== 'true') {
+        cy.wrap($navItem).click();
+      }
+    });
   if (path.length === 2) {
     cy.get('#page-sidebar')
       .contains(path[1])

--- a/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
@@ -5,6 +5,7 @@ import * as _ from 'lodash';
 import { testName, editKind, deleteKind, checkErrors } from '../../support';
 import { listPage, ListPageSelector } from '../../views/list-page';
 import { detailsPage, DetailsPageSelector } from '../../views/details-page';
+import { projectDropdown } from '../../views/common';
 import { modal } from '../../views/modal';
 import * as yamlEditor from '../../views/yaml-editor';
 import { errorMessage } from '../../views/form';
@@ -151,11 +152,11 @@ describe('Kubernetes resource CRUD operations', () => {
           );
           if (namespaced) {
             // should have a namespace dropdown for namespaced objects');
-            listPage.projectDropdownShouldExist();
-            listPage.projectDropdownShouldContain(testName);
+            projectDropdown.shouldExist();
+            projectDropdown.shouldContain(testName);
           } else {
             // should not have a namespace dropdown for non-namespaced objects');
-            listPage.projectDropdownShouldNotExist();
+            projectDropdown.shouldNotExist();
           }
           listPage.rows.shouldBeLoaded();
           cy.testA11y(`List page for ${kind}: ${name}`);

--- a/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
@@ -1,6 +1,8 @@
 import { checkErrors, testName } from '../../support';
 import { listPage } from '../../views/list-page';
 import { modal } from '../../views/modal';
+import { nav } from '../../views/nav';
+import { projectDropdown } from '../../views/common';
 
 describe('Namespace', () => {
   before(() => {
@@ -47,5 +49,58 @@ describe('Namespace', () => {
     modal.submit();
     modal.shouldBeClosed();
     cy.resourceShouldBeDeleted(testName, 'namespaces', newName);
+  });
+
+  it('nav and breadcrumbs restores last selected "All Projects" when navigating from details to list view', () => {
+    nav.sidenav.clickNavLink(['Workloads', 'Secrets']);
+    projectDropdown.selectProject('All Projects');
+    projectDropdown.shouldContain('All Projects');
+    cy.log(
+      'Nav from list page to details page should change Project from "All Projects" to resource specific project',
+    );
+    cy.get(`[data-test-rows="resource-row"]`)
+      .first()
+      .find('a')
+      .first()
+      .click();
+    projectDropdown.shouldNotContain('All Projects'); // after drilldown to Details page, project should be specific to resource
+    cy.log(
+      'Nav back to list page from details page via sidebar nav menu should change Project back to "All Projects"',
+    );
+    nav.sidenav.clickNavLink(['Workloads', 'Secrets']);
+    projectDropdown.shouldContain('All Projects');
+    cy.log(
+      'Nav back to list page from details page via sidebar nav menu should change Project back to "All Projects"',
+    );
+    cy.get(`[data-test-rows="resource-row"]`)
+      .first()
+      .find('a')
+      .first()
+      .click();
+    projectDropdown.shouldNotContain('All Projects'); // after drilldown to Details page, project should be specific to resource
+    cy.byLegacyTestID('breadcrumb-link-0').click();
+    projectDropdown.shouldContain('All Projects');
+  });
+
+  it('nav and breadcrumbs restores last selected Project when navigating from details to list view', () => {
+    nav.sidenav.clickNavLink(['Workloads', 'Secrets']);
+    projectDropdown.selectProject('default');
+    projectDropdown.shouldContain('default');
+    cy.get(`[data-test-rows="resource-row"]`)
+      .first()
+      .find('a')
+      .first()
+      .click();
+    projectDropdown.shouldContain('default');
+    nav.sidenav.clickNavLink(['Workloads', 'Secrets']);
+    projectDropdown.shouldContain('default');
+    cy.get(`[data-test-rows="resource-row"]`)
+      .first()
+      .find('a')
+      .first()
+      .click();
+    projectDropdown.shouldContain('default');
+    cy.byLegacyTestID('breadcrumb-link-0').click();
+    projectDropdown.shouldContain('default');
   });
 });

--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -2,6 +2,7 @@ import { checkErrors, testName } from '../../support';
 import { submitButton, errorMessage } from '../../views/form';
 import { listPage } from '../../views/list-page';
 import { detailsPage } from '../../views/details-page';
+import { projectDropdown } from '../../views/common';
 import { modal } from '../../views/modal';
 import { nav } from '../../views/nav';
 
@@ -43,7 +44,7 @@ xdescribe('Monitoring: Alerts', () => {
     nav.sidenav.clickNavLink(['Monitoring', 'Alerting']);
     // TODO, switch to 'listPage.titleShouldHaveText('Alerting');', when we switch to new test id
     cy.byLegacyTestID('resource-title').should('have.text', 'Alerting');
-    listPage.projectDropdownShouldNotExist();
+    projectDropdown.shouldNotExist();
     listPage.rows.shouldBeLoaded();
     cy.testA11y('Monitor Alerting list page');
 

--- a/frontend/packages/integration-tests-cypress/views/common.ts
+++ b/frontend/packages/integration-tests-cypress/views/common.ts
@@ -8,3 +8,19 @@ export const selectActionsMenuOption = (actionsMenuOption: string) => {
     .should('be.visible')
     .click();
 };
+
+export const projectDropdown = {
+  shouldExist: () => cy.byLegacyTestID('namespace-bar-dropdown').should('exist'),
+  selectProject: (projectName: string) => {
+    cy.byLegacyTestID('namespace-bar-dropdown')
+      .contains('Project:')
+      .click();
+    cy.byTestID('dropdown-menu-item-link')
+      .contains(projectName)
+      .click();
+  },
+  shouldContain: (name: string) => cy.byLegacyTestID('namespace-bar-dropdown').contains(name),
+  shouldNotContain: (name: string) =>
+    cy.byLegacyTestID('namespace-bar-dropdown').should('not.contain', name),
+  shouldNotExist: () => cy.byLegacyTestID('namespace-bar-dropdown').should('not.exist'),
+};

--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -1,11 +1,6 @@
 export const listPage = {
   titleShouldHaveText: (title: string) =>
     cy.byLegacyTestID('resource-title').should('have.text', title),
-  projectDropdownShouldExist: () => cy.byLegacyTestID('namespace-bar-dropdown').should('exist'),
-  projectDropdownShouldContain: (name: string) =>
-    cy.byLegacyTestID('namespace-bar-dropdown').contains(name),
-  projectDropdownShouldNotExist: () =>
-    cy.byLegacyTestID('namespace-bar-dropdown').should('not.exist'),
   clickCreateYAMLdropdownButton: () => {
     cy.byTestID('item-create')
       .click()

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -6,7 +6,10 @@ import * as _ from 'lodash-es';
 import store from '../redux';
 import { history } from '../components/utils/router';
 import { OverviewItem } from '@console/shared';
-import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';
+import {
+  ALL_NAMESPACES_KEY,
+  LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
+} from '@console/shared/src/constants';
 import { K8sResourceKind, PodKind, NodeKind } from '../module/k8s';
 import { allModels } from '../module/k8s/k8s-models';
 import { detectFeatures, clearSSARFlags } from './features';
@@ -199,8 +202,10 @@ export const setActiveNamespace = (namespace: string = '') => {
     if (newPath !== oldPath) {
       history.pushPath(newPath);
     }
-    // remember the most recently-viewed project, which is automatically
-    // selected when returning to the console
+    // save last namespace in session storage (persisted only for current browser tab). Used to remember/restore if
+    // "All Projects" was selected when returning to the list view (typically from details view) via breadcrumb or
+    // sidebar navigation
+    sessionStorage.setItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, namespace);
   }
 
   return action(ActionType.SetActiveNamespace, { namespace });

--- a/frontend/public/components/nav/items.tsx
+++ b/frontend/public/components/nav/items.tsx
@@ -17,7 +17,7 @@ import { stripBasePath } from '../utils';
 import { featureReducerName } from '../../reducers/features';
 import { RootState } from '../../redux';
 import { getActiveNamespace } from '../../reducers/ui';
-import { getActiveNamespace as getLastNamespace } from '../../actions/ui';
+import { LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
 
 export const matchesPath = (resourcePath, prefix) =>
@@ -111,7 +111,7 @@ export class ResourceNSLink extends NavLink<ResourceNSLinkProps> {
 
   get to() {
     const { resource, activeNamespace } = this.props;
-    const lastNamespace = getLastNamespace();
+    const lastNamespace = sessionStorage.getItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
     return formatNamespacedRouteForResource(
       resource,
       lastNamespace === ALL_NAMESPACES_KEY ? lastNamespace : activeNamespace,

--- a/frontend/public/components/utils/breadcrumbs.ts
+++ b/frontend/public/components/utils/breadcrumbs.ts
@@ -1,10 +1,10 @@
 import i18next from 'i18next';
 import { K8sKind } from '../../module/k8s';
+import { LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
-import { getActiveNamespace } from '../../actions/ui';
 
 export const getBreadcrumbPath = (match: any, customPlural?: string) => {
-  const lastNamespace = getActiveNamespace();
+  const lastNamespace = sessionStorage.getItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
   if (match.params.ns) {
     return lastNamespace === ALL_NAMESPACES_KEY
       ? `/k8s/all-namespaces/${customPlural || match.params.plural}`

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -181,6 +181,7 @@ class DropDownRow extends React.PureComponent {
           href="#"
           ref={this.link}
           id={`${itemKey}-link`}
+          data-test="dropdown-menu-item-link"
           className={classNames('pf-c-dropdown__menu-item', {
             'next-to-bookmark': !!prefix,
             hover,


### PR DESCRIPTION
This PR stores the last selected Project/Namespace in the brower's `sessionStorage`, which is only persisted for the current browser Tab.  This is primarliy for the usecase of seeing 'all projects' in a list view, drilling into a Details view which limits to a specific project/namespace, then navigating back to list view  -user expects list view to return to 'all projects' and not remain on the project/namespace shown in the Details view and often gets confused why they are seeing less items in the list view.

When navigating from a Details view via Breadcrumb or sidebar Nav Item, navigation will used the last project/namespace selected by the user.  This PR addresses a regression caused by:

https://github.com/openshift/console/pull/7433

...which removed the funcationality implemented by:

https://github.com/openshift/console/pull/5543

...which addressed JIRA story:

https://issues.redhat.com/browse/CONSOLE-2228

![Installed-Operators-·-OKD](https://user-images.githubusercontent.com/12733153/103685845-e3f47880-4f5b-11eb-8da1-4de5008a4da8.gif)

cc @sahil143