### PR TITLE
Bug 1913196: handle resizing of browser for guided tour

### DIFF
--- a/frontend/packages/console-shared/src/components/spotlight/StaticSpotlight.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/StaticSpotlight.tsx
@@ -1,26 +1,29 @@
 import * as React from 'react';
+import { useBoundingClientRect } from '../../hooks';
 import Portal from '../popper/Portal';
 import './spotlight.scss';
 
 type StaticSpotlightProps = {
-  element: Element;
+  element: Element | HTMLElement;
 };
 
 const StaticSpotlight: React.FC<StaticSpotlightProps> = ({ element }) => {
-  const { top, left, height, width } = element.getBoundingClientRect();
-  const style: React.CSSProperties = {
-    top,
-    left,
-    height,
-    width,
-  };
-  return (
+  const clientRect = useBoundingClientRect(element as HTMLElement);
+  const style: React.CSSProperties = clientRect
+    ? {
+        top: clientRect.top,
+        left: clientRect.left,
+        height: clientRect.height,
+        width: clientRect.width,
+      }
+    : {};
+  return clientRect ? (
     <Portal>
       <div className="pf-c-backdrop ocs-spotlight__with-backdrop">
         <div className="ocs-spotlight ocs-spotlight__element-highlight-noanimate" style={style} />
       </div>
     </Portal>
-  );
+  ) : null;
 };
 
 export default StaticSpotlight;

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -25,3 +25,5 @@ export * from './usePinnedResources';
 export * from './useActivePerspective';
 export * from './useActiveNamespace';
 export * from './useIsMobile';
+export * from './useResizeObserver';
+export * from './useBoundingClientRect';

--- a/frontend/packages/console-shared/src/hooks/useBoundingClientRect.ts
+++ b/frontend/packages/console-shared/src/hooks/useBoundingClientRect.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useResizeObserver } from './useResizeObserver';
+
+type BoundingClientRect = ClientRect | null;
+
+export const useBoundingClientRect = (targetElement: HTMLElement | null): BoundingClientRect => {
+  const [clientRect, setClientRect] = React.useState<BoundingClientRect>(() =>
+    targetElement ? targetElement.getBoundingClientRect() : null,
+  );
+
+  const observerCallback = React.useCallback(() => {
+    setClientRect(targetElement ? targetElement.getBoundingClientRect() : null);
+  }, [targetElement]);
+
+  useResizeObserver(observerCallback);
+
+  return clientRect;
+};

--- a/frontend/packages/console-shared/src/hooks/useResizeObserver.ts
+++ b/frontend/packages/console-shared/src/hooks/useResizeObserver.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export const useResizeObserver = (
+  callback: ResizeObserverCallback,
+  targetElement?: HTMLElement | null,
+  observerOptions: ResizeObserverObserveOptions = undefined,
+): void => {
+  const element = React.useMemo(() => targetElement ?? document.querySelector('body'), [
+    targetElement,
+  ]);
+  React.useEffect(() => {
+    const observer = new ResizeObserver(callback);
+    observer.observe(element, observerOptions);
+    return () => {
+      observer.disconnect();
+    };
+  }, [callback, observerOptions, element]);
+};


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5235
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: When resizing the window in the middle of the guided tour, the spotlight area fails to move with the popover.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: added a resize observer on the app which indicates any change in size of view and update the spotlight position.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![guidedTour-resize](https://user-images.githubusercontent.com/9278015/103746688-7c0b6400-5027-11eb-8f6f-8a4c623c8861.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
