### PR TITLE
Bug 1913249: Update info text alerting this template can't be adited

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -585,7 +585,7 @@
   "Virtualization": "Virtualization",
   "Templates": "Templates",
   "{{name}} Details": "{{name}} Details",
-  "{{provider}} provided templates can not be edited": "{{provider}} provided templates can not be edited",
+  "Templates provided by {{provider}} are not editable.": "Templates provided by {{provider}} are not editable.",
   "Create a new custom template": "Create a new custom template",
   "{{ name }} can not be edited because it is provided by the Red Hat OpenShift Virtualization Operator.": "{{ name }} can not be edited because it is provided by the Red Hat OpenShift Virtualization Operator.",
   "We suggest you create a custom Template from this {{provider}} template.": "We suggest you create a custom Template from this {{provider}} template.",

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details.tsx
@@ -47,7 +47,7 @@ export const VMTemplateDetails: React.FC<VMTemplateDetailsProps> = ({
               <Alert
                 variant="info"
                 isInline
-                title={t('kubevirt-plugin~{{provider}} provided templates can not be edited', {
+                title={t('kubevirt-plugin~Templates provided by {{provider}} are not editable.', {
                   provider,
                 })}
                 actionLinks={


### PR DESCRIPTION
Change to this UI text from:
Red Hat provided templates can not be edited.

To read:
Templates provided by Red Hat are not editable.

Screenshot:
![screenshot-localhost_9000-2021 01 06-13_16_06](https://user-images.githubusercontent.com/2181522/103763401-73fcf580-5022-11eb-87fd-fd2c497d68ab.png)
