### PR TITLE
Bug 1914405: Fix to keep quick-search modal opened with previous input on coming back from a selection

### DIFF
--- a/frontend/packages/topology/src/components/quick-search/QuickSearchController.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchController.tsx
@@ -1,5 +1,6 @@
-import { CatalogService } from '@console/dev-console/src/components/catalog/service/CatalogServiceProvider';
 import * as React from 'react';
+import { CatalogService } from '@console/dev-console/src/components/catalog/service/CatalogServiceProvider';
+import { getQueryArgument } from '@console/internal/components/utils';
 import QuickSearchButton from './QuickSearchButton';
 import QuickSearchModal from './QuickSearchModal';
 
@@ -14,7 +15,9 @@ const QuickSearchController: React.FC<QuickSearchControllerProps> = ({
   loaded,
   viewContainer,
 }) => {
-  const [isQuickSearchActive, setIsQuickSearchActive] = React.useState<boolean>(false);
+  const [isQuickSearchActive, setIsQuickSearchActive] = React.useState<boolean>(
+    !!getQueryArgument('catalogSearch'),
+  );
 
   React.useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { history, removeQueryArgument } from '@console/internal/components/utils';
+import { history } from '@console/internal/components/utils';
 import { CatalogItem } from '@console/plugin-sdk';
 import {
   Button,
@@ -31,7 +31,6 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({ selectedItem })
         variant={ButtonVariant.primary}
         className="odc-quick-search-details__form-button"
         onClick={() => {
-          removeQueryArgument('catalogSearch');
           history.push(selectedItem.cta.href);
         }}
       >

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import cx from 'classnames';
-import { history, removeQueryArgument } from '@console/internal/components/utils';
+import { history } from '@console/internal/components/utils';
 import { CatalogItem } from '@console/plugin-sdk';
 import {
   DataList,
@@ -42,12 +42,10 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
 
   const openForm = (e: React.SyntheticEvent, item: CatalogItem) => {
     e.preventDefault();
-    removeQueryArgument('catalogSearch');
     history.push(item.cta.href);
   };
 
   const goToCatalogPage = React.useCallback(() => {
-    removeQueryArgument('catalogSearch');
     history.push(`/catalog/ns/${namespace}?keyword=${searchTerm}`);
   }, [namespace, searchTerm]);
 

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
@@ -47,7 +47,13 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   const onSearch = React.useCallback(
     (value: string) => {
       setSearchTerm(value);
-      setCatalogItems(value ? searchCatalog(value) : null);
+      if (value) {
+        setCatalogItems(searchCatalog(value));
+        setQueryArgument('catalogSearch', value);
+      } else {
+        setCatalogItems(null);
+        removeQueryArgument('catalogSearch');
+      }
       setSelectedItemId('');
       setSelectedItem(null);
     },
@@ -61,7 +67,6 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
       onSearch('');
     } else {
       closeModal();
-      removeQueryArgument('catalogSearch');
     }
   }, [closeModal, onSearch]);
 
@@ -73,7 +78,6 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   const onEnter = React.useCallback(() => {
     const viewAllLink = document.getElementById('viewAll');
     const { activeElement } = document;
-    removeQueryArgument('catalogSearch');
     if (activeElement === viewAllLink) {
       history.push(`/catalog/ns/${namespace}?keyword=${searchTerm}`);
     } else if (selectedItem) {
@@ -120,13 +124,7 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
     };
 
     const onOutsideClick = (e: MouseEvent) => {
-      const searchInput = ref.current?.firstElementChild?.children?.[1] as HTMLInputElement;
       if (!ref.current?.contains(e.target as Node)) {
-        if (searchInput?.value) {
-          setQueryArgument('catalogSearch', searchInput.value);
-        } else {
-          removeQueryArgument('catalogSearch');
-        }
         closeModal();
       }
     };


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-5279

**Analysis/Root cause:**
This is a design change wherein the quick-search modal should be opened with the previous search when coming back to topology from a selection.

**Solution:**
Save the search input while navigating to a form or catalog-page from quick-search modal similar to what to is done when a user clicks outside the modal. When coming back to topology, keep the modal opened if the previous search was saved .  

**Gif:**
![Peek 2021-01-06 17-25](https://user-images.githubusercontent.com/20724543/103765737-b125af80-5043-11eb-8aa8-6d0b68e1b8c3.gif)

/kind bug