### PR TITLE
Bug 1913297: Remove restriction of taints for arbiter node

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/storage-and-nodes-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/storage-and-nodes-step.tsx
@@ -30,7 +30,6 @@ import {
   isFlexibleScaling,
   filterSCWithNoProv,
   getAssociatedNodes,
-  nodesWithoutTaints,
   isArbiterSC,
 } from '../../../../../utils/install';
 import { ValidationMessage, ValidationType } from '../../../../../utils/common-ocs-install-el';
@@ -148,7 +147,7 @@ export const StorageAndNodes: React.FC<StorageAndNodesProps> = ({ state, dispatc
           state={state}
           dispatch={dispatch}
           pvData={pvData}
-          nodesData={nodesWithoutTaints(nodesData)}
+          nodesData={nodesData}
         />
       )}
       <FormGroup

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/sc-node-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/sc-node-list.tsx
@@ -12,7 +12,7 @@ import {
 import { humanizeCpuCores, ResourceLink } from '@console/internal/components/utils/';
 import { Table } from '@console/internal/components/factory';
 import { NodeKind } from '@console/internal/module/k8s';
-import { getConvertedUnits } from '../../../utils/install';
+import { getConvertedUnits, getZone } from '../../../utils/install';
 import { GetRows, NodeTableProps } from '../types';
 import '../ocs-install.scss';
 
@@ -45,7 +45,7 @@ const getRows: GetRows = ({ componentProps }) => {
         title: `${getConvertedUnits(memSpec)}`,
       },
       {
-        title: node.metadata.labels?.['failure-domain.beta.kubernetes.io/zone'] || '-',
+        title: getZone(node) || '-',
       },
     ];
     return {

--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -111,14 +111,13 @@ export const isArbiterSC = (
 ): boolean => {
   const pvs: K8sResourceKind[] = getSCAvailablePVs(pvData, getName(sc));
   const scNodeNames = getAssociatedNodes(pvs);
-  const filteredNodes: NodeKind[] = nodesWithoutTaints(nodesData);
-  const tableData: NodeKind[] = filteredNodes.filter(
+  const tableData: NodeKind[] = nodesData.filter(
     (node: NodeKind) =>
       scNodeNames.includes(getName(node)) ||
       scNodeNames.includes(node.metadata.labels?.['kubernetes.io/hostname']),
   );
-  const uniqZones: Set<string> = new Set(filteredNodes.map((node) => getZone(node)));
-  const uniqSelectedNodesZones: Set<string> = new Set(tableData.map((node) => getZone(node)));
+  const uniqZones: Set<string> = new Set(nodesData.map(getZone));
+  const uniqSelectedNodesZones: Set<string> = new Set(tableData.map(getZone));
   if (uniqZones.size < 3) return false;
   if (uniqSelectedNodesZones.size !== 2) return false;
   const zonePerNode = countNodesPerZone(tableData);


### PR DESCRIPTION
- Node selection of attach devices should show zones using `topology.kubernetes.io/zone'` label
- User can choose master node zone for arbiter

Signed-off-by: Ankush Behl <cloudbehl@gmail.com>