### PR TITLE
Bug 1913332: Fix pipeline visualization issue when taskspecs is used

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
@@ -19,7 +19,6 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
   pipelineRun,
 }) => {
   const { t } = useTranslation();
-  const { nodes, edges } = getTopologyNodesEdges(pipeline, pipelineRun);
   let content: React.ReactElement;
   if (hasInlineTaskSpec(pipeline.spec.tasks)) {
     // TODO: Inline taskSpec is not yet supported feature
@@ -32,7 +31,12 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
         )}
       />
     );
-  } else if (nodes.length === 0 && edges.length === 0) {
+    return <div className="odc-pipeline-visualization">{content}</div>;
+  }
+
+  const { nodes, edges } = getTopologyNodesEdges(pipeline, pipelineRun);
+
+  if (nodes.length === 0 && edges.length === 0) {
     // Nothing to render
     // TODO: Confirm wording with UX; ODC-1860
     content = (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
@@ -92,10 +92,10 @@ export const useNodes = (
   const { clusterTasks, namespacedTasks, errorMsg } = useTasks(namespace);
 
   const getTask = (taskRef: PipelineTaskRef) => {
-    if (taskRef.kind === ClusterTaskModel.kind) {
-      return clusterTasks?.find((task) => task.metadata.name === taskRef.name);
+    if (taskRef?.kind === ClusterTaskModel.kind) {
+      return clusterTasks?.find((task) => task.metadata.name === taskRef?.name);
     }
-    return namespacedTasks?.find((task) => task.metadata.name === taskRef.name);
+    return namespacedTasks?.find((task) => task.metadata.name === taskRef?.name);
   };
 
   const taskGroupRef = React.useRef(taskGroup);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5306

**Analysis / Root cause**: 
Pipeline details page is broken if the newly created pipeline contains multiple taskSpecs in the yaml.

**Solution Description**: 
Add check for `taskspec` before load the pipeline visulation 

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/103779730-27cda780-505a-11eb-990c-85b8598ea2e7.png)

**Test setup:**
Install Openshift Pipleine operator
and create this pipeline https://github.com/karthikjeeyar/pipelines/blob/main/taskspec.yaml

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge