### PR TITLE
Bug 1913371: Fix Administrator missing key error

### DIFF
--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { CogsIcon } from '@patternfly/react-icons';
-import i18next from 'i18next';
 import { FLAGS } from '@console/shared/src/constants';
 import {
   Plugin,
@@ -82,7 +81,8 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Perspective',
     properties: {
       id: 'admin',
-      name: i18next.t('console-app~Administrator'),
+      // t('console-app~Administrator')
+      name: '%console-app~Administrator%',
       icon: <CogsIcon />,
       default: true,
       getLandingPageURL: (flags) =>


### PR DESCRIPTION
Modified key to use plugin syntax with %s.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1913371.