### PR TITLE
Bug 1912523: Fix to update standalone pods and pods side panels for topology

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
@@ -109,9 +109,7 @@ const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
     [itemList, selected.value],
   );
 
-  const debounceFilterText = useDebounceCallback<(text: string) => void>(filterSources, [
-    filterSources,
-  ]);
+  const debounceFilterText = useDebounceCallback<(text: string) => void>(filterSources);
 
   const handleFilterChange = (text: string) => {
     setFilterText(text);

--- a/frontend/packages/console-shared/src/components/text/ClampedText.tsx
+++ b/frontend/packages/console-shared/src/components/text/ClampedText.tsx
@@ -14,7 +14,6 @@ const ClampedText: React.FC<ClampedTextProps> = ({ children, lineClamp = 1 }) =>
   const debouncedSetContentClamped = useDebounceCallback(
     ({ scroll: { height: scrollHeight }, offset: { height: offsetHeight } }) =>
       setContentClamped(scrollHeight > offsetHeight),
-    [setContentClamped],
   );
   const style = { '--ocs-clamped-text--line-clamp': lineClamp } as React.CSSProperties;
 

--- a/frontend/packages/console-shared/src/hooks/debounce.ts
+++ b/frontend/packages/console-shared/src/hooks/debounce.ts
@@ -1,12 +1,25 @@
-import { useCallback } from 'react';
+import * as React from 'react';
 import { debounce } from 'lodash';
+import { useDeepCompareMemoize } from './deep-compare-memoize';
+
+interface Cancelable {
+  cancel(): void;
+  flush(): void;
+}
 
 export const useDebounceCallback = <T extends (...args: any[]) => any>(
   callback: T,
-  dependencies: any[],
   timeout: number = 500,
   debounceParams: { leading?: boolean; trailing?: boolean; maxWait?: number } = {
     leading: false,
     trailing: true,
   },
-): T => useCallback(debounce(callback, timeout, debounceParams), dependencies);
+): ((...args) => any) & Cancelable => {
+  const memDebounceParams = useDeepCompareMemoize(debounceParams);
+  const callbackRef = React.useRef<T>();
+  callbackRef.current = callback;
+
+  return React.useMemo(() => {
+    return debounce((...args) => callbackRef.current(...args), timeout, memDebounceParams);
+  }, [memDebounceParams, timeout]);
+};

--- a/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
+++ b/frontend/packages/console-shared/src/hooks/usePodsWatcher.ts
@@ -24,7 +24,7 @@ export const usePodsWatcher = (
   const resources = useK8sWatchResources(watchedResources);
 
   const updateResults = React.useCallback(
-    (updatedResources) => {
+    (watchedResource, updatedResources) => {
       const errorKey = Object.keys(updatedResources).find((key) => updatedResources[key].loadError);
       if (errorKey) {
         setLoadError(updatedResources[errorKey].loadError);
@@ -35,21 +35,19 @@ export const usePodsWatcher = (
         Object.keys(updatedResources).length > 0 &&
         Object.keys(updatedResources).every((key) => updatedResources[key].loaded)
       ) {
-        const updatedPods = getPodsDataForResource(resource, watchKind, updatedResources);
+        const updatedPods = getPodsDataForResource(watchedResource, watchKind, updatedResources);
         setPodData(updatedPods);
         setLoaded(true);
       }
     },
-    // Don't update on a resource change, we want the debounce callback to be consistent
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [watchKind],
   );
 
-  const debouncedUpdateResources = useDebounceCallback<any>(updateResults, [updateResults], 250);
+  const debouncedUpdateResources = useDebounceCallback(updateResults, 250);
 
   React.useEffect(() => {
-    debouncedUpdateResources(resources);
-  }, [debouncedUpdateResources, resources, updateResults]);
+    debouncedUpdateResources(resource, resources);
+  }, [debouncedUpdateResources, resources, resource]);
 
   return useDeepCompareMemoize({ loaded, loadError, podData });
 };

--- a/frontend/packages/dev-console/src/components/import/git/AdvancedGitOptions.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/AdvancedGitOptions.tsx
@@ -11,14 +11,12 @@ const AdvancedGitOptions: React.FC = () => {
   const { t } = useTranslation();
   const { setFieldValue } = useFormikContext<FormikValues>();
 
-  const handleGitRefChange = useDebounceCallback(
-    (e: React.SyntheticEvent) => setFieldValue('git.ref', (e.target as HTMLInputElement).value),
-    [setFieldValue],
+  const handleGitRefChange = useDebounceCallback((e: React.SyntheticEvent) =>
+    setFieldValue('git.ref', (e.target as HTMLInputElement).value),
   );
 
-  const handleGitDirChange = useDebounceCallback(
-    (e: React.SyntheticEvent) => setFieldValue('git.dir', (e.target as HTMLInputElement).value),
-    [setFieldValue],
+  const handleGitDirChange = useDebounceCallback((e: React.SyntheticEvent) =>
+    setFieldValue('git.dir', (e.target as HTMLInputElement).value),
   );
 
   return (

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -158,7 +158,7 @@ const GitSection: React.FC<GitSectionProps> = ({
     values.git.dir,
   ]);
 
-  const debouncedHandleGitUrlChange = useDebounceCallback(handleGitUrlChange, [handleGitUrlChange]);
+  const debouncedHandleGitUrlChange = useDebounceCallback(handleGitUrlChange);
 
   const handleGitUrlBlur = React.useCallback(() => {
     const { url } = values.git;

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -107,7 +107,7 @@ const ImageSearch: React.FC = () => {
     ],
   );
 
-  const debouncedHandleSearch = useDebounceCallback(handleSearch, [handleSearch]);
+  const debouncedHandleSearch = useDebounceCallback(handleSearch);
 
   const handleSave = React.useCallback(
     (name: string) => {

--- a/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
+++ b/frontend/packages/knative-plugin/src/utils/usePodsForRevisions.ts
@@ -83,7 +83,7 @@ export const usePodsForRevisions = (
     [revisions],
   );
 
-  const debouncedUpdateResources = useDebounceCallback<any>(updateResults, [updateResults], 250);
+  const debouncedUpdateResources = useDebounceCallback(updateResults, 250);
 
   React.useEffect(() => {
     debouncedUpdateResources(resources);

--- a/frontend/packages/kubevirt-plugin/src/utils/usePodsForVm.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/usePodsForVm.ts
@@ -81,7 +81,7 @@ export const usePodsForVm = (
     [vmName],
   );
 
-  const debouncedUpdateResources = useDebounceCallback<any>(updateResults, [updateResults], 250);
+  const debouncedUpdateResources = useDebounceCallback(updateResults, 250);
 
   React.useEffect(() => {
     debouncedUpdateResources(resources);

--- a/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
+++ b/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
@@ -28,7 +28,7 @@ const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({ trafficDa
     [dataModelContext.extensionsLoaded, dataModelContext.watchedResources, namespace],
   );
 
-  const debouncedUpdateResources = useDebounceCallback<any>(setResources, [setResources], 250);
+  const debouncedUpdateResources = useDebounceCallback(setResources, 250);
 
   const updatedResources = useK8sWatchResources<TopologyResourcesObject>(resourcesList);
   React.useEffect(() => debouncedUpdateResources(updatedResources), [


### PR DESCRIPTION
**Fixes**: 
Fixes https://issues.redhat.com/browse/ODC-5308
https://issues.redhat.com/browse/ODC-5314

**Analysis / Root cause**: 
Pod watchers were not updating when the resource changed.

**Solution Description**: 
Update the pod watcher's results when the resource changes.
Update the `useDebounceCallback` to remove dependencies in order to keep the debounce function stable in order to actually debounce the callback function.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug