### PR TITLE
Bug 1913455: Fix for topology flickering add page at load time

### DIFF
--- a/frontend/packages/topology/src/data-transforms/updateTopologyDataModel.ts
+++ b/frontend/packages/topology/src/data-transforms/updateTopologyDataModel.ts
@@ -13,7 +13,7 @@ export const updateTopologyDataModel = (
   monitoringAlerts: Alerts,
 ): Promise<{ loaded: boolean; loadError: string; model: Model }> => {
   const { extensionsLoaded, watchedResources } = dataModelContext;
-  if (!extensionsLoaded || !resources) {
+  if (!extensionsLoaded || !resources || !Object.keys(resources).length) {
     return Promise.resolve({ loaded: false, loadError: '', model: null });
   }
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5315

**Analysis / Root cause**: 
Intermittently, the useK8sWatchResources hook returns a blank list of resources before returning the requested resources. Since all resources are optional, the topology believes all resources are loaded and there really aren't any.

**Solution Description**: 
The resources returned should never be empty, if they are, do not flag that the resources have been loaded.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug