### PR TITLE
Changes to clarify the Job completions table column data

### DIFF
--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -85,7 +85,8 @@ const JobTableRow: RowFunction<JobKind> = ({ obj: job, index, key, style }) => {
       </TableData>
       <TableData className={tableColumnClasses[3]}>
         <Link to={`/k8s/ns/${job.metadata.namespace}/jobs/${job.metadata.name}/pods`} title="pods">
-          {job.status.succeeded || 0} of {completions}
+          <div>Desired {completions}</div>
+          <div>Succeeded {job.status.succeeded || 0}</div>
         </Link>
       </TableData>
       <TableData className={tableColumnClasses[4]}>{type}</TableData>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1902003 was opened regarding “Incorrect” sorting of the Job Completions column. The column data is sorting correctly on desired `{completions}` but the content is presented as `{succeeded} of {completions}` (eg 1 of 1) .   When sorted descending order, the following visually looks incorrect listed as, 2 of 20, 3 of 8, 1 of 1. 
To alleviate this confusion I suggest we include stack the `Desired {completions}` above `Succeeded {job.status.succeeded || 0}`.

<img width="922" alt="Screen Shot 2021-01-06 at 3 36 41 PM" src="https://user-images.githubusercontent.com/1874151/103833379-e1268000-504e-11eb-900a-36f5db5731db.png">
<img width="920" alt="Screen Shot 2021-01-06 at 3 32 54 PM" src="https://user-images.githubusercontent.com/1874151/103833383-e4ba0700-504e-11eb-8b44-591e105082f3.png">
 