### PR TITLE
Bug 1909004: make filesystem queries compatible with both RHCOS and RHEL nodes

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -468,11 +468,11 @@ const fetchNodeMetrics = (): Promise<NodeMetrics> => {
     {
       key: 'usedStorage',
       query:
-        'sum by (instance) (node_filesystem_size_bytes{mountpoint="/var"} - node_filesystem_free_bytes{mountpoint="/var"})',
+        'sum by (instance) (node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_free_bytes{mountpoint="/"})',
     },
     {
       key: 'totalStorage',
-      query: 'sum by (instance) (node_filesystem_size_bytes{mountpoint="/var"})',
+      query: 'sum by (instance) (node_filesystem_size_bytes{mountpoint="/"})',
     },
     {
       key: 'cpu',

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
@@ -37,10 +37,10 @@ const queries = {
   [NodeQueries.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance='<%= node %>'}`),
   [NodeQueries.POD_COUNT]: _.template(`kubelet_running_pods{instance=~'<%= ipAddress %>:.*'}`),
   [NodeQueries.FILESYSTEM_USAGE]: _.template(
-    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/var"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/var"})`,
+    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/"})`,
   ),
   [NodeQueries.FILESYSTEM_TOTAL]: _.template(
-    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/var"})`,
+    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/"})`,
   ),
   [NodeQueries.NETWORK_IN_UTILIZATION]: _.template(
     `instance:node_network_receive_bytes:rate:sum{instance='<%= node %>'}`,

--- a/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
@@ -44,7 +44,7 @@ const top25Queries = {
   [OverviewQuery.NODES_BY_MEMORY]:
     'topk(25, sort_desc(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes))',
   [OverviewQuery.NODES_BY_STORAGE]:
-    'topk(25, sort_desc(sum(node_filesystem_size_bytes{mountpoint="/var"} - node_filesystem_avail_bytes{instance=~".*",mountpoint="/var"}) BY (instance)))',
+    'topk(25, sort_desc(sum(node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_avail_bytes{instance=~".*",mountpoint="/"}) BY (instance)))',
   [OverviewQuery.NODES_BY_PODS]:
     'topk(25, sort_desc(sum(avg_over_time(kubelet_running_pods[5m])) BY (node)))',
   [OverviewQuery.NODES_BY_NETWORK_IN]:
@@ -74,8 +74,8 @@ const overviewQueries = {
   [OverviewQuery.CPU_UTILIZATION]: 'cluster:cpu_usage_cores:sum',
   [OverviewQuery.CPU_TOTAL]: 'sum(cluster:capacity_cpu_cores:sum)',
   [OverviewQuery.STORAGE_UTILIZATION]:
-    '(sum(node_filesystem_size_bytes{mountpoint="/var"}) - sum(node_filesystem_free_bytes{mountpoint="/var"}))',
-  [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes{mountpoint="/var"})',
+    '(sum(node_filesystem_size_bytes{mountpoint="/"}) - sum(node_filesystem_free_bytes{mountpoint="/"}))',
+  [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes{mountpoint="/"})',
   [OverviewQuery.POD_UTILIZATION]: 'count(kube_pod_info)',
   [OverviewQuery.NETWORK_IN_UTILIZATION]:
     'sum(instance:node_network_receive_bytes_excluding_lo:rate1m)',

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/queries.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/queries.ts
@@ -28,10 +28,10 @@ const nodeQueriesByNodeName = {
   [HostQuery.MEMORY_UTILIZATION]: _.template(`node_memory_Active_bytes{instance=~'<%= node %>'}`),
   [HostQuery.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance=~'<%= node %>'}`),
   [HostQuery.STORAGE_UTILIZATION]: _.template(
-    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/var"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/var"})`,
+    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/"})`,
   ),
   [HostQuery.STORAGE_TOTAL]: _.template(
-    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/var"})`,
+    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/"})`,
   ),
   [HostQuery.NETWORK_IN_UTILIZATION]: _.template(
     `instance:node_network_receive_bytes:rate:sum{instance=~'<%= node %>'}`,


### PR DESCRIPTION
https://github.com/openshift/console/pull/7201 fixed filesystem queries for RHCOS nodes but does not work for RHEL nodes.

For RHCOS, both `/` and `/var` are bind mounts to the same underlying `/sysroot`, which is just a dm-crypt on the 4th GPT disk partition.

```
$ lsblk
NAME                         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
vda                          252:0    0   120G  0 disk 
├─vda1                       252:1    0   384M  0 part /boot
├─vda2                       252:2    0   127M  0 part /boot/efi
├─vda3                       252:3    0     1M  0 part 
└─vda4                       252:4    0 119.5G  0 part 
  └─coreos-luks-root-nocrypt 253:0    0 119.5G  0 dm   /sysroot
```

Thus, using `/` instead of `/var` is less precise for RHCOS nodes, but should still provide correct behavior for RHCOS and mostly correct behavior for RHEL nodes.  If the RHEL node is using a separate `/var` partition, it will not be correct.  Right now, however, RHEL nodes show no data at all, which is the bug for which this PR is opened.

@spadgett @jhadvig 