### PR TITLE
Bug 1911382: If source PVC is selected, volumeMode changes to source volumeMode.

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -293,6 +293,7 @@
   "Storage class": "Storage class",
   "Access mode": "Access mode",
   "Volume mode": "Volume mode",
+  "Volume Mode is set by Source PVC": "Volume Mode is set by Source PVC",
   "Boot source type": "Boot source type",
   "--- Select boot source ---": "--- Select boot source ---",
   "Select boot source": "Select boot source",

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -69,6 +69,7 @@ import { FirehoseResourceEnhanced } from '../../types/custom';
 import { parseVMWizardInitialData } from '../../utils/url';
 import { VMWizardInitialData } from '../../types/url';
 import { getTemplateName } from '../../selectors/vm-template/basic';
+import { useUpdateStorages } from '../../hooks/use-update-data-volume';
 
 import './create-vm-wizard.scss';
 
@@ -478,6 +479,7 @@ export const CreateVMWizardPageComponent: React.FC<CreateVMWizardPageComponentPr
     [commonTemplates, userMode],
   );
 
+  useUpdateStorages(reduxID);
   const openshiftCNVBaseImagesListResult = useBaseImages(loadedCommonTemplates);
   // TODO integrate the list of watches into the redux store to prevent unnecessary copying of data
   const openshiftCNVBaseImages = React.useMemo(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -59,7 +59,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
   );
 
   const [namespace, setNamespace] = React.useState<string>(
-    new DataVolumeWrapper(dataVolume).getPesistentVolumeClaimNamespace() || vmNamespace,
+    new DataVolumeWrapper(dataVolume).getPersistentVolumeClaimNamespace() || vmNamespace,
   );
 
   const resources = [

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form-reducer.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form-reducer.ts
@@ -34,11 +34,13 @@ export type BootSourceState = {
   container?: { value: string; validation: ValidationObject };
   pvcName?: { value: string };
   pvcNamespace?: { value: string };
+  pvcVolumeMode?: { value: string };
   pvcSize?: { value: string };
   storageClass: { value: string };
   accessMode: { value: string };
   provider?: { value: string };
   volumeMode: { value: string };
+  volumeModeFlag: { value: boolean };
 };
 
 export enum BOOT_ACTION_TYPE {
@@ -56,6 +58,8 @@ export enum BOOT_ACTION_TYPE {
   SET_ACCESS_MODE = 'accessMode',
   SET_PROVIDER = 'provider',
   SET_VOLUME_MODE = 'volumeMode',
+  SET_PVC_VOLUME_MODE = 'pvcVolumeMode',
+  SET_VOLUME_MODE_FLAG = 'volumeModeFlag',
 }
 
 export type BootSourceAction =
@@ -67,6 +71,14 @@ export type BootSourceAction =
   | { type: BOOT_ACTION_TYPE.SET_URL; payload: BootSourceState['url']['value'] }
   | { type: BOOT_ACTION_TYPE.SET_CONTAINER; payload: BootSourceState['container']['value'] }
   | { type: BOOT_ACTION_TYPE.SET_PVC_NAME; payload: BootSourceState['pvcName']['value'] }
+  | {
+      type: BOOT_ACTION_TYPE.SET_PVC_VOLUME_MODE;
+      payload: BootSourceState['pvcVolumeMode']['value'];
+    }
+  | {
+      type: BOOT_ACTION_TYPE.SET_VOLUME_MODE_FLAG;
+      payload: BootSourceState['volumeModeFlag']['value'];
+    }
   | { type: BOOT_ACTION_TYPE.SET_PVC_NAMESPACE; payload: BootSourceState['pvcNamespace']['value'] }
   | { type: BOOT_ACTION_TYPE.SET_PVC_SIZE; payload: BootSourceState['pvcSize']['value'] }
   | { type: BOOT_ACTION_TYPE.SET_STORAGE_CLASS; payload: BootSourceState['storageClass']['value'] }
@@ -89,12 +101,14 @@ export const initBootFormState: BootSourceState = {
   container: undefined,
   pvcName: undefined,
   pvcNamespace: undefined,
+  pvcVolumeMode: undefined,
   isValid: false,
   pvcSize: undefined,
   storageClass: undefined,
   accessMode: { value: AccessMode.READ_WRITE_ONCE.getValue() },
   provider: undefined,
   volumeMode: undefined,
+  volumeModeFlag: { value: false },
 };
 
 export const bootFormReducer = (

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
@@ -106,7 +106,7 @@ const DiskModalFirehose: React.FC<DiskModalFirehoseProps> = (props) => {
   const vmNamespace = getNamespace(vmLikeEntity);
 
   const [namespace, setNamespace] = React.useState<string>(
-    new DataVolumeWrapper(props.dataVolume).getPesistentVolumeClaimNamespace() || vmNamespace,
+    new DataVolumeWrapper(props.dataVolume).getPersistentVolumeClaimNamespace() || vmNamespace,
   );
 
   const resources = [

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-source.tsx
@@ -228,8 +228,8 @@ export const SourceDescription: React.FC<SourceDescriptionProps> = ({ sourceStat
         case DataVolumeSourceType.PVC:
           return (
             <PVCSource
-              name={dvWrapper.getPesistentVolumeClaimName()}
-              namespace={dvWrapper.getPesistentVolumeClaimNamespace()}
+              name={dvWrapper.getPersistentVolumeClaimName()}
+              namespace={dvWrapper.getPersistentVolumeClaimNamespace()}
               isCDRom={isCDRom}
               clone
             />

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/provision-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/provision-source.ts
@@ -165,7 +165,7 @@ export class ProvisionSource extends SelectDropdownObjectEnum<string> {
         case StorageUISource.ATTACH_CLONED_DISK:
           return {
             type: ProvisionSource.DISK,
-            source: `${dataVolumeWrapper.getPesistentVolumeClaimNamespace()}/${dataVolumeWrapper.getPesistentVolumeClaimName()}`,
+            source: `${dataVolumeWrapper.getPersistentVolumeClaimNamespace()}/${dataVolumeWrapper.getPersistentVolumeClaimName()}`,
           };
         case StorageUISource.ATTACH_DISK:
           return {

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-update-data-volume.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-update-data-volume.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { PersistentVolumeClaimModel } from '../../../../public/models/index';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector, useDispatch } from 'react-redux';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { getStorages } from '../components/create-vm-wizard/selectors/selectors';
+import { VMWizardStorage } from '../components/create-vm-wizard/types';
+import { ActionType } from '../components/create-vm-wizard/redux/types';
+import { vmWizardActions } from '../components/create-vm-wizard/redux/actions';
+import { PersistentVolumeClaimKind } from '@console/internal/module/k8s';
+
+export const useUpdateStorages = (reduxID) => {
+  const dispatch = useDispatch();
+  const rootDisk = useSelector((state) =>
+    getStorages(state, reduxID)?.find(({ disk }) => disk?.name === 'rootdisk'),
+  );
+
+  const name = rootDisk?.dataVolume?.spec?.source?.pvc?.name;
+  const namespace = rootDisk?.dataVolume?.spec?.source?.pvc?.namespace;
+  const sourcePvc =
+    name && namespace
+      ? {
+          kind: PersistentVolumeClaimModel.kind,
+          namespace,
+          name,
+        }
+      : null;
+
+  const updateStorage = React.useCallback(
+    (storage: VMWizardStorage) => {
+      dispatch(vmWizardActions[ActionType.UpdateStorage](reduxID, storage));
+    },
+    [dispatch, reduxID],
+  );
+
+  const [pvc] = useK8sWatchResource<PersistentVolumeClaimKind>(sourcePvc);
+
+  if (pvc && rootDisk && rootDisk.dataVolume.spec.pvc.volumeMode !== pvc?.spec?.volumeMode) {
+    rootDisk.dataVolume.spec.pvc.volumeMode = pvc?.spec?.volumeMode;
+    updateStorage(rootDisk);
+  }
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
@@ -163,7 +163,7 @@ export class CombinedDisk {
       return this.volumeWrapper?.getPersistentVolumeClaimName();
     }
     if (source === StorageUISource.ATTACH_CLONED_DISK) {
-      return this.dataVolumeWrapper?.getPesistentVolumeClaimName();
+      return this.dataVolumeWrapper?.getPersistentVolumeClaimName();
     }
 
     return null;

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
@@ -49,9 +49,9 @@ export class DataVolumeWrapper extends K8sResourceObjectWithTypePropertyWrapper<
 
   getStorageClassName = () => getDataVolumeStorageClassName(this.data as any);
 
-  getPesistentVolumeClaimName = () => this.getIn(['spec', 'source', 'pvc', 'name']);
+  getPersistentVolumeClaimName = () => this.getIn(['spec', 'source', 'pvc', 'name']);
 
-  getPesistentVolumeClaimNamespace = () => this.getIn(['spec', 'source', 'pvc', 'namespace']);
+  getPersistentVolumeClaimNamespace = () => this.getIn(['spec', 'source', 'pvc', 'namespace']);
 
   getURL = () => this.getIn(['spec', 'source', 'http', 'url']);
 


### PR DESCRIPTION
If source PVC is selected, volumeMode changes to source volumeMode. volumeMode field will be disabled for changing and info message will be presented

*Also fixed a small typo in 2 functions names.

Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1911382

**Analysis / Root cause**: 
If source PVC was presented, volumeMode didn't change according to it.

**Solution Description**: 
Added support to read and apply the value of volumeMode from source PVC.

**Screen shots / Gifs for design review**: 
![Bug 1911382](https://user-images.githubusercontent.com/14824964/103908012-ac77fe80-510a-11eb-9e57-e21432756022.gif)
