### PR TITLE
Bug 1913851: sort cluster task in pipeline builder

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskListNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskListNode.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Button, Flex, FlexItem, FocusTrap } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
@@ -43,10 +44,13 @@ const TaskListNode: React.FC<TaskListNodeProps> = ({ element, unselectedText }) 
   const { height, width } = element.getBounds();
   const { clusterTaskList, namespaceTaskList, onNewTask, onRemoveTask } = element.getData();
 
-  const options = [
-    ...namespaceTaskList.map((task) => taskToOption(task, onNewTask)),
-    ...clusterTaskList.map((task) => taskToOption(task, onNewTask)),
-  ];
+  const options = _.sortBy(
+    [
+      ...namespaceTaskList.map((task) => taskToOption(task, onNewTask)),
+      ...clusterTaskList.map((task) => taskToOption(task, onNewTask)),
+    ],
+    (o) => o.label,
+  );
 
   return (
     <foreignObject width={width} height={height} className="odc-task-list-node">


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5304

**Analysis / Root cause**: 
Task selection dropdown in the pipeline builder contains an unsorted list of items.

**Solution Description**: 
Sort the cluster tasks in the pipeline builder

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/103926201-9dab3f00-513e-11eb-8339-6dc447ee15e5.png)
