### PR TITLE
Bug 1902003: Clarification of Jobs completions column data when sorting

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -131,7 +131,7 @@ const sorts = {
   dataSize: (resource) => _.size(_.get(resource, 'data')) + _.size(_.get(resource, 'binaryData')),
   ingressValidHosts,
   serviceCatalogStatus,
-  jobCompletions: (job) => getJobTypeAndCompletions(job).completions,
+  jobCompletionsSucceeded: (job) => job?.status?.succeeded || 0,
   jobType: (job) => getJobTypeAndCompletions(job).type,
   nodeReadiness: (node: NodeKind) => {
     let readiness = _.get(node, 'status.conditions');

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -217,7 +217,7 @@ const JobsList: React.FC = (props) => {
     },
     {
       title: t('public~Completions'),
-      sortFunc: 'jobCompletions',
+      sortFunc: 'jobCompletionsSucceeded',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -271,7 +271,7 @@ export const MachineSetList: React.SFC = (props) => {
       },
       {
         title: t('machine-sets~Machines'),
-        sortField: 'status.replicas',
+        sortField: 'status.readyReplicas',
         transforms: [sortable],
         props: { className: tableColumnClasses[2] },
       },


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1902003 was opened regarding “Incorrect” sorting of the Job Completions column. The column data is sorting correctly on desired `{completions}` but the content is presented as `{succeeded} of {completions}` (eg 1 of 1) .   When sorted descending order, the following visually looks incorrect listed as, 2 of 20, 3 of 8, 1 of 1. 
To alleviate this confusion I suggest we include stack the `Desired {completions}` above `Succeeded {job.status.succeeded || 0}`.

<img width="922" alt="Screen Shot 2021-01-06 at 3 36 41 PM" src="https://user-images.githubusercontent.com/1874151/103833379-e1268000-504e-11eb-900a-36f5db5731db.png">
<img width="920" alt="Screen Shot 2021-01-06 at 3 32 54 PM" src="https://user-images.githubusercontent.com/1874151/103833383-e4ba0700-504e-11eb-8b44-591e105082f3.png">
 