### PR TITLE
Bug 1914196: Use route port field for docker container port in Dockerfile import

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -202,8 +202,6 @@
   "Dockerfile": "Dockerfile",
   "Dockerfile path": "Dockerfile path",
   "Allows the builds to use a different path to locate your Dockerfile, relative to the Context Dir field.": "Allows the builds to use a different path to locate your Dockerfile, relative to the Context Dir field.",
-  "Container port": "Container port",
-  "Port number the Container exposes.": "Port number the Container exposes.",
   "Validating": "Validating",
   "No Devfile present, unable to continue": "No Devfile present, unable to continue",
   "Validated": "Validated",

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -546,7 +546,7 @@ export const gitImportInitialValues: GitImportFormData = {
     secret: '',
     isUrlValidating: false,
   },
-  docker: { dockerfilePath: 'Dockerfile', containerPort: 8080 },
+  docker: { dockerfilePath: 'Dockerfile' },
   image: {
     selected: 'python',
     recommended: '',

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -314,7 +314,6 @@ export const getIconInitialValues = (editAppResource: K8sResourceKind) => {
 export const getGitAndDockerfileInitialValues = (
   buildConfig: K8sResourceKind,
   pipeline: Pipeline,
-  route: K8sResourceKind,
 ) => {
   if (_.isEmpty(buildConfig) && _.isEmpty(pipeline)) {
     return {};
@@ -331,7 +330,6 @@ export const getGitAndDockerfileInitialValues = (
         buildConfig?.spec?.strategy?.dockerStrategy?.dockerfilePath ||
         pipeline?.spec?.params?.find((param) => param?.name === 'DOCKERFILE')?.default ||
         'Dockerfile',
-      containerPort: parseInt(_.split(_.get(route, 'spec.port.targetPort'), '-')[0], 10),
     },
     image: {
       selected:
@@ -456,11 +454,7 @@ export const getInitialValues = (
     appName,
     namespace,
   );
-  const gitDockerValues = getGitAndDockerfileInitialValues(
-    buildConfigData,
-    pipelineData,
-    routeData,
-  );
+  const gitDockerValues = getGitAndDockerfileInitialValues(buildConfigData, pipelineData);
 
   let iconValues = {};
   let externalImageValues = {};

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -75,7 +75,6 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
     },
     docker: {
       dockerfilePath: 'Dockerfile',
-      containerPort: 8080,
     },
     image: {
       selected: '',

--- a/frontend/packages/dev-console/src/components/import/ImportSamplePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportSamplePage.tsx
@@ -82,7 +82,6 @@ const ImportSamplePage: React.FC<ImportSamplePageProps> = ({ match }) => {
     },
     docker: {
       dockerfilePath: 'Dockerfile',
-      containerPort: 8080,
     },
     image: {
       selected: imageName,

--- a/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
@@ -24,7 +24,6 @@ export const mockFormData: GitImportFormData = {
   },
   docker: {
     dockerfilePath: 'Dockerfile',
-    containerPort: 8080,
   },
   image: {
     selected: 'nodejs',

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
@@ -170,7 +170,6 @@ export const defaultData: GitImportFormData = {
   },
   docker: {
     dockerfilePath: 'Dockerfile',
-    containerPort: 8080,
   },
   pipeline: {
     enabled: false,

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -242,14 +242,14 @@ describe('ValidationUtils', () => {
     it('should throw an error if containerPort is not an integer', async () => {
       const mockData = cloneDeep(mockFormData);
       mockData.build.strategy = 'Docker';
-      mockData.docker.containerPort = 808.5;
+      mockData.route.unknownTargetPort = '808.5';
       await validationSchema(t)
         .isValid(mockData)
         .then((valid) => expect(valid).toEqual(false));
       await validationSchema(t)
         .validate(mockData)
         .catch((err) => {
-          expect(err.message).toBe('devconsole~Container port should be an integer');
+          expect(err.message).toBe('devconsole~Port must be an Integer.');
         });
     });
 

--- a/frontend/packages/dev-console/src/components/import/git/DockerSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/DockerSection.tsx
@@ -21,13 +21,6 @@ const DockerSection: React.FC<DockerSectionProps> = ({ buildStrategy }) => {
             'devconsole~Allows the builds to use a different path to locate your Dockerfile, relative to the Context Dir field.',
           )}
         />
-        <InputField
-          type={TextInputTypes.number}
-          name="docker.containerPort"
-          label={t('devconsole~Container port')}
-          helpText={t('devconsole~Port number the Container exposes.')}
-          style={{ maxWidth: '100%' }}
-        />
       </FormSection>
     )
   );

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -160,7 +160,6 @@ export interface GitData {
 
 export interface DockerData {
   dockerfilePath?: string;
-  containerPort?: number;
 }
 
 type DevfileData = {

--- a/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
@@ -13,7 +13,7 @@ describe('Shared submit utils', () => {
       let serviceObj;
 
       mockData.build.strategy = 'Docker';
-      mockData.docker.containerPort = 8080;
+      mockData.route.unknownTargetPort = '8080';
       serviceObj = createService(mockData);
       expect(serviceObj.spec.ports[0].port).toEqual(8080);
 
@@ -42,7 +42,7 @@ describe('Shared submit utils', () => {
       let routeObj;
 
       mockData.build.strategy = 'Docker';
-      mockData.docker.containerPort = 8080;
+      mockData.route.unknownTargetPort = '8080';
       routeObj = createRoute(mockData);
       expect(routeObj.spec.port.targetPort).toEqual('8080-tcp');
 

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -43,8 +43,8 @@ export const createService = (
 
   let ports = imagePorts;
   const buildStrategy = formData.build?.strategy;
-  if (buildStrategy === 'Docker') {
-    const port = { containerPort: _.get(formData, 'docker.containerPort'), protocol: 'TCP' };
+  if (buildStrategy === 'Docker' && unknownTargetPort) {
+    const port = { containerPort: _.toInteger(unknownTargetPort), protocol: 'TCP' };
     ports = [port];
   } else if (buildStrategy === 'Devfile' && !_.isEmpty(originalService?.spec?.ports)) {
     ports = [
@@ -129,10 +129,9 @@ export const createRoute = (
 
   let targetPort: string;
   const buildStrategy = formData.build?.strategy;
-  if (buildStrategy === 'Docker') {
-    const port = _.get(formData, 'docker.containerPort');
+  if (buildStrategy === 'Docker' && unknownTargetPort) {
     targetPort = makePortName({
-      containerPort: _.toInteger(port),
+      containerPort: _.toInteger(unknownTargetPort),
       protocol: 'TCP',
     });
   } else if (buildStrategy === 'Devfile') {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4866
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When using the `from dockerfile` add flow, there are 2 similar fields that are used to specify which port the application is listening on: dockerfile conainer port & route target port
No matter what value is entered, `target port` never persisted anywhere.

**Solution Description**: 
Remove the docker container port, and use only the route target port to create the service and route.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/104005655-7c446480-51cb-11eb-9905-8d47049886b7.mp4

cc: @openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug