### PR TITLE
Bug 1914209: Associate image secret name to pipeline serviceaccount imagePullSecrets

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineSecretSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineSecretSection.tsx
@@ -51,7 +51,11 @@ const PipelineSecretSection: React.FC<PipelineSecretSectionProps> = ({ namespace
       .then((resp) => {
         actions.setSubmitting(false);
         setFieldValue(secretOpenField.name, false);
-        associateServiceAccountToSecret(resp, namespace);
+        associateServiceAccountToSecret(
+          resp,
+          namespace,
+          values.annotations.key === SecretAnnotationId.Image,
+        );
       })
       .catch((err) => {
         actions.setSubmitting(false);

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-serviceaccount-test-data.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-serviceaccount-test-data.ts
@@ -1,0 +1,19 @@
+export const mockPipelineServiceAccount = {
+  kind: 'ServiceAccount',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'pipeline',
+    namespace: 'karthik',
+    uid: 'fc2e60f5-d42f-4ba7-82ee-e03be2cbe2a8',
+  },
+  secrets: [
+    {
+      name: 'pipeline-dockercfg-p2jwc',
+    },
+  ],
+  imagePullSecrets: [
+    {
+      name: 'pipeline-dockercfg-p2jwc',
+    },
+  ],
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5305

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
While adding secret for `image Registry` in start pipeline model, the pipeline service account is missing the new secret name in the `imagePullSecrets` property.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
While adding Image Registry secret, associate the secret name to the `imagePullSecrets` on `pipeline` SA 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
no UI changes

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/9964343/104008573-9d0eb900-51cf-11eb-9005-c0c4030fccf8.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. In start pipeline modal, Advanced Options -> Add Secret
2. Choose Image Registry option
3. Fill the details and click on create secret check button.

 `pipeline` Service account should contain the newly created secret name in `imagePullSecrets`
 eg: 
 ```kind: ServiceAccount
apiVersion: v1
metadata:
  name: pipeline
  namespace: karthik
  uid: fc2e60f5-d42f-4ba7-82ee-e03be2cbe2a8
secrets:
  - name: pipeline-token-nk644
  - name: pipeline-dockercfg-p2jwc
  - name: image-secret
imagePullSecrets:
  - name: pipeline-dockercfg-p2jwc
  - name: image-secret
```

cc: @praveen4g0 @andrewballantyne 