### PR TITLE
Bug 1914212: Add test to validate bootable disk souce

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/mocks.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/mocks.ts
@@ -84,14 +84,18 @@ export const kubevirtStorage = getResourceObject(
   'configMap',
 );
 
-export const getTestDataVolume = () =>
-  dataVolumeManifest({
-    name: `testdv-${testName}`,
-    namespace: testName,
+export const AccessMode = resolveStorageDataAttribute(kubevirtStorage, 'accessMode');
+export const VolumeMode = resolveStorageDataAttribute(kubevirtStorage, 'volumeMode');
+
+export const getTestDataVolume = (name?: string, namespace?: string) => {
+  return dataVolumeManifest({
+    name: name || `testdv-${testName}`,
+    namespace: namespace || testName,
     sourceURL: ProvisionSource.URL.getSource(),
-    accessMode: resolveStorageDataAttribute(kubevirtStorage, 'accessMode'),
-    volumeMode: resolveStorageDataAttribute(kubevirtStorage, 'volumeMode'),
+    accessMode: AccessMode,
+    volumeMode: VolumeMode,
   });
+};
 
 export const getDiskToCloneFrom = (): Disk => {
   const testDV = getTestDataVolume();
@@ -160,7 +164,7 @@ export const rwxRootDisk = {
     volumeMode: diskVolumeMode.Block,
   },
 };
-deepFreeze(rootDisk);
+deepFreeze(rwxRootDisk);
 
 export const containerRootDisk: Disk = {
   name: 'rootdisk',
@@ -278,8 +282,8 @@ function getMetadata(
     },
     spec: {
       pvc: {
-        accessModes: [resolveStorageDataAttribute(kubevirtStorage, 'accessMode')],
-        volumeMode: resolveStorageDataAttribute(kubevirtStorage, 'volumeMode'),
+        accessModes: [AccessMode],
+        volumeMode: VolumeMode,
         resources: {
           requests: {
             storage: '1Gi',

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/vmBuilder.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/vmBuilder.ts
@@ -1,6 +1,5 @@
 import { BaseVMBuilder } from './baseVMBuilder';
 import { VMBuilderData } from '../types/vm';
-import { DiskAdvance } from '../types/types';
 import { VirtualMachineModel } from '../../../src/models/index';
 import { VirtualMachine } from './virtualMachine';
 
@@ -34,8 +33,8 @@ export class VMBuilder extends BaseVMBuilder<VMBuilderData> {
     return this;
   }
 
-  public setDiskAdvance(diskAdvance: DiskAdvance) {
-    this.data.diskAdvance = diskAdvance;
+  public setPVCName(pvcName: string) {
+    this.data.pvcName = pvcName;
     return this;
   }
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/types/types.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/types/types.ts
@@ -23,8 +23,8 @@ export type Disk = {
   name?: string;
   size?: string;
   storageClass?: string;
-  interface: string;
-  drive: DISK_DRIVE;
+  interface?: string;
+  drive?: DISK_DRIVE;
   advanced?: {
     volumeMode?: string;
     accessMode?: string;
@@ -143,10 +143,4 @@ export const VirtualMachineTemplateModel: K8sKind = {
   namespaced: true,
   kind: 'Template',
   id: 'template',
-};
-
-export type DiskAdvance = {
-  StorageClass?: string;
-  AccessMode?: string;
-  VolumeMode?: string;
 };

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/types/vm.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/types/vm.ts
@@ -1,4 +1,4 @@
-import { FlavorConfig, Network, Disk, CloudInitConfig, DiskAdvance } from './types';
+import { FlavorConfig, Network, Disk, CloudInitConfig } from './types';
 import { V1Disk } from '../../../src/types/vm/disk/V1Disk';
 import { V1Volume } from '../../../src/types/vm/disk/V1Volume';
 import { V1alpha1DataVolume } from '../../../src/types/vm/disk/V1alpha1DataVolume';
@@ -41,9 +41,9 @@ export type VMBuilderData = BaseVMBuilderData & {
   startOnCreation?: boolean;
   template?: string;
   pvcSize?: string;
+  pvcName?: string;
   customize?: boolean;
   mountAsCDROM?: boolean;
-  diskAdvance?: DiskAdvance;
 };
 
 export type KubevirtResourceConfig = {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/common.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/common.ts
@@ -57,6 +57,7 @@ export const VIRTUALIZATION_TITLE = 'Virtualization';
 // Wizard strings
 export const IMPORT_WIZARD_CONN_TO_NEW_INSTANCE = 'Connect to New Instance';
 export const NOT_RECOMMENDED_BUS_TYPE_WARN = 'Not recommended bus type';
+export const RECOMMENDED = 'Recommended';
 // Some times we need to use existing VMWare instance, which name always starts from 'administrator'
 export const IMPORT_WIZARD_CONN_NAME_PREFIX = 'admin';
 export const RHV_PROVIDER = 'Red Hat Virtualization (RHV)';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/vm.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/vm.ts
@@ -72,10 +72,11 @@ Object.freeze(networkTabCol);
 // Storage
 export enum DISK_SOURCE {
   AttachDisk = 'Use an existing PVC',
-  AttachClonedDisk = 'Clone an existing PVC',
+  AttachClonedDisk = 'Clone existing PVC',
   Blank = 'Blank',
-  Container = 'Container',
-  Url = 'Upload via URL',
+  Container = 'Import via Registry (creates PVC)',
+  EphemeralContainer = 'Container (ephemeral)',
+  Url = 'Import via URL',
 }
 
 export enum DISK_DRIVE {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
@@ -200,6 +200,12 @@ export const selectNonDefaultAccessMode = (defaultAccessMode) => {
   return diskAccessMode[accessModeKeys[0]];
 };
 
+export const selectAccessModeFromCM = (accessMode) => {
+  const accessModeKeys = _.keys(diskAccessMode);
+  const key = accessModeKeys.filter((k) => k === accessMode);
+  return diskAccessMode[key[0]];
+};
+
 export const selectNonDefaultVolumeMode = (defaultVolumeMode) => {
   const volumeModeKeys = _.keys(diskVolumeMode);
   volumeModeKeys.filter((k) => k !== defaultVolumeMode);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.dedicated-resources.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.dedicated-resources.scenario.ts
@@ -1,58 +1,56 @@
 import { browser, ExpectedConditions as until } from 'protractor';
-import { testName } from '@console/internal-integration-tests/protractor.conf';
-import { createResource, deleteResource, click } from '@console/shared/src/test-utils/utils';
+import { click, withResource, removeLeakedResources } from '@console/shared/src/test-utils/utils';
 import { isDedicatedCPUPlacement } from '../../src/selectors/vm';
 import * as editDedicatedResourcesView from '../views/dialogs/editDedicatedResourcesView';
 import * as virtualMachineView from '../views/virtualMachine.view';
 import { saveButton } from '../views/kubevirtUIResource.view';
 import { VM_CREATE_AND_EDIT_TIMEOUT_SECS } from './utils/constants/common';
-import { VirtualMachine } from './models/virtualMachine';
-import { getVMManifest } from './mocks/mocks';
-import { getRandStr } from './utils/utils';
+import { VMBuilder } from './models/vmBuilder';
+import { getBasicVMBuilder } from './mocks/vmBuilderPresets';
 import { ProvisionSource } from './utils/constants/enums/provisionSource';
 
 describe('KubeVirt VM detail - edit Dedicated Resources', () => {
-  const testVM = getVMManifest(
-    ProvisionSource.CONTAINER,
-    testName,
-    `dedicatedresourcevm-${getRandStr(5)}`,
-  );
-  const vm = new VirtualMachine(testVM.metadata);
+  const leakedResources = new Set<string>();
+  const vm = new VMBuilder(getBasicVMBuilder())
+    .setProvisionSource(ProvisionSource.URL)
+    .setCustomize(true)
+    .setStartOnCreation(false)
+    .build();
+
   const isDedicatedCPU = () => expect(isDedicatedCPUPlacement(vm.getResource()));
 
-  beforeAll(async () => {
-    createResource(testVM);
-  });
-
   afterAll(() => {
-    deleteResource(testVM);
+    removeLeakedResources(leakedResources);
   });
 
   it(
     'ID(CNV-3731) Enables dedicated resources guaranteed policy, then disables it',
     async () => {
-      await vm.navigateToDetail();
-      await vm.modalEditDedicatedResources();
-      await click(editDedicatedResourcesView.guaranteedPolicyCheckbox);
-      await click(saveButton);
-      await browser.wait(
-        until.textToBePresentInElement(
-          virtualMachineView.vmDetailDedicatedResources(vm.namespace, vm.name),
-          editDedicatedResourcesView.guaranteedPolicyText,
-        ),
-      );
-      isDedicatedCPU().toBeTruthy();
+      await vm.create();
+      await withResource(leakedResources, vm.asResource(), async () => {
+        await vm.navigateToDetail();
+        await vm.modalEditDedicatedResources();
+        await click(editDedicatedResourcesView.guaranteedPolicyCheckbox);
+        await click(saveButton);
+        await browser.wait(
+          until.textToBePresentInElement(
+            virtualMachineView.vmDetailDedicatedResources(vm.namespace, vm.name),
+            editDedicatedResourcesView.guaranteedPolicyText,
+          ),
+        );
+        isDedicatedCPU().toBeTruthy();
 
-      await vm.modalEditDedicatedResources();
-      await click(editDedicatedResourcesView.guaranteedPolicyCheckbox);
-      await click(saveButton);
-      await browser.wait(
-        until.textToBePresentInElement(
-          virtualMachineView.vmDetailDedicatedResources(vm.namespace, vm.name),
-          editDedicatedResourcesView.noGuaranteedPolicyText,
-        ),
-      );
-      isDedicatedCPU().toBeFalsy();
+        await vm.modalEditDedicatedResources();
+        await click(editDedicatedResourcesView.guaranteedPolicyCheckbox);
+        await click(saveButton);
+        await browser.wait(
+          until.textToBePresentInElement(
+            virtualMachineView.vmDetailDedicatedResources(vm.namespace, vm.name),
+            editDedicatedResourcesView.noGuaranteedPolicyText,
+          ),
+        );
+        isDedicatedCPU().toBeFalsy();
+      });
     },
     VM_CREATE_AND_EDIT_TIMEOUT_SECS,
   );

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
@@ -1,8 +1,10 @@
 import {
-  withResource,
   click,
+  createResource,
+  deleteResource,
   fillInput,
   removeLeakedResources,
+  withResource,
 } from '@console/shared/src/test-utils/utils';
 import * as virtualMachineView from '../views/virtualMachine.view';
 import { saveButton } from '../views/kubevirtUIResource.view';
@@ -11,35 +13,52 @@ import { selectOptionByText } from './utils/utils';
 import { getCPU, getMemory } from '../../src/selectors/vm/selectors';
 import { VMBuilder } from './models/vmBuilder';
 import { getBasicVMBuilder } from './mocks/vmBuilderPresets';
+import { getTestDataVolume } from './mocks/mocks';
+import { CLONE_VM_TIMEOUT_SECS } from './utils/constants/common';
 import { ProvisionSource } from './utils/constants/enums/provisionSource';
 
 describe('KubeVirt VM detail - edit flavor', () => {
   const leakedResources = new Set<string>();
+  const dvName = 'testdv-flavor';
+  const testDataVolume = getTestDataVolume(dvName);
   const vm = new VMBuilder(getBasicVMBuilder())
-    .setProvisionSource(ProvisionSource.CONTAINER)
+    .setProvisionSource(ProvisionSource.DISK)
+    .setPVCName(dvName)
     .build();
+
+  beforeAll(() => {
+    createResource(testDataVolume);
+  });
 
   afterEach(() => {
     removeLeakedResources(leakedResources);
   });
 
-  it('ID(CNV-3076) Changes tiny to custom', async () => {
-    await vm.create();
-    await withResource(leakedResources, vm.asResource(), async () => {
-      await vm.navigateToDetail();
-      await vm.modalEditFlavor();
-      await selectOptionByText(editFlavorView.flavorDropdown, 'Custom');
-      await fillInput(editFlavorView.cpusInput(), '2');
-      await fillInput(editFlavorView.memoryInput(), '3');
-      await click(saveButton);
-
-      expect(getCPU(vm.getResource()).cores).toEqual(2);
-      expect(getMemory(vm.getResource())).toEqual('3Gi');
-      expect(
-        (await virtualMachineView.vmDetailLabelValue('vm.kubevirt.io/template')).startsWith(
-          'rhel7-highperformance-large-', // template is not changed (might be in the future)
-        ),
-      ).toBeTruthy();
-    });
+  afterAll(() => {
+    deleteResource(testDataVolume);
   });
+
+  it(
+    'ID(CNV-3076) Changes tiny to custom',
+    async () => {
+      await vm.create();
+      await withResource(leakedResources, vm.asResource(), async () => {
+        await vm.navigateToDetail();
+        await vm.modalEditFlavor();
+        await selectOptionByText(editFlavorView.flavorDropdown, 'Custom');
+        await fillInput(editFlavorView.cpusInput(), '2');
+        await fillInput(editFlavorView.memoryInput(), '3');
+        await click(saveButton);
+
+        expect(getCPU(vm.getResource()).cores).toEqual(2);
+        expect(getMemory(vm.getResource())).toEqual('3Gi');
+        expect(
+          (await virtualMachineView.vmDetailLabelValue('vm.kubevirt.io/template')).startsWith(
+            'rhel7-highperformance-large-', // template is not changed (might be in the future)
+          ),
+        ).toBeTruthy();
+      });
+    },
+    CLONE_VM_TIMEOUT_SECS,
+  );
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.validation.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.validation.scenario.ts
@@ -1,29 +1,21 @@
 import { execSync } from 'child_process';
-import { browser } from 'protractor';
+import { browser, ExpectedConditions as until } from 'protractor';
 import { click, waitForStringInElement } from '@console/shared/src/test-utils/utils';
 import { VirtualMachineModel } from '@console/kubevirt-plugin/src/models';
-import {
-  KUBEVIRT_TEMPLATES_PATH,
-  KEBAP_ACTION,
-  PAGE_LOAD_TIMEOUT_SECS,
-  NOT_RECOMMENDED_BUS_TYPE_WARN,
-  CHARACTERS_NOT_ALLOWED,
-  SEC,
-} from './utils/constants/common';
+import { KUBEVIRT_TEMPLATES_PATH, KEBAP_ACTION, RECOMMENDED } from './utils/constants/common';
 import { Flavor, OperatingSystem, Workload } from './utils/constants/wizard';
+import { ProvisionSource } from './utils/constants/enums/provisionSource';
+import { DISK_SOURCE } from './utils/constants/vm';
 import { Wizard } from './models/wizard';
-import { FlavorConfig } from './types/types';
-import { customFlavorMemoryHintBlock, clickKebabAction, diskWarning } from '../views/wizard.view';
+import { Disk, FlavorConfig } from './types/types';
 import { getRandStr } from './utils/utils';
-import { diskInterfaceHelper } from '../views/dialogs/diskDialog.view';
+import * as view from '../views/wizard.view';
+import { diskInterface } from '../views/dialogs/diskDialog.view';
 import { DiskDialog } from './dialogs/diskDialog';
 import { saveButton } from '../views/kubevirtUIResource.view';
-import { vmNameHelper } from '../views/importWizard.view';
-import { ProvisionSource } from './utils/constants/enums/provisionSource';
 
 describe('Wizard validation', () => {
   const wizard = new Wizard();
-  const diskDialog = new DiskDialog();
   const customFlavorNotEnoughMemory: FlavorConfig = {
     flavor: Flavor.CUSTOM,
     cpu: '1',
@@ -46,27 +38,27 @@ describe('Wizard validation', () => {
   });
 
   beforeEach(async () => {
-    await wizard.openWizard(VirtualMachineModel);
+    await wizard.openWizard(VirtualMachineModel, true);
   });
 
   afterEach(async () => {
     await wizard.closeWizard();
+    await click(view.cancelButton);
   });
 
   it('ID(CNV-3697) Wizard validates custom flavor memory', async () => {
     await wizard.selectOperatingSystem(OperatingSystem.VALIDATION_TEST);
     await wizard.selectFlavor(customFlavorNotEnoughMemory);
     await browser.wait(
-      waitForStringInElement(customFlavorMemoryHintBlock, 'Memory must be at least'),
+      waitForStringInElement(view.customFlavorMemoryHintBlock, 'Memory must be at least'),
     );
     await wizard.selectFlavor(customFlavorSufficientMemory);
-    expect(customFlavorMemoryHintBlock.isPresent()).toBe(false);
+    expect(view.customFlavorMemoryHintBlock.isPresent()).toBe(false);
   });
 
   it('ID(CNV-3698) Disk Dialog displays warning when interface not recommended', async () => {
-    const WINDOWS_NOT_RECOMMENDED_INTERFACE = 'sata';
-    await wizard.selectProvisionSource(ProvisionSource.CONTAINER);
     await wizard.selectOperatingSystem(OperatingSystem.WINDOWS_10);
+    await wizard.selectProvisionSource(ProvisionSource.CONTAINER);
     await wizard.selectFlavor(customFlavorSufficientMemory);
     await wizard.selectWorkloadProfile(Workload.DESKTOP);
     await wizard.fillName(getRandStr(5));
@@ -74,27 +66,53 @@ describe('Wizard validation', () => {
     // Network tab
     await wizard.next();
     // Storage tab
-    await clickKebabAction('rootdisk', KEBAP_ACTION.Edit); // Open dialog
-    await diskDialog.selectInterface(WINDOWS_NOT_RECOMMENDED_INTERFACE);
-    await browser.wait(
-      waitForStringInElement(diskInterfaceHelper, NOT_RECOMMENDED_BUS_TYPE_WARN),
-      PAGE_LOAD_TIMEOUT_SECS,
-    );
+    await view.clickKebabAction('rootdisk', KEBAP_ACTION.Edit); // Open dialog
+    await browser.wait(waitForStringInElement(diskInterface, RECOMMENDED));
     await click(saveButton); // Close dialog
-    // Check that the Warning is also displayed in the storage list view
-    await browser.wait(
-      waitForStringInElement(diskWarning('rootdisk'), NOT_RECOMMENDED_BUS_TYPE_WARN),
-      PAGE_LOAD_TIMEOUT_SECS,
-    );
   });
 
   it('ID(CNV-4551) Import Wizard shows warning when using incorrect VM name', async () => {
     const WRONG_VM_NAME = 'VMNAME';
     await wizard.selectProvisionSource(ProvisionSource.CONTAINER);
-    await wizard.selectOperatingSystem(OperatingSystem.WINDOWS_10);
     await wizard.selectFlavor(customFlavorSufficientMemory);
     await wizard.selectWorkloadProfile(Workload.DESKTOP);
     await wizard.fillName(WRONG_VM_NAME);
-    await browser.wait(waitForStringInElement(vmNameHelper, CHARACTERS_NOT_ALLOWED), 2 * SEC);
+    await browser.wait(until.presenceOf(view.vmNameHelper));
+  });
+
+  it('ID(CNV-5469) Blank disk cannot be used as bootdisk', async () => {
+    const disk: Disk = { source: DISK_SOURCE.Blank, size: '1', name: 'blankdisk' };
+    const diskDialog = new DiskDialog();
+
+    await wizard.selectProvisionSource(ProvisionSource.DISK);
+    await wizard.selectFlavor(customFlavorSufficientMemory);
+    await wizard.selectWorkloadProfile(Workload.DESKTOP);
+    await wizard.fillName(getRandStr(5));
+    await wizard.next();
+    // Network tab
+    await wizard.next();
+    // Storage tab
+    await click(view.addDiskButton);
+    await diskDialog.create(disk);
+    await wizard.selectBootableDisk(disk.name);
+    await browser.wait(until.presenceOf(view.storageBootsourceHelper));
+  });
+
+  it('ID(CNV-5468) Ephemeral Container disk can be used as bootdisk', async () => {
+    const disk: Disk = { source: DISK_SOURCE.EphemeralContainer, size: '1', name: 'containerdisk' };
+    const diskDialog = new DiskDialog();
+
+    await wizard.selectProvisionSource(ProvisionSource.DISK);
+    await wizard.selectFlavor(customFlavorSufficientMemory);
+    await wizard.selectWorkloadProfile(Workload.DESKTOP);
+    await wizard.fillName(getRandStr(5));
+    await wizard.next();
+    // Network tab
+    await wizard.next();
+    // Storage tab
+    await click(view.addDiskButton);
+    await diskDialog.create(disk);
+    await wizard.selectBootableDisk(disk.name);
+    await browser.wait(until.stalenessOf(view.storageBootsourceHelper));
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/dialogs/diskDialog.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/dialogs/diskDialog.view.ts
@@ -12,6 +12,5 @@ export const diskStorageClass = $('#disk-storage-class');
 export const advancedDrawerToggle = $('.modal-body').element(by.buttonText('Advanced'));
 export const diskVolumeMode = $('#disk-volume-mode');
 export const diskAccessMode = $('#disk-access-mode');
-export const diskInterfaceHelper = $('#disk-interface-helper');
 export const diskDropDownItem = (text) =>
   element(by.cssContainingText('.pf-c-select__menu-item-main', text));

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/uiResource.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/uiResource.view.ts
@@ -27,3 +27,5 @@ export const dropDownItem = (text) =>
 export const dropDownItemMain = (text) =>
   element(by.cssContainingText('.pf-c-select__menu-item-main', text));
 export const dropDownList = $$('.pf-c-select__menu-item-main');
+
+export const confirmButton = $('#confirm-action');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
@@ -55,6 +55,7 @@ export const pxeBootSourceSelect = $('#pxe-bootsource');
 // Storage tab
 export const addDiskButton = $('#add-disk');
 export const storageBootSourceSelect = $('#storage-bootsource');
+export const storageBootsourceHelper = $('#storage-bootsource-helper');
 export const diskWarning = (resourceName) =>
   $(`[data-id="${resourceName}"]`).$('.kv-validation-cell__cell--warning');
 
@@ -99,3 +100,17 @@ export const tableRowAttribute = async (name: string, columnIndex: number): Prom
 };
 
 export const uploadLink = element(by.linkText('upload a new disk image'));
+
+// pvc dropdown button on customize wizard
+export const selectPVCNS = $('#clone-pvc-ns');
+export const selectPVCName = element(by.partialButtonText('Select Persistent Volume Claim'));
+
+// wizard boot source
+export const pvcNSButton = $('#pvc-ns-dropdown');
+export const pvcNameButton = $('#pvc-name-dropdown');
+export const pvcNS = (name: string) => $(`#${name}-Project-link`);
+export const pvcName = (name: string) => $(`#${name}-PersistentVolumeClaim-link`);
+export const diskAdvance = element(by.buttonText('Advanced'));
+export const selectSCButton = $('#form-ds-sc-select');
+export const selectAccessModeButton = $('#form-ds-access-mode-select');
+export const selectVolumeModeButton = $('#form-ds-volume-mode-select');


### PR DESCRIPTION
Notes for review:
1. change the way how VM created via wizard, now it always apply the accessMode/volumeMode based on the configmap.
2. adjust vm.detail.flavor test to adapt the new way of vm creation
3. adjust vm.detail.dedicated-resources test t0 adapt the new method of vm creation
4. add test to validate blank disk/container ephemeral disk