### PR TITLE
Bug 1914309: Redirect user to root when terminal operator is not installed

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { InlineTechPreviewBadge } from '@console/shared';
+import { Redirect } from 'react-router';
+import { InlineTechPreviewBadge, useFlag } from '@console/shared';
+import { FLAG_DEVWORKSPACE } from '../../consts';
 import CloudShellTerminal from './CloudShellTerminal';
 import './CloudShellTab.scss';
 
 const CloudShellTab: React.FC = () => {
   const { t } = useTranslation();
+  const devWorkspaceFlag = useFlag(FLAG_DEVWORKSPACE);
+
+  if (!devWorkspaceFlag) return <Redirect to="/" />;
+
   return (
     <>
       <div className="co-cloud-shell-tab__header">

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { Redirect } from 'react-router';
+import * as shared from '@console/shared';
 import CloudShellTab from '../CloudShellTab';
 import CloudShellTerminal from '../CloudShellTerminal';
 
@@ -13,7 +15,14 @@ jest.mock('react-i18next', () => {
 
 describe('CloudShellTab', () => {
   it('should render CloudShellTerminal', () => {
+    spyOn(shared, 'useFlag').and.returnValue(true);
     const cloudShellTabWrapper = shallow(<CloudShellTab />);
     expect(cloudShellTabWrapper.find(CloudShellTerminal).exists()).toBe(true);
+  });
+
+  it('should render redirect component if terminal operator is not installed', () => {
+    spyOn(shared, 'useFlag').and.returnValue(undefined);
+    const cloudShellTabWrapper = shallow(<CloudShellTab />);
+    expect(cloudShellTabWrapper.find(Redirect).exists()).toBe(true);
   });
 });


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5078
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Web terminal page was trying to load dev workspace resources even when the terminal operator was not installed. This resulted in showing empty state.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Check for dev workspace flag and redirect to root if not available.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
https://user-images.githubusercontent.com/6041994/104031309-92b1e680-51f2-11eb-95f0-9d01696693cb.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [x] Edge
