### PR TITLE
Bug 1914349: Fix alignment of plus and minus icon in number spinner

### DIFF
--- a/frontend/public/components/utils/number-spinner.tsx
+++ b/frontend/public/components/utils/number-spinner.tsx
@@ -20,7 +20,7 @@ export const NumberSpinner: React.FC<NumberSpinnerProps> = ({
         aria-label="Decrement"
         className="co-m-number-spinner__button"
       >
-        <MinusSquareIcon className="co-m-number-spinner__down-icon" />
+        <MinusSquareIcon className="co-m-number-spinner__down-icon" noVerticalAlign />
       </Button>
       <input
         type="number"
@@ -34,7 +34,7 @@ export const NumberSpinner: React.FC<NumberSpinnerProps> = ({
         aria-label="Increment"
         className="co-m-number-spinner__button"
       >
-        <PlusSquareIcon className="co-m-number-spinner__up-icon" />
+        <PlusSquareIcon className="co-m-number-spinner__up-icon" noVerticalAlign />
       </Button>
     </div>
   );


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-4627
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Plus and minus icons in number spinner were getting vertical alignment styles from patternfly which were not needed.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Pass `noVerticalAlign` prop to the icon components.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
<img width="276" alt="Screenshot 2021-01-08 at 9 30 15 PM" src="https://user-images.githubusercontent.com/6041994/104035902-b9731b80-51f8-11eb-9369-c82f1bef1447.png">

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [x] Edge
