### PR TITLE
Bug 1914060: choose first boot disk when not using PXE

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-boot-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-boot-source.tsx
@@ -34,7 +34,7 @@ export const StorageBootSource: React.FC<StorageBootOrderProps> = ({
   const isBootSourceValid =
     new VolumeWrapper(selectedStorage?.volume).getType() === VolumeType.PERSISTENT_VOLUME_CLAIM ||
     new VolumeWrapper(selectedStorage?.volume).getType() === VolumeType.CONTAINER_DISK ||
-    [DataVolumeSourceType.PVC, DataVolumeSourceType.HTTP].includes(
+    [DataVolumeSourceType.PVC, DataVolumeSourceType.HTTP, DataVolumeSourceType.REGISTRY].includes(
       new DataVolumeWrapper(selectedStorage?.dataVolume).getType(),
     );
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
@@ -215,7 +215,7 @@ const stateToProps = (state, { wizardReduxID }) => ({
   isUpdateDisabled: hasStepUpdateDisabled(state, wizardReduxID, VMWizardTab.STORAGE),
   isDeleteDisabled: hasStepDeleteDisabled(state, wizardReduxID, VMWizardTab.STORAGE),
   storages: getStorages(state, wizardReduxID),
-  isBootDiskRequired: iGetProvisionSource(state, wizardReduxID) === ProvisionSource.DISK,
+  isBootDiskRequired: iGetProvisionSource(state, wizardReduxID) !== ProvisionSource.PXE,
 });
 
 const dispatchToProps = (dispatch, { wizardReduxID }) => ({


### PR DESCRIPTION
First boot disk select drop down should not be hidden when boot source is a storage volume.

Screenshot:
No options to choose first boot disk (Bug):
![Peek 2021-01-10 12-15](https://user-images.githubusercontent.com/2181522/104120275-3065fc80-533e-11eb-8e6b-c3d59f9fd2df.gif)


Option to choose first boot disk:
![Peek 2021-01-10 12-16](https://user-images.githubusercontent.com/2181522/104120269-2d6b0c00-533e-11eb-8b46-a0e1d67a745d.gif)
