### PR TITLE
Bug 1891189: Stop non-positive values from being entered by users for max disk size and limit

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -8,6 +8,7 @@ import {
   TextInputTypes,
   Text,
   TextVariants,
+  Tooltip,
 } from '@patternfly/react-core';
 import { Dropdown } from '@console/internal/components/utils';
 import { ListPage } from '@console/internal/components/factory';
@@ -52,14 +53,9 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
     dispatch({ type: 'setShowNodesListOnLVS', value: !state.showNodesListOnLVS });
   };
 
-  const onMaxSizeChange = (size: string) => {
-    if (size && (Number.isNaN(Number(size)) || Number(size) < Number(state.minDiskSize))) {
-      dispatch({ type: 'setIsValidMaxSize', value: false });
-    } else {
-      dispatch({ type: 'setIsValidMaxSize', value: true });
-    }
-    dispatch({ type: 'setMaxDiskSize', value: size });
-  };
+  const validMaxDiskSize = /^\+?([1-9]\d*)$/.test(state.maxDiskSize || '1');
+  const validMaxDiskLimit = /^\+?([1-9]\d*)$/.test(state.maxDiskLimit || '1');
+
   return (
     <>
       <FormGroup
@@ -212,14 +208,20 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
               fieldId="create-lvs-max-disk-size"
               className="lso-create-lvs__disk-size-form-group-max-min-input"
             >
-              <TextInput
-                type={TextInputTypes.text}
-                id="create-lvs-max-disk-size"
-                value={state.maxDiskSize}
-                validated={state.isValidMaxSize ? 'default' : 'error'}
-                className="lso-create-lvs__disk-size-form-group-max-input"
-                onChange={onMaxSizeChange}
-              />
+              <Tooltip
+                content="Please enter a positive Integer"
+                isVisible={!validMaxDiskSize}
+                trigger="manual"
+              >
+                <TextInput
+                  type={TextInputTypes.number}
+                  id="create-lvs-max-disk-size"
+                  value={state.maxDiskSize}
+                  validated={validMaxDiskSize ? 'default' : 'error'}
+                  className="lso-create-lvs__disk-size-form-group-max-input"
+                  onChange={(value) => dispatch({ type: 'setMaxDiskSize', value })}
+                />
+              </Tooltip>
             </FormGroup>
             <Dropdown
               id="create-lvs-disk-size-unit-dropdown"
@@ -238,13 +240,20 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
               'lso-plugin~Disk limit will set the maximum number of PVs to create on a node. If the field is empty will create PVs for all available disks on the matching nodes.',
             )}
           </p>
-          <TextInput
-            type={TextInputTypes.number}
-            id="create-lvs-max-disk-limit"
-            value={state.maxDiskLimit}
-            onChange={(maxLimit) => dispatch({ type: 'setMaxDiskLimit', value: maxLimit })}
-            placeholder={t('lso-plugin~All')}
-          />
+          <Tooltip
+            content="Please enter a positive Integer"
+            isVisible={!validMaxDiskLimit}
+            trigger="manual"
+          >
+            <TextInput
+              type={TextInputTypes.number}
+              id="create-lvs-max-disk-limit"
+              value={state.maxDiskLimit}
+              validated={validMaxDiskLimit ? 'default' : 'error'}
+              onChange={(maxLimit) => dispatch({ type: 'setMaxDiskLimit', value: maxLimit })}
+              placeholder={t('lso-plugin~All')}
+            />
+          </Tooltip>
         </FormGroup>
       </ExpandableSection>
     </>

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -13,7 +13,6 @@ export const initialState = {
   minDiskSize: '0',
   maxDiskSize: '',
   diskSizeUnit: 'Ti',
-  isValidMaxSize: true,
   nodeNamesForLVS: [],
   hostNamesMapForLVS: {},
 };
@@ -30,7 +29,6 @@ export type State = {
   minDiskSize: string;
   maxDiskSize: string;
   diskSizeUnit: string;
-  isValidMaxSize: boolean;
   nodeNamesForLVS: string[];
   hostNamesMapForLVS: HostNamesMap;
 };
@@ -46,7 +44,6 @@ export type Action =
   | { type: 'setMinDiskSize'; value: string }
   | { type: 'setMaxDiskSize'; value: string }
   | { type: 'setDiskSizeUnit'; value: string }
-  | { type: 'setIsValidMaxSize'; value: boolean }
   | { type: 'setNodeNamesForLVS'; value: string[] }
   | { type: 'setHostNamesMapForLVS'; value: HostNamesMap }
   | { type: 'setDeviceType'; value: string[] };
@@ -75,8 +72,6 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { maxDiskSize: action.value });
     case 'setDiskSizeUnit':
       return Object.assign({}, state, { diskSizeUnit: action.value });
-    case 'setIsValidMaxSize':
-      return Object.assign({}, state, { isValidMaxSize: action.value });
     case 'setNodeNamesForLVS':
       return Object.assign({}, state, { nodeNamesForLVS: action.value });
     case 'setHostNamesMapForLVS':


### PR DESCRIPTION
Use Tooltip to provide basic guidance.
Before: 
![Screenshot from 2021-01-11 01-59-03](https://user-images.githubusercontent.com/54092533/104134687-4fea3d00-53b1-11eb-80d1-549cb3d6dbe7.png)
After:
![Screenshot from 2021-01-11 01-58-55](https://user-images.githubusercontent.com/54092533/104134696-5973a500-53b1-11eb-8f46-006ffe7aca7a.png)
![Screenshot from 2021-01-11 01-58-50](https://user-images.githubusercontent.com/54092533/104134697-5aa4d200-53b1-11eb-8426-d62775c50175.png)
![Screenshot from 2021-01-11 01-58-43](https://user-images.githubusercontent.com/54092533/104134699-5bd5ff00-53b1-11eb-9d9f-03eeff2cd065.png)
