### PR TITLE
Bug 1913563: Dont break h1 line in action dropdown

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.scss
@@ -1,3 +1,7 @@
+.kv-dropdown-group h1{
+  white-space: nowrap;
+}
+
 .kv-dropdown-group ul{
   list-style-type: none;
   padding-left: 0;


### PR DESCRIPTION
Drop down action headers should not wrappe

Screenshot:
before:
![screenshot-console-openshift-console apps ostest test metalkube [org-2021](https://issues.redhat.com/browse/org-2021) 01 11-11_20_47](https://user-images.githubusercontent.com/2181522/104163621-61f2cc80-53ff-11eb-9a70-cff3cd9c515b.png)

after:
![screenshot-localhost_9000-2021 01 11-11_19_39(1)](https://user-images.githubusercontent.com/2181522/104163609-5d2e1880-53ff-11eb-839d-402348f35eae.png)
