### PR TITLE
Bug 1914793: HW devices dont need to be translated

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
@@ -52,7 +52,7 @@ export class DiskWrapper extends ObjectWithTypePropertyWrapper<
 
   getReadableDiskBus = () => {
     const diskBus = this.getDiskBus();
-    return diskBus && diskBus.toString();
+    return diskBus && diskBus.getValue();
   };
 
   getBootOrder = () => this.get('bootOrder');

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/network-interface-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/network-interface-wrapper.ts
@@ -46,7 +46,7 @@ export class NetworkInterfaceWrapper extends ObjectWithTypePropertyWrapper<
 
   getReadableModel = () => {
     const model = this.getModel();
-    return model && model.toString();
+    return model && model.getValue();
   };
 
   getMACAddress = () => this.data?.macAddress;


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1914793

**Analysis / Root cause**: 
Devices used labelKey without t function

**Solution Description**: 
Using now the value untranslated as devices don't need to be translated.

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/104167451-fe6b9d80-5404-11eb-93cd-93e5594dc276.png)
![image](https://user-images.githubusercontent.com/14824964/104167490-0d525000-5405-11eb-88da-1963a9823deb.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/104167546-2e1aa580-5405-11eb-9afa-2b85513723c5.png)
![image](https://user-images.githubusercontent.com/14824964/104167582-3ecb1b80-5405-11eb-9163-507b41619ff1.png)
