### PR TITLE
Bug 1912852: Show not available when storage is not available

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/dev-console/use-catalog-vm-templates.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/dev-console/use-catalog-vm-templates.tsx
@@ -4,7 +4,7 @@ import { TFunction } from 'i18next';
 import { Form, Stack, StackItem } from '@patternfly/react-core';
 import { getNamespace } from '@console/shared';
 import { CatalogExtensionHook, CatalogItem } from '@console/plugin-sdk';
-import { SectionHeading } from '@console/internal/components/utils';
+import { humanizeBinaryBytes, SectionHeading } from '@console/internal/components/utils';
 import { PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
 import { FormRow } from '../../form/form-row';
 import { getOperatingSystemName, getWorkloadProfile } from '../../../selectors/vm';
@@ -17,7 +17,7 @@ import {
 } from '../../../selectors/vm-template/basic';
 import {
   getTemplateFlavorDesc,
-  getTemplateSizeRequirement,
+  getTemplateSizeRequirementInBytes,
 } from '../../../selectors/vm-template/advanced';
 import { isTemplateSourceError } from '../../../statuses/template/types';
 import { SourceDescription } from '../../vm-templates/vm-template-source';
@@ -56,7 +56,10 @@ const normalizeVmTemplates = (
     const imgUrl = getTemplateOSIcon(tmp);
     const workloadType = getWorkloadProfile(tmp) || t('kubevirt-plugin~Not available');
     const flavor = getTemplateFlavorDesc(tmp, false);
-    const storage = getTemplateSizeRequirement(tmp, sourceStatus);
+    const storage = getTemplateSizeRequirementInBytes(tmp, sourceStatus);
+    const storageLabel = storage
+      ? humanizeBinaryBytes(storage).string
+      : t('kubevirt-plugin~Not available');
     const providerType = getTemplateKindProviderType(tmp);
     const templateDescription = getDescription(tmp);
 
@@ -74,7 +77,8 @@ const normalizeVmTemplates = (
           <strong>{t('kubevirt-plugin~Flavor')}:</strong> {flavor}
         </StackItem>
         <StackItem>
-          <strong>{t('kubevirt-plugin~Storage')}:</strong> {storage}
+          <strong>{t('kubevirt-plugin~Storage')}:</strong>
+          {storageLabel}
         </StackItem>
       </Stack>
     );
@@ -121,7 +125,7 @@ const normalizeVmTemplates = (
                 title={t('kubevirt-plugin~Storage')}
                 fieldId="dev-console-vm-storage"
               >
-                {getTemplateSizeRequirement(tmp, sourceStatus)}
+                {storageLabel}
               </FormRow>
               <FormRow
                 className="vm-side-drawer-form-row"

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/create-vm-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/create-vm-form.tsx
@@ -16,6 +16,7 @@ import {
 } from '@patternfly/react-core';
 import {
   convertToBaseValue,
+  humanizeBinaryBytes,
   LoadingBox,
   useAccessReview2,
 } from '@console/internal/components/utils';
@@ -33,7 +34,7 @@ import {
   getDefaultDiskBus,
   getTemplateFlavorDesc,
   getTemplateMemory,
-  getTemplateSizeRequirement,
+  getTemplateSizeRequirementInBytes,
 } from '../../../selectors/vm-template/advanced';
 import { VMSettingsField } from '../../create-vm-wizard/types';
 import { helpKeyResolver } from '../../create-vm-wizard/strings/renderable-field';
@@ -200,6 +201,8 @@ export const CreateVMForm: React.FC<CreateVMFormProps> = ({
     );
   }
 
+  const storage = getTemplateSizeRequirementInBytes(template, sourceStatus, customSource);
+
   return (
     <Stack hasGutter>
       {showCreateInfo && (
@@ -256,7 +259,7 @@ export const CreateVMForm: React.FC<CreateVMFormProps> = ({
           <Split hasGutter className="kubevirt-create-vm-desc">
             <SplitItem>
               <FormRow fieldId="vm-storage" title={t('kubevirt-plugin~Storage')}>
-                {getTemplateSizeRequirement(template, sourceStatus, customSource)}
+                {storage ? humanizeBinaryBytes(storage).string : t('kubevirt-plugin~Not available')}
               </FormRow>
             </SplitItem>
             <SplitItem>

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
@@ -26,7 +26,7 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { FLAGS, VirtualizedGrid } from '@console/shared';
-import { StatusBox, ResourceName } from '@console/internal/components/utils';
+import { StatusBox, ResourceName, humanizeBinaryBytes } from '@console/internal/components/utils';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { ProjectModel } from '@console/internal/models';
 
@@ -45,7 +45,7 @@ import { getWorkloadProfile } from '../../../selectors/vm';
 import {
   getTemplateFlavorDesc,
   getTemplateOperatingSystems,
-  getTemplateSizeRequirement,
+  getTemplateSizeRequirementInBytes,
 } from '../../../selectors/vm-template/advanced';
 import { TemplateItem } from '../../../types/template';
 import { isTemplateSourceError, TemplateSourceStatus } from '../../../statuses/template/types';
@@ -78,6 +78,10 @@ export const TemplateTile: React.FC<TemplateTileProps> = ({
   const osName = getTemplateOperatingSystems(templateItem.variants)?.[0]?.name;
   const workloadProfile = getWorkloadProfile(template) || t('kubevirt-plugin~Not available');
   const provider = getTemplateProvider(t, template, true);
+  const storage = getTemplateSizeRequirementInBytes(template, sourceStatus);
+  const storageLable = storage
+    ? humanizeBinaryBytes(storage).string
+    : t('kubevirt-plugin~Not available');
 
   return (
     <CatalogTile
@@ -121,7 +125,7 @@ export const TemplateTile: React.FC<TemplateTileProps> = ({
             </StackItem>
             <StackItem>
               <b>{t('kubevirt-plugin~Storage ')}</b>
-              {getTemplateSizeRequirement(template, sourceStatus)}
+              {storageLable}
             </StackItem>
           </Stack>
         </StackItem>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -21,6 +21,7 @@ import {
   ResourceLink,
   FirehoseResult,
   ExternalLink,
+  humanizeBinaryBytes,
 } from '@console/internal/components/utils';
 import {
   TemplateModel,
@@ -42,7 +43,7 @@ import { menuActionsCreator } from './menu-actions';
 import { TemplateSource } from './vm-template-source';
 import { getTemplateOSIcon, PinnedIcon } from './os-icons';
 import {
-  getTemplateSizeRequirement,
+  getTemplateSizeRequirementInBytes,
   getTemplateMemory,
 } from '../../selectors/vm-template/advanced';
 import { useBaseImages } from '../../hooks/use-base-images';
@@ -119,6 +120,7 @@ const VMTemplateDetailsBody: React.FC<VMTemplateDetailsBodyProps> = ({
 }) => {
   const { t } = useTranslation();
   const osName = getOperatingSystemName(template);
+  const storage = getTemplateSizeRequirementInBytes(template, sourceStatus);
   return (
     <Stack hasGutter>
       <StackItem>
@@ -128,7 +130,9 @@ const VMTemplateDetailsBody: React.FC<VMTemplateDetailsBodyProps> = ({
       <StackItem>
         <div className="kubevirt-vm-template-popover">
           <div>{t('kubevirt-plugin~Storage')}</div>
-          <div>{getTemplateSizeRequirement(template, sourceStatus)}</div>
+          <div>
+            {storage ? humanizeBinaryBytes(storage).string : t('kubevirt-plugin~Not available')}
+          </div>
         </div>
         <div className="kubevirt-vm-template-popover">
           <div>{t('kubevirt-plugin~Memory')}</div>

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
@@ -125,7 +125,7 @@ export const getTemplateWorkloadProfiles = (templates: TemplateKind[]) =>
 export const isWindowsTemplate = (template: TemplateKind): boolean =>
   getTemplateOperatingSystems([template])?.some((os) => os.id.startsWith(OS_WINDOWS_PREFIX));
 
-export const getTemplateSizeRequirement = (
+export const getTemplateSizeRequirementInBytes = (
   template: TemplateKind,
   templateSource: TemplateSourceStatus,
   customSource?: BootSourceState,
@@ -157,9 +157,7 @@ export const getTemplateSizeRequirement = (
     sourceSize = convertToBaseValue(getDataVolumeStorageSize(templateSource.dvTemplate));
   }
 
-  return humanizeBinaryBytes(
-    templatesSize + sourceSize + (isCDRom ? convertToBaseValue('20Gi') : 0),
-  ).string;
+  return templatesSize + sourceSize + (isCDRom ? convertToBaseValue('20Gi') : 0);
 };
 
 export const getTemplateMemory = (template: TemplateKind): string => {


### PR DESCRIPTION
Show "not available" when storage is not available

Screenshots:
before:
![screenshot-console-openshift-console apps ostest test metalkube [org-2021](https://issues.redhat.com/browse/org-2021) 01 11-13_59_32](https://user-images.githubusercontent.com/2181522/104180084-67f3a800-5415-11eb-84f6-d4db6391d20b.png)

after:
![screenshot-localhost_9000-2021 01 11-13_58_54](https://user-images.githubusercontent.com/2181522/104180070-64f8b780-5415-11eb-9482-38ee8392eded.png)
