### PR TITLE
Bug 1914938: Selected PVC from short wizard is not passed to advanced wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -76,8 +76,11 @@ export const getInitialVmSettings = (data: CommonData): VMSettings => {
     },
     [VMSettingsField.CLONE_PVC_NS]: {
       isHidden: hiddenByProviderOrCloneCommonBaseDiskImage,
+      value: initialData?.source?.pvcNamespace,
     },
-    [VMSettingsField.CLONE_PVC_NAME]: {},
+    [VMSettingsField.CLONE_PVC_NAME]: {
+      value: initialData?.source?.pvcName,
+    },
     [VMSettingsField.DEFAULT_STORAGE_CLASS]: {},
   };
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/clone-pvc-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/clone-pvc-source.tsx
@@ -16,6 +16,7 @@ export const ClonePVCSource: React.FC<ClonePVCSourceProps> = React.memo(
     const { t } = useTranslation();
     const storage: VMWizardStorage = toShallowJS(provisionSourceStorage);
     const pvcNamespace = iGetFieldValue(nsField, '');
+    const pvcName = iGetFieldValue(nameField, '');
 
     return (
       <>
@@ -49,6 +50,8 @@ export const ClonePVCSource: React.FC<ClonePVCSourceProps> = React.memo(
                   .asResource(),
               });
             }}
+            selectedKey={pvcName}
+            selectedKeyKind={PersistentVolumeClaimModel.kind}
             placeholder={t('kubevirt-plugin~--- Select Persistent Volume Claim ---')}
             desc={PersistentVolumeClaimModel.label}
           />


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Initial data from URL wasn't updating the name and namespace of selected PVC at the advanced wizard

**Solution Description**: 
Added name and namespace to fields of PVC from initial data

**Screen shots / Gifs for design review**: 
After:
![Bug 1914938 - after](https://user-images.githubusercontent.com/14824964/104194454-0a1d8b00-542a-11eb-8ef1-724319f13fbc.gif)

Before:
![Bug 1914938 - before](https://user-images.githubusercontent.com/14824964/104194890-92039500-542a-11eb-9f66-c3993be27b8f.gif)
