### PR TITLE
Bug 1905370: Fix catalog dropdown alignment for firefox

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -107,7 +107,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   }
 
   &__btn-group__group-by {
-    display: inline-flex;
+    display: inline;
     margin-left: var(--pf-global--spacer--md);
   }
 


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5327
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Flex styles doesn't work correctly on firefox.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Update the css to use `inline` instead of `inline-flex`.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
<img width="1792" alt="Screenshot 2021-01-11 at 10 11 25 PM" src="https://user-images.githubusercontent.com/6041994/104211330-f558eb80-5459-11eb-9ff7-b7dbf327c12a.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
