### PR TITLE
Bug 1925562: Add new ArgoCD link from GitOps application environments page

### DIFF
--- a/frontend/packages/gitops-plugin/src/components/GitOpsListPage.tsx
+++ b/frontend/packages/gitops-plugin/src/components/GitOpsListPage.tsx
@@ -77,7 +77,7 @@ const GitOpsListPage: React.FC = () => {
       {!appGroups && !emptyStateMsg ? (
         <LoadingBox />
       ) : (
-        <GitOpsList appGroups={appGroups} emptyStateMsg={emptyStateMsg} />
+        <GitOpsList appGroups={appGroups} emptyStateMsg={emptyStateMsg} argocdLink={argocdLink} />
       )}
     </>
   );

--- a/frontend/packages/gitops-plugin/src/components/list/GitOpsList.tsx
+++ b/frontend/packages/gitops-plugin/src/components/list/GitOpsList.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import GitOpsListItem from './GitOpsListItem';
 import { Stack, StackItem, Split, SplitItem } from '@patternfly/react-core';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { GitOpsAppGroupData } from '../utils/gitops-types';
 import GitOpsEmptyState from '../GitOpsEmptyState';
 import './GitOpsList.scss';
@@ -10,9 +11,10 @@ import './GitOpsList.scss';
 interface GitOpsListProps {
   appGroups: GitOpsAppGroupData[];
   emptyStateMsg: string;
+  argocdLink?: K8sResourceKind;
 }
 
-const GitOpsList: React.FC<GitOpsListProps> = ({ appGroups, emptyStateMsg }) => {
+const GitOpsList: React.FC<GitOpsListProps> = ({ appGroups, emptyStateMsg, argocdLink }) => {
   const { t } = useTranslation();
   return (
     <div className="odc-gitops-list">
@@ -30,7 +32,7 @@ const GitOpsList: React.FC<GitOpsListProps> = ({ appGroups, emptyStateMsg }) => 
           </StackItem>
           {_.map(appGroups, (appGroup) => (
             <StackItem key={`${appGroup.name}-${appGroup.repo_url}`}>
-              <GitOpsListItem appGroup={appGroup} />
+              <GitOpsListItem appGroup={appGroup} argocdLink={argocdLink} />
             </StackItem>
           ))}
         </Stack>

--- a/frontend/packages/gitops-plugin/src/components/list/GitOpsListItem.tsx
+++ b/frontend/packages/gitops-plugin/src/components/list/GitOpsListItem.tsx
@@ -2,16 +2,20 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Grid, GridItem, Card, CardBody } from '@patternfly/react-core';
-import { history, ResourceLink } from '@console/internal/components/utils';
+import { history, ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { GitOpsAppGroupData } from '../utils/gitops-types';
+import { getArgoCDFilteredAppsURI } from '../utils/gitops-utils';
 import './GitOpsListItem.scss';
 
 interface GitOpsListItemProps {
   appGroup: GitOpsAppGroupData;
+  argocdLink?: K8sResourceKind;
 }
 
-const GitOpsListItem: React.FC<GitOpsListItemProps> = ({ appGroup }) => {
+const GitOpsListItem: React.FC<GitOpsListItemProps> = ({ appGroup, argocdLink }) => {
   const { t } = useTranslation();
+  const argocdLinkUrl = getArgoCDFilteredAppsURI(argocdLink.spec.href, appGroup.name);
   const handleCardClick = () => {
     history.push(`/environments/${appGroup.name}?url=${appGroup.repo_url}`);
   };
@@ -20,13 +24,22 @@ const GitOpsListItem: React.FC<GitOpsListItemProps> = ({ appGroup }) => {
     <Card className="odc-gitops-list-item" onClick={handleCardClick} isHoverable>
       <CardBody>
         <Grid className="odc-gitops-list-item__body">
-          <GridItem lg={6} md={6} sm={6}>
+          <GridItem lg={5} md={5} sm={5}>
             <ResourceLink kind="application" name={appGroup.name} linkTo={false} />
           </GridItem>
-          <GridItem lg={6} md={6} sm={6}>
+          <GridItem lg={5} md={5} sm={5}>
             {t('gitops-plugin~{{count, number}} Environment', {
               count: _.size(appGroup.environments),
             })}
+          </GridItem>
+          <GridItem lg={2} md={2} sm={2}>
+            {argocdLinkUrl && (
+              <ExternalLink
+                href={`${argocdLinkUrl}`}
+                text={t('gitops-plugin~Argo CD')}
+                stopPropagation
+              />
+            )}
           </GridItem>
         </Grid>
       </CardBody>

--- a/frontend/packages/gitops-plugin/src/components/utils/gitops-utils.ts
+++ b/frontend/packages/gitops-plugin/src/components/utils/gitops-utils.ts
@@ -67,6 +67,12 @@ export const getPipelinesBaseURI = (secretNS: string, secretName: string) => {
     : undefined;
 };
 
+export const getArgoCDFilteredAppsURI = (argocdBaseUri: string, appGroupName: string) => {
+  return argocdBaseUri && appGroupName
+    ? `${argocdBaseUri}/applications?labels=app.kubernetes.io%252Fname%253D${appGroupName}`
+    : undefined;
+};
+
 export const getApplicationsBaseURI = (
   appName: string,
   secretNS: string,

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -71,6 +71,7 @@ export const ExternalLink: React.FC<ExternalLinkProps> = ({
   text,
   additionalClassName = '',
   dataTestID,
+  stopPropagation,
 }) => (
   <a
     className={classNames('co-external-link', additionalClassName)}
@@ -78,6 +79,7 @@ export const ExternalLink: React.FC<ExternalLinkProps> = ({
     target="_blank"
     rel="noopener noreferrer"
     data-test-id={dataTestID}
+    {...(stopPropagation ? { onClick: (e) => e.stopPropagation() } : {})}
   >
     {children || text}
   </a>
@@ -94,4 +96,5 @@ type ExternalLinkProps = {
   text?: React.ReactNode;
   additionalClassName?: string;
   dataTestID?: string;
+  stopPropagation?: boolean;
 };


### PR DESCRIPTION
Signed-off-by: Keith Chong <kykchong@redhat.com>

See GitOps 544.  The new link within each card will link to the ArgoCD app list page with a filter-by-label added to show only the apps associated with the environments.

Screenshot:

![Screen Shot 2021-01-07 at 2 10 10 PM](https://user-images.githubusercontent.com/7726022/104362879-5a582400-54e2-11eb-9187-96b4e3f2437c.png)

For video see,

https://coreos.slack.com/archives/CMP95ST2N/p1610126728487400?thread_ts=1610118978.486800&cid=CMP95ST2N


