### PR TITLE
Bug 1915133: Fix missing default pinned nav items in dev perspective

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/usePinnedResources.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/usePinnedResources.spec.ts
@@ -1,0 +1,106 @@
+import { useExtensions } from '@console/plugin-sdk';
+
+import { testHook } from '../../../../../__tests__/utils/hooks-utils';
+
+import { useActivePerspective } from '../useActivePerspective';
+import { useUserSettingsCompatibility } from '../useUserSettingsCompatibility';
+import { usePinnedResources } from '../usePinnedResources';
+
+const useActivePerspectiveMock = useActivePerspective as jest.Mock;
+const useExtensionsMock = useExtensions as jest.Mock;
+const useUserSettingsCompatibilityMock = useUserSettingsCompatibility as jest.Mock;
+const setPinnedResourcesMock = jest.fn();
+
+jest.mock('@console/plugin-sdk', () => ({ useExtensions: jest.fn() }));
+jest.mock('../useActivePerspective', () => ({ useActivePerspective: jest.fn() }));
+jest.mock('../useUserSettingsCompatibility', () => ({ useUserSettingsCompatibility: jest.fn() }));
+
+describe('usePinnedResources', () => {
+  beforeEach(() => {
+    // Return default perspective
+    useActivePerspectiveMock.mockClear();
+    useActivePerspectiveMock.mockReturnValue(['admin']);
+
+    // Return defaultPins for dev perspective extension
+    useExtensionsMock.mockClear();
+    useExtensionsMock.mockReturnValue([
+      {
+        type: 'Perspective',
+        properties: {
+          id: 'dev',
+          name: 'Developer',
+          defaultPins: [{ kind: 'ConfigMap' }, { kind: 'Secret' }],
+        },
+      },
+    ]);
+
+    useUserSettingsCompatibilityMock.mockClear();
+    setPinnedResourcesMock.mockClear();
+  });
+
+  it('returns an empty array if user settings are not loaded yet', async () => {
+    // Mock user settings
+    useUserSettingsCompatibilityMock.mockReturnValue([null, setPinnedResourcesMock, false]);
+
+    const { result } = testHook(() => usePinnedResources());
+
+    // Expect empty data and loaded=false
+    expect(result.current).toEqual([[], expect.any(Function), false]);
+
+    // Setter was not used
+    expect(setPinnedResourcesMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns no default pins if there are no other pins defined and no extension could be found', async () => {
+    // Mock empty old data
+    useUserSettingsCompatibilityMock.mockReturnValue([{}, setPinnedResourcesMock, true]);
+
+    const { result } = testHook(() => usePinnedResources());
+
+    // Expect empty array
+    expect(result.current).toEqual([[], expect.any(Function), true]);
+
+    // Setter was not used
+    expect(setPinnedResourcesMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns some default pins if there are no other pins defined and the extension has default pins', async () => {
+    // Mock empty old data
+    useActivePerspectiveMock.mockReturnValue(['dev']);
+    useUserSettingsCompatibilityMock.mockReturnValue([{}, setPinnedResourcesMock, true]);
+
+    const { result } = testHook(() => usePinnedResources());
+
+    // Expect default pins
+    expect(result.current).toEqual([
+      [{ kind: 'ConfigMap' }, { kind: 'Secret' }],
+      expect.any(Function),
+      true,
+    ]);
+
+    // Setter was not used
+    expect(setPinnedResourcesMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns an array of pins saved in user settings for the current perspective', async () => {
+    // Mock user settings data
+    useActivePerspectiveMock.mockReturnValue(['dev']);
+    useUserSettingsCompatibilityMock.mockReturnValue([
+      { dev: ['ConfigMap', 'Secret', 'AnotherResource'] },
+      setPinnedResourcesMock,
+      true,
+    ]);
+
+    const { result } = testHook(() => usePinnedResources());
+
+    // Expect pins from user settings
+    expect(result.current).toEqual([
+      ['ConfigMap', 'Secret', 'AnotherResource'],
+      expect.any(Function),
+      true,
+    ]);
+
+    // Setter was not used
+    expect(setPinnedResourcesMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
+++ b/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { isPerspective, Perspective, useExtensions } from '@console/plugin-sdk';
 import { useUserSettingsCompatibility } from './useUserSettingsCompatibility';
 import { PINNED_RESOURCES_LOCAL_STORAGE_KEY } from '../constants';
@@ -13,27 +13,29 @@ const PINNED_RESOURCES_CONFIG_MAP_KEY = 'console.pinnedResources';
 export const usePinnedResources = (): [string[], (pinnedResources: string[]) => void, boolean] => {
   const [activePerspective] = useActivePerspective();
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
-  const activePerspectiveExtension = perspectiveExtensions.find(
-    (p) => p.properties.id === activePerspective,
-  );
   const [pinnedResources, setPinnedResources, loaded] = useUserSettingsCompatibility<
     PinnedResourcesType
-  >(
-    PINNED_RESOURCES_CONFIG_MAP_KEY,
-    PINNED_RESOURCES_LOCAL_STORAGE_KEY,
-    { [activePerspective]: activePerspectiveExtension.properties.defaultPins },
-    true,
-  );
-  const pins = useMemo(() => (loaded ? pinnedResources[activePerspective] ?? [] : []), [
-    loaded,
-    pinnedResources,
-    activePerspective,
-  ]);
-  return [
-    pins,
-    (pr: string[]) => {
-      setPinnedResources((prevPR) => ({ ...prevPR, [activePerspective]: pr }));
+  >(PINNED_RESOURCES_CONFIG_MAP_KEY, PINNED_RESOURCES_LOCAL_STORAGE_KEY, {}, true);
+
+  const pins = useMemo(() => {
+    if (!loaded) {
+      return [];
+    }
+    if (pinnedResources?.[activePerspective]) {
+      return pinnedResources[activePerspective];
+    }
+    const activePerspectiveExtension = perspectiveExtensions.find(
+      (extension) => extension.properties.id === activePerspective,
+    );
+    return activePerspectiveExtension?.properties?.defaultPins || [];
+  }, [loaded, pinnedResources, activePerspective, perspectiveExtensions]);
+
+  const setPins = useCallback(
+    (newPins: string[]) => {
+      setPinnedResources((prevPR) => ({ ...prevPR, [activePerspective]: newPins }));
     },
-    loaded,
-  ];
+    [activePerspective, setPinnedResources],
+  );
+
+  return [pins, setPins, loaded];
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5320
https://bugzilla.redhat.com/show_bug.cgi?id=1915133

**Analysis / Root cause**: 
After changing `usePinnedResources` to user settings the hook sets the "default pins" only to the first perspective. This happen because all "pinned resources" are stored in one single object.

```tsx
type PinnedResourcesType = {
  [perspective: string]: string[];
};
```

**Solution Description**: 
Return the default pins from the `Perspective` extension until there is a list of pins defined in user settings for the active perspective.

**Screen shots / Gifs for design review**: 
No UX change.

**Unit test coverage report**: 
Added new unit tests for usePinnedResources

```
 PASS  packages/console-shared/src/hooks/__tests__/usePinnedResources.spec.ts
  usePinnedResources
    ✓ returns an empty array if user settings are not loaded yet (31ms)
    ✓ returns no default pins if there are no other pins defined and no extension could be found (2ms)
    ✓ returns some default pins if there are no other pins defined and the extension has default pins (1ms)
    ✓ returns an array of pins saved in user settings for the current perspective (1ms)
```

**Test setup:**

1. Remove the pinned resources from user settings.
2. Reload the console or dev console

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
