### PR TITLE
Bug 1915176: Update snapshot API CRDs to v1 in web-console when creating volumesnapshot related resource

### DIFF
--- a/frontend/packages/integration-tests-cypress/mocks/snapshot.ts
+++ b/frontend/packages/integration-tests-cypress/mocks/snapshot.ts
@@ -74,7 +74,7 @@ export const PVC = {
 };
 
 export const SnapshotClass = {
-  apiVersion: 'snapshot.storage.k8s.io/v1beta1',
+  apiVersion: 'snapshot.storage.k8s.io/v1',
   kind: 'VolumeSnapshotClass',
   metadata: {
     name: 'csi-hostpath-snapclass',

--- a/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/k8-openshift-cruds.spec.ts
@@ -64,17 +64,17 @@ describe('Kubernetes resource CRUD operations', () => {
     .set('horizontalpodautoscalers', { kind: 'HorizontalPodAutoscaler', humanizeKind: false })
     .set('networkpolicies', { kind: 'NetworkPolicy', humanizeKind: false })
     .set('roles', { kind: 'Role', testI18n: false })
-    .set('snapshot.storage.k8s.io~v1beta1~VolumeSnapshot', {
-      kind: 'snapshot.storage.k8s.io~v1beta1~VolumeSnapshot',
+    .set('snapshot.storage.k8s.io~v1~VolumeSnapshot', {
+      kind: 'snapshot.storage.k8s.io~v1~VolumeSnapshot',
       testI18n: false,
     })
-    .set('snapshot.storage.k8s.io~v1beta1~VolumeSnapshotClass', {
-      kind: 'snapshot.storage.k8s.io~v1beta1~VolumeSnapshotClass',
+    .set('snapshot.storage.k8s.io~v1~VolumeSnapshotClass', {
+      kind: 'snapshot.storage.k8s.io~v1~VolumeSnapshotClass',
       namespaced: false,
       testI18n: false,
     })
-    .set('snapshot.storage.k8s.io~v1beta1~VolumeSnapshotContent', {
-      kind: 'snapshot.storage.k8s.io~v1beta1~VolumeSnapshotContent',
+    .set('snapshot.storage.k8s.io~v1~VolumeSnapshotContent', {
+      kind: 'snapshot.storage.k8s.io~v1~VolumeSnapshotContent',
       namespaced: false,
       testI18n: false,
     });
@@ -108,7 +108,7 @@ describe('Kubernetes resource CRUD operations', () => {
     'StorageClass',
     'Route',
     'PersistentVolumeClaim',
-    'snapshot.storage.k8s.io~v1beta1~VolumeSnapshot',
+    'snapshot.storage.k8s.io~v1~VolumeSnapshot',
   ]);
 
   testObjs.forEach(

--- a/frontend/packages/integration-tests-cypress/tests/storage/snapshot.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/storage/snapshot.spec.ts
@@ -50,7 +50,7 @@ if (Cypress.env('BRIDGE_AWS')) {
       modal.submit();
       cy.location('pathname').should(
         'include',
-        `snapshot.storage.k8s.io~v1beta1~VolumeSnapshot/${PVC.metadata.name}-snapshot`,
+        `snapshot.storage.k8s.io~v1~VolumeSnapshot/${PVC.metadata.name}-snapshot`,
       );
       detailsPage.titleShouldContain(PVC.metadata.name);
       resourceStatusShouldContain('Ready', { timeout: 40000 });

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -1282,7 +1282,7 @@ export const VolumeSnapshotModel: K8sKind = {
   label: 'VolumeSnapshot',
   // t('public~VolumeSnapshot')
   labelKey: 'public~VolumeSnapshot',
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1',
   apiGroup: 'snapshot.storage.k8s.io',
   plural: 'volumesnapshots',
   abbr: 'VS',
@@ -1299,7 +1299,7 @@ export const VolumeSnapshotClassModel: K8sKind = {
   label: 'VolumeSnapshotClass',
   // t('public~VolumeSnapshotClass')
   labelKey: 'public~VolumeSnapshotClass',
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1',
   apiGroup: 'snapshot.storage.k8s.io',
   plural: 'volumesnapshotclasses',
   abbr: 'VSC',
@@ -1316,7 +1316,7 @@ export const VolumeSnapshotContentModel: K8sKind = {
   label: 'VolumeSnapshotContent',
   // t('public~VolumeSnapshotContent')
   labelKey: 'public~VolumeSnapshotContent',
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1',
   apiGroup: 'snapshot.storage.k8s.io',
   plural: 'volumesnapshotcontents',
   abbr: 'VSC',

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -1325,7 +1325,7 @@ spec:
   .setIn(
     [referenceForModel(k8sModels.VolumeSnapshotModel), 'default'],
     `
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: example-snap
@@ -1338,7 +1338,7 @@ spec:
   .setIn(
     [referenceForModel(k8sModels.VolumeSnapshotClassModel), 'default'],
     `
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: example-snapclass
@@ -1349,7 +1349,7 @@ deletionPolicy: Delete
   .setIn(
     [referenceForModel(k8sModels.VolumeSnapshotContentModel), 'default'],
     `
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotContent
 metadata:
   name: example-snapcontent


### PR DESCRIPTION
Those resoruces are: 
- VolumeSnapshots
- VolumeSnapshotClasses
- VolumeSnapshotContents

/assign @spadgett 