### PR TITLE
Bug 1915357: Only show load error in catalog when no items are loaded with error

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/service/CatalogExtensionHookResolver.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/service/CatalogExtensionHookResolver.tsx
@@ -22,11 +22,13 @@ const CatalogExtensionHookResolver: React.FC<CatalogExtensionHookResolverProps> 
 }) => {
   const [value, loaded, loadError] = useValue(options);
 
-  if (loadError) onValueError(loadError);
-
   React.useEffect(() => {
     if (loaded) onValueResolved(value, id);
   }, [id, loaded, onValueResolved, value]);
+
+  React.useEffect(() => {
+    if (loadError) onValueError(loadError);
+  }, [loadError, onValueError]);
 
   return null;
 };

--- a/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -89,7 +89,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
     items: catalogItems,
     itemsMap: catalogItemsMap,
     loaded,
-    loadError,
+    loadError: loaded && catalogItems.length < 1 ? loadError : null,
     searchCatalog,
     catalogExtensions: catalogTypeExtensions,
   };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5331
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Error in loading items by any of the providers would result in catalog not loading anything and showing that load error. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Catalog should show all the other items which were successfully loaded by other providers and only show error when none of the providers could load items successfully.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/104324819-eb90c000-550d-11eb-9530-e8ee1a21cbb9.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
