### PR TITLE
Bug 1915594: add test for disk validation

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'child_process';
+import { testName } from '@console/internal-integration-tests/protractor.conf';
 import {
   click,
   createResource,
@@ -28,6 +30,7 @@ describe('KubeVirt VM detail - edit flavor', () => {
 
   beforeAll(() => {
     createResource(testDataVolume);
+    execSync(`oc wait -n ${testName} --for condition=Ready DataVolume ${dvName} --timeout=100s`);
   });
 
   afterEach(() => {


### PR DESCRIPTION
notes for reviewer:
1. add a test to verify registrt container disk can be selected as boot disk
2. remove invalid flavor test as it does not make sense to test it as OS field is disabled
3. adjust OS selection in customize general step as it's disabled
4. adjust volumeMode selection in Boot source step as it's default to PVC volumeMode if source is PVC.