### PR TITLE
Bug 1915624: Template provider name is required field only for vm templates

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -28,7 +28,7 @@ export const getInitialVmSettings = (data: CommonData): VMSettings => {
     [VMSettingsField.HOSTNAME]: {},
     [VMSettingsField.DESCRIPTION]: {},
     [VMSettingsField.TEMPLATE_PROVIDER]: {
-      isRequired: asRequired(true),
+      isRequired: asRequired(isCreateTemplate),
       isHidden: asHidden(!isCreateTemplate),
     },
     [VMSettingsField.TEMPLATE_SUPPORTED]: {


### PR DESCRIPTION
As discussed of line Template provider name is required field only for vm templates.

Screenshot:
before:
![screenshot-localhost_9000-2021 01 13-08_39_55](https://user-images.githubusercontent.com/2181522/104415602-f9c8f580-557a-11eb-94b3-c0a35fcdb46d.png)

after:
![screenshot-localhost_9000-2021 01 13-08_39_04](https://user-images.githubusercontent.com/2181522/104415618-ff264000-557a-11eb-8ff2-3c8cf245170a.png)
