### PR TITLE
Bug 1915649: template support message is not a warning

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -538,7 +538,7 @@
   "This template does not have a support statement defined.": "This template does not have a support statement defined.",
   "The support will be provided in accordance with Red Hat's ": "The support will be provided in accordance with Red Hat's ",
   "third party support policy": "third party support policy",
-  "Do not show this warning again": "Do not show this warning again",
+  "Do not show this message again": "Do not show this message again",
   "Continue": "Continue",
   "Edit Flavor": "Edit Flavor",
   "CPU count": "CPU count",

--- a/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
@@ -60,7 +60,7 @@ const SupportModal: React.FC<SupportModalProps> = ({ onConfirm, close, community
           <StackItem>
             <Checkbox
               id="support-warning"
-              label={t('kubevirt-plugin~Do not show this warning again')}
+              label={t('kubevirt-plugin~Do not show this message again')}
               onChange={setDoNotShow}
               isChecked={doNotShow}
             />


### PR DESCRIPTION
Screenshots:
before:
![screenshot-localhost_9000-2021 01 13-09_13_57](https://user-images.githubusercontent.com/2181522/104418543-ba50d800-557f-11eb-80f2-629da1b788d1.png)

after:
![screenshot-localhost_9000-2021 01 13-09_13_05](https://user-images.githubusercontent.com/2181522/104418534-b755e780-557f-11eb-8f1f-ce4eb9ac1e1e.png)
