### PR TITLE
Bug 1915694: Add immediate request annotaion to auploaded dvs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
@@ -11,6 +11,7 @@ export const CDI_UPLOAD_POD_ANNOTATION = 'cdi.kubevirt.io/storage.pod.phase';
 export const CDI_UPLOAD_POD_NAME_ANNOTATION = 'cdi.kubevirt.io/storage.uploadPodName';
 export const CDI_PHASE_PVC_ANNOTATION = 'cdi.kubevirt.io/storage.pod.phase';
 export const CDI_BOUND_PVC_ANNOTATION = 'cdi.kubevirt.io/storage.condition.bound';
+export const CDI_BIND_REQUESTED_ANNOTATION = 'cdi.kubevirt.io/storage.bind.immediate.requested';
 export const CDI_UPLOAD_RUNNING = 'Running';
 export const CDI_UPLOAD_OS_URL_PARAM = 'os';
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/cdi-upload/cdi-upload-requests.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/cdi-upload/cdi-upload-requests.ts
@@ -9,6 +9,7 @@ import {
   k8sKill,
   k8sGet,
 } from '@console/internal/module/k8s';
+import { CDI_BIND_REQUESTED_ANNOTATION } from '../../../components/cdi-upload-provider/consts';
 import { delay } from '../../../utils/utils';
 
 const PVC_STATUS_DELAY = 2 * 1000;
@@ -67,6 +68,12 @@ const createUploadToken = async (pvcName: string, namespace: string): Promise<st
 export const createUploadPVC = async (dataVolume: V1alpha1DataVolume) => {
   const dataVolumeName = getName(dataVolume);
   const namespace = getNamespace(dataVolume);
+
+  dataVolume.metadata = dataVolume?.metadata || {};
+  dataVolume.metadata.annotations = {
+    ...(dataVolume?.metadata?.annotations || {}),
+    [CDI_BIND_REQUESTED_ANNOTATION]: 'true',
+  };
 
   try {
     const dv = await k8sCreate(DataVolumeModel, dataVolume);


### PR DESCRIPTION
Add `storage.bind.immediate.requested` to uploaded data volumes.

Ref:
https://github.com/kubevirt/containerized-data-importer/pull/1560

Screenshoot:
![screenshot-localhost_9000-2021 01 13-13_08_43](https://user-images.githubusercontent.com/2181522/104445381-b930a280-55a1-11eb-9f1f-9986a1e831e7.png)

