### PR TITLE
Bug 1915793: Disable syncing of quick start all states

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.ts
@@ -49,7 +49,7 @@ const ALL_QUICK_START_STATE_KEY = `${QUICK_START_KEY}.allStates`;
 const useActiveQuickStartId = () =>
   useUserSettings<string>(ACTIVE_QUICK_START_ID_KEY, getInitialState()?.activeQuickStartId ?? '');
 const useAllQuickStartStates = () =>
-  useUserSettings(ALL_QUICK_START_STATE_KEY, getInitialState()?.allQuickStartStates ?? {}, true);
+  useUserSettings(ALL_QUICK_START_STATE_KEY, getInitialState()?.allQuickStartStates ?? {});
 
 export const useValuesForQuickStartContext = (): QuickStartContextValues => {
   const [activeQuickStartID, setActiveQuickStartID] = useActiveQuickStartId();


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5335
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Syncing of quick start all states result in unwanted changes in state of quick start in separate window. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Disable syncing of quick start all states.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
No Changes in UI.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
