### PR TITLE
Bug 1907480: fix query browser prometheus URL for non admin user

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -397,6 +397,7 @@ const Graph: React.FC<GraphProps> = ({
 
   return (
     <QueryBrowser
+      namespace={namespace}
       defaultTimespan={timespan}
       filterLabels={filterLabels}
       formatLegendLabel={formatLegendLabel}


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1907480

**Analysis / Root cause**: 
After creating alert rules for user-namespaces, there is a `forbidden` error shown in the `Active alerts` section while viewing the alerting rule query graph.

**Solution Description**: 
Use the Prometheus tenancy URL when the user is in the context of a namespace.

**Screen shots / Gifs for design review**: 
![Kapture 2021-01-13 at 21 09 45](https://user-images.githubusercontent.com/2561818/104474224-ccfcf880-55e3-11eb-986b-205b787eac01.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge