### PR TITLE
Bug 1915898: Drop "undefined" and keep empty lines in Pipeline log output

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/Logs.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/Logs.scss
@@ -8,5 +8,6 @@
 
   &__content {
     padding-left: var(--pf-global--spacer--md);
+    white-space: pre;
   }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/Logs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/Logs.tsx
@@ -29,33 +29,22 @@ const Logs: React.FC<LogsProps> = ({
   const { name } = container;
   const { kind, metadata = {} } = resource;
   const { name: resName, namespace: resNamespace } = metadata;
+  const scrollToRef = React.useRef<HTMLDivElement>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
   const [error, setError] = React.useState<boolean>(false);
   const resourceStatusRef = React.useRef<string>(resourceStatus);
   const onCompleteRef = React.useRef<(name) => void>();
   onCompleteRef.current = onComplete;
+
   const appendMessage = React.useRef<(blockContent) => void>();
-  const prevFetchNewline = React.useRef(true);
+
   appendMessage.current = React.useCallback(
     (blockContent: string) => {
-      const contentLines = blockContent.split('\n').filter((line) => !!line);
-      if (!prevFetchNewline.current && contentRef.current.lastChild) {
-        contentRef.current.lastChild.textContent += contentLines.shift();
+      if (contentRef.current && blockContent) {
+        contentRef.current.innerText += blockContent;
       }
-      prevFetchNewline.current = blockContent.endsWith('\n');
-      if (contentRef.current && contentLines.length >= 0) {
-        const elements = contentLines.map((content) => {
-          const customElement = document.createElement('div');
-          customElement.textContent = content;
-          return customElement;
-        });
-        elements.forEach((element) => {
-          contentRef.current.append(element);
-        });
-        const lastElement = elements[elements.length - 1];
-        if (render && lastElement && autoScroll) {
-          lastElement.scrollIntoView({ behavior: 'smooth', block: 'end' });
-        }
+      if (scrollToRef.current && blockContent && render && autoScroll) {
+        scrollToRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     },
     [autoScroll, render],
@@ -118,10 +107,11 @@ const Logs: React.FC<LogsProps> = ({
   }, [kind, name, resName, resNamespace]);
 
   React.useEffect(() => {
-    if (contentRef.current && render && autoScroll) {
-      contentRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    if (scrollToRef.current && render && autoScroll) {
+      scrollToRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [autoScroll, render]);
+
   return (
     <div className="odc-logs" style={{ display: render ? '' : 'none' }}>
       <p className="odc-logs__name">{name}</p>
@@ -132,7 +122,10 @@ const Logs: React.FC<LogsProps> = ({
           title={t('pipelines-plugin~An error occurred while retrieving the requested logs.')}
         />
       )}
-      <div className="odc-logs__content" ref={contentRef} />
+      <div>
+        <div className="odc-logs__content" ref={contentRef} />
+        <div ref={scrollToRef} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5224
https://bugzilla.redhat.com/show_bug.cgi?id=1915898

**Analysis / Root cause**: 
There are some edge cases where the old case appends "undefined" to the log output. The old solution also drops empty lines. 

**Solution Description**: 
Drop the string operations which split strings and append them to different div elements. Don't add new div elements per line. (Pod logs also doesn't do this.) Just use one single "content" div where new content was appended to the innerText, incl. \n.

Added a second empty div as scroll references for autoscrolling.

**Screen shots / Gifs for design review**: 
1. Could not add a screenshot for a "undefined" which should not appear anymore. :)
2. For the missing empty lines (see empty-lines.yaml) below the output changed **from** this:
![image](https://user-images.githubusercontent.com/139310/104481210-cb243c80-55c5-11eb-82e9-48c4922fcf23.png)

**to** this:
![image](https://user-images.githubusercontent.com/139310/104481240-d6776800-55c5-11eb-9cbb-05afb70e7a02.png)

The tkn cli outputs a similar look and contains the new lines:
![image](https://user-images.githubusercontent.com/139310/104481602-44bc2a80-55c6-11eb-9897-bc1be98b45bd.png)

**Unit test coverage report**: 
Not touched

**Test setup:**
To tests if the undefined doesn't appear anymore you need to run a pipeline with many output and delays multiple times. I could find this undefined in many cases when runing the `undefined-test.yaml` pipeline below.

To test the new lines you need a pipeline which creates one. One way is to disable the bash command output and run commands separated by an echo. See `empty-lines.yaml` pipeline below.

<details>
<summary>undefined-test.yaml</summary>
<pre>
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: empty-lines
spec:
  tasks:
    - name: undefined-test
      taskSpec:
        steps:
          - image: node
            name: step-name
            script: |
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
              sleep 1
              node --version
</pre>
</details>

<details>
<summary>empty-lines.yaml</summary>
<pre>
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: empty-lines
spec:
  tasks:
    - name: task-name
      taskSpec:
        steps:
          - image: node
            name: step-name
            script: |
              set +x
              echo
              node --version
              sleep 1
              node --version
              sleep 1
              echo
              node --version
              sleep 1
              echo
              echo
              node --version
              sleep 1
              node --version
              sleep 1
              echo
              node --version
              sleep 1
              echo
              node --version
              sleep 1
</pre>
</details>

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

The smooth scrolling doesn't work on Safari with and without this PR.
