### PR TITLE
Bug 1915939: Resizing the browser window removes Web Terminal Icon

### DIFF
--- a/frontend/packages/console-app/locales/en/cloudshell.json
+++ b/frontend/packages/console-app/locales/en/cloudshell.json
@@ -13,6 +13,7 @@
   "connecting to {{container}}": "connecting to {{container}}",
   "Reconnect to terminal": "Reconnect to terminal",
   "Restart terminal": "Restart terminal",
+  "OpenShift command line": "OpenShift command line",
   "Close command line terminal": "Close command line terminal",
   "Open command line terminal": "Open command line terminal",
   "OpenShift command line terminal": "OpenShift command line terminal",

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShell.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShell.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import { RootState } from '@console/internal/redux';
 import { WithFlagsProps, connectToFlags } from '@console/internal/reducers/features';
-import { isCloudShellExpanded } from '../../redux/reducers/cloud-shell-reducer';
+import { isCloudShellExpanded } from '../../redux/reducers/cloud-shell-selectors';
 import { toggleCloudShellExpanded } from '../../redux/actions/cloud-shell-actions';
-import cloudShellConfirmationModal from './cloudShellConfirmationModal';
 import CloudShellDrawer from './CloudShellDrawer';
 import CloudShellTerminal from './CloudShellTerminal';
 import { FLAG_DEVWORKSPACE } from '../../consts';
@@ -24,9 +22,8 @@ const CloudShell: React.FC<CloudShellProps> = ({ flags, open, onClose }) => {
   if (!flags[FLAG_DEVWORKSPACE]) {
     return null;
   }
-  const toggleWithModal = () => cloudShellConfirmationModal(onClose);
   return open ? (
-    <CloudShellDrawer onClose={toggleWithModal}>
+    <CloudShellDrawer onClose={onClose}>
       <CloudShellTerminal onCancel={onClose} />
     </CloudShellDrawer>
   ) : null;
@@ -36,7 +33,7 @@ const stateToProps = (state: RootState): StateProps => ({
   open: isCloudShellExpanded(state),
 });
 
-const dispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+const dispatchToProps = (dispatch): DispatchProps => ({
   onClose: () => dispatch(toggleCloudShellExpanded()),
 });
 

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadAction.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadAction.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { RootState } from '@console/internal/redux';
+import { CheckIcon } from '@patternfly/react-icons';
+import { toggleCloudShellExpanded } from '../../redux/actions/cloud-shell-actions';
+import { isCloudShellExpanded } from '../../redux/reducers/cloud-shell-selectors';
+import useCloudShellAvailable from './useCloudShellAvailable';
+
+type DispatchProps = {
+  onClick: () => void;
+};
+
+type StateProps = {
+  open?: boolean;
+};
+
+type Props = StateProps & DispatchProps & { className?: string };
+
+const ClouldShellMastheadAction: React.FC<Props> = ({ onClick, className, open }) => {
+  const terminalAvailable = useCloudShellAvailable();
+  const { t } = useTranslation();
+  if (!terminalAvailable) {
+    return null;
+  }
+  return (
+    <button
+      className={className}
+      type="button"
+      onClick={onClick}
+      data-tour-id="tour-cloud-shell-button"
+      data-quickstart-id="qs-masthead-cloudshell"
+    >
+      {t('cloudshell~OpenShift command line')}
+      {open ? (
+        <span
+          style={{
+            marginLeft: 'auto',
+            color: 'var(--pf-global--active-color--100)',
+            fontSize: 'var(--pf-global--FontSize--xs)',
+            paddingLeft: 'var(--pf-global--spacer--md)',
+          }}
+        >
+          <CheckIcon />
+        </span>
+      ) : null}
+    </button>
+  );
+};
+
+const stateToProps = (state: RootState): StateProps => ({
+  open: isCloudShellExpanded(state),
+});
+
+const dispatchToProps = (dispatch): DispatchProps => ({
+  onClick: () => dispatch(toggleCloudShellExpanded()),
+});
+
+export default connect<StateProps, DispatchProps>(
+  stateToProps,
+  dispatchToProps,
+)(ClouldShellMastheadAction);

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/useCloudShellAvailable.spec.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/useCloudShellAvailable.spec.ts
@@ -1,0 +1,51 @@
+import { act } from 'react-dom/test-utils';
+import useCloudShellAvailable from '../useCloudShellAvailable';
+import { checkTerminalAvailable } from '../cloud-shell-utils';
+import { useFlag } from '@console/shared';
+import { testHook } from '../../../../../../__tests__/utils/hooks-utils';
+
+const useFlagMock = useFlag as jest.Mock;
+const checkTerminalAvailableMock = checkTerminalAvailable as jest.Mock;
+
+jest.mock('../cloud-shell-utils', () => {
+  return {
+    checkTerminalAvailable: jest.fn<Promise<void>>(),
+  };
+});
+
+jest.mock('@console/shared', () => {
+  const originalModule = (jest as any).requireActual('@console/shared');
+  return {
+    ...originalModule,
+    useFlag: jest.fn<boolean>(),
+  };
+});
+
+describe('useCloudShellAvailable', () => {
+  it('should unavailable if flag is unavailable', () => {
+    useFlagMock.mockReturnValue(false);
+    const { result } = testHook(() => useCloudShellAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('should be unavailable if flag is set but service is unavailable', async () => {
+    useFlagMock.mockReturnValue(true);
+    checkTerminalAvailableMock.mockReturnValue(Promise.reject());
+    const { result, rerender } = testHook(() => useCloudShellAvailable());
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('should be available if flag is set and service is available', async () => {
+    useFlagMock.mockReturnValue(true);
+    checkTerminalAvailableMock.mockReturnValue(Promise.resolve());
+    const { result, rerender } = testHook(() => useCloudShellAvailable());
+
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellAvailable.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellAvailable.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { useFlag } from '@console/shared';
+import { FLAG_DEVWORKSPACE } from '../../consts';
+import { checkTerminalAvailable } from './cloud-shell-utils';
+
+const useCloudShellAvailable = () => {
+  const [terminalAvailable, setTerminalAvailable] = React.useState(false);
+  const flagEnabled = useFlag(FLAG_DEVWORKSPACE);
+  React.useEffect(() => {
+    let mounted = true;
+    if (flagEnabled) {
+      checkTerminalAvailable()
+        .then(() => {
+          if (mounted) {
+            setTerminalAvailable(true);
+          }
+        })
+        .catch(() => {
+          if (mounted) {
+            setTerminalAvailable(false);
+          }
+        });
+    } else {
+      setTerminalAvailable(false);
+    }
+    return () => {
+      mounted = false;
+    };
+  }, [flagEnabled]);
+
+  return flagEnabled && terminalAvailable;
+};
+
+export default useCloudShellAvailable;

--- a/frontend/packages/console-app/src/redux/actions/__tests__/cloud-shell-actions.spec.ts
+++ b/frontend/packages/console-app/src/redux/actions/__tests__/cloud-shell-actions.spec.ts
@@ -1,0 +1,128 @@
+import { Dispatch } from 'react-redux';
+import cloudShellConfirmationModal from '../../../components/cloud-shell/cloudShellConfirmationModal';
+import {
+  setCloudShellExpanded,
+  setCloudShellActive,
+  Actions,
+  toggleCloudShellExpanded,
+} from '../cloud-shell-actions';
+
+const cloudShellConfirmationModalMock = cloudShellConfirmationModal as jest.Mock;
+
+jest.mock('../../../components/cloud-shell/cloudShellConfirmationModal', () => ({
+  default: jest.fn((action) => action()),
+}));
+
+describe('Cloud shell actions', () => {
+  beforeEach(() => {
+    cloudShellConfirmationModalMock.mockClear();
+  });
+
+  it('should create expand action', () => {
+    expect(setCloudShellExpanded(false)).toEqual(
+      expect.objectContaining({
+        type: Actions.SetCloudShellExpanded,
+        payload: {
+          isExpanded: false,
+        },
+      }),
+    );
+    expect(setCloudShellExpanded(true)).toEqual(
+      expect.objectContaining({
+        type: Actions.SetCloudShellExpanded,
+        payload: {
+          isExpanded: true,
+        },
+      }),
+    );
+  });
+
+  it('should create active action', () => {
+    expect(setCloudShellActive(false)).toEqual(
+      expect.objectContaining({
+        type: Actions.SetCloudShellActive,
+        payload: {
+          isActive: false,
+        },
+      }),
+    );
+    expect(setCloudShellActive(true)).toEqual(
+      expect.objectContaining({
+        type: Actions.SetCloudShellActive,
+        payload: {
+          isActive: true,
+        },
+      }),
+    );
+  });
+
+  it('should thunk dispatch toggle expand true action', () => {
+    const dispatch = jest.fn<Dispatch>();
+    // initial isExpanded state is false
+    const state = { plugins: { console: { cloudShell: { isExpanded: false } } } } as any;
+    toggleCloudShellExpanded()(dispatch, () => state);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: Actions.SetCloudShellExpanded,
+        payload: {
+          isExpanded: true,
+        },
+      }),
+    );
+  });
+
+  it('should thunk dispatch toggle expand false action without confirmation', () => {
+    const dispatch = jest.fn<Dispatch>();
+    // initial isExpanded state is true but isActive is false
+    const state = {
+      plugins: { console: { cloudShell: { isExpanded: true, isActive: false } } },
+    } as any;
+    toggleCloudShellExpanded()(dispatch, () => state);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: Actions.SetCloudShellExpanded,
+        payload: {
+          isExpanded: false,
+        },
+      }),
+    );
+
+    expect(cloudShellConfirmationModal).not.toHaveBeenCalled();
+  });
+
+  it('should thunk dispatch toggle expand false action with confirmation', async () => {
+    const dispatch = jest.fn<Dispatch>();
+    // initial isExpanded state is true and isActive is true
+    const state = {
+      plugins: { console: { cloudShell: { isExpanded: true, isActive: true } } },
+    } as any;
+    await toggleCloudShellExpanded()(dispatch, () => state);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: Actions.SetCloudShellExpanded,
+        payload: {
+          isExpanded: false,
+        },
+      }),
+    );
+
+    expect(cloudShellConfirmationModal).toHaveBeenCalled();
+  });
+
+  it('should thunk dispatch toggle expand true action', () => {
+    const dispatch = jest.fn<Dispatch>();
+    // initial isExpanded state is false
+    const state = { plugins: { console: { cloudShell: { isExpanded: false } } } } as any;
+    toggleCloudShellExpanded()(dispatch, () => state);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: Actions.SetCloudShellExpanded,
+        payload: {
+          isExpanded: true,
+        },
+      }),
+    );
+
+    expect(cloudShellConfirmationModal).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/packages/console-app/src/redux/actions/cloud-shell-actions.ts
+++ b/frontend/packages/console-app/src/redux/actions/cloud-shell-actions.ts
@@ -1,13 +1,36 @@
+import { RootState } from '@console/internal/redux';
+import { Dispatch } from 'react-redux';
 import { action, ActionType } from 'typesafe-actions';
+import { isCloudShellExpanded, isCloudShellActive } from '../reducers/cloud-shell-selectors';
 
 export enum Actions {
-  ToggleCloudShellExpanded = 'toggleCloudShellExpanded',
+  SetCloudShellExpanded = 'setCloudShellExpanded',
+  SetCloudShellActive = 'setCloudShellActive',
 }
 
-export const toggleCloudShellExpanded = () => action(Actions.ToggleCloudShellExpanded);
+export const setCloudShellExpanded = (isExpanded: boolean) =>
+  action(Actions.SetCloudShellExpanded, { isExpanded });
+
+export const toggleCloudShellExpanded = () => async (
+  dispatch: Dispatch,
+  getState: () => RootState,
+) => {
+  const expanded = isCloudShellExpanded(getState());
+  if (expanded && isCloudShellActive(getState())) {
+    (await import('../../components/cloud-shell/cloudShellConfirmationModal')).default(() =>
+      dispatch(setCloudShellExpanded(false)),
+    );
+  } else {
+    dispatch(setCloudShellExpanded(!expanded));
+  }
+};
+
+export const setCloudShellActive = (isActive: boolean) =>
+  action(Actions.SetCloudShellActive, { isActive });
 
 const actions = {
-  toggleCloudShellExpanded,
+  setCloudShellExpanded,
+  setCloudShellActive,
 };
 
 export type CloudShellActions = ActionType<typeof actions>;

--- a/frontend/packages/console-app/src/redux/reducer.ts
+++ b/frontend/packages/console-app/src/redux/reducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
-import cloudShellReducer, { cloudShellReducerName } from './reducers/cloud-shell-reducer';
+import cloudShellReducer from './reducers/cloud-shell-reducer';
+import { cloudShellReducerName } from './reducers/cloud-shell-selectors';
 
 export default combineReducers({
   [cloudShellReducerName]: cloudShellReducer,

--- a/frontend/packages/console-app/src/redux/reducers/__tests__/cloud-shell-reducer.spec.ts
+++ b/frontend/packages/console-app/src/redux/reducers/__tests__/cloud-shell-reducer.spec.ts
@@ -1,0 +1,25 @@
+import { setCloudShellExpanded, setCloudShellActive } from '../../actions/cloud-shell-actions';
+import reducer from '../cloud-shell-reducer';
+
+describe('Cloud shell reducer', () => {
+  it('should have initial state', () => {
+    // create an unsupported test action
+    const state = reducer(undefined, { type: 'test' } as any);
+    expect(state.isExpanded).toBe(false);
+    expect(state.isActive).toBe(false);
+  });
+
+  it('should set expanded', () => {
+    let state = reducer(undefined, setCloudShellExpanded(true));
+    expect(state.isExpanded).toBe(true);
+    state = reducer(state, setCloudShellExpanded(false));
+    expect(state.isExpanded).toBe(false);
+  });
+
+  it('should set active', () => {
+    let state = reducer(undefined, setCloudShellActive(true));
+    expect(state.isActive).toBe(true);
+    state = reducer(state, setCloudShellActive(false));
+    expect(state.isActive).toBe(false);
+  });
+});

--- a/frontend/packages/console-app/src/redux/reducers/__tests__/cloud-shell-selectors.spec.ts
+++ b/frontend/packages/console-app/src/redux/reducers/__tests__/cloud-shell-selectors.spec.ts
@@ -1,0 +1,25 @@
+import {
+  isCloudShellExpanded,
+  isCloudShellActive,
+  cloudShellReducerName,
+} from '../cloud-shell-selectors';
+
+describe('Cloud shell selectors', () => {
+  it('should select isExpanded', () => {
+    expect(isCloudShellExpanded({} as any)).toBe(false);
+    expect(
+      isCloudShellExpanded({
+        plugins: { console: { [cloudShellReducerName]: { isExpanded: true } } },
+      } as any),
+    ).toBe(true);
+  });
+
+  it('should select isActive', () => {
+    expect(isCloudShellActive({} as any)).toBe(false);
+    expect(
+      isCloudShellActive({
+        plugins: { console: { [cloudShellReducerName]: { isActive: true } } },
+      } as any),
+    ).toBe(true);
+  });
+});

--- a/frontend/packages/console-app/src/redux/reducers/cloud-shell-reducer.ts
+++ b/frontend/packages/console-app/src/redux/reducers/cloud-shell-reducer.ts
@@ -1,25 +1,28 @@
 import { CloudShellActions, Actions } from '../actions/cloud-shell-actions';
-import { RootState } from '@console/internal/redux';
-
-export const cloudShellReducerName = 'cloudShell';
 
 type State = {
   isExpanded: boolean;
+  isActive: boolean;
 };
 
 const initialState: State = {
   isExpanded: false,
+  isActive: false,
 };
 
-export default (state = initialState, action: CloudShellActions) => {
-  if (action.type === Actions.ToggleCloudShellExpanded) {
-    return {
-      isExpanded: !state.isExpanded,
-    };
+export default (state = initialState, action: CloudShellActions): State => {
+  switch (action.type) {
+    case Actions.SetCloudShellExpanded:
+      return {
+        ...state,
+        isExpanded: action.payload.isExpanded,
+      };
+    case Actions.SetCloudShellActive:
+      return {
+        ...state,
+        isActive: action.payload.isActive,
+      };
+    default:
+      return state;
   }
-
-  return state;
 };
-
-export const isCloudShellExpanded = (state: RootState): boolean =>
-  !!state.plugins?.console?.[cloudShellReducerName]?.isExpanded;

--- a/frontend/packages/console-app/src/redux/reducers/cloud-shell-selectors.ts
+++ b/frontend/packages/console-app/src/redux/reducers/cloud-shell-selectors.ts
@@ -1,0 +1,9 @@
+import { RootState } from '@console/internal/redux';
+
+export const cloudShellReducerName = 'cloudShell';
+
+export const isCloudShellExpanded = (state: RootState): boolean =>
+  !!state.plugins?.console?.[cloudShellReducerName]?.isExpanded;
+
+export const isCloudShellActive = (state: RootState): boolean =>
+  !!state.plugins?.console?.[cloudShellReducerName]?.isActive;

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -25,6 +25,7 @@ import { Link } from 'react-router-dom';
 import { FLAGS, YellowExclamationTriangleIcon } from '@console/shared';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
 import CloudShellMastheadButton from '@console/app/src/components/cloud-shell/CloudShellMastheadButton';
+import CloudShellMastheadAction from '@console/app/src/components/cloud-shell/CloudShellMastheadAction';
 import * as UIActions from '../actions/ui';
 import { connectToFlags, flagPending, featureReducerName } from '../reducers/features';
 import { authSvc } from '../module/auth';
@@ -489,6 +490,9 @@ class MastheadToolbarContents_ extends React.Component {
         actions: [
           {
             component: <Link to={this._getImportYAMLPath()}>{t('masthead~Import YAML')}</Link>,
+          },
+          {
+            component: <CloudShellMastheadAction />,
           },
         ],
       });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5313

**Analysis / Root cause**: 
Web terminal button missing from mobile menu.

**Solution Description**: 
Adds the web terminal action to the mobile menu.

Refactored redux action component, `CloudShellMastheadAction`, and refactored `CloudShellMastheadButton` to reuse the same hook and redux state.

Added a new redux state `isActive` which captures when the terminal window is actually present. Works in conjunction with `isExpanded` which denotes the drawer is opened. This was necessary to know when the close confirmation model was required to prompt the user. Previously even if the setup form was opened we prompted the user to confirm ending their session even though no session was present. With this new state, I was able to reconcile all close actions into one.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux 

When the terminal is closed:
![image](https://user-images.githubusercontent.com/14068621/104497763-d7e66780-55a8-11eb-8d20-84fc46fdc082.png)

When the terminal is open:
![image](https://user-images.githubusercontent.com/14068621/104498417-a91cc100-55a9-11eb-9700-ad7d56199516.png)

**Unit test coverage report**: 
Added unit tests for cloud-shell redux reducers, actions, and selectors.
Added unit tests for `useCloudShellAvailable` hook.
![image](https://user-images.githubusercontent.com/14068621/104497373-4119ab00-55a8-11eb-9a01-5a7506514fe8.png)

**Test setup:**
Install web terminal operator from operator hub.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
