### PR TITLE
[release-4.6] Bug 1916406: Helm chart repository index can contain unresolvable relative URL's

### DIFF
--- a/pkg/helm/chartproxy/repos_test.go
+++ b/pkg/helm/chartproxy/repos_test.go
@@ -2,18 +2,18 @@ package chartproxy
 
 import (
 	"errors"
-	"fmt"
-	helmrepo "helm.sh/helm/v3/pkg/repo"
 	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+	"testing"
+
+	helmrepo "helm.sh/helm/v3/pkg/repo"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeclient "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	fakeclienttest "k8s.io/client-go/testing"
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"testing"
 
 	"github.com/openshift/console/pkg/helm/actions/fake"
 )
@@ -22,6 +22,12 @@ type apiError struct {
 	verb     string
 	resource string
 	msg      string
+}
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
 }
 
 func onlyResult(obj interface{}, err error) interface{} {
@@ -261,11 +267,12 @@ func TestHelmRepoGetter_ListErrors(t *testing.T) {
 
 func TestHelmRepo_IndexFile(t *testing.T) {
 	tests := []struct {
-		name      string
-		url       string
-		httpCode  int
-		indexFile string
-		err       bool
+		name              string
+		url               string
+		httpCode          int
+		indexFile         string
+		expectedIndexFile string
+		err               bool
 	}{
 		{
 			name:      "return index file",
@@ -283,6 +290,13 @@ func TestHelmRepo_IndexFile(t *testing.T) {
 			httpCode:  404,
 			err:       true,
 		},
+		{
+			name:              "return resolved index file",
+			indexFile:         "testdata/sampleRepoIndexWithRelativeURLs.yaml",
+			expectedIndexFile: "testdata/sampleRepoIndex.yaml",
+			httpCode:          200,
+			err:               false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -293,18 +307,7 @@ func TestHelmRepo_IndexFile(t *testing.T) {
 			url := tt.url
 
 			if url == "" {
-				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Set("Content-Type", "application/yaml")
-					w.WriteHeader(tt.httpCode)
-					if tt.indexFile != "" {
-						content, err := ioutil.ReadFile(tt.indexFile)
-						if err != nil {
-							t.Error(err)
-						}
-						fmt.Fprintln(w, string(content))
-					}
-				}))
-				url = ts.URL
+				url = "https://redhat-developer.github.com/redhat-helm-charts/charts/"
 			}
 			repoCR := unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -325,12 +328,37 @@ func TestHelmRepo_IndexFile(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
+			if tt.url == "" {
+				repo.httpClient = func() (*http.Client, error) {
+					return &http.Client{
+						Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+							resp := &http.Response{
+								StatusCode: tt.httpCode,
+							}
+							if tt.indexFile != "" {
+								r, err := os.Open(tt.indexFile)
+								if err != nil {
+									t.Error(err)
+								}
+								resp.Body = ioutil.NopCloser(r)
+							}
+							return resp
+						}),
+					}, nil
+				}
+			}
 			index, err := repo.IndexFile()
 			if tt.err && err == nil {
 				t.Errorf("Expected error %v but got %v", tt.err, err)
 			}
+
 			if err == nil && tt.indexFile != "" {
-				expectedIndex, err := helmrepo.LoadIndexFile(tt.indexFile)
+				var expectedIndex *helmrepo.IndexFile
+				if tt.expectedIndexFile != "" {
+					expectedIndex, err = helmrepo.LoadIndexFile(tt.expectedIndexFile)
+				} else {
+					expectedIndex, err = helmrepo.LoadIndexFile(tt.indexFile)
+				}
 				if err != nil {
 					t.Error(err)
 				}

--- a/pkg/helm/chartproxy/testdata/azureRepoIndex.yaml
+++ b/pkg/helm/chartproxy/testdata/azureRepoIndex.yaml
@@ -6,7 +6,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: a9bc374461e31cb1429021a898ef83d0a650783033f3bc121ed536ad99301bbc
       name: aks-helloworld
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.1.tgz
       version: 0.1.1
     - apiVersion: v1
@@ -14,7 +14,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: f4eb20e7116b24c4825861e6ff6f4303bbe83bcee4a7b2b6ea9fe6929852f34d
       name: aks-helloworld
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.0.tgz
       version: 0.1.0
   azure-vote:
@@ -23,7 +23,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: ac7698878230b11c766c0fcbfce36e7a1c8ab4ab18d55eae9e6551217042c164
       name: azure-vote
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/azure-vote-0.1.1.tgz
       version: 0.1.1
     - apiVersion: v1
@@ -31,7 +31,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: da054ba832f52ff3e8da26ffe705d6ad6c2ed0818c04588c832c716e8e8d84a7
       name: azure-vote
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/azure-vote-0.1.0.tgz
       version: 0.1.0
   azure-vote-osba:
@@ -40,7 +40,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 64f7688099208066cef552afc560bd4d0ff04a297365c4260d3116fd1af061da
       name: azure-vote-osba
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/azure-vote-osba-0.1.0.tgz
       version: 0.1.0
   burst-scheduler:
@@ -49,7 +49,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 326910e7174b98c337e508c1b2baa1e430720758e013256aa8fcbcf1551c2c13
       name: burst-scheduler
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/burst-scheduler-0.1.0.tgz
       version: 0.1.0
   image-pull-secret:
@@ -58,7 +58,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: ee937e26d72c420a9eb5af8eb0ef23206260858c830b06e7b5ec37c5752fa6a3
       name: image-pull-secret
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/image-pull-secret-0.1.0.tgz
       version: 0.1.0
   open-service-broker-azure:
@@ -86,7 +86,7 @@ entries:
       sources:
         - https://github.com/azure/open-service-broker-azure
         - https://hub.docker.com/r/microsoft/azure-service-broker/
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/open-service-broker-azure-v0.0.1.tgz
       version: v0.0.1
   osba-container-instances-demo:
@@ -95,7 +95,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: b5f25ecf64d72644166835e48afda396b83acaff341bcb7c1e60efc12e547df6
       name: osba-container-instances-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-container-instances-demo-0.1.0.tgz
       version: 0.1.0
   osba-cosmos-mongodb-demo:
@@ -104,7 +104,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: b581f67458cdf999ef0308786dc29f603bab6aadf5ad0a127f5fb1a816aef091
       name: osba-cosmos-mongodb-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-cosmos-mongodb-demo-0.1.0.tgz
       version: 0.1.0
   osba-mysql-demo:
@@ -113,7 +113,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 034fe8960dcc4948ae28110622c6ea5b5439eb5ee35750899446da2455acf6ea
       name: osba-mysql-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-mysql-demo-0.1.0.tgz
       version: 0.1.0
   osba-storage-demo:
@@ -122,7 +122,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: d74b4c6a348b988e4dfa8fb2ad6873f533aeb0390ee5a1a88fedcee9fc2abc3a
       name: osba-storage-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-storage-demo-0.1.0.tgz
       version: 0.1.0
   osba-text-analytics-demo:
@@ -131,7 +131,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: d249a3f0926c24f448e36bc40211faee4b320927919e27c1aabe337065496db0
       name: osba-text-analytics-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-text-analytics-demo-0.1.0.tgz
       version: 0.1.0
   tweet-factory-operator:
@@ -140,7 +140,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 8186cd27426d20d607f093f90ee05fe65be0e27fda7ecaeb6b98c1ee6204f11a
       name: tweet-factory-operator
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/tweet-factory-operator-0.1.0.tgz
       version: 0.1.0
   twitter-sentiment:
@@ -149,7 +149,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 0a71fceec9bc133c4d2e7a9475e19478bb997cd10898803eaf68f3ce33ff271a
       name: twitter-sentiment
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/twitter-sentiment-0.1.0.tgz
       version: 0.1.0
   twitter-sentiment-cnab:
@@ -158,7 +158,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: f6446a210a13c6f8a3b5d5feb7cd70115e3b00c8b445dc14c5186e5d2a56de2a
       name: twitter-sentiment-cnab
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/twitter-sentiment-cnab-0.1.0.tgz
       version: 0.1.0
 generated: "2020-03-30T16:27:13.4275217-05:00"

--- a/pkg/helm/chartproxy/testdata/mergedAzureRepoIndex.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedAzureRepoIndex.yaml
@@ -6,7 +6,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: a9bc374461e31cb1429021a898ef83d0a650783033f3bc121ed536ad99301bbc
       name: aks-helloworld
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.1.tgz
       version: 0.1.1
     - apiVersion: v1
@@ -14,7 +14,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: f4eb20e7116b24c4825861e6ff6f4303bbe83bcee4a7b2b6ea9fe6929852f34d
       name: aks-helloworld
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.0.tgz
       version: 0.1.0
   azure-vote--sample-repo-1:
@@ -23,7 +23,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: ac7698878230b11c766c0fcbfce36e7a1c8ab4ab18d55eae9e6551217042c164
       name: azure-vote
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/azure-vote-0.1.1.tgz
       version: 0.1.1
     - apiVersion: v1
@@ -31,7 +31,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: da054ba832f52ff3e8da26ffe705d6ad6c2ed0818c04588c832c716e8e8d84a7
       name: azure-vote
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/azure-vote-0.1.0.tgz
       version: 0.1.0
   azure-vote-osba--sample-repo-1:
@@ -40,7 +40,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 64f7688099208066cef552afc560bd4d0ff04a297365c4260d3116fd1af061da
       name: azure-vote-osba
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/azure-vote-osba-0.1.0.tgz
       version: 0.1.0
   burst-scheduler--sample-repo-1:
@@ -49,7 +49,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 326910e7174b98c337e508c1b2baa1e430720758e013256aa8fcbcf1551c2c13
       name: burst-scheduler
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/burst-scheduler-0.1.0.tgz
       version: 0.1.0
   image-pull-secret--sample-repo-1:
@@ -58,7 +58,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: ee937e26d72c420a9eb5af8eb0ef23206260858c830b06e7b5ec37c5752fa6a3
       name: image-pull-secret
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/image-pull-secret-0.1.0.tgz
       version: 0.1.0
   open-service-broker-azure--sample-repo-1:
@@ -86,7 +86,7 @@ entries:
       sources:
         - https://github.com/azure/open-service-broker-azure
         - https://hub.docker.com/r/microsoft/azure-service-broker/
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/open-service-broker-azure-v0.0.1.tgz
       version: v0.0.1
   osba-container-instances-demo--sample-repo-1:
@@ -95,7 +95,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: b5f25ecf64d72644166835e48afda396b83acaff341bcb7c1e60efc12e547df6
       name: osba-container-instances-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-container-instances-demo-0.1.0.tgz
       version: 0.1.0
   osba-cosmos-mongodb-demo--sample-repo-1:
@@ -104,7 +104,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: b581f67458cdf999ef0308786dc29f603bab6aadf5ad0a127f5fb1a816aef091
       name: osba-cosmos-mongodb-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-cosmos-mongodb-demo-0.1.0.tgz
       version: 0.1.0
   osba-mysql-demo--sample-repo-1:
@@ -113,7 +113,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 034fe8960dcc4948ae28110622c6ea5b5439eb5ee35750899446da2455acf6ea
       name: osba-mysql-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-mysql-demo-0.1.0.tgz
       version: 0.1.0
   osba-storage-demo--sample-repo-1:
@@ -122,7 +122,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: d74b4c6a348b988e4dfa8fb2ad6873f533aeb0390ee5a1a88fedcee9fc2abc3a
       name: osba-storage-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-storage-demo-0.1.0.tgz
       version: 0.1.0
   osba-text-analytics-demo--sample-repo-1:
@@ -131,7 +131,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: d249a3f0926c24f448e36bc40211faee4b320927919e27c1aabe337065496db0
       name: osba-text-analytics-demo
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/osba-text-analytics-demo-0.1.0.tgz
       version: 0.1.0
   tweet-factory-operator--sample-repo-1:
@@ -140,7 +140,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 8186cd27426d20d607f093f90ee05fe65be0e27fda7ecaeb6b98c1ee6204f11a
       name: tweet-factory-operator
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/tweet-factory-operator-0.1.0.tgz
       version: 0.1.0
   twitter-sentiment--sample-repo-1:
@@ -149,7 +149,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: 0a71fceec9bc133c4d2e7a9475e19478bb997cd10898803eaf68f3ce33ff271a
       name: twitter-sentiment
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/twitter-sentiment-0.1.0.tgz
       version: 0.1.0
   twitter-sentiment-cnab--sample-repo-1:
@@ -158,7 +158,7 @@ entries:
       description: A Helm chart for Kubernetes
       digest: f6446a210a13c6f8a3b5d5feb7cd70115e3b00c8b445dc14c5186e5d2a56de2a
       name: twitter-sentiment-cnab
-      response:
+      urls:
         - https://azure-samples.github.io/helm-charts/twitter-sentiment-cnab-0.1.0.tgz
       version: 0.1.0
 generated: "2020-03-30T16:27:13.4275217-05:00"

--- a/pkg/helm/chartproxy/testdata/mergedRepoIndexWithDuplicates.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedRepoIndexWithDuplicates.yaml
@@ -39,7 +39,7 @@ entries:
       maintainers:
         - name: IBM
       name: ibm-cpq-prod
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
       version: 2.0.0
   ibm-object-storage-plugin--sample-repo-1:
@@ -74,7 +74,7 @@ entries:
         - email: contsto2@in.ibm.com
           name: IBM
       name: ibm-object-storage-plugin
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
       version: 2.0.0
   ibm-oms-ent-prod--sample-repo-1:
@@ -112,7 +112,7 @@ entries:
         - name: IBM
       name: ibm-oms-ent-prod
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
       version: 5.0.0
   ibm-cpq-prod--sample-repo-2:
@@ -154,7 +154,7 @@ entries:
       maintainers:
         - name: IBM
       name: ibm-cpq-prod
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
       version: 2.0.0
   ibm-object-storage-plugin--sample-repo-2:
@@ -189,7 +189,7 @@ entries:
         - email: contsto2@in.ibm.com
           name: IBM
       name: ibm-object-storage-plugin
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
       version: 2.0.0
   ibm-oms-ent-prod--sample-repo-2:
@@ -227,7 +227,7 @@ entries:
         - name: IBM
       name: ibm-oms-ent-prod
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
       version: 5.0.0
 generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/mergedSampleRepoIndex2.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedSampleRepoIndex2.yaml
@@ -39,7 +39,7 @@ entries:
       maintainers:
         - name: IBM
       name: ibm-cpq-prod
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
       version: 2.0.0
   ibm-object-storage-plugin--sample-repo-1:
@@ -74,7 +74,7 @@ entries:
         - email: contsto2@in.ibm.com
           name: IBM
       name: ibm-object-storage-plugin
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
       version: 2.0.0
   ibm-oms-ent-prod--sample-repo-1:
@@ -112,7 +112,7 @@ entries:
         - name: IBM
       name: ibm-oms-ent-prod
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
       version: 5.0.0
   ibm-oms-pro-prod--sample-repo-1:
@@ -150,7 +150,7 @@ entries:
         - name: IBM
       name: ibm-oms-pro-prod
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
       version: 5.0.0
   ibm-operator-catalog-enablement--sample-repo-1:
@@ -183,7 +183,7 @@ entries:
         - name: IBM
       name: ibm-operator-catalog-enablement
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
       version: 1.0.0
   nodejs-ex-k--sample-repo-1:
@@ -194,7 +194,7 @@ entries:
       digest: 9f8eca455f8379baddd6ab61bd5517373514bb99bedbbddffb98ad88ac9841cc
       name: nodejs-ex-k
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.2.0.tgz
       version: 0.2.0
     - apiVersion: v2
@@ -204,7 +204,7 @@ entries:
       digest: 64b36fee719567e2aae8cb6186ba02a56dc62a90df71af7f90cc1d9d2cd1fb25
       name: nodejs-ex-k
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
       version: 0.1.1
 generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndex.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndex.yaml
@@ -39,7 +39,7 @@ entries:
       maintainers:
         - name: IBM
       name: ibm-cpq-prod
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
       version: 2.0.0
   ibm-object-storage-plugin:
@@ -74,7 +74,7 @@ entries:
         - email: contsto2@in.ibm.com
           name: IBM
       name: ibm-object-storage-plugin
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
       version: 2.0.0
   ibm-oms-ent-prod:
@@ -112,7 +112,7 @@ entries:
         - name: IBM
       name: ibm-oms-ent-prod
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
       version: 5.0.0
   ibm-oms-pro-prod:
@@ -150,7 +150,7 @@ entries:
         - name: IBM
       name: ibm-oms-pro-prod
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
       version: 5.0.0
   ibm-operator-catalog-enablement:
@@ -183,7 +183,7 @@ entries:
         - name: IBM
       name: ibm-operator-catalog-enablement
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
       version: 1.0.0
   nodejs-ex-k:
@@ -194,7 +194,7 @@ entries:
       digest: 9f8eca455f8379baddd6ab61bd5517373514bb99bedbbddffb98ad88ac9841cc
       name: nodejs-ex-k
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.2.0.tgz
       version: 0.2.0
     - apiVersion: v2
@@ -204,7 +204,7 @@ entries:
       digest: 64b36fee719567e2aae8cb6186ba02a56dc62a90df71af7f90cc1d9d2cd1fb25
       name: nodejs-ex-k
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
       version: 0.1.1
 generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndex2.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndex2.yaml
@@ -39,7 +39,7 @@ entries:
       maintainers:
         - name: IBM
       name: ibm-cpq-prod
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
       version: 2.0.0
   ibm-object-storage-plugin:
@@ -74,7 +74,7 @@ entries:
         - email: contsto2@in.ibm.com
           name: IBM
       name: ibm-object-storage-plugin
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
       version: 2.0.0
   ibm-oms-ent-prod:
@@ -112,7 +112,7 @@ entries:
         - name: IBM
       name: ibm-oms-ent-prod
       type: application
-      response:
+      urls:
         - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
       version: 5.0.0
 generated: "2020-07-15T16:32:34.538582491+05:30"

--- a/pkg/helm/chartproxy/testdata/sampleRepoIndexWithRelativeURLs.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoIndexWithRelativeURLs.yaml
@@ -1,167 +1,6 @@
 apiVersion: v1
 entries:
-  aks-helloworld--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4350608-05:00"
-      description: A Helm chart for Kubernetes
-      digest: a9bc374461e31cb1429021a898ef83d0a650783033f3bc121ed536ad99301bbc
-      name: aks-helloworld
-      urls:
-        - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.1.tgz
-      version: 0.1.1
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.433497-05:00"
-      description: A Helm chart for Kubernetes
-      digest: f4eb20e7116b24c4825861e6ff6f4303bbe83bcee4a7b2b6ea9fe6929852f34d
-      name: aks-helloworld
-      urls:
-        - https://azure-samples.github.io/helm-charts/aks-helloworld-0.1.0.tgz
-      version: 0.1.0
-  azure-vote--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4454224-05:00"
-      description: A Helm chart for Kubernetes
-      digest: ac7698878230b11c766c0fcbfce36e7a1c8ab4ab18d55eae9e6551217042c164
-      name: azure-vote
-      urls:
-        - https://azure-samples.github.io/helm-charts/azure-vote-0.1.1.tgz
-      version: 0.1.1
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4436157-05:00"
-      description: A Helm chart for Kubernetes
-      digest: da054ba832f52ff3e8da26ffe705d6ad6c2ed0818c04588c832c716e8e8d84a7
-      name: azure-vote
-      urls:
-        - https://azure-samples.github.io/helm-charts/azure-vote-0.1.0.tgz
-      version: 0.1.0
-  azure-vote-osba--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4518442-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 64f7688099208066cef552afc560bd4d0ff04a297365c4260d3116fd1af061da
-      name: azure-vote-osba
-      urls:
-        - https://azure-samples.github.io/helm-charts/azure-vote-osba-0.1.0.tgz
-      version: 0.1.0
-  burst-scheduler--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.455658-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 326910e7174b98c337e508c1b2baa1e430720758e013256aa8fcbcf1551c2c13
-      name: burst-scheduler
-      urls:
-        - https://azure-samples.github.io/helm-charts/burst-scheduler-0.1.0.tgz
-      version: 0.1.0
-  image-pull-secret--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4592817-05:00"
-      description: A Helm chart for Kubernetes
-      digest: ee937e26d72c420a9eb5af8eb0ef23206260858c830b06e7b5ec37c5752fa6a3
-      name: image-pull-secret
-      urls:
-        - https://azure-samples.github.io/helm-charts/image-pull-secret-0.1.0.tgz
-      version: 0.1.0
-  open-service-broker-azure--sample-repo-1:
-    - apiVersion: v1
-      appVersion: v0.0.1
-      created: "2020-03-30T16:27:13.4706997-05:00"
-      dependencies:
-        - condition: redis.embedded
-          name: redis
-          repository: https://kubernetes-charts.storage.googleapis.com/
-          version: 0.10.0
-      description: A Helm chart for Open Service Broker For Azure
-      digest: 407ba56844a0e8ed67014ea3d7ef32d2b2e15f7f34bf691b237da6f10818e265
-      home: https://github.com/azure/open-service-broker-azure
-      keywords:
-        - azure
-        - services
-        - service broker
-      maintainers:
-        - email: kent.rancourt@microsoft.com
-          name: Kent Rancourt
-        - email: jeremy.rickard@microsoft.com
-          name: Jeremy Rickard
-      name: open-service-broker-azure
-      sources:
-        - https://github.com/azure/open-service-broker-azure
-        - https://hub.docker.com/r/microsoft/azure-service-broker/
-      urls:
-        - https://azure-samples.github.io/helm-charts/open-service-broker-azure-v0.0.1.tgz
-      version: v0.0.1
-  osba-container-instances-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4798738-05:00"
-      description: A Helm chart for Kubernetes
-      digest: b5f25ecf64d72644166835e48afda396b83acaff341bcb7c1e60efc12e547df6
-      name: osba-container-instances-demo
-      urls:
-        - https://azure-samples.github.io/helm-charts/osba-container-instances-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-cosmos-mongodb-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.489062-05:00"
-      description: A Helm chart for Kubernetes
-      digest: b581f67458cdf999ef0308786dc29f603bab6aadf5ad0a127f5fb1a816aef091
-      name: osba-cosmos-mongodb-demo
-      urls:
-        - https://azure-samples.github.io/helm-charts/osba-cosmos-mongodb-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-mysql-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.4958437-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 034fe8960dcc4948ae28110622c6ea5b5439eb5ee35750899446da2455acf6ea
-      name: osba-mysql-demo
-      urls:
-        - https://azure-samples.github.io/helm-charts/osba-mysql-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-storage-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5013751-05:00"
-      description: A Helm chart for Kubernetes
-      digest: d74b4c6a348b988e4dfa8fb2ad6873f533aeb0390ee5a1a88fedcee9fc2abc3a
-      name: osba-storage-demo
-      urls:
-        - https://azure-samples.github.io/helm-charts/osba-storage-demo-0.1.0.tgz
-      version: 0.1.0
-  osba-text-analytics-demo--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5060898-05:00"
-      description: A Helm chart for Kubernetes
-      digest: d249a3f0926c24f448e36bc40211faee4b320927919e27c1aabe337065496db0
-      name: osba-text-analytics-demo
-      urls:
-        - https://azure-samples.github.io/helm-charts/osba-text-analytics-demo-0.1.0.tgz
-      version: 0.1.0
-  tweet-factory-operator--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5104606-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 8186cd27426d20d607f093f90ee05fe65be0e27fda7ecaeb6b98c1ee6204f11a
-      name: tweet-factory-operator
-      urls:
-        - https://azure-samples.github.io/helm-charts/tweet-factory-operator-0.1.0.tgz
-      version: 0.1.0
-  twitter-sentiment--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5145249-05:00"
-      description: A Helm chart for Kubernetes
-      digest: 0a71fceec9bc133c4d2e7a9475e19478bb997cd10898803eaf68f3ce33ff271a
-      name: twitter-sentiment
-      urls:
-        - https://azure-samples.github.io/helm-charts/twitter-sentiment-0.1.0.tgz
-      version: 0.1.0
-  twitter-sentiment-cnab--sample-repo-1:
-    - apiVersion: v1
-      created: "2020-03-30T16:27:13.5192786-05:00"
-      description: A Helm chart for Kubernetes
-      digest: f6446a210a13c6f8a3b5d5feb7cd70115e3b00c8b445dc14c5186e5d2a56de2a
-      name: twitter-sentiment-cnab
-      urls:
-        - https://azure-samples.github.io/helm-charts/twitter-sentiment-cnab-0.1.0.tgz
-      version: 0.1.0
-  ibm-cpq-prod--sample-repo-2:
+  ibm-cpq-prod:
     - apiVersion: v2
       appVersion: 10.0.0.6
       created: "2020-07-15T16:32:34.607411698+05:30"
@@ -201,9 +40,9 @@ entries:
         - name: IBM
       name: ibm-cpq-prod
       urls:
-        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-2.0.0.tgz
+        - ibm-cpq-prod-2.0.0.tgz
       version: 2.0.0
-  ibm-object-storage-plugin--sample-repo-2:
+  ibm-object-storage-plugin:
     - apiVersion: v2
       appVersion: 2.0.0
       created: "2020-07-15T16:32:34.612556197+05:30"
@@ -236,9 +75,9 @@ entries:
           name: IBM
       name: ibm-object-storage-plugin
       urls:
-        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+        - ibm-object-storage-plugin-2.0.0.tgz
       version: 2.0.0
-  ibm-oms-ent-prod--sample-repo-2:
+  ibm-oms-ent-prod:
     - apiVersion: v2
       appVersion: 10.0.0
       created: "2020-07-15T16:32:34.663118186+05:30"
@@ -274,9 +113,9 @@ entries:
       name: ibm-oms-ent-prod
       type: application
       urls:
-        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+        - ibm-oms-ent-prod-5.0.0.tgz
       version: 5.0.0
-  ibm-oms-pro-prod--sample-repo-2:
+  ibm-oms-pro-prod:
     - apiVersion: v2
       appVersion: 10.0.0
       created: "2020-07-15T16:32:34.695882333+05:30"
@@ -312,9 +151,9 @@ entries:
       name: ibm-oms-pro-prod
       type: application
       urls:
-        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
+        - ibm-oms-pro-prod-5.0.0.tgz
       version: 5.0.0
-  ibm-operator-catalog-enablement--sample-repo-2:
+  ibm-operator-catalog-enablement:
     - apiVersion: v2
       appVersion: 1.0.0
       created: "2020-07-15T16:32:34.697730479+05:30"
@@ -345,9 +184,9 @@ entries:
       name: ibm-operator-catalog-enablement
       type: application
       urls:
-        - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
+        - ibm-operator-catalog-enablement-1.0.0.tgz
       version: 1.0.0
-  nodejs-ex-k--sample-repo-2:
+  nodejs-ex-k:
     - apiVersion: v2
       appVersion: 1.16.0
       created: "2020-07-15T16:32:34.700484147+05:30"
@@ -356,7 +195,7 @@ entries:
       name: nodejs-ex-k
       type: application
       urls:
-        - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.2.0.tgz
+        - nodejs-ex-k-0.2.0.tgz
       version: 0.2.0
     - apiVersion: v2
       appVersion: 1.16.0
@@ -366,7 +205,6 @@ entries:
       name: nodejs-ex-k
       type: application
       urls:
-        - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
+        - nodejs-ex-k-0.1.1.tgz
       version: 0.1.1
-
-generated: "2020-03-30T16:27:13.4275217-05:00"
+generated: "2020-07-15T16:32:34.538582491+05:30"


### PR DESCRIPTION
Manual backport PR for failed attempt https://github.com/openshift/console/pull/7711#issuecomment-759821622

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1912907

(cherry-picked from 0bc500a6f3b3d0dc98d08071f0bcd13431eb2928)
fixed merge conflict + updated sample helm repo's as we rely on `urls` field:

pkg/helm/chartproxy/repos.go
pkg/helm/chartproxy/repos_test.go
pkg/helm/chartproxy/testdata/azureRepoIndex.yaml
pkg/helm/chartproxy/testdata/mergedAzureRepoIndex.yaml
pkg/helm/chartproxy/testdata/mergedRepoIndex.yaml
pkg/helm/chartproxy/testdata/mergedRepoIndexWithDuplicates.yaml
pkg/helm/chartproxy/testdata/mergedSampleRepoIndex2.yaml
pkg/helm/chartproxy/testdata/sampleRepoIndex.yaml
pkg/helm/chartproxy/testdata/sampleRepoIndex2.yaml
pkg/helm/chartproxy/testdata/sampleRepoIndexWithRelativeURLs.yaml

/assign pedjak