### PR TITLE
[release-4.6] Bug 1916378: fix skipped tasks in conditional pipelines

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -41,6 +41,7 @@ interface PipelineVisualizationTaskProp {
   pipelineRunStatus?: string;
   disableTooltip?: boolean;
   selected?: boolean;
+  isSkipped?: boolean;
 }
 
 export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> = ({
@@ -50,6 +51,7 @@ export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> 
   pipelineRunStatus,
   disableTooltip,
   selected,
+  isSkipped,
 }) => {
   const taskStatus = task.status || {
     duration: '',
@@ -59,6 +61,9 @@ export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> 
     if (task.status?.reason === runStatus.Idle || task.status?.reason === runStatus.Pending) {
       taskStatus.reason = runStatus.Cancelled;
     }
+  }
+  if (isSkipped) {
+    taskStatus.reason = runStatus.Skipped;
   }
 
   const taskComponent = (

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskNode.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/TaskNode.tsx
@@ -14,6 +14,7 @@ const TaskNode: React.FC<TaskNodeProps> = ({ element, disableTooltip }) => {
   const { height, width } = element.getBounds();
   const { pipeline, pipelineRun, task, selected } = element.getData();
 
+  const isTaskSkipped = pipelineRun?.status?.skippedTasks?.some((t) => t.name === task.name);
   return (
     <foreignObject width={width} height={height + DROP_SHADOW_SPACING}>
       <PipelineVisualizationTask
@@ -23,6 +24,7 @@ const TaskNode: React.FC<TaskNodeProps> = ({ element, disableTooltip }) => {
         namespace={pipeline?.metadata?.namespace}
         disableTooltip={disableTooltip}
         selected={selected}
+        isSkipped={isTaskSkipped}
       />
     </foreignObject>
   );

--- a/frontend/packages/dev-console/src/test/pipeline-data.ts
+++ b/frontend/packages/dev-console/src/test/pipeline-data.ts
@@ -10,6 +10,7 @@ export enum DataState {
   FAILED2 = 'Failed at stage 2',
   FAILED3 = 'Failed at stage 3',
   FAILED_BUT_COMPLETE = 'Completed But Failed',
+  SKIPPED = 'Skipped',
 }
 
 export enum PipelineExampleNames {
@@ -18,6 +19,7 @@ export enum PipelineExampleNames {
   SIMPLE_PIPELINE = 'simple-pipeline',
   CLUSTER_PIPELINE = 'cluster-pipeline',
   BROKEN_MOCK_APP = 'broken-mock-app',
+  CONDITIONAL_PIPELINE = 'conditional-pipeline',
   INVALID_PIPELINE_MISSING_TASK = 'missing-task-pipeline',
   INVALID_PIPELINE_INVALID_TASK = 'invalid-task-pipeline',
 }
@@ -1370,6 +1372,121 @@ export const pipelineTestData: PipelineTestData = {
                 ],
                 podName: '',
                 startTime: '2020-07-13T17:16:28Z',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  [PipelineExampleNames.CONDITIONAL_PIPELINE]: {
+    dataSource: 'conditional-pipeline',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'conditional-pipeline',
+        namespace: 'tekton-pipelines',
+      },
+      spec: {
+        tasks: [
+          {
+            name: 'first-create-file',
+            resources: {
+              outputs: [
+                {
+                  name: 'workspace',
+                  resource: 'source-repo',
+                },
+              ],
+            },
+            taskRef: {
+              kind: 'Task',
+              name: 'create-readme-file',
+            },
+          },
+          {
+            when: [
+              {
+                Input: '$(params.path)',
+                Operator: 'in',
+                Values: ['README.md'],
+              },
+            ],
+            name: 'then-check',
+            taskRef: {
+              kind: 'Task',
+              name: 'echo-hello',
+            },
+          },
+        ],
+      },
+    },
+    pipelineRuns: {
+      [DataState.SKIPPED]: {
+        apiVersion: 'tekton.dev/v1beta1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'when-expression-pipeline-cx05c9',
+          namespace: 'tekton-pipelines',
+          labels: {
+            'tekton.dev/pipeline': 'when-expression-pipeline',
+          },
+        },
+        spec: {
+          params: [
+            {
+              name: 'path',
+              value: 'README.txt',
+            },
+          ],
+          pipelineRef: {
+            name: 'when-expression-pipeline',
+          },
+          resources: [
+            {
+              name: 'source-repo',
+              resourceRef: {
+                name: 'pipeline-git',
+              },
+            },
+          ],
+          serviceAccountName: 'pipeline',
+          timeout: '1h0m0s',
+        },
+        status: {
+          completionTime: '2021-01-13T14:34:19Z',
+          conditions: [
+            {
+              lastTransitionTime: '2021-01-13T14:34:19Z',
+              message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 1',
+              reason: 'Completed',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+          skippedTasks: [
+            {
+              name: 'then-check',
+            },
+          ],
+          startTime: '2021-01-13T14:33:59Z',
+          taskRuns: {
+            'when-expression-pipeline-cx05c9-first-create-file-4sqr2': {
+              pipelineTaskName: 'first-create-file',
+              status: {
+                completionTime: '2021-01-13T14:34:19Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-01-13T14:34:19Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'when-expression-pipeline-cx05c9-first-create-file-4sqr2-p-2p5j8',
+                startTime: '2021-01-13T14:33:59Z',
               },
             },
           },

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
@@ -116,6 +116,7 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       Succeeded: 0,
       Failed: 0,
       Cancelled: 0,
+      Skipped: 0,
     });
   });
 
@@ -283,6 +284,25 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
       expect(sumCancelledTaskStatus(taskStatus)).toEqual(expected.cancelled);
+      expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
+    });
+  });
+
+  describe('Skipped pipelines', () => {
+    // When a pipeline run skips certain task based on the when expression/condtion
+    const sumSkippedTaskStatus = (status: TaskStatus): number => status.Skipped;
+    const sumSuccededTaskStatus = (status: TaskStatus): number => status.Succeeded;
+    const complexTestData = pipelineTestData[PipelineExampleNames.CONDITIONAL_PIPELINE];
+
+    it(`expect to return the skipped task status count if whenExpression is used`, () => {
+      const expected = { succeeded: 1, skipped: 1 };
+      const taskCount = getExpectedTaskCount(complexTestData.pipeline);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.SKIPPED],
+        complexTestData.pipeline,
+      );
+      expect(sumSkippedTaskStatus(taskStatus)).toEqual(expected.skipped);
+      expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
       expect(sumTaskStatuses(taskStatus)).toEqual(taskCount);
     });
   });

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-filter-reducer.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-filter-reducer.spec.ts
@@ -32,8 +32,19 @@ const mockPipelineRuns = [
     },
   },
   { status: { conditions: [{ status: 'Unknown', type: 'Succeeded' }] } },
-  { status: { conditions: [{ reason: 'PipelineRunCancelled' }] } },
-  { status: { conditions: [{ reason: 'TaskRunCancelled' }] } },
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'PipelineRunCancelled' }],
+    },
+  },
+  {
+    status: { conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'TaskRunCancelled' }] },
+  },
+  {
+    status: {
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'ConditionCheckFailed' }],
+    },
+  },
 ];
 
 describe('Check PipelineRun Status | Filter Reducer applied to the following:', () => {
@@ -92,5 +103,8 @@ describe('Check PipelineRun Status | Filter Reducer applied to the following:', 
   it('Pipelinerun with first element of condition array with type as "Succeeded" & status as "Unknown"', () => {
     const reducerOutput = pipelineRunStatus(mockPipelineRuns[10]);
     expect(reducerOutput).toBe('Cancelled');
+  });
+  it('Pipelinerun with ConditionCheckFailed status should be skipped', () => {
+    expect(pipelineRunStatus(mockPipelineRuns[11])).toBe('Skipped');
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
@@ -2,22 +2,37 @@ import * as _ from 'lodash';
 
 export const pipelineRunStatus = (pipelineRun): string => {
   const conditions = _.get(pipelineRun, ['status', 'conditions'], []);
-  const isCancelled = conditions.find((c) =>
-    ['PipelineRunCancelled', 'TaskRunCancelled'].some((cancel) => cancel === c.reason),
-  );
-  if (isCancelled) {
-    return 'Cancelled';
-  }
   if (conditions.length === 0) return null;
-
-  const condition = conditions.find((c) => c.type === 'Succeeded');
-  return !condition || !condition.status
-    ? null
-    : condition.status === 'True'
-    ? 'Succeeded'
-    : condition.status === 'False'
-    ? 'Failed'
-    : 'Running';
+  const succeedCondition = conditions.find((c) => c.type === 'Succeeded');
+  if (!succeedCondition || !succeedCondition.status) {
+    return null;
+  }
+  const status =
+    succeedCondition.status === 'True'
+      ? 'Succeeded'
+      : succeedCondition.status === 'False'
+      ? 'Failed'
+      : 'Running';
+  if (succeedCondition.reason && succeedCondition.reason !== status) {
+    switch (succeedCondition.reason) {
+      case 'PipelineRunCancelled':
+      case 'TaskRunCancelled':
+      case 'Cancelled':
+        return 'Cancelled';
+      case 'PipelineRunStopping':
+      case 'TaskRunStopping':
+        return 'Failed';
+      case 'CreateContainerConfigError':
+      case 'ExceededNodeResources':
+      case 'ExceededResourceQuota':
+        return 'Pending';
+      case 'ConditionCheckFailed':
+        return 'Skipped';
+      default:
+        return status;
+    }
+  }
+  return status;
 };
 
 export const pipelineFilterReducer = (pipeline): string => {


### PR DESCRIPTION
Manual Cherry-Pick of #7833 

Waiting for cluster-bot to give this an official test on 4.6. Merge conflicts and manual cherry-picking was needed since we have a pipelines plugin package in 4.7. 

Tested on 4.6.10 cluster with the 4.6 channel on the Pipeline Operator (1.2.2).

Tested with the RFE suggested [upstream file](https://github.com/tektoncd/pipeline/blob/master/examples/v1beta1/pipelineruns/conditional-pipelinerun.yaml).

## Screenshots

Success
![Screen Shot 2021-01-14 at 12 01 56 PM](https://user-images.githubusercontent.com/8126518/104623461-636eff80-5660-11eb-856d-20b6f973f6b2.png)

"Fail" (Skipped)
![Screen Shot 2021-01-14 at 12 01 42 PM](https://user-images.githubusercontent.com/8126518/104623458-62d66900-5660-11eb-9a4b-7eaa7490600f.png)
![Screen Shot 2021-01-14 at 12 02 06 PM](https://user-images.githubusercontent.com/8126518/104623462-636eff80-5660-11eb-96fd-f7ea36b02133.png)
