### PR TITLE
Bug 1916764: Avoid setting application name in edit flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -91,6 +91,7 @@ const GitSection: React.FC<GitSectionProps> = ({
 
       gitRepoName && !values.name && setFieldValue('name', gitRepoName);
       gitRepoName &&
+        values.formType !== 'edit' &&
         !values.application.name &&
         values.application.selectedKey !== UNASSIGNED_KEY &&
         setFieldValue('application.name', `${gitRepoName}-app`);
@@ -118,6 +119,7 @@ const GitSection: React.FC<GitSectionProps> = ({
       setFieldValue,
       values.application.name,
       values.application.selectedKey,
+      values.formType,
       values.git.type,
       values.name,
     ],
@@ -165,6 +167,7 @@ const GitSection: React.FC<GitSectionProps> = ({
     const gitRepoName = detectGitRepoName(url);
     values.formType !== 'edit' && gitRepoName && setFieldValue('name', gitRepoName);
     gitRepoName &&
+      values.formType !== 'edit' &&
       !values.application.name &&
       values.application.selectedKey !== UNASSIGNED_KEY &&
       setFieldValue('application.name', `${gitRepoName}-app`);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5072
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When editing a workload through the edit import forms, the application gets suggested when the value started off empty.

**Solution Description**: 
Set the application name only in add flow, and not in edit flow.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/104741962-e337bf80-576f-11eb-86f1-ca10a1753f0a.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug