### PR TITLE
Bug 1899627: Update project status icon and text in the dashboard Status panel to match health-item display

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/dashboard-card/card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/dashboard-card/card.scss
@@ -1,6 +1,8 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
+@import '../../../../../../public/components/_icon-and-text.scss';
 
 $co-dashboard-card--line-height: 19px;
+$co-dashboard-text-font-size: 0.875rem;
 
 .co-dashboard-card {
   margin: 0;
@@ -57,9 +59,9 @@ $co-dashboard-card--line-height: 19px;
 }
 
 .co-dashboard-icon {
-  font-size: 1.2rem;
+  font-size: $co-icon-and-text-icon-lg;
 }
 
 .co-dashboard-text--small {
-  font-size: 0.875rem;
+  font-size: $co-dashboard-text-font-size;
 }

--- a/frontend/public/components/_icon-and-text.scss
+++ b/frontend/public/components/_icon-and-text.scss
@@ -1,3 +1,5 @@
+$co-icon-and-text-icon-lg: 1.2rem;
+
 .co-icon-and-text {
   align-items: baseline;
   display: flex;
@@ -10,4 +12,13 @@
 
 .co-icon-and-text__icon {
   margin-right: 5px;
+}
+
+.co-icon-and-text--lg {
+  display: block;
+
+  .co-icon-and-text__icon {
+    font-size: $co-icon-and-text-icon-lg;
+    margin-right: 1rem;
+  }
 }

--- a/frontend/public/components/dashboard/project-dashboard/status-card.scss
+++ b/frontend/public/components/dashboard/project-dashboard/status-card.scss
@@ -1,9 +1,0 @@
-.co-project-dashboard__status {
-  display: flex;
-  align-items: center;
-  padding-right: var(--pf-global--spacer--xl);
-}
-
-.co-project-dashboard__status:last-of-type {
-  padding-right: 0;
-}

--- a/frontend/public/components/dashboard/project-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/status-card.tsx
@@ -15,8 +15,7 @@ import {
 } from '@console/plugin-sdk';
 import { ProjectDashboardContext } from './project-dashboard-context';
 import { ResourceHealthItem } from '../dashboards-page/cluster-dashboard/health-item';
-
-import './status-card.scss';
+import { Gallery } from '@patternfly/react-core';
 
 export const StatusCard: React.FC = () => {
   const { obj } = React.useContext(ProjectDashboardContext);
@@ -44,12 +43,14 @@ export const StatusCard: React.FC = () => {
       </DashboardCardHeader>
       <DashboardCardBody isLoading={!obj}>
         <HealthBody>
-          <div className="co-project-dashboard__status">
-            <Status status={obj.status.phase} />
-          </div>
-          {subsystem && (
-            <ResourceHealthItem subsystem={subsystem.properties} namespace={namespace} />
-          )}
+          <Gallery className="co-overview-status__health" hasGutter>
+            <div className="co-status-card__health-item">
+              <Status status={obj.status.phase} className="co-icon-and-text--lg" />
+            </div>
+            {subsystem && (
+              <ResourceHealthItem subsystem={subsystem.properties} namespace={namespace} />
+            )}
+          </Gallery>
         </HealthBody>
       </DashboardCardBody>
     </DashboardCard>


### PR DESCRIPTION
Changes to project status Icon and text sizes and spacing with Image Vulnerabilities.

- Wrap with `<Gallery>` component to match Admin overview status panel.
- Remove `frontend/public/components/dashboard/project-dashboard/status-card.scss` styles and use `.co-status-card__health-item` for positioning, same as `< ResourceHealthItem>`

Nested `.co-icon-and-text--lg  .co-icon-and-text__icon` rule needed to set size and spacing.

fix https://bugzilla.redhat.com/show_bug.cgi?id=1899627

cc @itsptk 

**Before**
<img width="1114" alt="Screen Shot 2021-01-15 at 10 27 51 AM" src="https://user-images.githubusercontent.com/1874151/104746734-aa6efa80-571d-11eb-9335-36cd36c77b42.png">

----
**After**
<img width="1087" alt="Screen Shot 2021-01-13 at 4 50 00 PM copy" src="https://user-images.githubusercontent.com/1874151/104746758-b064db80-571d-11eb-93f7-13360207c56f.png">

----
**Overview Dashboard**
<img width="1111" alt="Screen Shot 2021-01-15 at 10 37 08 AM" src="https://user-images.githubusercontent.com/1874151/104746823-c70b3280-571d-11eb-84b5-a061b0d907dd.png">
