### PR TITLE
Interop UI helm navigation

### DIFF
--- a/frontend/packages/dev-console/integration-tests/cypress.json
+++ b/frontend/packages/dev-console/integration-tests/cypress.json
@@ -23,7 +23,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "@smoke and not @manual"
+    "TAGS": "@smoke or @regression and not @manual"
   },
   "retries": {
     "runMode": 1,

--- a/frontend/packages/dev-console/integration-tests/features/helm/actions-on-HelmRelease.feature
+++ b/frontend/packages/dev-console/integration-tests/features/helm/actions-on-HelmRelease.feature
@@ -1,58 +1,58 @@
 Feature: Perform Actions on Helm Releases
     As a user, I want to perform the actions on the helm releases in topology page
 
-Background:
-    Given user is at developer perspecitve
-    And user has selected namespace "aut-actions-helm"
-    And helm release "nodejs-ex-k" is present in topology page
+    Background:
+        Given user is at developer perspective
+        And user has selected namespace "aut-actions-helm"
+        And helm release "nodejs-ex-k" is present in topology page
 
 
-@regression, @smoke
-Scenario: Context menu options of helm release: HR-07-TC01
-    Given user is on topology page
-    When user right clicks on the helm release "nodejs-ex-k"
-    Then user is able to see the context menu with actions Upgrade, Rollback and Uninstall Helm Release
+    @regression, @smoke
+    Scenario: Context menu options of helm release: HR-07-TC01
+        Given user is at the Topology page
+        When user right clicks on the helm release "nodejs-ex-k" to open the context menu
+        Then user is able to see the context menu with actions Upgrade, Rollback and Uninstall Helm Release
 
 
-@regression, @smoke
-Scenario: Actions drop down on the side bar: HR-10-TC08
-    Given user is on the topology sidebar of the helm release "nodejs-ex-k"
-    When user clicks on the Actions drop down menu
-    Then user is able to see the actions dropdown menu with actions Upgrade, Rollback and Uninstall Helm Release
+    @regression, @smoke
+    Scenario: Actions drop down on the side bar: HR-10-TC08
+        Given user is on the topology sidebar of the helm release "nodejs-ex-k"
+        When user clicks on the Actions drop down menu
+        Then user is able to see the actions dropdown menu with actions Upgrade, Rollback and Uninstall Helm Release
 
 
-@regression, @smoke
-Scenario: Actions menu on Helm page
-    Given user is on the Helm page with helm release "nodejs-ex-k"
-    When user clicks on the Kebab menu
-    Then user is able to see kebab menu with actions Upgrade, Rollback and Uninstall Helm Release
+    @regression, @smoke
+    Scenario: Actions menu on Helm page
+        Given user is on the Helm page with helm release "nodejs-ex-k"
+        When user clicks on the Kebab menu
+        Then user is able to see kebab menu with actions Upgrade, Rollback and Uninstall Helm Release
 
 
-@regression, @smoke
-Scenario: Perform Upgrade action on Helm Release through Context Menu: HR-08-TC02
-    Given user is at the Topolgy page
-    When user right clicks on the Helm Release "nodejs-ex-k" to open the context menu
-    And user clicks on the "Upgrade" action
-    And user upgrades the chart Version
-    And user clicks on the upgrade button
-    Then user will be redirected to Topology page
+    @regression, @smoke
+    Scenario: Perform Upgrade action on Helm Release through Context Menu: HR-08-TC02
+        Given user is at the Topology page
+        When user right clicks on the helm release "nodejs-ex-k" to open the context menu
+        And user clicks on the "Upgrade" action
+        And user upgrades the chart Version
+        And user clicks on the upgrade button
+        Then user will be redirected to Topology page
 
 
-@regression, @smoke
-Scenario: Perform Rollback action on Helm Release through Context Menu: HR-08-TC03
-    Given user is at the Topolgy page
-    When user right clicks on the Helm Release "nodejs-ex-k" to open the context menu
-    And user clicks on the "Rollback" action
-    And user selects the version to Rollback
-    And user clicks on the rollback button
-    Then user will be redirected to Topology page
+    @regression, @smoke
+    Scenario: Perform Rollback action on Helm Release through Context Menu: HR-08-TC03
+        Given user is at the Topology page
+        When user right clicks on the helm release "nodejs-ex-k" to open the context menu
+        And user clicks on the "Rollback" action
+        And user selects the version to Rollback
+        And user clicks on the rollback button
+        Then user will be redirected to Topology page
 
 
-@regression, @smoke
-Scenario: Uninstall Helm Release through Context Menu: HR-08-TC04
-    Given user is at the Topolgy page
-    When user right clicks on the Helm Release "nodejs-ex-k" to open the context menu
-    And user clicks on the "Uninstall Helm Release" action
-    And user enters the release name
-    And user clicks on the Uninstall button
-    Then user will be redirected to Topology page with no workloads
+    @regression, @smoke
+    Scenario: Uninstall Helm Release through Context Menu: HR-08-TC04
+        Given user is at the Topology page
+        When user right clicks on the helm release "nodejs-ex-k" to open the context menu
+        And user clicks on the "Uninstall Helm Release" action
+        And user enters the release name
+        And user clicks on the Uninstall button
+        Then user will be redirected to Topology page with no workloads

--- a/frontend/packages/dev-console/integration-tests/features/helm/helm-Installation-View.feature
+++ b/frontend/packages/dev-console/integration-tests/features/helm/helm-Installation-View.feature
@@ -2,36 +2,39 @@ Feature: Helm Chart Installation View
     As a user, I should be able switch between YAML and Form view to install Helm Chart
 
 
-Background:
-    Given user logged into the openshift application
-    And user is at developer perspecitve
+    Background:
+        Given user logged into the openshift application
+        And user is at developer perspective
 
 
-@regression
-Scenario: Grouping of Helm multiple chart versions together in developer catalog
-    Given user is at the developer catalog page
-    When user checks the Helm Charts checkbox
-    And user searches for the 'Nodejs Ex K v0.2.1' helm chart
-    Then user will see the one helm chart "Nodejs Ex K v0.2.1"
-    And user will see the chart version dropdown at the Install Helm Chart page
+    @regression
+    Scenario: Grouping of Helm multiple chart versions together in developer catalog
+        Given user is at Add page
+        When user selects "From Catalog" card from add page
+        And user selects "Helm Charts" option from Type section
+        And user searches 'Nodejs Ex K v0.2.1' card from catalog page
+        And user selects "Nodejs Ex K v0.2.1" helm chart from catalog page
+        And user will see the information of all the chart versions together
+        And user clicks on the Install Helm Chart button on side bar
+        Then user will see the chart version dropdown
 
 
-@regression, @smoke, @manual
-Scenario: Switch from YAML to Form view
-    Given user is at the Install Helm Chart page
-    When user selects the YAML View
-    And user does some changes in the yaml for helm chart
-    And user selects the Form view
-    And user comes back to YAML view
-    Then user will see that the data hasn't lost
+    @regression, @smoke, @manual
+    Scenario: Switch from YAML to Form view
+        Given user is at the Install Helm Chart page
+        When user selects the YAML View
+        And user does some changes in the yaml for helm chart
+        And user selects the Form view
+        And user comes back to YAML view
+        Then user will see that the data hasn't lost
 
 
-@regression, @smoke, @manual
-Scenario: Switch from Form to YAML view
-    Given user is at the Install Helm Chart page
-    When user selects the Form View
-    And user will see values and choices are pulled from JSON Schema associated with chart
-    And user does some changes in the form for helm chart
-    And user selects the YAML view
-    And user comes back to Form view
-    Then user will see that the data hasn't lost
+    @regression, @smoke, @manual
+    Scenario: Switch from Form to YAML view
+        Given user is at the Install Helm Chart page
+        When user selects the Form View
+        And user will see values and choices are pulled from JSON Schema associated with chart
+        And user does some changes in the form for helm chart
+        And user selects the YAML view
+        And user comes back to Form view
+        Then user will see that the data hasn't lost

--- a/frontend/packages/dev-console/integration-tests/features/helm/helm-Navigation.feature
+++ b/frontend/packages/dev-console/integration-tests/features/helm/helm-Navigation.feature
@@ -1,129 +1,123 @@
 Feature: Navigations on Helm Chart
     As a user, I want to navigate to different pages related to Helm Charts
 
-Background:
-    Given user is at developer perspecitve
-    And user has selected namespace "aut-helm-navigation"
+    Background:
+        Given user is at developer perspective
+        And user has selected namespace "aut-helm-navigation"
+
+    @regression, @smoke
+    Scenario: Open the Helm tab on the navigation bar when helm charts are absent: HR-11-TC02
+        Given user is at developer perspective
+        When user clicks on the Helm tab
+        Then user will be redirected to Helm releases page
+        And user is able to see the message as no helm charts present
+        And user will get the link to install helm charts from developer catalog
 
 
-@regression, @smoke
-Scenario: Open the Helm tab on the navigation bar when helm charts are absent: HR-11-TC02
-    Given user is at developer perspecitve
-    When user clicks on the Helm tab
-    Then user will be redirected to Helm releases page
-    And user is able to see the message as no helm charts present
-    And user will get the link to install helm charts from developer catalog
+    @regression, @smoke
+    Scenario: Install Helm Chart page: HR-02-TC04
+        Given user is at Add page
+        When user selects "Helm Chart" card from add page
+        And user searches "Nodejs Ex K v0.2.1" card from catalog page
+        And user selects "Nodejs Ex K v0.2.1" helm chart from catalog page
+        And user clicks on the Install Helm Chart button on side bar
+        Then Install Helm Chart page is displayed
+        And release name displays as "nodejs-ex-k"
 
 
-@regression, @smoke
-Scenario: Install Helm Chart page: HR-02-TC04
-    Given user is at Add page
-    When user clicks on the Helm Chart card on the Add page
-    And user searches for the "Nodejs Ex K v0.2.0" helm chart
-    And user clicks on the "Nodejs Ex K v0.2.0" helm chart card
-    And user clicks on the Install Helm Chart button on side bar
-    Then Install Helm Chart page is displayed
-    And release name displays as "nodejs-ex-k"
+    @regression, @smoke
+    Scenario: Yaml view editor for Install Helm Chart page: HR-02-TC05
+        Given user is at Install Helm Chart page
+        When user selects YAML view
+        Then user is able to see YAML editor
 
 
-@regression, @smoke
-Scenario: Yaml view editor for Install Helm Chart page: HR-02-TC05
-    Given user is at Install Helm Chart page
-    When user selects YAML view
-    Then user is able to see YAML editor
+    @regression, @smoke
+    Scenario: Install Helm Chart: HR-02-TC01, HR-02-TC03, HR-02-TC06
+        Given user is at Add page
+        When user selects "Helm Chart" card from add page
+        And user searches "Nodejs Ex K v0.2.1" card from catalog page
+        And user selects "Nodejs Ex K v0.2.1" helm chart from catalog page
+        And user clicks on the Install Helm Chart button on side bar
+        And user clicks on the Install button
+        Then user will be redirected to Topology page
+        And Topology page have the helm chart workload "nodejs-example"
 
 
-@regression, @smoke
-Scenario: Install Helm Chart: HR-02-TC01, HR-02-TC03, HR-02-TC06
-    Given user is at Add page
-    When user clicks on the Helm Chart card on the Add page
-    And user searches for the "Nodejs Ex K v0.2.0" helm chart
-    And user clicks on the "Nodejs Ex K v0.2.0" helm chart card
-    And user clicks on the Install Helm Chart button on side bar
-    And user clicks on the Install button
-    Then user will be redirected to Topology page
-    And Topology page have the helm chart workload "nodejs-example"
+    @regression, @smoke
+    Scenario: Open the Helm tab on the navigation bar when helm charts are present: HR-11-TC01
+        Given helm chart is installed
+        When user clicks on the Helm tab
+        Then user will be redirected to Helm releases page
+        And user will see the helm charts listed
 
 
-@regression, @smoke
-Scenario: Open the Helm tab on the navigation bar when helm charts are present: HR-11-TC01
-    Given helm chart is installed
-    When user clicks on the Helm tab
-    Then user will be redirected to Helm releases page
-    And user will see the helm charts listed
+    @regression
+    Scenario: Filter out deployed Helm Charts: HR-11-TC02
+        Given user is at the Helm page
+        When user clicks on the filter drop down
+        And user selects checkbox for the "Deployed" Helm charts
+        Then the checkbox for the "Deployed" Helm chart is checked
+        And helm charts with status "Deployed" are listed
+
+    @regression
+    Scenario: Filter out failed Helm Charts: HR-11-TC03
+        Given user is at the Helm page
+        When user clicks on the filter drop down
+        And user selects checkbox for the "Failed" Helm charts
+        Then the checkbox for the "Failed" Helm chart is checked
+        And helm charts with status "Failed" are listed
 
 
-@regression
-Scenario: Filter out deployed Helm Charts: HR-11-TC02
-    Given user is at the Helm page
-    When user clicks on the filter drop down
-    And user selects checkbox for the Deployed Helm charts
-    Then the checkbox for the Deployed Helm chart is checked
-    And helm charts with status deployed are listed
+    @regression
+    Scenario: Filter out other Helm charts : HR-11-TC04
+        Given user is at the Helm page
+        When user clicks on the filter drop down
+        And user selects checkbox for the "Other" Helm charts
+        Then the checkbox for the "Other" Helm chart is checked
+        And helm charts with status "Other" are listed
 
 
-@regression
-Scenario: Filter out failed Helm Charts: HR-11-TC03
-    Given user is at the Helm page
-    When user clicks on the filter drop down
-    And user selects checkbox for the Failed Helm charts
-    Then the checkbox for the Failed Helm chart is checked
-    And helm charts with status failed are listed
+    @regression
+    Scenario: Select all filters: HR-11-TC05
+        Given user is at the Helm page
+        When user clicks on the filter drop down
+        And user selects checkbox for the "all" Helm charts
+        Then the checkbox for the "all" Helm chart is checked
+
+    @regression
+    Scenario: Clear all filters: HR-11-TC06
+        When user selects checkbox for the "all" Helm charts
+        When user clicks on the clear all filters button
+        Then "all" filters selected will get removed
 
 
-@regression
-Scenario: Filter out other Helm charts : HR-11-TC04
-    Given user is at the Helm page
-    When user clicks on the filter drop down
-    And user selects checkbox for the Other Helm charts
-    Then the checkbox for the Other Helm chart is checked
-    And helm charts with status other are listed
+    @regression
+    Scenario: Search for the Helm Chart: HR-11-TC07
+        Given user is at the Helm page
+        When user searches for a helm chart "nodejs-ex-k"
+        Then the helm chart "nodejs-ex-k" will be shown
+
+    @regression, @smoke
+    Scenario: Search for the not available Helm Chart
+        Given user is at the Helm page
+        When user searches for a helm chart "Nodejs Ex K v0.10.0"
+        Then user is able to see message on the Helm page as "Not found"
 
 
-@regression
-Scenario: Select all filters: HR-11-TC05
-    Given user is at the Helm page
-    When user clicks on the filter drop down 
-    And user selects checkbox for the Deployed Helm charts
-    And user selects checkbox for the Failed Helm charts
-    And user selects checkbox for the Other Helm charts
-    Then the checkbox for the Deployed Helm chart is checked
-    And the checkbox for the Failed Helm chart is checked
-    And the checkbox for the Other Helm chart is checked
+    @regression, @smoke
+    Scenario: Helm release details page : HR-11-TC08
+        Given user is at the Helm page
+        When user clicks on the helm release name "nodejs-ex-k"
+        Then user will see the Details page opened
+        And user will see the Resources tab
+        And user will see the Revision History tab
+        And user will see the Release Notes tab
+        And user will see the Actions drop down menu
 
-
-@regression
-Scenario: Clear all filters: HR-11-TC06
-    Given user has selected all filters
-    When user clicks on the clear all filters button
-    Then all filters selected will get removed
-
-
-@regression
-Scenario: Search for the Helm Chart: HR-11-TC07
-    Given user is at the Helm page
-    When user searches for a helm chart "Nodejs Ex K v0.2.0"
-    Then the helm chart "Nodejs Ex K v0.2.0" will be shown
-
-
-Scenario: Search for the not available Helm Chart
-    Given user is at the Helm page
-    When user searches for a helm chart "Nodejs Ex K v0.10.0"
-    # Then user is able to see message on the Helm page as "message" - update message
-
-
-@regression, @smoke
-Scenario: Helm release details page : HR-11-TC08
-    Given user is at the Helm page with one helm release
-    When user clicks on the helm release name "nodejs-ex-k"
-    Then user will see the Details page opened
-    And user will see the Resources tab
-    And user will see the Revision History tab
-    And user will see the Release Notes tab
-    And user will see the Actions drop down menu
-
-
-Scenario: Actions menu of Helm Details page : P-03-TC10
-   Given user is at the Helm page
-   When user clicks Actions menu in Helm Details page
-   Then Actions menu display with options Upgrade, Rollback, and Uninstall Helm Release
+    @regression, @smoke
+    Scenario: Actions menu of Helm Details page : P-03-TC10
+        Given user is at the Helm page
+        When user clicks on the helm release name "nodejs-ex-k"
+        When user clicks Actions menu in Helm Details page
+        Then Actions menu display with options Upgrade, Rollback, and Uninstall Helm Release

--- a/frontend/packages/dev-console/integration-tests/features/helm/install-HelmChart.feature
+++ b/frontend/packages/dev-console/integration-tests/features/helm/install-HelmChart.feature
@@ -12,12 +12,12 @@ Feature: Install the Helm Release
         Then user can see "Helm Chart" card on the Add page
 
 
-    @regression, @smoke, @manual
+    @regression, @smoke
     Scenario: Developer Catalog Page when Helm Charts checkbox is selected: HR-01-TC02, HR-02-TC02
         Given user is at Add page
         And user has added multiple helm charts repositories
-        When user clicks on the Helm Chart card on the Add page
-        Then user will get redirected to Developer Catalog page
+        When user selects "Helm Chart" card from add page
+        Then user will get redirected to Helm Charts page
         And user will see the list of Chart Repositories
         And user will see the cards of Helm Charts
         And user will see Filter by Keyword field
@@ -74,11 +74,11 @@ Feature: Install the Helm Release
         And modal will have the warning of data lost
 
 
-    @regression, @manual
+    @regression
     Scenario: README should be updated when chart version is updated
-        Given user is at the Install Helm Chart page
-        When user clicks on the Chart Version dropdown menu
-        And user selects the different chart version
-        And modal will get popped up
-        And user clicks on yes to update the chart version
-        Then user will see that the README is also updated with new chart version
+        Given user is at Install Helm Chart page
+        Then user will see the chart version dropdown
+        When user selects YAML view
+        When user selects the Chart Version "0.2.0 / App Version 1.16.0 (Provided by Red Hat Helm Charts)"
+        When user selects "Proceed" button from Change Chart version confirmation dialog
+        Then user will see that the README is also updated with new chart version "0.2.0 / App Version 1.16.0 (Provided by Red Hat Helm Charts)"

--- a/frontend/packages/dev-console/integration-tests/features/helm/topology-HelmRelease.feature
+++ b/frontend/packages/dev-console/integration-tests/features/helm/topology-HelmRelease.feature
@@ -1,71 +1,69 @@
 Feature: Actions on Helm release in topology page
     User will be able to open the context menu and side bar for the helm releases
 
-Background:
-    Given user is at developer perspecitve
-    And user has selected namespace "aut-helm-sidebar"
-    And helm release "nodejs-ex-k" is present in topology page
+    Background:
+        Given user is at developer perspective
+        And user has selected namespace "aut-helm-sidebar"
+        And helm release "nodejs-ex-k" is present in topology page
+
+    @regression, @smoke
+    Scenario: Context menu options of helm release: HR-07-TC01
+        When user right clicks on the helm release "nodejs-ex-k" to open the context menu
+        Then user is able to see the context menu with actions Upgrade, Rollback and Uninstall Helm Release
 
 
-@regression, @smoke
-Scenario: Context menu options of helm release: HR-07-TC01
-    Given helm release "nodejs-ex-k" is present in topology page
-    When user right clicks on the helm release "nodejs-ex-k"
-    Then user is able to see the context menu with actions Upgrade, Rollback and Uninstall Helm Release
+    @regression, @smoke
+    Scenario: Open Side Bar for the Helm release: HR-10-TC01, HR-10-TC02
+        Given user is at the Topology page
+        When user clicks on the helm release "nodejs-ex-k"
+        Then user will see the sidebar for the helm release
+        And user will see the Details, Resources, Release notes tabs
 
 
-@regression, @smoke
-Scenario: Open Side Bar for the Helm release: HR-10-TC01, HR-10-TC02
-    Given user is at the Topolgy page
-    When user clicks on the helm release "nodejs-ex-k"
-    Then user will see the sidebar for the helm release
-    And user will see the Details, Resources, Release Notes tabs
+    @regression
+    Scenario: Deployment Configs link on the sidebar for the Helm Release: HR-10-TC03
+        Given user is on the topology sidebar of the helm release "nodejs-ex-k"
+        When user switches to the "Resources" tab
+        And user clicks on the link for the "Deployment Configs" of helm release
+        Then user is redirected to the "Deployment Config" Details page for the helm release
 
 
-@regression
-Scenario: Deployment Configs link on the sidebar for the Helm Release: HR-10-TC03
-    Given user is on the topology sidebar of the helm release "nodejs-ex-k"
-    When user switches to the Resources tab
-    And user clicks on the link for the deployment config of helm release
-    Then user is redirected to the Deployment Config Details page for the helm release
+    @regression
+    Scenario: Build Configs link on the sidebar for the Helm Release: HR-10-TC04
+        Given user is on the topology sidebar of the helm release "nodejs-ex-k"
+        When user switches to the "Resources" tab
+        And user clicks on the link for the "Build Configs" of helm release
+        Then user is redirected to the "Build Config" Details page for the helm release
 
 
-@regression
-Scenario: Build Configs link on the sidebar for the Helm Release: HR-10-TC04
-    Given user is on the topology sidebar of the helm release "nodejs-ex-k"
-    When user switches to the Resources tab
-    And user clicks on the link for the build config of helm release
-    Then user is redirected to the Build Config Details page for the helm release
+    @regression
+    Scenario: Services link on the sidebar for the Helm Release: HR-10-TC05
+        Given user is on the topology sidebar of the helm release "nodejs-ex-k"
+        When user switches to the "Resources" tab
+        And user clicks on the link for the "Services" of helm release
+        Then user is redirected to the "Service" Details page for the helm release
 
 
-@regression
-Scenario: Services link on the sidebar for the Helm Release: HR-10-TC05
-    Given user is on the topology sidebar of the helm release "nodejs-ex-k"
-    When user switches to the Resources tab
-    And user clicks on the link for the services of helm release
-    Then user is redirected to the Service Details page for the helm release
+    @regression
+    Scenario: Image Streams link on the sidebar for the Helm Release: HR-10-TC06
+        Given user is on the topology sidebar of the helm release "nodejs-ex-k"
+        When user switches to the "Resources" tab
+        And user clicks on the link for the "Image Streams" of helm release
+        Then user is redirected to the "Image Streams" Details page for the helm release
 
 
-@regression
-Scenario: Image Streams link on the sidebar for the Helm Release: HR-10-TC06
-    Given user is on the topology sidebar of the helm release "nodejs-ex-k"
-    When user switches to the Resources tab
-    And user clicks on the link for the image stream of helm release
-    Then user is redirected to the Image Stream Details page for the helm release
+    @regression
+    Scenario: Routes link on the sidebar for the Helm Release: HR-10-TC07
+        Given user is on the topology sidebar of the helm release "nodejs-ex-k"
+        When user switches to the "Resources" tab
+        And user clicks on the link for the "routes" of helm release
+        Then user is redirected to the "routes" Details page for the helm release
 
 
-@regression
-Scenario: Routes link on the sidebar for the Helm Release: HR-10-TC07
-    Given user is on the topology sidebar of the helm release "nodejs-ex-k"
-    When user switches to the Resources tab
-    And user clicks on the link for the routes of helm release
-    Then user is redirected to the Route Details page for the helm release
-
-
-@regression, @smoke
-Scenario: Actions drop down on the side bar: HR-10-TC08
-    Given user is on the topology sidebar of the helm release "nodejs-ex-k"
-    When user clicks on the Actions drop down menu
-    Then user will see the "Upgrade" action item
-    And user will see the "Rollback" action item
-    And user will see the "Uninstall Helm Release" action item
+    @regression, @smoke
+    Scenario: Actions drop down on the side bar: HR-10-TC08
+        Given user is on the topology sidebar of the helm release "nodejs-ex-k"
+        When user clicks on the Actions drop down menu
+        Then user will see the "Upgrade" action item
+        And user will see the "Rollback" action item
+        And user will see the "Uninstall Helm Release" action item

--- a/frontend/packages/dev-console/integration-tests/support/commands/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/app.ts
@@ -1,9 +1,11 @@
 // import { checkErrors } from '../../../../integration-tests-cypress/support';
 
-export {}; // needed in files which don't have an import to trigger ES6 module usage
+export { }; // needed in files which don't have an import to trigger ES6 module usage
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
+      pageTitleShouldContain(title: string): Chainable<Element>;
+      alertTitleShouldContain(title: string): Chainable<Element>;
       selectByDropDownText(selector: string, dropdownText: string): Chainable<Element>;
       mouseHover(selector: string): Chainable<Element>;
       selectValueFromAutoCompleteDropDown(
@@ -25,7 +27,36 @@ after(() => {
 });
 
 afterEach(() => {
-  // checkErrors();
+  checkErrors();
+});
+
+Cypress.Commands.add('pageTitleShouldContain', (title: string) => {
+  cy.get('[data-test-id ="resource-title"]')
+    .should('be.visible')
+    .and('contain.text', title);
+});
+
+Cypress.Commands.add('alertTitleShouldContain', (alertTitle: string) => {
+  cy.byLegacyTestID('modal-title').should('contain.text', alertTitle);
+});
+
+Cypress.Commands.add('clickNavLink', (path: [string, string]) => {
+  cy.get(`[data-component="pf-nav-expandable"]`) // this assumes all top level menu items are expandable
+    .contains(path[0])
+    .click(); // open top, expandable menu
+  cy.get('#page-sidebar')
+    .contains(path[1])
+    .click();
+});
+
+Cypress.Commands.add('pageTitleShouldContain', (title: string) => {
+  cy.get('[data-test-id ="resource-title"]')
+    .should('be.visible')
+    .and('contain.text', title);
+});
+
+Cypress.Commands.add('alertTitleShouldContain', (alertTitle: string) => {
+  cy.byLegacyTestID('modal-title').should('contain.text', alertTitle);
 });
 
 Cypress.Commands.add('selectByDropDownText', (selector: string, dropdownText: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
@@ -18,4 +18,5 @@ export const pageTitle = {
   Project: 'Project Details',
   ConfigMaps: 'Config Maps',
   Secrets: 'Secrets',
+  HelmCharts: 'Helm Charts',
 };

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -91,7 +91,7 @@ export const catalogPO = {
   cancel: '[data-test-id="reset-button"]',
   catalogTypes: {
     operatorBacked: '[data-test="kind-cluster-service-version"]',
-    helmCharts: '[data-test="kind-helm-chart"]',
+    helmCharts: '[href="/?catalogType=HelmChart"]',
     builderImage: '[data-test="kind-image-stream"]',
     template: '[data-test="kind-template"]',
     serviceClass: '[data-test="kind-cluster-service-class"]',

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -1,5 +1,6 @@
 export const helmPO = {
   noHelmReleasesMessage: 'h3',
+  noHelmSearchMessage: '.loading-box.loading-box__loaded',
   search: '[data-test-id="item-filter"]',
   table: '[role="grid"]',
   helmReleaseName: 'tr td:nth-child(1)',
@@ -7,6 +8,12 @@ export const helmPO = {
   revisionHistoryTab: '[data-test-id="horizontal-link-Revision History"]',
   releaseNotesTab: '[data-test-id="horizontal-link-Release Notes"]',
   filterDropdown: 'button[data-test-id="filter-dropdown-toggle"]',
+  filterDropdownDialog: '.pf-c-dropdown__group.co-filter-dropdown-group',
+  filterToolBar: '#filter-toolbar',
+  clearAllFilter: '.pf-c-button.pf-m-link.pf-m-inline',
+  deployedCheckbox: '#deployed-checkbox',
+  failedCheckbox: '#failed-checkbox',
+  otherCheckbox: '#other-checkbox',
   details: {
     title: '[data-test-section-heading="Helm Release Details"]',
   },
@@ -23,5 +30,8 @@ export const helmPO = {
   },
   uninstallHelmRelease: {
     releaseName: '#form-input-resourceName-field',
+  },
+  sidebarPage: {
+    chartVersion: '.properties-side-panel-pf-property-value',
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/topology-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/topology-po.ts
@@ -59,4 +59,5 @@ export const topologyPO = {
       cancel: '[data-test="cancel"]',
     },
   },
+  search: 'g.is-filtered',
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -45,9 +45,8 @@ export const addPage = {
         break;
       case 'Helm Chart':
       case addOptions.HelmChart:
-        cy.byLegacyTestID('helm').click();
-        detailsPage.titleShouldContain(pageTitle.DeveloperCatalog);
-        cy.byTestID('kind-helm-chart').should('be.checked');
+        cy.byLegacyTestID('helm').click({ force: true });
+        detailsPage.titleShouldContain(pageTitle.HelmCharts);
         break;
       case 'Operator Backed':
       case addOptions.OperatorBacked:

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -1,5 +1,27 @@
 import { catalogPO } from '../../pageObjects/add-flow-po';
 import { catalogCards, catalogTypes } from '../../constants/add';
+import { controls } from '../helm/controls';
+
+export const catalogPageObj = {
+  installHelmChart: {
+    releaseName: '#form-input-releaseName-field',
+    cancel: '[data-test-id="reset-button"]',
+  },
+};
+
+export const catalogPageObj = {
+  installHelmChart: {
+    releaseName: '#form-input-releaseName-field',
+    cancel: '[data-test-id="reset-button"]',
+  },
+};
+
+export const catalogPageObj = {
+  installHelmChart: {
+    releaseName: '#form-input-releaseName-field',
+    cancel: '[data-test-id="reset-button"]',
+  },
+};
 
 export const catalogPage = {
   isCheckBoxSelected: (type: string) => cy.get(`input[title="${type}"]`).should('be.checked'),
@@ -29,7 +51,7 @@ export const catalogPage = {
       }
       case catalogTypes.HelmCharts:
       case 'Helm Charts': {
-        cy.get(catalogPO.catalogTypes.helmCharts).check();
+        cy.get(catalogPO.catalogTypes.helmCharts).click();
         break;
       }
       case catalogTypes.BuilderImage:
@@ -96,4 +118,22 @@ export const catalogPage = {
       .find('div.catalog-tile-pf-title')
       .should('contain.text', partialCardName);
   },
+};
+
+export const catalogInstallPageObj = {
+  installHelmChart: {
+    install: '[data-test-id="submit-button"]',
+    chartVersion: '#form-dropdown-chartVersion-field',
+    yamlView: '#form-radiobutton-editorType-yaml-field',
+  },
+  selectHelmChartVersion: (version: string) => controls.dropdown.switchTo(version),
+  verifyChartVersionDropdownAvailable: () => controls.dropdown.verifyVisibility(),
+  selectChangeOfChartVersionDialog: (option: string) => {
+    if (option === 'Proceed') {
+      cy.get('#confirm-action').click();
+    } else {
+      cy.byLegacyTestID('modal-cancel-action').click();
+    }
+  },
+  selectHelmChartCard: (cardName: string) => controls.dropdown.switchTo(cardName),
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -130,13 +130,19 @@ export const projectNameSpace = {
     // Bug: ODC-5129 - is created related to Accesibiity violation - Until bug fix, below line is commented to execute the scripts in CI
     // cy.testA11y('Create Project modal');
     cy.byLegacyTestID('dropdown-text-filter').type(projectName);
+    cy.document()
+      .its('readyState')
+      .should('eq', 'complete');
     cy.get('[role="listbox"]').then(($el) => {
       if ($el.find('li[role="option"]').length === 0) {
         cy.byTestDropDownMenu('#CREATE_RESOURCE_ACTION#').click();
         cy.byTestID('input-name').type(projectName);
         modal.submit();
       } else {
-        cy.get(`[id="${projectName}-link"]`).click();
+        cy.get(`[id="${projectName}-link"]`).click({ force: true });
+        cy.document()
+          .its('readyState')
+          .should('eq', 'complete');
       }
     });
   },

--- a/frontend/packages/dev-console/integration-tests/support/pages/common.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/common.ts
@@ -1,0 +1,9 @@
+import { helmPO } from '../pageObjects/helm-po';
+
+export const sidebarPage = {
+  verifyChartVersion: () =>
+    cy
+      .get(helmPO.sidebarPage.chartVersion)
+      .eq(0)
+      .should('have.text', '0.2.1'),
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/helm/controls.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/helm/controls.ts
@@ -1,0 +1,18 @@
+export const controls = {
+  dropdown: {
+    switchTo: (newOption: string) => {
+      cy.byLegacyTestID('dropdown-button')
+        .click()
+        .get('.pf-c-dropdown__menu')
+        .contains(newOption)
+        .click();
+    },
+    verifyVisibility: () => {
+      cy.byLegacyTestID('dropdown-button').should('be.visible');
+      cy.byLegacyTestID('dropdown-button')
+        .click()
+        .get('.pf-c-dropdown__menu')
+        .should('be.visible');
+    },
+  },
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/helm/helm-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/helm/helm-page.ts
@@ -1,7 +1,44 @@
 import { helmPO } from '../../pageObjects/helm-po';
 import { messages } from '../../constants/staticText/helm-text';
 
+export const helmPageObj = {
+  noHelmReleasesMessage: 'h3',
+  search: '[data-test-id="item-filter"]',
+  table: '[role="grid"]',
+  helmReleaseName: 'tr td:nth-child(1)',
+  resourcesTab: '[data-test-id="horizontal-link-Resources"]',
+  revisionHistoryTab: '[data-test-id="horizontal-link-Revision history"]',
+  releaseNotesTab: '[data-test-id="horizontal-link-Release Notes"]',
+  filterDropdown: 'button[data-test-id="filter-dropdown-toggle"]',
+  details: {
+    title: '[data-test-section-heading="Helm Release details"]',
+  },
+  upgradeHelmRelease: {
+    replicaCount: '#root_replicaCount',
+    chartVersion: '#form-dropdown-chartVersion-field',
+    upgrade: '[data-test-id="submit-button"]',
+    cancel: '[data-test-id="reset-button"]',
+  },
+  rollBackHelmRelease: {
+    revision1: '#form-radiobutton-revision-1-field',
+    rollBack: '[data-test-id="submit-button"]',
+    cancel: '[data-test-id="reset-button"]',
+  },
+  uninstallHelmRelease: {
+    releaseName: '#form-input-resourceName-field',
+  },
+};
+
 export const helmPage = {
+  verifyHelmChartsListed: () => {
+    cy.get('.loading-box.loading-box__loaded')
+      .get(`[role=grid]`)
+      .get('table')
+      .its('length')
+      .should('be.greaterThan', 0);
+  },
+  verifySearchMessage: (message: string) =>
+    cy.get(helmPO.noHelmSearchMessage).should('contain.text', message),
   verifyMessage: () =>
     cy.get(helmPO.noHelmReleasesMessage).should('contain.text', messages.noHelmReleasesFound),
   verifyInstallHelmLink: () =>
@@ -13,31 +50,135 @@ export const helmPage = {
     cy.get(helmPO.search)
       .clear()
       .type(name);
-    cy.get(helmPO.table).should('be.visible');
   },
   verifyHelmReleasesDisplayed: () => cy.get(helmPO.table).should('be.visible'),
   clickHelmReleaseName: (name: string) => cy.get(`a[title="${name}"]`).click(),
-  selectHelmFilter: (filterName: string) => {
-    cy.get(helmPO.filterDropdown).click();
+  selectHelmFilterDropDown: () => {
+    cy.get(helmPO.filterToolBar).then((body) => {
+      if (body.find(helmPO.filterDropdownDialog).length <= 0) {
+        cy.get(helmPO.filterDropdown).click();
+      }
+    });
+  },
+
+  getItemFromReleaseTable: (header: string) => {
+    cy.get(helmPO.table)
+      .find(`[data-index="0"]`)
+      .should('be.visible')
+      .find(`[role=gridcell]`)
+      .should('contain.text', header);
+  },
+  verifyHelmFilterUnSelected: (filterName: string) => {
+    helmPage.selectHelmFilterDropDown();
     switch (filterName) {
       case 'Deployed': {
-        cy.get('#deployed').click();
+        cy.get('#deployed-checkbox')
+          .uncheck()
+          .should('not.be.checked');
         break;
       }
       case 'Failed': {
-        cy.get('#failed').click();
+        cy.get('#failed-checkbox')
+          .uncheck()
+          .should('not.be.checked');
         break;
       }
       case 'Other': {
-        cy.get('#other').click();
+        cy.get('#other-checkbox')
+          .uncheck()
+          .should('not.be.checked');
+        break;
+      }
+      case 'all': {
+        cy.get('#deployed-checkbox')
+          .uncheck()
+          .should('not.be.checked');
+        cy.get('#failed-checkbox')
+          .uncheck()
+          .should('not.be.checked');
+        cy.get('#other-checkbox')
+          .uncheck()
+          .should('not.be.checked');
         break;
       }
       default: {
         throw new Error(`${filterName} filter is not available in filter drop down`);
       }
     }
-    cy.byButtonText('Clear all filters').should('be.visible');
   },
+  verifyHelmFilterSelected: (filterName: string) => {
+    helmPage.selectHelmFilterDropDown();
+    switch (filterName) {
+      case 'Deployed': {
+        cy.get('#deployed-checkbox').should('be.checked');
+        break;
+      }
+      case 'Failed': {
+        cy.get('#failed-checkbox').should('be.checked');
+        break;
+      }
+      case 'Other': {
+        cy.get('#other-checkbox').should('be.checked');
+        break;
+      }
+      case 'all': {
+        cy.get('#deployed-checkbox').should('be.checked');
+        cy.get('#failed-checkbox').should('be.checked');
+        cy.get('#other-checkbox').should('be.checked');
+        break;
+      }
+      default: {
+        throw new Error(`${filterName} filter is not available in filter drop down`);
+      }
+    }
+    helmPage.clearAllFilter();
+  },
+  clearAllFilter: () => {
+    cy.get(helmPO.filterToolBar).then((body) => {
+      if (body.find(helmPO.clearAllFilter).length >= 0) {
+        cy.get(helmPO.clearAllFilter)
+          .eq(1)
+          .click();
+      }
+    });
+  },
+  selectHelmFilter: (filterName: string) => {
+    switch (filterName) {
+      case 'Deployed': {
+        helmPage.selectFilterCheckbox(helmPO.deployedCheckbox, '#deployed');
+        break;
+      }
+      case 'Failed': {
+        helmPage.selectFilterCheckbox(helmPO.failedCheckbox, '#failed');
+        break;
+      }
+      case 'Other': {
+        helmPage.selectFilterCheckbox(helmPO.otherCheckbox, '#other');
+        break;
+      }
+      case 'all': {
+        helmPage.selectAllHelmFilter();
+        break;
+      }
+      default: {
+        throw new Error(`${filterName} filter is not available in filter drop down`);
+      }
+    }
+  },
+  selectFilterCheckbox: (checkbox: string, option: string) => {
+    helmPage.selectHelmFilterDropDown();
+    cy.get(checkbox).then((body) => {
+      if (body.find('checked').length <= 0) {
+        cy.get(option).click();
+      }
+    });
+  },
+  selectAllHelmFilter: () => {
+    helmPage.selectFilterCheckbox(helmPO.deployedCheckbox, '#deployed');
+    helmPage.selectFilterCheckbox(helmPO.failedCheckbox, '#failed');
+    helmPage.selectFilterCheckbox(helmPO.otherCheckbox, '#other');
+  },
+
   verifyStatusInHelmReleasesTable: (helmReleaseName: string = 'Nodejs Ex K v0.2.1') => {
     cy.get(helmPO.table).should('exist');
     cy.get('tr td:nth-child(1)').each(($el, index) => {
@@ -53,5 +194,40 @@ export const helmPage = {
   selectKebabMenu: () => {
     cy.get(helmPO.table).should('exist');
     cy.byLegacyTestID('kebab-button').click();
+  },
+};
+
+export const helmDetailsPage = {
+  verifyTitle: () =>
+    cy.get(helmPageObj.details.title).should('contain.text', 'Helm Release details'),
+  verifyResourcesTab: () => cy.get(helmPageObj.resourcesTab).should('be.visible'),
+  verifyReleaseNotesTab: () =>
+    cy.byLegacyTestID('horizontal-link-Release notes').should('be.visible'),
+  verifyActionsDropdown: () => cy.byLegacyTestID('actions-menu-button').should('be.visible'),
+  verifyRevisionHistoryTab: () => cy.get(helmPageObj.revisionHistoryTab).should('be.visible'),
+  clickActionMenu: () => cy.byLegacyTestID('actions-menu-button').click(),
+  verifyActionsInActionMenu: () => {
+    cy.byLegacyTestID('action-items')
+      .find('li')
+      .each(($el) => {
+        expect(['Upgrade', 'Rollback', 'Uninstall Helm Release']).toContain($el.text());
+      });
+  },
+  verifyFieldValue: (fieldName: string, fieldValue: string) => {
+    cy.get('dl.co-m-pane__details dt')
+      .contains(fieldName)
+      .next('dd')
+      .should('contain.text', fieldValue);
+  },
+  uninstallHelmRelease: () => {
+    cy.alertTitleShouldContain('Uninstall Helm Release?');
+    cy.byTestID('confirm-action')
+      .should('be.enabled')
+      .click();
+  },
+  enterReleaseNameInUninstallPopup: (releaseName: string = 'nodejs-ex-k') => {
+    cy.alertTitleShouldContain('Uninstall Helm Release?');
+    cy.get('form strong').should('have.text', releaseName);
+    cy.get(helmPageObj.uninstallHelmRelease.releaseName).type(releaseName);
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-helper-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-helper-page.ts
@@ -1,0 +1,13 @@
+import { topologyPO } from '../../pageObjects/topology-po';
+
+export const topologyHelper = {
+  search: (name: string) =>
+    cy
+      .byLegacyTestID('item-filter')
+      .clear()
+      .type(name),
+  verifyWorkloadInTopologyPage: (appName: string) => {
+    topologyHelper.search(appName);
+    cy.get(topologyPO.search).should('be.visible');
+  },
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-page.ts
@@ -1,6 +1,7 @@
 import { displayOptions, nodeActions } from '../../constants/topology';
 import { topologyPO } from '../../pageObjects/topology-po';
 import { createHelmRelease } from '../functions/createHelmRelease';
+import { topologyHelper } from './topology-helper-page';
 
 export const topologyPage = {
   verifyTitle: () => {
@@ -14,17 +15,6 @@ export const topologyPage = {
   verifyNoWorkLoadsText: (text: string) =>
     cy.get('h2.co-hint-block__title').should('contain.text', text),
   verifyWorkLoads: () => cy.get('g[data-surface="true"]').should('be.visible'),
-  search: (name: string) =>
-    cy
-      .byLegacyTestID('item-filter')
-      .clear()
-      .type(name),
-  verifyWorkloadInTopologyPage: (appName: string) => {
-    cy.get(topologyPO.switcher).click();
-    topologyPage.search(appName);
-    cy.get('div.is-filtered').should('be.visible');
-    cy.get(topologyPO.switcher).click();
-  },
   clicKDisplayOptionDropdown: () =>
     cy
       .get('[id^=pf-select-toggle-id]')
@@ -60,7 +50,7 @@ export const topologyPage = {
       .find('span.co-icon-and-text span')
       .should('have.text', status),
   searchHelmRelease: (name: string) => {
-    topologyPage.search(name);
+    topologyHelper.search(name);
     cy.get('[data-kind="node"]').then(($el) => {
       if ($el.find('g.is-filtered').length === 0) {
         createHelmRelease(name);

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-catalog.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-catalog.ts
@@ -17,6 +17,12 @@ When('user selects {string} option from Type section', (catalogType: string) => 
   catalogPage.selectCatalogType(catalogType);
 });
 
+When('user searches and selects {string} card from catalog page', (cardName: string) => {
+  catalogPage.search(cardName);
+  cy.get(catalogPO.catalogTypes.template).should('be.checked');
+  catalogPage.selectCardInCatalog(cardName);
+});
+
 When('user searches and selects Template card {string} from catalog page', (cardName: string) => {
   catalogPage.search(cardName);
   cy.get(catalogPO.catalogTypes.template).should('be.checked');
@@ -86,4 +92,12 @@ When('user enters Name as {string} in Instantiate Template page', (name: string)
   cy.get('#NAME')
     .clear()
     .type(name);
+});
+
+When('user selects {string} card from catalog page', (cardName: string) => {
+  catalogPage.selectCardInCatalog(cardName);
+});
+
+When('user selects {string} helm chart from catalog page', (helmChartName: string) => {
+  catalogPage.selectHelmChartCard(helmChartName);
 });

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sidebar.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sidebar.ts
@@ -1,0 +1,11 @@
+import { When } from 'cypress-cucumber-preprocessor/steps';
+import { catalogPage } from '../../pages/add-flow/catalog-page';
+import { sidebarPage } from '../../pages/common';
+
+When('user clicks on the Install Helm Chart button on side bar', () => {
+  catalogPage.clickButtonOnCatalogPageSidePane();
+});
+
+When('user will see the information of all the chart versions together', () => {
+  sidebarPage.verifyChartVersion();
+});

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
@@ -26,7 +26,7 @@ Given(
   },
 );
 
-Given('user is at Developer Catlog page', () => {
+Given('user is at the developer catalog page', () => {
   addPage.selectCardFromOptions(addOptions.DeveloperCatalog);
 });
 
@@ -44,4 +44,12 @@ Then('user will be redirected to Add page', () => {
 
 When('user clicks Cancel button on Add page', () => {
   gitPage.clickCancel();
+});
+
+Then('user can see {string} card on the Add page', (cardName: string) => {
+  addPage.verifyCard(cardName);
+});
+
+When('user selects {string} card from add page', (cardName: string) => {
+  addPage.selectCardFromOptions(cardName);
 });

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm-navigation.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm-navigation.ts
@@ -1,0 +1,136 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { naviagteTo } from '../../pages/app';
+import { devNavigationMenu } from '../../constants/global';
+import { helmPage, helmDetailsPage } from '../../pages/helm/helm-page';
+import { addPage } from '../../pages/add-flow/add-page';
+import { addOptions } from '../../constants/add';
+import { topologyPage } from '../../pages/topology/topology-page';
+import { catalogPage, catalogPageObj } from '../../pages/add-flow/catalog-page';
+
+When('user clicks on the Helm tab', () => {
+  naviagteTo(devNavigationMenu.Helm);
+});
+
+Then('user will be redirected to Helm releases page', () => {
+  cy.pageTitleShouldContain('Helm Releases');
+});
+
+Then('user is able to see the message as no helm charts present', () => {
+  helmPage.verifyMessage();
+});
+
+Then('user will get the link to install helm charts from developer catalog', () => {
+  helmPage.verifyInstallHelmLink();
+});
+
+Then('Install Helm Chart page is displayed', () => {
+  cy.get('h1.pf-c-title').should('have.text', 'Install Helm Chart');
+});
+
+Then('release name displays as {string}', (name: string) => {
+  cy.get(catalogPageObj.installHelmChart.releaseName).should('have.value', name);
+  cy.get(catalogPageObj.installHelmChart.cancel).click();
+});
+
+Given('user is at Install Helm Chart page', () => {
+  naviagteTo(devNavigationMenu.Add);
+  addPage.selectCardFromOptions(addOptions.HelmChart);
+  catalogPage.search('Nodejs Ex K v0.2.1');
+  catalogPage.selectHelmChartCard('Nodejs Ex K v0.2.1');
+  catalogPage.clickButtonOnCatalogPageSidePane();
+});
+
+Then('user is able to see YAML editor', () => {
+  cy.get('div.view-lines').should('be.visible');
+  cy.get(catalogPageObj.installHelmChart.cancel).click();
+});
+
+Then('Topology page have the helm chart workload {string}', (nodeName: string) => {
+  topologyPage.verifyWorkloadInTopologyPage(nodeName);
+});
+
+Given('helm chart is installed', () => {
+  naviagteTo(devNavigationMenu.Topology);
+  topologyPage.verifyWorkloadInTopologyPage('nodejs-example');
+});
+
+Given('user is at the Helm page', () => {
+  naviagteTo(devNavigationMenu.Helm);
+});
+
+When('user selects checkbox for the Deployed Helm charts', (workloadname: string) => {
+  topologyPage.verifyWorkloadInTopologyPage(workloadname);
+});
+
+When('user searches for a helm chart {string}', (helmChartName: string) => {
+  helmPage.search(helmChartName);
+});
+
+Then('the helm chart {string} will be shown', (helmChartName: string) => {
+  cy.log(helmChartName);
+});
+
+When('user clicks on the helm release name {string}', (helmChartName: string) => {
+  helmPage.search(helmChartName);
+  helmPage.clickHelmReleaseName(helmChartName);
+});
+
+Then('user will see the Details page opened', () => {
+  helmDetailsPage.verifyTitle();
+});
+
+Then('user will see the Resources tab', () => {
+  helmDetailsPage.verifyResourcesTab();
+});
+
+Then('user will see the Revision History tab', () => {
+  helmDetailsPage.verifyRevisionHistoryTab();
+});
+
+Then('user will see the Release Notes tab', () => {
+  helmDetailsPage.verifyReleaseNotesTab();
+});
+
+Then('user will see the Actions drop down menu', () => {
+  helmDetailsPage.verifyActionsDropdown();
+});
+
+When('user clicks Actions menu in Helm Details page', () => {
+  helmDetailsPage.clickActionMenu();
+});
+
+Then('Actions menu display with options Upgrade, Rollback, and Uninstall Helm Release', () => {
+  helmDetailsPage.verifyActionsInActionMenu();
+});
+
+When('user clicks on the filter drop down', () => {
+  helmPage.selectHelmFilterDropDown();
+});
+
+When('user selects checkbox for the {string} Helm charts', (status: string) => {
+  helmPage.selectHelmFilter(status);
+});
+
+When('the checkbox for the {string} Helm chart is checked', (status: string) => {
+  helmPage.verifyHelmFilterSelected(status);
+});
+
+When('helm charts with status {string} are listed', (status: string) => {
+  helmPage.getItemFromReleaseTable(status);
+});
+
+When('user clicks on the clear all filters button', () => {
+  helmPage.clearAllFilter();
+});
+
+Then(`{string} filters selected will get removed`, (status: string) => {
+  helmPage.verifyHelmFilterUnSelected(status);
+});
+
+Then('user is able to see message on the Helm page as {string}', (message: string) => {
+  helmPage.verifySearchMessage(message);
+});
+
+Then('user will see the helm charts listed', () => {
+  helmPage.verifyHelmChartsListed();
+});

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm.ts
@@ -1,0 +1,34 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { catalogPage, catalogInstallPageObj } from '../../pages/add-flow/catalog-page';
+import { topologyPage } from '../../pages/topology/topology-page';
+
+When('user selects YAML view', () => {
+  cy.get(catalogInstallPageObj.installHelmChart.yamlView).click();
+});
+
+When('user selects the Chart Version {string}', (chartVersion: string) => {
+  catalogInstallPageObj.selectHelmChartVersion(chartVersion);
+});
+
+When(
+  'user selects {string} button from Change Chart version confirmation dialog',
+  (option: string) => {
+    catalogInstallPageObj.selectChangeOfChartVersionDialog(option);
+  },
+);
+
+When('user clicks on the Install button', () => {
+  catalogPage.clickOnInstallButton();
+});
+
+Then('Topology page have the helm chart workload {string}', (nodeName: string) => {
+  topologyPage.verifyWorkloadInTopologyPage(nodeName);
+});
+
+When('user enters Release Name as {string}', (releaseName: string) => {
+  catalogPage.enterReleaseName(releaseName);
+});
+
+Then('user will see the chart version dropdown', () => {
+  catalogInstallPageObj.verifyChartVersionDropdownAvailable();
+});


### PR DESCRIPTION
Jira Id: https://issues.redhat.com/browse/HELM-15, https://issues.redhat.com/browse/HELM-70
Add scenarios implementation for feature - on helm navigation
* Open the Helm tab on the navigation bar when helm charts are absent
* Install Helm Chart page
* Yaml view editor for Install Helm Chart page
* Install Helm Chart: HR-02-TC01, HR-02-TC03, HR-02-TC06
* Open the Helm tab on the navigation bar when helm charts are present
* Filter out deployed Helm Charts
* Filter out failed Helm Charts
* Filter out other Helm Charts
* Select all filters
* Clear all filters
* Search for the Helm Chart
* Helm release details page
* Actions menu of Helm Details page