### PR TITLE
Bug 1917239: fix devconsole monitoring dashboard toolbar

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -331,6 +331,7 @@
   "Alerts": "Alerts",
   "Silence for": "Silence for",
   "Dashboard": "Dashboard",
+  "Workload": "Workload",
   "All workloads": "All workloads",
   "Filter by workload": "Filter by workload",
   "Select a query or enter your own to view metrics for this Project": "Select a query or enter your own to view metrics for this Project",

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
@@ -1,41 +1,36 @@
-$no-wrap-breakpoint: 915px;
-.odc-monitoring-dashboard {
-  position: relative;
-  &__dropdown-options {
-    align-self: flex-end;
-    display: flex;
-    position: absolute;
-    right: 30px;
-    top: -65px;
-    @media (max-width: $no-wrap-breakpoint) {
-      display: block;
-      margin-left: 15px;
-      margin-top: 15px;
-      position: initial;
-      @media (min-width: 768px) {
-        margin-left: 30px;
-      }
-    }
+@import '~@patternfly/patternfly/sass-utilities/all';
 
-    .monitoring-dashboards__dropdown-wrap {
-      @media (max-width: $no-wrap-breakpoint) {
-        display: inline-block;
-        .monitoring-dashboards__dropdown-title {
-          margin-right: 10px;
-        }
-      }
-      &:last-of-type {
-        margin-right: 0;
-      }
-    }
-  }
+.odc-monitoring-dashboard {
   &__resource-toolbar {
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--xl);
     margin-right: 0;
+    display: flex;
+    justify-content: space-between;
+    @media screen and (max-width: $pf-global--breakpoint--md) {
+      display: block;
+      padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--md);
+    }
+  }
+  &__workload {
+    flex: 0.25;
+  }
+  &__dropdown-time-interval {
+    display: flex;
+    @media screen and (max-width: $pf-global--breakpoint--md) {
+      margin-top: var(--pf-global--spacer--sm);
+    }
   }
   &__workload-filter {
     li[role='presentation'] {
       list-style: none;
+    }
+  }
+  .monitoring-dashboards {
+    &__dropdown-wrap {
+      margin-bottom: 0;
+    }
+    &__dropdown-wrap:nth-child(2) {
+      margin-right: 0;
     }
   }
 }

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
@@ -109,17 +109,22 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
         <title>{t('devconsole~Dashboard')}</title>
       </Helmet>
       <div className="odc-monitoring-dashboard">
-        <div className="odc-monitoring-dashboard__dropdown-options">
-          <TimespanDropdown />
-          <PollIntervalDropdown />
-        </div>
-        <div className="row odc-monitoring-dashboard__resource-toolbar">
-          <div className="col-lg-3 col-md-3 col-sm-4 col-xs-6">
+        <div className="odc-monitoring-dashboard__resource-toolbar">
+          <div className="odc-monitoring-dashboard__workload">
+            <label htmlFor="odc-monitoring-dashboard-workload-filter">
+              {t('devconsole~Workload')}
+            </label>
             <MonitoringWorkloadFilter
               name={workloadName}
               namespace={namespace}
               onChange={onSelect}
             />
+          </div>
+          <div className="odc-monitoring-dashboard__dropdown-options">
+            <div className="odc-monitoring-dashboard__dropdown-time-interval">
+              <TimespanDropdown />
+              <PollIntervalDropdown />
+            </div>
           </div>
         </div>
         <Dashboard>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5293

**Analysis / Root cause**: 
Monitoring time options overlap monitoring tab navigation when Quickstart panel is opened

**Solution Description**: 
Fix the layout as per the [UX](https://docs.google.com/document/d/1N3YHCOrN69TR6TjCbsM1bui0cfbZtDsShdDqL_j1YcQ/edit?ts=5ede105d#heading=h.pw0zyzcincru) 
![image](https://user-images.githubusercontent.com/2561818/104884462-6897bb80-598c-11eb-83d5-ab42caba8bce.png)


**Screen shots / Gifs for design review**: 
![Kapture 2021-01-25 at 10 38 37](https://user-images.githubusercontent.com/2561818/105664001-96837f80-5ef9-11eb-9c14-5d0e3795c3df.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge