### PR TITLE
Bug 1917272: Should update the default minSize to 1Gi when create localvolumeset on web console

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
@@ -19,9 +19,9 @@ export const initialState: State = {
   deviceType: [],
   maxDiskLimit: '',
   nodeNames: [], // nodes selected on the LVS step
-  minDiskSize: '0',
+  minDiskSize: '1',
   maxDiskSize: '',
-  diskSizeUnit: 'Ti',
+  diskSizeUnit: 'Gi',
   isValidMaxSize: true,
   hostNamesMapForLVS: {},
   // states for chart

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -10,9 +10,9 @@ export const initialState = {
   deviceType: [],
   maxDiskLimit: '',
   nodeNames: [],
-  minDiskSize: '0',
+  minDiskSize: '1',
   maxDiskSize: '',
-  diskSizeUnit: 'Ti',
+  diskSizeUnit: 'Gi',
   nodeNamesForLVS: [],
   hostNamesMapForLVS: {},
 };


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1917272

Changes default `minDiskSize` for `ceph-storage-plugin` and
`local-storage-operator-plugin` from `0 TiB` to `1 GiB`.

![image](https://user-images.githubusercontent.com/33557095/104914688-888fa500-59b5-11eb-8a2a-47ddb422842c.png)
