### PR TITLE
Bug 1917656: fix the url for context menu event source url

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsModal.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsModal.tsx
@@ -27,7 +27,7 @@ const CatalogDetailsModal: React.FC<CatalogDetailsModalProps> = ({ item, onClose
   Object.values(CatalogQueryParams).map((q) => queryParams.delete(q)); // don't pass along catalog specific query params
 
   const to = params
-    ? `${url}?${params}${Object.keys(queryParams).length > 0 ? `&${queryParams.toString()}` : ''}`
+    ? `${url}?${params}${queryParams.toString() !== '' ? `&${queryParams.toString()}` : ''}`
     : `${url}?${queryParams.toString()}`;
 
   const vendor = item.provider

--- a/frontend/packages/dev-console/src/utils/__tests__/add-resources-menu-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/add-resources-menu-utils.spec.tsx
@@ -94,9 +94,9 @@ describe('addResourceMenuUtils: ', () => {
       getAddPageUrl(resource, '', ImportOptions.EVENTSOURCE, true),
       'https://mock.test.com',
     );
-    expect(url.pathname).toBe('/event-source/ns/testproject1');
+    expect(url.pathname).toBe('/catalog/ns/testproject1');
     expect(url.searchParams.get('application')).toBe('application-1');
-    expect(Array.from(url.searchParams.entries())).toHaveLength(1);
+    expect(Array.from(url.searchParams.entries())).toHaveLength(2);
   });
 
   it('should return the page url with proper queryparams for catalog flow', async () => {

--- a/frontend/packages/dev-console/src/utils/add-resources-menu-utils.ts
+++ b/frontend/packages/dev-console/src/utils/add-resources-menu-utils.ts
@@ -63,7 +63,8 @@ export const getAddPageUrl = (
       params.append('category', 'databases');
       break;
     case ImportOptions.EVENTSOURCE:
-      pageUrl = `/event-source/ns/${ns}`;
+      pageUrl = `/catalog/ns/${ns}`;
+      params.append('catalogType', 'EventSource');
       contextSource && params.append(QUERY_PROPERTIES.CONTEXT_SOURCE, contextSource);
       break;
     case ImportOptions.EVENTPUBSUB:


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5345
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: context menu option for event source takes user to a 404 page
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: update the redirect url for context menu option event source to the updated catalog event source page
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
