### PR TITLE
Bug 1917679: hide double CTA in admin pipelineruns tab

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
@@ -8,17 +8,18 @@ import PipelineRunsList from './list-page/PipelineRunList';
 
 interface PipelineRunsResourceListProps {
   hideBadge?: boolean;
+  canCreate?: boolean;
 }
 
 const PipelineRunsResourceList: React.FC<Omit<
   React.ComponentProps<typeof ListPage>,
-  'canCreate' | 'kind' | 'ListComponent' | 'rowFilters'
+  'kind' | 'ListComponent' | 'rowFilters'
 > &
   PipelineRunsResourceListProps> = (props) => {
   return (
     <ListPage
       {...props}
-      canCreate
+      canCreate={props.canCreate ?? true}
       kind={referenceForModel(PipelineRunModel)}
       ListComponent={PipelineRunsList}
       rowFilters={runFilters}

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
+import { Button } from '@patternfly/react-core';
 import { ListPage } from '@console/internal/components/factory';
 import PipelineRunsResourceList from '../PipelineRunsResourceList';
 
@@ -12,12 +13,9 @@ describe('PipelineRunsResourceList:', () => {
   beforeEach(() => {
     pipelineRunsResourceListProps = {
       hideBadge: false,
+      canCreate: false,
     };
     wrapper = shallow(<PipelineRunsResourceList {...pipelineRunsResourceListProps} />);
-  });
-
-  it('Should set the create button prop in the list page', () => {
-    expect(wrapper.find(ListPage).props().canCreate).toBeTruthy();
   });
 
   it('Should render the badge in the list page', () => {
@@ -28,5 +26,14 @@ describe('PipelineRunsResourceList:', () => {
   it('Should not render the badge in the list page', () => {
     wrapper.setProps({ hideBadge: true });
     expect(wrapper.find(ListPage).props().badge).toBeNull();
+  });
+
+  it('Should not render the create button in the list page', () => {
+    expect(wrapper.find(Button).exists()).toBe(false);
+  });
+
+  it('Should render the create button in the list page', () => {
+    wrapper.setProps({ canCreate: true });
+    expect(wrapper.find(Button).exists()).toBe(false);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-lists/PipelinesListsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-lists/PipelinesListsPage.tsx
@@ -51,7 +51,7 @@ const PipelinesListPage: React.FC<PipelinesListPageProps> = ({ match }) => {
       href: 'pipeline-runs',
       name: t('pipelines-plugin~Pipeline Runs'),
       component: PipelineRunsResourceList,
-      pageData: { showTitle, hideBadge },
+      pageData: { showTitle, hideBadge, canCreate },
     },
     {
       href: 'pipeline-resources',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5348

**Analysis / Root cause**: 
In Admin pipeline page, under pipeline runs tab there is a `Create Pipeline Runs` button

**Solution Description**: 
Remove the `Create Pipeline runs` button from the admin perspective and show the button only on the dev perspective list pages.

**Screen shots / Gifs for design review**: 
Admin Page:
![image](https://user-images.githubusercontent.com/9964343/104995259-01414080-5a4c-11eb-99a8-30592751c4e6.png)

Dev Perspective Search page:
![image](https://user-images.githubusercontent.com/9964343/104995309-161dd400-5a4c-11eb-8187-862980c25243.png)


**Unit test coverage report**: 

PipelineRunsResourceList:
   ✓ Should not render the create button in the list page (5ms)
   ✓ Should render the create button in the list page (3ms)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge