### PR TITLE
Bug 1915972: Global configuration breadcrumbs do not work as expected

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-version.tsx
+++ b/frontend/public/components/cluster-settings/cluster-version.tsx
@@ -7,6 +7,7 @@ import { DetailsPage } from '../factory';
 import { Conditions } from '../conditions';
 import { ClusterVersionKind, K8sResourceKindReference, referenceForModel } from '../../module/k8s';
 import { navFactory, ResourceSummary, SectionHeading } from '../utils';
+import { breadcrumbsForGlobalConfig } from './global-config';
 
 const clusterVersionReference: K8sResourceKindReference = referenceForModel(ClusterVersionModel);
 
@@ -34,6 +35,7 @@ export const ClusterVersionDetailsPage: React.FC<ClusterVersionDetailsPageProps>
     {...props}
     kind={clusterVersionReference}
     pages={[navFactory.details(ClusterVersionDetails), navFactory.editYaml()]}
+    breadcrumbsFor={() => breadcrumbsForGlobalConfig(ClusterVersionModel.label, props.match.url)}
   />
 );
 

--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -12,10 +12,22 @@ import { addIDPItems } from './oauth';
 import { TextFilter } from '../factory';
 import { fuzzyCaseInsensitive } from '../factory/table-filters';
 import { withExtensions, isGlobalConfig, GlobalConfig } from '@console/plugin-sdk';
+import i18next from 'i18next';
 
 const stateToProps = (state: RootState) => ({
   configResources: state.k8s.getIn(['RESOURCES', 'configResources']),
 });
+
+export const breadcrumbsForGlobalConfig = (detailsPageKind: string, detailsPagePath: string) => [
+  {
+    name: 'Global Configuration',
+    path: '/settings/cluster/globalconfig',
+  },
+  {
+    name: i18next.t('details-page~{{kind}} details', { kind: detailsPageKind }),
+    path: detailsPagePath,
+  },
+];
 
 const ItemRow = ({ item }) => {
   return (

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import i18next from 'i18next';
 import * as _ from 'lodash-es';
-import { Button, Popover } from '@patternfly/react-core';
+import { Button, Popover, Split, SplitItem } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -95,6 +95,7 @@ import { history } from '../utils/router';
 import { LoadingInline, StatusBox } from '../utils/status-box';
 import { Timestamp } from '../utils/timestamp';
 import { getPrometheusURL, PrometheusEndpoint } from '../graphs/helpers';
+import { breadcrumbsForGlobalConfig } from '../cluster-settings/global-config';
 
 const ruleURL = (rule: Rule) => `${RuleResource.plural}/${_.get(rule, 'id')}`;
 
@@ -1552,7 +1553,23 @@ const AlertingPage: React.FC<AlertingPageProps> = ({ match }) => {
 
   return (
     <>
-      <div className="co-m-nav-title co-m-nav-title--detail">
+      <div
+        className={classNames('co-m-nav-title', 'co-m-nav-title--detail', {
+          'co-m-nav-title--breadcrumbs': isAlertmanager,
+        })}
+      >
+        {isAlertmanager && (
+          <Split style={{ alignItems: 'baseline' }}>
+            <SplitItem isFilled>
+              <BreadCrumbs
+                breadcrumbs={breadcrumbsForGlobalConfig(
+                  'Alertmanager',
+                  '/monitoring/alertmanagerconfig',
+                )}
+              />
+            </SplitItem>
+          </Split>
+        )}
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name co-resource-item">
             <span className="co-resource-item__resource-name" data-test-id="resource-title">

--- a/frontend/public/components/utils/breadcrumbs.ts
+++ b/frontend/public/components/utils/breadcrumbs.ts
@@ -2,6 +2,7 @@ import i18next from 'i18next';
 import { K8sKind } from '../../module/k8s';
 import { LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
+import { breadcrumbsForGlobalConfig } from '../cluster-settings/global-config';
 
 export const getBreadcrumbPath = (match: any, customPlural?: string) => {
   const lastNamespace = sessionStorage.getItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
@@ -13,13 +14,16 @@ export const getBreadcrumbPath = (match: any, customPlural?: string) => {
   return `/k8s/cluster/${customPlural || match.params.plural}`;
 };
 
-export const breadcrumbsForDetailsPage = (kindObj: K8sKind, match: any) => () => [
-  {
-    name: `${kindObj.labelPlural}`,
-    path: getBreadcrumbPath(match),
-  },
-  {
-    name: i18next.t('details-page~{{kind}} details', { kind: kindObj.label }),
-    path: `${match.url}`,
-  },
-];
+export const breadcrumbsForDetailsPage = (kindObj: K8sKind, match: any) => () =>
+  kindObj.apiGroup === 'config.openshift.io' && match.params.name === 'cluster'
+    ? breadcrumbsForGlobalConfig(kindObj.label, match.url)
+    : [
+        {
+          name: `${kindObj.labelPlural}`,
+          path: getBreadcrumbPath(match),
+        },
+        {
+          name: i18next.t('details-page~{{kind}} details', { kind: kindObj.label }),
+          path: `${match.url}`,
+        },
+      ];

--- a/frontend/public/locales/en/details-page.json
+++ b/frontend/public/locales/en/details-page.json
@@ -1,4 +1,5 @@
 {
+  "{{kind}} details": "{{kind}} details",
   "Type": "Type",
   "Status": "Status",
   "Updated": "Updated",
@@ -8,7 +9,6 @@
   "ReplicationControllers": "ReplicationControllers",
   "ReplicaSets": "ReplicaSets",
   "Terminal": "Terminal",
-  "{{kind}} details": "{{kind}} details",
   "Name": "Name",
   "Namespace": "Namespace",
   "Labels": "Labels",


### PR DESCRIPTION
**Before**
Previously, when navigating to Admin->Cluster Settings->Global configuration, click on any cluster config resource to drilldown to details page.  Detail page has breadcrumbs such as: "Builds > Build details", where "Builds" navs to list view of cluster build configs.

**After**
Now if you click into a Global configuration resource details page, the breadcrumbs are "Global Configuration >
[resource] details" where "Global Configruation" navigates back to Admin->Cluster Settings->Global configuration