### PR TITLE
Bug 1918068: Fix flaky OLM Cypress tests

### DIFF
--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -216,7 +216,12 @@ export const watchK8sList = (
 
       if (!_.get(k8skind, 'verbs', ['watch']).includes('watch')) {
         // eslint-disable-next-line no-console
-        console.warn(`${referenceForModel(k8skind)} does not support watching`);
+        console.warn(
+          `${referenceForModel(k8skind)} does not support watching, falling back to polling.`,
+        );
+        if (!POLLs[id]) {
+          POLLs[id] = setTimeout(pollAndWatch, 15 * 1000);
+        }
         return;
       }
 


### PR DESCRIPTION
Update legacy k8s watch to fall back to polling when watch is unsupported. Remove conditional logic in OLM Operator install workflow integration tests and just use an extended timeout instead.