### PR TITLE
Bug 1910753: Check for devfile when context directory changes

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/AdvancedGitOptions.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/AdvancedGitOptions.tsx
@@ -9,15 +9,16 @@ import SourceSecretSelector from './SourceSecretSelector';
 
 const AdvancedGitOptions: React.FC = () => {
   const { t } = useTranslation();
-  const { setFieldValue } = useFormikContext<FormikValues>();
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
 
   const handleGitRefChange = useDebounceCallback((e: React.SyntheticEvent) =>
     setFieldValue('git.ref', (e.target as HTMLInputElement).value),
   );
 
-  const handleGitDirChange = useDebounceCallback((e: React.SyntheticEvent) =>
-    setFieldValue('git.dir', (e.target as HTMLInputElement).value),
-  );
+  const handleGitDirChange = useDebounceCallback((e: React.SyntheticEvent) => {
+    setFieldValue('git.dir', (e.target as HTMLInputElement).value);
+    setFieldTouched('git.dir');
+  });
 
   return (
     <ExpandCollapse

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -60,6 +60,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   const sampleRepo = showSample && getSampleRepo(tag);
   const { application = {}, name: nameTouched, git = {}, image = {} } = touched;
   const { type: gitTypeTouched } = git as FormikTouched<{ type: boolean }>;
+  const { dir: gitDirTouched } = git as FormikTouched<{ dir: boolean }>;
   const { name: applicationNameTouched } = application as FormikTouched<{ name: boolean }>;
   const { selected: imageSelectorTouched } = image as FormikTouched<{ selected: boolean }>;
   const [validated, setValidated] = React.useState<ValidatedOptions>(ValidatedOptions.default);
@@ -196,9 +197,18 @@ const GitSection: React.FC<GitSectionProps> = ({
   }, [handleBuilderImageRecommendation, values.build.strategy, values.git.url]);
 
   React.useEffect(() => {
-    const { url, ref, dir } = values.git;
-    (!dirty || gitTypeTouched) && values.git.url && handleGitUrlChange(url, ref, dir);
-  }, [dirty, gitTypeTouched, handleGitUrlChange, values.git]);
+    (!dirty || gitTypeTouched || gitDirTouched) &&
+      values.git.url &&
+      debouncedHandleGitUrlChange(values.git.url, values.git.ref, values.git.dir);
+  }, [
+    dirty,
+    gitTypeTouched,
+    gitDirTouched,
+    debouncedHandleGitUrlChange,
+    values.git.url,
+    values.git.ref,
+    values.git.dir,
+  ]);
 
   const getHelpText = () => {
     if (values.git.isUrlValidating) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5297
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The devfile is not validated when context directory is changed in advanced git options.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Check if directory field is touched, and try to fetch devfile again.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/105156781-4b9ced00-5b32-11eb-898b-3cc507b84fb9.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug