### PR TITLE
Bug 1917117: Template parameters are valid names

### DIFF
--- a/frontend/packages/console-shared/src/utils/validation/validation.ts
+++ b/frontend/packages/console-shared/src/utils/validation/validation.ts
@@ -45,6 +45,10 @@ export const validateDNS1123SubdomainValue = (
     return asValidationObject(emptyMsg, ValidationErrorType.TrivialError);
   }
 
+  if (value.match(/^\$\{[A-Z_]+\}$/)) {
+    return asValidationObject('template parameter', ValidationErrorType.Warn);
+  }
+
   if (min && value.length < min) {
     return asValidationObject(shortMsg);
   }

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/constants.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/constants.tsx
@@ -1,5 +1,12 @@
 import { BootableDeviceType } from '../../types';
 
 export const deviceKey = (device: BootableDeviceType) => `${device.type}-${device.value.name}`;
-export const deviceLabel = (device: BootableDeviceType) =>
-  `${device.value.name} (${device.typeLabel})`;
+export const deviceLabel = (device: BootableDeviceType) => {
+  const name = device?.value?.name;
+
+  if (name.match(/^\$\{[A-Z_]+\}$/)) {
+    return `${name} (${device.typeLabel}), template parameter`;
+  }
+
+  return `${name} (${device.typeLabel})`;
+};


### PR DESCRIPTION
don't show error message when device name is a valid template parameter

Screenshot:
before:
![screenshot-localhost_9000-2021 01 20-13_48_23](https://user-images.githubusercontent.com/2181522/105170854-39b54d00-5b26-11eb-9964-75036bd0aedf.png)

after:
![screenshot-localhost_9000-2021 01 20-13_47_25](https://user-images.githubusercontent.com/2181522/105170840-3752f300-5b26-11eb-9bfe-6313eb7c60d4.png)
