### PR TITLE
Bug 1918318: show kameletbinding in eventsource list and filters

### DIFF
--- a/frontend/packages/knative-plugin/src/components/eventing/eventsource-list/EventSourceRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/eventsource-list/EventSourceRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { Kebab, ResourceKebab, ResourceLink, Timestamp } from '@console/internal/components/utils';
-import { referenceFor } from '@console/internal/module/k8s';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { NamespaceModel } from '@console/internal/models';
 import { getDynamicEventSourceModel } from '../../../utils/fetch-dynamic-eventsources-utils';
 import { EventSourceKind, EventSourceConditionTypes } from '../../../types';
@@ -12,7 +12,7 @@ const EventSourceRow: RowFunction<EventSourceKind> = ({ obj, index, key, style }
     metadata: { name, namespace, creationTimestamp, uid },
   } = obj;
   const objReference = referenceFor(obj);
-  const kind = getDynamicEventSourceModel(objReference);
+  const kind = getDynamicEventSourceModel(objReference) || modelFor(objReference);
   const menuActions = [...Kebab.getExtensionsActionsForKind(kind), ...Kebab.factory.common];
   const readyCondition = obj.status
     ? getCondition(obj.status.conditions, EventSourceConditionTypes.Ready)


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5354

**Analysis / Root cause**: 
Kamelet connector's are not shown in eventing section under Admin perspective

**Solution Description**: 
added KameletBinding to show camel Connector in list and filter view

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/5129024/105175962-9cb8db00-5b4a-11eb-85c5-a66380e5d8e8.png)

![image](https://user-images.githubusercontent.com/5129024/105175989-a6dad980-5b4a-11eb-8ddc-739a082f6f8a.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
- Install Serverless and camel K integration operator
- Create CR integration platform in a namespace

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
