### PR TITLE
Bug 1918639: add missing trigger types and update the optional fields

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
@@ -11,6 +11,7 @@ export interface EventListenerDetailsProps {
 
 const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventListener }) => {
   const { t } = useTranslation();
+  const triggers = eventListener.spec.triggers?.filter((trigger) => trigger.template?.name) || [];
   return (
     <div className="co-m-pane__body">
       <SectionHeading text={t('pipelines-plugin~Event listener details')} />
@@ -23,10 +24,12 @@ const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventL
             eventListener={eventListener}
             namespace={eventListener.metadata.namespace}
           />
-          <EventListenerTriggers
-            namespace={eventListener.metadata.namespace}
-            triggers={eventListener.spec.triggers}
-          />
+          {triggers.length > 0 && (
+            <EventListenerTriggers
+              namespace={eventListener.metadata.namespace}
+              triggers={triggers}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerTriggers.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerTriggers.tsx
@@ -18,11 +18,15 @@ interface EventListenerTriggersProps {
 
 const EventListenerTriggers: React.FC<EventListenerTriggersProps> = ({ namespace, triggers }) => {
   const { t } = useTranslation();
+  const triggerTemplates = triggers.filter((tr) => tr.template?.name);
+  if (triggerTemplates.length === 0) {
+    return null;
+  }
   return (
     <dl>
       <dt>{t('pipelines-plugin~Triggers')}</dt>
       <dd>
-        {triggers.map((trigger) => {
+        {triggerTemplates.map((trigger) => {
           const triggerTemplateKind = referenceForModel(TriggerTemplateModel);
           const triggerTemplateName = trigger.template.name;
           const bindings: ResourceModelLink[] = getEventListenerTriggerBindingNames(

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/EventListenerDetails.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/EventListenerDetails.spec.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import EventListenerDetails from '../EventListenerDetails';
+import {
+  EventlistenerTestData,
+  EventlistenerTypes,
+} from '../../../../test-data/event-listener-data';
+import EventListenerTriggers from '../EventListenerTriggers';
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+type EventListenerDetailsProps = React.ComponentProps<typeof EventListenerDetails>;
+
+describe('EventListener Details', () => {
+  let wrapper: ShallowWrapper<EventListenerDetailsProps>;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <EventListenerDetails
+        obj={EventlistenerTestData[EventlistenerTypes.BINDINGS_TEMPLATE_NAME]}
+      />,
+    );
+  });
+
+  it('should not render EventListenerTriggers section if the trigger contains binding ref', () => {
+    wrapper.setProps({ obj: EventlistenerTestData[EventlistenerTypes.BINDINGS_TEMPLATE_REF] });
+    expect(wrapper.find(EventListenerTriggers).exists()).toBe(false);
+  });
+
+  it('should not render EventListenerTriggers section if triggers contains triggerRef', () => {
+    wrapper.setProps({ obj: EventlistenerTestData[EventlistenerTypes.TRIGGER_REF] });
+    expect(wrapper.find(EventListenerTriggers).exists()).toBe(false);
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-types/triggers.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-types/triggers.ts
@@ -1,4 +1,4 @@
-import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { K8sResourceCommon, K8sResourceKind, Toleration } from '@console/internal/module/k8s';
 import { PipelineRun } from '../../../utils/pipeline-augment';
 
 export type TriggerBindingParam = {
@@ -28,29 +28,79 @@ export type TriggerTemplateKind = K8sResourceCommon & {
 
 export type EventListenerKindBindingReference = {
   // TriggerBinding / ClusterTriggerBinding reference
-  kind: string;
+  // Kind can only be provided if Ref is also provided. Defaults to TriggerBinding
+  kind?: string;
   // Ref is used since Tekton Triggers 0.5 (part of OpenShift Pipeline Operator 1.1)
-  ref: string;
+  // Mutually exclusive with Name
+  ref?: string;
   // We also support older operators, so need to show & save the old field as well.
   // https://github.com/tektoncd/triggers/pull/603/files
   // https://github.com/tektoncd/triggers/releases/tag/v0.5.0 and
   // https://github.com/tektoncd/triggers/releases/tag/v0.6.0
   /** @deprecated use ref instead */
+  // name of the binding param
   name?: string;
+  // value for the binding param
+  value?: string;
+};
+export type WebhookHeader = {
+  name: string;
+  value: string | string[];
 };
 
-export type EventListenerKindTrigger = {
-  bindings: EventListenerKindBindingReference[];
-  template: {
-    // TriggerTemplateKind name reference
-    name: string;
+export type VCSInterceptor = {
+  secretRef: {
+    secretKey: string;
+    secretName: string;
   };
+  eventTypes: string[];
+};
+export type TriggerInterceptor = {
+  gitlab: VCSInterceptor;
+  github: VCSInterceptor;
+  bitbucket: VCSInterceptor;
+  webhook: {
+    header: WebhookHeader[];
+    objectRef: K8sResourceKind;
+  };
+  cel: {
+    filter?: string;
+    overlays: {
+      key: string;
+      expression: string;
+    }[];
+  };
+};
+export type EventListenerKindTrigger = {
+  name?: string;
+  bindings?: EventListenerKindBindingReference[];
+  interceptors?: TriggerInterceptor;
+  template?: {
+    // Ref is used since Tekton Triggers 0.10.x (part of OpenShift Pipeline Operator 1.3)
+    ref?: string;
+    // We also support older operators, so need to show & save the old field as well.
+    // TriggerTemplateKind name reference
+    // https://github.com/tektoncd/triggers/pull/898/files
+    // name will be deprecated in TP1.4
+    name?: string;
+  };
+  triggerRef?: string;
 };
 
 export type EventListenerKind = K8sResourceCommon & {
   spec: {
     serviceAccountName: string;
     triggers: EventListenerKindTrigger[];
+    // optional fields
+    replicas?: number;
+    serviceType?: string;
+    namespaceSelector?: {
+      matchNames: string[];
+    };
+    podTemplate?: {
+      nodeSelector: { [key: string]: string };
+      tolerations: Toleration[];
+    };
   };
   status?: {
     configuration: {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/triggers.ts
@@ -28,7 +28,7 @@ type TriggerTemplateMapping = { [key: string]: TriggerTemplateKind };
 
 const getResourceName = (resource: K8sResourceCommon): string => resource.metadata.name;
 const getEventListenerTemplateNames = (el: EventListenerKind): string[] =>
-  el.spec.triggers.map((elTrigger: EventListenerKindTrigger) => elTrigger.template?.name);
+  el.spec.triggers?.map((elTrigger: EventListenerKindTrigger) => elTrigger.template?.name) || [];
 const getEventListenerGeneratedName = (eventListener: EventListenerKind) =>
   eventListener.status?.configuration.generatedName;
 
@@ -185,8 +185,8 @@ export const useTriggerTemplateEventListenerNames = (triggerTemplate: TriggerTem
 
   return eventListenerResources
     .filter((eventListener: EventListenerKind) =>
-      eventListener.spec.triggers.find(
-        ({ template: { name } }) => name === getResourceName(triggerTemplate),
+      eventListener.spec.triggers?.find(
+        (trigger) => trigger.template?.name === getResourceName(triggerTemplate),
       ),
     )
     .map(getResourceName);
@@ -196,8 +196,8 @@ export const useTriggerBindingEventListenerNames = (triggerBinding: TriggerBindi
   const eventListenerResources = useAllEventListeners(triggerBinding.metadata.namespace) || [];
   return eventListenerResources
     .filter((eventListener: EventListenerKind) =>
-      eventListener.spec.triggers.find(({ bindings }) =>
-        bindings.find(
+      eventListener.spec.triggers?.find(({ bindings }) =>
+        bindings?.find(
           ({ kind, name }) =>
             getResourceName(triggerBinding) === name &&
             getResourceModelFromBindingKind(kind).kind === triggerBinding.kind,

--- a/frontend/packages/pipelines-plugin/src/test-data/event-listener-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/event-listener-data.ts
@@ -1,0 +1,88 @@
+import {
+  EventListenerKind,
+  EventListenerKindTrigger,
+} from '../components/pipelines/resource-types/triggers';
+
+export enum TriggerTypes {
+  BINDING_TEMPLATE_NAME = 'bindings-and-template-name',
+  BINDING_TEMPLATE_REF = 'bindings-and-template-ref',
+  TRIGGER_REF = 'trigger-ref',
+}
+
+export enum EventlistenerTypes {
+  BINDINGS_TEMPLATE_REF = 'el-with-bindings-template-ref',
+  BINDINGS_TEMPLATE_NAME = 'el-with-bindings-template-name',
+  TRIGGER_REF = 'el-with-triggerRef',
+}
+
+type TriggerTestData = { [key in TriggerTypes]?: EventListenerKindTrigger };
+type EventListenerTestData = { [key in EventlistenerTypes]?: EventListenerKind };
+export const TriggerTestData = {
+  [TriggerTypes.BINDING_TEMPLATE_REF]: {
+    name: 'foo-trig',
+    bindings: [
+      {
+        ref: 'pipeline-binding',
+      },
+      {
+        ref: 'message-binding',
+      },
+    ],
+    template: {
+      ref: 'pipeline-template',
+    },
+  },
+  [TriggerTypes.BINDING_TEMPLATE_NAME]: {
+    name: 'foo-trig',
+    bindings: [
+      {
+        ref: 'pipeline-binding',
+      },
+      {
+        ref: 'message-binding',
+      },
+    ],
+    template: {
+      name: 'pipeline-template',
+    },
+  },
+  [TriggerTypes.TRIGGER_REF]: {
+    triggerRef: 'vote-trigger',
+  },
+};
+export const EventlistenerTestData: EventListenerTestData = {
+  [EventlistenerTypes.BINDINGS_TEMPLATE_REF]: {
+    apiVersion: 'triggers.tekton.dev/v1alpha1',
+    kind: 'EventListener',
+    metadata: {
+      name: 'listener',
+    },
+    spec: {
+      serviceAccountName: 'trigger-sa',
+      triggers: [TriggerTestData[TriggerTypes.BINDING_TEMPLATE_REF]],
+    },
+  },
+  [EventlistenerTypes.BINDINGS_TEMPLATE_NAME]: {
+    apiVersion: 'triggers.tekton.dev/v1alpha1',
+    kind: 'EventListener',
+    metadata: {
+      name: 'listener',
+    },
+    spec: {
+      serviceAccountName: 'trigger-sa',
+      triggers: [TriggerTestData[TriggerTypes.BINDING_TEMPLATE_NAME]],
+    },
+  },
+
+  [EventlistenerTypes.TRIGGER_REF]: {
+    apiVersion: 'triggers.tekton.dev/v1alpha1',
+    kind: 'EventListener',
+    metadata: {
+      name: 'vote-app',
+    },
+    spec: {
+      serviceAccountName: 'trigger-sa',
+      triggers: [TriggerTestData[TriggerTypes.TRIGGER_REF]],
+    },
+  },
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5350

**Analysis / Root cause**: 
Event listeners has an optional `triggerRef` field which is not compatible in UI code causes the UI to crash


**Solution Description**: 
Add the missing trigger types such as `triggerRef` and update the checks for optional fields.

**Screen shots / Gifs for design review**: 
Eventlistener page:
![image](https://user-images.githubusercontent.com/9964343/105330964-e7912c00-5bf8-11eb-9deb-f6d188f96a04.png)

**Test setup:**
1. Create an eventlistener with the yaml

```
apiVersion: triggers.tekton.dev/v1alpha1
kind: EventListener
metadata:
  name: vote-app
spec:
  serviceAccountName: pipeline
  triggers:
    - triggerRef: vote-app
```

**Unit test cases:**

  EventListener Details
    ✓ should render eventlistener details page (25ms)
    ✓ should not render EventListenerTriggers section if the trigger contains binding ref (4ms)
    ✓ should not render EventListenerTriggers section if triggers contains triggerRef (3ms)
    
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

 