### PR TITLE
Bug 1891766: Stop non-positive values from being entered by users for min disk size

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.scss
@@ -38,7 +38,7 @@
   flex-direction: column;
 }
 
-.lso-create-lvs__disk-size-form-group-max-input {
+.lso-create-lvs__disk-input {
   max-width: 100px;
 }
 

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -53,8 +53,10 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
     dispatch({ type: 'setShowNodesListOnLVS', value: !state.showNodesListOnLVS });
   };
 
-  const validMaxDiskSize = /^\+?([1-9]\d*)$/.test(state.maxDiskSize || '1');
-  const validMaxDiskLimit = /^\+?([1-9]\d*)$/.test(state.maxDiskLimit || '1');
+  const INTEGER_REGEX = /^\+?([1-9]\d*)$/;
+  const validMinDiskSize = INTEGER_REGEX.test(state.minDiskSize || '1');
+  const validMaxDiskSize = INTEGER_REGEX.test(state.maxDiskSize || '1');
+  const validMaxDiskLimit = INTEGER_REGEX.test(state.maxDiskLimit || '1');
 
   return (
     <>
@@ -193,14 +195,21 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
               fieldId="create-lvs-min-disk-size"
               className="lso-create-lvs__disk-size-form-group-max-min-input"
             >
-              <TextInput
-                type={TextInputTypes.number}
-                id="create-lvs-min-disk-size"
-                value={state.minDiskSize}
-                onChange={(size: string) => {
-                  dispatch({ type: 'setMinDiskSize', value: size });
-                }}
-              />
+              <Tooltip
+                content="Please enter a positive Integer"
+                isVisible={!validMinDiskSize}
+                trigger="manual"
+              >
+                <TextInput
+                  type={TextInputTypes.number}
+                  id="create-lvs-min-disk-size"
+                  value={state.minDiskSize}
+                  validated={validMinDiskSize ? 'default' : 'error'}
+                  onChange={(size: string) => {
+                    dispatch({ type: 'setMinDiskSize', value: size });
+                  }}
+                />
+              </Tooltip>
             </FormGroup>
             <div>-</div>
             <FormGroup

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -53,10 +53,17 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
     dispatch({ type: 'setShowNodesListOnLVS', value: !state.showNodesListOnLVS });
   };
 
-  const INTEGER_REGEX = /^\+?([1-9]\d*)$/;
-  const validMinDiskSize = INTEGER_REGEX.test(state.minDiskSize || '1');
-  const validMaxDiskSize = INTEGER_REGEX.test(state.maxDiskSize || '1');
-  const validMaxDiskLimit = INTEGER_REGEX.test(state.maxDiskLimit || '1');
+  const INTEGER_MAX_REGEX = /^\+?([1-9]\d*)$/;
+  const INTEGER_MIN_REGEX = /^\+?([0-9]\d*)$/;
+  const [activeMinDiskSize, setMinActiveState] = React.useState(false);
+  const [activeMaxDiskSize, setMaxActiveState] = React.useState(false);
+  const validMinDiskSize = INTEGER_MIN_REGEX.test(state.minDiskSize || '1');
+  const validMaxDiskSize = INTEGER_MAX_REGEX.test(state.maxDiskSize || '1');
+  const validMaxDiskLimit = INTEGER_MAX_REGEX.test(state.maxDiskLimit || '1');
+  const invalidMinGreaterThanMax =
+    state.minDiskSize !== '' &&
+    state.maxDiskSize !== '' &&
+    Number(state.minDiskSize) > Number(state.maxDiskSize);
 
   return (
     <>
@@ -196,15 +203,26 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
               className="lso-create-lvs__disk-size-form-group-max-min-input"
             >
               <Tooltip
-                content="Please enter a positive Integer"
-                isVisible={!validMinDiskSize}
+                content={
+                  !validMinDiskSize
+                    ? 'Please enter a positive Integer'
+                    : 'Please enter a value less than or equal to max disk size'
+                }
+                isVisible={!validMinDiskSize || (invalidMinGreaterThanMax && activeMinDiskSize)}
                 trigger="manual"
               >
                 <TextInput
-                  type={TextInputTypes.number}
+                  type={TextInputTypes.text}
                   id="create-lvs-min-disk-size"
                   value={state.minDiskSize}
-                  validated={validMinDiskSize ? 'default' : 'error'}
+                  validated={
+                    !validMinDiskSize || (invalidMinGreaterThanMax && activeMinDiskSize)
+                      ? 'error'
+                      : 'default'
+                  }
+                  className="lso-create-lvs__disk-input"
+                  onFocus={() => setMinActiveState(true)}
+                  onBlur={() => setMinActiveState(false)}
                   onChange={(size: string) => {
                     dispatch({ type: 'setMinDiskSize', value: size });
                   }}
@@ -218,16 +236,26 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
               className="lso-create-lvs__disk-size-form-group-max-min-input"
             >
               <Tooltip
-                content="Please enter a positive Integer"
-                isVisible={!validMaxDiskSize}
+                content={
+                  !validMaxDiskSize
+                    ? 'Please enter a positive Integer'
+                    : 'Please enter a value greater than or equal to min disk size'
+                }
+                isVisible={!validMaxDiskSize || (invalidMinGreaterThanMax && activeMaxDiskSize)}
                 trigger="manual"
               >
                 <TextInput
-                  type={TextInputTypes.number}
+                  type={TextInputTypes.text}
                   id="create-lvs-max-disk-size"
                   value={state.maxDiskSize}
-                  validated={validMaxDiskSize ? 'default' : 'error'}
-                  className="lso-create-lvs__disk-size-form-group-max-input"
+                  validated={
+                    !validMaxDiskSize || (invalidMinGreaterThanMax && activeMaxDiskSize)
+                      ? 'error'
+                      : 'default'
+                  }
+                  className="lso-create-lvs__disk-input"
+                  onFocus={() => setMaxActiveState(true)}
+                  onBlur={() => setMaxActiveState(false)}
                   onChange={(value) => dispatch({ type: 'setMaxDiskSize', value })}
                 />
               </Tooltip>
@@ -255,10 +283,11 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
             trigger="manual"
           >
             <TextInput
-              type={TextInputTypes.number}
+              type={TextInputTypes.text}
               id="create-lvs-max-disk-limit"
               value={state.maxDiskLimit}
               validated={validMaxDiskLimit ? 'default' : 'error'}
+              className="lso-create-lvs__disk-input"
               onChange={(maxLimit) => dispatch({ type: 'setMaxDiskLimit', value: maxLimit })}
               placeholder={t('lso-plugin~All')}
             />


### PR DESCRIPTION
Before:
![Screenshot from 2021-01-21 16-09-02](https://user-images.githubusercontent.com/39404641/105341331-f8479f00-5c04-11eb-8017-40477dc1d962.png)
![Screenshot from 2021-01-21 16-08-58](https://user-images.githubusercontent.com/39404641/105341316-f4b41800-5c04-11eb-9c9b-08924b55ab7e.png)

After:
![Screenshot from 2021-01-21 16-11-49](https://user-images.githubusercontent.com/39404641/105341355-00074380-5c05-11eb-990e-bd0ca0b14292.png)
![Screenshot from 2021-01-21 16-11-53](https://user-images.githubusercontent.com/39404641/105341540-3e046780-5c05-11eb-96b8-4fa5b6ad4ac0.png)