### PR TITLE
Bug 1918648: Replace deprecated 'installplan' Subscription status field with new 'installPlanRef'

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from 'react-i18next';
 
 const getApprovalStrategy = (obj: InstallPlanKind | SubscriptionKind): InstallPlanApproval =>
   (obj as SubscriptionKind)?.spec?.installPlanApproval ??
-  obj?.spec?.approval ??
+  (obj as InstallPlanKind)?.spec?.approval ??
   InstallPlanApproval.Automatic;
 
 export const InstallPlanApprovalModal: React.FC<InstallPlanApprovalModalProps> = ({

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -298,7 +298,7 @@ const OperatorInstallStatus: React.FC<OperatorInstallPageProps> = (props) => {
     // There is no ClusterServiceVersion for the package, so look at Subscriptions/InstallPlans
     loading = false;
     status = subscription?.status?.state || null;
-    const installPlanName = subscription?.status?.installplan?.name || '';
+    const installPlanName = subscription?.status?.installPlanRef?.name || '';
     const installPlan: InstallPlanKind = resources?.installPlan?.data?.find(
       (ip) => ip.metadata.name === installPlanName,
     );

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -103,7 +103,7 @@ export const installPlanForSubscription = (
   installPlans: InstallPlanKind[] = [],
   subscription: SubscriptionKind,
 ): InstallPlanKind =>
-  installPlans.find((ip) => ip?.metadata?.name === subscription?.status?.installPlan?.name);
+  installPlans.find((ip) => ip?.metadata?.name === subscription?.status?.installPlanRef?.name);
 
 export const upgradeRequiresApproval = (subscription: SubscriptionKind): boolean =>
   subscription?.status?.state === SubscriptionState.SubscriptionStateUpgradePending &&
@@ -126,7 +126,7 @@ export const UpgradeApprovalLink: React.FC<{ subscription: SubscriptionKind }> =
   const { t } = useTranslation();
   const to = resourcePathFromModel(
     InstallPlanModel,
-    subscription.status.installplan.name,
+    subscription.status.installPlanRef.name,
     subscription.metadata.namespace,
   );
   return (
@@ -150,7 +150,7 @@ export const SubscriptionStatus: React.FC<{ subscription: SubscriptionKind }> = 
         </span>
       );
     case SubscriptionState.SubscriptionStateUpgradePending:
-      return upgradeRequiresApproval(subscription) && subscription.status.installplan ? (
+      return upgradeRequiresApproval(subscription) && subscription.status.installPlanRef ? (
         <UpgradeApprovalLink subscription={subscription} />
       ) : (
         <span>
@@ -600,11 +600,11 @@ export const SubscriptionUpdates: React.FC<SubscriptionUpdatesProps> = ({
                   <span>{t('olm~0 installed')}</span>
                 )}
                 {obj?.status?.state === SubscriptionState.SubscriptionStateUpgradePending &&
-                obj?.status?.installplan &&
+                obj?.status?.installPlanRef &&
                 installPlan ? (
                   <Link
                     to={`/k8s/ns/${obj.metadata.namespace}/${referenceForModel(InstallPlanModel)}/${
-                      obj.status.installplan.name
+                      obj.status.installPlanRef.name
                     }`}
                   >
                     <span>{installPlanPhase}</span>

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -2,7 +2,7 @@ import {
   K8sResourceCommon,
   K8sResourceCondition,
   K8sResourceKind,
-  OwnerReference,
+  ObjectReference,
   Selector,
 } from '@console/internal/module/k8s';
 import { Descriptor } from './components/descriptors/types';
@@ -195,7 +195,7 @@ export type SubscriptionKind = {
   };
   status?: {
     installedCSV?: string;
-    installplan?: OwnerReference;
+    installPlanRef?: ObjectReference;
     state?: SubscriptionState;
   };
 } & K8sResourceKind;

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -194,11 +194,18 @@ export type SubscriptionKind = {
     installPlanApproval?: InstallPlanApproval;
   };
   status?: {
+    catalogHealth?: {
+      catalogSourceRef?: ObjectReference;
+      healthy?: boolean;
+      lastUpdated?: string;
+    }[];
+    conditions?: K8sResourceCondition[];
     installedCSV?: string;
     installPlanRef?: ObjectReference;
     state?: SubscriptionState;
+    lastUpdated?: string;
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type CatalogSourceKind = {
   apiVersion: 'operators.coreos.com/v1alpha1';


### PR DESCRIPTION
Based on the info from the [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1918648), we are querying subscription.status.installPlan.name for subscription's installplan, but it has changed in 4.7, now it is subscription.status.installplan.name

Checked other occurrences where we are calling this field and this should be the only one.

/assign @TheRealJon 