### PR TITLE
Bug 1918748: helmchartrepo is not http(s)_proxy-aware 

### DIFF
--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -45,6 +45,7 @@ type helmRepo struct {
 func httpClient(tlsConfig *tls.Config) (*http.Client, error) {
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client := &http.Client{Transport: tr}


### PR DESCRIPTION
**Fixes:**

https://bugzilla.redhat.com/show_bug.cgi?id=1918748

**Analysis / Root cause:**

In a disconnected environment a `chartrepo` cannot fetch a remote index.yaml file directly from a remote source, hence a (cluster-wide) proxy is used to retrieve the file remotely. However currently the chartrepo's httpClient() does not consider any proxy environment variable.

**Solution Description:**

Ensure proxy environment variables are considered by providing a `http.ProxyFromEnvironment` as `Proxy` func to the `Transport` struct's initialization.

**Test setup:**

1. in a disconnected environment, update the Proxy to use http/https proxy
2. create a HelmChartRepository pointing to a cluster-external chart repo
3. install a Helm release from the Developer Console