### PR TITLE
Interop UI readme against chart version

### DIFF
--- a/frontend/packages/dev-console/integration-tests/cypress.json
+++ b/frontend/packages/dev-console/integration-tests/cypress.json
@@ -23,7 +23,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "@smoke and not @manual"
+    "TAGS": "@smoke or @regression and not @manual"
   },
   "retries": {
     "runMode": 1,

--- a/frontend/packages/dev-console/integration-tests/cypress.json
+++ b/frontend/packages/dev-console/integration-tests/cypress.json
@@ -23,7 +23,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "@smoke or @regression and not @manual"
+    "TAGS": "@smoke and not @manual"
   },
   "retries": {
     "runMode": 1,

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -7,6 +7,7 @@ export const helmPO = {
   revisionHistoryTab: '[data-test-id="horizontal-link-Revision History"]',
   releaseNotesTab: '[data-test-id="horizontal-link-Release Notes"]',
   filterDropdown: 'button[data-test-id="filter-dropdown-toggle"]',
+  readmeCSV: '.co-clusterserviceversion-logo',
   details: {
     title: '[data-test-section-heading="Helm Release Details"]',
   },

--- a/frontend/packages/dev-console/integration-tests/support/pages/helm/controls.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/helm/controls.ts
@@ -1,0 +1,18 @@
+export const controls = {
+  dropdown: {
+    switchTo: (newOption: string) => {
+      cy.byLegacyTestID('dropdown-button')
+        .click()
+        .get('.pf-c-dropdown__menu')
+        .contains(newOption)
+        .click();
+    },
+    verifyVisibility: () => {
+      cy.byLegacyTestID('dropdown-button').should('be.visible');
+      cy.byLegacyTestID('dropdown-button')
+        .click()
+        .get('.pf-c-dropdown__menu')
+        .should('be.visible');
+    },
+  },
+};

--- a/frontend/packages/dev-console/integration-tests/support/pages/helm/helm-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/helm/helm-page.ts
@@ -30,6 +30,11 @@ export const helmPage = {
       .type(name);
     cy.get(helmPO.table).should('be.visible');
   },
+  verifyChartVersionInReadme: (chartVersion: string) => {
+    cy.get(helmPO.readmeCSV)
+      .parent('div')
+      .should('contain.text', chartVersion);
+  },
   verifyHelmReleasesDisplayed: () => cy.get(helmPO.table).should('be.visible'),
   clickHelmReleaseName: (name: string) => cy.get(`a[title="${name}"]`).click(),
   selectHelmFilter: (filterName: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm.ts
@@ -1,6 +1,7 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { catalogPage, catalogInstallPageObj } from '../../pages/add-flow/catalog-page';
 import { topologyHelper } from '../../pages/topology/topology-helper-page';
+import { helmPage } from '../../pages/helm/helm-page';
 
 When('user selects YAML view', () => {
   cy.get(catalogInstallPageObj.installHelmChart.yamlView).click();
@@ -32,3 +33,10 @@ When('user enters Release Name as {string}', (releaseName: string) => {
 Then('user will see the chart version dropdown', () => {
   catalogInstallPageObj.verifyChartVersionDropdownAvailable();
 });
+
+Then(
+  'user will see that the README is also updated with new chart version {string}',
+  (chartVersion: string) => {
+    helmPage.verifyChartVersionInReadme(chartVersion);
+  },
+);


### PR DESCRIPTION
Jira Id: https://issues.redhat.com/browse/HELM-15, https://issues.redhat.com/browse/HELM-66

Problem:
Add scenarios implementation for feature - on install helm chart 
* README should be updated when chart version is updated

Solution: Is to automate manual step converted to automated

Test Setup:
Add @Regression under env.tags in cypress.json
Run yarn run test-cypress-devconsole in frontend
Execute feature file: frontend/packages/dev-console/integration-tests/features/helm/install-HelmChart.feature