### PR TITLE
Bug 1918785: Use kube_pod_resource_(request|limit) metric

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
@@ -85,40 +85,16 @@ const top25Queries = {
 
 const resourceQuotaQueries = {
   [NodeQueries.POD_RESOURCE_LIMIT_CPU]: _.template(
-    `sum(
-      max by (namespace, pod, container) (
-          kube_pod_container_resource_limits_cpu_cores{node='<%= node %>', job="kube-state-metrics"}
-      ) * on(namespace, pod) group_left() max by (namespace, pod) (
-          kube_pod_status_phase{phase=~"Pending|Running"} == 1
-      )
-    )`,
+    `sum(kube_pod_resource_limit{node='<%= node %>',resource='cpu'})`,
   ),
   [NodeQueries.POD_RESOURCE_LIMIT_MEMORY]: _.template(
-    `sum(
-      max by (namespace, pod, container) (
-          kube_pod_container_resource_limits_memory_bytes{node='<%= node %>', job="kube-state-metrics"}
-      ) * on(namespace, pod) group_left() max by (namespace, pod) (
-          kube_pod_status_phase{phase=~"Pending|Running"} == 1
-      )
-    )`,
+    `sum(kube_pod_resource_limit{node='<%= node %>',resource='memory'})`,
   ),
   [NodeQueries.POD_RESOURCE_REQUEST_CPU]: _.template(
-    `sum(
-      max by (namespace, pod, container) (
-          kube_pod_container_resource_requests_cpu_cores{node='<%= node %>', job="kube-state-metrics"}
-      ) * on(namespace, pod) group_left() max by (namespace, pod) (
-          kube_pod_status_phase{phase=~"Pending|Running"} == 1
-      )
-    )`,
+    `sum(kube_pod_resource_request{node='<%= node %>',resource='cpu'})`,
   ),
   [NodeQueries.POD_RESOURCE_REQUEST_MEMORY]: _.template(
-    `sum(
-      max by (namespace, pod, container) (
-          kube_pod_container_resource_requests_memory_bytes{node='<%= node %>', job="kube-state-metrics"}
-      ) * on(namespace, pod) group_left() max by (namespace, pod) (
-          kube_pod_status_phase{phase=~"Pending|Running"} == 1
-      )
-    )`,
+    `sum(kube_pod_resource_request{node='<%= node %>',resource='memory'})`,
   ),
 };
 

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -514,8 +514,8 @@ const PodGraphs = requirePrometheus(({ pod }) => {
             byteDataType={ByteDataTypes.BinaryBytes}
             namespace={pod.metadata.namespace}
             query={`sum(container_memory_working_set_bytes{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}',container='',}) BY (pod, namespace)`}
-            limitQuery={`sum(kube_pod_container_resource_limits_memory_bytes{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}) BY (pod, namespace)`}
-            requestedQuery={`sum(kube_pod_container_resource_requests_memory_bytes{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}) BY (pod, namespace)`}
+            limitQuery={`sum(label_replace(label_replace(kube_pod_resource_limit{resource='cpu',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)'))`}
+            requestedQuery={`sum(label_replace(label_replace(kube_pod_resource_request{resource='memory',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)')) BY (pod, namespace)`}
           />
         </div>
         <div className="col-md-12 col-lg-4">
@@ -524,8 +524,8 @@ const PodGraphs = requirePrometheus(({ pod }) => {
             humanize={humanizeCpuCores}
             namespace={pod.metadata.namespace}
             query={`pod:container_cpu_usage:sum{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}`}
-            limitQuery={`sum(kube_pod_container_resource_limits_cpu_cores{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}) BY (pod, namespace)`}
-            requestedQuery={`sum(kube_pod_container_resource_requests_cpu_cores{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}) BY (pod, namespace)`}
+            limitQuery={`sum(label_replace(label_replace(kube_pod_resource_limit{resource='cpu',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)'))`}
+            requestedQuery={`sum(label_replace(label_replace(kube_pod_resource_request{resource='cpu',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)')) BY (pod, namespace)`}
           />
         </div>
         <div className="col-md-12 col-lg-4">


### PR DESCRIPTION
The new kube_pod_resource_request and _limit metrics simplify the
visualization of the resources a running or pending pod is consuming
and perform init container calculations correctly. The console should
use them instead.