### PR TITLE
Fix to show CRW icon when CRW operator is installed

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/render-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/render-utils.spec.ts
@@ -1,6 +1,7 @@
 import { TFunction } from 'i18next';
 import { BitbucketIcon, GitAltIcon, GithubIcon, GitlabIcon } from '@patternfly/react-icons';
 import { routeDecoratorIcon } from '../render-utils';
+import CheIcon from '../CheIcon';
 
 const t = (key): TFunction => key;
 
@@ -61,6 +62,31 @@ describe('Ensure render utils works', () => {
       expect(
         routeDecoratorIcon('git@gitlab.com:gitlab-org/examples/npm-install.git', 10, t).type,
       ).toEqual(GitlabIcon);
+    });
+  });
+
+  describe('Ensure we get che icon when che is enabled', () => {
+    it('expect che icon when che icon url is available', () => {
+      expect(
+        routeDecoratorIcon(
+          'https://codeready-openshift-workspaces.apps.div.devcluster.openshift.com/f?url=https://github.com/divyanshiGupta/nationalparks-py/tree/master&policies.create=peruser',
+          10,
+          t,
+          true,
+          'https://codeready-openshift-workspaces.apps.div.devcluster.openshift.com/dashboard/assets/branding/loader.svg',
+        ).type,
+      ).toEqual('image');
+    });
+
+    it('expect default che icon when che icon url not available', () => {
+      expect(
+        routeDecoratorIcon(
+          'https://codeready-openshift-workspaces.apps.div.devcluster.openshift.com/f?url=https://github.com/divyanshiGupta/nationalparks-py/tree/master&policies.create=peruser',
+          10,
+          t,
+          true,
+        ).type,
+      ).toEqual(CheIcon);
     });
   });
 });

--- a/frontend/packages/dev-console/src/components/import/render-utils.tsx
+++ b/frontend/packages/dev-console/src/components/import/render-utils.tsx
@@ -10,9 +10,14 @@ export const routeDecoratorIcon = (
   radius: number,
   t: TFunction,
   cheEnabled?: boolean,
+  cheIconURL?: string,
 ): React.ReactElement => {
   if (cheEnabled && routeURL) {
-    return <CheIcon style={{ fontSize: radius }} />;
+    return cheIconURL ? (
+      <image xlinkHref={cheIconURL} width={radius} height={radius} />
+    ) : (
+      <CheIcon style={{ fontSize: radius }} />
+    );
   }
   switch (detectGitType(routeURL)) {
     case GitTypes.invalid:

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/EditDecorator.tsx
@@ -6,7 +6,7 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ConsoleLinkModel } from '@console/internal/models';
 import { routeDecoratorIcon } from '@console/dev-console/src/components/import/render-utils';
-import { getCheURL, getEditURL } from '../../../../../utils';
+import { getCheDecoratorData, getEditURL } from '../../../../../utils';
 import Decorator from './Decorator';
 
 interface DefaultDecoratorProps {
@@ -23,12 +23,12 @@ const EditDecorator: React.FC<DefaultDecoratorProps> = ({ element, radius, x, y 
     kind: referenceForModel(ConsoleLinkModel),
     optional: true,
   });
-  const cheURL = getCheURL(consoleLinks);
+  const { cheURL, cheIconURL } = getCheDecoratorData(consoleLinks);
   const workloadData = element.getData().data;
   const { editURL, vcsURI, vcsRef } = workloadData;
   const cheEnabled = !!cheURL;
   const editUrl = editURL || getEditURL(vcsURI, vcsRef, cheURL);
-  const repoIcon = routeDecoratorIcon(editUrl, radius, t, cheEnabled);
+  const repoIcon = routeDecoratorIcon(editUrl, radius, t, cheEnabled, cheIconURL);
 
   if (!repoIcon) {
     return null;

--- a/frontend/packages/topology/src/utils/topology-utils.ts
+++ b/frontend/packages/topology/src/utils/topology-utils.ts
@@ -28,11 +28,21 @@ export const WORKLOAD_TYPES = [
   'pods',
 ];
 
+export type CheDecoratorData = {
+  cheURL?: string;
+  cheIconURL?: string;
+};
+
 export const getServiceBindingStatus = ({ FLAGS }: RootState): boolean =>
   FLAGS.get(ALLOW_SERVICE_BINDING_FLAG);
 
-export const getCheURL = (consoleLinks: K8sResourceKind[]) =>
-  _.get(_.find(consoleLinks, ['metadata.name', 'che']), 'spec.href', '');
+export const getCheDecoratorData = (consoleLinks: K8sResourceKind[]): CheDecoratorData => {
+  const cheConsoleLink = _.find(consoleLinks, ['metadata.name', 'che']);
+  return {
+    cheURL: cheConsoleLink?.spec?.href,
+    cheIconURL: cheConsoleLink?.spec?.applicationMenu?.imageURL,
+  };
+};
 
 export const getEditURL = (vcsURI?: string, gitBranch?: string, cheURL?: string) => {
   if (!vcsURI) {


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-4939

**Analysis/Root cause:**
CHE icon is shown instead of CRW icon even when CRW operator is installed because a static CHE icon was being returned in both the cases.

**Solution:**
Use ConsoleLink CR to get the correct icon.

**Screenshot:**
![Screenshot from 2021-01-21 20-56-43](https://user-images.githubusercontent.com/20724543/105371030-33a89480-5c2a-11eb-8ff1-02150e3a01ea.png)

**Unit test Coverage:**
![image](https://user-images.githubusercontent.com/20724543/105371206-5f2b7f00-5c2a-11eb-9f3d-86cc205c87ef.png)

**PR test setup:**
Install CRW operator.
Go to CRW operator details page and create CRW cluster.
After all the pods are running check if the ConsoleLink CR has been created.
Once the CR is created, you should be able to see the icon.

/kind bug