### PR TITLE
Bug 1917372: Monitoring: Change Prometheus UI link text to "Platform Prometheus UI"

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -198,9 +198,11 @@ const headerPrometheusLinkStateToProps = ({ UI }: RootState) => {
 };
 
 const HeaderPrometheusLink_ = ({ url }) => {
+  const { t } = useTranslation();
+
   return url ? (
     <span className="monitoring-header-link">
-      <ExternalLink href={url} text="Prometheus UI" />
+      <ExternalLink href={url} text={t('public~Platform Prometheus UI')} />
     </span>
   ) : null;
 };

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -259,6 +259,7 @@
   "Collapse all query tables": "Collapse all query tables",
   "Expand all query tables": "Expand all query tables",
   "Delete all queries": "Delete all queries",
+  "Platform Prometheus UI": "Platform Prometheus UI",
   "Show graph": "Show graph",
   "Hide graph": "Hide graph",
   "Insert metric at cursor": "Insert metric at cursor",


### PR DESCRIPTION
To reflect that this link is to the UI for the platform (cluster-level) Prometheus.

"Platform" is the same wording as used on the Alerting pages.

FYI @sichvoge, @cshinn 

![screenshot](https://user-images.githubusercontent.com/460802/105426509-aba8a600-5c8e-11eb-8d6a-8a9497ba63dc.png)
