### PR TITLE
Bug 1919231: fix topology quick search modal layout

### DIFF
--- a/frontend/packages/topology/src/components/quick-search/QuickSearchContent.scss
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchContent.scss
@@ -1,9 +1,15 @@
 .odc-quick-search-content {
+  height: calc(100% - 60px);
   &__list {
     width: 40%;
+    height: 100%;
+    overflow-y: auto;
   }
   &__details {
+    background: var(--pf-global--palette--white);
     width: 60%;
+    overflow-y: auto;
+    height: 100%;
     padding-right: var(--pf-global--spacer--md);
   }
 }

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.scss
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.scss
@@ -5,7 +5,6 @@
     var(--pf-global--spacer--md);
   overflow-y: auto;
   overflow-wrap: break-word;
-  height: 400px;
   scrollbar-width: 12px;
   scrollbar-color: var(--pf-global--BackgroundColor--light-300) var(--pf-global--palette--white);
 

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.scss
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.scss
@@ -1,0 +1,3 @@
+.odc-quick-search-modal-body {
+  min-height: 60px;
+}

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
@@ -9,6 +9,7 @@ import {
   removeQueryArgument,
   setQueryArgument,
 } from '@console/internal/components/utils';
+import './QuickSearchModalBody.scss';
 
 interface QuickSearchModalBodyProps {
   allCatalogItemsLoaded: boolean;
@@ -139,7 +140,11 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   }, [closeModal, onCancel, onEnter, selectNext, selectPrevious]);
 
   return (
-    <div ref={ref}>
+    <div
+      ref={ref}
+      className="odc-quick-search-modal-body"
+      style={{ height: catalogItems?.length > 0 ? 468 : 60 }}
+    >
       <QuickSearchBar
         searchTerm={searchTerm}
         onSearch={onSearch}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5278

**Analysis / Root cause**: 
The quick search modal contents aren't scrollable and on small screens the contents is displayed beyond the bounds of the modal container.

**Solution Description**: 
Set content height and add properties `overflow-y: auto`.

**Screen shots / Gifs for design review**: 
![Kapture 2021-01-22 at 17 48 21](https://user-images.githubusercontent.com/2561818/105490207-72962300-5cda-11eb-9483-8ff1011d7376.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge