### PR TITLE
Bug 1918132: i18n VolumeSnapshotContents

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -24,5 +24,6 @@
   "Status": "Status",
   "API version": "API version",
   "Restore": "Restore",
-  "Administrator": "Administrator"
+  "Administrator": "Administrator",
+  "VolumeSnapshotContents": "VolumeSnapshotContents"
 }

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -228,7 +228,8 @@ const plugin: Plugin<ConsumedExtensions> = [
       id: 'volumesnapshots',
       section: 'storage',
       componentProps: {
-        name: 'Volume Snapshot Contents',
+        // t('console-app~VolumeSnapshotContents')
+        name: '%console-app~VolumeSnapshotContents%',
         resource: referenceForModel(VolumeSnapshotContentModel),
       },
     },


### PR DESCRIPTION
The VolumeSnapshotContents nav item was contributed by a plugin and wasn't internationalized. I added internationalization.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1918132.