### PR TITLE
Bug 1919877: fix sidebar error for ksvc resource

### DIFF
--- a/frontend/public/components/overview/pods-overview.tsx
+++ b/frontend/public/components/overview/pods-overview.tsx
@@ -147,7 +147,7 @@ export const PodsOverviewContent: React.SFC<PodsOverviewContentProps> = ({
   const { t } = useTranslation();
   const [showWaitingPods, setShowWaitingPods] = React.useState(false);
   const showWaitingForBuildAlert =
-    buildConfigData.buildConfigs?.length > 0 &&
+    buildConfigData?.buildConfigs?.length > 0 &&
     !buildConfigData.buildConfigs[0].builds.some((build) => isComplete(build)) &&
     isDeploymentGeneratedByWebConsole(obj);
 
@@ -190,7 +190,7 @@ export const PodsOverviewContent: React.SFC<PodsOverviewContentProps> = ({
           </Link>
         )}
       </SidebarSectionHeading>
-      {buildConfigData.loaded && !buildConfigData.loadError && podAlert}
+      {buildConfigData?.loaded && !buildConfigData?.loadError && podAlert}
       {_.isEmpty(filteredPods) ? (
         <span className="text-muted">{loaded || !!loadError ? emptyMessage : <LoadingBox />}</span>
       ) : (


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5391

**Root analysis:**
for ksvc the `buildConfigData` is undefined

**Solution description:**
checking if `buildConfigData` is undefined

**Screenshot:**
![ksvc](https://user-images.githubusercontent.com/22490998/105686974-e7a56a80-5f1d-11eb-85f7-ac894f37d857.png)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge