### PR TITLE
Bug 1919851: fix pipeline visualization with same pipeline & task name

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualization.tsx
@@ -49,7 +49,7 @@ const PipelineVisualization: React.FC<PipelineTopologyVisualizationProps> = ({
   } else {
     content = (
       <PipelineTopologyGraph
-        id={pipelineRun?.metadata?.name || pipeline.metadata.name}
+        id={`${pipelineRun?.metadata?.name || pipeline.metadata.name}-graph`}
         nodes={nodes}
         edges={edges}
         layout={PipelineLayout.DAGRE_VIEWER}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5357

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->


Sharing the same name for a pipeline and one of its tasks, does not render the visualization and adding additional tasks breaks the pipeline details page.

**Solution Description**: 

Pipeline visualization graph ID must be different from the node(task) ID. Id's used in the topology should be unique.

**Screen shots / Gifs for design review**: 
---
Before fix (_pipeline with same name as task name_):
---

![Screen Shot 2021-01-20 at 3 44 33 PM](https://user-images.githubusercontent.com/9964343/105686733-972e0d00-5f1d-11eb-9d44-89a60c72f502.png)
---
After fix (_pipeline with same name as task name_):
---
![image](https://user-images.githubusercontent.com/9964343/105686549-6352e780-5f1d-11eb-88e6-e74f42420fcd.png)
---
_Pipeline with an extra task_
---
![image](https://user-images.githubusercontent.com/9964343/105686631-7960a800-5f1d-11eb-8824-760a25126d26.png)
---

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create a pipeline with below yaml
```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: myapp-install
spec:
  tasks:
    - name: myapp-install
      taskRef:
        kind: Task
        name: myapp-install
```
2. Add an extra task using edit pipeline feature. (shouldn't throw Javascript error )

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge