### PR TITLE
Update gitops backend service namespace

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -52,7 +52,7 @@ const (
 	openshiftMeteringHost = "reporting-operator.openshift-metering.svc:8080"
 
 	// Well-known location of the GitOps service. This is only accessible in-cluster
-	openshiftGitOpsHost = "cluster.openshift-pipelines-app-delivery.svc:8080"
+	openshiftGitOpsHost = "cluster.openshift-gitops.svc:8080"
 )
 
 func main() {

--- a/contrib/oc-environment.sh
+++ b/contrib/oc-environment.sh
@@ -31,7 +31,7 @@ export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS
 BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
 export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER
 
-GITOPS_HOSTNAME=$(oc -n openshift-pipelines-app-delivery get route cluster -o jsonpath='{.spec.host}' 2> /dev/null)
+GITOPS_HOSTNAME=$(oc -n openshift-gitops get route cluster -o jsonpath='{.spec.host}' 2> /dev/null)
 if [ -n "$GITOPS_HOSTNAME" ]; then
     BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS="https://$GITOPS_HOSTNAME"
     export BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS


### PR DESCRIPTION
The GitOps operator will deploy the gitops backend service in openshift-gitops namespace. This PR will update the backend service namespace from openshift-pipelines-app-delivery to openshift-gitops.

Change in the operator: https://github.com/redhat-developer/gitops-operator/pull/32

Edit: Adding the complete list of PRs which enabled this feature in the operator:
https://github.com/redhat-developer/gitops-operator/pull/43
https://github.com/redhat-developer/gitops-operator/pull/29
https://github.com/redhat-developer/gitops-operator/pull/46

cc @bigkevmcd @wtam2018 @sbose78 