### PR TITLE
Bug 1919945: fix name field to avoid overwriting user input value

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -90,7 +90,7 @@ const GitSection: React.FC<GitSectionProps> = ({
         return;
       }
 
-      gitRepoName && !values.name && setFieldValue('name', gitRepoName);
+      gitRepoName && !nameTouched && !values.name && setFieldValue('name', gitRepoName);
       gitRepoName &&
         values.formType !== 'edit' &&
         !values.application.name &&
@@ -116,6 +116,7 @@ const GitSection: React.FC<GitSectionProps> = ({
     [
       buildStrategy,
       gitTypeTouched,
+      nameTouched,
       setFieldTouched,
       setFieldValue,
       values.application.name,
@@ -166,7 +167,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   const handleGitUrlBlur = React.useCallback(() => {
     const { url } = values.git;
     const gitRepoName = detectGitRepoName(url);
-    values.formType !== 'edit' && gitRepoName && setFieldValue('name', gitRepoName);
+    values.formType !== 'edit' && gitRepoName && !nameTouched && setFieldValue('name', gitRepoName);
     gitRepoName &&
       values.formType !== 'edit' &&
       !values.application.name &&
@@ -174,12 +175,13 @@ const GitSection: React.FC<GitSectionProps> = ({
       setFieldValue('application.name', `${gitRepoName}-app`);
     setFieldTouched('git.url', true);
   }, [
-    setFieldTouched,
-    setFieldValue,
-    values.application.name,
-    values.application.selectedKey,
     values.git,
     values.formType,
+    values.application.name,
+    values.application.selectedKey,
+    nameTouched,
+    setFieldValue,
+    setFieldTouched,
   ]);
 
   const fillSample: React.ReactEventHandler<HTMLButtonElement> = React.useCallback(() => {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5393

**Analysis / Root cause:**
User entered name value overridden by default value when changing git form value.

**Solution Description:**
check if the name field is touched before updating the name value

**Screen shots / Gifs for design review:**
![namefield](https://user-images.githubusercontent.com/38663217/105706627-c782a500-5f37-11eb-9dc0-d83b3660214f.gif)

**Test Coverage:**
NA

**Browser conformance:**
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge