### PR TITLE
Bug 1920200: Throw error if ConfigMap creation fails with unexpected response

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -84,8 +84,7 @@ export const useUserSettings = <T>(
           if (err?.response?.status === 403 || err?.response?.status === 404) {
             setFallbackLocalStorage(true);
           } else {
-            setSettings(defaultValueRef.current);
-            setLoaded(true);
+            throw err;
           }
         }
       })();


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5332
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
When the console backend cannot be reached, the console front end enters a loop trying to fetch user-settings resulting in high CPU usage for the browser.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
The loop seems to be caused by `useK8sWatchResource` on the userSettings ConfigMap, which keeps repeatedly polling if the request fails. That triggers an effect which tries to create or update the ConfigMap.

~The fix in this PR makes the effect always fall back to local storage if the ConfigMap fetch fails.~
Throw an exception preventing any further rendering of the hook.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
(No UI change)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Test setup:**
- Load up a page
- Disconnect the bridge
- Navigate to the +Add page
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug