### PR TITLE
Bug 1921227: Avoid require()'ing modules when generating @console/active-plugins

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { Extension } from '@console/plugin-sdk/src/typings/base';
 import {
+  applyCodeRefSymbol,
   isEncodedCodeRef,
   isExecutableCodeRef,
   filterEncodedCodeRefProperties,
@@ -10,13 +11,28 @@ import {
   resolveEncodedCodeRefs,
   resolveCodeRefProperties,
 } from '../coderef-resolver';
-import { EncodedCodeRef } from '../../types';
+import { EncodedCodeRef, CodeRef } from '../../types';
 import {
   getExecutableCodeRefMock,
   getEntryModuleMocks,
   ModuleFactoryMock,
   RemoteEntryModuleMock,
 } from '../../utils/test-utils';
+
+describe('applyCodeRefSymbol', () => {
+  it('marks the given function with CodeRef symbol', () => {
+    const ref: CodeRef = () => Promise.resolve('qux');
+    expect(isExecutableCodeRef(ref)).toBe(false);
+
+    const updatedRef = applyCodeRefSymbol(ref);
+    expect(isExecutableCodeRef(updatedRef)).toBe(true);
+  });
+
+  it('returns the same function instance', () => {
+    const ref: CodeRef = () => Promise.resolve('qux');
+    expect(applyCodeRefSymbol(ref)).toBe(ref);
+  });
+});
 
 describe('isEncodedCodeRef', () => {
   it('returns true if obj is structured as { $codeRef: string }', () => {
@@ -31,6 +47,7 @@ describe('isExecutableCodeRef', () => {
   it('returns true if obj is a function marked with CodeRef symbol', () => {
     expect(isExecutableCodeRef(() => {})).toBe(false);
     expect(isExecutableCodeRef(getExecutableCodeRefMock('qux'))).toBe(true);
+    expect(isExecutableCodeRef(applyCodeRefSymbol(() => Promise.resolve('qux')))).toBe(true);
   });
 });
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-utils.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-utils.spec.ts
@@ -1,5 +1,4 @@
-import { codeRefSymbol } from '../coderef-resolver';
-import { executeReferencedFunction, getExecutableCodeRef } from '../coderef-utils';
+import { executeReferencedFunction } from '../coderef-utils';
 
 describe('executeReferencedFunction', () => {
   it('executes the referenced function with given args and returns its result', async () => {
@@ -36,14 +35,5 @@ describe('executeReferencedFunction', () => {
     expect(ref).toHaveBeenCalledWith();
     expect(func).toHaveBeenCalledWith(...args);
     expect(result).toBe(null);
-  });
-});
-
-describe('getExecutableCodeRef', () => {
-  it('should add codeRefSymbol to the codeRef to make it executable', () => {
-    const codeRef = jest.fn(() => Promise.resolve({}));
-    expect(codeRef[codeRefSymbol]).toBeFalsy();
-    const executableCodeRef = getExecutableCodeRef(codeRef);
-    expect(executableCodeRef[codeRefSymbol]).toBe(true);
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-resolver.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-resolver.ts
@@ -12,7 +12,12 @@ import {
 
 // TODO(vojtech): support code refs at any level within the properties object
 
-export const codeRefSymbol = Symbol('CodeRef');
+const codeRefSymbol = Symbol('CodeRef');
+
+export const applyCodeRefSymbol = <T = any>(ref: CodeRef<T>) => {
+  ref[codeRefSymbol] = true;
+  return ref;
+};
 
 export const isEncodedCodeRef = (obj): obj is EncodedCodeRef =>
   _.isPlainObject(obj) &&
@@ -98,8 +103,7 @@ export const resolveEncodedCodeRefs = (
       const executableCodeRef: CodeRef = async () =>
         loadReferencedObject(ref, entryModule, pluginID, errorCallback);
 
-      executableCodeRef[codeRefSymbol] = true;
-      e.properties[propName] = executableCodeRef;
+      e.properties[propName] = applyCodeRefSymbol(executableCodeRef);
     });
 
     return e;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-utils.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 
 import { CodeRef } from '../types';
-import { codeRefSymbol } from './coderef-resolver';
+
+export { applyCodeRefSymbol as getExecutableCodeRef } from './coderef-resolver';
 
 /**
  * Execute function referenced by the `CodeRef` with given arguments.
@@ -21,18 +22,4 @@ export const executeReferencedFunction = async <T extends (...args: any[]) => an
     console.error('Failed to execute referenced function', error);
     return null;
   }
-};
-
-/**
- * Convert any codeRef to an executable codeRef that can be executed by useResolvedExtension.
- *
- * Adds codeRefSymbol to the codeRef.
- *
- * TODO: Remove this once https://github.com/openshift/console/pull/7163 gets merged that adds support for dynamic extensions in static plugins.
- *
- * @param ref codeRef that needs to be converted to an executable codeRef.
- */
-export const getExecutableCodeRef = (ref: CodeRef): CodeRef => {
-  ref[codeRefSymbol] = true;
-  return ref;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/test-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/test-utils.ts
@@ -1,5 +1,5 @@
 import { Extension } from '@console/plugin-sdk/src/typings/base';
-import { codeRefSymbol } from '../coderefs/coderef-resolver';
+import { applyCodeRefSymbol } from '../coderefs/coderef-resolver';
 import { SupportedExtension } from '../schema/console-extensions';
 import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
 import { RemoteEntryModule, CodeRef, Update } from '../types';
@@ -19,7 +19,7 @@ export const getExecutableCodeRefMock = <T = any>(
   resolvedValue: T,
 ): jest.Mock<ReturnType<CodeRef<T>>> => {
   const ref = jest.fn(() => Promise.resolve(resolvedValue));
-  ref[codeRefSymbol] = true;
+  applyCodeRefSymbol<T>(ref);
   return ref;
 };
 

--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -223,17 +223,6 @@ describe('getGatingFlagNames', () => {
 });
 
 describe('PluginStore', () => {
-  let debounce: jest.SpyInstance<typeof _.debounce>;
-
-  beforeEach(() => {
-    debounce = jest.spyOn(_, 'debounce');
-    debounce.mockImplementation((func) => func);
-  });
-
-  afterEach(() => {
-    debounce.mockRestore();
-  });
-
   describe('constructor', () => {
     it('processes all plugins and stores their extensions in staticPluginExtensions', () => {
       const store = new PluginStore([

--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -314,24 +314,24 @@ describe('PluginStore', () => {
         },
       ]);
 
-      const dynamicExtensions1: Extension[] = [
+      const dynamicPluginExtensions1: Extension[] = [
         { type: 'Qux', properties: { value: 'test' }, flags: { required: ['foo', 'bar'] } },
       ];
 
-      const dynamicExtensions2: Extension[] = [
+      const dynamicPluginExtensions2: Extension[] = [
         { type: 'Mux', properties: {}, flags: { required: ['foo'], disallowed: ['bar'] } },
       ];
 
       store.addDynamicPlugin(
         'Test1@1.2.3',
-        getPluginManifest('Test1', '1.2.3', dynamicExtensions1),
-        dynamicExtensions1,
+        getPluginManifest('Test1', '1.2.3', dynamicPluginExtensions1),
+        dynamicPluginExtensions1,
       );
 
       store.addDynamicPlugin(
         'Test2@2.3.4',
-        getPluginManifest('Test2', '2.3.4', dynamicExtensions2),
-        dynamicExtensions2,
+        getPluginManifest('Test2', '2.3.4', dynamicPluginExtensions2),
+        dynamicPluginExtensions2,
       );
 
       store.setDynamicPluginEnabled('Test1@1.2.3', true);

--- a/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
@@ -14,14 +14,6 @@ import { trimStartMultiLine } from '../utils/string';
 import { consolePkgScope, PluginPackage } from './plugin-resolver';
 
 /**
- * Reload the requested module, bypassing `require.cache` mechanism.
- */
-export const reloadModule = (request: string) => {
-  delete require.cache[require.resolve(request)];
-  return require(request);
-};
-
-/**
  * Generate the `@console/active-plugins` virtual module source.
  */
 export const getActivePluginsModule = (
@@ -105,20 +97,6 @@ export const getExecutableCodeRefSource = (
   }
 
   const importPath = `${pkg.name}/${exposedModules[moduleName]}`;
-  let requestedModule: object;
-
-  try {
-    requestedModule = reloadModule(importPath);
-  } catch (error) {
-    validationResult.addError(`Cannot import '${importPath}' ${errorTrace}`);
-    return emptyCodeRefSource;
-  }
-
-  if (!requestedModule[exportName]) {
-    validationResult.addError(`Invalid module export '${exportName}' ${errorTrace}`);
-    return emptyCodeRefSource;
-  }
-
   const pluginReference = pkg.name.replace(`${consolePkgScope}/`, '');
   const webpackChunkName = `${pluginReference}/code-refs/${moduleName}`;
   const webpackMagicComment = `/* webpackChunkName: '${webpackChunkName}' */`;

--- a/frontend/packages/console-plugin-sdk/src/typings/base.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/base.ts
@@ -87,13 +87,6 @@ export type ExtensionTypeGuard<E extends Extension> = (e: E) => e is E;
 export type LazyLoader<T extends {} = {}> = () => Promise<React.ComponentType<Partial<T>>>;
 
 /**
- * Code reference, resolved to a function that returns the object `T`.
- *
- * TODO: Remove this once https://github.com/openshift/console/pull/7163 gets merged that adds support for dynamic extensions in static plugins.
- */
-export type CodeRef<T> = () => Promise<T>;
-
-/**
  * From Console application perspective, a plugin is a list of extensions
  * enhanced with additional data.
  */

--- a/frontend/packages/console-plugin-sdk/src/typings/detail-page-bread-crumbs.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/detail-page-bread-crumbs.ts
@@ -1,6 +1,7 @@
 import { match } from 'react-router';
 import { K8sKind } from '@console/internal/module/k8s';
-import { CodeRef, Extension } from './base';
+import { CodeRef } from '@console/dynamic-plugin-sdk/src/types';
+import { Extension } from './base';
 
 export type DetailsPageBreadCrumbsHook = (
   kind: K8sKind,

--- a/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
@@ -1,5 +1,5 @@
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
-import { CodeRef, Extension } from './base';
+import { Extension } from './base';
 
 namespace ExtensionProperties {
   export interface DevCatalogModel {
@@ -26,7 +26,7 @@ namespace ExtensionProperties {
     /** Type ID for the catalog item type. */
     type: string;
     /** Fetch items and normalize it for the catalog. Value is a react effect hook. */
-    provider: CodeRef<CatalogExtensionHook<CatalogItem[]>>;
+    provider: () => Promise<CatalogExtensionHook<CatalogItem[]>>;
     /** Priority for this provider. Defaults to 0. Higher priority providers may override catalog
         items provided by other providers. */
     priority?: number;
@@ -36,7 +36,7 @@ namespace ExtensionProperties {
     /** Type ID for the catalog item type. */
     type: string;
     /** Filters items of a specific type. Value is a function that takes CatalogItem[] and returns a subset based on the filter criteria. */
-    filter: CodeRef<<T extends CatalogItem[]>(items: T) => T>;
+    filter: () => Promise<(items: CatalogItem[]) => CatalogItem[]>;
   }
 }
 

--- a/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
@@ -1,4 +1,5 @@
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { CodeRef } from '@console/dynamic-plugin-sdk/src/types';
 import { Extension } from './base';
 
 namespace ExtensionProperties {
@@ -26,7 +27,7 @@ namespace ExtensionProperties {
     /** Type ID for the catalog item type. */
     type: string;
     /** Fetch items and normalize it for the catalog. Value is a react effect hook. */
-    provider: () => Promise<CatalogExtensionHook<CatalogItem[]>>;
+    provider: CodeRef<CatalogExtensionHook<CatalogItem[]>>;
     /** Priority for this provider. Defaults to 0. Higher priority providers may override catalog
         items provided by other providers. */
     priority?: number;
@@ -36,7 +37,7 @@ namespace ExtensionProperties {
     /** Type ID for the catalog item type. */
     type: string;
     /** Filters items of a specific type. Value is a function that takes CatalogItem[] and returns a subset based on the filter criteria. */
-    filter: () => Promise<(items: CatalogItem[]) => CatalogItem[]>;
+    filter: CodeRef<(items: CatalogItem[]) => CatalogItem[]>;
   }
 }
 

--- a/frontend/packages/console-plugin-sdk/src/webpack/ConsoleActivePluginsModule.ts
+++ b/frontend/packages/console-plugin-sdk/src/webpack/ConsoleActivePluginsModule.ts
@@ -54,10 +54,20 @@ export class ConsoleActivePluginsModule {
 
         this.virtualModules.writeModule(
           'node_modules/@console/active-plugins.js',
-          getActivePluginsModule(this.pluginPackages, (pkg) =>
-            getDynamicExtensions(pkg, getExtensionsFilePath(pkg), (errorMessage) => {
-              errors.push(errorMessage);
-            }),
+          getActivePluginsModule(
+            this.pluginPackages,
+            () => `
+              import { applyCodeRefSymbol } from '@console/dynamic-plugin-sdk/src/coderefs/coderef-resolver';
+            `,
+            (pkg) =>
+              getDynamicExtensions(
+                pkg,
+                getExtensionsFilePath(pkg),
+                (errorMessage) => {
+                  errors.push(errorMessage);
+                },
+                (codeRefSource) => `applyCodeRefSymbol(${codeRefSource})`,
+              ),
           ),
         );
       }

--- a/frontend/packages/kubevirt-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/topology-plugin.ts
@@ -1,4 +1,5 @@
 import { Plugin } from '@console/plugin-sdk';
+import { getExecutableCodeRef } from '@console/dynamic-plugin-sdk/src/coderefs/coderef-utils';
 import {
   TopologyComponentFactory,
   TopologyDataModelFactory,
@@ -67,7 +68,7 @@ export const getTopologyPlugin = (required: string[]): Plugin<TopologyConsumedEx
   {
     type: 'Topology/ComponentFactory',
     properties: {
-      getFactory: getKubevirtComponentFactory,
+      getFactory: getExecutableCodeRef(getKubevirtComponentFactory),
     },
     flags: {
       required,
@@ -80,8 +81,8 @@ export const getTopologyPlugin = (required: string[]): Plugin<TopologyConsumedEx
       priority: 200,
       resources: virtualMachineResourceWatchers,
       workloadKeys: ['virtualmachines'],
-      getDataModel: getKubevirtTopologyDataModel,
-      isResourceDepicted: getIsKubevirtResource,
+      getDataModel: getExecutableCodeRef(getKubevirtTopologyDataModel),
+      isResourceDepicted: getExecutableCodeRef(getIsKubevirtResource),
     },
     flags: {
       required,

--- a/frontend/packages/topology/src/extensions/topology.ts
+++ b/frontend/packages/topology/src/extensions/topology.ts
@@ -1,4 +1,4 @@
-import { Extension, CodeRef } from '@console/plugin-sdk/src/typings/base';
+import { Extension } from '@console/plugin-sdk/src/typings/base';
 import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
 import {
   TopologyApplyDisplayOptions,
@@ -51,7 +51,7 @@ namespace ExtensionProperties {
     id: string;
     priority: number;
     quadrant: TopologyDecoratorQuadrant;
-    decorator: CodeRef<TopologyDecoratorGetter>;
+    decorator: () => Promise<TopologyDecoratorGetter>;
   }
 }
 

--- a/frontend/packages/topology/src/extensions/topology.ts
+++ b/frontend/packages/topology/src/extensions/topology.ts
@@ -1,4 +1,5 @@
 import { Extension } from '@console/plugin-sdk/src/typings/base';
+import { CodeRef } from '@console/dynamic-plugin-sdk/src/types';
 import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
 import {
   TopologyApplyDisplayOptions,
@@ -15,7 +16,7 @@ import {
 namespace ExtensionProperties {
   export interface TopologyComponentFactory {
     /** Getter for a ViewComponentFactory */
-    getFactory: () => Promise<ViewComponentFactory>;
+    getFactory: CodeRef<ViewComponentFactory>;
   }
 
   export interface TopologyDataModelFactory {
@@ -28,30 +29,30 @@ namespace ExtensionProperties {
     /** Keys in resources containing workloads. */
     workloadKeys?: string[];
     /** Getter for the data model factory */
-    getDataModel?: () => Promise<TopologyDataModelGetter>;
+    getDataModel?: CodeRef<TopologyDataModelGetter>;
     /** Getter for function to determine if a resource is depicted by this model factory */
-    isResourceDepicted?: () => Promise<TopologyDataModelDepicted>;
+    isResourceDepicted?: CodeRef<TopologyDataModelDepicted>;
     /** Getter for function to reconcile data model after all extensions' models have loaded */
-    getDataModelReconciler?: () => Promise<TopologyDataModelReconciler>;
+    getDataModelReconciler?: CodeRef<TopologyDataModelReconciler>;
   }
 
   export interface TopologyCreateConnector {
     /** Getter for the create connector function */
-    getCreateConnector: () => Promise<CreateConnectionGetter>;
+    getCreateConnector: CodeRef<CreateConnectionGetter>;
   }
 
   export interface TopologyDisplayFilters {
     // Getter for topology filters specific to the extension
-    getTopologyFilters: () => Promise<() => TopologyDisplayOption[]>;
+    getTopologyFilters: CodeRef<() => TopologyDisplayOption[]>;
     // Function to apply filters to the model
-    applyDisplayOptions: () => Promise<TopologyApplyDisplayOptions>;
+    applyDisplayOptions: CodeRef<TopologyApplyDisplayOptions>;
   }
 
   export interface TopologyDecoratorProvider {
     id: string;
     priority: number;
     quadrant: TopologyDecoratorQuadrant;
-    decorator: () => Promise<TopologyDecoratorGetter>;
+    decorator: CodeRef<TopologyDecoratorGetter>;
   }
 }
 


### PR DESCRIPTION
Depends on #7898

When building Console via webpack, static plugins have their dynamic extensions validated by `ConsoleActivePluginsModule` as part of `@console/active-plugins` virtual module generation.

This virtual webpack module exports all static plugins (and their extensions) for use in the Console app.

The idea was to keep dynamic extension validation logic consistent between [static plugins](https://github.com/openshift/console/tree/master/frontend/packages/console-plugin-sdk) and [dynamic plugins](https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk).

In case of static plugins, however, current implementation of test cases
- `code ref must reference a valid module`
- `code ref must reference a valid export of the given module`

relies on Node.js `require()` which fails on code that isn't strictly JavaScript (including ES module import syntax).

:memo: Note: _It is possible to re-implement ^^ test cases to utilize webpack `compilation` object similar to [`ExtensionValidator.ts`](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts) (or adapt it to support both static and dynamic plugin build context) but this effort is non-trivial, so out of this PR's scope._