### PR TITLE
Move baseCRDs definitions to console-app/console-extensions.json

### DIFF
--- a/frontend/__tests__/reducers/features.spec.tsx
+++ b/frontend/__tests__/reducers/features.spec.tsx
@@ -52,22 +52,7 @@ describe('featureReducer', () => {
     const initialState = Immutable.Map(defaults);
     const newState = featureReducer(initialState, action);
 
-    expect(newState).toEqual(
-      initialState.merge({
-        [FLAGS.PROMETHEUS]: false,
-        [FLAGS.CHARGEBACK]: false,
-        [FLAGS.SERVICE_CATALOG]: false,
-        [FLAGS.CLUSTER_API]: false,
-        [FLAGS.MACHINE_CONFIG]: false,
-        [FLAGS.MACHINE_AUTOSCALER]: false,
-        [FLAGS.MACHINE_HEALTH_CHECK]: false,
-        [FLAGS.CONSOLE_LINK]: false,
-        [FLAGS.CONSOLE_CLI_DOWNLOAD]: false,
-        [FLAGS.CONSOLE_NOTIFICATION]: false,
-        [FLAGS.CONSOLE_EXTERNAL_LOG_LINK]: false,
-        [FLAGS.CONSOLE_YAML_SAMPLE]: false,
-      }),
-    );
+    expect(newState).toEqual(initialState);
   });
 });
 

--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -4,6 +4,138 @@
     {
       "type": "console.flag/model",
       "properties": {
+        "flag": "CHARGEBACK",
+        "model": {
+          "group": "metering.openshift.io",
+          "version": "v1",
+          "kind": "Report"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "SERVICE_CATALOG",
+        "model": {
+          "group": "servicecatalog.k8s.io",
+          "version": "v1beta1",
+          "kind": "ClusterServiceClass"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "CONSOLE_LINK",
+        "model": {
+          "group": "console.openshift.io",
+          "version": "v1",
+          "kind": "ConsoleLink"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "CONSOLE_CLI_DOWNLOAD",
+        "model": {
+          "group": "console.openshift.io",
+          "version": "v1",
+          "kind": "ConsoleCLIDownload"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "CONSOLE_EXTERNAL_LOG_LINK",
+        "model": {
+          "group": "console.openshift.io",
+          "version": "v1",
+          "kind": "ConsoleExternalLogLink"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "CONSOLE_NOTIFICATION",
+        "model": {
+          "group": "console.openshift.io",
+          "version": "v1",
+          "kind": "ConsoleNotification"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "CONSOLE_YAML_SAMPLE",
+        "model": {
+          "group": "console.openshift.io",
+          "version": "v1",
+          "kind": "ConsoleYAMLSample"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "MACHINE_AUTOSCALER",
+        "model": {
+          "group": "autoscaling.openshift.io",
+          "version": "v1beta1",
+          "kind": "MachineAutoscaler"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "MACHINE_CONFIG",
+        "model": {
+          "group": "machineconfiguration.openshift.io",
+          "version": "v1",
+          "kind": "MachineConfig"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "MACHINE_HEALTH_CHECK",
+        "model": {
+          "group": "machine.openshift.io",
+          "version": "v1beta1",
+          "kind": "MachineHealthCheck"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "CLUSTER_API",
+        "model": {
+          "group": "machine.openshift.io",
+          "version": "v1beta1",
+          "kind": "Machine"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
+        "flag": "PROMETHEUS",
+        "model": {
+          "group": "monitoring.coreos.com",
+          "version": "v1",
+          "kind": "Prometheus"
+        }
+      }
+    },
+    {
+      "type": "console.flag/model",
+      "properties": {
         "flag": "DEVWORKSPACE",
         "model": {
           "group": "workspace.devfile.io",

--- a/frontend/packages/console-app/src/__tests__/extension-checks/features.spec.ts
+++ b/frontend/packages/console-app/src/__tests__/extension-checks/features.spec.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { baseCRDs } from '@console/internal/reducers/features';
 import { FLAGS } from '@console/shared/src/constants/common';
 import { testedExtensions, getDuplicates } from '../plugin-test-utils';
 import { isModelFeatureFlag } from '@console/plugin-sdk';
@@ -19,7 +18,7 @@ describe('ModelFeatureFlag', () => {
   });
 
   it('only one flag per model is allowed', () => {
-    const baseModelRefs = _.keys(baseCRDs);
+    const baseModelRefs = [];
     const pluginModelRefs = _.flatMap(
       testedExtensions
         .toArray()

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -8,20 +8,6 @@ import {
   subscribeToExtensions,
   extensionDiffListener,
 } from '@console/plugin-sdk/src/api/subscribeToExtensions';
-import {
-  ChargebackReportModel,
-  ClusterServiceClassModel,
-  ConsoleCLIDownloadModel,
-  ConsoleExternalLogLinkModel,
-  ConsoleLinkModel,
-  ConsoleNotificationModel,
-  ConsoleYAMLSampleModel,
-  MachineAutoscalerModel,
-  MachineConfigModel,
-  MachineHealthCheckModel,
-  MachineModel,
-  PrometheusModel,
-} from '../models';
 import { referenceForModel, referenceForGroupVersionKind } from '../module/k8s';
 import { RootState } from '../redux';
 import { ActionType as K8sActionType } from '../actions/k8s';
@@ -36,22 +22,7 @@ export const defaults = _.mapValues(FLAGS, (flag) =>
   flag === FLAGS.AUTH_ENABLED ? !window.SERVER_FLAGS.authDisabled : undefined,
 );
 
-export const baseCRDs = {
-  [referenceForModel(ChargebackReportModel)]: FLAGS.CHARGEBACK,
-  [referenceForModel(ClusterServiceClassModel)]: FLAGS.SERVICE_CATALOG,
-  [referenceForModel(ConsoleLinkModel)]: FLAGS.CONSOLE_LINK,
-  [referenceForModel(ConsoleCLIDownloadModel)]: FLAGS.CONSOLE_CLI_DOWNLOAD,
-  [referenceForModel(ConsoleExternalLogLinkModel)]: FLAGS.CONSOLE_EXTERNAL_LOG_LINK,
-  [referenceForModel(ConsoleNotificationModel)]: FLAGS.CONSOLE_NOTIFICATION,
-  [referenceForModel(ConsoleYAMLSampleModel)]: FLAGS.CONSOLE_YAML_SAMPLE,
-  [referenceForModel(MachineAutoscalerModel)]: FLAGS.MACHINE_AUTOSCALER,
-  [referenceForModel(MachineConfigModel)]: FLAGS.MACHINE_CONFIG,
-  [referenceForModel(MachineHealthCheckModel)]: FLAGS.MACHINE_HEALTH_CHECK,
-  [referenceForModel(MachineModel)]: FLAGS.CLUSTER_API,
-  [referenceForModel(PrometheusModel)]: FLAGS.PROMETHEUS,
-};
-
-const CRDs = { ...baseCRDs };
+const CRDs: { [modelRef: string]: FLAGS } = {};
 
 const addToCRDs = (ref: string, flag: string) => {
   if (!CRDs[ref]) {
@@ -80,8 +51,6 @@ subscribeToExtensions<DynamicModelFeatureFlag>(
     removed.forEach((e) => {
       delete CRDs[getModelRef(e)];
     });
-
-    // TODO(vojtech): change of 'CRDs' should trigger relevant detection logic
   }),
   isDynamicModelFeatureFlag,
 );


### PR DESCRIPTION
- [x] CRD to feature flag mapping defaults in `public/reducers/features.ts` removed
- [x] Equivalent `console.flag/model` extensions added to Console app's `console-extensions.json`