### PR TITLE
Bug 1916450: Alertmanager: add Title and Text fields to Adv. config section of Slack Receiver form

### DIFF
--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -255,6 +255,8 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
     ['slack_icon_emoji']: '{{ template "slack.default.iconemoji" .}}',
     ['slack_icon_url']: '{{ template "slack.default.iconurl" .}}',
     ['slack_link_names']: false,
+    ['slack_title']: '{{ template "slack.default.title" .}}',
+    ['slack_text']: '{{ template "slack.default.text" .}}',
     ['webhook_send_resolved']: true,
   };
 

--- a/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
@@ -2,6 +2,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { TextArea } from '@patternfly/react-core';
 
 import { RadioInput } from '../../radio';
 import { ExpandCollapse, ExternalLink } from '../../utils';
@@ -18,6 +19,8 @@ const GLOBAL_FIELDS = [
   'slack_icon_emoji',
   'slack_icon_url',
   'slack_link_names',
+  'slack_title',
+  'slack_text',
 ];
 
 export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormChange }) => {
@@ -227,6 +230,44 @@ export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormCha
               </div>
               <div className="help-block" id="slack-link-names-help">
                 {t('slack-receiver-form~Find and link channel names and usernames.')}
+              </div>
+            </div>
+            <div className="form-group">
+              <label className="control-label" htmlFor="slack-title">
+                {t('slack-receiver-form~Title')}
+              </label>
+              <TextArea
+                id="slack-title"
+                aria-describedby="slack-title-help"
+                onChange={(value) =>
+                  dispatchFormChange({
+                    type: 'setFormValues',
+                    payload: { slack_title: value },
+                  })
+                }
+                value={formValues.slack_title}
+              />
+              <div className="help-block" id="slack-title-help">
+                {t('slack-receiver-form~The title of the Slack message.')}
+              </div>
+            </div>
+            <div className="form-group">
+              <label className="control-label" htmlFor="slack-text">
+                {t('slack-receiver-form~Text')}
+              </label>
+              <TextArea
+                id="slack-text"
+                aria-describedby="slack-text-help"
+                onChange={(value) =>
+                  dispatchFormChange({
+                    type: 'setFormValues',
+                    payload: { slack_text: value },
+                  })
+                }
+                value={formValues.slack_text}
+              />
+              <div className="help-block" id="slack-text-help">
+                {t('slack-receiver-form~The text of the Slack message.')}
               </div>
             </div>
           </div>

--- a/frontend/public/locales/en/slack-receiver-form.json
+++ b/frontend/public/locales/en/slack-receiver-form.json
@@ -16,5 +16,9 @@
   "Username": "Username",
   "The displayed username.": "The displayed username.",
   "Link names": "Link names",
-  "Find and link channel names and usernames.": "Find and link channel names and usernames."
+  "Find and link channel names and usernames.": "Find and link channel names and usernames.",
+  "Title": "Title",
+  "The title of the Slack message.": "The title of the Slack message.",
+  "Text": "Text",
+  "The text of the Slack message.": "The text of the Slack message."
 }


### PR DESCRIPTION
**Added Title and Text fields to the advanced configuration section of the Slack Alertmananger Receiver form:**
![image](https://user-images.githubusercontent.com/12733153/105758214-00615080-5f1d-11eb-99a1-c34edeea6701.png)

### Default Text & Title of Slack message
**Using the default title and text values from above yields in Slack:**
![image](https://user-images.githubusercontent.com/12733153/105758427-3dc5de00-5f1d-11eb-88d8-f39e9ef8f1b6.png)

### Custom Text & Title
**Setting the title and text fields allows one to greatly customize the slack alert messages:**
![image](https://user-images.githubusercontent.com/12733153/105758910-d0667d00-5f1d-11eb-8677-e6835c65f56f.png)

**Using the custom title and text values from above yields:**
![image](https://user-images.githubusercontent.com/12733153/105758462-4ae2cd00-5f1d-11eb-8c4f-71b7fbac73b6.png)

