### PR TITLE
Bug 1920248: fix pipeline rerun when pipelineSpec is embedded

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -52,3 +52,6 @@ export const DEFAULT_LEGEND_CHART_HEIGHT = 375;
 export const DEFAULT_TIME_RANGE = '1w';
 export const DEFAULT_REFRESH_INTERVAL = '30s';
 export const DEFAULT_SAMPLES = 60;
+
+// Annotation for referencing pipeline name in case of PipelineRun with no reference to a Pipeline (embedded pipeline)
+export const preferredNameAnnotation = 'pipeline.openshift.io/preferredName';

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -1,6 +1,6 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Pipeline, PipelineRun, TaskRunKind, PipelineSpec } from '../utils/pipeline-augment';
-import { TektonResourceLabel } from '../components/pipelines/const';
+import { TektonResourceLabel, preferredNameAnnotation } from '../components/pipelines/const';
 
 export enum DataState {
   IN_PROGRESS = 'In Progress',
@@ -25,6 +25,7 @@ export enum PipelineExampleNames {
   CONDITIONAL_PIPELINE = 'conditional-pipeline',
   INVALID_PIPELINE_MISSING_TASK = 'missing-task-pipeline',
   INVALID_PIPELINE_INVALID_TASK = 'invalid-task-pipeline',
+  EMBEDDED_PIPELINE_SPEC = 'embedded-pipeline-spec',
 }
 
 type CombinedPipelineTestData = {
@@ -1881,6 +1882,107 @@ export const pipelineTestData: PipelineTestData = {
               },
             },
           },
+        },
+      },
+    },
+  },
+  [PipelineExampleNames.EMBEDDED_PIPELINE_SPEC]: {
+    dataSource: 'embedded-pipelineSpec',
+    pipeline: null,
+    pipelineRuns: {
+      [DataState.IN_PROGRESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'pipelinerun-with-embedded-pipelineSpec',
+          namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T06:11:46Z',
+        },
+        spec: {
+          pipelineSpec: {
+            tasks: [
+              {
+                name: 'echo-good-morning',
+                taskSpec: {
+                  metadata: {
+                    labels: {
+                      app: 'example',
+                    },
+                  },
+                  steps: [
+                    {
+                      name: 'echo',
+                      image: 'ubuntu',
+                      script: ['#!/usr/bin/env bash echo "Good Morning!"'],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            { name: 'web-image', resourceRef: { name: 'mapit-image' } },
+          ],
+        },
+      },
+      [DataState.SUCCESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'pipelinerun-wit-embedded-pipelineSpec-p1bun0',
+          namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T09:58:19Z',
+          annotations: {
+            [preferredNameAnnotation]: 'pipelinerun-wit-embedded-pipelineSpec',
+          },
+        },
+        spec: {
+          pipelineSpec: {
+            tasks: [
+              {
+                name: 'echo-good-morning',
+                taskSpec: {
+                  metadata: {
+                    labels: {
+                      app: 'example',
+                    },
+                  },
+                  steps: [
+                    {
+                      name: 'echo',
+                      image: 'ubuntu',
+                      script: ['#!/usr/bin/env bash echo "Good Morning!"'],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            {
+              name: 'web-image',
+              resourceRef: { name: 'mapit-image' },
+            },
+          ],
+        },
+      },
+      [DataState.SKIPPED]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'embedded-pipelineSpec-br8cxv',
+          namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T06:11:46Z',
+          labels: { [TektonResourceLabel.pipeline]: 'embedded-pipelineSpec' },
+        },
+        spec: {
+          pipelineRef: { name: 'embedded-pipelineSpec' },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            { name: 'web-image', resourceRef: { name: 'mapit-image' } },
+          ],
         },
       },
     },

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -43,8 +43,8 @@ export const reRunPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipeli
   labelKey: 'pipelines-plugin~Rerun',
   callback: () => {
     const namespace = _.get(pipelineRun, 'metadata.namespace');
-    const pipelineRef = _.get(pipelineRun, 'spec.pipelineRef.name');
-    if (namespace && pipelineRef) {
+    const { pipelineRef, pipelineSpec } = pipelineRun.spec;
+    if (namespace && (pipelineRef?.name || pipelineSpec)) {
       k8sCreate(PipelineRunModel, getPipelineRunData(null, pipelineRun));
     } else {
       errorModal({ error: 'Invalid Pipeline Run configuration, unable to start Pipeline.' });

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -64,6 +64,9 @@ export interface PipelineTaskSpec {
     args?: string[];
     script?: string[];
   }[];
+  metadata?: {
+    labels?: { [key: string]: string };
+  };
 }
 
 export interface PipelineTaskParam {
@@ -210,6 +213,7 @@ export type PLRTaskRuns = {
 export interface PipelineRun extends K8sResourceKind {
   spec?: {
     pipelineRef?: { name: string };
+    pipelineSpec?: PipelineSpec;
     params?: PipelineRunParam[];
     workspaces?: PipelineRunWorkspace[];
     resources?: PipelineRunResource[];


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-5395

Analysis / Root cause:
While re-running the pipelineRun with embedded pipelinespec causes the UI to crash.

Solution Description:
update util getPipelineRunData and kebab actions to handle the scenario when pipeline is passed in pipelineSpec instead of a reference in pipelineRef

Screen shots / Gifs for design review:
![pipelineSpec](https://user-images.githubusercontent.com/38663217/105771325-67671f80-5f86-11eb-9283-6dd59eb0dc96.gif)

Test Coverage:
![Screenshot from 2021-01-30 20-55-07](https://user-images.githubusercontent.com/38663217/106360281-97734180-633d-11eb-818c-57e30ccb70b8.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge