### PR TITLE
Bug 1920524: Fix topology crash on install of ODH operator to project

### DIFF
--- a/frontend/packages/topology/src/operators/operatorsDataModelReconciler.ts
+++ b/frontend/packages/topology/src/operators/operatorsDataModelReconciler.ts
@@ -57,6 +57,7 @@ export const operatorsDataModelReconciler = (
   }
   const defaultIcon = getImageForIconClass(`icon-openshift`);
 
+  const obsGroupNodes: OdcNodeModel[] = [];
   installedOperators.forEach((csv) => {
     const crds = csv?.spec?.customresourcedefinitions?.owned ?? [];
     const crdKinds = crds.map((crd) => crd.kind);
@@ -146,8 +147,9 @@ export const operatorsDataModelReconciler = (
           children,
           'Operator Backed Service',
         );
-        model.nodes.push(obsNode);
+        obsGroupNodes.push(obsNode);
       }
     });
   });
+  model.nodes.push(...obsGroupNodes);
 };


### PR DESCRIPTION
**Fixes**: 
Fixes https://issues.redhat.com/browse/ODC-5398

**Analysis / Root cause**: 
Operator backed service groups with multiple workload dependencies got added to the model prior to completion of the reconciliation. This caused workloads that reconciled later to create a new OBS group parented to itself causing a stack overflow when drawing the groups.

**Solution Description**: 
Do not add the OBS groups to the model until all workloads have been reconciled.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug