### PR TITLE
Bug 1920551: Should not allow to edit boot order of common templates

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -28,6 +28,7 @@ import {
   getTemplateParentProvider,
   getTemplateProvider,
   getTemplateSupport,
+  isCommonTemplate,
 } from '../../selectors/vm-template/basic';
 import { getVMTemplateResourceFlavorData } from './utils';
 
@@ -136,7 +137,7 @@ export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
     <dl className="co-m-pane__details">
       <VMDetailsItem
         title={t('kubevirt-plugin~Boot Order')}
-        canEdit
+        canEdit={!isCommonTemplate(template)}
         editButtonId={prefixedID(id, 'boot-order-edit')}
         onEditClick={() => BootOrderModal({ vmLikeEntity: template, modalClassName: 'modal-lg' })}
         idValue={prefixedID(id, 'boot-order')}


### PR DESCRIPTION
Should not allow to edit boot order of common templates

Screenshot:
before:
![screenshot-localhost_9000-2021 01 26-16_46_13](https://user-images.githubusercontent.com/2181522/105861395-560a2b80-5ff7-11eb-872a-5d240d4eaaaf.png)


after:
![screenshot-localhost_9000-2021 01 26-16_44_51](https://user-images.githubusercontent.com/2181522/105861402-586c8580-5ff7-11eb-9ff3-c929fd703891.png)
