### PR TITLE
Bug 1919750: Fix exception on InstallPlan list page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -199,7 +199,7 @@ export const InstallPlansList = requireOperatorGroup((props: InstallPlansListPro
       {...props}
       aria-label={t('olm~InstallPlans')}
       Header={InstallPlanTableHeader}
-      Row={InstallPlanTableRow}
+      Row={(rowArgs) => <InstallPlanTableRow {...rowArgs} />}
       EmptyMsg={EmptyMsg}
     />
   );


### PR DESCRIPTION
The Table component Row prop is not defined as a React component, so we were getting an exception for using React hooks in InstallPlanTableRow component and passing it directly to the Table Row prop. I worked around this by wrapping the InstallPlanTableRow component in a callback. This fixes the bug, but at some point we should also refactor the Table Row prop to be a real React component.