### PR TITLE
Bug 1918826: Adjust Insights popover icon to center align vertically

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/CriticalIcon.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/CriticalIcon.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
 const CriticalIcon = (props) => (
-  <svg viewbox="0 0 10 10" {...props}>
-    <polygon points="10 10, 10 3, 5 0, 0 3, 0 10, 5 8" />
+  <svg x="1.5">
+    <svg viewbox="0 0 10 10" {...props}>
+      <polygon points="10 10, 10 3, 5 0, 0 3, 0 10, 5 8" />
+    </svg>
   </svg>
 );
 


### PR DESCRIPTION
fix https://bugzilla.redhat.com/show_bug.cgi?id=1918826
note icons have varying widths 

<img width="388" alt="Screen Shot 2021-01-26 at 12 20 20 PM" src="https://user-images.githubusercontent.com/1874151/105880693-a9698300-5fd1-11eb-9f17-dbbc88c8b7d8.png">
