### PR TITLE
Fix data-test ID used for selecting "Operator recommended Namespace" input button

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/support/index.ts
@@ -25,7 +25,7 @@ Cypress.Commands.add('install', (mode: 'Internal' | 'Attached' = 'Internal', enc
 
       cy.log('Subscribe to OCS Operator');
       cy.byLegacyTestID('operator-install-btn').click({ force: true });
-      cy.byTestID('Operator recommended namespace:-radio-input').should('be.checked');
+      cy.byTestID('Operator recommended Namespace:-radio-input').should('be.checked');
       cy.byTestID('enable-monitoring').click();
       cy.byTestID('install-operator').click();
       cy.byTestID('success-icon', { timeout: 180000 }).should('be.visible');


### PR DESCRIPTION
Required as data-test was changed by https://github.com/openshift/console/pull/7858