### PR TITLE
Bug 1920868: fix cdi upload tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/cdi-upload.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/cdi-upload.scenario.ts
@@ -112,15 +112,19 @@ describe('KubeVirt Auto Clone', () => {
       2 * CDI_UPLOAD_TIMEOUT_SECS,
     );
 
-    it('ID(CNV-5176) It shows an error when uploading data to golden OS again', async () => {
-      await withResource(leakedResources, rhel7PVC.getDVResource(), async () => {
-        await rhel7PVC.create();
-        await uploadForm.openForm();
-        await uploadForm.selectGoldenOS(rhel7PVC.os);
-        await browser.wait(until.presenceOf(errorMessage));
-        expect(errorMessage.getText()).toContain('Operating system source already defined');
-      });
-    });
+    it(
+      'ID(CNV-5176) It shows an error when uploading data to golden OS again',
+      async () => {
+        await withResource(leakedResources, rhel7PVC.getDVResource(), async () => {
+          await rhel7PVC.create();
+          await uploadForm.openForm();
+          await uploadForm.selectGoldenOS(rhel7PVC.os);
+          await browser.wait(until.presenceOf(errorMessage));
+          expect(errorMessage.getText()).toContain('Operating system source already defined');
+        });
+      },
+      CDI_UPLOAD_TIMEOUT_SECS,
+    );
   });
 
   describe('KubeVirt GOLDEN OS Creation', () => {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvc.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvc.ts
@@ -8,8 +8,10 @@ import {
   pvcStatus,
 } from '@console/ceph-storage-plugin/integration-tests/views/pvc.view';
 import { clickNavLink } from '@console/internal-integration-tests/views/sidenav.view';
+import { listViewAction } from '@console/shared/src/test-utils/actions.view';
 import * as pvcView from '../../views/pvc.view';
 import { OperatingSystem } from '../utils/constants/wizard';
+import { PVC_ACTION } from '../utils/constants/pvc';
 import { PVC_STATUS } from '@console/ceph-storage-plugin/integration-tests/utils/consts';
 import { getTestDataVolume } from '../mocks/mocks';
 import { click } from '@console/shared/src/test-utils/utils';
@@ -34,10 +36,6 @@ export class PVC<T extends PVCData> extends UIResource {
   async create() {
     const uploadForm = new UploadForm();
     await uploadForm.upload(this.data);
-    // It has to click twice if uploading golden images.
-    if (this.data.os) {
-      await click(crudView.saveChangesBtn);
-    }
     await browser.wait(until.textToBePresentInElement(pvcView.uploadProgress, '100%'));
     await click(pvcView.viewStatusID);
     await browser.wait(until.textToBePresentInElement(pvcStatus, PVC_STATUS.BOUND));
@@ -45,12 +43,13 @@ export class PVC<T extends PVCData> extends UIResource {
 
   async delete() {
     await clickNavLink(['Storage', 'Persistent Volume Claims']);
+    // await clickNavLink(['Storage', 'PersistentVolumeClaims']);
     await crudView.isLoaded();
     await selectItemFromDropdown(this.namespace, namespaceDropdown);
     await crudView.resourceRowsPresent();
     await crudView.filterForName(this.name);
     await crudView.isLoaded();
-    await crudView.deleteRow('PersistentVolumeClaim')(this.name);
+    await listViewAction(this.name)(PVC_ACTION.Delete, true);
     await crudView.isLoaded();
     await browser.wait(until.stalenessOf(pvcView.pvcName(this.name)));
   }

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvcUploadForm.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/pvcUploadForm.ts
@@ -20,6 +20,7 @@ import { dropDownItem } from '../../views/uiResource.view';
 export class UploadForm {
   async openForm() {
     await clickNavLink(['Storage', 'Persistent Volume Claims']);
+    // await clickNavLink(['Storage', 'PersistentVolumeClaims']);
     await isLoaded();
     await click(createItemButton);
     await click(pvcView.uploadCdiFormButton);
@@ -55,7 +56,7 @@ export class UploadForm {
   }
 
   async fillPVCSize(pvcSize: string, pvcSizeUnits: string) {
-    await inputPVCSize.sendKeys(pvcSize);
+    await fillInput(inputPVCSize, pvcSize);
     if (pvcSizeUnits) {
       await selectItemFromDropdown(pvcSizeUnits, sizeUnitsDropdown);
     }
@@ -80,6 +81,11 @@ export class UploadForm {
       accessMode,
       volumeMode,
     } = data;
+    if (os) {
+      this.selectGoldenOS(os);
+    } else {
+      await this.fillPVCName(pvcName);
+    }
     await this.selectStorageClass(storageClass);
     await this.fillPVCSize(pvcSize, pvcSizeUnits);
     if (accessMode) {
@@ -87,11 +93,6 @@ export class UploadForm {
     }
     if (volumeMode) {
       await this.selectVolumeMode(volumeMode);
-    }
-    if (os) {
-      this.selectGoldenOS(os);
-    } else {
-      await this.fillPVCName(pvcName);
     }
     await this.fillUploadImage(image);
   }

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -34,7 +34,7 @@ import { DiskDialog } from '../dialogs/diskDialog';
 import { Flavor, StepTitle, TemplateByName } from '../utils/constants/wizard';
 import * as view from '../../views/wizard.view';
 import { resourceHorizontalTab, dropDownItem, dropDownItemMain } from '../../views/uiResource.view';
-import { saveButton } from '../../views/kubevirtUIResource.view';
+import { continueButton, saveButton, modalTitle } from '../../views/kubevirtUIResource.view';
 import { confirmActionButton } from '../../views/importWizard.view';
 import { virtualizationTitle } from '../../views/vms.list.view';
 import { diskStorageClass } from '../../views/dialogs/diskDialog.view';
@@ -285,6 +285,9 @@ export class Wizard {
     const { selectTemplateName } = data;
     await this.selectTemplate(selectTemplateName);
     await this.next(ignoreWarnings);
+    if (await modalTitle.isPresent()) {
+      await click(continueButton);
+    }
   }
 
   async processBootSource(data: VMBuilderData, ignoreWarnings: boolean = false) {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/pvc.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/constants/pvc.ts
@@ -50,3 +50,7 @@ export const WIN10_PVC: PVCData = {
   pvcSize: '1',
   storageClass: STORAGE_CLASS,
 };
+
+export enum PVC_ACTION {
+  Delete = 'Delete Persistent Volume Claim',
+}

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/kubevirtUIResource.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/kubevirtUIResource.view.ts
@@ -7,6 +7,7 @@ export const modalSubmitButton = $('.modal-content .pf-m-primary');
 export const cancelButton = element(by.buttonText('Cancel'));
 export const applyButton = element(by.buttonText('Add'));
 export const saveButton = element(by.buttonText('Save'));
+export const continueButton = element(by.buttonText('Continue'));
 
 export const createNICButton = $('#add-nic');
 export const createDiskButton = $('#add-disk');


### PR DESCRIPTION
Some cdi upload tests are failed due to:
1. Create VM from fedora template need to confirm the template support modal
2. Delete PVC from UI does not work any more, need to change it a bit
3. Upload confirm button might not be clickable, it click twice before for some reason
4. Move fillPVCSize after select OS, as select OS overwrite its the PVC size value

Verified in: https://cnv-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/test-kubevirt-[console-4](https://issues.redhat.com/browse/console-4).7-cnv-2.6-dev/23/console