### PR TITLE
Bug 1918803: adds details page and handles breadcrumb for knativeServing

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServingDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServingDetailsPage.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { navFactory } from '@console/internal/components/utils';
+import { DetailsPage } from '@console/internal/components/factory';
+import { DetailsForKind } from '@console/internal/components/default-resource';
+import { breadcrumbsForGlobalConfig } from '@console/internal/components/cluster-settings/global-config';
+import { K8sResourceKindReference, referenceForModel } from '@console/internal/module/k8s';
+import { KnativeServingModel } from '../../models';
+
+const knativeServingReference: K8sResourceKindReference = referenceForModel(KnativeServingModel);
+
+const KnativeServingDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => {
+  const pages = [navFactory.details(DetailsForKind(props.kind)), navFactory.editYaml()];
+
+  return (
+    <DetailsPage
+      {...props}
+      kind={knativeServingReference}
+      pages={pages}
+      breadcrumbsFor={() => breadcrumbsForGlobalConfig(KnativeServingModel.label, props.match.url)}
+    />
+  );
+};
+
+export default KnativeServingDetailsPage;

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -249,6 +249,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.KnativeServingModel,
+      loader: async () =>
+        (
+          await import(
+            './components/overview/KnativeServingDetailsPage' /* webpackChunkName: "knative-serving-details-page" */
+          )
+        ).default,
+    },
+  },
+  {
     type: 'Page/Resource/List',
     properties: {
       model: models.ServiceModel,


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1918803

**Analysis / Root cause**: 
Breadcrumb for knativeServing doesn't show Global Configuration 

**Solution Description**: 
Adds Details Page for knativeServing and breadcrumb for Global Configurations 

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/105997096-37786300-60d1-11eb-9ae7-d5588fdab298.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
