### PR TITLE
Bug 1878086: Disables filesystem name input field in StorageClassForm

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/utils/ocs-storage-class-params.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/ocs-storage-class-params.tsx
@@ -105,7 +105,8 @@ export const StorageClassFormProvisoners: ExtensionSCProvisionerProp = Object.fr
         fsName: {
           name: 'Filesystem Name',
           hintText: 'CephFS filesystem name into which the volume shall be created',
-          required: true,
+          value: 'ocs-storagecluster-cephfilesystem',
+          visible: () => false,
         },
         'csi.storage.k8s.io/provisioner-secret-name': {
           name: 'Provisioner Secret Name',


### PR DESCRIPTION
 when creating a storageclass with cephfs provisoner

Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>