### PR TITLE
Bug 1919823: Update zh-cn translation for Home

### DIFF
--- a/frontend/public/locales/zh/nav.json
+++ b/frontend/public/locales/zh/nav.json
@@ -3,7 +3,7 @@
   "Alerting": "警报",
   "Metrics": "指标",
   "Dashboards": "仪表板",
-  "Home": "家",
+  "Home": "主页",
   "Overview": "概述",
   "Projects": "项目",
   "Search": "搜索",


### PR DESCRIPTION
The translation team recommends updating the current translation for "Home" of 家 to 主页. I'm updating it manually so we can close out the associated bug earlier. They will update the files on their end so the old translation won't creep back in with the next batch of translations.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1919823.