### PR TITLE
Bug 1921253: i18n TextFilter placeholder

### DIFF
--- a/frontend/__tests__/components/factory/list-page.spec.tsx
+++ b/frontend/__tests__/components/factory/list-page.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow, mount, ShallowWrapper, ReactWrapper } from 'enzyme';
 import { TextInput } from '@patternfly/react-core';
 import {
   TextFilter,
@@ -8,6 +8,8 @@ import {
   MultiListPage,
 } from '../../../public/components/factory/list-page';
 import { Firehose, PageHeading } from '../../../public/components/utils';
+
+const i18nNS = 'public';
 
 jest.mock('react-i18next', () => {
   const reactI18next = require.requireActual('react-i18next');
@@ -18,23 +20,37 @@ jest.mock('react-i18next', () => {
 });
 
 describe(TextFilter.displayName, () => {
-  let wrapper: ShallowWrapper;
+  let wrapper: ReactWrapper;
   let label: string;
+  let placeholder: string;
   let onChange: React.ChangeEventHandler<any>;
   let defaultValue: string;
 
-  beforeEach(() => {
-    label = 'Pods';
+  it('renders text input', () => {
     onChange = () => null;
     defaultValue = '';
-    wrapper = shallow(<TextFilter label={label} onChange={onChange} defaultValue={defaultValue} />);
-  });
+    wrapper = mount(<TextFilter label={label} onChange={onChange} defaultValue={defaultValue} />);
 
-  it('renders text input', () => {
-    const input: ShallowWrapper<any> = wrapper.find(TextInput);
+    const input = wrapper.find(TextInput);
 
     expect(input.props().type).toEqual('text');
-    expect(input.props().placeholder).toEqual(`Filter ${label}...`);
+    expect(input.props().placeholder).toEqual(`${i18nNS}~Filter {{label}}...`);
+    expect(input.props().onChange).toEqual(onChange);
+    expect(input.props().defaultValue).toEqual(defaultValue);
+  });
+
+  it('renders text input with custom placeholder', () => {
+    placeholder = 'Pods';
+    onChange = () => null;
+    defaultValue = '';
+    wrapper = mount(
+      <TextFilter placeholder={placeholder} onChange={onChange} defaultValue={defaultValue} />,
+    );
+
+    const input = wrapper.find(TextInput);
+
+    expect(input.props().type).toEqual('text');
+    expect(input.props().placeholder).toEqual(placeholder);
     expect(input.props().onChange).toEqual(onChange);
     expect(input.props().defaultValue).toEqual(defaultValue);
   });

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -135,7 +135,7 @@ class Details extends React.Component {
           */}
 
             <TextFilter
-              label={t('role~Rules by action or resource')}
+              label={t('role~rules by action or resource')}
               onChange={this.changeFilter}
             />
           </div>

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -31,12 +31,14 @@ export const TextFilter = (props) => {
   const {
     label,
     className,
-    placeholder = `Filter ${label}...`,
+    placeholder,
     autoFocus = false,
     parentClassName,
     ...otherInputProps
   } = props;
   const { ref } = useDocumentListener();
+  const { t } = useTranslation();
+  const placeholderText = placeholder ?? t('public~Filter {{label}}...', { label });
 
   return (
     <div className={classNames('has-feedback', parentClassName)}>
@@ -44,8 +46,8 @@ export const TextFilter = (props) => {
         {...otherInputProps}
         className={classNames('co-text-filter', className)}
         data-test-id="item-filter"
-        aria-label={placeholder}
-        placeholder={placeholder}
+        aria-label={placeholderText}
+        placeholder={placeholderText}
         ref={ref}
         autoFocus={autoFocus}
         tabIndex={0}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -145,6 +145,7 @@
   "Progress deadline seconds": "Progress deadline seconds",
   "Deployment details": "Deployment details",
   "Deployments": "Deployments",
+  "Filter {{label}}...": "Filter {{label}}...",
   "Create": "Create",
   "No datapoints found.": "No datapoints found.",
   "resource {{name}}": "resource {{name}}",

--- a/frontend/public/locales/en/role.json
+++ b/frontend/public/locales/en/role.json
@@ -6,7 +6,7 @@
   "Namespace": "Namespace",
   "Created at": "Created at",
   "Rules": "Rules",
-  "Rules by action or resource": "Rules by action or resource",
+  "rules by action or resource": "rules by action or resource",
   "Name": "Name",
   "Subject kind": "Subject kind",
   "Subject name": "Subject name",


### PR DESCRIPTION
The default text for the placeholder in the TextFilter component was not internationalized. This change was not addressed in any of the three large sweep PRs from IBM. I also updated a couple of labels that didn't make sense capitalization-wise.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1921253.