### PR TITLE
Bug 1920367: When creating localvolumeset instance from the web console, the title for setting volumeMode is `Disk Mode`

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/locales/en/lso-plugin.json
+++ b/frontend/packages/local-storage-operator-plugin/locales/en/lso-plugin.json
@@ -31,7 +31,7 @@
   "Selecting all nodes will use the available disks that match the selected filters only on selected nodes.": "Selecting all nodes will use the available disks that match the selected filters only on selected nodes.",
   "Disk Type": "Disk Type",
   "Advanced": "Advanced",
-  "Disk Mode": "Disk Mode",
+  "Volume Mode": "Volume Mode",
   "Disk Size": "Disk Size",
   "Min": "Min",
   "Max": "Max",

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -152,7 +152,7 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
         data-test-id="create-lvs-form-advanced"
       >
         <FormGroup
-          label={t('lso-plugin~Disk Mode')}
+          label={t('lso-plugin~Volume Mode')}
           fieldId="create-lso-disk-mode-dropdown"
           className="lso-create-lvs__disk-mode-dropdown--margin"
         >


### PR DESCRIPTION
Rename 'Disk Mode' to 'Volume Mode'.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1920367