### PR TITLE
Bug 1913969: Fix edge case exception for fieldDependency spec descriptor

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
@@ -101,12 +101,12 @@ describe('capabilitiesToUISchema', () => {
   });
   it('Handles SpecCapablitiy.select', () => {
     const uiSchema = capabilitiesToUISchema([
-      `${SpecCapability.select}DEBUG`,
-      `${SpecCapability.select}INFO`,
-      `${SpecCapability.select}WARN`,
-      `${SpecCapability.select}ERROR`,
-      `${SpecCapability.select}FATAL`,
-    ] as SpecCapability[]);
+      `${SpecCapability.select}DEBUG` as SpecCapability,
+      `${SpecCapability.select}INFO` as SpecCapability,
+      `${SpecCapability.select}WARN` as SpecCapability,
+      `${SpecCapability.select}ERROR` as SpecCapability,
+      `${SpecCapability.select}FATAL` as SpecCapability,
+    ]);
     expect(uiSchema['ui:items']).toEqual({
       DEBUG: 'DEBUG',
       INFO: 'INFO',


### PR DESCRIPTION
The form field sort ordering logic was causing a stack overflow when the control field an dependent field had the same name. Resolved by keeping track of the current path and control field path to differentiate between the two. This also fixes https://bugzilla.redhat.com/show_bug.cgi?id=1890180