### PR TITLE
Bug 1921780: Clean up Search i18n

### DIFF
--- a/frontend/public/components/search-filter-dropdown.tsx
+++ b/frontend/public/components/search-filter-dropdown.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import { CaretDownIcon, FilterIcon } from '@patternfly/react-icons';
 import { TextFilter } from './factory';
 
 export enum searchFilterValues {
+  // t('public~Label')
   Label = 'Label',
+  // t('public~Name')
   Name = 'Name',
 }
 
@@ -14,6 +17,8 @@ export const SearchFilterDropdown: React.SFC<SearchFilterDropdownProps> = (props
 
   const { onChange, nameFilterInput, labelFilterInput } = props;
 
+  const { t } = useTranslation();
+
   const onToggle = (open: boolean) => setOpen(open);
   const onSelect = (event: React.SyntheticEvent) => {
     setSelected((event.target as HTMLInputElement).name as searchFilterValues);
@@ -21,10 +26,10 @@ export const SearchFilterDropdown: React.SFC<SearchFilterDropdownProps> = (props
   };
   const dropdownItems = [
     <DropdownItem key="label-action" name={searchFilterValues.Label} component="button">
-      {searchFilterValues.Label}
+      {t(searchFilterValues.Label)}
     </DropdownItem>,
     <DropdownItem key="name-action" name={searchFilterValues.Name} component="button">
-      {searchFilterValues.Name}
+      {t(searchFilterValues.Name)}
     </DropdownItem>,
   ];
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -45,7 +50,7 @@ export const SearchFilterDropdown: React.SFC<SearchFilterDropdownProps> = (props
         toggle={
           <DropdownToggle id="toggle-id" onToggle={onToggle} toggleIndicator={CaretDownIcon}>
             <>
-              <FilterIcon className="span--icon__right-margin" /> {selected}
+              <FilterIcon className="span--icon__right-margin" /> {t(selected)}
             </>
           </DropdownToggle>
         }

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -24,7 +24,12 @@ import { ResourceListDropdown } from './resource-dropdown';
 import { getResourceListPages } from './resource-pages';
 import { withStartGuide } from './start-guide';
 import { split, selectorFromString } from '../module/k8s/selector';
-import { kindForReference, modelFor, referenceForModel } from '../module/k8s';
+import {
+  kindForReference,
+  modelFor,
+  referenceForModel,
+  K8sResourceKindReference,
+} from '../module/k8s';
 import {
   LoadingBox,
   MsgBox,
@@ -183,15 +188,24 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
     if (!model) {
       return '';
     }
-    const { labelPlural, apiVersion, apiGroup } = model;
+    const { labelPlural, labelPluralKey, apiVersion, apiGroup } = model;
     return (
       <span className="co-search-group__accordion-label">
-        {labelPlural}{' '}
+        {labelPluralKey ? t(labelPluralKey) : labelPlural}{' '}
         <span className="text-muted show small">
           {apiGroup || 'core'}/{apiVersion}
         </span>
       </span>
     );
+  };
+
+  const getChipText = (reference: K8sResourceKindReference) => {
+    const model = modelFor(reference);
+    // API discovery happens asynchronously. Avoid runtime errors if the model hasn't loaded.
+    if (!model) {
+      return kindForReference(reference);
+    }
+    return model.labelKey ? t(model.labelKey) : model.label;
   };
 
   return (
@@ -204,6 +218,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
           id="search-toolbar"
           clearAllFilters={clearAll}
           collapseListedFiltersBreakpoint="xl"
+          clearFiltersButtonText={t('public~Clear all filters')}
         >
           <ToolbarContent>
             <ToolbarItem>
@@ -214,7 +229,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
                   node: (
                     <>
                       <ResourceIcon kind={resourceKind} />
-                      {kindForReference(resourceKind)}
+                      {getChipText(resourceKind)}
                     </>
                   ),
                 }))}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -423,6 +423,8 @@
   "{{selectedCount}} of {{itemCount}}": "{{selectedCount}} of {{itemCount}}",
   "Item": "Item",
   "Item_plural": "Items",
+  "Label": "Label",
+  "Clear all filters": "Clear all filters",
   "Add Secret to workload": "Add Secret to workload",
   "Edit Secret": "Edit Secret",
   "Secret details": "Secret details",


### PR DESCRIPTION
Many Search page-specific components were not internationalized. This includes chips, resource accordion headings, the label/name filter, and the "clear all filters" text. I updated these items.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1921780.