### PR TITLE
Bug 1921806: i18n APIResourceLinks

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -73,6 +73,7 @@ const APIResourceLink_: React.FC<APIResourceLinkStateProps & APIResourceLinkOwnP
   activeNamespace,
   model,
 }) => {
+  const { t } = useTranslation();
   const to = getAPIResourceLink(activeNamespace, model);
   return (
     <span className="co-resource-item">
@@ -80,7 +81,7 @@ const APIResourceLink_: React.FC<APIResourceLinkStateProps & APIResourceLinkOwnP
         <ResourceIcon kind={referenceForModel(model)} />
       </span>
       <Link to={to} className="co-resource-item__resource-name">
-        {model.kind}
+        {model.labelKey ? t(model.labelKey) : model.kind}
       </Link>
     </span>
   );
@@ -374,7 +375,7 @@ const APIResourceDetails: React.FC<APIResourceTabProps> = ({ customData: { kindO
         <dt>{t('public~API version')}</dt>
         <dd>{apiVersion}</dd>
         <dt>{t('public~Namespaced')}</dt>
-        <dd>{namespaced ? 'true' : 'false'}</dd>
+        <dd>{namespaced ? t('public~true') : t('public~false')}</dd>
         <dt>{t('public~Verbs')}</dt>
         <dd>{verbs.join(', ')}</dd>
         {shortNames && (


### PR DESCRIPTION
APIResourceLinks in the Explore page may not match navigation and other references to kinds. I updated them to use modal labelKeys where available instead of the kind. The fallback is the kind as originally laid out.

Note that the schema information has not been internationalized, so the descriptions that are closely associated to these in the Explore section will reference the English terms. That content is not hard-coded in the front-end, but we should look into getting that internationalized if we're externalizing Kubernetes kinds.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1921806. 