### PR TITLE
Bug 1921880: Load all dynamic plugins enabled on the cluster upon Console startup

### DIFF
--- a/frontend/@types/console/declarations.d.ts
+++ b/frontend/@types/console/declarations.d.ts
@@ -42,6 +42,7 @@ declare interface Window {
     graphqlBaseURL: string;
     developerCatalogCategories: string;
     userSettingsLocation: string;
+    consolePlugins: string[]; // Console dynamic plugins enabled on the cluster
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/frontend/__mocks__/serverFlags.js
+++ b/frontend/__mocks__/serverFlags.js
@@ -1,3 +1,4 @@
 window.SERVER_FLAGS = {
   basePath: '/',
+  consolePlugins: [],
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
@@ -25,7 +25,6 @@ export const getScriptElementID = (m: ConsolePluginManifestJSON) => `${scriptIDP
 
 export const loadDynamicPlugin = (baseURL: string, manifest: ConsolePluginManifestJSON) => {
   const pluginID = getPluginID(manifest);
-  console.info(`Loading plugin ${pluginID} from ${baseURL}`);
 
   const existingPluginData = Array.from(pluginMap.values()).find(
     (p) => p.manifest.name === manifest.name,
@@ -47,6 +46,7 @@ export const loadDynamicPlugin = (baseURL: string, manifest: ConsolePluginManife
     console.error(`Error while loading entry script for plugin ${pluginID}`, event);
   };
 
+  console.info(`Loading entry script for plugin ${pluginID} from ${script.src}`);
   document.head.appendChild(script);
 };
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
@@ -31,8 +31,11 @@ export const validatePluginManifestSchema = async (
 
 export const fetchPluginManifest = async (baseURL: string) => {
   const url = resolveURL(baseURL, pluginManifestFile, { trailingSlashInBaseURL: true });
+  console.info(`Loading plugin manifest from ${url}`);
+
   const response: Response = await coFetch(url, { method: 'GET' });
   const manifest = (await response.json()) as ConsolePluginManifestJSON;
+
   (await validatePluginManifestSchema(manifest, url)).report();
   return manifest;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
@@ -31,6 +31,7 @@ export const validatePluginManifestSchema = async (
 
 export const fetchPluginManifest = async (baseURL: string) => {
   const url = resolveURL(baseURL, pluginManifestFile, { trailingSlashInBaseURL: true });
+  // eslint-disable-next-line no-console
   console.info(`Loading plugin manifest from ${url}`);
 
   const response: Response = await coFetch(url, { method: 'GET' });

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -33,15 +33,18 @@ const loadPluginFromURL = async (baseURL: string) => {
 };
 
 // Load all dynamic plugins which are currently enabled on the cluster
-Promise.all(
-  window.SERVER_FLAGS.consolePlugins.map((pluginName) =>
-    loadPluginFromURL(`${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}`).then(
-      (pluginID) => {
-        pluginStore.setDynamicPluginEnabled(pluginID, true);
-      },
-    ),
-  ),
-);
+window.SERVER_FLAGS.consolePlugins.forEach((pluginName) => {
+  const url = `${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}`;
+
+  loadPluginFromURL(url)
+    .then((pluginID) => {
+      pluginStore.setDynamicPluginEnabled(pluginID, true);
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(`Error while loading plugin from ${url}`, error);
+    });
+});
 
 if (process.env.NODE_ENV !== 'production') {
   // Expose Console plugin store for debugging

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -35,9 +35,11 @@ const loadPluginFromURL = async (baseURL: string) => {
 // Load all dynamic plugins which are currently enabled on the cluster
 Promise.all(
   window.SERVER_FLAGS.consolePlugins.map((pluginName) =>
-    loadPluginFromURL(`/api/plugins/${pluginName}`).then((pluginID) => {
-      pluginStore.setDynamicPluginEnabled(pluginID, true);
-    }),
+    loadPluginFromURL(`${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}`).then(
+      (pluginID) => {
+        pluginStore.setDynamicPluginEnabled(pluginID, true);
+      },
+    ),
   ),
 );
 

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -6,6 +6,7 @@ import { ActivePlugin } from '@console/plugin-sdk/src/typings';
 import { initSubscriptionService } from '@console/plugin-sdk/src/api/subscribeToExtensions';
 import { fetchPluginManifest } from '@console/dynamic-plugin-sdk/src/runtime/plugin-manifest';
 import {
+  getPluginID,
   loadDynamicPlugin,
   registerPluginEntryCallback,
 } from '@console/dynamic-plugin-sdk/src/runtime/plugin-loader';
@@ -28,12 +29,15 @@ export const initConsolePlugins = _.once((reduxStore: Store<RootState>) => {
 const loadPluginFromURL = async (baseURL: string) => {
   const manifest = await fetchPluginManifest(baseURL);
   loadDynamicPlugin(baseURL, manifest);
+  return getPluginID(manifest);
 };
 
 // Load all dynamic plugins which are currently enabled on the cluster
 Promise.all(
   window.SERVER_FLAGS.consolePlugins.map((pluginName) =>
-    loadPluginFromURL(`/api/plugins/${pluginName}`),
+    loadPluginFromURL(`/api/plugins/${pluginName}`).then((pluginID) => {
+      pluginStore.setDynamicPluginEnabled(pluginID, true);
+    }),
   ),
 );
 


### PR DESCRIPTION
All dynamic plugins currently enabled on the cluster (`window.SERVER_FLAGS.consolePlugins`) will get loaded upon Console startup via `/api/plugins/<pluginName>` endpoint. Once loaded successfully, such plugins will be automatically enabled.

Non-production builds can still use `window.loadPluginFromURL` global function for development or testing purposes.