### PR TITLE
Bug 1921921:  Fix "Global configuration" breadcrumb casing

### DIFF
--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -20,7 +20,7 @@ const stateToProps = (state: RootState) => ({
 
 export const breadcrumbsForGlobalConfig = (detailsPageKind: string, detailsPagePath: string) => [
   {
-    name: i18next.t('details-page~Global Configuration'),
+    name: i18next.t('details-page~Global configuration'),
     path: '/settings/cluster/globalconfig',
   },
   {

--- a/frontend/public/locales/en/details-page.json
+++ b/frontend/public/locales/en/details-page.json
@@ -1,5 +1,5 @@
 {
-  "Global Configuration": "Global Configuration",
+  "Global configuration": "Global configuration",
   "{{kind}} details": "{{kind}} details",
   "Type": "Type",
   "Status": "Status",


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1921921

After:
<img width="346" alt="Screen Shot 2021-01-28 at 3 54 33 PM" src="https://user-images.githubusercontent.com/895728/106197976-5fbf9a80-6181-11eb-9a51-cd04944b74d7.png">

Which aligns it with the casing on the Cluster Settings > Global configuration tab.
<img width="513" alt="Screen Shot 2021-01-28 at 4 00 14 PM" src="https://user-images.githubusercontent.com/895728/106198360-f0967600-6181-11eb-9427-25a299361efc.png">
