### PR TITLE
Bug 1922050: Improve kubevirt clone tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.action.clone.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.action.clone.scenario.ts
@@ -13,6 +13,7 @@ import {
   removeLeakedResources,
   waitForCount,
   withResource,
+  applyResource,
   createResources,
   deleteResources,
   addLeakableResource,
@@ -161,7 +162,9 @@ describe('Test clone VM.', () => {
     };
 
     beforeAll(async () => {
-      createResources([multusNAD, testVM, datavolumeClonerClusterRole, allowCloneRoleBinding]);
+      createResources([multusNAD, testVM]);
+      applyResource(datavolumeClonerClusterRole);
+      applyResource(allowCloneRoleBinding);
       await vm.waitForStatus(VM_STATUS.Off, VM_IMPORT_TIMEOUT_SECS);
       await vm.addNIC(multusNetworkInterface);
       await vm.detailViewAction(VM_ACTION.Start);


### PR DESCRIPTION
The clusterrole is a global resource, better to use applyResource so the test isn't failed even the role is existing.
Verified in https://cnv-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/test-kubevirt-[console-4](https://issues.redhat.com/browse/console-4).7-cnv-2.6/21/