### PR TITLE
Restrict 'BackingStore' name to 43 characters

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
@@ -9,6 +9,7 @@ import {
   Form,
   InputGroupText,
   TextInput,
+  Tooltip,
   InputGroup,
   TextArea,
 } from '@patternfly/react-core';
@@ -540,6 +541,12 @@ const CreateBackingStoreForm: React.FC<CreateBackingStoreFormProps> = withHandle
     initialState,
   );
 
+  const handleBsNameTextInputChange = (strVal: string) => {
+    if (strVal.length <= 43) {
+      setBsName(strVal);
+    }
+  };
+
   const {
     cancel,
     className,
@@ -645,12 +652,19 @@ const CreateBackingStoreForm: React.FC<CreateBackingStoreFormProps> = withHandle
         )}
         isRequired
       >
-        <TextInput
-          onChange={setBsName}
-          value={bsName}
-          placeholder="my-backingstore"
-          aria-label={t('noobaa-storage-plugin~Backing Store Name')}
-        />
+        <Tooltip
+          content="Name can contain a max of 43 characters"
+          isVisible={bsName.length > 42}
+          trigger="manual"
+        >
+          <TextInput
+            onChange={handleBsNameTextInputChange}
+            value={bsName}
+            maxLength={43}
+            placeholder="my-backingstore"
+            aria-label={t('noobaa-storage-plugin~Backing Store Name')}
+          />
+        </Tooltip>
       </FormGroup>
 
       <FormGroup


### PR DESCRIPTION
Since there is a kubernetes restriction to pod name's length,
we have to limit the number of characters in backingstore name,
as the name is added as a prefix to noobaa agent's pod name.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>