### PR TITLE
[release-4.6] Bug 1921603: Fix crash when loaded is true but the data set doesn't include the pods

### DIFF
--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -146,7 +146,12 @@ const DaemonSetDetails: React.FC<DaemonSetDetailsProps> = ({ obj: daemonset }) =
         namespace={daemonset.metadata.namespace}
         kind={daemonset.kind}
         render={(d) => {
-          return d.loaded ? (
+          if (!d.loaded) {
+            return <LoadingInline />;
+          } else if (!d.data[daemonset.metadata.uid].pods) {
+            return null;
+          }
+          return (
             <PodRing
               key={daemonset.metadata.uid}
               pods={d.data[daemonset.metadata.uid].pods}
@@ -154,8 +159,6 @@ const DaemonSetDetails: React.FC<DaemonSetDetailsProps> = ({ obj: daemonset }) =
               resourceKind={DaemonSetModel}
               enableScaling={false}
             />
-          ) : (
-            <LoadingInline />
           );
         }}
       />

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -172,7 +172,12 @@ export const DeploymentConfigsDetails: React.FC<{ obj: K8sResourceKind }> = ({ o
           namespace={dc.metadata.namespace}
           kind={dc.kind}
           render={(d) => {
-            return d.loaded ? (
+            if (!d.loaded) {
+              return <LoadingInline />;
+            } else if (!d.data[dc.metadata.uid]) {
+              return null;
+            }
+            return (
               <PodRingSet
                 key={dc.metadata.uid}
                 podData={d.data[dc.metadata.uid]}
@@ -180,8 +185,6 @@ export const DeploymentConfigsDetails: React.FC<{ obj: K8sResourceKind }> = ({ o
                 resourceKind={DeploymentConfigModel}
                 path="/spec/replicas"
               />
-            ) : (
-              <LoadingInline />
             );
           }}
         />

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -61,7 +61,12 @@ const StatefulSetDetails: React.FC<StatefulSetDetailsProps> = ({ obj: ss }) => (
         namespace={ss.metadata.namespace}
         kind={ss.kind}
         render={(d) => {
-          return d.loaded ? (
+          if (!d.loaded) {
+            return <LoadingInline />;
+          } else if (!d.data[ss.metadata.uid]) {
+            return null;
+          }
+          return (
             <PodRingSet
               key={ss.metadata.uid}
               podData={d.data[ss.metadata.uid]}
@@ -69,8 +74,6 @@ const StatefulSetDetails: React.FC<StatefulSetDetailsProps> = ({ obj: ss }) => (
               resourceKind={StatefulSetModel}
               path="/spec/replicas"
             />
-          ) : (
-            <LoadingInline />
           );
         }}
       />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-23911
https://bugzilla.redhat.com/show_bug.cgi?id=1921603

**Analysis / Root cause**: 
The console components fetches two sets of data to show a DeploymentConfig (or DeamonSet or StatefulSet) with the correlated Pods. The Pod status donut was shown as soon as the data are "loaded". But in some situations the pod data are not available in this moment. This can happen if the Pod is already deleted (see PR #6689) or if the loading of the pods needs to fetch more then "one page". With the [default page size](https://github.com/openshift/console/blob/release-4.6/frontend/public/actions/k8s.ts#L39) this means more than 250 Pods.

In PR #6689 we fixed this already for Deployments but didn't changed this in the three similar code based for the resource types mention above.

**Solution Description**: 
Similar to PR #6689:
* Show the loading indicator only as long as the first page is loaded and loaded is true.
* Do not render the Pod donut when there are no data are available.

**Screen shots / Gifs for design review**: 
Nothing changed.

**Unit test coverage report**: 
Nothing changed.

**Test setup:**
1. Create a relevant list of DeploymentConfigs (6+, as mentioned Deployments are already fixed!)
```
#!/bin/bash
for ((i = 1; i <= 40; i++)); do
    echo Create nodeinfo-$i
    oc new-app jerolimov/nodeinfo --name nodeinfo-$i
    sleep 10
done
```

2. Change the paginationLimit in `frontend/public/actions/k8s.ts` to 5.
3. Open a DeploymentConfig in the developer perspective which needs to fetch at least two pages for fetch the right Pods.

If you are unsure open all detail pages for all ~10 DeploymentConfigs on your local development environment.

To completely reproduce this on a shared cluster you will need more then 250 DeploymentConfigs... :-/

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge