### PR TITLE
Bug 1922098: project dropdown should close after user pick a project

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
@@ -280,7 +280,6 @@ export const SelectTemplate: React.FC<SelectTemplateProps> = ({
                           }
                           selections={namespace}
                           className="kv-select-template__project"
-                          closeOnSelect={false}
                         >
                           {(canListNs
                             ? [allProjects, ...namespaces.sort()]


### PR DESCRIPTION
Namespace selection dialog is not closed after select a namespace

Screenshot:
Before:
![Peek 2021-01-31 12-40](https://user-images.githubusercontent.com/2181522/106381461-89ff9b00-63c1-11eb-9469-51db0ba60d05.gif)

After:
![Peek 2021-01-31 12-36](https://user-images.githubusercontent.com/2181522/106381435-591f6600-63c1-11eb-8100-1455e8a996e7.gif)
