### PR TITLE
Bug 1922782: Data sanity was false

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
@@ -37,7 +37,7 @@ export const ContainerSource: React.FC<ContainerSourceProps> = React.memo(
           onProvisionSourceStorageChange({
             ...storage,
             dataVolume: new DataVolumeWrapper(storage?.dataVolume, true)
-              .appendTypeData({ url }, false)
+              .appendTypeData({ url })
               .asResource(),
           });
       }


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1922782

**Analysis / Root cause**: 
Data sanity was false. return value without the docker:// prefix

**Solution Description**: 
Data sanity is now on

Before:
![screenshot-console-openshift-console apps ostest test metalkube [org-2021](https://issues.redhat.com/browse/org-2021) 01 31-11_16_33](https://user-images.githubusercontent.com/14824964/106388290-79ade700-63e6-11eb-905e-ad6b5324181f.png)
After:
![image](https://user-images.githubusercontent.com/14824964/106388311-8d594d80-63e6-11eb-912b-3e4f75248049.png)
