### PR TITLE
Bug 1921644: [e2e][automation]revert endlines to backslach

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/mocks.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/mocks.ts
@@ -113,7 +113,7 @@ export const getDiskToCloneFrom = (): Disk => {
   };
 };
 
-export const cloudInitScript = `#cloud-config\\nuser: cloud-user\\npassword: atomic\\nchpasswd: {expire: False}\\nhostname: vm-${testName}`;
+export const cloudInitScript = `#cloud-config\nuser: cloud-user\npassword: atomic\nchpasswd: {expire: False}\nhostname: vm-${testName}`;
 
 export const defaultPodNetworkingInterface = {
   name: 'default',

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.base.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.base.scenario.ts
@@ -14,7 +14,7 @@ import { ProvisionSource } from './utils/constants/enums/provisionSource';
 
 describe('Kubevirt VM details tab', () => {
   const vmName = `vm-${testName}`;
-  const cloudInit = `#cloud-config\\nuser: cloud-user\\npassword: atomic\\nchpasswd: {expire: False}`;
+  const cloudInit = `#cloud-config\nuser: cloud-user\npassword: atomic\nchpasswd: {expire: False}`;
   const serviceCommon = { name: vmName, kind: 'vm', type: 'NodePort', namespace: testName };
   const testVM = getVMManifest(ProvisionSource.CONTAINER, testName, vmName, cloudInit);
   const vm = new VirtualMachine(testVM.metadata);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.guest.agent.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.guest.agent.scenario.ts
@@ -56,7 +56,7 @@ describe('Tests involving guest agent', () => {
 
     // create linux vm
     const cloudInit =
-      '#cloud-config\\nuser: cloud-user\\npassword: atomic\\nchpasswd: {expire: False}\\nruncmd:\\n- dnf install -y qemu-guest-agent\\n- systemctl start qemu-guest-agent';
+      '#cloud-config\nuser: cloud-user\npassword: atomic\nchpasswd: {expire: False}\nruncmd:\n- dnf install -y qemu-guest-agent\n- systemctl start qemu-guest-agent';
     const testVM = getVMManifest(ProvisionSource.CONTAINER, testName, VM_LINUX_NAME, cloudInit);
     vmLinux = new VirtualMachine(testVM.metadata);
     createResource(testVM);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.tab.dashboard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.tab.dashboard.scenario.ts
@@ -19,7 +19,7 @@ import * as dashboardView from '../views/dashboard.view';
 import { ProvisionSource } from './utils/constants/enums/provisionSource';
 
 describe('Kubevirt VM dashboard tab', () => {
-  const cloudInit = `#cloud-config\\nuser: cloud-user\\npassword: atomic\\nchpasswd: {expire: False}\\nruncmd:\\n- dnf install -y qemu-guest-agent\\n- systemctl start qemu-guest-agent`;
+  const cloudInit = `#cloud-config\nuser: cloud-user\npassword: atomic\nchpasswd: {expire: False}\nruncmd:\n- dnf install -y qemu-guest-agent\n- systemctl start qemu-guest-agent`;
   const testVM = getVMManifest(ProvisionSource.CONTAINER, testName, null, cloudInit);
   const vm = new VirtualMachine(testVM.metadata);
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.tab.environment.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.tab.environment.scenario.ts
@@ -26,7 +26,7 @@ describe('Test VM enviromnet tab', () => {
   const configMap = getConfigMap(testName, configmapName);
   const serviceAccount = getServiceAccount(testName, serviceAccountName);
 
-  const cloudInit = `#cloud-config\\nuser: fedora\\npassword: fedora\\nchpasswd: {expire: False}`;
+  const cloudInit = `#cloud-config\nuser: fedora\npassword: fedora\nchpasswd: {expire: False}`;
   const testVM = getVMManifest(ProvisionSource.CONTAINER, testName, null, cloudInit);
   const vm = new VirtualMachine(testVM.metadata);
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.overview.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.overview.scenario.ts
@@ -15,7 +15,7 @@ import { ProvisionSource } from './utils/constants/enums/provisionSource';
 
 describe('Test VMI Details', () => {
   const vmiName = `vmi-${testName}`;
-  const cloudInit = `#cloud-config\\nuser: cloud-user\\npassword: atomic\\nchpasswd: {expire: False}`;
+  const cloudInit = `#cloud-config\nuser: cloud-user\npassword: atomic\nchpasswd: {expire: False}`;
   const serviceCommon = { name: vmiName, kind: 'vmi', type: 'NodePort', namespace: testName };
   const testVMI = getVMIManifest(ProvisionSource.CONTAINER, testName, vmiName, cloudInit);
   const vmi = new VirtualMachineInstance(testVMI.metadata);


### PR DESCRIPTION
Reverts the change of `\n` EOL to `\\` backslashes

Screenshot:
![screenshot-localhost_9000-2021 02 01-09_50_33](https://user-images.githubusercontent.com/2181522/106429380-0605eb80-6473-11eb-8c50-6070d0011c96.png)
