### PR TITLE
Bug 1923003: Update Insights widget state

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/mappers.ts
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/mappers.ts
@@ -56,9 +56,10 @@ export const mapMetrics = (response: PrometheusResponse): Metrics => {
   return values;
 };
 
-// Insights Operator is either not initialized, disabled or an error occurred
-export const isUnavailable = (values: Metrics) => _.isEmpty(values);
+// An error occurred while requesting Insights results (e.g. IO is turned off)
+export const isError = (values: Metrics) => _.isEmpty(values);
 
-// Insights Operator has been just initialized
-export const isInitialized = (values: Metrics) =>
+/* Insights Operator is disabled (e.g. pull-secret is removed) or has been
+   just initialized and waiting for the first results. */
+export const isWaitingOrDisabled = (values: Metrics) =>
   Object.values(values).some((cur: number) => cur === -1);

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/status.ts
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/status.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { PrometheusHealthHandler, SubsystemHealth } from '@console/plugin-sdk';
 import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
 import { PrometheusResponse } from '@console/internal/components/graphs';
-import { mapMetrics, isInitialized, isUnavailable } from './mappers';
+import { mapMetrics, isError, isWaitingOrDisabled } from './mappers';
 
 export const getClusterInsightsComponentStatus = (
   response: PrometheusResponse,
@@ -19,14 +19,14 @@ export const getClusterInsightsComponentStatus = (
   }
   const values = mapMetrics(response);
 
-  // Insights Operator is either not initialized, disabled or an error occurred
-  if (isUnavailable(values)) {
+  if (isError(values)) {
+    return { state: HealthState.ERROR, message: 'Not available' };
+  }
+
+  if (!isError(values) && isWaitingOrDisabled(values)) {
     return { state: HealthState.UNKNOWN, message: 'Not available' };
   }
-  // Insights Operator has been just initialized
-  if (isInitialized(values)) {
-    return { state: HealthState.PROGRESS, message: 'Issues pending' };
-  }
+
   // Insights Operator has sent rules results
   const issuesNumber = Object.values(values).reduce((acc, cur) => acc + cur, 0);
   const issueStr = `${issuesNumber} ${issuesNumber === 1 ? 'issue' : 'issues'} found`;


### PR DESCRIPTION
It turned out that we still show incorrect widget's state for some cases. 

When a customer opts out of the remote health reporting (IO Insights Operator won't send any report), then the OCP WebConsole shouldn't show the "Issues pending" state, but likely some other state.

The patch fixes the issue and aligns states to IO metrics as close as possible. See bug's details at https://issues.redhat.com/browse/CCXDEV-3862. 

Illustrations of reworked states:
1) for the case when an error occurred while receiving metrics (e.g., Insights Operator is manually turned off) ![Screenshot from 2021-01-29 16-37-45](https://user-images.githubusercontent.com/31385370/106441626-94ca3680-647a-11eb-8107-682cc4b35aaf.png)
2) for the case when a cluster is opted-out of health reporting (fixes the bug issue) or Insights Operator has been just initialized and waiting for the first results.
![Screenshot from 2021-01-29 16-39-18](https://user-images.githubusercontent.com/31385370/106441629-95fb6380-647a-11eb-9ac7-df458d3705bf.png)
