### PR TITLE
Bug 1916747: Dont link to missing quickstarts

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -23,6 +23,9 @@ import {
   getUID,
   useActiveNamespace,
 } from '@console/shared';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { QuickStart } from '@console/app/src/components/quick-starts/utils/quick-start-types';
+import { QuickStartModel } from '@console/app/src/models';
 import { NetworkAttachmentDefinitionModel } from '../../models';
 import { getConfigAsJSON, getType } from '../../selectors';
 import { NetworkAttachmentDefinitionKind } from '../../types';
@@ -124,6 +127,20 @@ const getCreateLink = (namespace: string): string =>
 const NADListEmpty: React.FC = () => {
   const { t } = useTranslation();
   const [namespace] = useActiveNamespace();
+
+  const searchText = 'network attachment definition';
+  const [quickStarts, quickStartsLoaded] = useK8sWatchResource<QuickStart[]>({
+    kind: referenceForModel(QuickStartModel),
+    isList: true,
+  });
+  const hasQuickStarts =
+    quickStartsLoaded &&
+    quickStarts.find(
+      ({ spec: { displayName, description } }) =>
+        displayName.toLowerCase().includes(searchText) ||
+        description.toLowerCase().includes(searchText),
+    );
+
   return (
     <EmptyState>
       <Title headingLevel="h4" size="lg">
@@ -138,16 +155,18 @@ const NADListEmpty: React.FC = () => {
       >
         {t('kubevirt-plugin~Create network attachment definition')}
       </Button>
-      <EmptyStateSecondaryActions>
-        <Button
-          data-test-id="nad-quickstart"
-          variant="secondary"
-          onClick={() => history.push('/quickstart?keyword=network+attachment+definition')}
-        >
-          <RocketIcon className="nad-quickstart-icon" />
-          {t('kubevirt-plugin~Learn how to use network attachment definitions')}
-        </Button>
-      </EmptyStateSecondaryActions>
+      {hasQuickStarts && (
+        <EmptyStateSecondaryActions>
+          <Button
+            data-test-id="nad-quickstart"
+            variant="secondary"
+            onClick={() => history.push('/quickstart?keyword=network+attachment+definition')}
+          >
+            <RocketIcon className="nad-quickstart-icon" />
+            {t('kubevirt-plugin~Learn how to use network attachment definitions')}
+          </Button>
+        </EmptyStateSecondaryActions>
+      )}
     </EmptyState>
   );
 };


### PR DESCRIPTION
When using OCP 4.7 and CNV 2.5 or older the links that take you to quick starts (in the virtual machine and Network attachment definitions empty states) with no results. 

Screenshot:
Before:
![screenshot-localhost_9000-2021 02 01-13_24_05](https://user-images.githubusercontent.com/2181522/106452608-cfd76480-6490-11eb-938e-868e157d750c.png)

After:
![screenshot-localhost_9000-2021 02 01-13_24_40](https://user-images.githubusercontent.com/2181522/106452650-dd8cea00-6490-11eb-8c56-61856afb3b9a.png)

