### PR TITLE
Fix PVC Create-Snapshot Edit-YAML routing

### DIFF
--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -359,7 +359,7 @@ const kebabFactory: KebabFactory = {
     labelKey: 'details-page~Create snapshot',
     isDisabled: obj?.status?.phase !== 'Bound',
     tooltip: obj?.status?.phase !== 'Bound' ? 'PVC is not Bound' : '',
-    href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/${
+    href: `${resourceObjPath(obj, referenceForModel(VolumeSnapshotModel))}/${
       VolumeSnapshotModel.plural
     }/~new/form`,
     accessReview: asAccessReview(kind, obj, 'create'),


### PR DESCRIPTION
Before:
PersistentVolumeClaims --> Create snapshot --> Edit YAML :- redirects to "Create PersistentVolumeClaim" YAML page.
After:
Now after the fix, it is redirecting correctly to "Create VolumeSnapshot" YAML page.

Signed-off-by: Sanjal Katiyar <skatiyar@redhat.com>