### PR TITLE
Bug 1922015:  prevent catalog modal header from collapsing

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -219,6 +219,12 @@ h6 {
   --pf-global--FontSize--md: 1rem;
 }
 
+.pf-c-modal-box__header {
+  // prevent header from collapsing in Safari
+  // temp fix for upstream issue https://github.com/patternfly/patternfly/issues/3825
+  flex-shrink: 0;
+}
+
 .pf-c-page {
   display: block !important;
   position: relative;


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1922015

After:
<img width="927" alt="Screen Shot 2021-02-01 at 9 19 33 AM" src="https://user-images.githubusercontent.com/895728/106470645-b9b8ac80-646e-11eb-9fed-de84d0a80bd1.png">
