### PR TITLE
Remove anonymous exports in NADs plugin

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -47,9 +47,11 @@ const CreateNetAttachDefYAMLConnected = connectToPlural(
   },
 );
 
-export default (props: any) => (
+const NetworkAttachmentDefinitionCreateYaml = (props: any) => (
   <CreateNetAttachDefYAMLConnected
     {...(props as any)}
     plural={NetworkAttachmentDefinitionModel.plural}
   />
 );
+
+export default NetworkAttachmentDefinitionCreateYaml;

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
@@ -47,7 +47,7 @@ const getSriovNetNodePolicyResourceNames = (sriovNetNodePoliciesData) => {
   return resourceNames;
 };
 
-export default (props) => {
+const NetworkTypeOptions = (props) => {
   const { networkType, setTypeParamsData, sriovNetNodePoliciesData, typeParamsData } = props;
   const params: NetworkTypeParams = networkType && networkTypeParams[networkType];
 
@@ -197,3 +197,5 @@ export default (props) => {
 
   return <>{dynamicContent}</>;
 };
+
+export default NetworkTypeOptions;


### PR DESCRIPTION
This PR removes anonymous exports in the network attachment definitions plugin.