### PR TITLE
Bug 1921949: Fix source code URL for apps created using self-hosted repositories

### DIFF
--- a/frontend/packages/topology/src/data-transforms/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/topology/src/data-transforms/__tests__/data-transformer.spec.ts
@@ -19,7 +19,7 @@ import { getWorkloadResources } from '../transform-utils';
 const namespace = 'test-project';
 
 jest.mock('git-url-parse', () => ({
-  default: jest.fn(() => ({ source: 'github.com', owner: 'openshift', name: 'console' })),
+  default: jest.fn(() => ({ resource: 'github.com', owner: 'openshift', name: 'console' })),
 }));
 
 function getTransformedTopologyData(

--- a/frontend/packages/topology/src/utils/topology-utils.ts
+++ b/frontend/packages/topology/src/utils/topology-utils.ts
@@ -49,7 +49,7 @@ export const getEditURL = (vcsURI?: string, gitBranch?: string, cheURL?: string)
     return null;
   }
   const parsedURL = GitUrlParse(vcsURI);
-  const gitURL = `https://${parsedURL.source}/${parsedURL.owner}/${parsedURL.name}`;
+  const gitURL = `https://${parsedURL.resource}/${parsedURL.owner}/${parsedURL.name}`;
   const fullGitURL = gitBranch ? `${gitURL}/tree/${gitBranch}` : gitURL;
   return cheURL ? `${cheURL}/f?url=${fullGitURL}&policies.create=peruser` : fullGitURL;
 };


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1921949

**Analysis/Root cause:**
After parsing the git url `source` attribute (provides only the git provider name) was being used instead of `resource` (which provides the url domain including the subdomains) and hence the wrong source code url was being generated.

**Solution:**
Use `resource` for creating source code url.

**Gifs:**
![Peek 2021-02-01 22-11](https://user-images.githubusercontent.com/20724543/106489434-c8d54400-64da-11eb-93b5-c136c8102923.gif)

/kind bug