### PR TITLE
Bug 1923721: Handle pipeline svg icon spin using a wrapped <g> element

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
@@ -14,6 +14,9 @@ $border-color: var(--pf-global--BorderColor--light-100);
   &.is-linked {
     cursor: pointer;
   }
+  &--icon-spin {
+    transform-origin: 16.7px 15.1px;
+  }
 }
 
 .odc-pipeline-vis-task-text {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -180,18 +180,24 @@ const TaskComponent: React.FC<TaskProps> = ({
         {truncatedVisualName}
       </text>
       {isPipelineRun && showStatusState && (
-        <svg
-          width={30}
-          height={30}
-          viewBox="-5 -5 20 20"
-          style={{
-            color: status
-              ? getRunStatusColor(status.reason, t).pftoken.value
-              : getRunStatusColor(runStatus.Cancelled, t).pftoken.value,
-          }}
+        <g
+          className={cx({
+            'fa-spin odc-pipeline-vis-task--icon-spin': status.reason === runStatus.Running,
+          })}
         >
-          <StatusIcon status={status.reason} shiftOrigin />
-        </svg>
+          <svg
+            width={30}
+            height={30}
+            viewBox="-5 -4 20 20"
+            style={{
+              color: status
+                ? getRunStatusColor(status.reason, t).pftoken.value
+                : getRunStatusColor(runStatus.Cancelled, t).pftoken.value,
+            }}
+          >
+            <StatusIcon status={status.reason} disableSpin />
+          </svg>
+        </g>
       )}
       {showStatusState && (
         <SvgTaskStatus steps={stepStatusList} x={30} y={23} width={width / 2 + 15} />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.scss
@@ -1,5 +1,0 @@
-.pipeline-status-icon {
-  &--spin {
-    transform-origin: 30% 30%;
-  }
-}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
@@ -12,25 +12,18 @@ import {
 } from '@patternfly/react-icons';
 import { getRunStatusColor, runStatus } from '../../../../utils/pipeline-augment';
 
-import './StatusIcon.scss';
-
 interface StatusIconProps {
   status: string;
   height?: number;
   width?: number;
-  shiftOrigin?: boolean;
+  disableSpin?: boolean;
 }
 
-export const StatusIcon: React.FC<StatusIconProps> = ({ status, shiftOrigin, ...props }) => {
+export const StatusIcon: React.FC<StatusIconProps> = ({ status, disableSpin, ...props }) => {
   switch (status) {
     case runStatus['In Progress']:
     case runStatus.Running:
-      return (
-        <SyncAltIcon
-          {...props}
-          className={cx('fa-spin', { 'pipeline-status-icon--spin': shiftOrigin })}
-        />
-      );
+      return <SyncAltIcon {...props} className={cx({ 'fa-spin': !disableSpin })} />;
 
     case runStatus.Succeeded:
       return <CheckCircleIcon {...props} />;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5452
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Chromium does not animate nested SVGs.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Wrap the SVG in a `<g>` element and animate that instead.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/106496448-e8706a80-64e2-11eb-8976-8ce179f6c488.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug