### PR TITLE
Bug 1924188: Update language selector modal dropdown

### DIFF
--- a/frontend/public/components/modals/language-preferences-modal.tsx
+++ b/frontend/public/components/modals/language-preferences-modal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TFunction } from 'i18next';
+import i18next, { TFunction } from 'i18next';
 
 import { Dropdown } from '../utils';
 import {
@@ -24,7 +24,8 @@ const LanguagePreferencesModal = (props: LanguagePreferencesModalProps) => {
   }));
   const initLang =
     localStorage.getItem('bridge/language') ||
-    langOptions.find((lang) => lang.lang === i18n.language)?.lang;
+    // handles languages we support, languages we don't support, and subsets of languages we support (such as en-us, zh-cn, etc.)
+    i18next.languages.find((lang) => langOptions.some((langOption) => langOption.lang === lang));
   const [language, setLanguage] = React.useState(initLang);
   const { close } = props;
   const submit: React.FormEventHandler<HTMLFormElement> = (e) => {


### PR DESCRIPTION
This was a quick tech-check for Megan Hall on a usability bug. The language selector dropdown now pre-selects the language. This previously only worked if the user was using zh, en, or ja exactly. It can now handle unsupported languages and subsets of languages we support, such as en-us and zh-cn.

**en-US (new behavior - example of subset of language)**
<img width="1001" alt="Screen Shot 2021-02-01 at 2 31 20 PM" src="https://user-images.githubusercontent.com/7014965/106508367-504e9300-649a-11eb-84ac-5e3648ad6836.png">

**es (new behavior - example of language we don't support)**
<img width="1001" alt="Screen Shot 2021-02-01 at 2 34 08 PM" src="https://user-images.githubusercontent.com/7014965/106508678-afaca300-649a-11eb-990e-73ffa80e8ad7.png">

**zh (existing behavior still works)**
<img width="993" alt="Screen Shot 2021-02-01 at 2 33 44 PM" src="https://user-images.githubusercontent.com/7014965/106508614-9dcb0000-649a-11eb-800e-c9fb451331dd.png">

I had to use i18next.languages since i18next.language and i18n.language.lang will return the detected language regardless of whether we support it. From the docs, i18next.languages is set to an array of language codes that will be used to look up the translation value. When the language is set, this array is populated with the new language codes. Unless overridden, this array is populated with less-specific versions of that code for fallback purposes, followed by the list of fallback languages. I filtered i18next.languages against our supported list of languages to get the correct display language.

CC @rhamilto @spadgett. Are you guys ok with this approach? Let me know if you have thoughts.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1924188.