### PR TITLE
Bug 1922911: Query Browser: Show empty state when all series are disabled

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -277,6 +277,10 @@ const Graph: React.FC<GraphProps> = React.memo(
       });
     });
 
+    if (data.every(_.isEmpty)) {
+      return <GraphEmpty />;
+    }
+
     let yTickFormat = formatValue;
 
     if (isStack) {


### PR DESCRIPTION
Rather than showing a graph with no data, it is better UX to show the
`GraphEmpty` empty state.

This also fixes a bug where disabling all series, then enabling one of
them again caused an error.

This change impacts the Metrics page for both admin and dev, since they
are the only pages that allow disabling all series.

![screenshot](https://user-images.githubusercontent.com/460802/106563773-9f1a2c80-656f-11eb-8722-066f71fbf71b.png)
