### PR TITLE
Bug 1923951: fixes eveting menuoptions for create flow for all namespace selection

### DIFF
--- a/frontend/packages/knative-plugin/src/components/eventing/EventingListPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/EventingListPage.tsx
@@ -21,13 +21,17 @@ const EventingListPage: React.FC<EventingListPageProps> = ({ match }) => {
     params: { ns: namespace },
   } = match;
   const [showTitle, canCreate] = [false, false];
+  const nsSelected = namespace || 'default';
   const menuActions: MenuActions = {
     eventSource: {
       label: t('knative-plugin~Event Source'),
-      onSelection: () => `/catalog/ns/${namespace}?catalogType=EventSource`,
+      onSelection: () => `/catalog/ns/${nsSelected}?catalogType=EventSource`,
     },
     brokers: { label: t('knative-plugin~Broker'), model: EventingBrokerModel },
-    channels: { label: t('knative-plugin~Channel'), onSelection: () => `/channel/ns/${namespace}` },
+    channels: {
+      label: t('knative-plugin~Channel'),
+      onSelection: () => `/channel/ns/${nsSelected}`,
+    },
   };
   const pages: Page[] = [
     {

--- a/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { NamespaceBar } from '@console/internal/components/namespace';
+import { MultiTabListPage } from '@console/shared';
+import EventingListPage from '../EventingListPage';
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+let eventingListPageProps: React.ComponentProps<typeof EventingListPage>;
+let wrapper: ShallowWrapper;
+const i18nNS = 'knative-plugin';
+
+describe('EventingListPage', () => {
+  beforeEach(() => {
+    eventingListPageProps = {
+      match: {
+        isExact: true,
+        path: '/eventing/ns/:ns',
+        url: 'eventing/ns/my-project',
+        params: {
+          ns: 'my-project',
+        },
+      },
+    };
+    wrapper = shallow(<EventingListPage {...eventingListPageProps} />);
+  });
+
+  it('should render NamespaceBar and MultiTabListPage', () => {
+    expect(wrapper.find(NamespaceBar)).toHaveLength(1);
+    expect(wrapper.find(MultiTabListPage)).toHaveLength(1);
+  });
+
+  it('should render MultiTabListPage with all pages and menuActions', () => {
+    const multiTablistPage = wrapper.find(MultiTabListPage);
+    expect(multiTablistPage.props().title).toEqual(`${i18nNS}~Eventing`);
+    expect(multiTablistPage.props().pages).toHaveLength(5);
+    expect(Object.keys(multiTablistPage.props().menuActions)).toHaveLength(3);
+    expect(multiTablistPage.props().menuActions.eventSource).toBeDefined();
+  });
+
+  it('should show correct url for creation for valid namespace', () => {
+    const multiTablistPage = wrapper.find(MultiTabListPage);
+    expect(Object.keys(multiTablistPage.props().menuActions)).toHaveLength(3);
+    expect(multiTablistPage.props().menuActions.eventSource).toBeDefined();
+    expect(
+      multiTablistPage
+        .props()
+        .menuActions.eventSource.onSelection('eventSource', { label: 'Event Source' }, undefined),
+    ).toEqual('/catalog/ns/my-project?catalogType=EventSource');
+  });
+
+  it('should show correct url for creation if namespace is not defined', () => {
+    eventingListPageProps = {
+      match: {
+        isExact: true,
+        path: '/eventing/all-namespaces',
+        url: 'eventing/all-namespaces',
+        params: {
+          ns: undefined,
+        },
+      },
+    };
+    wrapper = shallow(<EventingListPage {...eventingListPageProps} />);
+    const multiTablistPage = wrapper.find(MultiTabListPage);
+    expect(Object.keys(multiTablistPage.props().menuActions)).toHaveLength(3);
+    expect(multiTablistPage.props().menuActions.eventSource).toBeDefined();
+    expect(
+      multiTablistPage
+        .props()
+        .menuActions.eventSource.onSelection('eventSource', { label: 'Event Source' }, undefined),
+    ).toEqual('/catalog/ns/default?catalogType=EventSource');
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5457

**Analysis / Root cause**: 
for all namespace selection if user create from admin perspective for EventSources / Channels then namespace dropdown on create flow shows undefined

**Solution Description**: 
Added check for namespace in case of all namespace selects default namespace


**Unit test coverage report**: 

![image](https://user-images.githubusercontent.com/5129024/106595937-5320b500-657a-11eb-9109-8a2b951a6122.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
