### PR TITLE
Make OCS local volume set step responsive in wizard flow

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/attached-devices.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/attached-devices.scss
@@ -25,14 +25,15 @@
   padding-top: var(--pf-global--spacer--md);
 }
 
-.ceph-ocs-install__create-sc-form {
-  width: 80%;
+.ceph-ocs-install__form-wrapper {
+  margin-top: var(--pf-global--spacer--lg);
 }
 
-.ceph-ocs-install__form-wrapper {
-  display: flex;
-  margin-top: var(--pf-global--spacer--lg);
-  justify-content: space-between;
+.ceph-ocs-install__donut-chart {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: var(--pf-global--spacer--sm);
 }
 
 .ceph-ocs-install__chart-wrapper {
@@ -47,6 +48,7 @@
 }
 
 .ceph-ocs-install_capacity-header {
+  text-align: center;
   font-size: var(--pf-global--FontSize--xl);
   margin-bottom: var(--pf-c-wizard__main-body--PaddingBottom);
 }
@@ -55,6 +57,7 @@
   display: flex;
   font-size: var(--pf-global--FontSize--md);
   margin-bottom: var(--pf-global--spacer--xs);
+  text-align: center;
 }
 
 .ceph-ocs-install_stats--divider {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/wizard-pages/create-local-volume-set.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Form, Alert, Button } from '@patternfly/react-core';
+import { Form, Alert, Button, Grid, GridItem } from '@patternfly/react-core';
 import { Modal, useFlag } from '@console/shared';
 import { k8sCreate } from '@console/internal/module/k8s';
 import { LocalVolumeSetModel } from '@console/local-storage-operator-plugin/src/models';
@@ -65,18 +65,30 @@ export const CreateLocalVolumeSet: React.FC<CreateLocalVolumeSetProps> = ({
   return (
     <>
       <LocalVolumeSetHeader />
-      <div className="ceph-ocs-install__form-wrapper">
-        <Form noValidate={false} className="ceph-ocs-install__create-sc-form">
-          <LocalVolumeSetInner
-            state={state}
-            dispatch={dispatch}
-            diskModeOptions={diskModeDropdownItems}
-            allNodesHelpTxt={allNodesSelectorTxt}
-            taintsFilter={hasOCSTaint}
-          />
-        </Form>
-        <DiscoveryDonutChart state={state} dispatch={dispatch} />
-      </div>
+      <Grid className="ceph-ocs-install__form-wrapper">
+        <GridItem lg={10} md={12} sm={12}>
+          <Form noValidate={false}>
+            <LocalVolumeSetInner
+              state={state}
+              dispatch={dispatch}
+              diskModeOptions={diskModeDropdownItems}
+              allNodesHelpTxt={allNodesSelectorTxt}
+              taintsFilter={hasOCSTaint}
+            />
+          </Form>
+        </GridItem>
+        <GridItem
+          lg={2}
+          lgOffset={10}
+          md={4}
+          mdOffset={4}
+          sm={4}
+          smOffset={4}
+          className="ceph-ocs-install__donut-chart"
+        >
+          <DiscoveryDonutChart state={state} dispatch={dispatch} />
+        </GridItem>
+      </Grid>
       <ConfirmationModal
         ns={ns}
         state={state}


### PR DESCRIPTION
Before:
Donut chart on local volume set (OCS) page was non responsive. 
After:
https://drive.google.com/file/d/1Ndgo65s6LI3dXyNpdNdEXDd-SUR7-rMh/view?usp=sharing  (25-sec video of how the page looks now)



URL: https://issues.redhat.com/browse/RHSTOR-1603