### PR TITLE
Bug 1923894: Listing Subscriptions in OLM should also show them when 'All Projects' namespace is picked

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -642,7 +642,7 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
       ...(clusterServiceVersions?.data ?? []),
       ...(subscriptions?.data ?? []).filter(
         (sub) =>
-          ['', sub.metadata.namespace].includes(props.namespace) &&
+          ['', sub.metadata.namespace].includes(props.namespace || '') &&
           _.isNil(_.get(sub, 'status.installedCSV')),
       ),
     ].filter(


### PR DESCRIPTION
The issue is the when the `All Projects` namespace is picked, the `props.namespace` is set to `undefined`. When flattening the Subscriptions we should match that.

/assign @TheRealJon 