### PR TITLE
Bug 1924046: Avoid checking user settings if url has namespace

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -50,7 +50,7 @@ export const useValuesForNamespaceContext = () => {
   // Keep namespace in sync with redux.
   React.useEffect(() => {
     // Url namespace overrides everything. We don't need to wait for loaded
-    if (urlNamespace && !favoriteLoaded && !lastNamespaceLoaded) {
+    if (urlNamespace) {
       dispatch(setActiveNamespace(urlNamespace));
     }
     // Automatically sets favorited or latest namespace as soon as


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5451
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Loading userSettings from localStorage is synchronous and loads instantaneously, so dispatching of namespace from url fails since we check if userSettings are loaded.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Avoid checking for the status of the userSettings fetch, if url contains a namespace.
<!-- Describe your code changes in detail and explain the solution -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug