### PR TITLE
Add .dockerignore file so that all node_modules are ignored

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,15 @@
+# Dockerfile to build console image from pre-built front end.
+
+FROM quay.io/coreos/tectonic-console-builder:v22 AS build
+RUN mkdir -p /go/src/github.com/openshift/console/
+ADD . /go/src/github.com/openshift/console/
+WORKDIR /go/src/github.com/openshift/console/
+RUN ./build-backend.sh
+
+FROM openshift/origin-base
+COPY --from=build /go/src/github.com/openshift/console/bin/bridge /opt/bridge/bin/bridge
+COPY ./frontend/public/dist /opt/bridge/static
+COPY ./pkg/graphql/schema.graphql /pkg/graphql/schema.graphql
+
+USER 1001
+CMD [ "/opt/bridge/bin/bridge", "--public-dir=/opt/bridge/static" ]


### PR DESCRIPTION
Greatly improves performance of building an image locally.