### PR TITLE
Bug 1924143: Create application edit url based on git provider

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -204,6 +204,7 @@
     "@types/classnames": "^2.2.7",
     "@types/cypress-axe": "^0.8.0",
     "@types/enzyme": "3.10.x",
+    "@types/git-url-parse": "^9.0.0",
     "@types/glob": "7.x",
     "@types/immutable": "3.x",
     "@types/jasmine": "2.8.x",

--- a/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
@@ -39,7 +39,7 @@ Object {
   "kind": "Route",
   "metadata": Object {
     "defaultAnnotations": Object {
-      "app.openshift.io/vcs-ref": "master",
+      "app.openshift.io/vcs-ref": "",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
       "openshift.io/generated-by": "OpenShiftWebConsole",
     },
@@ -102,7 +102,7 @@ Object {
   "kind": "Service",
   "metadata": Object {
     "annotations": Object {
-      "app.openshift.io/vcs-ref": "master",
+      "app.openshift.io/vcs-ref": "",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
       "openshift.io/generated-by": "OpenShiftWebConsole",
     },

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -44,10 +44,9 @@ export const getAppLabels = ({
 };
 
 export const getGitAnnotations = (gitURL: string, gitRef?: string) => {
-  const ref = gitRef || 'master';
   return {
     'app.openshift.io/vcs-uri': gitURL,
-    'app.openshift.io/vcs-ref': ref,
+    'app.openshift.io/vcs-ref': gitRef || '',
   };
 };
 

--- a/frontend/packages/topology/src/data-transforms/__tests__/data-transformer.spec.ts
+++ b/frontend/packages/topology/src/data-transforms/__tests__/data-transformer.spec.ts
@@ -18,10 +18,6 @@ import { getWorkloadResources } from '../transform-utils';
 
 const namespace = 'test-project';
 
-jest.mock('git-url-parse', () => ({
-  default: jest.fn(() => ({ resource: 'github.com', owner: 'openshift', name: 'console' })),
-}));
-
 function getTransformedTopologyData(
   mockData: TopologyDataResources,
   transformByProp: string[] = WORKLOAD_TYPES,
@@ -160,6 +156,39 @@ describe('data transformer ', () => {
     const mockGitURI = 'git@github.com:openshift/console';
     const editUrl = getEditURL(mockGitURI, '', '');
     expect(editUrl).toBe('https://github.com/openshift/console');
+  });
+
+  it('should return full git url for GitHub URI', () => {
+    const mockGitURI = 'https://github.com/openshift/console';
+    const editUrl = getEditURL(mockGitURI, 'branch1');
+    expect(editUrl).toBe('https://github.com/openshift/console/tree/branch1');
+  });
+
+  it('should return full git url for GitLab URI', () => {
+    const mockGitURI = 'https://gitlab.com/example/reponame';
+    const editUrl = getEditURL(mockGitURI, 'branch1');
+    expect(editUrl).toBe('https://gitlab.com/example/reponame/-/tree/branch1');
+  });
+
+  it('should return full git url for Bitbucket URI', () => {
+    const mockGitURI = 'https://bitbucket.org/username/examplerepo';
+    const editUrl = getEditURL(mockGitURI, 'branch1');
+    expect(editUrl).toBe('https://bitbucket.org/username/examplerepo/src/branch1');
+  });
+
+  it('should return only git url for repo from non-supported git provider', () => {
+    const mockGitURI = 'https://example.com/username/examplerepo';
+    const editUrl = getEditURL(mockGitURI, 'branch1');
+    expect(editUrl).toBe('https://example.com/username/examplerepo');
+  });
+
+  it('should return full git url for supported providers with custom domains', () => {
+    let editUrl = getEditURL('https://github.example.com/uname/repo', 'branch1');
+    expect(editUrl).toBe('https://github.example.com/uname/repo/tree/branch1');
+    editUrl = getEditURL('https://gitlab.example.com/uname/repo', 'branch1');
+    expect(editUrl).toBe('https://gitlab.example.com/uname/repo/-/tree/branch1');
+    editUrl = getEditURL('https://bitbucket.example.com/uname/repo', 'branch1');
+    expect(editUrl).toBe('https://bitbucket.example.com/uname/repo/src/branch1');
   });
 
   it('should return builder image icon for nodejs', () => {

--- a/frontend/packages/topology/src/utils/topology-utils.ts
+++ b/frontend/packages/topology/src/utils/topology-utils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import GitUrlParse from 'git-url-parse';
+import * as GitUrlParse from 'git-url-parse';
 import i18next from 'i18next';
 import {
   K8sResourceKind,
@@ -44,13 +44,28 @@ export const getCheDecoratorData = (consoleLinks: K8sResourceKind[]): CheDecorat
   };
 };
 
+const getFullGitURL = (gitUrl: GitUrlParse.GitUrl, branch?: string) => {
+  const baseUrl = `https://${gitUrl.resource}/${gitUrl.owner}/${gitUrl.name}`;
+  if (!branch) {
+    return baseUrl;
+  }
+  if (gitUrl.resource.includes('github')) {
+    return `${baseUrl}/tree/${branch}`;
+  }
+  if (gitUrl.resource.includes('gitlab')) {
+    return `${baseUrl}/-/tree/${branch}`;
+  }
+  if (gitUrl.resource.includes('bitbucket')) {
+    return `${baseUrl}/src/${branch}`;
+  }
+  return baseUrl;
+};
+
 export const getEditURL = (vcsURI?: string, gitBranch?: string, cheURL?: string) => {
   if (!vcsURI) {
     return null;
   }
-  const parsedURL = GitUrlParse(vcsURI);
-  const gitURL = `https://${parsedURL.resource}/${parsedURL.owner}/${parsedURL.name}`;
-  const fullGitURL = gitBranch ? `${gitURL}/tree/${gitBranch}` : gitURL;
+  const fullGitURL = getFullGitURL(GitUrlParse(vcsURI), gitBranch);
   return cheURL ? `${cheURL}/f?url=${fullGitURL}&policies.create=peruser` : fullGitURL;
 };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2288,6 +2288,11 @@
   version "7946.0.4"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.4.tgz#4e049756383c3f055dd8f3d24e63fb543e98eb07"
 
+"@types/git-url-parse@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/git-url-parse/-/git-url-parse-9.0.0.tgz#aac1315a44fa4ed5a52c3820f6c3c2fb79cbd12d"
+  integrity sha512-kA2RxBT/r/ZuDDKwMl+vFWn1Z0lfm1/Ik6Qb91wnSzyzCDa/fkM8gIOq6ruB7xfr37n6Mj5dyivileUVKsidlg==
+
 "@types/glob@7.x", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5459
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
There is no standard way for git providers to display a repository's branch.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Craft the git url based on the git provider, and resort to not using branch name if the git provider is unsupported.
  ```
  GitHub: {repo}/tree/{branch}
  GitLab: {repo}/-/tree/{branch}
  Bitbucket: {repo}/src/{branch}
  ```
- Avoid adding `master` in import flow if branch is not provided, as this fails for branches whose default branch is not master.
<!-- Describe your code changes in detail and explain the solution -->

**Unit test coverage report**: 
Added tests.
```yarn run v1.22.10
$ jest /data-transforms/__tests__/data-transformer
 PASS  packages/topology/src/data-transforms/__tests__/data-transformer.spec.ts (8.066s)
Test Suites: 1 passed, 1 total
Tests:       1 skipped, 25 passed, 26 total
Snapshots:   0 total
Time:        9.822s
Ran all test suites matching /\/data-transforms\/__tests__\/data-transformer/i.
Done in 11.39s.
```
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug