### PR TITLE
Bug 1924078: Make Topology quick search View all results footer sticky

### DIFF
--- a/frontend/packages/topology/src/components/quick-search/QuickSearchContent.scss
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchContent.scss
@@ -1,9 +1,9 @@
 .odc-quick-search-content {
-  height: calc(100% - 60px);
+  flex: 1;
+  overflow-y: hidden;
   &__list {
     width: 40%;
     height: 100%;
-    overflow-y: auto;
   }
   &__details {
     background: var(--pf-global--palette--white);

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchContent.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchContent.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import cx from 'classnames';
 import { CatalogItem } from '@console/plugin-sdk';
 import { Split, SplitItem, Divider } from '@patternfly/react-core';
 import QuickSearchDetails from './QuickSearchDetails';
 import QuickSearchList from './QuickSearchList';
 import './QuickSearchContent.scss';
+
+const MAX_CATALOG_ITEMS_SHOWN = 5;
 
 interface QuickSearchContentProps {
   catalogItems: CatalogItem[];
@@ -24,9 +27,14 @@ const QuickSearchContent: React.FC<QuickSearchContentProps> = ({
 }) => {
   return (
     <Split className="odc-quick-search-content">
-      <SplitItem className="odc-quick-search-content__list">
+      <SplitItem
+        className={cx('odc-quick-search-content__list', {
+          'odc-quick-search-content__list--overflow':
+            catalogItems.length >= MAX_CATALOG_ITEMS_SHOWN,
+        })}
+      >
         <QuickSearchList
-          listItems={catalogItems.slice(0, 5)}
+          listItems={catalogItems.slice(0, MAX_CATALOG_ITEMS_SHOWN)}
           totalItems={catalogItems.length}
           selectedItemId={selectedItemId}
           searchTerm={searchTerm}

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchList.scss
@@ -1,9 +1,21 @@
 .odc-quick-search-list {
-  border-top: var(--pf-c-data-list--sm--BorderTopWidth) solid
-    var(--pf-c-data-list--sm--BorderTopColor) !important;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  &__list {
+    border-top: var(--pf-c-data-list--sm--BorderTopWidth) solid var(--pf-c-data-list--sm--BorderTopColor) !important;
+    border-bottom: var(--pf-c-data-list--sm--BorderTopWidth) solid var(--pf-c-data-list--sm--BorderTopColor) !important;
+    flex: 1;
+    overflow-y: auto;
+  }
   &__item {
     border-bottom: var(--pf-c-data-list__item--sm--BorderBottomWidth) solid
       var(--pf-c-data-list__item--sm--BorderBottomColor) !important;
+    &:last-of-type {
+      .odc-quick-search-content__list--overflow & {
+        border-bottom: 0 !important;
+      }
+    }
     &--highlight {
       background: var(--pf-global--active-color--200);
     }
@@ -12,7 +24,7 @@
     }
   }
   &__item-row {
-    padding: 0px var(--pf-global--spacer--sm);
+    padding: 0 var(--pf-global--spacer--sm);
   }
   &__item-content {
     align-items: center;
@@ -30,8 +42,7 @@
       var(--pf-c-data-list__item--sm--BorderBottomColor) !important;
   }
   &__all-items-link {
-    padding: var(--pf-global--spacer--sm) 0px;
+    padding: var(--pf-global--spacer--sm) 0 var(--pf-global--spacer--md);
     text-align: center;
-    font-size: var(--pf-global--FontSize--md);
   }
 }

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
@@ -61,74 +61,64 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
   };
 
   return (
-    <DataList
-      className="odc-quick-search-list"
-      aria-label={t('topology~Quick search list')}
-      selectedDataListItemId={selectedItemId}
-      onSelectDataListItem={(itemId) => itemId !== 'viewAll' && onSelectListItem(itemId)}
-      isCompact
-    >
-      {listItems.map((item) => (
-        <DataListItem
-          id={item.uid}
-          key={item.uid}
-          tabIndex={-1}
-          className={cx('odc-quick-search-list__item', {
-            'odc-quick-search-list__item--highlight': item.uid === selectedItemId,
-          })}
-          onDoubleClick={(e: React.SyntheticEvent) => openForm(e, item)}
-        >
-          <DataListItemRow className="odc-quick-search-list__item-row">
-            <DataListItemCells
-              className="odc-quick-search-list__item-content"
-              dataListCells={[
-                <DataListCell isIcon key={`${item.uid}-icon`}>
-                  {getIcon(item)}
-                </DataListCell>,
-                <DataListCell
-                  style={{ paddingTop: 'var(--pf-global--spacer--sm)' }}
-                  width={2}
-                  wrapModifier="truncate"
-                  key={`${item.uid}-name`}
-                >
-                  <span className="odc-quick-search-list__item-name">{item.name}</span>
-                  <Split style={{ alignItems: 'center' }} hasGutter>
-                    <SplitItem>
-                      <Label>{item.type}</Label>
-                    </SplitItem>
-                    <SplitItem>
-                      <TextContent>
-                        <Text component={TextVariants.small}>{item.provider}</Text>
-                      </TextContent>
-                    </SplitItem>
-                  </Split>
-                </DataListCell>,
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-      ))}
-      <DataListItem
-        id="viewAll"
-        className="odc-quick-search-list__all-items"
-        onClick={goToCatalogPage}
+    <div className="odc-quick-search-list">
+      <DataList
+        className="odc-quick-search-list__list"
+        aria-label={t('topology~Quick search list')}
+        selectedDataListItemId={selectedItemId}
+        onSelectDataListItem={(itemId) => itemId !== 'viewAll' && onSelectListItem(itemId)}
+        isCompact
       >
-        <DataListItemRow className="odc-quick-search-list__all-items-link">
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="view-all-link">
-                <Button variant="link" tabIndex={-1}>
-                  {t('topology~View all results for "{{searchTerm}}" ({{totalItems, number}})', {
-                    searchTerm,
-                    totalItems,
-                  })}
-                </Button>
-              </DataListCell>,
-            ]}
-          />
-        </DataListItemRow>
-      </DataListItem>
-    </DataList>
+        {listItems.map((item) => (
+          <DataListItem
+            id={item.uid}
+            key={item.uid}
+            tabIndex={-1}
+            className={cx('odc-quick-search-list__item', {
+              'odc-quick-search-list__item--highlight': item.uid === selectedItemId,
+            })}
+            onDoubleClick={(e: React.SyntheticEvent) => openForm(e, item)}
+          >
+            <DataListItemRow className="odc-quick-search-list__item-row">
+              <DataListItemCells
+                className="odc-quick-search-list__item-content"
+                dataListCells={[
+                  <DataListCell isIcon key={`${item.uid}-icon`}>
+                    {getIcon(item)}
+                  </DataListCell>,
+                  <DataListCell
+                    style={{ paddingTop: 'var(--pf-global--spacer--sm)' }}
+                    width={2}
+                    wrapModifier="truncate"
+                    key={`${item.uid}-name`}
+                  >
+                    <span className="odc-quick-search-list__item-name">{item.name}</span>
+                    <Split style={{ alignItems: 'center' }} hasGutter>
+                      <SplitItem>
+                        <Label>{item.type}</Label>
+                      </SplitItem>
+                      <SplitItem>
+                        <TextContent>
+                          <Text component={TextVariants.small}>{item.provider}</Text>
+                        </TextContent>
+                      </SplitItem>
+                    </Split>
+                  </DataListCell>,
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+        ))}
+      </DataList>
+      <div className="odc-quick-search-list__all-items-link">
+        <Button variant="link" onClick={goToCatalogPage}>
+          {t('topology~View all results for "{{searchTerm}}" ({{totalItems, number}})', {
+            searchTerm,
+            totalItems,
+          })}
+        </Button>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.scss
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.scss
@@ -1,3 +1,5 @@
 .odc-quick-search-modal-body {
+  display: flex;
+  flex-direction: column;
   min-height: 60px;
 }

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
@@ -143,7 +143,7 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
     <div
       ref={ref}
       className="odc-quick-search-modal-body"
-      style={{ height: catalogItems?.length > 0 ? 468 : 60 }}
+      style={{ height: catalogItems?.length > 0 ? 460 : 60 }}
     >
       <QuickSearchBar
         searchTerm={searchTerm}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5402

**Analysis / Root cause**: 
The link to all results was added to the data list rather than being a separate component and styling the list to be scrollable.

**Solution Description**: 
Make the all results link a component separate from the list. Update the layout to allow the list to scroll rather than the entire left side area. Use flex display for modal rather than setting an adjusted percentage height on the search content.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/106620525-a6c1dd00-653f-11eb-8a73-75eb42845883.png)

![image](https://user-images.githubusercontent.com/11633780/106620556-ade8eb00-653f-11eb-8b89-126f50253620.png)

![image](https://user-images.githubusercontent.com/11633780/106620585-b3463580-653f-11eb-8a3d-be24bad0d628.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge