### PR TITLE
Add check errors in add capacity tests

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/add-capacity.spec.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/add-capacity.spec.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import { modal } from '../../../integration-tests-cypress/views/modal';
+import { checkErrors } from '../../../integration-tests-cypress/support';
 import { CLUSTER_STATUS } from '../../integration-tests/utils/consts';
 import {
   createOSDTreeMap,
@@ -24,6 +25,10 @@ describe('OCS Operator Expansion of Storage Class Test', () => {
 
   beforeEach(() => {
     cy.visit('/');
+  });
+
+  afterEach(() => {
+    checkErrors();
   });
 
   after(() => {


### PR DESCRIPTION
`chekErrors` block was removed due to some issue. Enabled it again for the add capacity tests.

URL: https://issues.redhat.com/browse/RHSTOR-1614