### PR TITLE
Bug 1924480: When creating Snapshoot blockOwnerDeletion is now false

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/snapshot-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/snapshot-modal.tsx
@@ -62,7 +62,7 @@ const SnapshotsModal = withHandlePromise((props: SnapshotsModalProps) => {
         namespace: getNamespace(vmLikeEntity),
         vmName,
       })
-      .addOwnerReferences(buildOwnerReference(vmLikeEntity));
+      .addOwnerReferences(buildOwnerReference(vmLikeEntity, { blockOwnerDeletion: false }));
 
     handlePromise(k8sCreate(snapshotWrapper.getModel(), snapshotWrapper.asResource()), close);
   };


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1924480

**Analysis / Root cause**: 
Normal user is missing permissions

**Solution Description**: 
Changed blockOwnerDeletion to false

**Screen shots / Gifs for design review**: 
Before:
![snapshotissue](https://user-images.githubusercontent.com/14824964/106721264-1c47af00-660d-11eb-90be-18830c3f7489.png)
After:
![image](https://user-images.githubusercontent.com/14824964/106721332-34b7c980-660d-11eb-814f-51ea36a1c064.png)
