### PR TITLE
Bug 1924747: InventoryItems aren't internationalized

### DIFF
--- a/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/cluster-dashboard.scenario.ts
@@ -6,7 +6,7 @@ const inventoryItems = [
   { title: 'Node', link: '/k8s/cluster/nodes' },
   { title: 'Pod', link: '/k8s/all-namespaces/pods' },
   { title: 'StorageClass', link: '/k8s/cluster/storageclasses' },
-  { title: 'PVC', link: '/k8s/all-namespaces/persistentvolumeclaims' },
+  { title: 'PersistentVolumeClaim', link: '/k8s/all-namespaces/persistentvolumeclaims' },
 ];
 
 const utilizationItems = ['CPU', 'Memory', 'Filesystem', 'Network transfer', 'Pod count'];

--- a/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/dashboards/project-dashboard.scenario.ts
@@ -14,7 +14,7 @@ import * as projectDashboardView from '../../views/dashboard.view';
 const inventoryItems = [
   { title: 'Deployment', link: `/k8s/ns/${testName}/deployments` },
   { title: 'Pod', link: `/k8s/ns/${testName}/pods` },
-  { title: 'PVC', link: `/k8s/ns/${testName}/persistentvolumeclaims` },
+  { title: 'PersistentVolumeClaim', link: `/k8s/ns/${testName}/persistentvolumeclaims` },
   { title: 'Service', link: `/k8s/ns/${testName}/services` },
   { title: 'Route', link: `/k8s/ns/${testName}/routes` },
   { title: 'ConfigMap', link: `/k8s/ns/${testName}/configmaps` },

--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/ocs-presistent-dashboard.spec.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/ocs-presistent-dashboard.spec.ts
@@ -57,8 +57,10 @@ describe('Check OCS Dashboards', () => {
             getPVCJSON('dummy-pvc', 'openshift-storage', 'ocs-storagecluster-ceph-rbd', '5Gi'),
           )}' | oc create -f -`,
         ).then(() => {
-          cy.byTestID('inventory-pvc').contains(`${(initialPVC + 1).toString()} PVC`);
-          cy.byTestID('inventory-pv').contains(`${(initialPVC + 1).toString()} PV`);
+          cy.byTestID('inventory-pvc').contains(
+            `${(initialPVC + 1).toString()} PersistentVolumeClaims`,
+          );
+          cy.byTestID('inventory-pv').contains(`${(initialPVC + 1).toString()} PersistentVolumes`);
         });
       });
   });

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
@@ -105,7 +105,6 @@ const InventoryCard: React.FC<DashboardItemProps> = ({
           isLoading={!pvcsLoaded}
           error={!!pvcsLoadError}
           kind={PersistentVolumeClaimModel}
-          useAbbr
           resources={getCephPVCs(filteredSCNames, pvcsData, pvsData)}
           mapper={getPVCStatusGroups}
           showLink={false}
@@ -115,7 +114,6 @@ const InventoryCard: React.FC<DashboardItemProps> = ({
           isLoading={!pvsLoaded}
           error={!!pvsLoadError}
           kind={PersistentVolumeModel}
-          useAbbr
           resources={getCephPVs(pvsData)}
           mapper={getPVStatusGroups}
           showLink={false}

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -176,7 +176,6 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           '@console/shared/src/components/dashboard/inventory-card/utils' /* webpackChunkName: "console-app" */
         ).then((m) => m.getPVCStatusGroups),
-      useAbbr: true,
     },
   },
   {

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -159,9 +159,6 @@ namespace ExtensionProperties {
     /** Additional resources which will be fetched and passed to `mapper` function. */
     additionalResources?: WatchK8sResources<any>;
 
-    /** Defines whether model's label or abbr should be used when rendering the item. Defaults to false (label). */
-    useAbbr?: boolean;
-
     /** Loader for the component which will be used when item is expanded. */
     expandedComponent?: LazyLoader<ExpandedComponentProps>;
   }
@@ -219,9 +216,6 @@ namespace ExtensionProperties {
 
     /** Additional resources which will be fetched and passed to `mapper` function. */
     additionalResources?: FirehoseResource[];
-
-    /** Defines whether model's label or abbr should be used when rendering the item. Defaults to false (label). */
-    useAbbr?: boolean;
 
     /** Function which will map various statuses to groups. */
     mapper: StatusGroupMapper;

--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
@@ -210,7 +210,6 @@ const ResourceTitleComponent: React.FC<ResourceTitleComponentComponent> = ({
 
 export const ResourceInventoryItem: React.FC<ResourceInventoryItemProps> = ({
   kind,
-  useAbbr,
   TitleComponent,
   resources = [],
   additionalResources,
@@ -223,6 +222,7 @@ export const ResourceInventoryItem: React.FC<ResourceInventoryItemProps> = ({
   basePath,
   dataTest,
 }) => {
+  const { t } = useTranslation();
   let Title: React.ComponentType = React.useCallback(
     (props) => (
       <ResourceTitleComponent
@@ -266,11 +266,14 @@ export const ResourceInventoryItem: React.FC<ResourceInventoryItemProps> = ({
     [mapper, groups, resources],
   );
 
+  const titleLabel = kind.labelKey ? t(kind.labelKey) : kind.label;
+  const titlePluralLabel = kind.labelPluralKey ? t(kind.labelPluralKey) : kind.labelPlural;
+
   return (
     <InventoryItem
       isLoading={isLoading}
-      title={useAbbr ? kind.abbr : kind.label}
-      titlePlural={useAbbr ? undefined : kind.labelPlural}
+      title={titleLabel}
+      titlePlural={titlePluralLabel}
       count={totalCount}
       error={error}
       TitleComponent={showLink ? Title : null}
@@ -347,7 +350,6 @@ type ResourceInventoryItemProps = {
   additionalResources?: { [key: string]: K8sResourceKind[] };
   mapper?: StatusGroupMapper;
   kind: K8sKind;
-  useAbbr?: boolean;
   isLoading: boolean;
   namespace?: string;
   error: boolean;

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
@@ -21,7 +21,9 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
       <div className={classNames('co-status-card__health-item', className)}>
         {state === HealthState.LOADING ? (
           <div className="skeleton-health">
-            <span className="pf-u-screen-reader">Loading {title} Status</span>
+            <span className="pf-u-screen-reader">
+              {t('public~Loading {{title}} status', { title })}
+            </span>
           </div>
         ) : (
           !noIcon && <HealthItemIcon state={state} />

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -347,7 +347,6 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboards-page/overview-dashboard/inventory' /* webpackChunkName: "kubevirt" */
         ).then((m) => m.getVMStatusGroups),
-      useAbbr: true,
     },
     flags: {
       required: [FLAG_KUBEVIRT],
@@ -424,7 +423,6 @@ const plugin: Plugin<ConsumedExtensions> = [
       ],
       model: models.VirtualMachineModel,
       mapper: getVMStatusGroups,
-      useAbbr: true,
     },
     flags: {
       required: [FLAG_KUBEVIRT],

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -302,7 +302,6 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Project/Dashboard/Inventory/Item',
     properties: {
       model: models.NooBaaObjectBucketClaimModel,
-      useAbbr: true,
       mapper: getObcStatusGroups,
     },
     flags: {

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/inventory-card.tsx
@@ -45,7 +45,6 @@ const ClusterInventoryItem = withDashboardResources<ClusterInventoryItemProps>(
     ({
       model,
       mapperLoader,
-      useAbbr,
       additionalResources,
       expandedComponent,
     }: ClusterInventoryItemProps) => {
@@ -99,7 +98,6 @@ const ClusterInventoryItem = withDashboardResources<ClusterInventoryItemProps>(
           kind={model}
           resources={resourceData}
           mapper={mapper}
-          useAbbr={useAbbr}
           additionalResources={additionalResourcesData}
           ExpandedComponent={expandedComponent ? ExpandedComponent : null}
         />
@@ -136,7 +134,6 @@ export const InventoryCard = () => {
             model={item.properties.model}
             mapperLoader={item.properties.mapper}
             additionalResources={item.properties.additionalResources}
-            useAbbr={item.properties.useAbbr}
             expandedComponent={item.properties.expandedComponent}
           />
         ))}
@@ -148,7 +145,6 @@ export const InventoryCard = () => {
 type ClusterInventoryItemProps = DashboardItemProps & {
   model: K8sKind;
   mapperLoader?: () => Promise<StatusGroupMapper>;
-  useAbbr?: boolean;
   additionalResources?: WatchK8sResources<any>;
   expandedComponent?: LazyLoader;
 };

--- a/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/inventory-card.tsx
@@ -52,7 +52,6 @@ const ProjectInventoryItem = withDashboardResources(
     resources,
     model,
     mapper,
-    useAbbr,
     additionalResources,
   }: ProjectInventoryItemProps) => {
     React.useEffect(() => {
@@ -101,7 +100,6 @@ const ProjectInventoryItem = withDashboardResources(
         resources={resourceData}
         additionalResources={additionalResourcesData}
         mapper={mapper}
-        useAbbr={useAbbr}
       />
     );
   },
@@ -139,7 +137,6 @@ export const InventoryCard = () => {
           projectName={projectName}
           model={PersistentVolumeClaimModel}
           mapper={getPVCStatusGroups}
-          useAbbr
         />
         <ProjectInventoryItem projectName={projectName} model={ServiceModel} />
         <ProjectInventoryItem projectName={projectName} model={RouteModel} />
@@ -152,7 +149,6 @@ export const InventoryCard = () => {
             model={item.properties.model}
             mapper={item.properties.mapper}
             additionalResources={item.properties.additionalResources}
-            useAbbr={item.properties.useAbbr}
           />
         ))}
         <ProjectInventoryItem
@@ -169,6 +165,5 @@ type ProjectInventoryItemProps = DashboardItemProps & {
   projectName: string;
   model: K8sKind;
   mapper?: StatusGroupMapper;
-  useAbbr?: boolean;
   additionalResources?: FirehoseResource[];
 };

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -562,6 +562,7 @@
   "Resume": "Resume",
   "Pause": "Pause",
   "Warning": "Warning",
+  "Loading {{title}} status": "Loading {{title}} status",
   "Not available": "Not available",
   "Resource": "Resource",
   "Unsupported": "Unsupported",


### PR DESCRIPTION
InventoryItems were using model.label and model.labelPlural, as well as model.abbr. I updated the component to use internationalized values where available. I removed model.abbr usage after talking with Sam given that we don't internationalize these values at this point.

I also internationalized a couple of small things I noticed related to dashboards.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1924747.