### PR TITLE
Bug 1925024: removes form validation from net(sasl/tls) section for kafkaSource

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
@@ -13,6 +13,7 @@ import { RootState } from '@console/internal/redux';
 interface SecretKeySelectorProps {
   name: string;
   label: string;
+  isRequired?: boolean;
 }
 
 interface StateProps {
@@ -23,6 +24,7 @@ const SecretKeySelector: React.FC<SecretKeySelectorProps & StateProps> = ({
   name,
   label,
   namespace,
+  isRequired = false,
 }) => {
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const [field, { touched, error }] = useField(name);
@@ -61,7 +63,7 @@ const SecretKeySelector: React.FC<SecretKeySelectorProps & StateProps> = ({
       label={label}
       helperTextInvalid={errorMessage}
       validated={isValid ? 'default' : 'error'}
-      isRequired
+      isRequired={isRequired}
     >
       <ValueFromPair
         pair={{ secretKeyRef: field.value }}

--- a/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
@@ -98,6 +98,16 @@ describe('Event Source ValidationUtils', () => {
           expect(err.type).toBe('min');
         });
     });
+
+    it('should not throw error if net section is empty', async () => {
+      const defaultEventingData = getDefaultEventingData(EventSources.KafkaSource);
+      const mockData = _.cloneDeep(defaultEventingData);
+      delete mockData.formData.data.KafkaSource.net;
+      await eventSourceValidationSchema(t)
+        .resolve({ value: mockData })
+        .isValid(mockData)
+        .then((valid) => expect(valid).toEqual(true));
+    });
   });
 
   describe('ContainerSource : Event Source Validation', () => {

--- a/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
@@ -114,52 +114,37 @@ export const sourceDataSpecSchema = (t: TFunction) =>
           net: yup.object().shape({
             sasl: yup.object().shape({
               enable: yup.boolean(),
-              user: yup.object().when('enable', {
-                is: true,
-                then: yup.object().shape({
-                  secretKeyRef: yup.object().shape({
-                    name: yup.string().required(t('knative-plugin~Required')),
-                    key: yup.string().required(t('knative-plugin~Required')),
-                  }),
+              user: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string(),
+                  key: yup.string(),
                 }),
               }),
-              password: yup.object().when('enable', {
-                is: true,
-                then: yup.object().shape({
-                  secretKeyRef: yup.object().shape({
-                    name: yup.string().required(t('knative-plugin~Required')),
-                    key: yup.string().required(t('knative-plugin~Required')),
-                  }),
+              password: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string(),
+                  key: yup.string(),
                 }),
               }),
             }),
             tls: yup.object().shape({
               enable: yup.boolean(),
-              caCert: yup.object().when('enable', {
-                is: true,
-                then: yup.object().shape({
-                  secretKeyRef: yup.object().shape({
-                    name: yup.string().required(t('knative-plugin~Required')),
-                    key: yup.string().required(t('knative-plugin~Required')),
-                  }),
+              caCert: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string(),
+                  key: yup.string(),
                 }),
               }),
-              cert: yup.object().when('enable', {
-                is: true,
-                then: yup.object().shape({
-                  secretKeyRef: yup.object().shape({
-                    name: yup.string().required(t('knative-plugin~Required')),
-                    key: yup.string().required(t('knative-plugin~Required')),
-                  }),
+              cert: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string(),
+                  key: yup.string(),
                 }),
               }),
-              key: yup.object().when('enable', {
-                is: true,
-                then: yup.object().shape({
-                  secretKeyRef: yup.object().shape({
-                    name: yup.string().required(t('knative-plugin~Required')),
-                    key: yup.string().required(t('knative-plugin~Required')),
-                  }),
+              key: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string(),
+                  key: yup.string(),
                 }),
               }),
             }),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5458

**Analysis / Root cause**: 
In form view for kafksSource if sasl/tls are enebled then other fields i.e user , password or caCert, cert, key  where shown as required field which shouldn't be the case

**Solution Description**: 
Removed required validation from net section and rely on API validation for same

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/106863555-b5022b80-66ee-11eb-827d-915b21047147.png)

**Test:**

![image](https://user-images.githubusercontent.com/5129024/106890707-bd1e9300-670f-11eb-904b-9647e07a7f94.png)


**Test setup:**
- Install Serverless operator
- create CR for Knative Kafka (enable source) along with serving and eventing

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
