### PR TITLE
Bug 1925020: Console demo plugin deployment image should not point to dockerhub

### DIFF
--- a/frontend/dynamic-demo-plugin/oc-manifest.yaml
+++ b/frontend/dynamic-demo-plugin/oc-manifest.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: console-demo-plugin
-          image: docker.io/jhadvig/console-demo-plugin
+          image: quay.io/jhadvig/console-demo-plugin
           ports:
             - containerPort: 9001
               protocol: TCP


### PR DESCRIPTION
Points to https://quay.io/repository/jhadvig/console-demo-plugin

/assign @spadgett @vojtechszocs 