### PR TITLE
Bug 1922264: Fix rendering of access-mode selector

### DIFF
--- a/frontend/packages/console-app/src/components/access-modes/access-mode.tsx
+++ b/frontend/packages/console-app/src/components/access-modes/access-mode.tsx
@@ -24,8 +24,7 @@ export const getPVCAccessModes = (resource: PersistentVolumeClaimKind, key: stri
   );
 
 export const AccessModeSelector: React.FC<AccessModeSelectorProps> = (props) => {
-  const { formClassName, pvcResource, onChange, loadError, loaded, provisioner } = props;
-
+  const { formClassName, pvcResource, onChange, loaded, provisioner } = props;
   const pvcInitialAccessMode = pvcResource ? getPVCAccessModes(pvcResource, 'value') : '';
 
   const [allowedAccessModes, setAllowedAccessModes] = React.useState<string[]>();
@@ -69,24 +68,19 @@ export const AccessModeSelector: React.FC<AccessModeSelectorProps> = (props) => 
       {loaded &&
         allowedAccessModes &&
         accessModeRadios.map((radio) => {
-          let radioObj = null;
           const disabled = !allowedAccessModes.includes(radio.value);
-          allowedAccessModes.forEach((mode) => {
-            const checked =
-              !disabled && !loadError ? radio.value === accessMode : radio.value === mode;
-            radioObj = (
-              <RadioInput
-                {...radio}
-                key={radio.value}
-                onChange={onAccessModeChange}
-                inline
-                disabled={disabled}
-                checked={checked}
-                name="accessMode"
-              />
-            );
-          });
-          return radioObj;
+          const checked = radio.value === accessMode;
+          return (
+            <RadioInput
+              {...radio}
+              key={radio.value}
+              onChange={onAccessModeChange}
+              inline
+              disabled={disabled}
+              checked={checked}
+              name="accessMode"
+            />
+          );
         })}
       {(!loaded || !allowedAccessModes) && <div className="skeleton-text" />}
     </FormGroup>

--- a/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
+++ b/frontend/packages/console-app/src/components/modals/restore-pvc/restore-pvc-modal.tsx
@@ -172,11 +172,7 @@ const RestorePVCModal = withHandlePromise<RestorePVCModalProps>(
                 onChange={setPVCName}
               />
             </FormGroup>
-            <FormGroup
-              fieldId="restore-storage-class"
-              className="co-restore-pvc-modal__input"
-              isRequired
-            >
+            <FormGroup fieldId="restore-storage-class" className="co-restore-pvc-modal__input">
               {!snapshotClassResourceLoaded ? (
                 <div className="skeleton-text" />
               ) : (

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -4,6 +4,7 @@ import * as fuzzy from 'fuzzysearch';
 
 import { Firehose, LoadingInline, Dropdown, ResourceName, ResourceIcon } from '.';
 import { isDefaultClass } from '../storage-class';
+import * as classNames from 'classnames';
 
 /* Component StorageClassDropdown - creates a dropdown list of storage classes */
 
@@ -152,11 +153,9 @@ export class StorageClassDropdownInner extends React.Component<
         {loaded && itemsAvailableToShow && (
           <div>
             <label
-              className={
-                this.props.hideClassName
-                  ? `${this.props.hideClassName} control-label`
-                  : 'control-label'
-              }
+              className={classNames('control-label', this.props.hideClassName, {
+                'co-required': this.props.required,
+              })}
               htmlFor={id}
             >
               Storage Class


### PR DESCRIPTION
This commit fixes an issue where the radio buttons of the access mode selector are not rendered properly when parent pvc of the snapshot is deleted.
The commit removes the dependency of rendering based on the pvc load error.
 
below screenshots of the modal after removing the parent pvcs
Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>