### PR TITLE
Bug 1922911: Query Browser: Fix graph crash after hiding and then showing a series

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -357,7 +357,17 @@ const Graph: React.FC<GraphProps> = React.memo(
               data: { [isStack ? 'fill' : 'stroke']: color },
               labels: { fill: color, name: tooltipSeriesNames[i] },
             };
-            return <ChartComponent data={values} groupComponent={<g />} key={i} style={style} />;
+            return (
+              // We need to use the `name` prop to prevent an error in VictorySharedEvents when
+              // dynamically removing and then adding back data series
+              <ChartComponent
+                data={values}
+                groupComponent={<g />}
+                key={i}
+                name={`series-${i}`}
+                style={style}
+              />
+            );
           })}
         </GroupComponent>
         {!_.isEmpty(legendData) && (


### PR DESCRIPTION
When there were multiple queries, hiding all data series and then
showing one again could result in the graph component crashing.

Bug was introduced by https://github.com/openshift/console/pull/7408