### PR TITLE
Bug 1925200: show warning when alert type cannot be recognized

### DIFF
--- a/frontend/packages/console-shared/src/components/alerts/AlertSeverityIcon.tsx
+++ b/frontend/packages/console-shared/src/components/alerts/AlertSeverityIcon.tsx
@@ -22,6 +22,7 @@ const AlertSeverityIcon: React.FC<AlertSeverityIconProps> = ({
         />
       );
     case AlertSeverity.Warning:
+    default:
       return (
         <ExclamationTriangleIcon
           style={{
@@ -30,8 +31,6 @@ const AlertSeverityIcon: React.FC<AlertSeverityIconProps> = ({
           }}
         />
       );
-    default:
-      return null;
   }
 };
 

--- a/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
+++ b/frontend/packages/console-shared/src/utils/__mocks__/alerts-and-rules-data.ts
@@ -120,6 +120,37 @@ export const mockAlerts: Alerts = {
       activeAt: '2020-07-15T06:36:06.662770393Z',
       value: 12,
     },
+    {
+      labels: {
+        alertname: 'VersionNewAlert',
+        severity: 'Critical',
+        endpoint: 'web',
+        instance: '10.131.0.35:8080',
+        job: 'prometheus-example-app',
+        namespace: 'ns1',
+        deployment: 'prometheus-example-app',
+        prometheus: 'openshift-user-workload-monitoring/user-workload',
+        service: 'prometheus-example-app',
+        version: 'v0.1.0',
+      },
+      annotations: {
+        message: 'Alerts are not configured to be sent to a notification system.',
+      },
+      state: AlertStates.Firing,
+      activeAt: '2020-06-09T04:06:36.662770393Z',
+      value: 0,
+      rule: {
+        labels: {},
+        alerts: [],
+        annotations: {},
+        duration: 10,
+        id: '778oi9oi',
+        name: 'abc',
+        query: 'query2',
+        state: RuleStates.Firing,
+        type: 'type-1',
+      },
+    },
   ],
 };
 
@@ -269,6 +300,37 @@ export const expectedFiringAlerts: Alert[] = [
     activeAt: '2020-07-15T06:36:06.662770393Z',
     value: 12,
   },
+  {
+    labels: {
+      alertname: 'VersionNewAlert',
+      severity: 'Critical',
+      endpoint: 'web',
+      instance: '10.131.0.35:8080',
+      job: 'prometheus-example-app',
+      namespace: 'ns1',
+      deployment: 'prometheus-example-app',
+      prometheus: 'openshift-user-workload-monitoring/user-workload',
+      service: 'prometheus-example-app',
+      version: 'v0.1.0',
+    },
+    annotations: {
+      message: 'Alerts are not configured to be sent to a notification system.',
+    },
+    state: AlertStates.Firing,
+    activeAt: '2020-06-09T04:06:36.662770393Z',
+    value: 0,
+    rule: {
+      labels: {},
+      alerts: [],
+      annotations: {},
+      duration: 10,
+      id: '778oi9oi',
+      name: 'abc',
+      query: 'query2',
+      state: RuleStates.Firing,
+      type: 'type-1',
+    },
+  },
 ];
 
 export const expectedSortedAlerts: Alert[] = [
@@ -359,6 +421,37 @@ export const expectedSortedAlerts: Alert[] = [
     state: AlertStates.Firing,
     activeAt: '2020-07-15T06:36:06.662770393Z',
     value: 132,
+  },
+  {
+    labels: {
+      alertname: 'VersionNewAlert',
+      severity: 'Critical',
+      endpoint: 'web',
+      instance: '10.131.0.35:8080',
+      job: 'prometheus-example-app',
+      namespace: 'ns1',
+      deployment: 'prometheus-example-app',
+      prometheus: 'openshift-user-workload-monitoring/user-workload',
+      service: 'prometheus-example-app',
+      version: 'v0.1.0',
+    },
+    annotations: {
+      message: 'Alerts are not configured to be sent to a notification system.',
+    },
+    state: AlertStates.Firing,
+    activeAt: '2020-06-09T04:06:36.662770393Z',
+    value: 0,
+    rule: {
+      labels: {},
+      alerts: [],
+      annotations: {},
+      duration: 10,
+      id: '778oi9oi',
+      name: 'abc',
+      query: 'query2',
+      state: RuleStates.Firing,
+      type: 'type-1',
+    },
   },
   {
     rule: {

--- a/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
@@ -169,7 +169,7 @@ describe('TransformResourceData', () => {
       },
     };
     const alerts: Alert[] = getWorkloadMonitoringAlerts(deploymentResource, mockAlerts);
-    const expectedAlerts: Alert[] = _.pullAt(mockAlerts.data, [0, 1]);
+    const expectedAlerts: Alert[] = _.pullAt(mockAlerts.data, [0, 1, 4]);
     expect(alerts).toEqual(expectedAlerts);
   });
 });

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringOverview.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringOverview.spec.tsx
@@ -46,14 +46,15 @@ describe('Monitoring Metric Section', () => {
     expect(component.find('#monitoring-alerts-content').prop('isHidden')).toBe(false);
   });
 
-  it('monitoring alerts should be 2', () => {
-    expect(component.find(Badge).props().children).toBe(4);
+  it('monitoring alerts should be 5', () => {
+    expect(component.find(Badge).props().children).toBe(5);
   });
 
   it('alerts section should not be present if there are no firing alerts', () => {
     monitoringOverviewProps.monitoringAlerts[0].state = AlertStates.Pending;
     monitoringOverviewProps.monitoringAlerts[2].state = AlertStates.Pending;
     monitoringOverviewProps.monitoringAlerts[3].state = AlertStates.Pending;
+    monitoringOverviewProps.monitoringAlerts[4].state = AlertStates.Pending;
     component = shallow(<MonitoringOverview {...monitoringOverviewProps} />);
     expect(component.find('#monitoring-alerts').exists()).toBe(false);
   });

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringOverviewAlerts.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringOverviewAlerts.spec.tsx
@@ -32,5 +32,11 @@ describe('Monitoring Alerts Section', () => {
         .at(1)
         .prop('variant'),
     ).toBe('warning');
+    expect(
+      component
+        .find(Alert)
+        .at(2)
+        .prop('variant'),
+    ).toBe('warning');
   });
 });

--- a/frontend/packages/dev-console/src/components/monitoring/overview/monitoring-overview-alerts-utils.ts
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/monitoring-overview-alerts-utils.ts
@@ -5,11 +5,13 @@ export const getAlertType = (severity: string): 'danger' | 'warning' | 'info' =>
     case AlertSeverity.Critical: {
       return 'danger';
     }
-    case AlertSeverity.Warning: {
-      return 'warning';
-    }
-    default: {
+    case AlertSeverity.Info:
+    case AlertSeverity.None: {
       return 'info';
+    }
+    case AlertSeverity.Warning:
+    default: {
+      return 'warning';
     }
   }
 };


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5477

**Analysis / Root cause:**
The severity label can be anything (ex: bad-label) and the backend doesn't stop us from creating PrometheusRule with such a label. Currently, the logic for showing Monitoring alert decorator on topology doesn't handle that. Also, in the Monitoring Overview tab, in the topology sidebar, such unidentified labels are treated as `Info` alerts.
![bad-label](https://user-images.githubusercontent.com/22490998/106998512-a2e5c300-67aa-11eb-8c09-eaddfd7a75cd.png)

**Solution Description:**
We currently support labels `critical` , `warning` , `info` , `none` , anything apart from these is shown as `warning`. 

**Screen shot:** 
![bad-alert-1](https://user-images.githubusercontent.com/22490998/106998779-0e2f9500-67ab-11eb-881c-ff4a52ca0971.png)

**Unit test coverage report:**
Updated existing tests

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge