### PR TITLE
Bug 1925175: fix incorrect quickstart highlight

### DIFF
--- a/frontend/public/components/nav/index.tsx
+++ b/frontend/public/components/nav/index.tsx
@@ -16,7 +16,7 @@ export const Navigation: React.FC<NavigationProps> = React.memo(
         <Nav aria-label="Nav" onSelect={onNavSelect} theme="dark">
           <NavHeader onPerspectiveSelected={onPerspectiveSelected} />
           <NavList>
-            <PerspectiveNav />
+            <PerspectiveNav isNavOpen={isNavOpen} />
           </NavList>
         </Nav>
       }

--- a/frontend/public/components/nav/index.tsx
+++ b/frontend/public/components/nav/index.tsx
@@ -13,12 +13,14 @@ export const Navigation: React.FC<NavigationProps> = React.memo(
   ({ isNavOpen, onNavSelect, onPerspectiveSelected }) => (
     <PageSidebar
       nav={
-        <Nav aria-label="Nav" onSelect={onNavSelect} theme="dark">
-          <NavHeader onPerspectiveSelected={onPerspectiveSelected} />
-          <NavList>
-            <PerspectiveNav isNavOpen={isNavOpen} />
-          </NavList>
-        </Nav>
+        isNavOpen ? (
+          <Nav aria-label="Nav" onSelect={onNavSelect} theme="dark">
+            <NavHeader onPerspectiveSelected={onPerspectiveSelected} />
+            <NavList>
+              <PerspectiveNav />
+            </NavList>
+          </Nav>
+        ) : null
       }
       isNavOpen={isNavOpen}
       theme="dark"

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -31,7 +31,11 @@ const getLabelForResource = (resource: string): string => {
   return model ? model.labelPlural : '';
 };
 
-const PerspectiveNav: React.FC<{}> = () => {
+type PerspectiveNavProps = {
+  isNavOpen?: boolean;
+};
+
+const PerspectiveNav: React.FC<PerspectiveNavProps> = ({ isNavOpen }) => {
   const [perspective] = useActivePerspective();
   const allItems = useExtensions<PluginNavSection | NavItem | SeparatorNavItem>(
     isNavSection,
@@ -104,7 +108,7 @@ const PerspectiveNav: React.FC<{}> = () => {
           .filter((p) => p !== null)
       : [];
 
-  return (
+  return isNavOpen ? (
     <>
       {orderedNavItems.map((item, index) => {
         if (isNavSection(item)) {
@@ -124,7 +128,7 @@ const PerspectiveNav: React.FC<{}> = () => {
         </NavGroup>
       ) : null}
     </>
-  );
+  ) : null;
 };
 
 export default PerspectiveNav;

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -31,11 +31,7 @@ const getLabelForResource = (resource: string): string => {
   return model ? model.labelPlural : '';
 };
 
-type PerspectiveNavProps = {
-  isNavOpen?: boolean;
-};
-
-const PerspectiveNav: React.FC<PerspectiveNavProps> = ({ isNavOpen }) => {
+const PerspectiveNav: React.FC<{}> = () => {
   const [perspective] = useActivePerspective();
   const allItems = useExtensions<PluginNavSection | NavItem | SeparatorNavItem>(
     isNavSection,
@@ -108,7 +104,7 @@ const PerspectiveNav: React.FC<PerspectiveNavProps> = ({ isNavOpen }) => {
           .filter((p) => p !== null)
       : [];
 
-  return isNavOpen ? (
+  return (
     <>
       {orderedNavItems.map((item, index) => {
         if (isNavSection(item)) {
@@ -128,7 +124,7 @@ const PerspectiveNav: React.FC<PerspectiveNavProps> = ({ isNavOpen }) => {
         </NavGroup>
       ) : null}
     </>
-  ) : null;
+  );
 };
 
 export default PerspectiveNav;


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-5329

# Issue
`Devperspectivenav` doesn't get removed from DOM like the `AdminNav` perspective does when nav is closed.

#Solution
remove `DevPerspectiveNav` from DOM when nav is closed.

# Test Data
Apply the following quickstart through YAML


```
apiVersion: console.openshift.io/v1
kind: ConsoleQuickStart
metadata:
  name: test-highlights
spec:
  description: Description here
  displayName: test highlights
  durationMinutes: 1
  introduction: Introduction here
  tasks:
    - description: |
        Perspective switcher: [link]{{highlight qs-perspective-switcher}}

        ### Admin perspective nav Links:
        - [Home]{{highlight qs-nav-home}}
        - [Operators]{{highlight qs-nav-operators}}
        - [Workloads]{{highlight qs-nav-workloads}}
        - [Serverless]{{highlight qs-nav-serverless}}
        - [Networking]{{highlight qs-nav-networking}}
        - [Storage]{{highlight qs-nav-storage}}
        - [Service catalog]{{highlight qs-nav-servicecatalog}}
        - [Compute]{{highlight qs-nav-compute}}
        - [User maganement]{{highlight qs-nav-usermanagement}}
        - [Administration]{{highlight qs-nav-administration}}

        ### Dev perspective nav Links:
        - [Add]{{highlight qs-nav-add}}
        - [Topology]{{highlight qs-nav-topology}}
        - [Search]{{highlight qs-nav-search}}
        - [Project]{{highlight qs-nav-project}}
        - [Helm]{{highlight qs-nav-helm}}

        ### Common nav Links:
        - [Builds]{{highlight qs-nav-builds}}
        - [Pipelines]{{highlight qs-nav-pipelines}}
        - [Monitoring]{{highlight qs-nav-monitoring}}

        ### Masthead Links:
        - [CloudShell]{{highlight qs-masthead-cloudshell}}
        - [Utility Menu]{{highlight qs-masthead-utilitymenu}}
        - [User Menu]{{highlight qs-masthead-usermenu}}
        - [Applications]{{highlight qs-masthead-applications}}
        - [Import]{{highlight qs-masthead-import}}
        - [Help]{{highlight qs-masthead-help}}
        - [Notifications]{{highlight qs-masthead-notifications}}
      title: test highlight
```


# Screenshots
![qs-highlight](https://user-images.githubusercontent.com/24852534/106905070-e811e280-6721-11eb-838f-f0cfb4573c01.gif)

# Tests
No tests altered

# Browser conformance
Chrome 88
