### PR TITLE
Bug 1924585: Fix translation for edit annotation

### DIFF
--- a/frontend/public/locales/zh/details-page.json
+++ b/frontend/public/locales/zh/details-page.json
@@ -44,7 +44,7 @@
   "Edit {{kind}}": "编辑 {{kind}}",
   "Edit labels": "编辑标签",
   "Edit Pod selector": "编辑 Pod 选择器",
-  "Edit annotations": "Pod 注解",
+  "Edit annotations": "编辑注解",
   "Edit Pod count": "编辑 Pod 数量",
   "Edit taints": "编辑污点",
   "Edit tolerations": "编辑容限",

--- a/frontend/public/locales/zh/modal.json
+++ b/frontend/public/locales/zh/modal.json
@@ -43,7 +43,7 @@
   "Pod selector": "Pod 选择器",
   "Determines the set of pods targeted by this {{kind: props.kind.label.toLowerCase()}}.": "确定 pod 集是这个{{kind: props.kind.label.toLowerCase()}}的目标。",
   "Duplicate keys found.": "找到重复的键。",
-  "Edit annotations": "Pod 注解",
+  "Edit annotations": "编辑注解",
   "Edit taints": "编辑污点",
   "Taints": "污点",
   "Key": "键",


### PR DESCRIPTION
The Chinese translation was incorrect. I updated it with the one provided by QE.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1924585.