### PR TITLE
Fix issues related to loading plugins via SERVER_FLAGS.consolePlugins

### DIFF
--- a/frontend/dynamic-demo-plugin/README.md
+++ b/frontend/dynamic-demo-plugin/README.md
@@ -28,6 +28,10 @@ the script, for example:
 yarn http-server -a 127.0.0.1
 ```
 
+See the plugin development section in
+[Console Dynamic Plugins README](/frontend/packages/console-dynamic-plugin-sdk/README.md) for details
+on how to run Bridge using local plugins.
+
 ## Deployment on cluster
 
 Console dynamic plugins are supposed to be deployed via [OLM operators](https://github.com/operator-framework).
@@ -41,6 +45,25 @@ Note that the `Service` exposing the HTTP server is annotated to have a signed
 [service serving certificate](https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html)
 generated and mounted into the image. This allows us to run the server with HTTP/TLS enabled, using
 a trusted CA certificate.
+
+## Enabling the plugin
+
+Once deployed on the cluster, demo plugin must be enabled before it can be loaded by Console.
+
+To enable the plugin manually, edit [Console operator](https://github.com/openshift/console-operator)
+config and make sure the plugin's name is listed in the `spec.plugins` sequence (add one if missing):
+
+```sh
+oc edit console.operator.openshift.io cluster
+```
+
+```yaml
+# ...
+spec:
+  plugins:
+    - console-demo-plugin
+# ...
+```
 
 ## Docker image
 
@@ -59,28 +82,4 @@ Following commands should be executed in Console repository root.
    docker push quay.io/$USER/console-demo-plugin
    ```
 
-To test a locally built demo plugin image, simply update and re-apply `oc-manifest.yaml`.
-
-
-## Enable plugin
-
-To enable a Console plugin on the OpenShift cluster you need to edit console-operator's config.
-There you need to list all the Console plugins that you want to enable.
-
-To update the console-operator config use:
-
-  ```sh
-  oc edit console.operator.openshift.io cluster
-  ```
-
-There you need to update the config's spec by adding `plugins` field with the list of enabled Console plugins.
-
-```yaml
-...
-spec:
-  plugins:
-    - console-demo-plugin
-...
-```
-
-Only enabled Console plugins will be served.
+Update and apply `oc-manifest.yaml` to use a custom plugin image.

--- a/frontend/dynamic-demo-plugin/oc-manifest.yaml
+++ b/frontend/dynamic-demo-plugin/oc-manifest.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: console-demo-plugin
-          image: quay.io/jhadvig/console-demo-plugin
+          image: quay.io/vszocs/console-demo-plugin
           ports:
             - containerPort: 9001
               protocol: TCP

--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf ./dist",
-    "build": "yarn clean && yarn ts-node ./node_modules/.bin/webpack",
+    "build": "yarn clean && NODE_ENV=production yarn ts-node ./node_modules/.bin/webpack",
+    "build-dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack",
     "http-server": "./http-server.sh ./dist",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}' -I '/node_modules/(?!(@console)/)/'"
   },
@@ -22,7 +23,9 @@
     "webpack-cli": "3.3.9"
   },
   "consolePlugin": {
-    "displayName": "Dynamic Demo Plugin",
+    "name": "console-demo-plugin",
+    "version": "0.0.0",
+    "displayName": "Console Demo Plugin",
     "description": "Plasma reactors online. Initiating hyper drive.",
     "exposedModules": {
       "barUtils": "./utils/bar"

--- a/frontend/dynamic-demo-plugin/webpack.config.ts
+++ b/frontend/dynamic-demo-plugin/webpack.config.ts
@@ -5,10 +5,10 @@ import * as path from 'path';
 import { ConsoleRemotePlugin } from '@console/dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin';
 
 const config: webpack.Configuration = {
+  mode: 'development',
   context: path.resolve(__dirname, 'src'),
   output: {
     path: path.resolve(__dirname, 'dist'),
-    publicPath: 'http://localhost:9001/',
     filename: '[name]-bundle.js',
     chunkFilename: '[name]-chunk.js',
   },
@@ -32,7 +32,6 @@ const config: webpack.Configuration = {
     ],
   },
   plugins: [new ConsoleRemotePlugin()],
-  mode: 'development',
   devtool: 'source-map',
   optimization: {
     chunkIds: 'named',
@@ -41,9 +40,9 @@ const config: webpack.Configuration = {
 };
 
 if (process.env.NODE_ENV === 'production') {
+  config.mode = 'production';
   config.output.filename = '[name]-bundle-[hash].min.js';
   config.output.chunkFilename = '[name]-chunk-[chunkhash].min.js';
-  config.mode = 'production';
   config.optimization.chunkIds = 'deterministic';
   config.optimization.minimize = true;
 }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
@@ -27,7 +27,7 @@ describe('fetchPluginManifest', () => {
     coFetch.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve(manifest) }));
     validatePluginManifestSchema.mockImplementation(() => Promise.resolve(validator.result));
 
-    const result = await fetchPluginManifest('http://example.com/test');
+    const result = await fetchPluginManifest('http://example.com/test/');
 
     expect(result).toBe(manifest);
     expect(coFetch).toHaveBeenCalledWith(manifestURL, { method: 'GET' });
@@ -40,7 +40,7 @@ describe('fetchPluginManifest', () => {
 
     expect.assertions(2);
     try {
-      await fetchPluginManifest('http://example.com/test');
+      await fetchPluginManifest('http://example.com/test/');
     } catch (e) {
       expect(coFetch).toHaveBeenCalled();
       expect(validatePluginManifestSchema).not.toHaveBeenCalled();
@@ -61,7 +61,7 @@ describe('fetchPluginManifest', () => {
 
     expect.assertions(2);
     try {
-      await fetchPluginManifest('http://example.com/test');
+      await fetchPluginManifest('http://example.com/test/');
     } catch (e) {
       expect(coFetch).toHaveBeenCalled();
       expect(validatePluginManifestSchema).toHaveBeenCalled();

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
@@ -17,8 +17,8 @@ export const validatePluginManifestSchema = async (
   const validator = new SchemaValidator(manifestURL);
   validator.validate(pluginManifestSchema, manifest, 'manifest');
 
-  validator.assert.nonEmptyString(manifest.name, 'manifest.name');
-  validator.assert.nonEmptyString(manifest.version, 'manifest.version');
+  validator.assert.validDNSSubdomainName(manifest.name, 'manifest.name');
+  validator.assert.validSemverString(manifest.version, 'manifest.version');
 
   if (_.isPlainObject(manifest.dependencies)) {
     Object.entries(manifest.dependencies).forEach(([depName, versionRange]) => {
@@ -30,7 +30,7 @@ export const validatePluginManifestSchema = async (
 };
 
 export const fetchPluginManifest = async (baseURL: string) => {
-  const url = resolveURL(baseURL, pluginManifestFile, { trailingSlashInBaseURL: true });
+  const url = resolveURL(baseURL, pluginManifestFile);
   // eslint-disable-next-line no-console
   console.info(`Loading plugin manifest from ${url}`);
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-manifest.ts
@@ -4,11 +4,7 @@ import { SupportedExtension } from './console-extensions';
 /**
  * Schema of Console plugin's `plugin-manifest.json` file.
  */
-export type ConsolePluginManifestJSON = {
-  /** Plugin name (unique identifier), e.g. `kubevirt`. */
-  name: string;
-  /** Plugin version (semver compliant), e.g. `1.2.3`. */
-  version: string;
+export type ConsolePluginManifestJSON = Omit<ConsolePluginMetadata, 'exposedModules'> & {
   /** List of extensions contributed by the plugin. */
   extensions: SupportedExtension[];
-} & Omit<ConsolePluginMetadata, 'exposedModules'>;
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-package.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/plugin-package.ts
@@ -4,6 +4,13 @@ import * as readPkg from 'read-pkg';
  * Console plugin metadata in `package.json` file.
  */
 export type ConsolePluginMetadata = {
+  /**
+   * Plugin name. Should be the same as `metadata.name` of the corresponding
+   * `ConsolePlugin` resource used to represent the plugin on the cluster.
+   */
+  name: string;
+  /** Plugin version. Must be semver compliant. */
+  version: string;
   /** User-friendly plugin name. */
   displayName?: string;
   /** User-friendly plugin description. */

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/url.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/url.ts
@@ -1,21 +1,13 @@
 /**
  * Resolve URL string using `base` and `to` URLs.
  *
- * Delegates to `new URL(to, base)` for the actual resolution.
+ * If `base` is missing the protocol, it's considered to be relative to document origin.
  *
  * @param base Base URL.
  * @param to Target resource URL.
  * @param options Resolution options.
  */
-export const resolveURL = (
-  base: string,
-  to: string,
-  options: {
-    trailingSlashInBaseURL: boolean;
-  } = {
-    trailingSlashInBaseURL: false,
-  },
-): string => {
-  const from = options.trailingSlashInBaseURL && !base.endsWith('/') ? `${base}/` : base;
-  return new URL(to, from).toString();
+export const resolveURL = (base: string, to: string) => {
+  const baseAbsoluteURL = base.indexOf('://') === -1 ? window.location.origin + base : base;
+  return new URL(to, baseAbsoluteURL).toString();
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ValidationAssertions.ts
@@ -4,9 +4,21 @@ import { ValidationResult } from './ValidationResult';
 export class ValidationAssertions {
   constructor(private readonly result: ValidationResult) {}
 
-  nonEmptyString(obj: any, objPath: string) {
+  // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+  validDNSSubdomainName(obj: any, objPath: string) {
     if (typeof obj === 'string') {
-      this.result.assertThat(obj.trim().length > 0, `${objPath} must not be empty`);
+      this.result.assertThat(
+        obj.length <= 253,
+        `${objPath} must contain no more than 253 characters`,
+      );
+      this.result.assertThat(
+        /^[a-z0-9-.]*$/.test(obj),
+        `${objPath} must contain only lowercase alphanumeric characters, '-' or '.'`,
+      );
+      this.result.assertThat(
+        /^[a-z0-9]+/.test(obj) && /[a-z0-9]+$/.test(obj),
+        `${objPath} must start and end with an alphanumeric character`,
+      );
     }
   }
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
@@ -40,8 +40,8 @@ export class ConsoleAssetPlugin {
     validateExtensionsFileSchema(ext).report();
 
     this.manifest = {
-      name: pkg.name,
-      version: pkg.version,
+      name: pkg.consolePlugin.name,
+      version: pkg.consolePlugin.version,
       displayName: pkg.consolePlugin.displayName,
       description: pkg.consolePlugin.description,
       dependencies: pkg.consolePlugin.dependencies,

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -6,7 +6,6 @@ import { ActivePlugin } from '@console/plugin-sdk/src/typings';
 import { initSubscriptionService } from '@console/plugin-sdk/src/api/subscribeToExtensions';
 import { fetchPluginManifest } from '@console/dynamic-plugin-sdk/src/runtime/plugin-manifest';
 import {
-  getPluginID,
   loadDynamicPlugin,
   registerPluginEntryCallback,
 } from '@console/dynamic-plugin-sdk/src/runtime/plugin-loader';
@@ -28,23 +27,8 @@ export const initConsolePlugins = _.once((reduxStore: Store<RootState>) => {
 
 const loadPluginFromURL = async (baseURL: string) => {
   const manifest = await fetchPluginManifest(baseURL);
-  loadDynamicPlugin(baseURL, manifest);
-  return getPluginID(manifest);
+  return await loadDynamicPlugin(baseURL, manifest);
 };
-
-// Load all dynamic plugins which are currently enabled on the cluster
-window.SERVER_FLAGS.consolePlugins.forEach((pluginName) => {
-  const url = `${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}`;
-
-  loadPluginFromURL(url)
-    .then((pluginID) => {
-      pluginStore.setDynamicPluginEnabled(pluginID, true);
-    })
-    .catch((error) => {
-      // eslint-disable-next-line no-console
-      console.error(`Error while loading plugin from ${url}`, error);
-    });
-});
 
 if (process.env.NODE_ENV !== 'production') {
   // Expose Console plugin store for debugging
@@ -60,3 +44,17 @@ if (process.env.NODE_ENV !== 'test') {
   // eslint-disable-next-line no-console
   console.info(`Dynamic plugins: [${window.SERVER_FLAGS.consolePlugins.join(', ')}]`);
 }
+
+// Load all dynamic plugins which are currently enabled on the cluster
+window.SERVER_FLAGS.consolePlugins.forEach((pluginName) => {
+  const url = `${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}/`;
+
+  loadPluginFromURL(url)
+    .then((pluginID) => {
+      pluginStore.setDynamicPluginEnabled(pluginID, true);
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(`Error while loading plugin from ${url}`, error);
+    });
+});


### PR DESCRIPTION
This PR is meant to address issues related to loading [dynamic plugins](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/README.md) via the standard Console plugin mechanism.

- Plugin name and version must be declared in `package.json` explicitly via `consolePlugin` object. Plugin name should be the same as `metadata.name` in the corresponding `ConsolePlugin` resource.
- Plugin webpack config's `output.publicPath` option defaults to `/api/plugins/<PluginName>/` Bridge endpoint if not specified. Plugin developers are encouraged to use this default endpoint.
- Plugin development process involves running Bridge locally and instructing it to proxy `/api/plugins/<PluginName>/` requests directly to the local plugin asset server.
- `loadDynamicPlugin` function is now async and resolves/rejects as expected.
- Plugin name and version validation improved and unified.
- Demo plugin scripts: `yarn build` = production build, `yarn build-dev` = development build.

:memo: _Note:_ existing [static plugins](https://github.com/openshift/console/blob/master/frontend/packages/console-plugin-sdk/README.md) are unaffected by this change.