### PR TITLE
adding global config extension types to dynamic-plugin-sdk

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/cluster-settings.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/cluster-settings.ts
@@ -1,0 +1,29 @@
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+
+export namespace ExtensionProperties {
+  export type ClusterGlobalConfig = {
+    /** Unique identifier for the cluster config resource instance. */
+    id: string;
+    /** The name of the cluster config resource instance. */
+    name: string;
+    /** The model which refers to a cluster config resource. */
+    model: {
+      group: string;
+      version: string;
+      kind: string;
+    };
+    /** The namespace of the cluster config resource instance. */
+    namespace: string;
+  };
+}
+
+// Extension types
+
+export type ClusterGlobalConfig = Extension<ExtensionProperties.ClusterGlobalConfig> & {
+  type: 'console.global-config';
+};
+
+// Type guards
+
+export const isClusterGlobalConfig = (e: Extension): e is ClusterGlobalConfig =>
+  e.type === 'console.global-config';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
@@ -5,6 +5,7 @@ import { StandaloneRoutePage } from '../extensions/pages';
 import { PVCCreateProp, PVCStatus, PVCAlert, PVCDelete } from '../extensions/pvc';
 import { YAMLTemplate } from '../extensions/yaml-templates';
 import { AddAction } from '../extensions/add-actions';
+import { ClusterGlobalConfig } from '../extensions/cluster-settings';
 
 export type SupportedExtension =
   | FeatureFlag
@@ -17,7 +18,8 @@ export type SupportedExtension =
   | PVCAlert
   | PVCDelete
   | YAMLTemplate
-  | AddAction;
+  | AddAction
+  | ClusterGlobalConfig;
 
 /**
  * Schema of Console plugin's `console-extensions.json` file.


### PR DESCRIPTION
- Improve code reference handling for Console dynamic plugins
- Fix type related errors
- Improve unit test for applyCodeRefSymbol
- Avoid require()'ing modules when generating @console/active-plugins
- adding global config extension types to dynamic-plugin-sdk

Depends on #7919
