### PR TITLE
make quickstart drawer resizable

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -112,7 +112,7 @@
     "@patternfly/patternfly": "4.87.1",
     "@patternfly/react-catalog-view-extension": "4.10.0",
     "@patternfly/react-charts": "6.14.0",
-    "@patternfly/react-core": "4.97.0",
+    "@patternfly/react-core": "4.97.2",
     "@patternfly/react-table": "4.23.0",
     "@patternfly/react-tokens": "4.10.0",
     "@patternfly/react-topology": "4.7.32",

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.scss
@@ -1,9 +1,4 @@
 .co-quick-start-panel-content {
-  @media (min-width: 769px) and (max-width: 1600px) {
-    &.pf-c-drawer__panel {
-      flex-basis: 275px;
-    }
-  }
   &-head {
     position: sticky;
     top: 0px;

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
@@ -45,7 +45,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   });
 
   return quickStart ? (
-    <DrawerPanelContent className="co-quick-start-panel-content">
+    <DrawerPanelContent isResizable>
       <div className={`co-quick-start-panel-content-head ${headerClasses}`}>
         <DrawerHead>
           <div className="co-quick-start-panel-content__title">

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1820,7 +1820,20 @@
     file-saver "^1.3.8"
     xterm "^3.3.0"
 
-"@patternfly/react-core@4.97.0", "@patternfly/react-core@^4.97.0":
+"@patternfly/react-core@4.97.2":
+  version "4.97.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.97.2.tgz#a389f6984d03ed730506fa3cdccb1355f37b04fc"
+  integrity sha512-Xl/l/+OjWVtWnbb9Kw//1bn+6KEM9aOc1nk+Vm6D8wlbuuz+RAFBc0rZjPWuq00YYnVA+sExESe0W2d3wdn/SQ==
+  dependencies:
+    "@patternfly/react-icons" "^4.9.2"
+    "@patternfly/react-styles" "^4.8.2"
+    "@patternfly/react-tokens" "^4.10.2"
+    focus-trap "6.2.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "1.13.0"
+
+"@patternfly/react-core@^4.97.0":
   version "4.97.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.97.0.tgz#b5e77a32cefcfef046eddae406b3b93a901ff36d"
   integrity sha512-HNjk9wJtLRXYy3faodNqFsL4xWqpu+imnoTeTq+2B3kNLiRW1GNgZ2MQtDZ96zMloAeqYPGfeHKCk7wfrhV7kw==
@@ -1838,10 +1851,20 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.0.tgz#6169facdce016b81eabd2384445558ec2a2f4fed"
   integrity sha512-riJQnf+V5clbPSqD0bqMeMCziwSdIMot8GAigG62eXaT+w5teBisk29t3Dc1DuWq7n6s5WWNzOZ5S42cmU2Edw==
 
+"@patternfly/react-icons@^4.9.2":
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.2.tgz#dcb2efa9727de97d5aa5d6be47a75daee49addb8"
+  integrity sha512-3PY81A9mj9YyUpznSWhcWMKHRyGWNgZ1IDYqbMva7Q8wgd0fjsiTJ+5zAp4YQLo1mA8KwYX9v5s37hK8XiTbAA==
+
 "@patternfly/react-styles@^4.8.0":
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.0.tgz#1f496f8ecf68dd75ce7713018efeb94a4c99d8c4"
   integrity sha512-++odmYozQPJv9UbZyJU/sgb7uAHhHYLSS8rP5zNVoqFQJN9oYwgDOrWFL2m5gY4x0k3qa0XI2WXhBLoaxxX6sQ==
+
+"@patternfly/react-styles@^4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.2.tgz#4796a77b658541d75d616e2e2a00fc5d7ec42bc7"
+  integrity sha512-JLVZTUYa8LIyASLvfiAgByLgNcg+OPkuXSh8Za5KdjqrBaNVQ3Wlul+oWQGwlGjbq7KSiyDg1oWemxOuLJH1VQ==
 
 "@patternfly/react-table@4.23.0":
   version "4.23.0"
@@ -1860,6 +1883,11 @@
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.0.tgz#251fe04416d78e4fd124f2e0c5e1f3b71a320edf"
   integrity sha512-jweUTx/QV6sDmYySrsMrMVhmPlQwSv5bn/BPnjpNZJuny9wBMoG3rsfx+UYaliIwYGrQColxSVW+aYmJgkJezw==
+
+"@patternfly/react-tokens@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.2.tgz#fd0054379ac81c8490b901b5b8fb408263ce91fe"
+  integrity sha512-/G1MENPxVY7X9UUuieO79yfjJ3g6KjBUBsBQVKOQplCxuvcRCF1MpmQKAxfg9Yb804MbPY+IVzVD3c4u9S3Iww==
 
 "@patternfly/react-topology@4.7.32":
   version "4.7.32"


### PR DESCRIPTION
**Story**: 
https://issues.redhat.com/browse/ODC-5444
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
Make quick start drawer resizable, and undo changes made in #7607 so that drawer is resizable on smaller screens
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/107213953-30394980-6a2f-11eb-8d06-af17c55a59a8.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
