### PR TITLE
Interop UI install helmchart

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/helm/install-HelmChart.feature
+++ b/frontend/packages/dev-console/integration-tests/features/helm/install-HelmChart.feature
@@ -3,7 +3,7 @@ Feature: Install the Helm Release
 
     Background:
         Given user is at developer perspective
-        And user has created or selected namespace "aut-helm-installation-1"
+        And user has created or selected namespace "aut-helm-installation"
 
 
     @smoke
@@ -12,7 +12,7 @@ Feature: Install the Helm Release
         Then user can see "Helm Chart" card on the Add page
 
 
-    @smoke
+    @smoke, @manual
     Scenario: Developer Catalog Page when Helm Charts checkbox is selected: HR-01-TC02, HR-02-TC02
         Given user is at Add page
         And user has added multiple helm charts repositories
@@ -42,7 +42,7 @@ Feature: Install the Helm Release
 
     @smoke
     Scenario: Install Helm Chart from +Add Page using Form View: HR-02-TC01
-        Given user has created or selected namespace "aut-helm-installation-2"
+        Given user has created or selected namespace "aut-helm-installation"
         And user is at Add page
         When user selects "Helm Chart" card from add page
         And user searches "Nodejs Ex K v0.2.1" card from catalog page
@@ -57,7 +57,7 @@ Feature: Install the Helm Release
     @regression
     Scenario: Chart versions drop down menu
         Given user is at Add page
-        And user is at Developer Catalog page
+        When user selects "Helm Chart" card from add page
         And user searches 'Nodejs Ex K v0.2.1' card from catalog page
         And user selects "Nodejs Ex K v0.2.1" helm chart from catalog page
         And user will see the information of all the chart versions together
@@ -76,7 +76,7 @@ Feature: Install the Helm Release
         And modal will have the warning of data lost
 
 
-    @regression
+    @regression, @manual
     Scenario: README should be updated when chart version is updated
         Given user is at Install Helm Chart page
         Then user will see the chart version dropdown

--- a/frontend/packages/dev-console/integration-tests/support/commands/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/app.ts
@@ -16,6 +16,8 @@ declare global {
         dropdownText: string,
       ): Chainable<Element>;
       selectActionsMenuOption(actionsMenuOption: string): Chainable<Element>;
+      dropdownSwitchTo(dropdownMenuOption: string): Chainable<Element>;
+      isDropdownVisible(): Chainable<Element>;
     }
   }
 }
@@ -94,4 +96,20 @@ Cypress.Commands.add('selectActionsMenuOption', (actionsMenuOption: string) => {
   cy.byTestActionID(actionsMenuOption)
     .should('be.visible')
     .click();
+});
+
+Cypress.Commands.add('dropdownSwitchTo', (dropdownMenuOption: string) => {
+  cy.byLegacyTestID('dropdown-button')
+    .click()
+    .get('.pf-c-dropdown__menu')
+    .contains(dropdownMenuOption)
+    .click();
+});
+
+Cypress.Commands.add('isDropdownVisible', () => {
+  cy.byLegacyTestID('dropdown-button')
+    .should('be.visible')
+    .click()
+    .get('.pf-c-dropdown__menu')
+    .should('be.visible');
 });

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -1,4 +1,4 @@
-export const cardTitle = 'div.catalog-tile-pf-title';
+export const cardTitle = '.catalog-tile-pf-title';
 
 export const gitPO = {
   noWorkLoadsText: 'h2.co-hint-block__title',
@@ -128,6 +128,7 @@ export const catalogPO = {
     yamlView: '#form-radiobutton-editorType-yaml-field',
     formView: '#form-radiobutton-editorType-form-field',
     cancel: '[data-test-id="reset-button"]',
+    chartVersion: '#form-dropdown-chartVersion-field',
   },
   s2I: {
     gitRepoUrl: '[data-test-id="git-form-input-url"]',

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -24,7 +24,7 @@ export const helmPO = {
   uninstallHelmRelease: {
     releaseName: '#form-input-resourceName-field',
   },
-  sidebarPage: {
+  sidePane: {
     chartVersion: '.properties-side-panel-pf-property-value',
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -34,6 +34,9 @@ export const addPage = {
       case 'From Catalog':
       case addOptions.DeveloperCatalog:
         cy.byLegacyTestID('dev-catalog').click();
+        cy.document()
+          .its('readyState')
+          .should('eq', 'complete');
         detailsPage.titleShouldContain(pageTitle.DeveloperCatalog);
         break;
       case 'Database':
@@ -77,6 +80,7 @@ export const addPage = {
   verifyCard: (cardName: string) =>
     cy
       .get(cardTitle)
-      .contains(cardName)
+      .parent('div')
+      .should('contain.text', cardName)
       .should('be.visible'),
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -3,7 +3,7 @@ import { pageTitle } from '../../constants/pageTitle';
 import { addPage } from './add-page';
 import { addOptions, catalogCards, catalogTypes } from '../../constants/add';
 import { topologyHelper } from '../topology/topology-helper-page';
-import { devNavigationMenuPO } from '../../pageObjects/global-po';
+import { helmPO } from '../../pageObjects/helm-po';
 
 export const catalogPage = {
   verifyTitle: () => cy.pageTitleShouldContain('Developer Catalog'),
@@ -125,15 +125,8 @@ export const catalogPage = {
 };
 
 export const catalogInstallPageObj = {
-  installHelmChart: {
-    install: '[data-test-id="submit-button"]',
-    chartVersion: '#form-dropdown-chartVersion-field',
-    yamlView: '#form-radiobutton-editorType-yaml-field',
-  },
-  selectHelmChartVersion: (version: string) =>
-    cy.selectByDropDownText(devNavigationMenuPO.dropdownButton, version),
-  verifyChartVersionDropdownAvailable: () =>
-    cy.verifyDropdownselected(devNavigationMenuPO.dropdownButton),
+  selectHelmChartVersion: (version: string) => cy.dropdownSwitchTo(version),
+  verifyChartVersionDropdownAvailable: () => cy.isDropdownVisible(),
   selectChangeOfChartVersionDialog: (option: string) => {
     if (option === 'Proceed') {
       cy.get('#confirm-action').click();
@@ -141,4 +134,13 @@ export const catalogInstallPageObj = {
       cy.byLegacyTestID('modal-cancel-action').click();
     }
   },
+  selectHelmChartCard: (cardName: string) => cy.dropdownSwitchTo(cardName),
+};
+
+export const sidePaneObj = {
+  verifyChartVersion: () =>
+    cy
+      .get(helmPO.sidePane.chartVersion)
+      .eq(0)
+      .should('have.text', '0.2.1'),
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/common.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/common.ts
@@ -1,9 +1,0 @@
-import { helmPO } from '../pageObjects/helm-po';
-
-export const sidebarPage = {
-  verifyChartVersion: () =>
-    cy
-      .get(helmPO.sidebarPage.chartVersion)
-      .eq(0)
-      .should('have.text', '0.2.1'),
-};

--- a/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-helper-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-helper-page.ts
@@ -9,5 +9,8 @@ export const topologyHelper = {
   verifyWorkloadInTopologyPage: (appName: string) => {
     topologyHelper.search(appName);
     cy.get(topologyPO.search).should('be.visible');
+    cy.document()
+      .its('readyState')
+      .should('eq', 'complete');
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sidebar.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-sidebar.ts
@@ -1,11 +1,10 @@
 import { When } from 'cypress-cucumber-preprocessor/steps';
-import { catalogPage } from '../../pages/add-flow/catalog-page';
-import { sidebarPage } from '../../pages/common';
+import { catalogPage, sidePaneObj } from '../../pages/add-flow/catalog-page';
 
 When('user clicks on the Install Helm Chart button on side bar', () => {
   catalogPage.clickButtonOnCatalogPageSidePane();
 });
 
 When('user will see the information of all the chart versions together', () => {
-  sidebarPage.verifyChartVersion();
+  sidePaneObj.verifyChartVersion();
 });

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
@@ -28,8 +28,10 @@ Given('user has created namespace starts with {string}', (projectName: string) =
 });
 
 Given('user has created or selected namespace {string}', (projectName: string) => {
-  projectNameSpace.selectOrCreateProject(`${projectName}`);
-  cy.log(`User has selected namespace "${projectName}"`);
+  const d = new Date();
+  const timestamp = d.getTime();
+  projectNameSpace.selectOrCreateProject(`${projectName}-${timestamp}-ns`);
+  cy.log(`User has selected namespace "${projectName}-${timestamp}-ns"`);
 });
 
 Given('user is at pipelines page', () => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm.ts
@@ -1,9 +1,13 @@
 import { When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { catalogPage, catalogInstallPageObj } from '../../pages/add-flow/catalog-page';
+import { catalogPO } from '../../pageObjects/add-flow-po';
 import { topologyHelper } from '../../pages/topology/topology-helper-page';
 
 When('user selects YAML view', () => {
-  cy.get(catalogInstallPageObj.installHelmChart.yamlView).click();
+  cy.document()
+    .its('readyState')
+    .should('eq', 'complete');
+  cy.get(catalogPO.installHelmChart.yamlView).click();
 });
 
 When('user selects the Chart Version {string}', (chartVersion: string) => {


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/HELM-66

Problem: Automation to scenarios including installing helm chart and installation view

Solution: Is to automate all the scenarios including smoke and regression tags. 

Test Setup:
Add @regression under env.tags in cypress.json
Run yarn run test-cypress-devconsole in frontend
Execute feature file: frontend/packages/dev-console/integration-tests/features/helm/install-HelmChart.feature
Execute feature file: frontend/packages/dev-console/integration-tests/features/helm/helm-Installation-View.feature

Test Execution result: Results attached in the above JIRA ticket