### PR TITLE
Bug 1891766: Disable submit button for incorrect validations (LSO/OCS local volume set)

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/create-sc.tsx
@@ -222,6 +222,7 @@ const CreateSC: React.FC<CreateSCProps> = ({ match, hasNoProvSC, mode, lsoNs }) 
       case CreateStepsSC.STORAGECLASS:
         if (!state.volumeSetName.trim().length) return true;
         if (state.filteredNodes.length < MINIMUM_NODES) return true;
+        if (!state.isValidDiskSize) return true;
         return !state.volumeSetName.trim().length;
       case CreateStepsSC.STORAGEANDNODES:
         return state.nodes.length < MINIMUM_NODES || !getName(state.storageClass);

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices/create-sc/state.ts
@@ -15,6 +15,7 @@ export const initialState: State = {
   volumeSetName: '',
   storageClassName: '',
   showNodesListOnLVS: false,
+  isValidDiskSize: true,
   diskType: 'All',
   diskMode: diskModeDropdownItems.BLOCK,
   deviceType: [deviceTypeDropdownItems.DISK, deviceTypeDropdownItems.PART],
@@ -110,6 +111,7 @@ export type State = {
   volumeSetName: string;
   storageClassName: string;
   showNodesListOnLVS: boolean;
+  isValidDiskSize: boolean;
   diskType: string;
   diskMode: string;
   deviceType: string[];
@@ -154,6 +156,7 @@ export type Action =
   | { type: 'setVolumeSetName'; name: string }
   | { type: 'setStorageClassName'; name: string }
   | { type: 'setShowNodesListOnLVS'; value: boolean }
+  | { type: 'setIsValidDiskSize'; value: boolean }
   | { type: 'setDiskType'; value: string }
   | { type: 'setDeviceType'; value: string[] }
   | { type: 'setDiskMode'; value: string }
@@ -203,6 +206,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { storageClassName: action.name });
     case 'setShowNodesListOnLVS':
       return Object.assign({}, state, { showNodesListOnLVS: action.value });
+    case 'setIsValidDiskSize':
+      return Object.assign({}, state, { isValidDiskSize: action.value });
     case 'setDiskType':
       return Object.assign({}, state, { diskType: action.value });
     case 'setDiskMode':

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/create-local-volume-set.tsx
@@ -62,6 +62,7 @@ const CreateLocalVolumeSet: React.FC = withHandlePromise<
   const getDisabledCondition = () => {
     if (!state.volumeSetName.trim().length) return true;
     if (state.showNodesListOnLVS && state.nodeNames.length < 1) return true;
+    if (!state.isValidDiskSize) return true;
     return false;
   };
 

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/local-volume-set-inner.tsx
@@ -65,6 +65,14 @@ export const LocalVolumeSetInner: React.FC<LocalVolumeSetInnerProps> = ({
     state.maxDiskSize !== '' &&
     Number(state.minDiskSize) > Number(state.maxDiskSize);
 
+  React.useEffect(() => {
+    if (!validMinDiskSize || !validMaxDiskSize || !validMaxDiskLimit || invalidMinGreaterThanMax) {
+      dispatch({ type: 'setIsValidDiskSize', value: false });
+    } else {
+      dispatch({ type: 'setIsValidDiskSize', value: true });
+    }
+  }, [dispatch, validMinDiskSize, validMaxDiskSize, validMaxDiskLimit, invalidMinGreaterThanMax]);
+
   return (
     <>
       <FormGroup

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -5,6 +5,7 @@ export const initialState = {
   volumeSetName: '',
   storageClassName: '',
   showNodesListOnLVS: false,
+  isValidDiskSize: true,
   diskType: 'All',
   diskMode: diskModeDropdownItems.BLOCK,
   deviceType: [],
@@ -21,6 +22,7 @@ export type State = {
   volumeSetName: string;
   storageClassName: string;
   showNodesListOnLVS: boolean;
+  isValidDiskSize: boolean;
   diskType: string;
   diskMode: string;
   deviceType: string[];
@@ -37,6 +39,7 @@ export type Action =
   | { type: 'setVolumeSetName'; name: string }
   | { type: 'setStorageClassName'; name: string }
   | { type: 'setShowNodesListOnLVS'; value: boolean }
+  | { type: 'setIsValidDiskSize'; value: boolean }
   | { type: 'setDiskType'; value: string }
   | { type: 'setDiskMode'; value: string }
   | { type: 'setMaxDiskLimit'; value: string }
@@ -56,6 +59,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { storageClassName: action.name });
     case 'setShowNodesListOnLVS':
       return Object.assign({}, state, { showNodesListOnLVS: action.value });
+    case 'setIsValidDiskSize':
+      return Object.assign({}, state, { isValidDiskSize: action.value });
     case 'setDiskType':
       return Object.assign({}, state, { diskType: action.value });
     case 'setDiskMode':


### PR DESCRIPTION
Before:
"Next" button is enabled even if user has entered a wrong disk size/limit value.
![Screenshot from 2021-02-08 18-23-17](https://user-images.githubusercontent.com/39404641/107222724-4b11bb00-6a3b-11eb-951b-e602aa8b4ba3.png)

After:
"Next" button will be disabled if user enters a incorrect disk size/limit value.
![Screenshot from 2021-02-08 18-19-18](https://user-images.githubusercontent.com/39404641/107222743-506f0580-6a3b-11eb-8620-3d706a09a8b9.png)
