### PR TITLE
Interop UI Helm Topology

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -25,3 +25,11 @@ export enum operators {
   KnativeCamelOperator = 'Knative Apache Camel K',
   EclipseCheOperator = 'Eclipse Che',
 }
+
+export enum resources {
+  Deploymentconfigs = 'Deployment Configs',
+  Buildconfigs = 'Build Configs',
+  Services = 'Services',
+  Imagestreams = 'Image Streams',
+  Routes = 'Routes',
+}

--- a/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-page.ts
@@ -94,8 +94,10 @@ export const topologyPage = {
       .should('contain.text', sideBarTabs.details);
     cy.get(topologyPO.sidePane.tabName)
       .eq(1)
-      .should('contain.text', sideBarTabs.resources);
-    cy.get(topologyPO.sidePane.tabName).should('contain.text', sideBarTabs.releaseNotes);
+      .should('contain.text', 'Resources');
+    cy.get(topologyPO.sidePane.tabs)
+      .eq(2)
+      .should('contain.text', 'Release notes');
   },
   appNode: (appName: string) => {
     return cy.get(`[data-id="group:${appName}"] g.odc-resource-icon text`).contains('A');

--- a/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-side-pane-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/topology/topology-side-pane-page.ts
@@ -2,6 +2,7 @@ import { topologyPO } from '../../pageObjects/topology-po';
 import { topologyActions } from './topology-actions-page';
 import { nodeActions } from '../../constants/topology';
 import { modal } from '../../../../../integration-tests-cypress/views/modal';
+import { resources } from '../../constants/global';
 
 export const topologySidePane = {
   verify: () => cy.get(topologyPO.sidePane.dialog).should('be.visible'),
@@ -103,5 +104,38 @@ export const topologySidePane = {
   },
   verifyPipelineRuns: () => {
     cy.get(topologyPO.sidePane.resourcesTab.pipelineRuns).should('be.visible');
+  },
+  selectResource: (opt: resources | string) => {
+    const namespace = Cypress.env('namespace');
+    switch (opt) {
+      case 'Deployment Configs':
+      case resources.Deploymentconfigs: {
+        cy.get(`[href="/k8s/ns/${namespace}/deploymentconfigs/nodejs-example"]`).click();
+        break;
+      }
+      case 'Build Configs':
+      case resources.Buildconfigs: {
+        cy.get(`[href="/k8s/ns/${namespace}/buildconfigs/nodejs-example"]`).click();
+        break;
+      }
+      case 'Services':
+      case resources.Services: {
+        cy.get(`[href="/k8s/ns/${namespace}/services/nodejs-example"]`).click();
+        break;
+      }
+      case 'Image Streams':
+      case resources.Imagestreams: {
+        cy.get(`[href="/k8s/ns/${namespace}/imagestreams/nodejs-example"]`).click();
+        break;
+      }
+      case 'Routes':
+      case resources.Routes: {
+        cy.get(`[href="/k8s/ns/${namespace}/routes/nodejs-example"]`).click();
+        break;
+      }
+      default: {
+        throw new Error('resource is not available');
+      }
+    }
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/addFlow.ts
@@ -57,10 +57,6 @@ When('user clicks Instantiate Template button on side bar', () => {
   catalogPage.clickButtonOnCatalogPageSidePane();
 });
 
-Given('user is at Developer Catalog page', () => {
-  addPage.selectCardFromOptions(addOptions.DeveloperCatalog);
-});
-
 Given('user is at DevFile page', () => {
   addPage.selectCardFromOptions(addOptions.DevFile);
 });

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm-release.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/helm/helm-release.ts
@@ -97,9 +97,37 @@ When('user clicks on the Uninstall button', () => {
 });
 
 Then('user will be redirected to Topology page with no workloads', () => {
-  cy.document()
-    .its('readyState')
-    .should('eq', 'complete');
   topologyPage.verifyTitle();
   topologyPage.verifyNoWorkLoadsText('No resources found');
+});
+
+When('user clicks on the helm release {string}', (helmReleaseName: string) => {
+  topologyPage.clickOnNode(helmReleaseName);
+});
+
+Then('user will see the sidebar for the helm release', () => {
+  topologySidePane.verify();
+});
+
+Then('user will see the Details, Resources, Release notes tabs', () => {
+  topologyPage.verifyHelmReleaseSidePaneTabs();
+});
+
+Given('user is on the topology sidebar of the helm release {string}', (helmReleaseName: string) => {
+  cy.get('g.odc-base-node__label')
+    .should('be.visible')
+    .contains(helmReleaseName)
+    .click({ force: true });
+  topologySidePane.verify();
+});
+
+Then('user will see the {string} action item', (actionItem: string) => {
+  cy.byTestActionID(actionItem).should('be.visible');
+});
+
+Then('user is redirected to the {string} Details page for the helm release', (resource: string) => {
+  cy.get(`[data-test-section-heading="${resource} details"]`).should(
+    'contain.text',
+    `${resource} details`,
+  );
 });

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/topology.ts
@@ -37,3 +37,11 @@ Then('side bar is displayed with the pipelines section', () => {
   topologySidePane.verifyTab('Resources');
   topologySidePane.verifySection('Pipeline Runs');
 });
+
+When('user switches to the {string} tab', (tab: string) => {
+  topologySidePane.selectTab(tab);
+});
+
+When('user clicks on the link for the {string} of helm release', (resource: string) => {
+  topologySidePane.selectResource(resource);
+});


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/HELM-15, https://issues.redhat.com/browse/HELM-67

Problem: Automation to scenarios related to topology on helm release
* Open Side Bar for the Helm release
* Deployment Configs link on the sidebar for the Helm Release
* Build Configs link on the sidebar for the Helm Release
* Services link on the sidebar for the Helm Release
* Image Streams link on the sidebar for the Helm Release
* Routes link on the sidebar for the Helm Release
* Actions drop down on the side bar

Solution: Is to automate all the scenarios including smoke and regression tags.

Test Setup:
Add @Regression under env.tags in cypress.json
Run yarn run test-cypress-devconsole in frontend
Execute feature file: frontend/packages/dev-console/integration-tests/features/helm/topology-HelmRelease.feature

Test Execution result: Results attached in the above JIRA ticket