### PR TITLE
add copy to clipboard functionality to EventListenerURL

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerURL.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerURL.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ExternalLink } from '@console/internal/components/utils';
+import { ClipboardCopy } from '@patternfly/react-core';
 import { EventListenerKind } from '../resource-types';
 import { useEventListenerURL } from '../utils/triggers';
 
@@ -20,7 +20,7 @@ const EventListenerURL: React.FC<EventListenerURLProps> = ({ eventListener, name
         <dl>
           <dt>{t('pipelines-plugin~URL')}</dt>
           <dd>
-            <ExternalLink href={routeURL} text={routeURL} />
+            <ClipboardCopy isReadOnly>{routeURL}</ClipboardCopy>
           </dd>
         </dl>
       </div>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/EventListenerURL.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/EventListenerURL.spec.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { ClipboardCopy } from '@patternfly/react-core';
+import EventListenerURL from '../EventListenerURL';
+import { useEventListenerURL } from '../../utils/triggers';
+import {
+  EventlistenerTestData,
+  EventlistenerTypes,
+} from '../../../../test-data/event-listener-data';
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+jest.mock('../../utils/triggers', () => ({ useEventListenerURL: jest.fn<string | null>() }));
+
+type EventListenerURLProps = React.ComponentProps<typeof EventListenerURL>;
+
+describe('EventListenerURL', () => {
+  let wrapper: ShallowWrapper<EventListenerURLProps>;
+  const mockEventListener = EventlistenerTestData[EventlistenerTypes.TRIGGER_REF];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return an empty render if a routeURL does not exist', () => {
+    (useEventListenerURL as jest.Mock).mockReturnValueOnce(null);
+    wrapper = shallow(
+      <EventListenerURL eventListener={mockEventListener} namespace="test-namespace" />,
+    );
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('should return render the URL if a routeURL exists', () => {
+    (useEventListenerURL as jest.Mock).mockReturnValueOnce('test-URL');
+    wrapper = shallow(
+      <EventListenerURL eventListener={mockEventListener} namespace="test-namespace" />,
+    );
+    expect(wrapper.find(ClipboardCopy)).toBeTruthy();
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.scss
@@ -1,6 +1,3 @@
 .odc-trigger-template-list {
   margin-bottom: var(--pf-global--spacer--lg);
-  &__url {
-    margin-left: 30px;
-  }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { ResourceLink } from '@console/internal/components/utils';
 import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
+import { ClipboardCopy } from '@patternfly/react-core';
 import { RouteTemplate } from '../utils/triggers';
 import './TriggerTemplateResourceLink.scss';
 
@@ -34,11 +35,7 @@ const TriggerTemplateResourceLink: React.FC<TriggerTemplateResourceLinkProps> = 
                 title={triggerTemplateName}
                 inline
               />
-              {routeURL && (
-                <div className="odc-trigger-template-list__url">
-                  <ExternalLink href={routeURL} text={routeURL} />
-                </div>
-              )}
+              {routeURL && <ClipboardCopy isReadOnly>{routeURL}</ClipboardCopy>}
             </dd>
           );
         })}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/__tests__/TriggerTemplateResourceLink.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/__tests__/TriggerTemplateResourceLink.spec.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { ClipboardCopy } from '@patternfly/react-core';
+import { ResourceLink } from '@console/internal/components/utils';
+import TriggerTemplateResourceLink from '../TriggerTemplateResourceLink';
+import { TriggerTemplateModel } from '../../../../models';
+
+type TriggerTemplateResourceLinkProps = React.ComponentProps<typeof TriggerTemplateResourceLink>;
+describe('TriggerTemplateResourceLink', () => {
+  const props: TriggerTemplateResourceLinkProps = {
+    namespace: 'test-ns',
+    model: TriggerTemplateModel,
+    links: [
+      { routeURL: 'test-URL-1', triggerTemplateName: 'trigger1' },
+      { routeURL: 'test-URL-2', triggerTemplateName: 'trigger2' },
+    ],
+  };
+  let wrapper: ShallowWrapper<TriggerTemplateResourceLinkProps>;
+  beforeEach(() => {
+    wrapper = shallow(<TriggerTemplateResourceLink {...props} />);
+  });
+  it('should render null if links are empty', () => {
+    wrapper.setProps({ links: [] });
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('should render links if the links are passed', () => {
+    expect(wrapper.find(ResourceLink)).toHaveLength(2);
+    expect(wrapper.find(ClipboardCopy)).toHaveLength(2);
+  });
+
+  it('should not render routeURL if a link has null for routeURL', () => {
+    wrapper.setProps({
+      links: [
+        { routeURL: 'test-URL-1', triggerTemplateName: 'trigger1' },
+        { routeURL: null, triggerTemplateName: 'trigger2' },
+      ],
+    });
+    expect(wrapper.find(ResourceLink)).toHaveLength(2);
+    expect(wrapper.find(ClipboardCopy)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Story:
https://issues.redhat.com/browse/ODC-4283
 
Problem:
For adding a webhook to a Git repository, user has to copy the EventListener URL and paste in the Git provider webhook settings. Copying a URL using the mouse curse to select and copy is cumbersome and leads to unintentionally opening of the link and copying invalid trailing characters.

Solution:
Provide a copy-to-clipboard icon near EventListener url on the PipelineDetails page for user to copy the EventListener URL

Screens:
**PipelineDetails page**
![Screenshot from 2021-02-11 23-54-03](https://user-images.githubusercontent.com/38663217/107680950-7bb85580-6cc4-11eb-9717-b0cc8bf74ff4.png)
![Screenshot from 2021-02-11 19-56-29](https://user-images.githubusercontent.com/38663217/107681000-8b379e80-6cc4-11eb-8176-b5254835fbf9.png)



**EventListenerDetails page**
![Screenshot from 2021-02-11 23-53-42](https://user-images.githubusercontent.com/38663217/107681107-a73b4000-6cc4-11eb-8110-95ea5721bde3.png)
![Screenshot from 2021-02-11 19-57-29](https://user-images.githubusercontent.com/38663217/107681132-b15d3e80-6cc4-11eb-8e34-556b200d6631.png)

Test Coverage:
![Screenshot from 2021-02-08 22-17-36](https://user-images.githubusercontent.com/38663217/107252566-7c9a7e80-6a5b-11eb-8578-5d6d462243b2.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge