### PR TITLE
i18n: avoid 404 errors attempting to load en-US

### DIFF
--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -33,7 +33,7 @@ i18n
       },
       lng: localStorage.getItem('bridge/language'),
       fallbackLng: 'en',
-      load: 'all',
+      load: 'languageOnly',
       debug: process.env.NODE_ENV === 'development',
       detection: { caches: [] },
       contextSeparator: '~',


### PR DESCRIPTION
Configure i18next to only the language instead of the full locale
to avoid 404 errors on console load. This improves the load time of
console since we have many namespaces.

https://www.i18next.com/overview/configuration-options

/assign @rebeccaalpert 