### PR TITLE
Bug 1926072: Fix close button in the new 'Storage cluster exists' warning alert modal

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -188,7 +188,7 @@
   "Storage Cluster exists": "Storage Cluster exists",
   "Back to operator page": "Back to operator page",
   "Go to cluster page": "Go to cluster page",
-  "clusterExistText": "A storage cluster <1>{{clusterName}}</1> is already created.<3></3>You cannot create another storage cluster.",
+  "clusterExistText": "A storage cluster <1>{{clusterName}}</1> already exists.<3></3>You cannot create another storage cluster.",
   "Create Storage Cluster": "Create Storage Cluster",
   "OCS runs as a cloud-native service for optimal integration with applications in need of storage and handles the scenes such as provisioning and management.": "OCS runs as a cloud-native service for optimal integration with applications in need of storage and handles the scenes such as provisioning and management.",
   "The selected nodes will be labeled with <1>{{label}}</1> (unless they are already labeled). {{replica}} of the selected nodes will be used for initial deployment. The remaining nodes will be used by OpenShift as scheduling targets for OCS scaling.": "The selected nodes will be labeled with <1>{{label}}</1> (unless they are already labeled). {{replica}} of the selected nodes will be used for initial deployment. The remaining nodes will be used by OpenShift as scheduling targets for OCS scaling.",

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/existing-cluster-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/existing-cluster-modal.tsx
@@ -24,6 +24,17 @@ const ExistingClusterModal: React.FC<ExistingClusterModalProps> = ({ match, stor
     OCSServiceModel,
   )}/${clusterName}`;
 
+  const storageClusterListPage = `${resourcePathFromModel(
+    ClusterServiceVersionModel,
+    appName,
+    ns,
+  )}/${referenceForModel(OCSServiceModel)}`;
+
+  const onClose = () => {
+    setIsOpen(false);
+    history.push(storageClusterListPage);
+  };
+
   const onConfirm = () => {
     setIsOpen(false);
     history.push(resourcePathFromModel(ClusterServiceVersionModel, appName, ns));
@@ -39,6 +50,7 @@ const ExistingClusterModal: React.FC<ExistingClusterModalProps> = ({ match, stor
       title={t('ceph-storage-plugin~Storage Cluster exists')}
       titleIconVariant="warning"
       isOpen={isOpen}
+      onClose={onClose}
       variant="small"
       isFullScreen={false}
       actions={[
@@ -51,7 +63,7 @@ const ExistingClusterModal: React.FC<ExistingClusterModalProps> = ({ match, stor
       ]}
     >
       <Trans t={t} ns="ceph-storage-plugin" i18nKey="clusterExistText">
-        A storage cluster <Link to={storageClusterPath}>{{ clusterName }}</Link> is already created.
+        A storage cluster <Link to={storageClusterPath}>{{ clusterName }}</Link> already exists.
         <br />
         You cannot create another storage cluster.
       </Trans>


### PR DESCRIPTION
Before:
Close Button for the alert modal was not working.
![Screenshot from 2021-02-08 12-41-45](https://user-images.githubusercontent.com/39404641/107322530-a63ebe80-6aca-11eb-92a2-73fc92fe8072.png)

After:
Fixed the issue, it now redirects the user back to Storage Cluster Tab page.
