### PR TITLE
Bug 1926735: add template support check if use it separately

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -68,6 +68,9 @@ export class Wizard {
       if (customize) {
         await this.selectTemplate(template);
         await this.next();
+        if (await modalTitle.isPresent()) {
+          await click(continueButton);
+        }
         await click(view.customizeButton);
       }
     }


### PR DESCRIPTION
RHEL6 is not supported by Red Hat, it pops up a warning window for user to confirm the dialog, need to address this pop-up window when open it separately during tests.