### PR TITLE
Bug 1926843: Consider finally tasks when calculating task status

### DIFF
--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -27,6 +27,7 @@ export enum PipelineExampleNames {
   INVALID_PIPELINE_MISSING_TASK = 'missing-task-pipeline',
   INVALID_PIPELINE_INVALID_TASK = 'invalid-task-pipeline',
   EMBEDDED_PIPELINE_SPEC = 'embedded-pipeline-spec',
+  PIPELINE_WITH_FINALLY = 'pipeline-with-finally',
 }
 
 type CombinedPipelineTestData = {
@@ -282,6 +283,20 @@ const pipelineSpec: PipelineSpecData = {
           kind: 'Task',
           name: 'echo-hello',
         },
+      },
+    ],
+  },
+  [PipelineExampleNames.PIPELINE_WITH_FINALLY]: {
+    tasks: [
+      {
+        name: 'hello-world-1',
+        taskRef: { name: 'hello-world-1' },
+      },
+    ],
+    finally: [
+      {
+        name: 'run-anyway',
+        taskRef: { name: 'run-anyway' },
       },
     ],
   },
@@ -1984,6 +1999,65 @@ export const pipelineTestData: PipelineTestData = {
             { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
             { name: 'web-image', resourceRef: { name: 'mapit-image' } },
           ],
+        },
+      },
+    },
+  },
+  [PipelineExampleNames.PIPELINE_WITH_FINALLY]: {
+    dataSource: 'finally-pipeline',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'finally-pipeline',
+        namespace: 'tekton-pipelines',
+      },
+      spec: pipelineSpec[PipelineExampleNames.PIPELINE_WITH_FINALLY],
+    },
+    pipelineRuns: {
+      [DataState.SUCCESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'finally-pipeline-3tt7aw',
+          namespace: 'tekton-pipelines',
+          labels: { [TektonResourceLabel.pipeline]: 'finally-pipeline' },
+        },
+        spec: {
+          pipelineRef: { name: 'finally-pipeline' },
+        },
+        status: {
+          pipelineSpec: pipelineSpec[PipelineExampleNames.PIPELINE_WITH_FINALLY],
+          completionTime: '2019-10-29T11:57:53Z',
+          conditions: [
+            {
+              lastTransitionTime: '2019-09-12T20:38:01Z',
+              message: 'All Tasks have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+          taskRuns: {
+            'pipeline-p1bun0-hello-world-1-rlj9b': {
+              pipelineTaskName: 'hello-world-1',
+              status: {
+                completionTime: '2019-12-10T11:18:38Z',
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+                podName: 'test',
+                startTime: '2019-12-10T11:18:38Z',
+              },
+            },
+            'pipeline-p1bun0-run-anyway-cnd82': {
+              pipelineTaskName: 'run-anyway',
+              status: {
+                completionTime: '2019-12-10T11:18:38Z',
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+                podName: 'test',
+                startTime: '2019-12-10T11:18:38Z',
+              },
+            },
+          },
         },
       },
     },

--- a/frontend/packages/pipelines-plugin/src/types/pipeline.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipeline.ts
@@ -69,6 +69,7 @@ export type PipelineSpec = {
   serviceAccountName?: string;
   tasks: PipelineTask[];
   workspaces?: PipelineWorkspace[];
+  finally?: PipelineTask[];
 };
 
 export type PipelineKind = K8sResourceCommon & {

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -210,9 +210,18 @@ export const getPipelineFromPipelineRun = (pipelineRun: PipelineRunKind): Pipeli
   };
 };
 
-export const getTaskStatus = (pipelinerun: PipelineRunKind): TaskStatus => {
+export const totalPipelineRunTasks = (pipelinerun: PipelineRunKind): number => {
   const executedPipeline = getPipelineFromPipelineRun(pipelinerun);
-  const totalTasks = (executedPipeline?.spec?.tasks || []).length ?? 0;
+  if (!executedPipeline) {
+    return 0;
+  }
+  const totalTasks = (executedPipeline.spec?.tasks || []).length ?? 0;
+  const finallyTasks = (executedPipeline.spec?.finally || []).length ?? 0;
+  return totalTasks + finallyTasks;
+};
+
+export const getTaskStatus = (pipelinerun: PipelineRunKind): TaskStatus => {
+  const totalTasks = totalPipelineRunTasks(pipelinerun);
   const plrTasks =
     pipelinerun && pipelinerun.status && pipelinerun.status.taskRuns
       ? Object.keys(pipelinerun.status.taskRuns)


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5504
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Finally tasks are not considered when calculating task statuses.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Consider finally tasks when calculating status
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
(No UI change)
![scrt-screenshot-16128811333](https://user-images.githubusercontent.com/20013884/107379412-e6299400-6b12-11eb-84af-7d3732f752ea.png)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Test setup:**
Example pipeline with finally: https://raw.githubusercontent.com/tektoncd/pipeline/v0.19.0/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
