### PR TITLE
Bug 1924586: internationalize control plane and operator status

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -4,6 +4,13 @@
   "Add HorizontalPodAutoscaler": "Add HorizontalPodAutoscaler",
   "Edit HorizontalPodAutoscaler": "Edit HorizontalPodAutoscaler",
   "Remove HorizontalPodAutoscaler": "Remove HorizontalPodAutoscaler",
+  "API Servers": "API Servers",
+  "Controller Managers": "Controller Managers",
+  "Schedulers": "Schedulers",
+  "API Request Success Rate": "API Request Success Rate",
+  "Components of the Control Plane are responsible for maintaining and reconciling the state of the cluster.": "Components of the Control Plane are responsible for maintaining and reconciling the state of the cluster.",
+  "Components": "Components",
+  "Response rate": "Response rate",
   "Clone": "Clone",
   "Name": "Name",
   "Clone PVC": "Clone PVC",
@@ -25,5 +32,9 @@
   "API version": "API version",
   "Restore": "Restore",
   "Administrator": "Administrator",
+  "Cluster": "Cluster",
+  "Control Plane": "Control Plane",
+  "Control Plane status": "Control Plane status",
+  "Cluster operators": "Cluster operators",
   "VolumeSnapshotContents": "VolumeSnapshotContents"
 }

--- a/frontend/packages/console-app/src/components/dashboards-page/ControlPlaneStatus.tsx
+++ b/frontend/packages/console-app/src/components/dashboards-page/ControlPlaneStatus.tsx
@@ -11,16 +11,24 @@ import Status, {
 } from '@console/shared/src/components/dashboard/status-card/StatusPopup';
 import { PrometheusHealthPopupProps } from '@console/plugin-sdk';
 
-const titles = ['API Servers', 'Controller Managers', 'Schedulers', 'API Request Success Rate'];
-
 const ControlPlanePopup: React.FC<PrometheusHealthPopupProps> = ({ responses }) => {
   const { t } = useTranslation();
+  const titles = [
+    t('console-app~API Servers'),
+    t('console-app~Controller Managers'),
+    t('console-app~Schedulers'),
+    t('console-app~API Request Success Rate'),
+  ];
 
   return (
     <>
-      Components of the Control Plane are responsible for maintaining and reconciling the state of
-      the cluster.
-      <StatusPopupSection firstColumn="Components" secondColumn="Response rate">
+      {t(
+        'console-app~Components of the Control Plane are responsible for maintaining and reconciling the state of the cluster.',
+      )}
+      <StatusPopupSection
+        firstColumn={t('console-app~Components')}
+        secondColumn={t('console-app~Response rate')}
+      >
         {responses.map(({ response, error }, index) => {
           const health = getControlPlaneComponentHealth(response, error, t);
           const icon =

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -114,7 +114,8 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Health/URL',
     properties: {
-      title: 'Cluster',
+      // t('console-app~Cluster')
+      title: '%console-app~Cluster%',
       url: 'healthz',
       fetch: fetchK8sHealth,
       healthHandler: getK8sHealthState,
@@ -131,14 +132,16 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Health/Prometheus',
     properties: {
-      title: 'Control Plane',
+      // t('console-app~Control Plane')
+      title: '%console-app~Control Plane%',
       queries: [API_SERVERS_UP, CONTROLLER_MANAGERS_UP, SCHEDULERS_UP, API_SERVER_REQUESTS_SUCCESS],
       healthHandler: getControlPlaneHealth,
       popupComponent: () =>
         import(
           './components/dashboards-page/ControlPlaneStatus' /* webpackChunkName: "console-app" */
         ).then((m) => m.default),
-      popupTitle: 'Control Plane status',
+      // t('console-app~Control Plane status')
+      popupTitle: '%console-app~Control Plane status%',
       disallowedProviders: ['IBMCloud'],
     },
   },
@@ -182,7 +185,8 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Health/Operator',
     properties: {
-      title: 'Cluster operators',
+      // t('console-app~Cluster operators')
+      title: '%console-app~Cluster operators%',
       resources: [
         {
           kind: referenceForModel(ClusterOperatorModel),

--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -1,6 +1,11 @@
 {
   "An error occurred": "An error occurred",
   "No resources found": "No resources found",
+  "({{operatorStatusLength}} installed)": "({{operatorStatusLength}} installed)",
+  "Status": "Status",
+  "Not available": "Not available",
+  "View all": "View all",
+  "All {{status}}": "All {{status}}",
   "Error loading - {{placeholder}}": "Error loading - {{placeholder}}",
   "Value": "Value",
   "Resource requirements": "Resource requirements",

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/OperatorStatusBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/OperatorStatusBody.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { GetOperatorsWithStatuses, LazyLoader } from '@console/plugin-sdk';
 import { AsyncComponent, FirehoseResourcesResult } from '@console/internal/components/utils';
 import { HealthState } from './states';
@@ -15,6 +16,7 @@ export const OperatorsSection: React.FC<OperatorsSectionProps> = ({
   linkTo,
   rowLoader,
 }) => {
+  const { t } = useTranslation();
   const error = _.values(resources).some((r) => r.loadError);
   const operatorStatuses = getOperatorsWithStatuses(resources);
   const sortedOperatorStatuses = getMostImportantStatuses(operatorStatuses).sort((a, b) =>
@@ -27,12 +29,17 @@ export const OperatorsSection: React.FC<OperatorsSectionProps> = ({
       <div className="co-status-popup__row">
         <div>
           <span className="co-status-popup__text--bold">{title}</span>
-          <span className="text-secondary">{` (${operatorStatuses.length} installed)`}</span>
+          <span className="text-secondary">
+            {' '}
+            {t('console-shared~({{operatorStatusLength}} installed)', {
+              operatorStatusLength: operatorStatuses.length,
+            })}
+          </span>
         </div>
-        <div className="text-secondary">Status</div>
+        <div className="text-secondary">{t('console-shared~Status')}</div>
       </div>
       {error ? (
-        <div className="text-secondary">Not Available</div>
+        <div className="text-secondary">{t('console-shared~Not available')}</div>
       ) : (
         !operatorsHealthy &&
         sortedOperatorStatuses.map((operatorStatus) => (
@@ -45,11 +52,13 @@ export const OperatorsSection: React.FC<OperatorsSectionProps> = ({
         ))
       )}
       <div className="co-status-popup__row">
-        <Link to={linkTo}>View all</Link>
+        <Link to={linkTo}>{t('console-shared~View all')}</Link>
         {!error && operatorsHealthy && operatorStatuses.length && (
           <div className="co-status-popup__status">
             <div className="text-secondary">
-              All {operatorStatuses[0].status.title.toLowerCase()}
+              {t('console-shared~All {{status}}', {
+                status: operatorStatuses[0].status.title.toLowerCase(),
+              })}
             </div>
             <div className="co-status-popup__icon">{operatorStatuses[0].status.icon}</div>
           </div>

--- a/frontend/packages/insights-plugin/locales/en/insights-plugin.json
+++ b/frontend/packages/insights-plugin/locales/en/insights-plugin.json
@@ -13,5 +13,7 @@
   "More about Insights": "More about Insights",
   "Not available": "Not available",
   "{{issuesNumber}} issue found": "{{issuesNumber}} issue found",
-  "{{issuesNumber}} issues found": "{{issuesNumber}} issues found"
+  "{{issuesNumber}} issues found": "{{issuesNumber}} issues found",
+  "Insights": "Insights",
+  "Insights status": "Insights status"
 }

--- a/frontend/packages/insights-plugin/src/plugin.tsx
+++ b/frontend/packages/insights-plugin/src/plugin.tsx
@@ -9,7 +9,8 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Health/Prometheus',
     properties: {
-      title: 'Insights',
+      // t('insights-plugin~Insights')
+      title: '%insights-plugin~Insights%',
       queries: [
         "health_statuses_insights{metric=~'low|moderate|important|critical'}",
         'insightsclient_request_send_total',
@@ -26,7 +27,8 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/InsightsPopup/index' /* webpackChunkName: "insights-plugin" */).then(
           (m) => m.InsightsPopup,
         ),
-      popupTitle: 'Insights status',
+      // t('insights-plugin~Insights status')
+      popupTitle: '%insights-plugin~Insights status%',
     },
   },
 ];

--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -347,7 +347,8 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Health/Operator',
     properties: {
-      title: 'Operators',
+      // t('olm~Operators')
+      title: '%olm~Operators%',
       resources: [
         {
           kind: referenceForModel(models.ClusterServiceVersionModel),


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1924586

**Solution Description:**
localized `Control Plane` & Operator status in the cluster overview page

**Screen shot:**
![cluster overview](https://user-images.githubusercontent.com/22490998/107402218-bb970580-6b29-11eb-87ae-ed03aaaf4400.png)
![Screenshot from 2021-02-12 16-39-03](https://user-images.githubusercontent.com/22490998/107761114-d8615200-6d50-11eb-8b5b-556d35c276de.png)


**Browser conformance:**
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge