### PR TITLE
Bug 1874931: Add shortcut above YAML editor and tab toggle action shortcut to popover to improve accessibility

### DIFF
--- a/frontend/packages/console-shared/locales/en/editor.json
+++ b/frontend/packages/console-shared/locales/en/editor.json
@@ -1,6 +1,9 @@
 {
   "Shortcuts": "Shortcuts",
+  "Accessibility help": "Accessibility help",
+  "View all editor shortcuts": "View all editor shortcuts",
   "Activate auto complete": "Activate auto complete",
+  "Toggle Tab action between insert Tab character and move focus out of editor": "Toggle Tab action between insert Tab character and move focus out of editor",
   "View document outline": "View document outline",
   "View property descriptions": "View property descriptions",
   "Save": "Save",

--- a/frontend/packages/console-shared/src/components/editor/ShortcutsLink.tsx
+++ b/frontend/packages/console-shared/src/components/editor/ShortcutsLink.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Popover, Button } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { ShortcutTable, Shortcut } from '../shortcuts';
+import { isMac } from '../shortcuts/Shortcut';
 import { useTranslation } from 'react-i18next';
 
 interface ShortcutsLinkProps {
@@ -15,8 +16,17 @@ const ShortcutsLink: React.FC<ShortcutsLinkProps> = ({ onHideShortcuts }) => {
       aria-label={t('editor~Shortcuts')}
       bodyContent={
         <ShortcutTable>
+          <Shortcut alt keyName="F1">
+            {t('editor~Accessibility help')}
+          </Shortcut>
+          <Shortcut keyName="F1">{t('editor~View all editor shortcuts')}</Shortcut>
           <Shortcut ctrl keyName="space">
             {t('editor~Activate auto complete')}
+          </Shortcut>
+          <Shortcut ctrl shift={isMac} keyName="m">
+            {t(
+              'editor~Toggle Tab action between insert Tab character and move focus out of editor',
+            )}
           </Shortcut>
           <Shortcut ctrlCmd shift keyName="o">
             {t('editor~View document outline')}

--- a/frontend/packages/console-shared/src/components/editor/YAMLEditorToolbar.scss
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditorToolbar.scss
@@ -1,18 +1,23 @@
 @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
 
 .ocs-yaml-editor-toolbar {
-  &__links {
-    display: flex;
-    flex-shrink: 0;
-    justify-content: flex-end;
-    margin: 2px;
-    z-index: 1;
-    @media(max-width: $screen-sm-max) {
-      display: none;
-    }
-  }
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
+  margin: 2px;
+  z-index: 1;
 
-  &__link {
-    display: inline-block;
+  @media(max-width: $screen-sm-max) {
+    display: none;
   }
+}
+
+.ocs-yaml-editor-toolbar__link {
+  display: inline-block;
+}
+
+.ocs-yaml-editor-shortcut__text {
+  color: var(--pf-global--Color--200);
+  margin-left: var(--pf-global--spacer--sm);
 }

--- a/frontend/packages/console-shared/src/components/editor/YAMLEditorToolbar.tsx
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditorToolbar.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import ShortcutsLink from './ShortcutsLink';
 import './YAMLEditorToolbar.scss';
+import { useTranslation } from 'react-i18next';
+import { isMac, ShortcutCommand } from '../shortcuts/Shortcut';
 
 interface YAMLEditorToolbarProps {
   showShortcuts?: boolean;
@@ -8,10 +10,16 @@ interface YAMLEditorToolbarProps {
 }
 
 const YAMLEditorToolbar: React.FC<YAMLEditorToolbarProps> = ({ showShortcuts, toolbarLinks }) => {
+  const { t } = useTranslation();
   if (!showShortcuts && !toolbarLinks?.length) return null;
-
   return (
-    <div className="ocs-yaml-editor-toolbar__links">
+    <div className="ocs-yaml-editor-toolbar">
+      <span className="ocs-yaml-editor-shortcut__command">
+        <ShortcutCommand>{isMac ? '⌥ Opt' : 'Alt'}</ShortcutCommand>
+        <ShortcutCommand>F1</ShortcutCommand>
+      </span>
+      <span className="ocs-yaml-editor-shortcut__text">{t('editor~Accessibility help')}</span>
+      <div className="co-action-divider">|</div>
       {showShortcuts && (
         <div className="ocs-yaml-editor-toolbar__link">
           <ShortcutsLink />

--- a/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
+++ b/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
@@ -17,11 +17,13 @@ interface ShortcutProps {
   shift?: boolean;
 }
 
-const Command: React.FC = ({ children }) => (
+export const ShortcutCommand: React.FC = ({ children }) => (
   <span className="ocs-shortcut__command">
     <kbd>{children}</kbd>
   </span>
 );
+
+export const isMac = window.navigator.platform.includes('Mac');
 
 const Shortcut: React.FC<ShortcutProps> = ({
   children,
@@ -36,38 +38,37 @@ const Shortcut: React.FC<ShortcutProps> = ({
   shift,
 }) => {
   const { t } = useTranslation();
-  const isMac = window.navigator.platform.includes('Mac');
   return (
     <tr>
       <td className="ocs-shortcut__cell">
-        {(ctrl || (!isMac && ctrlCmd)) && <Command>Ctrl</Command>}
-        {alt && <Command>{isMac ? '⌥ Opt' : 'Alt'}</Command>}
-        {shift && <Command>Shift</Command>}
-        {isMac && ctrlCmd && <Command>⌘ Cmd</Command>}
+        {(ctrl || (!isMac && ctrlCmd)) && <ShortcutCommand>Ctrl</ShortcutCommand>}
+        {alt && <ShortcutCommand>{isMac ? '⌥ Opt' : 'Alt'}</ShortcutCommand>}
+        {shift && <ShortcutCommand>Shift</ShortcutCommand>}
+        {isMac && ctrlCmd && <ShortcutCommand>⌘ Cmd</ShortcutCommand>}
         {hover && (
-          <Command>
+          <ShortcutCommand>
             <MouseIcon /> {t('console-shared~Hover')}
-          </Command>
+          </ShortcutCommand>
         )}
         {keyName && (
-          <Command>
-            {keyName.length === 1 ? keyName.toUpperCase() : _.startCase(keyName.toLowerCase())}
-          </Command>
+          <ShortcutCommand>
+            {keyName.length === 1 ? keyName.toUpperCase() : _.upperFirst(keyName.toLowerCase())}
+          </ShortcutCommand>
         )}
         {drag && (
-          <Command>
+          <ShortcutCommand>
             <MouseIcon /> {t('console-shared~Drag')}
-          </Command>
+          </ShortcutCommand>
         )}
         {click && (
-          <Command>
+          <ShortcutCommand>
             <MouseIcon /> {t('console-shared~Click')}
-          </Command>
+          </ShortcutCommand>
         )}
         {rightClick && (
-          <Command>
+          <ShortcutCommand>
             <MouseIcon /> {t('console-shared~Right click')}
-          </Command>
+          </ShortcutCommand>
         )}
       </td>
       <td className="ocs-shortcut__cell">{children}</td>


### PR DESCRIPTION
Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1874931
<img width="1090" alt="Screen Shot 2021-02-09 at 1 30 12 PM" src="https://user-images.githubusercontent.com/1874151/107410196-f6be1800-6ada-11eb-8828-1e60d9130cb7.png">
