### PR TITLE
Bug 1920699: retry co-fetch on 409 POST or 429

### DIFF
--- a/frontend/__tests__/public/co-fetch.spec.js
+++ b/frontend/__tests__/public/co-fetch.spec.js
@@ -1,6 +1,15 @@
-import { shouldLogout } from '../../public/co-fetch';
+import { coFetch, shouldLogout, validateStatus, RetryError } from '../../public/co-fetch';
 
 describe('coFetch', () => {
+  const json = async () => ({
+    details: {
+      kind: 'clusterresourcequotas',
+    },
+  });
+  const emptyHeaders = new Headers();
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+
   it('logs out users who get a 401 from k8s', () => {
     expect(shouldLogout('/api/kubernetes/api/v1/pods')).toEqual(true);
   });
@@ -24,5 +33,62 @@ describe('coFetch', () => {
         '/api/kubernetes/api/v1/proxy/namespaces/tectonic-system/services/prometheus:9090/api/v1/query?query=100%20-%20(sum(rate(node_cpu%7Bjob%3D%22node-exporter%22%2Cmode%3D%22idle%22%7D%5B2m%5D))%20%2F%20count(node_cpu%7Bjob%3D%22node-exporter%22%2C%20mode%3D%22idle%22%7D))%20*%20100',
       ),
     ).toEqual(false);
+  });
+
+  it('should throw RetryError', async () => {
+    await expect(
+      validateStatus({ status: 409, json, headers }, '', 'GET', true),
+    ).rejects.not.toBeInstanceOf(RetryError);
+    await expect(
+      validateStatus({ status: 409, json, headers }, '', 'POST', true),
+    ).rejects.toBeInstanceOf(RetryError);
+    await expect(
+      validateStatus(
+        { status: 409, json: async () => ({ details: { kind: 'resourcequotas' } }), headers },
+        '',
+        'POST',
+        true,
+      ),
+    ).rejects.toBeInstanceOf(RetryError);
+    await expect(
+      validateStatus({ status: 409, json: async () => ({}), headers }, '', 'POST', true),
+    ).rejects.not.toBeInstanceOf(RetryError);
+    await expect(
+      validateStatus({ status: 409, json, headers }, '', 'POST', false),
+    ).rejects.not.toBeInstanceOf(RetryError);
+    await expect(
+      validateStatus({ status: 429, headers: emptyHeaders }, '', 'POST', true),
+    ).rejects.toBeInstanceOf(RetryError);
+    await expect(
+      validateStatus({ status: 429, headers: emptyHeaders }, '', 'POST', false),
+    ).rejects.not.toBeInstanceOf(RetryError);
+  });
+
+  it('should retry up to 3 times when RetryError is thrown', async () => {
+    window.fetch = jest.fn(() => Promise.resolve({ status: 404, headers: emptyHeaders }));
+    try {
+      await coFetch('');
+    } catch {
+      // ignore
+    }
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+
+    window.fetch.mockClear();
+    window.fetch = jest.fn(() => Promise.resolve({ status: 429, headers: emptyHeaders }));
+    try {
+      await coFetch('');
+    } catch {
+      // ignore
+    }
+    expect(window.fetch).toHaveBeenCalledTimes(3);
+
+    window.fetch.mockClear();
+    window.fetch = jest.fn(() => Promise.resolve({ status: 409, json, headers }));
+    try {
+      await coFetch('', { method: 'POST' });
+    } catch {
+      // ignore
+    }
+    expect(window.fetch).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1920699

**Analysis / Root cause**: 
When multiple requests are made in parallel to create k8s resources where there is a quota in place which counts the number of resources of a specific type, it's possible to receive a `409` error code back from the API server.

**Solution Description**: 
Modified `co-fetch` utility to retry automatically `fetch` requests which result in status code `429` or `409 + specific response`.
The reason for specifically checking for `POST` and the response json when status `409` is received is because a k8s call to update a resource which fails with status code `409` will most likely continue to fail unless the request is modified. Eg. 409 when a resource with the same name exists. There is however the case specified in the bugzilla where reattempting the same request after a `409` will succeed.

**Screen shots / Gifs for design review**: 
no UI change

**Unit test coverage report**: 
Added new unit tests to test retry attempts.

**Test setup:**
See https://bugzilla.redhat.com/show_bug.cgi?id=1920699#c11

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

cc @spadgett 