### PR TITLE
Add default value to the runtime VERSION parameter in add flow pipelines

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -194,6 +194,7 @@ describe('Import Submit Utils', () => {
         mockData.git.dir,
         mockData.pipeline,
         mockData.docker.dockerfilePath,
+        mockData.image.tag,
       );
       expect(createPipelineRunResourceSpy).toHaveBeenCalledTimes(1);
       expect(createPipelineRunResourceSpy).not.toThrowError();
@@ -223,6 +224,7 @@ describe('Import Submit Utils', () => {
         mockData.git.dir,
         mockData.pipeline,
         mockData.docker.dockerfilePath,
+        mockData.image.tag,
       );
       const pipelineRunResource = returnValue[1].data;
       expect(pipelineRunResource.metadata.name.includes(mockData.name)).toEqual(true);

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -423,7 +423,7 @@ export const managePipelineResources = async (
   formData: GitImportFormData,
   appResources: AppResources,
 ) => {
-  const { name, git, pipeline, project, docker } = formData;
+  const { name, git, pipeline, project, docker, image } = formData;
   let managedPipeline: PipelineKind;
 
   if (!_.isEmpty(appResources?.pipeline?.data)) {
@@ -436,6 +436,7 @@ export const managePipelineResources = async (
       git.ref,
       git.dir,
       docker.dockerfilePath,
+      image.tag,
     );
   } else if (pipeline.template) {
     managedPipeline = await createPipelineForImportFlow(
@@ -446,6 +447,7 @@ export const managePipelineResources = async (
       git.dir,
       pipeline,
       docker.dockerfilePath,
+      image.tag,
     );
   }
 

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/__tests__/pipeline-template-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/__tests__/pipeline-template-utils.spec.ts
@@ -67,6 +67,7 @@ describe('createPipelineForImportFlow', () => {
       formData.git.dir,
       formData.pipeline,
       formData.docker.dockerfilePath,
+      '14-ubi8',
     );
 
     const expectedPipeline: PipelineKind = {
@@ -107,6 +108,7 @@ describe('createPipelineForImportFlow', () => {
       formData.git.dir,
       formData.pipeline,
       formData.docker.dockerfilePath,
+      '14-ubi8',
     );
 
     const expectedPipeline: PipelineKind = {
@@ -156,6 +158,7 @@ describe('createPipelineForImportFlow', () => {
       formData.git.dir,
       formData.pipeline,
       formData.docker.dockerfilePath,
+      '14-ubi8',
     );
 
     const expectedPipeline: PipelineKind = {
@@ -194,6 +197,7 @@ describe('createPipelineForImportFlow', () => {
           { name: 'GIT_REVISION' },
           { name: 'PATH_CONTEXT', default: '.' },
           { name: 'IMAGE_NAME' },
+          { name: 'VERSION' },
         ],
         tasks: [],
       },
@@ -208,6 +212,7 @@ describe('createPipelineForImportFlow', () => {
       formData.git.dir,
       formData.pipeline,
       formData.docker.dockerfilePath,
+      '14-ubi8',
     );
 
     const expectedPipeline: PipelineKind = {
@@ -226,6 +231,7 @@ describe('createPipelineForImportFlow', () => {
             name: 'IMAGE_NAME',
             default: 'image-registry.openshift-image-registry.svc:5000/a-project/an-app',
           },
+          { name: 'VERSION', default: '14-ubi8' },
         ],
         tasks: [],
       },
@@ -261,6 +267,7 @@ describe('createPipelineForImportFlow', () => {
       '/anotherpath',
       formData.pipeline,
       'Dockerfile',
+      '14-ubi8',
     );
 
     const expectedPipeline: PipelineKind = {
@@ -330,6 +337,7 @@ describe('updatePipelineForImportFlow', () => {
     gitRef: '',
     gitDir: '',
     dockerfilePath: '',
+    image: { tag: '10-ubi7' },
   };
 
   it('should dissociate pipeline if template is not available', async () => {
@@ -342,6 +350,7 @@ describe('updatePipelineForImportFlow', () => {
       props.gitRef,
       props.gitDir,
       props.dockerfilePath,
+      props.image.tag,
     );
 
     const expectedPipeline: PipelineKind = {
@@ -370,6 +379,7 @@ describe('updatePipelineForImportFlow', () => {
       props.gitRef,
       props.gitDir,
       props.dockerfilePath,
+      props.image.tag,
     );
 
     const expectedPipeline: PipelineKind = {
@@ -381,6 +391,39 @@ describe('updatePipelineForImportFlow', () => {
       spec: {
         tasks: [],
         params: [{ name: 'PARAM1', type: 'string' }],
+      },
+    };
+
+    expect(k8sUpdate).toHaveBeenCalledTimes(1);
+    expect(k8sUpdate).toHaveBeenCalledWith(PipelineModel, expectedPipeline, 'test', 'test');
+  });
+
+  it('should update VERSION params if image tag is changed', async () => {
+    const template = {
+      ...mockTemplate,
+      spec: { tasks: [], params: [{ name: 'VERSION', default: 'latest' }] },
+    };
+    await updatePipelineForImportFlow(
+      mockPipeline,
+      template,
+      props.name,
+      props.namespace,
+      props.gitUrl,
+      props.gitRef,
+      props.gitDir,
+      props.dockerfilePath,
+      '14-ubi8',
+    );
+
+    const expectedPipeline: PipelineKind = {
+      metadata: {
+        name: 'test',
+        labels: { 'app.kubernetes.io/instance': 'sample' },
+        resourceVersion: 'test',
+      },
+      spec: {
+        tasks: [],
+        params: [{ name: 'VERSION', default: '14-ubi8' }],
       },
     };
 
@@ -400,6 +443,7 @@ describe('updatePipelineForImportFlow', () => {
       props.gitRef,
       props.gitDir,
       props.dockerfilePath,
+      props.image.tag,
     );
 
     const expectedPipeline: PipelineKind = {

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils.ts
@@ -37,6 +37,7 @@ export const getPipelineParams = (
   gitRef: string,
   gitDir: string,
   dockerfilePath: string,
+  tag: string,
 ) => {
   return params.map((param) => {
     switch (param.name) {
@@ -52,6 +53,8 @@ export const getPipelineParams = (
         return { ...param, default: getImageUrl(name, namespace) };
       case 'DOCKERFILE':
         return { ...param, default: dockerfilePath };
+      case 'VERSION':
+        return { ...param, default: tag || param.default };
       default:
         return param;
     }
@@ -66,6 +69,7 @@ export const createPipelineForImportFlow = async (
   gitDir: string,
   pipeline: PipelineData,
   dockerfilePath: string,
+  tag: string,
 ) => {
   const template = _.cloneDeep(pipeline.template);
 
@@ -85,6 +89,7 @@ export const createPipelineForImportFlow = async (
       gitRef,
       gitDir,
       dockerfilePath,
+      tag,
     );
 
   return k8sCreate(PipelineModel, template, { ns: namespace });
@@ -114,6 +119,7 @@ export const updatePipelineForImportFlow = async (
   gitRef: string,
   gitDir: string,
   dockerfilePath: string,
+  tag: string,
 ): Promise<PipelineKind> => {
   let updatedPipeline = _.cloneDeep(pipeline);
 
@@ -144,6 +150,7 @@ export const updatePipelineForImportFlow = async (
       gitRef,
       gitDir,
       dockerfilePath,
+      tag,
     );
   }
   return k8sUpdate(PipelineModel, updatedPipeline, namespace, name);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3786
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Builder Image runtime version is not considered during add flow pipeline creation, so choosing a different version will still use the same base image.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

In Add flow pipeline creation, pass appropriate VERSION param value  based on the user selection.

**Screen shots / Gifs for design review**: 
![Version_param](https://user-images.githubusercontent.com/9964343/107498293-9b168c00-6bb9-11eb-81d6-9765b3db884d.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/9964343/107498422-c4371c80-6bb9-11eb-81ca-3d94ba4414c4.png)

 ---
 
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

 VERSION parameter will be included in the pipeline templates only in 1.4 pipelines operator.
 
**workaround:** Manually replace MAJOR_VERSION param with  VERSION param in the pipeline templates in `openshift` namespace.
 
 1. In `openshift` ns , find `s2i-nodejs` pipeline and change the MAJOR_VERSION param with VERSION
 2. now,  from GIT add flow, add a `nodejs`  Git Repo URL 
 3. choose a Builder Image version
 4. add pipeline option before submitting the form.
 
 
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @andrewballantyne @pradeepitm12 @vdemeester 