### PR TITLE
Bug 1926126: Remove period in translation

### DIFF
--- a/frontend/packages/console-app/locales/zh/nodes.json
+++ b/frontend/packages/console-app/locales/zh/nodes.json
@@ -1,7 +1,7 @@
 {
   "This action cannot be undone. Deleting a node will instruct Kubernetes that the node is down or unrecoverable and delete all pods scheduled to that node. If the node is still running but unresponsive and the node is deleted, stateful workloads and persistent volumes may suffer corruption or data loss. Only delete a node that you have confirmed is completely stopped and cannot be restored.": "此操作无法撤消。删除节点会指示 Kubernetes 使该节点停止或无法恢复，并删除所有调度到该节点的 pod。如果节点仍然在运行但无法响应，则该节点被删除，有状态的工作负载和持久性卷可能会崩溃或造成数据丢失。只有删除已确认的节点才会完全停止且无法恢复。",
   "Delete node": "删除节点",
-  "Mark as unschedulable": "将节点标记为不可调度。",
+  "Mark as unschedulable": "将节点标记为不可调度",
   "Unschedulable nodes won't accept new pods. This is useful for scheduling maintenance or preparing to decommission a node.": "不可调度的节点不会接受新的 pod。这在调度维护或准备退出节点时很有用。",
   "Mark unschedulable": "标记为不可调度。",
   "Activity": "活跃",


### PR DESCRIPTION
Removed period in Chinese translation since it wasn't needed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1926126.