### PR TITLE
Bug 1905147: Show multiple pre-requisites as unordered list in popover

### DIFF
--- a/frontend/packages/console-app/locales/en/quickstart.json
+++ b/frontend/packages/console-app/locales/en/quickstart.json
@@ -11,6 +11,7 @@
   "Status": "Status",
   "{{count, number}} item": "{{count, number}} item",
   "{{count, number}} item_plural": "{{count, number}} items",
+  "Prerequisites ({{totalPrereqs}})": "Prerequisites ({{totalPrereqs}})",
   "Prerequisites": "Prerequisites",
   "Start the tour": "Start the tour",
   "Resume the tour": "Resume the tour",

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.scss
@@ -1,3 +1,20 @@
-.co-quick-start-tile-description {
-  margin: 0 0 var(--pf-global--spacer--md) 0;
+.co-quick-start-tile {
+  &-description {
+    margin: 0 0 var(--pf-global--spacer--md) 0;
+  }
+
+  &-prerequisites {
+    display: inline-flex;
+    &__text {
+      margin-right: var(--pf-global--spacer--sm);
+    }
+
+    &__icon {
+      color: var(--pf-global--info-color--100) !important;
+
+      &:hover {
+        color: var(--pf-global--info-color--200) !important;
+      }
+    }
+  }
 }

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Text, TextVariants } from '@patternfly/react-core';
+import {
+  Button,
+  Popover,
+  Text,
+  TextList,
+  TextListItem,
+  TextVariants,
+} from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import './QuickStartTileDescription.scss';
 
 type QuickStartTileDescriptionProps = {
   description: string;
   prerequisites?: string[];
-  unmetPrerequisite?: boolean;
 };
+
 const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
   description,
   prerequisites,
@@ -19,16 +27,38 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
       <Text component={TextVariants.p} className="oc-quick-start-tile-description">
         {description}
       </Text>
-      <div className="co-quick-start-tile-description">
-        {prerequisites && (
-          <>
-            <Text component={TextVariants.h5}>{t('quickstart~Prerequisites')}</Text>
-            {prerequisites.map((prerequisite) => (
-              <Text component={TextVariants.small}>{prerequisite}</Text>
-            ))}
-          </>
-        )}
-      </div>
+      {prerequisites && (
+        <div className="co-quick-start-tile-prerequisites">
+          <Text component={TextVariants.h5} className="co-quick-start-tile-prerequisites__text">
+            {t('quickstart~Prerequisites ({{totalPrereqs}})', {
+              totalPrereqs: prerequisites.length,
+            })}{' '}
+          </Text>
+          <Popover
+            aria-label="Prerequisites"
+            headerContent={<Text component={TextVariants.h5}>{t('quickstart~Prerequisites')}</Text>}
+            bodyContent={
+              <TextList aria-label="Prerequisites">
+                {prerequisites.map((prerequisite, index) => (
+                  <TextListItem key={index}>{prerequisite}</TextListItem> // eslint-disable-line react/no-array-index-key
+                ))}
+              </TextList>
+            }
+          >
+            <Button
+              variant="link"
+              isInline
+              className="co-quick-start-tile-prerequisites__icon"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              <InfoCircleIcon />
+            </Button>
+          </Popover>
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/__tests__/QuickStartTileDescription.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/__tests__/QuickStartTileDescription.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Text } from '@patternfly/react-core';
+import { Popover, Text } from '@patternfly/react-core';
 import QuickStartTileDescription from '../QuickStartTileDescription';
 import { getQuickStarts } from '../../utils/quick-start-utils';
 
@@ -14,10 +14,21 @@ jest.mock('react-i18next', () => {
 
 describe('QuickStartCatalog', () => {
   it('should show prerequisites only if provided', () => {
-    const QuickStartTileDescriptionProps = getQuickStarts()[0].spec;
+    const quickStart = getQuickStarts()[0].spec;
     const QuickStartTileDescriptionWrapper = shallow(
-      <QuickStartTileDescription description={QuickStartTileDescriptionProps.description} />,
+      <QuickStartTileDescription description={quickStart.description} />,
     );
     expect(QuickStartTileDescriptionWrapper.find(Text)).toHaveLength(1);
+  });
+
+  it('shoould render prerequisites inside a popover', () => {
+    const quickStart = getQuickStarts()[2].spec;
+    const QuickStartTileDescriptionWrapper = shallow(
+      <QuickStartTileDescription
+        description={quickStart.description}
+        prerequisites={quickStart.prerequisites}
+      />,
+    );
+    expect(QuickStartTileDescriptionWrapper.find(Popover)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-21374
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Quick starts prerequisites are currently being shown as one big text.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Show quict starts prerequisites inside a popover as unordered list. Recommended by UX team.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
@gdoyle1 @bmignano @openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/107571498-fcb61500-6c10-11eb-9825-c955fe65f3c0.mov


**Unit test coverage report**: 
<!-- Attach test coverage report -->
<img width="876" alt="Screenshot 2021-02-11 at 2 28 43 AM" src="https://user-images.githubusercontent.com/6041994/107571409-e019dd00-6c10-11eb-886b-f76eea51e579.png">

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
