### PR TITLE
Bug 1883587: Adds volume mode selector when restoring a volumesnapshot

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -25,6 +25,7 @@
   "Volume mode": "Volume mode",
   "Restore as new PVC": "Restore as new PVC",
   "When restore action for snapshot <1>{{snapshotName}}</1> is finished a new crash-consistent PVC copy will be created.": "When restore action for snapshot <1>{{snapshotName}}</1> is finished a new crash-consistent PVC copy will be created.",
+  "Volume Mode": "Volume Mode",
   "Size should be equal or greater than the restore size of snapshot": "Size should be equal or greater than the restore size of snapshot",
   "{{resourceKind}} details": "{{resourceKind}} details",
   "Created at": "Created at",

--- a/frontend/packages/console-app/src/components/access-modes/access-mode.tsx
+++ b/frontend/packages/console-app/src/components/access-modes/access-mode.tsx
@@ -24,8 +24,18 @@ export const getPVCAccessModes = (resource: PersistentVolumeClaimKind, key: stri
   );
 
 export const AccessModeSelector: React.FC<AccessModeSelectorProps> = (props) => {
-  const { formClassName, pvcResource, onChange, loaded, provisioner } = props;
-  const pvcInitialAccessMode = pvcResource ? getPVCAccessModes(pvcResource, 'value') : '';
+  const {
+    formClassName,
+    pvcResource,
+    onChange,
+    loaded,
+    provisioner,
+    availableAccessModes = [],
+  } = props;
+
+  const pvcInitialAccessMode = pvcResource
+    ? getPVCAccessModes(pvcResource, 'value')
+    : availableAccessModes;
 
   const [allowedAccessModes, setAllowedAccessModes] = React.useState<string[]>();
   const [accessMode, setAccessMode] = React.useState<string>('');
@@ -91,6 +101,7 @@ type AccessModeSelectorProps = {
   formClassName?: string;
   pvcResource?: PersistentVolumeClaimKind;
   onChange: Function;
+  availableAccessModes?: string[];
   loaded: boolean;
   loadError: any;
   provisioner: string;

--- a/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
@@ -37,7 +37,12 @@ import {
   StorageClassModel,
   NamespaceModel,
 } from '@console/internal/models';
-import { accessModeRadios } from '@console/internal/components/storage/shared';
+import {
+  accessModeRadios,
+  snapshotPVCStorageClassAnnotation,
+  snapshotPVCAccessModeAnnotation,
+  snapshotPVCVolumeModeAnnotation,
+} from '@console/internal/components/storage/shared';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { PVCDropdown } from '@console/internal/components/utils/pvc-dropdown';
 import { getName, getNamespace, getAnnotations } from '@console/shared';
@@ -201,6 +206,11 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
       metadata: {
         name: snapshotName,
         namespace: getNamespace(pvcObj),
+        annotations: {
+          [snapshotPVCAccessModeAnnotation]: pvcObj.spec.accessModes.join(','),
+          [snapshotPVCStorageClassAnnotation]: pvcObj.spec.storageClassName,
+          [snapshotPVCVolumeModeAnnotation]: pvcObj.spec.volumeMode,
+        },
       },
       spec: {
         volumeSnapshotClassName: snapshotClassName,

--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -2,6 +2,10 @@ import { isCephProvisioner } from '@console/shared/src/utils';
 
 export const cephRBDProvisionerSuffix = 'rbd.csi.ceph.com';
 
+export const snapshotPVCStorageClassAnnotation = 'snapshot.storage.kubernetes.io/pvc-storage-class';
+export const snapshotPVCAccessModeAnnotation = 'snapshot.storage.kubernetes.io/pvc-access-modes';
+export const snapshotPVCVolumeModeAnnotation = 'snapshot.storage.kubernetes.io/pvc-volume-mode';
+
 //See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes for more details
 export const provisionerAccessModeMapping = {
   'kubernetes.io/no-provisioner': ['ReadWriteOnce'],


### PR DESCRIPTION
This commit makes the following changes: 
1. When creating a snapshot, we are adding annotations to the VolumeSnapshot for information like PVC access-mode, storage-class, volume-mode.
2. StorageClassDropdown will be automatically populated based on the annotation in snapshot.
3. Radio buttons for selecting the volume mode ( Filesystem, Block )
4. Populating the defaults when restoring a pvc using the above info.

Overall this update will provide user the flexibility to choose volume mode when restoring a pvc and improve user experience.

![Screenshot from 2021-02-11 19-22-34](https://user-images.githubusercontent.com/57935785/107645935-62e97900-6c9f-11eb-88fa-b92c9a64a9f2.png)


Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>