### PR TITLE
Bug 1901207: Pipeline resources table not immediately updated after Name filter applied or removed

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
@@ -14,7 +14,7 @@ interface PipelinesResourceListProps extends React.ComponentProps<typeof FireMan
 
 const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
   const { t } = useTranslation();
-  const { namespace, showTitle = true, selector, name } = props;
+  const { namespace, showTitle = true, selector, name, nameFilter } = props;
 
   const resources = [
     {
@@ -22,7 +22,7 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       kind: referenceForModel(PipelineModel),
       namespace,
       prop: PipelineModel.id,
-      filters: { ...filters },
+      filters: { ...filters, name: nameFilter },
       selector,
       name,
     },


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1901207

**Analysis / Root cause:**
The name filter is not passed down to Firehose resources

**Solution Description:**
Passed nameFilter to Firehose resources

**GIF:** 
![pipeline-list](https://user-images.githubusercontent.com/22490998/107651677-caa2c280-6ca5-11eb-84ba-4b8b119c0f82.gif)

**Browser conformance:**
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge