### PR TITLE
remove gap in dashboard for empty quickstart card

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-starts/QuickStartsCatalogCard.tsx
+++ b/frontend/packages/console-shared/src/components/quick-starts/QuickStartsCatalogCard.tsx
@@ -32,12 +32,14 @@ type QuickStartsCatalogCardProps = {
   quickStarts: QuickStart[];
   storageKey: string;
   userSettingsKey: string;
+  shouldShowQSTile?: (boolean) => void;
 };
 
 const QuickStartsCatalogCard: React.FC<QuickStartsCatalogCardProps> = ({
   quickStarts,
   storageKey,
   userSettingsKey,
+  shouldShowQSTile,
 }) => {
   const { t } = useTranslation();
   const { allQuickStartStates, setActiveQuickStart } = React.useContext<QuickStartContextValues>(
@@ -49,6 +51,10 @@ const QuickStartsCatalogCard: React.FC<QuickStartsCatalogCardProps> = ({
     true,
   );
   const [isOpen, setOpen] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    shouldShowQSTile && shouldShowQSTile(showTile);
+  }, [showTile, shouldShowQSTile]);
 
   const onRemove = () => {
     setShowTile(false);

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/ClusterDashboardWithQuickStarts.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/ClusterDashboardWithQuickStarts.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import QuickStartsLoader from '@console/app/src/components/quick-starts/loader/QuickStartsLoader';
+import { ClusterDashboard } from './cluster-dashboard';
+
+const ClusterDashboardWithQuickStarts: React.FC<{}> = () => (
+  <QuickStartsLoader>
+    {(quickStarts) => <ClusterDashboard quickStarts={quickStarts} />}
+  </QuickStartsLoader>
+);
+
+export default ClusterDashboardWithQuickStarts;

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/cluster-dashboard.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { useUserSettings } from '@console/shared';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid from '@console/shared/src/components/dashboard/DashboardGrid';
-import QuickStartsLoader from '@console/app/src/components/quick-starts/loader/QuickStartsLoader';
 import { HIDE_QUICK_START_DASHBOARD_TILE_STORAGE_KEY } from '@console/shared/src/components/quick-starts/quick-starts-catalog-card-constants';
 import QuickStartsCatalogCard from '@console/shared/src/components/quick-starts/QuickStartsCatalogCard';
+import { QuickStart } from '@console/app/src/components/quick-starts/utils/quick-start-types';
 import { StatusCard } from './status-card';
 import { DetailsCard } from './details-card';
 import { InventoryCard } from './inventory-card';
@@ -21,38 +20,35 @@ const rightCards = [{ Card: ActivityCard }];
 
 const HIDE_QUICK_START_DASHBOARD_TILE_USER_SETTINGS_KEY = 'console.dashboard.quickStartTile';
 
-export const ClusterDashboard: React.FC<{}> = () => {
+interface ClusterDashboardProps {
+  quickStarts: QuickStart[];
+}
+
+export const ClusterDashboard: React.FC<ClusterDashboardProps> = ({ quickStarts }) => {
   const [infrastructure, infrastructureLoaded, infrastructureError] = useK8sGet<K8sResourceKind>(
     InfrastructureModel,
     'cluster',
   );
-  // [TODO](sahil143): use sync capability here
-  const [showQuickStartsCatalogCard, , loaded] = useUserSettings(
-    HIDE_QUICK_START_DASHBOARD_TILE_USER_SETTINGS_KEY,
-    true,
-  );
 
+  const [showQSTile, setShowQSTile] = React.useState<boolean>(true);
   const rc = React.useMemo(
     () =>
-      loaded && showQuickStartsCatalogCard
+      showQSTile && quickStarts?.length > 0
         ? [
             {
               Card: () => (
-                <QuickStartsLoader>
-                  {(quickStarts) => (
-                    <QuickStartsCatalogCard
-                      quickStarts={quickStarts}
-                      storageKey={HIDE_QUICK_START_DASHBOARD_TILE_STORAGE_KEY}
-                      userSettingsKey={HIDE_QUICK_START_DASHBOARD_TILE_USER_SETTINGS_KEY}
-                    />
-                  )}
-                </QuickStartsLoader>
+                <QuickStartsCatalogCard
+                  quickStarts={quickStarts}
+                  storageKey={HIDE_QUICK_START_DASHBOARD_TILE_STORAGE_KEY}
+                  userSettingsKey={HIDE_QUICK_START_DASHBOARD_TILE_USER_SETTINGS_KEY}
+                  shouldShowQSTile={setShowQSTile}
+                />
               ),
             },
             ...rightCards,
           ]
         : rightCards,
-    [showQuickStartsCatalogCard, loaded],
+    [quickStarts, showQSTile],
   );
 
   const context = {

--- a/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
@@ -4,10 +4,6 @@ import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-
-import { ClusterDashboard } from './cluster-dashboard/cluster-dashboard';
-import { HorizontalNav, PageHeading, LoadingBox, Page, AsyncComponent } from '../../utils';
-import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid, {
   GridPosition,
   GridDashboardCard,
@@ -19,7 +15,10 @@ import {
   isDashboardsCard,
   isDashboardsTab,
 } from '@console/plugin-sdk';
+import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
+import { HorizontalNav, PageHeading, LoadingBox, Page, AsyncComponent } from '../../utils';
 import { RootState } from '../../../redux';
+import ClusterDashboardWithQuickStarts from './cluster-dashboard/ClusterDashboardWithQuickStarts';
 
 const getCardsOnPosition = (cards: DashboardsCard[], position: GridPosition): GridDashboardCard[] =>
   cards
@@ -63,7 +62,7 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, 
       {
         href: '',
         name: t('dashboard~Cluster'),
-        component: ClusterDashboard,
+        component: ClusterDashboardWithQuickStarts,
       },
       ...pluginPages,
     ],


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-5221

# Issue
Gap in right hand panel occurs as a Card is rendered even when no Quickstarts are visible to a user

# Solution
Only render card when some Quickstart is visible to a user.

# How to test
Remove `ConsoleQuickStarts` CRD, it will take some time for the operator to restore them, meanwhile the scenario can be tested. Otherwise hardcode the output of `QuickStartLoader` to `null` or `[]`

# Screenshot
![Screenshot from 2021-02-12 17-12-23](https://user-images.githubusercontent.com/24852534/107765315-98ea3400-6d57-11eb-9229-57f3371238d3.png)
![Screenshot from 2021-02-12 17-03-07](https://user-images.githubusercontent.com/24852534/107765395-c8993c00-6d57-11eb-9cfc-336f6f68ad1a.png)

# Tests
No tests altered

# Browser Conformance
Chrome 88
