### PR TITLE
QuickStart highlight fixed for collapsed nav

### DIFF
--- a/frontend/packages/console-shared/src/components/spotlight/Spotlight.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/Spotlight.tsx
@@ -8,7 +8,18 @@ type SpotlightProps = {
 };
 
 const Spotlight: React.FC<SpotlightProps> = ({ selector, interactive }) => {
-  const element = React.useMemo(() => document.querySelector(selector), [selector]);
+  // if target element is a hidden one return null
+  const element = React.useMemo(() => {
+    const highlightElement = document.querySelector(selector);
+    let hiddenElement = highlightElement;
+    while (hiddenElement) {
+      const ariaHidden = hiddenElement.getAttribute('aria-hidden');
+      if (ariaHidden === 'true') return null;
+      hiddenElement = hiddenElement.parentElement;
+    }
+    return highlightElement;
+  }, [selector]);
+
   if (!element) return null;
   return interactive ? (
     <InteractiveSpotlight element={element} />

--- a/frontend/packages/console-shared/src/components/spotlight/__tests__/Spotlight.spec.tsx
+++ b/frontend/packages/console-shared/src/components/spotlight/__tests__/Spotlight.spec.tsx
@@ -8,7 +8,10 @@ describe('Spotlight', () => {
   type SpotlightProps = React.ComponentProps<typeof Spotlight>;
   let wrapper: ShallowWrapper<SpotlightProps>;
   const uiElementPos = { height: 100, width: 100, top: 100, left: 100 };
-  const uiElement = { getBoundingClientRect: jest.fn().mockReturnValue(uiElementPos) };
+  const uiElement = {
+    getBoundingClientRect: jest.fn().mockReturnValue(uiElementPos),
+    getAttribute: jest.fn().mockReturnValue('false'),
+  };
   beforeEach(() => {
     jest.spyOn(document, 'querySelector').mockImplementation(() => uiElement);
   });
@@ -24,5 +27,25 @@ describe('Spotlight', () => {
   it('should render InteractiveSpotlight if interactive is set to true', () => {
     wrapper = shallow(<Spotlight selector="selector" interactive />);
     expect(wrapper.find(InteractiveSpotlight).exists()).toBe(true);
+  });
+
+  it('should render nothing when element is hidden', () => {
+    const childEl = document.createElement('a');
+    childEl.setAttribute('aria-hidden', 'true');
+    jest.spyOn(document, 'querySelector').mockImplementation(() => childEl);
+    wrapper = shallow(<Spotlight selector="selector" />);
+    expect(wrapper.find(StaticSpotlight).exists()).toBe(false);
+  });
+
+  it('should render nothing when ancestor is hidden', () => {
+    const childEl = document.createElement('a');
+    const parentEl = document.createElement('a');
+    const ancestorEl = document.createElement('a');
+    ancestorEl.setAttribute('aria-hidden', 'true');
+    parentEl.appendChild(childEl);
+    ancestorEl.appendChild(parentEl);
+    jest.spyOn(document, 'querySelector').mockImplementation(() => childEl);
+    wrapper = shallow(<Spotlight selector="selector" />);
+    expect(wrapper.find(StaticSpotlight).exists()).toBe(false);
   });
 });


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-5329

# Screenshot
![highlight](https://user-images.githubusercontent.com/24852534/107782168-c1c9f380-6d6e-11eb-8305-6d0d81fae677.gif)

# Test Data
```
apiVersion: console.openshift.io/v1
kind: ConsoleQuickStart
metadata:
  name: test-highlights
spec:
  description: Description here
  displayName: test highlights
  durationMinutes: 1
  introduction: Introduction here
  tasks:
    - description: |
        Perspective switcher: [link]{{highlight qs-perspective-switcher}}

        ### Admin perspective nav Links:
        - [Home]{{highlight qs-nav-home}}
        - [Operators]{{highlight qs-nav-operators}}
        - [Workloads]{{highlight qs-nav-workloads}}
        - [Serverless]{{highlight qs-nav-serverless}}
        - [Networking]{{highlight qs-nav-networking}}
        - [Storage]{{highlight qs-nav-storage}}
        - [Service catalog]{{highlight qs-nav-servicecatalog}}
        - [Compute]{{highlight qs-nav-compute}}
        - [User maganement]{{highlight qs-nav-usermanagement}}
        - [Administration]{{highlight qs-nav-administration}}

        ### Dev perspective nav Links:
        - [Add]{{highlight qs-nav-add}}
        - [Topology]{{highlight qs-nav-topology}}
        - [Search]{{highlight qs-nav-search}}
        - [Project]{{highlight qs-nav-project}}
        - [Helm]{{highlight qs-nav-helm}}

        ### Common nav Links:
        - [Builds]{{highlight qs-nav-builds}}
        - [Pipelines]{{highlight qs-nav-pipelines}}
        - [Monitoring]{{highlight qs-nav-monitoring}}

        ### Masthead Links:
        - [CloudShell]{{highlight qs-masthead-cloudshell}}
        - [Utility Menu]{{highlight qs-masthead-utilitymenu}}
        - [User Menu]{{highlight qs-masthead-usermenu}}
        - [Applications]{{highlight qs-masthead-applications}}
        - [Import]{{highlight qs-masthead-import}}
        - [Help]{{highlight qs-masthead-help}}
        - [Notifications]{{highlight qs-masthead-notifications}}
      title: test highlight
```

# Tests
 Added tests for hidden check in Spotlight.spec.ts
      
# Browser conformance
      Chrome
      
      