### PR TITLE
refactor: Local volume discovery request and wizard footer changes for attached devices wizard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/create-sc/state.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/create-sc/state.ts
@@ -40,7 +40,6 @@ export const initialState: State = {
   // common states
   isLoading: false,
   error: '',
-  onNextClick: null,
 
   // states for step 3-5
   enableMinimal: false,
@@ -105,8 +104,6 @@ export type Discoveries = {
   node: string;
 };
 
-export type OnNextClick = () => void;
-
 export type State = {
   volumeSetName: string;
   storageClassName: string;
@@ -130,7 +127,6 @@ export type State = {
   allNodeNamesOnADV: string[];
   nodesDiscoveries: Discoveries[];
   showConfirmModal: boolean;
-  onNextClick: () => void;
   filteredDiscoveries: Discoveries[];
   filteredNodes: string[];
   finalStep: boolean;
@@ -176,7 +172,6 @@ export type Action =
   | { type: 'setChartSelectedData'; value: number }
   | { type: 'setChartTotalData'; value: number }
   | { type: 'setShowConfirmModal'; value: boolean }
-  | { type: 'setOnNextClick'; value: OnNextClick }
   | { type: 'setFilteredDiscoveries'; value: Discoveries[] }
   | { type: 'setFinalStep'; value: boolean }
   | { type: 'setShowDiskList'; value: boolean }
@@ -244,8 +239,6 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { chartTotalData: action.value });
     case 'setShowConfirmModal':
       return Object.assign({}, state, { showConfirmModal: action.value });
-    case 'setOnNextClick':
-      return Object.assign({}, state, { onNextClick: action.value });
     case 'setFilteredDiscoveries':
       return Object.assign({}, state, { filteredDiscoveries: action.value });
     case 'setFinalStep':

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
@@ -142,10 +142,13 @@ export const CreateInternalCluster: React.FC<CreateInternalClusterProps> = ({ ma
           navAriaLabel={t('ceph-storage-plugin~{{title}} steps', { title })}
           mainAriaLabel={t('ceph-storage-plugin~{{title}} content', { title })}
           steps={steps}
-          onSave={createCluster}
+          cancelButtonText={t('ceph-storage-plugin~Cancel')}
+          nextButtonText={t('ceph-storage-plugin~Next')}
+          backButtonText={t('ceph-storage-plugin~Back')}
           onClose={() =>
             history.push(resourcePathFromModel(ClusterServiceVersionModel, appName, ns))
           }
+          onSave={createCluster}
         />
       </StackItem>
     </Stack>

--- a/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/auto-detect-volume/auto-detect-volume.tsx
@@ -17,17 +17,12 @@ import {
 } from '@console/internal/module/k8s';
 import { fetchK8s } from '@console/internal/graphql/client';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
-import { getNodes, getLabelIndex, getHostNames } from '../../utils';
+import { getNodes, getNodeSelectorTermsIndices, getHostNames } from '../../utils';
 import { AutoDetectVolumeInner, AutoDetectVolumeHeader } from './auto-detect-volume-inner';
 import { getDiscoveryRequestData } from './discovery-request-data';
 import { LocalVolumeDiscovery as AutoDetectVolumeModel } from '../../models';
 import { initialState, reducer } from './state';
-import {
-  DISCOVERY_CR_NAME,
-  HOSTNAME_LABEL_KEY,
-  AUTO_DISCOVER_ERR_MSG,
-  LABEL_OPERATOR,
-} from '../../constants';
+import { DISCOVERY_CR_NAME, AUTO_DISCOVER_ERR_MSG } from '../../constants';
 import './auto-detect-volume.scss';
 import '../local-volume-set/create-local-volume-set.scss';
 
@@ -44,9 +39,7 @@ const AutoDetectVolume: React.FC = withHandlePromise<AutoDetectVolumeProps & Han
         fetchK8s(AutoDetectVolumeModel, DISCOVERY_CR_NAME, ns)
           .then((discoveryRes: K8sResourceKind) => {
             const nodeSelectorTerms = discoveryRes?.spec?.nodeSelector?.nodeSelectorTerms;
-            const [selectorIndex, expIndex] = nodeSelectorTerms
-              ? getLabelIndex(nodeSelectorTerms, HOSTNAME_LABEL_KEY, LABEL_OPERATOR)
-              : [-1, -1];
+            const [selectorIndex, expIndex] = getNodeSelectorTermsIndices(nodeSelectorTerms);
             if (selectorIndex !== -1 && expIndex !== -1) {
               const nodes = new Set<string>(
                 discoveryRes?.spec?.nodeSelector?.nodeSelectorTerms?.[

--- a/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/utils/index.ts
@@ -1,8 +1,8 @@
 import * as _ from 'lodash';
 import { NodeKind, MatchExpression } from '@console/internal/module/k8s';
-import { NodeAffinityTerm, HostNamesMap } from '../components/auto-detect-volume/types';
+import { HostNamesMap } from '../components/auto-detect-volume/types';
 import { getName } from '@console/shared';
-import { ZONE_LABELS } from '../constants';
+import { HOSTNAME_LABEL_KEY, LABEL_OPERATOR, ZONE_LABELS } from '../constants';
 
 export const hasNoTaints = (node: NodeKind): boolean => _.isEmpty(node.spec?.taints);
 
@@ -15,23 +15,18 @@ export const getNodes = (
   selectedNodes: string[],
 ): string[] => (showNodes ? selectedNodes : allNodes);
 
-export const getLabelIndex = (
-  nodeSelector: NodeAffinityTerm[],
-  label: string,
-  operator: string,
+export const getNodeSelectorTermsIndices = (
+  nodeSelectorTerms: { matchExpressions: MatchExpression[]; matchFields: MatchExpression[] }[] = [],
 ) => {
   let [selectorIndex, expIndex] = [-1, -1];
 
-  _.forEach(nodeSelector, (selector, index) => {
-    expIndex = _.findIndex(
-      selector?.matchExpressions,
-      (exp: MatchExpression) => exp.key === label && exp.operator === operator,
+  nodeSelectorTerms.forEach((selector, index) => {
+    expIndex = selector?.matchExpressions?.findIndex(
+      (exp: MatchExpression) => exp.key === HOSTNAME_LABEL_KEY && exp.operator === LABEL_OPERATOR,
     );
     if (expIndex !== -1) {
       selectorIndex = index;
-      return false;
     }
-    return true;
   });
 
   return [selectorIndex, expIndex];


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHSTOR-1655

### Footer:
- remove `onNextClick()` state : this state is set to utilize default `onNext()` function of Wizard in local volume set step. We can instead use `WizardContextConsumer` to consume the onNext function in lvset step.

    Before:
    
    ```javascript
    // State setting:
      const makeCall = (activeStep: WizardStep, onNext: OnNextClick) => {
        // TODO: Need to think of a way to remove this
    >>> dispatch({ type: 'setOnNextClick', value: onNext });
        if (activeStep.id === CreateStepsSC.DISCOVER) {
     ```
    
    
     ```javascript
    // State Utilization:
      const makeLocalVolumeSetCall = (
       ....
      k8sCreate(LocalVolumeSetModel, requestData)
          ......
    >>>state.onNextClick();
          setInProgress(false);
        })
    ```
    After:
    
    ```javascript
    // State Utilization via `WizardContextConsumer` directly:
    
    const ConfirmationModal = ({ state, dispatch, setInProgress, setErrorMessage, ns }) => {
      ....
      return (
        <WizardContextConsumer>
          {({ onNext }) => {
            const makeLVSCall = () => {
          ....
        </WizardContextConsumer>
    
    ```
### Local volume discovery request:
=========================
- the existing function `getLabelIndex` return multiple type of values - boolean and array. We must make it to return single type of value.

    Before :
    ```javascript
    export const getLabelIndex = (
      nodeSelector: NodeAffinityTerm[],
      label: string,
      operator: string,
    ) => {
      let [selectorIndex, expIndex] = [-1, -1];
    
      _.forEach(nodeSelector, (selector, index) => {
        expIndex = _.findIndex(
          selector?.matchExpressions,
          (exp: MatchExpression) => exp.key === label && exp.operator === operator,
        );
        if (expIndex !== -1) {
          selectorIndex = index;
          return false; // boolean value 
        }
        return true; //boolean value
      });
    
      return [selectorIndex, expIndex]; // array vaue
    };
    ```
    After:
    ```javascript
          export const getNodeSelectorTermsIndices = (
          nodeSelectorTerms: { matchExpressions: MatchExpression[]; matchFields: MatchExpression[] }[],
        ) => {
          let [selectorIndex, expIndex] = [-1, -1];
        
          _.forEach(nodeSelectorTerms, (selector, index) => {
            expIndex = _.findIndex(
              selector?.matchExpressions,
              (exp: MatchExpression) => exp.key === HOSTNAME_LABEL_KEY && exp.operator === LABEL_OPERATOR,
            );
            if (expIndex !== -1) {
              selectorIndex = index;
            }
          });
        
          return [selectorIndex, expIndex];
        };
    ```
    

- add a message when no indices of `matchExpression` are found.
    Before:
    ```javascript
    fetchK8s(LocalVolumeDiscovery, DISCOVERY_CR_NAME, ns)
          .....
          if (selectorIndex !== -1 && expIndex !== -1) {
           .....
          }
          throw new Error(AUTO_DISCOVER_ERR_MSG);
        })
       ....
    };
    ```
    After:
    ```javascript
        if (selectorIndex === -1 && expIndex !== 1) {
        .....
        } else {
          throw new Error(
            'Could not find matchExpression of type key: "kubernetes.io/hostname" and operator: "In"',
          );
        }
    ```
- use status code if request to fetch local volume discovery is failed instead of custom error message.
    Before:
    ```javascript
    fetchK8s(LocalVolumeDiscovery, DISCOVERY_CR_NAME, ns)
          ....
          throw new Error(AUTO_DISCOVER_ERR_MSG); 
        })
        .catch((err) => {
          // handle AUTO_DISCOVER_ERR_MSG and throw to next catch block to show the message
          if (err.message === AUTO_DISCOVER_ERR_MSG) {
            throw err;
          }
       ...
    };
    ```
    After:
    ```javascript
    catch (patchError) {
        if (patchError?.response?.status === 404) {
          try {
            const requestData = getDiscoveryRequestData({ ...state, ns, toleration: OCS_TOLERATION });
            await k8sCreate(LocalVolumeDiscovery, requestData);
            onNext();
          } catch (createError) {
            dispatch({ type: 'setError', value: createError.message });
          }
        } else {
          dispatch({ type: 'setError', value: patchError.message });
        }
      } finally {
        dispatch({ type: 'setIsLoading', value: false });
    ```
