### PR TITLE
Improve fetching LSO status during cluster installation

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/constants/common.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/common.ts
@@ -9,6 +9,7 @@ export const PODS = 'Pods';
 export const BY_USED = 'By Used Capacity';
 export const BY_REQUESTED = 'By Requested Capacity';
 export const OCS_OPERATOR = 'ocs-operator';
+export const LSO_OPERATOR = 'local-storage-operator';
 export const OCS_EXTERNAL_CR_NAME = 'ocs-external-storagecluster';
 export const OCS_INTERNAL_CR_NAME = 'ocs-storagecluster';
 export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';

--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -61,13 +61,16 @@ export const getCephSC = (scData: K8sResourceKind[]): K8sResourceKind[] =>
     );
   });
 
+export const getOperatorVersion = (operator: K8sResourceKind): string =>
+  operator?.status?.installedCSV;
+
 export const getOCSVersion = (items: FirehoseResult): string => {
   const itemsData: K8sResourceKind[] = _.get(items, 'data');
   const operator: K8sResourceKind = _.find(
     itemsData,
     (item) => _.get(item, 'spec.name') === OCS_OPERATOR,
   );
-  return _.get(operator, 'status.installedCSV');
+  return getOperatorVersion(operator);
 };
 
 export const calcPVsCapacity = (pvs: K8sResourceKind[]): number =>


### PR DESCRIPTION
URL: https://issues.redhat.com/browse/RHSTOR-1596
Earlier:
1) We were only considering subscription object to check the LSO status.
2) We were looking for specific LSO subscription by using "metadata.name", which can be changed when installing the operator from the CLI.

After:
1) We are considering both subscription object and status of corresponding CSV object to check for the LSO status.
2) We are looking for specific LSO subscription using "spec.name" instead of "metadata.name" ( we are filtering the LSO operator from all the installed operators and this filtering is being done on the UI side )
3) Edge Case - where multiple LSOs are installed, we are considering the first one only (0th index from a list of LSOs) and CSV corresponding to it ( this issue will be addressed when a drop-down menu will be introduced and user will specifically be able to choose among multiple installed LSOs )