### PR TITLE
Check for kindObj before accessing its properties

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -52,7 +52,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
     ? currentSelection.description
     : currentDefinition.description;
   const required = new Set(currentDefinition.required || []);
-  const kindLabel = kindObj.labelKey ? t(kindObj.labelKey) : kindObj.kind;
+  const kindLabel = kindObj?.labelKey ? t(kindObj.labelKey) : kindObj?.kind;
   const breadcrumbs = drilldownHistory.length
     ? [kindObj ? kindLabel : t('public~Schema'), ..._.map(drilldownHistory, 'name')]
     : [];


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5526
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Type explorer component was crashing because it was trying to access a property of `kindObj` when it was `undefined`.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Added optional chaining operator to `kindObj.labelKey` access.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/107925764-df7ba080-6f9a-11eb-8892-3af9eafdd654.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
