### PR TITLE
fix pipelinerun status icon rendering issue

### DIFF
--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -128,7 +128,7 @@ export const PipelineResourceListFilterLabels = {
  * @param pipeline
  * @param pipelineRun
  */
-const appendPipelineRunStatus = (pipeline, pipelineRun) => {
+export const appendPipelineRunStatus = (pipeline, pipelineRun) => {
   return _.map(pipeline.spec.tasks, (task) => {
     if (!pipelineRun.status) {
       return task;
@@ -151,6 +151,8 @@ const appendPipelineRunStatus = (pipeline, pipelineRun) => {
       mTask.status = { reason: runStatus.Idle };
     } else if (mTask.status && mTask.status.conditions) {
       mTask.status.reason = pipelineRunStatus(mTask) || runStatus.Idle;
+    } else if (mTask.status && !mTask.status.reason) {
+      mTask.status.reason = runStatus.Idle;
     }
     return mTask;
   });


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5524

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

While running a pipeline, the `taskruns` in the `pipelinerun.status` yaml doesn't have `status.reason` field for a moment causing the icon to disappear and the text to render outside the task bubble.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Add a default `Idle` taskrun status if the status.reason is not present.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![pipeline-taskrun](https://user-images.githubusercontent.com/9964343/108068009-905f6980-7087-11eb-8e74-d5cc3d1a0dca.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
pipeline-utils
    ✓ should append Idle status if a taskrun status reason is missing (2ms)
    ✓ should append pipelineRun running status for all the tasks (1ms)

Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create this pipeline using the below command
```
oc apply -f https://raw.githubusercontent.com/andrewballantyne/pipeline-scratch-pad/master/examples/mock-app-embedded-tasks/resources.yaml
```
2. Start the pipeline 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @andrewballantyne 