### PR TITLE
fix alerts notification layout

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertColumn.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlertColumn.tsx
@@ -7,6 +7,7 @@ type MonitoringAlertColumn = {
   transforms?: ITransform[];
   fieldName?: string;
   sortFunc?: string;
+  props?: { [className: string]: string };
 };
 
 export const MonitoringAlertColumn = (t: TFunction): MonitoringAlertColumn[] => [
@@ -25,15 +26,16 @@ export const MonitoringAlertColumn = (t: TFunction): MonitoringAlertColumn[] => 
   },
   {
     title: t('devconsole~Alert state'),
-    transforms: [sortable, cellWidth(15)],
+    transforms: [sortable, cellWidth(10)],
     fieldName: 'alertState',
     sortFunc: 'alertingRuleStateOrder',
   },
   {
     title: t('devconsole~Notifications'),
-    transforms: [sortable, cellWidth(20)],
+    transforms: [sortable],
     fieldName: 'notifications',
     sortFunc: 'alertingRuleNotificationsOrder',
+    props: { className: 'odc-monitoring-alert-column--notification' },
   },
   { title: '' },
 ];

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/MonitoringAlerts.scss
@@ -1,3 +1,5 @@
+@import '~@patternfly/patternfly/sass-utilities/all';
+
 .odc-monitoring-alerts {
   padding: var(--pf-global--spacer--lg);
   &--state-column {
@@ -6,6 +8,14 @@
   }
   &--kebab {
     text-align: right;
+  }
+  .odc-monitoring-alert-column {
+    &--notification {
+      width: 20%;
+      @media screen and (max-width: $pf-global--breakpoint--2xl) {
+        width: 30%;
+      }
+    }
   }
   .pf-c-table {
     table-layout: auto;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4422

**Analysis / Root cause**: 
When we silence the notification for a day and change the resolution of the page, that silence break notification is not in sync with the design

**Solution Description**: 
Increase the width for the `Notifications` column.

**Screen shots / Gifs for design review**: 
![Kapture 2021-02-17 at 18 28 26](https://user-images.githubusercontent.com/2561818/108207597-fca4a080-714d-11eb-9487-43e8c1f53a0c.gif)


**Test setup:**
It will create an alert in the `ns1` namespace.
`oc apply -f https://gist.githubusercontent.com/vikram-raj/27fa5c9d7e0cf223919c697d34bd2beb/raw/f85ab7a0e1f3e8a6270c124a4a97df13e5b9cb3c/ns-alert-setup.yaml`
