### PR TITLE
Bug 1929769: Switch to correct perspective when loading non-shared routes

### DIFF
--- a/frontend/packages/console-app/src/components/detect-perspective/PerspectiveDetector.tsx
+++ b/frontend/packages/console-app/src/components/detect-perspective/PerspectiveDetector.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useExtensions, Perspective, isPerspective } from '@console/plugin-sdk';
 
 type PerspectiveDetectorProps = {
-  setActivePerspective: (string) => void;
+  setActivePerspective: (perspective: string) => void;
 };
 
 const PerspectiveDetector: React.FC<PerspectiveDetectorProps> = ({ setActivePerspective }) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5283
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Routes specific to a perspective are not rendered if the currently active perspective does not match, resulting in a 404 error.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Render the inactive Routes after the active routes, and switch to the correct perspective if they are loaded.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/108228442-df2f0100-7164-11eb-99cd-3b2c2b148c98.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Test setup:**
1. Needs two browser tabs, both with open developer perspective
2. Tab 1: Open project from Sidebar, for example /project-details/ns/openshift-marketplace
3. Tab 2: Switch to Admin perspective
4. Tab 1: Browser reload via F5 / cmd-r
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug