### PR TITLE
Recently running pipeline should be listed first

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
@@ -16,7 +16,7 @@ const PipelineList: React.FC<PipelineListProps> = (props) => {
   return (
     <Table
       {...props}
-      defaultSortField="latestRun.status.completionTime"
+      defaultSortField="latestRun.status.startTime"
       defaultSortOrder={SortByDirection.desc}
       aria-label={PipelineModel.labelPlural}
       Header={PipelineHeader(t)}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -67,8 +67,8 @@ const PipelineRow: RowFunction<PipelineWithLatest> = ({ obj, index, key, style }
         <PipelineStatus obj={obj} />
       </TableData>
       <TableData className={tableColumnClasses[5]}>
-        {(obj.latestRun && obj.latestRun.status && obj.latestRun.status.completionTime && (
-          <Timestamp timestamp={obj.latestRun.status.completionTime} />
+        {(obj.latestRun?.status?.startTime && (
+          <Timestamp timestamp={obj.latestRun.status.startTime} />
         )) ||
           '-'}
       </TableData>


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5513

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Pipeline list is sorted by `completionTime` which will be available only when the pipeline run is completed its execution.
**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
PIpeline list is now sorted by `startTime` which will be always available when a pipeline run is created.


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![pipeline-list-order](https://user-images.githubusercontent.com/9964343/108236677-2b7e3f00-716d-11eb-9083-9eae72548f65.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
No UI change

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create two pipelines and start a pipeline
2. Go back to pipelines list page, recently running pipeline should be on the top of the list.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug