### PR TITLE
Bug 1917241: Format UTC date in tooltips

### DIFF
--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
+import * as moment from 'moment';
 
 import * as dateTime from './datetime';
 
@@ -54,7 +55,11 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
       <Tooltip
         content={[
           <span className="co-nowrap" key="co-timestamp">
-            {mdate.toISOString()}
+            {t('{{date, MMM D, h:mm a z}}', {
+              date: moment(mdate)
+                .utc()
+                .format('MMM D, h:mm a z'),
+            })}
           </span>,
         ]}
       >

--- a/frontend/public/locales/en-gb/public.json
+++ b/frontend/public/locales/en-gb/public.json
@@ -1,3 +1,4 @@
 {
-  "{{date, MMM D, h:mm a}}": "{{date, D MMM, H:mm}}"
+  "{{date, MMM D, h:mm a}}": "{{date, D MMM, H:mm}}",
+  "{{date, MMM D, h:mm a z}}": "{{date, D MMM, H:mm z}}"
 }

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -497,6 +497,7 @@
   "StorageClass": "StorageClass",
   "StorageClass for the new claim": "StorageClass for the new claim",
   "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
+  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}",
   "Pause event streaming": "Pause event streaming",
   "Start streaming events": "Start streaming events",
   "{{ metadataName }} is paused": "{{ metadataName }} is paused",

--- a/frontend/public/locales/ja/public.json
+++ b/frontend/public/locales/ja/public.json
@@ -411,6 +411,7 @@
   "Resource limits": "リソース制限",
   "Ports": "ポート",
   "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
+  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}",
   "Remove volume": "ボリュームの削除",
   "Mount path": "マウントパス",
   "SubPath": "SubPath",

--- a/frontend/public/locales/ko/public.json
+++ b/frontend/public/locales/ko/public.json
@@ -1,3 +1,4 @@
 {
-  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}"
+  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
+  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}"
 }

--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -411,6 +411,7 @@
   "Resource limits": "资源限制",
   "Ports": "端口",
   "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
+  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}",
   "Remove volume": "删除卷",
   "Mount path": "挂载路径",
   "SubPath": "SubPath",


### PR DESCRIPTION
Formatted UTC date in tooltip to be human-readable. I opened a story to track the suggestion to make UTC vs. local date a user preference: https://issues.redhat.com/browse/CONSOLE-2765.

En-gb date localization appears to have been broken by a recent i18n change; I'll open a separate bug for that.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1917241.

<img width="166" alt="Screen Shot 2021-02-18 at 4 27 32 PM" src="https://user-images.githubusercontent.com/7014965/108426071-4b634080-7209-11eb-8553-68a37602c793.png">

<img width="179" alt="Screen Shot 2021-02-18 at 4 27 05 PM" src="https://user-images.githubusercontent.com/7014965/108426084-50c08b00-7209-11eb-80b7-4c7473ac75c2.png">

<img width="171" alt="Screen Shot 2021-02-18 at 4 27 53 PM" src="https://user-images.githubusercontent.com/7014965/108426105-561dd580-7209-11eb-8da7-95cc8eef887c.png">

CC @openshift/team-ux-review.
