### PR TITLE
Update the Task Results error message to be an empty state message

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@patternfly/react-core';
+import { Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import { SectionHeading } from '@console/internal/components/utils';
 import { TektonResultsRun } from '../../../types';
@@ -32,13 +32,15 @@ const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status
           <TableBody />
         </Table>
       ) : (
-        <Alert
-          variant="danger"
-          isInline
-          title={t('pipelines-plugin~No {{resourceName}} results available due to failure', {
-            resourceName,
-          })}
-        />
+        <Bullseye>
+          <EmptyState variant={EmptyStateVariant.full}>
+            <EmptyStateBody>
+              {t('pipelines-plugin~No {{resourceName}} results available due to failure', {
+                resourceName,
+              })}
+            </EmptyStateBody>
+          </EmptyState>
+        </Bullseye>
       )}
     </>
   );

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { Table } from '@patternfly/react-table';
-import { Alert } from '@patternfly/react-core';
+import { EmptyState } from '@patternfly/react-core';
 import ResultsList, { ResultsListProps } from '../ResultsList';
 import { runStatus } from '../../../../utils/pipeline-augment';
 import { taskRunWithResults } from '../../../taskruns/__tests__/taskrun-test-data';
@@ -29,9 +29,9 @@ describe('ResultsList', () => {
 
   it('Should render Results Table', () => {
     expect(resultsListWrapper.find(Table).exists()).toBe(true);
-    expect(resultsListWrapper.find(Alert).exists()).toBe(false);
+    expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });
-  it('Should render an Alert instead', () => {
+  it('Should render an EmptyState instead', () => {
     resultsListProps = {
       status: runStatus.Failed,
       resourceName: 'Task Run',
@@ -39,6 +39,6 @@ describe('ResultsList', () => {
     };
     resultsListWrapper = shallow(<ResultsList {...resultsListProps} />);
     expect(resultsListWrapper.find(Table).exists()).toBe(false);
-    expect(resultsListWrapper.find(Alert).exists()).toBe(true);
+    expect(resultsListWrapper.find(EmptyState).exists()).toBe(true);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5542

**Description**: 
Update the Task Results error message to be an empty state message

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/108481666-7b205000-72be-11eb-99cc-05c832e495ff.png)
![image](https://user-images.githubusercontent.com/2561818/108481745-8ffce380-72be-11eb-808e-e4e617051d8b.png)


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/2561818/108482263-41037e00-72bf-11eb-817e-3e22a94e8135.png)

