### PR TITLE
fix validation in number type input field

### DIFF
--- a/frontend/packages/dev-console/src/components/health-checks/ProbeForm.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/ProbeForm.tsx
@@ -58,7 +58,7 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, probeType }) =
         />
         {getRequestTypeForm(healthChecks?.[probeType]?.data?.requestType, probeType)}
         <InputField
-          type={TextInputTypes.number}
+          type={TextInputTypes.text}
           name={`healthChecks.${probeType}.data.failureThreshold`}
           label={t('devconsole~Failure threshold')}
           style={{ maxWidth: '100%' }}
@@ -68,7 +68,7 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, probeType }) =
           isDisabled={viewOnly}
         />
         <InputField
-          type={TextInputTypes.number}
+          type={TextInputTypes.text}
           name={`healthChecks.${probeType}.data.successThreshold`}
           label={t('devconsole~Success threshold')}
           style={{ maxWidth: '100%' }}
@@ -78,7 +78,7 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, probeType }) =
           isDisabled={viewOnly}
         />
         <InputGroupField
-          type={TextInputTypes.number}
+          type={TextInputTypes.text}
           name={`healthChecks.${probeType}.data.initialDelaySeconds`}
           label={t('devconsole~Initial delay')}
           helpText={t(
@@ -89,7 +89,7 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, probeType }) =
           isDisabled={viewOnly}
         />
         <InputGroupField
-          type={TextInputTypes.number}
+          type={TextInputTypes.text}
           name={`healthChecks.${probeType}.data.periodSeconds`}
           label={t('devconsole~Period')}
           helpText={t('devconsole~How often to perform the probe.')}
@@ -98,7 +98,7 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, probeType }) =
           isDisabled={viewOnly}
         />
         <InputGroupField
-          type={TextInputTypes.number}
+          type={TextInputTypes.text}
           name={`healthChecks.${probeType}.data.timeoutSeconds`}
           label={t('devconsole~Timeout')}
           helpText={t(


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-3989

**Analysis / Root cause:**
Input fields with **type="number"** allows character input in Firefox.
For an input field of type number -
- Chromium allows only numbers to be entered in the field as part of its browser validation, i.e. any non numeric character is rejected as invalid input and will not show up on the input field nor will it be passed down as value to any event for that field.
- Firefox also does similar browser validation for such fields and rejects non numeric characters as invalid input and does not pass them as value to any event. However, it allows the non numeric characters to show up on the input field which leads to confusion.
Since, under the hood, the characters are restricted by browser validation, formik doesn't receive values. Thus yup validation does not occur and also the form is submitted with initial values. This is confusing to users on firefox.

**Solution Description:**
Change input type from **number** to **text** to bypass the browser validation and handle the number validation in yup.

**Note:** The solution will strip the fields from user experience related to number fields, e.g. numeric keypad on mobile devices.

**Screen shots / Gifs for design review:**
_Before -_
Firefox:
![invalid-input_pre-change_firefox](https://user-images.githubusercontent.com/38663217/109007568-45ba9e80-76d2-11eb-8086-101f69a6fd9b.gif)

Chrome:
![invalid-input_pre-change_chrome](https://user-images.githubusercontent.com/38663217/109007598-50753380-76d2-11eb-8be1-9e80c8ef5cc8.gif)

Edge:
![invalid-input_pre-change_edge](https://user-images.githubusercontent.com/38663217/109007649-61be4000-76d2-11eb-9698-b70f994b7b8b.gif)

_After_
Firefox:
![invalid-input_post-change_firefox](https://user-images.githubusercontent.com/38663217/109007720-769ad380-76d2-11eb-8673-67ce709faba4.gif)

Chrome:
![invalid-input_post-change_chrome](https://user-images.githubusercontent.com/38663217/109007742-7ef30e80-76d2-11eb-9308-ea4bcebd12ef.gif)

Edge:
![invalid-input_post-change_edge](https://user-images.githubusercontent.com/38663217/109007773-874b4980-76d2-11eb-9792-30e8d6da23f7.gif)

**Test Coverage:**
NA

**Browser Conformance:**
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [x] Edge