### PR TITLE
Make workload serverless

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -758,7 +758,7 @@ export const knExternalImageValues: DeployImageFormData = {
   route: {
     create: true,
     defaultUnknownPort: 8080,
-    disable: true,
+    disable: false,
     hostname: '',
     path: '',
     secure: false,

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
@@ -124,7 +124,7 @@ describe('Edit Application Utils', () => {
         },
       };
       const serverlessData = getServerlessData(knativeServiceData);
-      expect(serverlessData.scaling.autoscale.autoscalewindow).toBe('60');
+      expect(serverlessData.scaling.autoscale.autoscalewindow).toBe(60);
       expect(serverlessData.scaling.autoscale.autoscalewindowUnit).toBe('s');
     });
     it('getServerlessData should return correct autoscalewindow values when stable-window annotation has empty value', () => {
@@ -165,7 +165,7 @@ describe('Edit Application Utils', () => {
           concurrencytarget: '100',
           concurrencylimit: '3',
           autoscale: {
-            autoscalewindow: '60',
+            autoscalewindow: 60,
             autoscalewindowUnit: 's',
             defaultAutoscalewindowUnit: 's',
           },

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
@@ -8,6 +8,7 @@ import {
   getInitialValues,
   getExternalImagelValues,
   getServerlessData,
+  getKsvcRouteData,
 } from '../edit-application-utils';
 import { GitImportFormData, Resources } from '../../import/import-types';
 import {
@@ -174,5 +175,52 @@ describe('Edit Application Utils', () => {
       const serverlessData = getServerlessData(knativeServiceData);
       expect(serverlessData).toEqual(expectedValue);
     });
+  });
+});
+
+describe('KSVC Route Data', () => {
+  it('getKsvcRouteData should return values of route based on the resource', () => {
+    const routeData = {
+      create: true,
+      unknownTargetPort: '',
+      targetPort: '',
+      defaultUnknownPort: 8080,
+    };
+    expect(getKsvcRouteData(knativeService)).toEqual(routeData);
+  });
+
+  it('getKsvcRouteData should return values of route(clusterlocal and ports) based on the resource', () => {
+    const routeData = {
+      create: true,
+      unknownTargetPort: '8080',
+      targetPort: '8080',
+      defaultUnknownPort: 8080,
+    };
+    const ksvcData = {
+      ...knativeService,
+      metadata: {
+        ...knativeService.metadata,
+        labels: {
+          'serving.knative.dev/visibility': 'cluster-local',
+        },
+      },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                ...knativeService.spec.template.spec.containers[0],
+                ports: [
+                  {
+                    containerPort: 8080,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
+    expect(getKsvcRouteData(ksvcData)).toEqual(routeData);
   });
 });

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -180,7 +180,7 @@ export const getBuildData = (
   return buildData;
 };
 
-export const getServerlessData = (resource: K8sResourceKind) => {
+export const getServerlessData = (resource: K8sResourceKind): ServerlessData => {
   let serverlessData: ServerlessData = {
     scaling: {
       minpods: '',
@@ -203,7 +203,9 @@ export const getServerlessData = (resource: K8sResourceKind) => {
     } = resource;
     const annotations = metadata?.annotations;
     const autoscalewindowAnnotation = annotations?.[KNATIVE_AUTOSCALEWINDOW_ANNOTATION] || '';
-    const [autoscalewindow, autoscalewindowUnit] = getAutoscaleWindow(autoscalewindowAnnotation);
+    const { autoscalewindow, autoscalewindowUnit, defaultAutoscalewindowUnit } = getAutoscaleWindow(
+      autoscalewindowAnnotation,
+    );
     serverlessData = {
       scaling: {
         minpods: annotations?.[KNATIVE_MINSCALE_ANNOTATION] || '',
@@ -211,9 +213,9 @@ export const getServerlessData = (resource: K8sResourceKind) => {
         concurrencytarget: annotations?.[KNATIVE_CONCURRENCYTARGET_ANNOTATION] || '',
         concurrencylimit: spec?.containerConcurrency || '',
         autoscale: {
-          autoscalewindow: autoscalewindow || '',
-          autoscalewindowUnit: autoscalewindowUnit || 's',
-          defaultAutoscalewindowUnit: autoscalewindowUnit || 's',
+          autoscalewindow,
+          autoscalewindowUnit,
+          defaultAutoscalewindowUnit,
         },
         concurrencyutilization: annotations?.[KNATIVE_CONCURRENCYUTILIZATION_ANNOTATION] || '',
       },

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { FormFooter } from '@console/shared/src/components/form-utils';
 import { usePreventDataLossLock } from '@console/internal/components/utils';
 import { Form } from '@patternfly/react-core';
+import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import { DeployImageFormProps } from './import-types';
 import ImageSearchSection from './image-search/ImageSearchSection';
 import IconSection from './section/IconSection';
@@ -33,7 +34,7 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
         project={values.project}
         noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
       />
-      <ResourceSection />
+      {!isKnatifyForm(values.formType) && <ResourceSection />}
       <AdvancedSection values={values} />
       <FormFooter
         handleReset={handleReset}

--- a/frontend/packages/dev-console/src/components/import/__tests__/DeployImageForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/__tests__/DeployImageForm.spec.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import { FormFooter } from '@console/shared/src/components/form-utils';
+import DeployImageForm from '../DeployImageForm';
+import ImageSearchSection from '../image-search/ImageSearchSection';
+import IconSection from '../section/IconSection';
+import AppSection from '../app/AppSection';
+import ResourceSection from '../section/ResourceSection';
+import AdvancedSection from '../advanced/AdvancedSection';
+
+let deployImageFormProps: React.ComponentProps<typeof DeployImageForm>;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+describe('DeployImageForm', () => {
+  beforeEach(() => {
+    deployImageFormProps = {
+      ...formikFormProps,
+      projects: {
+        loaded: true,
+        data: [],
+      },
+    };
+  });
+
+  it('should render ImageSearchSection, IconSection, AppSection, ResourceSection, AdvancedSection and FormFooter', () => {
+    const wrapper = shallow(<DeployImageForm {...deployImageFormProps} />);
+    expect(wrapper.find(ImageSearchSection).exists()).toBe(true);
+    expect(wrapper.find(IconSection).exists()).toBe(true);
+    expect(wrapper.find(AppSection).exists()).toBe(true);
+    expect(wrapper.find(ResourceSection).exists()).toBe(true);
+    expect(wrapper.find(AdvancedSection).exists()).toBe(true);
+    expect(wrapper.find(FormFooter).exists()).toBe(true);
+  });
+
+  it('should render ImageSearchSection, IconSection, AppSection, AdvancedSection and FormFooter', () => {
+    const deployImageFormKnProps = {
+      ...deployImageFormProps,
+      values: { formType: 'knatify' },
+    };
+    const wrapper = shallow(<DeployImageForm {...deployImageFormKnProps} />);
+    expect(wrapper.find(ImageSearchSection).exists()).toBe(true);
+    expect(wrapper.find(IconSection).exists()).toBe(true);
+    expect(wrapper.find(AppSection).exists()).toBe(true);
+    expect(wrapper.find(ResourceSection).exists()).toBe(false);
+    expect(wrapper.find(AdvancedSection).exists()).toBe(true);
+    expect(wrapper.find(FormFooter).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -28,6 +28,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
       namespace,
     },
   };
+
   return (
     <FormSection title={t('devconsole~Deployment')} fullWidth>
       <CheckboxField

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -28,7 +28,6 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
       namespace,
     },
   };
-
   return (
     <FormSection title={t('devconsole~Deployment')} fullWidth>
       <CheckboxField

--- a/frontend/packages/dev-console/src/components/import/advanced/__tests__/AdvancedSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/__tests__/AdvancedSection.spec.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import HealthChecks from '../../../health-checks/HealthChecks';
+import { Resources } from '../../import-types';
+import RouteCheckbox from '../../route/RouteCheckbox';
+import AdvancedSection from '../AdvancedSection';
+import BuildConfigSection from '../BuildConfigSection';
+import DeploymentConfigSection from '../DeploymentConfigSection';
+import LabelSection from '../LabelSection';
+import ResourceLimitSection from '../ResourceLimitSection';
+import ScalingSection from '../ScalingSection';
+import ServerlessScalingSection from '../ServerlessScalingSection';
+
+let advanceSectionProps: React.ComponentProps<typeof AdvancedSection>;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+describe('AdvancedSection', () => {
+  beforeEach(() => {
+    advanceSectionProps = {
+      ...formikFormProps,
+      values: {
+        route: {
+          disable: true,
+        },
+        project: {
+          name: 'my-app',
+        },
+        resources: Resources.Kubernetes,
+        deployment: {
+          env: [],
+        },
+        pipeline: {
+          enabled: false,
+        },
+      },
+    };
+  });
+
+  it('Should render advance section for Kubernetes(D) resource and not serverless sections', () => {
+    const wrapper = shallow(<AdvancedSection {...advanceSectionProps} />);
+    expect(wrapper.find(RouteCheckbox).exists()).toBe(true);
+    expect(wrapper.find(HealthChecks).exists()).toBe(true);
+    expect(wrapper.find(BuildConfigSection).exists()).toBe(true);
+    expect(wrapper.find(DeploymentConfigSection).exists()).toBe(true);
+    expect(wrapper.find(ScalingSection).exists()).toBe(true);
+    expect(wrapper.find(ResourceLimitSection).exists()).toBe(true);
+    expect(wrapper.find(LabelSection).exists()).toBe(true);
+
+    expect(wrapper.find(ServerlessScalingSection).exists()).toBe(false);
+  });
+
+  it('Should render advance section for openshift(DC) resource and not show BuildConfigSection if pipelines enabled', () => {
+    const newAdvanceSectionProps = {
+      ...advanceSectionProps,
+      values: {
+        ...advanceSectionProps.values,
+        resources: Resources.OpenShift,
+        pipeline: {
+          enabled: true,
+        },
+      },
+    };
+    const wrapper = shallow(<AdvancedSection {...newAdvanceSectionProps} />);
+    expect(wrapper.find(RouteCheckbox).exists()).toBe(true);
+    expect(wrapper.find(HealthChecks).exists()).toBe(true);
+    expect(wrapper.find(DeploymentConfigSection).exists()).toBe(true);
+    expect(wrapper.find(ScalingSection).exists()).toBe(true);
+    expect(wrapper.find(ResourceLimitSection).exists()).toBe(true);
+    expect(wrapper.find(LabelSection).exists()).toBe(true);
+
+    expect(wrapper.find(BuildConfigSection).exists()).toBe(false);
+    expect(wrapper.find(ServerlessScalingSection).exists()).toBe(false);
+  });
+
+  it('Should render advance section specifiic for knative(KSVC) resource', () => {
+    const newAdvanceSectionProps = {
+      ...advanceSectionProps,
+      values: {
+        ...advanceSectionProps.values,
+        resources: Resources.KnativeService,
+      },
+    };
+    const wrapper = shallow(<AdvancedSection {...newAdvanceSectionProps} />);
+    expect(wrapper.find(RouteCheckbox).exists()).toBe(true);
+    expect(wrapper.find(HealthChecks).exists()).toBe(true);
+    expect(wrapper.find(BuildConfigSection).exists()).toBe(true);
+    expect(wrapper.find(DeploymentConfigSection).exists()).toBe(true);
+    expect(wrapper.find(ServerlessScalingSection).exists()).toBe(true);
+    expect(wrapper.find(ResourceLimitSection).exists()).toBe(true);
+    expect(wrapper.find(LabelSection).exists()).toBe(true);
+
+    expect(wrapper.find(ScalingSection).exists()).toBe(false);
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/advanced/__tests__/DeploymentConfigSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/__tests__/DeploymentConfigSection.spec.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { EnvironmentField } from '@console/shared';
+import DeploymentConfigSection from '../DeploymentConfigSection';
+
+let deploymentConfigSectionProps: React.ComponentProps<typeof DeploymentConfigSection>;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+jest.mock('formik', () => ({
+  useFormikContext: jest.fn(() => ({
+    values: {
+      project: {
+        name: 'my-app',
+      },
+      resources: 'kubernetes',
+      deployment: {
+        env: [
+          {
+            name: 'GREET',
+            value: 'hi',
+          },
+        ],
+      },
+    },
+  })),
+}));
+
+describe('DeploymentConfigSection', () => {
+  beforeEach(() => {
+    deploymentConfigSectionProps = {
+      namespace: 'my-app',
+    };
+  });
+
+  it('should render EnvironmentField and have values of Environment', () => {
+    const wrapper = shallow(<DeploymentConfigSection {...deploymentConfigSectionProps} />);
+    expect(wrapper.find(EnvironmentField).exists()).toBe(true);
+    expect(wrapper.find(EnvironmentField).props().envs).toEqual([
+      {
+        name: 'GREET',
+        value: 'hi',
+      },
+    ]);
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
@@ -45,7 +45,7 @@ const ImageSearchSection: React.FC<{ disabled?: boolean }> = ({ disabled = false
             label: imageRegistryType(t).Internal.label,
             value: imageRegistryType(t).Internal.value,
             isDisabled: (values.formType === 'edit' && values.registry === 'external') || disabled,
-            activeChildren: <ImageStream disabled />,
+            activeChildren: <ImageStream disabled={disabled} />,
           },
         ]}
       />

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { RadioGroupField } from '@console/shared';
-import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import FormSection from '../section/FormSection';
 import { imageRegistryType } from '../../../utils/imagestream-utils';
 import ImageStream from './ImageStream';
 import ImageSearch from './ImageSearch';
 
-const ImageSearchSection: React.FC = () => {
+const ImageSearchSection: React.FC<{ disabled?: boolean }> = ({ disabled = false }) => {
   const { t } = useTranslation();
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
   const [registry, setRegistry] = React.useState(values.registry);
@@ -39,18 +38,14 @@ const ImageSearchSection: React.FC = () => {
           {
             label: imageRegistryType(t).External.label,
             value: imageRegistryType(t).External.value,
-            isDisabled:
-              (values.formType === 'edit' || isKnatifyForm(values.formType)) &&
-              values.registry === 'internal',
+            isDisabled: (values.formType === 'edit' && values.registry === 'internal') || disabled,
             activeChildren: <ImageSearch />,
           },
           {
             label: imageRegistryType(t).Internal.label,
             value: imageRegistryType(t).Internal.value,
-            isDisabled:
-              (values.formType === 'edit' || isKnatifyForm(values.formType)) &&
-              values.registry === 'external',
-            activeChildren: <ImageStream />,
+            isDisabled: (values.formType === 'edit' && values.registry === 'external') || disabled,
+            activeChildren: <ImageStream disabled />,
           },
         ]}
       />

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { RadioGroupField } from '@console/shared';
+import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import FormSection from '../section/FormSection';
 import { imageRegistryType } from '../../../utils/imagestream-utils';
 import ImageStream from './ImageStream';
@@ -38,13 +39,17 @@ const ImageSearchSection: React.FC = () => {
           {
             label: imageRegistryType(t).External.label,
             value: imageRegistryType(t).External.value,
-            isDisabled: values.formType === 'edit' && values.registry === 'internal',
+            isDisabled:
+              (values.formType === 'edit' || isKnatifyForm(values.formType)) &&
+              values.registry === 'internal',
             activeChildren: <ImageSearch />,
           },
           {
             label: imageRegistryType(t).Internal.label,
             value: imageRegistryType(t).Internal.value,
-            isDisabled: values.formType === 'edit' && values.registry === 'external',
+            isDisabled:
+              (values.formType === 'edit' || isKnatifyForm(values.formType)) &&
+              values.registry === 'external',
             activeChildren: <ImageStream />,
           },
         ]}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
@@ -44,7 +44,7 @@ export const ImageStreamReducer = (state: ImageStreamState, action: ImageStreamA
   }
 };
 
-const ImageStream: React.FC = () => {
+const ImageStream: React.FC<{ disabled?: boolean }> = ({ disabled = false }) => {
   const { t } = useTranslation();
   const {
     values: { imageStream, project, registry, isi },
@@ -84,14 +84,14 @@ const ImageStream: React.FC = () => {
         >
           <div className="row">
             <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
-              <ImageStreamNsDropdown />
+              <ImageStreamNsDropdown disabled={disabled} />
             </div>
             <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
-              <ImageStreamDropdown />
+              <ImageStreamDropdown disabled={disabled} />
               <div className="odc-imagestream-separator">/</div>
             </div>
             <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
-              <ImageStreamTagDropdown />
+              <ImageStreamTagDropdown disabled={disabled} />
               <div className="odc-imagestream-separator">:</div>
             </div>
           </div>

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
@@ -57,7 +57,8 @@ const ImageStream: React.FC<{ disabled?: boolean }> = ({ disabled = false }) => 
   const imageStreamTagList = getImageStreamTags(selectedImageStream as K8sResourceKind);
   const isNamespaceSelected = imageStream.namespace !== '' && !accessLoading;
   const isStreamsAvailable = isNamespaceSelected && hasImageStreams && !loading;
-  const isTagsAvailable = isStreamsAvailable && !_.isEmpty(imageStreamTagList);
+  const isTagsAvailable =
+    imageStream.tag !== '' || (isStreamsAvailable && !_.isEmpty(imageStreamTagList));
   const isImageStreamSelected = imageStream.image !== '';
   const showCommandLineAlert =
     project.name !== imageStream.namespace &&

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
@@ -4,17 +4,16 @@ import { useTranslation } from 'react-i18next';
 import { useFormikContext, FormikValues } from 'formik';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ResourceDropdownField } from '@console/shared';
-import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import { getImageStreamResource } from '../../../utils/imagestream-utils';
 import { ImageStreamActions } from '../import-types';
 import { ImageStreamContext } from './ImageStreamContext';
 
-const ImageStreamDropdown: React.FC = () => {
+const ImageStreamDropdown: React.FC<{ disabled?: boolean }> = ({ disabled = false }) => {
   const { t } = useTranslation();
   const imgCollection = {};
 
   const {
-    values: { imageStream, formType },
+    values: { imageStream },
     setFieldValue,
     initialValues,
   } = useFormikContext<FormikValues>();
@@ -90,7 +89,7 @@ const ImageStreamDropdown: React.FC = () => {
       fullWidth
       required
       title={imageStream.image || getTitle()}
-      disabled={!isStreamsAvailable || (isKnatifyForm(formType) && isStreamsAvailable)}
+      disabled={!isStreamsAvailable || disabled}
       onChange={onDropdownChange}
       onLoad={onLoad}
       resourceFilter={resourceFilter}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useFormikContext, FormikValues } from 'formik';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ResourceDropdownField } from '@console/shared';
+import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import { getImageStreamResource } from '../../../utils/imagestream-utils';
 import { ImageStreamActions } from '../import-types';
 import { ImageStreamContext } from './ImageStreamContext';
@@ -13,7 +14,7 @@ const ImageStreamDropdown: React.FC = () => {
   const imgCollection = {};
 
   const {
-    values: { imageStream },
+    values: { imageStream, formType },
     setFieldValue,
     initialValues,
   } = useFormikContext<FormikValues>();
@@ -89,7 +90,7 @@ const ImageStreamDropdown: React.FC = () => {
       fullWidth
       required
       title={imageStream.image || getTitle()}
-      disabled={!isStreamsAvailable}
+      disabled={!isStreamsAvailable || (isKnatifyForm(formType) && isStreamsAvailable)}
       onChange={onDropdownChange}
       onLoad={onLoad}
       resourceFilter={resourceFilter}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFormikContext, FormikValues } from 'formik';
 import { ResourceDropdownField } from '@console/shared';
+import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import { getProjectResource, BuilderImagesNamespace } from '../../../utils/imagestream-utils';
 import { ImageStreamActions as Action } from '../import-types';
 import { ImageStreamContext } from './ImageStreamContext';
@@ -57,6 +58,7 @@ const ImageStreamNsDropdown: React.FC = () => {
       dataSelector={['metadata', 'name']}
       onChange={onDropdownChange}
       appendItems={{ openshift: BuilderImagesNamespace.Openshift }}
+      disabled={isKnatifyForm(values.formType) && values.imageStream.namespace}
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFormikContext, FormikValues } from 'formik';
 import { ResourceDropdownField } from '@console/shared';
-import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import { getProjectResource, BuilderImagesNamespace } from '../../../utils/imagestream-utils';
 import { ImageStreamActions as Action } from '../import-types';
 import { ImageStreamContext } from './ImageStreamContext';
 
-const ImageStreamNsDropdown: React.FC = () => {
+const ImageStreamNsDropdown: React.FC<{ disabled?: boolean }> = ({ disabled = false }) => {
   const { t } = useTranslation();
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
   const { dispatch } = React.useContext(ImageStreamContext);
@@ -58,7 +57,7 @@ const ImageStreamNsDropdown: React.FC = () => {
       dataSelector={['metadata', 'name']}
       onChange={onDropdownChange}
       appendItems={{ openshift: BuilderImagesNamespace.Openshift }}
-      disabled={isKnatifyForm(values.formType) && values.imageStream.namespace}
+      disabled={disabled}
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -8,6 +8,7 @@ import { DropdownField } from '@console/shared';
 import { k8sGet, K8sResourceKind, ContainerPort } from '@console/internal/module/k8s';
 import { ImageStreamTagModel } from '@console/internal/models';
 import { UNASSIGNED_KEY } from '@console/topology/src/const';
+import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import {
   getImageStreamTags,
   getPorts,
@@ -132,7 +133,9 @@ const ImageStreamTagDropdown: React.FC = () => {
           ? t('devconsole~No tag')
           : t('devconsole~Select tag'))
       }
-      disabled={!isImageStreamSelected || !isTagsAvailable}
+      disabled={
+        !isImageStreamSelected || !isTagsAvailable || (isKnatifyForm(formType) && isTagsAvailable)
+      }
       fullWidth
       required
       onChange={(tag) => {

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -8,7 +8,6 @@ import { DropdownField } from '@console/shared';
 import { k8sGet, K8sResourceKind, ContainerPort } from '@console/internal/module/k8s';
 import { ImageStreamTagModel } from '@console/internal/models';
 import { UNASSIGNED_KEY } from '@console/topology/src/const';
-import { isKnatifyForm } from '@console/knative-plugin/src/utils/knatify-utils';
 import {
   getImageStreamTags,
   getPorts,
@@ -18,7 +17,7 @@ import {
 } from '../../../utils/imagestream-utils';
 import { ImageStreamContext } from './ImageStreamContext';
 
-const ImageStreamTagDropdown: React.FC = () => {
+const ImageStreamTagDropdown: React.FC<{ disabled?: boolean }> = ({ disabled = false }) => {
   const { t } = useTranslation();
   let imageStreamTagList = {};
   const {
@@ -133,9 +132,7 @@ const ImageStreamTagDropdown: React.FC = () => {
           ? t('devconsole~No tag')
           : t('devconsole~Select tag'))
       }
-      disabled={
-        !isImageStreamSelected || !isTagsAvailable || (isKnatifyForm(formType) && isTagsAvailable)
-      }
+      disabled={!isImageStreamSelected || !isTagsAvailable || disabled}
       fullWidth
       required
       onChange={(tag) => {

--- a/frontend/packages/dev-console/src/components/import/image-search/__tests__/ImageStream.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/__tests__/ImageStream.spec.tsx
@@ -102,6 +102,14 @@ describe('Imagestream', () => {
 
   it('should render imagestream tag not found alert if there are no imagestreams tags', () => {
     spyGetImageStreamTags.mockReturnValue({});
+    spyUseFormikContext.mockReturnValue({
+      ...formikFormProps,
+      values: {
+        ...internalImageValues,
+        imageStream: { image: 'python', tag: '', namespace: 'div' },
+      },
+      initialValues: internalImageValues,
+    });
     wrapper = shallow(<ImageStream />);
     expect(wrapper.find(Alert)).toHaveLength(1);
   });

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -1,6 +1,7 @@
 import { ValidatedOptions } from '@patternfly/react-core';
 import { K8sResourceKind, ContainerPort } from '@console/internal/module/k8s';
 import { DeploymentModel, DeploymentConfigModel } from '@console/internal/models';
+import { WatchK8sResultsObject } from '@console/internal/components/utils/k8s-watch-hook';
 import { LazyLoader } from '@console/plugin-sdk';
 import { NameValuePair, NameValueFromPair } from '@console/shared';
 import { ServiceModel } from '@console/knative-plugin/src/models';
@@ -10,7 +11,7 @@ import { HealthCheckProbe } from '../health-checks/health-checks-types';
 
 export interface DeployImageFormProps {
   builderImages?: NormalizedBuilderImages;
-  projects?: FirehoseList;
+  projects?: FirehoseList | WatchK8sResultsObject<K8sResourceKind[]>;
 }
 export type ImageStreamPayload = boolean | K8sResourceKind;
 
@@ -178,10 +179,10 @@ export interface RouteData {
   targetPort: string;
   unknownTargetPort?: string;
   defaultUnknownPort?: number;
-  path: string;
-  hostname: string;
-  secure: boolean;
-  tls: TLSData;
+  path?: string;
+  hostname?: string;
+  secure?: boolean;
+  tls?: TLSData;
 }
 
 export interface TLSData {

--- a/frontend/packages/dev-console/src/components/import/serverless/__tests__/serverless-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/serverless/__tests__/serverless-utils.spec.ts
@@ -2,29 +2,51 @@ import { getAutoscaleWindow } from '../serverless-utils';
 
 describe('serverless-utils', () => {
   it('should return valid autoscale value and unit', () => {
-    const [autoscaleValue, autoscaleUnit] = getAutoscaleWindow('6s');
-    expect(autoscaleValue).toBe('6');
-    expect(autoscaleUnit).toBe('s');
-    const [autoscaleValue1, autoscaleUnit1] = getAutoscaleWindow('30m');
-    expect(autoscaleValue1).toBe('30');
+    const { autoscalewindow, autoscalewindowUnit, defaultAutoscalewindowUnit } = getAutoscaleWindow(
+      '6s',
+    );
+    expect(autoscalewindow).toBe(6);
+    expect(autoscalewindowUnit).toBe('s');
+    expect(defaultAutoscalewindowUnit).toBe('s');
+    const {
+      autoscalewindow: autoscaleValue1,
+      autoscalewindowUnit: autoscaleUnit1,
+      defaultAutoscalewindowUnit: defaultScaleUnit1,
+    } = getAutoscaleWindow('30m');
+    expect(autoscaleValue1).toBe(30);
     expect(autoscaleUnit1).toBe('m');
+    expect(defaultScaleUnit1).toBe('m');
   });
   it('should return valid value and unit', () => {
-    const [autoscaleValue, autoscaleUnit] = getAutoscaleWindow('12min');
-    expect(autoscaleValue).toBe('12');
-    expect(autoscaleUnit).toBe('min');
+    const { autoscalewindow, autoscalewindowUnit, defaultAutoscalewindowUnit } = getAutoscaleWindow(
+      '12min',
+    );
+    expect(autoscalewindow).toBe(12);
+    expect(autoscalewindowUnit).toBe('min');
+    expect(defaultAutoscalewindowUnit).toBe('min');
   });
   it('should return valid value and unit', () => {
-    const [autoscaleValue, autoscaleUnit] = getAutoscaleWindow('12min');
-    expect(autoscaleValue).toBe('12');
-    expect(autoscaleUnit).toBe('min');
+    const { autoscalewindow, autoscalewindowUnit, defaultAutoscalewindowUnit } = getAutoscaleWindow(
+      '12min',
+    );
+    expect(autoscalewindow).toBe(12);
+    expect(autoscalewindowUnit).toBe('min');
+    expect(defaultAutoscalewindowUnit).toBe('min');
   });
-  it('should return undefined unit', () => {
-    const [autoscaleValue, autoscaleUnit] = getAutoscaleWindow('');
-    expect(autoscaleValue).toBe('');
-    expect(autoscaleUnit).toBe(undefined);
-    const [autoscaleValue1, autoscaleUnit1] = getAutoscaleWindow('12');
-    expect(autoscaleValue1).toBe('12');
-    expect(autoscaleUnit1).toBe('');
+  it('should return default unit s', () => {
+    const { autoscalewindow, autoscalewindowUnit, defaultAutoscalewindowUnit } = getAutoscaleWindow(
+      '',
+    );
+    expect(autoscalewindow).toBe('');
+    expect(autoscalewindowUnit).toBe('s');
+    expect(defaultAutoscalewindowUnit).toBe('s');
+    const {
+      autoscalewindow: autoscaleValue1,
+      autoscalewindowUnit: autoscaleUnit1,
+      defaultAutoscalewindowUnit: defaultscaleUnit1,
+    } = getAutoscaleWindow('12');
+    expect(autoscaleValue1).toBe(12);
+    expect(autoscaleUnit1).toBe('s');
+    expect(defaultscaleUnit1).toBe('s');
   });
 });

--- a/frontend/packages/dev-console/src/components/import/serverless/serverless-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/serverless/serverless-utils.ts
@@ -1,4 +1,11 @@
-export const getAutoscaleWindow = (autoscaleValue: string) => {
+import { AutoscaleWindowType } from '../import-types';
+
+export const getAutoscaleWindow = (autoscaleValue: string): AutoscaleWindowType => {
   const windowRegEx = /^[0-9]+|[a-zA-Z]*/g;
-  return autoscaleValue?.match(windowRegEx);
+  const [val, unit] = autoscaleValue?.match(windowRegEx);
+  return {
+    autoscalewindow: Number(val) || '',
+    autoscalewindowUnit: unit || 's',
+    defaultAutoscalewindowUnit: unit || 's',
+  };
 };

--- a/frontend/packages/dev-console/src/components/import/serverless/useUpdateKnScalingDefaultValues.ts
+++ b/frontend/packages/dev-console/src/components/import/serverless/useUpdateKnScalingDefaultValues.ts
@@ -3,16 +3,16 @@ import { getAutoscaleWindow } from './serverless-utils';
 import { useGetAutoscalerConfig } from './useGetAutoscalerConfig';
 
 export const setKnScalingDefaultValue = (initialValues, knScalingConfig) => {
-  const [autoscalewindow, autoscalewindowUnit] =
+  const { autoscalewindow, autoscalewindowUnit, defaultAutoscalewindowUnit } =
     knScalingConfig && getAutoscaleWindow(knScalingConfig['stable-window'] ?? '');
   initialValues.serverless.scaling.concurrencytarget =
     knScalingConfig['container-concurrency-target-default'] || '';
   initialValues.serverless.scaling.concurrencyutilization =
     knScalingConfig['container-concurrency-target-percentage'] || '';
   initialValues.serverless.scaling.autoscale = {
-    autoscalewindow: autoscalewindow || '',
-    autoscalewindowUnit: autoscalewindowUnit || 's',
-    defaultAutoscalewindowUnit: autoscalewindowUnit || 's',
+    autoscalewindow,
+    autoscalewindowUnit,
+    defaultAutoscalewindowUnit,
   };
   return initialValues;
 };

--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -5,6 +5,7 @@
   "Add Trigger": "Add Trigger",
   "Delete Revision": "Delete Revision",
   "Edit URI": "Edit URI",
+  "Create Knative service": "Create Knative service",
   "Move {{kind}}": "Move {{kind}}",
   "Move sink": "Move sink",
   "Set traffic distribution": "Set traffic distribution",

--- a/frontend/packages/knative-plugin/src/actions/__tests__/knatify.spec.ts
+++ b/frontend/packages/knative-plugin/src/actions/__tests__/knatify.spec.ts
@@ -1,0 +1,81 @@
+import { deploymentData } from '../../utils/__tests__/knative-serving-data';
+import { hideKnatifyAction } from '../knatify';
+
+describe('knatify', () => {
+  it('hideKnatifyAction should return false is Workload standalone and avilable', () => {
+    expect(hideKnatifyAction(deploymentData)).toBe(false);
+  });
+
+  it('hideKnatifyAction should return true is Workload standalone and not avilable', () => {
+    const mockDeploymentData = {
+      ...deploymentData,
+      status: {
+        ...deploymentData.status,
+        conditions: [
+          {
+            type: 'Progressing',
+            status: 'False',
+            lastUpdateTime: '2019-09-24T11:21:14Z',
+            lastTransitionTime: '2019-09-24T11:21:03Z',
+            reason: 'NewReplicaSetAvailable',
+            message: 'ReplicaSet "overlayimage-54b47fbb75" has successfully progressed.',
+          },
+        ],
+      },
+    };
+    expect(hideKnatifyAction(mockDeploymentData)).toBe(true);
+  });
+
+  it('hideKnatifyAction should return true is Workload not standalone and avilable', () => {
+    const mockDeploymentData = {
+      ...deploymentData,
+      metadata: {
+        ...deploymentData.metadata,
+        ownerReferences: [
+          {
+            apiVersion: 'camel.apache.org/v1',
+            kind: 'Integration',
+            name: 'overlayimage-f56hh',
+            uid: 'c1b802c8-42ff-4224-824f-5d454814ab01',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+      },
+    };
+    expect(hideKnatifyAction(mockDeploymentData)).toBe(true);
+  });
+
+  it('hideKnatifyAction should return true is Workload not standalone and not avilable', () => {
+    const mockDeploymentData = {
+      ...deploymentData,
+      metadata: {
+        ...deploymentData.metadata,
+        ownerReferences: [
+          {
+            apiVersion: 'camel.apache.org/v1',
+            kind: 'Integration',
+            name: 'overlayimage-f56hh',
+            uid: 'c1b802c8-42ff-4224-824f-5d454814ab01',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+      },
+      status: {
+        ...deploymentData.status,
+        conditions: [
+          {
+            type: 'Progressing',
+            status: 'False',
+            lastUpdateTime: '2019-09-24T11:21:14Z',
+            lastTransitionTime: '2019-09-24T11:21:03Z',
+            reason: 'NewReplicaSetAvailable',
+            message: 'ReplicaSet "overlayimage-54b47fbb75" has successfully progressed.',
+          },
+        ],
+      },
+    };
+    expect(hideKnatifyAction(mockDeploymentData)).toBe(true);
+  });
+});

--- a/frontend/packages/knative-plugin/src/actions/index.ts
+++ b/frontend/packages/knative-plugin/src/actions/index.ts
@@ -2,3 +2,4 @@ export * from './add-event-source';
 export * from './traffic-splitting';
 export * from './add-trigger';
 export * from './add-subscription';
+export * from './knatify';

--- a/frontend/packages/knative-plugin/src/actions/knatify.ts
+++ b/frontend/packages/knative-plugin/src/actions/knatify.ts
@@ -1,0 +1,26 @@
+import { KebabOption } from '@console/internal/components/utils';
+import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { ServiceModel } from '../models';
+
+export const hideKnatifyAction = (resource: K8sResourceKind): boolean => {
+  const isWorkloadReady = resource.status?.conditions?.find(
+    (cd) => cd.type === 'Available' && cd.status === 'True',
+  );
+  return resource.metadata?.ownerReferences?.length > 0 || !isWorkloadReady;
+};
+
+export const setKnatify = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
+  return {
+    // t('knative-plugin~Create Knative service')
+    labelKey: 'knative-plugin~Create Knative service',
+    hidden: hideKnatifyAction(obj),
+    href: `/knatify/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
+      model.kind}`,
+    accessReview: {
+      group: ServiceModel.apiGroup,
+      resource: ServiceModel.plural,
+      namespace: obj.metadata.namespace,
+      verb: 'create',
+    },
+  };
+};

--- a/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
@@ -107,7 +107,7 @@ const CreateKnatifyPage: React.FunctionComponent<CreateKnatifyPageProps> = ({
         <title>{t('knative-plugin~Create Knative service')}</title>
       </Helmet>
       <PageHeading title={t('knative-plugin~Create Knative service')} />
-      <div className="co-m-pane__body">
+      <div className="co-m-pane__body" style={{ paddingBottom: 0 }}>
         {isResourcesLoaded() ? (
           <Formik
             initialValues={getInitialValuesKnatify(

--- a/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import { Formik, FormikHelpers } from 'formik';
+import { RouteComponentProps } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Helmet } from 'react-helmet';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useActivePerspective } from '@console/shared';
+import { useExtensions, Perspective, isPerspective } from '@console/plugin-sdk';
+import { ProjectModel } from '@console/internal/models';
+import { LoadingBox, history, PageHeading } from '@console/internal/components/utils';
+import {
+  useK8sWatchResources,
+  WatchK8sResults,
+  WatchK8sResultsObject,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import NamespacedPage, {
+  NamespacedPageVariants,
+} from '@console/dev-console/src/components/NamespacedPage';
+import DeployImageForm from '@console/dev-console/src/components/import/DeployImageForm';
+import { handleRedirect } from '@console/dev-console/src/components/import/import-submit-utils';
+import { DeployImageFormData } from '@console/dev-console/src/components/import/import-types';
+import { deployValidationSchema } from '@console/dev-console/src/components/import/deployImage-validation-utils';
+import {
+  getInitialValuesKnatify,
+  knatifyResources,
+  getKnatifyWorkloadData,
+} from '../../utils/knatify-utils';
+
+type watchResource = {
+  [key: string]: K8sResourceKind[] | K8sResourceKind;
+};
+
+type CreateKnatifyPageProps = RouteComponentProps<{ ns?: string }>;
+
+const CreateKnatifyPage: React.FunctionComponent<CreateKnatifyPageProps> = ({
+  match,
+  location,
+}) => {
+  const { t } = useTranslation();
+  const namespace = match.params.ns;
+  const queryParams = new URLSearchParams(location.search);
+  const kind = queryParams.get('kind');
+  const appName = queryParams.get('name');
+  const [perspective] = useActivePerspective();
+  const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
+
+  const watchedResources = React.useMemo(
+    () => ({
+      projects: {
+        kind: ProjectModel.kind,
+        isList: true,
+      },
+      imageStream: {
+        kind: 'ImageStream',
+        isList: true,
+        namespace,
+        selector: {
+          matchLabels: { 'app.kubernetes.io/instance': appName },
+        },
+        optional: true,
+      },
+      ...(kind &&
+        appName && {
+          workloadResource: {
+            kind,
+            name: appName,
+            namespace,
+            optional: true,
+          },
+        }),
+    }),
+    [namespace, kind, appName],
+  );
+
+  const resources: WatchK8sResults<watchResource> = useK8sWatchResources<watchResource>(
+    watchedResources,
+  );
+
+  const isResourcesLoaded = (): boolean => {
+    const resKeys = Object.keys(resources);
+    if (
+      resKeys.length > 0 &&
+      resKeys.every((key) => resources[key].loaded || !!resources[key].loadError)
+    ) {
+      return true;
+    }
+    return false;
+  };
+
+  const handleSubmit = (
+    values: DeployImageFormData,
+    helpers: FormikHelpers<DeployImageFormData>,
+  ) => {
+    return knatifyResources(values)
+      .then(() => {
+        helpers.setStatus({ submitError: '' });
+        handleRedirect(namespace, perspective, perspectiveExtensions);
+      })
+      .catch((err) => {
+        helpers.setStatus({ submitError: err.message });
+      });
+  };
+
+  return (
+    <NamespacedPage disabled variant={NamespacedPageVariants.light}>
+      <Helmet>
+        <title>{t('knative-plugin~Create Knative service')}</title>
+      </Helmet>
+      <PageHeading title={t('knative-plugin~Create Knative service')} />
+      <div className="co-m-pane__body">
+        {isResourcesLoaded() ? (
+          <Formik
+            initialValues={getInitialValuesKnatify(
+              getKnatifyWorkloadData(resources?.workloadResource?.data as K8sResourceKind),
+              appName,
+              namespace,
+              resources?.imageStream?.data as K8sResourceKind[],
+            )}
+            validationSchema={deployValidationSchema(t)}
+            onSubmit={handleSubmit}
+            onReset={history.goBack}
+          >
+            {(formikProps) => (
+              <DeployImageForm
+                {...formikProps}
+                projects={(resources?.projects as WatchK8sResultsObject<K8sResourceKind[]>) ?? {}}
+              />
+            )}
+          </Formik>
+        ) : (
+          <LoadingBox />
+        )}
+      </div>
+    </NamespacedPage>
+  );
+};
+
+export default CreateKnatifyPage;

--- a/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
@@ -16,7 +16,6 @@ import {
 import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
-import DeployImageForm from '@console/dev-console/src/components/import/DeployImageForm';
 import { handleRedirect } from '@console/dev-console/src/components/import/import-submit-utils';
 import { DeployImageFormData } from '@console/dev-console/src/components/import/import-types';
 import { deployValidationSchema } from '@console/dev-console/src/components/import/deployImage-validation-utils';
@@ -25,6 +24,7 @@ import {
   knatifyResources,
   getKnatifyWorkloadData,
 } from '../../utils/knatify-utils';
+import KnatifyForm from './KnatifyForm';
 
 type watchResource = {
   [key: string]: K8sResourceKind[] | K8sResourceKind;
@@ -121,7 +121,7 @@ const CreateKnatifyPage: React.FunctionComponent<CreateKnatifyPageProps> = ({
             onReset={history.goBack}
           >
             {(formikProps) => (
-              <DeployImageForm
+              <KnatifyForm
                 {...formikProps}
                 projects={(resources?.projects as WatchK8sResultsObject<K8sResourceKind[]>) ?? {}}
               />

--- a/frontend/packages/knative-plugin/src/components/knatify/KnatifyForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/KnatifyForm.tsx
@@ -2,17 +2,16 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
+import { Form } from '@patternfly/react-core';
 import { FormFooter } from '@console/shared/src/components/form-utils';
 import { usePreventDataLossLock } from '@console/internal/components/utils';
-import { Form } from '@patternfly/react-core';
-import { DeployImageFormProps } from './import-types';
-import ImageSearchSection from './image-search/ImageSearchSection';
-import IconSection from './section/IconSection';
-import AppSection from './app/AppSection';
-import AdvancedSection from './advanced/AdvancedSection';
-import ResourceSection from './section/ResourceSection';
+import { DeployImageFormProps } from '@console/dev-console/src/components/import/import-types';
+import ImageSearchSection from '@console/dev-console/src/components/import/image-search/ImageSearchSection';
+import IconSection from '@console/dev-console/src/components/import/section/IconSection';
+import AppSection from '@console/dev-console/src/components/import/app/AppSection';
+import AdvancedSection from '@console/dev-console/src/components/import/advanced/AdvancedSection';
 
-const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps> = ({
+const KnatifyForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps> = ({
   values,
   errors,
   handleSubmit,
@@ -26,26 +25,25 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
   usePreventDataLossLock(isSubmitting);
 
   return (
-    <Form className="co-deploy-image" data-test-id="deploy-image-form" onSubmit={handleSubmit}>
-      <ImageSearchSection />
+    <Form className="co-deploy-image" data-test-id="knatify-form" onSubmit={handleSubmit}>
+      <ImageSearchSection disabled />
       <IconSection />
       <AppSection
         project={values.project}
         noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
       />
-      <ResourceSection />
       <AdvancedSection values={values} />
       <FormFooter
         handleReset={handleReset}
         errorMessage={status && status.submitError}
         isSubmitting={isSubmitting}
-        submitLabel={t('devconsole~Create')}
+        submitLabel={t('knative-plugin~Create')}
         sticky
         disableSubmit={!dirty || !_.isEmpty(errors) || isSubmitting}
-        resetLabel={t('devconsole~Cancel')}
+        resetLabel={t('knative-plugin~Cancel')}
       />
     </Form>
   );
 };
 
-export default DeployImageForm;
+export default KnatifyForm;

--- a/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Formik } from 'formik';
+import { LoadingBox, PageHeading } from '@console/internal/components/utils';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
+import CreateKnatifyPage from '../CreateKnatifyPage';
+import { deploymentData } from '../../../utils/__tests__/knative-serving-data';
+
+let createKnatifyPageProps: React.ComponentProps<typeof CreateKnatifyPage>;
+
+const useK8sWatchResourcesMock = useK8sWatchResources as jest.Mock;
+
+jest.mock('react-i18next', () => {
+  const reactI18Next = require.requireActual('react-i18next');
+  return {
+    ...reactI18Next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResources: jest.fn(),
+}));
+
+describe('CreateKnatifyPage', () => {
+  beforeEach(() => {
+    createKnatifyPageProps = {
+      history: null,
+      location: {
+        pathname: 'knatify/ns/jai-test-1?name=ruby-ex-git-dc&kind=Deployment',
+        search: 'knatify/ns/jai-test-1?name=ruby-ex-git-dc&kind=Deployment',
+        state: null,
+        hash: null,
+      },
+      match: {
+        isExact: true,
+        path: 'knatify/ns/jai-test-1?name=ruby-ex-git-dc&kind=Deployment',
+        url: 'knatify/ns/jai-test-1?name=ruby-ex-git-dc&kind=Deployment',
+        params: {
+          ns: 'openshift',
+        },
+      },
+    };
+    useK8sWatchResourcesMock.mockClear();
+  });
+
+  it('CreateKnatifyPage should render PageHeading and Loading if resources is not loaded yet', () => {
+    useK8sWatchResourcesMock.mockReturnValue({
+      imageStream: { data: [], loaded: false },
+      projects: { data: [], loaded: false },
+      workloadResource: { data: deploymentData, loaded: true },
+    });
+    const wrapper = shallow(<CreateKnatifyPage {...createKnatifyPageProps} />);
+    expect(wrapper.find(PageHeading).exists()).toBe(true);
+    expect(wrapper.find(LoadingBox).exists()).toBe(true);
+    expect(wrapper.find(Formik).exists()).toBe(false);
+  });
+
+  it('CreateKnatifyPage should render PageHeading and Formik if resources are loaded', () => {
+    useK8sWatchResourcesMock.mockReturnValue({
+      imageStream: { data: [], loaded: true },
+      projects: { data: [], loaded: true },
+      workloadResource: { data: deploymentData, loaded: true },
+    });
+    const wrapper = shallow(<CreateKnatifyPage {...createKnatifyPageProps} />);
+    expect(wrapper.find(PageHeading).exists()).toBe(true);
+    expect(wrapper.find(Formik).exists()).toBe(true);
+    expect(wrapper.find(LoadingBox).exists()).toBe(false);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/knatify/__tests__/KnatifyForm.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/__tests__/KnatifyForm.spec.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 import { FormFooter } from '@console/shared/src/components/form-utils';
-import DeployImageForm from '../DeployImageForm';
-import ImageSearchSection from '../image-search/ImageSearchSection';
-import IconSection from '../section/IconSection';
-import AppSection from '../app/AppSection';
-import ResourceSection from '../section/ResourceSection';
-import AdvancedSection from '../advanced/AdvancedSection';
+import ImageSearchSection from '@console/dev-console/src/components/import/image-search/ImageSearchSection';
+import IconSection from '@console/dev-console/src/components/import/section/IconSection';
+import AppSection from '@console/dev-console/src/components/import/app/AppSection';
+import AdvancedSection from '@console/dev-console/src/components/import/advanced/AdvancedSection';
+import KnatifyForm from '../KnatifyForm';
 
-let deployImageFormProps: React.ComponentProps<typeof DeployImageForm>;
+let knatifyFormProps: React.ComponentProps<typeof KnatifyForm>;
 
 jest.mock('react-i18next', () => {
   const reactI18next = require.requireActual('react-i18next');
@@ -19,9 +18,9 @@ jest.mock('react-i18next', () => {
   };
 });
 
-describe('DeployImageForm', () => {
+describe('KnatifyForm', () => {
   beforeEach(() => {
-    deployImageFormProps = {
+    knatifyFormProps = {
       ...formikFormProps,
       projects: {
         loaded: true,
@@ -30,12 +29,11 @@ describe('DeployImageForm', () => {
     };
   });
 
-  it('should render ImageSearchSection, IconSection, AppSection, ResourceSection, AdvancedSection and FormFooter', () => {
-    const wrapper = shallow(<DeployImageForm {...deployImageFormProps} />);
+  it('should render ImageSearchSection, IconSection, AppSection, AdvancedSection and FormFooter', () => {
+    const wrapper = shallow(<KnatifyForm {...knatifyFormProps} />);
     expect(wrapper.find(ImageSearchSection).exists()).toBe(true);
     expect(wrapper.find(IconSection).exists()).toBe(true);
     expect(wrapper.find(AppSection).exists()).toBe(true);
-    expect(wrapper.find(ResourceSection).exists()).toBe(true);
     expect(wrapper.find(AdvancedSection).exists()).toBe(true);
     expect(wrapper.find(FormFooter).exists()).toBe(true);
   });

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -33,7 +33,7 @@ import {
   FLAG_KNATIVE_EVENTING_BROKER,
   FLAG_CAMEL_KAMELETS,
 } from './const';
-import { getKebabActionsForKind } from './utils/kebab-actions';
+import { getKebabActionsForKind, getKebabActionsForWorkload } from './utils/kebab-actions';
 import { TopologyConsumedExtensions, topologyPlugin } from './topology/topology-plugin';
 import * as eventSourceIcon from './imgs/event-source.svg';
 import * as channelIcon from './imgs/channel.svg';
@@ -428,9 +428,34 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: '/knatify/ns/:ns',
+      loader: async () =>
+        (
+          await import(
+            './components/knatify/CreateKnatifyPage' /* webpackChunkName: "knatify-create" */
+          )
+        ).default,
+    },
+    flags: {
+      required: [FLAG_KNATIVE_SERVING_SERVICE],
+    },
+  },
+  {
     type: 'KebabActions',
     properties: {
       getKebabActionsForKind,
+    },
+  },
+  {
+    type: 'KebabActions',
+    flags: {
+      required: [FLAG_KNATIVE_SERVING_SERVICE],
+    },
+    properties: {
+      getKebabActionsForKind: getKebabActionsForWorkload,
     },
   },
   {

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/knatify-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/knatify-mock.ts
@@ -15,6 +15,7 @@ export const ksvcData: K8sResourceKind = {
       spec: {
         containers: [
           {
+            name: 'overlayimage',
             image: 'openshift/hello-openshift',
             ports: [{ containerPort: 8080 }],
             imagePullPolicy: 'Always',
@@ -39,7 +40,18 @@ export const knatifyFormCommonInitailValues = {
   },
   resources: 'knative',
   serverless: {
-    scaling: { minpods: 0, maxpods: '', concurrencytarget: '', concurrencylimit: '' },
+    scaling: {
+      minpods: '',
+      maxpods: '',
+      concurrencytarget: '',
+      concurrencylimit: '',
+      concurrencyutilization: '',
+      autoscale: {
+        autoscalewindow: '',
+        autoscalewindowUnit: 's',
+        defaultAutoscalewindowUnit: 's',
+      },
+    },
   },
   pipeline: { enabled: false },
   deployment: { env: [], replicas: 1, triggers: { image: true } },

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/knatify-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/knatify-mock.ts
@@ -1,0 +1,190 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const ksvcData: K8sResourceKind = {
+  kind: 'Service',
+  apiVersion: 'serving.knative.dev/v1',
+  metadata: {
+    name: 'overlayimage',
+    namespace: 'testproject3',
+    labels: { 'app.kubernetes.io/part-of': 'application-3' },
+    annotations: { 'deployment.kubernetes.io/revision': '1' },
+  },
+  spec: {
+    template: {
+      metadata: { labels: { app: 'hello-openshift' }, annotations: {} },
+      spec: {
+        containers: [
+          {
+            image: 'openshift/hello-openshift',
+            ports: [{ containerPort: 8080 }],
+            imagePullPolicy: 'Always',
+            resources: {},
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const knatifyFormCommonInitailValues = {
+  name: 'overlayimage',
+  formType: 'knatify',
+  application: { name: 'application-3', selectedKey: 'application-3' },
+  project: { name: 'testproject3' },
+  route: {
+    create: true,
+    unknownTargetPort: '8080',
+    targetPort: '8080',
+    defaultUnknownPort: 8080,
+  },
+  resources: 'knative',
+  serverless: {
+    scaling: { minpods: 0, maxpods: '', concurrencytarget: '', concurrencylimit: '' },
+  },
+  pipeline: { enabled: false },
+  deployment: { env: [], replicas: 1, triggers: { image: true } },
+  labels: {},
+  limits: {
+    cpu: {
+      request: '',
+      requestUnit: '',
+      defaultRequestUnit: '',
+      limit: '',
+      limitUnit: '',
+      defaultLimitUnit: '',
+    },
+    memory: {
+      request: '',
+      requestUnit: 'Mi',
+      defaultRequestUnit: 'Mi',
+      limit: '',
+      limitUnit: 'Mi',
+      defaultLimitUnit: 'Mi',
+    },
+  },
+  healthChecks: {
+    readinessProbe: {
+      showForm: false,
+      modified: false,
+      enabled: false,
+      data: {
+        failureThreshold: 3,
+        requestType: 'httpGet',
+        httpGet: { scheme: 'HTTP', path: '/', port: 8080, httpHeaders: [] },
+        tcpSocket: { port: 8080 },
+        exec: { command: [''] },
+        initialDelaySeconds: 0,
+        periodSeconds: 10,
+        timeoutSeconds: 1,
+        successThreshold: 1,
+      },
+    },
+    livenessProbe: {
+      showForm: false,
+      modified: false,
+      enabled: false,
+      data: {
+        failureThreshold: 3,
+        requestType: 'httpGet',
+        httpGet: { scheme: 'HTTP', path: '/', port: 8080, httpHeaders: [] },
+        tcpSocket: { port: 8080 },
+        exec: { command: [''] },
+        initialDelaySeconds: 0,
+        periodSeconds: 10,
+        timeoutSeconds: 1,
+        successThreshold: 1,
+      },
+    },
+    startupProbe: {
+      showForm: false,
+      modified: false,
+      enabled: false,
+      data: {
+        failureThreshold: 3,
+        requestType: 'httpGet',
+        httpGet: { scheme: 'HTTP', path: '/', port: 8080, httpHeaders: [] },
+        tcpSocket: { port: 8080 },
+        exec: { command: [''] },
+        initialDelaySeconds: 0,
+        periodSeconds: 10,
+        timeoutSeconds: 1,
+        successThreshold: 1,
+      },
+    },
+  },
+};
+
+export const imageStremsData: K8sResourceKind[] = [
+  {
+    kind: 'ImageStream',
+    apiVersion: 'image.openshift.io/v1',
+    metadata: {
+      annotations: {
+        'app.openshift.io/vcs-ref': '',
+        'app.openshift.io/vcs-uri': 'https://github.com/sclorg/ruby-ex.git',
+        'openshift.io/generated-by': 'OpenShiftWebConsole',
+      },
+      resourceVersion: '552606',
+      name: 'ruby-ex-git-dc',
+      uid: '6c38fbc5-9f8d-4369-b26b-66000427e210',
+      creationTimestamp: '2021-02-24T10:26:52Z',
+      generation: 1,
+      managedFields: [
+        {
+          manager: 'Mozilla',
+          operation: 'Update',
+          apiVersion: 'image.openshift.io/v1',
+          time: '2021-02-24T10:26:52Z',
+          fieldsType: 'FieldsV1',
+          fieldsV1: {
+            'f:metadata': {
+              'f:annotations': {
+                '.': {},
+                'f:app.openshift.io/vcs-ref': {},
+                'f:app.openshift.io/vcs-uri': {},
+                'f:openshift.io/generated-by': {},
+              },
+              'f:labels': {
+                '.': {},
+                'f:app': {},
+                'f:app.kubernetes.io/component': {},
+                'f:app.kubernetes.io/instance': {},
+                'f:app.kubernetes.io/name': {},
+                'f:app.openshift.io/runtime': {},
+                'f:app.openshift.io/runtime-version': {},
+              },
+            },
+          },
+        },
+      ],
+      namespace: 'testproject3',
+      labels: {
+        app: 'ruby-ex-git-dc',
+        'app.kubernetes.io/component': 'ruby-ex-git-dc',
+        'app.kubernetes.io/instance': 'ruby-ex-git-dc',
+        'app.kubernetes.io/name': 'perl',
+        'app.openshift.io/runtime': 'perl',
+        'app.openshift.io/runtime-version': '5.30-el7',
+      },
+    },
+    spec: { lookupPolicy: { local: false } },
+    status: {
+      dockerImageRepository:
+        'image-registry.openshift-image-registry.svc:5000/testproject3/ruby-ex-git-dc',
+      tags: [
+        {
+          tag: 'latest',
+          items: [
+            {
+              created: '2021-02-24T10:27:35Z',
+              dockerImageReference:
+                'image-registry.openshift-image-registry.svc:5000/testproject3/ruby-ex-git-dc@sha256:731442c798a6afd04c4b2a97c29eb55993df87ee861185b736097ea72959d0bc',
+              image: 'sha256:731442c798a6afd04c4b2a97c29eb55993df87ee861185b736097ea72959d0bc',
+              generation: 1,
+            },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
@@ -1,6 +1,5 @@
 import {
   getKnatifyWorkloadData,
-  isKnatifyForm,
   getCommonInitialValues,
   getInitialValuesKnatify,
 } from '../knatify-utils';
@@ -14,14 +13,6 @@ import { deploymentData } from './knative-serving-data';
 describe('knatify-utils', () => {
   it('getKnatifyWorkloadData should return valid knative service spec', () => {
     expect(getKnatifyWorkloadData(deploymentData)).toEqual(ksvcData);
-  });
-
-  it('isKnatifyForm should return true if formType is knatify', () => {
-    expect(isKnatifyForm('knatify')).toBe(true);
-  });
-
-  it('isKnatifyForm should return false if formType is edit', () => {
-    expect(isKnatifyForm('edit')).toBe(false);
   });
 
   it('getCommonInitialValues should return valid formik common initial values', () => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
@@ -48,6 +48,7 @@ describe('knatify-utils', () => {
           spec: {
             containers: [
               {
+                name: ksvcData.metadata.name,
                 image:
                   'image-registry.openshift-image-registry.svc:5000/testproject3/ruby-ex-git-dc@sha256:731442c798a6afd04c4b2a97c29eb55993df87ee861185b736097ea72959d0bc',
                 ports: [{ containerPort: 8080 }],

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
@@ -1,0 +1,87 @@
+import {
+  getKnatifyWorkloadData,
+  isKnatifyForm,
+  getCommonInitialValues,
+  getInitialValuesKnatify,
+} from '../knatify-utils';
+import {
+  imageStremsData,
+  knatifyFormCommonInitailValues,
+  ksvcData,
+} from '../__mocks__/knatify-mock';
+import { deploymentData } from './knative-serving-data';
+
+describe('knatify-utils', () => {
+  it('getKnatifyWorkloadData should return valid knative service spec', () => {
+    expect(getKnatifyWorkloadData(deploymentData)).toEqual(ksvcData);
+  });
+
+  it('isKnatifyForm should return true if formType is knatify', () => {
+    expect(isKnatifyForm('knatify')).toBe(true);
+  });
+
+  it('isKnatifyForm should return false if formType is edit', () => {
+    expect(isKnatifyForm('edit')).toBe(false);
+  });
+
+  it('getCommonInitialValues should return valid formik common initial values', () => {
+    expect(getCommonInitialValues(ksvcData, 'overlayimage', 'testproject3')).toEqual(
+      knatifyFormCommonInitailValues,
+    );
+  });
+
+  it('getInitialValuesKnatify should return valid formik initial values with external regstry and searchTerm if image is not in imageStreams', () => {
+    const knatifyFormInitialVal = {
+      ...knatifyFormCommonInitailValues,
+      runtimeIcon: null,
+      searchTerm: 'openshift/hello-openshift',
+      registry: 'external',
+      allowInsecureRegistry: false,
+      imageStream: { image: '', tag: '', namespace: '' },
+      isi: { name: '', image: {}, tag: '', status: { metadata: {}, status: '' }, ports: [] },
+      image: { name: '', image: {}, tag: '', status: { metadata: {}, status: '' }, ports: [] },
+      build: { env: [], triggers: {}, strategy: '' },
+      isSearchingForImage: false,
+    };
+    expect(getInitialValuesKnatify(ksvcData, 'overlayimage', 'testproject3', [])).toEqual(
+      knatifyFormInitialVal,
+    );
+  });
+
+  it('getInitialValuesKnatify should return valid formik initial values with internal regstry and valid IS if image is not in imageStreams', () => {
+    const mockKsvcData = {
+      ...ksvcData,
+      spec: {
+        template: {
+          ...ksvcData.spec.template,
+          spec: {
+            containers: [
+              {
+                image:
+                  'image-registry.openshift-image-registry.svc:5000/testproject3/ruby-ex-git-dc@sha256:731442c798a6afd04c4b2a97c29eb55993df87ee861185b736097ea72959d0bc',
+                ports: [{ containerPort: 8080 }],
+                imagePullPolicy: 'Always',
+                resources: {},
+              },
+            ],
+          },
+        },
+      },
+    };
+    const knatifyFormInitialVal = {
+      ...knatifyFormCommonInitailValues,
+      runtimeIcon: null,
+      searchTerm: '',
+      registry: 'internal',
+      allowInsecureRegistry: false,
+      imageStream: { image: 'ruby-ex-git-dc', tag: 'latest', namespace: 'testproject3' },
+      isi: { name: '', image: {}, tag: '', status: { metadata: {}, status: '' }, ports: [] },
+      image: { name: '', image: {}, tag: '', status: { metadata: {}, status: '' }, ports: [] },
+      build: { env: [], triggers: {}, strategy: '' },
+      isSearchingForImage: false,
+    };
+    expect(
+      getInitialValuesKnatify(mockKsvcData, 'overlayimage', 'testproject3', imageStremsData),
+    ).toEqual(knatifyFormInitialVal);
+  });
+});

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -3,7 +3,9 @@ import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { KebabAction } from '@console/internal/components/utils';
 import { EditApplication } from '@console/topology/src/actions/modify-application';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { DeploymentConfigModel, DeploymentModel } from '@console/internal/models';
 import { setTrafficDistribution } from '../actions/traffic-splitting';
+import { setKnatify } from '../actions/knatify';
 import { addTrigger } from '../actions/add-trigger';
 import { addSubscription } from '../actions/add-subscription';
 import { setSinkSource } from '../actions/sink-source';
@@ -45,6 +47,18 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
     if (isEventingChannelResourceKind(referenceForModel(resourceKind))) {
       menuActions.push(addSubscription);
     }
+  }
+  return menuActions;
+};
+
+export const getKebabActionsForWorkload = (resourceKind: K8sKind): KebabAction[] => {
+  const menuActions: KebabAction[] = [];
+  if (
+    resourceKind &&
+    (referenceForModel(resourceKind) === referenceForModel(DeploymentModel) ||
+      referenceForModel(resourceKind) === referenceForModel(DeploymentConfigModel))
+  ) {
+    menuActions.push(setKnatify);
   }
   return menuActions;
 };

--- a/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
@@ -181,5 +181,3 @@ export const getInitialValuesKnatify = (
     ...(!isInternalImageValid && externalImageValues),
   };
 };
-
-export const isKnatifyForm = (formType: string): boolean => formType === knatify;

--- a/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
@@ -1,0 +1,185 @@
+import { k8sCreate, K8sResourceKind } from '@console/internal/module/k8s';
+import { UNASSIGNED_KEY } from '@console/topology/src/const';
+import {
+  getHealthChecksData,
+  getProbesData,
+} from '@console/dev-console/src/components/health-checks/create-health-checks-probe-utils';
+import {
+  DeployImageFormData,
+  Resources,
+} from '@console/dev-console/src/components/import/import-types';
+import { ensurePortExists } from '@console/dev-console/src/components/import/deployImage-submit-utils';
+import {
+  deployImageInitialValues,
+  getDeploymentData,
+  getExternalImagelValues,
+  getIconInitialValues,
+  getKsvcRouteData,
+  getLimitsData,
+  getServerlessData,
+  getUserLabels,
+} from '@console/dev-console/src/components/edit-application/edit-application-utils';
+import { RegistryType } from '@console/dev-console/src/utils/imagestream-utils';
+import { ServiceModel } from '../models';
+import { getKnativeServiceDepResource } from './create-knative-utils';
+
+const PART_OF = 'app.kubernetes.io/part-of';
+const knatify = 'knatify';
+
+export const getKnatifyWorkloadData = (obj: K8sResourceKind) => {
+  const { metadata, spec } = obj || {};
+  const { name = '', namespace = '', labels = {}, annotations = {} } = metadata || {};
+  const { metadata: templateMetadata, spec: templateSpec } = spec?.template || {};
+  const { image, ports, imagePullPolicy, env, resources } = templateSpec?.containers[0] || {};
+
+  const healthChecks = getHealthChecksData(obj, 0);
+  const { readinessProbe, livenessProbe } = getProbesData(healthChecks, Resources.KnativeService);
+
+  const newKnativeDeployResource: K8sResourceKind = {
+    kind: ServiceModel.kind,
+    apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+    metadata: {
+      name,
+      namespace,
+      labels,
+      annotations,
+    },
+    spec: {
+      template: {
+        metadata: {
+          labels: templateMetadata?.labels ?? {},
+          annotations: templateMetadata?.annotations ?? {},
+        },
+        spec: {
+          containers: [
+            {
+              image,
+              ...(ports?.length > 0 && {
+                ports: [
+                  {
+                    containerPort: ports[0]?.containerPort,
+                  },
+                ],
+              }),
+              ...(imagePullPolicy && {
+                imagePullPolicy,
+              }),
+              ...(env?.length > 0 && { env }),
+              ...(resources && { resources }),
+              ...(readinessProbe && {
+                readinessProbe,
+              }),
+              ...(livenessProbe && {
+                livenessProbe,
+              }),
+            },
+          ],
+        },
+      },
+    },
+  };
+  return newKnativeDeployResource;
+};
+
+export const knatifyResources = (rawFormData: DeployImageFormData): Promise<K8sResourceKind> => {
+  const formData = ensurePortExists(rawFormData);
+  const {
+    isi: { image },
+  } = formData;
+  const imageStreamUrl: string = image?.dockerImageReference ?? '';
+  const knDeploymentResource = getKnativeServiceDepResource(formData, imageStreamUrl);
+  return k8sCreate(ServiceModel, knDeploymentResource);
+};
+
+export const getCommonInitialValues = (
+  ksvcResourceData: K8sResourceKind,
+  name: string,
+  namespace: string,
+) => {
+  const appGroupName = ksvcResourceData?.metadata?.labels?.[PART_OF] ?? '';
+  const commonInitialValues = {
+    name,
+    formType: knatify,
+    application: {
+      name: appGroupName || '',
+      selectedKey: appGroupName || UNASSIGNED_KEY,
+    },
+    project: {
+      name: namespace,
+    },
+    route: getKsvcRouteData(ksvcResourceData),
+    resources: Resources.KnativeService,
+    serverless: getServerlessData(ksvcResourceData),
+    pipeline: {
+      enabled: false,
+    },
+    deployment: getDeploymentData(ksvcResourceData),
+    labels: getUserLabels(ksvcResourceData),
+    limits: getLimitsData(ksvcResourceData),
+    healthChecks: getHealthChecksData(ksvcResourceData),
+  };
+  return commonInitialValues;
+};
+
+const getInternalImageInitialValues = (
+  editAppResource: K8sResourceKind,
+  namespace: string,
+  imageStreams: K8sResourceKind[],
+) => {
+  const [, isSha] = editAppResource.spec?.template?.spec?.containers?.[0]?.image?.split('@') ?? [];
+  const { tag, image } = imageStreams.reduce(
+    (acc, is) => {
+      const tagData =
+        isSha &&
+        is.status?.tags?.find((t) => {
+          const itemData = t.items?.find((it) => it.image === isSha);
+          return !!itemData;
+        });
+      if (tagData) {
+        return {
+          tag: tagData.tag,
+          image: is.metadata.name,
+        };
+      }
+      return acc;
+    },
+    { tag: '', image: '' },
+  );
+  return {
+    ...deployImageInitialValues,
+    registry: RegistryType.Internal,
+    imageStream: {
+      image,
+      tag,
+      namespace,
+    },
+  };
+};
+
+export const getInitialValuesKnatify = (
+  ksvcResourceData: K8sResourceKind,
+  appName: string,
+  namespace: string,
+  imageStreams: K8sResourceKind[],
+): DeployImageFormData => {
+  const commonValues = getCommonInitialValues(ksvcResourceData, appName, namespace);
+  const iconValues = getIconInitialValues(ksvcResourceData);
+  const internalImageValues = getInternalImageInitialValues(
+    ksvcResourceData,
+    namespace,
+    imageStreams,
+  );
+  const {
+    imageStream: { image, tag },
+  } = internalImageValues;
+  const isInternalImageValid = image && tag && namespace;
+  const externalImageValues = getExternalImagelValues(ksvcResourceData);
+  return {
+    ...commonValues,
+    ...iconValues,
+    ...(!!isInternalImageValid && internalImageValues),
+    ...(!isInternalImageValid && externalImageValues),
+  };
+};
+
+export const isKnatifyForm = (formType: string): boolean => formType === knatify;

--- a/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
@@ -53,6 +53,7 @@ export const getKnatifyWorkloadData = (obj: K8sResourceKind) => {
         spec: {
           containers: [
             {
+              name,
               image,
               ...(ports?.length > 0 && {
                 ports: [


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5478


**Description**: 
User can create a serverless workload from regular workloads i,e Deployment/DeploymentConfig

**Solution:**
- Knatify applies only to standalone workloads (Deployment/DeploymentConfig)
- On Knatify, no additional resources are created apart from KSVC and other resources are shared currently
- Once workload is knatified , edit on KSVC will take user to original flow
- Original workload are not deleted 
- This is initial PR, so once we have design will have other stories to address that

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/109112514-d049df00-7760-11eb-8b32-7daf4ea69593.png)

- Dev Perspective

![knatify-devp](https://user-images.githubusercontent.com/5129024/108996520-7e537b80-76c4-11eb-80d3-35a80712a7c0.gif)


- Admin Perspective

![knatify-adminP](https://user-images.githubusercontent.com/5129024/108996588-93c8a580-76c4-11eb-8cbb-67689371e261.gif)


@openshift/team-devconsole-ux



**Unit test coverage report**: 

- DeployImageForm

![image](https://user-images.githubusercontent.com/5129024/108731063-2f85d480-7552-11eb-992f-7a040fcecb66.png)

- edit-application-utils.spec.ts

![image](https://user-images.githubusercontent.com/5129024/108731231-5cd28280-7552-11eb-9772-183faa856c03.png)

- AdvancedSection

![image](https://user-images.githubusercontent.com/5129024/108814583-13794600-75d9-11eb-8ce6-a5aa67cdc8f7.png)

- DeploymentConfigSection

![image](https://user-images.githubusercontent.com/5129024/108817719-58ec4200-75de-11eb-821d-95ef1ce0d068.png)

- knatify.ts

![image](https://user-images.githubusercontent.com/5129024/109013901-a8636880-76d9-11eb-90f6-6108d2c3cfb3.png)

- KnatifyForm

![image](https://user-images.githubusercontent.com/5129024/109112460-b5776a80-7760-11eb-8ebd-792dfe2cbd6f.png)


- serverless-utils

![image](https://user-images.githubusercontent.com/5129024/109119926-5408c900-776b-11eb-993f-ef6032b4df5e.png)

- CreateKnatifyPage

![image](https://user-images.githubusercontent.com/5129024/109029967-6510f600-76e9-11eb-8806-8912a7b095d9.png)

- knatify-utils

![image](https://user-images.githubusercontent.com/5129024/109037231-83c6bb00-76f0-11eb-9440-80aff4cba417.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- Install Serverless Operator
- Create KnativeServing CR


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
