### PR TITLE
Bug 1929577: Fix to avoid overriding of d/dc pod template container values

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -191,7 +191,10 @@ export const getDeploymentData = (resource: K8sResourceKind) => {
     replicas: 1,
     triggers: { image: true, config: true },
   };
-  const container = resource.spec?.template?.spec?.containers?.[0];
+  const container = _.find(
+    resource.spec?.template?.spec?.containers,
+    (c) => c.name === resource.metadata.name,
+  );
   const env = container?.env ?? [];
   switch (getResourcesType(resource)) {
     case Resources.KnativeService:

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { CheckboxField, EnvironmentField } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -18,7 +17,10 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
 }) => {
   const { t } = useTranslation();
   const {
-    values: { resources },
+    values: {
+      resources,
+      deployment: { env },
+    },
   } = useFormikContext<FormikValues>();
   const deploymentConfigObj = resource || {
     kind: 'DeploymentConfig',
@@ -26,7 +28,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
       namespace,
     },
   };
-  const envs = _.get(deploymentConfigObj, 'spec.template.spec.containers[0].env', []);
+
   return (
     <FormSection title={t('devconsole~Deployment')} fullWidth>
       <CheckboxField
@@ -42,7 +44,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
       <EnvironmentField
         name="deployment.env"
         label={t('devconsole~Environment variables (runtime only)')}
-        envs={envs}
+        envs={env}
         obj={deploymentConfigObj}
         envPath={['spec', 'template', 'spec', 'containers']}
       />

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -161,6 +161,7 @@ export const createOrUpdateDeployment = (
     ...annotations,
     'alpha.image.policy.openshift.io/resolve-names': '*',
     ...getTriggerAnnotation(
+      name,
       imgName || name,
       imgNamespace || namespace,
       imageChange,
@@ -440,6 +441,7 @@ export const createOrUpdateDeployImageResources = async (
     }
     const originalAnnotations = appResources?.editAppResource?.data?.metadata?.annotations || {};
     const triggerAnnotations = getTriggerAnnotation(
+      name,
       internalImageStreamName || name,
       internalImageStreamNamespace || namespace,
       imageChange,

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -265,11 +265,12 @@ export const createOrUpdateDeployment = (
 
   const imageStreamName = imageStream && imageStream.metadata.name;
   const defaultLabels = getAppLabels({ name, applicationName, imageStreamName, selectedTag });
+  const imageName = name;
   const annotations = {
     ...getGitAnnotations(repository, ref),
     ...getCommonAnnotations(),
     'alpha.image.policy.openshift.io/resolve-names': '*',
-    ...getTriggerAnnotation(name, namespace, imageChange),
+    ...getTriggerAnnotation(name, imageName, namespace, imageChange),
   };
   const podLabels = getPodLabels(name);
   const templateLabels = getTemplateLabels(originalDeployment);
@@ -632,6 +633,7 @@ export const createOrUpdateResources = async (
 
     const originalAnnotations = appResources?.editAppResource?.data?.metadata?.annotations || {};
     const triggerAnnotations = getTriggerAnnotation(
+      name,
       generatedImageStreamName || name,
       namespace,
       imageChange,

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
@@ -55,6 +55,13 @@ export const originalDeployment = {
                 protocol: 'TCP',
               },
             ],
+            envFrom: [
+              {
+                configMapRef: {
+                  name: 'testconfig',
+                },
+              },
+            ],
             volumeMounts: [
               {
                 name: 'test-volume',

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
@@ -49,11 +49,44 @@ describe('resource-label-utils', () => {
       );
     });
 
-    it('should return mergedData with newResource template containers', () => {
+    it('should return mergedData with newResource template container values', () => {
       const mergedResource = mergeData(originalDeployment, newDeployment);
-      expect(mergedResource.spec.template.spec.containers).toEqual(
-        newDeployment.spec.template.spec.containers,
-      );
+      expect(mergedResource.spec.template.spec.containers).toEqual([
+        {
+          name: 'nationalparks-py',
+          image:
+            'image-registry.openshift-image-registry.svc:5000/div/nationalparks-py@sha256:8b187a8f235f42e7ea3e21e740c4940fdfa3ec8b59a14bb1cd9a67ffedf2eef9',
+          ports: [
+            {
+              containerPort: 8080,
+              protocol: 'TCP',
+            },
+          ],
+          env: [
+            {
+              name: 'dev',
+              value: 'test',
+            },
+          ],
+          envFrom: [
+            {
+              configMapRef: {
+                name: 'testconfig',
+              },
+            },
+          ],
+          volumeMounts: [
+            {
+              name: 'test-volume',
+              mountPath: '/test',
+            },
+          ],
+          resources: {},
+          terminationMessagePath: '/dev/termination-log',
+          terminationMessagePolicy: 'File',
+          imagePullPolicy: 'Always',
+        },
+      ]);
     });
 
     it('should return mergedData with newResource strategy', () => {
@@ -71,13 +104,10 @@ describe('resource-label-utils', () => {
       expect(mergedResource.spec.triggers).toEqual(newDeploymentConfig.spec.triggers);
     });
 
-    it('should return mergedData with originalResource template volumes and volumeMounts ', () => {
+    it('should return mergedData with originalResource template volumes', () => {
       const mergedResource = mergeData(originalDeployment, newDeployment);
       expect(mergedResource.spec.template.spec.volumes).toEqual(
         originalDeployment.spec.template.spec.volumes,
-      );
-      expect(mergedResource.spec.template.spec.containers[0].volumeMounts).toEqual(
-        originalDeployment.spec.template.spec.containers[0].volumeMounts,
       );
     });
   });

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
@@ -1,4 +1,4 @@
-import { mergeData } from '../resource-label-utils';
+import { getTriggerAnnotation, mergeData } from '../resource-label-utils';
 import {
   devfileDeployment,
   newBuildConfig,
@@ -109,6 +109,20 @@ describe('resource-label-utils', () => {
       expect(mergedResource.spec.template.spec.volumes).toEqual(
         originalDeployment.spec.template.spec.volumes,
       );
+    });
+  });
+  describe('getTriggerAnnotation', () => {
+    it('should return trigger annotation with proper values', () => {
+      let annotation = getTriggerAnnotation('test', 'python', 'div', true);
+      expect(annotation).toEqual({
+        'image.openshift.io/triggers':
+          '[{"from":{"kind":"ImageStreamTag","name":"python:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","pause":"false"}]',
+      });
+      annotation = getTriggerAnnotation('test', 'test', 'div', false);
+      expect(annotation).toEqual({
+        'image.openshift.io/triggers':
+          '[{"from":{"kind":"ImageStreamTag","name":"test:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"test\\")].image","pause":"true"}]',
+      });
     });
   });
 });

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -57,15 +57,16 @@ export const getCommonAnnotations = () => {
 };
 
 export const getTriggerAnnotation = (
-  name: string,
-  namespace: string,
+  containerName: string,
+  imageName: string,
+  imageNamespace: string,
   imageTrigger: boolean,
-  tag: string = 'latest',
+  imageTag: string = 'latest',
 ) => ({
   [TRIGGERS_ANNOTATION]: JSON.stringify([
     {
-      from: { kind: 'ImageStreamTag', name: `${name}:${tag}`, namespace },
-      fieldPath: `spec.template.spec.containers[?(@.name=="${name}")].image`,
+      from: { kind: 'ImageStreamTag', name: `${imageName}:${imageTag}`, namespace: imageNamespace },
+      fieldPath: `spec.template.spec.containers[?(@.name=="${containerName}")].image`,
       pause: `${!imageTrigger}`,
     },
   ]),

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -93,6 +93,7 @@ export const getKnativeServiceDepResource = (
           ...(concurrencylimit && { containerConcurrency: concurrencylimit }),
           containers: [
             {
+              name,
               image: `${imageStreamUrl}`,
               ...(contTargetPort && {
                 ports: [


### PR DESCRIPTION
**Fixes**: https://bugzilla.redhat.com/show_bug.cgi?id=1929577
**Fixes:** https://issues.redhat.com/browse/ODC-5546

**Root Cause:**
Currently on editing d/dc using edit flow overrides the current resource containers completely with new resource containers https://github.com/openshift/console/pull/4517/files#diff-7fd530a4a1b4113f74f1e7e64beadbdb448845c1fad06d6a4d4824425583c2d6R53-R55 not taking in account the values that we dont add from UI like envFrom, imagePullPolicy etc thereby removing these values from the containers. 

In container image flow when imagestream from internal registry is selected then its name is wrongly used as container name in the trigger annotation. 

**Solution:**
Do not completely override the containers instead update only the values that we add from UI and leave other values as is.
Use correct container name in trigger annotation.

**Gif:**
![Peek 2021-02-19 21-31](https://user-images.githubusercontent.com/20724543/108539239-bbef8780-7305-11eb-9db7-ecd230b75a2e.gif)

![Peek 2021-02-22 14-53](https://user-images.githubusercontent.com/20724543/108691985-18c78980-7522-11eb-989c-aca7944d4832.gif)


**Unit Test Coverage:**
![image](https://user-images.githubusercontent.com/20724543/108692075-31d03a80-7522-11eb-8e47-2345ec31a2be.png)

/kind bug