### PR TITLE
Console extension processing improvements

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -10,6 +10,7 @@ import {
   augmentExtension,
   isExtensionInUse,
   getGatingFlagNames,
+  deepMergeExtensionProperties,
   PluginStore,
 } from '../store';
 import { Extension, ModelDefinition } from '../typings';
@@ -219,6 +220,59 @@ describe('getGatingFlagNames', () => {
     ].map(sanitizeExtension);
 
     expect(getGatingFlagNames(extensions)).toEqual(['foo', 'bar', 'baz', 'qux', 'test']);
+  });
+});
+
+describe('deepMergeExtensionProperties', () => {
+  it('merges the given object into extension properties', () => {
+    expect(
+      deepMergeExtensionProperties(
+        {
+          type: 'Foo/Bar',
+          properties: {},
+        },
+        {
+          test: true,
+          qux: { foo: ['value'], baz: 1 },
+        },
+      ),
+    ).toEqual({
+      type: 'Foo/Bar',
+      properties: {
+        test: true,
+        qux: { foo: ['value'], baz: 1 },
+      },
+    });
+
+    expect(
+      deepMergeExtensionProperties(
+        {
+          type: 'Foo/Bar',
+          properties: {
+            test: true,
+            qux: { foo: ['value'], baz: 1 },
+          },
+        },
+        {
+          test: false,
+          qux: { baz: 2 },
+        },
+      ),
+    ).toEqual({
+      type: 'Foo/Bar',
+      properties: {
+        test: false,
+        qux: { foo: ['value'], baz: 2 },
+      },
+    });
+  });
+
+  it('returns a new extension instance', () => {
+    const testExtension: Extension = { type: 'Foo/Bar', properties: {} };
+    const updatedExtension = deepMergeExtensionProperties(testExtension, {});
+
+    expect(updatedExtension).not.toBe(testExtension);
+    expect(Object.isFrozen(updatedExtension)).toBe(true);
   });
 });
 

--- a/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useForceRender } from '@console/shared/src/hooks/useForceRender';
+import { deepMergeExtensionProperties } from '../store';
 import { subscribeToExtensions } from './subscribeToExtensions';
 import { Extension, ExtensionTypeGuard, LoadedExtension } from '../typings';
 import useTranslationExt from '../utils/useTranslationExt';
 
-function translate(obj: any, t: (str: string) => string): any {
+const translate = (obj: any, t: (str: string) => string): typeof obj => {
   if (typeof obj === 'string') {
     return t(obj);
   }
@@ -21,7 +22,7 @@ function translate(obj: any, t: (str: string) => string): any {
     }, {});
   }
   return obj;
-}
+};
 
 /**
  * React hook for consuming Console extensions.
@@ -74,10 +75,9 @@ export const useExtensions = <E extends Extension>(
   const trySubscribe = React.useCallback(() => {
     if (unsubscribeRef.current === null) {
       unsubscribeRef.current = subscribeToExtensions<E>((extensions) => {
-        extensionsInUseRef.current = extensions.map((ext) => ({
-          ...ext,
-          properties: translate(ext.properties, t),
-        }));
+        extensionsInUseRef.current = extensions.map((e) =>
+          deepMergeExtensionProperties(e, translate(e.properties, t)),
+        );
         isMountedRef.current && forceRender();
       }, ...latestTypeGuardsRef.current);
     }

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -34,6 +34,9 @@ export const getGatingFlagNames = (extensions: Extension[]): string[] =>
     ..._.flatMap(extensions.map((e) => e.flags.disallowed)),
   ]);
 
+export const deepMergeExtensionProperties = <E extends Extension>(e: E, properties: {}): E =>
+  Object.freeze(_.merge({}, e, { properties }));
+
 /**
  * Provides access to Console plugin data.
  *


### PR DESCRIPTION
- [x] extension properties updates are now done via `deepMergeExtensionProperties` function
- [x] in `useResolvedExtensions` hook, if an error occurs, re-render the component and return the error

The change in `useResolvedExtensions` hook is compatible with existing code, which currently doesn't handle coderef resolution errors.