### PR TITLE
Remove offensive language

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/inclusive-language.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/inclusive-language.spec.ts
@@ -1,0 +1,20 @@
+const offensiveWords = ['master', 'slave', 'whitelist', 'blacklist'];
+
+describe('Test for offensive language', () => {
+  it('Looks for offensive words', () => {
+    offensiveWords.forEach((word) => {
+      cy.exec(
+        `git grep --ignore-case ${word} -- ../*\
+         ':(exclude)../integration-tests-cypress/tests/inclusive-language.spec.ts'\
+         ':(exclude)../src/components/create-vm-wizard/strings/strings-with-offensive-language.ts'\
+         ':(exclude)../integration-tests/deploy-kubevirt-gating.sh'`,
+        {
+          timeout: 10000,
+          failOnNonZeroExit: false,
+        },
+      )
+        .its('stdout')
+        .should('be.empty');
+    });
+  });
+});

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/ovirt-import-provider/ovirt-certificate.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/ovirt-import-provider/ovirt-certificate.tsx
@@ -73,7 +73,7 @@ const OvirtCertificateConnected: React.FC<OvirtCertificateProps> = React.memo(
         validation={additionalValidation}
         fieldHelp={
           <a
-            href="https://ovirt.github.io/ovirt-engine-api-model/master/#_obtaining_the_ca_certificate"
+            href="https://ovirt.github.io/ovirt-engine-api-model/4.4/#_obtaining_the_ca_certificate"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/ovirt-import-provider/ovirt-import-provider.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/import-providers-tab/providers/ovirt-import-provider/ovirt-import-provider.tsx
@@ -56,7 +56,7 @@ const OvirtImportProviderConnected: React.FC<OvirtImportProviderProps> = ({
         fieldType={FormFieldType.TEXT}
         fieldHelp={
           <a
-            href="https://ovirt.github.io/ovirt-engine-api-model/master/#_access_api_entry_point"
+            href="https://ovirt.github.io/ovirt-engine-api-model/4.4/#_access_api_entry_point"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/packages/kubevirt-plugin/src/topology/__tests__/topology-kubevirt-test-data.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/__tests__/topology-kubevirt-test-data.ts
@@ -204,7 +204,7 @@ const pods = {
         enableServiceLinks: true,
         terminationGracePeriodSeconds: 10,
         shareProcessNamespace: false,
-        nodeName: 'master-2',
+        nodeName: 'primary-2',
         securityContext: {
           seLinuxOptions: {
             level: 's0:c27,c19',
@@ -625,7 +625,7 @@ const pods = {
         schedulerName: 'default-scheduler',
         enableServiceLinks: true,
         terminationGracePeriodSeconds: 30,
-        nodeName: 'master-2',
+        nodeName: 'primary-2',
         securityContext: {
           seLinuxOptions: {
             type: 'virt_launcher.process',
@@ -2362,7 +2362,7 @@ const virtualmachineinstances = {
         labels: {
           'flavor.template.kubevirt.io/tiny': 'true',
           'kubevirt.io/domain': 'example-04',
-          'kubevirt.io/nodeName': 'master-2',
+          'kubevirt.io/nodeName': 'primary-2',
           'kubevirt.io/size': 'tiny',
           'os.template.kubevirt.io/fedora31': 'true',
           'vm.kubevirt.io/name': 'rhel-8-vm',
@@ -2468,7 +2468,7 @@ const virtualmachineinstances = {
           },
         ],
         migrationMethod: 'BlockMigration',
-        nodeName: 'master-2',
+        nodeName: 'primary-2',
         phase: 'Running',
         qosClass: 'Burstable',
       },

--- a/frontend/packages/kubevirt-plugin/src/types/vm/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vm/index.ts
@@ -5,14 +5,14 @@ import {
 } from '@console/internal/module/k8s';
 import { V1alpha1DataVolumeSpec, V1alpha1DataVolumeStatus, V1ObjectMeta } from '../api';
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_datavolumetemplatespec
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_datavolumetemplatespec
 export interface V1DataVolumeTemplateSpec {
   metadata?: V1ObjectMeta;
   spec: V1alpha1DataVolumeSpec;
   status?: V1alpha1DataVolumeStatus;
 }
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancespec
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstancespec
 export type VMISpec = {
   affinity: any;
   dnsConfig: any;
@@ -30,7 +30,7 @@ export type VMISpec = {
   volumes?: any[];
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancestatus
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstancestatus
 export type VMIStatus = {
   conditions: any[];
   interfaces: any[];
@@ -71,7 +71,7 @@ export type VMStatusStateChangeRequest = {
   data: { [key: string]: string };
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachine
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachine
 export type VMKind = {
   spec: VMSpec;
   status: VMStatus;

--- a/frontend/packages/kubevirt-plugin/src/types/vmi-guest-data-info/vmi-guest-agent-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vmi-guest-data-info/vmi-guest-agent-info.ts
@@ -1,6 +1,6 @@
 import { ObjectMetadata } from '@console/internal/module/k8s';
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestosinfo
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstanceguestosinfo
 export type V1VirtualMachineInstanceGuestOSInfo = {
   id?: string;
   kernelRelease?: string;
@@ -12,14 +12,14 @@ export type V1VirtualMachineInstanceGuestOSInfo = {
   versionId?: string;
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestosuser
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstanceguestosuser
 export type V1VirtualMachineInstanceGuestOSUser = {
   domain?: string;
   loginTime?: number;
   userName: string;
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestosuserlist
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstanceguestosuserlist
 export type V1VirtualMachineInstanceGuestOSUserList = {
   apiVersion?: string;
   items: V1VirtualMachineInstanceGuestOSUser[];
@@ -27,7 +27,7 @@ export type V1VirtualMachineInstanceGuestOSUserList = {
   metadata?: ObjectMetadata;
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesystem
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstancefilesystem
 export type V1VirtualMachineInstanceFileSystem = {
   diskName?: string;
   fileSystemType: string;
@@ -36,12 +36,12 @@ export type V1VirtualMachineInstanceFileSystem = {
   usedBytes: number;
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesysteminfo
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstancefilesysteminfo
 export type V1VirtualMachineInstanceFileSystemInfo = {
   disks: V1VirtualMachineInstanceFileSystem[];
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesystemlist
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstancefilesystemlist
 export type V1VirtualMachineInstanceFileSystemList = {
   apiVersion?: string;
   items: V1VirtualMachineInstanceFileSystem[];
@@ -49,7 +49,7 @@ export type V1VirtualMachineInstanceFileSystemList = {
   metadata?: ObjectMetadata;
 };
 
-// https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstanceguestagentinfo
+// https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_virtualmachineinstanceguestagentinfo
 export type V1VirtualMachineInstanceGuestAgentInfo = {
   apiVersion?: string;
   fsInfo?: V1VirtualMachineInstanceFileSystemInfo;


### PR DESCRIPTION
This PR removes offensive language from the kubevirt package. It also adds a test that will fail if specific offensive terms are detected.