### PR TITLE
fix spacing for MulitColumnField component

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
@@ -2,10 +2,15 @@
   &__row {
     position: relative;
     margin-right: var(--pf-global--spacer--lg);
-    margin-bottom: var(--pf-global--spacer--lg);
+    margin-bottom: var(--pf-global--spacer--md);
     max-height: var(--pf-global--spacer--xl);
   }
-
+  &__header {
+    position: relative;
+    margin-right: var(--pf-global--spacer--lg);
+    margin-bottom: var(--pf-global--spacer--sm);
+    max-height: var(--pf-global--spacer--xl);
+  }
   &__col {
     margin-right: var(--pf-global--spacer--md);
   }

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldHeader.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldHeader.tsx
@@ -8,8 +8,8 @@ export interface MultiColumnFieldHeaderProps {
 }
 
 const MultiColumnFieldHeader: React.FC<MultiColumnFieldHeaderProps> = ({ headers, spans }) => (
-  <div className="odc-multi-column-field__row">
-    <Grid className="odc-multi-column-field__row">
+  <div className="odc-multi-column-field__header">
+    <Grid className="odc-multi-column-field__header">
       {headers.map((header, i) => (
         <GridItem span={spans[i]} key={typeof header === 'string' ? header : header.name}>
           <div className="odc-multi-column-field__col">


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-3895

fix the spacing of  MulitColumnField component to 8px below header 16px below all other rows

Before:
![image-2020-05-15-12-09-33-058](https://user-images.githubusercontent.com/9278015/108682655-938aa780-7516-11eb-8f63-7ae270161513.png)

After:
<img width="904" alt="Screenshot 2021-02-22 at 1 59 06 PM" src="https://user-images.githubusercontent.com/9278015/108682460-51616600-7516-11eb-8cf9-4915434f27da.png">
