### PR TITLE
Fixes volume mode when selecting RBD + RWX

### DIFF
--- a/frontend/packages/console-shared/src/utils/index.ts
+++ b/frontend/packages/console-shared/src/utils/index.ts
@@ -18,3 +18,4 @@ export * from './hpa-utils';
 export * from './sample-utils';
 export * from './multiselectdropdown';
 export * from './annotations';
+export * from './info-tooltip';

--- a/frontend/packages/console-shared/src/utils/info-tooltip.tsx
+++ b/frontend/packages/console-shared/src/utils/info-tooltip.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Tooltip } from '@patternfly/react-core';
+
+export const InfoToolTip = ({ position, content }) => (
+  <Tooltip position={position} content={content}>
+    <OutlinedQuestionCircleIcon />
+  </Tooltip>
+);


### PR DESCRIPTION
This commit fixes the volume mode that is used when RBD + RWX is selected and renders a read-only text
It also refactors the code to add a InfoToolTip component to shared utils

![Screenshot from 2021-02-22 18-43-53](https://user-images.githubusercontent.com/57935785/108713291-052a1c00-753e-11eb-959f-9cc510235125.png)


Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>