### PR TITLE
[release-4.6] Bug 1931515:  allow choice of binding type when creating RoleBinding

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -287,9 +287,7 @@ export const RoleBindingsPage = ({
   showTitle = true,
   mock = false,
   staticFilters = undefined,
-  createPath = `/k8s/${namespace ? `ns/${namespace}` : 'cluster'}/rolebindings/~new${
-    namespace ? `?namespace=${namespace}` : ''
-  }`,
+  createPath = '/k8s/cluster/rolebindings/~new',
 }) => (
   <MultiListPage
     canCreate={!mock}


### PR DESCRIPTION
Manual back port of Bug 1927882 as 4.7 includes other fixes that are not part of 4.6.

Note this reverts part of the changes in Bug 1871996.