### PR TITLE
Fix builder image version dropdown value in pipeline edit flow

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -10,6 +10,11 @@ import { DeploymentConfigModel, DeploymentModel } from '@console/internal/models
 import { hasIcon } from '@console/internal/components/catalog/catalog-item-icon';
 import { ServiceModel } from '@console/knative-plugin';
 import { PipelineKind } from '@console/pipelines-plugin/src/types';
+import {
+  PIPELINE_RUNTIME_LABEL,
+  PIPELINE_RUNTIME_VERSION_LABEL,
+} from '@console/pipelines-plugin/src/const';
+import { isDockerPipeline } from '@console/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils';
 import { UNASSIGNED_KEY } from '@console/topology/src/const';
 import { Resources, DeploymentData, GitReadableTypes } from '../import/import-types';
 import { AppResources } from './edit-application-types';
@@ -154,10 +159,7 @@ export const getBuildData = (
     },
     strategy:
       buildStrategyType ||
-      (pipeline?.metadata?.labels?.['pipeline.openshift.io/strategy'] ===
-      _.toLower(BuildStrategyType.Docker)
-        ? BuildStrategyType.Docker
-        : BuildStrategyType.Source),
+      (isDockerPipeline(pipeline) ? BuildStrategyType.Docker : BuildStrategyType.Source),
   };
   return buildData;
 };
@@ -336,10 +338,9 @@ export const getGitAndDockerfileInitialValues = (
         'Dockerfile',
     },
     image: {
-      selected:
-        currentImage[0] || (pipeline?.metadata?.labels?.['pipeline.openshift.io/runtime'] ?? ''),
+      selected: pipeline?.metadata?.labels?.[PIPELINE_RUNTIME_LABEL] || currentImage[0] || '',
       recommended: '',
-      tag: currentImage[1] || '',
+      tag: pipeline?.metadata?.labels?.[PIPELINE_RUNTIME_VERSION_LABEL] || currentImage[1] || '',
       tagObj: {},
       ports: [],
       isRecommending: false,

--- a/frontend/packages/pipelines-plugin/src/const.ts
+++ b/frontend/packages/pipelines-plugin/src/const.ts
@@ -1,3 +1,5 @@
 export const FLAG_OPENSHIFT_PIPELINE = 'OPENSHIFT_PIPELINE';
 export const CLUSTER_PIPELINE_NS = 'openshift';
 export const PIPELINE_RUNTIME_LABEL = 'pipeline.openshift.io/runtime';
+export const PIPELINE_RUNTIME_VERSION_LABEL = 'pipeline.openshift.io/runtime-version';
+export const PIPELINE_STRATEGY_LABEL = 'pipeline.openshift.io/strategy';


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5536

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
In pipeline add/edit git flow, builder image version was not tracked in the newly created pipeline, hence the previously selected version was getting lost while going through the edit flow.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Added a label `pipeline.openshift.io/runtime-version` to get and set the builder image version and used it in the edit flow.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![version-edit-flow](https://user-images.githubusercontent.com/9964343/108744102-8d6ce900-755f-11eb-8fdc-fe48759b25be.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
  ```
updatePipelineForImportFlow
    ✓ should dissociate pipeline if template is not available (1ms)
    ✓ should update params if template is of same type
    ✓ should update VERSION params if image tag is changed (1ms)
    ✓ should update pipeline if template is of different type (1ms)
  isDockerPipeline
    ✓ should return false for a non docker based pipelines
    ✓ should return true for a docker based pipeline template
  pipelineRuntimOrVersionChanged
    ✓ should return false if runtime and version is same for two given pipelines
    ✓ should return false if runtime or version is different for two given pipelines
```
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. In git add flow, choose a builder image and version
2. check `Add pipeline` option
3. create the resource and choose edit option from topology page.
4. edit form should have pre-selected the correct builder image version in the dropdown 



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge