### PR TITLE
Add single control point of all toast notifications

### DIFF
--- a/frontend/__tests__/utils/hooks-utils.tsx
+++ b/frontend/__tests__/utils/hooks-utils.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { mount, MountRendererProps } from 'enzyme';
 
 const useRerender = () => {
   const [, setState] = React.useState(0);
@@ -21,11 +21,11 @@ const TestHook: React.FC<TestComponentProps> = ({ hook, result, rerenderRef }) =
   return null;
 };
 
-export const testHook = <T extends any>(hook: () => T) => {
+export const testHook = <T extends any>(hook: () => T, options?: MountRendererProps) => {
   // Inspired by https://github.com/testing-library/react-hooks-testing-library
   const result = { current: undefined as T };
   const rerenderRef: RerenderRef = {};
   const rerender = () => rerenderRef.current();
-  mount(<TestHook hook={hook} result={result} rerenderRef={rerenderRef} />);
+  mount(<TestHook hook={hook} result={result} rerenderRef={rerenderRef} />, options);
   return { result, rerender };
 };

--- a/frontend/packages/console-shared/src/components/index.ts
+++ b/frontend/packages/console-shared/src/components/index.ts
@@ -24,3 +24,4 @@ export * from './multi-tab-list';
 export * from './spotlight';
 export * from './markdown-highlight-extension';
 export * from './custom-resource-list';
+export * from './toast';

--- a/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { AlertVariant } from '@patternfly/react-core';
+
+export const ToastVariant = AlertVariant;
+
+export type ToastOptions = {
+  // Optional ID identifying this toast. If not provided, one will be generated.
+  id?: string;
+  // The toast title.
+  title: string;
+  // The toast variant, one of: success, danger, warning, info, default
+  variant: AlertVariant;
+  // The toast content.
+  content: React.ReactNode;
+  // Optional actions to display in the toast.
+  actions?: {
+    // The action label.
+    label: string;
+    // The action callback.
+    callback: () => void;
+    // If `true`, executing this action will dismiss the toast.
+    dismiss?: boolean;
+  }[];
+  // If `true`, displays a close button.
+  dismissible?: boolean;
+  // If set to true, the time out is 8000 milliseconds.
+  // If a number is provided, alert will be dismissed after that amount of time in milliseconds.
+  timeout?: number | boolean;
+  // Callback when the toast is removed.
+  onRemove?: (id: string) => void;
+};
+
+export type ToastContextType = {
+  // Add a toast alert. Returns the toast ID.
+  addToast: (options: ToastOptions) => string;
+  // Remove a toast alert.
+  removeToast: (id: string) => void;
+};
+
+export default React.createContext<ToastContextType>({} as any);

--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Alert, AlertGroup, AlertActionCloseButton, AlertActionLink } from '@patternfly/react-core';
+import ToastContext, { ToastOptions, ToastContextType } from './ToastContext';
+
+const ToastProvider: React.FC = ({ children }) => {
+  const [toasts, setToasts] = React.useState<ToastOptions[]>([]);
+
+  const removeToast = React.useCallback((id: string) => {
+    setToasts((state) => {
+      const index = state.findIndex((t) => t.id === id);
+      if (index !== -1) {
+        const toast = state[index];
+        if (toast.onRemove) {
+          toast.onRemove(toast.id);
+        }
+        return [...state.slice(0, index), ...state.slice(index + 1, state.length)];
+      }
+      return state;
+    });
+  }, []);
+
+  const addToast = React.useMemo(() => {
+    let counter = 0;
+    return (toast: ToastOptions) => {
+      const clone: ToastOptions = {
+        id: `toast-${++counter}`,
+        ...toast,
+      };
+      setToasts((state) => {
+        const index = state.findIndex((t) => t.id === clone.id);
+        if (index !== -1) {
+          return [...state.slice(0, index), clone, ...state.slice(index + 1, state.length)];
+        }
+        return [...state, clone];
+      });
+      return clone.id;
+    };
+  }, []);
+
+  const controller: ToastContextType = React.useMemo<ToastContextType>(
+    () => ({
+      addToast,
+      removeToast,
+    }),
+    [addToast, removeToast],
+  );
+
+  return (
+    <ToastContext.Provider value={controller}>
+      {children}
+      {toasts.length ? (
+        <AlertGroup appendTo={() => document.body} isToast>
+          {toasts.map((toast) => (
+            <Alert
+              key={toast.id}
+              isLiveRegion
+              title={toast.title}
+              variant={toast.variant}
+              timeout={toast.timeout}
+              onTimeout={() => removeToast(toast.id)}
+              actionClose={
+                toast.dismissible ? (
+                  <AlertActionCloseButton onClose={() => removeToast(toast.id)} />
+                ) : (
+                  undefined
+                )
+              }
+              actionLinks={
+                toast.actions?.length > 0 ? (
+                  <>
+                    {toast.actions.map((action) => (
+                      <AlertActionLink
+                        key={action.label}
+                        onClick={() => {
+                          if (action.dismiss) {
+                            removeToast(toast.id);
+                          }
+                          action.callback();
+                        }}
+                      >
+                        {action.label}
+                      </AlertActionLink>
+                    ))}
+                  </>
+                ) : (
+                  undefined
+                )
+              }
+            >
+              {toast.content}
+            </Alert>
+          ))}
+        </AlertGroup>
+      ) : null}
+    </ToastContext.Provider>
+  );
+};
+export default ToastProvider;

--- a/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
+++ b/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount, ReactWrapper } from 'enzyme';
+import { Alert, AlertActionLink } from '@patternfly/react-core';
+import ToastContext, { ToastContextType, ToastVariant } from '../ToastContext';
+import ToastProvider from '../ToastProvider';
+
+describe('ToastProvider', () => {
+  let toastContext: ToastContextType;
+  let wrapper: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
+
+  beforeEach(() => {
+    const TestComponent = () => {
+      toastContext = React.useContext(ToastContext);
+      return null;
+    };
+    wrapper = mount(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+  });
+
+  it('should provide a context', () => {
+    expect(typeof toastContext.addToast).toBe('function');
+    expect(typeof toastContext.removeToast).toBe('function');
+  });
+
+  it('should add and remove alerts', () => {
+    // fixed id
+    const id1 = 'foo';
+    // generated id
+    let id2: string;
+
+    act(() => {
+      toastContext.addToast({
+        id: id1,
+        title: 'test success',
+        variant: ToastVariant.success,
+        content: 'description 1',
+      });
+      id2 = toastContext.addToast({
+        title: 'test danger',
+        variant: ToastVariant.danger,
+        content: 'description 2',
+      });
+    });
+
+    wrapper.update();
+
+    const alerts = wrapper.find(Alert);
+    expect(alerts.length).toBe(2);
+
+    expect(alerts.at(0).props()).toMatchObject({
+      title: 'test success',
+      variant: ToastVariant.success,
+      children: 'description 1',
+    });
+
+    expect(alerts.at(1).props()).toMatchObject({
+      title: 'test danger',
+      variant: ToastVariant.danger,
+      children: 'description 2',
+    });
+
+    act(() => {
+      toastContext.removeToast(id1);
+      toastContext.removeToast(id2);
+    });
+
+    wrapper.update();
+    expect(wrapper.find(Alert).length).toBe(0);
+  });
+
+  it('should dismiss toast on action', () => {
+    const actionFn = jest.fn();
+    act(() => {
+      toastContext.addToast({
+        title: 'test success',
+        variant: ToastVariant.success,
+        content: 'description 1',
+        actions: [
+          {
+            label: 'action 1',
+            dismiss: true,
+            callback: actionFn,
+          },
+        ],
+      });
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find(Alert).length).toBe(1);
+    const alertActionLinks = wrapper.find(AlertActionLink);
+    expect(alertActionLinks.length).toBe(1);
+
+    act(() => {
+      alertActionLinks
+        .at(0)
+        .find('button')
+        .simulate('click');
+    });
+
+    wrapper.update();
+
+    expect(actionFn).toHaveBeenCalledTimes(1);
+
+    expect(wrapper.find(Alert).length).toBe(0);
+  });
+});

--- a/frontend/packages/console-shared/src/components/toast/__tests__/useToast.spec.tsx
+++ b/frontend/packages/console-shared/src/components/toast/__tests__/useToast.spec.tsx
@@ -1,0 +1,17 @@
+import ToastProvider from '../ToastProvider';
+import useToast from '../useToast';
+import { testHook } from '../../../../../../__tests__/utils/hooks-utils';
+
+describe('useToast', () => {
+  it('should provide a context', () => {
+    let toastContext;
+    testHook(
+      () => {
+        toastContext = useToast();
+      },
+      { wrappingComponent: ToastProvider },
+    );
+    expect(typeof toastContext.addToast).toBe('function');
+    expect(typeof toastContext.removeToast).toBe('function');
+  });
+});

--- a/frontend/packages/console-shared/src/components/toast/index.ts
+++ b/frontend/packages/console-shared/src/components/toast/index.ts
@@ -1,0 +1,3 @@
+export { default as ToastContext } from './ToastContext';
+export { default as ToastProvider } from './ToastProvider';
+export { default as useToast } from './useToast';

--- a/frontend/packages/console-shared/src/components/toast/useToast.ts
+++ b/frontend/packages/console-shared/src/components/toast/useToast.ts
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import ToastContext from './ToastContext';
+
+export default () => React.useContext(ToastContext);

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -30,6 +30,7 @@ import { useExtensions, withExtensions, isContextProvider } from '@console/plugi
 import { GuidedTour } from '@console/app/src/components/tour';
 import { isStandaloneRoutePage } from '@console/dynamic-plugin-sdk/src/extensions/pages';
 import QuickStartDrawer from '@console/app/src/components/quick-starts/QuickStartDrawer';
+import ToastProvider from '@console/shared/src/components/toast/ToastProvider';
 import '../i18n';
 import '../vendor.scss';
 import '../style.scss';
@@ -302,7 +303,9 @@ graphQLReady.onReady(() => {
   render(
     <React.Suspense fallback={<LoadingBox />}>
       <Provider store={store}>
-        <AppRouter />
+        <ToastProvider>
+          <AppRouter />
+        </ToastProvider>
       </Provider>
     </React.Suspense>,
     document.getElementById('app'),

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -388,7 +388,7 @@ h6 {
 
 // Necessary due to setting $pf-global--enable-reset to false
 .pf-c-pagination .pf-c-options-menu__menu,
-.pf-c-alert {
+.pf-c-alert-group {
   list-style: none;
 }
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -317,7 +317,8 @@ h6 {
   .pf-l-stack {
     font-size: $font-size-base;
   }
-  .pf-c-form-control.pf-m-success, .pf-c-form-control[aria-invalid="true"] {
+  .pf-c-form-control.pf-m-success,
+  .pf-c-form-control[aria-invalid='true'] {
     --pf-global--FontSize--md: #{$font-size-base};
   }
   .pf-c-form-control {
@@ -326,7 +327,7 @@ h6 {
       &.pf-m-success {
         -webkit-animation-name: autofill-success;
       }
-      &[aria-invalid="true"] {
+      &[aria-invalid='true'] {
         -webkit-animation-name: autofill-invalid;
       }
     }
@@ -386,7 +387,8 @@ h6 {
 }
 
 // Necessary due to setting $pf-global--enable-reset to false
-.pf-c-pagination .pf-c-options-menu__menu {
+.pf-c-pagination .pf-c-options-menu__menu,
+.pf-c-alert {
   list-style: none;
 }
 
@@ -510,6 +512,6 @@ button.pf-c-dropdown__menu-item.pf-m-disabled {
   position: absolute !important;
 }
 
-.text-muted{
+.text-muted {
   color: var(--pf-global--Color--200);
 }


### PR DESCRIPTION
While patternfly does support [alert group toasts](https://www.patternfly.org/v4/components/alert-group), it does not provide a mechanism for managing all toasts in the application. A leaf component which needs to throw up a toast, must manage the full lifecycle of the toast itself like any other react component. This isn't ideal when the need arises to throw up a toast in response to an async network call and then move on to a new page.

This PR adds a `ToastProvider` which wraps the root of the application similar to redux provider. A React context is setup which allows any child component to reach for the `ToastContext` and use the API:

- `context.addToast(options: ToastOptions)`
- `context.removeToast(id: string)`

Added a convenience hook `useToast` which can be used instead of `useContext(ToastContext)`;

The `ToastOptions` are flexible enough to give developers control over toasts which auto dismiss or require user interaction as well as support actions for future use cases.

![image](https://user-images.githubusercontent.com/14068621/108895557-bafa7680-75e1-11eb-9e11-c94e8bde3116.png)

Unfortunately there is no simple way to test right now as this PR does not the use of toasts anywhere.
To test locally I exported the toast context as follows: `(window as any).toast = controller;`
I can then use the APIs:
```
toastId = window.toast.addToast({
  variant:'success',
  title:'test',
  content:'This is the content',
  dismissible: true,
  actions: [{
    dismiss: true,
    label: 'link 1',
    callback: () => alert('action')
  }]
});

window.toast.removeToast(toastId)
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari (didn't test Safari because my safari is too old to support ResizeObserver until I update the OS)
- [x] Edge

cc @openshift/team-devconsole-ux @spadgett 