### PR TITLE
Monitoring: Add `title`s to the alert and alerting rule list rows

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -289,6 +289,7 @@ TableRow.displayName = 'TableRow';
 export type TableRowProps = {
   id: any;
   index: number;
+  title?: string;
   trKey: string;
   style: object;
   className?: string;

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1121,10 +1121,11 @@ const tableAlertClasses = [
 
 const AlertTableRow: RowFunction<Alert> = ({ index, key, obj, style }) => {
   const { annotations = {}, labels } = obj;
+  const description = annotations.description || annotations.message;
   const state = alertState(obj);
 
   return (
-    <TableRow id={obj.rule.id} index={index} trKey={key} style={style}>
+    <TableRow id={obj.rule.id} index={index} title={description} trKey={key} style={style}>
       <TableData className={tableAlertClasses[0]}>
         <div className="co-resource-item">
           <MonitoringResourceIcon resource={AlertResource} />
@@ -1136,9 +1137,7 @@ const AlertTableRow: RowFunction<Alert> = ({ index, key, obj, style }) => {
             {labels?.alertname}
           </Link>
         </div>
-        <div className="monitoring-description">
-          {annotations.description || annotations.message}
-        </div>
+        <div className="monitoring-description">{description}</div>
       </TableData>
       <TableData className={tableAlertClasses[1]}>
         <Severity severity={labels?.severity} />
@@ -1379,7 +1378,13 @@ const tableRuleClasses = [
 ];
 
 const RuleTableRow: RowFunction<Rule> = ({ index, key, obj, style }) => (
-  <TableRow id={obj.id} index={index} trKey={key} style={style}>
+  <TableRow
+    id={obj.id}
+    index={index}
+    style={style}
+    title={obj.annotations?.description || obj.annotations?.message}
+    trKey={key}
+  >
     <TableData className={tableRuleClasses[0]}>
       <div className="co-resource-item">
         <MonitoringResourceIcon resource={RuleResource} />


### PR DESCRIPTION
For both use the `description` annotation if available or the `message`
annotation otherwise.

FYI @cshinn 

<img width="786" alt="title" src="https://user-images.githubusercontent.com/460802/108963136-1188b300-76bd-11eb-83b6-0b0e8f608fb8.png">