### PR TITLE
Bug 1866322: Add prop to AlertItem to hide default link

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/status-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/status-card.tsx
@@ -41,7 +41,9 @@ export const CephAlerts = withDashboardResources(
       <AlertsBody error={!_.isEmpty(loadError)}>
         {loaded &&
           alerts.length > 0 &&
-          alerts.map((alert) => <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />)}
+          alerts.map((alert) => (
+            <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} hideLink />
+          ))}
       </AlertsBody>
     );
   },

--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -11,8 +11,14 @@ const enum status {
   BOUND = 'Bound',
   AVAILABLE = 'Available',
 }
-export const filterCephAlerts = (alerts: Alert[]): Alert[] =>
-  alerts.filter((alert) => _.get(alert, 'annotations.storage_type') === 'ceph');
+export const filterCephAlerts = (alerts: Alert[]): Alert[] => {
+  const rookRegex = /.*rook.*/;
+  return alerts?.filter(
+    (alert) =>
+      alert?.annotations?.storage_type === 'ceph' ||
+      Object.values(alert?.labels)?.some((item) => rookRegex.test(item)),
+  );
+};
 
 export const getCephPVs = (pvsData: K8sResourceKind[] = []): K8sResourceKind[] =>
   pvsData.filter((pv) => {

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -49,7 +49,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({ Icon, timestamp, message
   );
 };
 
-const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
+const AlertItem: React.FC<AlertItemProps> = ({ alert, hideLink }) => {
   const actionsExtensions = useExtensions<AlertAction>(isAlertAction);
   const action = getAlertActions(actionsExtensions).get(alert.rule.name);
   const { t } = useTranslation();
@@ -62,7 +62,7 @@ const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
       {action ? (
         <Link to={_.isFunction(action.path) ? action.path(alert) : action.path}>{action.text}</Link>
       ) : (
-        <Link to={alertURL(alert, alert.rule.id)}>{t('dashboard~View details')}</Link>
+        !hideLink && <Link to={alertURL(alert, alert.rule.id)}>{t('dashboard~View details')}</Link>
       )}
     </StatusItem>
   );
@@ -78,4 +78,5 @@ type StatusItemProps = {
 
 type AlertItemProps = {
   alert: Alert;
+  hideLink?: boolean;
 };

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
@@ -65,7 +65,9 @@ const ObjectStorageAlerts = withDashboardResources(
       <AlertsBody error={!_.isEmpty(loadError)}>
         {loaded &&
           alerts.length > 0 &&
-          alerts.map((alert) => <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />)}
+          alerts.map((alert) => (
+            <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} hideLink />
+          ))}
       </AlertsBody>
     );
   },


### PR DESCRIPTION
 - Disable default link from Ceph and Noobaa Dashboard
 - Add support for Rook related Alerts in Ceph Dashboard
 Before: 
![Screenshot from 2021-02-24 11-41-50](https://user-images.githubusercontent.com/54092533/108965214-931f1780-76a2-11eb-9ba5-ddd28738f79c.png)
After:
![Screenshot from 2021-02-24 13-13-38](https://user-images.githubusercontent.com/54092533/108965234-9b775280-76a2-11eb-999a-878089aa3b4f.png)
/assign @rawagner @yuvalgalanti 
