### PR TITLE
Bug 1924536: Change link for not available state

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -13,7 +13,7 @@ import {
 } from './mappers';
 import { PrometheusHealthPopupProps } from '@console/plugin-sdk';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { ExternalLink } from '@console/internal/components/utils';
+import { ExternalLink, openshiftHelpBase } from '@console/internal/components/utils';
 import './style.scss';
 
 const DataComponent: React.FC<DataComponentProps> = ({ x, y, datum }) => {
@@ -112,7 +112,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         )}
         {!hasIssues && (isWaitingOrDisabled || isError) && (
           <ExternalLink
-            href="https://docs.openshift.com/container-platform/latest/support/getting-support.html"
+            href={`${openshiftHelpBase}support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html`}
             text={t('insights-plugin~More about Insights')}
           />
         )}


### PR DESCRIPTION
Insights widget in OCP WebConsole has a state 'disabled/not available' when Insights Operator is off. There is a link 'More about Insights' that pointed to the wrong source. Preferred is `https://docs.openshift.com/container-platform/latest/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html`