### PR TITLE
Gherkin: Improve knative & build integration

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/features/Knative/actions-on-knative-revision.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/Knative/actions-on-knative-revision.feature
@@ -18,7 +18,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario: Edit labels modal details : Kn-03-TC02
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       When user selects "Edit Labels" option from knative revision context menu
       Then modal with "Edit Labels" appears
       And save button is disabled
@@ -27,7 +27,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario: Add new label to knative Revision: Kn-03-TC03
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
       And user selects "Edit Labels" option from knative revision context menu
       And user adds the label "app=label" to existing labels list in Edit Labels modal
@@ -38,7 +38,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario: Remove label from knative Revision: Kn-03-TC04
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       When user selects "Edit Labels" option from knative revision context menu
       And user removes the label "app=label" from existing labels list in "Edit Labels" modal
       And user clicks the save button on the "Edit Labels" modal
@@ -48,7 +48,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario: Add labels to existing labels list and cancel the activity : Kn-03-TC05
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       When user selects "Edit Labels" option from knative revision context menu
       And user adds the label "app=label" to existing labels list in Edit Labels modal
       And user clicks cancel button on the "Edit Labels" modal
@@ -58,7 +58,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario: Edit Annotation modal details : Kn-03-TC06
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       When user selects "Edit Annotaions" option from knative revision context menu
       Then modal with "Edit Annotations" appears
       And key, value columns are displayed with respecitve text fields
@@ -69,7 +69,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario Outline: Add annotation to the existing annonations list : Kn-03-TC07
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       And number of annotations are "5" present in revision side bar details of service "nodejs-ex-git-2"
       When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
       And user selects "Edit Annotaions" option from knative revision context menu
@@ -83,7 +83,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario: perform cancel action on Edit Annotations : Kn-03-TC09
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       And number of annotations are "6" present in side bar - details tab- annotation section
       When user selects "Edit Annotations" option from knative revision context menu
       And user clicks on "remove" icon for the annotation with key "serving.knative.dev/creator" present in "Edit Annotaions" modal
@@ -94,7 +94,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario Outline: Remove annotation from existing annonations list : Kn-03-TC08
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       And number of annotations are "6" present in side bar - details tab
       When user selects "Edit Annotaions" option from knative revision context menu
       And user clicks on "remove" icon for the annotation with key "<key_name>" present in "Edit Annotaions" modal
@@ -109,7 +109,7 @@ Feature: Perform actions on knative revision
    @regression, @manual
    Scenario: Edit revision details page : Kn-03-TC10
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       When user selects "Edit Revision" option from knative revision context menu
       And user clicks on Details tab
       Then details tab displayed with Revision Details and Conditions sections
@@ -119,7 +119,7 @@ Feature: Perform actions on knative revision
    @smoke, @manual
    Scenario: Update the revision detials : Kn-03-TC11
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       When user selects "Edit Revision" option from knative revision context menu
       And user modifies the Yaml file of the Revision details page
       And user clicks "save" button on Revision Yaml page
@@ -130,7 +130,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario Outline: Delete revision modal details for service with multiple revisions : Kn-03-TC13
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       And service should contain multiple revisions
       When user selects "Delete Revision" option from knative revision context menu
       Then modal with "Update the traffic distribution among the remaining Revisions" appears
@@ -140,7 +140,7 @@ Feature: Perform actions on knative revision
    @regression
    Scenario Outline: Delete revision for the service which contains multiple revisions : Kn-03-TC14
       Given user has created knative service "nodejs-ex-git-2"
-      And user is at the Topolgy page
+      And user is at the Topology page
       And service should contain multiple revisions
       When user selects "Delete Revision" option from knative revision context menu
       Then modal with "Update the traffic distribution among the remaining Revisions" appears
@@ -149,9 +149,27 @@ Feature: Perform actions on knative revision
 
    @smoke
    Scenario: Delete Revision not possible for the service which contains one revision : Kn-03-TC12
-      Given knative service named "<service_name>" is higlighted on topology page
+      Given knative service named "nodejs-ex-git-2" is higlighted on topology page
       When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
       And user selects "Delete Revision" option from knative revision context menu
       Then modal with "Unable to delete revision" appears
       And modal contains message as "You cannot delete the last Revision for the Service."
       And modal should get closed on clicking OK button
+
+
+   @regression
+   Scenario: Revison created with successful build
+      Given user is on Import from git page
+      When user creates knative service with name "nodejs-ex-git-1"
+      And user waits for the build to complete
+      And user reruns the build
+      Then user can see two revision created
+
+
+   @regression
+   Scenario: Revison created with new pipeline run
+      Given user has created knative service "nodejs-ex-git-2" with pipeline
+      And user is at the Topology page
+      When user waits for pipeline run to complete
+      And user reruns the pipeline
+      Then user can see two revision created


### PR DESCRIPTION
Problem: Builds don't trigger a new revision for Knative Services like it does for K8S deployments.
Fix: Designing gherkin for triggering a new revision for Knative Services with build
Story: https://issues.redhat.com/browse/ODC-5409
Epic: https://issues.redhat.com/browse/ODC-4709