### PR TITLE
Update KubeVirt types

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/types/vm/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vm/index.ts
@@ -4,9 +4,11 @@ import {
   ObjectMetadata,
 } from '@console/internal/module/k8s';
 import { V1alpha1DataVolumeSpec, V1alpha1DataVolumeStatus, V1ObjectMeta } from '../api';
+import { V1VirtualMachineInstanceGuestOSInfo } from '../vmi-guest-data-info/vmi-guest-agent-info';
 
 // https://kubevirt.io/api-reference/master/definitions.html#_v1_datavolumetemplatespec
 export interface V1DataVolumeTemplateSpec {
+  apiVersion?: string;
   metadata?: V1ObjectMeta;
   spec: V1alpha1DataVolumeSpec;
   status?: V1alpha1DataVolumeStatus;
@@ -14,31 +16,39 @@ export interface V1DataVolumeTemplateSpec {
 
 // https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancespec
 export type VMISpec = {
-  affinity: any;
-  dnsConfig: any;
-  dnsPolicy: string;
-  domain?: any;
+  accessCredentials?: any;
+  affinity?: any;
+  dnsConfig?: any;
+  dnsPolicy?: string;
+  domain: any;
   evictionStrategy?: string;
-  hostname: string;
-  livenessProbe: any;
+  hostname?: string;
+  livenessProbe?: any;
   networks?: any[];
-  nodeSelector: NodeSelector;
-  readinessProbe: any;
-  subdomain: string;
-  terminationGracePeriodSeconds: number;
-  tolerations: any[];
+  nodeSelector?: NodeSelector;
+  priorityClassName?: string;
+  readinessProbe?: any;
+  schedulerName?: string;
+  subdomain?: string;
+  terminationGracePeriodSeconds?: number;
+  tolerations?: any[];
   volumes?: any[];
 };
 
 // https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancestatus
 export type VMIStatus = {
-  conditions: any[];
-  interfaces: any[];
-  migrationMethod: string;
-  migrationState: any;
-  nodeName: string;
-  phase: string;
-  reason: string;
+  activePods?: { [key: string]: string };
+  conditions?: any[];
+  evacuationNodeName?: string;
+  guestOSInfo?: V1VirtualMachineInstanceGuestOSInfo;
+  interfaces?: any[];
+  migrationMethod?: string;
+  migrationState?: any;
+  nodeName?: string;
+  phase?: string;
+  qosClass?: string;
+  reason?: string;
+  volumeStatus?: any;
 };
 
 export type VMIKind = {

--- a/frontend/packages/kubevirt-plugin/src/types/vmi-guest-data-info/vmi-guest-agent-info.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vmi-guest-data-info/vmi-guest-agent-info.ts
@@ -29,7 +29,7 @@ export type V1VirtualMachineInstanceGuestOSUserList = {
 
 // https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancefilesystem
 export type V1VirtualMachineInstanceFileSystem = {
-  diskName?: string;
+  diskName: string;
   fileSystemType: string;
   mountPoint: string;
   totalBytes: number;


### PR DESCRIPTION
This PR updates KubeVirt API types to match the latest numbered release (v0.38.1). The documentation links are being updated to remove the word "master" from our code base, along with other offensive terms, in https://github.com/openshift/console/pull/8206. Going forward, KubeVirt types should be updated if needed before the version is updated in the accompanying documentation links.