### PR TITLE
Add badges support in catalog items and make cta optional

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
@@ -85,7 +85,7 @@ export type CatalogItem<T extends any = any> = {
   attributes?: {
     [key: string]: string;
   };
-  cta: {
+  cta?: {
     label: string;
     href: string;
   };
@@ -97,6 +97,8 @@ export type CatalogItem<T extends any = any> = {
     properties?: CatalogItemDetailsProperty[];
     descriptions?: CatalogItemDetailsDescription[];
   };
+  // Optional text only badges for the catalog item which will be rendered on the tile and details panel.
+  badges?: CatalogItemBadge[];
   // Optional data attached by the provider.
   // May be consumed by filters.
   // `data` for each `type` of CatalogItem should implement the same interface.
@@ -116,4 +118,11 @@ export type CatalogItemDetailsDescription = {
 export type CatalogItemAttribute = {
   label: string;
   attribute: string;
+};
+
+export type CatalogItemBadge = {
+  text: string;
+  color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
+  icon?: React.ReactNode;
+  variant?: 'outline' | 'filled';
 };

--- a/frontend/packages/dev-console/src/components/catalog/CatalogBadges.scss
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogBadges.scss
@@ -1,0 +1,9 @@
+.odc-catalog-badges {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: var(--pf-global--spacer--sm);
+
+  &__label {
+    margin: var(--pf-global--spacer--xs) var(--pf-global--spacer--xs) var(--pf-global--spacer--xs) 0;
+  }
+}

--- a/frontend/packages/dev-console/src/components/catalog/CatalogBadges.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogBadges.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { CatalogItemBadge } from '@console/plugin-sdk';
+import { Label } from '@patternfly/react-core';
+import './CatalogBadges.scss';
+
+type CatalogBadgesProps = {
+  badges: CatalogItemBadge[];
+};
+
+const CatalogBadges: React.FC<CatalogBadgesProps> = ({ badges }) => (
+  <div className="odc-catalog-badges">
+    {badges?.map((badge) => (
+      <Label
+        className="odc-catalog-badges__label"
+        color={badge.color}
+        icon={badge.icon}
+        variant={badge.variant}
+      >
+        {badge.text}
+      </Label>
+    ))}
+  </div>
+);
+
+export default CatalogBadges;

--- a/frontend/packages/dev-console/src/components/catalog/CatalogTile.scss
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogTile.scss
@@ -1,0 +1,10 @@
+.odc-catalog-tile {
+  > .catalog-tile-pf-body {
+    display: flex;
+    flex-direction: column;
+
+    > .catalog-tile-pf-description {
+      flex: 1 1 auto;
+    }
+  }
+}

--- a/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
@@ -9,6 +9,9 @@ import { Badge } from '@patternfly/react-core';
 import { CatalogItem } from '@console/plugin-sdk';
 import { getIconProps } from './utils/catalog-utils';
 import { CatalogType } from './utils/types';
+import CatalogBadges from './CatalogBadges';
+
+import './CatalogTile.scss';
 
 type CatalogTileProps = {
   item: CatalogItem;
@@ -18,12 +21,12 @@ type CatalogTileProps = {
 
 const CatalogTile: React.FC<CatalogTileProps> = ({ item, catalogTypes, onClick }) => {
   const { t } = useTranslation();
-  const { name, provider, description, type } = item;
+  const { name, provider, description, type, badges } = item;
 
   const vendor = provider ? t('devconsole~Provided by {{provider}}', { provider }) : null;
   const catalogType = _.find(catalogTypes, ['value', type]);
 
-  const badges = [
+  const typeBadges = [
     <CatalogTileBadge>
       <Badge isRead>{catalogType?.label}</Badge>
     </CatalogTileBadge>,
@@ -32,16 +35,17 @@ const CatalogTile: React.FC<CatalogTileProps> = ({ item, catalogTypes, onClick }
   const isDescriptionReactElement = React.isValidElement(description);
   return (
     <PfCatalogTile
-      className="co-catalog-tile"
+      className="odc-catalog-tile co-catalog-tile"
       onClick={() => onClick(item)}
       title={name}
-      badges={badges}
+      badges={typeBadges}
       vendor={vendor}
       description={isDescriptionReactElement ? undefined : description}
       data-test={`${type}-${name}`}
       {...getIconProps(item)}
     >
       {isDescriptionReactElement ? description : undefined}
+      {badges?.length > 0 ? <CatalogBadges badges={badges} /> : undefined}
     </PfCatalogTile>
   );
 };

--- a/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsModal.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsModal.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { CatalogItem } from '@console/plugin-sdk';
-import { Modal, useQueryParams } from '@console/shared';
+import { Modal } from '@console/shared';
 import { CatalogItemHeader } from '@patternfly/react-catalog-view-extension';
 import { getIconProps } from '../utils/catalog-utils';
-import { CatalogQueryParams } from '../utils/types';
+import useCtaLink from '../hooks/useCtaLink';
+import CatalogBadges from '../CatalogBadges';
 import CatalogDetailsPanel from './CatalogDetailsPanel';
 
 type CatalogDetailsModalProps = {
@@ -15,38 +16,45 @@ type CatalogDetailsModalProps = {
 
 const CatalogDetailsModal: React.FC<CatalogDetailsModalProps> = ({ item, onClose }) => {
   const { t } = useTranslation();
-  const queryParams = useQueryParams();
+  const [to, label] = useCtaLink(item?.cta);
 
   if (!item) {
     return null;
   }
 
-  const { href } = item.cta;
-  const [url, params] = href.split('?');
+  const { name, cta, badges } = item;
 
-  Object.values(CatalogQueryParams).map((q) => queryParams.delete(q)); // don't pass along catalog specific query params
-
-  const to = params
-    ? `${url}?${params}${queryParams.toString() !== '' ? `&${queryParams.toString()}` : ''}`
-    : `${url}?${queryParams.toString()}`;
-
-  const vendor = item.provider
+  const provider = item.provider
     ? t('devconsole~Provided by {{provider}}', { provider: item.provider })
     : null;
 
+  const vendor = (
+    <div>
+      {provider}
+      {badges?.length > 0 ? <CatalogBadges badges={badges} /> : undefined}
+    </div>
+  );
+
   const modalHeader = (
     <>
-      <CatalogItemHeader title={item.name} vendor={vendor} {...getIconProps(item)} />
-      <div className="co-catalog-page__overlay-actions">
-        <Link
-          className="pf-c-button pf-m-primary co-catalog-page__overlay-action"
-          to={to}
-          role="button"
-          onClick={onClose}
-        >
-          {item.cta.label}
-        </Link>
-      </div>
+      <CatalogItemHeader
+        className="co-catalog-page__overlay-header"
+        title={name}
+        vendor={vendor}
+        {...getIconProps(item)}
+      />
+      {cta && (
+        <div className="co-catalog-page__overlay-actions">
+          <Link
+            className="pf-c-button pf-m-primary co-catalog-page__overlay-action"
+            to={to}
+            role="button"
+            onClick={onClose}
+          >
+            {label}
+          </Link>
+        </div>
+      )}
     </>
   );
 

--- a/frontend/packages/dev-console/src/components/catalog/hooks/__tests__/useCtaLink.spec.ts
+++ b/frontend/packages/dev-console/src/components/catalog/hooks/__tests__/useCtaLink.spec.ts
@@ -1,0 +1,41 @@
+import { useQueryParams } from '@console/shared';
+import useCtaLink from '../useCtaLink';
+
+jest.mock('@console/shared', () => ({
+  useQueryParams: jest.fn(),
+}));
+
+describe('UseCtaLink', () => {
+  it('should return null values if there is no cta', () => {
+    expect(useCtaLink(null)).toEqual([null, null]);
+  });
+
+  it('should return link and label if there is cta', () => {
+    const mockCta = {
+      href: '/search?query=git',
+      label: 'Example CTA',
+    };
+    (useQueryParams as jest.Mock).mockReturnValue(new URLSearchParams());
+    expect(useCtaLink(mockCta)).toEqual([mockCta.href, mockCta.label]);
+  });
+
+  it('should return link and label with added queryParams from the page', () => {
+    const mockCta = {
+      href: '/search?query1=git',
+      label: 'Example CTA',
+    };
+    (useQueryParams as jest.Mock).mockReturnValue(new URLSearchParams('?query2=dockerfile'));
+    expect(useCtaLink(mockCta)).toEqual(['/search?query1=git&query2=dockerfile', 'Example CTA']);
+  });
+
+  it('should delete query params related to catalog from the url if any', () => {
+    const mockCta = {
+      href: '/search?query1=git',
+      label: 'Example CTA',
+    };
+    (useQueryParams as jest.Mock).mockReturnValue(
+      new URLSearchParams('?query2=dockerfile&keyword=node&category=cicd'),
+    );
+    expect(useCtaLink(mockCta)).toEqual(['/search?query1=git&query2=dockerfile', 'Example CTA']);
+  });
+});

--- a/frontend/packages/dev-console/src/components/catalog/hooks/useCtaLink.ts
+++ b/frontend/packages/dev-console/src/components/catalog/hooks/useCtaLink.ts
@@ -1,0 +1,23 @@
+import { useQueryParams } from '@console/shared';
+import { CatalogQueryParams } from '../utils/types';
+
+const useCtaLink = (cta: { label: string; href: string }): [string, string] => {
+  const queryParams = useQueryParams();
+
+  if (!cta) {
+    return [null, null];
+  }
+
+  const { href, label } = cta;
+  const [url, params] = href.split('?');
+
+  Object.values(CatalogQueryParams).map((q) => queryParams.delete(q)); // don't pass along catalog specific query params
+
+  const to = params
+    ? `${url}?${params}${queryParams.toString() !== '' ? `&${queryParams.toString()}` : ''}`
+    : `${url}?${queryParams.toString()}`;
+
+  return [to, label];
+};
+
+export default useCtaLink;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -497,6 +497,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
           header={
             <>
               <CatalogItemHeader
+                className="co-catalog-page__overlay-header"
                 iconClass={detailsItem.iconClass}
                 iconImg={detailsItem.imgUrl}
                 title={detailsItem.name}

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -241,9 +241,12 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   &__overlay-actions {
     display: flex;
     flex-wrap: wrap;
-    padding: var(--pf-global--spacer--lg) var(--pf-global--spacer--md) var(--pf-global--spacer--md)
-      0;
+    margin-bottom: var(--pf-global--spacer--md);
     white-space: normal;
+  }
+
+  &__overlay-header {
+    margin-bottom: var(--pf-global--spacer--md);
   }
 
   &__overlay-body {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5543
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: There was no support for adding custom badges in catalog items.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Add support for custom badges on catalog tiles and details page. Any provider can now contribute custom badges for it catalog item.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
@openshift/team-devconsole-ux @serenamarie125 

https://user-images.githubusercontent.com/6041994/109042570-5c72ec80-76f6-11eb-8bc8-51a90c401b71.mov




**Unit test coverage report**: 
<!-- Attach test coverage report -->
![Screenshot 2021-02-24 at 9 13 33 PM](https://user-images.githubusercontent.com/6041994/109025904-2d07b400-76e5-11eb-91f8-9566073fc1da.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
In order to test the badge support you have to add badge to one of the catalog item providers. Add below code snippet to `useBuilderImages.tsx`  and return badge in the CatalogItem object.

```js
    const badges: CatalogItemBadge[] = [
      {
        text: 'Unlock with token',
        color: 'orange',
        icon: <LockIcon />,
        variant: 'outline',
      },
    ];
```


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
