### PR TITLE
Bug 1932453: Update format for Japanese date/times

### DIFF
--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -3,12 +3,11 @@ import { connect } from 'react-redux';
 import { Tooltip } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
-import { useTranslation } from 'react-i18next';
 import * as moment from 'moment';
 
 import * as dateTime from './datetime';
 
-const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean, t: any) => {
+const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
   if (!dateTime.isValid(mdate)) {
     return '-';
   }
@@ -24,7 +23,7 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean, t: any) => {
   }
 
   // Apr 23, 4:33 pm
-  return t('{{date, MMM D, h:mm a}}', { date: mdate });
+  return moment(mdate).format('LLL');
 };
 
 const nowStateToProps = ({ UI }) => ({ now: UI.get('lastTick') });
@@ -38,8 +37,8 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
   const mdate = props.isUnix
     ? new Date((props.timestamp as number) * 1000)
     : new Date(props.timestamp);
-  const { t } = useTranslation();
-  const timestamp = timestampFor(mdate, new Date(props.now), props.omitSuffix, t);
+
+  const timestamp = timestampFor(mdate, new Date(props.now), props.omitSuffix);
 
   if (!dateTime.isValid(mdate)) {
     return <div className="co-timestamp">-</div>;
@@ -55,11 +54,9 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
       <Tooltip
         content={[
           <span className="co-nowrap" key="co-timestamp">
-            {t('{{date, MMM D, h:mm a z}}', {
-              date: moment(mdate)
-                .utc()
-                .format('MMM D, h:mm a z'),
-            })}
+            {moment(mdate)
+              .utc()
+              .format('LLL z')}
           </span>,
         ]}
       >

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -162,6 +162,12 @@ i18n
       moment.locale(i18n.language === 'zh' ? 'zh-cn' : i18n.language);
       // set default in case the i18n.language isn't a language we currently support -- otherwise Moment.js will default to the last region import
       moment.locale() !== i18n.language && i18n.language !== 'zh' && moment.locale('en');
+      // set override for date format for English
+      moment.updateLocale('en', {
+        longDateFormat: {
+          LLL: 'MMM D, h:mm a',
+        },
+      });
     },
   );
 

--- a/frontend/public/locales/en-gb/public.json
+++ b/frontend/public/locales/en-gb/public.json
@@ -1,4 +1,0 @@
-{
-  "{{date, MMM D, h:mm a}}": "{{date, D MMM, H:mm}}",
-  "{{date, MMM D, h:mm a z}}": "{{date, D MMM, H:mm z}}"
-}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -496,8 +496,6 @@
   "Select StorageClass": "Select StorageClass",
   "StorageClass": "StorageClass",
   "StorageClass for the new claim": "StorageClass for the new claim",
-  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
-  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}",
   "Pause event streaming": "Pause event streaming",
   "Start streaming events": "Start streaming events",
   "{{ metadataName }} is paused": "{{ metadataName }} is paused",

--- a/frontend/public/locales/ja/public.json
+++ b/frontend/public/locales/ja/public.json
@@ -410,8 +410,6 @@
   "StatefulSet details": "StatefulSet の詳細",
   "Resource limits": "リソース制限",
   "Ports": "ポート",
-  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
-  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}",
   "Remove volume": "ボリュームの削除",
   "Mount path": "マウントパス",
   "SubPath": "SubPath",

--- a/frontend/public/locales/ko/public.json
+++ b/frontend/public/locales/ko/public.json
@@ -1,4 +1,0 @@
-{
-  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
-  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}"
-}

--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -410,8 +410,6 @@
   "StatefulSet details": "StatefulSet 详细信息",
   "Resource limits": "资源限制",
   "Ports": "端口",
-  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
-  "{{date, MMM D, h:mm a z}}": "{{date, MMM D, h:mm a z}}",
   "Remove volume": "删除卷",
   "Mount path": "挂载路径",
   "SubPath": "SubPath",


### PR DESCRIPTION
Thanks @kyoto for pointing out an issue with the format of the Japanese dates/times.

I refactored our dates/times to rely on Moment "LLL" locale defaults so we don't need to worry about syntax. I overrode the "LLL" default in Moment for English so we could retain our existing date/time format (no year). This should also fix any other issues with our existing languages and prevent issues with any additional languages we add.

English example (with override):
<img width="174" alt="Screen Shot 2021-02-24 at 2 07 29 PM" src="https://user-images.githubusercontent.com/7014965/109052602-cb762400-76a9-11eb-9735-08d05ae90d95.png">

Japanese example (with defaults):
<img width="200" alt="Screen Shot 2021-02-24 at 2 08 06 PM" src="https://user-images.githubusercontent.com/7014965/109052654-d9c44000-76a9-11eb-8a51-db675d425a20.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1932453.