### PR TITLE
Avoid deep merging extension properties

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useExtensions } from '@console/plugin-sdk/src/api/useExtensions';
-import { deepMergeExtensionProperties } from '@console/plugin-sdk/src/store';
+import { mergeExtensionProperties } from '@console/plugin-sdk/src/store';
 import {
   Extension,
   ExtensionTypeGuard,
@@ -56,7 +56,7 @@ export const useResolvedExtensions = <E extends Extension>(
     Promise.all(
       extensions.map(async (e) => {
         const resolvedProperties = await resolveCodeRefProperties(e);
-        return deepMergeExtensionProperties(e, resolvedProperties) as ResolvedExtension<E>;
+        return mergeExtensionProperties(e, resolvedProperties) as ResolvedExtension<E>;
       }),
     )
       .then((result) => {

--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -10,7 +10,7 @@ import {
   augmentExtension,
   isExtensionInUse,
   getGatingFlagNames,
-  deepMergeExtensionProperties,
+  mergeExtensionProperties,
   PluginStore,
 } from '../store';
 import { Extension, ModelDefinition } from '../typings';
@@ -223,10 +223,10 @@ describe('getGatingFlagNames', () => {
   });
 });
 
-describe('deepMergeExtensionProperties', () => {
-  it('merges the given object into extension properties', () => {
+describe('mergeExtensionProperties', () => {
+  it('shallowly merges the given object into extension properties', () => {
     expect(
-      deepMergeExtensionProperties(
+      mergeExtensionProperties(
         {
           type: 'Foo/Bar',
           properties: {},
@@ -245,7 +245,7 @@ describe('deepMergeExtensionProperties', () => {
     });
 
     expect(
-      deepMergeExtensionProperties(
+      mergeExtensionProperties(
         {
           type: 'Foo/Bar',
           properties: {
@@ -262,14 +262,14 @@ describe('deepMergeExtensionProperties', () => {
       type: 'Foo/Bar',
       properties: {
         test: false,
-        qux: { foo: ['value'], baz: 2 },
+        qux: { baz: 2 },
       },
     });
   });
 
   it('returns a new extension instance', () => {
     const testExtension: Extension = { type: 'Foo/Bar', properties: {} };
-    const updatedExtension = deepMergeExtensionProperties(testExtension, {});
+    const updatedExtension = mergeExtensionProperties(testExtension, {});
 
     expect(updatedExtension).not.toBe(testExtension);
     expect(Object.isFrozen(updatedExtension)).toBe(true);

--- a/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useForceRender } from '@console/shared/src/hooks/useForceRender';
-import { deepMergeExtensionProperties } from '../store';
+import { mergeExtensionProperties } from '../store';
 import { subscribeToExtensions } from './subscribeToExtensions';
 import { Extension, ExtensionTypeGuard, LoadedExtension } from '../typings';
 import useTranslationExt from '../utils/useTranslationExt';
@@ -76,7 +76,7 @@ export const useExtensions = <E extends Extension>(
     if (unsubscribeRef.current === null) {
       unsubscribeRef.current = subscribeToExtensions<E>((extensions) => {
         extensionsInUseRef.current = extensions.map((e) =>
-          deepMergeExtensionProperties(e, translate(e.properties, t)),
+          mergeExtensionProperties(e, translate(e.properties, t)),
         );
         isMountedRef.current && forceRender();
       }, ...latestTypeGuardsRef.current);

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -33,8 +33,11 @@ export const getGatingFlagNames = (extensions: Extension[]): string[] =>
     ..._.flatMap(extensions.map((e) => e.flags.disallowed)),
   ]);
 
-export const deepMergeExtensionProperties = <E extends Extension>(e: E, properties: {}): E =>
-  Object.freeze(_.merge({}, e, { properties }));
+export const mergeExtensionProperties = <E extends Extension>(e: E, properties: {}): E =>
+  Object.freeze({
+    ...e,
+    properties: Object.assign({}, e.properties, properties),
+  });
 
 /**
  * Provides access to Console plugin data.


### PR DESCRIPTION
Minimal change from #8224 to fix the issue where objects within extension `properties` would be cloned due to deep merge.