### PR TITLE
Add pluginType to LoadedExtension interface

### DIFF
--- a/frontend/__tests__/components/nav/navSortUtils.spec.ts
+++ b/frontend/__tests__/components/nav/navSortUtils.spec.ts
@@ -7,57 +7,45 @@ import { LoadedExtension, NavItem, NavSection, SeparatorNavItem } from '@console
 const mockNavItems: LoadedExtension<NavSection | NavItem | SeparatorNavItem>[] = [
   {
     type: 'Nav/Section',
-    properties: {
-      id: 'test1',
-    },
+    properties: { id: 'test1' },
     pluginID: 'test-plugin-id',
-    pluginName: 'test-plugin-name',
-    uid: 'test-plugin-uid',
+    pluginType: 'static',
+    uid: 'test-plugin-uid-1',
   },
   {
     type: 'Nav/Section',
-    properties: {
-      id: 'test2',
-    },
+    properties: { id: 'test2' },
     pluginID: 'test-plugin-id',
-    pluginName: 'test-plugin-name',
-    uid: 'test-plugin-uid',
+    pluginType: 'static',
+    uid: 'test-plugin-uid-2',
   },
   {
     type: 'Nav/Section',
-    properties: {
-      id: 'test3',
-    },
+    properties: { id: 'test3' },
     pluginID: 'test-plugin-id',
-    pluginName: 'test-plugin-name',
-    uid: 'test-plugin-uid',
+    pluginType: 'static',
+    uid: 'test-plugin-uid-3',
   },
   {
     type: 'Nav/Section',
-    properties: {
-      id: 'test4',
-    },
+    properties: { id: 'test4' },
     pluginID: 'test-plugin-id',
-    pluginName: 'test-plugin-name',
-    uid: 'test-plugin-uid',
+    pluginType: 'static',
+    uid: 'test-plugin-uid-4',
   },
   {
     type: 'Nav/Section',
-    properties: {
-      id: 'test5',
-    },
+    properties: { id: 'test5' },
     pluginID: 'test-plugin-id',
-    pluginName: 'test-plugin-name',
-    uid: 'test-plugin-uid',
+    pluginType: 'static',
+    uid: 'test-plugin-uid-5',
   },
   {
     type: 'Nav/Section',
-    properties: {
-      id: 'test6',
-    },
+    properties: { id: 'test6' },
     pluginID: 'test-plugin-id',
-    pluginName: 'test-plugin-name',
-    uid: 'test-plugin-uid',
+    pluginType: 'static',
+    uid: 'test-plugin-uid-6',
   },
   {
     type: 'NavItem/Separator',
@@ -68,8 +56,8 @@ const mockNavItems: LoadedExtension<NavSection | NavItem | SeparatorNavItem>[] =
       },
     },
     pluginID: 'test-plugin-id',
-    pluginName: 'test-plugin-name',
-    uid: 'test-plugin-uid',
+    pluginType: 'static',
+    uid: 'test-plugin-uid-7',
   },
 ];
 

--- a/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/__tests__/store.spec.ts
@@ -114,14 +114,14 @@ describe('augmentExtension', () => {
           properties: {},
         },
         'Test@1.2.3',
-        'Test',
+        'dynamic',
         0,
       ),
     ).toEqual({
       type: 'Foo',
       properties: {},
       pluginID: 'Test@1.2.3',
-      pluginName: 'Test',
+      pluginType: 'dynamic',
       uid: 'Test@1.2.3[0]',
     });
 
@@ -132,14 +132,14 @@ describe('augmentExtension', () => {
           properties: {},
         },
         'Test',
-        'Test',
+        'static',
         1,
       ),
     ).toEqual({
       type: 'Bar',
       properties: {},
       pluginID: 'Test',
-      pluginName: 'Test',
+      pluginType: 'static',
       uid: 'Test[1]',
     });
   });
@@ -147,7 +147,7 @@ describe('augmentExtension', () => {
   it('returns the same extension instance', () => {
     const testExtension: Extension = { type: 'Foo/Bar', properties: {} };
 
-    expect(augmentExtension(testExtension, 'Test@1.2.3', 'Test', 0)).toBe(testExtension);
+    expect(augmentExtension(testExtension, 'Test@1.2.3', 'dynamic', 0)).toBe(testExtension);
   });
 });
 
@@ -301,7 +301,7 @@ describe('PluginStore', () => {
           properties: { test: true },
           flags: { required: ['foo'], disallowed: [] },
           pluginID: 'Test',
-          pluginName: 'Test',
+          pluginType: 'static',
           uid: 'Test[0]',
         },
         {
@@ -309,7 +309,7 @@ describe('PluginStore', () => {
           properties: { baz: 1 },
           flags: { required: [], disallowed: ['bar'] },
           pluginID: 'Test',
-          pluginName: 'Test',
+          pluginType: 'static',
           uid: 'Test[1]',
         },
       ]);
@@ -344,7 +344,7 @@ describe('PluginStore', () => {
           properties: { test: true },
           flags: { required: ['foo'], disallowed: [] },
           pluginID: 'Test0',
-          pluginName: 'Test0',
+          pluginType: 'static',
           uid: 'Test0[0]',
         },
         {
@@ -352,7 +352,7 @@ describe('PluginStore', () => {
           properties: { baz: 1 },
           flags: { required: [], disallowed: ['bar'] },
           pluginID: 'Test0',
-          pluginName: 'Test0',
+          pluginType: 'static',
           uid: 'Test0[1]',
         },
       ]);
@@ -386,7 +386,7 @@ describe('PluginStore', () => {
           properties: { test: true },
           flags: { required: ['foo'], disallowed: [] },
           pluginID: 'Test0',
-          pluginName: 'Test0',
+          pluginType: 'static',
           uid: 'Test0[0]',
         },
         {
@@ -394,7 +394,7 @@ describe('PluginStore', () => {
           properties: { baz: 1 },
           flags: { required: [], disallowed: ['bar'] },
           pluginID: 'Test0',
-          pluginName: 'Test0',
+          pluginType: 'static',
           uid: 'Test0[1]',
         },
         {
@@ -402,7 +402,7 @@ describe('PluginStore', () => {
           properties: { value: 'test' },
           flags: { required: ['foo', 'bar'], disallowed: [] },
           pluginID: 'Test1@1.2.3',
-          pluginName: 'Test1',
+          pluginType: 'dynamic',
           uid: 'Test1@1.2.3[0]',
         },
         {
@@ -410,7 +410,7 @@ describe('PluginStore', () => {
           properties: {},
           flags: { required: ['foo'], disallowed: ['bar'] },
           pluginID: 'Test2@2.3.4',
-          pluginName: 'Test2',
+          pluginType: 'dynamic',
           uid: 'Test2@2.3.4[0]',
         },
       ]);
@@ -521,7 +521,7 @@ describe('PluginStore', () => {
             properties: { test: true },
             flags: { required: ['foo'], disallowed: [] },
             pluginID: 'Test@1.2.3',
-            pluginName: 'Test',
+            pluginType: 'dynamic',
             uid: 'Test@1.2.3[0]',
           },
           {
@@ -529,7 +529,7 @@ describe('PluginStore', () => {
             properties: { baz: 1, qux: ref },
             flags: { required: [], disallowed: ['bar'] },
             pluginID: 'Test@1.2.3',
-            pluginName: 'Test',
+            pluginType: 'dynamic',
             uid: 'Test@1.2.3[1]',
           },
         ],
@@ -573,7 +573,7 @@ describe('PluginStore', () => {
             properties: {},
             flags: { required: [], disallowed: [] },
             pluginID: 'Test@1.2.3',
-            pluginName: 'Test',
+            pluginType: 'dynamic',
             uid: 'Test@1.2.3[0]',
           },
         ],
@@ -611,7 +611,7 @@ describe('PluginStore', () => {
           properties: {},
           flags: { required: [], disallowed: [] },
           pluginID: 'Test1@1.2.3',
-          pluginName: 'Test1',
+          pluginType: 'dynamic',
           uid: 'Test1@1.2.3[0]',
         },
       ]);
@@ -629,7 +629,7 @@ describe('PluginStore', () => {
           properties: {},
           flags: { required: [], disallowed: [] },
           pluginID: 'Test1@1.2.3',
-          pluginName: 'Test1',
+          pluginType: 'dynamic',
           uid: 'Test1@1.2.3[0]',
         },
         {
@@ -637,7 +637,7 @@ describe('PluginStore', () => {
           properties: {},
           flags: { required: [], disallowed: [] },
           pluginID: 'Test2@2.3.4',
-          pluginName: 'Test2',
+          pluginType: 'dynamic',
           uid: 'Test2@2.3.4[0]',
         },
       ]);
@@ -655,7 +655,7 @@ describe('PluginStore', () => {
           properties: {},
           flags: { required: [], disallowed: [] },
           pluginID: 'Test2@2.3.4',
-          pluginName: 'Test2',
+          pluginType: 'dynamic',
           uid: 'Test2@2.3.4[0]',
         },
       ]);

--- a/frontend/packages/console-plugin-sdk/src/store.ts
+++ b/frontend/packages/console-plugin-sdk/src/store.ts
@@ -14,12 +14,12 @@ export const sanitizeExtension = <E extends Extension>(e: E): E => {
 export const augmentExtension = <E extends Extension>(
   e: E,
   pluginID: string,
-  pluginName: string,
+  pluginType: LoadedExtension['pluginType'],
   index: number,
 ): LoadedExtension<E> =>
   Object.assign(e, {
     pluginID,
-    pluginName,
+    pluginType,
     uid: `${pluginID}[${index}]`,
   });
 
@@ -56,7 +56,7 @@ export class PluginStore {
     this.staticPluginExtensions = _.flatMap(
       plugins.map((p) =>
         p.extensions.map((e, index) =>
-          Object.freeze(augmentExtension(sanitizeExtension({ ...e }), p.name, p.name, index)),
+          Object.freeze(augmentExtension(sanitizeExtension({ ...e }), p.name, 'static', index)),
         ),
       ),
     );
@@ -91,7 +91,7 @@ export class PluginStore {
     this.dynamicPlugins.set(pluginID, {
       manifest: Object.freeze(manifest),
       processedExtensions: resolvedExtensions.map((e, index) =>
-        Object.freeze(augmentExtension(sanitizeExtension(e), pluginID, manifest.name, index)),
+        Object.freeze(augmentExtension(sanitizeExtension(e), pluginID, 'dynamic', index)),
       ),
       enabled: false,
     });

--- a/frontend/packages/console-plugin-sdk/src/typings/base.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/base.ts
@@ -100,6 +100,6 @@ export type ActivePlugin = {
  */
 export type LoadedExtension<E extends Extension = Extension> = E & {
   pluginID: string;
-  pluginName: string;
+  pluginType: 'static' | 'dynamic';
   uid: string;
 };


### PR DESCRIPTION
This PR modifies the `LoadedExtension` interface in the following way:
- add `pluginType` (static or dynamic)
- remove `pluginName` since it's already part of `pluginID` (note: static plugins don't have a version)

This makes unit test assertions more sensible (better distinction between extensions) and allows us to act upon extension's `pluginType` in the future.