### PR TITLE
Bug 1931279: Bump lodash-es to latest v4.17.21, to remove security vulnerabilities

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -144,7 +144,7 @@
     "js-base64": "^2.5.1",
     "js-yaml": "^3.13.1",
     "json-schema": "0.2.3",
-    "lodash-es": "4.17.x",
+    "lodash-es": "^4.17.21",
     "monaco-languageclient": "^0.13.0",
     "murmurhash-js": "1.0.x",
     "null-loader": "^3.0.0",
@@ -304,6 +304,7 @@
   },
   "resolutions": {
     "jquery": "3.5.1",
+    "lodash-es": "^4.17.21",
     "minimist": "1.2.5",
     "@types/jest": "21.x"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11863,10 +11863,10 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@4.17.x, lodash-es@^4.17.14:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+lodash-es@^4.17.14, lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._baseassign@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Fixes both:
- https://bugzilla.redhat.com/show_bug.cgi?id=1931279
- https://bugzilla.redhat.com/show_bug.cgi?id=1931272

since both of these issues fixes include bumping `lodash-es` to version `4.17.21`

/assign @spadgett PTAL