### PR TITLE
Bug 1839101: Add namespaced attribute to main navigation links

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
@@ -38,7 +38,8 @@ namespace ExtensionProperties {
   }
 
   export interface HrefNavItem extends NavItem {
-    componentProps: NavItem['componentProps'] & Pick<HrefLinkProps, 'href' | 'activePath'>;
+    componentProps: NavItem['componentProps'] &
+      Pick<HrefLinkProps, 'namespaced' | 'href' | 'activePath'>;
   }
 
   export interface ResourceNSNavItem extends NavItem {

--- a/frontend/packages/console-shared/src/utils/namespace.ts
+++ b/frontend/packages/console-shared/src/utils/namespace.ts
@@ -4,3 +4,6 @@ export const formatNamespacedRouteForResource = (resource, namespace) =>
   namespace === ALL_NAMESPACES_KEY
     ? `/k8s/all-namespaces/${resource}`
     : `/k8s/ns/${namespace}/${resource}`;
+
+export const formatNamespacedRouteForHref = (href: string, namespace: string) =>
+  namespace === ALL_NAMESPACES_KEY ? `${href}/all-namespaces` : `${href}/ns/${namespace}`;

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -72,6 +72,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('devconsole~+Add')
         name: '%devconsole~+Add%',
         href: '/add',
+        namespaced: true,
         testID: '+Add-header',
         'data-quickstart-id': 'qs-nav-add',
       },
@@ -87,6 +88,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('devconsole~Topology')
         name: '%devconsole~Topology%',
         href: '/topology',
+        namespaced: true,
         testID: 'topology-header',
         'data-quickstart-id': 'qs-nav-topology',
       },
@@ -105,6 +107,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('devconsole~Monitoring')
         name: '%devconsole~Monitoring%',
         href: '/dev-monitoring',
+        namespaced: true,
         testID: 'monitoring-header',
         'data-tour-id': 'tour-monitoring-nav',
         'data-quickstart-id': 'qs-nav-monitoring',
@@ -124,6 +127,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('devconsole~Search')
         name: '%devconsole~Search%',
         href: '/search',
+        namespaced: true,
         testID: 'search-header',
         'data-tour-id': 'tour-search-nav',
         'data-quickstart-id': 'qs-nav-search',
@@ -158,6 +162,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('devconsole~Project')
         name: '%devconsole~Project%',
         href: '/project-details',
+        namespaced: true,
         testID: 'project-details-header',
         'data-quickstart-id': 'qs-nav-project',
       },

--- a/frontend/packages/helm-plugin/src/plugin.ts
+++ b/frontend/packages/helm-plugin/src/plugin.ts
@@ -46,6 +46,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('helm-plugin~Helm')
         name: '%helm-plugin~Helm%',
         href: '/helm-releases',
+        namespaced: true,
         testID: 'helm-releases-header',
         'data-quickstart-id': 'qs-nav-helm',
       },

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -160,6 +160,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('knative-plugin~Serving')
         name: '%knative-plugin~Serving%',
         href: '/serving',
+        namespaced: true,
       },
     },
     flags: {
@@ -180,6 +181,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('knative-plugin~Eventing')
         name: '%knative-plugin~Eventing%',
         href: '/eventing',
+        namespaced: true,
       },
     },
     flags: {

--- a/frontend/packages/pipelines-plugin/src/plugin.tsx
+++ b/frontend/packages/pipelines-plugin/src/plugin.tsx
@@ -104,6 +104,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('pipelines-plugin~Pipelines')
         name: '%pipelines-plugin~Pipelines%',
         href: '/pipelines',
+        namespaced: true,
         'data-quickstart-id': 'qs-nav-pipelines',
       },
     },
@@ -121,6 +122,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('pipelines-plugin~Tasks')
         name: '%pipelines-plugin~Tasks%',
         href: '/tasks',
+        namespaced: true,
       },
     },
     flags: {
@@ -137,6 +139,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         // t('pipelines-plugin~Triggers')
         name: '%pipelines-plugin~Triggers%',
         href: '/triggers',
+        namespaced: true,
       },
     },
     flags: {

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -127,6 +127,7 @@ const AdminNav = () => {
         <HrefLink
           id="search"
           href="/search"
+          namespaced
           name={t('public~Search')}
           startsWith={searchStartsWith}
         />
@@ -268,6 +269,7 @@ const AdminNav = () => {
         <HrefLink
           id="provisionedservices"
           href="/provisionedservices"
+          namespaced
           name={t('public~Provisioned Services')}
           activePath="/provisionedservices/"
           startsWith={provisionedServicesStartsWith}

--- a/frontend/public/components/nav/items.tsx
+++ b/frontend/public/components/nav/items.tsx
@@ -11,7 +11,10 @@ import {
   isResourceNSNavItem,
   isResourceClusterNavItem,
 } from '@console/plugin-sdk';
-import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
+import {
+  formatNamespacedRouteForResource,
+  formatNamespacedRouteForHref,
+} from '@console/shared/src/utils';
 import { referenceForModel, K8sKind } from '../../module/k8s';
 import { stripBasePath } from '../utils';
 import { featureReducerName } from '../../reducers/features';
@@ -142,7 +145,11 @@ export class HrefLink extends NavLink<HrefLinkProps> {
   }
 
   get to() {
-    return this.props.href;
+    const { href, namespaced, activeNamespace } = this.props;
+    if (namespaced) {
+      return formatNamespacedRouteForHref(href, activeNamespace);
+    }
+    return href;
   }
 }
 
@@ -175,6 +182,8 @@ export type ResourceClusterLinkProps = NavLinkProps & {
 
 export type HrefLinkProps = NavLinkProps & {
   href: string;
+  namespaced?: boolean;
+  activeNamespace?: string;
 };
 
 export type NavLinkComponent<T extends NavLinkProps = NavLinkProps> = React.ComponentType<T> & {

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -111,12 +111,10 @@ const PerspectiveNav: React.FC<{}> = () => {
           const { id, name } = item.properties;
           return <NavSection id={id} title={name} key={id} isGrouped={!name} />;
         }
-        if (isNavItem(item)) {
-          return createLink(item, true);
-        }
         if (isSeparatorNavItem(item)) {
           return <NavItemSeparator key={`separator-${index}`} />;
         }
+        return createLink(item, true);
       })}
       {pinnedResourcesLoaded && pinnedResources?.length ? (
         <NavGroup className="oc-nav-group" title="" key="group-pins">


### PR DESCRIPTION
**Fixes**:
https://issues.redhat.com/browse/ODC-3976
https://bugzilla.redhat.com/show_bug.cgi?id=1839101

Based on PR #5831 from @fmartingr - Big thanks for this work!!

**Analysis / Root cause**: 
Currently the navigation from the console works well when the target comes from a resource in the cluster, but some views that depends on namespaces that are not resources (like topology) use direct links that need to handle the namespace the user is on internally.

This causes a mild bug on the console when you have two tabs open on different namespaces, since these links use the local storage to determine the namespace the user is on and that would be the last one the user accessed.

**Solution Description**: 
Created a new navigation item that operates using a name and a namespace in the form of: <view>/ns/<namespace> which is the format of the navigation items replaced with this.

**Screen shots / Gifs for design review**: 
Before:
https://user-images.githubusercontent.com/139310/109855919-29ca7600-7c59-11eb-9c82-863ab0ab445b.mp4

After:
https://user-images.githubusercontent.com/139310/109855939-3058ed80-7c59-11eb-92b4-07dbcc47b53d.mp4

**Unit test coverage report**:
Tests not touched

**Test setup:**
* Open console in two tabs
* Navigate to project A in tab A
* Navigate to another project in tab B (switch project for example)
* Open navigation links in tab A which should open project A (opens latest used project from user settings before)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
