### PR TITLE
Bug 1852743: Use consistent labels for CPU in node list

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -269,7 +269,7 @@ const NodesTableRow = connect<NodesRowMapFromStateProps, null, NodesTableRowProp
     const totalCores = metrics?.totalCPU?.[nodeName];
     const cpu =
       Number.isFinite(cores) && Number.isFinite(totalCores)
-        ? `${formatCores(cores)} / ${totalCores} cores`
+        ? `${formatCores(cores)} cores / ${totalCores} cores`
         : '-';
     const usedStrg = metrics?.usedStorage?.[nodeName];
     const totalStrg = metrics?.totalStorage?.[nodeName];


### PR DESCRIPTION
The other metrics show the label for both values before and after the `/`.

<img width="1928" alt="Screen Shot 2021-02-25 at 1 27 35 PM" src="https://user-images.githubusercontent.com/1167259/109199285-42282580-776d-11eb-8040-cadb646c20e6.png">

/assign @rhamilto 