### PR TITLE
Update console-extensions.json format

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -59,6 +59,12 @@
   "files.associations": {
     "**/console-extensions.json": "jsonc"
   },
+  "json.schemas": [
+    {
+      "fileMatch": ["**/console-extensions.json"],
+      "url": "./packages/console-dynamic-plugin-sdk/dist/schema/console-extensions.json"
+    }
+  ],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },

--- a/frontend/dynamic-demo-plugin/console-extensions.json
+++ b/frontend/dynamic-demo-plugin/console-extensions.json
@@ -1,34 +1,27 @@
 /**
  * This file declares all extensions contributed by the plugin.
  *
- * The '$schema' property is optional but recommended, allowing code editors to validate
- * the content as well as provide additional features such as code completion and property
- * description.
- *
  * Depending on extension 'type', the 'properties' object may contain code references, encoded
  * as object literals { $codeRef: string }. The '$codeRef' value should be formatted as either
  * 'moduleName.exportName' (referring to a named export) or 'moduleName' (referring to the
  * 'default' export). Only the plugin's exposed modules may be used in code references.
  */
-{
-  "$schema": "../packages/console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": [
-    {
-      "type": "console.flag",
-      "properties": {
-        "handler": { "$codeRef": "barUtils.testHandler" }
-      }
-    },
-    {
-      "type": "console.flag/model",
-      "properties": {
-        "flag": "EXAMPLE",
-        "model": {
-          "group": "kubevirt.io",
-          "version": "v1alpha3",
-          "kind": "ExampleModel"
-        }
+[
+  {
+    "type": "console.flag",
+    "properties": {
+      "handler": { "$codeRef": "barUtils.testHandler" }
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "flag": "EXAMPLE",
+      "model": {
+        "group": "kubevirt.io",
+        "version": "v1alpha3",
+        "kind": "ExampleModel"
       }
     }
-  ]
-}
+  }
+]

--- a/frontend/packages/ceph-storage-plugin/console-extensions.json
+++ b/frontend/packages/ceph-storage-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -1,16 +1,13 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": [
-    {
-      "type": "console.flag/model",
-      "properties": {
-        "flag": "DEVWORKSPACE",
-        "model": {
-          "group": "workspace.devfile.io",
-          "version": "v1alpha1",
-          "kind": "DevWorkspace"
-        }
+[
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "flag": "DEVWORKSPACE",
+      "model": {
+        "group": "workspace.devfile.io",
+        "version": "v1alpha1",
+        "kind": "DevWorkspace"
       }
     }
-  ]
-}
+  }
+]

--- a/frontend/packages/console-demo-plugin/console-extensions.json
+++ b/frontend/packages/console-demo-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -64,31 +64,28 @@ for details on the `consolePlugin` object and its schema.
 
 ## `console-extensions.json`
 
-Declares all extensions contributed by the plugin. The `$schema` property is optional but recommended.
+Declares all extensions contributed by the plugin.
 
 ```jsonc
-{
-  "$schema": "/path/to/schema/console-extensions.json",
-  "data": [
-    {
-      "type": "console.flag",
-      "properties": {
-        "handler": { "$codeRef": "barUtils.testHandler" }
-      }
-    },
-    {
-      "type": "console.flag/model",
-      "properties": {
-        "flag": "EXAMPLE",
-        "model": {
-          "group": "kubevirt.io",
-          "version": "v1alpha3",
-          "kind": "ExampleModel"
-        }
+[
+  {
+    "type": "console.flag",
+    "properties": {
+      "handler": { "$codeRef": "barUtils.testHandler" }
+    }
+  },
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "flag": "EXAMPLE",
+      "model": {
+        "group": "kubevirt.io",
+        "version": "v1alpha3",
+        "kind": "ExampleModel"
       }
     }
-  ]
-}
+  }
+]
 ```
 
 Depending on extension `type`, the `properties` object may contain code references, encoded as object

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
@@ -13,9 +13,4 @@ export type SupportedExtension =
 /**
  * Schema of Console plugin's `console-extensions.json` file.
  */
-export type ConsoleExtensionsJSON = {
-  /** Reference to JSON schema. */
-  $schema?: string;
-  /** List of extensions contributed by the plugin. */
-  data: SupportedExtension[];
-};
+export type ConsoleExtensionsJSON = SupportedExtension[];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
@@ -45,7 +45,7 @@ export class ConsoleAssetPlugin {
       displayName: pkg.consolePlugin.displayName,
       description: pkg.consolePlugin.description,
       dependencies: pkg.consolePlugin.dependencies,
-      extensions: ext.data,
+      extensions: ext,
     };
   }
 

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/active-plugins.spec.ts
@@ -269,19 +269,17 @@ describe('getDynamicExtensions', () => {
       consolePlugin: { entry: 'src/plugin.ts' },
     };
 
-    const extensionsObject: { data: Extension[] } = {
-      data: [
-        { type: 'Dynamic/Foo', properties: { test: true, mux: { $codeRef: 'a.b' } } },
-        { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'foo.bar' } } },
-      ],
-    };
+    const extensionsJSON: Extension[] = [
+      { type: 'Dynamic/Foo', properties: { test: true, mux: { $codeRef: 'a.b' } } },
+      { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'foo.bar' } } },
+    ];
 
     const extensionsFilePath = `${pluginPackage._path}/${extensionsFile}`;
     const errorCallback = jest.fn();
     const codeRefTransformer = jest.fn<string>((codeRefSource) => `ref(${codeRefSource})`);
 
     fsExistsSync.mockImplementation(() => true);
-    parseJSONC.mockImplementation(() => extensionsObject);
+    parseJSONC.mockImplementation(() => extensionsJSON);
     validateExtensionsFileSchema.mockImplementation(() => new ValidationResult('test'));
 
     getExecutableCodeRefSourceMock.mockImplementation((ref: EncodedCodeRef) => {
@@ -330,7 +328,7 @@ describe('getDynamicExtensions', () => {
 
     expect(fsExistsSync).toHaveBeenCalledWith(extensionsFilePath);
     expect(parseJSONC).toHaveBeenCalledWith(extensionsFilePath);
-    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsObject, extensionsFilePath);
+    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsJSON, extensionsFilePath);
 
     expect(getExecutableCodeRefSourceMock.mock.calls.length).toBe(2);
     expect(getExecutableCodeRefSourceMock.mock.calls[0]).toEqual([
@@ -381,13 +379,13 @@ describe('getDynamicExtensions', () => {
       consolePlugin: { entry: 'src/plugin.ts' },
     };
 
-    const extensionsObject: { data: Extension[] } = { data: [] };
+    const extensionsJSON: Extension[] = [];
     const extensionsFilePath = `${pluginPackage._path}/${extensionsFile}`;
     const errorCallback = jest.fn();
     const codeRefTransformer = jest.fn<string>(_.identity);
 
     fsExistsSync.mockImplementation(() => true);
-    parseJSONC.mockImplementation(() => extensionsObject);
+    parseJSONC.mockImplementation(() => extensionsJSON);
     validateExtensionsFileSchema.mockImplementation(() => {
       const result = new ValidationResult('test');
       result.addError('schema validation error');
@@ -402,7 +400,7 @@ describe('getDynamicExtensions', () => {
     expect(codeRefTransformer).not.toHaveBeenCalled();
     expect(fsExistsSync).toHaveBeenCalledWith(extensionsFilePath);
     expect(parseJSONC).toHaveBeenCalledWith(extensionsFilePath);
-    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsObject, extensionsFilePath);
+    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsJSON, extensionsFilePath);
     expect(getExecutableCodeRefSourceMock).not.toHaveBeenCalled();
   });
 
@@ -414,19 +412,17 @@ describe('getDynamicExtensions', () => {
       consolePlugin: { entry: 'src/plugin.ts' },
     };
 
-    const extensionsObject: { data: Extension[] } = {
-      data: [
-        { type: 'Dynamic/Foo', properties: { test: true, mux: { $codeRef: 'a.b' } } },
-        { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'foo.bar' } } },
-      ],
-    };
+    const extensionsJSON: Extension[] = [
+      { type: 'Dynamic/Foo', properties: { test: true, mux: { $codeRef: 'a.b' } } },
+      { type: 'Dynamic/Bar', properties: { baz: 1, qux: { $codeRef: 'foo.bar' } } },
+    ];
 
     const extensionsFilePath = `${pluginPackage._path}/${extensionsFile}`;
     const errorCallback = jest.fn();
     const codeRefTransformer = jest.fn<string>(_.identity);
 
     fsExistsSync.mockImplementation(() => true);
-    parseJSONC.mockImplementation(() => extensionsObject);
+    parseJSONC.mockImplementation(() => extensionsJSON);
     validateExtensionsFileSchema.mockImplementation(() => new ValidationResult('test'));
 
     getExecutableCodeRefSourceMock.mockImplementation(
@@ -461,7 +457,7 @@ describe('getDynamicExtensions', () => {
 
     expect(fsExistsSync).toHaveBeenCalledWith(extensionsFilePath);
     expect(parseJSONC).toHaveBeenCalledWith(extensionsFilePath);
-    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsObject, extensionsFilePath);
+    expect(validateExtensionsFileSchema).toHaveBeenCalledWith(extensionsJSON, extensionsFilePath);
 
     expect(getExecutableCodeRefSourceMock.mock.calls.length).toBe(2);
     expect(getExecutableCodeRefSourceMock.mock.calls[0]).toEqual([

--- a/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
@@ -131,7 +131,7 @@ export const getDynamicExtensions = (
 
   const codeRefValidationResult = new ValidationResult(extensionsFilePath);
   const source = JSON.stringify(
-    ext.data,
+    ext,
     (key, value) =>
       isEncodedCodeRef(value)
         ? `%${codeRefTransformer(

--- a/frontend/packages/container-security/console-extensions.json
+++ b/frontend/packages/container-security/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/gitops-plugin/console-extensions.json
+++ b/frontend/packages/gitops-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/insights-plugin/console-extensions.json
+++ b/frontend/packages/insights-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -1,24 +1,21 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": [
-    {
-      "type": "console.flag/model",
-      "properties": {
-        "model": {
-          "group": "kubevirt.io",
-          "version": "v1alpha3",
-          "kind": "VirtualMachine"
-        },
-        "flag": "KUBEVIRT"
-      }
-    },
-    {
-      "type": "console.page/route/standalone",
-      "properties": {
-        "exact": false,
-        "path": "/k8s/ns/:ns/virtualmachineinstances/:name/standaloneconsole",
-        "component": { "$codeRef": "standaloneConsole" }
-      }
+[
+  {
+    "type": "console.flag/model",
+    "properties": {
+      "model": {
+        "group": "kubevirt.io",
+        "version": "v1alpha3",
+        "kind": "VirtualMachine"
+      },
+      "flag": "KUBEVIRT"
     }
-  ]
-}
+  },
+  {
+    "type": "console.page/route/standalone",
+    "properties": {
+      "exact": false,
+      "path": "/k8s/ns/:ns/virtualmachineinstances/:name/standaloneconsole",
+      "component": { "$codeRef": "standaloneConsole" }
+    }
+  }
+]

--- a/frontend/packages/local-storage-operator-plugin/console-extensions.json
+++ b/frontend/packages/local-storage-operator-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/metal3-plugin/console-extensions.json
+++ b/frontend/packages/metal3-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/network-attachment-definition-plugin/console-extensions.json
+++ b/frontend/packages/network-attachment-definition-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/noobaa-storage-plugin/console-extensions.json
+++ b/frontend/packages/noobaa-storage-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/operator-lifecycle-manager/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/pipelines-plugin/console-extensions.json
+++ b/frontend/packages/pipelines-plugin/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]

--- a/frontend/packages/topology/console-extensions.json
+++ b/frontend/packages/topology/console-extensions.json
@@ -1,4 +1,1 @@
-{
-  "$schema": "../console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
-  "data": []
-}
+[]


### PR DESCRIPTION
### Before

```jsonc
{
  "$schema": "/path/to/console-dynamic-plugin-sdk/dist/schema/console-extensions.json",
  "data": [ /* extension declarations */ ]
}
```

### After

```jsonc
[ /* extension declarations */ ]
```

According to current [JSON Schema specification](http://json-schema.org/specification.html), the [`$schema`](http://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.1.1) keyword value (representing a meta-schema) must be a URI and when requested, its media type should be `application/schema+json`.

We should stick to the standards; having a top-level `$schema` property in a JSON document is apparently not the standard way to associate such document with the given schema.

@christianvogt Once we support "plugin extends plugin" scenario, the JSON schema will become dynamic, i.e. composed from core Console extension schema & extension schemas from dependent plugin(s). In this scenario, having a single static `$schema` property isn't very helpful anyway.