### PR TITLE
 Bug 1924641: Remove error message for "missing storage class"

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -331,8 +331,6 @@
   "Discover Disks": "Discover Disks",
   "Storage and Nodes": "Storage and Nodes",
   "Review and Create": "Review and Create",
-  "Missing storage class": "Missing storage class",
-  "The storage cluster needs to use a storage class to consume the local storage. In order to create one you need to discover the available disks and create a storage class using the filters to select the disks you wish to use": "The storage cluster needs to use a storage class to consume the local storage. In order to create one you need to discover the available disks and create a storage class using the filters to select the disks you wish to use",
   "Can be used on any platform. It means that OCS uses attached disks, via Local Storage Operator. In this case, the infrastructure storage class is actually provided by LSO, on top of attached drives.": "Can be used on any platform. It means that OCS uses attached disks, via Local Storage Operator. In this case, the infrastructure storage class is actually provided by LSO, on top of attached drives.",
   "Before we can create a storage cluster, the local storage operator needs to be installed. When installation is finished come back to OpenShift Container Storage to create a storage cluster.<1><0>Install</0></1>": "Before we can create a storage cluster, the local storage operator needs to be installed. When installation is finished come back to OpenShift Container Storage to create a storage cluster.<1><0>Install</0></1>",
   "Role": "Role",

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
@@ -109,7 +109,6 @@ const createCluster = async (
 
 const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
   match,
-  hasNoProvSC,
   mode,
   lsoNs,
   navUtils,
@@ -271,20 +270,12 @@ const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
             className="co-alert ocs-install-info-alert"
             variant="info"
             isInline
-            title={
-              !hasNoProvSC
-                ? t('ceph-storage-plugin~Missing storage class')
-                : 'Internal - Attached devices'
-            }
+            title="Internal - Attached devices"
             actionClose={<AlertActionCloseButton onClose={() => setShowInfoAlert(false)} />}
           >
-            {!hasNoProvSC
-              ? t(
-                  'ceph-storage-plugin~The storage cluster needs to use a storage class to consume the local storage. In order to create one you need to discover the available disks and create a storage class using the filters to select the disks you wish to use',
-                )
-              : t(
-                  'ceph-storage-plugin~Can be used on any platform. It means that OCS uses attached disks, via Local Storage Operator. In this case, the infrastructure storage class is actually provided by LSO, on top of attached drives.',
-                )}
+            {t(
+              'ceph-storage-plugin~Can be used on any platform. It means that OCS uses attached disks, via Local Storage Operator. In this case, the infrastructure storage class is actually provided by LSO, on top of attached drives.',
+            )}
           </Alert>
         )}
       </StackItem>
@@ -319,8 +310,6 @@ const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
 type CreateStorageClusterWizardProps = {
   navUtils: NavUtils;
   match: RouterMatch<{ appName: string; ns: string }>;
-  hasNoProvSC: boolean;
-  setHasNoProvSC: React.Dispatch<React.SetStateAction<boolean>>;
   mode: string;
   lsoNs: string;
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install.tsx
@@ -4,23 +4,16 @@ import { match as RouterMatch } from 'react-router';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { Alert, Button } from '@patternfly/react-core';
-import {
-  StorageClassResourceKind,
-  K8sResourceKind,
-  k8sList,
-  referenceForModel,
-} from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { history, LoadingBox } from '@console/internal/components/utils';
 import {
   useK8sWatchResource,
   WatchK8sResource,
 } from '@console/internal/components/utils/k8s-watch-hook';
-import { StorageClassModel } from '@console/internal/models';
 import { ClusterServiceVersionModel, SubscriptionModel } from '@console/operator-lifecycle-manager';
 import { getNamespace } from '@console/shared';
 import CreateStorageClusterWizard from './install-wizard';
 import { NavUtils } from '../../../types';
-import { filterSCWithNoProv } from '../../../utils/install';
 import { getOperatorVersion } from '../../../selectors';
 import { LSO_OPERATOR } from '../../../constants';
 import './attached-devices.scss';
@@ -37,8 +30,6 @@ export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesCluster
 }) => {
   const { t } = useTranslation();
 
-  const { appName, ns } = match.params;
-  const [hasNoProvSC, setHasNoProvSC] = React.useState(false);
   const [lsoSubscription, setLsoSubscription] = React.useState<K8sResourceKind>();
   const isDataLoaded = React.useRef(false);
   const lsoNs = getNamespace(lsoSubscription);
@@ -68,19 +59,6 @@ export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesCluster
     setLsoSubscription(subscriptions.find((item) => item?.spec?.name === LSO_OPERATOR));
   }, [subscriptions]);
 
-  React.useEffect(() => {
-    /* this call can't be watched here as watching will take the user back to this view
-    once a sc gets created from ocs install in case of no sc present */
-    k8sList(StorageClassModel)
-      .then((storageClasses: StorageClassResourceKind[]) => {
-        const filteredSCData = storageClasses.filter(filterSCWithNoProv);
-        if (filteredSCData.length) {
-          setHasNoProvSC(true);
-        }
-      })
-      .catch(() => setHasNoProvSC(false));
-  }, [appName, ns]);
-
   return !isDataLoaded.current && !subscriptionsLoadError && !csvLoadError ? (
     <LoadingBox />
   ) : subscriptionsLoadError || csvLoadError || !isLsoCsvSucceeded ? (
@@ -102,14 +80,7 @@ export const CreateAttachedDevicesCluster: React.FC<CreateAttachedDevicesCluster
       </Trans>
     </Alert>
   ) : (
-    <CreateStorageClusterWizard
-      navUtils={navUtils}
-      hasNoProvSC={hasNoProvSC}
-      setHasNoProvSC={setHasNoProvSC}
-      match={match}
-      lsoNs={lsoNs}
-      mode={mode}
-    />
+    <CreateStorageClusterWizard navUtils={navUtils} match={match} lsoNs={lsoNs} mode={mode} />
   );
 };
 


### PR DESCRIPTION
Mentioning here that I was able to replicate this issue only a couple
of times (as is mentioned in the BZ issue body), so this patch fix
addresses some parts of the codebase that I inferred to be the cause
of this issue from that observation.

It'd be nice if someone (who can replicate the issue successfully) can
apply this patch and provide their feedback on it.

***
To apply this, do `curl https://github.com/openshift/console/commit/f12891f445c73f0041c397813e9dedbeb36b8fe8.patch | git apply`.