### PR TITLE
Fix topology crash due to selfLink deprecation

### DIFF
--- a/frontend/packages/topology/src/operators/TopologyOperatorBackedPanel.tsx
+++ b/frontend/packages/topology/src/operators/TopologyOperatorBackedPanel.tsx
@@ -50,9 +50,9 @@ const ConnectedTopologyOperatorBackedPanel: React.FC<PropsFromState &
   PropsFromDispatch &
   TopologyOperatorBackedPanelProps> = ({ item, onClickTab, selectedDetailsTab }) => {
   const { t } = useTranslation();
-  const { name, resource } = item;
+  const { name, resource, data } = item;
   const { namespace } = resource.metadata;
-  const csvName = resource.metadata.selfLink.split('/').pop();
+  const { csvName } = data;
   const reference = referenceFor(resource);
   const actionExtensions = useExtensions<ClusterServiceVersionAction>(
     isClusterServiceVersionAction,

--- a/frontend/packages/topology/src/operators/operator-topology-types.ts
+++ b/frontend/packages/topology/src/operators/operator-topology-types.ts
@@ -1,4 +1,5 @@
 export type OperatorGroupData = {
+  csvName: string;
   operatorKind: string;
   builderImage: string;
   apiVersion: string;

--- a/frontend/packages/topology/src/operators/operatorsDataModelReconciler.ts
+++ b/frontend/packages/topology/src/operators/operatorsDataModelReconciler.ts
@@ -93,7 +93,7 @@ export const operatorsDataModelReconciler = (
       const operatorNodes = operatorGroupNodes[key];
 
       const baseNode = operatorNodes[0] as OdcNodeModel;
-      const operatorGroupItem = getOperatorGroupResource(baseNode.resource, resources);
+      const { operatorGroupItem, csvName } = getOperatorGroupResource(baseNode.resource, resources);
       if (operatorGroupItem) {
         const data = {
           id: operatorGroupItem.metadata.uid,
@@ -109,6 +109,7 @@ export const operatorsDataModelReconciler = (
           resource: operatorGroupItem,
           groupResources: operatorNodes,
           data: {
+            csvName,
             operatorKind: operatorGroupItem.kind,
             builderImage:
               getImageForCSVIcon(operatorGroupItem?.spec?.icon?.[0]) || getDefaultOperatorIcon(),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5563

**Analysis / Root cause**: 
https://github.com/kubernetes/enhancements/issues/1164 removed the `selfLink` attribute. This attribute was being used to determine the managed by resource for the operator group.

**Solution Description**: 
Remove the dependency on `selfLink` by passing back the name of the CSV and keeping this name as part of the data for the operator backed service group node.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug