### PR TITLE
[release-4.6] Bug 1933727: fix Internal registry deploy flow

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -497,7 +497,7 @@ export const externalImageValues: DeployImageFormData = {
   searchTerm: undefined,
   registry: 'external',
   allowInsecureRegistry: false,
-  imageStream: { image: '', tag: '', namespace: '', grantAccess: true },
+  imageStream: { image: '', tag: '', namespace: '' },
   isi: {
     name: '',
     image: {},
@@ -623,7 +623,7 @@ export const knExternalImageValues: DeployImageFormData = {
   deployment: { env: [], replicas: 1, triggers: { image: false } },
   formType: 'edit',
   image: { image: {}, name: '', ports: [], status: { metadata: {}, status: '' }, tag: '' },
-  imageStream: { grantAccess: true, image: '', namespace: '', tag: '' },
+  imageStream: { image: '', namespace: '', tag: '' },
   isSearchingForImage: false,
   isi: { image: {}, name: '', ports: [], status: { metadata: {}, status: '' }, tag: '' },
   labels: {},

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -371,7 +371,6 @@ export const getExternalImageInitialValues = (appResources: AppResources) => {
     allowInsecureRegistry: isAllowInsecureRegistry,
     imageStream: {
       ...deployImageInitialValues.imageStream,
-      grantAccess: true,
     },
   };
 };
@@ -410,7 +409,6 @@ export const getExternalImagelValues = (appResource: K8sResourceKind) => {
     registry: RegistryType.External,
     imageStream: {
       ...deployImageInitialValues.imageStream,
-      grantAccess: true,
     },
   };
 };

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -54,7 +54,6 @@ const DeployImage: React.FC<Props> = ({
       image: '',
       tag: '',
       namespace: namespace || '',
-      grantAccess: true,
     },
     isi: {
       name: '',

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -5,7 +5,6 @@ import {
   ImageStreamModel,
   ServiceModel,
   RouteModel,
-  RoleBindingModel,
 } from '@console/internal/models';
 import {
   K8sResourceKind,
@@ -32,34 +31,6 @@ import { DeployImageFormData, Resources } from './import-types';
 
 const WAIT_FOR_IMAGESTREAM_UPDATE_TIMEOUT = 5000;
 const WAIT_FOR_IMAGESTREAM_GENERATION = 2;
-
-export const createSystemImagePullerRoleBinding = (
-  formData: DeployImageFormData,
-  dryRun: boolean,
-): Promise<K8sResourceKind> => {
-  const { imageStream } = formData;
-  const roleBinding = {
-    kind: RoleBindingModel.kind,
-    apiVersion: `${RoleBindingModel.apiGroup}/${RoleBindingModel.apiVersion}`,
-    metadata: {
-      name: `system:image-puller-${imageStream.namespace}`,
-      namespace: formData.project.name,
-    },
-    subjects: [
-      {
-        kind: 'ServiceAccount',
-        name: 'default',
-        namespace: imageStream.namespace,
-      },
-    ],
-    roleRef: {
-      apiGroup: RoleBindingModel.apiGroup,
-      kind: 'ClusterRole',
-      name: 'system:image-puller',
-    },
-  };
-  return k8sCreate(RoleBindingModel, roleBinding, dryRun ? dryRunOpt : {});
-};
 
 export const createOrUpdateImageStream = async (
   formData: DeployImageFormData,
@@ -396,10 +367,7 @@ export const createOrUpdateDeployImageResources = async (
   } = formData;
   const internalImageName = getRuntime(image.metadata?.labels);
   const requests: Promise<K8sResourceKind>[] = [];
-  if (registry === RegistryType.Internal) {
-    formData.imageStream.grantAccess &&
-      requests.push(createSystemImagePullerRoleBinding(formData, dryRun));
-  }
+
   const imageStreamList = appResources?.imageStream?.data;
   const imageStreamData = _.orderBy(imageStreamList, ['metadata.resourceVersion'], ['desc']);
   const originalImageStream = (imageStreamData.length && imageStreamData[0]) || {};

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStream.scss
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStream.scss
@@ -6,3 +6,6 @@
 .odc-imagestream-alert {
   margin-top: 1em;
 }
+.odc-imagestream-clipboard {
+  margin-top: var(--pf-global--spacer--md);
+}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
@@ -18,7 +18,7 @@ const ImageStreamDropdown: React.FC = () => {
   const { state, dispatch, hasImageStreams, setHasImageStreams } = React.useContext(
     ImageStreamContext,
   );
-  const { accessLoading, loading, hasCreateAccess } = state;
+  const { accessLoading, loading } = state;
   const isNamespaceSelected = imageStream.namespace !== '' && !accessLoading;
   const isStreamsAvailable = isNamespaceSelected && hasImageStreams && !loading;
   const collectImageStreams = (namespace: string, resource: K8sResourceKind): void => {
@@ -30,7 +30,7 @@ const ImageStreamDropdown: React.FC = () => {
   const getTitle = () => {
     return loading && !isStreamsAvailable
       ? ''
-      : !isStreamsAvailable || !hasCreateAccess
+      : !isStreamsAvailable
       ? 'No Image Stream'
       : 'Select Image Stream';
   };
@@ -87,7 +87,7 @@ const ImageStreamDropdown: React.FC = () => {
       fullWidth
       required
       title={imageStream.image || getTitle()}
-      disabled={!hasCreateAccess || !isStreamsAvailable}
+      disabled={!isStreamsAvailable}
       onChange={onDropdownChange}
       onLoad={onLoad}
       resourceFilter={resourceFilter}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
-import { k8sGet } from '@console/internal/module/k8s';
-import { RoleBindingModel } from '@console/internal/models';
-import { checkAccess } from '@console/internal/components/utils';
 import { ResourceDropdownField } from '@console/shared';
 import { getProjectResource, BuilderImagesNamespace } from '../../../utils/imagestream-utils';
 import { ImageStreamActions as Action } from '../import-types';
@@ -11,57 +8,18 @@ import { ImageStreamContext } from './ImageStreamContext';
 const ImageStreamNsDropdown: React.FC = () => {
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
   const { dispatch } = React.useContext(ImageStreamContext);
-  const onDropdownChange = React.useCallback(
-    (selectedProject: string) => {
-      const promiseArr = [];
-      setFieldValue('imageStream.image', initialValues.imageStream.image);
-      setFieldValue('imageStream.tag', initialValues.imageStream.tag);
-      setFieldValue('isi', initialValues.isi);
-      dispatch({ type: Action.setLoading, value: true });
-      dispatch({ type: Action.setAccessLoading, value: true });
-      if (selectedProject === BuilderImagesNamespace.Openshift) {
-        dispatch({ type: Action.setHasCreateAccess, value: true });
-        dispatch({ type: Action.setHasAccessToPullImage, value: true });
-        setFieldValue('imageStream.grantAccess', false);
-      } else {
-        promiseArr.push(
-          checkAccess({
-            group: RoleBindingModel.apiGroup,
-            resource: RoleBindingModel.plural,
-            verb: 'create',
-            name: 'system:image-puller',
-            namespace: values.project.name,
-          })
-            .then((resp) =>
-              dispatch({ type: Action.setHasCreateAccess, value: resp.status.allowed }),
-            )
-            .catch(() => dispatch({ type: Action.setHasAccessToPullImage, value: false })),
-        );
-        promiseArr.push(
-          k8sGet(RoleBindingModel, `system:image-puller-${selectedProject}`, values.project.name)
-            .then(() => {
-              dispatch({
-                type: Action.setHasAccessToPullImage,
-                value: true,
-              });
-              setFieldValue('imageStream.grantAccess', false);
-            })
-            .catch(() => dispatch({ type: Action.setHasAccessToPullImage, value: false })),
-        );
-      }
-      return Promise.all(promiseArr).then(() =>
-        dispatch({ type: Action.setAccessLoading, value: false }),
-      );
-    },
-    [
-      dispatch,
-      initialValues.imageStream.image,
-      initialValues.imageStream.tag,
-      initialValues.isi,
-      setFieldValue,
-      values.project.name,
-    ],
-  );
+  const onDropdownChange = React.useCallback(() => {
+    setFieldValue('imageStream.image', initialValues.imageStream.image);
+    setFieldValue('imageStream.tag', initialValues.imageStream.tag);
+    setFieldValue('isi', initialValues.isi);
+    dispatch({ type: Action.setLoading, value: true });
+  }, [
+    dispatch,
+    initialValues.imageStream.image,
+    initialValues.imageStream.tag,
+    initialValues.isi,
+    setFieldValue,
+  ]);
 
   React.useEffect(() => {
     if (
@@ -70,7 +28,7 @@ const ImageStreamNsDropdown: React.FC = () => {
     ) {
       initialValues.imageStream.image = values.imageStream.image;
     }
-    values.imageStream.namespace && onDropdownChange(values.imageStream.namespace);
+    values.imageStream.namespace && onDropdownChange();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onDropdownChange, values.imageStream.namespace]);
 

--- a/frontend/packages/dev-console/src/components/import/image-search/__tests__/ImageStream.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/__tests__/ImageStream.spec.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import * as formik from 'formik';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { Alert } from '@patternfly/react-core';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import {
+  appResources,
+  internalImageValues,
+} from '../../../edit-application/__tests__/edit-application-data';
+import * as imgUtils from '../../../../utils/imagestream-utils';
+import ImageStreamTagDropdown from '../ImageStreamTagDropdown';
+import ImageStreamNsDropdown from '../ImageStreamNsDropdown';
+import ImageStreamDropdown from '../ImageStreamDropdown';
+import ImageStream from '../ImageStream';
+
+const spyUseFormikContext = jest.spyOn(formik, 'useFormikContext');
+const spyUseReducer = jest.spyOn(React, 'useReducer');
+const spyUseField = jest.spyOn(formik, 'useField');
+const spyGetImageStreamTags = jest.spyOn(imgUtils, 'getImageStreamTags');
+const spyUseState = jest.spyOn(React, 'useState');
+
+const mockReducerState = {
+  loading: false,
+  accessLoading: false,
+  selectedImageStream: appResources.imageStream.data[0],
+};
+type ImagestreamProps = React.ComponentProps<typeof ImageStream>;
+
+describe('Imagestream', () => {
+  let wrapper: ShallowWrapper<ImagestreamProps>;
+  beforeEach(() => {
+    spyGetImageStreamTags.mockReturnValue({ 3.6: 3.6 });
+    spyUseReducer.mockImplementation(() => [mockReducerState, jest.fn()]);
+    spyUseField.mockImplementation(() => [{ value: '' }, {}]);
+    spyUseState.mockReturnValue([true, jest.fn()]);
+    spyUseFormikContext.mockReturnValue({
+      ...formikFormProps,
+      values: internalImageValues,
+      initialValues: internalImageValues,
+    });
+    wrapper = shallow(<ImageStream />);
+  });
+
+  it('should render namespace, imagestream and imagestream-tag dropdowns ', () => {
+    expect(wrapper.find(ImageStreamNsDropdown)).toHaveLength(1);
+    expect(wrapper.find(ImageStreamDropdown)).toHaveLength(1);
+    expect(wrapper.find(ImageStreamTagDropdown)).toHaveLength(1);
+  });
+
+  it('should not render any alerts if current project and imagestream project is the same', () => {
+    expect(wrapper.find(Alert)).toHaveLength(0);
+  });
+
+  it('should not render any alerts if the imagestream namespace is openshift', () => {
+    spyUseFormikContext.mockReturnValue({
+      ...formikFormProps,
+      values: {
+        ...internalImageValues,
+        project: { name: 'project-a' },
+        imageStream: {
+          ...internalImageValues.imageStream,
+          namespace: 'openshift',
+        },
+      },
+      initialValues: internalImageValues,
+    });
+    wrapper = shallow(<ImageStream />);
+    expect(wrapper.find(Alert)).toHaveLength(0);
+  });
+
+  it('should render oc command alert if current namespace and imagestream namespace are not equal', () => {
+    spyUseFormikContext.mockReturnValue({
+      ...formikFormProps,
+      values: { ...internalImageValues, project: { name: 'project-a' } },
+      initialValues: internalImageValues,
+    });
+    wrapper = shallow(<ImageStream />);
+    const alert = wrapper.find(Alert);
+    expect(alert).toHaveLength(1);
+    expect(alert.props().title).toEqual(
+      `Service account default will need pull authority to deploy Images from ${mockReducerState.selectedImageStream.metadata.namespace}`,
+    );
+  });
+
+  it('should render imagestream not found alert if there are no imagestreams', () => {
+    spyUseFormikContext.mockReturnValue({
+      ...formikFormProps,
+      values: { ...internalImageValues, imageStream: { image: '' } },
+    });
+    wrapper = shallow(<ImageStream />);
+    expect(wrapper.find(Alert)).toHaveLength(1);
+  });
+
+  it('should render imagestream tag not found alert if there are no imagestreams tags', () => {
+    spyGetImageStreamTags.mockReturnValue({});
+    wrapper = shallow(<ImageStream />);
+    expect(wrapper.find(Alert)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -14,18 +14,14 @@ export interface DeployImageFormProps {
 export type ImageStreamPayload = boolean | K8sResourceKind;
 
 export type ImageStreamState = {
-  hasAccessToPullImage: ImageStreamPayload;
   accessLoading: ImageStreamPayload;
   loading: ImageStreamPayload;
-  hasCreateAccess: ImageStreamPayload;
   selectedImageStream: ImageStreamPayload;
 };
 export enum ImageStreamActions {
   setAccessLoading = 'setAccessLoading',
   setLoading = 'setLoading',
   setSelectedImageStream = 'setSelectedImageStream',
-  setHasAccessToPullImage = 'setHasAccessToPullImage',
-  setHasCreateAccess = 'setHasCreateAccess',
 }
 export type ImageStreamAction = { type: ImageStreamActions; value: ImageStreamPayload };
 export interface ImageStreamContextProps {
@@ -68,7 +64,6 @@ export interface DeployImageFormData {
     image: string;
     tag: string;
     namespace: string;
-    grantAccess?: boolean;
   };
   isi: ImageStreamImageData;
   image: ImageStreamImageData;


### PR DESCRIPTION
This is a manual cherry pick of https://github.com/openshift/console/pull/7727

**Note**: Removed Translation related content as we do not have translations handled on 4.6

**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5259

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Users with edit right are unable to deploy images from their own namespace in the UI but they can do it using the CLI.
**Solution Description**: 

<!-- Describe your code changes in detail and explain the solution -->
Reverting back to 3.11 like flow for avoiding the permission issue caused while granting access via UI

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
1. User chooses the same project
![image](https://user-images.githubusercontent.com/9964343/103775040-80e60d00-5053-11eb-907b-d4164e31b3bc.png)

2. User chooses a different project
![image](https://user-images.githubusercontent.com/9964343/103984538-58722600-51ad-11eb-8011-8034a69da4ed.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/9964343/103881501-8cdbd880-5100-11eb-884d-1aa3c38dcf24.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create a user with edit right to a namespace
2. go to the namespace and use internal image registry option
3. now choose an image stream from the user's own namespace for creation.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @invincibleJai @christianvogt 