### PR TITLE
Monitoring dashboards: Allow zooming all graphs and sync their ranges

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -29,6 +29,7 @@ export enum ActionType {
   MonitoringDashboardsClearVariables = 'monitoringDashboardsClearVariables',
   MonitoringDashboardsPatchVariable = 'monitoringDashboardsPatchVariable',
   MonitoringDashboardsPatchAllVariables = 'monitoringDashboardsPatchAllVariables',
+  MonitoringDashboardsSetEndTime = 'monitoringDashboardsSetEndTime',
   MonitoringDashboardsSetPollInterval = 'monitoringDashboardsSetPollInterval',
   MonitoringDashboardsSetTimespan = 'monitoringDashboardsSetTimespan',
   MonitoringDashboardsVariableOptionsLoaded = 'monitoringDashboardsVariableOptionsLoaded',
@@ -300,6 +301,8 @@ export const monitoringDashboardsPatchVariable = (key: string, patch: any) =>
   action(ActionType.MonitoringDashboardsPatchVariable, { key, patch });
 export const monitoringDashboardsPatchAllVariables = (variables: any) =>
   action(ActionType.MonitoringDashboardsPatchAllVariables, { variables });
+export const monitoringDashboardsSetEndTime = (endTime: number) =>
+  action(ActionType.MonitoringDashboardsSetEndTime, { endTime });
 export const monitoringDashboardsSetPollInterval = (pollInterval: number) =>
   action(ActionType.MonitoringDashboardsSetPollInterval, { pollInterval });
 export const monitoringDashboardsSetTimespan = (timespan: number) =>
@@ -403,6 +406,7 @@ const uiActions = {
   monitoringDashboardsClearVariables,
   monitoringDashboardsPatchVariable,
   monitoringDashboardsPatchAllVariables,
+  monitoringDashboardsSetEndTime,
   monitoringDashboardsSetPollInterval,
   monitoringDashboardsSetTimespan,
   monitoringDashboardsVariableOptionsLoaded,

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -1,36 +1,50 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch, useSelector } from 'react-redux';
 
+import {
+  monitoringDashboardsSetEndTime,
+  monitoringDashboardsSetTimespan,
+} from '../../../actions/ui';
 import { RootState } from '../../../redux';
 import { FormatLegendLabel, QueryBrowser } from '../query-browser';
-
-const Graph_: React.FC<Props> = ({
-  formatLegendLabel,
-  isStack,
-  pollInterval,
-  queries,
-  timespan,
-}) => (
-  <QueryBrowser
-    defaultSamples={30}
-    formatLegendLabel={formatLegendLabel}
-    hideControls
-    isStack={isStack}
-    pollInterval={pollInterval}
-    queries={queries}
-    timespan={timespan}
-  />
-);
-const Graph = connect(({ UI }: RootState) => ({
-  timespan: UI.getIn(['monitoringDashboards', 'timespan']),
-}))(Graph_);
 
 type Props = {
   formatLegendLabel?: FormatLegendLabel;
   isStack: boolean;
   pollInterval: number;
   queries: string[];
-  timespan: number;
+};
+
+const Graph: React.FC<Props> = ({ formatLegendLabel, isStack, pollInterval, queries }) => {
+  const dispatch = useDispatch();
+  const endTime = useSelector(({ UI }: RootState) => UI.getIn(['monitoringDashboards', 'endTime']));
+  const timespan = useSelector(({ UI }: RootState) =>
+    UI.getIn(['monitoringDashboards', 'timespan']),
+  );
+
+  const onZoom = React.useCallback(
+    (from, to) => {
+      dispatch(monitoringDashboardsSetEndTime(to));
+      dispatch(monitoringDashboardsSetTimespan(to - from));
+    },
+    [dispatch],
+  );
+
+  return (
+    <QueryBrowser
+      defaultSamples={30}
+      fixedEndTime={endTime}
+      formatLegendLabel={formatLegendLabel}
+      hideControls
+      isStack={isStack}
+      onZoom={onZoom}
+      pollInterval={pollInterval}
+      queries={queries}
+      timespan={timespan}
+    />
+  );
 };
 
 export default Graph;

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -3,7 +3,9 @@ import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-import { connect } from 'react-redux';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { connect, useDispatch } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 
 import { RedExclamationCircleIcon } from '@console/shared';
@@ -27,7 +29,7 @@ import BarChart from './bar-chart';
 import Graph from './graph';
 import SingleStat from './single-stat';
 import Table from './table';
-import { Panel } from './types';
+import { MONITORING_DASHBOARDS_DEFAULT_TIMESPAN, Panel } from './types';
 
 const NUM_SAMPLES = 30;
 
@@ -456,6 +458,7 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
   match,
   patchAllVariables,
 }) => {
+  const dispatch = useDispatch();
   const { t } = useTranslation();
 
   const [board, setBoard] = React.useState<string>();
@@ -525,11 +528,16 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
         });
         patchAllVariables(allVariables);
 
+        // Set time range options to their defaults since they may have been changed on the
+        // previous dashboard
+        dispatch(UIActions.monitoringDashboardsSetEndTime(null));
+        dispatch(UIActions.monitoringDashboardsSetTimespan(MONITORING_DASHBOARDS_DEFAULT_TIMESPAN));
+
         setBoard(newBoard);
         history.replace(`/monitoring/dashboards/${newBoard}`);
       }
     },
-    [board, boards, patchAllVariables],
+    [board, boards, dispatch, patchAllVariables],
   );
 
   // Default to displaying the first board

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -1,3 +1,5 @@
+export const MONITORING_DASHBOARDS_DEFAULT_TIMESPAN = 30 * 60 * 1000;
+
 export type ColumnStyle = {
   alias?: string;
   decimals?: number;

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -8,6 +8,7 @@ import { getNamespace } from '../components/utils/link';
 import { OverviewSpecialGroup } from '../components/overview/constants';
 import { RootState } from '../redux';
 import { Alert, AlertStates, RuleStates, SilenceStates } from '../components/monitoring/types';
+import { MONITORING_DASHBOARDS_DEFAULT_TIMESPAN } from '../components/monitoring/dashboards/types';
 
 export type UIState = ImmutableMap<string, any>;
 
@@ -64,8 +65,9 @@ export default (state: UIState, action: UIAction): UIState => {
       }),
       user: {},
       monitoringDashboards: ImmutableMap({
+        endTime: null,
         pollInterval: 30 * 1000,
-        timespan: 30 * 60 * 1000,
+        timespan: MONITORING_DASHBOARDS_DEFAULT_TIMESPAN,
         variables: ImmutableMap(),
       }),
       queryBrowser: ImmutableMap({
@@ -138,6 +140,9 @@ export default (state: UIState, action: UIAction): UIState => {
         ['monitoringDashboards', 'variables'],
         ImmutableMap(action.payload.variables),
       );
+
+    case ActionType.MonitoringDashboardsSetEndTime:
+      return state.setIn(['monitoringDashboards', 'endTime'], action.payload.endTime);
 
     case ActionType.MonitoringDashboardsSetPollInterval:
       return state.setIn(['monitoringDashboards', 'pollInterval'], action.payload.pollInterval);


### PR DESCRIPTION
Allow using the mouse to zoom in on any monitoring dashboard graph. When
doing this, update all other graphs on the page to display the same time
range.