### PR TITLE
Bug 1930546: show error in RsourceDropdown on load error

### DIFF
--- a/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
@@ -109,13 +109,13 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
       title,
       actionItems,
     } = nextProps;
-    if (!loaded) {
+    if (!loaded && !loadError) {
       this.setState({ title: <LoadingInline /> });
       return;
     }
 
     // If autoSelect is true only then have an item pre-selected based on selectedKey.
-    if (!autoSelect && (!this.props.loaded || !selectedKey)) {
+    if (!this.props.loadError && !autoSelect && (!this.props.loaded || !selectedKey)) {
       this.setState({
         title: <span className="btn-dropdown__item--placeholder">{placeholder}</span>,
       });
@@ -129,11 +129,12 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
           </span>
         ),
       });
+      return;
     }
 
     const resourceList = this.getDropdownList({ ...this.props, ...nextProps }, true);
     // set placeholder as title if resourceList is empty no actionItems are there
-    if (loaded && _.isEmpty(resourceList) && !actionItems && placeholder && !title) {
+    if (loaded && !loadError && _.isEmpty(resourceList) && !actionItems && placeholder && !title) {
       this.setState({
         title: <span className="btn-dropdown__item--placeholder">{placeholder}</span>,
       });

--- a/frontend/packages/console-shared/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
@@ -177,4 +177,14 @@ describe('ResourceDropdown test suite', () => {
     component.setProps({ resources: [] });
     expect(spy).toHaveBeenCalledWith('#CREATE_APPLICATION_KEY#', undefined, undefined);
   });
+
+  it('should show error if loadError', () => {
+    const spy = jest.fn();
+    const component = shallow(componentFactory({ onChange: spy }));
+    mockDropdownData[0].data = [];
+    mockDropdownData[0].loadError = 'Error in loading';
+    component.setProps({ resources: mockDropdownData, loadError: 'Error in loading' });
+    const titleWraper = shallow(component.state('title'));
+    expect(titleWraper.text()).toBe('console-shared~Error loading - {{placeholder}}');
+  });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-25270

**Analysis / Root cause**: 
Monitoring-dashboard-workload keep loading when the user with cluster-role cluster-monitoring-view rolebingding user login developer console and select a project

**Solution Description**: 
Show error when having load error

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/109643391-29a77900-7b7a-11eb-96fe-1738c31220f4.png)


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/2561818/109643579-6c695100-7b7a-11eb-9dfa-14876518332a.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge