### PR TITLE
fixes shadow and form footer for ksvc form

### DIFF
--- a/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/CreateKnatifyPage.tsx
@@ -107,30 +107,28 @@ const CreateKnatifyPage: React.FunctionComponent<CreateKnatifyPageProps> = ({
         <title>{t('knative-plugin~Create Knative service')}</title>
       </Helmet>
       <PageHeading title={t('knative-plugin~Create Knative service')} />
-      <div className="co-m-pane__body" style={{ paddingBottom: 0 }}>
-        {isResourcesLoaded() ? (
-          <Formik
-            initialValues={getInitialValuesKnatify(
-              getKnatifyWorkloadData(resources?.workloadResource?.data as K8sResourceKind),
-              appName,
-              namespace,
-              resources?.imageStream?.data as K8sResourceKind[],
-            )}
-            validationSchema={deployValidationSchema(t)}
-            onSubmit={handleSubmit}
-            onReset={history.goBack}
-          >
-            {(formikProps) => (
-              <KnatifyForm
-                {...formikProps}
-                projects={(resources?.projects as WatchK8sResultsObject<K8sResourceKind[]>) ?? {}}
-              />
-            )}
-          </Formik>
-        ) : (
-          <LoadingBox />
-        )}
-      </div>
+      {isResourcesLoaded() ? (
+        <Formik
+          initialValues={getInitialValuesKnatify(
+            getKnatifyWorkloadData(resources?.workloadResource?.data as K8sResourceKind),
+            appName,
+            namespace,
+            resources?.imageStream?.data as K8sResourceKind[],
+          )}
+          validationSchema={deployValidationSchema(t)}
+          onSubmit={handleSubmit}
+          onReset={history.goBack}
+        >
+          {(formikProps) => (
+            <KnatifyForm
+              {...formikProps}
+              projects={(resources?.projects as WatchK8sResultsObject<K8sResourceKind[]>) ?? {}}
+            />
+          )}
+        </Formik>
+      ) : (
+        <LoadingBox />
+      )}
     </NamespacedPage>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/knatify/KnatifyForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/KnatifyForm.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { Form } from '@patternfly/react-core';
-import { FormFooter } from '@console/shared/src/components/form-utils';
+import { FormFooter, FlexForm, FormBody } from '@console/shared/src/components/form-utils';
 import { usePreventDataLossLock } from '@console/internal/components/utils';
 import { DeployImageFormProps } from '@console/dev-console/src/components/import/import-types';
 import ImageSearchSection from '@console/dev-console/src/components/import/image-search/ImageSearchSection';
@@ -25,14 +24,16 @@ const KnatifyForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps> = 
   usePreventDataLossLock(isSubmitting);
 
   return (
-    <Form className="co-deploy-image" data-test-id="knatify-form" onSubmit={handleSubmit}>
-      <ImageSearchSection disabled />
-      <IconSection />
-      <AppSection
-        project={values.project}
-        noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
-      />
-      <AdvancedSection values={values} />
+    <FlexForm className="co-deploy-image" data-test-id="knatify-form" onSubmit={handleSubmit}>
+      <FormBody flexLayout>
+        <ImageSearchSection disabled />
+        <IconSection />
+        <AppSection
+          project={values.project}
+          noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
+        />
+        <AdvancedSection values={values} />
+      </FormBody>
       <FormFooter
         handleReset={handleReset}
         errorMessage={status && status.submitError}
@@ -42,7 +43,7 @@ const KnatifyForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps> = 
         disableSubmit={!dirty || !_.isEmpty(errors) || isSubmitting}
         resetLabel={t('knative-plugin~Cancel')}
       />
-    </Form>
+    </FlexForm>
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5589

**Analysis / Root cause**: 
Form footer and shadow effect not proper for the form created for knative service

**Solution Description**: 
used `FlexForm` and `FormBody` to wrap content and removed the unwanted wrapping

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/109794953-69cf3000-7c3c-11eb-9c5a-1b6947f77c7a.png)


![Mar-03-2021 16-18-08](https://user-images.githubusercontent.com/5129024/109794766-37253780-7c3c-11eb-94b9-4eca9d5a494b.gif)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- Install Serverless Operator
- Create a workload D/DC from container image or import flows
- Can see the option to "Create Knative service" once the workload is in ready state
- View the form footer

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
