### PR TITLE
Enable ceph dashboard flags for ocs-storagecluster CR

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -80,6 +80,7 @@
   "Not available": "Not available",
   "No StorageClass selected": "No StorageClass selected",
   "Add Capacity": "Add Capacity",
+  "Enable Ceph Dashboard": "Enable Ceph Dashboard",
   "Adding capacity for <1>{{name}}</1>, may increase your expenses.": "Adding capacity for <1>{{name}}</1>, may increase your expenses.",
   "Storage Class": "Storage Class",
   "x {{ replica, number }} replicas =": "x {{ replica, number }} replicas =",

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -202,3 +202,10 @@ export type ResourceConstraints = {
     memory: string;
   };
 };
+
+export type CephDashboardSet = {
+  cephDashboard: {
+    enable: boolean;
+    ssl: boolean;
+  };
+};


### PR DESCRIPTION
Add kabab action for ceph-dashboard enabling and
Update the ocs-storagecluster CR with required flags

The Flags:
    enable: true
    ssl: true
will be added under spec/managedResources/cephDashboard in the CR.

Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>