### PR TITLE
test: clear the session token before login

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/integration-tests-cypress/support/index.ts
@@ -6,6 +6,8 @@ import './resources';
 import './i18n';
 import { a11yTestResults } from './a11y';
 
+Cypress.Cookies.debug(true);
+
 Cypress.Cookies.defaults({
   preserve: ['openshift-session-token', 'csrf-token'],
 });


### PR DESCRIPTION
Sometimes Cypress will not correctly clear the session cookie on logout
when running in CI, possibly due to a Cypress bug in cookie handling. We
have not been able to reproduce manually or running the tests outside of
CI. Work around the problem by clearing the cookie manually before login.

Enable cookie debugging in Cypress to help troubleshoot similar problems
in the future.

This also changes the login command to use `window.SERVER_FLAGS.authDisabled`
to detect a local development environment regardless of whether
`BRIDGE_KUBEADMIN_PASSWORD` is set.
