### PR TITLE
Bug 1934664: Consider finally tasks when calculating task status

### DIFF
--- a/frontend/packages/dev-console/src/test/pipeline-data.ts
+++ b/frontend/packages/dev-console/src/test/pipeline-data.ts
@@ -24,6 +24,7 @@ export enum PipelineExampleNames {
   INVALID_PIPELINE_MISSING_TASK = 'missing-task-pipeline',
   INVALID_PIPELINE_INVALID_TASK = 'invalid-task-pipeline',
   EMBEDDED_PIPELINE_SPEC = 'embedded-pipeline-spec',
+  PIPELINE_WITH_FINALLY = 'pipeline-with-finally',
 }
 
 type CombinedPipelineTestData = {
@@ -1593,6 +1594,77 @@ export const pipelineTestData: PipelineTestData = {
             { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
             { name: 'web-image', resourceRef: { name: 'mapit-image' } },
           ],
+        },
+      },
+    },
+  },
+  [PipelineExampleNames.PIPELINE_WITH_FINALLY]: {
+    dataSource: 'finally-pipeline',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'finally-pipeline',
+        namespace: 'tekton-pipelines',
+      },
+      spec: {
+        tasks: [
+          {
+            name: 'hello-world-1',
+            taskRef: { name: 'hello-world-1' },
+          },
+        ],
+        finally: [
+          {
+            name: 'run-anyway',
+            taskRef: { name: 'run-anyway' },
+          },
+        ],
+      },
+    },
+    pipelineRuns: {
+      [DataState.SUCCESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'finally-pipeline-3tt7aw',
+          namespace: 'tekton-pipelines',
+          labels: { [TektonResourceLabel.pipeline]: 'finally-pipeline' },
+        },
+        spec: {
+          pipelineRef: { name: 'finally-pipeline' },
+        },
+        status: {
+          completionTime: '2019-10-29T11:57:53Z',
+          conditions: [
+            {
+              lastTransitionTime: '2019-09-12T20:38:01Z',
+              message: 'All Tasks have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+          taskRuns: {
+            'pipeline-p1bun0-hello-world-1-rlj9b': {
+              pipelineTaskName: 'hello-world-1',
+              status: {
+                completionTime: '2019-12-10T11:18:38Z',
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+                podName: 'test',
+                startTime: '2019-12-10T11:18:38Z',
+              },
+            },
+            'pipeline-p1bun0-run-anyway-cnd82': {
+              pipelineTaskName: 'run-anyway',
+              status: {
+                completionTime: '2019-12-10T11:18:38Z',
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+                podName: 'test',
+                startTime: '2019-12-10T11:18:38Z',
+              },
+            },
+          },
         },
       },
     },

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -133,6 +133,7 @@ export interface PipelineSpec {
   workspaces?: PipelineWorkspace[];
   tasks: PipelineTask[];
   serviceAccountName?: string;
+  finally?: PipelineTask[];
 }
 
 export interface Pipeline extends K8sResourceKind {
@@ -412,9 +413,17 @@ export const getRunStatusColor = (status: string): StatusMessage => {
 export const truncateName = (name: string, length: number): string =>
   name.length < length ? name : `${name.slice(0, length - 1)}...`;
 
+export const totalPipelineTasks = (pipeline: Pipeline): number => {
+  if (!pipeline) {
+    return 0;
+  }
+  const totalTasks = (pipeline.spec?.tasks || []).length ?? 0;
+  const finallyTasks = (pipeline.spec?.finally || []).length ?? 0;
+  return totalTasks + finallyTasks;
+};
+
 export const getTaskStatus = (pipelinerun: PipelineRun, pipeline: Pipeline): TaskStatus => {
-  const totalTasks =
-    pipeline && pipeline.spec && pipeline.spec.tasks ? pipeline.spec.tasks.length : 0;
+  const totalTasks = totalPipelineTasks(pipeline);
   const plrTasks =
     pipelinerun && pipelinerun.status && pipelinerun.status.taskRuns
       ? Object.keys(pipelinerun.status.taskRuns)


### PR DESCRIPTION
This is a manual cherry pick of #8149 / #8110 .

4.6 uses the pipeline to calculate total tasks, instead of using `pipelineSpec` from the pipeline run like in 4.7+.
This change also continues to use the pipeline, since switching to `pipelineSpec` requires too many type & file changes.