### PR TITLE
Bug 1934329: Bump sanitize-html version to 2.3.2 to improperly validate the hostnames

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -177,7 +177,7 @@
     "react-virtualized": "9.x",
     "redux": "4.0.1",
     "reselect": "4.x",
-    "sanitize-html": "2.x",
+    "sanitize-html": "^2.3.2",
     "screenfull": "4.x",
     "semver": "6.x",
     "showdown": "1.8.x",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16361,10 +16361,10 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sanitize-html@2.x:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.3.1.tgz#ab26df3b13041dee312033c4444d2a4fff7b7d43"
-  integrity sha512-JYziKrrtCEGhrsUAZK1mL0RdEcRxBGZ+ptgppv7ulAsan7MZVL+oVKRSPCIcYinfM1rVOMYh5dHLydMuHaQOUA==
+sanitize-html@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.3.2.tgz#a1954aea877a096c408aca7b0c260bef6e4fc402"
+  integrity sha512-p7neuskvC8pSurUjdVmbWPXmc9A4+QpOXIL+4gwFC+av5h+lYCXFT8uEneqsFQg/wEA1IH+cKQA60AaQI6p3cg==
   dependencies:
     deepmerge "^4.2.2"
     escape-string-regexp "^4.0.0"


### PR DESCRIPTION
Improper validation of hostnames set by the "allowedIframeHostnames" option can lead to bypass hostname whitelist for iframe element. Fixing this even though we are not using this option in this repo.

/assign @spadgett 