### PR TITLE
Bug 1935269: Include jobs in operator backed sidebar & resource details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -31,6 +31,7 @@ import { useTranslation } from 'react-i18next';
 import {
   ConfigMapModel,
   DeploymentModel,
+  JobModel,
   PodModel,
   ReplicaSetModel,
   SecretModel,
@@ -44,6 +45,7 @@ const DEFAULT_RESOURCES: CRDDescription['resources'] = [
   { kind: PodModel.kind, version: PodModel.apiVersion },
   { kind: SecretModel.kind, version: SecretModel.apiVersion },
   { kind: ConfigMapModel.kind, version: ConfigMapModel.apiVersion },
+  { kind: JobModel.kind, version: JobModel.apiVersion },
 ];
 
 const tableColumnClasses = [

--- a/frontend/packages/topology/src/operators/TopologyOperatorBackedResources.tsx
+++ b/frontend/packages/topology/src/operators/TopologyOperatorBackedResources.tsx
@@ -77,7 +77,15 @@ const OperatorResourcesGetter: React.FC<OperatorResourcesGetterProps> = ({
   const linkForResource = (obj: K8sResourceKind) => {
     return linkForCsvResource(obj, providedAPI, csv.metadata.name);
   };
-  const defaultResources = ['Deployment', 'Service', 'ReplicaSet', 'Pod', 'Secret', 'ConfigMap'];
+  const defaultResources = [
+    'Deployment',
+    'Service',
+    'ReplicaSet',
+    'Pod',
+    'Secret',
+    'ConfigMap',
+    'Job',
+  ];
   const resourcesToGet =
     providedAPI?.resources ??
     (defaultResources.map((kind) => ({


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4886
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The details page of an operator resource does not include `Job` as part of it's list of workloads in the resources page.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Include `Job` in the resources tab in the details page, and the resources tab in the topology sidebar.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![tmp0](https://user-images.githubusercontent.com/20013884/109985534-dde80180-7d2a-11eb-90e7-8bcff9858696.png)
![tmp1](https://user-images.githubusercontent.com/20013884/109985572-e80a0000-7d2a-11eb-8049-fab0c4c622b1.png)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug