### PR TITLE
display full quick start prerequisites in quick search

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
@@ -22,25 +22,27 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
   prerequisites,
 }) => {
   const { t } = useTranslation();
+  const prereqs = prerequisites?.filter((p) => p);
   return (
     <>
       <Text component={TextVariants.p} className="oc-quick-start-tile-description">
         {description}
       </Text>
-      {prerequisites?.length > 0 && (
+      {prereqs?.length > 0 && (
         <div className="co-quick-start-tile-prerequisites">
           <Text component={TextVariants.h5} className="co-quick-start-tile-prerequisites__text">
             {t('quickstart~Prerequisites ({{totalPrereqs}})', {
-              totalPrereqs: prerequisites.length,
+              totalPrereqs: prereqs.length,
             })}{' '}
           </Text>
           <Popover
-            aria-label="Prerequisites"
-            headerContent={<Text component={TextVariants.h5}>{t('quickstart~Prerequisites')}</Text>}
+            aria-label={t('quickstart~Prerequisites')}
+            headerContent={t('quickstart~Prerequisites')}
             bodyContent={
-              <TextList aria-label="Prerequisites">
-                {prerequisites.map((prerequisite, index) => (
-                  <TextListItem key={index}>{prerequisite}</TextListItem> // eslint-disable-line react/no-array-index-key
+              <TextList aria-label={t('quickstart~Prerequisites')}>
+                {prereqs.map((prerequisite, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <TextListItem key={index}>{prerequisite}</TextListItem>
                 ))}
               </TextList>
             }

--- a/frontend/packages/topology/locales/en/topology.json
+++ b/frontend/packages/topology/locales/en/topology.json
@@ -63,6 +63,8 @@
   "Provided by {{provider}}": "Provided by {{provider}}",
   "Quick search list": "Quick search list",
   "Quick search": "Quick search",
+  "Prerequisites": "Prerequisites",
+  "Start": "Start",
   "Visual connector": "Visual connector",
   "Binding connector": "Binding connector",
   "Traffic connector": "Traffic connector",

--- a/frontend/packages/topology/src/components/quick-search/QuickSearch.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearch.tsx
@@ -3,12 +3,9 @@ import CatalogServiceProvider, {
   CatalogService,
 } from '@console/dev-console/src/components/catalog/service/CatalogServiceProvider';
 import QuickStartsLoader from '@console/app/src/components/quick-starts/loader/QuickStartsLoader';
+import { QuickStart } from '@console/app/src/components/quick-starts/utils/quick-start-types';
 import QuickSearchController from './QuickSearchController';
-import {
-  QuickStartContext,
-  QuickStartContextValues,
-} from '@console/app/src/components/quick-starts/utils/quick-start-context';
-import { getTransformedQuickStarts } from './utils/quick-search-utils';
+import { useTransformedQuickStarts } from './utils/quick-search-utils';
 import { QuickSearchProviders } from './utils/quick-search-types';
 
 interface QuickSearchProps {
@@ -16,45 +13,56 @@ interface QuickSearchProps {
   viewContainer?: HTMLElement;
 }
 
+const Contents: React.FC<{
+  quickStarts: QuickStart[];
+  quickStartsLoaded: boolean;
+  catalogService: CatalogService;
+} & QuickSearchProps> = ({
+  quickStarts,
+  quickStartsLoaded,
+  catalogService,
+  namespace,
+  viewContainer,
+}) => {
+  const quickStartItems = useTransformedQuickStarts(quickStarts);
+  const quickSearchProviders: QuickSearchProviders = [
+    {
+      catalogType: 'devCatalog',
+      items: catalogService.items,
+      loaded: catalogService.loaded,
+      getCatalogURL: (searchTerm: string, ns: string) => `/catalog/ns/${ns}?keyword=${searchTerm}`,
+      // t('topology~View all developer catalog items ({{itemCount, number}})')
+      catalogLinkLabel: 'topology~View all developer catalog items ({{itemCount, number}})',
+    },
+    {
+      catalogType: 'quickStarts',
+      items: quickStartItems,
+      loaded: quickStartsLoaded,
+      getCatalogURL: (searchTerm: string) => `/quickstart?keyword=${searchTerm}`,
+      // t('topology~View all quick starts ({{itemCount, number}})'
+      catalogLinkLabel: 'topology~View all quick starts ({{itemCount, number}})',
+    },
+  ];
+  return (
+    <QuickSearchController
+      quickSearchProviders={quickSearchProviders}
+      allItemsLoaded={catalogService.loaded && quickStartsLoaded}
+      namespace={namespace}
+      viewContainer={viewContainer}
+    />
+  );
+};
+
 const QuickSearch: React.FC<QuickSearchProps> = ({ namespace, viewContainer }) => {
-  const { setActiveQuickStart } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <CatalogServiceProvider namespace={namespace}>
       {(catalogService: CatalogService) => (
         <QuickStartsLoader>
-          {(quickStarts, qsLoaded) => {
-            const quickStartItems = qsLoaded
-              ? getTransformedQuickStarts(quickStarts, setActiveQuickStart)
-              : [];
-            const quickSearchProviders: QuickSearchProviders = [
-              {
-                catalogType: 'devCatalog',
-                items: catalogService.items,
-                loaded: catalogService.loaded,
-                getCatalogURL: (searchTerm: string, ns: string) =>
-                  `/catalog/ns/${ns}?keyword=${searchTerm}`,
-                // t('topology~View all developer catalog items ({{itemCount, number}})')
-                catalogLinkLabel:
-                  'topology~View all developer catalog items ({{itemCount, number}})',
-              },
-              {
-                catalogType: 'quickStarts',
-                items: quickStartItems,
-                loaded: qsLoaded,
-                getCatalogURL: (searchTerm: string) => `/quickstart?keyword=${searchTerm}`,
-                // t('topology~View all quick starts ({{itemCount, number}})'
-                catalogLinkLabel: 'topology~View all quick starts ({{itemCount, number}})',
-              },
-            ];
-            return (
-              <QuickSearchController
-                quickSearchProviders={quickSearchProviders}
-                allItemsLoaded={catalogService.loaded && qsLoaded}
-                namespace={namespace}
-                viewContainer={viewContainer}
-              />
-            );
-          }}
+          {(quickStarts, quickStartsLoaded) => (
+            <Contents
+              {...{ namespace, viewContainer, catalogService, quickStarts, quickStartsLoaded }}
+            />
+          )}
         </QuickStartsLoader>
       )}
     </CatalogServiceProvider>

--- a/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
+++ b/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
@@ -1,36 +1,55 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TextList, TextListItem } from '@patternfly/react-core';
 import { CatalogItem } from '@console/plugin-sdk';
 import { keywordCompare } from '@console/dev-console/src/components/catalog/utils/catalog-utils';
 import { QuickStart } from '@console/app/src/components/quick-starts/utils/quick-start-types';
-import QuickStartTileDescription from '@console/app/src/components/quick-starts/catalog/QuickStartTileDescription';
+import {
+  QuickStartContext,
+  QuickStartContextValues,
+} from '@console/app/src/components/quick-starts/utils/quick-start-context';
 
 export const quickSearch = (items: CatalogItem[], query: string) => {
   return items.filter((item) => keywordCompare(query, item));
 };
 
-export const getTransformedQuickStarts = (
-  quickStarts: QuickStart[],
-  setActiveQuickStart: (quickStartId: string, totalTasks?: number) => void,
-): CatalogItem[] => {
-  return quickStarts.map((qs: QuickStart) => {
-    const description = (
-      <QuickStartTileDescription
-        description={qs.spec.description}
-        prerequisites={qs.spec.prerequisites}
-      />
-    );
-    return {
-      name: qs.spec.displayName,
-      type: 'Quick Start',
-      uid: qs.metadata.uid,
-      cta: {
-        callback: () => setActiveQuickStart(qs.metadata.name, qs.spec.tasks?.length),
-        label: 'Start',
-      },
-      icon: {
-        url: qs.spec.icon,
-      },
-      description,
-    };
-  });
+export const useTransformedQuickStarts = (quickStarts: QuickStart[]): CatalogItem[] => {
+  const { setActiveQuickStart } = React.useContext<QuickStartContextValues>(QuickStartContext);
+  const { t } = useTranslation();
+  return React.useMemo(
+    () =>
+      quickStarts.map((qs: QuickStart) => {
+        const prerequisites = qs.spec.prerequisites?.filter((p) => p);
+        const description = (
+          <>
+            <p>{qs.spec.description}</p>
+            {prerequisites?.length > 0 && (
+              <>
+                <h5>{t('topology~Prerequisites')}</h5>
+                <TextList>
+                  {prerequisites.map((prerequisite, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <TextListItem key={index}>{prerequisite}</TextListItem>
+                  ))}
+                </TextList>
+              </>
+            )}
+          </>
+        );
+        return {
+          name: qs.spec.displayName,
+          type: 'Quick Start',
+          uid: qs.metadata.uid,
+          cta: {
+            callback: () => setActiveQuickStart(qs.metadata.name, qs.spec.tasks?.length),
+            label: t('topology~Start'),
+          },
+          icon: {
+            url: qs.spec.icon,
+          },
+          description,
+        };
+      }),
+    [t, quickStarts, setActiveQuickStart],
+  );
 };


### PR DESCRIPTION
**Analysis / Root cause**: 
Reusing the quick starts tile contents component in the quick search hides the prerequisites in a popover even though there is ample room to display them.

also fixes: https://issues.redhat.com/browse/ODC-5557

**Solution Description**: 
Created a new simple component which displays the full prerequisites list in the quick search content area.
Fixed missing localization.
Also filtered the prerequisites list incase a quick search provides a list of empty prerequisites. 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Before:
![image](https://user-images.githubusercontent.com/14068621/110015345-c0e30c80-7cf1-11eb-8e70-a3eaf76d9d55.png)

After:
![image](https://user-images.githubusercontent.com/14068621/110015297-b45eb400-7cf1-11eb-8c2d-f9d189525ce5.png)

cc @openshift/team-devconsole-ux 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge