### PR TITLE
Install Web Terminal Operator

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/web-terminal/web-Terminal-adminuser.feature
+++ b/frontend/packages/dev-console/integration-tests/features/web-terminal/web-Terminal-adminuser.feature
@@ -1,22 +1,23 @@
+@web-terminal
 Feature: Web Terminal for Admin user
-    As a user with admin rights, I should be able to use web terminal
+              As a user with admin rights, I should be able to use web terminal
 
 
-Background:
-    Given user has logged in as admin user
-    And user has installed Web Terminal operator
-    And user is at developer perspective
+        Background:
+            Given user has logged in as admin user
+              And user has installed Web Terminal operator
+              And user is at developer perspective
 
 
-@regression, @smoke
-Scenario: Create new project and use Web Terminal
-    Given user can see terminal icon on masthead
-    When user clicks on the Web Terminal icon on the Masthead
-    Then user will see the terminal window for namespace "openshift-terminal"
+        @regression, @smoke
+        Scenario: Create new project and use Web Terminal
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+             Then user will see the terminal window for namespace "openshift-terminal"
 
 
-@regression, @smoke
-Scenario: Open Web Terminal for existing project
-    Given user can see terminal icon on masthead
-    When user clicks on the Web Terminal icon on the Masthead
-    Then user will see the terminal window for namespace "openshift-terminal"
+        @regression, @smoke
+        Scenario: Open Web Terminal for existing project
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+             Then user will see the terminal window for namespace "openshift-terminal"

--- a/frontend/packages/dev-console/integration-tests/features/web-terminal/web-Terminal-devuser.feature
+++ b/frontend/packages/dev-console/integration-tests/features/web-terminal/web-Terminal-devuser.feature
@@ -1,26 +1,27 @@
+@web-terminal
 Feature: Web Terminal for Developer user
-    As a developer user, I should be able to use web terminal
+              As a developer user, I should be able to use web terminal
 
 
-Background:
-    Given user has logged in as basic user
-    And user has installed Web Terminal operator
-    And user is at developer perspective
+        Background:
+            Given user has logged in as basic user
+              And user has installed Web Terminal operator
+              And user is at developer perspective
 
 
-@regression
-Scenario: Create new project and use Web Terminal
-    Given user can see terminal icon on masthead
-    When user clicks on the Web Terminal icon on the Masthead
-    And user selects Create Project from Project drop down menu
-    And user enters project name "aut-terminal-testuser"
-    And user clicks on Submit button
-    Then user will see the terminal window for namespace "aut-terminal-testuser"
+        @regression
+        Scenario: Create new project and use Web Terminal
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+              And user selects Create Project from Project drop down menu
+              And user enters project name "aut-terminal-testuser"
+              And user clicks on Submit button
+             Then user will see the terminal window for namespace "aut-terminal-testuser"
 
 
-@regression
-Scenario: Open Web Terminal for existing project
-    Given user can see terminal icon on masthead
-    When user clicks on the Web Terminal icon on the Masthead
-    And user selects "aut-terminal-testuser" from Project drop down menu
-    Then user will see the terminal window for namespace "aut-terminal-testuser"
+        @regression
+        Scenario: Open Web Terminal for existing project
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+              And user selects "aut-terminal-testuser" from Project drop down menu
+             Then user will see the terminal window for namespace "aut-terminal-testuser"

--- a/frontend/packages/dev-console/integration-tests/features/web-terminal/web-teminal-basic.feature
+++ b/frontend/packages/dev-console/integration-tests/features/web-terminal/web-teminal-basic.feature
@@ -1,23 +1,24 @@
+@web-terminal
 Feature: Web Terminal
-    As a user, I should be able to use web terminal
+              As a user, I should be able to use web terminal
 
 
-Background:
-    Given user is at developer perspective
-    And user has installed Web Terminal operator
-    And user has selected namespace "aut-terminal-basic"
+        Background:
+            Given user has installed Web Terminal operator
+              And user is at developer perspective
+              And user has created or selected namespace "aut-terminal-basic"
 
 
-@regression, @smoke
-Scenario: Web Terminal window
-    Given user can see terminal icon on masthead
-    When user clicks on the Web Terminal icon on the Masthead
-    Then user will see the terminal window
+        @regression, @smoke
+        Scenario: Web Terminal window
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+             Then user will see the terminal window
 
 
-@regression
-Scenario: Web Terminal in new tab
-    Given user can see terminal icon on masthead
-    When user clicks on the Web Terminal icon on the Masthead
-    And user clicks on Open Terminal in new tab button on the terminal window
-    Then user will see the terminal window opened in new tab
+        @regression
+        Scenario: Web Terminal in new tab
+            Given user can see terminal icon on masthead
+             When user clicks on the Web Terminal icon on the Masthead
+              And user clicks on Open Terminal in new tab button on the terminal window
+             Then user will see the terminal window opened in new tab

--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -26,6 +26,7 @@ export enum operators {
   KnativeCamelOperator = 'Knative Apache Camel K',
   EclipseCheOperator = 'Eclipse Che',
   GitOpsOperator = 'GitOps',
+  WebTerminalOperator = 'Web Terminal',
 }
 
 export enum authenticationType {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
@@ -16,6 +16,7 @@ export const operatorsPO = {
     knativeCamelOperatorCard: '[data-test^="red-hat-camel-k"]',
     installingOperatorModal: '#operator-install-page',
     gitOpsOperatorCard: '[data-test^="openshift-gitops-operator"]',
+    webTerminalOperatorCard: '[data-test="web-terminal-redhat-operators-openshift-marketplace"]',
   },
   subscription: {
     logo: 'h1.co-clusterserviceversion-logo__name__clusterserviceversion',

--- a/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
@@ -78,6 +78,11 @@ export const operatorsPage = {
         cy.get(operatorsPO.operatorHub.gitOpsOperatorCard).click();
         break;
       }
+      case 'Web Terminal':
+      case operators.WebTerminalOperator: {
+        cy.get(operatorsPO.operatorHub.webTerminalOperatorCard).click();
+        break;
+      }
       default: {
         throw new Error('operator is not available');
       }

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/operators.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/operators.ts
@@ -1,12 +1,27 @@
 import { Given } from 'cypress-cucumber-preprocessor/steps';
 import { nav } from '../../../../../integration-tests-cypress/views/nav';
-import { switchPerspective } from '../../constants/global';
-import { adminNavigationMenu, perspectiveName } from '../../constants/staticText/global-text';
+import { operators, switchPerspective } from '../../constants/global';
+import { perspectiveName } from '../../constants/staticText/global-text';
 import { perspective } from '../../pages/app';
 import { operatorsPage } from '../../pages/operators-page';
+import { operatorsPO } from '@console/dev-console/integration-tests/support/pageObjects/operators-po';
+import { installOperator } from '@console/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster';
 
-Given('user has installed OpenShift Serverless Operator', () => {
+Given('user has installed Web Terminal operator', () => {
   perspective.switchTo(switchPerspective.Administrator);
   nav.sidenav.switcher.shouldHaveText(perspectiveName.administrator);
-  operatorsPage.verifyOperatorInNavigationMenu(adminNavigationMenu.serverless);
+  operatorsPage.navigateToInstallOperatorsPage();
+  cy.get(operatorsPO.installOperators.search)
+    .should('be.visible')
+    .clear()
+    .type(operators.WebTerminalOperator);
+  cy.get('body', {
+    timeout: 50000,
+  }).then(($ele) => {
+    if ($ele.find(operatorsPO.installOperators.noOperatorsFound)) {
+      installOperator(operators.WebTerminalOperator);
+    } else {
+      cy.log('Serverless operator is installed in cluster');
+    }
+  });
 });


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/ODC-5572

Problem: Automation to install Web Terminal Operator

Solution: This script will only install the Web Terminal Operator

Test Setup:
1. Run yarn run test-cypress-devconsole in frontend
2. Execute feature file: console/frontend/packages/dev-console/integration-tests/features/web-terminal/web-teminal-basic.feature

(_**Note: Other steps and scenarios are not automated yet. This script will complete the background needed which is to install the operator.**_)

![Screenshot from 2021-03-08 11-47-55](https://user-images.githubusercontent.com/17041173/110282902-48d45980-8005-11eb-8f8d-25c827c3876b.png)
