### PR TITLE
Bug 1928319: Stretch cluster installed on 6 storage node cluster with 2 LSO devices on each storage node fails to utilize 8 LSO devices

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
@@ -61,6 +61,7 @@ const createCluster = async (
     selectedArbiterZone,
     stretchClusterChecked,
     enableTaint,
+    availablePvsCount,
   },
   setInProgress,
   flagDispatcher,
@@ -82,6 +83,7 @@ const createCluster = async (
       kms.hasHandled && encryption.advanced,
       selectedArbiterZone,
       stretchClusterChecked,
+      availablePvsCount,
     );
     const promises: Promise<K8sResourceKind>[] = [...labelNodes(nodes), labelOCSNamespace()];
     if (encryption.advanced && kms.hasHandled) {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/reducer.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/reducer.ts
@@ -69,6 +69,7 @@ export const initialState: State = {
     clientCertFile: '',
     clientKeyFile: '',
   },
+  availablePvsCount: 0,
   networkType: NetworkType.DEFAULT,
   clusterNetwork: '',
   publicNetwork: '',
@@ -106,6 +107,7 @@ export type State = {
   storageClass: StorageClassResourceKind;
   nodes: NodeKind[];
   enableTaint: boolean;
+  availablePvsCount: number;
   // Encryption state declare
   encryption: EncryptionType;
   kms: KMSConfig;
@@ -147,6 +149,7 @@ export type Action =
   | { type: 'setStorageClass'; value: StorageClassResourceKind }
   | { type: 'setNodes'; value: NodeKind[] }
   | { type: 'setEnableTaint'; value: boolean }
+  | { type: 'setAvailablePvsCount'; value: number }
   // Encryption state actions
   | { type: 'setEncryption'; value: EncryptionType }
   | { type: 'setKmsEncryption'; value: KMSConfig }
@@ -214,6 +217,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { nodes: action.value });
     case 'setEnableTaint':
       return Object.assign({}, state, { enableTaint: action.value });
+    case 'setAvailablePvsCount':
+      return Object.assign({}, state, { availablePvsCount: action.value });
     // Encryption state reducer
     case 'setEncryption':
       return Object.assign({}, state, { encryption: action.value });

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { StorageClassResourceKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { humanizeBinaryBytes } from '@console/internal/components/utils/';
 import { getName } from '@console/shared';
-import { pvResource } from '../../resources';
 import { calcPVsCapacity, getSCAvailablePVs } from '../../selectors';
 import '../modals/add-capacity-modal/add-capacity-modal.scss';
 import './pvs-available-capacity.scss';
@@ -12,10 +10,12 @@ import './pvs-available-capacity.scss';
 export const PVsAvailableCapacity: React.FC<PVAvaialbleCapacityProps> = ({
   replica,
   storageClass,
+  data,
+  loaded,
+  loadError,
 }) => {
   const { t } = useTranslation();
 
-  const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>(pvResource);
   let availableCapacity: string = '';
 
   let availableStatusElement = (
@@ -52,4 +52,7 @@ export const PVsAvailableCapacity: React.FC<PVAvaialbleCapacityProps> = ({
 type PVAvaialbleCapacityProps = {
   replica: number;
   storageClass: StorageClassResourceKind;
+  data: K8sResourceKind[];
+  loaded: boolean;
+  loadError: any;
 };

--- a/frontend/packages/ceph-storage-plugin/src/constants/common.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/common.ts
@@ -16,6 +16,7 @@ export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';
 export const OCS_SUPPORT_ANNOTATION = 'features.ocs.openshift.io/enabled';
 export const OCS_DEVICE_SET_REPLICA = 3;
 export const OCS_DEVICE_SET_ARBITER_REPLICA = 4;
+export const OCS_DEVICE_SET_FLEXIBLE_REPLICA = 1;
 export const ATTACHED_DEVICES_ANNOTATION = 'cluster.ocs.openshift.io/local-devices';
 export const DASHBOARD_LINK = '/dashboards/persistent-storage';
 export const AVAILABLE = 'Available';


### PR DESCRIPTION
**Earlier:**
Irrespective of the number of available-storage-devices (attached to the nodes), storage cluster after the creation was only utilising: 
4 devices (in case of arbiter), 
3 devices (in case of flexible scaling) and 
3 devices (in case of normal deployment).

**After:**
For all attached-device mode deployments, created storage cluster will utilise all possible available-storage-devices.
For example: 
storage devices available = 10; then, storage cluster after the creation will utilise: 
8 devices (in case of arbiter), 
10 devices (in case of flexible scaling) and 
9 devices (in case of normal deployment).

The same functionality/behaviour will be used for add capacity as well.