### PR TITLE
truncate select task text to prevent overlap with the dropdown icon

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -31,7 +31,7 @@ interface TaskProps {
   status?: TaskStatus;
   namespace: string;
   isPipelineRun: boolean;
-  disableTooltip?: boolean;
+  disableVisualizationTooltip?: boolean;
   selected?: boolean;
   width: number;
   height: number;
@@ -89,7 +89,7 @@ export const PipelineVisualizationTask: React.FC<PipelineVisualizationTaskProp> 
       namespace={namespace}
       status={taskStatus}
       isPipelineRun={!!pipelineRunStatus}
-      disableTooltip={disableTooltip}
+      disableVisualizationTooltip={disableTooltip}
       selected={selected}
       width={width}
       height={height}
@@ -128,7 +128,7 @@ const TaskComponent: React.FC<TaskProps> = ({
   status,
   name,
   isPipelineRun,
-  disableTooltip,
+  disableVisualizationTooltip,
   selected,
   width,
   height,
@@ -153,6 +153,19 @@ const TaskComponent: React.FC<TaskProps> = ({
     [visualName, showStatusState],
   );
 
+  const renderVisualName = (
+    <text
+      x={showStatusState ? 30 : width / 2}
+      y={height / 2 + 1}
+      className={cx('odc-pipeline-vis-task-text', {
+        'is-text-center': !isPipelineRun,
+        'is-linked': enableLogLink,
+      })}
+    >
+      {truncatedVisualName}
+    </text>
+  );
+
   let taskPill = (
     <g ref={hoverRef}>
       <SvgDropShadowFilter dy={1} id={FILTER_ID} />
@@ -166,16 +179,12 @@ const TaskComponent: React.FC<TaskProps> = ({
           'is-linked': enableLogLink,
         })}
       />
-      <text
-        x={showStatusState ? 30 : width / 2}
-        y={height / 2 + 1}
-        className={cx('odc-pipeline-vis-task-text', {
-          'is-text-center': !isPipelineRun,
-          'is-linked': enableLogLink,
-        })}
-      >
-        {truncatedVisualName}
-      </text>
+      {visualName !== truncatedVisualName && disableVisualizationTooltip ? (
+        <Tooltip content={visualName}>{renderVisualName}</Tooltip>
+      ) : (
+        renderVisualName
+      )}
+
       {isPipelineRun && showStatusState && (
         <g
           className={cx({
@@ -201,7 +210,7 @@ const TaskComponent: React.FC<TaskProps> = ({
       )}
     </g>
   );
-  if (!disableTooltip) {
+  if (!disableVisualizationTooltip) {
     taskPill = (
       <Tooltip
         position="bottom"

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import * as _ from 'lodash';
 import * as cx from 'classnames';
-import { FocusTrap } from '@patternfly/react-core';
+import { FocusTrap, Tooltip } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { useHover } from '@patternfly/react-topology';
 import Popper from '@console/shared/src/components/popper/Popper';
@@ -50,12 +50,20 @@ const TaskList: React.FC<any> = ({
     listOptions.map((task) => taskToOption(task, onNewTask)),
     (o) => o.label,
   );
+  const unselectedTaskText = unselectedText || t('pipelines-plugin~Select Task');
 
-  const unselectedTaskText = React.useMemo(
+  const truncatedTaskText = React.useMemo(
     () =>
-      truncateMiddle(unselectedText, { length: 10, truncateEnd: true }) ||
-      t('pipelines-plugin~Select Task'),
-    [unselectedText, t],
+      truncateMiddle(unselectedTaskText, {
+        length: 10,
+        truncateEnd: true,
+      }),
+    [unselectedTaskText],
+  );
+  const renderText = (
+    <text x={width / 2 - 10} y={height / 2 + 1}>
+      {truncatedTaskText}
+    </text>
   );
 
   return (
@@ -89,9 +97,11 @@ const TaskList: React.FC<any> = ({
               width={width}
               height={hover ? 2 : 1}
             />
-            <text x={width / 2 - 10} y={height / 2 + 1}>
-              {unselectedTaskText}
-            </text>
+            {unselectedTaskText !== truncatedTaskText ? (
+              <Tooltip content={unselectedTaskText}>{renderText}</Tooltip>
+            ) : (
+              renderText
+            )}
             <g transform={`translate(${width - 30}, ${height / 4})`}>
               <CaretDownIcon />
             </g>


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5558

**Root analysis:**
Because of localization, the text overlaps with the dropdown icon.

**Solution description:**
- added  ellipsis to localized `Select Task` text
- show tooltip only when an ellipsis is present

**GIF:**
![selecttask](https://user-images.githubusercontent.com/22490998/110914230-19428b80-833c-11eb-8ceb-9f99115bb5d1.gif)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge