### PR TITLE
Fix to show correct internal image-stream name in container image edit flow's internal registry image-stream dropdown for kn service

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -25,7 +25,7 @@ import {
 } from '../../utils/resource-label-utils';
 import { createRoute, createService, dryRunOpt } from '../../utils/shared-submit-utils';
 import { getProbesData } from '../health-checks/create-health-checks-probe-utils';
-import { RegistryType, getRuntime } from '../../utils/imagestream-utils';
+import { RegistryType } from '../../utils/imagestream-utils';
 import { AppResources } from '../edit-application/edit-application-types';
 import { DeployImageFormData, Resources } from './import-types';
 
@@ -366,7 +366,6 @@ export const createOrUpdateDeployImageResources = async (
       triggers: { image: imageChange },
     },
   } = formData;
-  const internalImageName = getRuntime(image.metadata?.labels);
   const requests: Promise<K8sResourceKind>[] = [];
 
   const imageStreamList = appResources?.imageStream?.data;
@@ -454,7 +453,7 @@ export const createOrUpdateDeployImageResources = async (
     const knDeploymentResource = getKnativeServiceDepResource(
       formData,
       imageStreamUrl,
-      internalImageName || name,
+      internalImageStreamName || name,
       imageStreamTag,
       internalImageStreamNamespace,
       annotations,

--- a/frontend/packages/dev-console/src/utils/imagestream-utils.ts
+++ b/frontend/packages/dev-console/src/utils/imagestream-utils.ts
@@ -40,9 +40,6 @@ export interface NormalizedBuilderImages {
 
 export const imageStreamLabels = ['app.kubernetes.io/name', 'app.openshift.io/runtime'];
 
-export const getRuntime = (labels: { [key: string]: string }) =>
-  labels?.['app.openshift.io/runtime'] || labels?.['app.kubernetes.io/name'];
-
 export const getSampleRepo = (tag) => tag?.annotations?.sampleRepo ?? '';
 export const getSampleRef = (tag) => tag?.annotations?.sampleRef ?? '';
 export const getSampleContextDir = (tag) => tag?.annotations?.sampleContextDir ?? '';


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-5607

**Analysis/Root cause:**
When support for selecting the runtime icon from the runtime icon dropdown was added to the edit flows the previous code for showing runtime icon for deployments created on creating an app using container image flow's internal registry option was not properly cleaned up for knative service resource. Label 'app.kubernetes.io/name' which is used for getting the internal imagestream name is set incorrectly with runtime icon name instead of the imagestream name for knative service resource.

**Solution:**
Clean up previous code for showing runtime icon for kn services created using internal registry option. Set value of lablel 'app.kubernetes.io/name' as internal image-stream name instead of runtime icon name for kn service.

**GIf:**
![Peek 2021-03-09 16-36](https://user-images.githubusercontent.com/20724543/110460912-cfb42f80-80f4-11eb-959e-7a0ad9575424.gif)

/kind bug