### PR TITLE
Rework terminal to check if the operator is installed before showing the terminal button

### DIFF
--- a/pkg/terminal/operator.go
+++ b/pkg/terminal/operator.go
@@ -5,17 +5,34 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-const (
-	webhookName = "controller.devfile.io"
+var (
+	OperatorAPIResource = &schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "subscriptions",
+	}
+
+	OperatorGroupVersion = &schema.GroupVersion{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+	}
 )
 
-// workspaceOperatorIsRunning checks if the workspace operator is running and webhooks are enabled,
+const (
+	webhookName             = "controller.devfile.io"
+	webTerminalOperatorName = "web-terminal"
+	operatorsNamespace      = "openshift-operators"
+)
+
+// checkWebTerminalOperatorIsRunning checks if the workspace operator is running and webhooks are enabled,
 // which is a prerequisite for sending a user's token to a workspace.
-func workspaceOperatorIsRunning() (bool, error) {
+func checkWebTerminalOperatorIsRunning() (bool, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return false, err
@@ -40,5 +57,33 @@ func workspaceOperatorIsRunning() (bool, error) {
 		}
 		return false, err
 	}
+	return true, nil
+}
+
+// checkWebTerminalOperatorIsInstalled checks to see that a web-terminal-operator is installed on the cluster
+func checkWebTerminalOperatorIsInstalled() (bool, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return false, err
+	}
+
+	config.GroupVersion = OperatorGroupVersion
+	config.APIPath = "apis"
+
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = client.Resource(*OperatorAPIResource).Namespace(operatorsNamespace).Get(context.TODO(), webTerminalOperatorName, metav1.GetOptions{})
+	if err != nil {
+		// Web Terminal subscription is not found but it's technically not a real error so we don't want to propogate it. Just say that the operator is not installed
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
 	return true, nil
 }


### PR DESCRIPTION
This PR reworks the terminal availability check to make sure that the web terminal operator is installed before showing the terminal button. Right now, the check only consists of making sure that specific webhookconfigurations are available on the cluster. This approach works fine right now. However, in the future, the web terminal operator will depend on the devworkspace-operator (devworkspace-operator will provide most of the actual functionality), and we don't want to show the web terminal button when the devworkspace-operator is installed but the web-terminal operator isn't.

Related issue: https://issues.redhat.com/browse/WTO-20
Related PR: https://github.com/openshift/console-operator/pull/513

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>