### PR TITLE
Fix @console/active-plugins generation interfering with i18n

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
@@ -134,12 +134,12 @@ export const getDynamicExtensions = (
     ext.data,
     (key, value) =>
       isEncodedCodeRef(value)
-        ? `%${codeRefTransformer(
+        ? `@${codeRefTransformer(
             getExecutableCodeRefSource(value, key, pkg, codeRefValidationResult),
-          )}%`
+          )}@`
         : value,
     2,
-  ).replace(/"%(.*)%"/g, '$1');
+  ).replace(/"@(.*)@"/g, '$1');
 
   if (codeRefValidationResult.hasErrors()) {
     errorCallback(codeRefValidationResult.formatErrors());


### PR DESCRIPTION
This fixes the issue where having `"%foo%"` strings inside the `console-extensions.json` file would cause unexpected transformation of such strings to `foo`.