### PR TITLE
Open link configured with OLM x-descriptors:urn:alm:descriptor:org.w3:link in new window/tab

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -69,7 +69,9 @@ const Link: React.FC<StatusCapabilityProps> = ({ description, fullPath, label, o
   return (
     <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
       {!_.isNil(value) ? (
-        <a href={value}>{value.replace(/https?:\/\//, '')}</a>
+        <a href={value} rel="noopener noreferrer" target="_blank">
+          {value.replace(/https?:\/\//, '')}
+        </a>
       ) : (
         <span className="text-muted">{t('public~None')}</span>
       )}


### PR DESCRIPTION
It would be prefer to open link configured with following OLM descriptor in new window/tab as users always lives Console application in case of click on the Link
