### PR TITLE
ODC-5698 - knative smoke test cases

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/staticText/global-text.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/staticText/global-text.ts
@@ -13,5 +13,6 @@ export const messages = {
     privateGitRepoMessage:
       'URL is valid but cannot be reached. If this is a private repository, enter a source Secret in advanced Git options',
     rateLimitExceeded: 'Rate limit exceeded',
+    unableToDetectBuilderImage: 'Unable to detect the Builder Image.',
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
@@ -31,4 +31,6 @@ export enum nodeActions {
   AddSubscription = 'Add Subscription',
   EditInMemoryChannel = 'Edit InMemoryChannel',
   DeleteInMemoryChannel = 'Delete InMemoryChannel',
+  EditRevision = 'Edit Revision',
+  DeleteRevision = 'Delete Revision',
 }

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -198,11 +198,10 @@ export const gitPage = {
         $body
           .find(gitPO.gitSection.validatedMessage)
           .text()
-          .includes(messages.addFlow.rateLimitExceeded)
+          .includes(messages.addFlow.rateLimitExceeded) ||
+        $body.find('[aria-label="Warning Alert"]').length
       ) {
         gitPage.selectBuilderImageForGitUrl(gitUrl);
-      } else {
-        cy.log(`git url validated`);
       }
     });
   },

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -30,7 +30,11 @@ export const perspective = {
     nav.sidenav.switcher.changePerspectiveTo(perspectiveName);
     app.waitForLoad();
     if (switchPerspective.Developer) {
+      // Bug: 1890676 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
+      // cy.testA11y('Developer perspective with guider tour modal');
       guidedTour.close();
+      // Bug: 1890678 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
+      // cy.testA11y('Developer perspective');
     }
     nav.sidenav.switcher.shouldHaveText(perspectiveName);
   },

--- a/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/modal.ts
@@ -61,9 +61,14 @@ export const setTrafficDistribution = {
       .get('form [type="button"]')
       .contains('Add')
       .click(),
-  enterSplit: (split: string) => cy.get('#form-input-trafficSplitting-0-percent-field').type(split),
+  enterSplit: (split: string) =>
+    cy
+      .get('[id$="percent-field"]')
+      .last()
+      .clear()
+      .type(split),
   selectRevision: (revisionName: string) => {
-    cy.get('#form-dropdown-trafficSplitting-0-revisionName-field').click();
+    cy.get('[id$="revisionName-field"]').click();
     cy.get(`[data-test-dropdown-menu^="${revisionName}"]`).click();
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/operators-page.ts
@@ -61,7 +61,6 @@ export const operatorsPage = {
   },
 
   selectOperator: (opt: operators | string) => {
-    operatorsPage.selectSourceType('redHat');
     switch (opt) {
       case 'OpenShift Pipelines Operator':
       case operators.PipelinesOperator: {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
@@ -41,9 +41,9 @@ When('user selects resource type as {string}', (resourceType: string) => {
 });
 
 Then(
-  'created workload {string} is linked to existing application {string}',
+  'user can see the created workload {string} is linked to existing application {string}',
   (workloadName: string, appName: string) => {
-    topologyPage.appNode(appName).click({ force: true });
+    topologyPage.getAppNode(appName).click({ force: true });
     topologySidePane.verifyResource(workloadName);
   },
 );

--- a/frontend/packages/knative-plugin/integration-tests/cypress.json
+++ b/frontend/packages/knative-plugin/integration-tests/cypress.json
@@ -23,7 +23,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "@knative-eventing and @smoke and not @manual and not @to-do",
+    "TAGS": "@smoke and not @manual and not @to-do",
     "NAMESPACE": "aut-pipelines"
   },
   "retries": {

--- a/frontend/packages/knative-plugin/integration-tests/features/knative/actions-on-knative-revision.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/knative/actions-on-knative-revision.feature
@@ -4,21 +4,14 @@ Feature: Perform actions on knative revision
 
         Background:
             Given user has created or selected namespace "aut-knative-actions-revision"
-              And user has created or selected knative service "nodejs-ex-git-2"
+              And user has created knative revision with knative service "nodejs-ex-git-2"
               And user is at the Topology page
 
 
-        @regression
+        @smoke
         Scenario: Context menu for knative Revision: Kn-03-TC01
              When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
              Then user is able to see Edit Labels, Edit Annotations, Edit Revision, Delete Revision options in context menu
-
-
-        @regression
-        Scenario: Edit labels modal details : Kn-03-TC02
-             When user selects "Edit Labels" option from knative revision context menu
-             Then modal with "Edit Labels" appears
-              And save button is disabled
 
 
         @regression
@@ -26,38 +19,31 @@ Feature: Perform actions on knative revision
              When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
               And user selects "Edit Labels" option from knative revision context menu
               And user adds the label "app=label" to existing labels list in Edit Labels modal
-              And user clicks the save button on the "Edit Labels" modal
+              And user clicks on Save button
              Then user can see the label "app-label" in the Details tab of the Sidebar of "nodejs-ex-git-2"
 
 
         @regression
         Scenario: Remove label from knative Revision: Kn-03-TC04
-             When user selects "Edit Labels" option from knative revision context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+              And user selects "Edit Labels" option from knative revision context menu
               And user removes the label "app=label" from existing labels list in "Edit Labels" modal
-              And user clicks the save button on the "Edit Labels" modal
+              And user clicks on Save button
              Then user will not see the label "app-label" in the Details tab of the Sidebar of "nodejs-ex-git-2"
 
 
         @regression
         Scenario: Add labels to existing labels list and cancel the activity : Kn-03-TC05
-             When user selects "Edit Labels" option from knative revision context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+              And user selects "Edit Labels" option from knative revision context menu
               And user adds the label "app=label" to existing labels list in Edit Labels modal
               And user clicks cancel button on the "Edit Labels" modal
              Then user will not see the label "app-label" in the Details tab of the Sidebar of "nodejs-ex-git-2"
 
 
         @regression
-        Scenario: Edit Annotation modal details : Kn-03-TC06
-             When user selects "Edit Annotaions" option from knative revision context menu
-             Then modal with "Edit Annotations" appears
-              And key, value columns are displayed with respecitve text fields
-              And Add more link is enabled
-              And save button is disabled
-
-
-        @regression
         Scenario: Add annotation to the existing annonations list : Kn-03-TC07
-              And number of annotations are "5" present in revision side bar details of service "nodejs-ex-git-2"
+            Given number of annotations are "5" present in revision side bar details of service "nodejs-ex-git-2"
              When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
               And user selects "Edit Annotaions" option from knative revision context menu
               And user clicks Add button on the Edit Annotaions modal
@@ -69,6 +55,8 @@ Feature: Perform actions on knative revision
 
         @regression
         Scenario: perform cancel action on Edit Annotations : Kn-03-TC09
+            Given number of annotations are "5" present in revision side bar details of service "nodejs-ex-git-2"
+             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
               And number of annotations are "6" present in side bar - details tab- annotation section
              When user selects "Edit Annotations" option from knative revision context menu
               And user clicks on "remove" icon for the annotation with key "serving.knative.dev/creator" present in "Edit Annotaions" modal
@@ -78,6 +66,8 @@ Feature: Perform actions on knative revision
 
         @regression
         Scenario Outline: Remove annotation from existing annonations list : Kn-03-TC08
+            Given number of annotations are "5" present in revision side bar details of service "nodejs-ex-git-2"
+             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
               And number of annotations are "6" present in side bar - details tab
              When user selects "Edit Annotaions" option from knative revision context menu
               And user clicks on "remove" icon for the annotation with key "<key_name>" present in "Edit Annotaions" modal
@@ -91,7 +81,8 @@ Feature: Perform actions on knative revision
 
         @regression @manual
         Scenario: Edit revision details page : Kn-03-TC10
-             When user selects "Edit Revision" option from knative revision context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+              And user selects "Edit Revision" option from knative revision context menu
               And user clicks on Details tab
              Then details tab displayed with Revision Details and Conditions sections
               And Revision details contains fields like Name, Namespace, Labels, Annotations, Created At, Owner
@@ -99,33 +90,30 @@ Feature: Perform actions on knative revision
 
         @smoke @manual
         Scenario: Update the revision detials : Kn-03-TC11
-             When user selects "Edit Revision" option from knative revision context menu
+             When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
+              And user selects "Edit Revision" option from knative revision context menu
               And user modifies the Yaml file of the Revision details page
-              And user clicks "save" button on Revision Yaml page
+              And user clicks save button on Revision Yaml page
              Then the message display as "{revision name} has been updated to version {nnnnnn}"
               And another message display as "This object has been updated."
 
 
         @regression
         Scenario: Delete revision modal details for service with multiple revisions : Kn-03-TC13
-            Given service should contain multiple revisions
+            Given Knative service with multiple revisions
              When user selects "Delete Revision" option from knative revision context menu
              Then modal with "Update the traffic distribution among the remaining Revisions" appears
-              And modal should get closed on clicking OK button
 
 
         @regression
         Scenario: Delete revision for the service which contains multiple revisions : Kn-03-TC14
-            Given service should contain multiple revisions
+            Given Knative service with multiple revisions
              When user selects "Delete Revision" option from knative revision context menu
              Then modal with "Update the traffic distribution among the remaining Revisions" appears
-              And modal should get closed on clicking OK button
 
 
         @smoke
         Scenario: Delete Revision not possible for the service which contains one revision : Kn-03-TC12
              When user right clicks on the revision of knative service "nodejs-ex-git-2" to open the context menu
               And user selects "Delete Revision" option from knative revision context menu
-             Then modal with "Unable to delete revision" appears
-              And modal contains message as "You cannot delete the last Revision for the Service."
-              And modal should get closed on clicking OK button
+             Then user is able to see message "You cannot delete the last Revision for the Service." in modal with header "Unable to delete Revision"

--- a/frontend/packages/knative-plugin/integration-tests/features/knative/actions-on-knative-service.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/knative/actions-on-knative-service.feature
@@ -3,21 +3,22 @@ Feature: Perform actions on knative service
               As a user I want to perform edit or delete operations and Set Traffic Distribution on knative Service in topology page
 
         Background:
-            Given user has created or selected namespace "aut-create-knative-actions-service"
-              And user has created knative service "nodejs-ex-git"
+            Given user has created or selected namespace "aut-knative"
+              And user has created knative service "kn-service"
 
 
-        @regression
+        @smoke
         Scenario: knative service menu options: Kn-04-TC01
             Given user is at the Topology page
-             When user right clicks on the knative service "nodejs-ex-git"
-             Then user is able to see the options like Edit Application Grouping, Set Traffic Distribution, Edit Health Checks, Edit Labels, Edit Annotations, Edit Service, Delete Service, "nodejs-ex-git"
+             When user right clicks on the knative service "kn-service"
+             Then user is able to see the options like Edit Application Grouping, Set Traffic Distribution, Edit Health Checks, Edit Labels, Edit Annotations, Edit Service, Delete Service, Edit "kn-service"
 
 
         @regression
         Scenario: Edit labels modal details : Kn-04-TC02
             Given user is at the Topology page
-             When user selects "Edit Labels" context menu option of knative service "nodejs-ex-git"
+             When user right clicks on the knative service "kn-service"
+              And user selects "Edit labels" from context menu
              Then modal with "Edit labels" appears
               And save, cancel buttons are displayed
 
@@ -25,36 +26,37 @@ Feature: Perform actions on knative service
         @regression
         Scenario: Add label to the existing labels list : Kn-04-TC03
             Given user is at the Topology page
-             When user selects "Edit Labels" context menu option of knative service "nodejs-ex-git"
+             When user right clicks on the knative service "kn-service"
+              And user selects "Edit labels" from context menu
               And user adds the label "app=label" to existing labels list in Edit Labels modal
-              And user clicks the save button on the "Edit labels" modal
-             Then user will see the label "app=label" in "nodejs-ex-git" service side bar details
+              And user clicks on Save button
+             Then user will see the label "app=label" in "kn-service" service side bar details
 
 
         @regression
         Scenario: Remove label from existing labels list : Kn-04-TC04
             Given user is at the Topology page
-              And label "app=label" is added to the knative service "nodejs-ex-git"
-             When user selects "Edit Labels" context menu option of knative service "nodejs-ex-git"
+              And label "app=label" is added to the knative service "kn-service"
+             When user selects "Edit labels" context menu option of knative service "kn-service"
               And user removes the label "app=label" from existing labels list in "Edit labels" modal
               And user clicks the save button on the "Edit labels" modal
-             Then user will not see the label "app=label" in "nodejs-ex-git" service side bar details
+             Then user will not see the label "app=label" in "kn-service" service side bar details
 
 
         @regression
         Scenario: Add labels to existing labels list and cancel it : Kn-04-TC05
-            Given user has created another knative service "nodejs-ex-git-1"
+            Given user has created another knative service "kn-service-1"
               And user is at the Topology page
-             When user selects "Edit Labels" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Labels" context menu option of knative service "kn-service"
               And user adds the label "app=label" to existing labels list in Edit Labels modal
               And user clicks cancel button on the "Edit labels" modal
-             Then user will not see the label "app=label" in "nodejs-ex-git" service side bar details
+             Then user will not see the label "app=label" in "kn-service" service side bar details
 
 
         @regression
         Scenario: Edit Annotation modal details : Kn-04-TC11
             Given user is at the Topology page
-             When user selects "Edit Annotations" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Annotations" context menu option of knative service "kn-service"
              Then modal with "Edit annotations" appears
               And key, value columns are displayed with respecitve text fields
               And Add more link is enabled
@@ -64,29 +66,29 @@ Feature: Perform actions on knative service
         @regression
         Scenario: Add annotation to the existing annotations list : Kn-04-TC12
             Given user is at the Topology page
-              And number of annotations are "5" present in "nodejs-ex-git" service side bar details tab
-             When user selects "Edit Annotations" context menu option of knative service "nodejs-ex-git"
+              And number of annotations are "5" present in "kn-service" service side bar details tab
+             When user selects "Edit Annotations" context menu option of knative service "kn-service"
               And user clicks Add button on the Edit Annotations modal
               And user enters annotation key as "serving.knative.qe/creator "
               And user enters annotation value as "kube:admin"
               And user clicks the save button on the "Edit annotations" modal
-             Then number of Annotations increased to "6" in "nodejs-ex-git" service side bar details
+             Then number of Annotations increased to "6" in "kn-service" service side bar details
 
 
         Scenario: perform cancel action after Edit Annotations : Kn-04-TC14
             Given user is at the Topology page
-              And number of annotations are "5" present in "nodejs-ex-git" service side bar details tab
-             When user selects "Edit Annotations" context menu option of knative service "nodejs-ex-git"
+              And number of annotations are "5" present in "kn-service" service side bar details tab
+             When user selects "Edit Annotations" context menu option of knative service "kn-service"
               And user clicks on remove icon for the annotation with key "serving.knative.dev/creator" present in Edit Annotations modal
               And user clicks cancel button on the "Edit annotations" modal
-             Then number of Annotations display as "5" in "nodejs-ex-git" service side bar details
+             Then number of Annotations display as "5" in "kn-service" service side bar details
 
 
         @regression
         Scenario: Remove annotation from existing annotations list : Kn-04-TC13
             Given user is at the Topology page
               And number of annotations are "6" present in side bar - details tab
-             When user selects "Edit Annotations" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Annotations" context menu option of knative service "kn-service"
               And user clicks on remove icon for the annotation with key "serving.knative.dev/creator" present in Edit Annotations modal
               And user clicks the save button on the "Edit annotations" modal
              Then number of Annotations decreased to "5" in side bar details
@@ -95,7 +97,7 @@ Feature: Perform actions on knative service
         @regression
         Scenario: Edit the service from yaml editor: Kn-04-TC15
             Given user is at the Topology page
-             When user selects "Edit Service" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Service" context menu option of knative service "kn-service"
               And user modifies the Yaml file of the Service details page
               And user clicks save button on yaml page
              Then message should display as "{service name} has been updated to version {nnnnnn}"
@@ -104,9 +106,8 @@ Feature: Perform actions on knative service
 
         @regression
         Scenario: Update the service to different application group existing in same project : Kn-04-TC07
-            Given user has created a workload named "openshift-app"
-              And user is at the Topology page
-             When user selects "Edit Application Grouping" context menu option of knative service "nodejs-ex-git"
+            Given user is at the Topology page
+             When user selects "Edit Application Grouping" context menu option of knative service "kn-service"
               And user selects the "openshift-app" option from application drop down present in "Edit Application Grouping" modal
               And user clicks the save button on the "Edit Application Grouping" modal
               And user searches for application name "openshift-app"
@@ -116,7 +117,7 @@ Feature: Perform actions on knative service
 
         Scenario: Perform cancel operation while editing application group : Kn-04-TC08
             Given user is at the Topology page
-             When user selects "Edit Application Grouping" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Application Grouping" context menu option of knative service "kn-service"
               And user selects the "openshift-app" option from application drop down present in "Edit Application Grouping" modal
               And user clicks cancel button on the "Edit Application Grouping" modal
               And user searches for application name "openshift-app"
@@ -127,7 +128,7 @@ Feature: Perform actions on knative service
         @regression
         Scenario: Update the service to new application group : Kn-04-TC06
             Given user is at the Topology page
-             When user selects "Edit Application Grouping" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Application Grouping" context menu option of knative service "kn-service"
               And user selects the "openshift-app" option from application drop down present in "Edit Application Grouping" modal
               And user enters "openshift-app" into the Application Name text box
               And user clicks the save button on the "Edit Application Grouping" modal
@@ -138,45 +139,45 @@ Feature: Perform actions on knative service
 
         @regression
         Scenario: Set traffic distribution greater than 100% for the Revisions of the knative Service : Kn-04-TC17
-            Given user created another revision "nodejs-ex-git-1" for knative Service "nodejs-ex-git"
+            Given user created another revision "kn-service-1" for knative Service "kn-service"
               And user is at the Topology page
-             When user selects "Set Traffic Distribution" context menu option of knative service "nodejs-ex-git"
+             When user selects "Set traffic distribution" context menu option of knative service "kn-service"
               And user clicks on Add Revision button present in Set Traffic Distribution modal
               And user enters "50" into the Split text box of new revision
               And user selects another revision from Revision drop down
-              And user clicks the save button on the "Set Traffic Distribution" modal
+              And user clicks the save button on the "Set traffic distribution" modal
              Then error message displays as "validation failed: Traffic targets sum to 150, want 100: spec.traffic"
 
 
         @regression
         Scenario: Set traffic distribution less than 100% for the Revisions of the knative Service : Kn-04-TC18
-            Given user created another revision "nodejs-ex-git-1" for knative Service "nodejs-ex-git"
+            Given user created another revision "kn-service-1" for knative Service "kn-service"
               And user is at the Topology page
-             When user selects "Set Traffic Distribution" context menu option of knative service "nodejs-ex-git"
+             When user selects "Set traffic distribution" context menu option of knative service "kn-service"
               And user enters "25" into the Split text box of new revision
               And user clicks on Add Revision button present in Set Traffic Distribution modal
               And user enters "50" into the Split text box of new revision
               And user selects another revision from Revision drop down
-              And user clicks the save button on the "Set Traffic Distribution" modal
+              And user clicks the save button on the "Set traffic distribution" modal
              Then error message displays as "validation failed: Traffic targets sum to 75, want 100: spec.traffic"
 
 
-        @smoke
+        @regression
         Scenario: Set traffic distribution equal to 100% for the Revisions of the knative Service : Kn-04-TC19
-            Given user created another revision "nodejs-ex-git-1" for knative Service "nodejs-ex-git"
+            Given user created another revision "kn-service-1" for knative Service "kn-service"
               And user is at the Topology page
-             When user selects "Set Traffic Distribution" context menu option of knative service "nodejs-ex-git"
+             When user selects "Set traffic distribution" context menu option of knative service "kn-service"
               And user enters "50" into the Split text box of new revision
               And user clicks on Add Revision button present in Set Traffic Distribution modal
               And user enters "50" into the Split text box of new revision
               And user selects another revision from Revision drop down
-              And user clicks the save button on the "Set Traffic Distribution" modal
+              And user clicks the save button on the "Set traffic distribution" modal
              Then number of routes should get increased in side bar - resources tab - routes section
 
 
         Scenario: Perform cancel opeartion on Edit Health Checks for a service : Kn-04-TC10
             Given user is at the Topology page
-             When user selects "Edit Health Checks" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Health Checks" context menu option of knative service "kn-service"
               And user clicks cancel button on "Edit Health Checks" page
              Then user will be redirected to Topology page
 
@@ -184,12 +185,12 @@ Feature: Perform actions on knative service
         @regression
         Scenario: Edit Health Checks for a service: Kn-04-TC09
             Given user is at the Topology page
-             When user selects "Edit Health Checks" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit Health Checks" context menu option of knative service "kn-service"
 
 
         Scenario: Perform cancel opeartion on Edit NameOfWorkload for a service : Kn-04-TC21
             Given user is at the Topology page
-             When user selects "Edit nodejs-ex-git" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit kn-service" context menu option of knative service "kn-service"
               And user clicks cancel button on "Edit Service" page
              Then user will be redirected to Topology page
 
@@ -197,7 +198,7 @@ Feature: Perform actions on knative service
         @regression
         Scenario: Edit NameOfWorkload for a service [TBD] : Kn-04-TC20
             Given user is at the Topology page
-             When user selects "Edit nodejs-ex-git" context menu option of knative service "nodejs-ex-git"
+             When user selects "Edit kn-service" context menu option of knative service "kn-service"
               And user selects the "Application -1" option from Application drop down
               And user clicks save button on the Edit Service Page
 
@@ -205,7 +206,6 @@ Feature: Perform actions on knative service
         @smoke
         Scenario: Delete service : Kn-04-TC16
             Given user is at the Topology page
-             When user selects "Delete Service" context menu option of knative service "nodejs-ex-git"
-             Then modal with "Delete Service?" appears
-              And modal get closed on clicking Delete button
-              And "nodejs-ex-git" service should not be displayed in project
+             When user selects "Delete Service" context menu option of knative service "kn-service"
+              And user clicks Delete button on Delete Service modal
+             Then "kn-service" service should not be displayed in project

--- a/frontend/packages/knative-plugin/integration-tests/features/knative/cards-display-on-serverless-operator-installation.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/knative/cards-display-on-serverless-operator-installation.feature
@@ -3,9 +3,8 @@ Feature: Create event sources
               As a user, I want to create event sources
 
         Background:
-            Given user has installed knative Apache camel operator
-              And user has created or selected namespace "aut-namespace"
-              And user is at developer perspective
+            Given user has installed Knative Apache Camelk Integration Operator
+              And user has created or selected namespace "aut-knative"
 
 
         @smoke @manual
@@ -26,14 +25,6 @@ Feature: Create event sources
             Given user is at Add page
              Then user is able to see "Event Source" card on Add page
               And user is able to see "Operator Backed" card on Add page
-
-
-        @smoke
-        Scenario: CamelSource event source : Kn-08-TC03
-            Given user is at Add page
-             When user clicks on "Event Source" card
-             Then user will be redirected to "Event Sources" page
-              And user is able to see "Camel Source" event source type
 
 
         @regression

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -1,4 +1,4 @@
-import { Given, When } from 'cypress-cucumber-preprocessor/steps';
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import {
   perspective,
   projectNameSpace,
@@ -15,16 +15,11 @@ import {
   operators,
   resourceTypes,
 } from '@console/dev-console/integration-tests/support/constants';
-import { guidedTour } from '../../../../../integration-tests-cypress/views/guided-tour';
 import { operatorsPO } from '@console/dev-console/integration-tests/support/pageObjects';
+import { modal } from '@console/cypress-integration-tests/views/modal';
 
 Given('user is at developer perspective', () => {
   perspective.switchTo(switchPerspective.Developer);
-  // Bug: 1890676 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
-  // cy.testA11y('Developer perspective with guider tour modal');
-  guidedTour.close();
-  // Bug: 1890678 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
-  // cy.testA11y('Developer perspective');
 });
 
 Given('user is at administrator perspective', () => {
@@ -130,4 +125,21 @@ Given('user has created knative service {string}', (knativeServiceName: string) 
     knativeServiceName,
     resourceTypes.knativeService,
   );
+});
+
+Given(
+  'user has created knative revision with knative service {string}',
+  (knativeServiceName: string) => {
+    createGitWorkloadIfNotExistsOnTopologyPage(
+      'https://github.com/sclorg/nodejs-ex.git',
+      knativeServiceName,
+      resourceTypes.knativeService,
+    );
+    topologyPage.waitForKnativeRevision();
+  },
+);
+
+Then('modal with {string} appears', (header: string) => {
+  modal.modalTitleShouldContain(header);
+  modal.cancel();
 });

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/actions-on-knative-revision.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/actions-on-knative-revision.ts
@@ -1,0 +1,196 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import {
+  deleteRevision,
+  editLabels,
+  editAnnotations,
+  createGitWorkload,
+} from '@console/dev-console/integration-tests/support/pages';
+import {
+  topologyPage,
+  topologySidePane,
+} from '@console/topology/integration-tests/support/pages/topology';
+import { modal } from '@console/cypress-integration-tests/views/modal';
+import { nodeActions } from '@console/dev-console/integration-tests/support/constants';
+
+Given(
+  'number of annotations are {string} present in revision side bar details of service {string}',
+  (numOfAnnotations: string, serviceName: string) => {
+    topologyPage.getRevisionNode(serviceName).click();
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyNumberOfAnnotations(numOfAnnotations);
+  },
+);
+
+Given('Knative service with multiple revisions', () => {
+  createGitWorkload('https://github.com/sclorg/nodejs-ex.git', 'nodejs-ex-git-1', 'Knative');
+  // TODO: implement step
+});
+
+When(
+  'user right clicks on the revision of knative service {string} to open the context menu',
+  (serviceName: string) => {
+    topologyPage.getRevisionNode(serviceName).trigger('contextmenu', { force: true });
+  },
+);
+
+When('user clicks on Save button', () => {
+  modal.submit();
+});
+
+Given(
+  'user added label {string} to the revision of knative service {string}',
+  (labelName: string, serviceName: string) => {
+    topologyPage.getRevisionNode(serviceName).trigger('contextmenu', { force: true });
+    cy.byTestActionID('Edit Labels').click();
+    editLabels.enterLabel(labelName);
+    modal.submit();
+  },
+);
+
+When('user selects {string} option from knative revision context menu', (option: string) => {
+  cy.byTestActionID(option).click();
+});
+
+When(
+  'user removes the label {string} from existing labels list in Edit Labels modal',
+  (labelName: string) => {
+    editLabels.removeLabel(labelName);
+  },
+);
+
+When(
+  'user adds the label {string} to existing labels list in Edit Labels modal',
+  (labelName: string) => {
+    editLabels.enterLabel(labelName);
+  },
+);
+
+When(
+  'removes the label {string} from existing labels list in {string} modal',
+  (labelName: string, modalHeader: string) => {
+    modal.modalTitleShouldContain(modalHeader);
+    editLabels.removeLabel(labelName);
+  },
+);
+
+When(
+  'user clicks on remove icon for the annotation with key {string} present in {string} modal',
+  (annotationKey: string, modalHeader: string) => {
+    modal.modalTitleShouldContain(modalHeader);
+    editAnnotations.removeAnnotation(annotationKey);
+  },
+);
+
+When('user clicks cancel button on the {string} modal', (modalTitle: string) => {
+  modal.modalTitleShouldContain(modalTitle);
+  modal.cancel();
+});
+
+When('user clicks on Details tab', () => {
+  topologyPage.revisionDetails.clickOnDetailsTab();
+});
+
+When('user modifies the Yaml file of the Revision details page', () => {});
+
+When('user clicks save button on Revision Yaml page', () => {
+  topologyPage.revisionDetails.yaml.clickOnSave();
+});
+
+Then(
+  'user is able to see Edit Labels, Edit Annotations, Edit Revision, Delete Revision options in context menu',
+  () => {
+    cy.byTestActionID(nodeActions.EditLabels).should('be.visible');
+    cy.byTestActionID(nodeActions.EditAnnotations).should('be.visible');
+    cy.byTestActionID(nodeActions.EditRevision).should('be.visible');
+    cy.byTestActionID(nodeActions.DeleteRevision).should('be.visible');
+  },
+);
+
+Then('save button is displayed', () => {
+  modal.submitShouldBeEnabled();
+  modal.cancel();
+});
+
+Then('save, cancel buttons are displayed', () => {
+  // modal.verifyCancelButtonIsDisplayed();
+  // modal.verifySaveButtonIsDisplayed();
+  modal.cancel();
+});
+
+Then(
+  'user can see the label {string} in the Details tab of the Sidebar of {string}',
+  (label: string, serviceName: string) => {
+    cy.log(`knative revision of service ${serviceName}`);
+    cy.byLegacyTestID('base-node-handler')
+      .find('g.odc-resource-icon')
+      .click({ force: true });
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyLabel(label);
+  },
+);
+
+Then('key, value columns are displayed with respecitve text fields', () => {
+  cy.get('input[placeholder="key"]')
+    .its('length')
+    .should('be.gte', 1);
+  cy.get('input[placeholder="value"]')
+    .its('length')
+    .should('be.gte', 1);
+});
+
+Then('Add more link is enabled', () => {
+  editAnnotations.add();
+});
+
+Then(
+  'user can see the annotation {string} in the Details tab of the Sidebar of {string}',
+  (numOfAnnotations: string, serviceName: string) => {
+    cy.byLegacyTestID('base-node-handler')
+      .find('g.odc-resource-icon')
+      .click({ force: true });
+    cy.log(numOfAnnotations, serviceName);
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+  },
+);
+
+Then('details tab displayed with Revision Details and Conditions sections', () => {
+  topologyPage.revisionDetails.details.verifyRevisionSummary();
+  topologyPage.revisionDetails.details.verifyConditionsSection();
+});
+
+Then(
+  'Revision details contains fields like Name, Namespace, Labels, Annotations, Created At, Owner',
+  () => {
+    cy.get('[data-test-selector="details-item-label__Name"]').should('be.visible');
+    cy.get('[data-test-selector="details-item-label__Namespace"]').should('be.visible');
+    cy.get('[data-test-selector="details-item-label__Labels"]').should('be.visible');
+    cy.get('[data-test-selector="details-item-label__Annotations"]').should('be.visible');
+    cy.get('[data-test-selector="details-item-label__Created at"]').should('be.visible');
+    cy.get('[data-test-selector="details-item-label__Owner"]').should('be.visible');
+  },
+);
+
+Then(
+  'user is able to see message {string} in modal with header {string}',
+  (message: string, header: string) => {
+    modal.modalTitleShouldContain(header);
+    deleteRevision.verifyMessage(message);
+    modal.cancel();
+  },
+);
+
+Then(
+  'number of Annotations increased to {string} in revision side bar details of service {string}',
+  (numOfAnnotations: string, serviceName: string) => {
+    cy.byLegacyTestID('base-node-handler')
+      .find('g.odc-resource-icon')
+      .click({ force: true });
+    cy.log(serviceName);
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyNumberOfAnnotations(numOfAnnotations);
+  },
+);

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/actions-on-knative-service.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/actions-on-knative-service.ts
@@ -1,0 +1,263 @@
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { modal } from '@console/cypress-integration-tests/views/modal';
+import {
+  devNavigationMenu,
+  nodeActions,
+  resourceTypes,
+} from '@console/dev-console/integration-tests/support/constants';
+import { topologyPO } from '@console/dev-console/integration-tests/support/pageObjects';
+import {
+  createEventSourcePage,
+  createGitWorkload,
+  editAnnotations,
+  editApplicationGrouping,
+  editLabels,
+  navigateTo,
+  setTrafficDistribution,
+  topologyPage,
+  topologySidePane,
+} from '@console/dev-console/integration-tests/support/pages';
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+
+When('user right clicks on the knative service {string}', (serviceName: string) => {
+  topologyPage.waitForLoad();
+  topologyPage.rightClickOnKnativeService(serviceName);
+});
+
+Given('user has created {string} event source', (eventSourceName: string) => {
+  navigateTo(devNavigationMenu.Add);
+  createEventSourcePage.createSinkBinding(eventSourceName);
+});
+
+When('user right clicks on the knative service {string}', (knativeServiceName: string) => {
+  topologyPage.rightClickOnNode(knativeServiceName);
+});
+
+Then(
+  'user is able to see the options like Edit Application Grouping, Set Traffic Distribution, Edit Health Checks, Edit Labels, Edit Annotations, Edit Service, Delete Service, Edit {string}',
+  (knativeServiceName: string) => {
+    cy.byTestActionID(nodeActions.EditApplicationGrouping).should('be.visible');
+    cy.byTestActionID(nodeActions.SetTrafficDistribution).should('be.visible');
+    cy.byTestActionID(`Edit ${knativeServiceName}`).should('be.visible');
+    cy.byTestActionID(nodeActions.EditHealthChecks).should('be.visible');
+    cy.byTestActionID(nodeActions.EditLabels).should('be.visible');
+    cy.byTestActionID(nodeActions.EditAnnotations).should('be.visible');
+    cy.byTestActionID(nodeActions.EditService).should('be.visible');
+    cy.byTestActionID(nodeActions.DeleteService).should('be.visible');
+  },
+);
+
+Given(
+  'user created another revision {string} for knative Service {string}',
+  (revisionName: string, knativeServiceName: string) => {
+    navigateTo(devNavigationMenu.Add);
+    createGitWorkload(
+      'https://github.com/sclorg/nodejs-ex.git',
+      revisionName,
+      resourceTypes.knativeService,
+      knativeServiceName,
+    );
+    topologyPage.verifyWorkloadInTopologyPage(revisionName);
+  },
+);
+
+Then('user clicks Delete button on Delete Service modal', () => {
+  modal.modalTitleShouldContain('Delete Service?');
+  modal.submit();
+  modal.shouldBeClosed();
+});
+
+When('user clicks on Add Revision button present in Set Traffic Distribution modal', () => {
+  setTrafficDistribution.add();
+});
+
+When(
+  'user adds the label {string} to exisitng labels list in Edit Labels modal',
+  (labelName: string) => {
+    editLabels.enterLabel(labelName);
+  },
+);
+
+When('user clicks the save button on the {string} modal', (modalTitle: string) => {
+  modal.modalTitleShouldContain(modalTitle);
+  modal.submit();
+});
+
+When('user clicks the cancel button on the {string} modal', (modalTitle: string) => {
+  modal.modalTitleShouldContain(modalTitle);
+  modal.cancel();
+});
+
+When('user searches for application name {string}', (appName: string) => {
+  topologyPage.search(appName);
+});
+
+Given('service should have at least 2 revisions', () => {
+  cy.get('[data-test-id="base-node-handler"]', { timeout: 150000 }).should('be.visible');
+});
+
+When(
+  'user selects {string} context menu option of knative service {string}',
+  (option: string, knativeServiceName: string) => {
+    topologyPage.rightClickOnNode(knativeServiceName);
+    topologyPage.selectContextMenuAction(option);
+  },
+);
+
+When('user clicks Add button on the Edit Annotations modal', () => {
+  editAnnotations.add();
+});
+
+Given(
+  'number of annotations are {string} present in {string} service side bar details tab',
+  (numOfAnnotations: string, serviceName: string) => {
+    topologyPage.clickOnNode(serviceName);
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyNumberOfAnnotations(numOfAnnotations);
+    topologySidePane.close();
+  },
+);
+
+When('user enters annotation key as {string}', (key: string) => {
+  editAnnotations.enterKey(key);
+});
+
+When('user enters annotation value as {string}', (value: string) => {
+  editAnnotations.enterValue(value);
+});
+
+When('user enters {string} into the Split text box', (splitPercentage: string) => {
+  setTrafficDistribution.enterSplit(splitPercentage);
+});
+
+When('user enters {string} into the Split text box of new revision', (splitPercentage: string) => {
+  setTrafficDistribution.enterSplit(splitPercentage);
+});
+
+When('user selects another revision from Revision drop down', () => {
+  cy.byLegacyTestID('dropdown-button').click();
+  cy.byLegacyTestID('dropdown-menu')
+    .last()
+    .click();
+});
+
+Then(
+  'user will see the label {string} in {string} service side bar details',
+  (label: string, serviceName: string) => {
+    topologyPage.clickOnNode(serviceName);
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyLabel(label);
+  },
+);
+
+Then(
+  'user will not see the label {string} in {string} service side bar details',
+  (label: string, serviceName: string) => {
+    topologyPage.clickOnNode(serviceName);
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    cy.get('[data-test-selector="details-item-label__Labels"]').should('be.visible');
+    cy.get('[data-test="label-list"] a')
+      .contains(label)
+      .should('not.be.visible');
+  },
+);
+
+Given(
+  'label {string} is added to the knative service {string}',
+  (labelName: string, knativeServiceName: string) => {
+    topologyPage.rightClickOnNode(knativeServiceName);
+    topologyPage.selectContextMenuAction(nodeActions.EditLabels);
+    modal.shouldBeOpened();
+    editLabels.enterLabel(labelName);
+    modal.submit();
+  },
+);
+
+Then(
+  'number of Annotations increased to {string} in {string} service side bar details',
+  (numOfAnnotations: string, serviceName: string) => {
+    topologyPage.clickOnNode(serviceName);
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyNumberOfAnnotations(numOfAnnotations);
+  },
+);
+
+Then(
+  'number of Annotations display as {string} in {string} service side bar details',
+  (numOfAnnotations: string, serviceName: string) => {
+    topologyPage.clickOnNode(serviceName);
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyNumberOfAnnotations(numOfAnnotations);
+  },
+);
+
+When(
+  'user clicks on remove icon for the annotation with key {string} present in Edit Annotations modal',
+  (key: string) => {
+    editAnnotations.removeAnnotation(key);
+  },
+);
+
+Then('error message displays as {string}', (errorMessage: string) => {
+  cy.get('div[aria-label="Danger Alert"] div.co-pre-line').should('contain.text', errorMessage);
+});
+
+Then('number of routes should get increased in side bar - resources tab - routes section', () => {
+  topologyPage.clickOnNode('nodejs-ex-git-1');
+  topologySidePane.verify();
+  topologySidePane.verifyTab('Resources');
+  cy.get('[title="Route"]').should('have.length', 2);
+});
+
+Then('{string} service should not be displayed in project', (serviceName: string) => {
+  cy.get('body').then(($body) => {
+    if ($body.find(topologyPO.graph.node).length) {
+      topologyPage.search(serviceName);
+      cy.get(topologyPO.highlightNode).should('not.be.visible');
+    } else {
+      topologyPage.verifyNoWorkLoadsText('No resources found');
+    }
+  });
+});
+
+When('user clicks save button on yaml page', () => {
+  cy.get('#save-changes').click();
+});
+
+When('user clicks cancel button on {string} page', (pageName: string) => {
+  detailsPage.titleShouldContain(pageName);
+  cy.byLegacyTestID('reset-button').click();
+});
+
+When(
+  'user removes the label {string} from exisitng labels list in {string} modal',
+  (labelName: string, modalHeader: string) => {
+    modal.modalTitleShouldContain(modalHeader);
+    editLabels.removeLabel(labelName);
+  },
+);
+
+When(
+  'user selects the {string} option from application drop down present in {string} modal',
+  (option: string, modalHeader: string) => {
+    modal.modalTitleShouldContain(modalHeader);
+    editApplicationGrouping.selectApplication(option);
+  },
+);
+
+Then('number of Annotations decreased to {string} in side bar details', (num: string) => {
+  topologySidePane.verifyNumberOfAnnotations(num);
+});
+
+Then(
+  'updated service {string} is present in side bar of application {string}',
+  (serviceName: string, applicationName: string) => {
+    topologyPage.clickOnKnativeService(serviceName);
+    topologySidePane.verifyResource(applicationName);
+  },
+);

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/create-apache-camel.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/create-apache-camel.ts
@@ -1,0 +1,11 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { eventSourcesPage } from '@console/dev-console/integration-tests/support/pages';
+
+Then('user will be redirected to page with header name {string}', (headerName: string) => {
+  detailsPage.titleShouldContain(headerName);
+});
+
+Then('user is able to see CamelSource event type', () => {
+  eventSourcesPage.verifyEventSourceType('Camel Source');
+});

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/create-knative-workload.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/create-knative-workload.ts
@@ -1,17 +1,19 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
-import { addPage } from '@console/dev-console/integration-tests/support/pages/add-flow/add-page';
-import { gitPage } from '@console/dev-console/integration-tests/support/pages/add-flow/git-page';
-import { containerImagePage } from '@console/dev-console/integration-tests/support/pages/add-flow/container-image-page';
-import { catalogPage } from '@console/dev-console/integration-tests/support/pages/add-flow/catalog-page';
+import {
+  addPage,
+  gitPage,
+  containerImagePage,
+  catalogPage,
+  navigateTo,
+} from '@console/dev-console/integration-tests/support/pages';
 import {
   addOptions,
   catalogCards,
   catalogTypes,
-} from '@console/dev-console/integration-tests/support/constants/add';
-import { navigateTo } from '@console/dev-console/integration-tests/support/pages/app';
-import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
-import { detailsPage } from '../../../../../integration-tests-cypress/views/details-page';
-import { gitPO } from '@console/dev-console/integration-tests/support/pageObjects/add-flow-po';
+  devNavigationMenu,
+} from '@console/dev-console/integration-tests/support/constants';
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { gitPO } from '@console/dev-console/integration-tests/support/pageObjects';
 
 Given('user is on {string} form', (formName: string) => {
   navigateTo(devNavigationMenu.Add);

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/side-bar-of-knative-revision-and-service.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/knative/side-bar-of-knative-revision-and-service.ts
@@ -1,0 +1,129 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps';
+import {
+  topologyPage,
+  topologySidePane,
+} from '@console/topology/integration-tests/support/pages/topology';
+
+When('user clicks on the revision of knative service {string}', (serviceName: string) => {
+  cy.get('[data-test-id="base-node-handler"]', { timeout: 150000 }).should('be.visible');
+  cy.byLegacyTestID('base-node-handler')
+    .find('g.odc-resource-icon')
+    .click({ force: true });
+  cy.log(serviceName);
+});
+
+When('user clicks on Resources section', () => {
+  // TODO: implement step
+});
+
+When('user clicks on Actions dropdown in top right corner of side bar', () => {});
+
+When('user clicks on the knative service {string}', (serviceName: string) => {
+  cy.get('g.odc-base-node__label')
+    .should('be.visible')
+    .contains(serviceName)
+    .click({ force: true });
+});
+
+When('user click on the knative revision name {string}', (a: string) => {
+  cy.log(a);
+});
+
+Then('side bar is displayed with heading name as {string}', (serviceName: string) => {
+  topologySidePane.verifyTitle(serviceName);
+});
+
+Then('user able to see pods status as {string} by default', (podStatus: string) => {
+  cy.log(podStatus);
+});
+
+// Then('name displays as {string}', (a: string) => {
+//  cy.log(a)
+// });
+
+// Then('namespace displays as {string}', (a: string) => {
+//  cy.log(a)
+// });
+
+// Then('Labels section contain n number of Labels', () => {
+//   // TODO: implement step
+// });
+
+// Then('Annotations section contain {string}', (a: string) => {
+//  cy.log(a)
+// });
+
+// Then('{string} field the date in format {string}', (a: string, b: string) => {
+//  cy.log(a, b)
+// });
+
+Then(
+  'user able to see the options {string}, {string}, {string}, {string}',
+  (a: string, b: string, c: string, d: string) => {
+    cy.log(a, b, c, d);
+  },
+);
+
+Then(
+  'side bar is displayed with heading name same as knative service name {string}',
+  (serviceName: string) => {
+    topologySidePane.verifyTitle(serviceName);
+  },
+);
+
+When('user clicks on the knative service name {string}', (serviceName: string) => {
+  topologyPage.componentNode(serviceName).click();
+});
+
+// Then('Name should display as {string} in topology details', (name: string) => {
+
+// });
+
+// Then('Namespace should display as {string} in topology details', (namespace: string) => {
+//  cy.log(namespace);
+// });
+
+// Then('Labels section should contain n number of Labels in topology details', () => {
+
+// });
+
+// Then('Annotations section should contain {string} in topology details', (a: string) => {
+//  cy.log(a)
+// });
+
+// Then('{string} field display the date in format {string} in topology details', (a: string, b: string) => {
+//  cy.log(a, b,)
+// });
+
+// Then('owner field should be displayed in topology details', () => {
+//   // TODO: implement step
+// });
+
+Then(
+  'Name, Namespace, Labels, Annotations, Created at, Owner fields displayed  in topology details',
+  () => {
+    topologySidePane.verify();
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyFieldInDetailsTab('Name');
+    topologySidePane.verifyFieldInDetailsTab('Namespace');
+    topologySidePane.verifyFieldInDetailsTab('Labels');
+    topologySidePane.verifyFieldInDetailsTab('Annotations');
+    topologySidePane.verifyFieldInDetailsTab('Created at');
+    topologySidePane.verifyFieldInDetailsTab('Owner');
+    topologySidePane.close();
+  },
+);
+
+Then(
+  'user able to see the options Edit Labels, Edit Annotations, Edit Revision, Delete Revision',
+  () => {
+    // TODO: implement step
+  },
+);
+
+Then(
+  'user able to see the options like Edit Application Grouping, Set Traffic Distribution, Edit NameOfWorkLoad, Edit Health Checks, Edit Labels, Edit Annotations, Edit Service, Delete Service',
+  () => {
+    // TODO: implement step
+  },
+);

--- a/frontend/packages/knative-plugin/integration-tests/support/testData/installation-yamls/createBootStrap-CR.yaml
+++ b/frontend/packages/knative-plugin/integration-tests/support/testData/installation-yamls/createBootStrap-CR.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka
+---
+apiVersion: sources.knative.dev/v1beta1
+kind: KafkaSource
+metadata:
+  name: kafka-source
+spec:
+  consumerGroup: knative-group
+  bootstrapServers:
+    - my-cluster-kafka-bootstrap.kafka:9092 #note the kafka namespace
+  topics:
+    - logs
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display

--- a/frontend/packages/knative-plugin/integration-tests/support/testData/installation-yamls/createKnativeKafka-CR.yaml
+++ b/frontend/packages/knative-plugin/integration-tests/support/testData/installation-yamls/createKnativeKafka-CR.yaml
@@ -1,0 +1,11 @@
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: knative-eventing
+spec:
+  channel:
+    bootstrapServers: REPLACE_WITH_COMMA_SEPARATED_KAFKA_BOOTSTRAP_SERVERS
+    enabled: false
+  source:
+    enabled: false


### PR DESCRIPTION
**Problem**: Smoke test cases related to knative
**Solution**: Included below step definitions

Not automating admin perspective test cases, as they are releated to admin console

actions-on-knative-revision.ts
actions-on-knative-service.ts
create-knative-workload.ts
side-bar-of-knative-revision-and-service.ts

Browser and its version:
Chrome 88.0.4324.182

**Execution Process**:

Cypress file modification [local to plugin folder]
Update TAGS section in knative-plugin/cypress.json as @@knative and @smoke and not @manual and not @to-do

**Command to execute**
`yarn run test-cypress-knative`
and select the below files from knative folder

actions-on-knative-revision.feature
actions-on-knative-service.feature
create-knative-workload.feature
side-bar-of-knative-revision-and-service.feature

**Screenshots**
![image](https://user-images.githubusercontent.com/61005404/114202821-35563e80-9975-11eb-90a8-2322abd7c324.png)
![image](https://user-images.githubusercontent.com/61005404/114202524-e4464a80-9974-11eb-91c9-1b384ef915a3.png)
![image](https://user-images.githubusercontent.com/61005404/114204182-8450a380-9976-11eb-8d09-d80bf3d0909b.png)
![image](https://user-images.githubusercontent.com/61005404/114204852-4acc6800-9977-11eb-82b6-0ce52e7321d1.png)
