### PR TITLE
Fix ResolvedExtension type inference

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
@@ -79,7 +79,6 @@ export const useResolvedExtensions = <E extends Extension>(
   return [resolvedExtensions, resolved, error];
 };
 
-export type ResolvedExtension<
-  E extends Extension,
-  P = ExtensionProperties<E>
-> = UpdateExtensionProperties<LoadedExtension<E>, ResolvedCodeRefProperties<P>>;
+export type ResolvedExtension<E extends Extension, P = ExtensionProperties<E>> = LoadedExtension<
+  UpdateExtensionProperties<E, ResolvedCodeRefProperties<P>>
+>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
@@ -253,7 +253,7 @@ describe('resolveCodeRefProperties', () => {
       },
     ];
 
-    expect(await resolveCodeRefProperties(extensions[0])).toEqual({});
-    expect(await resolveCodeRefProperties(extensions[1])).toEqual({ qux: 'value' });
+    expect(await resolveCodeRefProperties(extensions[0])).toEqual({ test: true });
+    expect(await resolveCodeRefProperties(extensions[1])).toEqual({ baz: 1, qux: 'value' });
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-resolver.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/coderef-resolver.ts
@@ -110,13 +110,13 @@ export const resolveEncodedCodeRefs = (
   });
 
 /**
- * Returns an object representing resolved `CodeRef` properties for the given extension.
+ * Returns the properties of extension `E` with `CodeRef` functions replaced with referenced objects.
  */
 export const resolveCodeRefProperties = async <E extends Extension<P>, P = ExtensionProperties<E>>(
   extension: E,
 ): Promise<ResolvedCodeRefProperties<P>> => {
   const refs = filterExecutableCodeRefProperties(extension.properties);
-  const resolvedValues = {} as ResolvedCodeRefProperties<P>;
+  const resolvedValues = Object.assign({}, extension.properties);
 
   await Promise.all(
     Object.entries(refs).map(async ([propName, ref]) => {
@@ -124,5 +124,5 @@ export const resolveCodeRefProperties = async <E extends Extension<P>, P = Exten
     }),
   );
 
-  return resolvedValues;
+  return resolvedValues as ResolvedCodeRefProperties<P>;
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
@@ -38,7 +38,7 @@ export type CodeRef<T = any> = () => Promise<T>;
  * Infer resolved `CodeRef` properties from object `O`.
  */
 export type ResolvedCodeRefProperties<O extends {}> = {
-  [K in keyof O]: O[K] extends CodeRef<infer T> ? T : never;
+  [K in keyof O]: O[K] extends CodeRef<infer T> ? T : O[K];
 };
 
 /**

--- a/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { CatalogExtensionHookOptions, CatalogItem } from '@console/plugin-sdk';
+import { CatalogExtensionHookOptions, CatalogItem, CatalogItemType } from '@console/plugin-sdk';
 import { ResolvedExtension } from '@console/dynamic-plugin-sdk/src/api/useResolvedExtensions';
 import { keywordCompare } from '../utils/catalog-utils';
 import useCatalogExtensions from '../hooks/useCatalogExtensions';
@@ -13,7 +13,7 @@ export type CatalogService = {
   loaded: boolean;
   loadError: any;
   searchCatalog: (query: string) => CatalogItem[];
-  catalogExtensions: ResolvedExtension<any>;
+  catalogExtensions: ResolvedExtension<CatalogItemType>[];
 };
 
 type CatalogServiceProviderProps = {
@@ -36,7 +36,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
   ] = useCatalogExtensions(catalogType);
 
   const [extItemsMap, setExtItemsMap] = React.useState<{ [uid: string]: CatalogItem[] }>({});
-  const [loadError, setLoadError] = React.useState();
+  const [loadError, setLoadError] = React.useState<any>();
 
   const loaded =
     extensionsResolved &&


### PR DESCRIPTION
This fixes the issue where `ResolvedExtension` return type of `useResolvedExtensions` hook would cause non-coderef extension properties to be typed as `never`.