### PR TITLE
improve i18n parser to support console-extensions.json

### DIFF
--- a/frontend/i18n-scripts/.eslintrc.js
+++ b/frontend/i18n-scripts/.eslintrc.js
@@ -1,61 +1,9 @@
-var fs = require('fs');
-
 module.exports = {
   root: true,
-  env: {
-    browser: true,
-    es6: true,
-    jasmine: true,
-    jest: true,
-  },
-  extends: [
-    'eslint:recommended',
-    'plugin:import/errors',
-    'plugin:import/warnings',
-    'plugin:console/prettier',
-  ],
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  extends: ['plugin:console/node-typescript-prettier'],
   rules: {
-    camelcase: [
-      'error',
-      { allow: [] },
-    ],
-    'consistent-return': 0,
-    'consistent-this': [1, 'that'],
-    curly: [2, 'all'],
-    'default-case': [2],
-    'dot-notation': [2],
-    'no-multiple-empty-lines': [2, { max: 2, maxEOF: 0 }],
-    eqeqeq: [2, 'allow-null'],
-    'guard-for-in': 2,
-    'import/no-unresolved': ['error'],
-    'import/no-duplicates': ['error'],
-    'max-nested-callbacks': [1, 4],
-    'no-alert': 2,
-    'no-caller': 2,
-    'no-console': 0,
-    'no-constant-condition': 2,
-    'no-debugger': 2,
-    'no-else-return': ['error'],
-    'no-global-strict': 0,
-    'no-irregular-whitespace': ['error'],
-    'no-prototype-builtins': 0, // Disable with exlint v6 update.
-    'no-shadow': ['error'],
-    'no-undef': 0,
-    'no-underscore-dangle': 0,
-    'no-var': 2,
-    'object-shorthand': ['error', 'properties'],
-    'prefer-const': ['error', { destructuring: 'all' }],
-    'prefer-template': 2,
-    radix: 2,
-    'require-atomic-updates': 0,
-  },
-  settings: {
-    'import/extensions': ['.js'],
-    'import/resolver': { node: { extensions: ['.js'] } },
-  },
-  globals: {
-    process: 'readonly',
+    'no-console': 'off',
+    // fs.promises requires a newer version of node however our compliance is set to node >=10
+    'node/no-unsupported-features/node-builtins': 'off',
   },
 };

--- a/frontend/i18n-scripts/__tests__/lexers.spec.ts
+++ b/frontend/i18n-scripts/__tests__/lexers.spec.ts
@@ -1,0 +1,29 @@
+import { CustomJSONLexer } from '../lexers';
+
+describe('CustomJSONLexer', () => {
+  it('should fail gracefully with invalid JSON', () => {
+    expect(new CustomJSONLexer().extract('{"key": "%test%", invalid}', 'test.json')).toEqual([]);
+  });
+
+  it('should parse strings matching pattern `^%.+%$`', () => {
+    expect(
+      new CustomJSONLexer().extract(
+        '{"nope": false, "foo": "%bar%", "test": ["%arr1%", "%arr2%", "arr3"]}',
+        'test.json',
+      ),
+    ).toEqual([{ key: 'bar' }, { key: 'arr1' }, { key: 'arr2' }]);
+  });
+
+  it('should parse json with comments', () => {
+    expect(
+      new CustomJSONLexer().extract(
+        `{"nope": false,
+        // comment
+        "foo": "%bar%", "test": ["%arr1%",
+        // comment
+        "%arr2%", "arr3"]}`,
+        'test.json',
+      ),
+    ).toEqual([{ key: 'bar' }, { key: 'arr1' }, { key: 'arr2' }]);
+  });
+});

--- a/frontend/i18n-scripts/build-i18n.sh
+++ b/frontend/i18n-scripts/build-i18n.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-FILE_PATTERN="!(dist|node_modules)**/**/*.{js,jsx,ts,tsx}"
+FILE_PATTERN="!(dist|node_modules)**/**/*.{js,jsx,ts,tsx,json}"
 
 i18next "public/${FILE_PATTERN}" [-oc] -c "./i18next-parser.config.js" -o "public/locales/\$LOCALE/\$NAMESPACE.json"
 

--- a/frontend/i18n-scripts/build-i18n.sh
+++ b/frontend/i18n-scripts/build-i18n.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-FILE_PATTERN="!(dist|node_modules)**/**/*.{js,jsx,ts,tsx,json}"
+FILE_PATTERN="{!(dist|node_modules)/**/*.{js,jsx,ts,tsx,json},*.{js,jsx,ts,tsx,json}}"
 
 i18next "public/${FILE_PATTERN}" [-oc] -c "./i18next-parser.config.js" -o "public/locales/\$LOCALE/\$NAMESPACE.json"
 

--- a/frontend/i18n-scripts/common.js
+++ b/frontend/i18n-scripts/common.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  isDirectory: function(filePath) {
+  isDirectory(filePath) {
     try {
       const stat = fs.lstatSync(filePath);
       return stat.isDirectory();
@@ -11,26 +11,27 @@ module.exports = {
       return false;
     }
   },
-  findLocalesFolder: function(directory, argFunction, package) {
+  findLocalesFolder(directory, argFunction, packageDir) {
     const localesFolder = path.join(directory, 'locales');
     if (fs.existsSync(localesFolder)) {
-      return argFunction(localesFolder, package);
+      return argFunction(localesFolder, packageDir);
     }
+    return undefined;
   },
-  parseFolder: function(directory, argFunction, package) {
+  parseFolder(directory, argFunction, packageDir) {
     (async () => {
       try {
         const files = await fs.promises.readdir(directory);
         for (const file of files) {
           const filePath = path.join(directory, file);
-          argFunction(filePath, package);
+          argFunction(filePath, packageDir);
         }
       } catch (e) {
         console.error(e);
       }
     })();
   },
-  deleteFile: function(filePath) {
+  deleteFile(filePath) {
     try {
       fs.unlinkSync(filePath);
     } catch (e) {

--- a/frontend/i18n-scripts/consolidate-public-folders.js
+++ b/frontend/i18n-scripts/consolidate-public-folders.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const common = require('./common.js');
 
-const public = path.join(__dirname, './../public/locales/');
+const publicDir = path.join(__dirname, './../public/locales/');
 const packages = path.join(__dirname, './../packages');
 
 const publicFileNames = {};
@@ -73,5 +73,5 @@ function processPublic(filePath) {
   }
 }
 
-common.parseFolder(public, processPublic);
+common.parseFolder(publicDir, processPublic);
 common.parseFolder(packages, processPackages);

--- a/frontend/i18n-scripts/lexers.js
+++ b/frontend/i18n-scripts/lexers.js
@@ -1,0 +1,30 @@
+const EventEmitter = require('events');
+const jsonc = require('comment-json');
+
+/**
+ * Custom JSON parser for localizing keys matching format: /%.+%/
+ */
+module.exports.CustomJSONLexer = class extends EventEmitter {
+  extract(content, filename) {
+    let keys = [];
+    try {
+      jsonc.parse(
+        content,
+        (key, value) => {
+          if (typeof value === 'string') {
+            const match = value.match(/^%(.+)%$/);
+            if (match && match[1]) {
+              keys.push({ key: match[1] });
+            }
+          }
+          return value;
+        },
+        true,
+      );
+    } catch (e) {
+      console.error('Failed to parse as JSON.', filename, e);
+      keys = [];
+    }
+    return keys;
+  }
+};

--- a/frontend/i18n-scripts/po-to-i18n.js
+++ b/frontend/i18n-scripts/po-to-i18n.js
@@ -11,22 +11,22 @@ function save(target) {
 
 function processFile(fileName, language) {
   let newFilePath;
-  const package =
+  const packageDir =
     fileName.includes('_package=') && path.basename(fileName, '.po').split('_package=')[1];
-  const newFileName = package
+  const newFileName = packageDir
     ? path.basename(fileName, '.po').split('_package=')[0]
     : path.basename(fileName, '.po');
-  if (package) {
-    if (!fs.existsSync(path.join(__dirname, `./../packages/${package}/locales/${language}`))) {
-      fs.mkdirSync(path.join(__dirname, `./../packages/${package}/locales/${language}`), {
+  if (packageDir) {
+    if (!fs.existsSync(path.join(__dirname, `./../packages/${packageDir}/locales/${language}`))) {
+      fs.mkdirSync(path.join(__dirname, `./../packages/${packageDir}/locales/${language}`), {
         recursive: true,
       });
     }
     newFilePath = path.join(
       __dirname,
-      `./../packages/${package}/locales/${language}/${newFileName}.json`,
+      `./../packages/${packageDir}/locales/${language}/${newFileName}.json`,
     );
-    console.log(`Saving packages/${package}/locales/${language}/${newFileName}.json`);
+    console.log(`Saving packages/${packageDir}/locales/${language}/${newFileName}.json`);
   } else {
     if (!fs.existsSync(path.join(__dirname, `../public/locales/${language}/`))) {
       fs.mkdirSync(path.join(__dirname, `../public/locales/${language}/`), { recursive: true });
@@ -34,7 +34,9 @@ function processFile(fileName, language) {
     newFilePath = path.join(__dirname, `../public/locales/${language}/${newFileName}.json`);
     console.log(`Saving public/locales/${language}/${newFileName}.json`);
   }
-  gettextToI18next(language, fs.readFileSync(fileName)).then(save(newFilePath));
+  gettextToI18next(language, fs.readFileSync(fileName))
+    .then(save(newFilePath))
+    .catch((e) => console.error(fileName, e));
 }
 
 function processDirectory(directory, language) {
@@ -68,11 +70,9 @@ const options = {
 const args = minimist(process.argv.slice(2), options);
 
 if (args.help) {
-  return console.log(
+  console.log(
     "-h: help\n-l: language (i.e. 'ja')\n-d: directory to convert files in (i.e. './new-pos')",
   );
-}
-
-if (args.directory && args.language) {
+} else if (args.directory && args.language) {
   processDirectory(args.directory, args.language);
 }

--- a/frontend/i18n-scripts/set-english-defaults.js
+++ b/frontend/i18n-scripts/set-english-defaults.js
@@ -3,8 +3,8 @@ const path = require('path');
 const pluralize = require('pluralize');
 const common = require('./common.js');
 
-const public = path.join(__dirname, './../public/locales/');
-const packages = path.join(__dirname, './../packages');
+const publicDir = path.join(__dirname, './../public/locales/');
+const packagesDir = path.join(__dirname, './../packages');
 
 function determineRule(key) {
   if (key.includes('WithCount_plural')) {
@@ -36,15 +36,15 @@ function updateFile(fileName) {
       // "keyWithCount_plural": "{{count}} items"
       switch (determineRule(keys[i])) {
         case 0:
-          originalKey = keys[i].split('WithCount_plural')[0];
+          [originalKey] = keys[i].split('WithCount_plural');
           updatedFile[keys[i]] = `{{count}} ${pluralize(originalKey)}`;
           break;
         case 1:
-          originalKey = keys[i].split('WithCount')[0];
+          [originalKey] = keys[i].split('WithCount');
           updatedFile[keys[i]] = `{{count}} ${originalKey}`;
           break;
         case 2:
-          originalKey = keys[i].split('_plural')[0];
+          [originalKey] = keys[i].split('_plural');
           updatedFile[keys[i]] = pluralize(originalKey);
           break;
         default:
@@ -55,11 +55,9 @@ function updateFile(fileName) {
     }
   }
 
-  fs.writeFile(fileName, JSON.stringify(updatedFile, null, 2), function writeJSON(e) {
-    if (e) {
-      return console.error(e);
-    }
-  });
+  fs.promises
+    .writeFile(fileName, JSON.stringify(updatedFile, null, 2))
+    .catch((e) => console.error(fileName, e));
 }
 
 function processLocalesFolder(filePath) {
@@ -78,5 +76,5 @@ function processPackages(filePath) {
   }
 }
 
-common.parseFolder(public, processLocalesFolder);
-common.parseFolder(packages, processPackages);
+common.parseFolder(publicDir, processLocalesFolder);
+common.parseFolder(packagesDir, processPackages);

--- a/frontend/i18next-parser.config.js
+++ b/frontend/i18next-parser.config.js
@@ -1,3 +1,5 @@
+const { CustomJSONLexer } = require('./i18n-scripts/lexers');
+
 const FALLBACK_LOCALE = 'en';
 
 /*eslint no-undef: "error"*/
@@ -41,6 +43,7 @@ module.exports = {
     ts: ['JavascriptLexer'],
     jsx: ['JsxLexer'],
     tsx: ['JsxLexer'],
+    json: [CustomJSONLexer],
 
     default: ['JavascriptLexer'],
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -275,6 +275,7 @@
     "jest-transform-graphql": "^2.1.0",
     "lint-staged": "^10.2.2",
     "mini-css-extract-plugin": "0.4.x",
+    "minimist": "1.2.5",
     "mocha-junit-reporter": "^1.23.3",
     "mochawesome": "^6.1.1",
     "mochawesome-merge": "^4.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -242,6 +242,7 @@
     "chalk": "2.4.x",
     "chromedriver": "77.x",
     "circular-dependency-plugin": "5.x",
+    "comment-json": "4.x",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "0.28.x",
     "cypress": "^6.0.0",

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -9,7 +9,6 @@
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"
   },
   "devDependencies": {
-    "comment-json": "4.x",
     "ts-json-schema-generator": "0.x",
     "webpack": "5.0.0-beta.16"
   }


### PR DESCRIPTION
Dynamic plugins contribute extensions through the `console-extensions.json`. To localize a string in json, the string must match the format `/%.+%/`.
eg.
```
{
  "foo": "%bar%"
}
```

This PR adds a custom lexer which parses `*.json` files and matches string values against the localization pattern.

Added unit test for custom JSON lexer.

Update the `i18n-scripts/.eslintrc.js` rules to reuse those defined in the console eslint plugin.

cc @rohitkrai03 @vojtechszocs @rebeccaalpert @spadgett 

Before this change we would require a comment to pick up the localized string. Although there is no lexer currently for json files.
```
  [
    {
      "type": "AddAction",
      "flags": {
        "required": ["OPENSHIFT_HELM"]
      },
      "properties": {
        "id": "helm",
        "url": "/catalog?catalogType=HelmChart",
        // t('helm-plugin~Helm Chart')
        "label": "%helm-plugin~Helm Chart%",
        // t('helm-plugin~Browse the catalog to discover and install Helm Charts')
        "description": "%helm-plugin~Browse the catalog to discover and install Helm Charts%"
      }
    }
  ]
```

After this change, the lexer will pickup the string without the comment:
```
  [
    {
      "type": "AddAction",
      "flags": {
        "required": ["OPENSHIFT_HELM"]
      },
      "properties": {
        "id": "helm",
        "url": "/catalog?catalogType=HelmChart",
        "label": "%helm-plugin~Helm Chart%",
        "description": "%helm-plugin~Browse the catalog to discover and install Helm Charts%"
      }
    }
  ]
```

locale file: `helm-plugin.json`
```
{
  "Helm Chart": "Helm Chart",
  "Browse the catalog to discover and install Helm Charts": "Browse the catalog to discover and install Helm Charts"
}
```