### PR TITLE
Query Browser: Show dates on X-axis when time range is over one day

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -31,9 +31,8 @@ $tooltip-background-color: #151515;
   padding-right: 10px;
 }
 
-.graph-wrapper--query-browser {
-  padding-left: 50px;
-  padding-right: 10px;
+.graph-wrapper.graph-wrapper--query-browser {
+  padding: 5px 10px 15px 50px;
 
   &--with-legend {
     min-height: 305px;

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -47,6 +47,7 @@ import {
 } from '../utils';
 import {
   formatPrometheusDuration,
+  getLocaleDate,
   parsePrometheusDuration,
   twentyFourHourTime,
 } from '../utils/datetime';
@@ -226,7 +227,7 @@ const LegendContainer = ({ children }: { children?: React.ReactNode }) => {
   // The first child should be a <rect> with a `width` prop giving the legend's content width
   const width = children?.[0]?.[0]?.props?.width ?? '100%';
   return (
-    <foreignObject height={75} width="100%" y={230}>
+    <foreignObject height={75} width="100%" y={245}>
       <div className="monitoring-dashboards__legend-wrap">
         <svg width={width}>{children}</svg>
       </div>
@@ -312,18 +313,11 @@ const Graph: React.FC<GraphProps> = React.memo(
         yTickFormat = (v: number) => (v === 0 ? '0' : v.toExponential(1));
       }
     }
-    const xTickFormat = (d) => twentyFourHourTime(d, span < 5 * ONE_MINUTE);
-    let xAxisStyle;
-    if (width < 225) {
-      xAxisStyle = {
-        tickLabels: {
-          angle: 45,
-          fontSize: 10,
-          textAnchor: 'start',
-          verticalAnchor: 'middle',
-        },
-      };
-    }
+
+    const xTickFormat =
+      span > parsePrometheusDuration('1d')
+        ? (d) => `${getLocaleDate(d, { month: 'short', day: 'numeric' })}\n${twentyFourHourTime(d)}`
+        : (d) => twentyFourHourTime(d, span < 5 * ONE_MINUTE);
 
     const GroupComponent = isStack ? ChartStack : ChartGroup;
     const ChartComponent = isStack ? ChartArea : ChartLine;
@@ -339,7 +333,7 @@ const Graph: React.FC<GraphProps> = React.memo(
         theme={theme}
         width={width}
       >
-        <ChartAxis style={xAxisStyle} tickCount={5} tickFormat={xTickFormat} />
+        <ChartAxis tickCount={Math.round(width / 100)} tickFormat={xTickFormat} />
         <ChartAxis
           crossAxis={false}
           dependentAxis

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -1,9 +1,15 @@
 import * as _ from 'lodash-es';
 import * as moment from 'moment';
 
+const getLocale = () => localStorage.getItem('bridge/language');
+
+export const getLocaleDate = (date: Date, options): string =>
+  date.toLocaleDateString(getLocale() || undefined, options);
+
 // Behaves like moment.js's fromNow
 export const fromNow = (dateTime, now = undefined, options = { omitSuffix: false }) => {
-  // Check for null. If dateTime is null, it returns incorrect date and time of Wed Dec 31 1969 19:00:00 GMT-0500 (Eastern Standard Time)
+  // Check for null. If dateTime is null, it returns incorrect date and time of Wed Dec 31 1969
+  // 19:00:00 GMT-0500 (Eastern Standard Time)
   if (!dateTime) {
     return '-';
   }
@@ -67,7 +73,8 @@ export const formatPrometheusDuration = (ms: number) => {
   return _.trim(str);
 };
 
-// Converts a duration like "1h 10m 23s" to milliseconds or returns 0 if the duration could not be parsed
+// Converts a duration like "1h 10m 23s" to milliseconds or returns 0 if the duration could not be
+// parsed
 export const parsePrometheusDuration = (duration: string): number => {
   try {
     const parts = duration


### PR DESCRIPTION
Also adjusts the styling of the X-axis labels to accommodate the now
potentially longer label strings.

![en](https://user-images.githubusercontent.com/460802/110787066-434e6c00-82b0-11eb-99b8-60e2c95d733e.png)
![ja](https://user-images.githubusercontent.com/460802/110787071-45182f80-82b0-11eb-9b26-901832c190be.png)
