### PR TITLE
Bug 1937683: Show plane image destination of output in buildConfig when the destination is a DockerImage

### DIFF
--- a/frontend/public/components/utils/build-strategy.tsx
+++ b/frontend/public/components/utils/build-strategy.tsx
@@ -109,7 +109,7 @@ export const BuildStrategy: React.SFC<BuildStrategyProps> = ({ resource, childre
           {buildFrom.name}
         </DetailsItem>
       )}
-      {outputTo && (
+      {outputTo && outputTo.kind === 'ImageStreamTag' && (
         <DetailsItem label={t('build-strategy~Output to')} obj={resource} path="spec.output.to">
           <ResourceLink
             kind={ImageStreamTagsReference}
@@ -117,6 +117,11 @@ export const BuildStrategy: React.SFC<BuildStrategyProps> = ({ resource, childre
             namespace={outputTo.namespace || resource.metadata.namespace}
             title={outputTo.name}
           />
+        </DetailsItem>
+      )}
+      {outputTo && outputTo.kind === 'DockerImage' && (
+        <DetailsItem label={t('build-strategy~Output to')} obj={resource} path="spec.output.to">
+          {outputTo.name}
         </DetailsItem>
       )}
       {pushSecret && (


### PR DESCRIPTION
Before:
![Screenshot_2021-03-11 nodejs-echo Â· Details Â· Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/1668218/110780590-2771a880-8265-11eb-852b-cfceebf9c2aa.png)


After:
<img width="1588" alt="Screenshot 2021-03-11 at 12 20 20" src="https://user-images.githubusercontent.com/1668218/110780668-3b1d0f00-8265-11eb-8c12-5ea8860f2247.png">


/assign @rhamilto 