### PR TITLE
Update Dev perspective to show `Add` page on first visit

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
@@ -33,4 +33,4 @@ export const isPerspective = (e: Extension): e is Perspective => {
   return e.type === 'Perspective';
 };
 
-export type GetLandingPage = (flags: FlagsObject) => string;
+export type GetLandingPage = (flags: FlagsObject, isFirstVisit: boolean) => string;

--- a/frontend/packages/console-shared/src/hooks/useActivePerspective.ts
+++ b/frontend/packages/console-shared/src/hooks/useActivePerspective.ts
@@ -4,6 +4,12 @@ import {
   PerspectiveContextType,
   PerspectiveType,
 } from '@console/app/src/components/detect-perspective/perspective-context';
+import { USERSETTINGS_PREFIX } from '../constants';
+
+const PERSPECTIVE_VISITED_FEATURE_KEY = 'perspective.visited';
+
+export const getPerspectiveVisitedKey = (perspective: PerspectiveType): string =>
+  `${USERSETTINGS_PREFIX}.${PERSPECTIVE_VISITED_FEATURE_KEY}.${perspective}`;
 
 export const useActivePerspective = (): [
   PerspectiveType,

--- a/frontend/packages/dev-console/integration-tests/features/project-creation.feature
+++ b/frontend/packages/dev-console/integration-tests/features/project-creation.feature
@@ -8,4 +8,3 @@ Scenario: Create the namespace
     And user enters project name as "aut-project" in Create Project modal
     And user clicks Create button present in Create Project modal
     Then modal will get closed
-    And topology page displays with the empty state

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -188,7 +188,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       name: '%devconsole~Developer%',
       icon: <CodeIcon />,
       defaultPins: [referenceForModel(ConfigMapModel), referenceForModel(SecretModel)],
-      getLandingPageURL: () => '/topology',
+      getLandingPageURL: (flags, isFirstVisit) => (isFirstVisit ? '/add' : '/topology'),
       getK8sLandingPageURL: () => '/add',
       getImportRedirectURL: (project) => `/topology/ns/${project}`,
       usePerspectiveDetection,

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -1,22 +1,15 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { Dropdown, DropdownItem, DropdownToggle, Title } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { Perspective, useExtensions, isPerspective } from '@console/plugin-sdk';
-import { RootState } from '../../redux';
-import { featureReducerName, getFlagsObject, FlagsObject } from '../../reducers/features';
 import { history } from '../utils';
 import { useActivePerspective } from '@console/shared';
-
-type StateProps = {
-  flags: FlagsObject;
-};
 
 export type NavHeaderProps = {
   onPerspectiveSelected: () => void;
 };
 
-const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({ onPerspectiveSelected, flags }) => {
+const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
   const [activePerspective, setActivePerspective] = useActivePerspective();
   const [isPerspectiveDropdownOpen, setPerspectiveDropdownOpen] = React.useState(false);
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
@@ -29,13 +22,14 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({ onPerspectiveSelect
       event.preventDefault();
       if (perspective.properties.id !== activePerspective) {
         setActivePerspective(perspective.properties.id);
-        history.push(perspective.properties.getLandingPageURL(flags));
+        // Navigate to root and let the default page determine where to go to next
+        history.push('/');
       }
 
       setPerspectiveDropdownOpen(false);
       onPerspectiveSelected && onPerspectiveSelected();
     },
-    [activePerspective, flags, onPerspectiveSelected, setActivePerspective],
+    [activePerspective, onPerspectiveSelected, setActivePerspective],
   );
 
   const renderToggle = React.useCallback(
@@ -96,10 +90,4 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({ onPerspectiveSelect
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
-  flags: getFlagsObject(state),
-});
-
-export default connect<StateProps, {}, NavHeaderProps, RootState>(mapStateToProps, null, null, {
-  areStatesEqual: (next, prev) => next[featureReducerName] === prev[featureReducerName],
-})(NavHeader_);
+export default NavHeader;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5613

**Solution Description**: 
Add a flag to the perspective extension for the `GetLandingPage` indicating if the user has visited the perspective before. On a nav to the perspective, update the user settings to flag that the user has visited the perspective.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind feature