### PR TITLE
Update the scope of GitOpsService resource

### DIFF
--- a/frontend/packages/gitops-plugin/src/models/gitops.ts
+++ b/frontend/packages/gitops-plugin/src/models/gitops.ts
@@ -9,6 +9,6 @@ export const GitOpsServiceModel: K8sKind = {
   label: 'Gitops Service',
   labelPlural: 'Gitops Services',
   abbr: 'GS',
-  namespaced: true,
+  namespaced: false,
   crd: true,
 };


### PR DESCRIPTION
The GitOpsService CRD is a cluster scoped resource. Currently, the operand UI page shows a 404:Not Found error because the model considers it to be a namespace scoped resource. This commit changes the scope of GitOpsService from namespace to cluster.

BZ Ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1937929

![Screenshot from 2021-03-11 10-38-26](https://user-images.githubusercontent.com/21128732/111153724-4e5b1200-85b8-11eb-921c-4511397dcbd8.png)

cc @reginapizza @keithchong 