### PR TITLE
add support for finally tasks in pipeline builder

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -190,6 +190,7 @@
   "Represents the location of the blob storage i.e gs://some-private-bucket": "Represents the location of the blob storage i.e gs://some-private-bucket",
   "Directory": "Directory",
   "Represents whether the blob storage is a directory or not": "Represents whether the blob storage is a directory or not",
+  "Add finally task": "Add finally task",
   "Add a sequential task after this task": "Add a sequential task after this task",
   "Add a sequential task before this task": "Add a sequential task before this task",
   "Add a parallel task": "Add a parallel task",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -83,14 +83,21 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
     [setStatus],
   );
 
-  const onTaskSelection = (task: PipelineVisualizationTaskItem, resource: TaskKind) => {
+  const onTaskSelection = (
+    task: PipelineVisualizationTaskItem,
+    resource: TaskKind,
+    isFinallyTask: boolean,
+  ) => {
+    const builderNodes = isFinallyTask ? values.formData.finallyTasks : values.formData.tasks;
     setSelectedTask({
-      taskIndex: values.formData.tasks.findIndex(({ name }) => name === task.name),
+      isFinallyTask,
+      taskIndex: builderNodes.findIndex(({ name }) => name === task.name),
       resource,
     });
   };
 
   useResourceValidation(
+    values.formData.finallyTasks,
     values.formData.tasks,
     values.formData.resources,
     values.formData.workspaces,
@@ -98,20 +105,25 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
   );
 
   const updateTasks = (changes: CleanupResults): void => {
-    const { tasks, listTasks, errors: taskErrors } = changes;
+    const { tasks, listTasks, finallyTasks, finallyListTasks, errors: taskErrors } = changes;
 
     setFieldValue('formData.tasks', tasks);
     setFieldValue('formData.listTasks', listTasks);
+    setFieldValue('formData.finallyTasks', finallyTasks);
+    setFieldValue('formData.finallyListTasks', finallyListTasks);
     updateErrors(taskErrors);
   };
 
-  const selectedId = values.formData.tasks[selectedTask?.taskIndex]?.name;
+  const nodeType = selectedTask?.isFinallyTask ? 'finallyTasks' : 'tasks';
+  const selectedId = values.formData[nodeType][selectedTask?.taskIndex]?.name;
   const selectedIds = selectedId ? [selectedId] : [];
 
   const taskGroup: PipelineBuilderTaskGroup = {
     tasks: values.formData.tasks,
     listTasks: values.formData.listTasks,
     highlightedIds: selectedIds,
+    finallyTasks: values.formData.finallyTasks,
+    finallyListTasks: values.formData.finallyListTasks,
   };
 
   const closeSidebarAndHandleReset = React.useCallback(() => {
@@ -141,6 +153,8 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
       ...newFormData.spec,
       name: newFormData.metadata?.name,
       listTasks: values.formData.listTasks,
+      finallyTasks: newFormData.spec.finally,
+      finallyListTasks: values.formData.finallyListTasks,
     };
     return _.merge({}, initialPipelineFormData, formData);
   };
@@ -230,6 +244,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
                   t,
                 );
               }}
+              isFinallyTask={selectedTask.isFinallyTask}
               selectedPipelineTaskIndex={selectedTask.taskIndex}
               taskResource={selectedTask.resource}
             />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/const.ts
@@ -5,7 +5,9 @@ export const TASK_INCOMPLETE_ERROR_MESSAGE = 'Incomplete Task';
 
 export enum UpdateOperationType {
   ADD_LIST_TASK,
+  ADD_FINALLY_LIST_TASK,
   CONVERT_LIST_TO_TASK,
+  CONVERT_LIST_TO_FINALLY_TASK,
   UPDATE_TASK,
   REMOVE_TASK,
   DELETE_LIST_TASK,
@@ -39,4 +41,6 @@ export const initialPipelineFormData: PipelineBuilderFormValues = {
   workspaces: [],
   tasks: [],
   listTasks: [],
+  finallyTasks: [],
+  finallyListTasks: [],
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { getRandomChars } from '@console/shared';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { ClusterTaskModel, TaskModel } from '../../../models';
@@ -15,12 +16,16 @@ import { PipelineVisualizationTaskItem } from '../../../utils/pipeline-utils';
 import { AddNodeDirection } from '../pipeline-topology/const';
 import {
   PipelineBuilderTaskNodeModel,
+  PipelineBuilderFinallyNodeModel,
   PipelineMixedNodeModel,
   PipelineTaskListNodeModel,
 } from '../pipeline-topology/types';
 import {
+  createBuilderFinallyNode,
   createInvalidTaskListNode,
   createTaskListNode,
+  getFinallyTaskHeight,
+  getLastRegularTasks,
   handleParallelToParallelNodes,
   tasksToBuilderNodes,
 } from '../pipeline-topology/utils';
@@ -30,6 +35,7 @@ import {
   TaskErrorMap,
   UpdateErrors,
   UpdateOperationAddData,
+  UpdateOperationConvertToFinallyTaskData,
   UpdateOperationConvertToTaskData,
   UpdateOperationFixInvalidTaskListData,
   UpdateTasksCallback,
@@ -77,6 +83,75 @@ export const useTasks = (namespace?: string): UseTasks => {
   };
 };
 
+const useConnectFinally = (
+  namespace,
+  nodes,
+  taskGroup: PipelineBuilderTaskGroup,
+  onTaskSelection: SelectTaskCallback,
+  onUpdateTasks: UpdateTasksCallback,
+  tasksInError: TaskErrorMap,
+): PipelineMixedNodeModel => {
+  const { clusterTasks, namespacedTasks } = useTasks(namespace);
+  const taskGroupRef = React.useRef(taskGroup);
+  taskGroupRef.current = taskGroup;
+  const addNewFinallyListNode = () => {
+    const data: UpdateOperationConvertToFinallyTaskData = {
+      listTaskName: `finally-list-${getRandomChars(6)}`,
+    };
+    onUpdateTasks(taskGroupRef.current, { type: UpdateOperationType.ADD_FINALLY_LIST_TASK, data });
+  };
+  // TODO: Cleanup in ODC-3165
+  const getTask = (taskRef: PipelineTaskRef) => {
+    if (taskRef?.kind === ClusterTaskModel.kind) {
+      return clusterTasks?.find((task) => task.metadata.name === taskRef?.name);
+    }
+    return namespacedTasks?.find((task) => task.metadata.name === taskRef?.name);
+  };
+
+  const convertListToFinallyTask = (resource: TaskKind, name: string) => {
+    const data: UpdateOperationConvertToTaskData = { resource, name };
+    onUpdateTasks(taskGroupRef.current, {
+      type: UpdateOperationType.CONVERT_LIST_TO_FINALLY_TASK,
+      data,
+    });
+  };
+  const allTasksLength = taskGroup.finallyTasks.length + taskGroup.finallyListTasks.length;
+  const finallyNodeName = `finally-node-${taskGroup.finallyTasks.length}-${taskGroup.finallyListTasks.length}`;
+  const regularRunAfters = getLastRegularTasks(nodes);
+
+  const finallyGroupNode: PipelineBuilderFinallyNodeModel = createBuilderFinallyNode(
+    getFinallyTaskHeight(allTasksLength, false),
+  )(finallyNodeName, {
+    isFinallyTask: true,
+    namespace,
+    namespaceTaskList: namespacedTasks,
+    clusterTaskList: clusterTasks,
+    task: {
+      isFinallyTask: true,
+      name: finallyNodeName,
+      runAfter: regularRunAfters,
+      addNewFinallyListNode,
+      finallyTasks: taskGroup.finallyTasks.map((ft) => ({
+        ...ft,
+        onTaskSelection: () => onTaskSelection(ft, getTask(ft.taskRef), true),
+        error: getErrorMessage(nodeTaskErrors, tasksInError)(ft.name),
+        selected: taskGroup.highlightedIds.includes(ft.name),
+        disableTooltip: true,
+      })),
+      finallyListTasks: taskGroup.finallyListTasks.map((flt) => ({
+        ...flt,
+        convertList: (resource: TaskKind) => convertListToFinallyTask(resource, flt.name),
+        onRemoveTask: () => {
+          onUpdateTasks(taskGroupRef.current, {
+            type: UpdateOperationType.DELETE_LIST_TASK,
+            data: { listTaskName: flt.name },
+          });
+        },
+      })),
+    },
+  });
+  return finallyGroupNode;
+};
 type UseNodes = {
   nodes: PipelineMixedNodeModel[];
   tasksCount: number;
@@ -175,7 +250,7 @@ export const useNodes = (
       ? tasksToBuilderNodes(
           validTaskList,
           onNewListNode,
-          (task) => onTaskSelection(task, getTask(task.taskRef)),
+          (task) => onTaskSelection(task, getTask(task.taskRef), false),
           getErrorMessage(nodeTaskErrors, tasksInError),
           taskGroup.highlightedIds,
         )
@@ -193,16 +268,24 @@ export const useNodes = (
 
   const localTaskCount = namespacedTasks?.length || 0;
   const clusterTaskCount = clusterTasks?.length || 0;
-
+  const finallyNode = useConnectFinally(
+    namespace,
+    nodes,
+    taskGroup,
+    onTaskSelection,
+    onUpdateTasks,
+    tasksInError,
+  );
   return {
     tasksCount: localTaskCount + clusterTaskCount,
     tasksLoaded: !!namespacedTasks && !!clusterTasks,
     loadingTasksError: errorMsg,
-    nodes,
+    nodes: [...nodes, finallyNode],
   };
 };
 
 export const useResourceValidation = (
+  finallyTasks: PipelineTask[],
   tasks: PipelineTask[],
   resourceValues: TektonResource[],
   workspaceValues: PipelineWorkspace[],
@@ -213,7 +296,7 @@ export const useResourceValidation = (
   React.useEffect(() => {
     const resourceNames = resourceValues.map((r) => r.name);
 
-    const errors = tasks.reduce((acc, task) => {
+    const errors = [...tasks, ...finallyTasks].reduce((acc, task) => {
       const output = task.resources?.outputs || [];
       const input = task.resources?.inputs || [];
       const missingResources = [...output, ...input].filter(
@@ -262,5 +345,13 @@ export const useResourceValidation = (
       }
       onError(outputErrors);
     }
-  }, [tasks, resourceValues, workspaceValues, onError, previousErrorIds, setPreviousErrorIds]);
+  }, [
+    tasks,
+    resourceValues,
+    workspaceValues,
+    onError,
+    previousErrorIds,
+    setPreviousErrorIds,
+    finallyTasks,
+  ]);
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -29,6 +29,7 @@ type TaskSidebarProps = {
   workspaceList: PipelineWorkspace[];
   selectedPipelineTaskIndex: number;
   taskResource: TaskKind;
+  isFinallyTask: boolean;
   onClose: () => void;
 };
 
@@ -40,10 +41,12 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
     workspaceList,
     selectedPipelineTaskIndex,
     taskResource,
+    isFinallyTask,
     onClose,
   } = props;
   const { t } = useTranslation();
-  const formikTaskReference = `formData.tasks.${selectedPipelineTaskIndex}`;
+  const taskType = isFinallyTask ? 'finallyTasks' : 'tasks';
+  const formikTaskReference = `formData.${taskType}.${selectedPipelineTaskIndex}`;
   const [taskField] = useField<PipelineTask>(formikTaskReference);
 
   const updateTask = (newData: Partial<UpdateOperationUpdateTaskData>) => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/types.ts
@@ -21,6 +21,8 @@ export type PipelineBuilderListTask = PipelineBuilderTaskBase;
 export type PipelineBuilderTaskGrouping = {
   tasks: PipelineTask[];
   listTasks: PipelineBuilderListTask[];
+  finallyTasks: PipelineTask[];
+  finallyListTasks: PipelineBuilderListTask[];
 };
 
 export type PipelineBuilderTaskGroup = PipelineBuilderTaskGrouping & {
@@ -45,6 +47,7 @@ export type PipelineBuilderFormikValues = FormikValues & PipelineBuilderFormYaml
 export type SelectedBuilderTask = {
   resource: TaskKind;
   taskIndex: number;
+  isFinallyTask: boolean;
 };
 
 export type TaskErrorMap = {
@@ -54,6 +57,7 @@ export type TaskErrorMap = {
 export type SelectTaskCallback = (
   task: PipelineVisualizationTaskItem,
   taskResource: TaskKind,
+  isFinallyTask: boolean,
 ) => void;
 
 export type UpdateOperation<D extends UpdateOperationBaseData = UpdateOperationBaseData> = {
@@ -76,6 +80,9 @@ export type UpdateOperationConvertToTaskData = UpdateOperationBaseData & {
   name: string;
   resource: TaskKind;
   runAfter?: string[];
+};
+export type UpdateOperationConvertToFinallyTaskData = {
+  listTaskName: string;
 };
 export type UpdateOperationFixInvalidTaskListData = UpdateOperationBaseData & {
   existingName: string;
@@ -118,11 +125,12 @@ export type UpdateOperationUpdateTaskData = UpdateOperationBaseData & {
 export type CleanupResults = {
   tasks: PipelineTask[];
   listTasks: PipelineBuilderListTask[];
+  finallyTasks: PipelineTask[];
+  finallyListTasks: PipelineBuilderListTask[];
   errors?: TaskErrorMap;
 };
 
 export type UpdateOperationAction<D extends UpdateOperationBaseData> = (
-  tasks: PipelineTask[],
-  listTasks: PipelineBuilderListTask[],
+  taskGrouping: PipelineBuilderTaskGrouping,
   data: D,
 ) => CleanupResults;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
@@ -95,8 +95,18 @@ export const convertBuilderFormToPipeline = (
   namespace: string,
   existingPipeline?: PipelineKind,
 ): PipelineKind => {
-  const { name, resources, params, workspaces, tasks, listTasks, ...unhandledSpec } = formValues;
+  const {
+    name,
+    resources,
+    params,
+    workspaces,
+    tasks,
+    listTasks,
+    finallyTasks,
+    ...unhandledSpec
+  } = formValues;
   const listIds = listTasks.map((listTask) => listTask.name);
+  const extraYamlSpec = _.omit(unhandledSpec, 'finallyListTasks');
 
   return {
     ...existingPipeline,
@@ -109,11 +119,12 @@ export const convertBuilderFormToPipeline = (
     },
     spec: {
       ...existingPipeline?.spec,
-      ...unhandledSpec,
+      ...extraYamlSpec,
       params: removeEmptyDefaultFromPipelineParams(params),
       resources,
       workspaces,
       tasks: tasks.map((task) => removeEmptyDefaultParams(removeListRunAfters(task, listIds))),
+      finally: finallyTasks,
     },
   };
 };
@@ -138,6 +149,8 @@ export const convertPipelineToBuilderForm = (
       workspaces,
       tasks,
       listTasks: [],
+      finallyTasks: pipeline.spec?.finally ?? [],
+      finallyListTasks: [],
     },
   };
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/BuilderFinallyNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/BuilderFinallyNode.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { chart_color_blue_300 as blueColor } from '@patternfly/react-tokens';
+import { observer, Node, NodeModel } from '@patternfly/react-topology';
+import { PipelineVisualizationTask } from '../detail-page-tabs/pipeline-details/PipelineVisualizationTask';
+import {
+  BUILDER_NODE_ADD_RADIUS,
+  NODE_WIDTH,
+  NODE_HEIGHT,
+  FINALLY_NODE_PADDING,
+  FINALLY_NODE_VERTICAL_SPACING,
+  FINALLY_ADD_LINK_TEXT_HEIGHT,
+  BUILDER_NODE_ERROR_RADIUS,
+  FINALLY_ADD_LINK_SIZE,
+} from './const';
+import PlusNodeDecorator from './PlusNodeDecorator';
+import ErrorNodeDecorator from './ErrorNodeDecorator';
+import { BuilderFinallyNodeModel } from './types';
+import TaskList from './TaskList';
+
+type BuilderFinallyNodeProps = {
+  element: Node<NodeModel, BuilderFinallyNodeModel>;
+};
+
+const BuilderFinallyNode: React.FC<BuilderFinallyNodeProps> = ({ element }) => {
+  const { t } = useTranslation();
+  const { width, height } = element.getBounds();
+  const { clusterTaskList = [], namespaceTaskList = [], task, namespace } = element.getData();
+  const { addNewFinallyListNode, finallyTasks = [], finallyListTasks = [] } = task;
+  const allTasksLength = finallyTasks.length + finallyListTasks.length;
+  return (
+    <>
+      <rect
+        fill="transparent"
+        strokeWidth={1}
+        stroke="var(--pf-global--BorderColor--light-100)"
+        width={width}
+        height={height}
+        rx="20"
+        ry="20"
+      />
+
+      {finallyTasks.map((ft, i) => (
+        <g
+          key={ft.name}
+          transform={`translate(${FINALLY_NODE_PADDING}, ${NODE_HEIGHT * i +
+            FINALLY_NODE_VERTICAL_SPACING * i +
+            FINALLY_NODE_PADDING})`}
+          onClick={ft.onTaskSelection}
+        >
+          <PipelineVisualizationTask
+            task={ft}
+            namespace={namespace}
+            disableTooltip
+            selected={ft.selected}
+            width={NODE_WIDTH}
+            height={NODE_HEIGHT}
+          />
+          {ft.error && (
+            <ErrorNodeDecorator
+              x={BUILDER_NODE_ADD_RADIUS / 2}
+              y={BUILDER_NODE_ERROR_RADIUS / 4}
+              errorStr={ft.error}
+            />
+          )}
+        </g>
+      ))}
+      {finallyListTasks.map((flt, i) => (
+        <g
+          key={flt.name}
+          transform={`translate(${FINALLY_NODE_PADDING}, 
+              ${NODE_HEIGHT * (i + finallyTasks.length) +
+                FINALLY_NODE_VERTICAL_SPACING * (i + finallyTasks.length) +
+                FINALLY_NODE_PADDING})`}
+        >
+          <TaskList
+            width={NODE_WIDTH}
+            height={NODE_HEIGHT}
+            listOptions={[...clusterTaskList, ...namespaceTaskList]}
+            onRemoveTask={flt.onRemoveTask}
+            onNewTask={flt.convertList}
+          />
+        </g>
+      ))}
+      {
+        <g
+          transform={`translate(${FINALLY_NODE_PADDING +
+            FINALLY_NODE_PADDING / 2}, ${allTasksLength * NODE_HEIGHT +
+            allTasksLength * FINALLY_NODE_VERTICAL_SPACING +
+            FINALLY_ADD_LINK_TEXT_HEIGHT +
+            FINALLY_NODE_PADDING})`}
+          style={{ cursor: 'pointer' }}
+          onClick={addNewFinallyListNode}
+        >
+          <g>
+            <PlusNodeDecorator
+              x={0}
+              y={FINALLY_ADD_LINK_TEXT_HEIGHT - FINALLY_ADD_LINK_SIZE}
+              tooltip={t('pipelines-plugin~Add finally task')}
+            />
+            <text fill={blueColor.value} x={FINALLY_ADD_LINK_SIZE}>
+              {t('pipelines-plugin~Add finally task')}
+            </text>
+          </g>
+        </g>
+      }
+    </>
+  );
+};
+
+export default observer(BuilderFinallyNode);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/FinallyNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/FinallyNode.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { observer, Node, NodeModel } from '@patternfly/react-topology';
+import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { PipelineVisualizationTask } from '../detail-page-tabs/pipeline-details/PipelineVisualizationTask';
+import {
+  NODE_WIDTH,
+  NODE_HEIGHT,
+  FINALLY_NODE_PADDING,
+  FINALLY_NODE_VERTICAL_SPACING,
+} from './const';
+import { FinallyNodeModel } from './types';
+
+type FinallyNodeProps = {
+  element: Node<NodeModel, FinallyNodeModel>;
+};
+
+const FinallyNode: React.FC<FinallyNodeProps> = ({ element }) => {
+  const { task, pipeline, pipelineRun } = element.getData();
+  const { width, height } = element.getBounds();
+  const { finallyTasks = [] } = task;
+  return (
+    <>
+      <rect
+        fill="transparent"
+        strokeWidth={1}
+        stroke="var(--pf-global--BorderColor--light-100)"
+        width={width}
+        height={height}
+        rx="20"
+        ry="20"
+      />
+      {finallyTasks.map((ft, i) => (
+        <g
+          key={ft.name}
+          transform={`translate(${FINALLY_NODE_PADDING}, ${NODE_HEIGHT * i +
+            FINALLY_NODE_VERTICAL_SPACING * i +
+            FINALLY_NODE_PADDING})`}
+        >
+          <PipelineVisualizationTask
+            pipelineRunName={pipelineRun?.metadata?.name}
+            task={ft}
+            pipelineRunStatus={pipelineRun && pipelineRunFilterReducer(pipelineRun)}
+            namespace={pipeline?.metadata?.namespace}
+            selected={ft.selected}
+            width={NODE_WIDTH}
+            height={NODE_HEIGHT}
+          />
+        </g>
+      ))}
+    </>
+  );
+};
+
+export default observer(FinallyNode);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PipelineVisualizationSurface.tsx
@@ -8,7 +8,7 @@ import {
   VisualizationProvider,
 } from '@patternfly/react-topology';
 import { componentFactory, layoutFactory } from './factories';
-import { DROP_SHADOW_SPACING, NODE_WIDTH, NODE_HEIGHT, PipelineLayout } from './const';
+import { DROP_SHADOW_SPACING, NODE_HEIGHT, NODE_WIDTH, PipelineLayout } from './const';
 import { getLayoutData } from './utils';
 
 type PipelineVisualizationSurfaceProps = {
@@ -24,6 +24,12 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
   const onLayoutUpdate = React.useCallback(
     (nodes: Node[]) => {
       const nodeBounds = nodes.map((node) => node.getBounds());
+      const maxHeight = Math.floor(
+        nodeBounds.map((bounds) => bounds.height).reduce((h1, h2) => Math.max(h1, h2), 0),
+      );
+      const maxObject = nodeBounds.find((nb) => nb.height === maxHeight);
+      const hasFinallyNodes = nodes.some((n) => !!n.getData()?.isFinallyTask);
+
       const maxX = Math.floor(
         nodeBounds.map((bounds) => bounds.x).reduce((x1, x2) => Math.max(x1, x2), 0),
       );
@@ -38,11 +44,19 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
         verticalMargin = getLayoutData(layout).marginy || 0;
       }
 
-      setMaxSize({
-        // Nodes are rendered from the top-left
-        height: maxY + NODE_HEIGHT + DROP_SHADOW_SPACING + verticalMargin * 2,
-        width: maxX + NODE_WIDTH + horizontalMargin * 2,
-      });
+      if (hasFinallyNodes) {
+        setMaxSize({
+          // Nodes are rendered from the top-left
+          height: maxObject.y + maxHeight + DROP_SHADOW_SPACING + verticalMargin * 2,
+          width: maxObject.x + maxObject.width + DROP_SHADOW_SPACING + horizontalMargin * 2,
+        });
+      } else {
+        setMaxSize({
+          // Nodes are rendered from the top-left
+          height: maxY + NODE_HEIGHT + DROP_SHADOW_SPACING + verticalMargin * 2,
+          width: maxX + NODE_WIDTH + horizontalMargin * 2,
+        });
+      }
     },
     [setMaxSize, layout],
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskList.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import * as _ from 'lodash';
+import * as cx from 'classnames';
+import { FocusTrap } from '@patternfly/react-core';
+import { CaretDownIcon } from '@patternfly/react-icons';
+import { useHover } from '@patternfly/react-topology';
+import Popper from '@console/shared/src/components/popper/Popper';
+import {
+  KebabItem,
+  KebabOption,
+  ResourceIcon,
+  truncateMiddle,
+} from '@console/internal/components/utils';
+import { TaskKind } from '../../../types';
+import { NewTaskNodeCallback } from './types';
+
+type KeyedKebabOption = KebabOption & { key: string };
+
+const taskToOption = (task: TaskKind, callback: NewTaskNodeCallback): KeyedKebabOption => {
+  const {
+    kind,
+    metadata: { name },
+  } = task;
+
+  return {
+    key: `${name}-${kind}`,
+    label: name,
+    icon: <ResourceIcon kind={kind} />,
+    callback: () => {
+      callback(task);
+    },
+  };
+};
+
+const TaskList: React.FC<any> = ({
+  width,
+  height,
+  listOptions,
+  unselectedText,
+  onRemoveTask,
+  onNewTask,
+}) => {
+  const { t } = useTranslation();
+  const triggerRef = React.useRef(null);
+  const [isMenuOpen, setMenuOpen] = React.useState(false);
+  const [hover, hoverRef] = useHover();
+
+  const options = _.sortBy(
+    listOptions.map((task) => taskToOption(task, onNewTask)),
+    (o) => o.label,
+  );
+
+  const unselectedTaskText = React.useMemo(
+    () =>
+      truncateMiddle(unselectedText, { length: 10, truncateEnd: true }) ||
+      t('pipelines-plugin~Select Task'),
+    [unselectedText, t],
+  );
+
+  return (
+    <>
+      <g
+        ref={hoverRef}
+        className="odc-task-list-node__trigger"
+        onClick={() => setMenuOpen(!isMenuOpen)}
+      >
+        <rect
+          ref={triggerRef}
+          className={cx('odc-task-list-node__trigger-background', {
+            'is-disabled': options.length === 0,
+          })}
+          width={width}
+          height={height}
+        />
+        {options.length === 0 ? (
+          <text className="odc-task-list-node__trigger-disabled" x={width / 2} y={height / 2 + 1}>
+            {t('pipelines-plugin~No Tasks')}
+          </text>
+        ) : (
+          <g>
+            <rect
+              className={
+                hover
+                  ? 'odc-task-list-node__trigger-underline--hover'
+                  : 'odc-task-list-node__trigger-underline'
+              }
+              y={height}
+              width={width}
+              height={hover ? 2 : 1}
+            />
+            <text x={width / 2 - 10} y={height / 2 + 1}>
+              {unselectedTaskText}
+            </text>
+            <g transform={`translate(${width - 30}, ${height / 4})`}>
+              <CaretDownIcon />
+            </g>
+          </g>
+        )}
+      </g>
+      <Popper
+        open={isMenuOpen}
+        placement="bottom-start"
+        closeOnEsc
+        closeOnOutsideClick
+        onRequestClose={(e) => {
+          if (!e || !triggerRef?.current?.contains(e.target as Element)) {
+            setMenuOpen(false);
+          }
+        }}
+        reference={() => triggerRef.current}
+      >
+        <FocusTrap
+          focusTrapOptions={{ clickOutsideDeactivates: true, returnFocusOnDeactivate: false }}
+        >
+          <div className="pf-c-dropdown pf-m-expanded odc-task-list-node__container">
+            <ul className="pf-c-dropdown__menu pf-m-align-right oc-kebab__popper-items odc-task-list-node__list-items">
+              {options.map((option) => (
+                <li key={option.key}>
+                  <KebabItem
+                    option={option}
+                    onClick={() => {
+                      option.callback && option.callback();
+                    }}
+                  />
+                </li>
+              ))}
+              {onRemoveTask && (
+                <>
+                  <li>
+                    <hr className="odc-task-list-node__divider" />
+                  </li>
+                  <li>
+                    <KebabItem
+                      option={{ label: t('pipelines-plugin~Delete Task'), callback: onRemoveTask }}
+                      onClick={onRemoveTask}
+                    />
+                  </li>
+                </>
+              )}
+            </ul>
+          </div>
+        </FocusTrap>
+      </Popper>
+    </>
+  );
+};
+export default TaskList;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskListNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskListNode.tsx
@@ -1,39 +1,9 @@
 import * as React from 'react';
-import * as _ from 'lodash';
-import { useTranslation } from 'react-i18next';
-import * as cx from 'classnames';
-import { FocusTrap } from '@patternfly/react-core';
-import { CaretDownIcon } from '@patternfly/react-icons';
-import Popper from '@console/shared/src/components/popper/Popper';
-import {
-  KebabItem,
-  KebabOption,
-  ResourceIcon,
-  truncateMiddle,
-} from '@console/internal/components/utils';
-import { observer, Node, NodeModel, useHover } from '@patternfly/react-topology';
-import { TaskKind } from '../../../types';
-import { NewTaskNodeCallback, TaskListNodeModelData } from './types';
+import { observer, Node, NodeModel } from '@patternfly/react-topology';
+import { TaskListNodeModelData } from './types';
+import TaskList from './TaskList';
 
 import './TaskListNode.scss';
-
-type KeyedKebabOption = KebabOption & { key: string };
-
-const taskToOption = (task: TaskKind, callback: NewTaskNodeCallback): KeyedKebabOption => {
-  const {
-    kind,
-    metadata: { name },
-  } = task;
-
-  return {
-    key: `${name}-${kind}`,
-    label: name,
-    icon: <ResourceIcon kind={kind} />,
-    callback: () => {
-      callback(task);
-    },
-  };
-};
 
 type TaskListNodeProps = {
   element: Node<NodeModel, TaskListNodeModelData>;
@@ -41,114 +11,23 @@ type TaskListNodeProps = {
 };
 
 const TaskListNode: React.FC<TaskListNodeProps> = ({ element, unselectedText }) => {
-  const { t } = useTranslation();
-  const triggerRef = React.useRef(null);
-  const [isMenuOpen, setMenuOpen] = React.useState(false);
-  const { height, width } = element.getBounds();
-  const { clusterTaskList, namespaceTaskList, onNewTask, onRemoveTask } = element.getData();
-
-  const options = _.sortBy(
-    [
-      ...namespaceTaskList.map((task) => taskToOption(task, onNewTask)),
-      ...clusterTaskList.map((task) => taskToOption(task, onNewTask)),
-    ],
-    (o) => o.label,
-  );
-
-  const unselectedTaskText = React.useMemo(
-    () =>
-      truncateMiddle(unselectedText, { length: 10, truncateEnd: true }) ||
-      t('pipelines-plugin~Select Task'),
-    [unselectedText, t],
-  );
-
-  const [hover, hoverRef] = useHover();
+  const { height = 30, width = 120 } = {};
+  const {
+    clusterTaskList = [],
+    namespaceTaskList = [],
+    onNewTask = () => {},
+    onRemoveTask = () => {},
+  } = element.getData() || {};
 
   return (
-    <>
-      <g
-        ref={hoverRef}
-        className="odc-task-list-node__trigger"
-        onClick={() => setMenuOpen(!isMenuOpen)}
-      >
-        <rect
-          ref={triggerRef}
-          className={cx('odc-task-list-node__trigger-background', {
-            'is-disabled': options.length === 0,
-          })}
-          width={width}
-          height={height}
-        />
-        {options.length === 0 ? (
-          <text className="odc-task-list-node__trigger-disabled" x={width / 2} y={height / 2 + 1}>
-            {t('pipelines-plugin~No Tasks')}
-          </text>
-        ) : (
-          <g>
-            <rect
-              className={
-                hover
-                  ? 'odc-task-list-node__trigger-underline--hover'
-                  : 'odc-task-list-node__trigger-underline'
-              }
-              y={height}
-              width={width}
-              height={hover ? 2 : 1}
-            />
-            <text x={width / 2 - 10} y={height / 2 + 1}>
-              {unselectedTaskText}
-            </text>
-            <g transform={`translate(${width - 30}, ${height / 4})`}>
-              <CaretDownIcon />
-            </g>
-          </g>
-        )}
-      </g>
-      <Popper
-        open={isMenuOpen}
-        placement="bottom-start"
-        closeOnEsc
-        closeOnOutsideClick
-        onRequestClose={(e) => {
-          if (!e || !triggerRef?.current?.contains(e.target as Element)) {
-            setMenuOpen(false);
-          }
-        }}
-        reference={() => triggerRef.current}
-      >
-        <FocusTrap
-          focusTrapOptions={{ clickOutsideDeactivates: true, returnFocusOnDeactivate: false }}
-        >
-          <div className="pf-c-dropdown pf-m-expanded odc-task-list-node__container">
-            <ul className="pf-c-dropdown__menu pf-m-align-right oc-kebab__popper-items odc-task-list-node__list-items">
-              {options.map((option) => (
-                <li key={option.key}>
-                  <KebabItem
-                    option={option}
-                    onClick={() => {
-                      option.callback && option.callback();
-                    }}
-                  />
-                </li>
-              ))}
-              {onRemoveTask && (
-                <>
-                  <li>
-                    <hr className="odc-task-list-node__divider" />
-                  </li>
-                  <li>
-                    <KebabItem
-                      option={{ label: t('pipelines-plugin~Delete Task'), callback: onRemoveTask }}
-                      onClick={onRemoveTask}
-                    />
-                  </li>
-                </>
-              )}
-            </ul>
-          </div>
-        </FocusTrap>
-      </Popper>
-    </>
+    <TaskList
+      width={width}
+      height={height}
+      listOptions={[...clusterTaskList, ...namespaceTaskList]}
+      unselectedText={unselectedText}
+      onRemoveTask={onRemoveTask}
+      onNewTask={onNewTask}
+    />
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -1,0 +1,63 @@
+import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
+import { getLastRegularTasks, getTopologyNodesEdges, getFinallyTaskHeight } from '../utils';
+
+const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
+const { pipeline } = pipelineData;
+const pipelineWithFinally = {
+  ...pipeline,
+  spec: {
+    ...pipeline.spec,
+    finally: [{ ...pipeline.spec.tasks[0], name: 'finally-task' }],
+  },
+};
+
+describe('getTopologyNodesEdges', () => {
+  it('expect to return nodes and edges for a pipeline without finally tasks', () => {
+    const { nodes, edges } = getTopologyNodesEdges(pipeline);
+    expect(nodes).toHaveLength(pipeline.spec.tasks.length);
+    expect(edges).toHaveLength(19);
+  });
+
+  it('expect to return nodes and edges for a pipeline with finally tasks', () => {
+    const { nodes, edges } = getTopologyNodesEdges(pipelineWithFinally);
+    expect(nodes).toHaveLength(
+      pipelineWithFinally.spec.tasks.length + pipelineWithFinally.spec.finally.length,
+    );
+    expect(edges).toHaveLength(20);
+  });
+});
+
+describe('getLastRegularTasks', () => {
+  it('expect to handle the empty array input', () => {
+    expect(getLastRegularTasks([])).toHaveLength(0);
+  });
+
+  it('expect to return the last regular task name in the pipeline', () => {
+    const { nodes } = getTopologyNodesEdges(pipeline);
+    expect(getLastRegularTasks(nodes)).toHaveLength(1);
+    expect(getLastRegularTasks(nodes)).toEqual(['verify']);
+  });
+
+  it('expect to return the list of task names that will be executed at the end', () => {
+    const [task1, task2, task3, task4] = pipeline.spec.tasks;
+    const pipelineWithMultipleLastTasks = {
+      ...pipeline,
+      spec: {
+        ...pipeline.spec,
+        tasks: [task1, task2, task3, task4],
+      },
+    };
+    const { nodes } = getTopologyNodesEdges(pipelineWithMultipleLastTasks);
+    expect(getLastRegularTasks(nodes)).toHaveLength(3);
+    expect(getLastRegularTasks(nodes)).toEqual(['analyse-code', 'style-checks', 'find-bugs']);
+  });
+});
+
+describe('getFinallyTaskHeight', () => {
+  it('expect to return dynamic height for finally task based on tasks length and builder options ', () => {
+    const numberOfTasks = 5;
+    const disableBuilder = true;
+    expect(getFinallyTaskHeight(numberOfTasks, disableBuilder)).toBe(290);
+    expect(getFinallyTaskHeight(numberOfTasks, !disableBuilder)).toBe(320);
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
@@ -9,13 +9,19 @@ export const BUILDER_NODE_ADD_PADDING = 4;
 
 export const NODE_WIDTH = 120;
 export const NODE_HEIGHT = 30;
+export const FINALLY_NODE_PADDING = 30;
+export const FINALLY_NODE_VERTICAL_SPACING = 20;
 
+export const FINALLY_ADD_LINK_TEXT_HEIGHT = 10;
+export const FINALLY_ADD_LINK_SIZE = 15;
 export enum NodeType {
   TASK_NODE = 'task',
   SPACER_NODE = 'spacer',
   TASK_LIST_NODE = 'task-list',
   BUILDER_NODE = 'builder',
   INVALID_TASK_LIST_NODE = 'invalid-task-list',
+  FINALLY_NODE = 'finally-node',
+  BUILDER_FINALLY_NODE = 'builder-finally-node',
 }
 export enum DrawDesign {
   INTEGRAL_SHAPE = 'integral-shape',

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/factories.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/factories.ts
@@ -14,6 +14,8 @@ import TaskNode from './TaskNode';
 import TaskEdge from './TaskEdge';
 import TaskListNode from './TaskListNode';
 import { getLayoutData } from './utils';
+import FinallyNode from './FinallyNode';
+import BuilderFinallyNode from './BuilderFinallyNode';
 
 export const componentFactory: ComponentFactory = (kind: ModelKind, type: string) => {
   switch (kind) {
@@ -33,6 +35,10 @@ export const componentFactory: ComponentFactory = (kind: ModelKind, type: string
           return InvalidTaskListNode;
         case NodeType.BUILDER_NODE:
           return BuilderNode;
+        case NodeType.FINALLY_NODE:
+          return FinallyNode;
+        case NodeType.BUILDER_FINALLY_NODE:
+          return BuilderFinallyNode;
         default:
           return undefined;
       }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
@@ -17,6 +17,49 @@ export type PipelineRunAfterNodeModelData = {
     runAfter?: string[];
   };
 };
+
+type FinallyTask = {
+  name: string;
+  runAfter?: string[];
+  error?: string;
+  selected?: boolean;
+  disableTooltip?: boolean;
+  onTaskSelection?: () => void;
+};
+type FinallyListTask = {
+  name: string;
+  convertList: (resource: TaskKind) => void;
+  onRemoveTask: () => void;
+};
+type FinallyNodeTask = {
+  name: string;
+  runAfter: string[];
+  selected?: boolean;
+  isFinallyTask: boolean;
+  finallyTasks: FinallyTask[];
+};
+export type FinallyNodeData = {
+  task: FinallyNodeTask;
+};
+export type BuilderFinallyNodeData = {
+  task: FinallyNodeTask & {
+    finallyListTasks?: FinallyListTask[];
+    addNewFinallyListNode?: () => void;
+  };
+};
+export type FinallyNodeModel = FinallyNodeData & {
+  pipeline: PipelineKind;
+  pipelineRun?: PipelineRunKind;
+  isFinallyTask: boolean;
+};
+
+export type BuilderFinallyNodeModel = BuilderFinallyNodeData & {
+  clusterTaskList: TaskKind[];
+  namespaceTaskList: TaskKind[];
+  namespace: string;
+  isFinallyTask: boolean;
+};
+
 export type TaskListNodeModelData = PipelineRunAfterNodeModelData & {
   clusterTaskList: TaskKind[];
   namespaceTaskList: TaskKind[];
@@ -45,6 +88,8 @@ export type PipelineMixedNodeModel = PipelineNodeModel<PipelineRunAfterNodeModel
 export type PipelineTaskNodeModel = PipelineNodeModel<TaskNodeModelData>;
 export type PipelineBuilderTaskNodeModel = PipelineNodeModel<BuilderNodeModelData>;
 export type PipelineTaskListNodeModel = PipelineNodeModel<TaskListNodeModelData>;
+export type PipelineFinallyNodeModel = PipelineNodeModel<FinallyNodeModel>;
+export type PipelineBuilderFinallyNodeModel = PipelineNodeModel<BuilderFinallyNodeModel>;
 
 export type PipelineEdgeModel = EdgeModel;
 
@@ -56,4 +101,5 @@ export type NodeCreator<D extends PipelineRunAfterNodeModelData> = (
 export type NodeCreatorSetup = (
   type: NodeType,
   width?: number,
+  height?: number,
 ) => NodeCreator<PipelineRunAfterNodeModelData>;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -10,6 +10,8 @@ import {
   PipelineLayout,
   DAGRE_BUILDER_PROPS,
   DAGRE_VIEWER_PROPS,
+  FINALLY_NODE_PADDING,
+  FINALLY_NODE_VERTICAL_SPACING,
 } from './const';
 import {
   PipelineEdgeModel,
@@ -22,13 +24,16 @@ import {
   PipelineTaskNodeModel,
   BuilderNodeModelData,
   PipelineRunAfterNodeModelData,
+  BuilderFinallyNodeModel,
+  FinallyNodeModel,
+  PipelineFinallyNodeModel,
 } from './types';
 
-const createGenericNode: NodeCreatorSetup = (type, width?) => (name, data) => ({
+const createGenericNode: NodeCreatorSetup = (type, width?, height?) => (name, data) => ({
   id: name,
   data,
-  height: NODE_HEIGHT,
-  width: width != null ? width : NODE_WIDTH,
+  height: height ?? NODE_HEIGHT,
+  width: width ?? NODE_WIDTH,
   type,
 });
 
@@ -47,6 +52,11 @@ export const createInvalidTaskListNode: NodeCreator<TaskListNodeModelData> = cre
 export const createBuilderNode: NodeCreator<BuilderNodeModelData> = createGenericNode(
   NodeType.BUILDER_NODE,
 );
+
+export const createFinallyNode = (height): NodeCreator<FinallyNodeModel> =>
+  createGenericNode(NodeType.FINALLY_NODE, NODE_WIDTH + FINALLY_NODE_PADDING * 2, height);
+export const createBuilderFinallyNode = (height): NodeCreator<BuilderFinallyNodeModel> =>
+  createGenericNode(NodeType.BUILDER_FINALLY_NODE, NODE_WIDTH + FINALLY_NODE_PADDING * 2, height);
 
 export const getNodeCreator = (type: NodeType): NodeCreator<PipelineRunAfterNodeModelData> => {
   switch (type) {
@@ -223,6 +233,57 @@ export const getEdgesFromNodes = (nodes: PipelineMixedNodeModel[]): PipelineEdge
     }),
   ).filter((edgeList) => !!edgeList);
 
+export const getFinallyTaskHeight = (allTasksLength: number, disableBuilder: boolean): number => {
+  return (
+    allTasksLength * NODE_HEIGHT +
+    (allTasksLength - 1) * FINALLY_NODE_VERTICAL_SPACING +
+    (!disableBuilder ? NODE_HEIGHT : 0) +
+    FINALLY_NODE_PADDING * 2
+  );
+};
+
+export const getLastRegularTasks = (regularTasks: PipelineMixedNodeModel[]): string[] => {
+  const runAfters = _.uniq(
+    regularTasks.reduce((acc, { data: { task: { runAfter } } }) => {
+      return runAfter ? acc.concat(runAfter) : acc;
+    }, []),
+  );
+  return _.difference(
+    regularTasks.map((n) => n.id),
+    runAfters,
+  );
+};
+
+export const connectFinallyTasksToNodes = (
+  nodes: PipelineMixedNodeModel[],
+  pipeline?: PipelineKind,
+  pipelineRun?: PipelineRunKind,
+): PipelineMixedNodeModel[] => {
+  if (!pipeline.spec?.finally) {
+    return nodes;
+  }
+  const finallyTasks = pipeline.spec.finally;
+  const regularRunAfters = getLastRegularTasks(nodes);
+  const name = 'finally-node';
+  const finallyGroupNode: PipelineFinallyNodeModel = createFinallyNode(
+    getFinallyTaskHeight(finallyTasks.length, true),
+  )(name, {
+    isFinallyTask: true,
+    pipeline,
+    pipelineRun,
+    task: {
+      isFinallyTask: true,
+      name,
+      runAfter: regularRunAfters,
+      finallyTasks: finallyTasks.map((ft) => ({
+        ...ft,
+        disableTooltip: false,
+      })),
+    },
+  });
+  return [...nodes, finallyGroupNode];
+};
+
 export const getTopologyNodesEdges = (
   pipeline: PipelineKind,
   pipelineRun?: PipelineRunKind,
@@ -230,7 +291,13 @@ export const getTopologyNodesEdges = (
   const taskList: PipelineVisualizationTaskItem[] = _.flatten(
     getPipelineTasks(pipeline, pipelineRun),
   );
-  const nodes: PipelineMixedNodeModel[] = tasksToNodes(taskList, pipeline, pipelineRun);
+  const taskNodes: PipelineMixedNodeModel[] = tasksToNodes(taskList, pipeline, pipelineRun);
+
+  const nodes: PipelineMixedNodeModel[] = connectFinallyTasksToNodes(
+    taskNodes,
+    pipeline,
+    pipelineRun,
+  );
   const edges: PipelineEdgeModel[] = getEdgesFromNodes(nodes);
 
   return { nodes, edges };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-4313
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
As a user, I'd like to be able to compose finally tasks in the Pipeline Builder.


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Add support to finally section in the pipeline builder.


**Screen shots / Gifs for design review**: 

finally tasks in pipeline builder:
![image](https://user-images.githubusercontent.com/9964343/111215867-a9612900-85f9-11eb-83ba-1b17f895cde2.png)


<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Finally tasks while creating pipeline:
![create_pipeline](https://user-images.githubusercontent.com/9964343/111211644-ab74b900-85f4-11eb-8dac-0441e32db6fd.gif)

Editing pipeline
![editing_pipeline](https://user-images.githubusercontent.com/9964343/111211660-afa0d680-85f4-11eb-8fb6-06e0e794fc7e.gif)



**Unit test coverage report**: 
<!-- Attach test coverage report -->

```
 packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts

  getTopologyNodesEdges
    ✓ expect to return nodes and edges for a pipeline without finally tasks (25ms)
    ✓ expect to return nodes and edges for a pipeline with finally tasks (2ms)
  getLastRegularTasks
    ✓ expect to handle the empty array input
    ✓ expect to return the list of task names that will be executed at the end (3ms)
  getFinallyTaskHeight
    ✓ expect to return dynamic height for finally task based on tasks length and builder options  (1ms)
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @bgliwa01 @andrewballantyne @nemesis09 