### PR TITLE
Bug 1937018: Fix null handling in FilterToolbar_ to prevent possible exceptions

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -370,17 +370,20 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
         owners(metadata.ownerReferences || [], allResources).length > 0,
     );
 
-  const rowFilters = [
-    {
-      filterGroupName: 'Resource Kind',
-      type: 'clusterserviceversion-resource-kind',
-      reducer: ({ kind }) => kind,
-      items: firehoseResources.map(({ kind }) => ({
-        id: kindForReference(kind),
-        title: kindForReference(kind),
-      })),
-    },
-  ];
+  const rowFilters =
+    firehoseResources.length > 1
+      ? [
+          {
+            filterGroupName: 'Resource Kind',
+            type: 'clusterserviceversion-resource-kind',
+            reducer: ({ kind }) => kind,
+            items: firehoseResources.map(({ kind }) => ({
+              id: kindForReference(kind),
+              title: kindForReference(kind),
+            })),
+          },
+        ]
+      : [];
 
   return firehoseResources.length > 0 ? (
     <MultiListPage
@@ -399,7 +402,7 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
             })
       }
       flatten={flatten}
-      rowFilters={firehoseResources.length > 1 ? rowFilters : null}
+      rowFilters={rowFilters}
     />
   ) : (
     <StatusBox loaded EmptyMsg={EmptyMsg} />

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -86,7 +86,7 @@ const getDropdownItems = (rowFilters: RowFilter[], selectedItems, data, props) =
 
 const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (props) => {
   const {
-    rowFilters = [],
+    rowFilters,
     data,
     hideColumnManagement,
     hideLabelFilter,
@@ -128,7 +128,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   );
 
   // (rowFilters) => {'rowFilterTypeA': ['staA', 'staB'], 'rowFilterTypeB': ['stbA'] }
-  const filters: Filter = rowFilters.reduce((acc, curr) => {
+  const filters: Filter = (rowFilters ?? [])?.reduce((acc, curr) => {
     const rowItems = curr.itemsGenerator ? curr.itemsGenerator(props, props?.kinds) : curr.items;
     const items = _.map(rowItems, 'id');
     acc[curr.filterGroupName] = items;
@@ -136,7 +136,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   }, {});
 
   // {id: 'a' , title: 'A'} => filterNameMap['a'] = A
-  const filtersNameMap: FilterKeys = rowFilters.reduce((acc, curr) => {
+  const filtersNameMap: FilterKeys = (rowFilters ?? []).reduce((acc, curr) => {
     const rowItems = curr.itemsGenerator ? curr.itemsGenerator(props, props?.kinds) : curr.items;
     const items = rowItems.reduce((itemAcc, itemCurr) => {
       itemAcc[itemCurr.id] = itemCurr.title;
@@ -146,7 +146,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   }, {});
 
   // (storagePrefix, rowFilters) => { 'rowFilterTypeA' = 'storagePrefix-filterTypeA' ...}
-  const filterKeys: FilterKeys = rowFilters.reduce((acc, curr) => {
+  const filterKeys: FilterKeys = (rowFilters ?? []).reduce((acc, curr) => {
     const str = `${storagePrefix}${curr.type}`;
     acc[curr.filterGroupName] = str;
     return acc;
@@ -212,7 +212,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   /* Logic Related to Row Filters Ex:(Status, Type) */
 
   const applyRowFilter = (selected: string[]) => {
-    rowFilters.forEach((filter) => {
+    rowFilters?.forEach((filter) => {
       const rowItems = filter.itemsGenerator
         ? filter.itemsGenerator(props, props?.kinds)
         : filter.items;
@@ -273,7 +273,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
       applyFilter(nameFilter, FilterType.NAME);
     }
     if (_.isEmpty(selectedRowFilters)) {
-      updateRowFilterSelected(_.uniq(_.flatMap(rowFilters, 'defaultSelected')));
+      updateRowFilterSelected(_.uniq(_.flatMap(rowFilters ?? [], 'defaultSelected')));
     } else {
       applyRowFilter(selectedRowFilters);
     }
@@ -295,7 +295,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     setInputText(nameFilter && FilterType[type] === FilterType.NAME ? nameFilter : '');
   };
 
-  const dropdownItems = getDropdownItems(rowFilters, selectedRowFilters, data, props);
+  const dropdownItems = getDropdownItems(rowFilters ?? [], selectedRowFilters, data, props);
   return (
     <Toolbar
       data-test="filter-toolbar"
@@ -304,7 +304,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
       clearFiltersButtonText={t('filter-toolbar~Clear all filters')}
     >
       <ToolbarContent>
-        {rowFilters.length > 0 && (
+        {rowFilters?.length && (
           <ToolbarItem>
             {_.reduce(
               Object.keys(filters),


### PR DESCRIPTION
- Remove initializer for deconstructed prop
- Add optional chaining/null coalescence wherever the rowFilters prop is used in FilterToolbar_
- Update ProvidedAPIs component so that it does not pass 'null' into this prop