### PR TITLE
Fix for a11y issue on monitoring page

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -57,8 +57,7 @@ export const navigateTo = (opt: devNavigationMenu) => {
     case devNavigationMenu.Monitoring: {
       cy.get(devNavigationMenuPO.monitoring).click();
       detailsPage.titleShouldContain(pageTitle.Monitoring);
-      // Bug: ODC-5119 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
-      // cy.testA11y('Monitoring Page in dev perspective');
+      cy.testA11y('Monitoring Page in dev perspective');
       break;
     }
     case devNavigationMenu.Builds: {

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
@@ -36,13 +37,19 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
   timespan,
   pollInterval,
 }) => {
+  const { t } = useTranslation();
   return (
     <DashboardCard className="monitoring-dashboards__card odc-monitoring-dashboard-graph">
       <DashboardCardHeader>
         <DashboardCardTitle>{title}</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <PrometheusGraphLink query={query}>
+        <PrometheusGraphLink
+          query={query}
+          ariaChartLinkLabel={t('dashboard~View metrics for {{title}}', {
+            title,
+          })}
+        >
           <QueryBrowser
             hideControls
             defaultTimespan={DEFAULT_TIME_SPAN}

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
@@ -8,6 +8,14 @@ import { MonitoringDashboardGraph, GraphTypes } from '../MonitoringDashboardGrap
 
 const t = (key: TFunction) => key;
 
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
 describe('Monitoring Dashboard graph', () => {
   let monitoringDashboardGraphProps: React.ComponentProps<typeof MonitoringDashboardGraph>;
 

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -63,5 +63,6 @@
   "View {{title}} metrics in query browser": "View {{title}} metrics in query browser",
   "{{humanAvailable}} available of {{humanLimit}} total limit": "{{humanAvailable}} available of {{humanLimit}} total limit",
   "{{humanAvailable}} available of {{humanMax}}": "{{humanAvailable}} available of {{humanMax}}",
-  "{{humanAvailable}} available": "{{humanAvailable}} available"
+  "{{humanAvailable}} available": "{{humanAvailable}} available",
+  "View metrics for {{title}}": "View metrics for {{title}}"
 }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5206

**Analysis / Root cause**: 
Missing setting for the `ariaChartLinkLabel` on the monitoring page charts

**Solution Description**: 
Add the `ariaChartLinkLabel` setting
