### PR TITLE
Remove "Tech preview" encryption label

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FormGroup, Checkbox, Radio } from '@patternfly/react-core';
 import { FieldLevelHelp, Firehose } from '@console/internal/components/utils';
-import { TechPreviewBadge, getName, ResourceDropdown, useFlag } from '@console/shared';
+import { getName, ResourceDropdown, useFlag } from '@console/shared';
 import { NetworkAttachmentDefinitionKind } from '@console/network-attachment-definition-plugin/src/types';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -25,7 +25,6 @@ const StorageClassEncryptionLabel: React.FC = () => {
       <span className="ocs-install-encryption__pv-title--padding">
         {t('ceph-storage-plugin~Storage class encryption')}
       </span>
-      <TechPreviewBadge />
       <AdvancedSubscription />
     </div>
   );

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
@@ -27,7 +27,6 @@ import {
 } from '@console/internal/components/utils/k8s-watch-hook';
 import { useFlag } from '@console/shared/src/hooks/flag';
 import { ProvisionerProps } from '@console/plugin-sdk';
-import TechPreviewBadge from '@console/shared/src/components/badges/TechPreviewBadge';
 import { ConfigMapKind, K8sResourceKind } from '@console/internal/module/k8s/types';
 import { ButtonBar } from '@console/internal/components/utils/button-bar';
 import { ConfigMapModel } from '@console/internal/models';
@@ -206,7 +205,6 @@ const StorageClassEncryptionLabel: React.FC = () => {
       <span className="ocs-storageClass-encryption__pv-title--padding">
         {t('ceph-storage-plugin~Enable Encryption')}
       </span>
-      <TechPreviewBadge />
     </div>
   );
 };


### PR DESCRIPTION
Removed the "Tech preview" label for configure-step in internal and attached-devices mode and from create-storage-class page.