### PR TITLE
CONSOLE-2524: Add Kata container RuntimeClass to workload detail pages

### DIFF
--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -34,6 +34,7 @@ import {
   getExtensionsKebabActionsForKind,
   navFactory,
   togglePaused,
+  RuntimeClass,
 } from './utils';
 import { ReplicationControllersPage } from './replication-controller';
 import { WorkloadTableRow, WorkloadTableHeader } from './workload-table';
@@ -171,6 +172,7 @@ export const DeploymentConfigDetailsList = ({ dc }) => {
       <DetailsItem label={t('public~Triggers')} obj={dc} path="spec.triggers" hideEmpty>
         {triggers}
       </DetailsItem>
+      <RuntimeClass obj={dc} />
     </dl>
   );
 };

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -32,6 +32,7 @@ import {
   SectionHeading,
   togglePaused,
   WorkloadPausedAlert,
+  RuntimeClass,
 } from './utils';
 import { ReplicaSetsPage } from './replicaset';
 import { WorkloadTableRow, WorkloadTableHeader } from './workload-table';
@@ -127,6 +128,7 @@ export const DeploymentDetailsList: React.FC<DeploymentDetailsListProps> = ({ de
           ? t('public~{{count}} second', { count: deployment.spec.minReadySeconds })
           : t('public~Not configured')}
       </DetailsItem>
+      <RuntimeClass obj={deployment} />
     </dl>
   );
 };

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -54,6 +54,7 @@ import {
   navFactory,
   units,
   LabelList,
+  RuntimeClass,
 } from './utils';
 import { PodLogs } from './pod-logs';
 import {
@@ -659,6 +660,7 @@ export const PodDetailsList: React.FC<PodDetailsListProps> = ({ pod }) => {
       <DetailsItem label={t('public~Node')} obj={pod} path="spec.nodeName" hideEmpty>
         <NodeLink name={pod.spec.nodeName} />
       </DetailsItem>
+      <RuntimeClass obj={pod} path="spec.runtimeClassName" />
     </dl>
   );
 };

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -22,6 +22,7 @@ import {
   OwnerReferences,
   Timestamp,
   PodsComponent,
+  RuntimeClass,
 } from './utils';
 import { ResourceEventStream } from './events';
 import { VolumesTable } from './volumes-table';
@@ -59,7 +60,10 @@ const Details = ({ obj: replicaSet }) => {
             </ResourceSummary>
           </div>
           <div className="col-md-6">
-            <ResourcePodCount resource={replicaSet} />
+            <dl className="co-m-pane__details">
+              <ResourcePodCount resource={replicaSet} />
+              <RuntimeClass obj={replicaSet} />
+            </dl>
           </div>
         </div>
       </div>

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -24,6 +24,7 @@ import {
   OwnerReferences,
   Timestamp,
   PodsComponent,
+  RuntimeClass,
 } from './utils';
 
 import { VolumesTable } from './volumes-table';
@@ -119,15 +120,18 @@ export const ReplicationControllersDetailsPage = (props) => {
               </ResourceSummary>
             </div>
             <div className="col-md-6">
-              {phase && (
-                <>
-                  <dt>{t('public~Phase')}</dt>
-                  <dd>
-                    <Status status={phase} />
-                  </dd>
-                </>
-              )}
-              <ResourcePodCount resource={replicationController} />
+              <dl className="co-m-pane__details">
+                {phase && (
+                  <>
+                    <dt>{t('public~Phase')}</dt>
+                    <dd>
+                      <Status status={phase} />
+                    </dd>
+                  </>
+                )}
+                <ResourcePodCount resource={replicationController} />
+                <RuntimeClass obj={replicationController} />
+              </dl>
             </div>
           </div>
         </div>

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -17,6 +17,7 @@ import {
   SectionHeading,
   navFactory,
   PodsComponent,
+  RuntimeClass,
 } from './utils';
 import { VolumesTable } from './volumes-table';
 import { StatefulSetModel } from '../models';
@@ -60,7 +61,9 @@ const StatefulSetDetails: React.FC<StatefulSetDetailsProps> = ({ obj: ss }) => {
         <PodRingSet key={ss.metadata.uid} obj={ss} path="/spec/replicas" />
         <div className="row">
           <div className="col-md-6">
-            <ResourceSummary resource={ss} showPodSelector showNodeSelector showTolerations />
+            <ResourceSummary resource={ss} showPodSelector showNodeSelector showTolerations>
+              <RuntimeClass obj={ss} />
+            </ResourceSummary>
           </div>
         </div>
       </div>

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -12,7 +12,13 @@ import { ResourceLink } from './resource-link';
 import { Selector } from './selector';
 import { Timestamp } from './timestamp';
 import { useAccessReview } from './rbac';
-import { K8sResourceKind, modelFor, referenceFor, Toleration } from '../../module/k8s';
+import {
+  K8sResourceCommon,
+  K8sResourceKind,
+  modelFor,
+  referenceFor,
+  Toleration,
+} from '../../module/k8s';
 import { labelsModal } from '../modals';
 
 const editLabelsModal = (e, props) => {
@@ -166,7 +172,7 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
 export const ResourcePodCount: React.SFC<ResourcePodCountProps> = ({ resource }) => {
   const { t } = useTranslation();
   return (
-    <dl>
+    <>
       <DetailsItem
         label={t('details-page~Current count')}
         obj={resource}
@@ -179,7 +185,19 @@ export const ResourcePodCount: React.SFC<ResourcePodCountProps> = ({ resource })
         path="spec.replicas"
         defaultValue="0"
       />
-    </dl>
+    </>
+  );
+};
+
+export const RuntimeClass: React.FC<RuntimeClassProps> = ({ obj, path }) => {
+  const { t } = useTranslation();
+  return (
+    <DetailsItem
+      label={t('public~Runtime class')}
+      obj={obj}
+      path={path || 'spec.template.spec.runtimeClassName'}
+      hideEmpty
+    />
   );
 };
 
@@ -198,6 +216,11 @@ export type ResourceSummaryProps = {
 
 export type ResourcePodCountProps = {
   resource: K8sResourceKind;
+};
+
+export type RuntimeClassProps = {
+  obj: K8sResourceCommon;
+  path?: string;
 };
 
 ResourceSummary.displayName = 'ResourceSummary';

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -475,6 +475,7 @@
   "Ports": "Ports",
   "Copied": "Copied",
   "Copy to clipboard": "Copy to clipboard",
+  "Runtime class": "Runtime class",
   "Help": "Help",
   "Maximum file size exceeded. File limit is 4MB.": "Maximum file size exceeded. File limit is 4MB.",
   "Drop file here": "Drop file here",


### PR DESCRIPTION
[CONSOLE-2524](https://issues.redhat.com/browse/CONSOLE-2524)

If you install the [Kata Operator](https://github.com/openshift/sandboxed-containers-operator/blob/release-4.7/README.md) on an OpenShift cluster you can then specify Deployment, DeploymentConfigs, ReplicaSets, etc. to create Pods using Kata containers.  For example, update a Deployment YAML to include `runtimeClassName`:

```
apiVersion: apps/v1
kind: Deployment
spec:
  template:
    spec:
      runtimeClassName: kata # ---> This can be changed
```
This will cause the Deployment to create Pods using kata containers which is shown in Pod YAML:
```
apiVersion: v1 
kind: Pod 
ginx-runc 
spec:     
  runtimeClassName: kata # ---> This cannot be changed here, it is generated
```

This PR addresses JIRA story [Add Kata runtime class property to workload details pages](https://issues.redhat.com/browse/CONSOLE-2524) and is part of a larger epic [Add Basic Visibility for Kata in Openshift UI](https://issues.redhat.com/browse/CONSOLE-2514)

The following workload Detail pages now have `RuntimeClass` field:

- Pods
- ReplicaSets
- ReplicationControllers
- StatefulSets
- Deployments
- DeploymentConfigs

### Pod Details page
![image](https://user-images.githubusercontent.com/12733153/111648512-d10ee780-87d9-11eb-948e-75bcc3656fd7.png)

### InfoTip
![image](https://user-images.githubusercontent.com/12733153/111648571-e3892100-87d9-11eb-8543-297d837e9b23.png)

### Misc 
- Verified that `runtimeClassName` appears for Deployments and DeploymentConfigurations in Topology panel in Developer perspective.
- If `runtimeClassName` is not set for a particular resource, the field will be hidden on the details page.


