### PR TITLE
Cypress:  numerically naming cypress screenshot files

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/other-routes.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/other-routes.spec.ts
@@ -43,7 +43,7 @@ describe('Visiting other routes', () => {
       : []),
   ];
   otherRoutes.forEach((route) => {
-    it(`successfully displays view for route: ${route}`, () => {
+    it(`successfully visited route: '${route.replace(/\//g, ' ')}'`, () => {
       cy.visit(route);
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000); // wait for page to load


### PR DESCRIPTION
Prepends cypress screenshot filenames with a number, ex '1_', '2_', etc..  The CI artifacts cypress screenshot directory (/artifacts/e2e-gcp-console/test/artifacts/gui_test_screenshots/cypress/screenshots/) seems to sort screenshot filenames alphanumerically, so adding this will order the screenshots from first to last (which doesn't seem to correspond to `Modified` datetime).

This should order the files by: `before all, before each, test suite, retries, after each, after all,` and should help us quickly determine what failed first.

![image](https://user-images.githubusercontent.com/12733153/111654914-9019d180-87df-11eb-940f-17dcee5bbaf1.png)
