### PR TITLE
fix autofill name field values

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -1,7 +1,12 @@
 import { cloneDeep } from 'lodash';
 import { TFunction } from 'i18next';
 import { CREATE_APPLICATION_KEY, UNASSIGNED_KEY } from '@console/topology/src/const';
-import { validationSchema, detectGitType, detectGitRepoName } from '../import-validation-utils';
+import {
+  validationSchema,
+  detectGitType,
+  detectGitRepoName,
+  createComponentName,
+} from '../import-validation-utils';
 import { mockFormData } from '../__mocks__/import-validation-mock';
 import { GitTypes } from '../import-types';
 import { serverlessCommonTests } from './serverless-common-tests';
@@ -36,6 +41,32 @@ describe('ValidationUtils', () => {
 
       const gitType3 = detectGitType('git@bitbucket.org:atlassian_tutorial/helloworld.git');
       expect(gitType3).toEqual(GitTypes.bitbucket);
+    });
+  });
+
+  describe('createComponentName', () => {
+    const invalidConvertedtoValidNamePair: { [key: string]: string } = {
+      '0name': 'ocp-0name',
+      '-name': 'ocp--name',
+      'name-': 'ocp-name',
+      'invalid&name': 'ocp-invalidname',
+      'invalid name': 'ocp-invalidname',
+      'invalid-Name': 'ocp-invalid-name',
+    };
+    const validNames: string[] = ['name', 'valid-name', 'name0', 'name-0'];
+
+    Object.keys(invalidConvertedtoValidNamePair).forEach((invalidName) => {
+      it(`should convert ${invalidName} to a valid k8s name`, () => {
+        expect(createComponentName(invalidName)).toEqual(
+          invalidConvertedtoValidNamePair[invalidName],
+        );
+      });
+    });
+
+    validNames.forEach((validName) => {
+      it(`should leave ${validName} unchanged`, () => {
+        expect(createComponentName(validName)).toEqual(validName);
+      });
     });
   });
 

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -13,7 +13,7 @@ import {
 import { UNASSIGNED_KEY, CREATE_APPLICATION_KEY } from '@console/topology/src/const';
 import { BuildStrategyType } from '@console/internal/components/build';
 import { GitReadableTypes, GitTypes } from '../import-types';
-import { detectGitType, detectGitRepoName } from '../import-validation-utils';
+import { detectGitType, detectGitRepoName, createComponentName } from '../import-validation-utils';
 import {
   getSampleRepo,
   getSampleRef,
@@ -90,7 +90,10 @@ const GitSection: React.FC<GitSectionProps> = ({
         return;
       }
 
-      gitRepoName && !nameTouched && !values.name && setFieldValue('name', gitRepoName);
+      gitRepoName &&
+        !nameTouched &&
+        !values.name &&
+        setFieldValue('name', createComponentName(gitRepoName));
       gitRepoName &&
         values.formType !== 'edit' &&
         !values.application.name &&
@@ -167,7 +170,10 @@ const GitSection: React.FC<GitSectionProps> = ({
   const handleGitUrlBlur = React.useCallback(() => {
     const { url } = values.git;
     const gitRepoName = detectGitRepoName(url);
-    values.formType !== 'edit' && gitRepoName && !nameTouched && setFieldValue('name', gitRepoName);
+    values.formType !== 'edit' &&
+      gitRepoName &&
+      !nameTouched &&
+      setFieldValue('name', createComponentName(gitRepoName));
     gitRepoName &&
       values.formType !== 'edit' &&
       !values.application.name &&

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -17,6 +17,7 @@ import {
   gitUrlRegex,
   resourcesValidationSchema,
   devfileValidationSchema,
+  nameRegex,
 } from './validation-schema';
 import { healthChecksProbesValidationSchema } from '../health-checks/health-checks-probe-validation-utils';
 
@@ -70,4 +71,12 @@ export const detectGitRepoName = (url: string): string | undefined => {
   }
 
   return _.kebabCase(url.split('/').pop());
+};
+
+export const createComponentName = (nameString: string): string => {
+  const prefixToValidate = 'ocp-';
+  if (!nameRegex.test(nameString)) {
+    return `${prefixToValidate}${nameString.replace(/[^-a-zA-Z0-9]|(-*)$/g, '').toLowerCase()}`;
+  }
+  return nameString;
 };

--- a/frontend/packages/dev-console/src/components/import/validation-schema.ts
+++ b/frontend/packages/dev-console/src/components/import/validation-schema.ts
@@ -8,7 +8,7 @@ import { Resources } from './import-types';
 
 const hostnameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const pathRegex = /^\/.*$/;
-const nameRegex = /^([a-z]([-a-z0-9]*[a-z0-9])?)*$/;
+export const nameRegex = /^([a-z]([-a-z0-9]*[a-z0-9])?)*$/;
 const projectNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
 
 export const gitUrlRegex = /^((((ssh|git|https?:?):\/\/:?)(([^\s@]+@|[^@]:?)[-\w.]+(:\d\d+:?)?(\/[-\w.~/?[\]!$&'()*+,;=:@%]*:?)?:?))|([^\s@]+@[-\w.]+:[-\w.~/?[\]!$&'()*+,;=:@%]*?:?))$/;


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-5556

Problem/Description:
When the Name field is auto-filled, then the field validation doesn't occur immediately. As a result, for a repo name like `101-tutorial`, the create button is disabled and no error is being displayed.

Solution:
create a util to create a valid k8s name from repo/image name before prefilling the name field.

Screens:
![namefield-autofill](https://user-images.githubusercontent.com/38663217/111680578-5fba4d80-8848-11eb-9f67-bc5c4cac6d3f.gif)

Test Coverage:
![Screenshot from 2021-03-19 12-05-42](https://user-images.githubusercontent.com/38663217/111741037-cd4b9580-88ab-11eb-97f2-20851a7c89b5.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge