### PR TITLE
Cypress: Fix OLM test flakes

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -55,48 +55,37 @@ describe(`Interacting with a global install mode Operator (${operatorName})`, ()
     cy.byTestID('view-installed-operators-btn').click();
     cy.log(`verify the ClusterServiceVersion row for ${operatorRow} exists`);
     cy.byTestOperatorRow(operatorRow, { timeout: 60000 }).should('exist');
-  });
-
-  it(`displays details about ${operatorName} ClusterServiceVersion on the "Details" tab`, () => {
-    cy.log(`navigate to the ${operatorName} details page`);
+    cy.log(`displays details about ${operatorName} ClusterServiceVersion on the "Details" tab`);
     cy.byTestOperatorRow(operatorRow).click();
     cy.byTestSectionHeading('Provided APIs').should('exist');
     cy.byTestSectionHeading('ClusterServiceVersion details').should('exist');
     cy.byLegacyTestID('resource-summary').should('exist');
-  });
-
-  it(`displays empty message on the ${operatorName} ClusterServiceVersion "All Instances" tab`, () => {
-    cy.log('navigate to the "All instances" tab');
+    cy.log(
+      `displays empty message on the ${operatorName} ClusterServiceVersion "All Instances" tab`,
+    );
     cy.byLegacyTestID('horizontal-link-olm~All instances').click();
     cy.byTestID('msg-box-title').should('contain', 'No operands found');
     cy.byTestID('msg-box-detail').should(
       'contain',
       'Operands are declarative components used to define the behavior of the application.',
     );
-  });
-
-  it(`displays ${operatorName} ${operatorInstance} creation form`, () => {
-    cy.log('navigate to the form');
+    cy.log(`displays ${operatorName} ${operatorInstance} creation form`);
     cy.byLegacyTestID('dropdown-button')
       .click()
       .get('[data-test-dropdown-menu="storageclusters.core.libopenstorage.org"]')
       .click();
+    cy.byTestID('loading-indicator').should('not.exist');
+    cy.url().should('include', '~new');
     cy.byLegacyTestID('resource-title').should('contain', `Create ${operatorInstance}`);
-  });
-
-  it(`creates a ${operatorName} ${operatorInstance} instance via the form`, () => {
-    cy.log('create a new instance');
+    cy.log(`creates a ${operatorName} ${operatorInstance} instance via the form`);
     cy.byTestID('create-dynamic-form').click();
     cy.byTestOperandLink(operandLink).should('contain', 'portworx');
-  });
-
-  it(`displays details about ${operatorName} ${operatorInstance} instance on the "Details" tab`, () => {
-    cy.log(`navigate to the "Details" tab`);
+    cy.log(
+      `displays details about ${operatorName} ${operatorInstance} instance on the "Details" tab`,
+    );
     cy.byTestOperandLink(operandLink).click();
     cy.byTestSectionHeading('Storage Cluster overview').should('exist');
-  });
-
-  it(`deletes the ${operatorName} ${operatorInstance} instance`, () => {
+    cy.log(`deletes the ${operatorName} ${operatorInstance} instance`);
     detailsPage.clickPageActionFromDropdown(`Delete ${operatorInstance}`);
     modal.shouldBeOpened();
     modal.submit();

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -9,7 +9,6 @@ const operatorID = 'couchbase-enterprise-console-e2e-openshift-marketplace';
 const operatorRow = 'Couchbase Operator';
 const operatorPkgName = 'couchbase-enterprise';
 const operatorInstallFormURL = `/operatorhub/subscribe?pkg=${operatorPkgName}&catalog=${catalogSourceName}&catalogNamespace=openshift-marketplace&targetNamespace=${testName}`;
-const operatorInstance = 'CouchbaseCluster';
 const operandLink = 'cb-example';
 
 describe(`Interacting with a single namespace install mode Operator (${operatorName})`, () => {
@@ -43,8 +42,8 @@ describe(`Interacting with a single namespace install mode Operator (${operatorN
   });
 
   it(`creates the single namespace install mode ClusterServiceVersion for ${operatorName}`, () => {
-    cy.visit(operatorInstallFormURL);
     cy.log('configure Operator install form for single namespace');
+    cy.visit(operatorInstallFormURL);
     cy.byTestID('A specific namespace on the cluster-radio-input').check();
     cy.log(`verify the dropdown selection shows the ${testName} namespace`);
     cy.byTestID('dropdown-selectbox').should('contain', `${testName}`);
@@ -58,17 +57,11 @@ describe(`Interacting with a single namespace install mode Operator (${operatorN
     cy.byTestID('view-installed-operators-btn').click();
     cy.log(`verify the ClusterServiceVersion row for ${operatorRow} exists`);
     cy.byTestOperatorRow(operatorRow, { timeout: 60000 }).should('exist');
-  });
-
-  it(`displays details about ${operatorName} ClusterServiceVersion on the "Details" tab`, () => {
     cy.log(`navigate to the ${operatorName} details page`);
     cy.byTestOperatorRow(operatorRow).click();
     cy.byTestSectionHeading('Provided APIs').should('exist');
     cy.byTestSectionHeading('ClusterServiceVersion details').should('exist');
     cy.byLegacyTestID('resource-summary').should('exist');
-  });
-
-  it(`displays empty message on the ${operatorName} ClusterServiceVersion "All Instances" tab`, () => {
     cy.log('navigate to the "All Instances" tab');
     cy.byLegacyTestID('horizontal-link-olm~All instances').click();
     cy.byTestID('msg-box-title').should('contain', 'No operands found');
@@ -76,24 +69,19 @@ describe(`Interacting with a single namespace install mode Operator (${operatorN
       'contain',
       'Operands are declarative components used to define the behavior of the application.',
     );
-  });
 
-  it(`displays ${operatorName} ${operatorInstance} creation form`, () => {
     cy.log('navigate to the form');
     cy.byLegacyTestID('dropdown-button')
       .click()
       .get('[data-test-dropdown-menu="couchbaseclusters.couchbase.com"]')
       .click();
-    cy.byLegacyTestID('resource-title').should('contain', `Create ${operatorInstance}`);
-  });
-
-  it(`creates a ${operatorName} ${operatorInstance} instance via the form`, () => {
+    cy.byTestID('loading-indicator').should('not.exist');
+    cy.url().should('include', '~new');
+    cy.byLegacyTestID('resource-title').should('contain', `Create CouchbaseCluster`);
     cy.log('create a new instance');
     cy.byTestID('create-dynamic-form').click();
     cy.byTestOperandLink(operandLink).should('contain', operandLink);
-  });
 
-  it(`displays details about ${operatorName} ${operatorInstance} instance on the "Details" tab`, () => {
     cy.log(`navigate to the "Details" tab`);
     cy.byTestOperandLink(operandLink).click();
     cy.byTestSectionHeading('Couchbase Cluster overview').should('exist');


### PR DESCRIPTION
- consolidated non-independant `it` tests, into single test
- Added check for loading indicators to not exist
- Add check for url to contain '~new`