### PR TITLE
Fix for creating visual connectors to operator workload nodes

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/componentUtils.ts
+++ b/frontend/packages/topology/src/components/graph-view/components/componentUtils.ts
@@ -356,9 +356,9 @@ const createConnectorCallback = () => (
     return Promise.resolve(createVisualConnector(source, target));
   }
 
-  const creator = createConnectors.find((getter) => !!getter(dropHints));
+  const creator = createConnectors.find((getter) => !!getter(dropHints, source, target));
   if (creator) {
-    return creator(dropHints)(source, target);
+    return creator(dropHints, source, target)(source, target);
   }
   return Promise.resolve(createVisualConnector(source, target));
 };

--- a/frontend/packages/topology/src/operators/actions/serviceBindings.ts
+++ b/frontend/packages/topology/src/operators/actions/serviceBindings.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { Node } from '@patternfly/react-topology';
 import {
   k8sCreate,
   K8sResourceKind,
@@ -6,9 +7,8 @@ import {
   referenceFor,
   apiVersionForModel,
 } from '@console/internal/module/k8s';
-import { Node } from '@patternfly/react-topology';
-
 import { ServiceBindingModel } from '../../models';
+import { TYPE_OPERATOR_BACKED_SERVICE } from '../components/const';
 
 export const createServiceBinding = (
   source: K8sResourceKind,
@@ -62,11 +62,11 @@ const createServiceBindingConnection = (source: Node, target: Node) => {
   return createServiceBinding(sourceResource, targetResource).then(() => null);
 };
 
-export const getCreateConnector = (createHints: string[]) => {
+export const getCreateConnector = (createHints: string[], source: Node, target: Node) => {
   if (
     createHints &&
     createHints.includes('createServiceBinding') &&
-    !createHints.includes('operator-workload')
+    target.getType() === TYPE_OPERATOR_BACKED_SERVICE
   ) {
     return createServiceBindingConnection;
   }

--- a/frontend/packages/topology/src/topology-types.ts
+++ b/frontend/packages/topology/src/topology-types.ts
@@ -54,7 +54,11 @@ export type CreateConnection = (
   target: Node | Graph,
 ) => Promise<React.ReactElement[] | null>;
 
-export type CreateConnectionGetter = (createHints: string[]) => CreateConnection;
+export type CreateConnectionGetter = (
+  createHints: string[],
+  source?: Node,
+  target?: Node,
+) => CreateConnection;
 
 export enum TopologyDisplayFilterType {
   show = 'show',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5621

**Analysis / Root cause**: 
The create service binding connection function was accepting any targets as valid as long as the drop hints included `serviceBinding`. It has an old check for a hint over a operator workload but those are not used any more.

**Solution Description**: 
Pass source and target to the create connection functions and check target type in the create service binding connection function.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug