### PR TITLE
Fix LSO's local-volume-discovery radio buttons

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-discovery/create-local-volume-discovery.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-discovery/create-local-volume-discovery.tsx
@@ -101,7 +101,7 @@ export const CreateLocalVolumeDiscovery: React.FC<CreateLocalVolumeDiscoveryProp
           allNodes={allNodes}
           selectNodes={selectNodes}
           showSelectNodes={showSelectNodes}
-          setShowSelectNodes={setShowSelectNodes}
+          setShowSelectNodes={() => setShowSelectNodes(!showSelectNodes)}
           setSelectNodes={setSelectNodes}
         />
         <FormFooter


### PR DESCRIPTION
Earlier:
Radio buttons were not functioning properly in LSO's Create-Local-Volume-Discovery page.

After:
Fixed it and now they are working as expected.