### PR TITLE
[release-4.7] Bug 1941468: Change link for not available state

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -12,7 +12,7 @@ import {
 } from './mappers';
 import { PrometheusHealthPopupProps } from '@console/plugin-sdk';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { ExternalLink } from '@console/internal/components/utils';
+import { ExternalLink, openshiftHelpBase } from '@console/internal/components/utils';
 import './style.scss';
 
 const DataComponent: React.FC<DataComponentProps> = ({ x, y, datum }) => {
@@ -93,7 +93,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         )}
         {!hasIssues && (isWaitingOrDisabled || isError) && (
           <ExternalLink
-            href="https://docs.openshift.com/container-platform/latest/support/getting-support.html"
+            href={`${openshiftHelpBase}support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html`}
             text="More about Insights"
           />
         )}


### PR DESCRIPTION
4.7.z Backport clone of https://github.com/openshift/console/pull/8232

This is an urgent fix, as we are showing incorrect links to users in the 4.7 release.