### PR TITLE
Bug 1941995: fix backwards incompatible trigger api changes

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/__tests__/submit-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/__tests__/submit-utils.spec.ts
@@ -1,0 +1,55 @@
+import * as k8s from '@console/internal/module/k8s';
+import * as utils from '../resource-utils';
+import { EventListenerModel, TriggerModel, TriggerTemplateModel } from '../../../../../models';
+import { PipelineExampleNames, pipelineTestData } from '../../../../../test-data/pipeline-data';
+import { formValues } from '../../../../../test-data/trigger-data';
+import * as operatorUtils from '../../../utils/pipeline-operator';
+import { submitTrigger } from '../submit-utils';
+
+const pipelineData = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
+
+describe('submitTrigger', () => {
+  beforeAll(() => {
+    jest.spyOn(k8s, 'k8sCreate').mockImplementation((model, data) => Promise.resolve(data));
+    jest.spyOn(operatorUtils, 'getPipelineOperatorVersion').mockReturnValue({ version: '1.3.1' });
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('expect to run the new flow when trigger resource dry run results in success', async () => {
+    jest.spyOn(utils, 'dryRunTriggerResource').mockReturnValue(true);
+    try {
+      const resources = await submitTrigger(pipelineData.pipeline, formValues);
+      expect(resources).toHaveLength(3);
+      expect(resources.find((r) => r.kind === TriggerModel.kind)).toBeDefined();
+      expect(resources.find((r) => r.kind === TriggerTemplateModel.kind)).toBeDefined();
+      expect(resources.find((r) => r.kind === EventListenerModel.kind)).toBeDefined();
+    } catch (e) {
+      fail(e);
+    }
+  });
+
+  it('expect to the eventlistener to contain triggerRef', async () => {
+    jest.spyOn(utils, 'dryRunTriggerResource').mockReturnValue(true);
+    try {
+      const resources = await submitTrigger(pipelineData.pipeline, formValues);
+      const el = resources.find((r) => r.kind === EventListenerModel.kind);
+      expect(el.spec.triggers[0].triggerRef).toBeDefined();
+    } catch (e) {
+      fail(e);
+    }
+  });
+
+  it('expect to fallback to the old flow when trigger resource dry run results in not found', async () => {
+    jest.spyOn(utils, 'dryRunTriggerResource').mockReturnValue(false);
+    try {
+      const resources = await submitTrigger(pipelineData.pipeline, formValues);
+      expect(resources).toHaveLength(2);
+      expect(resources.find((r) => r.kind === TriggerTemplateModel.kind)).toBeDefined();
+      expect(resources.find((r) => r.kind === EventListenerModel.kind)).toBeDefined();
+    } catch (e) {
+      fail(e);
+    }
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/submit-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/submit-utils.ts
@@ -1,7 +1,7 @@
 import { RouteModel, ServiceModel } from '@console/internal/models';
 import { errorModal } from '@console/internal/components/modals';
 import { k8sCreate, k8sGet, K8sResourceKind, RouteKind } from '@console/internal/module/k8s';
-import { EventListenerModel, TriggerTemplateModel } from '../../../../models';
+import { EventListenerModel, TriggerModel, TriggerTemplateModel } from '../../../../models';
 import { PipelineKind, PipelineRunKind } from '../../../../types';
 import {
   EventListenerKind,
@@ -12,7 +12,10 @@ import { getPipelineRunFromForm } from '../common/utils';
 import {
   createEventListener,
   createEventListenerRoute,
+  createEventListenerWithTrigger,
+  createTrigger,
   createTriggerTemplate,
+  dryRunTriggerResource,
 } from './resource-utils';
 import { AddTriggerFormValues } from './types';
 
@@ -68,28 +71,47 @@ export const submitTrigger = async (
     pipelineRun,
     triggerTemplateParams,
   );
-  const eventListener: EventListenerKind = await createEventListener(
-    thisNamespace,
-    [triggerBinding.resource],
-    triggerTemplate,
-  );
-
   const metadata = { ns: thisNamespace };
   let resources: K8sResourceKind[];
   try {
+    // try to dry run and see if see if the Trigger resource exists.
+    const trigger = createTrigger(thisNamespace, triggerTemplate.metadata.name, [
+      triggerBinding.resource,
+    ]);
     // Validates the modal contents, should be done first
     const ttResource = await k8sCreate(TriggerTemplateModel, triggerTemplate, metadata);
+    const triggerAvailable = await dryRunTriggerResource(trigger);
 
-    // Creates the linkages and will provide the link to non-trigger resources created
-    const elResource = await k8sCreate(EventListenerModel, eventListener, metadata);
+    if (triggerAvailable) {
+      // Create  Trigger,TriggerTemplate and EventListener resources.
+      const triggerResource = await k8sCreate(TriggerModel, trigger, metadata);
 
-    // Capture all related resources
-    resources = [ttResource, elResource];
-  } catch (e) {
-    return Promise.reject(e);
+      const eventListener: EventListenerKind = createEventListenerWithTrigger(
+        triggerResource.metadata.name,
+      );
+      const elResource = await k8sCreate(EventListenerModel, eventListener, metadata);
+      // Capture all related resources
+      resources = [triggerResource, ttResource, elResource];
+    } else {
+      // fallback to old flow
+      const eventListener: EventListenerKind = await createEventListener(
+        thisNamespace,
+        [triggerBinding.resource],
+        triggerTemplate,
+      );
+      // Creates the linkages and will provide the link to non-trigger resources created
+      const elResource = await k8sCreate(EventListenerModel, eventListener, metadata);
+
+      // Capture all related resources
+      resources = [ttResource, elResource];
+    }
+  } catch (err) {
+    return Promise.reject(err);
   }
-
-  exposeRoute(eventListener.metadata.name, thisNamespace);
+  const {
+    metadata: { name: elName },
+  } = resources.find((r) => r.kind === EventListenerModel.kind);
+  exposeRoute(elName, thisNamespace);
 
   return Promise.resolve(resources);
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-types/triggers.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-types/triggers.ts
@@ -1,6 +1,23 @@
 import { K8sResourceCommon, K8sResourceKind, Toleration } from '@console/internal/module/k8s';
 import { PipelineRunKind } from '../../../types';
 
+export type TriggerKind = K8sResourceCommon & {
+  spec: {
+    serviceAccountName: string;
+    bindings?: EventListenerKindBindingReference[];
+    interceptors?: TriggerInterceptor;
+    template?: {
+      // Ref is used since Tekton Triggers 0.10.x (part of OpenShift Pipeline Operator 1.3)
+      ref?: string;
+      // We also support older operators, so need to show & save the old field as well.
+      // TriggerTemplateKind name reference
+      // https://github.com/tektoncd/triggers/pull/898/files
+      // name will be deprecated in TP1.4
+      name?: string;
+    };
+    triggerRef?: string;
+  };
+};
 export type TriggerBindingParam = {
   name: string;
   value: string;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts
@@ -119,6 +119,50 @@ describe('getPipelineOperatorVersion', () => {
     expect(k8sList).toHaveBeenCalledTimes(1);
   });
 
+  it('should return the installed version for the old name of pipeline ClusterServiceVersion', async () => {
+    const csvs = [
+      {
+        metadata: { name: 'redhat-openshift-pipelines.v1.3.1' },
+        spec: { version: '1.3.1' },
+        status: { phase: 'Deleting' },
+      } as ClusterServiceVersionKind,
+      {
+        metadata: { name: 'openshift-pipelines-operator.v1.1.1' },
+        spec: { version: '1.1.1' },
+        status: { phase: 'Succeeded' },
+      } as ClusterServiceVersionKind,
+    ];
+    k8sListMock.mockReturnValueOnce(Promise.resolve(csvs));
+    const version = await getPipelineOperatorVersion('unit-test');
+    expect(version.raw).toBe('1.1.1');
+    expect(version.major).toBe(1);
+    expect(version.minor).toBe(1);
+    expect(version.patch).toBe(1);
+    expect(k8sList).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return installed version for the new name of pipeline ClusterServiceVersion', async () => {
+    const csvs = [
+      {
+        metadata: { name: 'redhat-openshift-pipelines.v1.3.1' },
+        spec: { version: '1.3.1' },
+        status: { phase: 'Succeeded' },
+      } as ClusterServiceVersionKind,
+      {
+        metadata: { name: 'openshift-pipelines-operator.v1.1.1' },
+        spec: { version: '1.1.1' },
+        status: { phase: 'Deleting' },
+      } as ClusterServiceVersionKind,
+    ];
+    k8sListMock.mockReturnValueOnce(Promise.resolve(csvs));
+    const version = await getPipelineOperatorVersion('unit-test');
+    expect(version.raw).toBe('1.3.1');
+    expect(version.major).toBe(1);
+    expect(version.minor).toBe(3);
+    expect(version.patch).toBe(1);
+    expect(k8sList).toHaveBeenCalledTimes(1);
+  });
+
   it('should return null if there is no matching ClusterServiceVersion available', async () => {
     const csvs = [
       {

--- a/frontend/packages/pipelines-plugin/src/models/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/src/models/pipelines.ts
@@ -154,6 +154,21 @@ export const TriggerTemplateModel: K8sKind = {
   color,
 };
 
+export const TriggerModel: K8sKind = {
+  apiGroup: 'triggers.tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'Trigger',
+  plural: 'triggers',
+  abbr: 'T',
+  namespaced: true,
+  kind: 'Trigger',
+  id: 'trigger',
+  labelPlural: 'Triggers',
+  crd: true,
+  badge: BadgeType.TECH,
+  color,
+};
+
 export const EventListenerModel: K8sKind = {
   apiGroup: 'triggers.tekton.dev',
   apiVersion: 'v1alpha1',

--- a/frontend/packages/pipelines-plugin/src/test-data/trigger-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/trigger-data.ts
@@ -1,0 +1,87 @@
+import { AddTriggerFormValues } from '../components/pipelines/modals/triggers/types';
+
+export const formValues: AddTriggerFormValues = {
+  namespace: 'test-ns',
+  parameters: [
+    {
+      default: 'test-node',
+      name: 'APP_NAME',
+      type: 'string',
+    },
+    {
+      default: 'https://github.com/karthikjeeyar/nodejs-ex',
+      name: 'GIT_REPO',
+      type: 'string',
+    },
+    {
+      default: 'master',
+      name: 'GIT_REVISION',
+      type: 'string',
+    },
+    {
+      default: 'image-registry.openshift-image-registry.svc:5000/karthik/test-node',
+      name: 'APP_NAME',
+      type: 'string',
+    },
+    {
+      default: '.',
+      name: 'PATH_CONTEXT',
+      type: 'string',
+    },
+    {
+      default: '12',
+      name: 'MAJOR_VERSION',
+      type: 'string',
+    },
+  ],
+  resources: [],
+  workspaces: [
+    {
+      name: 'workspace',
+      type: 'PVC',
+      data: {
+        persistentVolumeClaim: {
+          claimName: 'pvc-c9a548597b',
+        },
+      },
+    },
+  ],
+  triggerBinding: {
+    name: '2~github-push',
+    resource: {
+      kind: 'ClusterTriggerBinding',
+      apiVersion: 'triggers.tekton.dev/v1alpha1',
+      metadata: {
+        name: 'github-push',
+      },
+      spec: {
+        params: [
+          {
+            name: 'git-revision',
+            value: '$(body.head_commit.id)',
+          },
+          {
+            name: 'git-commit-message',
+            value: '$(body.head_commit.message)',
+          },
+          {
+            name: 'git-repo-url',
+            value: '$(body.repository.url)',
+          },
+          {
+            name: 'git-repo-name',
+            value: '$(body.repository.name)',
+          },
+          {
+            name: 'content-type',
+            value: '$(header.Content-Type)',
+          },
+          {
+            name: 'pusher-name',
+            value: '$(body.pusher.name)',
+          },
+        ],
+      },
+    },
+  },
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5405

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Current logic of adding trigger from UI using `template.name` in Eventlisteners is a BREAKING change in 1.4 Pipelines operator, therefore update the logic to support new trigger Api and use `triggerRef` while creating the Trigger resources.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

New flow for creating the eventlistener via triggerRef is added based on the availability of `Trigger` resource in the cluster (availability of the resource is determined using `dryRun` option), in case if the trigger resource is not available the control will fallback to the old flow (template.name).


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
NO UI changes
**Unit test coverage report**: 
<!-- Attach test coverage report -->

packages/pipelines-plugin/src/components/pipelines/modals/triggers/__tests__/submit-utils.spec.ts (8.609s)
  submitTrigger
  
    ✓ expect to run the new flow when trigger resource dry run results in success (20ms)
    ✓ expect to the eventlistener to contain triggerRef (3ms)
    ✓ expect to fallback to the old flow when trigger resource dry run results in not found (2ms)

packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts

    ✓ should return the installed version for the old name of pipeline ClusterServiceVersion (1ms)
    ✓ should return installed version for the new name of pipeline ClusterServiceVersion (1ms)
    
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Install 1.3.1 or 1.4 OSP operator.

1. Add a pipeline through git import flow
2. Add trigger from pipelines list view
3. Check if the Trigger, Trigger Template, EventListener is created and in pipeline's details page the url should be listed inside copy to clipboard component.

In Operators < 1.3.1,
1. Adding Trigger should create TriggerTemplate and Eventlistener only.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @andrewballantyne @jerolimov @vdemeester 