### PR TITLE
Bug 1933857: Follow on fix to ensure operand details page 404s when no model is found

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useK8sModel.ts
+++ b/frontend/packages/console-shared/src/hooks/useK8sModel.ts
@@ -10,8 +10,7 @@ export const useK8sModel = (groupVersionKind: GroupVersionKind): [K8sKind, boole
   useSelector<RootState, K8sKind>(
     ({ k8s }) =>
       k8s.getIn(['RESOURCES', 'models', groupVersionKind]) ??
-      k8s.getIn(['RESOURCES', 'models', kindForReference(groupVersionKind)]) ??
-      {},
+      k8s.getIn(['RESOURCES', 'models', kindForReference(groupVersionKind)]),
   ),
   useSelector<RootState, boolean>(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
 ];

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -67,6 +67,25 @@ jest.mock('@console/shared/src/hooks/useK8sModels', () => ({
   ],
 }));
 
+jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
+  useK8sModel: () => [
+    {
+      abbr: 'TR',
+      apiGroup: 'testapp.coreos.com',
+      apiVersion: 'v1alpha1',
+      crd: true,
+      kind: 'TestResource',
+      label: 'Test Resource',
+      labelPlural: 'Test Resources',
+      namespaced: true,
+      plural: 'testresources',
+      verbs: ['create'],
+    },
+    false,
+    null,
+  ],
+}));
+
 const i18nNS = 'details-page';
 
 describe(OperandTableRow.displayName, () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -584,7 +584,7 @@ export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
     () => getOperandActions(props.match.params.plural, actionExtensions),
     [props.match.params.plural, actionExtensions],
   );
-  return (
+  return model ? (
     <DetailsPage
       match={props.match}
       name={props.match.params.name}
@@ -633,6 +633,8 @@ export const OperandDetailsPage = (props: OperandDetailsPageProps) => {
         navFactory.events(ResourceEventStream),
       ]}
     />
+  ) : (
+    <ErrorPage404 />
   );
 };
 

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -91,7 +91,7 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
                     </LinkifyExternal>
                   ),
                 })}
-                {...(path && { footerContent: <PropertyPath kind={model.kind} path={path} /> })}
+                {...(path && { footerContent: <PropertyPath kind={model?.kind} path={path} /> })}
                 maxWidth="30rem"
               >
                 <Button data-test={label} variant="plain" className="details-item__popover-button">

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -168,8 +168,8 @@ const RequireCreatePermission_: React.FC<RequireCreatePermissionProps> = ({
 }) => {
   const isAllowed = useAccessReview(
     {
-      group: model.apiGroup,
-      resource: model.plural,
+      group: model?.apiGroup,
+      resource: model?.plural,
       verb: 'create',
       namespace,
     },

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -11,9 +11,9 @@ export const getDefinitionKey = _.memoize(
     return _.findKey(definitions, (def: SwaggerDefinition) => {
       return _.some(def['x-kubernetes-group-version-kind'], ({ group, version, kind }) => {
         return (
-          (model.apiGroup || '') === (group || '') &&
-          model.apiVersion === version &&
-          model.kind === kind
+          (model?.apiGroup ?? '') === (group || '') &&
+          model?.apiVersion === version &&
+          model?.kind === kind
         );
       });
     });


### PR DESCRIPTION
Follow on for #8271:
- Adjust the `useK8sModel` hook to return `undefined` instead of `{}` when no model is found. 
- Update all uses of `useK8sModel` hook to make sure `undefined` result is handled.
- Render 404 error on operand details page when CRD doesn't exist (no model is present in the redux store).