### PR TITLE
Bug 1938321: PackageManifest lists link to details pages

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
@@ -102,7 +102,7 @@ export const iconFor = (pkg: PackageManifestKind) => {
   });
 };
 
-export const ClusterServiceVersionLogo: React.SFC<ClusterServiceVersionLogoProps> = (props) => {
+export const ClusterServiceVersionLogo: React.FC<ClusterServiceVersionLogoProps> = (props) => {
   const { icon, displayName, provider, version } = props;
   const imgSrc: string = _.isString(icon)
     ? icon
@@ -215,13 +215,6 @@ export const NamespaceIncludesManualApproval: React.FC<NamespaceIncludesManualAp
   </Trans>
 );
 
-export type ClusterServiceVersionLogoProps = {
-  displayName: string;
-  icon: ClusterServiceVersionIcon | string;
-  provider: { name: string } | string;
-  version?: string;
-};
-
 const InstallPlanCSVNames: React.FC<InstallPlanReviewProps> = ({ installPlan }) =>
   installPlan?.spec.clusterServiceVersionNames
     .sort()
@@ -238,6 +231,13 @@ export const InstallPlanReview: React.FC<InstallPlanReviewProps> = ({ installPla
     </Trans>
   </p>
 );
+
+export type ClusterServiceVersionLogoProps = {
+  displayName: string;
+  icon: ClusterServiceVersionIcon | string;
+  provider: { name: string } | string;
+  version?: string;
+};
 
 export type OperatorsWithManualApprovalProps = {
   subscriptions: SubscriptionKind[];

--- a/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
@@ -3,7 +3,12 @@ import * as _ from 'lodash';
 import { Link, match } from 'react-router-dom';
 import * as classNames from 'classnames';
 import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
-import { MsgBox, Timestamp, ResourceLink } from '@console/internal/components/utils';
+import {
+  MsgBox,
+  Timestamp,
+  ResourceLink,
+  resourcePathFromModel,
+} from '@console/internal/components/utils';
 import {
   MultiListPage,
   Table,
@@ -66,11 +71,19 @@ export const PackageManifestTableRow: RowFunction<
   return (
     <TableRow id={packageManifest.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ClusterServiceVersionLogo
-          displayName={displayName}
-          icon={iconFor(packageManifest)}
-          provider={provider.name}
-        />
+        <Link
+          to={resourcePathFromModel(
+            PackageManifestModel,
+            packageManifest.metadata.name,
+            packageManifest.metadata.namespace,
+          )}
+        >
+          <ClusterServiceVersionLogo
+            displayName={displayName}
+            icon={iconFor(packageManifest)}
+            provider={provider.name}
+          />
+        </Link>
       </TableData>
       <TableData className={tableColumnClasses[1]}>
         {version} ({channel.name})


### PR DESCRIPTION
Make PackageManifestTableRow name column link to details page.
<img width="1792" alt="Screen Shot 2021-03-23 at 9 08 18 AM" src="https://user-images.githubusercontent.com/22625502/112151319-77cafd80-8bb7-11eb-825b-fbe01132f9a1.png">
