### PR TITLE
Bug 1941990: fix pipeline metrics endpoint for 1.4 osp

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -44,6 +44,7 @@ export const SecretAnnotationType = {
   [SecretAnnotationId.Image]: 'Image Registry',
 };
 
+export const PIPELINE_GA_VERSION = '1.4.0';
 export const PIPELINE_SERVICE_ACCOUNT = 'pipeline';
 export const PIPELINE_RUN_AUTO_START_FAILED = `bridge/pipeline-run-auto-start-failed`;
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineRuns.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../utils/pipeline-filter-reducer';
 import { ListFilterId, ListFilterLabels } from '../../../utils/pipeline-utils';
 import { PipelineRunModel } from '../../../models';
+import { PipelineDetailsTabProps } from './types';
 
 export const runFilters = [
   {
@@ -30,11 +31,7 @@ export const runFilters = [
   },
 ];
 
-interface PipelineRunsProps {
-  obj: any;
-}
-
-const PipelineRuns: React.FC<PipelineRunsProps> = ({ obj }) => (
+const PipelineRuns: React.FC<PipelineDetailsTabProps> = ({ obj }) => (
   <ListPage
     showTitle={false}
     canCreate={false}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/PipelineRuns.spec.tsx
@@ -8,6 +8,13 @@ const pipelineRunProps: React.ComponentProps<typeof PipelineRuns> = {
     metadata: {
       name: 'pipeline-a',
     },
+    spec: {
+      tasks: [{ name: 'task1' }],
+    },
+  },
+  customData: {
+    templateNames: [],
+    queryPrefix: '',
   },
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineDetails.tsx
@@ -3,22 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
 import { TriggerTemplateModel } from '../../../../models';
 import WorkspaceDefinitionList from '../../../shared/workspaces/WorkspaceDefinitionList';
-import { PipelineKind } from '../../../../types';
-import { RouteTemplate } from '../../utils/triggers';
 import DynamicResourceLinkList from '../../resource-overview/DynamicResourceLinkList';
 import TriggerTemplateResourceLink from '../../resource-overview/TriggerTemplateResourceLink';
 import PipelineVisualization from './PipelineVisualization';
 import { getPipelineTaskLinks } from '../utils';
+import { PipelineDetailsTabProps } from '../types';
 
-interface PipelineDetailsProps {
-  obj: PipelineKind;
-  customData: RouteTemplate[];
-}
-
-const PipelineDetails: React.FC<PipelineDetailsProps> = ({
-  obj: pipeline,
-  customData: routeTemplates,
-}) => {
+const PipelineDetails: React.FC<PipelineDetailsTabProps> = ({ obj: pipeline, customData }) => {
   const { t } = useTranslation();
   const { taskLinks, finallyTaskLinks } = getPipelineTaskLinks(pipeline);
 
@@ -34,7 +25,7 @@ const PipelineDetails: React.FC<PipelineDetailsProps> = ({
           <TriggerTemplateResourceLink
             namespace={pipeline.metadata.namespace}
             model={TriggerTemplateModel}
-            links={routeTemplates}
+            links={customData.templateNames}
           />
           <DynamicResourceLinkList
             namespace={pipeline.metadata.namespace}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/types.ts
@@ -1,0 +1,10 @@
+import { PipelineKind } from 'packages/pipelines-plugin/src/types';
+import { RouteTemplate } from '../utils/triggers';
+
+export type PipelineDetailsTabProps = {
+  obj: PipelineKind;
+  customData: {
+    templateNames: RouteTemplate[];
+    queryPrefix: string;
+  };
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/hooks.ts
@@ -65,11 +65,11 @@ export const usePipelinePVC = (
   return [!PVCError && PVC.length > 0 ? PVC[0] : null, PVCLoaded];
 };
 
-export const usePipelineSuccessRatioPoll = ({ delay, namespace, name, timespan }) => {
+export const usePipelineSuccessRatioPoll = ({ delay, namespace, name, timespan, queryPrefix }) => {
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries[PipelineQuery.PIPELINE_SUCCESS_RATIO]({ name, namespace }),
+      query: metricQueries(queryPrefix)[PipelineQuery.PIPELINE_SUCCESS_RATIO]({ name, namespace }),
       samples: 1,
       endTime: Date.now(),
       timespan,
@@ -80,11 +80,14 @@ export const usePipelineSuccessRatioPoll = ({ delay, namespace, name, timespan }
   );
 };
 
-export const usePipelineRunTaskRunPoll = ({ delay, namespace, name, timespan }) => {
+export const usePipelineRunTaskRunPoll = ({ delay, namespace, name, timespan, queryPrefix }) => {
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries[PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]({ name, namespace }),
+      query: metricQueries(queryPrefix)[PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]({
+        name,
+        namespace,
+      }),
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
@@ -95,11 +98,17 @@ export const usePipelineRunTaskRunPoll = ({ delay, namespace, name, timespan }) 
   );
 };
 
-export const usePipelineRunDurationPoll = ({ delay, namespace, name, timespan }): any => {
+export const usePipelineRunDurationPoll = ({
+  delay,
+  namespace,
+  name,
+  timespan,
+  queryPrefix,
+}): any => {
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries[PipelineQuery.PIPELINE_RUN_DURATION]({ name, namespace }),
+      query: metricQueries(queryPrefix)[PipelineQuery.PIPELINE_RUN_DURATION]({ name, namespace }),
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,
@@ -110,11 +119,11 @@ export const usePipelineRunDurationPoll = ({ delay, namespace, name, timespan })
   );
 };
 
-export const usePipelineRunPoll = ({ delay, namespace, name, timespan }) => {
+export const usePipelineRunPoll = ({ delay, namespace, name, timespan, queryPrefix }) => {
   return useURLPoll<PrometheusResponse>(
     getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      query: metricQueries[PipelineQuery.NUMBER_OF_PIPELINE_RUNS]({ name, namespace }),
+      query: metricQueries(queryPrefix)[PipelineQuery.NUMBER_OF_PIPELINE_RUNS]({ name, namespace }),
       samples: DEFAULT_SAMPLES,
       endTime: Date.now(),
       timespan,

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.tsx
@@ -6,7 +6,6 @@ import DashboardCardBody from '@console/shared/src/components/dashboard/dashboar
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
-import { PipelineKind } from '../../../types';
 import PipelineMetricsTimeRangeDropdown from './PipelineMetricsTimeRangeDropdown';
 import PipelineMetricsRefreshDropdown from './PipelineMetricsRefreshDropdown';
 import PipelineMetricsEmptyState from './PipelineMetricsEmptyState';
@@ -15,18 +14,16 @@ import PipelineRunDurationGraph from './PipelineRunDurationGraph';
 import PipelineRunTaskRunGraph from './PipelineRunTaskRunGraph';
 import { GraphData } from './pipeline-metrics-utils';
 import PipelineRunCount from './PipelineRunCount';
+import { PipelineDetailsTabProps } from '../detail-page-tabs/types';
 import { useLatestPipelineRun } from '../hooks';
 
 import './PipelineMetrics.scss';
 
-interface PipelineMeticsProps {
-  obj: PipelineKind;
-}
-
-const PipelineMetrics: React.FC<PipelineMeticsProps> = ({ obj }) => {
+const PipelineMetrics: React.FC<PipelineDetailsTabProps> = ({ obj, customData }) => {
   const {
     metadata: { name, namespace },
   } = obj;
+  const { queryPrefix } = customData;
   const { t } = useTranslation();
   const latestPipelineRun = useLatestPipelineRun(name, namespace);
   const [timespan, setTimespan] = React.useState(parsePrometheusDuration('1w'));
@@ -85,6 +82,7 @@ const PipelineMetrics: React.FC<PipelineMeticsProps> = ({ obj }) => {
                   pipeline={obj}
                   loaded={loaded}
                   onLoad={graphOnLoad}
+                  queryPrefix={queryPrefix}
                 />
               </DashboardCardBody>
             </DashboardCard>
@@ -103,6 +101,7 @@ const PipelineMetrics: React.FC<PipelineMeticsProps> = ({ obj }) => {
                   pipeline={obj}
                   loaded={loaded}
                   onLoad={graphOnLoad}
+                  queryPrefix={queryPrefix}
                 />
               </DashboardCardBody>
             </DashboardCard>
@@ -122,6 +121,7 @@ const PipelineMetrics: React.FC<PipelineMeticsProps> = ({ obj }) => {
                   timespan={timespan}
                   loaded={loaded}
                   onLoad={graphOnLoad}
+                  queryPrefix={queryPrefix}
                 />
               </DashboardCardBody>
             </DashboardCard>
@@ -138,6 +138,7 @@ const PipelineMetrics: React.FC<PipelineMeticsProps> = ({ obj }) => {
                   pipeline={obj}
                   loaded={loaded}
                   onLoad={graphOnLoad}
+                  queryPrefix={queryPrefix}
                 />
               </DashboardCardBody>
             </DashboardCard>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
@@ -22,6 +22,7 @@ const PipelineRunCount: React.FC<PipelineMetricsGraphProps> = ({
   interval,
   loaded = true,
   onLoad: onInitialLoad,
+  queryPrefix,
 }) => {
   const {
     metadata: { name, namespace },
@@ -32,6 +33,7 @@ const PipelineRunCount: React.FC<PipelineMetricsGraphProps> = ({
     namespace,
     timespan,
     delay: interval,
+    queryPrefix,
   });
   const pipelineRunResultData = pipelineRunResult?.data?.result ?? [];
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
@@ -19,6 +19,7 @@ const PipelineRunDurationGraph: React.FC<PipelineMetricsGraphProps> = ({
   interval,
   loaded = true,
   onLoad: onInitialLoad,
+  queryPrefix,
 }) => {
   const {
     metadata: { name, namespace },
@@ -29,6 +30,7 @@ const PipelineRunDurationGraph: React.FC<PipelineMetricsGraphProps> = ({
     namespace,
     timespan,
     delay: interval,
+    queryPrefix,
   });
   const pipelineRunDurationData = runData?.data?.result ?? [];
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunTaskRunGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunTaskRunGraph.tsx
@@ -29,6 +29,7 @@ const PipelineRunTaskRunGraph: React.FC<PipelineMetricsGraphProps> = ({
   interval,
   loaded = true,
   onLoad: onInitialLoad,
+  queryPrefix,
 }) => {
   const {
     metadata: { name, namespace },
@@ -41,6 +42,7 @@ const PipelineRunTaskRunGraph: React.FC<PipelineMetricsGraphProps> = ({
     namespace,
     timespan,
     delay: interval,
+    queryPrefix,
   });
 
   const taskNameMap = pipeline.spec.tasks

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
@@ -24,6 +24,7 @@ const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
   interval,
   loaded = true,
   onLoad: onInitialLoad,
+  queryPrefix,
 }) => {
   const {
     metadata: { name, namespace },
@@ -34,6 +35,7 @@ const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
     namespace,
     timespan,
     delay: interval,
+    queryPrefix,
   });
   const pipelineSuccessData = runData?.data?.result ?? [];
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineMetrics.spec.tsx
@@ -15,6 +15,7 @@ import PipelineRunDurationGraph from '../PipelineRunDurationGraph';
 import PipelineRunTaskRunGraph from '../PipelineRunTaskRunGraph';
 import PipelineMetricsTimeRangeDropdown from '../PipelineMetricsTimeRangeDropdown';
 import PipelineMetricsRefreshDropdown from '../PipelineMetricsRefreshDropdown';
+import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
 
 jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
   useK8sGet: jest.fn(),
@@ -39,6 +40,10 @@ describe('Pipeline Metrics', () => {
   beforeEach(() => {
     PipelineMetricsProps = {
       obj: pipeline,
+      customData: {
+        templateNames: [],
+        queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
+      },
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunCount.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunCount.spec.tsx
@@ -9,6 +9,7 @@ import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pi
 import PipelineRunCount from '../PipelineRunCount';
 import { DEFAULT_REFRESH_INTERVAL } from '../../const';
 import { TimeSeriesChart } from '../charts/TimeSeriesChart';
+import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
 
 jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
   useK8sGet: jest.fn(),
@@ -34,6 +35,7 @@ describe('Pipeline Run Count Graph', () => {
       pipeline,
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunDuration.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunDuration.spec.tsx
@@ -10,6 +10,7 @@ import { LineChart } from '../charts/lineChart';
 import { DEFAULT_REFRESH_INTERVAL } from '../../const';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
 import PipelineRunDurationGraph from '../PipelineRunDurationGraph';
+import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
 
 jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
   useK8sGet: jest.fn(),
@@ -37,6 +38,7 @@ describe('Pipeline Run Duration Graph', () => {
       pipeline,
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunTaskRunGraph.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineRunTaskRunGraph.spec.tsx
@@ -10,6 +10,7 @@ import { LineChart } from '../charts/lineChart';
 import { DEFAULT_REFRESH_INTERVAL } from '../../const';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
 import PipelineRunTaskRunGraph from '../PipelineRunTaskRunGraph';
+import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
 
 jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
   useK8sGet: jest.fn(),
@@ -37,6 +38,7 @@ describe('TaskRun Duration Graph', () => {
       pipeline,
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineSuccessRatioDonut.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/PipelineSuccessRatioDonut.spec.tsx
@@ -11,6 +11,7 @@ import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pi
 import PipelineSuccessRatioDonut from '../PipelineSuccessRatioDonut';
 import SuccessRatioDonut from '../charts/successRatioDonut';
 import { TimeSeriesChart } from '../charts/TimeSeriesChart';
+import { MetricsQueryPrefix } from '../pipeline-metrics-utils';
 
 jest.mock('@console/internal/components/utils/k8s-get-hook', () => ({
   useK8sGet: jest.fn(),
@@ -38,6 +39,7 @@ describe('Pipeline Success Ratio Graph', () => {
       pipeline,
       timespan: DEFAULT_PROMETHEUS_TIMESPAN,
       interval: parsePrometheusDuration(DEFAULT_REFRESH_INTERVAL),
+      queryPrefix: MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER,
     };
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
@@ -13,6 +13,7 @@ export interface GraphData {
 export interface PipelineMetricsGraphProps {
   pipeline: PipelineKind;
   timespan: number;
+  queryPrefix: string;
   interval: number;
   width?: number;
 
@@ -25,20 +26,25 @@ export enum PipelineQuery {
   PIPELINE_RUN_TASK_RUN_DURATION = 'PIPELINE_RUN_TASK_RUN_DURATION',
   PIPELINE_SUCCESS_RATIO = 'PIPELINE_SUCCESS_RATIO',
 }
-export const metricQueries = {
+
+export enum MetricsQueryPrefix {
+  TEKTON = 'tekton',
+  TEKTON_PIPELINES_CONTROLLER = 'tekton_pipelines_controller',
+}
+export const metricQueries = (prefix: string = MetricsQueryPrefix.TEKTON_PIPELINES_CONTROLLER) => ({
   [PipelineQuery.NUMBER_OF_PIPELINE_RUNS]: _.template(
-    `sum(count by (pipelinerun) (tekton_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"}))`,
+    `sum(count by (pipelinerun) (${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"}))`,
   ),
   [PipelineQuery.PIPELINE_RUN_TASK_RUN_DURATION]: _.template(
-    `sum(tekton_pipelinerun_taskrun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun, task)`,
+    `sum(${prefix}_pipelinerun_taskrun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun, task)`,
   ),
   [PipelineQuery.PIPELINE_RUN_DURATION]: _.template(
-    `sum(tekton_pipelinerun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun)`,
+    `sum(${prefix}_pipelinerun_duration_seconds_sum{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})  by (pipelinerun)`,
   ),
   [PipelineQuery.PIPELINE_SUCCESS_RATIO]: _.template(
-    `count(sort_desc(tekton_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})) by (status)`,
+    `count(sort_desc(${prefix}_pipelinerun_duration_seconds_count{pipeline="<%= name %>",exported_namespace="<%= namespace %>"})) by (status)`,
   ),
-};
+});
 
 const formatPositiveValue = (v: number): string =>
   v === 0 || (v >= 0.001 && v < 1e23) ? humanizeNumberSI(v).string : v.toExponential(1);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts
@@ -1,6 +1,7 @@
+import { SemVer } from 'semver';
 import { k8sList } from '@console/internal/module/k8s';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
-import { getPipelineOperatorVersion } from '../pipeline-operator';
+import { getPipelineOperatorVersion, isGAVersionInstalled } from '../pipeline-operator';
 
 jest.mock('@console/internal/module/k8s', () => ({
   k8sList: jest.fn(),
@@ -11,6 +12,20 @@ beforeEach(() => {
 });
 
 const k8sListMock = k8sList as jest.Mock;
+
+describe('isGAVersionInstalled', () => {
+  it('should return false if the operator is not identified', () => {
+    expect(isGAVersionInstalled(null)).toBe(false);
+  });
+
+  it('should return true if the installed operator is below 1.4.0', () => {
+    expect(isGAVersionInstalled(new SemVer('1.3.1'))).toBe(false);
+  });
+
+  it('should return true if the installed operator is above 1.4.0', () => {
+    expect(isGAVersionInstalled(new SemVer('1.5.1'))).toBe(true);
+  });
+});
 
 describe('getPipelineOperatorVersion', () => {
   it('should fetch the ClusterServiceVersion from the api', async () => {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5667

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Pipeline Metrics is not showing any data in 1.4 OSP as the metrics endpoint is changed in upstream operator

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Conditionally forming the metrics endpoint using the pipeline operator installed.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Before fix:
![image](https://user-images.githubusercontent.com/9964343/112124767-ba58fe00-8be8-11eb-9033-fab5ebd411aa.png)

After fix:
![image](https://user-images.githubusercontent.com/9964343/112124804-c47afc80-8be8-11eb-9cc2-9cd0d30cbdb9.png)



**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Pipeline Metrics should work in both 1.3.1 and as well as in 1.4 Openshift pipelines operator.

Unit tests:
```

  pipelineDetailsPage.spec.tsx
    ✓ should have the latest metrics endpoint as default queryPrefix (5ms)
    ✓ should use the new metrics endpoint if the pipeline operator is greater than 1.4.0 (3ms)
    ✓ should use the old metrics endpoint if the pipeline operator is less than 1.4.0 (3ms)
```
```
packages/pipelines-plugin/src/components/pipelines/utils/__tests__/pipeline-operator.spec.ts
  isGAVersionInstalled
    ✓ should return false if the operator is not identified (3ms)
    ✓ should return true if the installed operator is below 1.4.0 (1ms)
    ✓ should return true if the installed operator is above 1.4.0
```

/assign @jerolimov 
/kind bug
cc: @andrewballantyne @VeereshAradhya 
