### PR TITLE
Bug 1939606: Attempting to put a host into maintenance mode warns about Ceph cluster health, but no storage cluster problems are apparent

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/modals/StartNodeMaintenanceModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/StartNodeMaintenanceModal.tsx
@@ -41,7 +41,7 @@ const StartNodeMaintenanceModal = withHandlePromise<StartNodeMaintenanceModalPro
 
   const [cephClusters, loaded] = useK8sWatchResource<K8sResourceKind[]>(cephClusterResource);
   const cephCluster = cephClusters?.[0];
-  const cephClusterHealthy = !cephCluster || cephCluster?.status?.health === 'OK';
+  const cephClusterHealthy = cephCluster?.status?.ceph?.health === 'HEALTH_OK';
 
   const action = t('metal3-plugin~Start Maintenance');
   return (
@@ -70,7 +70,7 @@ const StartNodeMaintenanceModal = withHandlePromise<StartNodeMaintenanceModalPro
               />
             </FormGroup>
           </StackItem>
-          {!cephClusterHealthy && (
+          {!!cephCluster && !cephClusterHealthy && (
             <StackItem>
               <Alert
                 variant="warning"


### PR DESCRIPTION
**Earlier:**
In bare metal OCP cluster, attempting to put a node into maintenance mode was resulting in the warning-alert even though there were no problems with the Ceph cluster.

**After:**
There will be no alert if the status of the Ceph cluster is `HEALTH_OK` 