### PR TITLE
Expose plugin API

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -54,6 +54,7 @@ declare interface Window {
   loadPluginEntry?: Function;
   loadPluginFromURL?: Function;
   Cypress?: {};
+  api: {};
 }
 
 // From https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-api.ts
@@ -1,0 +1,7 @@
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+
+export const exposePluginAPI = () => {
+  window.api = {
+    useK8sWatchResource,
+  };
+};

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -9,6 +9,7 @@ import {
   loadDynamicPlugin,
   registerPluginEntryCallback,
 } from '@console/dynamic-plugin-sdk/src/runtime/plugin-loader';
+import { exposePluginAPI } from '@console/dynamic-plugin-sdk/src/runtime/plugin-api';
 
 // The '@console/active-plugins' module is generated during a webpack build,
 // so we use dynamic require() instead of the usual static import statement.
@@ -22,6 +23,7 @@ export const pluginStore = new PluginStore(activePlugins);
 export const initConsolePlugins = _.once((reduxStore: Store<RootState>) => {
   initSubscriptionService(pluginStore, reduxStore);
   registerPluginEntryCallback(pluginStore);
+  exposePluginAPI();
 });
 
 const loadPluginFromURL = async (baseURL: string) => {


### PR DESCRIPTION
This is a possible solution of how we can expose utils/components via window object and use them in dynamic plugin such as https://github.com/rawagner/console-dynamic-foo
The dynamic plugin uses the exposed `useK8sWatchResource` to load all pods when you access `/foo` page