### PR TITLE
show modal for editing resource limits

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -1,4 +1,5 @@
 {
+  "Edit resource limits": "Edit resource limits",
   "Add Health Checks": "Add Health Checks",
   "Edit Health Checks": "Edit Health Checks",
   "Add HorizontalPodAutoscaler": "Add HorizontalPodAutoscaler",

--- a/frontend/packages/console-app/src/actions/edit-resource-limits.ts
+++ b/frontend/packages/console-app/src/actions/edit-resource-limits.ts
@@ -1,0 +1,20 @@
+import { KebabOption } from '@console/internal/components/utils';
+import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
+import { resourceLimitsModal } from '../components/modals/resource-limits';
+
+export const EditResourceLimits = (kind: K8sKind, obj: K8sResourceKind): KebabOption => ({
+  // t('console-app~Edit resource limits')
+  labelKey: 'console-app~Edit resource limits',
+  callback: () =>
+    resourceLimitsModal({
+      model: kind,
+      resource: obj,
+    }),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.plural,
+    name: obj.metadata.name,
+    namespace: obj.metadata.namespace,
+    verb: 'patch',
+  },
+});

--- a/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModal.tsx
+++ b/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModal.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import * as _ from 'lodash';
+import { FormikProps, FormikValues } from 'formik';
+import {
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import ResourceLimitSection from '@console/dev-console/src/components/import/advanced/ResourceLimitSection';
+
+interface ResourceLimitsModalProps {
+  cancel?: () => void;
+}
+
+type Props = FormikProps<FormikValues> & ResourceLimitsModalProps;
+
+const ResourceLimitsModal: React.FC<Props> = ({
+  handleSubmit,
+  cancel,
+  isSubmitting,
+  status,
+  errors,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <form className="modal-content modal-content--no-inner-scroll" onSubmit={handleSubmit}>
+      <ModalTitle>{t('modal~Edit resource limits')}</ModalTitle>
+      <ModalBody>
+        <ResourceLimitSection hideTitle />
+      </ModalBody>
+      <ModalSubmitFooter
+        submitDisabled={!_.isEmpty(errors)}
+        inProgress={isSubmitting}
+        errorMessage={status && status.submitError}
+        submitText={t('modal~Save')}
+        cancel={cancel}
+      />
+    </form>
+  );
+};
+
+export default ResourceLimitsModal;

--- a/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModalLauncher.tsx
+++ b/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModalLauncher.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import { Formik } from 'formik';
+import { K8sKind, k8sPatch, K8sResourceKind } from '@console/internal/module/k8s';
+import { limitsValidationSchema } from '@console/dev-console/src/components/import/validation-schema';
+import { getLimitsDataFromResource, getResourceLimitsData } from '@console/shared/src';
+import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import ResourceLimitsModal from './ResourceLimitsModal';
+
+export type ResourceLimitsModalLauncherProps = {
+  model: K8sKind;
+  resource: K8sResourceKind;
+  close?: () => void;
+} & ModalComponentProps;
+
+const rlValidationSchema = (t: TFunction) =>
+  yup.object().shape({
+    limits: limitsValidationSchema(t),
+  });
+
+const ResourceLimitsModalLauncher: React.FC<ResourceLimitsModalLauncherProps> = (props) => {
+  const { t } = useTranslation();
+
+  const handleSubmit = (values, actions) => {
+    const {
+      limits: { cpu, memory },
+    } = values;
+    const resources = getResourceLimitsData({ cpu, memory });
+    k8sPatch(props.model, props.resource, [
+      {
+        op: 'replace',
+        path: `/spec/template/spec/containers/0/resources`,
+        value: resources,
+      },
+    ])
+      .then(() => {
+        actions.setSubmitting(false);
+        props.close();
+      })
+      .catch((error) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: error });
+      });
+  };
+
+  const currentValues = {
+    limits: getLimitsDataFromResource(props.resource),
+    container: props.resource.spec.template.spec.containers[0].name,
+  };
+
+  return (
+    <Formik
+      initialValues={currentValues}
+      onSubmit={handleSubmit}
+      validationSchema={rlValidationSchema(t)}
+    >
+      {(formikProps) => <ResourceLimitsModal {...formikProps} {...props} />}
+    </Formik>
+  );
+};
+
+export const resourceLimitsModal = createModalLauncher(
+  (props: ResourceLimitsModalLauncherProps) => <ResourceLimitsModalLauncher {...props} />,
+);

--- a/frontend/packages/console-app/src/components/modals/resource-limits/__tests__/ResourceLimitsModal.spec.tsx
+++ b/frontend/packages/console-app/src/components/modals/resource-limits/__tests__/ResourceLimitsModal.spec.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { FormikProps, FormikValues } from 'formik';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import ResourceLimitSection from '@console/dev-console/src/components/import/advanced/ResourceLimitSection';
+import ResourceLimitsModal from '../ResourceLimitsModal';
+
+type ResourceLimitsModalProps = React.ComponentProps<typeof ResourceLimitsModal>;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+describe('ResourceLimitsModal Form', () => {
+  let formProps: ResourceLimitsModalProps;
+  let ResourceLimitsModalWrapper: ShallowWrapper<ResourceLimitsModalProps>;
+
+  type Props = FormikProps<FormikValues> & ResourceLimitsModalProps;
+
+  beforeEach(() => {
+    formProps = {
+      ...formikFormProps,
+      resource: {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'xyz-deployment',
+        },
+        spec: {
+          selector: {
+            matchLabels: {
+              app: 'hello-openshift',
+            },
+          },
+          replicas: 1,
+          template: {
+            metadata: {
+              labels: {
+                app: 'hello-openshift',
+              },
+            },
+            spec: {
+              containers: [
+                {
+                  name: 'hello-openshift',
+                  image: 'openshift/hello-openshift',
+                  ports: [
+                    {
+                      containerPort: 8080,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    } as Props;
+    ResourceLimitsModalWrapper = shallow(<ResourceLimitsModal {...formProps} />);
+  });
+
+  it('should render ResouceLimitSection', () => {
+    expect(ResourceLimitsModalWrapper.find(ResourceLimitSection)).toHaveLength(1);
+  });
+
+  it('should call handleSubmit on form submit', () => {
+    ResourceLimitsModalWrapper.simulate('submit');
+    expect(formProps.handleSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/packages/console-app/src/components/modals/resource-limits/index.ts
+++ b/frontend/packages/console-app/src/components/modals/resource-limits/index.ts
@@ -1,0 +1,4 @@
+export const resourceLimitsModal = (props) =>
+  import(
+    './ResourceLimitsModalLauncher' /* webpackChunkName: "resource-limits-modal" */
+  ).then((m) => m.resourceLimitsModal(props));

--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -26,3 +26,16 @@ export type OverviewItem<T = K8sResourceKind> = {
 };
 
 export type DeploymentStrategy = DEPLOYMENT_STRATEGY.recreate | DEPLOYMENT_STRATEGY.rolling;
+
+export interface ResourceType {
+  request: number | string;
+  requestUnit: string;
+  defaultRequestUnit: string;
+  limit: number | string;
+  limitUnit: string;
+  defaultLimitUnit: string;
+}
+export interface LimitsData {
+  cpu: ResourceType;
+  memory: ResourceType;
+}

--- a/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/resource-utils.spec.ts
@@ -13,7 +13,11 @@ import {
 } from '@console/knative-plugin/src/topology/__tests__/topology-knative-test-data';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Alert } from '@console/internal/components/monitoring/types';
-import { createOverviewItemsForType, getWorkloadMonitoringAlerts } from '../resource-utils';
+import {
+  createOverviewItemsForType,
+  getResourceData,
+  getWorkloadMonitoringAlerts,
+} from '../resource-utils';
 import { mockAlerts } from '../__mocks__/alerts-and-rules-data';
 
 declare global {
@@ -171,5 +175,22 @@ describe('TransformResourceData', () => {
     const alerts: Alert[] = getWorkloadMonitoringAlerts(deploymentResource, mockAlerts);
     const expectedAlerts: Alert[] = _.pullAt(mockAlerts.data, [0, 1, 4]);
     expect(alerts).toEqual(expectedAlerts);
+  });
+
+  it('should return proper limit with unit data', () => {
+    let limit;
+    let unit;
+    [limit, unit] = getResourceData('3Mi');
+    expect(limit).toBe('3');
+    expect(unit).toBe('Mi');
+    [limit, unit] = getResourceData('5');
+    expect(limit).toBe('5');
+    expect(unit).toBe('');
+    [limit, unit] = getResourceData('4m');
+    expect(limit).toBe('4');
+    expect(unit).toBe('m');
+    [limit, unit] = getResourceData('2Gi');
+    expect(limit).toBe('2');
+    expect(unit).toBe('Gi');
   });
 });

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -205,6 +205,7 @@
   "Environment variables (runtime only)": "Environment variables (runtime only)",
   "Each label is applied to each created resource.": "Each label is applied to each created resource.",
   "Resource limit": "Resource limit",
+  "Resource limits control how much CPU and memory a container will consume on a node.": "Resource limits control how much CPU and memory a container will consume on a node.",
   "Request": "Request",
   "The minimum amount of CPU the Container is guaranteed.": "The minimum amount of CPU the Container is guaranteed.",
   "Limit": "Limit",

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -25,6 +25,7 @@ import {
 } from '@console/pipelines-plugin/src/const';
 import { isDockerPipeline } from '@console/pipelines-plugin/src/components/import/pipeline/pipeline-template-utils';
 import { UNASSIGNED_KEY } from '@console/topology/src/const';
+import { getLimitsDataFromResource } from '@console/shared/src';
 import {
   Resources,
   DeploymentData,
@@ -308,34 +309,6 @@ export const getDeploymentData = (resource: K8sResourceKind) => {
   }
 };
 
-export const getLimitsData = (resource: K8sResourceKind) => {
-  const containers = _.get(resource, 'spec.template.spec.containers', []);
-  const resourcesRegEx = /^[0-9]*|[a-zA-Z]*/g;
-  const cpuLimit = _.get(containers[0], 'resources.limits.cpu', '').match(resourcesRegEx);
-  const memoryLimit = _.get(containers[0], 'resources.limits.memory', '').match(resourcesRegEx);
-  const cpuRequest = _.get(containers[0], 'resources.requests.cpu', '').match(resourcesRegEx);
-  const memoryRequest = _.get(containers[0], 'resources.requests.memory', '').match(resourcesRegEx);
-  const limitsData = {
-    cpu: {
-      request: cpuRequest[0],
-      requestUnit: cpuRequest[1] || '',
-      defaultRequestUnit: cpuRequest[1] || '',
-      limit: cpuLimit[0],
-      limitUnit: cpuLimit[1] || '',
-      defaultLimitUnit: cpuLimit[1] || '',
-    },
-    memory: {
-      request: memoryRequest[0],
-      requestUnit: memoryRequest[1] || 'Mi',
-      defaultRequestUnit: memoryRequest[1] || 'Mi',
-      limit: memoryLimit[0],
-      limitUnit: memoryLimit[1] || 'Mi',
-      defaultLimitUnit: memoryLimit[1] || 'Mi',
-    },
-  };
-  return limitsData;
-};
-
 export const getUserLabels = (resource: K8sResourceKind) => {
   const defaultLabels = [
     'app',
@@ -379,7 +352,7 @@ export const getCommonInitialValues = (
     },
     deployment: getDeploymentData(editAppResource),
     labels: getUserLabels(editAppResource),
-    limits: getLimitsData(editAppResource),
+    limits: getLimitsDataFromResource(editAppResource),
     healthChecks: getHealthChecksData(editAppResource),
   };
   return commonInitialValues;

--- a/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
+++ b/frontend/packages/dev-console/src/components/hpa/hpa-utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@console/internal/module/k8s';
 import { HorizontalPodAutoscalerModel } from '@console/internal/models';
 import { baseTemplates } from '@console/internal/models/yaml-templates';
-import { LimitsData } from '../import/import-types';
+import { LimitsData } from '@console/shared/src';
 import { HPAFormValues, SupportedMetricTypes } from './types';
 
 export const VALID_HPA_TARGET_KINDS = ['Deployment', 'DeploymentConfig'];

--- a/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
@@ -1,19 +1,38 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ResourceLimitField } from '@console/shared';
 import { useFormikContext, FormikValues } from 'formik';
+import { ResourceLimitField } from '@console/shared';
+import { ResourceIcon } from '@console/internal/components/utils';
+import { ContainerModel } from '@console/internal/models';
 import FormSection from '../section/FormSection';
 import { MemoryUnits, CPUUnits } from '../import-types';
 
-const ResourceLimitSection: React.FC = () => {
+export type ResourceLimitSectionProps = {
+  hideTitle?: boolean;
+};
+
+const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }) => {
   const { t } = useTranslation();
   const {
     values: {
       limits: { cpu, memory },
+      container,
     },
   } = useFormikContext<FormikValues>();
   return (
-    <FormSection title={t('devconsole~Resource limit')}>
+    <FormSection
+      title={!hideTitle && t('devconsole~Resource limit')}
+      subTitle={t(
+        'devconsole~Resource limits control how much CPU and memory a container will consume on a node.',
+      )}
+      fullWidth
+    >
+      {container && (
+        <span>
+          {t('devconsole~Container')} &nbsp;
+          <ResourceIcon kind={ContainerModel.kind} /> {container}
+        </span>
+      )}
       <div className="co-section-heading-tertiary">{t('devconsole~CPU')}</div>
       <ResourceLimitField
         name="limits.cpu.request"
@@ -35,7 +54,7 @@ const ResourceLimitSection: React.FC = () => {
         )}
       />
 
-      <div className="co-section-heading-tertiary">Memory</div>
+      <div className="co-section-heading-tertiary">{t('devconsole~Memory')}</div>
       <ResourceLimitField
         name="limits.memory.request"
         label={t('devconsole~Request')}

--- a/frontend/packages/dev-console/src/components/import/advanced/__tests__/ResourceLimitSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/__tests__/ResourceLimitSection.spec.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { useFormikContext } from 'formik';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import ResourceLimitSection from '../ResourceLimitSection';
+import FormSection from '../../section/FormSection';
+
+let resourceLimitSectionProps: React.ComponentProps<typeof ResourceLimitSection>;
+const useFormikContextMock = useFormikContext as jest.Mock;
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+jest.mock('formik', () => ({
+  useFormikContext: jest.fn(() => ({
+    values: {
+      limits: {
+        cpu: {
+          request: '',
+          requestUnit: '',
+          defaultRequestUnit: '',
+          limit: '',
+          limitUnit: '',
+          defaultLimitUnit: '',
+        },
+        memory: {
+          request: '',
+          requestUnit: 'Mi',
+          defaultRequestUnit: 'Mi',
+          limit: '',
+          limitUnit: 'Mi',
+          defaultLimitUnit: 'Mi',
+        },
+      },
+      container: 'nodejs-container',
+    },
+  })),
+}));
+
+const i18nNS = 'devconsole';
+
+describe('ResourceLimitSection', () => {
+  beforeEach(() => {
+    resourceLimitSectionProps = {
+      ...formikFormProps,
+      hideTitle: true,
+    };
+  });
+
+  it('should render helptext for resource limit section', () => {
+    const wrapper = shallow(<ResourceLimitSection {...resourceLimitSectionProps} />);
+    expect(wrapper.find(FormSection).props().subTitle).toEqual(
+      `${i18nNS}~Resource limits control how much CPU and memory a container will consume on a node.`,
+    );
+  });
+
+  it('should not render Title for resource limit section', () => {
+    const wrapper = shallow(<ResourceLimitSection {...resourceLimitSectionProps} />);
+    expect(wrapper.find(FormSection).props().title).toBe(false);
+  });
+
+  it('should render container name for resource limit section', () => {
+    const wrapper = shallow(<ResourceLimitSection {...resourceLimitSectionProps} />);
+    expect(
+      wrapper
+        .find('span')
+        .at(0)
+        .props().children,
+    ).toContainEqual('nodejs-container');
+  });
+
+  it('should not render container for resource limit section', () => {
+    useFormikContextMock.mockReturnValue({
+      values: {
+        limits: {
+          cpu: {
+            request: '',
+            requestUnit: '',
+            defaultRequestUnit: '',
+            limit: '',
+            limitUnit: '',
+            defaultLimitUnit: '',
+          },
+          memory: {
+            request: '',
+            requestUnit: 'Mi',
+            defaultRequestUnit: 'Mi',
+            limit: '',
+            limitUnit: 'Mi',
+            defaultLimitUnit: 'Mi',
+          },
+        },
+        container: undefined,
+      },
+    });
+    const wrapper = shallow(<ResourceLimitSection {...resourceLimitSectionProps} />);
+
+    expect(wrapper.find('span').exists()).toBe(false);
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -15,7 +15,7 @@ import {
 } from '@console/internal/module/k8s';
 import { ServiceModel as KnServiceModel } from '@console/knative-plugin';
 import { getKnativeServiceDepResource } from '@console/knative-plugin/src/utils/create-knative-utils';
-import { getRandomChars } from '@console/shared/src/utils';
+import { getRandomChars, getResourceLimitsData } from '@console/shared/src/utils';
 import {
   getAppLabels,
   getPodLabels,
@@ -206,20 +206,7 @@ export const createOrUpdateDeployment = (
               ports,
               volumeMounts,
               env,
-              resources: {
-                ...((cpu.limit || memory.limit) && {
-                  limits: {
-                    ...(cpu.limit && { cpu: `${cpu.limit}${cpu.limitUnit}` }),
-                    ...(memory.limit && { memory: `${memory.limit}${memory.limitUnit}` }),
-                  },
-                }),
-                ...((cpu.request || memory.request) && {
-                  requests: {
-                    ...(cpu.request && { cpu: `${cpu.request}${cpu.requestUnit}` }),
-                    ...(memory.request && { memory: `${memory.request}${memory.requestUnit}` }),
-                  },
-                }),
-              },
+              resources: getResourceLimitsData({ cpu, memory }),
               ...getProbesData(healthChecks),
             },
           ],
@@ -280,20 +267,7 @@ export const createOrUpdateDeploymentConfig = (
               ports,
               volumeMounts,
               env,
-              resources: {
-                ...((cpu.limit || memory.limit) && {
-                  limits: {
-                    ...(cpu.limit && { cpu: `${cpu.limit}${cpu.limitUnit}` }),
-                    ...(memory.limit && { memory: `${memory.limit}${memory.limitUnit}` }),
-                  },
-                }),
-                ...((cpu.request || memory.request) && {
-                  requests: {
-                    ...(cpu.request && { cpu: `${cpu.request}${cpu.requestUnit}` }),
-                    ...(memory.request && { memory: `${memory.request}${memory.requestUnit}` }),
-                  },
-                }),
-              },
+              resources: getResourceLimitsData({ cpu, memory }),
               ...getProbesData(healthChecks),
             },
           ],

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -15,7 +15,7 @@ import { ServiceModel as KnServiceModel } from '@console/knative-plugin';
 import { getKnativeServiceDepResource } from '@console/knative-plugin/src/utils/create-knative-utils';
 import { SecretType } from '@console/internal/components/secrets/create-secret';
 import { history } from '@console/internal/components/utils';
-import { getRandomChars } from '@console/shared/src/utils';
+import { getRandomChars, getResourceLimitsData } from '@console/shared/src/utils';
 import {
   createPipelineForImportFlow,
   createPipelineRunForImportFlow,
@@ -303,20 +303,7 @@ export const createOrUpdateDeployment = (
               image: `${name}:latest`,
               ports,
               env,
-              resources: {
-                ...((cpu.limit || memory.limit) && {
-                  limits: {
-                    ...(cpu.limit && { cpu: `${cpu.limit}${cpu.limitUnit}` }),
-                    ...(memory.limit && { memory: `${memory.limit}${memory.limitUnit}` }),
-                  },
-                }),
-                ...((cpu.request || memory.request) && {
-                  requests: {
-                    ...(cpu.request && { cpu: `${cpu.request}${cpu.requestUnit}` }),
-                    ...(memory.request && { memory: `${memory.request}${memory.requestUnit}` }),
-                  },
-                }),
-              },
+              resources: getResourceLimitsData({ cpu, memory }),
               ...getProbesData(healthChecks),
             },
           ],
@@ -379,20 +366,7 @@ export const createOrUpdateDeploymentConfig = (
               image: `${name}:latest`,
               ports,
               env,
-              resources: {
-                ...((cpu.limit || memory.limit) && {
-                  limits: {
-                    ...(cpu.limit && { cpu: `${cpu.limit}${cpu.limitUnit}` }),
-                    ...(memory.limit && { memory: `${memory.limit}${memory.limitUnit}` }),
-                  },
-                }),
-                ...((cpu.request || memory.request) && {
-                  requests: {
-                    ...(cpu.request && { cpu: `${cpu.request}${cpu.requestUnit}` }),
-                    ...(memory.request && { memory: `${memory.request}${memory.requestUnit}` }),
-                  },
-                }),
-              },
+              resources: getResourceLimitsData({ cpu, memory }),
               ...getProbesData(healthChecks),
             },
           ],

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -3,7 +3,7 @@ import { K8sResourceKind, ContainerPort } from '@console/internal/module/k8s';
 import { DeploymentModel, DeploymentConfigModel } from '@console/internal/models';
 import { WatchK8sResultsObject } from '@console/internal/components/utils/k8s-watch-hook';
 import { LazyLoader } from '@console/plugin-sdk';
-import { NameValuePair, NameValueFromPair } from '@console/shared';
+import { NameValuePair, NameValueFromPair, LimitsData } from '@console/shared';
 import { ServiceModel } from '@console/knative-plugin/src/models';
 import { PipelineData } from '@console/pipelines-plugin/src/components/import/import-types';
 import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
@@ -297,20 +297,6 @@ export enum InsecureTrafficTypes {
 export enum PassthroughInsecureTrafficTypes {
   None = 'None',
   Redirect = 'Redirect',
-}
-
-export interface LimitsData {
-  cpu: ResourceType;
-  memory: ResourceType;
-}
-
-export interface ResourceType {
-  request: number | string;
-  requestUnit: string;
-  defaultRequestUnit: string;
-  limit: number | string;
-  limitUnit: string;
-  defaultLimitUnit: string;
 }
 
 export interface AutoscaleWindowType {

--- a/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
@@ -11,7 +11,8 @@ import {
 import { coFetch } from '@console/internal/co-fetch';
 import { getKnativeServiceDepResource } from '@console/knative-plugin/src/utils/create-knative-utils';
 import { ServiceModel as KnServiceModel } from '@console/knative-plugin';
-import { NameValuePair } from '@console/shared';
+import { NameValuePair, getResourceLimitsData } from '@console/shared';
+
 import { createProject, createWebhookSecret } from './import-submit-utils';
 import {
   getAppLabels,
@@ -103,20 +104,7 @@ export const createOrUpdateDeployment = (
               image: `${name}:latest`,
               ports,
               env,
-              resources: {
-                ...((cpu.limit || memory.limit) && {
-                  limits: {
-                    ...(cpu.limit && { cpu: `${cpu.limit}${cpu.limitUnit}` }),
-                    ...(memory.limit && { memory: `${memory.limit}${memory.limitUnit}` }),
-                  },
-                }),
-                ...((cpu.request || memory.request) && {
-                  requests: {
-                    ...(cpu.request && { cpu: `${cpu.request}${cpu.requestUnit}` }),
-                    ...(memory.request && { memory: `${memory.request}${memory.requestUnit}` }),
-                  },
-                }),
-              },
+              resources: getResourceLimitsData({ cpu, memory }),
               ...getProbesData(healthChecks),
             },
           ],
@@ -187,20 +175,7 @@ const createOrUpdateDeploymentConfig = (
               image: `${name}:latest`,
               ports,
               env,
-              resources: {
-                ...((cpu.limit || memory.limit) && {
-                  limits: {
-                    ...(cpu.limit && { cpu: `${cpu.limit}${cpu.limitUnit}` }),
-                    ...(memory.limit && { memory: `${memory.limit}${memory.limitUnit}` }),
-                  },
-                }),
-                ...((cpu.request || memory.request) && {
-                  requests: {
-                    ...(cpu.request && { cpu: `${cpu.request}${cpu.requestUnit}` }),
-                    ...(memory.request && { memory: `${memory.request}${memory.requestUnit}` }),
-                  },
-                }),
-              },
+              resources: getResourceLimitsData({ cpu, memory }),
               ...getProbesData(healthChecks),
             },
           ],

--- a/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
@@ -2,6 +2,7 @@ import { ServiceModel } from '@console/internal/models';
 import { EditApplication } from '@console/topology/src/actions';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { EditResourceLimits } from '@console/app/src/actions/edit-resource-limits';
 import { getKebabActionsForKind } from '../kebab-actions';
 import { setTrafficDistribution } from '../../actions/traffic-splitting';
 import { setSinkSource } from '../../actions/sink-source';
@@ -36,6 +37,7 @@ describe('kebab-actions: ', () => {
       AddHealthChecks,
       EditApplication,
       EditHealthChecks,
+      EditResourceLimits,
     ]);
   });
 

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -3,6 +3,7 @@ import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { KebabAction } from '@console/internal/components/utils';
 import { EditApplication } from '@console/topology/src/actions/modify-application';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { EditResourceLimits } from '@console/app/src/actions/edit-resource-limits';
 import { DeploymentConfigModel, DeploymentModel } from '@console/internal/models';
 import { setTrafficDistribution } from '../actions/traffic-splitting';
 import { setKnatify } from '../actions/knatify';
@@ -27,7 +28,13 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
   const eventSourceModelrefs: string[] = getDynamicEventSourcesModelRefs();
   if (resourceKind) {
     if (referenceForModel(resourceKind) === referenceForModel(ServiceModel)) {
-      menuActions.push(setTrafficDistribution, AddHealthChecks, EditApplication, EditHealthChecks);
+      menuActions.push(
+        setTrafficDistribution,
+        AddHealthChecks,
+        EditApplication,
+        EditHealthChecks,
+        EditResourceLimits,
+      );
     }
     if (
       _.includes(eventSourceModelrefs, referenceForModel(resourceKind)) ||

--- a/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
@@ -15,10 +15,10 @@ import {
   getExternalImagelValues,
   getIconInitialValues,
   getKsvcRouteData,
-  getLimitsData,
   getServerlessData,
   getUserLabels,
 } from '@console/dev-console/src/components/edit-application/edit-application-utils';
+import { getLimitsDataFromResource } from '@console/shared/src';
 import { RegistryType } from '@console/dev-console/src/utils/imagestream-utils';
 import { ServiceModel } from '../models';
 import { getKnativeServiceDepResource } from './create-knative-utils';
@@ -126,7 +126,7 @@ export const getCommonInitialValues = (
     },
     deployment: getDeploymentData(ksvcResourceData),
     labels: getUserLabels(ksvcResourceData),
-    limits: getLimitsData(ksvcResourceData),
+    limits: getLimitsDataFromResource(ksvcResourceData),
     healthChecks: getHealthChecksData(ksvcResourceData),
   };
   return commonInitialValues;

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -8,6 +8,7 @@ import { Status, useCsvWatchResource } from '@console/shared';
 import { useTranslation } from 'react-i18next';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { EditResourceLimits } from '@console/app/src/actions/edit-resource-limits';
 import {
   AddHorizontalPodAutoScaler,
   DeleteHorizontalPodAutoScaler,
@@ -100,6 +101,7 @@ export const menuActions: KebabAction[] = [
   EditHorizontalPodAutoScaler,
   AddStorage,
   DeleteHorizontalPodAutoScaler,
+  EditResourceLimits,
   ...getExtensionsKebabActionsForKind(DeploymentConfigModel),
   EditHealthChecks,
   ...common,

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -7,6 +7,7 @@ import { RootState } from '@console/internal/redux';
 import { Status, useCsvWatchResource } from '@console/shared';
 import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
+import { EditResourceLimits } from '@console/app/src/actions/edit-resource-limits';
 import {
   AddHorizontalPodAutoScaler,
   DeleteHorizontalPodAutoScaler,
@@ -76,6 +77,7 @@ export const menuActions = [
   AddStorage,
   UpdateStrategy,
   DeleteHorizontalPodAutoScaler,
+  EditResourceLimits,
   ...Kebab.getExtensionsActionsForKind(DeploymentModel),
   EditHealthChecks,
   ...common,

--- a/frontend/public/locales/en/modal.json
+++ b/frontend/public/locales/en/modal.json
@@ -61,5 +61,6 @@
   "Add more": "Add more",
   "Edit tolerations": "Edit tolerations",
   "Tolerations": "Tolerations",
-  "Operator": "Operator"
+  "Operator": "Operator",
+  "Edit resource limits": "Edit resource limits"
 }


### PR DESCRIPTION
**JIRA story:**
https://issues.redhat.com/browse/ODC-5636

**Analysis / Root cause:**
As a user, I want to have a separate cta for editing deployment resource limits.

**Solution Description:**
- Created a modal that will show the Resource Limit section
- `Edit resource limits` option is shown for D/DC/KSVC
- refactored some code

**GIF:**
![rl](https://user-images.githubusercontent.com/22490998/112329502-43e9f800-8cdd-11eb-9c3f-bc1f8c8d43ac.gif)

**Unit test coverage report:**
- added tests for ResouceLimitsModal component

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge