### PR TITLE
Bug 1766287: Use httpd in workload YAML templates

### DIFF
--- a/frontend/integration-tests/tests/crd-extensions.scenario.ts
+++ b/frontend/integration-tests/tests/crd-extensions.scenario.ts
@@ -274,9 +274,6 @@ describe('CRD extensions', () => {
         { metadata: { name: podName, labels: { app: name } } },
         safeLoad(content),
       );
-      // TODO: Remove when the default `registry.redhat.io/openshift4/ose-hello-openshift-rhel8`
-      // image is published.
-      newContent.spec.containers[0].image = 'openshift/hello-openshift:latest';
       await yamlView.setEditorContent(safeDump(newContent));
       await yamlView.saveButton.click();
       expect(crudView.errorMessage.isPresent()).toBe(false);

--- a/frontend/integration-tests/tests/environment.scenario.ts
+++ b/frontend/integration-tests/tests/environment.scenario.ts
@@ -89,7 +89,7 @@ describe('Interacting with the environment variable editor', () => {
       expect(resourceText).toEqual(valueFrom);
       expect(prefixText).toEqual(prefix);
     } else {
-      expect(resourceText).toEqual('hello-openshift');
+      expect(resourceText).toEqual('httpd');
       expect(prefixText).toEqual('');
     }
   };

--- a/frontend/integration-tests/tests/event.scenario.ts
+++ b/frontend/integration-tests/tests/event.scenario.ts
@@ -14,8 +14,8 @@ describe('Events', () => {
     spec: {
       containers: [
         {
-          name: 'hello-openshift',
-          image: 'openshift/hello-openshift',
+          name: 'httpd',
+          image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest',
         },
       ],
     },

--- a/frontend/integration-tests/tests/filter.scenario.ts
+++ b/frontend/integration-tests/tests/filter.scenario.ts
@@ -95,7 +95,7 @@ describe('Filtering', () => {
 
   it('searches for pod by label and filtering by name', async () => {
     await browser.get(
-      `${appHost}/search/all-namespaces?kind=Pod&name=${WORKLOAD_NAME}&q=app%3Dhello-openshift`,
+      `${appHost}/search/all-namespaces?kind=Pod&name=${WORKLOAD_NAME}&q=app%3Dhttpd`,
     );
     await crudView.isLoaded();
     await browser.wait(

--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -388,8 +388,8 @@ describe('Add Secret to Workloads', () => {
         spec: {
           containers: [
             {
-              name: 'hello-openshift',
-              image: 'openshift/hello-openshift',
+              name: 'httpd',
+              image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest',
             },
           ],
         },

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -231,30 +231,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example
-  annotations:
-    image.openshift.io/triggers: |-
-      [
-        {
-          "from": {
-            "kind": "ImageStreamTag",
-            "name": "openshift/hello-openshift:latest"
-          },
-          "fieldPath": "spec.template.spec.containers[0].image"
-        }
-      ]
 spec:
   selector:
     matchLabels:
-      app: hello-openshift
+      app: httpd
   replicas: 3
   template:
     metadata:
       labels:
-        app: hello-openshift
+        app: httpd
     spec:
       containers:
-      - name: hello-openshift
-        image: openshift/hello-openshift
+      - name: httpd
+        image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
         ports:
         - containerPort: 8080
 `,
@@ -353,27 +342,16 @@ metadata:
   name: example
 spec:
   selector:
-    app: hello-openshift
+    app: httpd
   replicas: 3
   template:
     metadata:
       labels:
-        app: hello-openshift
+        app: httpd
     spec:
-      triggers: 
-        image.openshift.io/triggers: |-
-          [
-            {
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "openshift/hello-openshift:latest"
-              },
-              "fieldPath": "spec.template.spec.containers[0].image"
-            }
-          ]
       containers:
-      - name: hello-openshift
-        image: openshift/hello-openshift
+      - name: httpd
+        image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
         ports:
         - containerPort: 8080
 `,
@@ -428,11 +406,11 @@ kind: Pod
 metadata:
   name: example
   labels:
-    app: hello-openshift
+    app: httpd
 spec:
   containers:
-    - name: hello-openshift
-      image: openshift/hello-openshift
+    - name: httpd
+      image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
       ports:
         - containerPort: 8080
 `,
@@ -622,29 +600,18 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example
-  annotations:
-    image.openshift.io/triggers: |-
-      [
-        {
-          "from": {
-            "kind": "ImageStreamTag",
-            "name": "openshift/hello-openshift:latest"
-          },
-          "fieldPath": "spec.template.spec.containers[0].image"
-        }
-      ]
 spec:
   selector:
     matchLabels:
-      app: hello-openshift
+      app: httpd
   template:
     metadata:
       labels:
-        app: hello-openshift
+        app: httpd
     spec:
       containers:
-      - name: hello-openshift
-        image: openshift/hello-openshift
+      - name: httpd
+        image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
         ports:
         - containerPort: 8080
 `,
@@ -776,31 +743,20 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: example
-  annotations:
-    image.openshift.io/triggers: |-
-      [
-        {
-          "from": {
-            "kind": "ImageStreamTag",
-            "name": "openshift/hello-openshift:latest"
-          },
-          "fieldPath": "spec.template.spec.containers[0].image"
-        }
-      ]
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: hello-openshift
+      app: httpd
   template:
     metadata:
-      name: hello-openshift
+      name: httpd
       labels:
-        app: hello-openshift
+        app: httpd
     spec:
       containers:
-      - name: hello-openshift
-        image: openshift/hello-openshift
+      - name: httpd
+        image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
         ports:
         - containerPort: 8080
 `,
@@ -828,30 +784,19 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: example
-  annotations:
-    image.openshift.io/triggers: |-
-      [
-        {
-          "from": {
-            "kind": "ImageStreamTag",
-            "name": "openshift/hello-openshift:latest"
-          },
-          "fieldPath": "spec.template.spec.containers[0].image"
-        }
-      ]
 spec:
   replicas: 2
   selector:
-    app: hello-openshift
+    app: httpd
   template:
     metadata:
-      name: hello-openshift
+      name: httpd
       labels:
-        app: hello-openshift
+        app: httpd
     spec:
       containers:
-      - name: hello-openshift
-        image: openshift/hello-openshift
+      - name: httpd
+        image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
         ports:
         - containerPort: 8080
 `,
@@ -1257,36 +1202,36 @@ spec:
   tasks:
     - title: Deploy an existing image from an image registry
       description: |-
-        ### To deploy the **hello-openshift** image, follow these steps:
+        ### To deploy the **httpd-24-centos7** image, follow these steps:
         1. Enter the developer perspective: In the main navigation menu, click the [dropdown menu]{{highlight tour-perspective-dropdown}} and select **Developer**.
         2. In the main navigation menu, click **Add.**
         3. Using the project dropdown menu, select the project you would like to deploy the image in.
         4. Click the **Container Image** tile.
-        5. In the **Image name from external registry** field, enter **openshift/hello-openshift**.
+        5. In the **Image name from external registry** field, enter **quay.io/centos7/httpd-24-centos7**.
         6. Fill in the remaining image deployment details, and then click **Create.**
-        The **Topology** view will load with your **hello-openshift-app** application. The outer rim of the larger circle represents your application, and the small circle represents the deployment.
+        The **Topology** view will load with your **httpd-24-centos7-app** application. The outer rim of the larger circle represents your application, and the small circle represents the deployment.
       review:
         instructions: |-
           #### Verify the image was successfully deployed:
-          Do you see a **hello-openshift** deployment?
+          Do you see a **httpd-24-centos7** deployment?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
-        success: Great work! You deployed an example application using the **openshift/hello-openshift** image.
+        success: Great work! You deployed an example application using the **quay.io/centos7/httpd-24-centos7** image.
         failed: Try the steps again.
     - title: Run the deployed application
       description: |-
-        ### To run the **hello-openshift** deployment application, follow these steps:
-        1. In the **Topology** view, click the **hello-openshift** deployment circle.
+        ### To run the **httpd-24-centos7** deployment application, follow these steps:
+        1. In the **Topology** view, click the **httpd-24-centos7** deployment circle.
         2. In the panel that slides out, click the link in the **Routes** section. This opens the URL and runs the application.
       review:
         instructions: |-
           #### Verify your application is running:
-          In the new tab, do you see **Hello OpenShift!** ?
+          In the new tab, do you see the Apache HTTP server test page?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
-        success: Great work! You deployed the **hello-openshift** image.
+        success: Great work! You deployed the **quay.io/centos7/httpd-24-centos7** image.
         failed: Try the steps again.
-  conclusion: Your example **hello-openshift-app** application, using the **hello-openshift** image, is deployed and ready.
+  conclusion: Your example **httpd-24-centos7-app** application, using the **quay.io/centos7/httpd-24-centos7** image, is deployed and ready.
 `,
   )
   .setIn(


### PR DESCRIPTION
Use the httpd sample image in place of hello-openshift in our YAML templates. This requires that the sample images are imported on the cluster to run successfully.

This is a better example as it runs a real web server and will show the Apache test page if exposed by a route.

<img width="1012" alt="Screen Shot 2021-03-24 at 2 49 47 PM" src="https://user-images.githubusercontent.com/1167259/112367422-43873800-8cb0-11eb-94bd-cb7fc30057af.png">

/cc @smarterclayton 