### PR TITLE
Bug 1927423: Monitoring: Add warning to list pages when silences cannot be loaded

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import i18next from 'i18next';
 import * as _ from 'lodash-es';
-import { Button, Popover, Split, SplitItem } from '@patternfly/react-core';
+import { Alert as PFAlert, Button, Popover, Split, SplitItem } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -1244,7 +1244,13 @@ const MonitoringListPage: React.FC<ListPageProps> = ({
   Row,
   rowFilters,
 }) => {
+  const { t } = useTranslation();
+
   const filters = useSelector(({ k8s }: RootState) => k8s.getIn([reduxID, 'filters']));
+
+  const silencesLoadError = useSelector(
+    ({ UI }: RootState) => UI.getIn(['monitoring', 'silences'])?.loadError,
+  );
 
   return (
     <>
@@ -1266,6 +1272,18 @@ const MonitoringListPage: React.FC<ListPageProps> = ({
           rowFilters={rowFilters}
           textFilter={nameFilterID}
         />
+        {silencesLoadError && !loadError && (
+          <PFAlert
+            className="co-alert"
+            isInline
+            title={t(
+              'public~Error loading silences from Alertmanager. Some of the alerts below may actually be silenced.',
+            )}
+            variant="warning"
+          >
+            {silencesLoadError.toString()}
+          </PFAlert>
+        )}
         <div className="row">
           <div className="col-xs-12">
             <Table

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -260,6 +260,7 @@
   "Ends at": "Ends at",
   "Created by": "Created by",
   "Comment": "Comment",
+  "Error loading silences from Alertmanager. Some of the alerts below may actually be silenced.": "Error loading silences from Alertmanager. Some of the alerts below may actually be silenced.",
   "Alert state": "Alert state",
   "Create silence": "Create silence",
   "Error loading options": "Error loading options",


### PR DESCRIPTION
Adds a warning message to the alerts list and alerting rules list pages
when the silences cannot be loaded from Alertmanager.

![screenshot](https://user-images.githubusercontent.com/460802/112414681-ccac7680-8d65-11eb-8cf5-fba086d241c7.png)

FYI @cshinn 