### PR TITLE
Bug 1942716: Fix different Image Manifest Vulnerabilities issues

### DIFF
--- a/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
+++ b/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
@@ -6,6 +6,7 @@ import {
   ImageManifestVulnDetails,
   ImageManifestVulnDetailsProps,
   totalCount,
+  highestSeverityIndex,
 } from '../image-manifest-vuln';
 import { fakeVulnFor } from '../../../integration-tests/bad-pods';
 import { Priority, totalFor, vulnPriority } from '../../const';
@@ -29,6 +30,18 @@ describe('totalCount', () => {
     const vuln = fakeVulnFor(Priority.Critical);
     const tCount = totalCount(vuln);
     expect(tCount).toBe(2);
+  });
+});
+
+describe('highestSeverityIndex', () => {
+  it('should return the correct indexes for different priorities', () => {
+    expect(highestSeverityIndex(fakeVulnFor(Priority.Defcon1))).toBe(0);
+    expect(highestSeverityIndex(fakeVulnFor(Priority.Critical))).toBe(1);
+    expect(highestSeverityIndex(fakeVulnFor(Priority.High))).toBe(2);
+    expect(highestSeverityIndex(fakeVulnFor(Priority.Medium))).toBe(3);
+    expect(highestSeverityIndex(fakeVulnFor(Priority.Low))).toBe(4);
+    expect(highestSeverityIndex(fakeVulnFor(Priority.Negligible))).toBe(5);
+    expect(highestSeverityIndex(fakeVulnFor(Priority.Unknown))).toBe(6);
   });
 });
 

--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -54,6 +54,9 @@ export const totalCount = (obj: ImageManifestVuln) => {
 export const affectedPodsCount = (obj: ImageManifestVuln) =>
   Object.keys(obj.status.affectedPods).length;
 
+export const highestSeverityIndex = (obj: ImageManifestVuln) =>
+  priorityFor(obj.status.highestSeverity).index;
+
 export const ImageManifestVulnDetails: React.FC<ImageManifestVulnDetailsProps> = (props) => {
   const { t } = useTranslation();
   const total = props.obj.spec.features.reduce((sum, f) => sum + f.vulnerabilities.length, 0);
@@ -254,7 +257,7 @@ export const ImageManifestVulnTableHeader = (t: TFunction) => () => [
   },
   {
     title: t('container-security~Highest severity'),
-    sortField: 'status.highestSeverity',
+    sortFunc: 'highestSeverityOrder',
     transforms: [sortable],
     props: { className: tableColumnClasses[2] },
   },
@@ -301,6 +304,7 @@ export const ImageManifestVulnList: React.FC<ImageManifestVulnListProps> = (prop
       customSorts={{
         totalOrder: totalCount,
         affectedPodsOrder: affectedPodsCount,
+        highestSeverityOrder: highestSeverityIndex,
       }}
       aria-label={t('container-security~Image Manifest Vulnerabilities')}
       Header={ImageManifestVulnTableHeader(t)}

--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -318,7 +318,7 @@ export const ImageManifestVulnList: React.FC<ImageManifestVulnListProps> = (prop
 export const ImageManifestVulnPage: React.FC<ImageManifestVulnPageProps> = (props) => {
   const { t } = useTranslation();
   const { showTitle = true, hideNameLabelFilters = true } = props;
-  const namespace = props.namespace || props.match.params.ns || props.match.params.name;
+  const namespace = props.namespace || props.match?.params?.ns || props.match?.params?.name;
   return (
     <MultiListPage
       {...props}

--- a/frontend/packages/container-security/src/const.ts
+++ b/frontend/packages/container-security/src/const.ts
@@ -124,5 +124,12 @@ export const totalFor = (priority: Priority) => (obj: ImageManifestVuln) => {
   }
 };
 
-export const priorityFor = (severity: string) =>
-  vulnPriority.find(({ title }) => title === severity) || vulnPriority.get(Priority.Unknown);
+const vulnPriorityByTitle = vulnPriority.mapEntries(
+  ([, vulnPriorityDescription]: [Priority, VulnPriorityDescription]) => [
+    vulnPriorityDescription.title,
+    vulnPriorityDescription,
+  ],
+) as ImmutableMap<string, VulnPriorityDescription>;
+
+export const priorityFor = (severityTitle: string) =>
+  vulnPriorityByTitle.get(severityTitle) || vulnPriority.get(Priority.Unknown);

--- a/frontend/packages/container-security/src/const.ts
+++ b/frontend/packages/container-security/src/const.ts
@@ -53,7 +53,7 @@ export const vulnPriority = ImmutableMap<Priority, VulnPriorityDescription>()
     value: 'High',
   })
   .set(Priority.Medium, {
-    color: gold400,
+    color: orange300,
     description:
       'Medium is a real security problem, and is exploitable for many people. Includes network daemon denial of service attacks, cross-site scripting, and gaining user privileges.',
     index: 3,
@@ -63,7 +63,7 @@ export const vulnPriority = ImmutableMap<Priority, VulnPriorityDescription>()
     value: 'Medium',
   })
   .set(Priority.Low, {
-    color: orange300,
+    color: gold400,
     description:
       'Low is a security problem, but is hard to exploit due to environment, requires a user-assisted attack, a small install base, or does very little damage.',
     index: 4,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-26924
https://bugzilla.redhat.com/show_bug.cgi?id=1942716

**Analysis / Root cause**: 
While analyse bug report https://bugzilla.redhat.com/show_bug.cgi?id=1942716 I found three different small issues:

1. The original color issue where medium severity issues are yellow and low severity issue are orange.
2. When the user changed the order to "Highest severity" the IMV entries are not ordered correctly. The current order was Critical, High, Low, Medium
3. When using the search, select IMVs as resource and switch from a project to all projects the app crashs and shows a white screen.

**Solution Description**: 

1. https://github.com/openshift/console/pull/8474/commits/0d10db85c1b6faae4f69f1735d6e502897b74fdd Switched both colors
2. https://github.com/openshift/console/pull/8474/commits/61562342c7beabcef8d26a2c8aacf699f951d3e2 Implement a custom order function
3. https://github.com/openshift/console/pull/8474/commits/76c8351944c9460f8f3ea2d41d41f585eb0f154f Ensure that `props.match.params` is defined when checking these params.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

Admin dashboard with vulnerabilities **before** (invalid colors):
![val-before](https://user-images.githubusercontent.com/139310/112540494-8b8e8380-8db2-11eb-8af9-a589bb6292e2.png)

**After** (fixed colors):
![val-after](https://user-images.githubusercontent.com/139310/112540861-f9d34600-8db2-11eb-9fcd-77dc9797f26e.png)

Vulnerability search result **before** (invalid colors and wrong order):
![val-before-wrong-order-as-well](https://user-images.githubusercontent.com/139310/112540621-ae209c80-8db2-11eb-8c94-618e8fbfbc75.png)

**After** (fixed colors and order):
![order-after](https://user-images.githubusercontent.com/139310/112540887-ffc92700-8db2-11eb-9f64-b1310c8e0a31.png)

**Unit test coverage report**: 
```
 PASS  packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx (5.833s)
  totalCount
    ✓ should return 0 if vuln status not present
    ✓ Total vuln should be 2
  highestSeverityIndex
    ✓ should return the correct indexes for different priorities
    ✓ renders donut chart with breakdown of vulnerabilities by severity (7ms)
    ✓ renders text breakdown of vulnerabilities by severity (5ms)
```

**Test setup:**
1. Install Quay Container Security operator
2. Create the 4 deployments below to import Pods with different vulnerabilities.
3. For the three issues:
  a. Search for IMVs, check the colors
  b. Order by "Highest severity"
  c. switch between your project and all projects

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: appvuln-critical
  labels:
    app: appvuln-critical
spec:
  replicas: 1
  selector:
    matchLabels:
      app: appvuln-critical
  template:
    metadata:
      labels:
        app: appvuln-critical
    spec:
      containers:
      - name: appvuln
        image: quay.io/coreos/awscli:master
        command: ["sleep", "123456"]
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: appvuln-high
  labels:
    app: appvuln-high
spec:
  replicas: 1
  selector:
    matchLabels:
      app: appvuln-high
  template:
    metadata:
      labels:
        app: appvuln-high
    spec:
      containers:
      - name: appvuln
        image: quay.io/coreos/helm:release-4.4
        command: ["sleep", "123456"]
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: appvuln-medium
  labels:
    app: appvuln-medium
spec:
  replicas: 1
  selector:
    matchLabels:
      app: appvuln-medium
  template:
    metadata:
      labels:
        app: appvuln-medium
    spec:
      containers:
      - name: appvuln
        image: quay.io/coreos/etcd-operator:v0.7.0
        command: ["sleep", "123456"]
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: appvuln-low
  labels:
    app: appvuln-low
spec:
  replicas: 1
  selector:
    matchLabels:
      app: appvuln-low
  template:
    metadata:
      labels:
        app: appvuln-low
    spec:
      containers:
      - name: appvuln
        image: quay.io/andrewrothstein/ansible-podman:debian_bullseye
        command: ["sleep", "123456"]
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
