### PR TITLE
Create KSVC with min/max scale if workload has related HPA

### DIFF
--- a/frontend/packages/knative-plugin/src/actions/knatify.ts
+++ b/frontend/packages/knative-plugin/src/actions/knatify.ts
@@ -10,12 +10,13 @@ export const hideKnatifyAction = (resource: K8sResourceKind): boolean => {
 };
 
 export const setKnatify = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
+  const kind = obj.kind || model.kind;
+  const apiVersion = obj.apiVersion || `${model.apiGroup}/${model.apiVersion}`;
   return {
     // t('knative-plugin~Create Knative service')
     labelKey: 'knative-plugin~Create Knative service',
     hidden: hideKnatifyAction(obj),
-    href: `/knatify/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
-      model.kind}`,
+    href: `/knatify/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${kind}&apiversion=${apiVersion}`,
     accessReview: {
       group: ServiceModel.apiGroup,
       resource: ServiceModel.plural,

--- a/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/knatify/__tests__/CreateKnatifyPage.spec.tsx
@@ -5,10 +5,12 @@ import { LoadingBox, PageHeading } from '@console/internal/components/utils';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import CreateKnatifyPage from '../CreateKnatifyPage';
 import { deploymentData } from '../../../utils/__tests__/knative-serving-data';
+import { useRelatedHPA } from '@console/shared/src/hooks/hpa-hooks';
 
 let createKnatifyPageProps: React.ComponentProps<typeof CreateKnatifyPage>;
 
 const useK8sWatchResourcesMock = useK8sWatchResources as jest.Mock;
+const useRelatedHPAMock = useRelatedHPA as jest.Mock;
 
 jest.mock('react-i18next', () => {
   const reactI18Next = require.requireActual('react-i18next');
@@ -20,6 +22,10 @@ jest.mock('react-i18next', () => {
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
   useK8sWatchResources: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/hooks/hpa-hooks', () => ({
+  useRelatedHPA: jest.fn(),
 }));
 
 describe('CreateKnatifyPage', () => {
@@ -50,6 +56,20 @@ describe('CreateKnatifyPage', () => {
       projects: { data: [], loaded: false },
       workloadResource: { data: deploymentData, loaded: true },
     });
+    useRelatedHPAMock.mockReturnValue([{}, true, null]);
+    const wrapper = shallow(<CreateKnatifyPage {...createKnatifyPageProps} />);
+    expect(wrapper.find(PageHeading).exists()).toBe(true);
+    expect(wrapper.find(LoadingBox).exists()).toBe(true);
+    expect(wrapper.find(Formik).exists()).toBe(false);
+  });
+
+  it('CreateKnatifyPage should render PageHeading and Loading if Hpa is not loaded', () => {
+    useK8sWatchResourcesMock.mockReturnValue({
+      imageStream: { data: [], loaded: true },
+      projects: { data: [], loaded: true },
+      workloadResource: { data: deploymentData, loaded: true },
+    });
+    useRelatedHPAMock.mockReturnValue([null, false, null]);
     const wrapper = shallow(<CreateKnatifyPage {...createKnatifyPageProps} />);
     expect(wrapper.find(PageHeading).exists()).toBe(true);
     expect(wrapper.find(LoadingBox).exists()).toBe(true);
@@ -62,6 +82,7 @@ describe('CreateKnatifyPage', () => {
       projects: { data: [], loaded: true },
       workloadResource: { data: deploymentData, loaded: true },
     });
+    useRelatedHPAMock.mockReturnValue([{}, true, null]);
     const wrapper = shallow(<CreateKnatifyPage {...createKnatifyPageProps} />);
     expect(wrapper.find(PageHeading).exists()).toBe(true);
     expect(wrapper.find(Formik).exists()).toBe(true);

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knatify-utils.spec.ts
@@ -1,3 +1,4 @@
+import { K8sResourceKind } from 'public/module/k8s';
 import {
   getKnatifyWorkloadData,
   getCommonInitialValues,
@@ -8,11 +9,31 @@ import {
   knatifyFormCommonInitailValues,
   ksvcData,
 } from '../__mocks__/knatify-mock';
-import { deploymentData } from './knative-serving-data';
+import { deploymentData, hpaData } from './knative-serving-data';
 
 describe('knatify-utils', () => {
   it('getKnatifyWorkloadData should return valid knative service spec', () => {
     expect(getKnatifyWorkloadData(deploymentData)).toEqual(ksvcData);
+  });
+
+  it('getKnatifyWorkloadData should return valid knative service spec with associated min/max pods based on related HPA', () => {
+    const mockKsvcData: K8sResourceKind = {
+      ...ksvcData,
+      spec: {
+        ...ksvcData.spec,
+        template: {
+          ...ksvcData.spec.template,
+          metadata: {
+            ...ksvcData.spec.template.metadata,
+            annotations: {
+              'autoscaling.knative.dev/minScale': '1',
+              'autoscaling.knative.dev/maxScale': '3',
+            },
+          },
+        },
+      },
+    };
+    expect(getKnatifyWorkloadData(deploymentData, hpaData)).toEqual(mockKsvcData);
   });
 
   it('getCommonInitialValues should return valid formik common initial values', () => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -192,6 +192,71 @@ export const deploymentData: K8sResourceKind = {
   },
 };
 
+export const hpaData: K8sResourceKind = {
+  kind: 'HorizontalPodAutoscaler',
+  apiVersion: 'autoscaling/v2beta2',
+  metadata: {
+    name: 'example',
+    namespace: 'testproject3',
+    uid: 'c5c6e70e-5a95-4851-9027-ece28739378a',
+    resourceVersion: '36526',
+    creationTimestamp: '2021-03-25T05:23:38Z',
+  },
+  spec: {
+    scaleTargetRef: { kind: 'Deployment', name: 'overlayimage', apiVersion: 'apps/v1' },
+    minReplicas: 1,
+    maxReplicas: 3,
+    metrics: [
+      {
+        type: 'Resource',
+        resource: { name: 'memory', target: { type: 'Utilization', averageUtilization: 70 } },
+      },
+      {
+        type: 'Resource',
+        resource: { name: 'cpu', target: { type: 'Utilization', averageUtilization: 70 } },
+      },
+    ],
+  },
+  status: {
+    currentReplicas: 1,
+    desiredReplicas: 1,
+    currentMetrics: [
+      {
+        type: 'Resource',
+        resource: { name: 'memory', current: { averageValue: '1630208', averageUtilization: 0 } },
+      },
+      {
+        type: 'Resource',
+        resource: { name: 'cpu', current: { averageValue: '0', averageUtilization: 0 } },
+      },
+    ],
+    conditions: [
+      {
+        type: 'AbleToScale',
+        status: 'True',
+        lastTransitionTime: '2021-03-25T05:23:53Z',
+        reason: 'ReadyForNewScale',
+        message: 'recommended size matches current size',
+      },
+      {
+        type: 'ScalingActive',
+        status: 'True',
+        lastTransitionTime: '2021-03-25T05:24:23Z',
+        reason: 'ValidMetricFound',
+        message:
+          'the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)',
+      },
+      {
+        type: 'ScalingLimited',
+        status: 'True',
+        lastTransitionTime: '2021-03-25T05:28:54Z',
+        reason: 'TooFewReplicas',
+        message: 'the desired replica count is less than the minimum replica count',
+      },
+    ],
+  },
+};
+
 export const deploymentKnativeData: K8sResourceKind = {
   kind: 'Deployment',
   apiVersion: 'apps/v1',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5655


**Solution Description**: 
Create KSVC with min/max scale if the workload has related HPA


**Unit test coverage report**: 

![image](https://user-images.githubusercontent.com/5129024/112584255-7dc21800-8e1d-11eb-886e-fce7639ca888.png)


**Test setup:**
- Install serverless operator created associated CRs (KnativeServing)
- Create an ns and add workload as D/DC
- Add HPA to the created workload with min/max replicas
- In topology, the workload context menu will have the action "Create Knatve Service"
- KSVC will be created with min/max scale based on related HPA

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
