### PR TITLE
fix Task badge color in pipeline builder page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useField } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { ActionsMenu, ResourceIcon, CloseButton } from '@console/internal/components/utils';
-import { referenceFor } from '@console/internal/module/k8s';
+import { referenceForModel } from '@console/internal/module/k8s';
 import { getResourceModelFromTaskKind } from '../../../../utils/pipeline-augment';
 import {
   PipelineTask,
@@ -64,7 +64,6 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
     const thisResource = taskResources.find(
       (taskFieldResource) => taskFieldResource.name === resource.name,
     );
-
     return (
       <div key={resource.name} className="odc-task-sidebar__resource">
         <TaskSidebarResource
@@ -95,7 +94,7 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
           <div className="co-m-pane__name co-resource-item">
             <ResourceIcon
               className="co-m-resource-icon--lg"
-              kind={referenceFor(getResourceModelFromTaskKind(taskResource.kind))}
+              kind={referenceForModel(getResourceModelFromTaskKind(taskResource.kind))}
             />
             {taskResource.metadata.name}
           </div>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskList.tsx
@@ -6,12 +6,14 @@ import { FocusTrap, Tooltip } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { useHover } from '@patternfly/react-topology';
 import Popper from '@console/shared/src/components/popper/Popper';
+import { referenceForModel } from '@console/internal/module/k8s';
 import {
   KebabItem,
   KebabOption,
   ResourceIcon,
   truncateMiddle,
 } from '@console/internal/components/utils';
+import { getResourceModelFromTaskKind } from '../../../utils/pipeline-augment';
 import { TaskKind } from '../../../types';
 import { NewTaskNodeCallback } from './types';
 
@@ -26,7 +28,7 @@ const taskToOption = (task: TaskKind, callback: NewTaskNodeCallback): KeyedKebab
   return {
     key: `${name}-${kind}`,
     label: name,
-    icon: <ResourceIcon kind={kind} />,
+    icon: <ResourceIcon kind={referenceForModel(getResourceModelFromTaskKind(kind))} />,
     callback: () => {
       callback(task);
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5661

**Analysis / Root cause**: 
When viewing tasks (eg "(CT) task-name") on the details tab of a Pipeline, the badge appears green. If you edit said Pipeline and click on the task, the badge at the top appears Blue.

**Solution Description**: 
Make badge color for task is green

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/112628003-5a688e80-8e58-11eb-8e76-430f06294a13.png)
![image](https://user-images.githubusercontent.com/2561818/112629923-ec719680-8e5a-11eb-81d5-cc03391bc429.png)

