### PR TITLE
Bug 1943543: Fix to include template and selected options for RC rollbacks

### DIFF
--- a/frontend/public/components/modals/rollback-modal.jsx
+++ b/frontend/public/components/modals/rollback-modal.jsx
@@ -50,6 +50,10 @@ const BaseRollbackModal = withHandlePromise((props) => {
       spec: {
         from: {},
         revision: dcVersion,
+        includeTemplate: true,
+        includeReplicationMeta: changeScaleSettings,
+        includeStrategy: changeStrategy,
+        includeTriggers: changeTriggers,
       },
     };
     const opts = {


### PR DESCRIPTION
Fixes rollbacks for ReplicationControllers to include the template in the rollback as well as the options selected by the user.