### PR TITLE
Bug 1862084: Consistent formatting of dates and times

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -57,5 +57,13 @@ declare interface Window {
   api: {};
 }
 
+// TODO: Remove when upgrading to TypeScript 4.1.2+, which has a type for RelativeTimeFormat.
+declare namespace Intl {
+  class RelativeTimeFormat {
+    constructor(locale: string);
+    format(n: number, unit: string);
+  }
+}
+
 // From https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 declare type Diff<T, K> = Omit<T, keyof K>;

--- a/frontend/__tests__/components/utils/datetime.spec.ts
+++ b/frontend/__tests__/components/utils/datetime.spec.ts
@@ -1,7 +1,7 @@
 import {
-  isValid,
-  formatDuration,
   formatPrometheusDuration,
+  getDuration,
+  isValid,
   parsePrometheusDuration,
 } from '../../../public/components/utils/datetime';
 
@@ -19,46 +19,23 @@ describe('isValid', () => {
   });
 });
 
-describe('formatDuration', () => {
-  const toMS = (h: number, m: number, s: number) => (h * 60 * 60 + m * 60 + s) * 1000;
-
-  it('prints durations correctly', () => {
-    expect(formatDuration(toMS(0, 0, 1))).toEqual('1s');
-    expect(formatDuration(toMS(0, 0, 23))).toEqual('23s');
-    expect(formatDuration(toMS(0, 3, 42))).toEqual('3m 42s');
-    expect(formatDuration(toMS(2, 0, 0))).toEqual('2h 0m 0s');
-    expect(formatDuration(toMS(1, 0, 4))).toEqual('1h 0m 4s');
-    expect(formatDuration(toMS(13, 10, 23))).toEqual('13h 10m 23s');
-  });
-
-  it('handles hours greater than 24', () => {
-    expect(formatDuration(toMS(273, 18, 3))).toEqual('273h 18m 3s');
-  });
-
-  it('handles 0 values', () => {
-    expect(formatDuration(0)).toEqual('0s');
-  });
-
-  it('returns the empty string for negative values', () => {
-    expect(formatDuration(-88210)).toEqual('');
-  });
-
-  it('handles null and undefined values', () => {
-    expect(formatDuration(null)).toEqual('');
-    expect(formatDuration(undefined)).toEqual('');
-  });
-
-  it('rounds seconds correctly', () => {
-    expect(formatDuration(499)).toEqual('0s');
-    expect(formatDuration(500)).toEqual('1s');
-    expect(formatDuration(toMS(0, 3, 42) + 499)).toEqual('3m 42s');
-    expect(formatDuration(toMS(0, 3, 42) + 500)).toEqual('3m 43s');
-  });
-});
-
 // Converts time durations to milliseconds
 const ms = (s = 0, m = 0, h = 0, d = 0, w = 0) =>
   ((((w * 7 + d) * 24 + h) * 60 + m) * 60 + s) * 1000;
+
+describe('getDuration', () => {
+  it('returns correct durations', () => {
+    expect(getDuration(ms(1))).toEqual({ days: 0, hours: 0, minutes: 0, seconds: 1 });
+    expect(getDuration(ms(2, 1))).toEqual({ days: 0, hours: 0, minutes: 1, seconds: 2 });
+    expect(getDuration(ms(3, 2, 1))).toEqual({ days: 0, hours: 1, minutes: 2, seconds: 3 });
+    expect(getDuration(ms(4, 3, 2, 1))).toEqual({ days: 1, hours: 2, minutes: 3, seconds: 4 });
+  });
+  it('handles invalid values', () => {
+    [null, undefined, 0, -1, -9999].forEach((v) =>
+      expect(getDuration(v)).toEqual({ days: 0, hours: 0, minutes: 0, seconds: 0 }),
+    );
+  });
+});
 
 describe('formatPrometheusDuration', () => {
   it('formats durations correctly', () => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -284,8 +284,6 @@
     "mochawesome-merge": "^4.1.0",
     "mochawesome-report-generator": "^5.1.0",
     "mock-socket": "^9.0.3",
-    "moment": "2.22.x",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "monaco-editor-core": "0.20.0",
     "monaco-editor-webpack-plugin": "^1.9.0",
     "node-sass": "^5.0.0",

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/object-service/activity-card/data-resiliency-activity/data-resiliency-activity.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/object-service/activity-card/data-resiliency-activity/data-resiliency-activity.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PrometheusResponse } from '@console/internal/components/graphs';
-import { formatDuration } from '@console/internal/components/utils/datetime';
+import { formatPrometheusDuration } from '@console/internal/components/utils/datetime';
 import { DataResiliency } from '../../../common/data-resiliency/data-resiliency-activity';
 import { getGaugeValue } from '../../../../../utils';
 import './data-resiliency-activity.scss';
@@ -10,7 +10,7 @@ export const NoobaaDataResiliency: React.FC<DataResiliencyProps> = ({ results })
   const { t } = useTranslation();
 
   const eta = getGaugeValue(results[1]);
-  const formattedEta = formatDuration(parseInt(eta, 10) * 1000);
+  const formattedEta = formatPrometheusDuration(parseInt(eta, 10) * 1000);
 
   return (
     <>

--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { typeFilter, getLastTime } from '@console/internal/components/events';
-import { twentyFourHourTime } from '@console/internal/components/utils/datetime';
+import { timeFormatter } from '@console/internal/components/utils/datetime';
 import { ResourceIcon } from '@console/internal/components/utils/resource-icon';
 import { ResourceLink } from '@console/internal/components/utils/resource-link';
 import { EventKind, referenceFor } from '@console/internal/module/k8s';
@@ -35,7 +35,7 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
           <div className="co-recent-item__title">
             <div className="co-recent-item__title-timestamp text-secondary">
               {lastTime ? (
-                <span title={lastTime}>{twentyFourHourTime(new Date(lastTime))}</span>
+                <span title={lastTime}>{timeFormatter.format(new Date(lastTime))}</span>
               ) : (
                 '-'
               )}

--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -144,7 +144,7 @@
 }
 
 .co-recent-item__title-timestamp {
-  min-width: 45px;
+  min-width: 65px;
   padding-right: 0.3rem;
   text-align: left;
 }

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationBody.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react';
 import { ChartAxis, ChartContainer } from '@patternfly/react-charts';
 import { Grid } from '@patternfly/react-core';
+import { timeFormatter } from '@console/internal/components/utils/datetime';
 import { useRefWidth } from '@console/internal/components/utils/ref-width-hook';
 import { useTranslation } from 'react-i18next';
 
 import './utilization-card.scss';
-
-const formatDate = (date: Date): string => {
-  const minutes = `0${date.getMinutes()}`.slice(-2);
-  return `${date.getHours()}:${minutes}`;
-};
 
 const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps = [] }) => {
   const [containerRef, width] = useRefWidth();
@@ -21,7 +17,7 @@ const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps = [] }) =>
           containerComponent={<ChartContainer title={t('dashboard~time axis')} />}
           scale={{ x: 'time' }}
           domain={{ x: [timestamps[0], timestamps[timestamps.length - 1]] }}
-          tickFormat={formatDate}
+          tickFormat={timeFormatter.format}
           orientation="top"
           height={15}
           width={width}

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewEvents.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewEvents.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import { twentyFourHourTime } from '@console/internal/components/utils/datetime';
+import { timeFormatter } from '@console/internal/components/utils/datetime';
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { referenceFor, EventKind } from '@console/internal/module/k8s';
 import { ResourceLink } from '@console/internal/components/utils';
@@ -23,7 +23,7 @@ const MonitoringOverviewEvents: React.FC<MonitoringOverviewEventsProps> = ({ eve
             <div className="odc-monitoring-events__event-item" key={e.metadata.uid}>
               <Flex alignSelf={{ default: 'alignSelfBaseline' }}>
                 <FlexItem title={e.lastTimestamp} className="text-secondary">
-                  {twentyFourHourTime(new Date(getLastTime(e)))}
+                  {timeFormatter.format(new Date(getLastTime(e)))}
                 </FlexItem>
                 {e.type === 'Warning' && (
                   <FlexItem>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
@@ -5,7 +5,7 @@ import { ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts
 import { Bullseye, Flex, FlexItem, Grid, GridItem } from '@patternfly/react-core';
 import { LoadingInline, truncateMiddle } from '@console/internal/components/utils';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
-import { formatDuration } from '@console/internal/components/utils/datetime';
+import { formatPrometheusDuration } from '@console/internal/components/utils/datetime';
 import { usePipelineRunDurationPoll } from '../hooks';
 import { DEFAULT_LEGEND_CHART_HEIGHT } from '../const';
 import { getRangeVectorData, PipelineMetricsGraphProps } from './pipeline-metrics-utils';
@@ -63,13 +63,13 @@ const PipelineRunDurationGraph: React.FC<PipelineMetricsGraphProps> = ({
       if (!prun) return acc;
       const obj = prun[prun.length - 1];
       acc.totalDuration += obj.y;
-      acc.duration.push({ ...obj, time: formatDuration(obj.y * 1000) });
+      acc.duration.push({ ...obj, time: formatPrometheusDuration(obj.y * 1000) });
       return acc;
     },
     { totalDuration: 0, duration: [] },
   );
   const averageDuration = finalArray.totalDuration
-    ? formatDuration((finalArray.totalDuration * 1000) / finalArray.duration.length)
+    ? formatPrometheusDuration((finalArray.totalDuration * 1000) / finalArray.duration.length)
     : 0;
 
   return (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunTaskRunGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunTaskRunGraph.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-charts';
 import { PipelineTask } from '../../../types';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
-import { formatDuration } from '@console/internal/components/utils/datetime';
+import { formatPrometheusDuration } from '@console/internal/components/utils/datetime';
 import { LoadingInline, truncateMiddle } from '@console/internal/components/utils';
 import { usePipelineRunTaskRunPoll } from '../hooks';
 import {
@@ -148,7 +148,7 @@ const PipelineRunTaskRunGraph: React.FC<PipelineMetricsGraphProps> = ({
                   datum.childName.includes('line-') && datum.y !== null
                     ? `${datum?.metric?.pipelinerun}
                 ${getCustomTaskName(datum?.metric?.task)}
-            ${formatDuration(datum?.y * 1000)}`
+            ${formatPrometheusDuration(datum?.y * 1000)}`
                     : null
                 }
               />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
@@ -1,9 +1,12 @@
 import * as _ from 'lodash';
-import * as moment from 'moment';
 import { TFunction } from 'i18next';
 import { humanizeNumberSI } from '@console/internal/components/utils';
+import {
+  dateFormatterNoYear,
+  parsePrometheusDuration,
+} from '@console/internal/components/utils/datetime';
 import { PrometheusResponse, PrometheusResult } from '@console/internal/components/graphs';
-import { parsePrometheusDuration } from '@console/internal/components/utils/datetime';
+
 import { PipelineKind } from '../../../types';
 
 export interface GraphData {
@@ -51,7 +54,7 @@ const formatPositiveValue = (v: number): string =>
 export const formatValue = (v: number): string =>
   (v < 0 ? '-' : '') + formatPositiveValue(Math.abs(v));
 export const formatDate = (date: Date) => {
-  return `${moment(date).format('MMM DD')}`;
+  return dateFormatterNoYear.format(date);
 };
 export const formatTimeSeriesValues = (result: PrometheusResult, samples: number, span: number) => {
   const { metric, values } = result;
@@ -103,10 +106,12 @@ export const getXaxisValues = (timespan: number): number[] => {
   const xValues = [];
   if (!timespan) return xValues;
   const oneDayDuration = parsePrometheusDuration('1d');
-  const endDate = new Date(Date.now()).setHours(0, 0, 0, 0);
   const numDays = Math.round(timespan / oneDayDuration);
-  for (let m = moment(endDate); xValues.length - 1 < numDays; m.subtract(1, 'days')) {
-    xValues.push(m.unix() * 1000);
+  const d = new Date(Date.now());
+  d.setHours(0, 0, 0, 0);
+  while (xValues.length - 1 < numDays) {
+    xValues.push(d.getTime());
+    d.setDate(d.getDate() - 1);
   }
   return xValues.slice(0, numDays);
 };

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { formatDuration } from '@console/internal/components/utils/datetime';
+import { formatPrometheusDuration } from '@console/internal/components/utils/datetime';
 import {
   ContainerStatus,
   k8sUpdate,
@@ -127,7 +127,7 @@ export const appendPipelineRunStatus = (pipeline, pipelineRun, isFinallyTasks = 
       const date =
         new Date(mTask.status.completionTime).getTime() -
         new Date(mTask.status.startTime).getTime();
-      mTask.status.duration = formatDuration(date);
+      mTask.status.duration = formatPrometheusDuration(date);
     }
     // append task status
     if (!mTask.status) {

--- a/frontend/public/components/_icon-and-text.scss
+++ b/frontend/public/components/_icon-and-text.scss
@@ -11,6 +11,7 @@ $co-icon-and-text-icon-lg: 1.2rem;
 }
 
 .co-icon-and-text__icon {
+  flex-shrink: 0;
   margin-right: 5px;
 }
 

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -43,7 +43,7 @@ import { BuildLogs } from './build-logs';
 import { ResourceEventStream } from './events';
 import { Area, requirePrometheus } from './graphs';
 import { BuildModel } from '../models';
-import { twentyFourHourTime } from './utils/datetime';
+import { timeFormatter, timeFormatterWithSeconds } from './utils/datetime';
 
 const BuildsReference: K8sResourceKindReference = 'Build';
 
@@ -155,7 +155,8 @@ const BuildGraphs = requirePrometheus(({ build }) => {
       namespace,
       endTime,
       timespan,
-      formatDate: (d) => twentyFourHourTime(d, timespan < 5 * ONE_MINUTE),
+      formatDate: (d) =>
+        timespan < 5 * ONE_MINUTE ? timeFormatterWithSeconds.format(d) : timeFormatter.format(d),
       domain, // force domain to match queried timespan
     }),
     [domain, endTime, namespace, timespan],

--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -8,16 +8,16 @@ import { OAuthModel } from '../../models';
 import { IdentityProvider, OAuthKind, referenceForModel } from '../../module/k8s';
 import { DetailsPage } from '../factory';
 import { EmptyBox, Kebab, ResourceSummary, SectionHeading, history, navFactory } from '../utils';
-import { formatDuration } from '../utils/datetime';
+import { formatPrometheusDuration } from '../utils/datetime';
 
 const { common } = Kebab.factory;
 const menuActions = [...Kebab.getExtensionsActionsForKind(OAuthModel), ...common];
 
 const oAuthReference = referenceForModel(OAuthModel);
 
-// Convert to ms for formatDuration
+// Convert to ms for formatPrometheusDuration
 const tokenDuration = (seconds: number) =>
-  _.isNil(seconds) ? '-' : formatDuration(seconds * 1000);
+  _.isNil(seconds) ? '-' : formatPrometheusDuration(seconds * 1000);
 
 const IdentityProviders: React.FC<IdentityProvidersProps> = ({ identityProviders }) => {
   const { t } = useTranslation();

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -14,7 +14,7 @@ import {
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import { processFrame, ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
-import { twentyFourHourTime } from '../utils/datetime';
+import { timeFormatter } from '../utils/datetime';
 import { humanizeNumber, useRefWidth, Humanize } from '../utils';
 import { PrometheusEndpoint } from './helpers';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
@@ -31,7 +31,7 @@ import { GraphEmpty } from './graph-empty';
 import { ChartLegendTooltip } from './tooltip';
 
 const DEFAULT_HEIGHT = 180;
-const DEFAULT_TICK_COUNT = 3;
+const DEFAULT_TICK_COUNT = 2;
 
 export enum AreaChartStatus {
   ERROR = 'ERROR',
@@ -47,7 +47,7 @@ export const chartStatusColors = {
 export const AreaChart: React.FC<AreaChartProps> = ({
   className,
   data = [],
-  formatDate = twentyFourHourTime,
+  formatDate = timeFormatter.format,
   height = DEFAULT_HEIGHT,
   humanize = humanizeNumber,
   loading = true,

--- a/frontend/public/components/graphs/stack.tsx
+++ b/frontend/public/components/graphs/stack.tsx
@@ -10,7 +10,7 @@ import {
   getCustomTheme,
 } from '@patternfly/react-charts';
 import { processFrame, ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
-import { twentyFourHourTime } from '../utils/datetime';
+import { timeFormatter } from '../utils/datetime';
 import { humanizeNumber, useRefWidth } from '../utils';
 import { PrometheusEndpoint } from './helpers';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
@@ -24,13 +24,13 @@ import { AreaChart, AreaChartProps } from './area';
 
 const DEFAULT_HEIGHT = 180;
 const DEFAULT_SAMPLES = 60;
-const DEFAULT_TICK_COUNT = 3;
+const DEFAULT_TICK_COUNT = 2;
 const DEFAULT_TIMESPAN = 60 * 60 * 1000; // 1 hour
 
 export const StackChart: React.FC<AreaChartProps> = ({
   className,
   data = [],
-  formatDate = twentyFourHourTime,
+  formatDate = timeFormatter.format,
   height = DEFAULT_HEIGHT,
   humanize = humanizeNumber,
   loading = true,

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -32,7 +32,7 @@ $tooltip-background-color: #151515;
 }
 
 .graph-wrapper.graph-wrapper--query-browser {
-  padding: 5px 10px 15px 50px;
+  padding: 5px 15px 15px 50px;
 
   &--with-legend {
     min-height: 305px;
@@ -44,7 +44,8 @@ $tooltip-background-color: #151515;
   margin: 0 0 20px 0;
 
   .co-dashboard-card__body--dashboard-graph {
-    padding: 10px;
+    // Add extra padding to the right. X-axis times with AM/PM at certain screen widths can overflow the card otherwise.
+    padding: 10px 15px 10px 10px;
   }
 
   &.co-dashboard-card--gradient {

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -1,52 +1,120 @@
 import * as _ from 'lodash-es';
-import * as moment from 'moment';
+import i18n from 'i18next';
 
 const getLocale = () => localStorage.getItem('bridge/language');
 
-export const getLocaleDate = (date: Date, options): string =>
-  date.toLocaleDateString(getLocale() || undefined, options);
+// The maximum allowed clock skew in milliseconds where we show a date as "Just now" even if it is from the future.
+export const maxClockSkewMS = -60000;
 
-// Behaves like moment.js's fromNow
-export const fromNow = (dateTime, now = undefined, options = { omitSuffix: false }) => {
-  // Check for null. If dateTime is null, it returns incorrect date and time of Wed Dec 31 1969
-  // 19:00:00 GMT-0500 (Eastern Standard Time)
+// https://tc39.es/ecma402/#datetimeformat-objects
+export const timeFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  hour: 'numeric',
+  minute: 'numeric',
+});
+
+export const timeFormatterWithSeconds = new Intl.DateTimeFormat(getLocale() || undefined, {
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+});
+
+export const dateFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+export const dateFormatterNoYear = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+});
+
+export const dateTimeFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  year: 'numeric',
+});
+
+export const utcDateTimeFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+});
+
+export const relativeTimeFormatter = new Intl.RelativeTimeFormat(getLocale() || undefined);
+
+export const getDuration = (ms: number) => {
+  if (!ms || ms < 0) {
+    ms = 0;
+  }
+  let seconds = Math.floor(ms / 1000);
+  let minutes = Math.floor(seconds / 60);
+  seconds = seconds % 60;
+  let hours = Math.floor(minutes / 60);
+  minutes = minutes % 60;
+  const days = Math.floor(hours / 24);
+  hours = hours % 24;
+  return { days, hours, minutes, seconds };
+};
+
+export const fromNow = (dateTime: string | Date, now?: Date, options?) => {
+  // Check for null. If dateTime is null, it returns incorrect date Jan 1 1970.
   if (!dateTime) {
     return '-';
   }
+
   if (!now) {
     now = new Date();
   }
-  dateTime = new Date(dateTime);
-  return moment(dateTime).from(moment(now), options.omitSuffix === true);
+
+  const d = new Date(dateTime);
+  const ms = now.getTime() - d.getTime();
+  const justNow = i18n.t('public~Just now');
+
+  // If the event occurred less than one minute in the future, assume it's clock drift and show "Just now."
+  if (!options?.omitSuffix && ms < 60000 && ms > maxClockSkewMS) {
+    return justNow;
+  }
+
+  // Do not attempt to handle other dates in the future.
+  if (ms < 0) {
+    return '-';
+  }
+
+  const { days, hours, minutes } = getDuration(ms);
+
+  if (options?.omitSuffix) {
+    if (days) {
+      return i18n.t('public~{{count}} day', { count: days });
+    }
+    if (hours) {
+      return i18n.t('public~{{count}} hour', { count: hours });
+    }
+    return i18n.t('public~{{count}} minute', { count: minutes });
+  }
+
+  if (!days && !hours && !minutes) {
+    return justNow;
+  }
+
+  if (days) {
+    return relativeTimeFormatter.format(-days, 'day');
+  }
+
+  if (hours) {
+    return relativeTimeFormatter.format(-hours, 'hour');
+  }
+
+  return relativeTimeFormatter.format(-minutes, 'minute');
 };
 
 export const isValid = (dateTime: Date) => dateTime instanceof Date && !_.isNaN(dateTime.valueOf());
-
-// Formats a duration in milliseconds like '1h 10m 23s'.
-export const formatDuration = (ms: number) => {
-  if (!_.isFinite(ms) || ms < 0) {
-    return '';
-  }
-
-  const totalSeconds = Math.round(ms / 1000);
-  const secondsInHour = 60 * 60;
-  const secondsInMinute = 60;
-
-  const hours = Math.floor(totalSeconds / secondsInHour);
-  const minutes = Math.floor((totalSeconds % secondsInHour) / secondsInMinute);
-  const seconds = totalSeconds % secondsInMinute;
-
-  let formatted = '';
-  if (hours) {
-    formatted += `${hours}h `;
-  }
-  if (hours || minutes) {
-    formatted += `${minutes}m `;
-  }
-  formatted += `${seconds}s`;
-
-  return formatted;
-};
 
 // Conversions between units and milliseconds
 const s = 1000;

--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { Tooltip } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
-import * as moment from 'moment';
 
 import * as dateTime from './datetime';
 
@@ -16,14 +15,14 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
   if (omitSuffix) {
     return dateTime.fromNow(mdate, undefined, { omitSuffix: true });
   }
-  if (Math.sign(timeDifference) !== -1 && timeDifference < 630000) {
-    // 10.5 minutes
-    // Show a relative time if within 10.5 minutes in the past from the current time.
+
+  // Show a relative time if within 10.5 minutes in the past from the current time.
+  if (timeDifference > dateTime.maxClockSkewMS && timeDifference < 630000) {
     return dateTime.fromNow(mdate);
   }
 
-  // Apr 23, 4:33 pm
-  return moment(mdate).format('LLL');
+  // Apr 23, 2021, 4:33 PM
+  return dateTime.dateTimeFormatter.format(mdate);
 };
 
 const nowStateToProps = ({ UI }) => ({ now: UI.get('lastTick') });
@@ -54,9 +53,7 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
       <Tooltip
         content={[
           <span className="co-nowrap" key="co-timestamp">
-            {moment(mdate)
-              .utc()
-              .format('LLL z')}
+            {dateTime.utcDateTimeFormatter.format(mdate)}
           </span>,
         ]}
       >

--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -4,12 +4,7 @@ import detector from 'i18next-browser-languagedetector';
 import httpBackend from 'i18next-http-backend';
 import Pseudo from 'i18next-pseudo';
 
-// Load moment.js locales (en is default and always loaded)
-import 'moment/locale/en-gb';
-import 'moment/locale/ja';
-import 'moment/locale/ko';
-import 'moment/locale/zh-cn';
-import moment from 'moment';
+import { dateTimeFormatter, fromNow } from './components/utils/datetime';
 
 const params = new URLSearchParams(window.location.search);
 const pseudolocalizationEnabled = params.get('pseudolocalization') === 'true';
@@ -26,155 +21,136 @@ i18n
   .use(initReactI18next)
   // init i18next
   // for all options read: https://www.i18next.com/overview/configuration-options
-  .init(
-    {
-      backend: {
-        loadPath: 'static/locales/{{lng}}/{{ns}}.json',
-      },
-      lng: localStorage.getItem('bridge/language'),
-      fallbackLng: 'en',
-      load: 'languageOnly',
-      debug: process.env.NODE_ENV === 'development',
-      detection: { caches: [] },
-      contextSeparator: '~',
-      ns: [
-        'add-users-modal',
-        'badge',
-        'bindings',
-        'build',
-        'build-strategy',
-        'ceph-storage-plugin',
-        'cloudshell',
-        'cluster-channel-modal',
-        'cluster-operator',
-        'cluster-settings',
-        'cluster-update-modal',
-        'cluster-version',
-        'console-app',
-        'console-shared',
-        'container-security',
-        'custom-resource-definition',
-        'dashboard',
-        'details-page',
-        'devconsole',
-        'dropdown',
-        'editor',
-        'email-receiver-form',
-        'environment',
-        'events',
-        'filter-toolbar',
-        'github-idp-form',
-        'gitlab-idp-form',
-        'git-service',
-        'gitops-plugin',
-        'global-config',
-        'google-idp-form',
-        'group',
-        'helm-plugin',
-        'htpasswd-idp-form',
-        'idp-cafile-input',
-        'idp-name-input',
-        'image-stream',
-        'ingress',
-        'insights-plugin',
-        'k8s',
-        'keystone-idp-form',
-        'knative-plugin',
-        'kubevirt-plugin',
-        'language-preferences-modal',
-        'ldap-idp-form',
-        'limit-range',
-        'logs',
-        'list-page',
-        'lso-plugin',
-        'masthead',
-        'machines',
-        'machine-autoscalers',
-        'machine-configs',
-        'machine-config-pools',
-        'machine-health-checks',
-        'machine-sets',
-        'metal3-plugin',
-        'modal',
-        'network-policy',
-        'network-route',
-        'network-service',
-        'nodes',
-        'notification-drawer',
-        'oauth',
-        'olm',
-        'openid-idp-form',
-        'olm',
-        'pagerduty-receiver-form',
-        'pipelines-plugin',
-        'public',
-        'quickstart',
-        'related-objects',
-        'remove-user-modal',
-        'request-header-idp-form',
-        'resource-quota',
-        'rhoas-plugin',
-        'role',
-        'routing-labels-editor',
-        'rules',
-        'search',
-        'service-account',
-        'sidebar',
-        'slack-receiver-form',
-        'topology',
-        'tour',
-        'user',
-        'webhook-receiver-form',
-        'yaml',
-      ],
-      defaultNS: 'public',
-      nsSeparator: '~',
-      keySeparator: false,
-      postProcess: ['pseudo'],
-      interpolation: {
-        format: function(value, format, lng, options) {
-          if (format === 'number') {
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat#Browser_compatibility
-            return new Intl.NumberFormat(lng).format(value);
-          }
-          if (value instanceof Date) {
-            if (format === 'fromNow') {
-              return moment(value).fromNow(options.omitSuffix === true);
-            }
-            return moment(value).format(format);
-          }
-          return value;
-        },
-        escapeValue: false, // not needed for react as it escapes by default
-      },
-      react: {
-        useSuspense: true,
-        wait: true,
-      },
-      saveMissing: true,
-      missingKeyHandler: function(lng, ns, key) {
-        window.windowError = `Missing i18n key "${key}" in namespace "${ns}" and language "${lng}."`;
-        // eslint-disable-next-line no-console
-        console.error(window.windowError);
-      },
+  .init({
+    backend: {
+      loadPath: 'static/locales/{{lng}}/{{ns}}.json',
     },
-    () => {
-      moment.locale(i18n.language === 'zh' ? 'zh-cn' : i18n.language);
-      // set default in case the i18n.language isn't a language we currently support -- otherwise Moment.js will default to the last region import
-      moment.locale() !== i18n.language && i18n.language !== 'zh' && moment.locale('en');
-      // set override for date format for English
-      moment.updateLocale('en', {
-        longDateFormat: {
-          LLL: 'MMM D, h:mm a',
-        },
-      });
+    lng: localStorage.getItem('bridge/language'),
+    fallbackLng: 'en',
+    load: 'languageOnly',
+    debug: process.env.NODE_ENV === 'development',
+    detection: { caches: [] },
+    contextSeparator: '~',
+    ns: [
+      'add-users-modal',
+      'badge',
+      'bindings',
+      'build',
+      'build-strategy',
+      'ceph-storage-plugin',
+      'cloudshell',
+      'cluster-channel-modal',
+      'cluster-operator',
+      'cluster-settings',
+      'cluster-update-modal',
+      'cluster-version',
+      'console-app',
+      'console-shared',
+      'container-security',
+      'custom-resource-definition',
+      'dashboard',
+      'details-page',
+      'devconsole',
+      'dropdown',
+      'editor',
+      'email-receiver-form',
+      'environment',
+      'events',
+      'filter-toolbar',
+      'github-idp-form',
+      'gitlab-idp-form',
+      'git-service',
+      'gitops-plugin',
+      'global-config',
+      'google-idp-form',
+      'group',
+      'helm-plugin',
+      'htpasswd-idp-form',
+      'idp-cafile-input',
+      'idp-name-input',
+      'image-stream',
+      'ingress',
+      'insights-plugin',
+      'k8s',
+      'keystone-idp-form',
+      'knative-plugin',
+      'kubevirt-plugin',
+      'language-preferences-modal',
+      'ldap-idp-form',
+      'limit-range',
+      'logs',
+      'list-page',
+      'lso-plugin',
+      'masthead',
+      'machines',
+      'machine-autoscalers',
+      'machine-configs',
+      'machine-config-pools',
+      'machine-health-checks',
+      'machine-sets',
+      'metal3-plugin',
+      'modal',
+      'network-policy',
+      'network-route',
+      'network-service',
+      'nodes',
+      'notification-drawer',
+      'oauth',
+      'olm',
+      'openid-idp-form',
+      'olm',
+      'pagerduty-receiver-form',
+      'pipelines-plugin',
+      'public',
+      'quickstart',
+      'related-objects',
+      'remove-user-modal',
+      'request-header-idp-form',
+      'resource-quota',
+      'rhoas-plugin',
+      'role',
+      'routing-labels-editor',
+      'rules',
+      'search',
+      'service-account',
+      'sidebar',
+      'slack-receiver-form',
+      'topology',
+      'tour',
+      'user',
+      'webhook-receiver-form',
+      'yaml',
+    ],
+    defaultNS: 'public',
+    nsSeparator: '~',
+    keySeparator: false,
+    postProcess: ['pseudo'],
+    interpolation: {
+      format: function(value, format, lng, options) {
+        if (format === 'number') {
+          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat#Browser_compatibility
+          return new Intl.NumberFormat(lng).format(value);
+        }
+        if (value instanceof Date) {
+          if (format === 'fromNow') {
+            return fromNow(value, null, options);
+          }
+          return dateTimeFormatter.format(value);
+        }
+        return value;
+      },
+      escapeValue: false, // not needed for react as it escapes by default
     },
-  );
-
-i18n.on('languageChanged', function(lng) {
-  moment.locale(lng === 'zh' ? 'zh-cn' : lng);
-  // set default in case the i18n.language isn't a language we currently support -- otherwise Moment.js will default to the last region import
-  moment.locale() !== lng && lng !== 'zh' && moment.locale('en');
-});
+    react: {
+      useSuspense: true,
+      wait: true,
+    },
+    saveMissing: true,
+    missingKeyHandler: function(lng, ns, key) {
+      window.windowError = `Missing i18n key "${key}" in namespace "${ns}" and language "${lng}."`;
+      // eslint-disable-next-line no-console
+      console.error(window.windowError);
+    },
+  });
 
 export default i18n;

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -577,6 +577,7 @@
   "Ports": "Ports",
   "Copied": "Copied",
   "Copy to clipboard": "Copy to clipboard",
+  "Just now": "Just now",
   "Runtime class": "Runtime class",
   "Help": "Help",
   "Maximum file size exceeded. File limit is 4MB.": "Maximum file size exceeded. File limit is 4MB.",

--- a/frontend/public/module/k8s/builds.ts
+++ b/frontend/public/module/k8s/builds.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 
 import { BuildModel, BuildConfigModel } from '../../models';
 import { k8sCreate } from './';
-import { formatDuration } from '../../components/utils/datetime';
+import { formatPrometheusDuration } from '../../components/utils/datetime';
 
 const BUILD_NUMBER_ANNOTATION = 'openshift.io/build.number';
 
@@ -52,7 +52,7 @@ export const formatBuildDuration = (build) => {
 
   // Duration in the build is returned as nanoseconds. Convert to milliseconds.
   const ms = Math.floor(duration / 1000 / 1000);
-  return formatDuration(ms);
+  return formatPrometheusDuration(ms);
 };
 
 export const getBuildNumber = (build) => {

--- a/frontend/webpack.circular-deps.ts
+++ b/frontend/webpack.circular-deps.ts
@@ -4,7 +4,6 @@
 import * as webpack from 'webpack';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as moment from 'moment';
 import * as CircularDependencyPlugin from 'circular-dependency-plugin';
 import chalk from 'chalk';
 
@@ -122,7 +121,7 @@ export class CircularDependencyPreset {
             }
 
             const hash = compilation.getStats().hash;
-            const builtAt = moment(compilation.getStats().endTime).format('MM/DD/YYYY HH:mm:ss');
+            const builtAt = compilation.getStats().endTime.toString();
             const header = `webpack compilation ${hash} built at ${builtAt}\n`;
 
             const reportPath = path.resolve(__dirname, this.options.reportFile);

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -19,7 +19,6 @@ interface Configuration extends webpack.Configuration {
 
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const HOT_RELOAD = process.env.HOT_RELOAD || 'true';
@@ -226,9 +225,6 @@ const config: Configuration = {
     new CopyWebpackPlugin([
       { from: './packages/local-storage-operator-plugin/locales', to: 'locales' },
     ]),
-    new MomentLocalesPlugin({
-      localesToKeep: ['en', 'ja', 'ko', 'zh-cn'],
-    }),
     extractCSS,
     virtualModules,
     new ConsoleActivePluginsModule(resolvePluginPackages(), virtualModules),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12209,11 +12209,6 @@ lodash.defaults@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.difference@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
-  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
-
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -13014,20 +13009,13 @@ module-deps@^6.0.0, module-deps@^6.2.3:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment-locales-webpack-plugin@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
-  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
-  dependencies:
-    lodash.difference "^4.5.0"
-
 moment-timezone@^0.4.0, moment-timezone@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.4.1.tgz#81f598c3ad5e22cdad796b67ecd8d88d0f5baa06"
   dependencies:
     moment ">= 2.6.0"
 
-moment@2.22.x, "moment@>= 2.6.0", moment@^2.10, moment@^2.19.1:
+"moment@>= 2.6.0", moment@^2.10, moment@^2.19.1:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 


### PR DESCRIPTION
https://issues.redhat.com/browse/CONSOLE-2790

/cc @rhamilto @rebeccaalpert @kyoto @alimobrem @andybraren 

@cloudbehl I have not changed any of the ceph package code since I didn't have an environment to test.

Consistently format dates with `Intl.DateTimeFormat`. This will ensure
that we honor the browser's locale setting even for languages we don't
yet support. Always use AM/PM instead of 24 hour times so that we are
consistent. Ultimately, we want to make the date and time format
a user preference.

Remove moment.js in favor of native browser date-time utilities.
moment.js is no longer receiving new features. See project status here:

https://momentjs.com/docs/

![Screen Shot 2021-03-26 at 2 44 09 PM](https://user-images.githubusercontent.com/1167259/112680697-15d2f800-8e44-11eb-8297-54c9b4e98b7c.png)

![Screen Shot 2021-03-26 at 2 44 13 PM](https://user-images.githubusercontent.com/1167259/112680714-1b304280-8e44-11eb-9653-d55eb179bdf3.png)

![Screen Shot 2021-03-26 at 2 44 17 PM](https://user-images.githubusercontent.com/1167259/112680727-1e2b3300-8e44-11eb-9f89-6223e4c60a0c.png)

![Screen Shot 2021-03-26 at 2 44 33 PM](https://user-images.githubusercontent.com/1167259/112680752-23887d80-8e44-11eb-867a-5c6e8402b7cf.png)
