### PR TITLE
Add customized project access list to server flags

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -125,6 +125,7 @@ func main() {
 	fUserSettingsLocation := fs.String("user-settings-location", "configmap", "DEV ONLY. Define where the user settings should be stored. (configmap | localstorage).")
 	fQuickStarts := fs.String("quick-starts", "", "Allow customization of available ConsoleQuickStart resources in console. (JSON as string)")
 	fAddPage := fs.String("add-page", "", "DEV ONLY. Allow add page customization. (JSON as string)")
+	fProjectAccessClusterRoles := fs.String("project-access-cluster-roles", "", "The list of Cluster Roles assignable for the project access page. (JSON as string)")
 
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -214,31 +215,32 @@ func main() {
 	consolePluginsMap := consolePluginsFlags.ToMap()
 	if len(consolePluginsMap) > 0 {
 		klog.Infoln("The following console plugins are enabled:")
-		for pluginName, _ := range consolePluginsMap {
+		for pluginName := range consolePluginsMap {
 			klog.Infof(" - %s\n", pluginName)
 		}
 	}
 
 	srv := &server.Server{
-		PublicDir:             *fPublicDir,
-		BaseURL:               baseURL,
-		LogoutRedirect:        logoutRedirect,
-		Branding:              branding,
-		CustomProductName:     *fCustomProductName,
-		CustomLogoFile:        *fCustomLogoFile,
-		StatuspageID:          *fStatuspageID,
-		DocumentationBaseURL:  documentationBaseURL,
-		AlertManagerPublicURL: alertManagerPublicURL,
-		GrafanaPublicURL:      grafanaPublicURL,
-		PrometheusPublicURL:   prometheusPublicURL,
-		ThanosPublicURL:       thanosPublicURL,
-		LoadTestFactor:        *fLoadTestFactor,
-		InactivityTimeout:     *fInactivityTimeout,
-		DevCatalogCategories:  *fDevCatalogCategories,
-		UserSettingsLocation:  *fUserSettingsLocation,
-		EnabledConsolePlugins: consolePluginsMap,
-		QuickStarts:           *fQuickStarts,
-		AddPage:               *fAddPage,
+		PublicDir:                 *fPublicDir,
+		BaseURL:                   baseURL,
+		LogoutRedirect:            logoutRedirect,
+		Branding:                  branding,
+		CustomProductName:         *fCustomProductName,
+		CustomLogoFile:            *fCustomLogoFile,
+		StatuspageID:              *fStatuspageID,
+		DocumentationBaseURL:      documentationBaseURL,
+		AlertManagerPublicURL:     alertManagerPublicURL,
+		GrafanaPublicURL:          grafanaPublicURL,
+		PrometheusPublicURL:       prometheusPublicURL,
+		ThanosPublicURL:           thanosPublicURL,
+		LoadTestFactor:            *fLoadTestFactor,
+		InactivityTimeout:         *fInactivityTimeout,
+		DevCatalogCategories:      *fDevCatalogCategories,
+		UserSettingsLocation:      *fUserSettingsLocation,
+		EnabledConsolePlugins:     consolePluginsMap,
+		QuickStarts:               *fQuickStarts,
+		AddPage:                   *fAddPage,
+		ProjectAccessClusterRoles: *fProjectAccessClusterRoles,
 	}
 
 	// if !in-cluster (dev) we should not pass these values to the frontend

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,41 +59,42 @@ const (
 )
 
 type jsGlobals struct {
-	ConsoleVersion           string   `json:"consoleVersion"`
-	AuthDisabled             bool     `json:"authDisabled"`
-	KubectlClientID          string   `json:"kubectlClientID"`
-	BasePath                 string   `json:"basePath"`
-	LoginURL                 string   `json:"loginURL"`
-	LoginSuccessURL          string   `json:"loginSuccessURL"`
-	LoginErrorURL            string   `json:"loginErrorURL"`
-	LogoutURL                string   `json:"logoutURL"`
-	LogoutRedirect           string   `json:"logoutRedirect"`
-	RequestTokenURL          string   `json:"requestTokenURL"`
-	KubeAdminLogoutURL       string   `json:"kubeAdminLogoutURL"`
-	KubeAPIServerURL         string   `json:"kubeAPIServerURL"`
-	PrometheusBaseURL        string   `json:"prometheusBaseURL"`
-	PrometheusTenancyBaseURL string   `json:"prometheusTenancyBaseURL"`
-	AlertManagerBaseURL      string   `json:"alertManagerBaseURL"`
-	MeteringBaseURL          string   `json:"meteringBaseURL"`
-	Branding                 string   `json:"branding"`
-	CustomProductName        string   `json:"customProductName"`
-	CustomLogoURL            string   `json:"customLogoURL"`
-	StatuspageID             string   `json:"statuspageID"`
-	DocumentationBaseURL     string   `json:"documentationBaseURL"`
-	AlertManagerPublicURL    string   `json:"alertManagerPublicURL"`
-	GrafanaPublicURL         string   `json:"grafanaPublicURL"`
-	PrometheusPublicURL      string   `json:"prometheusPublicURL"`
-	ThanosPublicURL          string   `json:"thanosPublicURL"`
-	LoadTestFactor           int      `json:"loadTestFactor"`
-	InactivityTimeout        int      `json:"inactivityTimeout"`
-	GOARCH                   string   `json:"GOARCH"`
-	GOOS                     string   `json:"GOOS"`
-	GraphQLBaseURL           string   `json:"graphqlBaseURL"`
-	DevCatalogCategories     string   `json:"developerCatalogCategories"`
-	UserSettingsLocation     string   `json:"userSettingsLocation"`
-	AddPage                  string   `json:"addPage"`
-	ConsolePlugins           []string `json:"consolePlugins"`
-	QuickStarts              string   `json:"quickStarts"`
+	ConsoleVersion            string   `json:"consoleVersion"`
+	AuthDisabled              bool     `json:"authDisabled"`
+	KubectlClientID           string   `json:"kubectlClientID"`
+	BasePath                  string   `json:"basePath"`
+	LoginURL                  string   `json:"loginURL"`
+	LoginSuccessURL           string   `json:"loginSuccessURL"`
+	LoginErrorURL             string   `json:"loginErrorURL"`
+	LogoutURL                 string   `json:"logoutURL"`
+	LogoutRedirect            string   `json:"logoutRedirect"`
+	RequestTokenURL           string   `json:"requestTokenURL"`
+	KubeAdminLogoutURL        string   `json:"kubeAdminLogoutURL"`
+	KubeAPIServerURL          string   `json:"kubeAPIServerURL"`
+	PrometheusBaseURL         string   `json:"prometheusBaseURL"`
+	PrometheusTenancyBaseURL  string   `json:"prometheusTenancyBaseURL"`
+	AlertManagerBaseURL       string   `json:"alertManagerBaseURL"`
+	MeteringBaseURL           string   `json:"meteringBaseURL"`
+	Branding                  string   `json:"branding"`
+	CustomProductName         string   `json:"customProductName"`
+	CustomLogoURL             string   `json:"customLogoURL"`
+	StatuspageID              string   `json:"statuspageID"`
+	DocumentationBaseURL      string   `json:"documentationBaseURL"`
+	AlertManagerPublicURL     string   `json:"alertManagerPublicURL"`
+	GrafanaPublicURL          string   `json:"grafanaPublicURL"`
+	PrometheusPublicURL       string   `json:"prometheusPublicURL"`
+	ThanosPublicURL           string   `json:"thanosPublicURL"`
+	LoadTestFactor            int      `json:"loadTestFactor"`
+	InactivityTimeout         int      `json:"inactivityTimeout"`
+	GOARCH                    string   `json:"GOARCH"`
+	GOOS                      string   `json:"GOOS"`
+	GraphQLBaseURL            string   `json:"graphqlBaseURL"`
+	DevCatalogCategories      string   `json:"developerCatalogCategories"`
+	UserSettingsLocation      string   `json:"userSettingsLocation"`
+	AddPage                   string   `json:"addPage"`
+	ConsolePlugins            []string `json:"consolePlugins"`
+	QuickStarts               string   `json:"quickStarts"`
+	ProjectAccessClusterRoles string   `json:"projectAccessClusterRoles"`
 }
 
 type Server struct {
@@ -135,14 +136,15 @@ type Server struct {
 	GOARCH                             string
 	GOOS                               string
 	// Monitoring and Logging related URLs
-	AlertManagerPublicURL *url.URL
-	GrafanaPublicURL      *url.URL
-	PrometheusPublicURL   *url.URL
-	ThanosPublicURL       *url.URL
-	DevCatalogCategories  string
-	UserSettingsLocation  string
-	QuickStarts           string
-	AddPage               string
+	AlertManagerPublicURL     *url.URL
+	GrafanaPublicURL          *url.URL
+	PrometheusPublicURL       *url.URL
+	ThanosPublicURL           *url.URL
+	DevCatalogCategories      string
+	UserSettingsLocation      string
+	QuickStarts               string
+	AddPage                   string
+	ProjectAccessClusterRoles string
 }
 
 func (s *Server) authDisabled() bool {
@@ -498,34 +500,35 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsg := &jsGlobals{
-		ConsoleVersion:        version.Version,
-		AuthDisabled:          s.authDisabled(),
-		KubectlClientID:       s.KubectlClientID,
-		BasePath:              s.BaseURL.Path,
-		LoginURL:              proxy.SingleJoiningSlash(s.BaseURL.String(), authLoginEndpoint),
-		LoginSuccessURL:       proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginSuccessEndpoint),
-		LoginErrorURL:         proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginErrorEndpoint),
-		LogoutURL:             proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutEndpoint),
-		LogoutRedirect:        s.LogoutRedirect.String(),
-		KubeAPIServerURL:      s.KubeAPIServerURL,
-		Branding:              s.Branding,
-		CustomProductName:     s.CustomProductName,
-		StatuspageID:          s.StatuspageID,
-		InactivityTimeout:     s.InactivityTimeout,
-		DocumentationBaseURL:  s.DocumentationBaseURL.String(),
-		AlertManagerPublicURL: s.AlertManagerPublicURL.String(),
-		GrafanaPublicURL:      s.GrafanaPublicURL.String(),
-		PrometheusPublicURL:   s.PrometheusPublicURL.String(),
-		ThanosPublicURL:       s.ThanosPublicURL.String(),
-		GOARCH:                s.GOARCH,
-		GOOS:                  s.GOOS,
-		LoadTestFactor:        s.LoadTestFactor,
-		GraphQLBaseURL:        proxy.SingleJoiningSlash(s.BaseURL.Path, graphQLEndpoint),
-		DevCatalogCategories:  s.DevCatalogCategories,
-		UserSettingsLocation:  s.UserSettingsLocation,
-		ConsolePlugins:        getMapKeys(s.EnabledConsolePlugins),
-		QuickStarts:           s.QuickStarts,
-		AddPage:               s.AddPage,
+		ConsoleVersion:            version.Version,
+		AuthDisabled:              s.authDisabled(),
+		KubectlClientID:           s.KubectlClientID,
+		BasePath:                  s.BaseURL.Path,
+		LoginURL:                  proxy.SingleJoiningSlash(s.BaseURL.String(), authLoginEndpoint),
+		LoginSuccessURL:           proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginSuccessEndpoint),
+		LoginErrorURL:             proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginErrorEndpoint),
+		LogoutURL:                 proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutEndpoint),
+		LogoutRedirect:            s.LogoutRedirect.String(),
+		KubeAPIServerURL:          s.KubeAPIServerURL,
+		Branding:                  s.Branding,
+		CustomProductName:         s.CustomProductName,
+		StatuspageID:              s.StatuspageID,
+		InactivityTimeout:         s.InactivityTimeout,
+		DocumentationBaseURL:      s.DocumentationBaseURL.String(),
+		AlertManagerPublicURL:     s.AlertManagerPublicURL.String(),
+		GrafanaPublicURL:          s.GrafanaPublicURL.String(),
+		PrometheusPublicURL:       s.PrometheusPublicURL.String(),
+		ThanosPublicURL:           s.ThanosPublicURL.String(),
+		GOARCH:                    s.GOARCH,
+		GOOS:                      s.GOOS,
+		LoadTestFactor:            s.LoadTestFactor,
+		GraphQLBaseURL:            proxy.SingleJoiningSlash(s.BaseURL.Path, graphQLEndpoint),
+		DevCatalogCategories:      s.DevCatalogCategories,
+		UserSettingsLocation:      s.UserSettingsLocation,
+		ConsolePlugins:            getMapKeys(s.EnabledConsolePlugins),
+		QuickStarts:               s.QuickStarts,
+		AddPage:                   s.AddPage,
+		ProjectAccessClusterRoles: s.ProjectAccessClusterRoles,
 	}
 
 	if !s.authDisabled() {

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -269,6 +269,15 @@ func addCustomization(fs *flag.FlagSet, customization *Customization) {
 	} else {
 		klog.Fatalf("Could not marshal ConsoleConfig customization.addPage field: %v", err)
 	}
+
+	if customization.ProjectAccess.AvailableClusterRoles != nil {
+		projectAccessClusterRoles, err := json.Marshal(customization.ProjectAccess.AvailableClusterRoles)
+		if err != nil {
+			klog.Fatalf("Could not marshal ConsoleConfig customization.projectAccess field: %v", err)
+		} else {
+			fs.Set("project-access-cluster-roles", string(projectAccessClusterRoles))
+		}
+	}
 }
 
 func isAlreadySet(fs *flag.FlagSet, name string) bool {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -70,12 +70,18 @@ type Customization struct {
 	DeveloperCatalog DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
 	QuickStarts      QuickStarts                          `yaml:"quickStarts,omitempty"`
 	// addPage allows customizing actions on the Add page in developer perspective.
-	AddPage AddPage `yaml:"addPage,omitempty"`
+	AddPage       AddPage       `yaml:"addPage,omitempty"`
+	ProjectAccess ProjectAccess `yaml:"projectAccess,omitempty"`
 }
 
 // QuickStarts contains options for ConsoleQuickStarts resource
 type QuickStarts struct {
 	Disabled []string `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+}
+
+// ProjectAccess contains options for project access roles
+type ProjectAccess struct {
+	AvailableClusterRoles []string `json:"availableClusterRoles,omitempty" yaml:"availableClusterRoles,omitempty"`
 }
 
 // DeveloperConsoleCatalogCustomization allow cluster admin to configure developer catalog.

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -24,6 +24,10 @@ func Validate(fs *flag.FlagSet) error {
 		return err
 	}
 
+	if _, err := validateProjectAccessClusterRolesJSON(fs.Lookup("project-access-cluster-roles").Value.String()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -87,4 +91,19 @@ func validateAddPage(value string) (*AddPage, error) {
 	}
 
 	return &addPage, nil
+}
+
+func validateProjectAccessClusterRolesJSON(value string) ([]string, error) {
+	if value == "" {
+		return nil, nil
+	}
+	var projectAccessOptions []string
+
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&projectAccessOptions); err != nil {
+		return nil, err
+	}
+
+	return projectAccessOptions, nil
 }

--- a/pkg/serverconfig/validate_test.go
+++ b/pkg/serverconfig/validate_test.go
@@ -151,3 +151,23 @@ func TestValidAddPage(t *testing.T) {
 		})
 	}
 }
+
+func TestValidEmptyProjectAccessClusterRoles(t *testing.T) {
+	_, err := validateProjectAccessClusterRolesJSON("")
+	if err != nil {
+		t.Error("Unexpected error when parsing an empty string.", err)
+	}
+}
+
+func TestValidObjectForProjectAccessClusterRoles(t *testing.T) {
+	projectAccess, err := validateProjectAccessClusterRolesJSON("[ \"View\", \"Edit\", \"Admin\" ]")
+	if err != nil {
+		t.Error("Unexpected error when parsing data.", err)
+	}
+	if projectAccess == nil {
+		t.Errorf("Unexpected value: actual %v, expected array of strings", projectAccess)
+	}
+	if len(projectAccess) != 3 {
+		t.Errorf("Unexpected value: actual %v, expected %v", len(projectAccess), 3)
+	}
+}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5447
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
Based on the enhancement proposal https://github.com/openshift/enhancements/pull/668, get the project access configuration options from `console-config` or through arguments supplied to bridge. And make it available in `window.SERVER_FLAGS`.

Fetching of options from `Console` CRD into the `console-config` ConfigMap is handled in https://github.com/openshift/console-operator/pull/514
<!-- Describe your code changes in detail and explain the solution -->

**Test setup:**
Pass options as string to bridge with `-project-access-cluster-roles` or pass a `ConsoleConfig` yaml with `-config` option.

Example:
- Specify project access options to bridge with `bin/bridge -project-access-cluster-roles '["View", "Edit", "Admin"]'`.
- Open localhost:9000 and check `SERVER_FLAGS` in console:
  ```js
  > console.log(window.SERVER_FLAGS.projectAccessClusterRoles)
  '["View", "Edit", "Admin"]'
  ```
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
