### PR TITLE
[release-4.7] Bug 1944349: fix backwards incompatible trigger api changes

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/__tests__/submit-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/__tests__/submit-utils.spec.ts
@@ -1,0 +1,41 @@
+import { SemVer } from 'semver';
+import * as k8s from '@console/internal/module/k8s';
+import { EventListenerModel } from '../../../../../models';
+import { PipelineExampleNames, pipelineTestData } from '../../../../../test-data/pipeline-data';
+import { formValues } from './trigger-data';
+import * as operatorUtils from '../../../utils/pipeline-operator';
+import { submitTrigger } from '../submit-utils';
+
+const pipelineData = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE];
+
+describe('submitTrigger', () => {
+  beforeAll(() => {
+    jest.spyOn(k8s, 'k8sCreate').mockImplementation((model, data) => Promise.resolve(data));
+    jest.spyOn(k8s, 'k8sGet').mockImplementation(() => Promise.resolve());
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('expect the eventlistener to contain template.name if the operator is below GA version (1.4.0)', async () => {
+    jest.spyOn(operatorUtils, 'getPipelineOperatorVersion').mockReturnValue(new SemVer('1.3.0'));
+    try {
+      const resources = await submitTrigger(pipelineData.pipeline, formValues);
+      const el = resources.find((r) => r.kind === EventListenerModel.kind);
+      expect(el.spec.triggers[0].template.name).toBeDefined();
+    } catch (e) {
+      fail(e);
+    }
+  });
+
+  it('expect the eventlistener to contain template.ref if the operator is GA version (1.4.0)', async () => {
+    jest.spyOn(operatorUtils, 'getPipelineOperatorVersion').mockReturnValue(new SemVer('1.4.0'));
+    try {
+      const resources = await submitTrigger(pipelineData.pipeline, formValues);
+      const el = resources.find((r) => r.kind === EventListenerModel.kind);
+      expect(el.spec.triggers[0].template.ref).toBeDefined();
+    } catch (e) {
+      fail(e);
+    }
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/__tests__/trigger-data.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/__tests__/trigger-data.ts
@@ -1,0 +1,87 @@
+import { AddTriggerFormValues } from '../types';
+
+export const formValues: AddTriggerFormValues = {
+  namespace: 'test-ns',
+  parameters: [
+    {
+      default: 'test-node',
+      name: 'APP_NAME',
+      type: 'string',
+    },
+    {
+      default: 'https://github.com/karthikjeeyar/nodejs-ex',
+      name: 'GIT_REPO',
+      type: 'string',
+    },
+    {
+      default: 'master',
+      name: 'GIT_REVISION',
+      type: 'string',
+    },
+    {
+      default: 'image-registry.openshift-image-registry.svc:5000/karthik/test-node',
+      name: 'APP_NAME',
+      type: 'string',
+    },
+    {
+      default: '.',
+      name: 'PATH_CONTEXT',
+      type: 'string',
+    },
+    {
+      default: '12',
+      name: 'MAJOR_VERSION',
+      type: 'string',
+    },
+  ],
+  resources: [],
+  workspaces: [
+    {
+      name: 'workspace',
+      type: 'PVC',
+      data: {
+        persistentVolumeClaim: {
+          claimName: 'pvc-c9a548597b',
+        },
+      },
+    },
+  ],
+  triggerBinding: {
+    name: '2~github-push',
+    resource: {
+      kind: 'ClusterTriggerBinding',
+      apiVersion: 'triggers.tekton.dev/v1alpha1',
+      metadata: {
+        name: 'github-push',
+      },
+      spec: {
+        params: [
+          {
+            name: 'git-revision',
+            value: '$(body.head_commit.id)',
+          },
+          {
+            name: 'git-commit-message',
+            value: '$(body.head_commit.message)',
+          },
+          {
+            name: 'git-repo-url',
+            value: '$(body.repository.url)',
+          },
+          {
+            name: 'git-repo-name',
+            value: '$(body.repository.name)',
+          },
+          {
+            name: 'content-type',
+            value: '$(header.Content-Type)',
+          },
+          {
+            name: 'pusher-name',
+            value: '$(body.pusher.name)',
+          },
+        ],
+      },
+    },
+  },
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/remove-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/remove-utils.ts
@@ -1,7 +1,7 @@
 import { k8sKill, k8sList, k8sPatch } from '@console/internal/module/k8s';
 import { EventListenerModel, TriggerTemplateModel } from '../../../../models';
 import { Pipeline } from '../../../../utils/pipeline-augment';
-import { EventListenerKind } from '../../resource-types';
+import { EventListenerKind, EventListenerKindTrigger } from '../../resource-types';
 import { RemoveTriggerFormValues } from './types';
 
 export const removeTrigger = async (values: RemoveTriggerFormValues, pipeline: Pipeline) => {
@@ -13,8 +13,12 @@ export const removeTrigger = async (values: RemoveTriggerFormValues, pipeline: P
     metadata: { name: selectedTriggerTemplate, namespace: ns },
   });
 
-  const triggerMatchesTriggerTemplate = ({ template: { name } }) =>
-    name === selectedTriggerTemplate;
+  const triggerMatchesTriggerTemplate = ({ triggerRef, template }: EventListenerKindTrigger) => {
+    if (triggerRef) {
+      return triggerRef === selectedTriggerTemplate;
+    }
+    return template?.ref === selectedTriggerTemplate || template?.name === selectedTriggerTemplate;
+  };
 
   // Get all the event listeners so we can update their references
   const eventListeners: EventListenerKind[] = await k8sList(EventListenerModel, { ns });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/resource-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/resource-utils.ts
@@ -1,3 +1,4 @@
+import { lt } from 'semver';
 import { getRandomChars } from '@console/shared';
 import { apiVersionForModel, RouteKind } from '@console/internal/module/k8s';
 import { RouteModel } from '@console/internal/models';
@@ -57,6 +58,14 @@ export const createEventListener = async (
       ref: triggerBinding.metadata.name,
     };
   };
+  const getTriggerTemplate = (name: string) => {
+    if (lt(pipelineOperatorVersion, '1.4.0')) {
+      return {
+        name,
+      };
+    }
+    return { ref: name };
+  };
 
   return {
     apiVersion: apiVersionForModel(EventListenerModel),
@@ -69,7 +78,7 @@ export const createEventListener = async (
       triggers: [
         {
           bindings: triggerBindings.map(mapTriggerBindings),
-          template: { name: triggerTemplate.metadata.name },
+          template: getTriggerTemplate(triggerTemplate.metadata.name),
         },
       ],
     },

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
@@ -13,7 +13,8 @@ export const getPipelineOperatorVersion = async (namespace: string): Promise<Sem
   });
   const matchingCSVs = allCSVs.filter(
     (csv) =>
-      csv.metadata?.name?.startsWith('openshift-pipelines-operator') &&
+      (csv.metadata?.name?.startsWith('openshift-pipelines-operator') ||
+        csv.metadata?.name?.startsWith('redhat-openshift-pipelines')) &&
       csv.status?.phase === ClusterServiceVersionPhase.CSVPhaseSucceeded,
   );
   const versions = matchingCSVs.map((csv) => parse(csv.spec.version)).filter(Boolean);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/triggers.ts
@@ -28,7 +28,9 @@ type TriggerTemplateMapping = { [key: string]: TriggerTemplateKind };
 
 const getResourceName = (resource: K8sResourceCommon): string => resource.metadata.name;
 const getEventListenerTemplateNames = (el: EventListenerKind): string[] =>
-  el.spec.triggers?.map((elTrigger: EventListenerKindTrigger) => elTrigger.template?.name) || [];
+  el.spec.triggers?.map(
+    (elTrigger: EventListenerKindTrigger) => elTrigger.template?.ref || elTrigger.template?.name,
+  ) || [];
 const getEventListenerGeneratedName = (eventListener: EventListenerKind) =>
   eventListener.status?.configuration.generatedName;
 
@@ -185,8 +187,8 @@ export const useTriggerTemplateEventListenerNames = (triggerTemplate: TriggerTem
 
   return eventListenerResources
     .filter((eventListener: EventListenerKind) =>
-      eventListener.spec.triggers?.find(
-        (trigger) => trigger.template?.name === getResourceName(triggerTemplate),
+      eventListener.spec.triggers?.find((trigger) =>
+        [trigger.template?.ref, trigger.template?.name].includes(getResourceName(triggerTemplate)),
       ),
     )
     .map(getResourceName);


### PR DESCRIPTION
This is a manual cherry pick of https://github.com/openshift/console/pull/8437
Problem: 
OSP 1.4 (GA version) has breaking api changes which needs to be addressed in OCP-4.7.

Solution:
Fixes the trigger API breaking changes in 1.4 OSP in OCP-4.7. Replaced `template.name` with `template.ref` and still support earlier versions operator to use template.name via Yaml.

Screenshots:
No UI changes

Test cases:
submitTrigger
    ✓ expect the eventlistener to contain template.name if the operator is below GA version (1.4.0) (23ms)
    ✓ expect the eventlistener to contain template.ref if the operator is GA version (1.4.0) (4ms)
    
/kind bug
