### PR TITLE
Query Browser: Switch colors to `ChartThemeColor.multiUnordered`

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -59,9 +59,11 @@ import { ONE_MINUTE } from '@console/shared/src/constants/time';
 
 const spans = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2w'];
 const dropdownItems = _.zipObject(spans, spans);
-// Note: Victory incorrectly typed ThemeBaseProps.padding as number instead of PaddingProps
-// @ts-ignore
-const theme = getCustomTheme(ChartThemeColor.multi, ChartThemeVariant.light, queryBrowserTheme);
+const theme = getCustomTheme(
+  ChartThemeColor.multiUnordered,
+  ChartThemeVariant.light,
+  queryBrowserTheme,
+);
 export const colors = theme.line.colorScale;
 
 const formatDate = (date) => getLocaleDate(date, { month: 'short', day: 'numeric' });


### PR DESCRIPTION
Also removes the `@ts-ignore`, which seems to no longer be necessary.

Before | After
-|-
![multi](https://user-images.githubusercontent.com/460802/112919893-e32a4780-9142-11eb-8ca5-2cf20f19a2d7.png) | ![multiUnordered](https://user-images.githubusercontent.com/460802/112919970-0228d980-9143-11eb-8ee3-87d4b2546320.png)
![multi2](https://user-images.githubusercontent.com/460802/112919912-ea515580-9142-11eb-8614-abe3364b48a3.png) | ![multiUnordered2](https://user-images.githubusercontent.com/460802/112919963-fe955280-9142-11eb-9384-f6482874bb86.png)
