### PR TITLE
Align checkboxes

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/style.scss
+++ b/frontend/packages/kubevirt-plugin/src/style.scss
@@ -12,3 +12,9 @@
 
 // Console StyleSheets
 @import "~xterm/css/xterm.css";
+
+// Note(yaacov): Workaround bootstrap issue, checkbox and radio buttons are not alligned with input label
+// hack should be removed once bootstrap is fixed
+input[type="radio"], input[type="checkbox"] {
+    margin-top: 1px !important;
+}


### PR DESCRIPTION
Console CSS + Patternflay create misaligned checkboxes and labels, this is a CSS fix for that issue

After
![screenshot-localhost_9000-2021 03 30-13_17_20](https://user-images.githubusercontent.com/2181522/112973882-77ec6f80-915a-11eb-971b-49affdef23bc.png)

Before
![screenshot-localhost_9000-2021 03 30-13_18_04](https://user-images.githubusercontent.com/2181522/112973888-791d9c80-915a-11eb-865b-85bee682a1e1.png)
