### PR TITLE
Bug 1939069: Add source to vm template silently failed

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -394,6 +394,7 @@
   "No base image specified": "No base image specified",
   "You cannot add source to this template because it is missing base image specification.": "You cannot add source to this template because it is missing base image specification.",
   "This data can be found in <2>Storage &gt; Persistent volume claims &gt; {baseImageName}</2> under the <5>{baseImageNamespace}</5> project.": "This data can be found in <2>Storage &gt; Persistent volume claims &gt; {baseImageName}</2> under the <5>{baseImageNamespace}</5> project.",
+  " No Storage classes found in cluster, adding source is disabled.": " No Storage classes found in cluster, adding source is disabled.",
   "Customizing boot source will be available after the source is added": "Customizing boot source will be available after the source is added",
   "For customizing boot source, select 'Customize boot source' from the template actions menu.": "For customizing boot source, select 'Customize boot source' from the template actions menu.",
   "Add boot source to template": "Add boot source to template",


### PR DESCRIPTION
Added safety net for a case where there are no storage classes in the cluster, adding source is disabled

<img width="632" alt="Screen Shot 2021-03-30 at 14 14 45" src="https://user-images.githubusercontent.com/24938324/112980954-34e2ca00-9163-11eb-8152-4321906f96c8.png">
