### PR TITLE
show type header for serverless function in topology

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -141,6 +141,7 @@
   "No Routes found for this resource.": "No Routes found for this resource.",
   "Location": "Location",
   "Unique Route": "Unique Route",
+  "Function": "Function",
   "Service": "Service",
   "Services": "Services",
   "Serving": "Serving",

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeOverview.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeOverview.tsx
@@ -3,6 +3,8 @@ import { ResourceSummary } from '@console/internal/components/utils';
 import { OverviewItem, PodRing } from '@console/shared';
 import { RevisionModel } from '../../models';
 import { usePodsForRevisions } from '../../utils/usePodsForRevisions';
+import { isServerlessFunction } from '../../topology/knative-topology-utils';
+import ServerlessFunctionType from './ServerlessFunctionType';
 
 type KnativeOverviewProps = {
   item?: OverviewItem;
@@ -32,6 +34,11 @@ const KnativeOverview: React.FC<KnativeOverviewProps> = ({ item }) => {
       <div className="resource-overview__summary">
         <ResourceSummary resource={obj} />
       </div>
+      {isServerlessFunction(obj) && (
+        <div className="resource-overview__details">
+          <ServerlessFunctionType />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -23,7 +23,7 @@ import {
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
 import KnativeOverview from './KnativeOverview';
 import SinkUriResourcesTab from './SinkUriResourcesTab';
-import { NodeType } from '../../topology/topology-types';
+import { URI_KIND } from '../../topology/const';
 
 interface StateProps {
   kindsInFlight?: boolean;
@@ -50,7 +50,7 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
   knativeModels,
   kindsInFlight,
 }: KnativeResourceOverviewPageProps) => {
-  if (NodeType.SinkUri === item?.obj?.type?.nodeType) {
+  if (item?.obj?.kind === URI_KIND) {
     return <SinkUriResourcesTab itemData={item} menuAction={editSinkUri} />;
   }
   if (kindsInFlight) {

--- a/frontend/packages/knative-plugin/src/components/overview/ServerlessFunctionType.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/ServerlessFunctionType.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const ServerlessFunctionType: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <dl className="co-m-pane__details">
+      <dt>{t('knative-plugin~Type')}</dt>
+      <dd>{t('knative-plugin~Function')}</dd>
+    </dl>
+  );
+};
+
+export default ServerlessFunctionType;

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
@@ -3,10 +3,15 @@ import { shallow } from 'enzyme';
 import * as _ from 'lodash';
 import { PodRing, OverviewItem, usePodScalingAccessStatus } from '@console/shared';
 import { ResourceSummary } from '@console/internal/components/utils';
-import { revisionObj } from '../../../topology/__tests__/topology-knative-test-data';
+import {
+  revisionObj,
+  knativeServiceObj,
+  serverlessFunctionObj,
+} from '../../../topology/__tests__/topology-knative-test-data';
 import { RevisionModel } from '../../../models';
 import KnativeOverview, { KnativeOverviewRevisionPodsRing } from '../KnativeOverview';
 import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
+import ServerlessFunctionType from '../ServerlessFunctionType';
 
 jest.mock('@console/shared', () => {
   const ActualShared = require.requireActual('@console/shared');
@@ -56,5 +61,15 @@ describe('KnativeOverview', () => {
     const mockItemKindRoute = _.set(_.cloneDeep(item), 'obj.kind', 'Route');
     const wrapper = shallow(<KnativeOverview item={mockItemKindRoute} />);
     expect(wrapper.find(PodRing)).toHaveLength(0);
+  });
+
+  it('should not render ServerlessFunctionType if obj is not a serverless function', () => {
+    const wrapper = shallow(<KnativeOverview item={{ obj: knativeServiceObj }} />);
+    expect(wrapper.find(ServerlessFunctionType).exists()).toBeFalsy();
+  });
+
+  it('should render ServerlessFunctionType if obj is a serverless function', () => {
+    const wrapper = shallow(<KnativeOverview item={{ obj: serverlessFunctionObj }} />);
+    expect(wrapper.find(ServerlessFunctionType).exists()).toBeTruthy();
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
@@ -10,7 +10,7 @@ import {
 import { RevisionModel, EventingSubscriptionModel } from '../../../models';
 import { KnativeResourceOverviewPage } from '../KnativeResourceOverviewPage';
 import SinkUriResourcesTab from '../SinkUriResourcesTab';
-import { NodeType } from '../../../topology/topology-types';
+import { URI_KIND } from '../../../topology/const';
 
 describe('KnativeResourceOverviewPage', () => {
   let item: OverviewItem;
@@ -59,11 +59,11 @@ describe('KnativeResourceOverviewPage', () => {
     const itemData = {
       ...item,
       obj: {
+        kind: URI_KIND,
         metadata: {
           uid: '02c34a0e-9638-11e9-b134-06a61d886b62_nodesinkuri',
         },
         spec: { sinkUri: 'http://overlayimage.testproject3.svc.cluster.local' },
-        type: { nodeType: NodeType.SinkUri },
       },
     };
     const wrapper = shallow(

--- a/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
@@ -3,12 +3,20 @@ import { Kebab, navFactory } from '@console/internal/components/utils';
 import { DetailsPage } from '@console/internal/components/factory';
 import { DetailsForKind } from '@console/internal/components/default-resource';
 import { useTabbedTableBreadcrumbsFor } from '@console/shared';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ServiceModel } from '../../models';
 import { serverlessTab } from '../../utils/serverless-tab-utils';
+import ServerlessFunctionType from '../overview/ServerlessFunctionType';
+import { isServerlessFunction } from '../../topology/knative-topology-utils';
 
 const ServiceDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => {
   const { kindObj, match, kind } = props;
-  const pages = [navFactory.details(DetailsForKind(kind)), navFactory.editYaml()];
+  const renderTypeForServerlessFunction = (obj: K8sResourceKind) =>
+    isServerlessFunction(obj) ? <ServerlessFunctionType /> : null;
+  const pages = [
+    navFactory.details(DetailsForKind(kind, renderTypeForServerlessFunction)),
+    navFactory.editYaml(),
+  ];
   const commonActions = Kebab.factory.common.map((action) => action);
   const menuActionsCreator = [...Kebab.getExtensionsActionsForKind(ServiceModel), ...commonActions];
   const breadcrumbs = useTabbedTableBreadcrumbsFor(

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -5,6 +5,7 @@ import {
   K8sResourceConditionStatus,
   referenceForModel,
   K8sKind,
+  K8sResourceKind,
 } from '@console/internal/module/k8s';
 import { TopologyDataResources } from '@console/topology/src/topology-types';
 import {
@@ -34,6 +35,9 @@ import {
   EventChannelKind,
   EventTriggerKind,
 } from '../../types';
+import { SERVERLESS_FUNCTION_LABEL } from '../../const';
+import { KnativeServiceOverviewItem, KnativeTopologyDataObject, NodeType } from '../topology-types';
+import { URI_KIND } from '../const';
 
 export const sampleDeploymentsCamelConnector: FirehoseResult<DeploymentKind[]> = {
   loaded: true,
@@ -603,6 +607,11 @@ export const knativeServiceObj: knativeServiceKind = {
       { lastTransitionTime: '2019-12-27T05:07:29Z', status: 'True', type: 'RoutesReady' },
     ],
   },
+};
+
+export const serverlessFunctionObj = {
+  ...knativeServiceObj,
+  metadata: { ...knativeServiceObj.metadata, labels: { [SERVERLESS_FUNCTION_LABEL]: 'true' } },
 };
 
 export const sampleKnativeServices: FirehoseResult = {
@@ -1179,4 +1188,32 @@ export const MockKnativeBuildConfig = {
       },
     ],
   },
+};
+
+export const sinkUriUid = '1317f615-9636-11e9-b134-06a61d886b689_1_nodesinkuri';
+const sinkUri = 'http://overlayimage.testproject3.svc.cluster.local';
+
+export const eventSourceWithSinkUri: K8sResourceKind = {
+  ...getEventSourceResponse(EventSourceCronJobModel).data[0],
+  spec: { sink: { uri: sinkUri } },
+};
+
+export const sinkUriObj: K8sResourceKind = {
+  kind: URI_KIND,
+  metadata: {
+    uid: sinkUriUid,
+  },
+  spec: { sinkUri },
+};
+
+export const sinkUriData: KnativeTopologyDataObject<KnativeServiceOverviewItem> = {
+  id: sinkUriUid,
+  name: 'URI',
+  type: NodeType.SinkUri,
+  resources: {
+    obj: sinkUriObj,
+    eventSources: [eventSourceWithSinkUri],
+  },
+  resource: sinkUriObj,
+  data: { sinkUri },
 };

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -33,6 +33,7 @@ import {
 } from '@console/topology/src/filters';
 import SvgBoxedText from '@console/topology/src/components/svg/SvgBoxedText';
 import { getNodeDecorators } from '@console/topology/src/components/graph-view/components/nodes/decorators/getNodeDecorators';
+import { getResource } from '@console/topology/src/utils/topology-utils';
 import { TYPE_KNATIVE_SERVICE, EVENT_MARKER_RADIUS } from '../../const';
 import RevisionTrafficSourceAnchor from '../anchors/RevisionTrafficSourceAnchor';
 import { isServerlessFunction } from '../../knative-topology-utils';
@@ -120,7 +121,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
     height,
   );
 
-  const typeIconClass: string = isServerlessFunction(element)
+  const typeIconClass: string = isServerlessFunction(getResource(element))
     ? 'icon-serverless-function'
     : 'icon-knative';
 
@@ -155,7 +156,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
               'is-highlight': canDrop || edgeDragging,
               'is-dropTarget': canDrop && dropTarget,
               'is-filtered': filtered,
-              'is-function': isServerlessFunction(element),
+              'is-function': isServerlessFunction(getResource(element)),
             })}
           >
             <rect

--- a/frontend/packages/knative-plugin/src/topology/const.ts
+++ b/frontend/packages/knative-plugin/src/topology/const.ts
@@ -21,3 +21,6 @@ export const KNATIVE_GROUP_NODE_PADDING = [
 ];
 
 export const EVENT_MARKER_RADIUS = 6;
+
+// URI Kind
+export const URI_KIND = 'URI';

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -37,6 +37,7 @@ import {
   KNATIVE_GROUP_NODE_HEIGHT,
   KNATIVE_GROUP_NODE_PADDING,
   KNATIVE_GROUP_NODE_WIDTH,
+  URI_KIND,
 } from './const';
 import {
   getDynamicEventSourcesModelRefs,
@@ -996,8 +997,7 @@ const sinkURIDataModel = (
           namespace: data.resources.obj.metadata.namespace || '',
         },
         spec: { sinkUri },
-        type: { nodeType: NodeType.SinkUri },
-        kind: 'URI',
+        kind: URI_KIND,
       };
       const sinkData: KnativeTopologyDataObject<KnativeServiceOverviewItem> = {
         id: sinkTargetUid,
@@ -1140,7 +1140,7 @@ export const createKnativeEventSourceSink = (
   }
   const eventSourceObj = _.omit(source, 'status');
   let sink = {};
-  if (NodeType.SinkUri === target.type?.nodeType) {
+  if (target.kind === URI_KIND) {
     sink = {
       uri: target?.spec?.sinkUri,
     };
@@ -1246,13 +1246,12 @@ export const createSinkPubSubConnection = (
   return createEventingPubSubSink(resources.obj, targetObj);
 };
 
-export const isServerlessFunction = (element: Node): boolean => {
+export const isServerlessFunction = (element: K8sResourceKind): boolean => {
   if (!element) {
     return false;
   }
-
   const {
     metadata: { labels },
-  } = getResource(element);
+  } = element;
   return !!labels?.[SERVERLESS_FUNCTION_LABEL];
 };

--- a/frontend/packages/knative-plugin/src/topology/listView/KnativeServiceListViewNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/listView/KnativeServiceListViewNode.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Node, observer } from '@patternfly/react-topology';
-import { getResourceKind } from '@console/topology/src/utils';
+import { getResource, getResourceKind } from '@console/topology/src/utils';
 import {
   TopologyListViewNode,
   TypedResourceBadgeCell,
@@ -21,7 +21,7 @@ const ObservedKnativeServiceListViewNode: React.FC<KnativeServiceListViewNodePro
 }) => {
   const kind = getResourceKind(item);
 
-  const typeIconClass: string = isServerlessFunction(item)
+  const typeIconClass: string = isServerlessFunction(getResource(item))
     ? 'icon-serverless-function'
     : 'icon-knative';
 

--- a/frontend/public/components/default-resource.tsx
+++ b/frontend/public/components/default-resource.tsx
@@ -41,7 +41,10 @@ const tableColumnClasses = [
   Kebab.columnClass,
 ];
 
-export const DetailsForKind = (kind: string) =>
+export const DetailsForKind = (
+  kind: string,
+  additionalDetailsCallback?: (obj: K8sResourceKind) => React.ReactNode,
+) =>
   function DetailsForKind_({ obj }) {
     const { t } = useTranslation();
 
@@ -49,6 +52,9 @@ export const DetailsForKind = (kind: string) =>
       const model = modelFor(item);
       return model?.labelKey ? t(model.labelKey) : kindForReference(item);
     };
+
+    const additionalDetails: React.ReactNode =
+      additionalDetailsCallback && additionalDetailsCallback(obj);
 
     return (
       <>
@@ -64,6 +70,7 @@ export const DetailsForKind = (kind: string) =>
                 showNodeSelector={false}
               />
             </div>
+            {additionalDetails && <div className="col-md-6">{additionalDetails}</div>}
           </div>
         </div>
         {_.isArray(obj?.status?.conditions) && (

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -19,6 +19,7 @@ import {
 } from './utils';
 import { SecretType } from './secrets/create-secret';
 import { configureAddSecretToWorkloadModal } from './modals/add-secret-to-workload';
+import { DetailsItem } from './utils/details-item';
 
 export const WebHookSecretKey = 'WebHookSecretKey';
 
@@ -102,6 +103,7 @@ const SecretTableRow = ({ obj: secret, index, key, style }) => {
 
 const SecretDetails = ({ obj: secret }) => {
   const { t } = useTranslation();
+  const { data, type } = secret;
   return (
     <>
       <div className="co-m-pane__body">
@@ -110,10 +112,17 @@ const SecretDetails = ({ obj: secret }) => {
           <div className="col-md-6">
             <ResourceSummary resource={secret} />
           </div>
+          {type && (
+            <div className="col-md-6">
+              <dl data-test-id="resource-type" className="co-m-pane__details">
+                <DetailsItem label={t('public~Type')} obj={secret} path="type" />
+              </dl>
+            </div>
+          )}
         </div>
       </div>
       <div className="co-m-pane__body">
-        <SecretData data={secret.data} type={secret.type} />
+        <SecretData data={data} type={type} />
       </div>
     </>
   );

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -7,7 +7,7 @@ import { Base64 } from 'js-base64';
 import { ActionGroup, Button } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
-import { k8sCreate, k8sUpdate, K8sResourceKind, referenceFor } from '../../module/k8s';
+import { k8sCreate, k8sUpdate, K8sResourceKind, referenceFor, SecretKind } from '../../module/k8s';
 import {
   ButtonBar,
   Firehose,
@@ -1342,7 +1342,7 @@ type SecretLoadingWrapperState = {
 
 type BaseEditSecretState_ = {
   secretTypeAbstraction?: SecretTypeAbstraction;
-  secret: K8sResourceKind;
+  secret: SecretKind;
   inProgress: boolean;
   type: SecretType;
   stringData: {

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -60,7 +60,7 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
   nodeSelector = 'spec.template.spec.nodeSelector',
 }) => {
   const { t } = useTranslation();
-  const { metadata, type } = resource;
+  const { metadata } = resource;
   const reference = referenceFor(resource);
   const model = modelFor(reference);
   const tolerationsPath = getTolerationsPath(resource);
@@ -91,8 +91,6 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
           />
         </DetailsItem>
       )}
-      {type ? <dt>{t('details-page~Type')}</dt> : null}
-      {type ? <dd>{type}</dd> : null}
       <DetailsItem
         label={t('details-page~Labels')}
         obj={resource}

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -59,7 +59,6 @@ export type K8sResourceKind = K8sResourceCommon & {
     [key: string]: any;
   };
   status?: { [key: string]: any };
-  type?: { [key: string]: any };
   data?: { [key: string]: any };
 };
 


### PR DESCRIPTION
Story:
https://issues.redhat.com/browse/ODC-5658

Problem/Description:
The Topology sidebar and Service details page should show that it belongs to serverless function

Solution:
Add a "Type" header with content "Function" under it to indicate the details belong to serverless function

Screens:
_Topology Sidebar for Serverless function_
![Screenshot from 2021-03-30 21-22-14](https://user-images.githubusercontent.com/38663217/113018464-38477700-919e-11eb-88c5-108f8bec7dcd.png)

_Service details page for Serverless function_
![Screenshot from 2021-03-30 21-23-05](https://user-images.githubusercontent.com/38663217/113018576-51502800-919e-11eb-9fee-8f2630e0ba7d.png)

_Topology Sidebar for Knative service_
![Screenshot from 2021-03-30 21-22-32](https://user-images.githubusercontent.com/38663217/113018644-61680780-919e-11eb-9299-6c3a71f245ec.png)

_Service details page for Knative service_
![Screenshot from 2021-03-30 21-22-42](https://user-images.githubusercontent.com/38663217/113018707-717fe700-919e-11eb-9a45-0b9332db7867.png)

_Secret details page_
![Screenshot from 2021-04-09 22-34-24](https://user-images.githubusercontent.com/38663217/114215927-d8ae5000-9983-11eb-9829-b41b1c70881a.png)


Test Coverage:
![Screenshot from 2021-03-30 21-27-00](https://user-images.githubusercontent.com/38663217/113019379-2adebc80-919f-11eb-977a-ab41969f472a.png)
![Screenshot from 2021-03-30 21-30-05](https://user-images.githubusercontent.com/38663217/113019388-2ca88000-919f-11eb-8d83-6190c7dc31e6.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge