### PR TITLE
Fix to show resources to filter by in Topology

### DIFF
--- a/frontend/packages/topology/src/components/page/DroppableTopologyComponent.tsx
+++ b/frontend/packages/topology/src/components/page/DroppableTopologyComponent.tsx
@@ -8,7 +8,7 @@ import {
   FileUploadContextType,
   FileUploadContext,
 } from '@console/app/src/components/file-upload/file-upload-context';
-import { ConnectedTopologyView, TopologyViewProps } from './TopologyView';
+import TopologyView, { TopologyViewProps } from './TopologyView';
 import { TopologyViewType } from '../../topology-types';
 
 const boxTarget = {
@@ -29,7 +29,7 @@ const DroppableTopology = DropTarget(
       canDrop: monitor.canDrop() && props.canDropFile,
     };
   },
-)(ConnectedTopologyView);
+)(TopologyView);
 
 export const DroppableTopologyComponent = withDragDropContext<DroppableTopologyComponentProps>(
   (props) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5701

**Analysis / Root cause**: 
The `DroppableTopologyComponent` imported the incorrect export from `TopologyView` so the Redux functions to update  the supported filters/kinds did not get set correctly.

**Solution Description**: 
Fix the import of TopologyView

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug