### PR TITLE
Kafka Source creation form to support bootstrap server host from KC

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
@@ -86,7 +86,9 @@ const EventSourceSection: React.FC<EventSourceSectionProps> = ({
       EventSource = <ApiServerSection title={sectionTitle} fullWidth={fullWidth} />;
       break;
     case EventSources.KafkaSource:
-      EventSource = <KafkaSourceSection title={sectionTitle} fullWidth={fullWidth} />;
+      EventSource = (
+        <KafkaSourceSection title={sectionTitle} fullWidth={fullWidth} namespace={namespace} />
+      );
       break;
     case EventSources.ContainerSource:
       EventSource = <ContainerSourceSection title={sectionTitle} fullWidth={fullWidth} />;

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -13,22 +13,31 @@ import { EventSources } from '../import-types';
 
 interface KafkaSourceSectionProps {
   title: string;
+  namespace: string;
   fullWidth?: boolean;
 }
 
-const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title, fullWidth }) => {
+const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title, namespace, fullWidth }) => {
   const { t } = useTranslation();
-  const memoResources = React.useMemo(() => strimziResourcesWatcher(), []);
-  const { kafkas, kafkatopics } = useK8sWatchResources<{
+  const memoResources = React.useMemo(() => strimziResourcesWatcher(namespace), [namespace]);
+  const { kafkas, kafkatopics, kafkaconnections } = useK8sWatchResources<{
     [key: string]: K8sResourceKind[];
   }>(memoResources);
 
   const [bootstrapServers, bsPlaceholder] = React.useMemo(() => {
     let bootstrapServersOptions: SelectInputOption[] = [];
     let placeholder: React.ReactNode = '';
-    if (kafkas.loaded && !kafkas.loadError) {
-      bootstrapServersOptions = !_.isEmpty(kafkas.data)
-        ? _.map(getBootstrapServers(kafkas.data), (bs) => ({
+    const isKafkasLoaded =
+      (kafkas.loaded && !kafkas.loadError) ||
+      (kafkaconnections.loaded && !kafkaconnections.loadError);
+    const isKafkasLoadError = !!(kafkas.loadError && kafkaconnections.loadError);
+    if (isKafkasLoaded) {
+      const kafkasData = [
+        ...(kafkas.data ? kafkas.data : []),
+        ...(kafkaconnections.data ? kafkaconnections.data : []),
+      ];
+      bootstrapServersOptions = !_.isEmpty(kafkasData)
+        ? _.map(getBootstrapServers(kafkasData), (bs) => ({
             value: bs,
             disabled: false,
           }))
@@ -39,11 +48,11 @@ const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title, fullWidt
             },
           ];
       placeholder = t('knative-plugin~Add bootstrap servers');
-    } else if (kafkas.loadError) {
+    } else if (isKafkasLoadError) {
       placeholder = t(
         'knative-plugin~{{loadErrorMessage}}. Try adding bootstrap servers manually.',
         {
-          loadErrorMessage: kafkas.loadError?.message,
+          loadErrorMessage: `${kafkas.loadError.message}, ${kafkaconnections.loadError.message}`,
         },
       );
     } else {
@@ -53,7 +62,15 @@ const KafkaSourceSection: React.FC<KafkaSourceSectionProps> = ({ title, fullWidt
       placeholder = '...';
     }
     return [bootstrapServersOptions, placeholder];
-  }, [kafkas.loaded, kafkas.loadError, kafkas.data, t]);
+  }, [
+    kafkas.loaded,
+    kafkas.loadError,
+    kafkas.data,
+    kafkaconnections.loaded,
+    kafkaconnections.loadError,
+    kafkaconnections.data,
+    t,
+  ]);
 
   const [kafkaTopics, ktPlaceholder] = React.useMemo(() => {
     let topicsOptions: SelectInputOption[] = [];

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/KafkaSourceSection.spec.tsx
@@ -26,8 +26,9 @@ describe('KafkaSourceSection', () => {
     (useK8sWatchResources as jest.Mock).mockReturnValue({
       kafkas: { data: [], loaded: true },
       kafkatopics: { data: [], loaded: true },
+      kafkaconnections: { data: [], loaded: true },
     });
-    wrapper = shallow(<KafkaSourceSection title={title} />);
+    wrapper = shallow(<KafkaSourceSection title={title} namespace="my-app" />);
     expect(wrapper.find(FormSection)).toHaveLength(1);
     expect(wrapper.find(FormSection).props().title).toBe('Kafka Source');
   });
@@ -36,8 +37,9 @@ describe('KafkaSourceSection', () => {
     (useK8sWatchResources as jest.Mock).mockReturnValue({
       kafkas: { data: [], loaded: true },
       kafkatopics: { data: [], loaded: true },
+      kafkaconnections: { data: [], loaded: true },
     });
-    wrapper = shallow(<KafkaSourceSection title={title} />);
+    wrapper = shallow(<KafkaSourceSection title={title} namespace="my-app" />);
     const bootstrapServersField = wrapper.find(
       '[data-test-id="kafkasource-bootstrapservers-field"]',
     );
@@ -53,11 +55,30 @@ describe('KafkaSourceSection', () => {
     (useK8sWatchResources as jest.Mock).mockReturnValue({
       kafkas: { data: [], loaded: true },
       kafkatopics: { data: [], loaded: true },
+      kafkaconnections: { data: [], loaded: true },
     });
-    wrapper = shallow(<KafkaSourceSection title={title} />);
+    wrapper = shallow(<KafkaSourceSection title={title} namespace="my-app" />);
     const consumerGroupField = wrapper.find('[data-test-id="kafkasource-consumergroup-field"]');
     expect(consumerGroupField).toHaveLength(1);
     expect(consumerGroupField.props().required).toBeTruthy();
     expect(wrapper.find(KafkaSourceNetSection)).toHaveLength(1);
+  });
+
+  it('should render BootstrapServers and Topics fields with even if kafkaconnections loaded failed', () => {
+    (useK8sWatchResources as jest.Mock).mockReturnValue({
+      kafkas: { data: [], loaded: true },
+      kafkatopics: { data: [], loaded: true },
+      kafkaconnections: { data: null, loaded: false, loadError: 'Error' },
+    });
+    wrapper = shallow(<KafkaSourceSection title={title} namespace="my-app" />);
+    const bootstrapServersField = wrapper.find(
+      '[data-test-id="kafkasource-bootstrapservers-field"]',
+    );
+    expect(bootstrapServersField).toHaveLength(1);
+    expect(bootstrapServersField.props().required).toBeTruthy();
+
+    const topicsField = wrapper.find('[data-test-id="kafkasource-topics-field"]');
+    expect(topicsField).toHaveLength(1);
+    expect(topicsField.props().required).toBeTruthy();
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -32,6 +32,7 @@ describe('Create knative Utils', () => {
       'my-cluster-kafka-bootstrap.div.svc:9093',
       'my-cluster2-kafka-bootstrap.div.svc:9092',
       'my-cluster2-kafka-bootstrap.div.svc:9093',
+      'jai-test--qcxzgigqva-d-bxib-gn-g--ni.kafka.devshift.org:443',
     ]);
   });
 

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -630,6 +630,66 @@ export const Kafkas: K8sResourceKind[] = [
       observedGeneration: 1,
     },
   },
+  {
+    apiVersion: 'rhoas.redhat.com/v1alpha1',
+    kind: 'KafkaConnection',
+    metadata: {
+      resourceVersion: '8324966',
+      name: 'ajay-test',
+      uid: 'bc6c508f-0167-48a3-9a13-96f2aeb7aff2',
+      creationTimestamp: '2021-03-30T08:28:59Z',
+      generation: 1,
+      namespace: 'div',
+      finalizers: ['kafkaconnections.rhoas.redhat.com/finalizer'],
+    },
+    spec: {
+      accessTokenSecretName: 'rh-cloud-services-api-accesstoken',
+      credentials: {
+        serviceAccountSecretName: 'rh-cloud-services-service-account',
+      },
+      kafkaId: '1qCXzgiGqva0D5bXIB0Gn9g23Ni',
+    },
+    status: {
+      bootstrapServerHost: 'jai-test--qcxzgigqva-d-bxib-gn-g--ni.kafka.devshift.org:443',
+      conditions: [
+        {
+          lastTransitionGeneration: 1,
+          lastTransitionTime: '2021-03-30T08:29:00.092273Z',
+          message: '',
+          reason: '',
+          status: 'True',
+          type: 'AcccesTokenSecretValid',
+        },
+        {
+          lastTransitionGeneration: 1,
+          lastTransitionTime: '2021-03-30T08:29:00.092277Z',
+          message: '',
+          reason: '',
+          status: 'True',
+          type: 'FoundKafkaById',
+        },
+        {
+          lastTransitionGeneration: 1,
+          lastTransitionTime: '2021-03-30T08:29:00.092278Z',
+          message: '',
+          reason: '',
+          status: 'True',
+          type: 'Finished',
+        },
+      ],
+      message: 'Created',
+      metadata: {
+        cloudUI:
+          'https://cloud.redhat.com/beta/application-services/openshift-streams/kafkas/1qCXzgiGqva0D5bXIB0Gn9g23Ni',
+        provider: 'rhoas',
+        saslMechanism: 'PLAIN',
+        securityProtocol: 'SASL_SSL',
+        type: 'kafka',
+      },
+      serviceAccountSecretName: 'rh-cloud-services-service-account',
+      updated: '2021-03-30T08:29:00.092250Z',
+    },
+  },
 ];
 
 export const getDefaultChannelData = (ref: string): AddChannelFormData => {

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -318,13 +318,16 @@ export const getEventSourceModelsWithAccess = (
 };
 
 export const getBootstrapServers = (kafkaResources: K8sResourceKind[]) => {
-  const servers = [];
-  _.forEach(kafkaResources, (kafka) => {
-    const listeners = kafka?.status?.listeners;
-    _.map(listeners, (l) => {
-      servers.push(..._.split(l?.bootstrapServers, ','));
-    });
-  });
+  const servers = kafkaResources?.reduce((acc, kafka) => {
+    const listners = [
+      ...(kafka?.status?.listeners
+        ? kafka.status.listeners.map((l) => l?.bootstrapServers?.split(','))?.flat()
+        : []),
+      ...(kafka?.status?.bootstrapServerHost ? [kafka.status.bootstrapServerHost] : []),
+    ];
+    acc.push(...listners);
+    return acc;
+  }, []);
   return servers;
 };
 

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -1,8 +1,8 @@
 import * as _ from 'lodash';
 import { K8sResourceKind, PodKind, referenceForModel } from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
-import { KNATIVE_SERVING_LABEL } from '../const';
 import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
+import { KafkaConnectionModel } from '@console/rhoas-plugin/src/models';
 import {
   ServiceModel,
   RevisionModel,
@@ -16,6 +16,7 @@ import {
   CamelIntegrationModel,
   CamelKameletBindingModel,
 } from '../models';
+import { KNATIVE_SERVING_LABEL } from '../const';
 
 export type KnativeItem = {
   revisions?: K8sResourceKind[];
@@ -271,11 +272,17 @@ export const knativeCamelIntegrationsResourceWatchers = (
   };
 };
 
-export const strimziResourcesWatcher = (): WatchK8sResources<any> => {
+export const strimziResourcesWatcher = (namespace: string): WatchK8sResources<any> => {
   const strimziResources = {
     [KafkaModel.plural]: {
       isList: true,
       kind: referenceForModel(KafkaModel),
+      optional: true,
+    },
+    [KafkaConnectionModel.plural]: {
+      isList: true,
+      kind: referenceForModel(KafkaConnectionModel),
+      namespace,
       optional: true,
     },
     [KafkaTopicModel.plural]: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5657

**Solution Description**: 
Kafka Source creation form, show type ahead with bootstrap server from (Kafka connection) KC if the project has KC and user has access to them

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/5129024/113289914-8085a700-930e-11eb-8a25-68ca7ec38ae6.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/5129024/113026274-83fe1e80-91a6-11eb-8add-470fa5906a8f.png)



**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- Install RHOAS operator / Serverless operator
- Create KC in ns with catalog
- Create Kafka Source Form

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
