### PR TITLE
Support URLs in Result values

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -213,6 +213,7 @@
   "Create Pipeline": "Create Pipeline",
   "by name": "by name",
   "{{resourceName}} results": "{{resourceName}} results",
+  "Value": "Value",
   "No {{resourceName}} results available due to failure": "No {{resourceName}} results available due to failure",
   "Task": "Task",
   "Pod": "Pod",
@@ -245,6 +246,5 @@
   "Skipped": "Skipped",
   "Cancelled": "Cancelled",
   "Pending": "Pending",
-  "PipelineRun not started yet": "PipelineRun not started yet",
-  "Value": "Value"
+  "PipelineRun not started yet": "PipelineRun not started yet"
 }

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/ResultsList.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
-import { Table, TableHeader, TableBody } from '@patternfly/react-table';
+import { TableComposable, Thead, Tbody, Th, Td, Tr } from '@patternfly/react-table';
 import { SectionHeading } from '@console/internal/components/utils';
 import { TektonResultsRun } from '../../../types';
-import { getCellsFromResults } from '../../../utils/pipeline-utils';
 import { runStatus } from '../../../utils/pipeline-augment';
+import { handleURLs } from '../../../utils/render-utils';
 
 export interface ResultsListProps {
   results: TektonResultsRun[];
@@ -13,24 +13,44 @@ export interface ResultsListProps {
   status: string;
 }
 
+/**
+ * Without this prop our current TS types fail to match and require a `translate` prop to be added. PF suggests we
+ * update our types, but that causes other issues. This will have to do as a workaround for now.
+ *
+ * This is the best that I can find relates to this value:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3423b4fc3e3da09f8acc386bc2fee6fb8f5e0880/types/react/index.d.ts#L1763
+ */
+const reactPropFix = {
+  translate: 'no',
+};
+
 const ResultsList: React.FC<ResultsListProps> = ({ results, resourceName, status }) => {
   const { t } = useTranslation();
   if (!results.length) return null;
-
-  const { rows, columns } = getCellsFromResults(results);
 
   return (
     <>
       <SectionHeading text={t('pipelines-plugin~{{resourceName}} results', { resourceName })} />
       {status !== runStatus.Failed ? (
-        <Table
+        <TableComposable
           aria-label={t('pipelines-plugin~{{resourceName}} results', { resourceName })}
-          cells={columns.map((column) => ({ title: t(column) }))}
-          rows={rows.map((row) => ({ cells: row }))}
+          {...reactPropFix}
         >
-          <TableHeader />
-          <TableBody />
-        </Table>
+          <Thead {...reactPropFix}>
+            <Tr {...reactPropFix}>
+              <Th {...reactPropFix}>{t('pipelines-plugin~Name')}</Th>
+              <Th {...reactPropFix}>{t('pipelines-plugin~Value')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody {...reactPropFix}>
+            {results.map(({ name, value }) => (
+              <Tr key={`row-${name}`} {...reactPropFix}>
+                <Td {...reactPropFix}>{name}</Td>
+                <Td {...reactPropFix}>{handleURLs(value)}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
       ) : (
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.full}>

--- a/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/results/__tests__/ResultsList.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
-import { Table } from '@patternfly/react-table';
+import { TableComposable } from '@patternfly/react-table';
 import { EmptyState } from '@patternfly/react-core';
 import ResultsList, { ResultsListProps } from '../ResultsList';
 import { runStatus } from '../../../../utils/pipeline-augment';
@@ -28,7 +28,7 @@ describe('ResultsList', () => {
   });
 
   it('Should render Results Table', () => {
-    expect(resultsListWrapper.find(Table).exists()).toBe(true);
+    expect(resultsListWrapper.find(TableComposable).exists()).toBe(true);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(false);
   });
   it('Should render an EmptyState instead', () => {
@@ -38,7 +38,7 @@ describe('ResultsList', () => {
       results: taskRunWithResults.status.taskResults,
     };
     resultsListWrapper = shallow(<ResultsList {...resultsListProps} />);
-    expect(resultsListWrapper.find(Table).exists()).toBe(false);
+    expect(resultsListWrapper.find(TableComposable).exists()).toBe(false);
     expect(resultsListWrapper.find(EmptyState).exists()).toBe(true);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -10,7 +10,6 @@ import { ContainerStatus } from '@console/internal/module/k8s';
 import { SecretAnnotationId } from '../../components/pipelines/const';
 import { DataState, PipelineExampleNames, pipelineTestData } from '../../test-data/pipeline-data';
 import { runStatus } from '../pipeline-augment';
-import { taskRunWithResults } from '../../components/taskruns/__tests__/taskrun-test-data';
 import { PipelineRunModel } from '../../models';
 import {
   getPipelineTasks,
@@ -24,7 +23,6 @@ import {
   LatestPipelineRunStatus,
   updateServiceAccount,
   appendPipelineRunStatus,
-  getCellsFromResults,
   getMatchedPVCs,
 } from '../pipeline-utils';
 import {
@@ -180,20 +178,6 @@ describe('pipeline-utils ', () => {
   it('expect pipeline without inline task spec to return false', () => {
     const hasSpec = hasInlineTaskSpec(mockPipelinesJSON[1].spec.tasks);
     expect(hasSpec).toBe(false);
-  });
-
-  it('expect correct rows and columns for task with results', () => {
-    const { rows, columns } = getCellsFromResults(taskRunWithResults.status.taskResults);
-    expect(columns.length).toBe(2);
-    expect(rows.length).toBe(4);
-    expect(rows[0][0]).toBe('sum');
-    expect(rows[0][1]).toBe('30');
-    expect(rows[1][0]).toBe('difference');
-    expect(rows[1][1]).toBe('10');
-    expect(rows[2][0]).toBe('multiply');
-    expect(rows[2][1]).toBe('200');
-    expect(rows[3][0]).toBe('divide');
-    expect(rows[3][1]).toBe('2');
   });
 
   it('should return PVCs correctly matched with name and kind', () => {

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/render-utils.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/render-utils.spec.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { ExternalLink } from '@console/internal/components/utils';
+import { handleURLs, GROUP_MATCH_REGEXP } from '../render-utils';
+
+describe('handleURLs', () => {
+  it('should return the same value if it is not a string', () => {
+    // We will only likely get strings, but it shouldn't break/NPE if they are not
+    expect(handleURLs(null)).toBe(null);
+    expect(handleURLs(undefined)).toBe(undefined);
+    expect(handleURLs(true as any)).toBe(true);
+    const v = {};
+    expect(handleURLs(v as any)).toBe(v);
+  });
+
+  it('should not do anything if there are no URLs in the string', () => {
+    const stringsWithoutURLs = ['not a URL', 'redhat.com', 'http', '://something.com'];
+    stringsWithoutURLs.forEach((string: string) => {
+      expect(handleURLs(string)).toBe(string);
+    });
+  });
+
+  describe('Test easy URL Examples', () => {
+    const validStringsWithURL: { [testName: string]: string } = {
+      straightURL: 'https://redhat.com',
+      prefixedURL: 'Red Hat website: https://redhat.com',
+      suffixedURL: "https://redhat.com is Red Hat's website",
+      bothPrefixAndSuffixURL: 'This is the company website https://redhat.com for Red Hat',
+    };
+
+    Object.keys(validStringsWithURL).forEach((testName: string) => {
+      const string = validStringsWithURL[testName];
+      it(`should create an ExternalLink for the URL, test ${testName}`, () => {
+        const reactRendering = handleURLs(string);
+        expect(typeof reactRendering).not.toBe('string');
+        const comp = shallow(<div>{reactRendering}</div>);
+        expect(comp.find(ExternalLink).exists()).toBe(true);
+      });
+    });
+
+    describe('verify backing RegExp finds the urls', () => {
+      Object.keys(validStringsWithURL).forEach((testName: string) => {
+        const string = validStringsWithURL[testName];
+        it(`should find the URL, test ${testName}`, () => {
+          const [, , url] = string.match(GROUP_MATCH_REGEXP);
+          expect(url).toBe('https://redhat.com');
+        });
+      });
+    });
+  });
+
+  describe('Test edge-case URL Examples', () => {
+    const enzymeExternalLink = '< />'; // how enzyme represents <ExternalLink /> in .text() format
+
+    it('should create multiple ExternalLinks and not lose the interim prefix/suffix values', () => {
+      const data =
+        'some prefix https://github.com/openshift/console some middle http://example.com some suffix';
+      const result = handleURLs(data);
+      const comp = shallow(<div>{result}</div>);
+      expect(comp.find(ExternalLink)).toHaveLength(2);
+      expect(comp.text()).toEqual(
+        `some prefix ${enzymeExternalLink} some middle ${enzymeExternalLink} some suffix`,
+      );
+    });
+
+    it('should create multiple ExternalLinks when more than one url is present', () => {
+      const links = [
+        'https://github.com/openshift/console',
+        'https://github.com/openshift/api',
+        'https://github.com/openshift/kubernetes',
+        'https://github.com/openshift/origin',
+        'https://github.com/openshift/release',
+      ];
+      const data = links.join(' '); // join multiple links together with a space (so they are unique urls);
+      const result = handleURLs(data);
+      const comp = shallow(<div>{result}</div>);
+      expect(comp.find(ExternalLink)).toHaveLength(links.length);
+      expect(comp.text()).toEqual(links.map(() => enzymeExternalLink).join(' '));
+    });
+
+    it('should handle escaped URLs (such as googling for a URL)', () => {
+      // Google for 'https://github.com/openshift/console'
+      const data =
+        'https://www.google.com/search?q=https%3A%2F%2Fgithub.com%2Fopenshift%2Fconsole&ei=SO5lYNXrK_Ox5NoPwN-soAw&oq=https%3A%2F%2Fgithub.com%2Fopenshift%2Fconsole&gs_lcp=Cgdnd3Mtd2l6EAM6BwgAEEcQsAM6BwgAELADEEM6DgguEMcBEK8BEJECEJMCOgsILhDHARCvARCRAjoICAAQsQMQgwE6DgguELEDEIMBEMcBEKMCOgUIABCxAzoLCC4QsQMQxwEQowI6AggAOgQIABBDOgcIABCxAxBDOgQIABAKOgYIABAWEB5QlzVYmKYBYJ2nAWgCcAJ4AIABbYgBvBmSAQQzMy40mAEAoAEBqgEHZ3dzLXdpesgBCsABAQ&sclient=gws-wiz&ved=0ahUKEwjVr7S5td3vAhXzGFkFHcAvC8QQ4dUDCA0&uact=5';
+      const result = handleURLs(data);
+      const comp = shallow(<div>{result}</div>);
+      expect(comp.find(ExternalLink)).toHaveLength(1);
+      expect(comp.text()).toEqual(enzymeExternalLink);
+    });
+
+    it('should handle redirect wrapper URLs', () => {
+      // Probably not a common case, but some sites wrap all links by a query param at the end of the URL
+      const data = 'https://github.com/openshift?externalLink=https://github.com/openshift/console';
+      const result = handleURLs(data);
+      const comp = shallow(<div>{result}</div>);
+      expect(comp.find(ExternalLink)).toHaveLength(1);
+      expect(comp.text()).toEqual(enzymeExternalLink);
+    });
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -28,7 +28,6 @@ import {
   PipelineKind,
   TaskRunKind,
   TektonParam,
-  TektonResultsRun,
 } from '../types';
 import { getLatestRun, runStatus } from './pipeline-augment';
 import { pipelineRunFilterReducer, pipelineRunStatus } from './pipeline-filter-reducer';
@@ -433,21 +432,6 @@ export const pipelinesTab = (kindObj: K8sKind) => {
     default:
       return null;
   }
-};
-
-type ResultColumn = [string, string];
-
-export type ResultCells = {
-  rows: ResultColumn[];
-  columns: ResultColumn;
-};
-
-export const getCellsFromResults = (results: TektonResultsRun[]): ResultCells => {
-  // t('pipelines-plugin~Name') t('pipelines-plugin~Value')
-  return {
-    columns: ['pipelines-plugin~Name', 'pipelines-plugin~Value'],
-    rows: results.map((result) => [result.name, result.value]),
-  };
 };
 
 export const getMatchedPVCs = (

--- a/frontend/packages/pipelines-plugin/src/utils/render-utils.scss
+++ b/frontend/packages/pipelines-plugin/src/utils/render-utils.scss
@@ -1,0 +1,3 @@
+.opp-render-utils-external-url {
+  max-width: 100%;
+}

--- a/frontend/packages/pipelines-plugin/src/utils/render-utils.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/render-utils.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { ExternalLink } from '@console/internal/components/utils';
+
+import './render-utils.scss';
+
+const URL_REGEXP = /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)/;
+export const GROUP_MATCH_REGEXP = new RegExp(`^(.*\\s)?(${URL_REGEXP.source})(\\s.*)?$`, 'i');
+
+export const handleURLs = (value: string): React.ReactNode => {
+  if (typeof value !== 'string') return value;
+
+  const matches = value.match(GROUP_MATCH_REGEXP);
+  const [, prefix, link, suffix] = matches || [];
+
+  if (link) {
+    return (
+      <>
+        {handleURLs(prefix)}
+        <ExternalLink additionalClassName="opp-render-utils-external-url" href={link}>
+          {link}
+        </ExternalLink>
+        {handleURLs(suffix)}
+      </>
+    );
+  }
+
+  return value;
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5711

**Analysis / Root cause**: 
When results had URLs they were just presented like strings. This is apparently a common use-case that we would like to support.

**Solution Description**: 
When a URL is present, make it clickable.

**Screen shots / Gifs for design review**: 

With clickable link:
![Screen Shot 2021-03-30 at 5 06 59 PM](https://user-images.githubusercontent.com/8126518/113057704-62d40880-917b-11eb-82ca-0a93cafe6dfa.png)

And the trigger settings (that generated it):
![Screen Shot 2021-03-30 at 5 07 39 PM](https://user-images.githubusercontent.com/8126518/113057705-636c9f00-917b-11eb-9818-efe8233f7408.png)

More complicated example:
![Screen Shot 2021-04-01 at 12 05 20 PM](https://user-images.githubusercontent.com/8126518/113322608-e6f4d000-92e2-11eb-8cc8-576b039a0edb.png)


**Unit test coverage report**: 

```
 PASS  packages/pipelines-plugin/src/utils/__tests__/render-utils.spec.tsx (17.368s)
  handleURLs
    ✓ should return the same value if it is not a string (2ms)
    ✓ should not do anything if there are no URLs in the string
    Test easy URL Examples
      ✓ should create an ExternalLink for the URL, test straightURL (11ms)
      ✓ should create an ExternalLink for the URL, test prefixedURL (4ms)
      ✓ should create an ExternalLink for the URL, test suffixedURL (3ms)
      ✓ should create an ExternalLink for the URL, test bothPrefixAndSuffixURL (2ms)
      verify backing RegExp finds the urls
        ✓ should find the URL, test straightURL
        ✓ should find the URL, test prefixedURL
        ✓ should find the URL, test suffixedURL
        ✓ should find the URL, test bothPrefixAndSuffixURL
    Test edge-case URL Examples
      ✓ should create multiple ExternalLinks and not lose the interim prefix/suffix values (2ms)
      ✓ should create multiple ExternalLinks when more than one url is present (3ms)
      ✓ should handle escaped URLs (such as googling for a URL) (3ms)
      ✓ should handle redirect wrapper URLs (2ms)
```

**Test setup:**

* Have OpenShift Pipelines Operator installed.
* My sample resources from the screenshots: https://raw.githubusercontent.com/andrewballantyne/pipeline-scratch-pad/master/examples/results/resources.yaml

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge