### PR TITLE
Bug 1945146: Remove pipeline Tech preview badge for  pipelines GA operator

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/cluster-tasks/ClusterTaskDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/cluster-tasks/ClusterTaskDetailsPage.tsx
@@ -3,14 +3,17 @@ import { DetailsPageProps, DetailsPage } from '@console/internal/components/fact
 import { navFactory, Kebab } from '@console/internal/components/utils';
 import ClusterTaskDetails from './ClusterTaskDetails';
 import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 const ClusterTaskDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
   const breadcrumbsFor = useTasksBreadcrumbsFor(kindObj, match);
+  const badge = usePipelineTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       menuActions={Kebab.factory.common}
       breadcrumbsFor={() => breadcrumbsFor}
       pages={[navFactory.details(ClusterTaskDetails), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/cluster-tasks/ClusterTaskListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/cluster-tasks/ClusterTaskListPage.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { DefaultList } from '@console/internal/components/default-resource';
+import { ListPage } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
+import { ClusterTaskModel } from '../../models';
+
+interface ClusterTaskListPageProps {
+  hideBadge?: boolean;
+  canCreate?: boolean;
+}
+
+const ClusterTaskListPage: React.FC<Omit<
+  React.ComponentProps<typeof ListPage>,
+  'canCreate' | 'kind' | 'ListComponent'
+> &
+  ClusterTaskListPageProps> = ({ hideBadge, ...props }) => {
+  const badge = usePipelineTechPreviewBadge(props.namespace);
+  return (
+    <ListPage
+      {...props}
+      canCreate={props.canCreate ?? true}
+      kind={referenceForModel(ClusterTaskModel)}
+      ListComponent={DefaultList}
+      badge={hideBadge ? null : badge}
+    />
+  );
+};
+export default ClusterTaskListPage;

--- a/frontend/packages/pipelines-plugin/src/components/conditions/ConditionListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/conditions/ConditionListPage.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { DefaultList } from '@console/internal/components/default-resource';
+import { ListPage } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
+import { ConditionModel } from '../../models';
+
+interface ConditionListPageProps {
+  hideBadge?: boolean;
+  canCreate?: boolean;
+}
+
+const ConditionListPage: React.FC<Omit<
+  React.ComponentProps<typeof ListPage>,
+  'canCreate' | 'kind' | 'ListComponent'
+> &
+  ConditionListPageProps> = ({ hideBadge, ...props }) => {
+  const badge = usePipelineTechPreviewBadge(props.namespace);
+  return (
+    <ListPage
+      {...props}
+      canCreate={props.canCreate ?? true}
+      kind={referenceForModel(ConditionModel)}
+      ListComponent={DefaultList}
+      badge={hideBadge ? null : badge}
+    />
+  );
+};
+export default ConditionListPage;

--- a/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/import/pipeline/PipelineSection.tsx
@@ -10,6 +10,7 @@ import { NormalizedBuilderImages } from '@console/dev-console/src/utils/imagestr
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import { FLAG_OPENSHIFT_PIPELINE, CLUSTER_PIPELINE_NS } from '../../../const';
 import { PipelineModel, PipelineResourceModel } from '../../../models';
+import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 import { PipelineKind } from '../../../types';
 import PipelineTemplate from './PipelineTemplate';
 
@@ -55,16 +56,18 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
   const { values } = useFormikContext<FormikValues>();
 
   const hasCreatePipelineAccess = usePipelineAccessReview();
-
+  const badge = usePipelineTechPreviewBadge(values.project.name);
   if (flags[FLAG_OPENSHIFT_PIPELINE] && hasCreatePipelineAccess) {
     const title = (
       <Split className="odc-form-section-pipeline" hasGutter>
         <SplitItem className="odc-form-section__heading">
           {t('pipelines-plugin~Pipelines')}
         </SplitItem>
-        <SplitItem>
-          <TechPreviewBadge />
-        </SplitItem>
+        {badge && (
+          <SplitItem>
+            <TechPreviewBadge />
+          </SplitItem>
+        )}
       </Split>
     );
     return (

--- a/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesListPage.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { getBadgeFromType } from '@console/shared';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import PipelineResourcesList from './PipelineResourcesList';
@@ -8,6 +7,7 @@ import {
   pipelineResourceFilterReducer,
   pipelineResourceTypeFilter,
 } from '../../../utils/pipeline-filter-reducer';
+import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 import {
   PipelineResourceListFilterId,
   PipelineResourceListFilterLabels,
@@ -57,6 +57,7 @@ const PipelineResourcesListPage: React.FC<Omit<
   'canCreate' | 'kind' | 'ListComponent' | 'rowFilters'
 > &
   PipelineResourcesListPageProps> = (props) => {
+  const badge = usePipelineTechPreviewBadge(props.namespace);
   return (
     <ListPage
       {...props}
@@ -64,7 +65,7 @@ const PipelineResourcesListPage: React.FC<Omit<
       kind={referenceForModel(PipelineResourceModel)}
       ListComponent={PipelineResourcesList}
       rowFilters={pipelineResourceFilters}
-      badge={props.hideBadge ? null : getBadgeFromType(PipelineResourceModel.badge)}
+      badge={props.hideBadge ? null : badge}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -10,6 +10,7 @@ import { useMenuActionsWithUserAnnotation } from './triggered-by';
 import { usePipelinesBreadcrumbsFor } from '../pipelines/hooks';
 import TaskRuns from './detail-page-tabs/TaskRuns';
 import PipelineRunEvents from './events/PipelineRunEvents';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { t } = useTranslation();
@@ -18,10 +19,12 @@ const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
     getPipelineRunKebabActions(true),
   );
   const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
+  const badge = usePipelineTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       menuActions={menuActions}
       getResourceStatus={pipelineRunStatus}
       breadcrumbsFor={() => breadcrumbsFor}

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsPage.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { Button } from '@patternfly/react-core';
-import { getBadgeFromType } from '@console/shared';
 import CreateProjectListPage from '@console/dev-console/src/components/projects/CreateProjectListPage';
 import { PipelineRunModel } from '../../models';
 import PipelineRunsResourceList from './PipelineRunsResourceList';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 type PipelineRunsPageProps = RouteComponentProps<{ ns: string }>;
 
@@ -16,13 +16,14 @@ const PipelineRunsPage: React.FC<PipelineRunsPageProps> = (props) => {
       params: { ns: namespace },
     },
   } = props;
-  const { labelPlural: pipelineRunLabel, badge } = PipelineRunModel;
+  const badge = usePipelineTechPreviewBadge(namespace);
+  const { labelPlural: pipelineRunLabel } = PipelineRunModel;
   return namespace ? (
     <div>
       <PipelineRunsResourceList {...props} namespace={namespace} />
     </div>
   ) : (
-    <CreateProjectListPage title={pipelineRunLabel} badge={getBadgeFromType(badge)}>
+    <CreateProjectListPage title={pipelineRunLabel} badge={badge}>
       {(openProjectModal) => (
         <Trans t={t} ns="pipelines-plugin" values={{ pipelineRunLabel }}>
           Select a Project to view the list of

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/PipelineRunsResourceList.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { getBadgeFromType } from '@console/shared';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
 import { runFilters } from '../pipelines/detail-page-tabs/PipelineRuns';
 import PipelineRunsList from './list-page/PipelineRunList';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 interface PipelineRunsResourceListProps {
   hideBadge?: boolean;
@@ -16,6 +16,7 @@ const PipelineRunsResourceList: React.FC<Omit<
   'kind' | 'ListComponent' | 'rowFilters'
 > &
   PipelineRunsResourceListProps> = (props) => {
+  const badge = usePipelineTechPreviewBadge(props.namespace);
   return (
     <ListPage
       {...props}
@@ -23,7 +24,7 @@ const PipelineRunsResourceList: React.FC<Omit<
       kind={referenceForModel(PipelineRunModel)}
       ListComponent={PipelineRunsList}
       rowFilters={runFilters}
-      badge={props.hideBadge ? null : getBadgeFromType(PipelineRunModel.badge)}
+      badge={props.hideBadge ? null : badge}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/__tests__/PipelineRunsResourceList.spec.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Button } from '@patternfly/react-core';
 import { ListPage } from '@console/internal/components/factory';
+import * as operatorUtils from '../../pipelines/utils/pipeline-operator';
 import PipelineRunsResourceList from '../PipelineRunsResourceList';
+import { PIPELINE_GA_VERSION } from '../../pipelines/const';
 
 type PipelineRunsResourceListProps = React.ComponentProps<typeof PipelineRunsResourceList>;
 
@@ -16,6 +18,7 @@ describe('PipelineRunsResourceList:', () => {
       canCreate: false,
     };
     wrapper = shallow(<PipelineRunsResourceList {...pipelineRunsResourceListProps} />);
+    jest.spyOn(operatorUtils, 'usePipelineOperatorVersion').mockReturnValue({ version: '1.3.1' });
   });
 
   it('Should render the badge in the list page', () => {
@@ -25,6 +28,14 @@ describe('PipelineRunsResourceList:', () => {
 
   it('Should not render the badge in the list page', () => {
     wrapper.setProps({ hideBadge: true });
+    expect(wrapper.find(ListPage).props().badge).toBeNull();
+  });
+
+  it('Should not render the badge in the list page if the pipeline GA operator is installed', () => {
+    jest
+      .spyOn(operatorUtils, 'usePipelineOperatorVersion')
+      .mockReturnValue({ version: PIPELINE_GA_VERSION });
+    wrapper.setProps({ hideBadge: false });
     expect(wrapper.find(ListPage).props().badge).toBeNull();
   });
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines-lists/PipelinesListsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines-lists/PipelinesListsPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { match as Rmatch } from 'react-router-dom';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { Page } from '@console/internal/components/utils';
-import { TechPreviewBadge, MenuAction, MenuActions, MultiTabListPage } from '@console/shared';
+import { MenuAction, MenuActions, MultiTabListPage } from '@console/shared';
 import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
@@ -17,6 +17,7 @@ import PipelineRunsResourceList from '../pipelineruns/PipelineRunsResourceList';
 import { DefaultPage } from '@console/internal/components/default-resource';
 import PipelineResourcesListPage from '../pipeline-resources/list-page/PipelineResourcesListPage';
 import PipelinesList from '../pipelines/list-page/PipelinesList';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 interface PipelinesListPageProps {
   match: Rmatch<any>;
@@ -27,6 +28,7 @@ const PipelinesListPage: React.FC<PipelinesListPageProps> = ({ match }) => {
   const {
     params: { ns: namespace },
   } = match;
+  const badge = usePipelineTechPreviewBadge(namespace);
   const [showTitle, hideBadge, canCreate] = [false, true, false];
   const menuActions: MenuActions = {
     pipeline: {
@@ -78,7 +80,7 @@ const PipelinesListPage: React.FC<PipelinesListPageProps> = ({ match }) => {
         pages={pages}
         match={match}
         title={t('pipelines-plugin~Pipelines')}
-        badge={<TechPreviewBadge />}
+        badge={badge}
         menuActions={menuActions}
       />
     </NamespacedPage>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelineDetailsPage.tsx
@@ -23,6 +23,7 @@ import { isGAVersionInstalled, usePipelineOperatorVersion } from './utils/pipeli
 import { MetricsQueryPrefix } from './pipeline-metrics/pipeline-metrics-utils';
 import { usePipelinesBreadcrumbsFor, useLatestPipelineRun } from './hooks';
 import { PipelineDetailsTabProps } from './detail-page-tabs/types';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { t } = useTranslation();
@@ -32,6 +33,7 @@ const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const [, pipelineLoaded, pipelineError] = useK8sGet<PipelineKind>(PipelineModel, name, namespace);
   const latestPipelineRun = useLatestPipelineRun(name, namespace);
   const pipelineOperator = usePipelineOperatorVersion(namespace);
+  const badge = usePipelineTechPreviewBadge(namespace);
   const queryPrefix =
     pipelineOperator && !isGAVersionInstalled(pipelineOperator)
       ? MetricsQueryPrefix.TEKTON
@@ -46,6 +48,7 @@ const PipelineDetailsPage: React.FC<DetailsPageProps> = (props) => {
   return pipelineLoaded ? (
     <DetailsPage
       {...props}
+      badge={badge}
       menuActions={augmentedMenuActions}
       customData={{ templateNames, queryPrefix }}
       breadcrumbsFor={() => breadcrumbsFor}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesPage.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { Button } from '@patternfly/react-core';
-import { getBadgeFromType } from '@console/shared';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import CreateProjectListPage from '@console/dev-console/src/components/projects/CreateProjectListPage';
-import { PipelineModel } from '../../models';
 import PipelinesResourceList from './PipelinesResourceList';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 type PipelinesPageProps = RouteComponentProps<{ ns: string }>;
 
@@ -17,20 +16,19 @@ export const PipelinesPage: React.FC<PipelinesPageProps> = (props) => {
       params: { ns: namespace },
     },
   } = props;
+  const badge = usePipelineTechPreviewBadge(namespace);
+
   return namespace ? (
     <div>
       <PipelinesResourceList
         {...props}
-        badge={getBadgeFromType(PipelineModel.badge)}
+        badge={badge}
         namespace={namespace}
         title={t('pipelines-plugin~Pipelines')}
       />
     </div>
   ) : (
-    <CreateProjectListPage
-      title={t('pipelines-plugin~Pipelines')}
-      badge={getBadgeFromType(PipelineModel.badge)}
-    >
+    <CreateProjectListPage title={t('pipelines-plugin~Pipelines')} badge={badge}>
       {(openProjectModal) => (
         <Trans t={t} ns="pipelines-plugin">
           Select a Project to view the list of Pipelines or{' '}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { getBadgeFromType } from '@console/shared';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { Firehose } from '@console/internal/components/utils';
 import { FireMan_ as FireMan } from '@console/internal/components/factory';
 import { PipelineModel } from '../../models';
 import PipelineAugmentRunsWrapper from './list-page/PipelineAugmentRunsWrapper';
 import { filters } from './list-page/PipelineAugmentRuns';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 interface PipelinesResourceListProps extends React.ComponentProps<typeof FireMan> {
   namespace: string;
@@ -15,7 +15,7 @@ interface PipelinesResourceListProps extends React.ComponentProps<typeof FireMan
 const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
   const { t } = useTranslation();
   const { namespace, showTitle = true, selector, name, nameFilter } = props;
-
+  const badge = usePipelineTechPreviewBadge(namespace);
   const resources = [
     {
       isList: true,
@@ -43,7 +43,7 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       textFilter="name"
       resources={resources}
       title={showTitle ? t('pipelines-plugin~Pipelines') : null}
-      badge={getBadgeFromType(PipelineModel.badge)}
+      badge={badge}
     >
       <Firehose resources={resources}>
         <PipelineAugmentRunsWrapper hideNameLabelFilters={props.hideNameLabelFilters} />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineConditionDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineConditionDetailsPage.tsx
@@ -3,14 +3,17 @@ import { DetailsPageProps, DetailsPage } from '@console/internal/components/fact
 import { navFactory, Kebab } from '@console/internal/components/utils';
 import { DetailsForKind } from '@console/internal/components/default-resource';
 import { usePipelinesBreadcrumbsFor } from '../hooks';
+import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 
 const PipelineConditionDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match, kind } = props;
   const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
+  const badge = usePipelineTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       menuActions={Kebab.factory.common}
       breadcrumbsFor={() => breadcrumbsFor}
       pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineResourceDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineResourceDetailsPage.tsx
@@ -3,14 +3,17 @@ import { DetailsPageProps, DetailsPage } from '@console/internal/components/fact
 import { navFactory, Kebab } from '@console/internal/components/utils';
 import { DetailsForKind } from '@console/internal/components/default-resource';
 import { usePipelinesBreadcrumbsFor } from '../hooks';
+import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 
 const PipelineResourceDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match, kind } = props;
   const breadcrumbsFor = usePipelinesBreadcrumbsFor(kindObj, match);
+  const badge = usePipelineTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       menuActions={Kebab.factory.common}
       breadcrumbsFor={() => breadcrumbsFor}
       pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -146,7 +146,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
       <div ref={contentRef} className="odc-pipeline-builder-form">
         <Stack>
           <StackItem>
-            <PipelineBuilderHeader />
+            <PipelineBuilderHeader namespace={namespace} />
           </StackItem>
           <FlexForm onSubmit={handleSubmit}>
             <FormBody flexLayout disablePaneBody className="odc-pipeline-builder-form__grid">

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
@@ -4,9 +4,12 @@ import { TechPreviewBadge } from '@console/shared';
 
 import './PipelineBuilderHeader.scss';
 import { useTranslation } from 'react-i18next';
+import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 
-const PipelineBuilderHeader: React.FC = () => {
+const PipelineBuilderHeader: React.FC<{ namespace: string }> = ({ namespace }) => {
   const { t } = useTranslation();
+  const badge = usePipelineTechPreviewBadge(namespace);
+
   return (
     <div className="odc-pipeline-builder-header">
       <Flex className="odc-pipeline-builder-header__content">
@@ -15,9 +18,11 @@ const PipelineBuilderHeader: React.FC = () => {
             {t('pipelines-plugin~Pipeline builder')}
           </h1>
         </FlexItem>
-        <FlexItem>
-          <TechPreviewBadge />
-        </FlexItem>
+        {badge && (
+          <FlexItem>
+            <TechPreviewBadge />
+          </FlexItem>
+        )}
       </Flex>
     </div>
   );

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsPage.tsx
@@ -6,15 +6,18 @@ import TaskRunDetails from './TaskRunDetails';
 import TaskRunEvents from './events/TaskRunEvents';
 import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
 import TaskRunLog from './TaskRunLog';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 const TaskRunDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { t } = useTranslation();
   const { kindObj, match } = props;
   const breadcrumbsFor = useTasksBreadcrumbsFor(kindObj, match);
+  const badge = usePipelineTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       breadcrumbsFor={() => breadcrumbsFor}
       pages={[
         navFactory.details(TaskRunDetails),

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsListPage.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { getBadgeFromType } from '@console/shared';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { getURLSearchParams } from '@console/internal/components/utils';
 import TaskRunsList from './TaskRunsList';
 import { TaskRunModel } from '../../../models';
 import { runFilters as taskRunFilters } from '../../pipelines/detail-page-tabs/PipelineRuns';
+import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 
 interface TaskRunsListPageProps {
   hideBadge?: boolean;
@@ -19,7 +19,7 @@ const TaskRunsListPage: React.FC<Omit<
   TaskRunsListPageProps> = ({ hideBadge, showPipelineColumn = true, ...props }) => {
   const searchParams = getURLSearchParams();
   const kind = searchParams?.kind;
-
+  const badge = usePipelineTechPreviewBadge(props.namespace);
   return (
     <ListPage
       {...props}
@@ -28,7 +28,7 @@ const TaskRunsListPage: React.FC<Omit<
       kind={referenceForModel(TaskRunModel)}
       ListComponent={TaskRunsList}
       rowFilters={taskRunFilters}
-      badge={hideBadge ? null : getBadgeFromType(TaskRunModel.badge)}
+      badge={hideBadge ? null : badge}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/tasks/TaskDetailsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/tasks/TaskDetailsPage.tsx
@@ -3,14 +3,17 @@ import { DetailsPageProps, DetailsPage } from '@console/internal/components/fact
 import { navFactory, Kebab } from '@console/internal/components/utils';
 import { useTasksBreadcrumbsFor } from '../pipelines/hooks';
 import TaskDetails from './TaskDetails';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
 
 const TaskDetailsPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
   const breadcrumbsFor = useTasksBreadcrumbsFor(kindObj, match);
+  const badge = usePipelineTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       menuActions={Kebab.factory.common}
       breadcrumbsFor={() => breadcrumbsFor}
       pages={[navFactory.details(TaskDetails), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/tasks/TaskListPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/tasks/TaskListPage.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { DefaultList } from '@console/internal/components/default-resource';
+import { ListPage } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { usePipelineTechPreviewBadge } from '../../utils/hooks';
+import { TaskModel } from '../../models';
+
+interface TaskListPageProps {
+  hideBadge?: boolean;
+  canCreate?: boolean;
+}
+
+const TaskListPage: React.FC<Omit<
+  React.ComponentProps<typeof ListPage>,
+  'canCreate' | 'kind' | 'ListComponent'
+> &
+  TaskListPageProps> = ({ hideBadge, ...props }) => {
+  const badge = usePipelineTechPreviewBadge(props.namespace);
+  return (
+    <ListPage
+      {...props}
+      canCreate={props.canCreate ?? true}
+      kind={referenceForModel(TaskModel)}
+      ListComponent={DefaultList}
+      badge={hideBadge ? null : badge}
+    />
+  );
+};
+export default TaskListPage;

--- a/frontend/packages/pipelines-plugin/src/components/tasks/list-page/TasksListsPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/tasks/list-page/TasksListsPage.tsx
@@ -4,12 +4,13 @@ import { match as Rmatch } from 'react-router-dom';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskModel, ClusterTaskModel, TaskRunModel } from '../../../models';
 import { Page } from '@console/internal/components/utils';
-import { TechPreviewBadge, MenuActions, MultiTabListPage } from '@console/shared';
+import { MenuActions, MultiTabListPage } from '@console/shared';
 import { DefaultPage } from '@console/internal/components/default-resource';
 import TaskRunsListPage from '../../taskruns/list-page/TaskRunsListPage';
 import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
+import { usePipelineTechPreviewBadge } from '../../../utils/hooks';
 
 interface TasksListsPageProps {
   match: Rmatch<any>;
@@ -20,6 +21,7 @@ const TasksListsPage: React.FC<TasksListsPageProps> = ({ match }) => {
   const {
     params: { ns: namespace },
   } = match;
+  const badge = usePipelineTechPreviewBadge(namespace);
   const [showTitle, canCreate, hideBadge] = [false, false, true];
   const menuActions: MenuActions = {
     tasks: { label: t('pipelines-plugin~Task'), model: TaskModel },
@@ -65,7 +67,7 @@ const TasksListsPage: React.FC<TasksListsPageProps> = ({ match }) => {
         pages={pages}
         match={match}
         title={t('pipelines-plugin~Tasks')}
-        badge={<TechPreviewBadge />}
+        badge={badge}
         menuActions={menuActions}
       />
     </NamespacedPage>

--- a/frontend/packages/pipelines-plugin/src/models/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/src/models/pipelines.ts
@@ -17,7 +17,6 @@ export const PipelineModel: K8sKind = {
   id: 'pipeline',
   labelPlural: 'Pipelines',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -34,7 +33,6 @@ export const PipelineRunModel: K8sKind = {
   id: 'pipelinerun',
   labelPlural: 'Pipeline Runs',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -51,7 +49,6 @@ export const TaskModel: K8sKind = {
   id: 'task',
   labelPlural: 'Tasks',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -68,7 +65,6 @@ export const TaskRunModel: K8sKind = {
   id: 'taskrun',
   labelPlural: 'Task Runs',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -85,7 +81,6 @@ export const PipelineResourceModel: K8sKind = {
   id: 'pipelineresource',
   labelPlural: 'Pipeline Resources',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -102,7 +97,6 @@ export const ClusterTaskModel: K8sKind = {
   id: 'clustertask',
   labelPlural: 'Cluster Tasks',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -119,7 +113,6 @@ export const ConditionModel: K8sKind = {
   id: 'condition',
   labelPlural: 'Conditions',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 

--- a/frontend/packages/pipelines-plugin/src/plugin.tsx
+++ b/frontend/packages/pipelines-plugin/src/plugin.tsx
@@ -319,6 +319,42 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Resource/List',
+    properties: {
+      model: ConditionModel,
+      loader: async () =>
+        (
+          await import(
+            './components/conditions/ConditionListPage' /* webpackChunkName: "condition-list" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/List',
+    properties: {
+      model: TaskModel,
+      loader: async () =>
+        (
+          await import(
+            './components/tasks/TaskListPage' /* webpackChunkName: "task-resource-list" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/List',
+    properties: {
+      model: ClusterTaskModel,
+      loader: async () =>
+        (
+          await import(
+            './components/cluster-tasks/ClusterTaskListPage' /* webpackChunkName: "clustertask-resource-list" */
+          )
+        ).default,
+    },
+  },
+  {
     type: 'Page/Route',
     properties: {
       exact: true,

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/hooks.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/hooks.spec.ts
@@ -1,0 +1,24 @@
+import { PIPELINE_GA_VERSION } from '../../components/pipelines/const';
+import { testHook } from '../../test-data/test-utils';
+import { usePipelineTechPreviewBadge } from '../hooks';
+import * as operatorUtils from '../../components/pipelines/utils/pipeline-operator';
+
+describe('usePipelineTechPreviewBadge:', () => {
+  it('should return the badge if pipeline GA opertaor is installed', () => {
+    jest.spyOn(operatorUtils, 'usePipelineOperatorVersion').mockReturnValue({ version: '1.3.1' });
+    testHook(() => {
+      const badge = usePipelineTechPreviewBadge('test-ns');
+      expect(badge).toBeDefined();
+    });
+  });
+
+  it('should return not return badge if pipelien GA opertaor is installed', () => {
+    jest
+      .spyOn(operatorUtils, 'usePipelineOperatorVersion')
+      .mockReturnValue({ version: PIPELINE_GA_VERSION });
+    testHook(() => {
+      const badge = usePipelineTechPreviewBadge('test-ns');
+      expect(badge).toBeNull();
+    });
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/utils/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/hooks.ts
@@ -1,0 +1,12 @@
+import { BadgeType, getBadgeFromType } from '@console/shared';
+import {
+  isGAVersionInstalled,
+  usePipelineOperatorVersion,
+} from '../components/pipelines/utils/pipeline-operator';
+
+export const usePipelineTechPreviewBadge = (namespace: string) => {
+  const operator = usePipelineOperatorVersion(namespace);
+  if (!operator) return null;
+  const installedGA = isGAVersionInstalled(operator);
+  return installedGA ? null : getBadgeFromType(BadgeType.TECH);
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5625
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Tech preview badge needs to be removed for pipelines >1.4.x  operator.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Conditionally render the Tech preview badge based on the installed operator.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

1.4.0 OSP Installed:
Pipelines page:
![image](https://user-images.githubusercontent.com/9964343/113121830-aa689c00-9230-11eb-83a8-627f3b6ec1d8.png)
PipelineRuns Page:
![image](https://user-images.githubusercontent.com/9964343/113121868-b5233100-9230-11eb-879e-642d74c42535.png)
pipeline builder page
![image](https://user-images.githubusercontent.com/9964343/113122001-d6841d00-9230-11eb-8b67-c65f128c3351.png)

Note: Tech preview badge will be shown in all pipeline component pages if the version installed is prior to GA version.

**Unit test coverage report**: 
<!-- Attach test coverage report -->
  usePipelineTechPreviewBadge:
    ✓ should return not return badge if pipelien GA opertaor is installed (31ms)
    ✓ should return the badge if pipelien GA opertaor is installed (3ms)
    
 PipelineRunsResourceList:
 
   ✓ Should not render the badge in the list page if the pipeline GA operator is installed (3ms)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Install OSP 1.4

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
cc: @andrewballantyne