### PR TITLE
provide code snippet to customize roles in project access

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -135,6 +135,8 @@
   "Namespace dashboard links appear on the project dashboard and namespace details pages in a section called \"Launcher\". Namespace dashboard links can optionally be restricted to a specific namespace or namespaces.": "Namespace dashboard links appear on the project dashboard and namespace details pages in a section called \"Launcher\". Namespace dashboard links can optionally be restricted to a specific namespace or namespaces.",
   "Add catalog categories": "Add catalog categories",
   "Provides a list of default categories which are shown in the Developer Catalog. The categories must be added below customization developerCatalog.": "Provides a list of default categories which are shown in the Developer Catalog. The categories must be added below customization developerCatalog.",
+  "Add project access roles": "Add project access roles",
+  "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.": "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.",
   "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.": "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.",
   "Cannot be longer than {{characterCount}} characters.": "Cannot be longer than {{characterCount}} characters.",
   "Required": "Required"

--- a/frontend/packages/console-shared/src/utils/sample-utils.ts
+++ b/frontend/packages/console-shared/src/utils/sample-utils.ts
@@ -30,6 +30,7 @@ import * as webAllowExternalImg from '@console/internal/imgs/network-policy-samp
 import * as webDbAllowAllNsImg from '@console/internal/imgs/network-policy-samples/6-web-db-allow-all-ns.svg';
 import * as webAllowProductionImg from '@console/internal/imgs/network-policy-samples/7-web-allow-production.svg';
 import { FirehoseResult } from '@console/internal/components/utils';
+import { defaultProjectAccessRoles } from '@console/dev-console/src/components/project-access/project-access-form-utils';
 
 export type Sample = {
   highlightText?: string;
@@ -290,6 +291,16 @@ const defaultSamples = (t: TFunction) =>
           id: 'devcatalog-categories',
           snippet: true,
           lazyYaml: () => YAML.dump(defaultCatalogCategories),
+          targetResource: getTargetResource(ConsoleOperatorConfigModel),
+        },
+        {
+          title: t('console-shared~Add project access roles'),
+          description: t(
+            'console-shared~Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.',
+          ),
+          id: 'projectaccess-roles',
+          snippet: true,
+          lazyYaml: () => YAML.dump(defaultProjectAccessRoles),
           targetResource: getTargetResource(ConsoleOperatorConfigModel),
         },
       ],

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
@@ -12,6 +12,10 @@ export enum Roles {
   edit = 'edit',
 }
 
+export type ProjectAccessRoles = {
+  availableClusterRoles: string[];
+};
+
 export interface UserRoleBinding {
   roleBindingName?: string;
   user: string;

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-utils.ts
@@ -1,5 +1,9 @@
 import * as _ from 'lodash';
-import { UserRoleBinding, RoleBinding } from './project-access-form-utils-types';
+import {
+  UserRoleBinding,
+  RoleBinding,
+  ProjectAccessRoles,
+} from './project-access-form-utils-types';
 
 export const filterRoleBindings = (roleBindings: RoleBinding[], roles): RoleBinding[] => {
   return _.filter(roleBindings, (user: RoleBinding) => _.keys(roles).includes(user.roleRef.name));
@@ -14,3 +18,7 @@ export const getUsersFromSubject = (user: RoleBinding): UserRoleBinding[] =>
 
 export const getUserRoleBindings = (roleBindings: RoleBinding[]): UserRoleBinding[] =>
   _.flatten(roleBindings.map((user) => getUsersFromSubject(user)));
+
+export const defaultProjectAccessRoles: ProjectAccessRoles = {
+  availableClusterRoles: ['admin', 'edit', 'view'],
+};


### PR DESCRIPTION
**Story:**
https://issues.redhat.com/browse/ODC-5449

**Root analysis:**
To support the admin to configure the roles correctly, the developer console should provide a code snippet for the customization YAML resource (Console CRD).

**Solution description:**
Added snippet in the Console resources which provides a default list of Roles. 

**Screenshot:**
![Screenshot from 2021-03-31 19-56-06](https://user-images.githubusercontent.com/22490998/113160514-31326e80-925b-11eb-9217-fb1a4ffabbd0.png)

**Test setup:**
1. CRD URL example: http://localhost:9000/k8s/cluster/customresourcedefinitions/consoles.operator.openshift.io
Search for customProductName, add this yaml between customProductName and documentationBaseURL.
Add :
```
                  projectAccess:
                    description: projectAccess allows customizing the available list
                      of ClusterRoles in the Developer Console Project access page
                      which can be used by a project admin to specify roles to other
                      users and restrict access within the project.
                    type: object
                    properties:
                      availableClusterRoles:
                        description: availableClusterRoles are the list of ClusterRoles
                          that are assignable to users through the project access
                          tab.
                        type: array
                        items:
                          type: string
```

2. Open the cluster resource of the YAML and open the sidebar.
Cluster config example: http://localhost:9000/k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml

3. Insert the default project access roles snippet and save the resource.

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
