### PR TITLE
Embedded Tasks in Pipeline Builder

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -158,7 +158,6 @@
   "Add workspace": "Add workspace",
   "Error loading the tasks.": "Error loading the tasks.",
   "Unable to locate any tasks.": "Unable to locate any tasks.",
-  "This Pipeline cannot be visualized. Pipeline taskSpec is not supported.": "This Pipeline cannot be visualized. Pipeline taskSpec is not supported.",
   "Input resources": "Input resources",
   "Output resources": "Output resources",
   "Display Name": "Display Name",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -12,7 +12,7 @@ import {
   truncateMiddle,
 } from '@console/internal/components/utils';
 import { SvgDropShadowFilter } from '@console/topology/src/components/svg';
-import { PipelineTaskSpec, PipelineTaskRef, TaskKind } from '../../../../types';
+import { TektonTaskSpec, PipelineTaskRef, TaskKind } from '../../../../types';
 import { runStatus, getRunStatusColor } from '../../../../utils/pipeline-augment';
 import { PipelineRunModel, TaskModel, ClusterTaskModel } from '../../../../models';
 import { StatusIcon } from './StatusIcon';
@@ -43,7 +43,7 @@ interface PipelineVisualizationTaskProp {
   namespace: string;
   task: {
     name?: string;
-    taskSpec?: PipelineTaskSpec;
+    taskSpec?: TektonTaskSpec;
     taskRef?: PipelineTaskRef;
     status?: TaskStatus;
   };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -12,8 +12,7 @@ import {
 } from '@console/shared';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { safeJSToYAML } from '@console/shared/src/utils/yaml';
-import { PipelineKind, TaskKind } from '../../../types';
-import { PipelineVisualizationTaskItem } from '../../../utils/pipeline-utils';
+import { PipelineKind, PipelineTask, TaskKind } from '../../../types';
 import { PipelineModel } from '../../../models';
 import { useFormikFetchAndSaveTasks } from './hooks';
 import { removeTaskModal } from './modals';
@@ -65,11 +64,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
   const statusRef = React.useRef(status);
   statusRef.current = status;
 
-  const onTaskSelection = (
-    task: PipelineVisualizationTaskItem,
-    resource: TaskKind,
-    isFinallyTask: boolean,
-  ) => {
+  const onTaskSelection = (task: PipelineTask, resource: TaskKind, isFinallyTask: boolean) => {
     const builderNodes = isFinallyTask ? formData.finallyTasks : formData.tasks;
     setSelectedTask({
       isFinallyTask,

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { useFormikContext } from 'formik';
 import { Alert } from '@patternfly/react-core';
 import { LoadingBox } from '@console/internal/components/utils';
-import { hasInlineTaskSpec } from '../../../utils/pipeline-utils';
 import { PipelineLayout } from '../pipeline-topology/const';
 import PipelineTopologyGraph from '../pipeline-topology/PipelineTopologyGraph';
 import { getEdgesFromNodes } from '../pipeline-topology/utils';
@@ -55,18 +54,6 @@ const PipelineBuilderVisualization: React.FC<PipelineBuilderVisualizationProps> 
     // No tasks, nothing we can do here...
     return (
       <Alert variant="danger" isInline title={t('pipelines-plugin~Unable to locate any tasks.')} />
-    );
-  }
-
-  if (hasInlineTaskSpec(taskGroup.tasks)) {
-    return (
-      <Alert
-        variant="info"
-        isInline
-        title={t(
-          'pipelines-plugin~This Pipeline cannot be visualized. Pipeline taskSpec is not supported.',
-        )}
-      />
     );
   }
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
@@ -64,7 +64,10 @@ describe('findTaskFromFormikData / findTask', () => {
   it('should decompose formik state & handle nulls', () => {
     const formValues = createFormValues();
     expect(findTaskFromFormikData(formValues, null)).toBe(null);
-    expect(findTaskFromFormikData(formValues, { name: 'unavailable-task' })).toBe(null);
+    expect(findTaskFromFormikData(formValues, { name: 'test' })).toBe(null);
+    expect(findTaskFromFormikData(formValues, { name: 'test', taskRef: { name: 'test' } })).toBe(
+      null,
+    );
   });
 
   it('should handle fail states', () => {
@@ -75,17 +78,20 @@ describe('findTaskFromFormikData / findTask', () => {
     expect(
       findTask(
         { tasksLoaded: true, clusterTasks: [externalTask], namespacedTasks: [] },
-        { name: 'unavailable-task' },
+        { name: 'test', taskRef: { name: 'unavailable-task' } },
       ),
-    ).toBe(null);
+    ).toBe(undefined);
   });
 
   it('should be able to find a clusterTask', () => {
     const formValues = createFormValues([externalTask]);
     expect(
       findTask(formValues.taskResources, {
-        name: externalTask.metadata.name,
-        kind: externalTask.kind,
+        name: 'test',
+        taskRef: {
+          name: externalTask.metadata.name,
+          kind: externalTask.kind,
+        },
       }),
     ).toBe(externalTask);
   });
@@ -95,8 +101,11 @@ describe('findTaskFromFormikData / findTask', () => {
     const formValues = createFormValues([], [namespacedTask]);
     expect(
       findTask(formValues.taskResources, {
-        name: namespacedTask.metadata.name,
-        kind: namespacedTask.kind,
+        name: 'test',
+        taskRef: {
+          name: namespacedTask.metadata.name,
+          kind: namespacedTask.kind,
+        },
       }),
     ).toBe(namespacedTask);
   });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/validation-utils-data.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/validation-utils-data.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash';
 import { getRandomChars } from '@console/shared';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
-import { PipelineTask, PipelineTaskSpec, TaskKind, TektonTaskSteps } from '../../../../types';
+import { PipelineTask, TektonTaskSpec, TaskKind, TektonTaskSteps } from '../../../../types';
 import { initialPipelineFormData } from '../const';
 import { validationSchema } from '../validation-utils';
 
@@ -20,7 +20,7 @@ const taskSpecTemplate: TektonTaskSteps[] = [
     args: ['$(params.some-value-that-does-not-break-tests)'],
   },
 ];
-const embeddedTaskTemplate: PipelineTaskSpec = {
+const embeddedTaskTemplate: TektonTaskSpec = {
   steps: taskSpecTemplate,
 };
 const externalTaskTemplate: TaskKind = {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/hooks.ts
@@ -5,8 +5,7 @@ import { useFormikContext } from 'formik';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { ClusterTaskModel, TaskModel } from '../../../models';
-import { TaskKind } from '../../../types';
-import { PipelineVisualizationTaskItem } from '../../../utils/pipeline-utils';
+import { PipelineTask, TaskKind } from '../../../types';
 import { AddNodeDirection } from '../pipeline-topology/const';
 import {
   PipelineBuilderTaskNodeModel,
@@ -127,7 +126,7 @@ const useConnectFinally = (
       addNewFinallyListNode,
       finallyTasks: taskGroup.finallyTasks.map((ft, idx) => ({
         ...ft,
-        onTaskSelection: () => onTaskSelection(ft, findTask(taskResources, ft.taskRef), true),
+        onTaskSelection: () => onTaskSelection(ft, findTask(taskResources, ft), true),
         error: getTopLevelErrorMessage(tasksInError)(idx),
         selected: taskGroup.highlightedIds.includes(ft.name),
         disableTooltip: true,
@@ -158,7 +157,7 @@ export const useNodes = (
   const taskGroupRef = React.useRef(taskGroup);
   taskGroupRef.current = taskGroup;
 
-  const onNewListNode = (task: PipelineVisualizationTaskItem, direction: AddNodeDirection) => {
+  const onNewListNode = (task: PipelineTask, direction: AddNodeDirection) => {
     const data: UpdateOperationAddData = { direction, relatedTask: task };
     onUpdateTasks(taskGroupRef.current, { type: UpdateOperationType.ADD_LIST_TASK, data });
   };
@@ -220,8 +219,8 @@ export const useNodes = (
       },
     });
 
-  const invalidTaskList = taskGroup.tasks.filter((task) => !findTask(taskResources, task.taskRef));
-  const validTaskList = taskGroup.tasks.filter((task) => !!findTask(taskResources, task.taskRef));
+  const invalidTaskList = taskGroup.tasks.filter((task) => !findTask(taskResources, task));
+  const validTaskList = taskGroup.tasks.filter((task) => !!findTask(taskResources, task));
 
   const invalidTaskListNodes: PipelineTaskListNodeModel[] = invalidTaskList.map((task) =>
     newInvalidListNode(task.name, task.runAfter),
@@ -231,7 +230,7 @@ export const useNodes = (
       ? tasksToBuilderNodes(
           validTaskList,
           onNewListNode,
-          (task) => onTaskSelection(task, findTask(taskResources, task.taskRef), false),
+          (task) => onTaskSelection(task, findTask(taskResources, task), false),
           getTopLevelErrorMessage(tasksInError.tasks),
           taskGroup.highlightedIds,
         )

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.scss
@@ -1,11 +1,5 @@
 .odc-task-sidebar {
-  &__header {
-    font-size: var(--pf-global--FontSize--md);
-    height: 33px; // fixed height header to avoid actions from bouncing the header
-    margin: 0;
-  }
-
-  &__header, &__content {
+  &__content {
     padding: 0 var(--pf-global--spacer--lg);
   }
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { FormikErrors, useField } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { ActionsMenu, ResourceIcon, CloseButton } from '@console/internal/components/utils';
-import { referenceForModel } from '@console/internal/module/k8s';
-import { getResourceModelFromTaskKind } from '../../../../utils/pipeline-augment';
+import { CloseButton } from '@console/internal/components/utils';
 import {
   PipelineTask,
   PipelineTaskParam,
@@ -12,13 +10,15 @@ import {
   TektonParam,
   PipelineTaskResource,
   ResourceTarget,
+  TektonResourceGroup,
 } from '../../../../types';
-import { getTaskParameters, getTaskResources, InputOutputResources } from '../../resource-utils';
+import { getTaskParameters, getTaskResources } from '../../resource-utils';
 import { SelectedBuilderTask, TaskType, UpdateOperationRenameTaskData } from '../types';
 import TaskSidebarParam from './TaskSidebarParam';
 import TaskSidebarResource from './TaskSidebarResource';
 import TaskSidebarName from './TaskSidebarName';
 import TaskSidebarWorkspace from './TaskSidebarWorkspace';
+import TaskSidebarHeader from './TaskSidebarHeader';
 
 import './TaskSidebar.scss';
 
@@ -53,7 +53,7 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
   const [{ value: thisTask }] = useField<PipelineTask>(formikTaskReference);
 
   const params: TektonParam[] = getTaskParameters(taskResource) || [];
-  const resources: InputOutputResources = getTaskResources(taskResource);
+  const resources: TektonResourceGroup<TektonResource> = getTaskResources(taskResource);
   const inputResources: TektonResource[] = resources.inputs || [];
   const outputResources: TektonResource[] = resources.outputs || [];
   const workspaces: TektonWorkspace[] = taskResource.spec.workspaces || [];
@@ -78,28 +78,10 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
       <div className="co-sidebar-dismiss clearfix">
         <CloseButton onClick={onClose} />
       </div>
-      <div className="odc-task-sidebar__header">
-        <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name co-resource-item">
-            <ResourceIcon
-              className="co-m-resource-icon--lg"
-              kind={referenceForModel(getResourceModelFromTaskKind(taskResource.kind))}
-            />
-            {taskResource.metadata.name}
-          </div>
-          <div className="co-actions">
-            <ActionsMenu
-              actions={[
-                {
-                  label: t('pipelines-plugin~Remove Task'),
-                  callback: () => onRemoveTask(thisTask.name),
-                },
-              ]}
-            />
-          </div>
-        </h1>
-      </div>
-      <hr />
+      <TaskSidebarHeader
+        taskResource={taskResource}
+        removeThisTask={() => onRemoveTask(thisTask.name)}
+      />
 
       <div className="odc-task-sidebar__content">
         <TaskSidebarName

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.scss
@@ -1,0 +1,10 @@
+.opp-task-sidebar-header {
+  font-size: var(--pf-global--FontSize--md);
+  height: 33px; // fixed height header to avoid actions from bouncing the header
+  margin: 0;
+  padding: 0 var(--pf-global--spacer--lg);
+
+  &__pipeline-color {
+    background-color: var(--pf-chart-color-green-400);
+  }
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarHeader.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import cx from 'classnames';
+import { useTranslation } from 'react-i18next';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ActionsMenu, ResourceIcon } from '@console/internal/components/utils';
+import { getResourceModelFromTaskKind } from '../../../../utils/pipeline-augment';
+import { TaskKind } from '../../../../types';
+
+import './TaskSidebarHeader.scss';
+
+type TaskSidebarHeaderProps = {
+  removeThisTask: () => void;
+  taskResource: TaskKind;
+};
+
+const TaskSidebarHeader: React.FC<TaskSidebarHeaderProps> = ({ removeThisTask, taskResource }) => {
+  const { t } = useTranslation();
+
+  let resourceKind: string = taskResource.kind;
+  const model = getResourceModelFromTaskKind(resourceKind);
+  if (model) {
+    resourceKind = referenceForModel(model);
+  }
+
+  return (
+    <>
+      <div className="opp-task-sidebar-header">
+        <h1 className="co-m-pane__heading">
+          <div className="co-m-pane__name co-resource-item">
+            <ResourceIcon
+              className={cx('co-m-resource-icon--lg', {
+                'opp-task-sidebar-header__pipeline-color': !model,
+              })}
+              kind={resourceKind}
+            />
+            {taskResource.metadata.name}
+          </div>
+          <div className="co-actions">
+            <ActionsMenu
+              actions={[
+                {
+                  label: t('pipelines-plugin~Remove Task'),
+                  callback: () => removeThisTask(),
+                },
+              ]}
+            />
+          </div>
+        </h1>
+      </div>
+      <hr />
+    </>
+  );
+};
+
+export default TaskSidebarHeader;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/types.ts
@@ -7,7 +7,6 @@ import {
   TaskKind,
   TektonWorkspace,
 } from '../../../types';
-import { PipelineVisualizationTaskItem } from '../../../utils/pipeline-utils';
 import { AddNodeDirection } from '../pipeline-topology/const';
 // eslint-disable-next-line import/no-cycle
 import { UpdateOperationType } from './const';
@@ -67,7 +66,7 @@ export type SelectedBuilderTask = {
 };
 
 export type SelectTaskCallback = (
-  task: PipelineVisualizationTaskItem,
+  task: PipelineTask,
   taskResource: TaskKind,
   isFinallyTask: boolean,
 ) => void;
@@ -86,7 +85,7 @@ type UpdateOperationBaseData = {};
 
 export type UpdateOperationAddData = UpdateOperationBaseData & {
   direction: AddNodeDirection;
-  relatedTask: PipelineVisualizationTaskItem;
+  relatedTask: PipelineTask;
 };
 export type UpdateOperationConvertToTaskData = UpdateOperationBaseData & {
   name: string;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
@@ -1,6 +1,5 @@
 import { EdgeModel, NodeModel } from '@patternfly/react-topology';
-import { PipelineKind, TaskKind, PipelineRunKind } from '../../../types';
-import { PipelineVisualizationTaskItem } from '../../../utils/pipeline-utils';
+import { PipelineKind, TaskKind, PipelineRunKind, PipelineTask } from '../../../types';
 import { AddNodeDirection, NodeType } from './const';
 
 // Builder Callbacks
@@ -68,13 +67,13 @@ export type TaskListNodeModelData = PipelineRunAfterNodeModelData & {
 };
 export type BuilderNodeModelData = PipelineRunAfterNodeModelData & {
   error?: string;
-  task: PipelineVisualizationTaskItem;
+  task: PipelineTask;
   onAddNode: NewTaskListNodeCallback;
   onNodeSelection: NodeSelectionCallback;
 };
 export type SpacerNodeModelData = PipelineRunAfterNodeModelData & {};
 export type TaskNodeModelData = PipelineRunAfterNodeModelData & {
-  task: PipelineVisualizationTaskItem;
+  task: PipelineTask;
   pipeline?: PipelineKind;
   pipelineRun?: PipelineRunKind;
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -1,11 +1,7 @@
 import * as dagre from 'dagre';
 import * as _ from 'lodash';
-import { PipelineKind, PipelineRunKind } from '../../../types';
-import {
-  getPipelineTasks,
-  getFinallyTasksWithStatus,
-  PipelineVisualizationTaskItem,
-} from '../../../utils/pipeline-utils';
+import { PipelineKind, PipelineRunKind, PipelineTask } from '../../../types';
+import { getPipelineTasks, getFinallyTasksWithStatus } from '../../../utils/pipeline-utils';
 import {
   NODE_HEIGHT,
   NodeType,
@@ -181,7 +177,7 @@ export const handleParallelToParallelNodes = (
 };
 
 export const tasksToNodes = (
-  taskList: PipelineVisualizationTaskItem[],
+  taskList: PipelineTask[],
   pipeline?: PipelineKind,
   pipelineRun?: PipelineRunKind,
 ): PipelineMixedNodeModel[] => {
@@ -197,9 +193,9 @@ export const tasksToNodes = (
 };
 
 export const tasksToBuilderNodes = (
-  taskList: PipelineVisualizationTaskItem[],
-  onAddNode: (task: PipelineVisualizationTaskItem, direction: AddNodeDirection) => void,
-  onNodeSelection: (task: PipelineVisualizationTaskItem) => void,
+  taskList: PipelineTask[],
+  onAddNode: (task: PipelineTask, direction: AddNodeDirection) => void,
+  onNodeSelection: (task: PipelineTask) => void,
   getError: CheckTaskErrorMessage,
   selectedIds: string[],
 ): PipelineMixedNodeModel[] => {
@@ -295,9 +291,7 @@ export const getTopologyNodesEdges = (
   pipeline: PipelineKind,
   pipelineRun?: PipelineRunKind,
 ): { nodes: PipelineMixedNodeModel[]; edges: PipelineEdgeModel[] } => {
-  const taskList: PipelineVisualizationTaskItem[] = _.flatten(
-    getPipelineTasks(pipeline, pipelineRun),
-  );
+  const taskList: PipelineTask[] = _.flatten(getPipelineTasks(pipeline, pipelineRun));
   const taskNodes: PipelineMixedNodeModel[] = tasksToNodes(taskList, pipeline, pipelineRun);
 
   const nodes: PipelineMixedNodeModel[] = connectFinallyTasksToNodes(

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-utils.ts
@@ -1,5 +1,5 @@
 import { get } from 'lodash';
-import { TaskKind, TektonParam, TektonResource } from '../../types';
+import { TaskKind, TektonParam, TektonResource, TektonResourceGroup } from '../../types';
 
 export type TaskKindAlpha = TaskKind & {
   spec: {
@@ -13,11 +13,6 @@ export type TaskKindAlpha = TaskKind & {
   };
 };
 
-export type InputOutputResources = {
-  inputs?: TektonResource[];
-  outputs?: TektonResource[];
-};
-
 enum PATHS {
   alphaInputResources = 'spec.inputs.resources',
   alphaOutputResources = 'spec.outputs.resources',
@@ -28,7 +23,9 @@ enum PATHS {
   betaParameters = 'spec.params',
 }
 
-export const getTaskResources = (taskResource: TaskKind | TaskKindAlpha): InputOutputResources => {
+export const getTaskResources = (
+  taskResource: TaskKind | TaskKindAlpha,
+): TektonResourceGroup<TektonResource> => {
   const inputs =
     get(taskResource, PATHS.alphaInputResources) || get(taskResource, PATHS.betaInputResources);
   const outputs =

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -1918,11 +1918,6 @@ export const pipelineTestData: PipelineTestData = {
               {
                 name: 'echo-good-morning',
                 taskSpec: {
-                  metadata: {
-                    labels: {
-                      app: 'example',
-                    },
-                  },
                   steps: [
                     {
                       name: 'echo',
@@ -1957,11 +1952,6 @@ export const pipelineTestData: PipelineTestData = {
               {
                 name: 'echo-good-morning',
                 taskSpec: {
-                  metadata: {
-                    labels: {
-                      app: 'example',
-                    },
-                  },
                   steps: [
                     {
                       name: 'echo',

--- a/frontend/packages/pipelines-plugin/src/types/coreTekton.ts
+++ b/frontend/packages/pipelines-plugin/src/types/coreTekton.ts
@@ -17,7 +17,25 @@ export type TektonTaskSteps = {
   script?: string[];
 };
 
-// Deprecated upstream, workspaces are more desired
+export type TaskResult = {
+  name: string;
+  description?: string;
+};
+
+export type TektonTaskSpec = {
+  steps: TektonTaskSteps[];
+  params?: TektonParam[];
+  resources?: TektonResourceGroup<TektonResource>;
+  results?: TaskResult[];
+  workspaces?: TektonWorkspace[];
+};
+
+export type TektonResourceGroup<ResourceType> = {
+  inputs?: ResourceType[];
+  outputs?: ResourceType[];
+};
+
+/** Deprecated upstream - Workspaces are replacing Resources */
 export type TektonResource = {
   name: string;
   optional?: boolean;

--- a/frontend/packages/pipelines-plugin/src/types/pipeline.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipeline.ts
@@ -1,16 +1,15 @@
 import { K8sResourceCommon } from '@console/internal/module/k8s';
-import { TektonParam, TektonResource, TektonTaskSteps, TektonWorkspace } from './coreTekton';
+import {
+  TektonParam,
+  TektonResource,
+  TektonResourceGroup,
+  TektonTaskSpec,
+  TektonWorkspace,
+} from './coreTekton';
 
 export type PipelineTaskRef = {
   kind?: string;
   name: string;
-};
-
-export type PipelineTaskSpec = {
-  metadata?: {
-    labels?: { [key: string]: string };
-  };
-  steps: TektonTaskSteps[];
 };
 
 export type PipelineTaskWorkspace = {
@@ -22,11 +21,6 @@ export type PipelineTaskResource = {
   name: string;
   resource?: string;
   from?: string[];
-};
-
-export type PipelineTaskResources = {
-  inputs?: PipelineTaskResource[];
-  outputs?: PipelineTaskResource[];
 };
 
 export type PipelineTaskParam = {
@@ -49,10 +43,10 @@ export type PipelineResult = {
 export type PipelineTask = {
   name: string;
   params?: PipelineTaskParam[];
-  resources?: PipelineTaskResources;
+  resources?: TektonResourceGroup<PipelineTaskResource>;
   runAfter?: string[];
   taskRef?: PipelineTaskRef;
-  taskSpec?: PipelineTaskSpec;
+  taskSpec?: TektonTaskSpec;
   when?: WhenExpression[];
   workspaces?: PipelineTaskWorkspace[];
 };

--- a/frontend/packages/pipelines-plugin/src/types/task.ts
+++ b/frontend/packages/pipelines-plugin/src/types/task.ts
@@ -1,21 +1,6 @@
 import { K8sResourceCommon } from '@console/internal/module/k8s';
-import { TektonParam, TektonResource, TektonTaskSteps, TektonWorkspace } from './coreTekton';
-
-export type TaskResult = {
-  name: string;
-  description?: string;
-};
+import { TektonTaskSpec } from './coreTekton';
 
 export type TaskKind = K8sResourceCommon & {
-  spec: {
-    params?: TektonParam[];
-    resources?: {
-      inputs?: TektonResource[];
-      outputs?: TektonResource[];
-    };
-    workspaces?: TektonWorkspace[];
-
-    steps: TektonTaskSteps[];
-    results?: TaskResult[];
-  };
+  spec: TektonTaskSpec;
 };

--- a/frontend/packages/pipelines-plugin/src/types/taskRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/taskRun.ts
@@ -1,6 +1,6 @@
 import { K8sResourceCommon, PersistentVolumeClaimKind } from '@console/internal/module/k8s';
-import { TektonResource, TektonResultsRun } from './coreTekton';
-import { PipelineTaskParam, PipelineTaskRef, PipelineTaskSpec } from './pipeline';
+import { TektonResource, TektonResultsRun, TektonTaskSpec } from './coreTekton';
+import { PipelineTaskParam, PipelineTaskRef } from './pipeline';
 
 import {
   Condition,
@@ -32,7 +32,7 @@ export type TaskRunStatus = {
 export type TaskRunKind = K8sResourceCommon & {
   spec: {
     taskRef?: PipelineTaskRef;
-    taskSpec?: PipelineTaskSpec;
+    taskSpec?: TektonTaskSpec;
     serviceAccountName?: string;
     params?: PipelineTaskParam[];
     resources?: TektonResource[];

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-actions.spec.ts
@@ -5,9 +5,7 @@ import {
   reRunPipelineRun,
   startPipeline,
   getPipelineKebabActions,
-  editPipeline,
 } from '../pipeline-actions';
-import { mockPipelinesJSON } from './pipeline-test-data';
 import { pipelineTestData, PipelineExampleNames, DataState } from '../../test-data/pipeline-data';
 
 const samplePipeline = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipeline;
@@ -93,11 +91,5 @@ describe('getPipelineKebabActions', () => {
     expect(pipelineKebabActions[1](PipelineRunModel, samplePipelineRun).labelKey).not.toBe(
       `${i18nNS}~Start last run`,
     );
-  });
-  it('expect Edit Pipeline option should be hidden when pipeline has inline taskSpec', () => {
-    const editPipelineAction = editPipeline(PipelineModel, mockPipelinesJSON[2]);
-    expect(editPipelineAction.labelKey).toBe(`${i18nNS}~Edit Pipeline`);
-    expect(editPipelineAction.callback).not.toBeNull();
-    expect(editPipelineAction.hidden).toBeTruthy();
   });
 });

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -14,8 +14,17 @@ import {
   pipelineRefExists,
   getPipelineFromPipelineRun,
   totalPipelineRunTasks,
+  getResourceModelFromTaskKind,
+  getResourceModelFromBindingKind,
 } from '../pipeline-augment';
-import { ClusterTaskModel, PipelineRunModel, TaskModel, PipelineModel } from '../../models';
+import {
+  ClusterTaskModel,
+  PipelineRunModel,
+  TaskModel,
+  PipelineModel,
+  ClusterTriggerBindingModel,
+  TriggerBindingModel,
+} from '../../models';
 import { testData } from './pipeline-augment-test-data';
 
 const t = (key): TFunction => key;
@@ -394,5 +403,55 @@ describe('Pipelinerun graph to show the executed pipeline structure', () => {
       ...pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipeline,
       apiVersion: apiVersionForModel(PipelineModel),
     });
+  });
+});
+
+describe('getResourceModelFromTaskKind', () => {
+  it('should handle null', () => {
+    expect(getResourceModelFromTaskKind(null)).toBe(null);
+  });
+
+  it('should be able to find ClusterTaskModel', () => {
+    expect(getResourceModelFromTaskKind('ClusterTask')).toBe(ClusterTaskModel);
+  });
+
+  it('should be able to find TaskModel', () => {
+    expect(getResourceModelFromTaskKind('Task')).toBe(TaskModel);
+  });
+
+  it('should return the TaskModel for undefined', () => {
+    expect(getResourceModelFromTaskKind(undefined)).toBe(TaskModel);
+  });
+
+  it('should return null for any unknown value', () => {
+    expect(getResourceModelFromTaskKind('EmbeddedTask')).toBe(null);
+    expect(getResourceModelFromTaskKind('123%$^&asdf')).toBe(null);
+    expect(getResourceModelFromTaskKind('Nothing special')).toBe(null);
+  });
+});
+
+describe('getResourceModelFromBindingKind', () => {
+  it('should handle null', () => {
+    expect(getResourceModelFromBindingKind(null)).toBe(null);
+  });
+
+  it('should be able to find ClusterTriggerBindingModel', () => {
+    expect(getResourceModelFromBindingKind('ClusterTriggerBinding')).toBe(
+      ClusterTriggerBindingModel,
+    );
+  });
+
+  it('should be able to find TriggerBindingModel', () => {
+    expect(getResourceModelFromBindingKind('TriggerBinding')).toBe(TriggerBindingModel);
+  });
+
+  it('should return TriggerBindingModel for undefined', () => {
+    expect(getResourceModelFromBindingKind(undefined)).toBe(TriggerBindingModel);
+  });
+
+  it('should return null for any unknown value', () => {
+    expect(getResourceModelFromBindingKind('EmbeddedBinding')).toBe(null);
+    expect(getResourceModelFromBindingKind('123%$^&asdf')).toBe(null);
+    expect(getResourceModelFromBindingKind('Nothing special')).toBe(null);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -19,7 +19,6 @@ import {
   pipelineRunDuration,
   getSecretAnnotations,
   calculateRelativeTime,
-  hasInlineTaskSpec,
   LatestPipelineRunStatus,
   updateServiceAccount,
   appendPipelineRunStatus,
@@ -168,16 +167,6 @@ describe('pipeline-utils ', () => {
   it('expected relative time should be "about 2 hours"', () => {
     const relativeTime = calculateRelativeTime('2020-05-22T10:57:53Z', '2020-05-22T12:57:57Z');
     expect(relativeTime).toBe('about 2 hours');
-  });
-
-  it('expect pipeline with inline task spec to return true', () => {
-    const hasSpec = hasInlineTaskSpec(mockPipelinesJSON[2].spec.tasks);
-    expect(hasSpec).toBe(true);
-  });
-
-  it('expect pipeline without inline task spec to return false', () => {
-    const hasSpec = hasInlineTaskSpec(mockPipelinesJSON[1].spec.tasks);
-    expect(hasSpec).toBe(false);
   });
 
   it('should return PVCs correctly matched with name and kind', () => {

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -17,7 +17,6 @@ import { StartedByAnnotation } from '../components/pipelines/const';
 import { EventListenerModel, PipelineModel, PipelineRunModel } from '../models';
 import { PipelineKind, PipelineRunKind } from '../types';
 import { pipelineRunFilterReducer } from './pipeline-filter-reducer';
-import { hasInlineTaskSpec } from './pipeline-utils';
 
 export const handlePipelineRunSubmit = (pipelineRun: PipelineRunKind) => {
   history.push(
@@ -62,7 +61,6 @@ export const reRunPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipeli
 export const editPipeline: KebabAction = (kind: K8sKind, pipeline: PipelineKind) => ({
   // t('pipelines-plugin~Edit Pipeline')
   labelKey: 'pipelines-plugin~Edit Pipeline',
-  hidden: hasInlineTaskSpec(pipeline.spec.tasks),
   callback: () => {
     const {
       metadata: { name, namespace },

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -276,11 +276,25 @@ export const getTaskStatus = (pipelinerun: PipelineRunKind): TaskStatus => {
   return taskStatus;
 };
 
-export const getResourceModelFromTaskKind = (kind: string): K8sKind =>
-  kind === ClusterTaskModel.kind ? ClusterTaskModel : TaskModel;
+export const getResourceModelFromTaskKind = (kind: string): K8sKind => {
+  if (kind === ClusterTaskModel.kind) {
+    return ClusterTaskModel;
+  }
+  if (kind === TaskModel.kind || kind === undefined) {
+    return TaskModel;
+  }
+  return null;
+};
 
-export const getResourceModelFromBindingKind = (kind: string): K8sKind =>
-  kind === ClusterTriggerBindingModel.kind ? ClusterTriggerBindingModel : TriggerBindingModel;
+export const getResourceModelFromBindingKind = (kind: string): K8sKind => {
+  if (kind === ClusterTriggerBindingModel.kind) {
+    return ClusterTriggerBindingModel;
+  }
+  if (kind === TriggerBindingModel.kind || kind === undefined) {
+    return TriggerBindingModel;
+  }
+  return null;
+};
 
 export const getResourceModelFromTask = (task: PipelineTask): K8sKind => {
   const {

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -22,7 +22,6 @@ import { PipelineModalFormWorkspace } from '../components/pipelines/modals/commo
 import {
   PipelineRunKind,
   PipelineRunParam,
-  PipelineTaskRef,
   PipelineRunWorkspace,
   PipelineTask,
   PipelineKind,
@@ -45,17 +44,6 @@ import {
   EventListenerModel,
 } from '../models';
 
-interface Resources {
-  inputs?: Resource[];
-  outputs?: Resource[];
-}
-
-interface Resource {
-  name: string;
-  resource?: string;
-  from?: string[];
-}
-
 interface ServiceAccountSecretNames {
   [name: string]: string;
 }
@@ -65,14 +53,6 @@ export type ServiceAccountType = {
   imagePullSecrets: ServiceAccountSecretNames[];
 } & K8sResourceCommon;
 
-export interface PipelineVisualizationTaskItem {
-  name: string;
-  resources?: Resources;
-  params?: object;
-  runAfter?: string[];
-  taskRef?: PipelineTaskRef;
-}
-
 export const TaskStatusClassNameMap = {
   'In Progress': 'is-running',
   Succeeded: 'is-done',
@@ -81,13 +61,12 @@ export const TaskStatusClassNameMap = {
 };
 
 export const conditions = {
-  hasFromDependency: (task: PipelineVisualizationTaskItem): boolean =>
+  hasFromDependency: (task: PipelineTask): boolean =>
     task.resources &&
     task.resources.inputs &&
     task.resources.inputs.length > 0 &&
     !!task.resources.inputs[0].from,
-  hasRunAfterDependency: (task: PipelineVisualizationTaskItem): boolean =>
-    task.runAfter && task.runAfter.length > 0,
+  hasRunAfterDependency: (task: PipelineTask): boolean => task.runAfter && task.runAfter.length > 0,
 };
 
 export enum ListFilterId {
@@ -161,8 +140,6 @@ export const appendPipelineRunStatus = (pipeline, pipelineRun, isFinallyTasks = 
     return mTask;
   });
 };
-export const hasInlineTaskSpec = (tasks: PipelineTask[] = []): boolean =>
-  tasks.some((task) => !!(task.taskSpec && !task.taskRef));
 
 export const getPipelineTasks = (
   pipeline: PipelineKind,
@@ -172,7 +149,7 @@ export const getPipelineTasks = (
     kind: 'PipelineRun',
     spec: {},
   },
-): PipelineVisualizationTaskItem[][] => {
+): PipelineTask[][] => {
   // Each unit in 'out' array is termed as stage | out = [stage1 = [task1], stage2 = [task2,task3], stage3 = [task4]]
   const out = [];
   if (!pipeline.spec?.tasks || _.isEmpty(pipeline.spec.tasks)) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5612

**Analysis / Root cause**: 
We currently support Embedded Tasks outside of the Pipeline Builder to a small extent (visualization and the UI doesn't crash). We need to support it in the Pipeline Builder.

**Solution Description**: 
Support Embedded Tasks in the Pipeline Builder by taking the `taskSpec` and wrapping it in a fake TaskKind resource ... thus allowing the rest of the Pipeline Builder to work unimpeded.

Also fixed some types that were overlapping / redundant.

**Screen shots / Gifs for design review**: 
![Screen Shot 2021-03-31 at 8 36 24 PM](https://user-images.githubusercontent.com/8126518/113232333-f0daec80-926a-11eb-8f5e-736d4746aa22.png)
![Screen Shot 2021-03-31 at 8 36 58 PM](https://user-images.githubusercontent.com/8126518/113232334-f1738300-926a-11eb-959b-97cf8bd877ee.png)

cc @bgliwa01 Not a lot to show, but FYI.

**Unit test coverage report**: 

New tests...
```
 PASS  packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/validation-utils.spec.ts
  Pipeline Build validation schema
    Tasks and ListTasks validation
      Validate Run Afters
        ✓ should pass if runAfter is on a taskSpec task (4ms)
      Validate Parameters
        ✓ should fail if the taskSpec params are required and not provided (6ms)
        ✓ should pass if the taskSpec params have defaults (4ms)
        ✓ should pass if the taskSpec params are required but a value is provided (3ms)
      Validate Resources
        ✓ should fail if the taskSpec has resources but the task does not (4ms)
        ✓ should pass if the taskSpec has resources and the task provides it (7ms)
      Validate Workspaces
        ✓ should fail if the taskSpec requests a workspace (4ms)
        ✓ should pass if the taskSpec requests a workspace and it is provided (3ms)
```
```
 PASS  packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
  getResourceModelFromTaskKind
    ✓ should handle null
    ✓ should be able to find ClusterTaskModel
    ✓ should be able to find TaskModel (1ms)
    ✓ should return the TaskModel for undefined
    ✓ should return null for any unknown value
  getResourceModelFromBindingKind
    ✓ should handle null (1ms)
    ✓ should be able to find ClusterTriggerBindingModel
    ✓ should be able to find TriggerBindingModel
    ✓ should return TriggerBindingModel for undefined
    ✓ should return null for any unknown value
```

Removed tests in `frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts` around `hasInlineTaskSpec` as the utility is no longer used.

**Test setup:**

Add a `taskSpec` based task in the YAML view (or edit an existing Pipeline). Then interact with it in the visualization. Everything should work as if it was powered by a stand-alone Task resource.

eg. Sample Pipeline:
```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: new-pipeline
spec:
  tasks:
    - name: echo-good-morning
      taskSpec:
        params:
          - name: name
            description: Your name
        workspaces:
          - name: input
        steps:
          - name: echo
            image: ubuntu
            script: |
              #!/usr/bin/env bash
              echo "Good Morning, $(params.name)!"
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge