### PR TITLE
ODC-5725-Add owners file to topology folder

### DIFF
--- a/frontend/packages/topology/integration-tests/OWNERS
+++ b/frontend/packages/topology/integration-tests/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - gajanan-more
+  - sanketpathak
+approvers:
+  - makambalaji


### PR DESCRIPTION
Problem: Owners file to topology folder
Solution: Create and add owners file to topology folder
JIRA ID: https://issues.redhat.com/browse/ODC-5725