### PR TITLE
Fix for creation of visual connectors

### DIFF
--- a/frontend/packages/rhoas-plugin/src/topology/createConnector.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/createConnector.ts
@@ -1,5 +1,6 @@
 import { Node } from '@patternfly/react-topology';
 import { createServiceBinding } from '@console/topology/src/operators/actions/serviceBindings';
+import { TYPE_MANAGED_KAFKA_CONNECTION } from './components/const';
 
 const createServiceBindingConnection = (source: Node, target: Node) => {
   const sourceResource = source.getData().resource || source.getData().resources?.obj;
@@ -8,8 +9,12 @@ const createServiceBindingConnection = (source: Node, target: Node) => {
   return createServiceBinding(sourceResource, targetResource).then(() => null);
 };
 
-export const getCreateConnector = (createHints: string[]) => {
-  if (createHints) {
+export const getCreateConnector = (createHints: string[], source: Node, target: Node) => {
+  if (
+    createHints &&
+    createHints.includes('createServiceBinding') &&
+    target.getType() === TYPE_MANAGED_KAFKA_CONNECTION
+  ) {
     return createServiceBindingConnection;
   }
   return null;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5726

**Analysis / Root cause**: 
The rhoas plugin is grabbing all connector creation requests and creating SBRs for them.

**Solution Description**: 
Check the createHints for the SBR type, and check the target node being a managed kafka connection before accepting the create connection request.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/bug
