### PR TITLE
Implement externalLink option for the org.w3 alm x-descriptor

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/mocks/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/mocks/index.tsx
@@ -39,6 +39,8 @@ const defaultValueFor = <C extends SpecCapability | StatusCapability>(capability
       return 3;
     case StatusCapability.w3Link:
       return 'https://google.com';
+    case StatusCapability.w3ExternalLink:
+      return 'https://google.com';
     case StatusCapability.conditions:
       return [
         {

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/const.ts
@@ -73,6 +73,7 @@ export const PRIMITIVE_COMPATIBLE_CAPABILITIES: (SpecCapability | StatusCapabili
   SpecCapability.select,
   SpecCapability.text,
   StatusCapability.w3Link,
+  StatusCapability.w3ExternalLink,
   StatusCapability.text,
   StatusCapability.k8sPhase,
   StatusCapability.k8sPhaseReason,

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
@@ -27,11 +27,12 @@
 #### [statusDescriptors](#statusDescriptors-1):
   1. [podStatuses](#1-podStatuses)
   2. [w3Link](#2-w3Link)
-  3. [conditions](#3-conditions)
-  4. [text](#4-text)
-  5. [k8sPhase](#5-k8sPhase)
-  6. [k8sPhaseReason](#6-k8sPhaseReason)
-  7. [k8sResourcePrefix](#7-k8sResourcePrefix)
+  3. [w3ExternalLink](#3-w3ExternalLink)
+  4. [conditions](#4-conditions)
+  5. [text](#5-text)
+  6. [k8sPhase](#6-k8sPhase)
+  7. [k8sPhaseReason](#7-k8sPhaseReason)
+  8. [k8sResourcePrefix](#8-k8sResourcePrefix)
 ---------------------------------------
 
 #### [DEPRECATED Descriptors](#deprecated-descriptors-1)
@@ -853,7 +854,55 @@ status:
   </tr>
 </table>
 
-#### 3. conditions
+#### 3. w3ExternalLink
+
+**x-descriptors**
+
+This descriptor allows you to expose an external link of your instance and open it in the separate browser tab or window. It expects the output format in the status block of your instance in:
+```yaml
+…
+status:
+  [PATH_TO_THE_FIELD]: [FIELD_VALUE]
+…
+```
+
+**Example**
+
+```yaml
+…
+- displayName: Eclipse Che URL
+  description: Route to access Eclipse Che
+  path: cheURL
+  x-descriptors:
+    - urn:alm:descriptor:org.w3:externalLink
+…
+```
+
+The status block of the field being specified:
+
+```yaml
+…
+status:
+  …
+  cheURL: 'http://che-tony.apps.rhamilto.devcluster.openshift.com'
+…
+```
+
+**On the DISPLAY VIEW:**
+<table style="width:100%">
+  <tr valign="top">
+    <td width="50%">
+      <img src="img/status/2-1_w3Link.png" />
+      <h6><small>Click on the link sends users to target URL.</small></h6>
+      </td>
+    <td width="50%">
+      <img src="img/status/2-2_w3Link.png" />
+      <h6><small>Hover over displayName shows descriptions on tooltip.</small></h6>
+      </td>
+  </tr>
+</table>
+
+#### 4. conditions
 
 **x-descriptors**
 
@@ -926,7 +975,7 @@ status:
   </tr>
 </table>
 
-#### 4. text
+#### 5. text
 
 **x-descriptors**
 
@@ -968,7 +1017,7 @@ status:
   </tr>
 </table>
 
-#### 5. k8sPhase
+#### 6. k8sPhase
 
 **x-descriptors**
 
@@ -1008,7 +1057,7 @@ status:
   </tr>
 </table>
 
-#### 6. k8sPhaseReason
+#### 7. k8sPhaseReason
 
 **x-descriptors**
 
@@ -1049,7 +1098,7 @@ status:
   </tr>
 </table>
 
-#### 7. k8sResourcePrefix
+#### 8. k8sResourcePrefix
 
 **x-descriptors**
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.spec.tsx
@@ -89,6 +89,14 @@ describe('Status descriptors', () => {
     expect(wrapper.find('dd').text()).toEqual('example.com');
   });
 
+  it('renders an external link status', () => {
+    descriptor['x-descriptors'] = [StatusCapability.w3ExternalLink];
+    descriptor.path = 'externalLink';
+    wrapper = wrapper.setProps({ descriptor });
+
+    expect(wrapper.find('dd').text()).toEqual('example.com');
+  });
+
   it('renders a resource status', () => {
     descriptor['x-descriptors'] = [
       `${StatusCapability.k8sResourcePrefix}Service`,

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -64,6 +64,27 @@ const StatusConditions: React.FC<StatusCapabilityProps> = ({
   );
 };
 
+const ExternalLink: React.FC<StatusCapabilityProps> = ({
+  description,
+  fullPath,
+  label,
+  obj,
+  value,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
+      {!_.isNil(value) ? (
+        <a href={value} rel="noopener noreferrer" target="_blank">
+          {value.replace(/https?:\/\//, '')}
+        </a>
+      ) : (
+        <span className="text-muted">{t('public~None')}</span>
+      )}
+    </DetailsItem>
+  );
+};
+
 const Link: React.FC<StatusCapabilityProps> = ({ description, fullPath, label, obj, value }) => {
   const { t } = useTranslation();
   return (
@@ -167,6 +188,8 @@ export const StatusDescriptorDetailsItem: React.FC<StatusCapabilityProps> = (pro
       return <StatusConditions {...props} />;
     case StatusCapability.w3Link:
       return <Link {...props} />;
+    case StatusCapability.w3ExternalLink:
+      return <ExternalLink {...props} />;
     case StatusCapability.k8sPhase:
       return <K8sPhase {...props} />;
     case StatusCapability.k8sPhaseReason:

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
@@ -36,6 +36,7 @@ export enum StatusCapability {
   podStatuses = 'urn:alm:descriptor:com.tectonic.ui:podStatuses',
   podCount = 'urn:alm:descriptor:com.tectonic.ui:podCount',
   w3Link = 'urn:alm:descriptor:org.w3:link',
+  w3ExternalLink = 'urn:alm:descriptor:org.w3:externalLink',
   conditions = 'urn:alm:descriptor:io.kubernetes.conditions',
   text = 'urn:alm:descriptor:text',
   prometheusEndpoint = 'urn:alm:descriptor:prometheusEndpoint',


### PR DESCRIPTION
It would be prefer to open link configured with following OLM descriptor in new window/tab as users always lives Console application in case of click on the provide link
However, changing default behavior for the standard configuration, i.e. `x-descriptors:urn:alm:descriptor:org.w3:link` could have an impact on other applications and configurations
Implement functionality for support `x-descriptors:urn:alm:descriptor:org.w3:externalLink` option

fixes #8477