### PR TITLE
Bug 1945630: Fix default resource log download file name

### DIFF
--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -149,7 +149,7 @@ export const LogControls: React.FC<LogControlsProps> = ({
         <span aria-hidden="true" className="co-action-divider hidden-xs">
           |
         </span>
-        <a href={currentLogURL} download>
+        <a href={currentLogURL} download={`${resource.metadata.name}-${containerName}.log`}>
           <DownloadIcon className="co-icon-space-r" />
           {t('logs~Download')}
         </a>


### PR DESCRIPTION
Update download link in ResourceLog component so that the default file name will be `${podName}-${containerName}.log`