### PR TITLE
Bug 1946434: Added OWNERS file to pipelines plugin integratoin-tests folders

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/OWNERS
+++ b/frontend/packages/pipelines-plugin/integration-tests/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - gajanan-more
+  - sanketpathak
+  - VeereshAradhya
+  - praveen4g0
+approvers:
+  - makambalaji


### PR DESCRIPTION
**Problem**:  Need approval rights for QE team to add tests to Pipelines/Integation-tests folder
**Solution**: Added owners file to Pipelines/Integration-tests folder

