### PR TITLE
Bug 1946449: fix cloud init tests as UI changed

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/vmBuilderPresets.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/mocks/vmBuilderPresets.ts
@@ -92,8 +92,6 @@ export const getBasicVMBuilder = () =>
     .setNamespace(testName)
     .setDescription('Default vm description')
     .setSelectTemplateName(TemplateByName.RHEL7)
-    .setFlavor(flavorConfigs.Tiny)
-    .setWorkload(Workload.DESKTOP)
     .setStartOnCreation(true);
 
 export const getBasicVMTBuilder = () =>

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -191,6 +191,7 @@ export class Wizard {
   }
 
   async configureCloudInit(cloudInitOptions: CloudInitConfig) {
+    await click(view.cloud);
     if (cloudInitOptions.useCustomScript) {
       await click(view.cloudInitCustomScriptCheckbox);
       await fillInput(view.customCloudInitScriptTextArea, cloudInitOptions.customScript);
@@ -376,15 +377,11 @@ export class Wizard {
 
       if (workload) {
         await this.selectWorkloadProfile(workload);
-      } else {
-        throw Error('VM Workload not defined');
       }
     }
 
     if (flavor) {
       await this.selectFlavor(flavor);
-    } else {
-      throw Error('VM Flavor not defined');
     }
     await this.next(ignoreWarnings);
   }

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
@@ -19,7 +19,6 @@ import {
   JASMINE_EXTENDED_TIMEOUT_INTERVAL,
 } from './utils/constants/common';
 import { multusNAD, cdGuestTools, getTestDataVolume } from './mocks/mocks';
-import { Workload } from './utils/constants/wizard';
 import { vmPresets, getBasicVMBuilder } from './mocks/vmBuilderPresets';
 import { VMBuilder } from './models/vmBuilder';
 import { ProvisionSource } from './utils/constants/enums/provisionSource';
@@ -94,7 +93,6 @@ describe('Kubevirt create VM using wizard', () => {
     const vm = new VMBuilder(getBasicVMBuilder())
       .setName(testName)
       .setProvisionSource(ProvisionSource.PXE)
-      .setWorkload(Workload.DESKTOP)
       .setCustomize(true)
       .build();
     const wizard = new Wizard();

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
@@ -63,6 +63,7 @@ export const diskWarning = (resourceName) =>
   $(`[data-id="${resourceName}"]`).$('.kv-validation-cell__cell--warning');
 
 // Advanced -- Cloud-init
+export const cloud = $('#cloud');
 export const cloudInitFormCheckbox = $('#cloud-init-edit-mode-first-option');
 export const cloudInitCustomScriptCheckbox = $('#cloud-init-edit-mode-second-option');
 export const customCloudInitScriptTextArea = $('#cloudinit-custom-custom-script');


### PR DESCRIPTION
- remove workload/flavor set if it's using common template
- click cloud-init to open the cloud-init form before the tests