### PR TITLE
Bug 1937941: Fix wording for favorite templates

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -665,7 +665,7 @@
   "Create new Template from": "Create new Template from",
   "Delete Template": "Delete Template",
   "Red Hat templates cannot be deleted": "Red Hat templates cannot be deleted",
-  "Unfavorite template": "Unfavorite template",
+  "Remove favorite": "Remove favorite",
   "Favorite template": "Favorite template",
   "View full details": "View full details",
   "Template details": "Template details",

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -21,7 +21,7 @@ import { TemplateItem } from '../../types/template';
 import { getVMWizardCreateLink } from '../../utils/url';
 import { deleteVMTemplateModal } from '../modals/menu-actions-modals/delete-vm-template-modal';
 import deleteVMTCustomizationModal from '../modals/menu-actions-modals/DeleteVMTCustomizationModal';
-import { PinnedIcon } from './os-icons';
+import { RemovePinnedIcon, PinnedIcon } from './os-icons';
 import { createVMAction } from './utils';
 
 type CustomData = {
@@ -129,8 +129,8 @@ const PinTemplateLabel: React.FC<{ pinned: boolean }> = ({ pinned }) => {
   const { t } = useTranslation();
   return (
     <>
-      {pinned ? t('kubevirt-plugin~Unfavorite template') : t('kubevirt-plugin~Favorite template')}
-      <PinnedIcon />
+      {pinned ? t('kubevirt-plugin~Remove favorite') : t('kubevirt-plugin~Favorite template')}
+      {pinned ? <RemovePinnedIcon /> : <PinnedIcon />}
     </>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/os-icons.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/os-icons.scss
@@ -2,3 +2,8 @@
   width: 2rem;
   color: var(--pf-global--palette--gold-300);
 }
+
+.kv-remove-pin-icon {
+  width: 2rem;
+  color: var(--pf-global--palette--black-300);
+}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/os-icons.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/os-icons.tsx
@@ -36,3 +36,5 @@ export const getTemplateOSIcon = (template: TemplateKind): string => {
 };
 
 export const PinnedIcon = () => <StarIcon className="kv-pin-icon" />;
+
+export const RemovePinnedIcon = () => <StarIcon className="kv-remove-pin-icon" />;


### PR DESCRIPTION
In this example, I fix the typo of the "Unfavorita template" to "Remove favorite".
Also changed the color of icon next to "Remove favorite" to be grey so it shows we remove it

before:

![Screenshot from 2021-04-06 15-51-39](https://user-images.githubusercontent.com/67270715/113717854-b7840000-96f4-11eb-84aa-dfb5f7686d89.png)

after:

![Screenshot from 2021-04-06 16-18-14](https://user-images.githubusercontent.com/67270715/113718000-e39f8100-96f4-11eb-8195-06e26e9cee3f.png)


Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1937941
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>