### PR TITLE
Bug 1946705: Use search terms as separate words in quick add search

### DIFF
--- a/frontend/packages/console-shared/src/utils/index.ts
+++ b/frontend/packages/console-shared/src/utils/index.ts
@@ -20,3 +20,4 @@ export * from './multiselectdropdown';
 export * from './annotations';
 export * from './xterm-addon-fullscreen';
 export * from './yup-validations';
+export * from './keyword-filter';

--- a/frontend/packages/console-shared/src/utils/keyword-filter.ts
+++ b/frontend/packages/console-shared/src/utils/keyword-filter.ts
@@ -1,0 +1,23 @@
+import * as _ from 'lodash';
+
+export const keywordFilter = <T>(
+  filterText: string,
+  items: T[],
+  compareFunction: (keyword: string, item: T) => boolean,
+): T[] => {
+  if (!filterText) {
+    return items;
+  }
+  const keywords = _.uniq(filterText.match(/\S+/g)).map((w) => w.toLowerCase());
+
+  // Sort the longest keyword fist
+  keywords.sort(function(a: string, b: string) {
+    return b.length - a.length;
+  });
+
+  return items.filter((item) => {
+    return keywords.every((keyword) => {
+      return compareFunction(keyword, item);
+    });
+  });
+};

--- a/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx
@@ -72,7 +72,7 @@ const CatalogServiceProvider: React.FC<CatalogServiceProviderProps> = ({
 
   const searchCatalog = React.useCallback(
     (query: string) => {
-      return catalogItems.filter((item) => keywordCompare(query, item));
+      return keywordCompare(query, catalogItems);
     },
     [catalogItems],
   );

--- a/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
@@ -1,24 +1,25 @@
+import { keywordFilter } from '@console/shared';
 import { history } from '@console/internal/components/utils';
 import { normalizeIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
 import * as catalogImg from '@console/internal/imgs/logos/catalog-icon.svg';
 import { CatalogType, CatalogTypeCounts } from './types';
 
-export const keywordCompare = (filterString: string, item: CatalogItem): boolean => {
-  if (!filterString) {
-    return true;
-  }
+const catalogItemCompare = (keyword: string, item: CatalogItem): boolean => {
   if (!item) {
     return false;
   }
-
-  const filterStringLowerCase = filterString.toLowerCase();
   return (
-    item.name.toLowerCase().includes(filterStringLowerCase) ||
-    (typeof item.description === 'string' &&
-      item.description.toLowerCase().includes(filterStringLowerCase)) ||
-    (item.tags && item.tags.some((tag) => tag.includes(filterStringLowerCase)))
+    item.name.toLowerCase().includes(keyword) ||
+    (typeof item.description === 'string' && item.description.toLowerCase().includes(keyword)) ||
+    item.type.toLowerCase().includes(keyword) ||
+    item.tags?.some((tag) => tag.includes(keyword)) ||
+    item.cta?.label.toLowerCase().includes(keyword)
   );
+};
+
+export const keywordCompare = (filterString: string, items: CatalogItem[]): CatalogItem[] => {
+  return keywordFilter(filterString, items, catalogItemCompare);
 };
 
 export const getIconProps = (item: CatalogItem) => {

--- a/frontend/packages/dev-console/src/components/catalog/utils/filter-utils.ts
+++ b/frontend/packages/dev-console/src/components/catalog/utils/filter-utils.ts
@@ -62,7 +62,7 @@ export const filterBySearchKeyword = (
   items: CatalogItem[],
   searchKeyword: string,
 ): CatalogItem[] => {
-  return searchKeyword ? items.filter((item) => keywordCompare(searchKeyword, item)) : items;
+  return keywordCompare(searchKeyword, items);
 };
 
 export const filterByCategory = (

--- a/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
+++ b/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
@@ -11,7 +11,7 @@ import {
 } from '@console/app/src/components/quick-starts/utils/quick-start-context';
 
 export const quickSearch = (items: CatalogItem[], query: string) => {
-  return items.filter((item) => keywordCompare(query, item));
+  return keywordCompare(query, items);
 };
 
 export const useTransformedQuickStarts = (quickStarts: QuickStart[]): CatalogItem[] => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5662
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Using multiple words to narrow down search results does not work because the catalog items are compared against the full query string at once.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Break down the query string into multiple words, and match all the catalog items against every word separately.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
Before:
![1](https://user-images.githubusercontent.com/20013884/113750188-1b73ec00-9728-11eb-9c99-3e7ec1c93370.png)

After:

https://user-images.githubusercontent.com/20013884/113751050-2418f200-9729-11eb-8b0f-3b98a202718f.mp4


<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Unchanged.
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
