### PR TITLE
Bug 1942193: Override default PF Accordion blue border on the edit Operator form. Only target the field group heading when used to display dynamic form field groups.

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
@@ -79,7 +79,7 @@ export const OperandForm: React.FC<OperandFormProps> = ({
             </div>
           )}
         </div>
-        <div className="col-md-8 col-md-pull-4 col-lg-7 col-lg-pull-5">
+        <div className="col-md-8 col-md-pull-4 col-lg-7 col-lg-pull-5 co-create-operand__form--toggle-no-border">
           <DynamicForm
             noValidate
             errors={errors}

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -26,6 +26,13 @@ form.pf-c-form {
   @include co-break-word;
 }
 
+// Override to remove accordion left border and prevent overlap https://bugzilla.redhat.com/show_bug.cgi?id=1942193
+.co-create-operand__form--toggle-no-border {
+  .pf-c-accordion__toggle.pf-m-expanded {
+    --pf-c-accordion__toggle--before--BackgroundColor: transparent;
+  }
+}
+
 // For input & label alignment while using bootstrap with @patternfly/react-catalog-view-extension
 .filter-panel-pf-category-item {
   .pf-c-check {


### PR DESCRIPTION
This is a simple fix to correct the bug. See Related notes below for further info.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1942193

### before
<img width="836" alt="4 8__operand-form__accordion (1)" src="https://user-images.githubusercontent.com/1874151/113758977-8995c000-96e2-11eb-8861-89156206bac5.png">

### after
<img width="668" alt="Screen Shot 2021-04-06 at 1 47 33 PM" src="https://user-images.githubusercontent.com/1874151/113766024-fad97100-96ea-11eb-898d-690492bd5a5c.png">


**_Related notes:_** 
The `Accordion` component is sub optimal, as it's currently being used, to show these expandable/nested sections. 

[PatternFly recently added functionality](https://github.com/patternfly/patternfly-react/pull/5569) 
 `FormFieldGroupExpandable` as a way to nest expandable form field groups sections.  
https://www.patternfly.org/v4/components/form/#field-groups

Going forward `FormFieldGroupExpandable` should be used present these form sections. 
Should we create a follow up story to convert existing forms?

<img width="603" alt="Screen Shot 2021-04-06 at 3 13 30 PM" src="https://user-images.githubusercontent.com/1874151/113765760-afbf5e00-96ea-11eb-9659-545f8946f46c.png">


