### PR TITLE
Add support for MultiColumnField to support multiline

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -79,9 +79,10 @@ export interface ResourceLimitFieldProps extends FieldProps {
 export interface MultiColumnFieldProps extends FieldProps {
   addLabel?: string;
   toolTip?: string;
-  emptyValues: { [name: string]: string };
+  emptyValues: { [name: string]: string | boolean };
   emptyMessage?: string;
   headers: ({ name: string; required: boolean } | string)[];
+  complexFields?: boolean[];
   children: React.ReactNode;
   spans?: gridItemSpanValueShape[];
 }

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
@@ -3,7 +3,10 @@
     position: relative;
     margin-right: var(--pf-global--spacer--lg);
     margin-bottom: var(--pf-global--spacer--md);
-    max-height: var(--pf-global--spacer--xl);
+
+    &--singleLine {
+      max-height: var(--pf-global--spacer--xl);
+    }
   }
   &__header {
     position: relative;

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -25,6 +25,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
   disableAddRow,
   toolTip,
   spans,
+  complexFields,
 }) => {
   const { values } = useFormikContext<FormikValues>();
   const fieldValue = _.get(values, name, []);
@@ -64,6 +65,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
                   isReadOnly={isReadOnly}
                   disableDeleteRow={disableDeleteRow}
                   spans={fieldSpans}
+                  complexFields={complexFields}
                 >
                   {children}
                 </MultiColumnFieldRow>

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import * as _ from 'lodash';
+import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import {
@@ -21,6 +23,7 @@ export interface MultiColumnFieldRowProps {
   isReadOnly?: boolean;
   disableDeleteRow?: boolean;
   spans: gridItemSpanValueShape[];
+  complexFields?: boolean[];
 }
 
 const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
@@ -32,14 +35,24 @@ const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
   isReadOnly,
   disableDeleteRow,
   spans,
+  complexFields = [],
 }) => {
   const { t } = useTranslation();
   return (
-    <div className="odc-multi-column-field__row">
+    <div
+      className={cx('odc-multi-column-field__row', {
+        'odc-multi-column-field__row--singleLine': _.isEmpty(complexFields),
+      })}
+    >
       <Grid>
         {React.Children.map(children, (child: React.ReactElement, i) => {
-          const fieldName = `${name}.${rowIndex}.${child.props.name}`;
-          const newProps = { ...child.props, name: fieldName };
+          const fieldName = `${name}.${rowIndex}`;
+          let newProps = child.props;
+          if (complexFields[i]) {
+            newProps = { ...newProps, namePrefix: fieldName };
+          } else {
+            newProps = { ...newProps, name: `${fieldName}.${child.props.name}` };
+          }
           return (
             <GridItem span={spans[i]} key={fieldName}>
               <div className="odc-multi-column-field__col">

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -49,6 +49,7 @@
   "Event Listener details": "Event Listener details",
   "Triggers": "Triggers",
   "URL": "URL",
+  "Optional workspace": "Optional workspace",
   "Pipeline details": "Pipeline details",
   "Tasks": "Tasks",
   "Finally tasks": "Finally tasks",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/OptionalableWorkspace.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/OptionalableWorkspace.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TextInputTypes } from '@patternfly/react-core';
+import { CheckboxField, InputField } from '@console/shared';
+
+type OptionalableWorkspace = {
+  namePrefix?: string;
+  isReadOnly?: boolean;
+};
+
+const OptionalableWorkspace: React.FC<OptionalableWorkspace> = ({ namePrefix, isReadOnly }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <InputField
+        name={`${namePrefix}.name`}
+        type={TextInputTypes.text}
+        placeholder={t('pipelines-plugin~Name')}
+        isReadOnly={isReadOnly}
+      />
+      <div style={{ marginBottom: 'var(--pf-global--spacer--xs)' }} />
+      <CheckboxField
+        name={`${namePrefix}.optional`}
+        label={t('pipelines-plugin~Optional workspace')}
+      />
+    </>
+  );
+};
+
+export default OptionalableWorkspace;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineWorkspaces.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineWorkspaces.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TextInputTypes } from '@patternfly/react-core';
-import { MultiColumnField, InputField } from '@console/shared';
+import { Grid, GridItem } from '@patternfly/react-core';
+import { MultiColumnField } from '@console/shared';
+import OptionalableWorkspace from './OptionalableWorkspace';
 
 type PipelineWorkspacesParam = {
   addLabel?: string;
@@ -18,21 +19,21 @@ const PipelineWorkspaces: React.FC<PipelineWorkspacesParam> = (props) => {
   } = props;
   const emptyMessage = t('pipelines-plugin~No workspaces are associated with this pipeline.');
   return (
-    <MultiColumnField
-      name={fieldName}
-      addLabel={addLabel}
-      headers={[t('pipelines-plugin~Name')]}
-      emptyValues={{ name: '' }}
-      emptyMessage={emptyMessage}
-      isReadOnly={isReadOnly}
-    >
-      <InputField
-        name="name"
-        type={TextInputTypes.text}
-        placeholder={t('pipelines-plugin~Name')}
-        isReadOnly={isReadOnly}
-      />
-    </MultiColumnField>
+    <Grid span={6}>
+      <GridItem>
+        <MultiColumnField
+          name={fieldName}
+          addLabel={addLabel}
+          headers={[t('pipelines-plugin~Name')]}
+          emptyValues={{ name: '', optional: false }}
+          emptyMessage={emptyMessage}
+          isReadOnly={isReadOnly}
+          complexFields={[true]}
+        >
+          <OptionalableWorkspace />
+        </MultiColumnField>
+      </GridItem>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5742

**Analysis / Root cause**: 
MultiColumnField assumed everything is a singular line height - this was problematic for the design in Pipeline Builder.

**Solution Description**: 
Supported an optional complex field setting to avoid over reaching into fields and assuming their size / layout.

**Screen shots / Gifs for design review**: 

Pipeline Builder Example...

Single entry:
![Screen Shot 2021-04-06 at 3 28 45 PM](https://user-images.githubusercontent.com/8126518/113767576-daaab180-96ec-11eb-8763-61ed34f688d9.png)

Multiple entries:
![image](https://user-images.githubusercontent.com/8126518/113767720-062d9c00-96ed-11eb-9016-db512e68aeac.png)

Multiple `MultiColumnField`s:
![Screen Shot 2021-04-06 at 3 28 19 PM](https://user-images.githubusercontent.com/8126518/113767593-df6f6580-96ec-11eb-9ac9-bfbe8d2e5853.png)

**Unit test coverage report**: 
No change.

**Test setup:**

Go to Pipeline Builder and add workspaces.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge