### PR TITLE
Fix skipped task status when using conditions

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/FinallyNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/FinallyNode.tsx
@@ -45,6 +45,7 @@ const FinallyNode: React.FC<FinallyNodeProps> = ({ element }) => {
             width={NODE_WIDTH}
             height={NODE_HEIGHT}
             isFinallyTask
+            isSkipped={pipelineRun?.status?.skippedTasks?.some((t) => t.name === ft.name)}
           />
         </g>
       ))}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskNode.tsx
@@ -12,6 +12,7 @@ type TaskNodeProps = {
 const TaskNode: React.FC<TaskNodeProps> = ({ element, disableTooltip }) => {
   const { height, width } = element.getBounds();
   const { pipeline, pipelineRun, task, selected } = element.getData();
+  const isTaskSkipped = pipelineRun?.status?.skippedTasks?.some((t) => t.name === task.name);
 
   return (
     <PipelineVisualizationTask
@@ -23,6 +24,7 @@ const TaskNode: React.FC<TaskNodeProps> = ({ element, disableTooltip }) => {
       selected={selected}
       width={width}
       height={height}
+      isSkipped={isTaskSkipped}
     />
   );
 };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5743

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
If When expression or conditions are used in a pipeline, then all the skipped tasks status are shown incorrectly.


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Pass the isSkipped prop to the task component to show the skipped status.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

PipelineRun details page visualization
![image](https://user-images.githubusercontent.com/9964343/113773501-bd550200-9743-11eb-817a-8c7196fd5152.png)

List page component
![image](https://user-images.githubusercontent.com/9964343/113773597-d9f13a00-9743-11eb-99c5-f60e60c2a6cc.png)



**Test setup:**
1. Create the pipelineRun using https://github.com/tektoncd/pipeline/blob/main/examples/v1beta1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug