### PR TITLE
Bug 1930015 - OS list is overlapped by buttons in template wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.scss
@@ -2,3 +2,9 @@
   width: 100%;
   margin-bottom: var(--pf-global--spacer--md);
 }
+
+.kv-create-vm-modal__footer {
+  // --pf-global--ZIndex--xs == 100
+  z-index: calc(var(--pf-global--ZIndex--xs) - 4); 
+  display: block;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
@@ -125,7 +125,7 @@ const CreateVMWizardFooterComponent: React.FC<CreateVMWizardFooterComponentProps
         const isBackButtonDisabled = isFirstStep || isAnyStepLocked || isLastTabErrorFatal;
 
         return (
-          <footer className={css(styles.wizardFooter)}>
+          <footer className={css(`${styles.wizardFooter} kv-create-vm-modal__footer`)}>
             <Prompt
               key="prompt"
               message={(location) => {


### PR DESCRIPTION
In this example, it shows footer block is overlapping the drop-down menus which is blocking automation testing.

before:

![bz_1930015_before_1](https://user-images.githubusercontent.com/67270715/113828878-8a376080-978d-11eb-981d-a7f07a360915.png)

![bz_1930015_before_2](https://user-images.githubusercontent.com/67270715/113828891-8c99ba80-978d-11eb-95ea-2f8aaf742076.png)

after:

![bz_1930015_after_1](https://user-images.githubusercontent.com/67270715/113828933-9a4f4000-978d-11eb-9856-6de2b6a8cae7.png)

![bz_1930015_after_2](https://user-images.githubusercontent.com/67270715/113828943-9d4a3080-978d-11eb-8c73-a0104edc128f.png)

![bz_1930015_after_3](https://user-images.githubusercontent.com/67270715/113829170-d97d9100-978d-11eb-913f-1dea4e899534.png)



Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1930015
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>