### PR TITLE
[release-4.7] Bug 1947091: Fix skipped task status when using conditions

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/TaskNode.tsx
@@ -12,6 +12,7 @@ type TaskNodeProps = {
 const TaskNode: React.FC<TaskNodeProps> = ({ element, disableTooltip }) => {
   const { height, width } = element.getBounds();
   const { pipeline, pipelineRun, task, selected } = element.getData();
+  const isTaskSkipped = pipelineRun?.status?.skippedTasks?.some((t) => t.name === task.name);
 
   return (
     <PipelineVisualizationTask
@@ -23,6 +24,7 @@ const TaskNode: React.FC<TaskNodeProps> = ({ element, disableTooltip }) => {
       selected={selected}
       width={width}
       height={height}
+      isSkipped={isTaskSkipped}
     />
   );
 };


### PR DESCRIPTION
This is a manual cherrypick of https://github.com/openshift/console/pull/8577

**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5743

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
If When expression or conditions are used in a pipeline, then all the skipped tasks status are shown incorrectly.


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Pass the isSkipped prop to the task component to show the skipped status.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

PipelineRun details page visualization
![image](https://user-images.githubusercontent.com/9964343/113920453-6d894000-9802-11eb-9ca2-921fcc02182c.png)

List page component
![image](https://user-images.githubusercontent.com/9964343/113920501-7c6ff280-9802-11eb-9f6f-629940567f09.png)



**Test setup:**
1. Create the pipelineRun using https://github.com/tektoncd/pipeline/blob/main/examples/v1beta1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug