### PR TITLE
[WIP] Bug 1885359: Cypress get() doesn't find the `Install` button element rendered on a side pop up in install operators page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -27,7 +27,7 @@ describe('Create namespace from install operators', () => {
     cy.log('test namespace creation from dropdown');
     cy.visit(`/operatorhub/ns/${testName}`);
     cy.byTestID(operatorSelector).click();
-    cy.byLegacyTestID('operator-install-btn').click({ force: true });
+    cy.byLegacyTestID('operator-install-btn').click();
 
     // configure operator install
     cy.byTestID('Select a Namespace-radio-input').check();

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -512,6 +512,10 @@ button.pf-c-dropdown__menu-item.pf-m-disabled {
   position: absolute !important;
 }
 
+#modal-container.pf-c-backdrop__open {
+  overflow: visible;
+}
+
 .text-muted {
   color: var(--pf-global--Color--200);
 }


### PR DESCRIPTION
Previously, we had to use `cy.byLegacyTestID('operator-install-btn').click({ force: true });`  -note the `force:true` in order to click on the **Install** button.

When `force:true` was removed Cypress throws: 
```
"This element `<a.pf-c-button.pf-m-primary.co-catalog-page__overlay-action>` [the Install button] is not 
visible because its parent `<div#modal-container.pf-c-backdrop__open>` has CSS property: 
`overflow: hidden` and an effective width and height of: `1000 x 0` pixels."
```
![image](https://user-images.githubusercontent.com/12733153/113899925-49dedf00-979b-11eb-9eb8-a5f94a57f30f.png)

Updated `.pf-c-backdrop__open` to `overflow: visible;` which fixed the [Cypress 'covering' issue](https://docs.cypress.io/guides/core-concepts/interacting-with-elements#Covering).  

`<div id="modal-container" role="dialog" aria-modal="true" class="">` is the top modal div and is defined in [app.jsx](https://github.com/openshift/console/blob/cf09e61f9e19bd81e5ab0b3f2c643c14ef6ec6cd/frontend/public/components/app.jsx#L184); It has a height of 10px and a width of 1301px (as computed in browser's dev console), but nothing I can see on the screen.  -Wondering if setting `overflow: visible` really changes anything visual? 

`<div class="pf-c-backdrop">` seems to be the first really 'visible' object, it contains the semi-transparanent background behind the modal.  Checked z-indexes and they are 'stacked' correctly, so the Install button is on top.