### PR TITLE
Bug 1947828: fix resource log download filename for long lines

### DIFF
--- a/frontend/public/components/utils/resource-log.tsx
+++ b/frontend/public/components/utils/resource-log.tsx
@@ -356,7 +356,7 @@ export const ResourceLog: React.FC<ResourceLogProps> = ({
               open the raw file in another window
             </a>{' '}
             or{' '}
-            <a href={linkURL} download>
+            <a href={linkURL} download={`${resource.metadata.name}-${containerName}.log`}>
               download it
             </a>
             .


### PR DESCRIPTION
Fix `download it` link in ResourceLog component when there are long lines in logs so that the log file will be saved in ${podName}-${containerName}.log format