### PR TITLE
Bug 1848151: Don't poll ClusterVersion when user doesn't have authority

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -31,6 +31,7 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
+import { useClusterVersion } from '@console/shared/src/hooks/version';
 import { usePrevious } from '@console/shared/src/hooks/previous';
 import {
   AlertAction,
@@ -46,11 +47,9 @@ import {
   getNewerClusterVersionChannel,
   getSimilarClusterVersionChannels,
   getSortedUpdates,
-  referenceForModel,
   splitClusterVersionChannel,
 } from '../module/k8s';
 import { ClusterVersionModel } from '../models';
-import { useK8sWatchResource, WatchK8sResource } from './utils/k8s-watch-hook';
 import { useAccessReview } from './utils/rbac';
 import { LinkifyExternal } from './utils';
 import { PrometheusEndpoint } from './graphs/helpers';
@@ -195,13 +194,6 @@ const getUpdateNotificationEntries = (
 
 const pollerTimeouts = {};
 const pollers = {};
-const cvResource: WatchK8sResource = {
-  kind: referenceForModel(ClusterVersionModel),
-  namespaced: false,
-  name: 'version',
-  isList: false,
-  optional: true,
-};
 
 export const refreshNotificationPollers = () => {
   _.each(pollerTimeouts, clearTimeout);
@@ -281,7 +273,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
 
     return () => _.each(pollerTimeouts, clearTimeout);
   }, [t]);
-  const [clusterVersionData] = useK8sWatchResource<ClusterVersionKind>(cvResource);
+  const clusterVersion: ClusterVersionKind = useClusterVersion();
 
   const { data, loaded, loadError } = alerts || {};
   const alertIds = React.useMemo(() => data?.map((datum) => datum.rule.name) || [], [data]);
@@ -301,7 +293,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
     }) && window.SERVER_FLAGS.branding !== 'dedicated';
 
   const updateList: React.ReactNode[] = getUpdateNotificationEntries(
-    clusterVersionData,
+    clusterVersion,
     clusterVersionIsEditable,
     toggleNotificationDrawer,
   );


### PR DESCRIPTION
Update the notification drawer to use the `useClusterVersion` hook,
which checks the `CLUSTER_VERSION` flag before trying to watch the
`ClusterVersion` resource. The `CLUSTER_VERSION` flag will resolve to
false if the user doesn't have permission to get the `ClusterVesrion`
resource.

/assign @rhamilto 