### PR TITLE
Bug 1918785: Update all resource request/limit queries based on new labels

### DIFF
--- a/frontend/packages/console-shared/src/promql/project-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/project-dashboard.ts
@@ -23,13 +23,13 @@ const queries = {
     `namespace:container_cpu_usage:sum{namespace='<%= project %>'}`,
   ),
   [ProjectQueries.CPU_REQUESTS]: _.template(
-    `sum(kube_pod_resource_request{resource="cpu", exported_namespace="<%= project %>"}) by (exported_namespace)`,
+    `sum(kube_pod_resource_request{resource="cpu", namespace="<%= project %>"}) by (namespace)`,
   ),
   [ProjectQueries.MEMORY_USAGE]: _.template(
     `sum(container_memory_working_set_bytes{namespace='<%= project %>',container="",pod!=""}) BY (namespace)`,
   ),
   [ProjectQueries.MEMORY_REQUESTS]: _.template(
-    `sum(kube_pod_resource_request{resource="memory", exported_namespace="<%= project %>"}) by (exported_namespace)`,
+    `sum(kube_pod_resource_request{resource="memory", namespace="<%= project %>"}) by (namespace)`,
   ),
   [ProjectQueries.POD_COUNT]: _.template(
     `count(kube_running_pod_ready{namespace='<%= project %>'}) BY (namespace)`,

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -527,8 +527,8 @@ const PodGraphs = requirePrometheus(({ pod }) => {
             byteDataType={ByteDataTypes.BinaryBytes}
             namespace={pod.metadata.namespace}
             query={`sum(container_memory_working_set_bytes{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}',container='',}) BY (pod, namespace)`}
-            limitQuery={`sum(label_replace(label_replace(kube_pod_resource_limit{resource='cpu',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)'))`}
-            requestedQuery={`sum(label_replace(label_replace(kube_pod_resource_request{resource='memory',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)')) BY (pod, namespace)`}
+            limitQuery={`sum(kube_pod_resource_limit{resource='memory',pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'})`}
+            requestedQuery={`sum(kube_pod_resource_request{resource='memory',pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}) BY (pod, namespace)`}
           />
         </div>
         <div className="col-md-12 col-lg-4">
@@ -540,8 +540,8 @@ const PodGraphs = requirePrometheus(({ pod }) => {
             humanize={humanizeCpuCores}
             namespace={pod.metadata.namespace}
             query={`pod:container_cpu_usage:sum{pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}`}
-            limitQuery={`sum(label_replace(label_replace(kube_pod_resource_limit{resource='cpu',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)'))`}
-            requestedQuery={`sum(label_replace(label_replace(kube_pod_resource_request{resource='cpu',exported_pod='${pod.metadata.name}',exported_namespace='${pod.metadata.namespace}'},'pod','$1','exported_pod','(.+)'),'namespace','$1','exported_namespace','(.+)')) BY (pod, namespace)`}
+            limitQuery={`sum(kube_pod_resource_limit{resource='cpu',pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'})`}
+            requestedQuery={`sum(kube_pod_resource_request{resource='cpu',pod='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}) BY (pod, namespace)`}
           />
         </div>
         <div className="col-md-12 col-lg-4">


### PR DESCRIPTION
We renamed the "exported_pod" and "exported_namespace" labels on the service monitor in 4.8 so that the tenant metric endpoint would correctly serve the metrics to regular users in pod details.  Update the queries to take that into account.
