### PR TITLE
Update prow deployment script

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/deploy-kubevirt-gating.sh
+++ b/frontend/packages/kubevirt-plugin/integration-tests/deploy-kubevirt-gating.sh
@@ -1,37 +1,20 @@
+#!/bin/bash
+
 KUBEVIRT_VERSION=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-#CDI_VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-CDI_VERSION="v1.29.0"
 
 VIRTCTL_DOWNLOAD_URL="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}"
 VIRTCTL_X86_64="${VIRTCTL_DOWNLOAD_URL}-linux-x86_64"
 VIRTCTL_AMD64="${VIRTCTL_DOWNLOAD_URL}-linux-amd64"
 
+HCO_VERSION="master"
+
+curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/$HCO_VERSION/deploy/deploy.sh | bash
+
 # Create openshift-cnv namespace for Integration Tests
 oc create namespace openshift-cnv
 
-oc create namespace kubevirt-os-images
-
-# Deploy Kubevirt, Storage, CDI Pods
-oc create -f https://github.com/kubevirt/kubevirt/releases/download/$KUBEVIRT_VERSION/kubevirt-operator.yaml
-
-oc create -f https://github.com/kubevirt/kubevirt/releases/download/$KUBEVIRT_VERSION/kubevirt-cr.yaml
-
-# File was deleted upstream, using last known file in github, until a more permanent fix:
-# https://github.com/openshift/console/pull/8608 - will fix this issue.
-# oc create -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/storage-setup.yml
-oc create -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/f6530b3fe71e8821208cad8fcac165c54a42bd54/labs/manifests/storage-setup.yml
-
-oc create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
-
-oc create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
-
-# Deploy Common Templates
-oc project openshift
-oc create -f https://github.com/kubevirt/common-templates/releases/download/v0.13.1/common-templates-v0.13.1.yaml
-oc project default
-
-# Wait for kubevirt to be available
-oc wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m
+# Setup storage
+oc create -f https://raw.githubusercontent.com/openshift/console/master/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/hostpath-provisioner-setup.yml
 
 oc patch storageclass hostpath -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 
@@ -47,22 +30,28 @@ data:
   volumeMode: Filesystem
 EOF
 
-# Enable live-migration feature-gate
-oc create -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubevirt-config
-  namespace: kubevirt
-  labels:
-  kubevirt.io: ""
-data:
-  feature-gates: "DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar,Snapshot"
-EOF
+num_of_lines=0
 
-# TODO remove this once the test image is built from Dockerfile
+# Wait for templates to be created before continuing
+while [ "$num_of_lines" -eq 0 ]
+do
+  echo "Waiting for creation of common templates"
+  num_of_lines=$(oc get -n openshift templates | grep windows10-desktop-large | wc -l)
+done
+
+echo "Common templates created"
+
+# Pause the SSP operator to prevent overwrites
+oc annotate -n kubevirt-hyperconverged deployments ssp-operator kubevirt.io/operator.paused="true"
+
+# Annotate templates
+curl https://raw.githubusercontent.com/openshift/console/master/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/add-support-annotations.sh | bash
+
+# Unpause the SSP operator
+oc annotate -n kubevirt-hyperconverged deployments ssp-operator kubevirt.io/operator.paused-
+
 if ! type virtctl; then
-  # Install virtctl binary and add in to PATH
+  # Install virtctl binary and add to PATH
   mkdir virtctl
 
   wget ${VIRTCTL_AMD64} -O virtctl/virtctl || wget ${VIRTCTL_X86_64} -O virtctl/virtctl
@@ -73,3 +62,5 @@ if ! type virtctl; then
   export PATH="${PATH}:$(pwd)/virtctl"
 fi
 
+# Wait for kubevirt to be available
+oc -n kubevirt-hyperconverged wait deployment/virt-operator --for=condition=Available --timeout="300s"


### PR DESCRIPTION
This script will replace the current installation of KubeVirt on prow with an HCO installation. It will also add the Red Hat support annotations to Red Hat supported templates.

Depends on https://github.com/openshift/console/pull/8654