### PR TITLE
Bug 1862989: [RFE]VM import wizard - storage class filter or a tooltip

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -245,6 +245,8 @@
   "This disk does not have a source defined and can not be used as a boot source": "This disk does not have a source defined and can not be used as a boot source",
   "A boot source disk must have a source and can not be blank": "A boot source disk must have a source and can not be blank",
   "--- Select Bootable Disk ---": "--- Select Bootable Disk ---",
+  "Supported Storage classes": "Supported Storage classes",
+  "Supported Storage classes for selected provider": "Supported Storage classes for selected provider",
   "Disks": "Disks",
   "Add Disk": "Add Disk",
   "No disks attached": "No disks attached",

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -24,7 +24,14 @@ import { ActionType } from '../../redux/types';
 import { iGetCommonData } from '../../selectors/immutable/selectors';
 import { getStorages } from '../../selectors/selectors';
 import { getTemplateValidation } from '../../selectors/template';
-import { VMWizardProps, VMWizardStorage, VMWizardStorageType } from '../../types';
+import {
+  ImportProvidersField,
+  VMImportProvider,
+  VMWizardProps,
+  VMWizardStorage,
+  VMWizardStorageType,
+} from '../../types';
+import { iGetImportProvidersValue } from '../../selectors/immutable/import-providers';
 
 const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
   const {
@@ -36,6 +43,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
     storages,
     templateValidations,
     storageClassConfigMap,
+    importProvider,
     ...restProps
   } = props;
   const { type, disk, volume, dataVolume, persistentVolumeClaim, editConfig } = storage || {};
@@ -98,6 +106,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
         disk={new DiskWrapper(disk, true)}
         volume={new VolumeWrapper(volume, true)}
         dataVolume={dataVolume && new DataVolumeWrapper(dataVolume, true)}
+        importProvider={importProvider}
         persistentVolumeClaim={
           persistentVolumeClaim && new PersistentVolumeClaimWrapper(persistentVolumeClaim, true)
         }
@@ -143,6 +152,7 @@ type VMWizardStorageModalProps = ModalComponentProps & {
   storages: VMWizardStorage[];
   addUpdateStorage: (storage: VMWizardStorage) => void;
   templateValidations: TemplateValidations;
+  importProvider?: VMImportProvider;
 };
 
 const stateToProps = (state, { wizardReduxID }) => {
@@ -156,6 +166,7 @@ const stateToProps = (state, { wizardReduxID }) => {
     ),
     storages: getStorages(state, wizardReduxID),
     templateValidations: getTemplateValidation(state, wizardReduxID),
+    importProvider: iGetImportProvidersValue(state, wizardReduxID, ImportProvidersField.PROVIDER),
   };
 };
 

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -31,6 +31,10 @@ export const CLOUD_INIT_MISSING_USERNAME =
 export const CLOUD_INIT_DOC_LINK = 'https://cloudinit.readthedocs.io/en/latest/index.html';
 export const STORAGE_CLASS_SUPPORTED_MATRIX_DOC_LINK =
   'https://docs.openshift.com/container-platform/4.6/virt/virtual_machines/virtual_disks/virt-features-for-storage.html';
+export const STORAGE_CLASS_SUPPORTED_RHV_LINK =
+  'https://docs.openshift.com/container-platform/4.7/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html';
+export const STORAGE_CLASS_SUPPORTED_VMWARE_LINK =
+  'https://docs.openshift.com/container-platform/4.7/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html';
 
 export const getDialogUIError = (hasAllRequiredFilled, t: TFunction) =>
   hasAllRequiredFilled


### PR DESCRIPTION
Added an Alert for the storage tab and disk modal in Import provider wizard.
The alert states the supported Storage classes for the selected provider.

<img width="1173" alt="Screen Shot 2021-04-11 at 14 05 02" src="https://user-images.githubusercontent.com/24938324/114302415-92ff9d80-9ad1-11eb-8bb5-5a7f80f27522.png">

-----------------------------------

<img width="629" alt="Screen Shot 2021-04-11 at 14 18 28" src="https://user-images.githubusercontent.com/24938324/114302417-95fa8e00-9ad1-11eb-874d-6e7ba074daa3.png">
