### PR TITLE
Bug 1926289: create app-content div with modal-container as sibling

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/project.ts
+++ b/frontend/packages/integration-tests-cypress/support/project.ts
@@ -22,7 +22,7 @@ Cypress.Commands.add('createProject', (name: string, devConsole: boolean = false
   listPage.clickCreateYAMLbutton();
   modal.shouldBeOpened();
   cy.byTestID('input-name').type(name);
-  cy.testA11y('Create Project modal', '#modal-container');
+  cy.testA11y('Create Project modal');
   modal.submit();
   modal.shouldBeClosed();
   // TODO, switch to 'listPage.titleShouldHaveText(name)', when we switch to new test id
@@ -39,7 +39,7 @@ Cypress.Commands.add('deleteProject', (name: string) => {
   modal.submitShouldBeDisabled();
   cy.byTestID('project-name-input').type(name);
   modal.submitShouldBeEnabled();
-  cy.testA11y('Delete Project modal', '#modal-container');
+  cy.testA11y('Delete Project modal');
   modal.submit();
   modal.shouldBeClosed();
   listPage.titleShouldHaveText('Projects');

--- a/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
@@ -36,7 +36,7 @@ describe('Namespace', () => {
     listPage.clickCreateYAMLbutton();
     modal.shouldBeOpened();
     cy.byTestID('input-name').type(newName);
-    cy.testA11y('Create Namespace modal', '#modal-container');
+    cy.testA11y('Create Namespace modal');
     modal.submit();
     modal.shouldBeClosed();
     cy.url().should('include', `/k8s/cluster/namespaces/${newName}`);
@@ -48,7 +48,7 @@ describe('Namespace', () => {
     listPage.rows.clickKebabAction(newName, 'Delete Namespace');
     modal.shouldBeOpened();
     cy.byTestID('project-name-input').type(newName);
-    cy.testA11y('Delete Namespace modal', '#modal-container');
+    cy.testA11y('Delete Namespace modal');
     modal.submit();
     modal.shouldBeClosed();
     cy.resourceShouldBeDeleted(testName, 'namespaces', newName);

--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -149,7 +149,7 @@ describe('Monitoring: Alerts', () => {
     cy.log('expires the Silence');
     detailsPage.clickPageActionFromDropdown('Expire silence');
     modal.shouldBeOpened();
-    cy.testA11y('Expire silence modal', '#modal-container');
+    cy.testA11y('Expire silence modal');
     modal.submit();
     modal.shouldBeClosed();
     cy.get(errorMessage).should('not.exist');

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -152,36 +152,38 @@ class App_ extends React.PureComponent {
       <>
         <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
         <QuickStartDrawer>
-          <ConsoleNotifier location="BannerTop" />
-          <Page
-            header={<Masthead onNavToggle={this._onNavToggle} />}
-            sidebar={
-              <Navigation
-                isNavOpen={isNavOpen}
-                onNavSelect={this._onNavSelect}
-                onPerspectiveSelected={this._onNavSelect}
-              />
-            }
-            skipToContent={
-              <SkipToContent
-                href={`${this.props.location.pathname}${this.props.location.search}#content`}
-              >
-                Skip to Content
-              </SkipToContent>
-            }
-          >
-            <ConnectedNotificationDrawer
-              isDesktop={isDrawerInline}
-              onDrawerChange={this._onNotificationDrawerToggle}
+          <div id="app-content" className="co-m-page__body">
+            <ConsoleNotifier location="BannerTop" />
+            <Page
+              header={<Masthead onNavToggle={this._onNavToggle} />}
+              sidebar={
+                <Navigation
+                  isNavOpen={isNavOpen}
+                  onNavSelect={this._onNavSelect}
+                  onPerspectiveSelected={this._onNavSelect}
+                />
+              }
+              skipToContent={
+                <SkipToContent
+                  href={`${this.props.location.pathname}${this.props.location.search}#content`}
+                >
+                  Skip to Content
+                </SkipToContent>
+              }
             >
-              <AppContents />
-            </ConnectedNotificationDrawer>
-          </Page>
-          <CloudShell />
-          <GuidedTour />
-          <ConsoleNotifier location="BannerBottom" />
+              <ConnectedNotificationDrawer
+                isDesktop={isDrawerInline}
+                onDrawerChange={this._onNotificationDrawerToggle}
+              >
+                <AppContents />
+              </ConnectedNotificationDrawer>
+            </Page>
+            <CloudShell />
+            <GuidedTour />
+            <ConsoleNotifier location="BannerBottom" />
+          </div>
+          <div id="modal-container" role="dialog" aria-modal="true" />
         </QuickStartDrawer>
-        <div id="modal-container" role="dialog" aria-modal="true" />
       </>
     );
 

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -23,7 +23,7 @@ export const createModal: CreateModal = (getModalContainer) => {
       ReactDOM.unmountComponentAtNode(modalContainer);
       resolve();
     };
-    Modal.setAppElement(document.getElementById('app'));
+    Modal.setAppElement(document.getElementById('app-content'));
     ReactDOM.render(getModalContainer(closeModal), modalContainer);
   });
   return { result };


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/OCPBUGSM-24598

Issue:
1. Catalog Sidebar overlaps the Quick Starts
2. If `#modal-container` is moved as a children of `#app` it's hidden from screen readers because `#app` is markd as aria-hidden true.

Solution:
```
<QuickStartDrawer>
  <div id="app-content"> // mark aria-hidden=true when modal is open
  ....
  </div>
  <div id="modal-container" />
</QuickStartDrawer>
```
create a wrapper `div` and move everything as children of that div except QuickStartDrawer, #modal-container. 
one the modal is open mark `#app-content` as aria-hidden true instead of `#app` so that modal and QuickStartDrawer both are visible to screen readers

![overlap-modal](https://user-images.githubusercontent.com/9278015/114392039-e0553b00-9bb5-11eb-8ec2-85b3000623b9.gif)

