### PR TITLE
Bug 1946922: Fix ingress details page to show referenced secret name

### DIFF
--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -37,7 +37,7 @@ const getHosts = (ingress) => {
   return <div className="text-muted">No hosts</div>;
 };
 
-const TLSCert = (ingress) => {
+const TLSCert = ({ ingress }) => {
   const { t } = useTranslation();
   if (!_.has(ingress.spec, 'tls')) {
     return (


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1946922

Before:
<img width="702" alt="Screen Shot 2021-04-12 at 12 43 29 PM" src="https://user-images.githubusercontent.com/35978579/114430904-e682f180-9b8c-11eb-8a0f-d45c48e57112.png">

After:
<img width="695" alt="Screen Shot 2021-04-12 at 12 45 30 PM" src="https://user-images.githubusercontent.com/35978579/114430977-fc90b200-9b8c-11eb-8ff1-146c93363f1d.png">
