### PR TITLE
Fix broken link document Sealing Virtual Machines on CNV

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceStatus.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceStatus.tsx
@@ -65,7 +65,7 @@ const CustomizeSourceStatus: React.FC<CustomizeSourceStatusProps> = ({
           >
             <ExternalLink
               text={t('kubevirt-plugin~Learn how to generalize a boot source')}
-              href="foo"
+              href="https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/chap-templates#Sealing_Virtual_Machines_in_Preparation_for_Deployment_as_Templates"
             />
           </Alert>
         </StackItem>


### PR DESCRIPTION
Since CNV has no doc for document Sealing Virtual Machines
attached doc from rhv due to similarity of procedures,
and fixing broken link

after(watch on bottom left where the link is showing):
![Screenshot from 2021-04-12 20-53-53](https://user-images.githubusercontent.com/67270715/114440232-8fa00b00-9bd2-11eb-85db-f8629401572b.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>