### PR TITLE
Bug 1942673: Fix pipeline model label references not using keys

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/cluster-tasks/ClusterTaskDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/cluster-tasks/ClusterTaskDetails.tsx
@@ -17,7 +17,7 @@ const ClusterTaskDetails: React.FC<ClusterTaskDetailsProps> = ({ obj: task }) =>
     <div className="co-m-pane__body">
       <SectionHeading
         text={t('pipelines-plugin~{{clusterTaskLabel}} details', {
-          clusterTaskLabel: ClusterTaskModel.label,
+          clusterTaskLabel: t(ClusterTaskModel.labelKey),
         })}
       />
       <div className="row">

--- a/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesList.tsx
@@ -10,7 +10,7 @@ const PipelineResourcesList: React.FC = (props) => {
   return (
     <Table
       {...props}
-      aria-label={PipelineResourceModel.labelPlural}
+      aria-label={t(PipelineResourceModel.labelPluralKey)}
       Header={PipelineResourcesHeader(t)}
       Row={PipelineResourcesRow}
       virtualize

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { PipelineRunKind } from '../../../types';
 import { PipelineRunModel } from '../../../models';
 import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
@@ -11,6 +12,7 @@ export interface PipelineRunDetailsProps {
 }
 
 export const PipelineRunDetails: React.FC<PipelineRunDetailsProps> = ({ obj: pipelineRun }) => {
+  const { t } = useTranslation();
   return (
     <>
       <div className="co-m-pane__body odc-pipeline-run-details">
@@ -21,7 +23,7 @@ export const PipelineRunDetails: React.FC<PipelineRunDetailsProps> = ({ obj: pip
         <div className="co-m-pane__body">
           <ResultsList
             results={pipelineRun.status?.pipelineResults}
-            resourceName={PipelineRunModel.label}
+            resourceName={t(PipelineRunModel.labelKey)}
             status={pipelineRunFilterReducer(pipelineRun)}
           />
         </div>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunList.tsx
@@ -11,7 +11,7 @@ export const PipelineRunList: React.FC = (props) => {
   return (
     <Table
       {...props}
-      aria-label={PipelineRunModel.labelPlural}
+      aria-label={t(PipelineRunModel.labelPluralKey)}
       defaultSortField="status.startTime"
       defaultSortOrder={SortByDirection.desc}
       Header={PipelineRunHeader(t)}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/TriggerBindingDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/TriggerBindingDetails.tsx
@@ -18,7 +18,7 @@ const TriggerBindingDetails: React.FC<TriggerBindingDetailsProps> = ({ obj: trig
     <div className="co-m-pane__body">
       <SectionHeading
         text={t('pipelines-plugin~{{triggerBindingLabel}} details', {
-          triggerBindingLabel: getResourceModelFromBindingKind(triggerBinding.kind).label,
+          triggerBindingLabel: t(getResourceModelFromBindingKind(triggerBinding.kind).labelKey),
         })}
       />
       <div className="row">

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineList.tsx
@@ -18,7 +18,7 @@ const PipelineList: React.FC<PipelineListProps> = (props) => {
       {...props}
       defaultSortField="latestRun.status.startTime"
       defaultSortOrder={SortByDirection.desc}
-      aria-label={PipelineModel.labelPlural}
+      aria-label={t(PipelineModel.labelPluralKey)}
       Header={PipelineHeader(t)}
       Row={PipelineRow}
       virtualize

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/MultipleResourceKeySelector.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/MultipleResourceKeySelector.tsx
@@ -86,7 +86,7 @@ const MultipleResourceKeySelector: React.FC<StateProps & MultipleResourceKeySele
         loadError={loadError}
         dataSelector={['metadata', 'name']}
         selectedKey={field.value}
-        placeholder={t('pipelines-plugin~Select a {{label}}', { label: resourceModel.label })}
+        placeholder={t('pipelines-plugin~Select a {{label}}', { label: t(resourceModel.labelKey) })}
         autocompleteFilter={autocompleteFilter}
         dropDownClassName={cx({ 'dropdown--full-width': true })}
         onChange={(value: string) => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/TriggerBindingSelector.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/TriggerBindingSelector.tsx
@@ -18,7 +18,7 @@ const KEY_DIVIDER = '~';
 
 const TriggerBindingSelector: React.FC<TriggerBindingSelectorProps> = (props) => {
   const { t } = useTranslation();
-  const { description, label = TriggerBindingModel.label, onChange } = props;
+  const { description, label = t(TriggerBindingModel.labelKey), onChange } = props;
   const { values } = useFormikContext<AddTriggerFormValues>();
   const autoCompleteFilter = (strText: string, item: React.ReactElement): boolean =>
     fuzzy(strText, item?.props?.name);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
@@ -45,7 +45,7 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
 
   return (
     <>
-      <SidebarSectionHeading text={PipelineRunModel.labelPlural}>
+      <SidebarSectionHeading text={t(PipelineRunModel.labelPluralKey)}>
         {showAlert && pipelineRuns.length === 0 && (
           <PipelineOverviewAlert
             title={t('pipelines-plugin~Pipeline could not be started automatically')}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/ResourceLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/ResourceLinkList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { K8sKind } from '@console/internal/module/k8s';
 import DynamicResourceLinkList from './DynamicResourceLinkList';
 
@@ -8,11 +9,12 @@ type ResourceLinkListProps = {
   links: string[];
 };
 const ResourceLinkList: React.FC<ResourceLinkListProps> = ({ links, model, namespace }) => {
+  const { t } = useTranslation();
   return (
     <DynamicResourceLinkList
       links={links.map((name) => ({ model, name }))}
       namespace={namespace}
-      title={model.labelPlural}
+      title={t(model.labelPluralKey)}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ResourceLink } from '@console/internal/components/utils';
 import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { ClipboardCopy } from '@patternfly/react-core';
@@ -15,7 +16,8 @@ const TriggerTemplateResourceLink: React.FC<TriggerTemplateResourceLinkProps> = 
   namespace,
   model,
 }) => {
-  const title = model.labelPlural;
+  const { t } = useTranslation();
+  const title = t(model.labelPluralKey);
   const kind = referenceForModel(model);
 
   if (links.length === 0) {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/__tests__/TriggerTemplateResourceLink.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/__tests__/TriggerTemplateResourceLink.spec.tsx
@@ -5,6 +5,14 @@ import { ResourceLink } from '@console/internal/components/utils';
 import TriggerTemplateResourceLink from '../TriggerTemplateResourceLink';
 import { TriggerTemplateModel } from '../../../../models';
 
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
 type TriggerTemplateResourceLinkProps = React.ComponentProps<typeof TriggerTemplateResourceLink>;
 describe('TriggerTemplateResourceLink', () => {
   const props: TriggerTemplateResourceLinkProps = {

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetails.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { TaskRunKind } from '../../types';
 import { TaskRunModel } from '../../models';
 import { taskRunFilterReducer } from '../../utils/pipeline-filter-reducer';
@@ -12,6 +13,7 @@ export interface TaskRunDetailsProps {
 }
 
 const TaskRunDetails: React.FC<TaskRunDetailsProps> = ({ obj: taskRun }) => {
+  const { t } = useTranslation();
   return (
     <>
       <div className="co-m-pane__body">
@@ -21,7 +23,7 @@ const TaskRunDetails: React.FC<TaskRunDetailsProps> = ({ obj: taskRun }) => {
         <div className="co-m-pane__body">
           <ResultsList
             results={taskRun.status?.taskResults}
-            resourceName={TaskRunModel.label}
+            resourceName={t(TaskRunModel.labelKey)}
             status={taskRunFilterReducer(taskRun)}
           />
         </div>

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/TaskRunDetailsSection.tsx
@@ -15,7 +15,7 @@ const TaskRunDetailsSection: React.FC<TaskRunDetailsSectionProps> = ({ taskRun }
     <>
       <SectionHeading
         text={t('pipelines-plugin~{{taskRunLabel}} details', {
-          taskRunLabel: TaskRunModel.label,
+          taskRunLabel: t(TaskRunModel.labelKey),
         })}
       />
       <div className="row">

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsList.tsx
@@ -15,7 +15,7 @@ const TaskRunsList: React.FC<TaskRunsListProps> = (props) => {
   return (
     <Table
       {...props}
-      aria-label={TaskRunModel.labelPlural}
+      aria-label={t(TaskRunModel.labelPluralKey)}
       defaultSortField="status.startTime"
       defaultSortOrder={SortByDirection.desc}
       Header={TaskRunsHeader(props.customData?.showPipelineColumn, t)}

--- a/frontend/packages/pipelines-plugin/src/components/tasks/TaskDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/tasks/TaskDetails.tsx
@@ -17,7 +17,7 @@ const TaskDetails: React.FC<TaskDetailsProps> = ({ obj: task }) => {
     <div className="co-m-pane__body">
       <SectionHeading
         text={t('pipelines-plugin~{{taskLabel}} details', {
-          taskLabel: TaskModel.label,
+          taskLabel: t(TaskModel.labelKey),
         })}
       />
       <div className="row">


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1942673

Address the references to the label and labelPlural in pipeline model to use translated lableKey and labelPluralKeys. Includes detail and list pages, and overviews and sections.

cc: @rebeccaalpert 