### PR TITLE
fixes issue with kn resources not shown if KS is created

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
@@ -316,7 +316,6 @@ describe('event-source-kafka', () => {
   });
 
   it('should not return any edges', () => {
-    // downcastconst kafkaConnection = _.cloneDeep(getKafkaConnection);
     const kafkaConnection = {
       ...kafkaConnectionData,
       data: [
@@ -328,8 +327,12 @@ describe('event-source-kafka', () => {
         },
       ],
     };
-    // kafkaConnection.data[0].status.bootstrapServerHost = null;
     const edges = getKnSourceKafkaTopologyEdgeItems(mockKafkaData, kafkaConnection);
+    expect(edges).toEqual([]);
+  });
+
+  it('should not return any edges if KafkaConnection is not present', () => {
+    const edges = getKnSourceKafkaTopologyEdgeItems(mockKafkaData, undefined);
     expect(edges).toEqual([]);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5759

**Analysis / Root cause**: 
In Topology, Kntive resources were not shown but underlying Deployments were shown instead if Kafka Source is created in same ns


**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/114503096-64f19900-9c4a-11eb-8839-04e0ef361bf0.png)

**Unit Test**: 

![image](https://user-images.githubusercontent.com/5129024/114503640-4344e180-9c4b-11eb-8425-b7dea08787c7.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
