### PR TITLE
Bug 1949093:  fix a.pf-c-button hover issues

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -160,20 +160,17 @@ h6 {
   }
 }
 
-.pf-c-button.pf-m-link {
-  white-space: normal; // override default .pf-c-button to enable wrapping
+.pf-c-button {
+  &:hover,
+  &:focus {
+    .pf-c-button-icon--plain {
+      color: var(--pf-c-button--m-plain--hover--Color);
+    }
+  }
 }
 
-.pf-c-button.pf-m-inline {
-  text-align: left; // override default .pf-c-button text centering
-}
-
-.pf-c-button.pf-m-link--align-left {
-  padding-left: 0;
-}
-
-.pf-c-button.pf-m-link--align-right {
-  padding-right: 0;
+.pf-c-button-icon--plain {
+  color: var(--pf-c-button--m-plain--Color);
 }
 
 .pf-c-button.pf-c-button--no-default-values {
@@ -186,29 +183,30 @@ h6 {
   white-space: normal;
 }
 
-.pf-c-button.co-p-has-sidebar__sidebar-close {
-  float: right;
-  font-size: 21px !important;
-  line-height: 1;
-  opacity: 0.35;
-  padding: 0;
-  &:hover,
-  &:focus {
-    opacity: 1;
-  }
+.pf-c-button.pf-m-inline {
+  text-align: left; // override default .pf-c-button text centering
 }
 
-.pf-c-button {
-  &:hover,
-  &:focus {
-    .pf-c-button-icon--plain {
-      color: var(--pf-c-button--m-plain--hover--Color);
-    }
-  }
+.pf-c-button.pf-m-link {
+  white-space: normal; // override default .pf-c-button to enable wrapping
 }
 
-.pf-c-button-icon--plain {
-  color: var(--pf-c-button--m-plain--Color);
+.pf-c-button.pf-m-link--align-left {
+  padding-left: 0;
+}
+
+.pf-c-button.pf-m-link--align-right {
+  padding-right: 0;
+}
+
+// Fix upstream issue https://github.com/patternfly/patternfly/issues/3996 introduced in v4.96.2
+.pf-c-button.pf-m-primary {
+  color: var(--pf-c-button--m-primary--Color);
+}
+
+// Fix upstream issue https://github.com/patternfly/patternfly/issues/3996 introduced in v4.96.2
+.pf-c-button.pf-m-plain:hover {
+  color: var(--pf-c-button--m-plain--hover--Color);
 }
 
 .pf-c-chip-group.pf-m-toolbar {


### PR DESCRIPTION
Bonus:
* correctly alphabetize related rules
* remove duplicated `.pf-c-button.co-p-has-sidebar__sidebar-close` rule

Before:
<img width="252" alt="Screen Shot 2021-04-13 at 7 56 02 AM" src="https://user-images.githubusercontent.com/895728/114550579-5c8c6480-9c30-11eb-969c-2e4869809b85.png">
<img width="213" alt="Screen Shot 2021-04-13 at 7 56 20 AM" src="https://user-images.githubusercontent.com/895728/114550580-5d24fb00-9c30-11eb-924e-72087d774b1b.png">

After:
<img width="208" alt="Screen Shot 2021-04-13 at 8 13 43 AM" src="https://user-images.githubusercontent.com/895728/114550614-644c0900-9c30-11eb-9434-889bff8d0595.png">
<img width="234" alt="Screen Shot 2021-04-13 at 8 13 37 AM" src="https://user-images.githubusercontent.com/895728/114550615-64e49f80-9c30-11eb-9192-a9c1ba2aad4d.png">
