### PR TITLE
Bug 1952697: Add Segment support for analytics

### DIFF
--- a/Dockerfile.plugins.demo2
+++ b/Dockerfile.plugins.demo2
@@ -3,6 +3,12 @@
 # See frontend/dynamic-demo-plugin/README.md for details.
 
 # Stage 0: build the demo plugin
+# Manually pre-build the demo plugin:
+# cd frontend
+# yarn install
+# cd dynamic-demo-plugin
+# yarn install
+# yarn build
 
 # Stage 1: build the target image
 FROM node:10

--- a/Dockerfile.plugins.demo2
+++ b/Dockerfile.plugins.demo2
@@ -1,0 +1,22 @@
+# This image is used for testing OpenShift Console dynamic plugin capabilities.
+#
+# See frontend/dynamic-demo-plugin/README.md for details.
+
+# Stage 0: build the demo plugin
+
+# Stage 1: build the target image
+FROM node:10
+
+COPY ./frontend/dynamic-demo-plugin/dist /opt/console-demo-plugin/static
+COPY ./frontend/dynamic-demo-plugin/node_modules /opt/console-demo-plugin/node_modules
+COPY ./frontend/dynamic-demo-plugin/http-server.sh /opt/console-demo-plugin/http-server.sh
+
+LABEL io.k8s.display-name="OpenShift Console Demo Plugin" \
+      io.k8s.description="Sample OpenShift Console dynamic plugin used for testing purposes." \
+      io.openshift.tags="openshift" \
+      maintainer="Vojtech Szocs <vszocs@redhat.com>"
+
+USER node
+
+WORKDIR /opt/console-demo-plugin
+ENTRYPOINT [ "./http-server.sh", "./static" ]

--- a/frontend/dynamic-demo-plugin/console-extensions.json
+++ b/frontend/dynamic-demo-plugin/console-extensions.json
@@ -23,5 +23,13 @@
         "kind": "ExampleModel"
       }
     }
+  },
+  {
+    "type": "console.telemetry/listener",
+    "properties": {
+      "listener": {
+        "$codeRef": "telemetry.eventListener"
+      }
+    }
   }
 ]

--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -28,7 +28,8 @@
     "displayName": "Console Demo Plugin",
     "description": "Plasma reactors online. Initiating hyper drive.",
     "exposedModules": {
-      "barUtils": "./utils/bar"
+      "barUtils": "./utils/bar",
+      "telemetry": "./utils/telemetry"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/frontend/dynamic-demo-plugin/src/utils/telemetry.ts
+++ b/frontend/dynamic-demo-plugin/src/utils/telemetry.ts
@@ -1,0 +1,4 @@
+export const eventListener = (eventType: string, properties: {}) => {
+  // eslint-disable-next-line no-console
+  console.log('Demo Plugin received telemetry event: ', eventType, properties);
+};

--- a/frontend/dynamic-demo-plugin/src/utils/telemetry.ts
+++ b/frontend/dynamic-demo-plugin/src/utils/telemetry.ts
@@ -1,4 +1,84 @@
-export const eventListener = (eventType: string, properties: {}) => {
+import { createHash } from "crypto";
+
+const SEGMENT_KEY = '';
+
+const initSegment = () => {
+  const analytics = ((window as any).analytics = (window as any).analytics || []);
+  if (!analytics.initialize)
+    if (analytics.invoked)
+      window.console && console.error && console.error('Segment snippet included twice.');
+    else {
+      analytics.invoked = !0;
+      analytics.methods = [
+        'trackSubmit',
+        'trackClick',
+        'trackLink',
+        'trackForm',
+        'pageview',
+        'identify',
+        'reset',
+        'group',
+        'track',
+        'ready',
+        'alias',
+        'debug',
+        'page',
+        'once',
+        'off',
+        'on',
+        'addSourceMiddleware',
+        'addIntegrationMiddleware',
+        'setAnonymousId',
+        'addDestinationMiddleware',
+      ];
+      analytics.factory = function(e: string) {
+        return function() {
+          var t = Array.prototype.slice.call(arguments);
+          t.unshift(e);
+          analytics.push(t);
+          return analytics;
+        };
+      };
+      for (var e = 0; e < analytics.methods.length; e++) {
+        var key = analytics.methods[e];
+        analytics[key] = analytics.factory(key);
+      }
+      analytics.load = function(key: string, e: Event) {
+        const t = document.createElement('script');
+        t.type = 'text/javascript';
+        t.async = !0;
+        t.src = 'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js';
+        const n = document.getElementsByTagName('script')[0];
+        if (n.parentNode) {
+          n.parentNode.insertBefore(t, n);
+        }
+        analytics._loadOptions = e;
+      };
+      analytics.SNIPPET_VERSION = '4.13.1';
+      if (SEGMENT_KEY) {
+        analytics.load(SEGMENT_KEY);
+      }
+    }
+  return analytics;
+};
+
+initSegment();
+
+export const eventListener = (eventType: string, properties?: any) => {
   // eslint-disable-next-line no-console
   console.log('Demo Plugin received telemetry event: ', eventType, properties);
+  const analytics = initSegment();
+  switch (eventType) {
+    case 'identify':
+      const { clusterId, id, user } = properties;
+      // Use md5 hash to anonymize the user
+      const anonymousId = createHash('md5').update(`${clusterId}-${id}`).digest('hex');
+      (window as any).analytics.identify(anonymousId, user);
+      break;
+    case 'page':
+      analytics.page(undefined, properties);
+      break;
+    default:
+      analytics.track(eventType, properties);
+  }
 };

--- a/frontend/dynamic-demo-plugin/src/utils/telemetry.ts
+++ b/frontend/dynamic-demo-plugin/src/utils/telemetry.ts
@@ -1,84 +1,90 @@
-import { createHash } from "crypto";
-
 const SEGMENT_KEY = '';
 
 const initSegment = () => {
   const analytics = ((window as any).analytics = (window as any).analytics || []);
-  if (!analytics.initialize)
-    if (analytics.invoked)
-      window.console && console.error && console.error('Segment snippet included twice.');
-    else {
-      analytics.invoked = !0;
-      analytics.methods = [
-        'trackSubmit',
-        'trackClick',
-        'trackLink',
-        'trackForm',
-        'pageview',
-        'identify',
-        'reset',
-        'group',
-        'track',
-        'ready',
-        'alias',
-        'debug',
-        'page',
-        'once',
-        'off',
-        'on',
-        'addSourceMiddleware',
-        'addIntegrationMiddleware',
-        'setAnonymousId',
-        'addDestinationMiddleware',
-      ];
-      analytics.factory = function(e: string) {
-        return function() {
-          var t = Array.prototype.slice.call(arguments);
-          t.unshift(e);
-          analytics.push(t);
-          return analytics;
-        };
+  if (analytics.initialize) {
+    return;
+  }
+  if (analytics.invoked)
+    window.console && console.error && console.error('Segment snippet included twice.');
+  else {
+    analytics.invoked = true;
+    analytics.methods = [
+      'trackSubmit',
+      'trackClick',
+      'trackLink',
+      'trackForm',
+      'pageview',
+      'identify',
+      'reset',
+      'group',
+      'track',
+      'ready',
+      'alias',
+      'debug',
+      'page',
+      'once',
+      'off',
+      'on',
+      'addSourceMiddleware',
+      'addIntegrationMiddleware',
+      'setAnonymousId',
+      'addDestinationMiddleware',
+    ];
+    analytics.factory = function(e: string) {
+      return function() {
+        let t = Array.prototype.slice.call(arguments);
+        t.unshift(e);
+        analytics.push(t);
+        return analytics;
       };
-      for (var e = 0; e < analytics.methods.length; e++) {
-        var key = analytics.methods[e];
-        analytics[key] = analytics.factory(key);
-      }
-      analytics.load = function(key: string, e: Event) {
-        const t = document.createElement('script');
-        t.type = 'text/javascript';
-        t.async = !0;
-        t.src = 'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js';
-        const n = document.getElementsByTagName('script')[0];
-        if (n.parentNode) {
-          n.parentNode.insertBefore(t, n);
-        }
-        analytics._loadOptions = e;
-      };
-      analytics.SNIPPET_VERSION = '4.13.1';
-      if (SEGMENT_KEY) {
-        analytics.load(SEGMENT_KEY);
-      }
+    };
+    for (let e = 0; e < analytics.methods.length; e++) {
+      let key = analytics.methods[e];
+      analytics[key] = analytics.factory(key);
     }
-  return analytics;
+    analytics.load = function(key: string, e: Event) {
+      const t = document.createElement('script');
+      t.type = 'text/javascript';
+      t.async = true;
+      t.src = 'https://cdn.segment.com/analytics.js/v1/' + encodeURIComponent(key) + '/analytics.min.js';
+      const n = document.getElementsByTagName('script')[0];
+      if (n.parentNode) {
+        n.parentNode.insertBefore(t, n);
+      }
+      analytics._loadOptions = e;
+    };
+    analytics.SNIPPET_VERSION = '4.13.1';
+    if (SEGMENT_KEY) {
+      analytics.load(SEGMENT_KEY);
+    }
+  }
 };
 
 initSegment();
 
-export const eventListener = (eventType: string, properties?: any) => {
+export const eventListener = async (eventType: string, properties?: any) => {
   // eslint-disable-next-line no-console
   console.log('Demo Plugin received telemetry event: ', eventType, properties);
-  const analytics = initSegment();
+  const anonymousIP = {
+    context: {
+      ip: '0.0.0.0',
+    },
+  };
   switch (eventType) {
     case 'identify':
-      const { clusterId, id, user } = properties;
-      // Use md5 hash to anonymize the user
-      const anonymousId = createHash('md5').update(`${clusterId}-${id}`).digest('hex');
-      (window as any).analytics.identify(anonymousId, user);
+      const { user, ...otherProperties } = properties;
+      const id = user.metadata.uid || `${location.host}-${user.metadata.name}`;
+      // Use SHA1 hash algorithm to anonymize the user
+      const anonymousIdBuffer = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(id));
+      const anonymousIdArray = Array.from(new Uint8Array(anonymousIdBuffer));
+      const anonymousId = anonymousIdArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+      (window as any).analytics.identify(anonymousId, otherProperties, anonymousIP);
       break;
     case 'page':
-      analytics.page(undefined, properties);
+      (window as any).analytics.page(undefined, properties, anonymousIP);
       break;
     default:
-      analytics.track(eventType, properties);
+      (window as any).analytics.track(eventType, properties, anonymousIP);
   }
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/index.ts
@@ -9,6 +9,7 @@ export * from './pages';
 export * from './pvc';
 export * from './redux';
 export * from './resource-metadata';
+export * from './telemetry';
 export * from './yaml-templates';
 export * from './notification-alert';
 export * from './console-types';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/telemetry.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/telemetry.ts
@@ -1,37 +1,22 @@
-import { Extension } from '@console/plugin-sdk/src/typings/base';
+import { Extension, ExtensionDeclaration, CodeRef } from '../types';
 import { JSONSchema6Object } from 'json-schema';
-import { CodeRef, EncodedCodeRef, UpdateExtensionProperties } from '../types';
 
-namespace ExtensionProperties {
-  export type TelemetryListener = {
+export type TelemetryListener = ExtensionDeclaration<
+  'console.telemetry/listener',
+  {
     /** Listen for telemetry events */
-    listener: EncodedCodeRef;
-  };
-
-  export type TelemetryListenerCodeRefs = {
     listener: CodeRef<TelemetryEventListener>;
-  };
-}
-
-// Extension types
-
-export type TelemetryListener = Extension<ExtensionProperties.TelemetryListener> & {
-  type: 'console.telemetry/listener';
-};
-
-export type ResolvedTelemetryListener = UpdateExtensionProperties<
-  TelemetryListener,
-  ExtensionProperties.TelemetryListenerCodeRefs
+  }
 >;
 
 // P should be valid JSON
 export type TelemetryEventListener = <P extends JSONSchema6Object = JSONSchema6Object>(
   eventType: string,
-  properties: P,
+  properties?: P,
 ) => void;
 
 // Type guards
 
-export const isTelemetryListener = (e: Extension): e is ResolvedTelemetryListener => {
+export const isTelemetryListener = (e: Extension): e is TelemetryListener => {
   return e.type === 'console.telemetry/listener';
 };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/telemetry.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/telemetry.ts
@@ -1,0 +1,37 @@
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+import { JSONSchema6Object } from 'json-schema';
+import { CodeRef, EncodedCodeRef, UpdateExtensionProperties } from '../types';
+
+namespace ExtensionProperties {
+  export type TelemetryListener = {
+    /** Listen for telemetry events */
+    listener: EncodedCodeRef;
+  };
+
+  export type TelemetryListenerCodeRefs = {
+    listener: CodeRef<TelemetryEventListener>;
+  };
+}
+
+// Extension types
+
+export type TelemetryListener = Extension<ExtensionProperties.TelemetryListener> & {
+  type: 'console.telemetry/listener';
+};
+
+export type ResolvedTelemetryListener = UpdateExtensionProperties<
+  TelemetryListener,
+  ExtensionProperties.TelemetryListenerCodeRefs
+>;
+
+// P should be valid JSON
+export type TelemetryEventListener = <P extends JSONSchema6Object = JSONSchema6Object>(
+  eventType: string,
+  properties: P,
+) => void;
+
+// Type guards
+
+export const isTelemetryListener = (e: Extension): e is ResolvedTelemetryListener => {
+  return e.type === 'console.telemetry/listener';
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/telemetry.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/telemetry.ts
@@ -1,5 +1,4 @@
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
-import { JSONSchema6Object } from 'json-schema';
 
 export type TelemetryListener = ExtensionDeclaration<
   'console.telemetry/listener',
@@ -10,10 +9,7 @@ export type TelemetryListener = ExtensionDeclaration<
 >;
 
 // P should be valid JSON
-export type TelemetryEventListener = <P extends JSONSchema6Object = JSONSchema6Object>(
-  eventType: string,
-  properties?: P,
-) => void;
+export type TelemetryEventListener = <P = any>(eventType: string, properties?: P) => void;
 
 // Type guards
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/schema/console-extensions.ts
@@ -18,6 +18,7 @@ import { ModelMetadata } from '../extensions/resource-metadata';
 import { AlertAction } from '../extensions/notification-alert';
 import { PVCCreateProp, PVCStatus, PVCAlert, PVCDelete } from '../extensions/pvc';
 import { StorageProvider } from '../extensions/storage-provider';
+import { TelemetryListener } from '../extensions/telemetry';
 
 export type SupportedExtension =
   | FeatureFlag
@@ -43,7 +44,8 @@ export type SupportedExtension =
   | FileUpload
   | ModelMetadata
   | AlertAction
-  | StorageProvider;
+  | StorageProvider
+  | TelemetryListener;
 
 /**
  * Schema of Console plugin's `console-extensions.json` file.

--- a/frontend/packages/console-shared/src/components/quick-starts/QuickStartsCatalogCard.tsx
+++ b/frontend/packages/console-shared/src/components/quick-starts/QuickStartsCatalogCard.tsx
@@ -27,6 +27,7 @@ import {
 } from '@console/app/src/components/quick-starts/utils/quick-start-context';
 import { useUserSettingsCompatibility } from '../../hooks';
 import './QuickStartsCatalogCard.scss';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 
 type QuickStartsCatalogCardProps = {
   quickStarts: QuickStart[];
@@ -49,8 +50,12 @@ const QuickStartsCatalogCard: React.FC<QuickStartsCatalogCardProps> = ({
     true,
   );
   const [isOpen, setOpen] = React.useState<boolean>(false);
+  const fireTelemetryEvent = useTelemetry();
 
   const onRemove = () => {
+    fireTelemetryEvent('Dev Customized', {
+      event: 'remove quick start card',
+    });
     setShowTile(false);
   };
 

--- a/frontend/packages/console-shared/src/hoc/index.ts
+++ b/frontend/packages/console-shared/src/hoc/index.ts
@@ -3,3 +3,4 @@ export * from './withUserSettingsCompatibility';
 export * from './withUserSettings';
 export * from './withActivePerspective';
 export * from './withLastNamespace';
+export * from './withTelemetry';

--- a/frontend/packages/console-shared/src/hoc/withTelemetry.tsx
+++ b/frontend/packages/console-shared/src/hoc/withTelemetry.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { useTelemetry } from '../hooks';
+
+type WithTelemetryProps = {
+  fireTelementryEvent: (eventType: string, properties: any) => void;
+};
+
+export const withTelemetry = <Props extends WithTelemetryProps>(
+  WrappedComponent: React.ComponentType<Props>,
+): React.FC<Omit<Props, keyof WithTelemetryProps>> => (props: Props) => {
+  const fireTelemetryEvent = useTelemetry();
+  return <WrappedComponent {...props} fireTelemetryEvent={fireTelemetryEvent} />;
+};

--- a/frontend/packages/console-shared/src/hooks/__tests__/usePinnedResources.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/usePinnedResources.spec.ts
@@ -67,7 +67,11 @@ describe('usePinnedResources', () => {
   it('returns some default pins if there are no other pins defined and the extension has default pins', async () => {
     // Mock empty old data
     useActivePerspectiveMock.mockReturnValue(['dev']);
-    useUserSettingsCompatibilityMock.mockReturnValue([{}, setPinnedResourcesMock, true]);
+    useUserSettingsCompatibilityMock.mockImplementation((configKey, storageKey, defaultPins) => [
+      defaultPins,
+      setPinnedResourcesMock,
+      true,
+    ]);
 
     const { result } = testHook(() => usePinnedResources());
 

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -30,3 +30,4 @@ export * from './useResizeObserver';
 export * from './useBoundingClientRect';
 export * from './useScrollContainer';
 export * from './useEventListener';
+export * from './useTelemetry';

--- a/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
+++ b/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
@@ -1,8 +1,10 @@
 import { useMemo, useCallback } from 'react';
+import * as _ from 'lodash';
 import { isPerspective, Perspective, useExtensions } from '@console/plugin-sdk';
 import { useUserSettingsCompatibility } from './useUserSettingsCompatibility';
 import { PINNED_RESOURCES_LOCAL_STORAGE_KEY } from '../constants';
 import { useActivePerspective } from './useActivePerspective';
+import { useTelemetry } from './useTelemetry';
 
 type PinnedResourcesType = {
   [perspective: string]: string[];
@@ -11,6 +13,7 @@ type PinnedResourcesType = {
 const PINNED_RESOURCES_CONFIG_MAP_KEY = 'console.pinnedResources';
 
 export const usePinnedResources = (): [string[], (pinnedResources: string[]) => void, boolean] => {
+  const fireTelemetryEvent = useTelemetry();
   const [activePerspective] = useActivePerspective();
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
   const [pinnedResources, setPinnedResources, loaded] = useUserSettingsCompatibility<
@@ -32,9 +35,25 @@ export const usePinnedResources = (): [string[], (pinnedResources: string[]) => 
 
   const setPins = useCallback(
     (newPins: string[]) => {
-      setPinnedResources((prevPR) => ({ ...prevPR, [activePerspective]: newPins }));
+      setPinnedResources((prevPR) => {
+        _.difference(newPins, prevPR[activePerspective]).forEach((resource) =>
+          fireTelemetryEvent('Navigation Added', {
+            resource,
+            perspective: activePerspective,
+          }),
+        );
+
+        _.difference(prevPR[activePerspective], newPins).forEach((resource) =>
+          fireTelemetryEvent('Navigation Removed', {
+            resource,
+            perspective: activePerspective,
+          }),
+        );
+
+        return { ...prevPR, [activePerspective]: newPins };
+      });
     },
-    [activePerspective, setPinnedResources],
+    [activePerspective, setPinnedResources, fireTelemetryEvent],
   );
 
   return [pins, setPins, loaded];

--- a/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
+++ b/frontend/packages/console-shared/src/hooks/usePinnedResources.ts
@@ -16,22 +16,24 @@ export const usePinnedResources = (): [string[], (pinnedResources: string[]) => 
   const fireTelemetryEvent = useTelemetry();
   const [activePerspective] = useActivePerspective();
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
+  const defaultPins = useMemo(
+    () =>
+      perspectiveExtensions.reduce(
+        (acc, e) => ({ ...acc, [e.properties.id]: e.properties.defaultPins || [] }),
+        {},
+      ),
+    [perspectiveExtensions],
+  );
   const [pinnedResources, setPinnedResources, loaded] = useUserSettingsCompatibility<
     PinnedResourcesType
-  >(PINNED_RESOURCES_CONFIG_MAP_KEY, PINNED_RESOURCES_LOCAL_STORAGE_KEY, {}, true);
+  >(PINNED_RESOURCES_CONFIG_MAP_KEY, PINNED_RESOURCES_LOCAL_STORAGE_KEY, defaultPins, true);
 
   const pins = useMemo(() => {
     if (!loaded) {
       return [];
     }
-    if (pinnedResources?.[activePerspective]) {
-      return pinnedResources[activePerspective];
-    }
-    const activePerspectiveExtension = perspectiveExtensions.find(
-      (extension) => extension.properties.id === activePerspective,
-    );
-    return activePerspectiveExtension?.properties?.defaultPins || [];
-  }, [loaded, pinnedResources, activePerspective, perspectiveExtensions]);
+    return pinnedResources[activePerspective] ?? [];
+  }, [loaded, pinnedResources, activePerspective]);
 
   const setPins = useCallback(
     (newPins: string[]) => {

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -6,10 +6,16 @@ import {
 } from '@console/dynamic-plugin-sdk';
 
 export const useTelemetry = () => {
+  // TODO how can we wait for all plugins to load such that we can create a stable callback reference and not end up firing events multiple times whenever plugins asynchronously load
   const [extensions] = useResolvedExtensions(isTelemetryListener);
   return React.useCallback<TelemetryEventListener>(
     (eventType, properties) => {
-      extensions.forEach((e) => e.properties.listener(eventType, properties));
+      extensions.forEach((e) =>
+        e.properties.listener(eventType, {
+          consoleVersion: window.SERVER_FLAGS.consoleVersion,
+          ...properties,
+        }),
+      );
     },
     [extensions],
   );

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import {
+  useResolvedExtensions,
+  isTelemetryListener,
+  TelemetryEventListener,
+} from '@console/dynamic-plugin-sdk';
+
+export const useTelemetry = () => {
+  const [extensions] = useResolvedExtensions(isTelemetryListener);
+  return React.useCallback<TelemetryEventListener>(
+    (eventType, properties) => {
+      extensions.forEach((e) => e.properties.listener(eventType, properties));
+    },
+    [extensions],
+  );
+};

--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -15,6 +15,7 @@ import {
   AddAction,
   isAddAction,
 } from '@console/dynamic-plugin-sdk';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 
 const navigateTo = (e: React.SyntheticEvent, url: string) => {
   history.push(url);
@@ -32,6 +33,7 @@ const Item: React.FC<ItemProps> = ({
   },
   namespace,
 }) => {
+  const fireTelemetryEvent = useTelemetry();
   const access =
     !accessReview ||
     // Defined extensions are immutable. This check will be consistent.
@@ -47,7 +49,13 @@ const Item: React.FC<ItemProps> = ({
       <CatalogTile
         data-test-id={id}
         className="co-catalog-tile"
-        onClick={(e: React.SyntheticEvent) => navigateTo(e, resolvedHref)}
+        onClick={(e: React.SyntheticEvent) => {
+          fireTelemetryEvent('Add Item Selected', {
+            id,
+            name: label,
+          });
+          navigateTo(e, resolvedHref);
+        }}
         href={resolvedHref}
         title={label}
         iconImg={typeof icon === 'string' ? icon : undefined}

--- a/frontend/packages/topology/src/components/page/TopologyView.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyView.tsx
@@ -47,6 +47,7 @@ import { getSelectedEntityDetails } from '../side-bar/getSelectedEntityDetails';
 import { FilterContext } from '../../filters/FilterProvider';
 import TopologyEmptyState from './TopologyEmptyState';
 import QuickSearch from '../quick-search/QuickSearch';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 
 import './TopologyView.scss';
 
@@ -89,6 +90,7 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
   canDrop,
 }) => {
   const { t } = useTranslation();
+  const fireTelemetryEvent = useTelemetry();
   const [viewContainer, setViewContainer] = React.useState<HTMLElement>(null);
   const { setTopologyFilters: onFiltersChange } = React.useContext(FilterContext);
   const [filteredModel, setFilteredModel] = React.useState<Model>();
@@ -101,6 +103,12 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
   const [isQuickSearchOpen, setIsQuickSearchOpen] = React.useState<boolean>(
     !!getQueryArgument('catalogSearch'),
   );
+  const setIsQuickSearchOpenAndFireEvent = React.useCallback((open: boolean) => {
+    if (open) {
+      fireTelemetryEvent('Quick Search Accessed');
+    }
+    setIsQuickSearchOpen(open);
+  }, [fireTelemetryEvent]);
   const appliedFilters = useAppliedDisplayFilters();
   const [displayFilterExtensions, displayFilterExtensionsResolved] = useResolvedExtensions<
     TopologyDisplayFilters
@@ -285,7 +293,7 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
           <TopologyFilterBar
             viewType={viewType}
             visualization={visualization}
-            setIsQuickSearchOpen={setIsQuickSearchOpen}
+            setIsQuickSearchOpen={setIsQuickSearchOpenAndFireEvent}
             isDisabled={!model.nodes?.length}
           />
         </StackItem>
@@ -307,7 +315,7 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
               )}
               {viewContent}
               {!model.nodes?.length ? (
-                <TopologyEmptyState setIsQuickSearchOpen={setIsQuickSearchOpen} />
+                <TopologyEmptyState setIsQuickSearchOpen={setIsQuickSearchOpenAndFireEvent} />
               ) : null}
             </div>
           </div>
@@ -319,7 +327,7 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
           namespace={namespace}
           viewContainer={viewContainer}
           isOpen={isQuickSearchOpen}
-          setIsOpen={setIsQuickSearchOpen}
+          setIsOpen={setIsQuickSearchOpenAndFireEvent}
         />
       </Stack>
     </div>

--- a/frontend/packages/topology/src/components/page/TopologyView.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyView.tsx
@@ -103,12 +103,15 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
   const [isQuickSearchOpen, setIsQuickSearchOpen] = React.useState<boolean>(
     !!getQueryArgument('catalogSearch'),
   );
-  const setIsQuickSearchOpenAndFireEvent = React.useCallback((open: boolean) => {
-    if (open) {
-      fireTelemetryEvent('Quick Search Accessed');
-    }
-    setIsQuickSearchOpen(open);
-  }, [fireTelemetryEvent]);
+  const setIsQuickSearchOpenAndFireEvent = React.useCallback(
+    (open: boolean) => {
+      if (open) {
+        fireTelemetryEvent('Quick Search Accessed');
+      }
+      setIsQuickSearchOpen(open);
+    },
+    [fireTelemetryEvent],
+  );
   const appliedFilters = useAppliedDisplayFilters();
   const [displayFilterExtensions, displayFilterExtensionsResolved] = useResolvedExtensions<
     TopologyDisplayFilters

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.tsx
@@ -4,6 +4,7 @@ import { CatalogItem } from '@console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, TextContent, Title } from '@patternfly/react-core';
 import './QuickSearchDetails.scss';
 import { handleCta } from './utils/quick-search-utils';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 
 interface QuickSearchDetailsProps {
   selectedItem: CatalogItem;
@@ -12,6 +13,7 @@ interface QuickSearchDetailsProps {
 
 const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({ selectedItem, closeModal }) => {
   const { t } = useTranslation();
+  const fireTelemetryEvent = useTelemetry();
 
   return (
     <div className="odc-quick-search-details">
@@ -25,12 +27,7 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({ selectedItem, c
         variant={ButtonVariant.primary}
         className="odc-quick-search-details__form-button"
         onClick={(e) => {
-          handleCta(e, selectedItem, closeModal);
-          fireTelemetryEvent('Quick Search Used', {
-            id: selectedItem.uid,
-            type: selectedItem.type,
-            name: selectedItem.name,
-          });
+          handleCta(e, selectedItem, closeModal, fireTelemetryEvent);
         }}
       >
         {selectedItem.cta.label}

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchDetails.tsx
@@ -26,6 +26,11 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({ selectedItem, c
         className="odc-quick-search-details__form-button"
         onClick={(e) => {
           handleCta(e, selectedItem, closeModal);
+          fireTelemetryEvent('Quick Search Used', {
+            id: selectedItem.uid,
+            type: selectedItem.type,
+            name: selectedItem.name,
+          });
         }}
       >
         {selectedItem.cta.label}

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
@@ -21,6 +21,7 @@ import './QuickSearchList.scss';
 import { CatalogLinkData } from './utils/quick-search-types';
 import { handleCta } from './utils/quick-search-utils';
 import { Link } from 'react-router-dom';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 
 interface QuickSearchListProps {
   listItems: CatalogItem[];
@@ -40,6 +41,7 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
   closeModal,
 }) => {
   const { t } = useTranslation();
+  const fireTelemetryEvent = useTelemetry();
 
   const getIcon = (item: CatalogItem) => {
     const { iconImg, iconClass } = getIconProps(item);
@@ -70,12 +72,7 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
               'odc-quick-search-list__item--highlight': item.uid === selectedItemId,
             })}
             onDoubleClick={(e: React.SyntheticEvent) => {
-              handleCta(e, item, closeModal);
-              fireTelemetryEvent('Quick Search Used', {
-                id: item.uid,
-                type: item.type,
-                name: item.name,
-              });
+              handleCta(e, item, closeModal, fireTelemetryEvent);
             }}
           >
             <DataListItemRow className="odc-quick-search-list__item-row">

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
@@ -69,7 +69,14 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
             className={cx('odc-quick-search-list__item', {
               'odc-quick-search-list__item--highlight': item.uid === selectedItemId,
             })}
-            onDoubleClick={(e: React.SyntheticEvent) => handleCta(e, item, closeModal)}
+            onDoubleClick={(e: React.SyntheticEvent) => {
+              handleCta(e, item, closeModal);
+              fireTelemetryEvent('Quick Search Used', {
+                id: item.uid,
+                type: item.type,
+                name: item.name,
+              });
+            }}
           >
             <DataListItemRow className="odc-quick-search-list__item-row">
               <DataListItemCells

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
@@ -12,6 +12,7 @@ import './QuickSearchButton.scss';
 import './QuickSearchModalBody.scss';
 import { CatalogLinkData, QuickSearchData } from './utils/quick-search-types';
 import { handleCta } from './utils/quick-search-utils';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 
 interface QuickSearchModalBodyProps {
   allCatalogItemsLoaded: boolean;
@@ -35,6 +36,7 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   const [viewAll, setViewAll] = React.useState<CatalogLinkData[]>(null);
   const listCatalogItems = catalogItems?.slice(0, 5);
   const ref = React.useRef<HTMLDivElement>(null);
+  const fireTelemetryEvent = useTelemetry();
 
   React.useEffect(() => {
     if (searchTerm) {
@@ -88,15 +90,10 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   const onEnter = React.useCallback(
     (e) => {
       if (selectedItem) {
-        handleCta(e, selectedItem, closeModal);
-        fireTelemetryEvent('Quick Search Used', {
-          id: selectedItem.uid,
-          type: selectedItem.type,
-          name: selectedItem.name,
-        });
+        handleCta(e, selectedItem, closeModal, fireTelemetryEvent);
       }
     },
-    [closeModal, selectedItem],
+    [closeModal, fireTelemetryEvent, selectedItem],
   );
 
   const selectPrevious = React.useCallback(() => {

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
@@ -89,6 +89,11 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
     (e) => {
       if (selectedItem) {
         handleCta(e, selectedItem, closeModal);
+        fireTelemetryEvent('Quick Search Used', {
+          id: selectedItem.uid,
+          type: selectedItem.type,
+          name: selectedItem.name,
+        });
       }
     },
     [closeModal, selectedItem],

--- a/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
+++ b/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
@@ -55,10 +55,20 @@ export const useTransformedQuickStarts = (quickStarts: QuickStart[]): CatalogIte
   );
 };
 
-export const handleCta = (e: React.SyntheticEvent, item: CatalogItem, closeModal: () => void) => {
+export const handleCta = (
+  e: React.SyntheticEvent,
+  item: CatalogItem,
+  closeModal: () => void,
+  fireTelemetryEvent: (event: string, properties?: {}) => void,
+) => {
   e.preventDefault();
   const { href, callback } = item.cta;
   if (callback) {
+    fireTelemetryEvent('Quick Search Used', {
+      id: item.uid,
+      type: item.type,
+      name: item.name,
+    });
     closeModal();
     callback();
     removeQueryArgument('catalogSearch');

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { render } from 'react-dom';
 import { Helmet } from 'react-helmet';
 import { linkify } from 'react-linkify';
-import { Provider } from 'react-redux';
+import { Provider, useSelector } from 'react-redux';
 import { Route, Router, Switch } from 'react-router-dom';
 // AbortController is not supported in some older browser versions
 import 'abort-controller/polyfill';
@@ -33,6 +33,8 @@ import { GuidedTour } from '@console/app/src/components/tour';
 import { isStandaloneRoutePage } from '@console/dynamic-plugin-sdk';
 import QuickStartDrawer from '@console/app/src/components/quick-starts/QuickStartDrawer';
 import ToastProvider from '@console/shared/src/components/toast/ToastProvider';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
+import { useDebounceCallback } from '@console/shared/src/hooks/debounce';
 import '../i18n';
 import '../vendor.scss';
 import '../style.scss';
@@ -238,6 +240,37 @@ const AppRouter = () => {
   );
 };
 
+const CaptureTelemetry = React.memo(() => {
+  const fireTelemetryEvent = useTelemetry();
+
+  // notify of identity change
+  const user = useSelector(({ UI }) => UI.get('user'));
+  const clusterId = useSelector(({ UI }) => UI.get('clusterID'));
+  React.useEffect(() => {
+    if (user && clusterId) {
+      fireTelemetryEvent('identify', { clusterId, user });
+    }
+  }, [clusterId, user, fireTelemetryEvent]);
+
+  // notify url change events
+  // Debouncing the url change events so that redirects don't fire multiple events.
+  // Also because some pages update the URL as the user enters a search term.
+  const fireUrlChangeEvent = useDebounceCallback(fireTelemetryEvent);
+  React.useEffect(() => {
+    fireUrlChangeEvent('page', history.location);
+
+    let { pathname, search } = history.location;
+    history.listen((location) => {
+      const { pathname: nextPathname, search: nextSearch } = history.location;
+      if (pathname !== nextPathname || search !== nextSearch) {
+        pathname = nextPathname;
+        search = nextSearch;
+        fireUrlChangeEvent('page', location);
+      }
+    });
+  }, [fireUrlChangeEvent]);
+});
+
 graphQLReady.onReady(() => {
   const startDiscovery = () => store.dispatch(watchAPIServices());
 
@@ -309,6 +342,7 @@ graphQLReady.onReady(() => {
   render(
     <React.Suspense fallback={<LoadingBox />}>
       <Provider store={store}>
+        <CaptureTelemetry />
         <ToastProvider>
           <AppRouter />
         </ToastProvider>

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -245,12 +245,13 @@ const CaptureTelemetry = React.memo(() => {
 
   // notify of identity change
   const user = useSelector(({ UI }) => UI.get('user'));
-  const clusterId = useSelector(({ UI }) => UI.get('clusterID'));
   React.useEffect(() => {
-    if (user && clusterId) {
-      fireTelemetryEvent('identify', { clusterId, user });
+    if (user.metadata?.uid || user.metadata?.name) {
+      fireTelemetryEvent('identify', { user });
     }
-  }, [clusterId, user, fireTelemetryEvent]);
+    // Only trigger identify event when the user identifier changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user.metadata?.uid || user.metadata?.name, fireTelemetryEvent]);
 
   // notify url change events
   // Debouncing the url change events so that redirects don't fire multiple events.
@@ -269,6 +270,8 @@ const CaptureTelemetry = React.memo(() => {
       }
     });
   }, [fireUrlChangeEvent]);
+
+  return null;
 });
 
 graphQLReady.onReady(() => {

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -38,6 +38,7 @@ import * as redhatLogoImg from '../imgs/logos/redhat.svg';
 import { GuidedTourMastheadTrigger } from '@console/app/src/components/tour';
 import { ConsoleLinkModel } from '../models';
 import { languagePreferencesModal } from './modals';
+import { withTelemetry } from '@console/shared/src/hoc';
 
 const SystemStatusButton = ({ statuspageData, className }) => {
   const { t } = useTranslation();
@@ -246,7 +247,7 @@ class MastheadToolbarContents_ extends React.Component {
   }
 
   _launchActions = () => {
-    const { clusterID, consoleLinks, t } = this.props;
+    const { clusterID, consoleLinks, t, fireTelemetryEvent } = this.props;
     const launcherItems = this._getAdditionalLinks(consoleLinks?.data, 'ApplicationMenu');
 
     const sections = [];
@@ -266,7 +267,8 @@ class MastheadToolbarContents_ extends React.Component {
             image: <img src={redhatLogoImg} alt="" />,
             callback: () => {
               fireTelemetryEvent('Launcher Menu Accessed', {
-                item: 'OpenShift Cluster Manager',
+                id: 'OpenShift Cluster Manager',
+                name: 'OpenShift Cluster Manager',
               });
             },
           },
@@ -293,7 +295,8 @@ class MastheadToolbarContents_ extends React.Component {
           image: <img src={_.get(item, 'spec.applicationMenu.imageURL')} alt="" />,
           callback: () => {
             fireTelemetryEvent('Launcher Menu Accessed', {
-              item: _.get(item, 'spec.text'),
+              id: item.metadata.name,
+              name: _.get(item, 'spec.text'),
             });
           },
         });
@@ -304,7 +307,7 @@ class MastheadToolbarContents_ extends React.Component {
   };
 
   _helpActions(additionalHelpActions) {
-    const { flags, cv, t } = this.props;
+    const { flags, cv, t, fireTelemetryEvent } = this.props;
     const helpActions = [];
     const reportBugLink = cv && cv.data ? getReportBugLink(cv.data) : null;
 
@@ -688,7 +691,9 @@ const mastheadToolbarStateToProps = (state) => ({
   canAccessNS: !!state[featureReducerName].get(FLAGS.CAN_GET_NS),
 });
 
-const MastheadToolbarContentsWithTranslation = withTranslation()(MastheadToolbarContents_);
+const MastheadToolbarContentsWithTranslation = withTranslation()(
+  withTelemetry(MastheadToolbarContents_),
+);
 const MastheadToolbarContents = connect(mastheadToolbarStateToProps, {
   drawerToggle: UIActions.notificationDrawerToggleExpanded,
 })(

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -264,6 +264,11 @@ class MastheadToolbarContents_ extends React.Component {
             externalLink: true,
             href: getOCMLink(clusterID),
             image: <img src={redhatLogoImg} alt="" />,
+            callback: () => {
+              fireTelemetryEvent('Launcher Menu Accessed', {
+                item: 'OpenShift Cluster Manager',
+              });
+            },
           },
         ],
       });
@@ -286,6 +291,11 @@ class MastheadToolbarContents_ extends React.Component {
           externalLink: true,
           href: _.get(item, 'spec.href'),
           image: <img src={_.get(item, 'spec.applicationMenu.imageURL')} alt="" />,
+          callback: () => {
+            fireTelemetryEvent('Launcher Menu Accessed', {
+              item: _.get(item, 'spec.text'),
+            });
+          },
         });
       });
     });
@@ -309,11 +319,23 @@ class MastheadToolbarContents_ extends React.Component {
           label: t('masthead~Documentation'),
           externalLink: true,
           href: openshiftHelpBase,
+          callback: () => {
+            fireTelemetryEvent('Documentation Clicked');
+          },
         },
         ...(flags[FLAGS.CONSOLE_CLI_DOWNLOAD]
           ? [
               {
-                component: <Link to="/command-line-tools">{t('masthead~Command line tools')}</Link>,
+                component: (
+                  <Link
+                    onClick={() => {
+                      fireTelemetryEvent('CLI Clicked');
+                    }}
+                    to="/command-line-tools"
+                  >
+                    {t('masthead~Command line tools')}
+                  </Link>
+                ),
               },
             ]
           : []),

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -4,6 +4,7 @@ import { CaretDownIcon } from '@patternfly/react-icons';
 import { Perspective, useExtensions, isPerspective } from '@console/plugin-sdk';
 import { history } from '../utils';
 import { useActivePerspective } from '@console/shared';
+import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
 
 export type NavHeaderProps = {
   onPerspectiveSelected: () => void;
@@ -16,6 +17,7 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
   const togglePerspectiveOpen = React.useCallback(() => {
     setPerspectiveDropdownOpen(!isPerspectiveDropdownOpen);
   }, [isPerspectiveDropdownOpen]);
+  const fireTelemetryEvent = useTelemetry();
 
   const onPerspectiveSelect = React.useCallback(
     (event: React.MouseEvent<HTMLLinkElement>, perspective: Perspective): void => {
@@ -24,12 +26,14 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
         setActivePerspective(perspective.properties.id);
         // Navigate to root and let the default page determine where to go to next
         history.push('/');
+        fireTelemetryEvent('Perspective Changed', {
+          perspective: perspective.properties.id,
+        });
       }
-
       setPerspectiveDropdownOpen(false);
       onPerspectiveSelected && onPerspectiveSelected();
     },
-    [activePerspective, onPerspectiveSelected, setActivePerspective],
+    [activePerspective, fireTelemetryEvent, onPerspectiveSelected, setActivePerspective],
   );
 
   const renderToggle = React.useCallback(


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/CONSOLE-2536

**Solution/Description:**
Add telemetry support via dynamic plugins, create a demo extension of using [segment.io](https://segment.com) to instrument the UI.

NOTE: `SEGMENT_KEY` in `frontend/dynamic-demo-plugin/src/utils/telemetry.ts` need to be provided to connect the [segment.io](https://segment.com) console.