### PR TITLE
Provide add page customization config object as server flag and hide actions from the Add page

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -124,6 +124,7 @@ func main() {
 	fDevCatalogCategories := fs.String("developer-catalog-categories", "", "Allow catalog categories customization. (JSON as string)")
 	fUserSettingsLocation := fs.String("user-settings-location", "configmap", "DEV ONLY. Define where the user settings should be stored. (configmap | localstorage).")
 	fQuickStarts := fs.String("quick-starts", "", "Allow customization of available ConsoleQuickStart resources in console. (JSON as string)")
+	fAddPage := fs.String("add-page", "", "DEV ONLY. Allow add page customization. (JSON as string)")
 
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -237,6 +238,7 @@ func main() {
 		UserSettingsLocation:  *fUserSettingsLocation,
 		EnabledConsolePlugins: consolePluginsMap,
 		QuickStarts:           *fQuickStarts,
+		AddPage:               *fAddPage,
 	}
 
 	// if !in-cluster (dev) we should not pass these values to the frontend

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -46,6 +46,7 @@ declare interface Window {
     graphqlBaseURL: string;
     developerCatalogCategories: string;
     userSettingsLocation: string;
+    addPage: string; // JSON encoded configuration
     consolePlugins: string[]; // Console dynamic plugins enabled on the cluster
     quickStarts: string;
   };

--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -9,13 +9,10 @@ import { ALL_NAMESPACES_KEY, PageLayout } from '@console/shared';
 import { HIDE_QUICK_START_ADD_TILE_STORAGE_KEY } from '@console/shared/src/components/quick-starts/quick-starts-catalog-card-constants';
 import QuickStartsLoader from '@console/app/src/components/quick-starts/loader/QuickStartsLoader';
 import QuickStartsCatalogCard from '@console/shared/src/components/quick-starts/QuickStartsCatalogCard';
-import {
-  ResolvedExtension,
-  useResolvedExtensions,
-  AddAction,
-  isAddAction,
-} from '@console/dynamic-plugin-sdk';
+import { ResolvedExtension, AddAction } from '@console/dynamic-plugin-sdk';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
+
+import { useAddActionExtensions } from '../utils/useAddActionExtensions';
 
 const navigateTo = (e: React.SyntheticEvent, url: string) => {
   history.push(url);
@@ -84,7 +81,7 @@ const ODCEmptyState: React.FC<Props> = ({ title, activeNamespace, hintBlock }) =
   const defaultHintBlockText = t(
     'devconsole~Select a way to create an Application, component or service from one of the options.',
   );
-  const [addActionExtensions, resolved] = useResolvedExtensions<AddAction>(isAddAction);
+  const [addActionExtensions, resolved] = useAddActionExtensions();
 
   if (!resolved) return <LoadingBox />;
 

--- a/frontend/packages/dev-console/src/utils/__tests__/useAddActionExtensions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/useAddActionExtensions.spec.ts
@@ -1,0 +1,87 @@
+import { useResolvedExtensions, AddAction, ResolvedExtension } from '@console/dynamic-plugin-sdk';
+import { testHook } from '../../../../../__tests__/utils/hooks-utils';
+import { useAddActionExtensions } from '../useAddActionExtensions';
+
+const useResolvedExtensionsMock = useResolvedExtensions as jest.Mock;
+
+jest.mock('@console/dynamic-plugin-sdk', () => {
+  return {
+    useResolvedExtensions: jest.fn(),
+  };
+});
+
+describe('useAddActionExtensions', () => {
+  const addAction1: ResolvedExtension<AddAction> = {
+    type: 'dev-console.add/action',
+    properties: {
+      id: 'action1',
+      label: 'Action 1',
+      description: 'A description for action 1',
+      href: '/action1',
+    },
+    pluginID: 'plugin1',
+    pluginName: 'Plugin 1',
+    uid: '1234-1',
+  };
+  const addAction2: ResolvedExtension<AddAction> = {
+    type: 'dev-console.add/action',
+    properties: {
+      id: 'action2',
+      label: 'Action 2',
+      description: 'A description for action 2',
+      href: '/action2',
+    },
+    pluginID: 'plugin2',
+    pluginName: 'Plugin 2',
+    uid: '1234-2',
+  };
+  const addAction3: ResolvedExtension<AddAction> = {
+    type: 'dev-console.add/action',
+    properties: {
+      id: 'action3',
+      label: 'Action 3',
+      description: 'A description for action 3',
+      href: '/action3',
+    },
+    pluginID: 'plugin3',
+    pluginName: 'Plugin 3',
+    uid: '1234-3',
+  };
+
+  afterEach(() => {
+    delete window.SERVER_FLAGS.addPage;
+  });
+
+  it('return all actions if SERVER_FLAGS.addPage is not defined', () => {
+    useResolvedExtensionsMock.mockReturnValue([[addAction1, addAction2, addAction3], true]);
+    delete window.SERVER_FLAGS.addPage;
+
+    testHook(() => {
+      const [addActionExtensions, resolved] = useAddActionExtensions();
+      expect(addActionExtensions).toEqual([addAction1, addAction2, addAction3]);
+      expect(resolved).toEqual(true);
+    });
+  });
+
+  it('return all actions if SERVER_FLAGS.addPage customization is empty', () => {
+    useResolvedExtensionsMock.mockReturnValue([[addAction1, addAction2, addAction3], true]);
+    window.SERVER_FLAGS.addPage = '{}';
+
+    testHook(() => {
+      const [addActionExtensions, resolved] = useAddActionExtensions();
+      expect(addActionExtensions).toEqual([addAction1, addAction2, addAction3]);
+      expect(resolved).toEqual(true);
+    });
+  });
+
+  it('return filtered actions if SERVER_FLAGS.addPage contains some disabledActions', () => {
+    useResolvedExtensionsMock.mockReturnValue([[addAction1, addAction2, addAction3], true]);
+    window.SERVER_FLAGS.addPage = '{"disabledActions":["action2"]}';
+
+    testHook(() => {
+      const [addActionExtensions, resolved] = useAddActionExtensions();
+      expect(addActionExtensions).toEqual([addAction1, addAction3]);
+      expect(resolved).toEqual(true);
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/utils/useAddActionExtensions.ts
+++ b/frontend/packages/dev-console/src/utils/useAddActionExtensions.ts
@@ -1,0 +1,33 @@
+import {
+  ResolvedExtension,
+  useResolvedExtensions,
+  AddAction,
+  isAddAction,
+} from '@console/dynamic-plugin-sdk';
+
+interface AddPage {
+  disabledActions?: string[];
+}
+
+const getDisabledAddActions = (): string[] | undefined => {
+  if (window.SERVER_FLAGS.addPage) {
+    const addPage: AddPage = JSON.parse(window.SERVER_FLAGS.addPage);
+    const { disabledActions } = addPage;
+    return disabledActions;
+  }
+  return undefined;
+};
+
+export const useAddActionExtensions = (): [ResolvedExtension<AddAction>[], boolean] => {
+  const [allAddActionExtensions, resolved] = useResolvedExtensions<AddAction>(isAddAction);
+  const disabledActions = getDisabledAddActions();
+
+  if (allAddActionExtensions && disabledActions && disabledActions.length > 0) {
+    const filteredAddActionExtensions = allAddActionExtensions.filter(
+      (addActionExtension) => !disabledActions.includes(addActionExtension.properties.id),
+    );
+    return [filteredAddActionExtensions, resolved];
+  }
+
+  return [allAddActionExtensions, resolved];
+};

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,6 +91,7 @@ type jsGlobals struct {
 	GraphQLBaseURL           string   `json:"graphqlBaseURL"`
 	DevCatalogCategories     string   `json:"developerCatalogCategories"`
 	UserSettingsLocation     string   `json:"userSettingsLocation"`
+	AddPage                  string   `json:"addPage"`
 	ConsolePlugins           []string `json:"consolePlugins"`
 	QuickStarts              string   `json:"quickStarts"`
 }
@@ -141,6 +142,7 @@ type Server struct {
 	DevCatalogCategories  string
 	UserSettingsLocation  string
 	QuickStarts           string
+	AddPage               string
 }
 
 func (s *Server) authDisabled() bool {
@@ -523,6 +525,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		UserSettingsLocation:  s.UserSettingsLocation,
 		ConsolePlugins:        getMapKeys(s.EnabledConsolePlugins),
 		QuickStarts:           s.QuickStarts,
+		AddPage:               s.AddPage,
 	}
 
 	if !s.authDisabled() {

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -263,6 +263,12 @@ func addCustomization(fs *flag.FlagSet, customization *Customization) {
 		}
 	}
 
+	addPage, err := json.Marshal(customization.AddPage)
+	if err == nil {
+		fs.Set("add-page", string(addPage))
+	} else {
+		klog.Fatalf("Could not marshal ConsoleConfig customization.addPage field: %v", err)
+	}
 }
 
 func isAlreadySet(fs *flag.FlagSet, name string) bool {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -69,6 +69,8 @@ type Customization struct {
 	// developerCatalog allows to configure the shown developer catalog categories.
 	DeveloperCatalog DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
 	QuickStarts      QuickStarts                          `yaml:"quickStarts,omitempty"`
+	// addPage allows customizing actions on the Add page in developer perspective.
+	AddPage AddPage `yaml:"addPage,omitempty"`
 }
 
 // QuickStarts contains options for ConsoleQuickStarts resource
@@ -100,6 +102,13 @@ type DeveloperConsoleCatalogCategory struct {
 	DeveloperConsoleCatalogCategoryMeta `json:",inline" yaml:",inline"`
 	// subcategories defines a list of child categories.
 	Subcategories []DeveloperConsoleCatalogCategoryMeta `json:"subcategories,omitempty" yaml:"subcategories,omitempty"`
+}
+
+// AddPage allows customizing actions on the Add page in developer perspective.
+type AddPage struct {
+	// disabledActions is a list of actions that are not shown to users.
+	// Each action in the list is represented by its ID.
+	DisabledActions []string `json:"disabledActions,omitempty" yaml:"disabledActions,omitempty"`
 }
 
 type Providers struct {

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -20,6 +20,10 @@ func Validate(fs *flag.FlagSet) error {
 		return err
 	}
 
+	if _, err := validateAddPage(fs.Lookup("add-page").Value.String()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -62,4 +66,25 @@ func validateQuickStarts(value string) (QuickStarts, error) {
 	}
 
 	return quickStarts, nil
+}
+
+func validateAddPage(value string) (*AddPage, error) {
+	if value == "" {
+		return nil, nil
+	}
+	var addPage AddPage
+
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&addPage); err != nil {
+		return nil, err
+	}
+
+	for index, action := range addPage.DisabledActions {
+		if action == "" {
+			return &addPage, fmt.Errorf("Add page disabled action at index %d must not be empty.", index)
+		}
+	}
+
+	return &addPage, nil
 }

--- a/pkg/serverconfig/validate_test.go
+++ b/pkg/serverconfig/validate_test.go
@@ -1,6 +1,8 @@
 package serverconfig
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -100,5 +102,52 @@ func TestValidObjectForQuickStarts(t *testing.T) {
 	}
 	if len(quickStarts.Disabled) != 3 {
 		t.Errorf("Unexpected value: actual %v, expected %v", len(quickStarts.Disabled), 3)
+	}
+}
+
+func TestValidAddPage(t *testing.T) {
+	tests := []struct {
+		testcase      string
+		input         string
+		expectedData  *AddPage
+		expectedError error
+	}{
+		{
+			testcase:      "empty data",
+			input:         "",
+			expectedData:  nil,
+			expectedError: nil,
+		},
+		{
+			testcase:      "invalid json",
+			input:         "invalid json",
+			expectedData:  nil,
+			expectedError: errors.New("invalid character 'i' looking for beginning of value"),
+		},
+		{
+			testcase: "two valid disabled actions",
+			input:    "{ \"disabledActions\": [ \"action1\", \"action2\" ] }",
+			expectedData: &AddPage{
+				DisabledActions: []string{
+					"action1",
+					"action2",
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testcase, func(t *testing.T) {
+			actualData, actualError := validateAddPage(test.input)
+			if !reflect.DeepEqual(test.expectedData, actualData) {
+				t.Errorf("Data does not match expectation:\n%v\nbut got\n%v", test.expectedData, actualData)
+			}
+			if test.expectedError == nil && actualError != nil {
+				t.Errorf("Error does not match expectation:\n%v\nbut got\n%v", test.expectedError, actualError)
+			} else if test.expectedError != nil && (actualError == nil || test.expectedError.Error() != actualError.Error()) {
+				t.Errorf("Error does not match expectation:\n%v\nbut got\n%v", test.expectedError, actualError)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**Fixes**: 
Epic: https://issues.redhat.com/browse/ODC-5013
Story: https://issues.redhat.com/browse/ODC-5416

**Analysis / Root cause**:
As an admin, I should be able to hide any of the entrypoints from the Add page.

**Solution Description**: 
This PR provides the "add page" customization config object as server flags. The API is defined here https://github.com/openshift/enhancements/pull/669 and https://github.com/openshift/api/pull/889.

The customization is provided as `ConsoleConfig` yaml file to the console Pods, are loaded by the `bridge` binary and provides some of these config entries as `SERVER_FLAGS` to the frontend code.

The second commit also hide these add actions from the Add page by using a new `useAddActionExtensions` hook which wraps `useResolvedExtensions` and the `SERVER_FLAGS` parsing.

**Screen shots / Gifs for design review**: 
The only change is that some actions from the Add page are not shown if the config contains some `disableActions`:

![Peek 2021-04-21 13-31](https://user-images.githubusercontent.com/139310/115547390-7f5cef80-a2a6-11eb-9d9c-3367f5ebca22.gif)

**Unit test coverage report**: 
Added small test to `validate_test.go` for `ValidAddPage`

```
ok  	github.com/openshift/console/pkg/serverconfig	0.037s
```

Add new tests for the `useAddActionExtensions` hook:

```
 PASS  packages/dev-console/src/utils/__tests__/useAddActionExtensions.spec.ts
  useAddActionExtensions
    ✓ return all actions if SERVER_FLAGS.addPage is not defined (16ms)
    ✓ return all actions if SERVER_FLAGS.addPage customization is empty (1ms)
    ✓ return filtered actions if SERVER_FLAGS.addPage contains some disabledActions (2ms)
```

## Test setup (test local frontend with local backend)

1. Create a `config.yaml` file:
```apiVersion: console.openshift.io/v1
apiVersion: console.openshift.io/v1
kind: ConsoleConfig
customization:
  addPage:
    disabledActions:
    - git
    - git2
    - import-from-samples
```

2. Build the backend and start your local bridge with the config file:

```bash
# oc login
# source ./contrib/oc-environment.sh
./build-backend.sh
bin/bridge -config config.yaml
```

3. Use your browser or the following curl command to check if the SERVER_FLAGS are set correctly:

```bash
curl localhost:9000 | grep SERVER_FLAGS | sed 's/.*SERVER_FLAGS = //;s/;$//' | jq .addPageJSON
```

4. Open the developer perspective and open the Add page. With the config above the Samples card should not be displayed anymore.

## Test setup E2E incl. frontend change

To test this change together with https://github.com/openshift/api/pull/889 and https://github.com/openshift/console-operator/pull/527 you need to start cluster with the console-operator PR and the frontend change:

1. Launch a cluster with `launch openshift/console-operator#527,openshift/console#8643`

2. Search for "Console", select apiVersion "operator.openshift.io/v1" and select the "cluster" resource.

3. Open the YAML tab (Quick link for this resource: `https://cluster/k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml`)

4. Add customization:

```yaml
spec:
  customization:
    addPage:
      disabledActions:
        - git
        - git2
        - import-from-samples
```

5. Alternative you can just add `spec.customization.addPage.disabledActions` (see above) as YAML and then insert all add action IDs from the snippet sidebar.

6. Open `https://cluster/k8s/ns/openshift-console/configmaps/console-config` and check data key `console-config.yaml`. The YAML should contain the `disabledActions` after a few seconds.

```yaml
customization:
  addPage:
    disabledActions:
    - git
    - git2
    - import-from-samples
```

7. You need to reload your browser to get the latest customization loaded. Unfortunately they are not loaded directly. So please remember to reload the page if your latest change are not displayed.

8. Open the Developer perspective, and open the Add page. Disabled add actions should now not displayed anymore.

**Full demo:** https://user-images.githubusercontent.com/139310/116062842-932c9b00-a684-11eb-91b9-d1279fb954f8.mp4

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
