### PR TITLE
Topology - Workload Sidebar

### DIFF
--- a/frontend/packages/topology/integration-tests/features/topology/topology-workload-sidebar.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-workload-sidebar.feature
@@ -3,29 +3,24 @@ Feature: Sidebar in topology
               As a user, I want to check sidebar of workloads
 
         Background:
-            Given user is at developer perspective
-              And user has selected namespace "aut-topology-sidebar"
+            Given user has created or selected namespace "aut-topology-sidebar"
+              And user is at Add page
 
 
         @smoke
-        Scenario Outline: Sidebar for workload: T-05-TC01
-            Given user created workload "<workload_name>" with resource type "<resource_type>"
-             When user clicks on workload "<workload_name>"
+        Scenario: Sidebar for workload: T-05-TC01
+            Given user has created workload "nodejs-ex-git" with resource type "deployment"
+             When user clicks on workload "nodejs-ex-git"
              Then user can see sidebar opens with Resources tab selected by default
               And user can see sidebar Details, Resources and Monitoring tabs
-              And user verifies name of the node "<workload_name>" and Action drop down present on top of the sidebar
-              And user is able to see health check notifiation
+              And user verifies name of the node "nodejs-ex-git" and Action drop down present on top of the sidebar
+              And user is able to see health check notification
               And user can see close button
-
-        Examples:
-                  | resource_type     | workload_name   |
-                  | deployment        | nodejs-ex-git   |
-                  | deployment config | dancer-ex-git-1 |
 
 
         @smoke
         Scenario: Sidebar for knative service: T-05-TC01
-            Given user created workload "hello-openshift" with resource type "knative service"
+            Given user has created workload "hello-openshift" with resource type "Knative Service"
              When user clicks on workload "hello-openshift"
              Then user can see sidebar opens with Resources tab selected by default
               And user can see sidebar Details, Resources tabs
@@ -34,31 +29,19 @@ Feature: Sidebar in topology
 
 
         @regression
-        Scenario Outline: Pod scale up in sidebar
-            Given user created workload "<workload_name>" with resource type "<resource_type>"
-             When user clicks on workload "<workload_name>"
+        Scenario: Pod scale up in sidebar
+            Given user has created workload "dancer-ex-git-1" with resource type "deployment"
+             When user clicks on workload "dancer-ex-git-1"
               And user goes to Details tab
               And user scales up the pod
-             Then user is able to see pod Scaling to 2
-              And user can see two half circles in light and dark blue representing two pods
-
-        Examples:
-                  | resource_type     | workload_name   |
-                  | deployment        | nodejs-ex-git   |
-                  | deployment config | dancer-ex-git-1 |
+             Then user is able to see pod Scaling to "2 Pods" for workload "nodejs-ex-git-1"
 
 
         @regression
-        Scenario Outline: Pod scale down in sidebar
-            Given user created workload "<workload_name>" with resource type "<resource_type>"
-              And user has scaled up the pod to 2
-             When user clicks on workload "<workload_name>"
+        Scenario: Pod scale down in sidebar
+            Given user has created workload "nodejs-ex-git-1" with resource type "deployment"
+              And user has scaled up the pod to 2 for workload "nodejs-ex-git-1"
+             When user clicks on workload "nodejs-ex-git-1"
               And user goes to Details tab
               And user scales down the pod number
-             Then user is able to see pod number change to 1
-              And user can see two half circles appearing and changing to one
-
-        Examples:
-                  | resource_type     | workload_name   |
-                  | deployment        | nodejs-ex-git   |
-                  | deployment config | dancer-ex-git-1 |
+             Then user is able to see pod Scaling to "1 Pod" for workload "nodejs-ex-git-1"

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -28,6 +28,7 @@ export const topologyPO = {
     nodeName: '#HelmRelease ul li div',
   },
   sidePane: {
+    actionsDropDown: '[data-test-id="actions-menu-button"]',
     dialog: '[role="dialog"]',
     title: '[role="dialog"] h1',
     tabs: '[role="dialog"] li button',
@@ -36,6 +37,9 @@ export const topologyPO = {
     labelsList: '[data-test="label-list"]',
     editAnnotations: '[data-test="edit-annotations"]',
     tabName: '[role="dialog"] li button',
+    healthCheckAlert: 'div.ocs-health-checks-alert',
+    podScale: 'button.pf-c-button.pf-m-plain.pf-m-block',
+    podText: 'text.pf-chart-donut-title.pod-ring__center-text',
     detailsTab: {
       labels: 'dt[data-test-selector$="Labels"]',
       annotations: '[data-test-selector="details-item-label__Annotations"]',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
@@ -17,6 +17,7 @@ export const topologySidePane = {
       .get(topologyPO.sidePane.tabName)
       .contains(tabName)
       .should('be.visible'),
+  verifyActionsDropDown: () => cy.get(topologyPO.sidePane.actionsDropDown).should('be.visible'),
   selectTab: (tabName: string) =>
     cy
       .get(topologyPO.sidePane.tabName)
@@ -56,6 +57,19 @@ export const topologySidePane = {
       .get('a')
       .contains('Add Health Checks')
       .click(),
+  scaleUpPodCount: () =>
+    cy
+      .get(topologyPO.sidePane.podScale)
+      .eq(0)
+      .click(),
+  scaleDownPodCount: () =>
+    cy
+      .get(topologyPO.sidePane.podScale)
+      .eq(1)
+      .click(),
+  verifyPodText: (scaleNumber: string) =>
+    cy.get(topologyPO.sidePane.podText).should('contain.text', scaleNumber),
+  verifyHealthCheckAlert: () => cy.get(topologyPO.sidePane.healthCheckAlert).should('be.visible'),
   verifyWorkloadInAppSideBar: (workloadName: string) =>
     cy
       .get(topologyPO.sidePane.dialog)

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -1,8 +1,21 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
-import { navigateTo } from '@console/dev-console/integration-tests/support/pages/app';
-import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
+import {
+  perspective,
+  projectNameSpace,
+  navigateTo,
+} from '@console/dev-console/integration-tests/support/pages/app';
+import {
+  switchPerspective,
+  devNavigationMenu,
+} from '@console/dev-console/integration-tests/support/constants/global';
 import { topologySidePane } from '@console/topology/integration-tests/support/pages/topology/topology-side-pane-page';
+import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
+import { nav } from '@console/cypress-integration-tests/views/nav';
+import {
+  createGitWorkload,
+  topologyHelper,
+} from '@console/dev-console/integration-tests/support/pages';
 
 Given('user is at the Topology page', () => {
   navigateTo(devNavigationMenu.Topology);
@@ -36,4 +49,69 @@ Then('user can see sidebar opens with Resources tab selected by default', () => 
 Then('side bar is displayed with the pipelines section', () => {
   topologySidePane.verifyTab('Resources');
   topologySidePane.verifySection('Pipeline Runs');
+});
+
+Then('user can see sidebar Details, Resources and Monitoring tabs', () => {
+  topologySidePane.verifyTab('Details');
+  topologySidePane.verifyTab('Resources');
+  topologySidePane.verifyTab('Monitoring');
+});
+
+Then('user can see sidebar Details, Resources tabs', () => {
+  topologySidePane.verifyTab('Details');
+  topologySidePane.verifyTab('Resources');
+});
+
+When('user goes to Details tab', () => {
+  topologySidePane.selectTab('Details');
+});
+
+Then('user can see close button', () => {
+  topologySidePane.close();
+});
+
+Then(
+  'user verifies name of the node {string} and Action drop down present on top of the sidebar',
+  (nodeName: string) => {
+    topologySidePane.verifyTitle(nodeName);
+    topologySidePane.verifyActionsDropDown();
+  },
+);
+
+Then('user is able to see health check notification', () => {
+  topologySidePane.verifyHealthCheckAlert();
+});
+
+Given('user is at developer perspective', () => {
+  perspective.switchTo(switchPerspective.Developer);
+  guidedTour.close();
+  nav.sidenav.switcher.shouldHaveText(switchPerspective.Developer);
+});
+
+Given('user has created namespace starts with {string}', (projectName: string) => {
+  const d = new Date();
+  const timestamp = d.getTime();
+  projectNameSpace.selectOrCreateProject(`${projectName}-${timestamp}-ns`);
+});
+
+Given('user has created or selected namespace {string}', (projectName: string) => {
+  Cypress.env('NAMESPACE', projectName);
+  projectNameSpace.selectOrCreateProject(`${projectName}`);
+});
+
+Given(
+  'user has created workload {string} with resource type {string}',
+  (componentName: string, resourceType: string = 'Deployment') => {
+    createGitWorkload(
+      'https://github.com/sclorg/nodejs-ex.git',
+      componentName,
+      resourceType,
+      'nodejs-ex-git-app',
+    );
+    topologyHelper.verifyWorkloadInTopologyPage(componentName);
+  },
+);
+
+Given('user is at Add page', () => {
+  navigateTo(devNavigationMenu.Add);
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/workload-sidebar.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/workload-sidebar.ts
@@ -1,0 +1,27 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
+import { topologySidePane } from '@console/topology/integration-tests/support/pages/topology/topology-side-pane-page';
+
+Given('user has scaled up the pod to 2 for workload {string}', (workloadName: string) => {
+  topologyPage.componentNode(workloadName).click({ force: true });
+  topologySidePane.selectTab('Details');
+  topologySidePane.scaleUpPodCount();
+});
+
+When('user scales up the pod', () => {
+  topologySidePane.scaleUpPodCount();
+});
+
+When('user scales down the pod number', () => {
+  topologySidePane.scaleDownPodCount();
+});
+
+Then(
+  'user is able to see pod Scaling to {string} for workload {string}',
+  (podText: string, workloadName: string) => {
+    topologySidePane.close();
+    topologyPage.componentNode(workloadName).click({ force: true });
+    topologySidePane.selectTab('Details');
+    topologySidePane.verifyPodText(podText);
+  },
+);


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/ODC-5575

**Problem:** Automation to open the sidebar for the workload

**Solution:** This script will open the sidebar for the workload and validate the sidebar tabs

**Test Setup:**
1. Add _"test-cypress-topology": "cd packages/topology/integration-tests && yarn run test-cypress",_ under **scripts** in package.json
2. Run **yarn run test-cypress-topology** in frontend
3. Execute feature file: **frontend/packages/topology/features/topology/topology-workload-sidebar.feature**

**Screenshots:**
![Screenshot from 2021-04-14 14-54-25](https://user-images.githubusercontent.com/17041173/114688645-8463f100-9d32-11eb-8313-536c43bf4741.png)
