### PR TITLE
Bug 1949410: Fix "Create binding" link from Role page, RoleBindings tab

### DIFF
--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -231,7 +231,7 @@ export const BindingsForRolePage = (props) => {
       createProps={{
         to: `/k8s/${
           ns ? `ns/${ns}` : 'cluster'
-        }/rolebindings/~new?rolekind=${kind}&rolename=${name}${ns && `&namespace=${ns}`}`,
+        }/rolebindings/~new?rolekind=${kind}&rolename=${name}${ns ? `&namespace=${ns}` : ''}`,
       }}
       ListComponent={BindingsListComponent}
       staticFilters={[{ 'role-binding-roleRef-name': name }, { 'role-binding-roleRef-kind': kind }]}


### PR DESCRIPTION
The link incorrectly added `undefined` to the URL when creating a binding for a ClusterRole.

/assign @zherman0 