### PR TITLE
Bug 1949514:  make Location column visible at smaller screen resolutions

### DIFF
--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -143,8 +143,9 @@ RouteStatus.displayName = 'RouteStatus';
 const tableColumnClasses = [
   '',
   '',
-  classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'),
-  classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
+  // Status is less important than Location, so hide it earlier, but maintain its position for consistency with other tables
+  classNames('pf-m-hidden', 'pf-m-visible-on-lg', 'pf-u-w-16-on-lg'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-sm'),
   classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
   Kebab.columnClass,
 ];


### PR DESCRIPTION
by hiding Status and showing Location

After:
![localhost_9000_k8s_ns_openshift-monitoring_routes (1)](https://user-images.githubusercontent.com/895728/114755106-4c0ae580-9d27-11eb-85a9-6efb176e7e5d.png)
![localhost_9000_k8s_ns_openshift-monitoring_routes (2)](https://user-images.githubusercontent.com/895728/114755107-4c0ae580-9d27-11eb-84f8-6d5392eaf3c4.png)
![localhost_9000_k8s_ns_openshift-monitoring_routes (3)](https://user-images.githubusercontent.com/895728/114755109-4ca37c00-9d27-11eb-9ac5-4de7619fe4ac.png)
![localhost_9000_k8s_ns_openshift-monitoring_routes (6)](https://user-images.githubusercontent.com/895728/114755115-4d3c1280-9d27-11eb-8e97-642039f21b9f.png)
![localhost_9000_k8s_ns_openshift-monitoring_routes (5)](https://user-images.githubusercontent.com/895728/114755113-4d3c1280-9d27-11eb-8a83-be42f24dc144.png)
![localhost_9000_k8s_ns_openshift-monitoring_routes (4)](https://user-images.githubusercontent.com/895728/114755111-4ca37c00-9d27-11eb-9c27-70717cc4955f.png)