### PR TITLE
Add No Workspace value to Start Modal

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -95,6 +95,7 @@
   "Add item": "Add item",
   "Config Map": "Config Map",
   "Empty Directory doesn't support shared data between tasks.": "Empty Directory doesn't support shared data between tasks.",
+  "No workspace": "No workspace",
   "Empty Directory": "Empty Directory",
   "PersistentVolumeClaim": "PersistentVolumeClaim",
   "VolumeClaimTemplate": "VolumeClaimTemplate",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -20,6 +20,7 @@ export enum PipelineResourceType {
 }
 
 export enum VolumeTypes {
+  NoWorkspace = 'noWorkspace',
   EmptyDirectory = 'emptyDirectory',
   ConfigMap = 'configMap',
   Secret = 'secret',

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineWorkspacesSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineWorkspacesSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { useFormikContext, FormikValues, useField } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
@@ -73,6 +74,7 @@ const PipelineWorkspacesSection: React.FC = () => {
   const [{ value: workspaces }] = useField<PipelineModalFormWorkspace[]>('workspaces');
 
   const volumeTypeOptions: { [type in VolumeTypes]: string } = {
+    [VolumeTypes.NoWorkspace]: t('pipelines-plugin~No workspace'),
     [VolumeTypes.EmptyDirectory]: t('pipelines-plugin~Empty Directory'),
     [VolumeTypes.ConfigMap]: t('pipelines-plugin~Config Map'),
     [VolumeTypes.Secret]: t('pipelines-plugin~Secret'),
@@ -83,26 +85,32 @@ const PipelineWorkspacesSection: React.FC = () => {
   return (
     workspaces.length > 0 && (
       <FormSection title={t('pipelines-plugin~Workspaces')} fullWidth>
-        {workspaces.map((workspace, index) => (
-          <div className="form-group" key={workspace.name}>
-            <DropdownField
-              name={`workspaces.${index}.type`}
-              label={workspace.name}
-              items={volumeTypeOptions}
-              onChange={(type) =>
-                setFieldValue(
-                  `workspaces.${index}.data`,
-                  type === VolumeTypes.EmptyDirectory ? { emptyDir: {} } : {},
-                  // Validation is automatically done by DropdownField useFormikValidationFix
-                  false,
-                )
-              }
-              fullWidth
-              required={!workspace.optional}
-            />
-            {getVolumeTypeFields(workspace.type, index, t)}
-          </div>
-        ))}
+        {workspaces.map((workspace, index) => {
+          return (
+            <div className="form-group" key={workspace.name}>
+              <DropdownField
+                name={`workspaces.${index}.type`}
+                label={workspace.name}
+                items={
+                  workspace.optional
+                    ? volumeTypeOptions
+                    : _.omit(volumeTypeOptions, VolumeTypes.NoWorkspace)
+                }
+                onChange={(type) =>
+                  setFieldValue(
+                    `workspaces.${index}.data`,
+                    type === VolumeTypes.EmptyDirectory ? { emptyDir: {} } : {},
+                    // Validation is automatically done by DropdownField useFormikValidationFix
+                    false,
+                  )
+                }
+                fullWidth
+                required={!workspace.optional}
+              />
+              {getVolumeTypeFields(workspace.type, index, t)}
+            </div>
+          );
+        })}
       </FormSection>
     )
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
@@ -332,7 +332,10 @@ describe('convertPipelineToModalData', () => {
     const { workspaces } = convertPipelineToModalData(workspacePipeline);
     expect(
       workspaces.filter((workspace) => workspace.type === VolumeTypes.EmptyDirectory),
-    ).toHaveLength(3);
+    ).toHaveLength(2);
+    expect(
+      workspaces.filter((workspace) => workspace.type === VolumeTypes.NoWorkspace),
+    ).toHaveLength(1);
   });
 
   it('expect to return workspaces with type PVC, if preselect PVC argument is passed', () => {
@@ -340,6 +343,9 @@ describe('convertPipelineToModalData', () => {
     expect(
       workspaces.filter((workspace) => workspace.type === VolumeTypes.EmptyDirectory),
     ).toHaveLength(0);
-    expect(workspaces.filter((workspace) => workspace.type === VolumeTypes.PVC)).toHaveLength(3);
+    expect(workspaces.filter((workspace) => workspace.type === VolumeTypes.PVC)).toHaveLength(2);
+    expect(
+      workspaces.filter((workspace) => workspace.type === VolumeTypes.NoWorkspace),
+    ).toHaveLength(1);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/types.ts
@@ -19,25 +19,43 @@ export type PipelineModalFormResource = {
   };
 };
 
-export type PipelineModalFormWorkspace = TektonWorkspace & {
-  type: VolumeTypes;
-  data:
-    | {
+export type PipelineModalFormWorkspaceStructure =
+  | {
+      type: VolumeTypes.NoWorkspace;
+      data: {};
+    }
+  | {
+      type: VolumeTypes.EmptyDirectory;
+      data: {
         emptyDir: {};
-      }
-    | {
+      };
+    }
+  | {
+      type: VolumeTypes.Secret;
+      data: {
         secret: VolumeTypeSecret;
-      }
-    | {
+      };
+    }
+  | {
+      type: VolumeTypes.ConfigMap;
+      data: {
         configMap: VolumeTypeConfigMaps;
-      }
-    | {
+      };
+    }
+  | {
+      type: VolumeTypes.PVC;
+      data: {
         persistentVolumeClaim: VolumeTypePVC;
-      }
-    | {
+      };
+    }
+  | {
+      type: VolumeTypes.VolumeClaimTemplate;
+      data: {
         volumeClaimTemplate: VolumeTypeClaim;
       };
-};
+    };
+
+export type PipelineModalFormWorkspace = TektonWorkspace & PipelineModalFormWorkspaceStructure;
 
 export type CommonPipelineModalFormikValues = FormikValues & {
   namespace: string;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/submit-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/submit-utils.ts
@@ -9,6 +9,7 @@ import { CREATE_PIPELINE_RESOURCE } from '../common/const';
 import { PipelineModalFormResource } from '../common/types';
 import { getPipelineRunFromForm } from '../common/utils';
 import { StartPipelineFormValues } from './types';
+import { VolumeTypes } from '../../const';
 
 export const resourceSubmit = async (
   resourceValues: PipelineModalFormResource,
@@ -25,12 +26,9 @@ export const resourceSubmit = async (
     : createPipelineResource(params, type, namespace);
 };
 
-export const submitStartPipeline = async (
+const processResources = async (
   values: StartPipelineFormValues,
-  pipeline: PipelineKind,
-  labels?: { [key: string]: string },
-  annotations?: { [key: string]: string },
-): Promise<PipelineRunKind> => {
+): Promise<StartPipelineFormValues> => {
   const { namespace, resources } = values;
 
   const toCreateResources: { [index: string]: PipelineModalFormResource } = resources.reduce(
@@ -42,26 +40,46 @@ export const submitStartPipeline = async (
   const createdResources = await Promise.all(
     Object.values(toCreateResources).map((resource) => resourceSubmit(resource, namespace)),
   );
+  if (!createdResources || createdResources.length === 0) return values;
 
+  const indexLookup = Object.keys(toCreateResources);
+  return {
+    ...values,
+    resources: resources.map(
+      (resource, index): PipelineModalFormResource => {
+        if (toCreateResources[index]) {
+          const creationIndex = indexLookup.indexOf(index.toString());
+          return {
+            ...resource,
+            selection: createdResources[creationIndex].metadata.name,
+          };
+        }
+        return resource;
+      },
+    ),
+  };
+};
+
+const processWorkspaces = (values: StartPipelineFormValues): StartPipelineFormValues => {
+  const { workspaces } = values;
+
+  if (!workspaces || workspaces.length === 0) return values;
+
+  return {
+    ...values,
+    workspaces: workspaces.filter((workspace) => workspace.type !== VolumeTypes.NoWorkspace),
+  };
+};
+
+export const submitStartPipeline = async (
+  values: StartPipelineFormValues,
+  pipeline: PipelineKind,
+  labels?: { [key: string]: string },
+  annotations?: { [key: string]: string },
+): Promise<PipelineRunKind> => {
   let formValues = values;
-  if (createdResources.length > 0) {
-    const indexLookup = Object.keys(toCreateResources);
-    formValues = {
-      ...formValues,
-      resources: formValues.resources.map(
-        (resource, index): PipelineModalFormResource => {
-          if (toCreateResources[index]) {
-            const creationIndex = indexLookup.indexOf(index.toString());
-            return {
-              ...resource,
-              selection: createdResources[creationIndex].metadata.name,
-            };
-          }
-          return resource;
-        },
-      ),
-    };
-  }
+  formValues = await processResources(formValues);
+  formValues = processWorkspaces(formValues);
 
   const pipelineRunResource: PipelineRunKind = await k8sCreate(
     PipelineRunModel,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5766

**Analysis / Root cause**: 
Our values in the Pipeline Start modal only allow for you to select options... however optional means you should be able to omit it.

**Solution Description**: 
Support a special No workspace value that omits the workspace.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

![Screen Shot 2021-04-14 at 4 07 01 PM](https://user-images.githubusercontent.com/8126518/114772208-8a120480-9d3b-11eb-93f8-962be6a1159f.png)
![Screen Shot 2021-04-14 at 4 07 08 PM](https://user-images.githubusercontent.com/8126518/114772211-8aaa9b00-9d3b-11eb-89b9-4f34bf249f6b.png)
![Screen Shot 2021-04-14 at 4 07 17 PM](https://user-images.githubusercontent.com/8126518/114772212-8aaa9b00-9d3b-11eb-8b41-7d4e9c6c1e66.png)
![Screen Shot 2021-04-14 at 4 07 35 PM](https://user-images.githubusercontent.com/8126518/114772336-aada5a00-9d3b-11eb-9f31-26df12f695b7.png)


**Unit test coverage report**: 
No changes

**Test setup:**

Create a Pipeline via the Pipeline Builder, add an optional workspace. Start the Pipeline via the modal.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge