### PR TITLE
pipelinerun visualisation for status PipelineRunPending

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { LoadingInline } from '@console/internal/components/utils';
 import PipelineVisualization from '../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualization';
-import { PipelineRunKind } from '../../../types';
-import { getPipelineFromPipelineRun } from '../../../utils/pipeline-augment';
-
+import { PipelineKind, PipelineRunKind } from '../../../types';
+import { usePipelineFromPipelineRun } from '../hooks/usePipelineFromPipelineRun';
 import './PipelineRunVisualization.scss';
 
 type PipelineRunVisualizationProps = {
@@ -11,7 +10,7 @@ type PipelineRunVisualizationProps = {
 };
 
 const PipelineRunVisualization: React.FC<PipelineRunVisualizationProps> = ({ pipelineRun }) => {
-  const pipeline = getPipelineFromPipelineRun(pipelineRun);
+  const pipeline: PipelineKind = usePipelineFromPipelineRun(pipelineRun);
   if (!pipeline) {
     return (
       <div className="pipeline-plr-loader">

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunVisualization.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunVisualization.spec.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../test-data/pipeline-data';
 import PipelineRunVisualization from '../PipelineRunVisualization';
 import PipelineVisualization from '../../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualization';
+import * as plrDetailsHooks from '../../hooks/usePipelineFromPipelineRun';
 
 const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
 const pipelineRun = pipelineData.pipelineRuns[DataState.SUCCESS];
@@ -15,19 +16,23 @@ const pipelineRun = pipelineData.pipelineRuns[DataState.SUCCESS];
 describe('PipelineRunVisualization', () => {
   type PipelineRunVisualizationProps = React.ComponentProps<typeof PipelineRunVisualization>;
   let wrapper: ShallowWrapper<PipelineRunVisualizationProps>;
+  const usePipelineFromPipelineRunSpy = jest.spyOn(plrDetailsHooks, 'usePipelineFromPipelineRun');
 
-  beforeEach(() => {
-    wrapper = shallow(<PipelineRunVisualization pipelineRun={pipelineRun} />);
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
-  it('Should render the loading component if pipelinerun status is not yet resolved', () => {
-    wrapper = shallow(<PipelineRunVisualization pipelineRun={{ ...pipelineRun, status: null }} />);
+  it('Should render the loading component if pipeline from pipeline run is not defined or null', () => {
+    usePipelineFromPipelineRunSpy.mockReturnValueOnce(null);
+    wrapper = shallow(<PipelineRunVisualization pipelineRun={pipelineRun} />);
     const LoadingInlineComponent = wrapper.find(LoadingInline);
-    expect(LoadingInlineComponent).toHaveLength(1);
+    expect(LoadingInlineComponent.exists()).toBe(true);
   });
 
   it('Should render the visualization component if the pipelinerun has the graphable data', () => {
+    usePipelineFromPipelineRunSpy.mockReturnValueOnce(pipelineData.pipeline);
+    wrapper = shallow(<PipelineRunVisualization pipelineRun={pipelineRun} />);
     const PipelineVisualizationComponent = wrapper.find(PipelineVisualization);
-    expect(PipelineVisualizationComponent).toHaveLength(1);
+    expect(PipelineVisualizationComponent.exists()).toBe(true);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/__tests__/usePipelineFromPipelineRun.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/__tests__/usePipelineFromPipelineRun.spec.ts
@@ -1,0 +1,80 @@
+import { act } from 'react-dom/test-utils';
+import * as k8s from '@console/internal/module/k8s';
+import { getPipelineFromPipelineRun } from '../../../../utils/pipeline-augment';
+import {
+  DataState,
+  PipelineExampleNames,
+  pipelineTestData,
+} from '../../../../test-data/pipeline-data';
+import { usePipelineFromPipelineRun } from '../usePipelineFromPipelineRun';
+import { testHook } from '../../../../../../../__tests__/utils/hooks-utils';
+
+describe('usePipelineFromPipelineRun', () => {
+  const pipelineData = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
+  const pipelineRun = pipelineData.pipelineRuns[DataState.SUCCESS];
+  const plrWithEmbeddedPipeline =
+    pipelineTestData[PipelineExampleNames.EMBEDDED_PIPELINE_SPEC].pipelineRuns[DataState.SUCCESS];
+  const plrWithoutPipelineSpec = { ...pipelineRun, status: null };
+  const k8sGetSpy = jest.spyOn(k8s, 'k8sGet');
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return pipeline from getPipelineFromPipelineRun if pipelineSpec is present in status field', () => {
+    const {
+      result: { current: pipeline },
+    } = testHook(() => usePipelineFromPipelineRun(pipelineRun));
+    expect(pipeline).toMatchObject(getPipelineFromPipelineRun(pipelineRun));
+  });
+
+  it('should return pipeline from getPipelineFromPipelineRun if pipelineSpec is present in spec field', () => {
+    const {
+      result: { current: pipeline },
+    } = testHook(() => usePipelineFromPipelineRun(plrWithEmbeddedPipeline));
+    expect(pipeline).toMatchObject(getPipelineFromPipelineRun(plrWithEmbeddedPipeline));
+  });
+
+  it('should return pipeline if pipelineSpec does not exist in status or spec field but pipelineRef in spec field has a valid name', async () => {
+    k8sGetSpy.mockReturnValueOnce(Promise.resolve(pipelineData.pipeline));
+    const { result, rerender } = testHook(() => usePipelineFromPipelineRun(plrWithoutPipelineSpec));
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toMatchObject(pipelineData.pipeline);
+  });
+
+  it('should return empty pipeline if pipelineSpec does not exist in status or spec field and pipelineRef.name does not exist', async () => {
+    const pipelineRunWithoutPipelineRef = {
+      ...pipelineRun,
+      spec: { ...pipelineRun.spec, pipelineRef: { name: null } },
+      status: null,
+    };
+    const { result, rerender } = testHook(() =>
+      usePipelineFromPipelineRun(pipelineRunWithoutPipelineRef),
+    );
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toMatchObject({ spec: { tasks: [] } });
+    expect(k8sGetSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return empty pipeline if pipelineSpec does not exist in status or spec field and pipelineRef.name does not exist', async () => {
+    k8sGetSpy.mockReturnValueOnce(Promise.reject());
+    const { result, rerender } = testHook(() => usePipelineFromPipelineRun(plrWithoutPipelineSpec));
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toMatchObject({ spec: { tasks: [] } });
+  });
+
+  it('should return null until network call is resolved', async () => {
+    k8sGetSpy.mockReturnValueOnce(Promise.resolve(pipelineData.pipeline));
+    const { result, rerender } = testHook(() => usePipelineFromPipelineRun(plrWithoutPipelineSpec));
+    await act(async () => {
+      rerender();
+      expect(result.current).toBeNull();
+    });
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineFromPipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/usePipelineFromPipelineRun.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { k8sGet } from '@console/internal/module/k8s';
+import { PipelineKind, PipelineRunKind } from '../../../types';
+import { getPipelineFromPipelineRun } from '../../../utils/pipeline-augment';
+import { PipelineModel } from '../../../models';
+
+export const usePipelineFromPipelineRun = (pipelineRun: PipelineRunKind): PipelineKind => {
+  const [pipeline, setPipeline] = React.useState<PipelineKind>(null);
+  React.useEffect(() => {
+    const emptyPipeline: PipelineKind = { spec: { tasks: [] } };
+    const pipelineFromPipelineRun = getPipelineFromPipelineRun(pipelineRun);
+    if (pipelineFromPipelineRun) {
+      setPipeline(pipelineFromPipelineRun);
+    } else if (pipelineRun.spec.pipelineRef?.name) {
+      const pipelineName = pipelineRun.spec.pipelineRef.name;
+      k8sGet(PipelineModel, pipelineName, pipelineRun.metadata.namespace)
+        .then((newPipeline: PipelineKind) => {
+          setPipeline(newPipeline);
+        })
+        .catch(() => setPipeline(emptyPipeline));
+    } else {
+      setPipeline(emptyPipeline);
+    }
+  }, [pipelineRun]);
+  return pipeline;
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskStatus.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/hooks/useTaskStatus.ts
@@ -1,0 +1,8 @@
+import { PipelineKind, PipelineRunKind } from '../../../types';
+import { getTaskStatus, TaskStatus } from '../../../utils/pipeline-augment';
+import { usePipelineFromPipelineRun } from './usePipelineFromPipelineRun';
+
+export const useTaskStatus = (pipelineRun: PipelineRunKind): TaskStatus => {
+  const pipeline: PipelineKind = usePipelineFromPipelineRun(pipelineRun);
+  return getTaskStatus(pipelineRun, pipeline);
+};

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/status/PipelineBars.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import HorizontalStackedBars from '../../charts/HorizontalStackedBars';
 import { PipelineRunKind } from '../../../types';
-import { getTaskStatus, runStatus, getRunStatusColor } from '../../../utils/pipeline-augment';
+import { runStatus, getRunStatusColor } from '../../../utils/pipeline-augment';
+import { useTaskStatus } from '../hooks/useTaskStatus';
 import TaskStatusToolTip from './TaskStatusTooltip';
 
 export interface PipelineBarProps {
@@ -10,7 +11,7 @@ export interface PipelineBarProps {
 }
 
 export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun }) => {
-  const taskStatus = getTaskStatus(pipelinerun);
+  const taskStatus = useTaskStatus(pipelinerun);
 
   return (
     <Tooltip content={<TaskStatusToolTip taskStatus={taskStatus} />}>

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -14,6 +14,8 @@ export enum DataState {
   FAILED3 = 'Failed at stage 3',
   FAILED_BUT_COMPLETE = 'Completed But Failed',
   SKIPPED = 'Skipped',
+  PIPELINE_RUN_PENDING = 'PipelineRunPending',
+  PIPELINE_RUN_CANCELLED = 'PipelineRunCancelled',
 }
 
 export enum PipelineExampleNames {
@@ -584,6 +586,75 @@ export const pipelineTestData: PipelineTestData = {
               },
             },
           },
+        },
+      },
+      [DataState.PIPELINE_RUN_PENDING]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'simple-pipeline-p1bun0',
+          namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T09:58:19Z',
+          labels: { [TektonResourceLabel.pipeline]: 'simple-pipeline' },
+        },
+        spec: {
+          pipelineRef: { name: 'simple-pipeline' },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            {
+              name: 'web-image',
+              resourceRef: { name: 'mapit-image' },
+            },
+          ],
+          status: 'PipelineRunPending',
+        },
+        status: {
+          pipelineSpec: pipelineSpec[PipelineExampleNames.SIMPLE_PIPELINE],
+          completionTime: '2019-10-29T11:57:53Z',
+          conditions: [
+            {
+              lastTransitionTime: '2019-09-12T20:38:01Z',
+              message: 'All Tasks have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+        },
+      },
+
+      [DataState.PIPELINE_RUN_CANCELLED]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'simple-pipeline-p1bun0',
+          namespace: 'tekton-pipelines',
+          creationTimestamp: '2020-10-29T09:58:19Z',
+          labels: { [TektonResourceLabel.pipeline]: 'simple-pipeline' },
+        },
+        spec: {
+          pipelineRef: { name: 'simple-pipeline' },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            {
+              name: 'web-image',
+              resourceRef: { name: 'mapit-image' },
+            },
+          ],
+          status: 'PipelineRunCancelled',
+        },
+        status: {
+          pipelineSpec: pipelineSpec[PipelineExampleNames.SIMPLE_PIPELINE],
+          completionTime: '2019-10-29T11:57:53Z',
+          conditions: [
+            {
+              lastTransitionTime: '2019-09-12T20:38:01Z',
+              message: 'All Tasks have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
         },
       },
     },

--- a/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineBuildDecoratorTooltip.tsx
+++ b/frontend/packages/pipelines-plugin/src/topology/build-decorators/PipelineBuildDecoratorTooltip.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PipelineRunKind } from '../../types';
-import { getRunStatusColor, getTaskStatus, runStatus } from '../../utils/pipeline-augment';
+import { getRunStatusColor, runStatus } from '../../utils/pipeline-augment';
 import HorizontalStackedBars from '../../components/charts/HorizontalStackedBars';
 import TaskStatusToolTip from '../../components/pipelineruns/status/TaskStatusTooltip';
 import './PipelineBuildDecoratorTooltip.scss';
+import { useTaskStatus } from '../../components/pipelineruns/hooks/useTaskStatus';
 
 export interface PipelineBuildDecoratorTooltipProps {
   pipelineRun: PipelineRunKind;
@@ -16,11 +17,11 @@ const PipelineBuildDecoratorTooltip: React.FC<PipelineBuildDecoratorTooltipProps
   status,
 }) => {
   const { t } = useTranslation();
+  const taskStatus = useTaskStatus(pipelineRun);
   if (!pipelineRun || !status) {
     return null;
   }
 
-  const taskStatus = getTaskStatus(pipelineRun);
   const pipelineBars = (
     <HorizontalStackedBars
       height="1em"

--- a/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
@@ -135,7 +135,7 @@ export type PipelineRunKind = K8sResourceCommon & {
     serviceAccountName?: string;
     timeout?: string;
     // Only used in a single case - cancelling a pipeline; should not be copied between PLRs
-    status?: 'PipelineRunCancelled';
+    status?: 'PipelineRunCancelled' | 'PipelineRunPending';
   };
   status?: {
     succeededCondition?: string;

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -119,7 +119,7 @@ describe('PipelineAugment test getRunStatusColor handles all runStatus values', 
 describe('PipelineAugment test correct task status state is pulled from pipeline/pipelineruns', () => {
   it('expect no arguments to produce a net-zero result', () => {
     // Null check + showcasing we get at least 1 value out of the function
-    const emptyTaskStatus = getTaskStatus(null);
+    const emptyTaskStatus = getTaskStatus(null, null);
     expect(emptyTaskStatus).toEqual({
       PipelineNotStarted: 1,
       Pending: 0,
@@ -142,8 +142,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const simpleTestData = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
 
       const expectedTaskCount = getExpectedTaskCount(simpleTestData.pipeline);
-      const taskStatus = getTaskStatus(simpleTestData.pipelineRuns[DataState.SUCCESS]);
-      const taskCount = totalPipelineRunTasks(simpleTestData.pipelineRuns[DataState.SUCCESS]);
+      const taskStatus = getTaskStatus(
+        simpleTestData.pipelineRuns[DataState.SUCCESS],
+        simpleTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(simpleTestData.pipeline);
 
       expect(taskStatus.Succeeded).toEqual(expectedTaskCount);
       expect(sumTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
@@ -154,8 +157,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const complexTestData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
 
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.SUCCESS]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.SUCCESS]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.SUCCESS],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(taskStatus.Succeeded).toEqual(expectedTaskCount);
       expect(sumTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
@@ -166,8 +172,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const finallyTestData = pipelineTestData[PipelineExampleNames.PIPELINE_WITH_FINALLY];
 
       const expectedTaskCount = getExpectedTaskCount(finallyTestData.pipeline);
-      const taskStatus = getTaskStatus(finallyTestData.pipelineRuns[DataState.SUCCESS]);
-      const taskCount = totalPipelineRunTasks(finallyTestData.pipelineRuns[DataState.SUCCESS]);
+      const taskStatus = getTaskStatus(
+        finallyTestData.pipelineRuns[DataState.SUCCESS],
+        finallyTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(finallyTestData.pipeline);
 
       expect(taskStatus.Succeeded).toEqual(expectedTaskCount);
       expect(taskCount).toEqual(expectedTaskCount);
@@ -186,8 +195,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const simpleTestData = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
 
       const expectedTaskCount = getExpectedTaskCount(simpleTestData.pipeline);
-      const taskStatus = getTaskStatus(simpleTestData.pipelineRuns[DataState.IN_PROGRESS]);
-      const taskCount = totalPipelineRunTasks(simpleTestData.pipelineRuns[DataState.IN_PROGRESS]);
+      const taskStatus = getTaskStatus(
+        simpleTestData.pipelineRuns[DataState.IN_PROGRESS],
+        simpleTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(simpleTestData.pipeline);
 
       expect(sumInProgressTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
       expect(sumTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
@@ -198,8 +210,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const complexTestData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
 
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.IN_PROGRESS]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.IN_PROGRESS]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.IN_PROGRESS],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumInProgressTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
       expect(sumTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
@@ -218,10 +233,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       const partialTestData = pipelineTestData[PipelineExampleNames.PARTIAL_PIPELINE];
 
       const expectedTaskCount = getExpectedTaskCount(partialTestData.pipeline);
-      const taskStatus = getTaskStatus(partialTestData.pipelineRuns[DataState.FAILED_BUT_COMPLETE]);
-      const taskCount = totalPipelineRunTasks(
+      const taskStatus = getTaskStatus(
         partialTestData.pipelineRuns[DataState.FAILED_BUT_COMPLETE],
+        partialTestData.pipeline,
       );
+      const taskCount = totalPipelineRunTasks(partialTestData.pipeline);
 
       expect(sumFailedTaskStatus(taskStatus)).toEqual(0);
       expect(sumCancelledTaskStatus(taskStatus)).toEqual(expectedTaskCount);
@@ -232,8 +248,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
     it(`expect correct task status for PipelineRun cancelled at beginning`, () => {
       const expected = { succeeded: 1, failed: 0, cancelled: 12 };
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.CANCELLED1]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.CANCELLED1]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.CANCELLED1],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
@@ -245,8 +264,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
     it(`expect correct task status for PipelineRun failed at beginning`, () => {
       const expected = { succeeded: 0, failed: 1, cancelled: 12 };
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.FAILED1]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.FAILED1]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.FAILED1],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
@@ -258,8 +280,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
     it(`expect correct task status for PLR cancelled at stage 2 parallel`, () => {
       const expected = { succeeded: 3, failed: 0, cancelled: 10 };
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.CANCELLED2]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.CANCELLED2]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.CANCELLED2],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
@@ -271,8 +296,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
     it(`expect correct task status for PLR failed at stage 2 parallel`, () => {
       const expected = { succeeded: 2, failed: 1, cancelled: 10 };
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.FAILED2]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.FAILED2]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.FAILED2],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
@@ -284,8 +312,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
     it(`expect correct task status for PLR cancelled at stage 3`, () => {
       const expected = { succeeded: 4, failed: 0, cancelled: 9 };
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.CANCELLED3]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.CANCELLED3]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.CANCELLED3],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
@@ -297,8 +328,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
     it(`expect correct task status for PLR failed at stage 3`, () => {
       const expected = { succeeded: 2, failed: 2, cancelled: 9 };
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.FAILED3]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.FAILED3]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.FAILED3],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumFailedTaskStatus(taskStatus)).toEqual(expected.failed);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
@@ -317,8 +351,11 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
     it(`expect to return the skipped task status count if whenExpression is used`, () => {
       const expected = { succeeded: 1, skipped: 1 };
       const expectedTaskCount = getExpectedTaskCount(complexTestData.pipeline);
-      const taskStatus = getTaskStatus(complexTestData.pipelineRuns[DataState.SKIPPED]);
-      const taskCount = totalPipelineRunTasks(complexTestData.pipelineRuns[DataState.SKIPPED]);
+      const taskStatus = getTaskStatus(
+        complexTestData.pipelineRuns[DataState.SKIPPED],
+        complexTestData.pipeline,
+      );
+      const taskCount = totalPipelineRunTasks(complexTestData.pipeline);
 
       expect(sumSkippedTaskStatus(taskStatus)).toEqual(expected.skipped);
       expect(sumSuccededTaskStatus(taskStatus)).toEqual(expected.succeeded);
@@ -373,24 +410,33 @@ describe('Pipelinerun graph to show the executed pipeline structure', () => {
   const testPipelineRun =
     pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.SUCCESS];
 
-  it('expect to return null, if pipelinerun does not have a status field', () => {
+  it('expect to return null, if pipelinerun does not have a pipelineSpec field in status or spec', () => {
     const plrWithoutPipelineSpec = _.omit(testPipelineRun, ['status']);
     const executedPipeline = getPipelineFromPipelineRun(plrWithoutPipelineSpec);
     expect(executedPipeline).toEqual(null);
   });
 
-  it('expect to return null, if pipelinerun does not have pipelineSpec in status field', () => {
+  it('expect to return null, if pipelinerun does not have pipeline labels or name in the metadata field', () => {
     const executedPipeline = getPipelineFromPipelineRun(
-      _.omit(testPipelineRun, ['status.pipelineSpec']),
+      _.omit(testPipelineRun, ['metadata.labels', 'metadata.name']),
     );
     expect(executedPipeline).toBe(null);
   });
 
-  it('expect to return null, if pipelinerun does not have pipeline labels in the metadata field', () => {
-    const executedPipeline = getPipelineFromPipelineRun(
-      _.omit(testPipelineRun, ['metadata.labels']),
-    );
-    expect(executedPipeline).toBe(null);
+  it('expect to return pipeline, if pipelinerun has pipelineSpec in spec field', () => {
+    const plrWithEmbeddedPipeline =
+      pipelineTestData[PipelineExampleNames.EMBEDDED_PIPELINE_SPEC].pipelineRuns[DataState.SUCCESS];
+    const executedPipeline = getPipelineFromPipelineRun(plrWithEmbeddedPipeline);
+    expect(executedPipeline).not.toBe(null);
+    expect(executedPipeline).toMatchObject({
+      apiVersion: apiVersionForModel(PipelineModel),
+      kind: 'Pipeline',
+      metadata: {
+        name: plrWithEmbeddedPipeline.metadata.name,
+        namespace: plrWithEmbeddedPipeline.metadata.namespace,
+      },
+      spec: { ...plrWithEmbeddedPipeline.spec.pipelineSpec },
+    });
   });
 
   it('expect to return the pipeline, if pipelinerun has pipelineSpec in status field', () => {

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -232,6 +232,24 @@ describe('pipeline-utils ', () => {
     expect(taskList.filter((t) => t.status.reason === runStatus.Running)).toHaveLength(2);
   });
 
+  it('should append pipelineRun pending status for all the tasks if taskruns are not present and pipelinerun status is PipelineRunPending', () => {
+    const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
+    const pipelineRun = pipelineRuns[DataState.PIPELINE_RUN_PENDING];
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
+    expect(taskList.filter((t) => t.status.reason === runStatus.Idle)).toHaveLength(
+      pipeline.spec.tasks.length,
+    );
+  });
+
+  it('should append pipelineRun cancelled status for all the tasks if taskruns are not present and pipelinerun status is PipelineRunCancelled', () => {
+    const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE];
+    const pipelineRun = pipelineRuns[DataState.PIPELINE_RUN_CANCELLED];
+    const taskList = appendPipelineRunStatus(pipeline, pipelineRun);
+    expect(taskList.filter((t) => t.status.reason === runStatus.Cancelled)).toHaveLength(
+      pipeline.spec.tasks.length,
+    );
+  });
+
   it('should append status to only pipeline tasks if isFinallyTasks is false', () => {
     const { pipeline, pipelineRuns } = pipelineTestData[PipelineExampleNames.PIPELINE_WITH_FINALLY];
     const pipelineRun = pipelineRuns[DataState.SUCCESS];

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
@@ -1,6 +1,19 @@
 import i18next from 'i18next';
 import * as _ from 'lodash';
 
+export enum SucceedConditionReason {
+  PipelineRunCancelled = 'PipelineRunCancelled',
+  TaskRunCancelled = 'TaskRunCancelled',
+  Cancelled = 'Cancelled',
+  PipelineRunStopping = 'PipelineRunStopping',
+  PipelineRunPending = 'PipelineRunPending',
+  TaskRunStopping = 'TaskRunStopping',
+  CreateContainerConfigError = 'CreateContainerConfigError',
+  ExceededNodeResources = 'ExceededNodeResources',
+  ExceededResourceQuota = 'ExceededResourceQuota',
+  ConditionCheckFailed = 'ConditionCheckFailed',
+}
+
 // Converts the PipelineRun (and TaskRun) condition status into a human readable string.
 // See also tkn cli implementation at https://github.com/tektoncd/cli/blob/release-v0.15.0/pkg/formatted/k8s.go#L54-L83
 export const pipelineRunStatus = (pipelineRun): string => {
@@ -20,18 +33,19 @@ export const pipelineRunStatus = (pipelineRun): string => {
 
   if (succeedCondition.reason && succeedCondition.reason !== status) {
     switch (succeedCondition.reason) {
-      case 'PipelineRunCancelled':
-      case 'TaskRunCancelled':
-      case 'Cancelled':
+      case SucceedConditionReason.PipelineRunCancelled:
+      case SucceedConditionReason.TaskRunCancelled:
+      case SucceedConditionReason.Cancelled:
         return i18next.t('pipelines-plugin~Cancelled');
-      case 'PipelineRunStopping':
-      case 'TaskRunStopping':
+      case SucceedConditionReason.PipelineRunStopping:
+      case SucceedConditionReason.TaskRunStopping:
         return i18next.t('pipelines-plugin~Failed');
-      case 'CreateContainerConfigError':
-      case 'ExceededNodeResources':
-      case 'ExceededResourceQuota':
+      case SucceedConditionReason.CreateContainerConfigError:
+      case SucceedConditionReason.ExceededNodeResources:
+      case SucceedConditionReason.ExceededResourceQuota:
+      case SucceedConditionReason.PipelineRunPending:
         return i18next.t('pipelines-plugin~Pending');
-      case 'ConditionCheckFailed':
+      case SucceedConditionReason.ConditionCheckFailed:
         return i18next.t('pipelines-plugin~Skipped');
       default:
         return status;

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -29,7 +29,11 @@ import {
   TektonParam,
 } from '../types';
 import { getLatestRun, runStatus } from './pipeline-augment';
-import { pipelineRunFilterReducer, pipelineRunStatus } from './pipeline-filter-reducer';
+import {
+  pipelineRunFilterReducer,
+  pipelineRunStatus,
+  SucceedConditionReason,
+} from './pipeline-filter-reducer';
 import {
   PipelineRunModel,
   TaskRunModel,
@@ -116,7 +120,13 @@ export const appendPipelineRunStatus = (pipeline, pipelineRun, isFinallyTasks = 
     if (!pipelineRun.status) {
       return task;
     }
-    if (pipelineRun.status && !pipelineRun.status.taskRuns) {
+    if (!pipelineRun?.status?.taskRuns) {
+      if (pipelineRun.spec.status === SucceedConditionReason.PipelineRunCancelled) {
+        return _.merge(task, { status: { reason: runStatus.Cancelled } });
+      }
+      if (pipelineRun.spec.status === SucceedConditionReason.PipelineRunPending) {
+        return _.merge(task, { status: { reason: runStatus.Idle } });
+      }
       return _.merge(task, { status: { reason: runStatus.Failed } });
     }
     const mTask = _.merge(task, {


### PR DESCRIPTION
Fixes issue:
https://issues.redhat.com/browse/ODC-5626

Problem/Description:
Pipeline Run Visualization does not support pipeline runs with `spec.status` "PipelineRunPending"

Solution:
Show visualization of pipeline when pipeline run has status "PipelineRunPending"

Screens:
_PipelineRunPending_
![Screenshot from 2021-05-20 07-51-10](https://user-images.githubusercontent.com/38663217/118909690-03a3a080-b941-11eb-9bef-fcb8d14d390b.png)

![Screenshot from 2021-05-20 07-50-36](https://user-images.githubusercontent.com/38663217/118909723-0ef6cc00-b941-11eb-82f0-748f9c26799b.png)


_PipelineRunCancelled_
![Screenshot from 2021-05-20 07-51-43](https://user-images.githubusercontent.com/38663217/118909781-203fd880-b941-11eb-84c3-c7c4d3871aa9.png)
![Screenshot from 2021-05-20 07-51-53](https://user-images.githubusercontent.com/38663217/118909803-27ff7d00-b941-11eb-8f24-a192e31b6823.png)


Test Coverage:
![Screenshot from 2021-05-20 08-00-37](https://user-images.githubusercontent.com/38663217/118911910-96920a00-b944-11eb-97db-e7bb69f09a9a.png)
![Screenshot from 2021-05-20 08-19-58](https://user-images.githubusercontent.com/38663217/118911914-97c33700-b944-11eb-971b-48af98805ccd.png)
![Screenshot from 2021-05-20 08-22-16](https://user-images.githubusercontent.com/38663217/118911921-98f46400-b944-11eb-8ed3-649486e7e3c6.png)


Browser Conformance:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge

Additional information:
Since a pipeline run in pending state contains no information about its pipeline, so this solution introduces an unusual behavior where a pipeline run gets updated when the pipeline off which it has been created is updated.

Test Setup:
- create a namespace ns-pipe
- `oc apply -f pipeline.yaml`

To test the PipelineRunPending state:
- `oc apply -f pipelinerunpending.yaml`

To test the PipelineRunCancelled state:
- `oc apply -f pipelineruncancelled.yaml`

YAML files:

**pipeline.yaml**
```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: nodejs-ex-git
  generation: 1
  namespace: ns-pipe
  labels:
    app.kubernetes.io/instance: nodejs-ex-git
    app.kubernetes.io/name: nodejs-ex-git
    pipeline.openshift.io/runtime: nodejs
    pipeline.openshift.io/runtime-version: 14-ubi7
    pipeline.openshift.io/type: kubernetes
spec:
  params:
    - default: nodejs-ex-git
      name: APP_NAME
      type: string
    - default: 'https://github.com/sclorg/nodejs-ex.git'
      name: GIT_REPO
      type: string
    - default: master
      name: GIT_REVISION
      type: string
    - default: 'image-registry.openshift-image-registry.svc:5000/ns-pipe/nodejs-ex-git'
      name: IMAGE_NAME
      type: string
    - default: .
      name: PATH_CONTEXT
      type: string
    - default: 14-ubi7
      name: VERSION
      type: string
  tasks:
    - name: fetch-repo
      params:
        - name: url
          value: $(params.GIT_REPO)
        - name: revision
          value: $(params.GIT_REVISION)
        - name: subdirectory
          value: ''
        - name: deleteExisting
          value: 'true'
      taskRef:
        kind: ClusterTask
        name: git-clone
      workspaces:
        - name: output
          workspace: workspace
    - name: fetch-repository
      params:
        - name: url
          value: $(params.GIT_REPO)
        - name: revision
          value: $(params.GIT_REVISION)
        - name: subdirectory
          value: ''
        - name: deleteExisting
          value: 'true'
      runAfter:
        - fetch-repo
      taskRef:
        kind: ClusterTask
        name: git-clone
      workspaces:
        - name: output
          workspace: workspace
    - name: build
      params:
        - name: IMAGE
          value: $(params.IMAGE_NAME)
        - name: TLSVERIFY
          value: 'false'
        - name: PATH_CONTEXT
          value: $(params.PATH_CONTEXT)
        - name: VERSION
          value: $(params.VERSION)
      runAfter:
        - fetch-repository
      taskRef:
        kind: ClusterTask
        name: s2i-nodejs
      workspaces:
        - name: source
          workspace: workspace
    - name: deploy
      params:
        - name: SCRIPT
          value: kubectl $@
        - name: ARGS
          value:
            - rollout
            - status
            - deploy/$(params.APP_NAME)
      runAfter:
        - build
      taskRef:
        kind: ClusterTask
        name: openshift-client
  workspaces:
    - name: workspace

```

**pipelinerunpending.yaml**
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: nodejs-ex-git-test
  generation: 1
  namespace: ns-pipe
  labels:
    app.kubernetes.io/instance: nodejs-ex-git
    app.kubernetes.io/name: nodejs-ex-git
    pipeline.openshift.io/runtime: nodejs
    pipeline.openshift.io/runtime-version: 14-ubi7
    pipeline.openshift.io/type: kubernetes
    tekton.dev/pipeline: nodejs-ex-git
spec:
  params:
    - name: APP_NAME
      value: nodejs-ex-git
    - name: GIT_REPO
      value: 'https://github.com/sclorg/nodejs-ex.git'
    - name: GIT_REVISION
      value: master
    - name: IMAGE_NAME
      value: 'image-registry.openshift-image-registry.svc:5000/ns-pipe/nodejs-ex-git'
    - name: PATH_CONTEXT
      value: .
    - name: VERSION
      value: 14-ubi7
  pipelineRef:
    name: nodejs-ex-git
  serviceAccountName: pipeline
  status: PipelineRunPending
  timeout: 1h0m0s
  workspaces:
    - name: workspace
      volumeClaimTemplate:
        metadata:
          creationTimestamp: null
          labels:
            tekton.dev/pipeline: nodejs-ex-git
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
        status: {}
```

**pipelineruncancelled.yaml**
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: nodejs-ex-git-test
  generation: 1
  namespace: ns-pipe
  labels:
    app.kubernetes.io/instance: nodejs-ex-git
    app.kubernetes.io/name: nodejs-ex-git
    pipeline.openshift.io/runtime: nodejs
    pipeline.openshift.io/runtime-version: 14-ubi7
    pipeline.openshift.io/type: kubernetes
    tekton.dev/pipeline: nodejs-ex-git
spec:
  params:
    - name: APP_NAME
      value: nodejs-ex-git
    - name: GIT_REPO
      value: 'https://github.com/sclorg/nodejs-ex.git'
    - name: GIT_REVISION
      value: master
    - name: IMAGE_NAME
      value: 'image-registry.openshift-image-registry.svc:5000/ns-pipe/nodejs-ex-git'
    - name: PATH_CONTEXT
      value: .
    - name: VERSION
      value: 14-ubi7
  pipelineRef:
    name: nodejs-ex-git
  serviceAccountName: pipeline
  status: PipelineRunCancelled
  timeout: 1h0m0s
  workspaces:
    - name: workspace
      volumeClaimTemplate:
        metadata:
          creationTimestamp: null
          labels:
            tekton.dev/pipeline: nodejs-ex-git
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
        status: {}
```