### PR TITLE
Highlight only the navigation button when quick start hint clicked

### DIFF
--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -235,7 +235,7 @@ export const NavSection = connect(navSectionStateToProps)(
               isExpanded={isOpen}
               onExpand={this.toggle}
               data-test="nav"
-              data-quickstart-id={dataQuickStartId}
+              buttonProps={{ 'data-quickstart-id': dataQuickStartId }}
             >
               {children}
             </NavExpandable>


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5344
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: once the navigation is expanded, quick start `highlights` used to highlight the expanded section as well
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Patternfly introduced a new prop `buttonProps` for the primary navigation button. Pass the data-quickstart-id to `buttonProps`
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![highlight-issue](https://user-images.githubusercontent.com/9278015/114843553-90fe4d00-9df7-11eb-88c7-b94e144eb7d5.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
