### PR TITLE
Avoid memoizing topology sidebar components

### DIFF
--- a/frontend/packages/topology/src/components/page/TopologyView.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyView.tsx
@@ -268,9 +268,7 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
     [filteredModel, namespace, onSelect, viewType],
   );
 
-  const topologySideBarDetails = React.useMemo(() => getSelectedEntityDetails(selectedEntity), [
-    selectedEntity,
-  ]);
+  const topologySideBarDetails = getSelectedEntityDetails(selectedEntity);
 
   if (!filteredModel) {
     return null;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5717
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Topology sidebar components were memoized and only updated when the selected entity changed.
This caused the sidebar to display stale data.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Avoid memoizing the sidebar component so the data is correct.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/114874835-5528af00-9e1a-11eb-8cdd-b4c1df811aae.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
