### PR TITLE
Refactor Console plugin init code

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
@@ -1,0 +1,21 @@
+import { Store } from 'redux';
+import * as _ from 'lodash';
+import { RootState } from '@console/internal/redux';
+import { PluginStore } from '@console/plugin-sdk/src/store';
+import { initSubscriptionService } from '@console/plugin-sdk/src/api/subscribeToExtensions';
+import { registerPluginEntryCallback, loadAndEnablePlugin } from './plugin-loader';
+import { exposePluginAPI } from './plugin-api';
+
+export const initConsolePlugins = _.once(
+  (pluginStore: PluginStore, reduxStore: Store<RootState>) => {
+    initSubscriptionService(pluginStore, reduxStore);
+    registerPluginEntryCallback(pluginStore);
+    exposePluginAPI();
+
+    // Load all dynamic plugins which are currently enabled on the cluster
+    window.SERVER_FLAGS.consolePlugins.forEach((pluginName) => {
+      // TODO(vojtech): use error handler that adds new entry into the notification drawer
+      loadAndEnablePlugin(pluginName, pluginStore);
+    });
+  },
+);

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -20,17 +20,20 @@ import { history, AsyncComponent, LoadingBox } from './utils';
 import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources } from '../module/k8s';
 import { receivedResources, watchAPIServices } from '../actions/k8s';
-import { initConsolePlugins } from '../plugins';
+import { pluginStore } from '../plugins';
 // cloud shell imports must come later than features
 import CloudShell from '@console/app/src/components/cloud-shell/CloudShell';
 import CloudShellTab from '@console/app/src/components/cloud-shell/CloudShellTab';
 import DetectPerspective from '@console/app/src/components/detect-perspective/DetectPerspective';
 import DetectNamespace from '@console/app/src/components/detect-namespace/DetectNamespace';
 import { useExtensions } from '@console/plugin-sdk';
-import { useResolvedExtensions } from '@console/dynamic-plugin-sdk/src/api/useResolvedExtensions';
-import { isContextProvider } from '@console/dynamic-plugin-sdk/src/extensions/context-providers';
+import {
+  useResolvedExtensions,
+  isContextProvider,
+  isStandaloneRoutePage,
+} from '@console/dynamic-plugin-sdk';
+import { initConsolePlugins } from '@console/dynamic-plugin-sdk/src/runtime/plugin-init';
 import { GuidedTour } from '@console/app/src/components/tour';
-import { isStandaloneRoutePage } from '@console/dynamic-plugin-sdk';
 import QuickStartDrawer from '@console/app/src/components/quick-starts/QuickStartDrawer';
 import ToastProvider from '@console/shared/src/components/toast/ToastProvider';
 import '../i18n';
@@ -210,7 +213,7 @@ const AppWithExtensions = withTranslation()((props) => {
   return resolved && <App_ contextProviderExtensions={contextProviderExtensions} {...props} />;
 });
 
-initConsolePlugins(store);
+initConsolePlugins(pluginStore, store);
 
 render(<LoadingBox />, document.getElementById('app'));
 

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -1,15 +1,6 @@
-import { Store } from 'redux';
-import * as _ from 'lodash';
-import { RootState } from '@console/internal/redux';
 import { PluginStore } from '@console/plugin-sdk/src/store';
 import { ActivePlugin } from '@console/plugin-sdk/src/typings';
-import { initSubscriptionService } from '@console/plugin-sdk/src/api/subscribeToExtensions';
-import { fetchPluginManifest } from '@console/dynamic-plugin-sdk/src/runtime/plugin-manifest';
-import {
-  loadDynamicPlugin,
-  registerPluginEntryCallback,
-} from '@console/dynamic-plugin-sdk/src/runtime/plugin-loader';
-import { exposePluginAPI } from '@console/dynamic-plugin-sdk/src/runtime/plugin-api';
+import { loadPluginFromURL } from '@console/dynamic-plugin-sdk/src/runtime/plugin-loader';
 
 // The '@console/active-plugins' module is generated during a webpack build,
 // so we use dynamic require() instead of the usual static import statement.
@@ -19,17 +10,6 @@ const activePlugins =
     : [];
 
 export const pluginStore = new PluginStore(activePlugins);
-
-export const initConsolePlugins = _.once((reduxStore: Store<RootState>) => {
-  initSubscriptionService(pluginStore, reduxStore);
-  registerPluginEntryCallback(pluginStore);
-  exposePluginAPI();
-});
-
-const loadPluginFromURL = async (baseURL: string) => {
-  const manifest = await fetchPluginManifest(baseURL);
-  return await loadDynamicPlugin(baseURL, manifest);
-};
 
 if (process.env.NODE_ENV !== 'production') {
   // Expose Console plugin store for debugging
@@ -45,17 +25,3 @@ if (process.env.NODE_ENV !== 'test') {
   // eslint-disable-next-line no-console
   console.info(`Dynamic plugins: [${window.SERVER_FLAGS.consolePlugins.join(', ')}]`);
 }
-
-// Load all dynamic plugins which are currently enabled on the cluster
-window.SERVER_FLAGS.consolePlugins.forEach((pluginName) => {
-  const url = `${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}/`;
-
-  loadPluginFromURL(url)
-    .then((pluginID) => {
-      pluginStore.setDynamicPluginEnabled(pluginID, true);
-    })
-    .catch((error) => {
-      // eslint-disable-next-line no-console
-      console.error(`Error while loading plugin from ${url}`, error);
-    });
-});


### PR DESCRIPTION
- `loadPluginFromURL` & associated logic moved to dynamic SDK `src/runtime/plugin-loader.ts`
- Console plugin initialization logic moved to dynamic SDK `src/runtime/plugin-init.ts`
- `public/plugins.ts` module is now only responsible for creating the `PluginStore` instance