### PR TITLE
Fix dynamic demo plugin build

### DIFF
--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -4,13 +4,13 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf ./dist",
-    "build": "yarn clean && NODE_ENV=production yarn ts-node ./node_modules/.bin/webpack",
-    "build-dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack",
+    "build": "yarn clean && NODE_ENV=production yarn ts-node ./node_modules/.bin/webpack --mode=production",
+    "build-dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack --mode=development",
     "http-server": "./http-server.sh ./dist",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}' -I '/node_modules/(?!(@console)/)/'"
   },
   "dependencies": {
-    "react": "16.9.0"
+    "react": "17.0.1"
   },
   "devDependencies": {
     "@console/dynamic-plugin-sdk": "link:../packages/console-dynamic-plugin-sdk",

--- a/frontend/dynamic-demo-plugin/src/utils/bar.ts
+++ b/frontend/dynamic-demo-plugin/src/utils/bar.ts
@@ -1,4 +1,4 @@
-import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
+import { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
 
 export default (label: string) => `Hello ${label} Function!`;
 

--- a/frontend/dynamic-demo-plugin/tsconfig.json
+++ b/frontend/dynamic-demo-plugin/tsconfig.json
@@ -6,8 +6,9 @@
     "target": "es2016",
     "jsx": "react",
     "allowJs": true,
-    "strict": true,
-    "noUnusedLocals": true
+    "experimentalDecorators": true,
+    "noUnusedLocals": true,
+    "skipLibCheck": true
   },
   "include": ["src"]
 }

--- a/frontend/dynamic-demo-plugin/yarn.lock
+++ b/frontend/dynamic-demo-plugin/yarn.lock
@@ -844,7 +844,7 @@ lodash@^4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1090,15 +1090,6 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.6.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -1121,19 +1112,13 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-is@^16.8.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+react@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
+  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 "readable-stream@1 || 2", readable-stream@^2.0.1:
   version "2.3.7"

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -15,9 +15,6 @@
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",
     "publish": "yarn build && yarn publish dist --no-git-tag-version"
   },
-  "dependencies": {
-    "webpack": "5.0.0-beta.16"
-  },
   "devDependencies": {
     "@types/ejs": "3.x",
     "@types/fs-extra": "9.x",
@@ -25,6 +22,7 @@
     "fs-extra": "9.x",
     "ts-json-schema-generator": "0.89.0",
     "tsutils": "3.x",
-    "typescript": "4.2.x"
+    "typescript": "4.2.x",
+    "webpack": "5.0.0-beta.16"
   }
 }

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-pkg-assets.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-pkg-assets.ts
@@ -1,6 +1,7 @@
 import * as readPkg from 'read-pkg';
-import chalk from 'chalk';
 import * as fs from 'fs-extra';
+import * as _ from 'lodash';
+import chalk from 'chalk';
 
 import { resolvePath, relativePath } from './utils/path';
 
@@ -16,7 +17,7 @@ const createPackageJson = (packagePath: string) => {
     './api': './lib/api/api.js',
   };
   packageJson.readme = 'README.md';
-  packageJson.peerDependencies = packageJson.dependencies;
+  packageJson.peerDependencies = _.pick(packageJson.devDependencies, 'webpack');
   delete packageJson.dependencies;
   delete packageJson.devDependencies;
   delete packageJson.scripts;


### PR DESCRIPTION
- [x] reconcile recent changes with Console root `package.json`
- [x] reconcile recent changes with dynamic SDK `tsconfig.json`

For now, demo plugin code does not import from SDK's main index file (`packages/console-dynamic-plugin-sdk/src/index.ts`). This will change once current static & dynamic SDKs are refactored into two new packages:
- **Console plugin SDK** - contains everything needed to build & develop dynamic plugins
- **Console plugin runtime** - code needed to initialize & load plugins, including static plugin support

Dynamic SDK's `webpack` dependency moved to `devDependencies` to avoid clash with demo plugin's `devDependencies`.