### PR TITLE
Bug 1948427: Fix issue where react-modal was removing Operator modal from the DOM

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-community-provider-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-community-provider-modal.tsx
@@ -20,8 +20,8 @@ export const OperatorHubCommunityProviderModal: React.FC<OperatorHubCommunityPro
   const submit = React.useCallback(
     (event) => {
       event.preventDefault();
-      showCommunityOperators(ignoreWarnings);
       close();
+      showCommunityOperators(ignoreWarnings);
     },
     [close, ignoreWarnings, showCommunityOperators],
   );


### PR DESCRIPTION
Ensure that the submit handler in the community Operator warning modal closes the current modal *before* opening the Operator details modal.

**More details:**

Here's what I suspect was happening:

- User selects community operator from OperatorHub
- Community operator warning modal is triggered
- react-modal appends the appropriate modal component to the `#modal-container` DOM element
- User clicks "continue"
- 'showCommunityOperators' callback is called, which triggers the PF modal to be appended to the same `#modal-container` DOM element
- `close` callback is called which removes both the community operator modal and the Operator details modal elements from the DOM.
- The Operator details modal state is now corrupt because the underlying DOM element was removed by a parallel React instance *and the Operator details modal will not render until a page reload has happened*. This is probably the behavior observed in https://bugzilla.redhat.com/show_bug.cgi?id=1948566.
- Calling close before showCommunityOperators resolves the problem.

I think the updates in React v17 and/or react-modal v3.12 made it possible for react-modal to remove DOM elements that it wasn't able to see/touch before, which is why this wasn't an issue up until now.