### PR TITLE
CONSOLE-2351 Add a "Wrap lines" toggle to log viewers

### DIFF
--- a/frontend/public/components/utils/_log-window.scss
+++ b/frontend/public/components/utils/_log-window.scss
@@ -30,3 +30,8 @@ $color-log-window-divider: $color-log-window-header-bg;
   white-space: pre;
   width: 0;
 }
+
+.log-window__lines--wrap {
+  white-space: pre-wrap;
+  width: inherit;
+}

--- a/frontend/public/components/utils/log-window.jsx
+++ b/frontend/public/components/utils/log-window.jsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { STREAM_EOF, STREAM_PAUSED, STREAM_ACTIVE } from './resource-log';
 import { OutlinedPlayCircleIcon } from '@patternfly/react-icons';
 import { Button } from '@patternfly/react-core';
@@ -114,7 +115,7 @@ class LogWindowWithTranslation extends React.PureComponent {
   }
 
   render() {
-    const { bufferFull, lines, linesBehind, status, t } = this.props;
+    const { bufferFull, lines, linesBehind, status, t, wrapLines } = this.props;
     const { content, height } = this.state;
     // TODO maybe move these variables into state so they are only updated on changes
     const headerText = bufferFull
@@ -131,7 +132,13 @@ class LogWindowWithTranslation extends React.PureComponent {
         <div className="log-window__body">
           <div className="log-window__scroll-pane" ref={this._setScrollPane}>
             <div className="log-window__contents" ref={this._setLogContents} style={{ height }}>
-              <div className="log-window__lines">{content}</div>
+              <div
+                className={classnames('log-window__lines', {
+                  'log-window__lines--wrap': wrapLines,
+                })}
+              >
+                {content}
+              </div>
             </div>
           </div>
         </div>
@@ -154,4 +161,9 @@ LogWindow.propTypes = {
   linesBehind: PropTypes.number.isRequired,
   status: PropTypes.string.isRequired,
   updateStatus: PropTypes.func.isRequired,
+  wrapLines: PropTypes.bool,
+};
+
+LogWindow.defaultProps = {
+  wrapLines: false,
 };

--- a/frontend/public/locales/en/logs.json
+++ b/frontend/public/locales/en/logs.json
@@ -3,6 +3,7 @@
   "Loading log...": "Loading log...",
   "Log stream paused.": "Log stream paused.",
   "Log streaming...": "Log streaming...",
+  "Wrap lines": "Wrap lines",
   "Raw": "Raw",
   "Download": "Download",
   "Collapse": "Collapse",


### PR DESCRIPTION
This allows the user to turn on or off line wrap when viewing logs.

Addresses [CONSOLE-2351](https://issues.redhat.com/browse/CONSOLE-2351)

Added:
 - "Wrap lines" checkbox
 - CSS class to wrap lines
 -  Persist wrap lines settings when moving to different logs

![CONSOLE-2351-WrapLines-Screenshot](https://user-images.githubusercontent.com/82059948/115051340-556c8d00-9ea2-11eb-8787-31d2194ff729.png)


https://user-images.githubusercontent.com/82059948/115767962-4c326300-a36f-11eb-8f47-9e25c674de2f.mov

NOTE: Tests were not added because there doesn't appear to be text and the changes are almost entirely on the presentation layer.