### PR TITLE
add data for quickStarts from configmap to window.SERVER_FLAGS

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -123,6 +123,7 @@ func main() {
 
 	fDevCatalogCategories := fs.String("developer-catalog-categories", "", "Allow catalog categories customization. (JSON as string)")
 	fUserSettingsLocation := fs.String("user-settings-location", "configmap", "DEV ONLY. Define where the user settings should be stored. (configmap | localstorage).")
+	fQuickStarts := fs.String("quick-starts", "", "Allow customization of available ConsoleQuickStart resources in console. (JSON as string)")
 
 	if err := serverconfig.Parse(fs, os.Args[1:], "BRIDGE"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -235,6 +236,7 @@ func main() {
 		DevCatalogCategories:  *fDevCatalogCategories,
 		UserSettingsLocation:  *fUserSettingsLocation,
 		EnabledConsolePlugins: consolePluginsMap,
+		QuickStarts:           *fQuickStarts,
 	}
 
 	// if !in-cluster (dev) we should not pass these values to the frontend

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -46,6 +46,7 @@ declare interface Window {
     developerCatalogCategories: string;
     userSettingsLocation: string;
     consolePlugins: string[]; // Console dynamic plugins enabled on the cluster
+    quickStarts: string;
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,6 +92,7 @@ type jsGlobals struct {
 	DevCatalogCategories     string   `json:"developerCatalogCategories"`
 	UserSettingsLocation     string   `json:"userSettingsLocation"`
 	ConsolePlugins           []string `json:"consolePlugins"`
+	QuickStarts              string   `json:"quickStarts"`
 }
 
 type Server struct {
@@ -139,6 +140,7 @@ type Server struct {
 	ThanosPublicURL       *url.URL
 	DevCatalogCategories  string
 	UserSettingsLocation  string
+	QuickStarts           string
 }
 
 func (s *Server) authDisabled() bool {
@@ -520,6 +522,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		DevCatalogCategories:  s.DevCatalogCategories,
 		UserSettingsLocation:  s.UserSettingsLocation,
 		ConsolePlugins:        getMapKeys(s.EnabledConsolePlugins),
+		QuickStarts:           s.QuickStarts,
 	}
 
 	if !s.authDisabled() {

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -253,6 +253,16 @@ func addCustomization(fs *flag.FlagSet, customization *Customization) {
 			klog.Fatalf("Could not marshal ConsoleConfig customization.developerCatalog.categories field: %v", err)
 		}
 	}
+
+	if customization.QuickStarts.Disabled != nil {
+		quickStarts, err := json.Marshal(customization.QuickStarts)
+		if err == nil {
+			fs.Set("quick-starts", string(quickStarts))
+		} else {
+			klog.Fatalf("Could not marshal ConsoleConfig customization.quickStarts field: %v", err)
+		}
+	}
+
 }
 
 func isAlreadySet(fs *flag.FlagSet, name string) bool {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -68,6 +68,12 @@ type Customization struct {
 	CustomLogoFile       string `yaml:"customLogoFile,omitempty"`
 	// developerCatalog allows to configure the shown developer catalog categories.
 	DeveloperCatalog DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
+	QuickStarts      QuickStarts                          `yaml:"quickStarts,omitempty"`
+}
+
+// QuickStarts contains options for ConsoleQuickStarts resource
+type QuickStarts struct {
+	Disabled []string `json:"disabled,omitempty" yaml:"disabled,omitempty"`
 }
 
 // DeveloperConsoleCatalogCustomization allow cluster admin to configure developer catalog.

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -16,6 +16,10 @@ func Validate(fs *flag.FlagSet) error {
 
 	bridge.ValidateFlagIs("user-settings-location", fs.Lookup("user-settings-location").Value.String(), "configmap", "localstorage")
 
+	if _, err := validateQuickStarts(fs.Lookup("quick-starts").Value.String()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -43,4 +47,19 @@ func validateDeveloperCatalogCategories(value string) ([]DeveloperConsoleCatalog
 	}
 
 	return categories, nil
+}
+
+func validateQuickStarts(value string) (QuickStarts, error) {
+	if value == "" {
+		return QuickStarts{}, nil
+	}
+	var quickStarts QuickStarts
+
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&quickStarts); err != nil {
+		return QuickStarts{}, err
+	}
+
+	return quickStarts, nil
 }

--- a/pkg/serverconfig/validate_test.go
+++ b/pkg/serverconfig/validate_test.go
@@ -82,3 +82,23 @@ func TestUnknownPropertyInDeveloperCatalogCategory(t *testing.T) {
 		t.Errorf("Unexpected error: actual\n%s\n, expected\n%s", actualMsg, expectedMsg)
 	}
 }
+
+func TestValidEmptyQuickStarts(t *testing.T) {
+	_, err := validateQuickStarts("")
+	if err != nil {
+		t.Error("Unexpected error when parsing an empty string.", err)
+	}
+}
+
+func TestValidObjectForQuickStarts(t *testing.T) {
+	quickStarts, err := validateQuickStarts("{ \"disabled\": [ \"quickstarts0\", \"quickstarts1\", \"quickstarts2\" ] }")
+	if err != nil {
+		t.Error("Unexpected error when parsing data.", err)
+	}
+	if quickStarts.Disabled == nil {
+		t.Errorf("Unexpected value: actual %v, expected array of strings", quickStarts.Disabled)
+	}
+	if len(quickStarts.Disabled) != 3 {
+		t.Errorf("Unexpected value: actual %v, expected %v", len(quickStarts.Disabled), 3)
+	}
+}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-5566

Description:
Based on the enhancement proposal  https://github.com/openshift/enhancements/pull/715, get the quick starts options from console-config and make it available at window.SERVER_FLAGS

Based on API definition https://github.com/openshift/api/pull/883 for `operator.openshift.io~v1~Console`
Export quick start data to console-config https://github.com/openshift/console-operator/pull/528


Test setup:
Pass options as string to bridge with -quick-starts or pass a ConsoleConfig yaml with -config option.

Example:

Specify quick starts options to bridge with `bin/bridge -quick-starts '{ "disabled": ["quickStart-0", "quickStart-1"] }'`.
Open localhost:9000 and check SERVER_FLAGS in console:
```
JSON.parse(window.SERVER_FLAGS.quickStarts)
{ disabled: ["quickStart-0", "quickStart-1"] }
```
Test Setup for UI:
To hide any of quick starts, Admin can add customization.quickStarts.disabled to `Console~operator.openshift.io~v1` yaml
example:
```
spec:
  customization:
    quickStarts:
      disabled:
         - quick-start-id
         - quick-start-id-2
```