### PR TITLE
[WIP] Bug 1897621: Auth test.Login test.logs in as kubeadmin user, Timeout

### DIFF
--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -11,8 +11,10 @@ const { BRIDGE_KUBEADMIN_PASSWORD } = process.env;
 
 describe('Auth test', () => {
   beforeAll(async () => {
+    console.log(`\n----> getting ${appHost}`);
     await browser.get(appHost);
-    await browser.sleep(6000); // Wait long enough for the login redirect to complete
+    console.log('----> sleeping 10 seconds');
+    await browser.sleep(10000); // Wait long enough for the login redirect to complete
   });
 
   describe('Login test', async () => {

--- a/frontend/integration-tests/views/login.view.ts
+++ b/frontend/integration-tests/views/login.view.ts
@@ -10,22 +10,33 @@ export const pf3Login = until.presenceOf($('.login-pf'));
 export const pf4Login = until.presenceOf($('[data-test-id="login"]'));
 
 export const selectProvider = async (provider: string) => {
+  console.log('  ----> selectProvider: getting idpLink');
   const idpLink = element(by.cssContainingText('.idp', provider));
+  console.log('  ----> selectProvider: while !(await idpLink.isPresent())');
   while (!(await idpLink.isPresent())) {
+    console.log('    ----> selectProvider: idpLink not Present, get appHost, sleep 10 secs.');
     await browser.get(appHost);
-    await browser.sleep(3000);
+    await browser.sleep(10000);
   }
+  console.log('  ----> selectProvider: idpLink.click()');
   await idpLink.click();
 };
 
 export const login = async (providerName: string, username: string, password: string) => {
+  console.log('----> in login');
   if (providerName) {
+    console.log('----> calling selectProvider(providerName)');
     await selectProvider(providerName);
   }
+  console.log('----> wait for visibility of username input');
   await browser.wait(until.visibilityOf(nameInput));
+  console.log('----> type username');
   await nameInput.sendKeys(username);
+  console.log('----> type password');
   await passwordInput.sendKeys(password);
+  console.log('----> click submit');
   await submitButton.click();
+  console.log('----> wait for userDropdown');
   await browser.wait(until.presenceOf(userDropdown));
 };
 


### PR DESCRIPTION
During CI the very first step of the first Protractor test which attempts to login seems to occasionly timeout/fail.  This seems to periodically be an issue when CI is running expecially slow.  We saw this last week for a few hours.  Protractor screenshots from recently failed PRs just shows the three loading dots.  

I can't reproduce this locally, or running `test-protractor.sh` against a remote cluster. Extended wait period to 10 seconds after redirect.