### PR TITLE
Bug 1952585: Enhance operator modal repo and container links

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import { PropertiesSidePanel, PropertyItem } from '@patternfly/react-catalog-view-extension';
+import { ClipboardCopy } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { ExternalLink, HintBlock, Timestamp } from '@console/internal/components/utils';
@@ -224,10 +225,21 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
                   value={mappedValidSubscription}
                 />
               )}
-              <PropertyItem label={t('olm~Repository')} value={repository || notAvailable} />
+              <PropertyItem
+                label={t('olm~Repository')}
+                value={
+                  repository ? <ExternalLink href={repository} text={repository} /> : notAvailable
+                }
+              />
               <PropertyItem
                 label={t('olm~Container image')}
-                value={containerImage || notAvailable}
+                value={
+                  containerImage ? (
+                    <ClipboardCopy isReadOnly>{containerImage}</ClipboardCopy>
+                  ) : (
+                    notAvailable
+                  )
+                }
               />
               <PropertyItem label={t('olm~Created at')} value={created || notAvailable} />
               <PropertyItem

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import { PropertiesSidePanel, PropertyItem } from '@patternfly/react-catalog-view-extension';
-import { ClipboardCopy } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { ExternalLink, HintBlock, Timestamp } from '@console/internal/components/utils';
@@ -235,7 +234,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
                 label={t('olm~Container image')}
                 value={
                   containerImage ? (
-                    <ClipboardCopy isReadOnly>{containerImage}</ClipboardCopy>
+                    <div className="co-break-all co-select-to-copy">{containerImage}</div>
                   ) : (
                     notAvailable
                   )


### PR DESCRIPTION
Updates the operator hub item details modal to use a link widget for the repository  and copyclipboard for container.

![image](https://user-images.githubusercontent.com/21317056/115746514-61ed5b80-a362-11eb-8661-ac6a7837b698.png)


https://issues.redhat.com/projects/CONSOLE/issues/CONSOLE-2034?filter=allissues