### PR TITLE
Support webpack ConcatenatedModule in ExtensionValidator

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ExtensionValidator.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ExtensionValidator.spec.ts
@@ -74,6 +74,7 @@ describe('ExtensionValidator', () => {
         compilation,
         extensions as SupportedExtension[],
         exposedModules,
+        'testExtensions',
       );
       afterResult(result, getProvidedExports);
     };
@@ -143,8 +144,8 @@ describe('ExtensionValidator', () => {
         },
         (result, getProvidedExports) => {
           expect(result.getErrors().length).toBe(1);
-          expect(result.getErrors()[0].startsWith("Invalid code reference '.fooExport'")).toBe(
-            true,
+          expect(result.getErrors()[0]).toBe(
+            "Invalid code reference '.fooExport' in testExtensions[1] property 'mux'",
           );
           expect(getProvidedExports).toHaveBeenCalledTimes(1);
         },
@@ -179,7 +180,9 @@ describe('ExtensionValidator', () => {
         },
         (result, getProvidedExports) => {
           expect(result.getErrors().length).toBe(1);
-          expect(result.getErrors()[0].startsWith("Invalid module 'barModule'")).toBe(true);
+          expect(result.getErrors()[0]).toBe(
+            "Invalid module 'barModule' in testExtensions[1] property 'mux'",
+          );
           expect(getProvidedExports).toHaveBeenCalledTimes(1);
         },
       );
@@ -213,7 +216,9 @@ describe('ExtensionValidator', () => {
         },
         (result, getProvidedExports) => {
           expect(result.getErrors().length).toBe(1);
-          expect(result.getErrors()[0].startsWith("Invalid module export 'barExport'")).toBe(true);
+          expect(result.getErrors()[0]).toBe(
+            "Invalid module export 'barExport' in testExtensions[1] property 'mux'",
+          );
           expect(getProvidedExports).toHaveBeenCalledTimes(2);
         },
       );


### PR DESCRIPTION
Webpack `compilation.modules` might contain `ConcatenatedModule` instances instead of individual `NormalModule` instances.

This typically happens when running webpack in `production` mode.

To reproduce this issue in `dynamic-demo-plugin` project:

1. modify `console-extensions.json`
```diff
+  {
+    "type": "console.page/route/standalone",
+    "properties": {
+      "exact": false,
+      "path": "/foo/:bar",
+      "component": { "$codeRef": "fooComp" }
+    }
+  }
```

2. modify `package.json`
```diff
     "exposedModules": {
-      "barUtils": "./utils/bar"
+      "barUtils": "./utils/bar",
+      "fooComp": "./components/Foo"
     },
```

3. modify `src/components/Foo.tsx`
```diff
 import * as React from 'react';
+import { RouteComponentProps } from 'react-router';
+import { isStandaloneRoutePage } from '@console/dynamic-plugin-sdk/src/extensions/pages';
 
-const Foo: React.FC<{ label: string }> = ({ label }) => <h2>Hello {label} Component!</h2>;
+const FooPage: React.FC<RouteComponentProps<{ bar: string }>> = ({ match }) => {
+  const { bar } = match.params;
+  console.log(isStandaloneRoutePage({ type: 'x', properties: {} }));
+  return <h2>Hello {bar}</h2>;
+};
 
-export default Foo;
+export default FooPage;
```