### PR TITLE
Bug 1921106: A11y Violation: button name(s) on Utilization Card on Cluster Dashboard

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/other-routes.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/other-routes.spec.ts
@@ -1,4 +1,6 @@
 import { checkErrors } from '../../support';
+import { listPage } from '../../views/list-page';
+import { detailsPage } from '../../views/details-page';
 
 describe('Visiting other routes', () => {
   before(() => {
@@ -13,41 +15,121 @@ describe('Visiting other routes', () => {
     cy.logout();
   });
 
-  const otherRoutes = [
-    '/',
-    '/k8s/cluster/clusterroles/view',
-    '/k8s/cluster/nodes',
-    '/k8s/all-namespaces/events',
-    '/k8s/all-namespaces/import',
-    '/api-explorer',
-    '/api-resource/ns/default/core~v1~Pod',
-    '/api-resource/ns/default/core~v1~Pod/schema',
-    '/api-resource/ns/default/core~v1~Pod/instances',
+  const otherRoutes: { path: string; waitFor: () => void }[] = [
+    {
+      path: '/',
+      waitFor: () => {
+        cy.byLegacyTestID('resource-title').should('exist');
+        cy.byTestID('skeleton-chart').should('not.exist');
+      },
+    },
+    {
+      path: '/k8s/cluster/clusterroles/view',
+      waitFor: () => cy.byLegacyTestID('resource-title').should('exist'),
+    },
+    {
+      path: '/k8s/cluster/nodes',
+      waitFor: () => listPage.rows.shouldBeLoaded(),
+    },
+    {
+      path: '/k8s/all-namespaces/events',
+      waitFor: () => cy.get('[role="row"]').should('be.visible'),
+    },
+    {
+      path: '/k8s/all-namespaces/import',
+      waitFor: () => cy.get('textarea').should('be.visible'),
+    },
+    {
+      path: '/api-explorer',
+      waitFor: () => cy.get('[data-ouia-component-type$="TableRow"]').should('be.visible'),
+    },
+    {
+      path: '/api-resource/ns/default/core~v1~Pod',
+      waitFor: () => detailsPage.isLoaded(),
+    },
+    {
+      path: '/api-resource/ns/default/core~v1~Pod/schema',
+      waitFor: () => cy.get('li.co-resource-sidebar-item').should('be.visible'),
+    },
+    {
+      path: '/api-resource/ns/default/core~v1~Pod/instances',
+      waitFor: () => cy.byTestID('empty-message').should('exist'),
+    },
     ...(Cypress.env('openshift') === true
       ? [
-          '/api-resource/ns/default/core~v1~Pod/access',
-          '/k8s/cluster/user.openshift.io~v1~User',
-          '/k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~Machine',
-          '/k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet',
-          '/k8s/ns/openshift-machine-api/autoscaling.openshift.io~v1beta1~MachineAutoscaler',
-          '/k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineHealthCheck',
-          '/k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig',
-          '/k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool',
-          '/k8s/all-namespaces/monitoring.coreos.com~v1~Alertmanager',
-          '/k8s/ns/openshift-monitoring/monitoring.coreos.com~v1~Alertmanager/main',
-          '/settings/cluster',
-          '/monitoring/query-browser',
-          // Test loading search page for a kind with no static model.
-          '/search/all-namespaces?kind=config.openshift.io~v1~Console',
+          {
+            path: '/api-resource/ns/default/core~v1~Pod/access',
+            waitFor: () => cy.get('[data-ouia-component-type$="TableRow"]').should('be.visible'),
+          },
+          {
+            path: '/k8s/cluster/user.openshift.io~v1~User',
+            waitFor: () => {},
+          },
+          {
+            path: '/k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~Machine',
+            waitFor: () => listPage.rows.shouldBeLoaded(),
+          },
+          {
+            path: '/k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineSet',
+            waitFor: () => listPage.rows.shouldBeLoaded(),
+          },
+          {
+            path:
+              '/k8s/ns/openshift-machine-api/autoscaling.openshift.io~v1beta1~MachineAutoscaler',
+            waitFor: () => cy.byTestID('empty-message').should('be.visible'),
+          },
+          {
+            path: '/k8s/ns/openshift-machine-api/machine.openshift.io~v1beta1~MachineHealthCheck',
+            waitFor: () => listPage.rows.shouldBeLoaded(),
+          },
+          {
+            path: '/k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfig',
+            waitFor: () => listPage.rows.shouldBeLoaded(),
+          },
+          {
+            path: '/k8s/cluster/machineconfiguration.openshift.io~v1~MachineConfigPool',
+            waitFor: () => listPage.rows.shouldBeLoaded(),
+          },
+          {
+            path: '/k8s/all-namespaces/monitoring.coreos.com~v1~Alertmanager',
+            waitFor: () => listPage.rows.shouldBeLoaded(),
+          },
+          {
+            path: '/k8s/ns/openshift-monitoring/monitoring.coreos.com~v1~Alertmanager/main',
+            waitFor: () => {
+              detailsPage.isLoaded();
+              cy.byTestID('label-list').should('be.visible');
+            },
+          },
+          {
+            path: '/settings/cluster',
+            waitFor: () => cy.byLegacyTestID('cluster-version').should('exist'),
+          },
+          {
+            path: '/monitoring/query-browser',
+            waitFor: () => {
+              cy.byLegacyTestID('kebab-button').should('exist');
+              // loading indicator shows in metrics dropdown until loaded
+              cy.byTestID('loading-indicator').should('not.exist');
+            },
+          },
+          {
+            // Test loading search page for a kind with no static model.
+            path: '/search/all-namespaces?kind=config.openshift.io~v1~Console',
+            waitFor: () => listPage.rows.shouldBeLoaded(),
+          },
         ]
       : []),
   ];
   otherRoutes.forEach((route) => {
-    it(`successfully visited route: '${route.replace(/\//g, ' ')}'`, () => {
-      cy.visit(route);
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(5000); // wait for page to load
+    it(`successfully displays view for route: ${route.path.replace(/\//g, ' ')}`, () => {
+      cy.visit(route.path);
+      cy.url().should('equal', Cypress.config().baseUrl + route.path);
+      cy.byTestID('loading-indicator').should('not.exist');
       cy.byLegacyTestID('error-page').should('not.exist');
+      if (route.waitFor) {
+        route.waitFor();
+      }
       cy.testA11y(`${route} page`);
     });
   });

--- a/frontend/public/components/graphs/graph-empty.tsx
+++ b/frontend/public/components/graphs/graph-empty.tsx
@@ -17,7 +17,7 @@ export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = 
       }}
     >
       {loading ? (
-        <div className="skeleton-chart" />
+        <div className="skeleton-chart" data-test="skeleton-chart" />
       ) : (
         <div className="text-secondary">{t('public~No datapoints found.')}</div>
       )}


### PR DESCRIPTION
This bug was originally thrown in the Cypress `other-routes.spec.ts` test which initially tests URL `/` which results in the Overview Dashboard.  I was able to reproduce this error by reducing our `cy.wait(...)` from 5 seconds to 1 second which resulted in `cy.testA11y()` executing while the dashboard charts were still rendering:
![image](https://user-images.githubusercontent.com/12733153/115295611-f15afa80-a127-11eb-8eb4-9f255ba6fc95.png)

Investigating further I restored the original `cy.wait` of 5 seconds and determined that it was long enough to address this particular BZ.  

However, in an effort to remove any `cy.waiting`, I added a `waitFor` method for each url to determine when the url/view/page was truly loaded.  Since `other-routes.spec.ts` loads a variety of one-off routes, each one needed their own `waitFor` criteria.

Fixed this BZ by adding a `waitFor () => cy.byTestID('skeleton-chart').should('not.exist')` check for route `/` (Overview Dashboard).

This fix should:
1. reduce uneccesary waiting and speed up our CI test runs
2. execute `cy.testA11y` exactly after the url/page is loaded

