### PR TITLE
Bug 1951209: kubevirt-plugin: take into account Succeeded VMI Phase

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
@@ -60,8 +60,8 @@ const BootOrderModalComponent = withHandlePromise(
     const [showUpdatedAlert, setUpdatedAlert] = React.useState<boolean>(false);
     const [showPatchError, setPatchError] = React.useState<boolean>(false);
     const vm = asVM(vmLikeEntity);
-    const isVMRunning = isVMRunningOrExpectedRunning(vm);
     const vmi = getLoadedData(vmiProp);
+    const isVMRunning = isVMRunningOrExpectedRunning(vm, vmi);
 
     const onReload = React.useCallback(() => {
       const updatedDevices = bootableDevices;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/clone-vm-modal.tsx
@@ -37,7 +37,7 @@ import {
   getVolumes,
   isVMExpectedRunning,
 } from '../../../selectors/vm';
-import { VMKind } from '../../../types';
+import { VMKind, VMIKind } from '../../../types';
 import { V1alpha1DataVolume } from '../../../types/api';
 import { getLoadedData, getLoadError, prefixedID } from '../../../utils';
 import { COULD_NOT_LOAD_DATA } from '../../../utils/strings';
@@ -51,6 +51,7 @@ import './_clone-vm-modal.scss';
 export const CloneVMModal = withHandlePromise<CloneVMModalProps>((props) => {
   const {
     vm,
+    vmi,
     namespace,
     onNamespaceChanged,
     namespaces,
@@ -102,6 +103,7 @@ export const CloneVMModal = withHandlePromise<CloneVMModalProps>((props) => {
     const promise = cloneVM(
       {
         vm,
+        vmi,
         dataVolumes: dataVolumesData,
         persistentVolumeClaims: persistentVolumeClaimsData,
       },
@@ -116,7 +118,7 @@ export const CloneVMModal = withHandlePromise<CloneVMModalProps>((props) => {
   };
 
   const vmRunningWarning =
-    isVMExpectedRunning(vm) &&
+    isVMExpectedRunning(vm, vmi) &&
     t('kubevirt-plugin~The VM {{vmName}} is still running. It will be powered off while cloning.', {
       vmName: getName(vm),
     });
@@ -299,6 +301,7 @@ const CloneVMModalFirehose: React.FC<CloneVMModalFirehoseProps> = (props) => {
 
 type CloneVMModalFirehoseProps = ModalComponentProps & {
   vm: VMKind;
+  vmi: VMIKind;
   useProjects: boolean;
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/modals/vm-flavor-modal/vm-flavor-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/vm-flavor-modal/vm-flavor-modal.tsx
@@ -128,7 +128,7 @@ const VMFlavorModal = withHandlePromise((props: VMFlavornModalProps) => {
     return sourceMemSize !== memSize || sourceMemUnit !== memUnit || `${sourceCPU}` !== cpus;
   };
 
-  const showPendingChangesWarning = isVMExpectedRunning(vm) && isChanged();
+  const showPendingChangesWarning = isVMExpectedRunning(vm, vmi) && isChanged();
 
   const {
     validations: { cpus: cpusValidation, memory: memoryValidation },
@@ -173,7 +173,7 @@ const VMFlavorModal = withHandlePromise((props: VMFlavornModalProps) => {
     <div className="modal-content">
       <ModalTitle>{t('kubevirt-plugin~Edit Flavor')}</ModalTitle>
       <ModalBody>
-        {isVMExpectedRunning(vm) && (
+        {isVMExpectedRunning(vm, vmi) && (
           <ModalPendingChangesAlert isChanged={showPendingChangesWarning} />
         )}
         <Form>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -15,6 +15,7 @@ import { CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
 import { VirtualMachineModel } from '../../models';
 import { isVM, isVMI } from '../../selectors/check-type';
 import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
+import { VMIKind } from '../../types';
 import { VMLikeEntityKind } from '../../types/vmLike';
 import { validateDisk } from '../../utils/validations/vm/disk';
 import { deleteDiskModal } from '../modals/delete-disk-modal/delete-disk-modal';
@@ -80,10 +81,11 @@ const menuActionDelete = (
 const getActions = (
   disk: CombinedDisk,
   vmLikeEntity: VMLikeEntityKind,
+  vmi: VMIKind,
   opts: VMStorageRowActionOpts,
 ) => {
   const actions = [];
-  if (isVMI(vmLikeEntity) || isVMRunningOrExpectedRunning(asVM(vmLikeEntity))) {
+  if (isVMI(vmLikeEntity) || isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi)) {
     return actions;
   }
 
@@ -162,6 +164,7 @@ export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
     isDisabled,
     withProgress,
     vmLikeEntity,
+    vmi,
     columnClasses,
     templateValidations,
     pendingChangesDisks,
@@ -197,7 +200,7 @@ export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
       style={style}
       actionsComponent={
         <Kebab
-          options={getActions(disk, vmLikeEntity, {
+          options={getActions(disk, vmLikeEntity, vmi, {
             withProgress,
             templateValidations,
           })}
@@ -205,7 +208,7 @@ export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
             isDisabled ||
             isVMI(vmLikeEntity) ||
             !!getDeletetionTimestamp(vmLikeEntity) ||
-            isVMRunningOrExpectedRunning(asVM(vmLikeEntity))
+            isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi)
           }
           id={`kebab-for-${disk.getName()}`}
         />

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -2,6 +2,7 @@ import { ValidationObject } from '@console/shared';
 
 import { DiskType } from '../../constants';
 import { CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
+import { VMIKind } from '../../types';
 import { UIStorageValidation } from '../../types/ui/storage';
 import { VMLikeEntityKind } from '../../types/vmLike';
 import { TemplateValidations } from '../../utils/validations/template/template-validations';
@@ -41,6 +42,7 @@ export type VMStorageRowActionOpts = {
 
 export type VMStorageRowCustomData = {
   vmLikeEntity: VMLikeEntityKind;
+  vmi: VMIKind;
   columnClasses: string[];
   isDisabled: boolean;
   pendingChangesDisks?: Set<string>;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -173,10 +173,11 @@ export const VMDisks: React.FC<VMDisksProps> = ({
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
   const templateValidations = getTemplateValidationsFromTemplate(getLoadedData(vmTemplate));
-  const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
-  const pendingChangesDisks: Set<string> = vmi
-    ? new Set(changedDisks(new VMWrapper(asVM(vmLikeEntity)), new VMIWrapper(vmi)))
-    : null;
+  const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi);
+  const pendingChangesDisks: Set<string> =
+    isVMRunning && vmi
+      ? new Set(changedDisks(new VMWrapper(asVM(vmLikeEntity)), new VMIWrapper(vmi)))
+      : null;
 
   const resources = [
     getResource(PersistentVolumeClaimModel, {
@@ -223,6 +224,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({
       rowFilters={[diskSourceFilter]}
       customData={{
         vmLikeEntity,
+        vmi,
         withProgress,
         isDisabled: isLocked || isCommonTemplate,
         templateValidations,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
@@ -9,6 +9,7 @@ import { PENDING_RESTART_LABEL } from '../../constants';
 import { VirtualMachineModel } from '../../models';
 import { isVM, isVMI } from '../../selectors/check-type';
 import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
+import { VMIKind } from '../../types';
 import { VMLikeEntityKind } from '../../types/vmLike';
 import { deleteNICModal } from '../modals/delete-nic-modal/delete-nic-modal';
 import { nicModalEnhanced } from '../modals/nic-modal/nic-modal-enhanced';
@@ -62,8 +63,14 @@ const menuActionDelete = (
   ),
 });
 
-const getActions = (nic, network, vmLikeEntity: VMLikeEntityKind, opts: VMNicRowActionOpts) => {
-  if (isVMI(vmLikeEntity) || isVMRunningOrExpectedRunning(asVM(vmLikeEntity))) {
+const getActions = (
+  nic,
+  network,
+  vmLikeEntity: VMLikeEntityKind,
+  vmi: VMIKind,
+  opts: VMNicRowActionOpts,
+) => {
+  if (isVMI(vmLikeEntity) || isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi)) {
     return [];
   }
   const actions = [menuActionEdit, menuActionDelete];
@@ -122,7 +129,7 @@ export const NicSimpleRow: React.FC<VMNicSimpleRowProps> = ({
 
 export const NicRow: RowFunction<NetworkBundle, VMNicRowCustomData> = ({
   obj: { name, nic, network, ...restData },
-  customData: { isDisabled, withProgress, vmLikeEntity, columnClasses, pendingChangesNICs },
+  customData: { isDisabled, withProgress, vmLikeEntity, vmi, columnClasses, pendingChangesNICs },
   index,
   style,
 }) => (
@@ -134,12 +141,12 @@ export const NicRow: RowFunction<NetworkBundle, VMNicRowCustomData> = ({
     isPendingRestart={!!pendingChangesNICs?.has(name)}
     actionsComponent={
       <Kebab
-        options={getActions(nic, network, vmLikeEntity, { withProgress })}
+        options={getActions(nic, network, vmLikeEntity, vmi, { withProgress })}
         isDisabled={
           isDisabled ||
           isVMI(vmLikeEntity) ||
           !!getDeletetionTimestamp(vmLikeEntity) ||
-          isVMRunningOrExpectedRunning(asVM(vmLikeEntity))
+          isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi)
         }
         id={`kebab-for-${name}`}
       />

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
@@ -1,6 +1,7 @@
 import { ValidationObject } from '@console/shared';
 
 import { VMLikeEntityKind } from '../../types/vmLike';
+import { VMIKind } from '../../types';
 
 export type NetworkSimpleData = {
   name?: string;
@@ -27,6 +28,7 @@ export type VMNicRowActionOpts = { withProgress: (promise: Promise<any>) => void
 
 export type VMNicRowCustomData = {
   vmLikeEntity: VMLikeEntityKind;
+  vmi: VMIKind;
   columnClasses: string[];
   isDisabled: boolean;
   pendingChangesNICs?: Set<string>;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -120,10 +120,11 @@ export const VMNics: React.FC<VMTabProps> = ({
   const { t } = useTranslation();
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
-  const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
+  const vmi = vmisProp[0];
+  const isVMRunning = isVM(vmLikeEntity) && isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi);
   const pendingChangesNICs: Set<string> =
-    vmisProp?.length > 0 && isVMI(vmisProp[0])
-      ? new Set(changedNics(new VMWrapper(asVM(vmLikeEntity)), new VMIWrapper(vmisProp[0])))
+    isVMRunning && vmisProp?.length > 0 && isVMI(vmi)
+      ? new Set(changedNics(new VMWrapper(asVM(vmLikeEntity)), new VMIWrapper(vmi)))
       : null;
 
   return (
@@ -155,6 +156,7 @@ export const VMNics: React.FC<VMTabProps> = ({
           data={getNicsData(vmLikeEntity)}
           customData={{
             vmLikeEntity,
+            vmi,
             withProgress,
             isDisabled: isLocked || isCommonTemplate,
             pendingChangesNICs,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
@@ -18,10 +18,10 @@ import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
 import { VMSnapshot } from '../../types';
 import { wrapWithProgress } from '../../utils/utils';
 import SnapshotModal from '../modals/snapshot-modal/snapshot-modal';
-import { VMLikeEntityTabProps } from '../vms/types';
 import { useMappedVMRestores } from './use-mapped-vm-restores';
 import { snapshotsTableColumnClasses } from './utils';
 import { VMSnapshotRow } from './vm-snapshot-row';
+import { VMTabProps } from '../vms/types';
 
 export type VMSnapshotsTableProps = {
   data?: any[];
@@ -88,10 +88,11 @@ export const VMSnapshotsTable: React.FC<VMSnapshotsTableProps> = ({
   );
 };
 
-export const VMSnapshotsPage: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEntity }) => {
+export const VMSnapshotsPage: React.FC<VMTabProps> = ({ obj: vmLikeEntity, vmis: vmisProp }) => {
   const { t } = useTranslation();
   const vmName = getName(vmLikeEntity);
   const namespace = getNamespace(vmLikeEntity);
+  const vmi = vmisProp[0];
 
   const snapshotResource: WatchK8sResource = {
     isList: true,
@@ -108,7 +109,7 @@ export const VMSnapshotsPage: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEnt
   const [isLocked, setIsLocked] = useSafetyFirst(false);
   const withProgress = wrapWithProgress(setIsLocked);
   const filteredSnapshots = snapshots.filter((snap) => getVmSnapshotVmName(snap) === vmName);
-  const isDisabled = isLocked || isVMRunningOrExpectedRunning(asVM(vmLikeEntity));
+  const isDisabled = isLocked || isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi);
 
   return (
     <div className="co-m-list">

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -110,7 +110,7 @@ export const menuActionDeleteVMImport = (
 export const menuActionStart = (
   kindObj: K8sKind,
   vm: VMKind,
-  { vmStatusBundle }: ActionArgs,
+  { vmi, vmStatusBundle }: ActionArgs,
 ): KebabOption => {
   const StartMessage: React.FC = () => {
     const name = getName(vm);
@@ -128,7 +128,7 @@ export const menuActionStart = (
   };
 
   return {
-    hidden: vmStatusBundle?.status?.isMigrating() || isVMRunningOrExpectedRunning(vm),
+    hidden: vmStatusBundle?.status?.isMigrating() || isVMRunningOrExpectedRunning(vm, vmi),
     // t('kubevirt-plugin~Start Virtual Machine')
     labelKey: 'kubevirt-plugin~Start Virtual Machine',
     callback: () => {
@@ -157,7 +157,7 @@ const menuActionStop = (
   const isImporting = vmStatusBundle?.status?.isImporting();
   return {
     isDisabled: isImporting,
-    hidden: !isImporting && !isVMExpectedRunning(vm),
+    hidden: !isImporting && !isVMExpectedRunning(vm, vmi),
     // t('kubevirt-plugin~Stop Virtual Machine')
     labelKey: 'kubevirt-plugin~Stop Virtual Machine',
     callback: () =>
@@ -186,7 +186,7 @@ const menuActionRestart = (
     hidden:
       vmStatusBundle?.status?.isImporting() ||
       vmStatusBundle?.status?.isMigrating() ||
-      !isVMExpectedRunning(vm) ||
+      !isVMExpectedRunning(vm, vmi) ||
       !isVMCreated(vm),
     // t('kubevirt-plugin~Restart Virtual Machine')
     labelKey: 'kubevirt-plugin~Restart Virtual Machine',
@@ -244,7 +244,7 @@ const menuActionMigrate = (
       vmStatusBundle?.status?.isMigrating() ||
       vmStatusBundle?.status?.isError() ||
       vmStatusBundle?.status?.isInProgress() ||
-      !isVMRunningOrExpectedRunning(vm),
+      !isVMRunningOrExpectedRunning(vm, vmi),
     // t('kubevirt-plugin~Migrate Virtual Machine')
     labelKey: 'kubevirt-plugin~Migrate Virtual Machine',
     callback: () =>
@@ -297,13 +297,13 @@ const menuActionCancelMigration = (
 const menuActionClone = (
   kindObj: K8sKind,
   vm: VMKind,
-  { vmStatusBundle }: ActionArgs,
+  { vmi, vmStatusBundle }: ActionArgs,
 ): KebabOption => {
   return {
     hidden: vmStatusBundle?.status?.isImporting(),
     // t('kubevirt-plugin~Clone Virtual Machine')
     labelKey: 'kubevirt-plugin~Clone Virtual Machine',
-    callback: () => cloneVMModal({ vm }),
+    callback: () => cloneVMModal({ vm, vmi }),
     accessReview: asAccessReview(kindObj, vm, 'patch'),
   };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/pending-changes-warning.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/pending-changes-warning.tsx
@@ -95,11 +95,10 @@ export const PendingChangesWarning: React.FC<PendingChangesWarningProps> = ({
   vmi: vmiProp,
 }) => {
   const vm: VMKind = asVM(getLoadedData(vmLikeEntity));
-  if (!isVMRunningOrExpectedRunning(vm)) {
+  const vmi = getLoadedData(vmiProp);
+  if (!isVMRunningOrExpectedRunning(vm, vmi)) {
     return <></>;
   }
-
-  const vmi = getLoadedData(vmiProp);
 
   const vmWrapper = new VMWrapper(vm);
   const vmiWrapper = new VMIWrapper(vmi);

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -164,7 +164,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         idValue={prefixedID(id, 'boot-order')}
         arePendingChanges={
           isVM &&
-          isVMRunningOrExpectedRunning(vm) &&
+          isVMRunningOrExpectedRunning(vm, vmi) &&
           isBootOrderChanged(new VMWrapper(vm), new VMIWrapper(vmi))
         }
       >
@@ -238,7 +238,7 @@ export const VMSchedulingList: React.FC<VMSchedulingListProps> = ({
     vmiLike &&
     canUpdateVM &&
     kindObj !== VirtualMachineInstanceModel &&
-    !isVMRunningOrExpectedRunning(vm);
+    !isVMRunningOrExpectedRunning(vm, vmi);
 
   const id = getBasicID(vmiLike);
   const flavorText = t(
@@ -318,7 +318,7 @@ export const VMSchedulingList: React.FC<VMSchedulingListProps> = ({
             isNotAvail={!flavorText}
             arePendingChanges={
               isVM &&
-              isVMRunningOrExpectedRunning(vm) &&
+              isVMRunningOrExpectedRunning(vm, vmi) &&
               isFlavorChanged(new VMWrapper(vm), new VMIWrapper(vmi))
             }
           >

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/clone.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/clone.ts
@@ -6,21 +6,22 @@ import {
 
 import { VirtualMachineModel } from '../../../models';
 import { isVMExpectedRunning } from '../../../selectors/vm';
-import { VMKind } from '../../../types/vm';
+import { VMIKind, VMKind } from '../../../types/vm';
 import { CloneTo, VMClone } from '../../helpers/vm-clone';
 import { stopVM } from './actions';
 
 type CloneFrom = {
   vm: VMKind;
+  vmi: VMIKind;
   persistentVolumeClaims: PersistentVolumeClaimKind[];
   dataVolumes: K8sResourceKind[];
 };
 
 export const cloneVM = async (
-  { vm, persistentVolumeClaims, dataVolumes }: CloneFrom,
+  { vm, vmi, persistentVolumeClaims, dataVolumes }: CloneFrom,
   cloneTo: CloneTo,
 ) => {
-  if (isVMExpectedRunning(vm)) {
+  if (isVMExpectedRunning(vm, vmi)) {
     await stopVM(vm);
   }
 

--- a/frontend/packages/kubevirt-plugin/src/utils/pending-changes.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/pending-changes.ts
@@ -12,6 +12,7 @@ import {
 } from '../selectors/vm-like/next-run-changes';
 import { VMIKind, VMKind } from '../types';
 import { getVMTabURL, redirectToTab } from './url';
+import { VMIPhase } from '../constants/vmi/phase';
 
 export const getPendingChanges = (vmWrapper: VMWrapper, vmiWrapper: VMIWrapper): PendingChanges => {
   const vm = vmWrapper.asResource();
@@ -58,7 +59,11 @@ export const getPendingChanges = (vmWrapper: VMWrapper, vmiWrapper: VMIWrapper):
 };
 
 export const hasPendingChanges = (vm: VMKind, vmi: VMIKind, pc?: PendingChanges): boolean => {
-  const pendingChanges = pc || (!!vmi && getPendingChanges(new VMWrapper(vm), new VMIWrapper(vmi)));
+  const pendingChanges =
+    pc ||
+    (!!vmi &&
+      vmi.status.phase !== VMIPhase.Succeeded &&
+      getPendingChanges(new VMWrapper(vm), new VMIWrapper(vmi)));
   return Object.keys(pendingChanges || {}).reduce(
     (boolVal, k) => boolVal || pendingChanges[k].isPendingChange,
     false,


### PR DESCRIPTION
when computing isVMRunning and other fields