### PR TITLE
Bug 1950532 - Include "update" when referring to operator approval

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -260,6 +260,7 @@
   "Install Operator": "Install Operator",
   "Install your Operator by subscribing to one of the update channels to keep the Operator up to date. The strategy determines either manual or automatic updates.": "Install your Operator by subscribing to one of the update channels to keep the Operator up to date. The strategy determines either manual or automatic updates.",
   "Update channel": "Update channel",
+  "Update approval": "Update approval",
   "The channel to track and receive the updates from.": "The channel to track and receive the updates from.",
   "Installation mode": "Installation mode",
   "All namespaces on the cluster": "All namespaces on the cluster",

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -729,7 +729,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
               </div>
               <div className="form-group">
                 <fieldset>
-                  <label className="co-required">{t('olm~Approval strategy')}</label>
+                  <label className="co-required">{t('olm~Update approval')}</label>
                   <FieldLevelHelp>
                     {t('olm~The strategy to determine either manual or automatic updates.')}
                   </FieldLevelHelp>

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -16,6 +16,7 @@ import {
   RowFunctionArgs,
 } from '@console/internal/components/factory';
 import {
+  FieldLevelHelp,
   Kebab,
   LoadingInline,
   MsgBox,
@@ -515,7 +516,12 @@ export const SubscriptionUpdates: React.FC<SubscriptionUpdatesProps> = ({
       <div className="co-detail-table__row row">
         <div className="co-detail-table__section col-sm-3">
           <dl className="co-m-pane__details">
-            <dt className="co-detail-table__section-header">{t('olm~Channel')}</dt>
+            <dt className="co-detail-table__section-header">
+              {t('olm~Update channel')}
+              <FieldLevelHelp>
+                {t('olm~The channel to track and receive the updates from.')}
+              </FieldLevelHelp>
+            </dt>
             <dd>
               {waitingForUpdate ? (
                 <LoadingInline />
@@ -536,7 +542,12 @@ export const SubscriptionUpdates: React.FC<SubscriptionUpdatesProps> = ({
         </div>
         <div className="co-detail-table__section col-sm-3">
           <dl className="co-m-pane__details">
-            <dt className="co-detail-table__section-header">{t('olm~Approval')}</dt>
+            <dt className="co-detail-table__section-header">
+              {t('olm~Update approval')}
+              <FieldLevelHelp>
+                {t('olm~The strategy to determine either manual or automatic updates.')}
+              </FieldLevelHelp>
+            </dt>
             <dd>
               {waitingForUpdate ? (
                 <LoadingInline />


### PR DESCRIPTION
Updates the install operator page terminology to use update approval and
aligns the installed operators subscription tab to use the same help icon and
text for update channel and update approval.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1950532