### PR TITLE
Add new customization snippet to list all available Add page actions

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -141,6 +141,8 @@
   "Provides a list of default categories which are shown in the Developer Catalog. The categories must be added below customization developerCatalog.": "Provides a list of default categories which are shown in the Developer Catalog. The categories must be added below customization developerCatalog.",
   "Add project access roles": "Add project access roles",
   "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.": "Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.",
+  "Add page actions": "Add page actions",
+  "Provides a list of all available actions on the Add page in the Developer perspective. The IDs must be added below customization addPage disabledActions to hide these actions.": "Provides a list of all available actions on the Add page in the Developer perspective. The IDs must be added below customization addPage disabledActions to hide these actions.",
   "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.": "Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.",
   "Cannot be longer than {{characterCount}} characters.": "Cannot be longer than {{characterCount}} characters.",
   "Required": "Required"

--- a/frontend/packages/console-shared/src/utils/sample-utils.ts
+++ b/frontend/packages/console-shared/src/utils/sample-utils.ts
@@ -5,6 +5,10 @@ import { TFunction } from 'i18next';
 
 import { defaultCatalogCategories } from '@console/dev-console/src/components/catalog/utils/default-categories';
 
+import { AddAction, isAddAction } from '@console/dynamic-plugin-sdk';
+import { LoadedExtension } from '@console/plugin-sdk/src';
+import { subscribeToExtensions } from '@console/plugin-sdk/src/api/subscribeToExtensions';
+
 import {
   BuildConfigModel,
   ClusterRoleModel,
@@ -39,7 +43,7 @@ export type Sample = {
   description: string;
   id: string;
   yaml?: string;
-  lazyYaml?: () => string;
+  lazyYaml?: () => Promise<string>;
   snippet?: boolean;
   targetResource: {
     apiVersion: string;
@@ -301,6 +305,51 @@ const defaultSamples = (t: TFunction) =>
           id: 'projectaccess-roles',
           snippet: true,
           lazyYaml: () => YAML.dump(defaultProjectAccessRoles),
+          targetResource: getTargetResource(ConsoleOperatorConfigModel),
+        },
+        {
+          title: t('console-shared~Add page actions'),
+          description: t(
+            'console-shared~Provides a list of all available actions on the Add page in the Developer perspective. The IDs must be added below customization addPage disabledActions to hide these actions.',
+          ),
+          id: 'addpage-actions',
+          snippet: true,
+          lazyYaml: () => {
+            // Similar to useTranslationExt
+            const translateExtension = (key: string) => {
+              if (key.length < 3 || key[0] !== '%' || key[key.length - 1] !== '%') {
+                return key;
+              }
+              return t(key.substr(1, key.length - 2));
+            };
+            return new Promise<string>((resolve) => {
+              // Using subscribeToExtensions here instead of useExtensions hook because
+              // this lazyYaml method is not called in a render flow.
+              // We should probably have a yaml snippets extension later for this.
+              const unsubscribe = subscribeToExtensions<AddAction>(
+                (extensions: LoadedExtension<AddAction>[]) => {
+                  const sortedExtensions = extensions
+                    .slice()
+                    .sort((a, b) => a.properties.id.localeCompare(b.properties.id));
+                  const yaml = sortedExtensions
+                    .map((extension) => {
+                      const { id, label, description } = extension.properties;
+                      const labelComment = translateExtension(label)
+                        .split('\n')
+                        .join('\n  # ');
+                      const descriptionComment = translateExtension(description)
+                        .split('\n')
+                        .join('\n  # ');
+                      return `- # ${labelComment}\n  # ${descriptionComment}\n  ${id}`;
+                    })
+                    .join('\n');
+                  resolve(yaml);
+                  unsubscribe();
+                },
+                isAddAction,
+              );
+            });
+          },
           targetResource: getTargetResource(ConsoleOperatorConfigModel),
         },
       ],


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5414

**Analysis / Root cause**: 
As an admin, I should be able to hide any of the entrypoints aka "actions" from the Add page.

To support the admin to configure the shown (or hidden) entry list correctly, the developer console should provide a code snippet for the customization yaml resource (Console CRD).

**Solution Description**: 
Create a new snippet which use a Promise to get all available `AddAction` extensions and show / insert their IDs.

It shows the actions ordered by ID with their title and description. When inserting the snippet the comments are automatically removed by the `sanitizeYamlContent` function in `packages/console-shared/src/components/editor/YAMLEditorSidebar.tsx`.

To store the customization a cluster with PR https://github.com/openshift/console-operator/pull/527 is required. The snippet could be tested / verified without this.

**Screen shots / Gifs for design review**: 
![Peek 2021-04-21 00-21](https://user-images.githubusercontent.com/139310/115470984-8567b780-a237-11eb-9972-a94245fb3eb4.gif)

Text for the snippet is:
> **Add page actions**
> Provides a list of all available actions on the Add page in Developer perspective. The IDs could be used to disable individual actions.

@openshift/team-devconsole-ux Can you verify the wording as well? Thanks

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Search for Console resource (api: operator.openshift.io/v1) and select a resource.
    For example https://your-cluster/k8s/cluster/operator.openshift.io~v1~Console/cluster
2. Open the YAML tab
3. Open the sidebar and switch to Snippets
4. You should now see a new snippet called "Add project access roles"
5. Insert the snippet

Currently it shows this YAML as snippet in the sidebar for a cluster without additional pipelines:

```yaml
- # Container Image
  # Deploy an existing Image from an Image registry or Image stream tag
  deploy-image
- # From Catalog
  # Browse the catalog to discover, deploy and connect to services
  dev-catalog
- # Database
  # Browse the catalog to discover database services to add to your Application
  dev-catalog-databases
- # Helm Chart
  # Browse the catalog to discover and install Helm Charts
  helm
- # From Devfile
  # Import your Devfile from your Git repository to be built and deployed
  import-from-devfile
- # From Dockerfile
  # Import your Dockerfile from your Git repository to be built and deployed
  import-from-dockerfile
- # From Git
  # Import code from your Git repository to be built and deployed
  import-from-git
- # Samples
  # Create an Application from a code sample
  import-from-samples
- # YAML
  # Create resources from their YAML or JSON definitions
  import-yaml
- # Operator Backed
  # Browse the catalog to discover and deploy operator managed services
  operator-backed
- # Upload JAR file
  # Upload a JAR file from your local desktop to OpenShift
  upload-jar
```

With installed OpenShift Pipelines and OpenShift Serverless operator this shows also:

```yaml
- # Container Image
  # Deploy an existing Image from an Image registry or Image stream tag
  deploy-image
- # From Catalog
  # Browse the catalog to discover, deploy and connect to services
  dev-catalog
- # Database
  # Browse the catalog to discover database services to add to your Application
  dev-catalog-databases
- # Helm Chart
  # Browse the catalog to discover and install Helm Charts
  helm
- # From Devfile
  # Import your Devfile from your Git repository to be built and deployed
  import-from-devfile
- # From Dockerfile
  # Import your Dockerfile from your Git repository to be built and deployed
  import-from-dockerfile
- # From Git
  # Import code from your Git repository to be built and deployed
  import-from-git
- # Samples
  # Create an Application from a code sample
  import-from-samples
- # YAML
  # Create resources from their YAML or JSON definitions
  import-yaml
- # Event Source
  # Create an Event source to register interest in a class of events from a particular system
  knative-event-source
- # Channel
  # Create a Knative Channel to create an event forwarding and persistence layer with in-memory and reliable implementations
  knative-eventing-channel
- # Operator Backed
  # Browse the catalog to discover and deploy operator managed services
  operator-backed
- # Pipeline
  # Create a Tekton Pipeline to automate delivery of your Application
  pipeline
- # Upload JAR file
  # Upload a JAR file from your local desktop to OpenShift
  upload-jar
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge