### PR TITLE
fix Quick Search CTA in topology

### DIFF
--- a/frontend/packages/topology/src/components/page/TopologyEmptyState.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyEmptyState.tsx
@@ -29,7 +29,8 @@ const TopologyEmptyState: React.FC<TopologyEmptyStateProps> = ({ setIsQuickSearc
           <Button
             isInline
             variant="link"
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               setIsQuickSearchOpen(true);
             }}
           >

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchButton.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchButton.tsx
@@ -16,7 +16,10 @@ const QuickSearchButton: React.FC<QuickSearchButtonProps> = ({ onClick }) => {
       <Button
         className="odc-quick-search-button"
         variant="plain"
-        onClick={onClick}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
+        }}
         aria-label={t('topology~Quick search button')}
       >
         <QuickSearchIcon />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5760

**Analysis / Root cause**: 
The "Start building your application" and the Quick Search "Add to project" catalog icon (in the top left) don't seem to be working when I click on them.

**Solution Description**: 
stopPropagation is required for the button.

**Screen shots / Gifs for design review**: 
![Kapture 2021-04-20 at 20 41 21](https://user-images.githubusercontent.com/2561818/115420959-33179e00-a219-11eb-9bb0-e5cf8f9635c4.gif)
