### PR TITLE
Bug 1949019: - PersistentVolumes page cannot sync project status automatically which will block user to create PV

### DIFF
--- a/frontend/public/components/start-guide.tsx
+++ b/frontend/public/components/start-guide.tsx
@@ -8,10 +8,8 @@ import { FLAGS } from '@console/shared/src/constants';
 import { createProjectMessageStateToProps } from '../reducers/ui';
 import { Disabled, HintBlock, ExternalLink, openshiftHelpBase, LinkifyExternal } from './utils';
 import { connectToFlags } from '../reducers/features';
-import { ProjectModel, RoleModel, StorageClassModel } from '../models';
+import { ProjectModel } from '../models';
 import { createProjectModal } from './modals/create-namespace-modal';
-
-const WHITELIST = [RoleModel.kind, StorageClassModel.kind];
 
 export const OpenShiftGettingStarted = connect(createProjectMessageStateToProps)(
   ({ canCreateProject = true, createProjectMessage }: OpenShiftGettingStartedProps) => (
@@ -70,9 +68,7 @@ export const withStartGuide = (WrappedComponent, disable: boolean = true) =>
               <OpenShiftGettingStarted canCreateProject={flags[FLAGS.CAN_CREATE_PROJECT]} />
             </HintBlock>
           </div>
-          {// Whitelist certain resource kinds that should not be disabled when no projects are
-          // available. Disabling should also be optional
-          !disable || WHITELIST.includes(kind) ? (
+          {!disable || (rest.kindObj && !rest.kindObj.namespaced) ? (
             <WrappedComponent {...rest} noProjectsAvailable />
           ) : (
             <Disabled>


### PR DESCRIPTION
/assign @TheRealJon 
cc: @spadgett 

Since PV and Storage classes are cluster resources and don't need a project creation before creating a resource, I have removed the Start Guide hint from them. So the Create button will be enabled by default for PV.

![Screen Shot 2021-04-21 at 9 54 25 AM](https://user-images.githubusercontent.com/15249132/115567434-43676180-a289-11eb-909b-605e6b77c0b2.png)
![Screen Shot 2021-04-21 at 9 54 36 AM](https://user-images.githubusercontent.com/15249132/115567439-43676180-a289-11eb-8ed6-75d671a6dd26.png)
![Screen Shot 2021-04-21 at 9 54 50 AM](https://user-images.githubusercontent.com/15249132/115567441-43fff800-a289-11eb-9520-d8b51dc3e068.png)
![Screen Shot 2021-04-21 at 9 55 00 AM](https://user-images.githubusercontent.com/15249132/115567442-43fff800-a289-11eb-8483-31e395d085fe.png)
