### PR TITLE
disable Quick Starts

### DIFF
--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -33,6 +33,7 @@ declare interface Window {
     meteringBaseURL: string;
     prometheusBaseURL: string;
     prometheusTenancyBaseURL: string;
+    quickStarts: string;
     requestTokenURL: string;
     alertManagerPublicURL: string;
     grafanaPublicURL: string;

--- a/frontend/packages/console-app/src/components/quick-starts/__tests__/quick-start-utils.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/__tests__/quick-start-utils.spec.tsx
@@ -1,9 +1,16 @@
-import { getQuickStartByName } from '../utils/quick-start-utils';
+import { getQuickStartByName, isDisabledQuickStart } from '../utils/quick-start-utils';
 import { allQuickStarts } from '../data/quick-start-test-data';
 
 describe('quick-start-utils', () => {
-  it('should return the quick start corresponding to the id', () => {
+  it('should return the quick start corresponding to the id for getQuickStartByName function', () => {
     const mockID = allQuickStarts[0].metadata.name;
-    expect(getQuickStartByName(mockID).metadata.name === mockID).toBe(true);
+    const quickStart = getQuickStartByName(mockID);
+    expect(quickStart.metadata.name === mockID).toBe(true);
+  });
+
+  it('should filter out disabled quick starts', () => {
+    const disabledQuickStarts = [allQuickStarts[0].metadata.name]; // setting allQuickStart[0] as disabled
+    expect(isDisabledQuickStart(allQuickStarts[1], disabledQuickStarts)).toBe(false);
+    expect(isDisabledQuickStart(allQuickStarts[0], disabledQuickStarts)).toBe(true);
   });
 });

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-types.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-types.ts
@@ -1,12 +1,9 @@
-import { AccessReviewResourceAttributes } from '@console/internal/module/k8s';
+import { AccessReviewResourceAttributes, ObjectMetadata } from '@console/internal/module/k8s';
 
 export type QuickStart = {
   apiVersion: string;
   kind: string;
-  metadata: {
-    name: string;
-    uid?: string;
-  };
+  metadata: ObjectMetadata;
   spec: QuickStartSpec;
 };
 

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-utils.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-utils.ts
@@ -1,6 +1,7 @@
 import { QuickStart, QuickStartStatus, AllQuickStartStates } from './quick-start-types';
 import { allQuickStarts } from '../data/quick-start-test-data';
 
+export const QUICK_START_NAME = 'console.openshift.io/name';
 export const getQuickStarts = (): QuickStart[] => allQuickStarts;
 
 export const getQuickStartByName = (name: string): QuickStart =>
@@ -27,6 +28,29 @@ export const getQuickStartStatusCount = (
       [QuickStartStatus.NOT_STARTED]: 0,
     },
   );
+};
+
+export const getDisabledQuickStarts = (): string[] => {
+  let disabledQuickStarts = [];
+  const quickStartServerData = window.SERVER_FLAGS.quickStarts;
+  try {
+    if (quickStartServerData) {
+      disabledQuickStarts = JSON.parse(quickStartServerData).disabled ?? [];
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('error while parsing SERVER_FLAG.quickStarts', e);
+  }
+  return disabledQuickStarts;
+};
+
+export const isDisabledQuickStart = (
+  quickstart: QuickStart,
+  disabledQuickStarts: string[],
+): boolean => {
+  const quickStartName =
+    quickstart.metadata.annotations?.[QUICK_START_NAME] ?? quickstart.metadata.name;
+  return disabledQuickStarts.includes(quickStartName);
 };
 
 export const filterQuickStarts = (


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-5567

# How to test PR
Either add this in a file or through browser console and then revisit the quickStartCatalog

`window.SERVER_FLAGS.quickStarts = '{"disabled":["explore-pipelines"]}'`

# Screenshot
![Screenshot from 2021-04-21 22-34-29](https://user-images.githubusercontent.com/24852534/115593637-5febb400-a2f2-11eb-8f32-193b87ba71cc.png)

### Before applying ServerFlag.quickstart
![Screenshot from 2021-04-21 22-34-49](https://user-images.githubusercontent.com/24852534/115593646-637f3b00-a2f2-11eb-99f5-7566c1c2a166.png)

### After applying serverflag
![Screenshot from 2021-04-21 22-35-04](https://user-images.githubusercontent.com/24852534/115593651-6712c200-a2f2-11eb-9991-2df78e76686c.png)

# Tests
Added to `quick-start-util.spec`

# Browser conformance
Chrome