### PR TITLE
Bug 1949810: adds check for templates

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/useTemplates.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useTemplates.tsx
@@ -84,7 +84,7 @@ const useTemplates: ExtensionHook<CatalogItem<PartialObjectMetadata>[]> = ({
   React.useEffect(() => {
     k8sListPartialMetadata(TemplateModel, { ns: 'openshift' })
       .then((metadata) => {
-        setTemplates(metadata);
+        setTemplates(metadata ?? []);
         setTemplatesLoaded(true);
         setTemplatesError(null);
       })


### PR DESCRIPTION
**Fixes**: 
https://github.com/openshift/console/issues/8499

**Analysis / Root cause**: 
If the OpenShift samples operator is not installed, there will be no Templates in the openshift namespace. This results in an error when loading topology.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
needed to have a check to avoid setting templates if undefined.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
