### PR TITLE
Bug 1951858: Unexpected text '0' on filter toolbar

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -304,7 +304,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
       clearFiltersButtonText={t('filter-toolbar~Clear all filters')}
     >
       <ToolbarContent>
-        {rowFilters?.length && (
+        {rowFilters?.length > 0 && (
           <ToolbarItem>
             {_.reduce(
               Object.keys(filters),


### PR DESCRIPTION
Addresses [Bug 1951858](https://bugzilla.redhat.com/show_bug.cgi?id=1951858)

Changes: 
  - Changed logic so filter item length isn't accidentally displaying on screen 

RoleBinding Tab:
<img width="1084" alt="Bug 1951858" src="https://user-images.githubusercontent.com/82059948/115601500-82a2ac00-a2a3-11eb-819c-7d8881582f11.png">


Other component that uses the toolbar and has the filter option:
<img width="1084" alt="Bug 1951858-otherfilter" src="https://user-images.githubusercontent.com/82059948/115601597-9e0db700-a2a3-11eb-86f9-03a0a614f5ce.png">
 