### PR TITLE
Bug 1952209: Consistent formatting of dates and times

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { typeFilter, getLastTime } from '@console/internal/components/events';
-import { twentyFourHourTime } from '@console/internal/components/utils/datetime';
+import { timeFormatter } from '@console/internal/components/utils/datetime';
 import { ResourceIcon } from '@console/internal/components/utils/resource-icon';
 import { ResourceLink } from '@console/internal/components/utils/resource-link';
 import { EventKind, referenceFor } from '@console/internal/module/k8s';
@@ -35,7 +35,7 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
           <div className="co-recent-item__title">
             <div className="co-recent-item__title-timestamp text-secondary">
               {lastTime ? (
-                <span title={lastTime}>{twentyFourHourTime(new Date(lastTime))}</span>
+                <span title={lastTime}>{timeFormatter.format(new Date(lastTime))}</span>
               ) : (
                 '-'
               )}

--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -144,7 +144,7 @@
 }
 
 .co-recent-item__title-timestamp {
-  min-width: 45px;
+  min-width: 65px;
   padding-right: 0.3rem;
   text-align: left;
 }

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationBody.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react';
 import { ChartAxis, ChartContainer } from '@patternfly/react-charts';
 import { Grid } from '@patternfly/react-core';
+import { timeFormatter } from '@console/internal/components/utils/datetime';
 import { useRefWidth } from '@console/internal/components/utils/ref-width-hook';
 import { useTranslation } from 'react-i18next';
 
 import './utilization-card.scss';
-
-const formatDate = (date: Date): string => {
-  const minutes = `0${date.getMinutes()}`.slice(-2);
-  return `${date.getHours()}:${minutes}`;
-};
 
 const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps = [] }) => {
   const [containerRef, width] = useRefWidth();
@@ -21,7 +17,7 @@ const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps = [] }) =>
           containerComponent={<ChartContainer title={t('dashboard~time axis')} />}
           scale={{ x: 'time' }}
           domain={{ x: [timestamps[0], timestamps[timestamps.length - 1]] }}
-          tickFormat={formatDate}
+          tickFormat={timeFormatter.format}
           orientation="top"
           height={15}
           width={width}

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewEvents.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverviewEvents.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import { twentyFourHourTime } from '@console/internal/components/utils/datetime';
+import { timeFormatter } from '@console/internal/components/utils/datetime';
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { referenceFor, EventKind } from '@console/internal/module/k8s';
 import { ResourceLink } from '@console/internal/components/utils';
@@ -23,7 +23,7 @@ const MonitoringOverviewEvents: React.FC<MonitoringOverviewEventsProps> = ({ eve
             <div className="odc-monitoring-events__event-item" key={e.metadata.uid}>
               <Flex alignSelf={{ default: 'alignSelfBaseline' }}>
                 <FlexItem title={e.lastTimestamp} className="text-secondary">
-                  {twentyFourHourTime(new Date(getLastTime(e)))}
+                  {timeFormatter.format(new Date(getLastTime(e)))}
                 </FlexItem>
                 {e.type === 'Warning' && (
                   <FlexItem>

--- a/frontend/public/components/_icon-and-text.scss
+++ b/frontend/public/components/_icon-and-text.scss
@@ -11,6 +11,7 @@ $co-icon-and-text-icon-lg: 1.2rem;
 }
 
 .co-icon-and-text__icon {
+  flex-shrink: 0;
   margin-right: 5px;
 }
 

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -43,7 +43,7 @@ import { BuildLogs } from './build-logs';
 import { ResourceEventStream } from './events';
 import { Area, requirePrometheus } from './graphs';
 import { BuildModel } from '../models';
-import { twentyFourHourTime } from './utils/datetime';
+import { timeFormatter, timeFormatterWithSeconds } from './utils/datetime';
 
 const BuildsReference: K8sResourceKindReference = 'Build';
 
@@ -155,7 +155,8 @@ const BuildGraphs = requirePrometheus(({ build }) => {
       namespace,
       endTime,
       timespan,
-      formatDate: (d) => twentyFourHourTime(d, timespan < 5 * ONE_MINUTE),
+      formatDate: (d) =>
+        timespan < 5 * ONE_MINUTE ? timeFormatterWithSeconds.format(d) : timeFormatter.format(d),
       domain, // force domain to match queried timespan
     }),
     [domain, endTime, namespace, timespan],

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -14,7 +14,7 @@ import {
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import { processFrame, ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
-import { twentyFourHourTime } from '../utils/datetime';
+import { timeFormatter } from '../utils/datetime';
 import { humanizeNumber, useRefWidth, Humanize } from '../utils';
 import { PrometheusEndpoint } from './helpers';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
@@ -31,7 +31,7 @@ import { GraphEmpty } from './graph-empty';
 import { ChartLegendTooltip } from './tooltip';
 
 const DEFAULT_HEIGHT = 180;
-const DEFAULT_TICK_COUNT = 3;
+const DEFAULT_TICK_COUNT = 2;
 
 export enum AreaChartStatus {
   ERROR = 'ERROR',
@@ -47,7 +47,7 @@ export const chartStatusColors = {
 export const AreaChart: React.FC<AreaChartProps> = ({
   className,
   data = [],
-  formatDate = twentyFourHourTime,
+  formatDate = timeFormatter.format,
   height = DEFAULT_HEIGHT,
   humanize = humanizeNumber,
   loading = true,

--- a/frontend/public/components/graphs/stack.tsx
+++ b/frontend/public/components/graphs/stack.tsx
@@ -10,7 +10,7 @@ import {
   getCustomTheme,
 } from '@patternfly/react-charts';
 import { processFrame, ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
-import { twentyFourHourTime } from '../utils/datetime';
+import { timeFormatter } from '../utils/datetime';
 import { humanizeNumber, useRefWidth } from '../utils';
 import { PrometheusEndpoint } from './helpers';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
@@ -24,13 +24,13 @@ import { AreaChart, AreaChartProps } from './area';
 
 const DEFAULT_HEIGHT = 180;
 const DEFAULT_SAMPLES = 60;
-const DEFAULT_TICK_COUNT = 3;
+const DEFAULT_TICK_COUNT = 2;
 const DEFAULT_TIMESPAN = 60 * 60 * 1000; // 1 hour
 
 export const StackChart: React.FC<AreaChartProps> = ({
   className,
   data = [],
-  formatDate = twentyFourHourTime,
+  formatDate = timeFormatter.format,
   height = DEFAULT_HEIGHT,
   humanize = humanizeNumber,
   loading = true,

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -33,7 +33,7 @@ $tooltip-background-color: #151515;
 
 .graph-wrapper--query-browser {
   padding-left: 50px;
-  padding-right: 10px;
+  padding-right: 15px;
 
   &--with-legend {
     min-height: 305px;
@@ -45,7 +45,7 @@ $tooltip-background-color: #151515;
   margin: 0 0 20px 0;
 
   .co-dashboard-card__body--dashboard-graph {
-    padding: 10px;
+    padding: 10px 15px 10px 10px;
   }
 
   &.co-dashboard-card--gradient {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -46,9 +46,11 @@ import {
   useSafeFetch,
 } from '../utils';
 import {
+  dateTimeFormatterWithSeconds,
   formatPrometheusDuration,
   parsePrometheusDuration,
-  twentyFourHourTime,
+  timeFormatter,
+  timeFormatterWithSeconds,
 } from '../utils/datetime';
 import { PrometheusAPIError } from './types';
 import { ONE_MINUTE } from '@console/shared/src/constants/time';
@@ -190,7 +192,9 @@ const Tooltip_: React.FC<TooltipProps> = ({ activePoints, center, height, style,
             <div className="query-browser__tooltip-arrow" />
             <div className="query-browser__tooltip">
               <div className="query-browser__tooltip-group">
-                <div className="query-browser__tooltip-time">{twentyFourHourTime(time, true)}</div>
+                <div className="query-browser__tooltip-time">
+                  {dateTimeFormatterWithSeconds.format(time)}
+                </div>
               </div>
               {allSeries.map((s, i) => (
                 <div className="query-browser__tooltip-group" key={i}>
@@ -312,7 +316,11 @@ const Graph: React.FC<GraphProps> = React.memo(
         yTickFormat = (v: number) => (v === 0 ? '0' : v.toExponential(1));
       }
     }
-    const xTickFormat = (d) => twentyFourHourTime(d, span < 5 * ONE_MINUTE);
+    const xAxisTickCount = Math.round(width / 100);
+    const xAxisTickShowSeconds = span < xAxisTickCount * ONE_MINUTE;
+    const xTickFormat = xAxisTickShowSeconds
+      ? timeFormatterWithSeconds.format
+      : timeFormatter.format;
     let xAxisStyle;
     if (width < 225) {
       xAxisStyle = {
@@ -339,7 +347,7 @@ const Graph: React.FC<GraphProps> = React.memo(
         theme={theme}
         width={width}
       >
-        <ChartAxis style={xAxisStyle} tickCount={5} tickFormat={xTickFormat} />
+        <ChartAxis style={xAxisStyle} tickCount={xAxisTickCount} tickFormat={xTickFormat} />
         <ChartAxis
           crossAxis={false}
           dependentAxis

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -1,6 +1,53 @@
 import * as _ from 'lodash-es';
 import * as moment from 'moment';
 
+const getLocale = () => localStorage.getItem('bridge/language');
+
+// https://tc39.es/ecma402/#datetimeformat-objects
+export const timeFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  hour: 'numeric',
+  minute: 'numeric',
+});
+
+export const timeFormatterWithSeconds = new Intl.DateTimeFormat(getLocale() || undefined, {
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+});
+
+export const dateFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+export const dateTimeFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  year: 'numeric',
+});
+
+export const dateTimeFormatterWithSeconds = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  year: 'numeric',
+});
+
+export const utcDateTimeFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+});
+
 // Behaves like moment.js's fromNow
 export const fromNow = (dateTime, now = undefined, options = { omitSuffix: false }) => {
   // Check for null. If dateTime is null, it returns incorrect date and time of Wed Dec 31 1969 19:00:00 GMT-0500 (Eastern Standard Time)

--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -3,11 +3,10 @@ import { connect } from 'react-redux';
 import { Tooltip } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
-import { useTranslation } from 'react-i18next';
 
 import * as dateTime from './datetime';
 
-const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean, t: any) => {
+const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
   if (!dateTime.isValid(mdate)) {
     return '-';
   }
@@ -22,8 +21,8 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean, t: any) => {
     return dateTime.fromNow(mdate);
   }
 
-  // Apr 23, 4:33 pm
-  return t('{{date, MMM D, h:mm a}}', { date: mdate });
+  // Apr 23, 2021, 4:33 PM
+  return dateTime.dateTimeFormatter.format(mdate);
 };
 
 const nowStateToProps = ({ UI }) => ({ now: UI.get('lastTick') });
@@ -37,8 +36,7 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
   const mdate = props.isUnix
     ? new Date((props.timestamp as number) * 1000)
     : new Date(props.timestamp);
-  const { t } = useTranslation();
-  const timestamp = timestampFor(mdate, new Date(props.now), props.omitSuffix, t);
+  const timestamp = timestampFor(mdate, new Date(props.now), props.omitSuffix);
 
   if (!dateTime.isValid(mdate)) {
     return <div className="co-timestamp">-</div>;
@@ -54,7 +52,7 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
       <Tooltip
         content={[
           <span className="co-nowrap" key="co-timestamp">
-            {mdate.toISOString()}
+            {dateTime.utcDateTimeFormatter.format(mdate)}
           </span>,
         ]}
       >

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -444,7 +444,6 @@
   "Resource limits": "Resource limits",
   "Ports": "Ports",
   "Select {{item}}": "Select {{item}}",
-  "{{date, MMM D, h:mm a}}": "{{date, MMM D, h:mm a}}",
   "Remove volume": "Remove volume",
   "Mount path": "Mount path",
   "SubPath": "SubPath",


### PR DESCRIPTION
Manual 4.7.z backport of #8490. This PR does not include removing moment.js, only the time format changes.

Consistently format dates with Intl.DateTimeFormat. This will ensure that we honor the browser's locale setting even for languages we don't yet support. Always show the year for dates. Ultimately, we want to make the date and time format a user preference.

/assign @rhamilto 
/cc @kyoto 