### PR TITLE
Support user help for workspaces over resources in the Pipeline Builder

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -163,6 +163,7 @@
   "Add workspace": "Add workspace",
   "Error loading the tasks.": "Error loading the tasks.",
   "Unable to locate any tasks.": "Unable to locate any tasks.",
+  "Resources aren't in beta, so it is recommended to use workspaces instead.": "Resources aren't in beta, so it is recommended to use workspaces instead.",
   "Input resources": "Input resources",
   "Output resources": "Output resources",
   "Display Name": "Display Name",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderFormEditor.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderFormEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { TextInputTypes } from '@patternfly/react-core';
 import { InputField } from '@console/shared';
 import { PipelineParameters, PipelineResources, PipelineWorkspaces } from '../detail-page-tabs';
+import PipelineWorkspaceSuggestionIcon from './PipelineWorkspaceSuggestionIcon';
 import PipelineBuilderVisualization from './PipelineBuilderVisualization';
 import {
   PipelineBuilderTaskResources,
@@ -67,7 +68,9 @@ const PipelineBuilderFormEditor: React.FC<PipelineBuilderFormEditorProps> = (pro
       </div>
 
       <div>
-        <h2>{t('pipelines-plugin~Workspaces')}</h2>
+        <h2>
+          {t('pipelines-plugin~Workspaces')} <PipelineWorkspaceSuggestionIcon />
+        </h2>
         <PipelineWorkspaces
           addLabel={t('pipelines-plugin~Add workspace')}
           fieldName="formData.workspaces"

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.scss
@@ -1,0 +1,5 @@
+.opp-pipeline-workspace-suggestion-icon {
+  height: 1rem;
+  width: 1rem;
+  cursor: pointer;
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+
+import './PipelineWorkspaceSuggestionIcon.scss';
+
+const PipelineWorkspaceSuggestionIcon: React.FC = () => {
+  const { t } = useTranslation();
+
+  const content = t(
+    "pipelines-plugin~Resources aren't in beta, so it is recommended to use workspaces instead.",
+  );
+
+  return (
+    <Popover aria-label={content} bodyContent={content}>
+      <OutlinedQuestionCircleIcon className="opp-pipeline-workspace-suggestion-icon" />
+    </Popover>
+  );
+};
+
+export default PipelineWorkspaceSuggestionIcon;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5775

**Analysis / Root cause**: 
Resources are deprecated upstream, workspaces are more useful -- the user has no way to know the desire to use workspaces over resources.

**Solution Description**: 
Add a help popover for workspaces.

**Screen shots / Gifs for design review**: 

![Screen Shot 2021-04-21 at 3 35 32 PM](https://user-images.githubusercontent.com/8126518/115611858-9f95aa00-a2b8-11eb-8d25-199af1a7cd43.png)
![Screen Shot 2021-04-21 at 3 35 41 PM](https://user-images.githubusercontent.com/8126518/115611861-a02e4080-a2b8-11eb-8a2f-eac5334c5d2d.png)
![image](https://user-images.githubusercontent.com/8126518/115611888-aae8d580-a2b8-11eb-81cc-b030ad911e03.png)


**Unit test coverage report**: 
No change.

**Test setup:**
Visit the Pipeline Builder.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge