### PR TITLE
Bug 1926776: "Template support" modal appears when select the RHEL6 common template

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -563,6 +563,7 @@
   "Restore": "Restore",
   "Support for this template is provided through the OS community Red Hat participates in and contributes to.": "Support for this template is provided through the OS community Red Hat participates in and contributes to.",
   "Learn more about the community": "Learn more about the community",
+  "This template is provided by Red Hat, But is not supported ": "This template is provided by Red Hat, But is not supported ",
   "The support level is not defined in the template yaml. To mark this template as supported, add these two annotations in the template details:": "The support level is not defined in the template yaml. To mark this template as supported, add these two annotations in the template details:",
   "Do not show this message again": "Do not show this message again",
   "Continue": "Continue",

--- a/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
@@ -13,6 +13,7 @@ import { Checkbox, Label, Stack, StackItem } from '@patternfly/react-core';
 
 import { TEMPLATE_PROVIDER_ANNOTATION, TEMPLATE_SUPPORT_LEVEL } from '../../../constants';
 import { TemplateSupport } from '../../../constants/vm-templates/support';
+import { SUPPORT_URL } from '../../../constants/vm-templates/constants';
 import { ModalFooter } from '../modal/modal-footer';
 
 import './support-modal.scss';
@@ -20,9 +21,15 @@ import './support-modal.scss';
 type SupportModalProps = ModalComponentProps & {
   onConfirm: (disable: boolean) => void;
   communityURL?: string;
+  isCommonTemplate?: boolean;
 };
 
-const SupportModal: React.FC<SupportModalProps> = ({ onConfirm, close, communityURL }) => {
+const SupportModal: React.FC<SupportModalProps> = ({
+  onConfirm,
+  close,
+  communityURL,
+  isCommonTemplate,
+}) => {
   const { t } = useTranslation();
   const [doNotShow, setDoNotShow] = React.useState(false);
   return (
@@ -45,6 +52,13 @@ const SupportModal: React.FC<SupportModalProps> = ({ onConfirm, close, community
                   href={communityURL}
                   text={t('kubevirt-plugin~Learn more about the community')}
                 />
+              </StackItem>
+            </>
+          ) : isCommonTemplate ? (
+            <>
+              <StackItem>
+                {t('kubevirt-plugin~This template is provided by Red Hat, But is not supported ')}
+                <ExternalLink href={SUPPORT_URL} text={t('kubevirt-plugin~Learn more')} />
               </StackItem>
             </>
           ) : (

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-support-modal.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-support-modal.ts
@@ -4,7 +4,7 @@ import { TemplateKind } from '@console/internal/module/k8s';
 
 import { createSupportModal } from '../components/modals/support-modal/support-modal';
 import { TEMPLATE_WARN_SUPPORT } from '../constants';
-import { getTemplateSupport } from '../selectors/vm-template/basic';
+import { getTemplateSupport, isCommonTemplate } from '../selectors/vm-template/basic';
 import { useLocalStorage } from './use-local-storage';
 
 export type SupportModalFunction = (template: TemplateKind, onConfirm: VoidFunction) => void;
@@ -15,6 +15,7 @@ export const useSupportModal = (): SupportModalFunction => {
     (template, onConfirm) => {
       const isUpstream = window.SERVER_FLAGS.branding === 'okd';
       const templateSupport = getTemplateSupport(template);
+      const commonTemplat = isCommonTemplate(template);
       const showSupportModal =
         !isUpstream &&
         template &&
@@ -31,6 +32,7 @@ export const useSupportModal = (): SupportModalFunction => {
         : createSupportModal({
             onConfirm: onModalConfirm,
             communityURL: templateSupport.providerURL || templateSupport.parentURL,
+            isCommonTemplate: commonTemplat,
           });
     },
     [setWarnSupport, warnSupport],


### PR DESCRIPTION
In this example, I create a different support message for common templates which are provided by Red Hat, and are unsupported.
before (taken from BZ):
![screencapture-console-openshift-console-apps-uit01-cnv-qe-rhcloud-com-k8s-virtualization-new-from-template-1612865404956 (2)](https://user-images.githubusercontent.com/67270715/115683400-138a8d80-a35f-11eb-9bb2-d5c771dd1edf.png)

after:
![bz_1926776_after_message](https://user-images.githubusercontent.com/67270715/115683437-1e452280-a35f-11eb-88c7-b71b9aeb018f.png)

the link in screenshot: 
https://access.redhat.com/articles/4234591

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1926776
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>