### PR TITLE
Bug 1950219: fixes issue with KnativeServing not shown in list on global config page

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -78,7 +78,7 @@
       "namespace": "knative-serving"
     },
     "flags": {
-      "required": ["FLAG_KNATIVE_SERVING"]
+      "required": ["KNATIVE_SERVING"]
     }
   }
 ]


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1950219

**Analysis / Root cause**: 
KnativeServing is not shown in list on global config page as with dynamic plugins we don't models as `k8sKind` get only group, version, kind  which won't help for custom resources as underlying utils expects `apiVersion`, `apiGroup`  alongwith `kind` and optional types`plural`, `namespaced`, `crd` for custom resources.

 

**Solution Description**: 
- updated models type definition and model data
- updated flags

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/115690506-bdc3de80-a37a-11eb-99e0-a5c22f896d19.png)

![image](https://user-images.githubusercontent.com/5129024/115690574-ccaa9100-a37a-11eb-8942-021db29e17af.png)



**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
- Install Serverless Operator
- Create an instance of `knativeServing` in `knative-serving` namespace

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
