### PR TITLE
Bug 1952545: Fix new selection after inserting a YAML snippet

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/YAMLEditorSidebar.tsx
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditorSidebar.tsx
@@ -45,22 +45,21 @@ const YAMLEditorSidebar: React.FC<YAMLEditorSidebarProps> = ({
       const indentSize = new Array(selection.startColumn).join(' ');
       const lines = yaml.split('\n');
       const lineCount = lines.length;
-      const indentedText = lines
-        .map((line, i) => {
-          if (i === 0) {
-            // Already indented, leave it alone
-            return line;
-          }
-          return `${indentSize}${line}`;
-        })
-        .join('\n');
+      const indentedLines = lines.map((line, i) => {
+        if (i === 0) {
+          // Already indented, leave it alone
+          return line;
+        }
+        return `${indentSize}${line}`;
+      });
+      const indentedText = indentedLines.join('\n');
 
       // Grab the selection size of what we are about to add
       const newContentSelection = new window.monaco.Selection(
         selection.startLineNumber,
-        0,
+        selection.startColumn,
         selection.startLineNumber + lineCount - 1,
-        lines[lines.length - 1].length,
+        selection.startColumn + indentedLines[indentedLines.length - 1].length,
       );
 
       const op = { range, text: indentedText, forceMoveMarkers: true };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5777
https://bugzilla.redhat.com/show_bug.cgi?id=1952545

**Analysis / Root cause**: 
When the user inserts a YAML snippet the new snippet is tried to be selected but the selection doesn't match the new snippet.

The new cursor was set to first column of the current line, and the selection end ignores the used intention.

**Solution Description**: 
The new cursor position now keeps the start position and adds the missing intention for the cursor end position.

At the end this means that the new selection matches the inserted YAML code.

**Screen shots / Gifs for design review**: 
Before:
![insert-yaml-snippet-selection-issues](https://user-images.githubusercontent.com/139310/115695119-cb209f00-a361-11eb-9fc6-e6f4d422f15c.gif)

After:
![insert-yaml-snippet-selection-issues-fixed](https://user-images.githubusercontent.com/139310/115695136-ce1b8f80-a361-11eb-8ebc-e1c89742ab3e.gif)

**Unit test coverage report**: 
None affected, no new test added

**Test setup:**
To test additional cases you can add the following snippets to `packages/console-shared/src/utils/sample-utils.ts`:

```diff
    .setIn(
      [referenceForModel(ConsoleOperatorConfigModel)],
      [
+       {
+         title: 'Single line',
+         description: 'Single line',
+         id: 'single-line',
+         snippet: true,
+         lazyYaml: () => 'single-line',
+         targetResource: getTargetResource(ConsoleOperatorConfigModel),
+       },
+       {
+         title: 'Multiline',
+         description: 'Multiline',
+         id: 'multiline',
+         snippet: true,
+         lazyYaml: () => YAML.dump('Multiline\nAnother line\nAnd one more line'),
+         targetResource: getTargetResource(ConsoleOperatorConfigModel),
+       },
+       {
+         title: 'Sample list',
+         description: 'Sample list',
+         id: 'sample-list',
+         snippet: true,
+         lazyYaml: () => YAML.dump(['item 1', 'item 2', 'item 3\nmultiline']),
+         targetResource: getTargetResource(ConsoleOperatorConfigModel),
+       },
        {
          title: t('console-shared~Add catalog categories'),
          description: t(
            'console-shared~Provides a list of default categories which are shown in the Developer Catalog. The categories must be added below customization developerCatalog.',
          ),
          id: 'devcatalog-categories',
          snippet: true,
          lazyYaml: () => YAML.dump(defaultCatalogCategories),
          targetResource: getTargetResource(ConsoleOperatorConfigModel),
        },
        {
          title: t('console-shared~Add project access roles'),
          description: t(
            'console-shared~Provides a list of default roles which are shown in the Project Access. The roles must be added below customization projectAccess.',
          ),
          id: 'projectaccess-roles',
          snippet: true,
          lazyYaml: () => YAML.dump(defaultProjectAccessRoles),
          targetResource: getTargetResource(ConsoleOperatorConfigModel),
        },
      ],
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
