### PR TITLE
Bug 1952394: Not able to create a project in the wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -341,6 +341,7 @@
   "Select a template": "Select a template",
   "The virtual machine can be <1>customized</1> in the next step.": "The virtual machine can be <1>customized</1> in the next step.",
   "Templates that are in an <1>error</1> or <3>in-progress</3> state will not be shown.": "Templates that are in an <1>error</1> or <3>in-progress</3> state will not be shown.",
+  "Create Project": "Create Project",
   "All template providers": "All template providers",
   "All boot sources": "All boot sources",
   "text filter": "text filter",

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.scss
@@ -17,6 +17,10 @@
   }
 }
 
+.kv-select-template__create-project-btn {
+  color: var(--pf-c-button--m-plain--active--Color);
+}
+
 .kv-select-template__tile {
   width: 300px;
   height: 100%;

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
@@ -2,7 +2,6 @@ import * as classnames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-
 import { humanizeBinaryBytes, ResourceName, StatusBox } from '@console/internal/components/utils';
 import { ProjectModel } from '@console/internal/models';
 import { PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
@@ -14,6 +13,7 @@ import {
   AlertVariant,
   Button,
   ButtonVariant,
+  Divider,
   InputGroup,
   SelectOption,
   SelectVariant,
@@ -30,7 +30,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-
+import { createProjectModal } from '@console/internal/components/modals';
 import { BOOT_SOURCE_AVAILABLE, BOOT_SOURCE_REQUIRED } from '../../../constants';
 import { usePinnedTemplates } from '../../../hooks/use-pinned-templates';
 import { getWorkloadProfile } from '../../../selectors/vm';
@@ -237,6 +237,7 @@ export const SelectTemplate: React.FC<SelectTemplateProps> = ({
   });
 
   const canListNs = useFlag(FLAGS.CAN_LIST_NS);
+  const canCreateNs = useFlag(FLAGS.CAN_CREATE_PROJECT);
   const allProjects = t('kubevirt-plugin~All projects');
 
   return (
@@ -282,14 +283,38 @@ export const SelectTemplate: React.FC<SelectTemplateProps> = ({
                           selections={namespace}
                           className="kv-select-template__project"
                         >
-                          {(canListNs
-                            ? [allProjects, ...namespaces.sort()]
-                            : namespaces.sort()
-                          ).map((ns) => (
-                            <SelectOption key={ns} value={ns}>
-                              <ResourceName kind={ProjectModel.kind} name={ns} />
-                            </SelectOption>
-                          ))}
+                          <>
+                            {canCreateNs && (
+                              <>
+                                <Button
+                                  className="kv-select-template__create-project-btn"
+                                  variant="plain"
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    createProjectModal({
+                                      blocking: true,
+                                      onSubmit: (newProject) => {
+                                        setNamespace(newProject.metadata.name);
+                                      },
+                                    });
+                                  }}
+                                >
+                                  {t('kubevirt-plugin~Create Project')}
+                                </Button>
+                                <Divider component="li" key={5} />
+                              </>
+                            )}
+                          </>
+                          <>
+                            {(canListNs
+                              ? [allProjects, ...namespaces.sort()]
+                              : namespaces.sort()
+                            ).map((ns) => (
+                              <SelectOption key={ns} value={ns}>
+                                <ResourceName kind={ProjectModel.kind} name={ns} />
+                              </SelectOption>
+                            ))}
+                          </>
                         </FormPFSelect>
                       </ToolbarItem>
                     </SplitItem>


### PR DESCRIPTION
Added a button and a divider to the project dropdown, helping users create a namespace from within the wizard if they have permissions. Once created the namespace changes to the new one.

<img width="670" alt="Screen Shot 2021-04-22 at 14 48 41" src="https://user-images.githubusercontent.com/24938324/115709496-f57e5680-a379-11eb-95ad-dae3c722a658.png">
