### PR TITLE
Added styling to vm status events

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/VMEventsStatusCard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/VMEventsStatusCard.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -59,7 +60,12 @@ export const VMEventsStatusCard: React.FC<VMEventsStatusCardProps> = ({ vm }) =>
     : null;
 
   return title ? (
-    <Text component={TextVariants.p} className="VMEventsStatusCard-title">
+    <Text
+      component={TextVariants.p}
+      className={cn('kv--vm-event-status-card__title text-secondary', {
+        eventsErrors: 'kv--vm-event-status-card__title--errors',
+      })}
+    >
       {title}
     </Text>
   ) : (

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-events-status-card.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-events-status-card.scss
@@ -1,3 +1,8 @@
-.VMEventsStatusCard-title {
+.kv--vm-event-status-card__title {
   margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  &.kv--vm-event-status-card__title--errors {
+    color: var(--pf-global--danger-color--200);
+  }
 }


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Solution Description**: 
Added styling to VM status events

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/115724164-61b48680-a389-11eb-9e76-bdbc62c92137.png)
Before:
![image](https://user-images.githubusercontent.com/14824964/115724319-801a8200-a389-11eb-811f-5c1c76e707c6.png)
