### PR TITLE
Bug 1952578: Don't poll ClusterVersion when user doesn't have authority

### DIFF
--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -32,6 +32,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { isAlertAction, useExtensions, AlertAction } from '@console/plugin-sdk';
+import { useClusterVersion } from '@console/shared/src/hooks/version';
 import { usePrevious } from '@console/shared/src/hooks/previous';
 
 import { coFetchJSON } from '../co-fetch';
@@ -41,11 +42,9 @@ import {
   getNewerClusterVersionChannel,
   getSimilarClusterVersionChannels,
   getSortedUpdates,
-  referenceForModel,
   splitClusterVersionChannel,
 } from '../module/k8s';
 import { ClusterVersionModel } from '../models';
-import { useK8sWatchResource, WatchK8sResource } from './utils/k8s-watch-hook';
 import { useAccessReview } from './utils/rbac';
 import { LinkifyExternal } from './utils';
 import { PrometheusEndpoint } from './graphs/helpers';
@@ -187,13 +186,6 @@ const getUpdateNotificationEntries = (
 
 const pollerTimeouts = {};
 const pollers = {};
-const cvResource: WatchK8sResource = {
-  kind: referenceForModel(ClusterVersionModel),
-  namespaced: false,
-  name: 'version',
-  isList: false,
-  optional: true,
-};
 
 export const refreshNotificationPollers = () => {
   _.each(pollerTimeouts, clearTimeout);
@@ -273,7 +265,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
 
     return () => _.each(pollerTimeouts, clearTimeout);
   }, [t]);
-  const [clusterVersionData] = useK8sWatchResource<ClusterVersionKind>(cvResource);
+  const clusterVersion: ClusterVersionKind = useClusterVersion();
   const alertActionExtensions = useExtensions<AlertAction>(isAlertAction);
 
   const { data, loaded, loadError } = alerts || {};
@@ -287,7 +279,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
     }) && window.SERVER_FLAGS.branding !== 'dedicated';
 
   const updateList: React.ReactNode[] = getUpdateNotificationEntries(
-    clusterVersionData,
+    clusterVersion,
     clusterVersionIsEditable,
     toggleNotificationDrawer,
   );


### PR DESCRIPTION
Manual 4.7 backport of #8602

Update the notification drawer to use the `useClusterVersion` hook,
which checks the `CLUSTER_VERSION` flag before trying to watch the
`ClusterVersion` resource. The `CLUSTER_VERSION` flag will resolve to
false if the user doesn't have permission to get the `ClusterVesrion`
resource.

/assign @rhamilto 