### PR TITLE
Pipeline Builder AutoComplete (Part 2 - Improved UX)

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/index.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/index.ts
@@ -16,6 +16,7 @@ export { default as TextAreaField } from './TextAreaField';
 export { default as YAMLEditorField } from './YAMLEditorField';
 export { default as ItemSelectorField } from './item-selector-field/ItemSelectorField';
 export { default as InputGroupField } from './InputGroupField';
+export * from './text-column-field/text-column-types';
 export { default as TextColumnField } from './text-column-field/TextColumnField';
 export { default as DynamicFormField } from './DynamicFormField';
 export { default as SyncedEditorField } from './SyncedEditorField';

--- a/frontend/packages/console-shared/src/components/formik-fields/text-column-field/TextColumnField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/text-column-field/TextColumnField.tsx
@@ -10,7 +10,7 @@ import TextColumnItem from './TextColumnItem';
 import { TextColumnFieldProps } from './text-column-types';
 
 const TextColumnField: React.FC<TextColumnFieldProps> = (props) => {
-  const { required, name, label, addLabel, helpText, isReadOnly, onChange } = props;
+  const { required, name, label, addLabel, helpText, isReadOnly, onChange, children } = props;
   const [field, { touched, error }] = useField<string[]>(name);
   useFormikValidationFix(field.value);
   const rowValues = field.value ?? [];
@@ -37,7 +37,9 @@ const TextColumnField: React.FC<TextColumnFieldProps> = (props) => {
                     idx={idx}
                     arrayHelpers={arrayHelpers}
                     rowValues={rowValues}
-                  />
+                  >
+                    {children}
+                  </TextColumnItem>
                 );
               })}
             </FormGroup>

--- a/frontend/packages/console-shared/src/components/formik-fields/text-column-field/text-column-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/text-column-field/text-column-types.ts
@@ -1,6 +1,20 @@
 import { ArrayHelpers } from 'formik';
 import { FieldProps } from '../field-types';
 
+export type OnChangeHandler = (newValue: string[]) => void;
+export type TextColumnFieldChildParameterProps = {
+  name: string;
+  onChange?: OnChangeHandler;
+  isReadOnly?: boolean;
+  placeholder?: string;
+};
+
+export type MergeNewValueUtil = (newValue: string) => string[];
+export type TextColumnFieldChildProps = (
+  data: TextColumnFieldChildParameterProps,
+  mergeNewValue: MergeNewValueUtil,
+) => React.ReactNode;
+
 export type TextColumnFieldProps = FieldProps & {
   required?: boolean;
   name: string;
@@ -8,8 +22,9 @@ export type TextColumnFieldProps = FieldProps & {
   addLabel?: string;
   tooltip?: string;
   placeholder?: string;
-  onChange?: (newValue: string[]) => void;
+  onChange?: OnChangeHandler;
   dndEnabled?: boolean;
+  children?: TextColumnFieldChildProps;
 };
 
 export type TextColumnItemProps = TextColumnFieldProps & {

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -241,6 +241,7 @@
   "Select a Project to view the list of Pipelines or <2>create a Project</2>.": "Select a Project to view the list of Pipelines or <2>create a Project</2>.",
   "Create Pipeline": "Create Pipeline",
   "by name": "by name",
+  "No options matching your criteria": "No options matching your criteria",
   "{{resourceName}} results": "{{resourceName}} results",
   "Value": "Value",
   "No {{resourceName}} results available due to failure": "No {{resourceName}} results available due to failure",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.scss
@@ -1,4 +1,10 @@
 .opp-task-sidebar {
+  &__header {
+    // Hack for Popper to go under the header
+    background: white;
+    z-index: 10000;
+  }
+
   &__content {
     padding: var(--pf-global--spacer--lg);
     overflow-y: auto;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -69,7 +69,7 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
 
   return (
     <Stack className="opp-task-sidebar">
-      <StackItem>
+      <StackItem className="opp-task-sidebar__header">
         <TaskSidebarHeader
           onClose={onClose}
           taskResource={taskResource}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.scss
@@ -1,0 +1,5 @@
+.opp-task-sidebar-param {
+  textarea {
+    vertical-align: bottom; // fix for extra whitespace under the textarea
+  }
+}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { useFormikContext } from 'formik';
 import { TektonParam } from '../../../../types';
 import { taskParamIsRequired } from '../utils';
-import { TextAreaField, TextColumnField } from '@console/shared';
+import { TextAreaField, TextColumnField, MergeNewValueUtil } from '@console/shared';
 import { PipelineBuilderFormikValues, SelectedBuilderTask } from '../types';
 import AutoCompletePopover from '../../../shared/common/auto-complete/AutoCompletePopover';
 import { useBuilderParams } from '../../../shared/common/auto-complete/autoCompleteValueParsers';
+
+import './TaskSidebarParam.scss';
 
 type TaskSidebarParamProps = {
   hasParam: boolean;
@@ -22,46 +24,74 @@ const TaskSidebarParam: React.FC<TaskSidebarParamProps> = (props) => {
   const emptyIsInvalid = taskParamIsRequired(resourceParam);
 
   const resourceParamName = resourceParam.name;
+  const fieldName = `${name}.value`;
+
   const setValue = React.useCallback(
     (value: string) => {
-      setFieldValue(name, { name: resourceParamName, value });
+      if (hasParam) {
+        setFieldValue(fieldName, value);
+      } else {
+        setFieldValue(name, { name: resourceParamName, value });
+      }
     },
-    [name, setFieldValue, resourceParamName],
+    [hasParam, fieldName, name, setFieldValue, resourceParamName],
   );
 
-  const fieldValue = `${name}.value`;
-  return resourceParam.type === 'array' ? (
-    <TextColumnField
-      name={fieldValue}
-      label={resourceParam.name}
-      required={emptyIsInvalid}
-      onChange={(values: string[]) => {
-        if (!hasParam) {
-          setFieldValue(name, { name: resourceParam.name, value: values });
-        }
-      }}
-    />
-  ) : (
-    <AutoCompletePopover autoCompleteValues={autoCompleteOptions} onAutoComplete={setValue}>
-      {(ref) => (
-        <TextAreaField
-          ref={ref}
-          name={fieldValue}
-          label={resourceParam.name}
-          placeholder={resourceParam.default as string}
-          helpText={resourceParam.description}
-          required={emptyIsInvalid}
-          onChange={(value: string) => {
-            if (!hasParam) {
-              setValue(value);
-            }
-          }}
-          rows={1}
-          resizeOrientation="vertical"
-          style={{ minHeight: 33 }}
-        />
+  const textAreaSettings: Omit<React.ComponentProps<typeof TextAreaField>, 'name'> = {
+    rows: 1,
+    resizeOrientation: 'vertical',
+  };
+
+  return (
+    <div className="opp-task-sidebar-param">
+      {resourceParam.type === 'array' ? (
+        <TextColumnField name={fieldName} label={resourceParam.name} required={emptyIsInvalid}>
+          {({ name: arrayName, ...additionalProps }, mergeNewValue: MergeNewValueUtil) => (
+            <AutoCompletePopover
+              autoCompleteValues={autoCompleteOptions}
+              onAutoComplete={(newValue: string) => {
+                const newValues = mergeNewValue(newValue);
+                setFieldValue(name, { name: resourceParamName, value: newValues });
+              }}
+            >
+              {(ref) => (
+                <TextAreaField
+                  ref={ref}
+                  name={arrayName}
+                  {...additionalProps}
+                  {...textAreaSettings}
+                  onChange={(newValue: string) => {
+                    const values: string[] = mergeNewValue(newValue);
+                    if (!hasParam) {
+                      setFieldValue(name, { name: resourceParamName, value: values });
+                    }
+                  }}
+                />
+              )}
+            </AutoCompletePopover>
+          )}
+        </TextColumnField>
+      ) : (
+        <AutoCompletePopover autoCompleteValues={autoCompleteOptions} onAutoComplete={setValue}>
+          {(ref) => (
+            <TextAreaField
+              ref={ref}
+              name={fieldName}
+              label={resourceParam.name}
+              placeholder={resourceParam.default as string}
+              helpText={resourceParam.description}
+              required={emptyIsInvalid}
+              onChange={(value: string) => {
+                if (!hasParam) {
+                  setValue(value);
+                }
+              }}
+              {...textAreaSettings}
+            />
+          )}
+        </AutoCompletePopover>
       )}
-    </AutoCompletePopover>
+    </div>
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/AutoCompletePopover.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/AutoCompletePopover.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { FocusTrap, Menu, MenuList, MenuItem } from '@patternfly/react-core';
 import Popper from '@console/shared/src/components/popper/Popper';
 import useAutoComplete from './useAutoComplete';
+import { WithScrollContainer } from '@console/internal/components/utils';
 
 type AutoCompletePopoverProps = {
   autoCompleteValues: string[];
-  children: (contentRef) => React.ReactNode;
+  children: (contentRefCallback: (ref: HTMLElement) => void) => React.ReactNode;
   onAutoComplete: (newValue: string) => void;
 };
 
@@ -14,25 +16,74 @@ const AutoCompletePopover: React.FC<AutoCompletePopoverProps> = ({
   children,
   onAutoComplete,
 }) => {
-  const { contentRef, popperProps, options, insertAutoComplete } = useAutoComplete(
-    autoCompleteValues,
-    onAutoComplete,
-  );
+  const { t } = useTranslation();
+
+  const {
+    contentRefCallback,
+    focusTrapProps,
+    insertAutoComplete,
+    popperProps,
+    menuWidth,
+    options,
+  } = useAutoComplete(autoCompleteValues, onAutoComplete);
 
   return (
     <>
-      {children(contentRef)}
-      <Popper placement="bottom-start" closeOnEsc closeOnOutsideClick {...popperProps}>
-        <Menu onSelect={(event, itemId: number) => insertAutoComplete(options[itemId])}>
-          <MenuList translate="no">
-            {options.map((value, idx) => (
-              <MenuItem key={value} itemId={idx} translate="no">
-                {value}
-              </MenuItem>
-            ))}
-          </MenuList>
-        </Menu>
-      </Popper>
+      {children(contentRefCallback)}
+      <WithScrollContainer>
+        {(scrollContainer) => (
+          <Popper
+            {...popperProps}
+            placement="bottom-start"
+            closeOnEsc
+            closeOnOutsideClick
+            container={scrollContainer}
+            popperOptions={{
+              modifiers: {
+                hide: {
+                  enabled: false,
+                },
+                preventOverflow: {
+                  enabled: false,
+                },
+                flip: {
+                  enabled: false,
+                },
+              },
+            }}
+          >
+            <FocusTrap {...focusTrapProps}>
+              <Menu
+                style={{ maxHeight: 200, overflow: 'auto', width: menuWidth }}
+                onSelect={(event, itemId: number) => {
+                  const text = options[itemId];
+                  if (text) {
+                    insertAutoComplete(text);
+                  }
+                }}
+              >
+                <MenuList translate="no">
+                  {options.length === 0 ? (
+                    // There is a tab-index problem with the Menus from PF. If the first option is removed, it breaks tab indexes
+                    // Need key 0 because of PF bug
+                    <MenuItem key={0} itemId={-1} translate="no" isDisabled>
+                      {t('pipelines-plugin~No options matching your criteria')}
+                    </MenuItem>
+                  ) : (
+                    options.map((value, idx) => (
+                      // Using index-based keys to get around PF bug, see above
+                      // eslint-disable-next-line react/no-array-index-key
+                      <MenuItem key={idx} itemId={idx} translate="no">
+                        {value}
+                      </MenuItem>
+                    ))
+                  )}
+                </MenuList>
+              </Menu>
+            </FocusTrap>
+          </Popper>
+        )}
+      </WithScrollContainer>
     </>
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/__tests__/autoCompleteUtils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/__tests__/autoCompleteUtils.spec.ts
@@ -1,0 +1,112 @@
+import {
+  paramToAutoComplete,
+  taskToResult,
+  taskToStatus,
+  workspaceToAutoComplete,
+} from '../autoCompleteUtils';
+import { PipelineTask } from '../../../../../types';
+import { PipelineExampleNames, pipelineTestData } from '../../../../../test-data/pipeline-data';
+import { PipelineBuilderTaskResources } from '../../../../pipelines/pipeline-builder/types';
+import { resultTask } from '../../../../../test-data/task-data';
+
+jest.mock('i18next', () => {
+  const dependency = require.requireActual('i18next');
+  return {
+    ...dependency,
+    default: {
+      ...dependency.default,
+      use() {
+        return this;
+      },
+      init: () => Promise.resolve(),
+      t: (key) => key,
+    },
+  };
+});
+
+describe('autoCompleteUtils', () => {
+  describe('paramToAutoComplete', () => {
+    it('should return a valid param variable reference path', () => {
+      expect(paramToAutoComplete({ name: 'test' })).toBe('params.test');
+    });
+
+    it('should not be impacted by other properties in the Param', () => {
+      expect(paramToAutoComplete({ name: 'test', type: 'string' })).toBe('params.test');
+      expect(paramToAutoComplete({ name: 'test', type: 'string', default: '' })).toBe(
+        'params.test',
+      );
+      expect(paramToAutoComplete({ name: 'test', type: 'string', default: 'valid default' })).toBe(
+        'params.test',
+      );
+      expect(paramToAutoComplete({ name: 'test', type: 'array', default: [''] })).toBe(
+        'params.test',
+      );
+      expect(paramToAutoComplete({ name: 'test', type: 'array', default: ['one', 'two'] })).toBe(
+        'params.test',
+      );
+    });
+  });
+
+  describe('workspaceToAutoComplete', () => {
+    it('should return a valid workspace variable reference path', () => {
+      expect(workspaceToAutoComplete({ name: 'workspace' })).toBe('workspaces.workspace.bound');
+    });
+
+    it('should not be impacted by other properties in the Workspace', () => {
+      expect(workspaceToAutoComplete({ name: 'workspace', optional: false })).toBe(
+        'workspaces.workspace.bound',
+      );
+      expect(workspaceToAutoComplete({ name: 'workspace', optional: true })).toBe(
+        'workspaces.workspace.bound',
+      );
+    });
+  });
+
+  describe('taskToStatus', () => {
+    it('should return a valid task status variable reference path', () => {
+      const pipelineTask: PipelineTask =
+        pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE].pipeline.spec.tasks[0];
+
+      expect(taskToStatus(pipelineTask)).toBe('tasks.fetch-the-recipe.status');
+    });
+
+    it("should return a valid task status variable even if it's a taskSpec task", () => {
+      const pipelineTask: PipelineTask =
+        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipeline.spec.tasks[0];
+
+      expect(taskToStatus(pipelineTask)).toBe('tasks.install-deps.status');
+    });
+  });
+
+  describe('taskToResult', () => {
+    const resources: PipelineBuilderTaskResources = {
+      clusterTasks: [],
+      namespacedTasks: [resultTask],
+      tasksLoaded: true,
+    };
+
+    it('should handle nulls', () => {
+      expect(taskToResult(null)(null)).toBe(null);
+      expect(taskToResult(undefined)(undefined)).toBe(null);
+      expect(taskToResult(resources)(null)).toBe(null);
+    });
+
+    it('should return null if the task is found but does not have results', () => {
+      const task: PipelineTask =
+        pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE].pipeline.spec.tasks[0];
+      expect(taskToResult(resources)(task)).toBe(null);
+    });
+
+    it('should return null if the taskSpec is found but does not have results', () => {
+      const task: PipelineTask =
+        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipeline.spec.tasks[0];
+      expect(taskToResult(resources)(task)).toBe(null);
+    });
+
+    it('should return an array of match results', () => {
+      const task: PipelineTask =
+        pipelineTestData[PipelineExampleNames.RESULTS].pipeline.spec.tasks[0];
+      expect(taskToResult(resources)(task)).toEqual(['tasks.first-add.results.sum']);
+    });
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/autoCompleteUtils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/autoCompleteUtils.ts
@@ -53,5 +53,5 @@ export const computeAvailableResultACs = (
 export type CursorPosition = [number, number];
 export const insertIntoValue = (value: string, position: CursorPosition, insertText = '') => {
   const [startPos, endPos] = position;
-  return `${value.substr(0, startPos)}${insertText}${value.substr(endPos)}`;
+  return `${value.substring(0, startPos)}${insertText}${value.substring(endPos)}`;
 };

--- a/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/useAutoComplete.ts
+++ b/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/useAutoComplete.ts
@@ -4,8 +4,17 @@ import { CursorPosition, insertIntoValue } from './autoCompleteUtils';
 
 type ElementType = HTMLInputElement | HTMLTextAreaElement;
 type AutoCompleteHook = {
-  contentRef: (contentNode: ElementType) => void;
+  contentRefCallback: (contentNode: ElementType) => void;
+  focusTrapProps: {
+    active: boolean;
+    focusTrapOptions: {
+      clickOutsideDeactivates: boolean;
+      onDeactivate: () => void;
+      fallbackFocus: ElementType;
+    };
+  };
   insertAutoComplete: (newValue: string) => void;
+  menuWidth: number;
   options: string[];
   popperProps: {
     open: boolean;
@@ -14,52 +23,58 @@ type AutoCompleteHook = {
   };
 };
 
-type InsertAtCursor = (additionalValue: string) => void;
-
+type ShouldOpenCallback = (event) => boolean;
 type MenuKeyWatcherHook = {
   isOpen: boolean;
-  shouldOpen: (event, insertAtCursor: InsertAtCursor) => void;
-  close: () => void;
+  shouldOpen: ShouldOpenCallback;
+  closeMenu: () => void;
 };
+
+type SetAutoCompleteCallback = (newValue: string) => void;
 
 type SetFilterOptions = (filterValue: string) => void;
 type FilterOptionsHook = [string[], SetFilterOptions];
+
+const PARAM_REFERENCE = '$(';
+const PARAM_REFERENCE_CHARS = PARAM_REFERENCE.split('');
 
 /**
  * Tracks open state + manages keystrokes to open.
  */
 const useOpenMenuKeyWatcher = (): MenuKeyWatcherHook => {
   const [isOpen, setOpen] = React.useState<boolean>(false);
-  const lastKey = React.useRef<string>('');
 
-  const shouldOpen = React.useCallback(
-    (event, insertAtCursor: InsertAtCursor) => {
+  const shouldOpen = React.useCallback<ShouldOpenCallback>(
+    (event) => {
       const { key, code, ctrlKey } = event;
 
       if (code === 'Space' && ctrlKey) {
         // Hotkey to open
         setOpen(true);
-        insertAtCursor('$(');
-        return;
+        return true;
       }
 
-      if (!['$', '('].includes(key) || isOpen) {
+      if (!PARAM_REFERENCE_CHARS.includes(key) || isOpen) {
         // Ignore event, does not apply to opening
-        return;
+        return false;
       }
 
-      if (lastKey.current === '$' && key === '(') {
+      const cursorPos = event.target.selectionStart;
+      // Go back the character we added and then one more to get the previous character
+      const lastCharacter = event.target.value[cursorPos - 2];
+
+      if (lastCharacter === PARAM_REFERENCE_CHARS[0] && key === PARAM_REFERENCE_CHARS[1]) {
         // Manual open
         setOpen(true);
-      } else {
-        // Not manual open, track the key for next loop
-        lastKey.current = key;
+        return true;
       }
+
+      return false;
     },
     [isOpen],
   );
 
-  return { isOpen, shouldOpen, close: React.useCallback(() => setOpen(false), []) };
+  return { isOpen, shouldOpen, closeMenu: React.useCallback(() => setOpen(false), []) };
 };
 
 /**
@@ -76,6 +91,7 @@ const useFilterOptions = (options: string[]): FilterOptionsHook => {
       const optionPartMap = option.split('.').reduce((optionAcc, optionPart: string) => {
         return {
           ...optionAcc,
+          // startsWith value + unique identifier to allow multiple overlapping parts
           [`${optionPart}|${idx}`]: option,
         };
       }, {});
@@ -83,20 +99,109 @@ const useFilterOptions = (options: string[]): FilterOptionsHook => {
       return {
         ...acc,
         ...optionPartMap,
+        [option]: option,
       };
     }, {});
   }, [options]);
 
-  const setFilter: SetFilterOptions = (newFilterValue) => {
-    const newOptions: string[] = _.uniq(
-      Object.keys(filterMappings.current)
-        .filter((value: string) => value.startsWith(newFilterValue))
-        .map((value: string) => filterMappings.current[value]),
-    );
-    setFilteredOptions(newOptions);
-  };
+  const setFilter: SetFilterOptions = React.useCallback(
+    (newFilterValue: string) => {
+      if (!newFilterValue) {
+        setFilteredOptions(options);
+        return;
+      }
+
+      const newOptions: string[] = _.uniq(
+        Object.keys(filterMappings.current)
+          .filter((value: string) => value.toLowerCase().startsWith(newFilterValue.toLowerCase()))
+          .map((value: string) => filterMappings.current[value]),
+      );
+      setFilteredOptions(newOptions);
+    },
+    [options],
+  );
 
   return [filteredOptions, setFilter];
+};
+
+/**
+ * Listens to the node in various ways to prefer functions of AutoComplete.
+ */
+const useNodeListener = (
+  cursorPosition: React.MutableRefObject<CursorPosition>,
+  menuOptions: MenuKeyWatcherHook,
+  filterOptions: FilterOptionsHook,
+  setFocusingOptions: (isFocusing: boolean) => void,
+  closeCleanup: () => void,
+): [React.MutableRefObject<ElementType>, (node: ElementType) => void] => {
+  const [node, setNode] = React.useState<ElementType>(null);
+  const nodeRef = React.useRef<ElementType>(null);
+  nodeRef.current = node;
+
+  const { isOpen, shouldOpen } = menuOptions;
+  const [, setFilter] = filterOptions;
+
+  const onKeyCallback = React.useCallback(
+    (e) => {
+      const applyFilterAtCursor = () => {
+        const filterValue = nodeRef.current.value.substring(
+          cursorPosition.current[0],
+          cursorPosition.current[1],
+        );
+        setFilter(filterValue);
+      };
+
+      if (isOpen) {
+        cursorPosition.current = [cursorPosition.current[0], nodeRef.current.selectionEnd];
+
+        if (cursorPosition.current[1] < cursorPosition.current[0]) {
+          // User moved before the start of the autoComplete trigger, close
+          closeCleanup();
+          return;
+        }
+
+        applyFilterAtCursor();
+      } else {
+        cursorPosition.current = [nodeRef.current.selectionStart, nodeRef.current.selectionEnd];
+        const isOpening = shouldOpen(e);
+
+        if (isOpening) {
+          // In the case they are highlighting text, invoke auto complete immediately on the text
+          applyFilterAtCursor();
+        }
+      }
+    },
+    [isOpen, setFilter, shouldOpen, closeCleanup, cursorPosition],
+  );
+
+  const focusDropdownCallback = React.useCallback(
+    (e) => {
+      if (!isOpen) return;
+
+      if (e.code === 'Tab' || e.code === 'ArrowDown') {
+        e.stopPropagation();
+        e.preventDefault();
+        setFocusingOptions(true);
+      }
+    },
+    [isOpen, setFocusingOptions],
+  );
+
+  React.useEffect(() => {
+    if (node) {
+      node.addEventListener('keydown', focusDropdownCallback);
+      node.addEventListener('keyup', onKeyCallback);
+    }
+
+    return () => {
+      if (node) {
+        node.removeEventListener('keydown', focusDropdownCallback);
+        node.removeEventListener('keyup', onKeyCallback);
+      }
+    };
+  }, [focusDropdownCallback, onKeyCallback, node]);
+
+  return [nodeRef, (contentNode) => setNode(contentNode)];
 };
 
 /**
@@ -104,68 +209,72 @@ const useFilterOptions = (options: string[]): FilterOptionsHook => {
  */
 const useAutoComplete = (
   autoCompleteValues: string[],
-  onAutoComplete: (newValue: string) => void,
+  onAutoComplete: SetAutoCompleteCallback,
 ): AutoCompleteHook => {
-  const [node, setNode] = React.useState<ElementType>(null);
-  const nodeRef = React.useRef<ElementType>(null);
-  nodeRef.current = node;
   const cursorPosition = React.useRef<CursorPosition>([0, 0]);
-  const { isOpen, shouldOpen, close } = useOpenMenuKeyWatcher();
-  const [options, setFilter] = useFilterOptions(autoCompleteValues);
+  const [focusingOptions, setFocusingOptions] = React.useState<boolean>(false);
+  const menuOptions = useOpenMenuKeyWatcher();
+  const filterOptions = useFilterOptions(autoCompleteValues);
 
-  const onKeyCallback = React.useCallback(
-    (e) => {
-      if (isOpen) {
-        cursorPosition.current = [cursorPosition.current[0], nodeRef.current.selectionEnd];
-        const filterValue = nodeRef.current.value.substr(...cursorPosition.current);
-        setFilter(filterValue);
-      } else {
-        cursorPosition.current = [nodeRef.current.selectionStart, nodeRef.current.selectionEnd];
-        shouldOpen(e, (additionalContent = '') => {
-          onAutoComplete(
-            insertIntoValue(nodeRef.current.value, cursorPosition.current, additionalContent),
-          );
-          // Align the start to be after any additional characters so we can track just new content
-          const startPos = cursorPosition.current[0];
-          const newStartPos = startPos + additionalContent.length;
-          cursorPosition.current = [newStartPos, newStartPos];
-        });
-      }
-    },
-    [isOpen, setFilter, shouldOpen, onAutoComplete],
+  const { isOpen, closeMenu } = menuOptions;
+  const [options, setFilter] = filterOptions;
+
+  const closeCleanup = React.useCallback(() => {
+    closeMenu();
+    setFilter('');
+    setFocusingOptions(false);
+    cursorPosition.current = [0, 0];
+  }, [closeMenu, setFilter]);
+
+  const [nodeRef, setNodeRef] = useNodeListener(
+    cursorPosition,
+    menuOptions,
+    filterOptions,
+    setFocusingOptions,
+    closeCleanup,
   );
-
-  React.useEffect(() => {
-    if (node) {
-      node.addEventListener('keyup', onKeyCallback);
-    }
-
-    return () => {
-      if (node) {
-        node.removeEventListener('keyup', onKeyCallback);
-      }
-    };
-  }, [onKeyCallback, node]);
 
   const insertAutoComplete = React.useCallback(
     (newValue: string) => {
-      // Note: '$(' should already exist, add the value they selected and end the block with ')'
-      const insertValue = `${newValue})`;
+      // Look for the PARAM_REFERENCE prefix to see if we need to add it
+      const leftCapturePoint = cursorPosition.current[0] - PARAM_REFERENCE.length;
+      const prefix =
+        leftCapturePoint >= 0
+          ? nodeRef.current.value.substr(leftCapturePoint, PARAM_REFERENCE.length)
+          : null;
+      const hasPrefix = prefix === PARAM_REFERENCE;
 
+      // Update the value + the node
+      const insertValue = `${hasPrefix ? '' : PARAM_REFERENCE}${newValue})`;
       onAutoComplete(insertIntoValue(nodeRef.current.value, cursorPosition.current, insertValue));
-      close();
-      setFilter('');
+
+      // Make sure the cursor remains at the end of the inserted text so they can continue typing a prefix (if desired)
+      const cursorEndPoint: number = cursorPosition.current[0] + insertValue.length;
+      setTimeout(() => {
+        nodeRef.current.setSelectionRange(cursorEndPoint, cursorEndPoint);
+      }, 0);
+
+      closeCleanup();
     },
-    [close, onAutoComplete, setFilter],
+    [nodeRef, closeCleanup, onAutoComplete],
   );
 
   return {
-    contentRef: (contentNode) => setNode(contentNode),
+    contentRefCallback: setNodeRef,
+    focusTrapProps: {
+      active: focusingOptions,
+      focusTrapOptions: {
+        clickOutsideDeactivates: true,
+        onDeactivate: closeCleanup,
+        fallbackFocus: nodeRef.current,
+      },
+    },
     insertAutoComplete,
+    menuWidth: nodeRef.current?.getBoundingClientRect().width || 300,
     options,
     popperProps: {
       open: isOpen,
-      onRequestClose: close,
+      onRequestClose: closeCleanup,
       reference: () => nodeRef.current,
     },
   };

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -26,8 +26,10 @@ export enum PipelineExampleNames {
   CONDITIONAL_PIPELINE = 'conditional-pipeline',
   INVALID_PIPELINE_MISSING_TASK = 'missing-task-pipeline',
   INVALID_PIPELINE_INVALID_TASK = 'invalid-task-pipeline',
+  EMBEDDED_TASK_SPEC_MOCK_APP = 'embedded-task-spec',
   EMBEDDED_PIPELINE_SPEC = 'embedded-pipeline-spec',
   PIPELINE_WITH_FINALLY = 'pipeline-with-finally',
+  RESULTS = 'results-pipeline',
 }
 
 type CombinedPipelineTestData = {
@@ -254,7 +256,6 @@ const pipelineSpec: PipelineSpecData = {
       },
     ],
   },
-
   [PipelineExampleNames.CONDITIONAL_PIPELINE]: {
     tasks: [
       {
@@ -288,6 +289,96 @@ const pipelineSpec: PipelineSpecData = {
       },
     ],
   },
+  [PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP]: {
+    tasks: [
+      {
+        name: 'install-deps',
+        taskSpec: {
+          metadata: {},
+          steps: [
+            {
+              args: ['Installing dependencies...\n\nDependencies installed successfully.'],
+              command: ['echo'],
+              image: 'ubuntu',
+              name: 'install',
+              resources: {},
+            },
+          ],
+        },
+      },
+      {
+        name: 'code-sanity',
+        runAfter: ['install-deps'],
+        taskSpec: {
+          metadata: {},
+          steps: [
+            {
+              args: ['Running Linter and Tests'],
+              command: ['echo'],
+              image: 'ubuntu',
+              name: 'startup',
+              resources: {},
+            },
+            {
+              args: ['0 Lint Errors'],
+              command: ['echo'],
+              image: 'ubuntu',
+              name: 'lint-errors',
+              resources: {},
+            },
+            {
+              args: ['0 Test Failures'],
+              command: ['echo'],
+              image: 'ubuntu',
+              name: 'test-status',
+              resources: {},
+            },
+            {
+              args: [
+                'Exporting Test Coverage Report...\n\nCoverage report can be found in __coverage__',
+              ],
+              command: ['echo'],
+              image: 'ubuntu',
+              name: 'coverage-report',
+              resources: {},
+            },
+          ],
+        },
+      },
+      {
+        name: 'compile',
+        runAfter: ['install-deps'],
+        taskSpec: {
+          metadata: {},
+          steps: [
+            {
+              args: ['Compiling code and producing dist folder...\n\nFolder public/dist created'],
+              command: ['echo'],
+              image: 'ubuntu',
+              name: 'build',
+              resources: {},
+            },
+          ],
+        },
+      },
+      {
+        name: 'e2e-tests',
+        runAfter: ['code-sanity', 'compile'],
+        taskSpec: {
+          metadata: {},
+          steps: [
+            {
+              args: ['Running end-to-end tests...\n\nAll tests pass'],
+              command: ['echo'],
+              image: 'ubuntu',
+              name: 'status',
+              resources: {},
+            },
+          ],
+        },
+      },
+    ],
+  },
   [PipelineExampleNames.PIPELINE_WITH_FINALLY]: {
     tasks: [
       {
@@ -303,6 +394,78 @@ const pipelineSpec: PipelineSpecData = {
       {
         name: 'run-anyway',
         taskRef: { name: 'run-anyway' },
+      },
+    ],
+  },
+  [PipelineExampleNames.RESULTS]: {
+    params: [
+      {
+        description: 'the first operand',
+        name: 'first',
+        type: 'string',
+      },
+      {
+        description: 'the second operand',
+        name: 'second',
+        type: 'string',
+      },
+      {
+        description: 'the third operand',
+        name: 'third',
+        type: 'string',
+      },
+    ],
+    results: [
+      {
+        description: 'the sum of all three operands',
+        name: 'sum',
+        value: '$(tasks.second-add.results.sum)',
+      },
+      {
+        description: 'the sum of first two operands',
+        name: 'partial-sum',
+        value: '$(tasks.first-add.results.sum)',
+      },
+      {
+        description: 'the sum of everything',
+        name: 'all-sum',
+        value: '$(tasks.second-add.results.sum)-$(tasks.first-add.results.sum)',
+      },
+    ],
+    tasks: [
+      {
+        name: 'first-add',
+        params: [
+          {
+            name: 'first',
+            value: '$(params.first)',
+          },
+          {
+            name: 'second',
+            value: '$(params.second)',
+          },
+        ],
+        taskRef: {
+          kind: 'Task',
+          name: 'add-task',
+        },
+      },
+      {
+        name: 'second-add',
+        params: [
+          {
+            name: 'first',
+            value: '$(tasks.first-add.results.sum)',
+          },
+          {
+            name: 'second',
+            value: '$(params.third)',
+          },
+        ],
+        taskRef: {
+          kind: 'Task',
+          name: 'add-task',
+        },
       },
     ],
   },
@@ -1902,6 +2065,390 @@ export const pipelineTestData: PipelineTestData = {
       },
     },
   },
+  [PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP]: {
+    dataSource: 'mock-app-embedded-pipeline',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1beta1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'mock-app-embedded-pipeline',
+        uid: '702ba12f-e159-44b4-827f-7e3d0696ca6e',
+      },
+      spec: pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP],
+    },
+    pipelineRuns: {
+      [DataState.IN_PROGRESS]: {
+        apiVersion: 'tekton.dev/v1beta1',
+        kind: 'PipelineRun',
+        metadata: {
+          annotations: {
+            'pipeline.openshift.io/preferredName': 'mock-app-embedded-pipeline',
+            'pipeline.openshift.io/started-by': 'kube:admin',
+          },
+          name: 'mock-app-embedded-pipeline-zuazs0',
+          uid: '7d03e1f1-69d7-4c2d-90b6-e17316482e68',
+          labels: {
+            'tekton.dev/pipeline': 'mock-app-embedded-pipeline',
+          },
+        },
+        spec: {
+          pipelineRef: {
+            name: 'mock-app-embedded-pipeline',
+          },
+          serviceAccountName: 'pipeline',
+          timeout: '1h0m0s',
+        },
+        status: {
+          conditions: [
+            {
+              lastTransitionTime: '2021-04-23T14:43:50Z',
+              message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Incomplete: 3, Skipped: 0',
+              reason: 'Running',
+              status: 'Unknown',
+              type: 'Succeeded',
+            },
+          ],
+          pipelineSpec: pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP],
+          startTime: '2021-04-23T14:43:30Z',
+          taskRuns: {
+            'mock-app-embedded-pipeline-zuazs0-code-sanity-6hpzr': {
+              pipelineTaskName: 'code-sanity',
+              status: {
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T14:43:56Z',
+                    message:
+                      'pod status "Ready":"False"; message: "containers with unready status: [step-startup step-lint-errors step-test-status step-coverage-report]"',
+                    reason: 'Pending',
+                    status: 'Unknown',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'mock-app-embedded-pipeline-zuazs0-code-sanity-6hpzr-pod-tgrm2',
+                startTime: '2021-04-23T14:43:50Z',
+                steps: [
+                  {
+                    container: 'step-startup',
+                    name: 'startup',
+                    waiting: {
+                      reason: 'PodInitializing',
+                    },
+                  },
+                  {
+                    container: 'step-lint-errors',
+                    name: 'lint-errors',
+                    waiting: {
+                      reason: 'PodInitializing',
+                    },
+                  },
+                  {
+                    container: 'step-test-status',
+                    name: 'test-status',
+                    waiting: {
+                      reason: 'PodInitializing',
+                    },
+                  },
+                  {
+                    container: 'step-coverage-report',
+                    name: 'coverage-report',
+                    waiting: {
+                      reason: 'PodInitializing',
+                    },
+                  },
+                ],
+                taskSpec:
+                  pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].tasks[1].taskSpec,
+              },
+            },
+            'mock-app-embedded-pipeline-zuazs0-compile-gtx5z': {
+              pipelineTaskName: 'compile',
+              status: {
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T14:43:57Z',
+                    message: 'Not all Steps in the Task have finished executing',
+                    reason: 'Running',
+                    status: 'Unknown',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'mock-app-embedded-pipeline-zuazs0-compile-gtx5z-pod-hhbgw',
+                startTime: '2021-04-23T14:43:50Z',
+                steps: [
+                  {
+                    container: 'step-build',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'build',
+                    running: {
+                      startedAt: '2021-04-23T14:43:56Z',
+                    },
+                  },
+                ],
+                taskSpec:
+                  pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].tasks[2].taskSpec,
+              },
+            },
+            'mock-app-embedded-pipeline-zuazs0-install-deps-75vvh': {
+              pipelineTaskName: 'install-deps',
+              status: {
+                completionTime: '2021-04-23T14:43:49Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T14:43:49Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'mock-app-embedded-pipeline-zuazs0-install-deps-75vvh-pod-pdldm',
+                startTime: '2021-04-23T14:43:30Z',
+                steps: [
+                  {
+                    container: 'step-install',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'install',
+                    terminated: {
+                      containerID:
+                        'cri-o://4e21f21a73bf9d3d650464821e30adcaa282b6a4b6cbaca642deebdd1da3aeb2',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:43:49Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:43:49Z',
+                    },
+                  },
+                ],
+                taskSpec:
+                  pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].tasks[0].taskSpec,
+              },
+            },
+          },
+        },
+      },
+      [DataState.SUCCESS]: {
+        apiVersion: 'tekton.dev/v1beta1',
+        kind: 'PipelineRun',
+        metadata: {
+          annotations: {
+            'pipeline.openshift.io/preferredName': 'mock-app-embedded-pipeline',
+            'pipeline.openshift.io/started-by': 'kube:admin',
+          },
+          name: 'mock-app-embedded-pipeline-zuazs0',
+          uid: '7d03e1f1-69d7-4c2d-90b6-e17316482e68',
+          labels: {
+            'tekton.dev/pipeline': 'mock-app-embedded-pipeline',
+          },
+        },
+        spec: {
+          pipelineRef: {
+            name: 'mock-app-embedded-pipeline',
+          },
+          serviceAccountName: 'pipeline',
+          timeout: '1h0m0s',
+        },
+        status: {
+          completionTime: '2021-04-23T14:44:11Z',
+          conditions: [
+            {
+              lastTransitionTime: '2021-04-23T14:44:11Z',
+              message: 'Tasks Completed: 4 (Failed: 0, Cancelled 0), Skipped: 0',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+          pipelineSpec: pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP],
+          startTime: '2021-04-23T14:43:30Z',
+          taskRuns: {
+            'mock-app-embedded-pipeline-zuazs0-code-sanity-6hpzr': {
+              pipelineTaskName: 'code-sanity',
+              status: {
+                completionTime: '2021-04-23T14:44:03Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T14:44:03Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'mock-app-embedded-pipeline-zuazs0-code-sanity-6hpzr-pod-tgrm2',
+                startTime: '2021-04-23T14:43:50Z',
+                steps: [
+                  {
+                    container: 'step-startup',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'startup',
+                    terminated: {
+                      containerID:
+                        'cri-o://3cf477b2c7bd79d5a0b09c7b06b7f73e29037034a63cd6d0b14dde552194dc57',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:44:00Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:44:00Z',
+                    },
+                  },
+                  {
+                    container: 'step-lint-errors',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'lint-errors',
+                    terminated: {
+                      containerID:
+                        'cri-o://52029e07d5f1da01d5d43d7b9b8bf2de9344e871d024a9eb811ee8283d015b6b',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:44:01Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:44:01Z',
+                    },
+                  },
+                  {
+                    container: 'step-test-status',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'test-status',
+                    terminated: {
+                      containerID:
+                        'cri-o://a8e63c405c9c2ccd017daf610a1424285202ceed001ebe93aeaf038298ca998f',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:44:01Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:44:01Z',
+                    },
+                  },
+                  {
+                    container: 'step-coverage-report',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'coverage-report',
+                    terminated: {
+                      containerID:
+                        'cri-o://66696f96ad23e0fd383f076e0845963953f2559d79133fe8533efefc3eeadb7c',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:44:02Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:44:02Z',
+                    },
+                  },
+                ],
+                taskSpec:
+                  pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].tasks[1].taskSpec,
+              },
+            },
+            'mock-app-embedded-pipeline-zuazs0-compile-gtx5z': {
+              pipelineTaskName: 'compile',
+              status: {
+                completionTime: '2021-04-23T14:43:59Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T14:43:59Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'mock-app-embedded-pipeline-zuazs0-compile-gtx5z-pod-hhbgw',
+                startTime: '2021-04-23T14:43:50Z',
+                steps: [
+                  {
+                    container: 'step-build',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'build',
+                    terminated: {
+                      containerID:
+                        'cri-o://86be196caf01689b4900d17fc71bc34751ce45e01433931ef8c3a0222f1ae474',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:43:58Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:43:58Z',
+                    },
+                  },
+                ],
+                taskSpec:
+                  pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].tasks[2].taskSpec,
+              },
+            },
+            'mock-app-embedded-pipeline-zuazs0-e2e-tests-7zrkm': {
+              pipelineTaskName: 'e2e-tests',
+              status: {
+                completionTime: '2021-04-23T14:44:11Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T14:44:11Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'mock-app-embedded-pipeline-zuazs0-e2e-tests-7zrkm-pod-qcr97',
+                startTime: '2021-04-23T14:44:04Z',
+                steps: [
+                  {
+                    container: 'step-status',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'status',
+                    terminated: {
+                      containerID:
+                        'cri-o://8a5989caa2ddcc7a2b838150c028bc27e1a2d7bc6a458cad651ae67c3cef31b4',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:44:10Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:44:10Z',
+                    },
+                  },
+                ],
+                taskSpec:
+                  pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].tasks[3].taskSpec,
+              },
+            },
+            'mock-app-embedded-pipeline-zuazs0-install-deps-75vvh': {
+              pipelineTaskName: 'install-deps',
+              status: {
+                completionTime: '2021-04-23T14:43:49Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T14:43:49Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'mock-app-embedded-pipeline-zuazs0-install-deps-75vvh-pod-pdldm',
+                startTime: '2021-04-23T14:43:30Z',
+                steps: [
+                  {
+                    container: 'step-install',
+                    imageID:
+                      'docker.io/library/ubuntu@sha256:3c9c713e0979e9bd6061ed52ac1e9e1f246c9495aa063619d9d695fb8039aa1f',
+                    name: 'install',
+                    terminated: {
+                      containerID:
+                        'cri-o://4e21f21a73bf9d3d650464821e30adcaa282b6a4b6cbaca642deebdd1da3aeb2',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T14:43:49Z',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T14:43:49Z',
+                    },
+                  },
+                ],
+                taskSpec:
+                  pipelineSpec[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].tasks[0].taskSpec,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   [PipelineExampleNames.EMBEDDED_PIPELINE_SPEC]: {
     dataSource: 'embedded-pipelineSpec',
     pipeline: null,
@@ -2054,6 +2601,242 @@ export const pipelineTestData: PipelineTestData = {
                 conditions: [{ status: 'True', type: 'Succeeded' }],
                 podName: 'test',
                 startTime: '2019-12-10T11:18:38Z',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  [PipelineExampleNames.RESULTS]: {
+    dataSource: 'upstream-results-example',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1beta1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'sum-three-pipeline',
+        uid: 'de0ace30-54f1-4e77-b99f-1894263f1d20',
+      },
+      spec: pipelineSpec[PipelineExampleNames.RESULTS],
+    },
+    pipelineRuns: {
+      [DataState.SUCCESS]: {
+        apiVersion: 'tekton.dev/v1beta1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'sum-three-pipeline-run',
+          uid: 'fc2f17c0-f53d-4373-99e9-14f4636696a0',
+          labels: {
+            'tekton.dev/pipeline': 'sum-three-pipeline',
+          },
+        },
+        spec: {
+          params: [
+            {
+              name: 'first',
+              value: '2',
+            },
+            {
+              name: 'second',
+              value: '10',
+            },
+            {
+              name: 'third',
+              value: '10',
+            },
+          ],
+          pipelineRef: {
+            name: 'sum-three-pipeline',
+          },
+          serviceAccountName: 'pipeline',
+          timeout: '1h0m0s',
+        },
+        status: {
+          completionTime: '2021-04-23T15:22:32Z',
+          conditions: [
+            {
+              lastTransitionTime: '2021-04-23T15:22:32Z',
+              message: 'Tasks Completed: 2 (Failed: 0, Cancelled 0), Skipped: 0',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+          pipelineResults: [
+            {
+              name: 'sum',
+              value: '22',
+            },
+            {
+              name: 'partial-sum',
+              value: '12',
+            },
+            {
+              name: 'all-sum',
+              value: '22-12',
+            },
+          ],
+          pipelineSpec: pipelineSpec[PipelineExampleNames.RESULTS],
+          startTime: '2021-04-23T15:22:19Z',
+          taskRuns: {
+            'sum-three-pipeline-run-first-add-tpmxp': {
+              pipelineTaskName: 'first-add',
+              status: {
+                completionTime: '2021-04-23T15:22:27Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T15:22:27Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'sum-three-pipeline-run-first-add-tpmxp-pod-22wv9',
+                startTime: '2021-04-23T15:22:19Z',
+                steps: [
+                  {
+                    container: 'step-add',
+                    imageID:
+                      'docker.io/library/alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f',
+                    name: 'add',
+                    terminated: {
+                      containerID:
+                        'cri-o://52386d3a95311cd3104289b077bb89952b7263d52dd2cc0b34460b4c7b5428cd',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T15:22:27Z',
+                      message: '[{"key":"sum","value":"12","type":"TaskRunResult"}]',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T15:22:27Z',
+                    },
+                  },
+                ],
+                taskResults: [
+                  {
+                    name: 'sum',
+                    value: '12',
+                  },
+                ],
+                taskSpec: {
+                  params: [
+                    {
+                      description: 'the first operand',
+                      name: 'first',
+                      type: 'string',
+                    },
+                    {
+                      description: 'the second operand',
+                      name: 'second',
+                      type: 'string',
+                    },
+                  ],
+                  results: [
+                    {
+                      description: 'the sum of the first and second operand',
+                      name: 'sum',
+                    },
+                  ],
+                  steps: [
+                    {
+                      // eslint-disable-next-line no-template-curly-in-string
+                      args: ['echo -n $((${OP1}+${OP2})) | tee $(results.sum.path);'],
+                      command: ['/bin/sh', '-c'],
+                      env: [
+                        {
+                          name: 'OP1',
+                          value: '$(params.first)',
+                        },
+                        {
+                          name: 'OP2',
+                          value: '$(params.second)',
+                        },
+                      ],
+                      image: 'alpine',
+                      name: 'add',
+                      resources: {},
+                    },
+                  ],
+                },
+              },
+            },
+            'sum-three-pipeline-run-second-add-tt8n6': {
+              pipelineTaskName: 'second-add',
+              status: {
+                completionTime: '2021-04-23T15:22:32Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-04-23T15:22:32Z',
+                    message: 'All Steps have completed executing',
+                    reason: 'Succeeded',
+                    status: 'True',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'sum-three-pipeline-run-second-add-tt8n6-pod-jlfxr',
+                startTime: '2021-04-23T15:22:27Z',
+                steps: [
+                  {
+                    container: 'step-add',
+                    imageID:
+                      'docker.io/library/alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f',
+                    name: 'add',
+                    terminated: {
+                      containerID:
+                        'cri-o://9861764a11f0a12af4c1fa61b5c185947abb79b20c6d99fe3334d35b84f88eb2',
+                      exitCode: 0,
+                      finishedAt: '2021-04-23T15:22:32Z',
+                      message: '[{"key":"sum","value":"22","type":"TaskRunResult"}]',
+                      reason: 'Completed',
+                      startedAt: '2021-04-23T15:22:32Z',
+                    },
+                  },
+                ],
+                taskResults: [
+                  {
+                    name: 'sum',
+                    value: '22',
+                  },
+                ],
+                taskSpec: {
+                  params: [
+                    {
+                      description: 'the first operand',
+                      name: 'first',
+                      type: 'string',
+                    },
+                    {
+                      description: 'the second operand',
+                      name: 'second',
+                      type: 'string',
+                    },
+                  ],
+                  results: [
+                    {
+                      description: 'the sum of the first and second operand',
+                      name: 'sum',
+                    },
+                  ],
+                  steps: [
+                    {
+                      // eslint-disable-next-line no-template-curly-in-string
+                      args: ['echo -n $((${OP1}+${OP2})) | tee $(results.sum.path);'],
+                      command: ['/bin/sh', '-c'],
+                      env: [
+                        {
+                          name: 'OP1',
+                          value: '$(params.first)',
+                        },
+                        {
+                          name: 'OP2',
+                          value: '$(params.second)',
+                        },
+                      ],
+                      image: 'alpine',
+                      name: 'add',
+                      resources: {},
+                    },
+                  ],
+                },
               },
             },
           },

--- a/frontend/packages/pipelines-plugin/src/test-data/task-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/task-data.ts
@@ -1,0 +1,50 @@
+import { TaskKind } from '../types';
+
+export const resultTask: TaskKind = {
+  apiVersion: 'tekton.dev/v1beta1',
+  kind: 'Task',
+  metadata: {
+    name: 'add-task',
+    uid: '276780d6-96a8-4eb0-a7b9-54da43b7b4f9',
+  },
+  spec: {
+    params: [
+      {
+        description: 'the first operand',
+        name: 'first',
+        type: 'string',
+      },
+      {
+        description: 'the second operand',
+        name: 'second',
+        type: 'string',
+      },
+    ],
+    results: [
+      {
+        description: 'the sum of the first and second operand',
+        name: 'sum',
+      },
+    ],
+    steps: [
+      {
+        // eslint-disable-next-line no-template-curly-in-string
+        args: ['echo -n $((${OP1}+${OP2})) | tee $(results.sum.path);'],
+        command: ['/bin/sh', '-c'],
+        env: [
+          {
+            name: 'OP1',
+            value: '$(params.first)',
+          },
+          {
+            name: 'OP2',
+            value: '$(params.second)',
+          },
+        ],
+        image: 'alpine',
+        name: 'add',
+        resources: {},
+      },
+    ],
+  },
+};

--- a/frontend/packages/pipelines-plugin/src/types/coreTekton.ts
+++ b/frontend/packages/pipelines-plugin/src/types/coreTekton.ts
@@ -13,7 +13,8 @@ export type TektonTaskSteps = {
   args?: string[];
   command?: string[];
   image?: string;
-  resources?: {}[];
+  resources?: {}[] | {};
+  env?: { name: string; value: string }[];
   script?: string[];
 };
 
@@ -23,6 +24,8 @@ export type TaskResult = {
 };
 
 export type TektonTaskSpec = {
+  metadata?: {};
+
   steps: TektonTaskSteps[];
   params?: TektonParam[];
   resources?: TektonResourceGroup<TektonResource>;

--- a/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
+++ b/frontend/packages/pipelines-plugin/src/types/pipelineRun.ts
@@ -1,17 +1,24 @@
 import { K8sResourceCommon, ObjectMetadata } from '@console/internal/module/k8s';
 import { PipelineKind, PipelineSpec } from './pipeline';
-import { TektonResultsRun } from './coreTekton';
+import { TektonResultsRun, TektonTaskSpec } from './coreTekton';
 
 export type PLRTaskRunStep = {
   container: string;
-  imageID: string;
+  imageID?: string;
   name: string;
+  waiting?: {
+    reason: string;
+  };
+  running?: {
+    startedAt: string;
+  };
   terminated?: {
     containerID: string;
     exitCode: number;
     finishedAt: string;
     reason: string;
     startedAt: string;
+    message?: string;
   };
 };
 
@@ -24,6 +31,8 @@ export type PLRTaskRunData = {
     podName: string;
     startTime: string;
     steps?: PLRTaskRunStep[];
+    taskSpec?: TektonTaskSpec;
+    taskResults?: { name: string; value: string }[];
   };
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4277

Based off the foundation started in https://github.com/openshift/console/pull/8692.

**Analysis / Root cause**: 
Support missing items that were missed from #8692.

**Solution Description**: 

Known missing items from #8692:
- [x] Keyboard support to enter auto complete dropdown (currently only mouse or in some cases, tab)
- [x] Better support for inserting $( at the start of existing text
- [x] Potential support for handling $( in the middle of an existing item / error handling for incomplete $( references
- [x] String Array fields are not currently supported
- [x] Removing `$(` after the dropdown has started doesn't close it
- [ ] Tests

**Screen shots / Gifs for design review**: 
![PipelineBuilder-AutoCompleteImproved](https://user-images.githubusercontent.com/8126518/115809426-16ff3280-a3ba-11eb-91b2-ac1d1653102f.gif)

- Supported Keyboard Support: `Tab` key and `Down Arrow` will enter the auto complete dropdown. 
- Type Searches work on a startsWith concept for all the sections (split on `.`) as well as the full value. Potential here for us to do also every section within (see gif, `pipelineRun.name` does not match anything, but `context.pipelineRun.name` does).
- Empty option was not in the designs, WIP wording. cc @bgliwa01 

**Unit test coverage report**: 
Coming soon...

**Test setup:**

Easiest way to test is to create a nodejs app from the From Git add flow and add a Pipeline to it. Editing that created Pipeline gives you plenty of parameters as well as workspaces.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge