### PR TITLE
Add Trigger Param Auto Complete

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/InputField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/InputField.tsx
@@ -3,13 +3,13 @@ import { TextInput, TextInputTypes } from '@patternfly/react-core';
 import { BaseInputFieldProps } from './field-types';
 import BaseInputField from './BaseInputField';
 
-const InputField: React.FC<BaseInputFieldProps> = ({
-  type = TextInputTypes.text,
-  ...baseProps
-}) => (
+const InputField: React.FC<BaseInputFieldProps> = (
+  { type = TextInputTypes.text, ...baseProps },
+  ref,
+) => (
   <BaseInputField type={type} {...baseProps}>
-    {(props) => <TextInput {...props} />}
+    {(props) => <TextInput ref={ref} {...props} />}
   </BaseInputField>
 );
 
-export default InputField;
+export default React.forwardRef(InputField);

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -22,6 +22,7 @@ export interface BaseInputFieldProps extends FieldProps {
   placeholder?: string;
   onChange?: (event) => void;
   onBlur?: (event) => void;
+  autocomplete?: string;
 }
 
 export interface GroupInputProps extends BaseInputFieldProps {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineParameterSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineParameterSection.tsx
@@ -1,17 +1,26 @@
 import * as React from 'react';
-import { FieldArray } from 'formik';
+import { FieldArray, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { TextInputTypes } from '@patternfly/react-core';
 import { InputField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
+import AutoCompletePopover from '../../../shared/common/auto-complete/AutoCompletePopover';
 import { TektonParam } from '../../../../types';
+import { AddTriggerFormValues } from '../triggers/types';
 
 type ParametersSectionProps = {
+  autoCompleteValues?: string[];
   parameters: TektonParam[];
 };
 
-const PipelineParameterSection: React.FC<ParametersSectionProps> = ({ parameters }) => {
+const PipelineParameterSection: React.FC<ParametersSectionProps> = ({
+  autoCompleteValues,
+  parameters,
+}) => {
   const { t } = useTranslation();
+
+  const { setFieldValue } = useFormikContext<AddTriggerFormValues>();
+
   return (
     <FieldArray
       name="parameters"
@@ -19,17 +28,34 @@ const PipelineParameterSection: React.FC<ParametersSectionProps> = ({ parameters
       render={() =>
         parameters.length > 0 && (
           <FormSection title={t('pipelines-plugin~Parameters')} fullWidth>
-            {parameters.map((parameter, index) => (
-              <InputField
-                key={parameter.name}
-                name={`parameters.${index}.default`}
-                type={TextInputTypes.text}
-                label={parameter.name}
-                helpText={parameter.description}
-                placeholder={t('pipelines-plugin~Name')}
-                required
-              />
-            ))}
+            {parameters.map((parameter, index) => {
+              const name = `parameters.${index}.default`;
+
+              const input = (ref?) => (
+                <InputField
+                  ref={ref}
+                  key={parameter.name}
+                  name={name}
+                  type={TextInputTypes.text}
+                  label={parameter.name}
+                  helpText={parameter.description}
+                  placeholder={t('pipelines-plugin~Name')}
+                  required
+                  autocomplete="off"
+                />
+              );
+
+              return autoCompleteValues ? (
+                <AutoCompletePopover
+                  autoCompleteValues={autoCompleteValues}
+                  onAutoComplete={(value: string) => setFieldValue(name, value)}
+                >
+                  {(callbackRef) => input(callbackRef)}
+                </AutoCompletePopover>
+              ) : (
+                input()
+              );
+            })}
           </FormSection>
         )
       }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerForm.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { FormikProps } from 'formik';
+import { useAddTriggerParams } from '../../../shared/common/auto-complete/autoCompleteValueParsers';
 import PipelineResourceSection from '../common/PipelineResourceSection';
 import PipelineParameterSection from '../common/PipelineParameterSection';
 import PipelineWorkspacesSection from '../common/PipelineWorkspacesSection';
@@ -11,10 +12,15 @@ type AddTriggerFormProps = FormikProps<AddTriggerFormValues>;
 const AddTriggerForm: React.FC<AddTriggerFormProps> = (props) => {
   const { values } = props;
 
+  const autoCompleteValues: string[] = useAddTriggerParams();
+
   return (
     <>
       <TriggerBindingSection />
-      <PipelineParameterSection parameters={values.parameters} />
+      <PipelineParameterSection
+        autoCompleteValues={autoCompleteValues}
+        parameters={values.parameters}
+      />
       <PipelineResourceSection />
       <PipelineWorkspacesSection />
     </>

--- a/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/autoCompleteValueParsers.ts
+++ b/frontend/packages/pipelines-plugin/src/components/shared/common/auto-complete/autoCompleteValueParsers.ts
@@ -1,4 +1,5 @@
 import { useFormikContext } from 'formik';
+import { AddTriggerFormValues } from '../../../pipelines/modals/triggers/types';
 import {
   PipelineBuilderFormikValues,
   SelectedBuilderTask,
@@ -37,4 +38,18 @@ export const useBuilderParams = (selectedData: SelectedBuilderTask): string[] =>
   const taskResultACs: string[] = computeAvailableResultACs(tasks, taskResources, taskIndex);
 
   return [...paramACs, ...workspaceACs, ...contextualACs, ...finallyStatusACs, ...taskResultACs];
+};
+
+export const useAddTriggerParams = (): string[] => {
+  const {
+    values: { triggerBinding },
+  } = useFormikContext<AddTriggerFormValues>();
+
+  const bindingParamACs: string[] =
+    triggerBinding?.resource?.spec?.params?.map((param) => `tt.${paramToAutoComplete(param)}`) ||
+    [];
+
+  const staticACs: string[] = ['uid'];
+
+  return [...bindingParamACs, ...staticACs];
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5686

**Analysis / Root cause**: 
With the added support of AutoComplete in the Pipeline Builder it is only fitting the Add Trigger modal gets the same treatment.

**Solution Description**: 
Add support for AutoComplete using the mechanism added in https://github.com/openshift/console/pull/8752.

**Screen shots / Gifs for design review**: 

(taken with https://github.com/openshift/console/pull/8752 implemented for ease of use of the keyboard)
![AddTriggerAutoComplete](https://user-images.githubusercontent.com/8126518/115812686-c4287980-a3bf-11eb-8603-371ba5e62841.gif)

**Unit test coverage report**: 
None

**Test setup:**
Have a Pipeline, use Add Trigger kebab. Once the modal is open, select a trigger to get access to more parameters, otherwise `uid` should be the only one currently.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge