### PR TITLE
Bug 1891696: [LSO] Add capacity UI does not check for node present in selected storageclass

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/mocks/storageclass.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/mocks/storageclass.ts
@@ -14,3 +14,93 @@ export const testEbsSC = {
   parameters: { type: 'io1' },
   reclaimPolicy: 'Retain',
 };
+
+export const testPersistentVolume1 = {
+  kind: 'PersistentVolume',
+  apiVersion: 'v1',
+  metadata: { name: 'test-pv-1' },
+  spec: {
+    capacity: {
+      storage: '10Mi',
+    },
+    local: { path: '/mnt/local-storage/test-1/' },
+    accessModes: ['ReadWriteOnce'],
+    persistentVolumeReclaimPolicy: 'Delete',
+    storageClassName: 'test-no-prov-sc',
+    nodeAffinity: {
+      required: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              {
+                key: 'kubernetes.io/hostname',
+                operator: 'In',
+                values: [],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const testPersistentVolume2 = {
+  kind: 'PersistentVolume',
+  apiVersion: 'v1',
+  metadata: { name: 'test-pv-2' },
+  spec: {
+    capacity: {
+      storage: '10Mi',
+    },
+    local: { path: '/mnt/local-storage/test-2/' },
+    accessModes: ['ReadWriteOnce'],
+    persistentVolumeReclaimPolicy: 'Delete',
+    storageClassName: 'test-no-prov-sc',
+    nodeAffinity: {
+      required: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              {
+                key: 'kubernetes.io/hostname',
+                operator: 'In',
+                values: [],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const testPersistentVolume3 = {
+  kind: 'PersistentVolume',
+  apiVersion: 'v1',
+  metadata: { name: 'test-pv-3' },
+  spec: {
+    capacity: {
+      storage: '10Mi',
+    },
+    local: { path: '/mnt/local-storage/test-3/' },
+    accessModes: ['ReadWriteOnce'],
+    persistentVolumeReclaimPolicy: 'Delete',
+    storageClassName: 'test-no-prov-sc',
+    nodeAffinity: {
+      required: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              {
+                key: 'kubernetes.io/hostname',
+                operator: 'In',
+                values: [],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};

--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -268,6 +268,8 @@
   "Token": "Token",
   "Advanced Settings": "Advanced Settings",
   "No StorageClass selected": "No StorageClass selected",
+  "The Arbiter stretch cluster requires a minimum of 4 nodes (2 different zones, 2 nodes per zone). Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.": "The Arbiter stretch cluster requires a minimum of 4 nodes (2 different zones, 2 nodes per zone). Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.",
+  "The StorageCluster requires a minimum of 3 nodes. Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.": "The StorageCluster requires a minimum of 3 nodes. Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.",
   "Adding capacity for <1>{{name}}</1>, may increase your expenses.": "Adding capacity for <1>{{name}}</1>, may increase your expenses.",
   "Storage Class": "Storage Class",
   "x {{ replica, number }} replicas =": "x {{ replica, number }} replicas =",

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard-steps/storage-and-nodes-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard-steps/storage-and-nodes-step.tsx
@@ -135,7 +135,7 @@ export const StorageAndNodes: React.FC<StorageAndNodesProps> = ({ state, dispatc
   const filterSC = ({ resource }): boolean => {
     const noProvSC = filterSCWithNoProv(resource);
     if (hasStretchClusterChecked && noProvSC && !nodesError && nodesData.length && nodesLoaded) {
-      return isArbiterSC(resource, pvData, nodesData);
+      return isArbiterSC(getName(resource), pvData, nodesData);
     }
     return noProvSC;
   };

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/capacity-and-nodes.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/capacity-and-nodes.tsx
@@ -16,7 +16,7 @@ import {
 import { humanizeBinaryBytes, Dropdown, FieldLevelHelp } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { StorageClassResourceKind, NodeKind, K8sResourceKind } from '@console/internal/module/k8s';
-import { TechPreviewBadge, useDeepCompareMemoize } from '@console/shared';
+import { TechPreviewBadge, useDeepCompareMemoize, getName } from '@console/shared';
 import { State, Action } from '../attached-devices-mode/reducer';
 import { scResource } from '../../../resources';
 import { arbiterText, MODES } from '../../../constants';
@@ -125,7 +125,8 @@ export const StretchClusterFormGroup: React.FC<StretchClusterFormGroupProps> = (
   const nodesDataMemoized: NodeKind[] = useDeepCompareMemoize(nodesData, true);
 
   const isArbiterDisabled = React.useCallback(
-    (): boolean => !storageClassData?.some((sc) => isArbiterSC(sc, pvData, nodesDataMemoized)),
+    (): boolean =>
+      !storageClassData?.some((sc) => isArbiterSC(getName(sc), pvData, nodesDataMemoized)),
     [nodesDataMemoized, pvData, storageClassData],
   );
 

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -5,6 +5,8 @@ export const ZONE_LABELS = [
   'failure-domain.beta.kubernetes.io/zone', // deprecated
 ];
 
+export const RACK_LABEL = 'topology.rook.io/rack';
+
 export enum MODES {
   INTERNAL = 'Internal',
   ATTACHED_DEVICES = 'Internal - Attached Devices',

--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -18,7 +18,7 @@ import {
 } from '@console/local-storage-operator-plugin/src/constants';
 import { getNodeCPUCapacity, getNodeAllocatableMemory, getName } from '@console/shared';
 import { NodeModel } from '@console/internal/models';
-import { ocsTaint, NO_PROVISIONER, MINIMUM_NODES, ZONE_LABELS } from '../constants';
+import { ocsTaint, NO_PROVISIONER, MINIMUM_NODES, ZONE_LABELS, RACK_LABEL } from '../constants';
 import { getSCAvailablePVs } from '../selectors';
 
 export const hasNoTaints = (node: NodeKind) => {
@@ -58,6 +58,8 @@ export const filterSCWithoutNoProv = (sc: StorageClassResourceKind) =>
 export const getZone = (node: NodeKind) =>
   node.metadata.labels?.[ZONE_LABELS[0]] || node.metadata.labels?.[ZONE_LABELS[1]];
 
+export const getRack = (node: NodeKind) => node.metadata.labels?.[RACK_LABEL];
+
 export const getAssociatedNodes = (pvs: K8sResourceKind[]): string[] => {
   const nodes = pvs.reduce((res, pv) => {
     const matchExpressions: MatchExpression[] =
@@ -73,6 +75,21 @@ export const getAssociatedNodes = (pvs: K8sResourceKind[]): string[] => {
   return Array.from(nodes);
 };
 
+export const getTopologyInfo = (nodes: NodeKind[]) =>
+  nodes.reduce(
+    (data, node) => {
+      const zone = getZone(node);
+      const rack = getRack(node);
+      if (zone && (hasOCSTaint(node) || hasNoTaints(node))) data.zones.add(zone);
+      if (rack && (hasOCSTaint(node) || hasNoTaints(node))) data.racks.add(rack);
+      return data;
+    },
+    {
+      zones: new Set<string>(),
+      racks: new Set<string>(),
+    },
+  );
+
 export const getNodeInfo = (nodes: NodeKind[]) =>
   nodes.reduce(
     (data, node) => {
@@ -82,13 +99,13 @@ export const getNodeInfo = (nodes: NodeKind[]) =>
       const zone = getZone(node);
       data.cpu += cpus;
       data.memory += memory;
-      if (zone && hasNoTaints(node)) data.zones.add(zone);
+      if (zone && (hasOCSTaint(node) || hasNoTaints(node))) data.zones.add(zone);
       return data;
     },
     {
       cpu: 0,
       memory: 0,
-      zones: new Set(),
+      zones: new Set<string>(),
     },
   );
 
@@ -113,22 +130,45 @@ export const countNodesPerZone = (nodes: NodeKind[]) =>
 export const nodesWithoutTaints = (nodes: NodeKind[]) =>
   nodes.filter((node: NodeKind) => hasOCSTaint(node) || hasNoTaints(node));
 
-export const isArbiterSC = (
-  sc: StorageClassResourceKind,
+const getSelectedNodes = (
+  scName: string,
   pvData: K8sResourceKind[],
   nodesData: NodeKind[],
-): boolean => {
-  const pvs: K8sResourceKind[] = getSCAvailablePVs(pvData, getName(sc));
+): NodeKind[] => {
+  const pvs: K8sResourceKind[] = getSCAvailablePVs(pvData, scName);
   const scNodeNames = getAssociatedNodes(pvs);
   const tableData: NodeKind[] = nodesData.filter(
     (node: NodeKind) =>
       scNodeNames.includes(getName(node)) ||
       scNodeNames.includes(node.metadata.labels?.['kubernetes.io/hostname']),
   );
+  return tableData;
+};
+
+export const isValidTopology = (
+  scName: string,
+  pvData: K8sResourceKind[],
+  nodesData: NodeKind[],
+): boolean => {
+  const tableData: NodeKind[] = getSelectedNodes(scName, pvData, nodesData);
+
+  /** For AWS scenario, checking if PVs are in 3 different zones or not
+   *  For Baremetal/Vsphere scenario, checking if PVs are in 3 different racks or not
+   */
+  const { zones, racks } = getTopologyInfo(tableData);
+  return zones.size >= MINIMUM_NODES || racks.size >= MINIMUM_NODES;
+};
+
+export const isArbiterSC = (
+  scName: string,
+  pvData: K8sResourceKind[],
+  nodesData: NodeKind[],
+): boolean => {
+  const tableData: NodeKind[] = getSelectedNodes(scName, pvData, nodesData);
   const uniqZones: Set<string> = new Set(nodesData.map(getZone));
-  const uniqSelectedNodesZones: Set<string> = new Set(tableData.map(getZone));
+  const uniqSelectedNodesZones: Set<string> = getNodeInfo(tableData).zones;
   if (_.compact([...uniqZones]).length < 3) return false;
-  if (_.compact([...uniqSelectedNodesZones]).length !== 2) return false;
+  if (uniqSelectedNodesZones.size !== 2) return false;
   const zonePerNode = countNodesPerZone(tableData);
   return Object.keys(zonePerNode).every((zone) => zonePerNode[zone] >= 2);
 };


### PR DESCRIPTION
Added UI validations for add-capacity modal (for arbiter and normal deployment modes).

![Screenshot from 2021-04-23 10-07-09](https://user-images.githubusercontent.com/39404641/115821314-2fa23380-a420-11eb-9779-ec5ee552f0b0.png)

![Screenshot from 2021-04-23 10-09-54](https://user-images.githubusercontent.com/39404641/115821324-34ff7e00-a420-11eb-8c9e-f639e77ee6b9.png)

![Screenshot from 2021-04-23 10-29-40](https://user-images.githubusercontent.com/39404641/115821336-3a5cc880-a420-11eb-9014-0eac2e314aa1.png)
