### PR TITLE
show all visited tasks of quickstart, change icon of failed tasks

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTaskHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Title, WizardNavItem } from '@patternfly/react-core';
-import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { QuickStartTaskStatus } from '../utils/quick-start-types';
 
 import './QuickStartTaskHeader.scss';
@@ -17,19 +17,11 @@ type QuickStartTaskHeaderProps = {
   onTaskSelect: (index: number) => void;
 };
 
-const TaskIcon: React.FC<{ taskIndex; taskStatus; isActiveTask }> = ({
+const TaskIcon: React.FC<{ taskIndex: number; taskStatus: QuickStartTaskStatus }> = ({
   taskIndex,
   taskStatus,
-  isActiveTask,
 }) => {
   const { t } = useTranslation();
-  if (isActiveTask) {
-    return (
-      <span className="co-icon-and-text__icon co-quick-start-task-header__task-icon-init">
-        {t('quickstart~{{taskIndex, number}}', { taskIndex })}
-      </span>
-    );
-  }
   switch (taskStatus) {
     case QuickStartTaskStatus.SUCCESS:
       return (
@@ -40,7 +32,10 @@ const TaskIcon: React.FC<{ taskIndex; taskStatus; isActiveTask }> = ({
     case QuickStartTaskStatus.FAILED:
       return (
         <span className="co-icon-and-text__icon">
-          <TimesCircleIcon size="md" className="co-quick-start-task-header__task-icon-failed" />
+          <ExclamationCircleIcon
+            size="md"
+            className="co-quick-start-task-header__task-icon-failed"
+          />
         </span>
       );
     default:
@@ -62,16 +57,14 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
   onTaskSelect,
 }) => {
   const classNames = cx('co-quick-start-task-header__title', {
-    'co-quick-start-task-header__title-success':
-      taskStatus === QuickStartTaskStatus.SUCCESS && !isActiveTask,
-    'co-quick-start-task-header__title-failed':
-      taskStatus === QuickStartTaskStatus.FAILED && !isActiveTask,
+    'co-quick-start-task-header__title-success': taskStatus === QuickStartTaskStatus.SUCCESS,
+    'co-quick-start-task-header__title-failed': taskStatus === QuickStartTaskStatus.FAILED,
   });
 
   const content = (
     <span className="co-quick-start-task-header">
       <Title headingLevel="h3" size={size} className={classNames}>
-        <TaskIcon taskIndex={taskIndex} taskStatus={taskStatus} isActiveTask={isActiveTask} />
+        <TaskIcon taskIndex={taskIndex} taskStatus={taskStatus} />
         {title}
         {isActiveTask && subtitle && (
           <>

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTasks.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartTasks.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import QuickStartMarkdownView from '../QuickStartMarkdownView';
+import { QUICKSTART_TASKS_INITIAL_STATES } from '../utils/const';
 import { QuickStartTask, QuickStartTaskStatus } from '../utils/quick-start-types';
 import TaskHeader from './QuickStartTaskHeader';
 import QuickStartTaskReview from './QuickStartTaskReview';
@@ -24,14 +25,11 @@ const QuickStartTasks: React.FC<QuickStartTaskProps> = ({
   return (
     <>
       {tasks
-        .filter((_, index) => index <= taskNumber)
+        .filter((_, index) => allTaskStatuses[index] !== QuickStartTaskStatus.INIT)
         .map((task, index) => {
-          const { title, description, review, summary } = task;
+          const { title, description, review } = task;
           const isActiveTask = index === taskNumber;
           const taskStatus = allTaskStatuses[index];
-          const summaryInstructions =
-            taskStatus === QuickStartTaskStatus.SUCCESS ? summary?.success : summary?.failed;
-          const taskInstructions = isActiveTask ? description : summaryInstructions;
 
           return (
             <React.Fragment key={title}>
@@ -47,13 +45,17 @@ const QuickStartTasks: React.FC<QuickStartTaskProps> = ({
                 isActiveTask={isActiveTask}
                 onTaskSelect={onTaskSelect}
               />
-              <QuickStartMarkdownView content={taskInstructions} />
-              {isActiveTask && taskStatus !== QuickStartTaskStatus.INIT && review && (
-                <QuickStartTaskReview
-                  review={review}
-                  taskStatus={taskStatus}
-                  onTaskReview={onTaskReview}
-                />
+              {isActiveTask && (
+                <div style={{ marginBottom: 'var(--pf-global--spacer--md)' }}>
+                  <QuickStartMarkdownView content={description} />
+                  {!QUICKSTART_TASKS_INITIAL_STATES.includes(taskStatus) && review && (
+                    <QuickStartTaskReview
+                      review={review}
+                      taskStatus={taskStatus}
+                      onTaskReview={onTaskReview}
+                    />
+                  )}
+                </div>
               )}
             </React.Fragment>
           );

--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTasks.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTasks.spec.tsx
@@ -35,40 +35,25 @@ describe('QuickStartTasks', () => {
   });
 
   it('should render correct number of tasks based on currentTaskIndex', () => {
-    expect(wrapper.find(TaskHeader).length).toBe(2);
+    expect(wrapper.find(TaskHeader).length).toBe(1);
   });
 
-  it('should render SyncMarkdownView with description or summary according to task status', () => {
+  it('should render SyncMarkdownView with description if a task is active', () => {
     wrapper = shallow(
       <QuickStartTask
         {...props}
         allTaskStatuses={[
           QuickStartTaskStatus.SUCCESS,
           QuickStartTaskStatus.FAILED,
-          QuickStartTaskStatus.INIT,
+          QuickStartTaskStatus.VISITED,
         ]}
         taskNumber={2}
       />,
     );
-
     expect(
       wrapper
         .find(QuickStartMarkdownView)
         .at(0)
-        .props().content,
-    ).toEqual(props.tasks[0].summary.success);
-
-    expect(
-      wrapper
-        .find(QuickStartMarkdownView)
-        .at(1)
-        .props().content,
-    ).toEqual(props.tasks[1].summary.failed);
-
-    expect(
-      wrapper
-        .find(QuickStartMarkdownView)
-        .at(2)
         .props().content,
     ).toEqual(props.tasks[2].description);
   });

--- a/frontend/packages/console-app/src/components/quick-starts/utils/const.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/const.ts
@@ -1,3 +1,9 @@
+import { QuickStartTaskStatus } from './quick-start-types';
+
 export const QUICKSTART_SEARCH_FILTER_KEY = 'keyword';
 export const QUICKSTART_STATUS_FILTER_KEY = 'status';
 export const QUICKSTART_REDUX_STATE_LOCAL_STORAGE_KEY = 'bridge/quick-start-redux-state';
+export const QUICKSTART_TASKS_INITIAL_STATES = [
+  QuickStartTaskStatus.INIT,
+  QuickStartTaskStatus.VISITED,
+];

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-types.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-types.ts
@@ -53,6 +53,7 @@ export enum QuickStartStatus {
 
 export enum QuickStartTaskStatus {
   INIT = 'Initial',
+  VISITED = 'Visited',
   REVIEW = 'Review',
   SUCCESS = 'Success',
   FAILED = 'Failed',

--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-utils.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-utils.ts
@@ -12,6 +12,8 @@ export const getQuickStartStatus = (
 ): QuickStartStatus =>
   (allQuickStartStates?.[quickStartID]?.status as QuickStartStatus) ?? QuickStartStatus.NOT_STARTED;
 
+export const getTaskStatusKey = (taskNumber: number): string => `taskStatus${taskNumber}`;
+
 export const getQuickStartStatusCount = (
   allQuickStartStates: AllQuickStartStates,
   quickStarts: QuickStart[],


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-4787

While testing consider these points:

- error icon is changed from the Times Circle to Exclamation circle
- task header status should should be changed as soon as the success or fail is selected from review
- once a user visits a step and decider to go back , step header should be shown for that step
- remove the summary of each step

![quick-starts-new-icon](https://user-images.githubusercontent.com/9278015/115865213-a73e8580-a455-11eb-8458-46e6921d8ac2.gif)
