### PR TITLE
Avoid setting JAVA_ARGS if cmd args are not provided

### DIFF
--- a/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
@@ -71,11 +71,13 @@ export const createOrUpdateDeployment = (
   const templateLabels = getTemplateLabels(originalDeployment);
 
   const jArgsIndex = env?.findIndex((e) => e.name === 'JAVA_ARGS');
-  if (jArgsIndex !== -1 && javaArgs !== '') {
-    (env[jArgsIndex] as NameValuePair).value = javaArgs;
-  } else if (jArgsIndex !== -1 && javaArgs === '') {
-    env.splice(jArgsIndex, 1);
-  } else {
+  if (jArgsIndex !== -1) {
+    if (javaArgs !== '') {
+      (env[jArgsIndex] as NameValuePair).value = javaArgs;
+    } else {
+      env.splice(jArgsIndex, 1);
+    }
+  } else if (javaArgs !== '') {
     env.push({ name: 'JAVA_ARGS', value: javaArgs });
   }
 
@@ -146,11 +148,13 @@ const createOrUpdateDeploymentConfig = (
   const templateLabels = getTemplateLabels(originalDeploymentConfig);
 
   const jArgsIndex = env?.findIndex((e) => e.name === 'JAVA_ARGS');
-  if (jArgsIndex !== -1 && javaArgs !== '') {
-    (env[jArgsIndex] as NameValuePair).value = javaArgs;
-  } else if (jArgsIndex !== -1 && javaArgs === '') {
-    env.splice(jArgsIndex, 1);
-  } else {
+  if (jArgsIndex !== -1) {
+    if (javaArgs !== '') {
+      (env[jArgsIndex] as NameValuePair).value = javaArgs;
+    } else {
+      env.splice(jArgsIndex, 1);
+    }
+  } else if (javaArgs !== '') {
     env.push({ name: 'JAVA_ARGS', value: javaArgs });
   }
 

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -72,11 +72,13 @@ export const getKnativeServiceDepResource = (
   delete defaultLabel.app;
   if (fileUpload) {
     const jArgsIndex = env?.findIndex((e) => e.name === 'JAVA_ARGS');
-    if (jArgsIndex !== -1 && fileUpload.javaArgs !== '') {
-      (env[jArgsIndex] as NameValuePair).value = fileUpload.javaArgs;
-    } else if (jArgsIndex !== -1 && fileUpload.javaArgs === '') {
-      env.splice(jArgsIndex, 1);
-    } else {
+    if (jArgsIndex !== -1) {
+      if (fileUpload.javaArgs !== '') {
+        (env[jArgsIndex] as NameValuePair).value = fileUpload.javaArgs;
+      } else {
+        env.splice(jArgsIndex, 1);
+      }
+    } else if (fileUpload.javaArgs !== '') {
       env.push({ name: 'JAVA_ARGS', value: fileUpload.javaArgs });
     }
   }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5781
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The `JAVA_ARGS` env var was being set even when cmd args were not provided.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Only set `JAVA_ARGS` if cmd args are given.
<!-- Describe your code changes in detail and explain the solution -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug