### PR TITLE
fixes issue with ksvc edit for upload jar flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/upload-jar-submit-utils.ts
@@ -356,7 +356,8 @@ export const createOrUpdateJarFile = async (
     resources === Resources.KnativeService &&
     imageStreamList &&
     imageStreamList.length &&
-    verb === 'update'
+    verb === 'update' &&
+    fileValue !== ''
   ) {
     generatedImageStreamName = `${name}-${getRandomChars()}`;
   }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5782

**Analysis / Root cause**: 
Edit flow on upload jar flow for KSVC doesn't create active revision if jar is not modified as new ImageStream is created on all edit, should happen only if jar gets updated.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
