### PR TITLE
Bug 1952367: No VM status on overview page when VM is pending

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/status/VMStatusHealth.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/status/VMStatusHealth.tsx
@@ -22,7 +22,7 @@ const VMStatusHealth: React.FC<VMStatusHealthProps> = ({ vmStatusBundle }) => {
       Error: HealthState.ERROR,
       Running: HealthState.OK,
       Completed: HealthState.OK,
-      Pending: HealthState.LOADING,
+      Pending: HealthState.PROGRESS,
       Importing: HealthState.PROGRESS,
       InProgress: HealthState.PROGRESS,
       Starting: HealthState.PROGRESS,


### PR DESCRIPTION
`HealthState.LOADING` seems to be bugged, replaced `Pending` to be `HealthState.Loading`

<img width="415" alt="Screen Shot 2021-04-25 at 16 53 14" src="https://user-images.githubusercontent.com/24938324/115996230-19929f80-a5e7-11eb-9c37-f323e19bdb52.png">
