### PR TITLE
fixes issue with kamelets not shown on catalog for sources

### DIFF
--- a/frontend/packages/knative-plugin/src/catalog/index.ts
+++ b/frontend/packages/knative-plugin/src/catalog/index.ts
@@ -1,2 +1,2 @@
 export { default as eventSourceProvider } from './useEventSourceProvider';
-export { default as kameletsProvider } from './useEventSourceProvider';
+export { default as kameletsProvider } from './useKameletsProvider';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5783

**Analysis / Root cause**: 
Kamelets are not shown under event sources in the catalog view


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/5129024/116071636-bf0f4700-a6ab-11eb-967f-cf300cc3457e.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
 - install serverless operator/create KS and KE CRs
 - install camel K integration operator
 - create IP CR in a specific namespace

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
