### PR TITLE
Bug 1952730: “Customize virtual machine” and the “Advanced” feature are confusing in wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -320,6 +320,7 @@
   "Ensure your PVC size covers the requirements of the uncompressed image and any other space requirements. More storage can be added later.": "Ensure your PVC size covers the requirements of the uncompressed image and any other space requirements. More storage can be added later.",
   "Source provider": "Source provider",
   "Example: your company name": "Example: your company name",
+  "Advanced Storage settings": "Advanced Storage settings",
   "Permissions required": "Permissions required",
   "You do not have permissions to clone base image into this namespace.": "You do not have permissions to clone base image into this namespace.",
   "You are creating a virtual machine from the <1>{getTemplateName(template)}</1> template.": "You are creating a virtual machine from the <1>{getTemplateName(template)}</1> template.",

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
@@ -470,7 +470,10 @@ export const BootSourceForm: React.FC<BootSourceFormProps> = ({
           </div>
         </FormRow>
       )}
-      <ExpandableSection toggleText={t('kubevirt-plugin~Advanced')} data-test="advanced-section">
+      <ExpandableSection
+        toggleText={t('kubevirt-plugin~Advanced Storage settings')}
+        data-test="advanced-section"
+      >
         <AdvancedSection
           state={state}
           dispatch={dispatch}


### PR DESCRIPTION
in this example, changing expandable component text from 'Advanced' to 'Advanced Storage settings'

before:
![bz_1952730_before](https://user-images.githubusercontent.com/67270715/116092146-3b0a8e80-a6ae-11eb-8f50-82d96a52772a.png)

after:
![bz_1952730_after](https://user-images.githubusercontent.com/67270715/116092172-3f36ac00-a6ae-11eb-8e16-c9724262a115.png)

 

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1952730
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>