### PR TITLE
Bug 1952728: VM will be turned off when creating snapshots and a warning will be presented

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -556,6 +556,7 @@
   "Edit the disk or contact your cluster admin for further details.": "Edit the disk or contact your cluster admin for further details.",
   "Edit the disk or contact your cluster admin for further details._plural": "Edit the disks or contact your cluster admin for further details.",
   "Learn more about snapshots": "Learn more about snapshots",
+  "The VM {{vmName}} is still running. It will be powered off.": "The VM {{vmName}} is still running. It will be powered off.",
   "unsupported approve checkbox": "unsupported approve checkbox",
   "I am aware of this warning and wish to proceed": "I am aware of this warning and wish to proceed",
   "Restore Snapshot": "Restore Snapshot",

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
@@ -18,10 +18,10 @@ import { asVM, isVMRunningOrExpectedRunning } from '../../selectors/vm';
 import { VMSnapshot } from '../../types';
 import { wrapWithProgress } from '../../utils/utils';
 import SnapshotModal from '../modals/snapshot-modal/snapshot-modal';
+import { VMTabProps } from '../vms/types';
 import { useMappedVMRestores } from './use-mapped-vm-restores';
 import { snapshotsTableColumnClasses } from './utils';
 import { VMSnapshotRow } from './vm-snapshot-row';
-import { VMTabProps } from '../vms/types';
 
 export type VMSnapshotsTableProps = {
   data?: any[];
@@ -124,10 +124,14 @@ export const VMSnapshotsPage: React.FC<VMTabProps> = ({ obj: vmLikeEntity, vmis:
                   SnapshotModal({
                     blocking: true,
                     vmLikeEntity,
+                    isVMRunningOrExpectedRunning: isVMRunningOrExpectedRunning(
+                      asVM(vmLikeEntity),
+                      vmi,
+                    ),
+                    snapshots,
                   }).result,
                 )
               }
-              isDisabled={isDisabled}
             >
               {t('kubevirt-plugin~Take Snapshot')}
             </Button>


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1952728

**Analysis / Root cause**: 
The ability to stop the machine wasn't connected.

**Solution Description**: 
Added support for stopping the machine and show a warning about it.

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/116092066-28905500-a6ae-11eb-8e6b-ba98c1198cee.png)
Before:
![image](https://user-images.githubusercontent.com/14824964/116092242-4f4e8b80-a6ae-11eb-8dee-134275746af3.png)
