### PR TITLE
Bug 1952111: Optimized imports from @patternfly/react-tokens

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/DashboardGrid.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/DashboardGrid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
-import { global_breakpoint_lg as breakpointLG } from '@patternfly/react-tokens';
+import { global_breakpoint_lg as breakpointLG } from '@patternfly/react-tokens/dist/js/global_breakpoint_lg';
 import { DashboardCardSpan } from '@console/plugin-sdk';
 import { useRefWidth } from '@console/internal/components/utils/ref-width-hook';
 

--- a/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
+++ b/frontend/packages/console-shared/src/components/editor/yaml-editor-utils.ts
@@ -8,7 +8,7 @@ import {
 import { getLanguageService, TextDocument } from 'yaml-language-server';
 import { openAPItoJSONSchema } from '@console/internal/module/k8s/openapi-to-json-schema';
 import { getSwaggerDefinitions } from '@console/internal/module/k8s/swagger';
-import { global_BackgroundColor_dark_100 as editorBackground } from '@patternfly/react-tokens';
+import { global_BackgroundColor_dark_100 as editorBackground } from '@patternfly/react-tokens/dist/js/global_BackgroundColor_dark_100';
 import * as yaml from 'yaml-ast-parser';
 
 window.monaco.editor.defineTheme('console', {

--- a/frontend/packages/console-shared/src/components/hpa/DeleteHPAModal.tsx
+++ b/frontend/packages/console-shared/src/components/hpa/DeleteHPAModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 import {
   createModalLauncher,
   ModalBody,

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-popover.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-popover.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ProgressStatus } from '@console/shared';
 import { InProgressIcon, ErrorCircleOIcon, BanIcon } from '@patternfly/react-icons';
-import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens';
+import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import {
   Button,
   Popover,

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -5,10 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Tooltip } from '@patternfly/react-core';
 import { createSvgIdUrl, useHover } from '@patternfly/react-topology';
-import {
-  global_BackgroundColor_light_100 as lightBackgroundColor,
-  global_BackgroundColor_200 as greyBackgroundColor,
-} from '@patternfly/react-tokens';
+import { global_BackgroundColor_light_100 as lightBackgroundColor } from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import { global_BackgroundColor_200 as greyBackgroundColor } from '@patternfly/react-tokens/dist/js/global_BackgroundColor_200';
 import { referenceForModel } from '@console/internal/module/k8s';
 import {
   Firehose,

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/RemoveTriggerForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/RemoveTriggerForm.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Split, SplitItem } from '@patternfly/react-core';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { PipelineKind } from '../../../../types';
 import TriggerTemplateSelector from './TriggerTemplateSelector';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/modals/index.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/modals/index.tsx
@@ -3,7 +3,7 @@ import { TFunction } from 'i18next';
 import { confirmModal } from '@console/internal/components/modals/confirm-modal';
 import ModalContent from './ModalContent';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 
 type ModalCallback = () => void;
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/BuilderFinallyNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/BuilderFinallyNode.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { chart_color_blue_300 as blueColor } from '@patternfly/react-tokens';
+import { chart_color_blue_300 as blueColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
 import { observer, Node, NodeModel } from '@patternfly/react-topology';
 import { PipelineVisualizationTask } from '../detail-page-tabs/pipeline-details/PipelineVisualizationTask';
 import {
@@ -68,7 +68,7 @@ const BuilderFinallyNode: React.FC<BuilderFinallyNodeProps> = ({ element }) => {
       {finallyListTasks.map((flt, i) => (
         <g
           key={flt.name}
-          transform={`translate(${FINALLY_NODE_PADDING}, 
+          transform={`translate(${FINALLY_NODE_PADDING},
               ${NODE_HEIGHT * (i + finallyTasks.length) +
                 FINALLY_NODE_VERTICAL_SPACING * (i + finallyTasks.length) +
                 FINALLY_NODE_PADDING})`}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/ErrorNodeDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/ErrorNodeDecorator.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { ExclamationIcon } from '@patternfly/react-icons';
-import { global_danger_color_100 as redColor } from '@patternfly/react-tokens';
+import { global_danger_color_100 as redColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import { BUILDER_NODE_ERROR_RADIUS } from './const';
 
 import './ErrorNodeDecorator.scss';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PlusNodeDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/PlusNodeDecorator.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PlusIcon } from '@patternfly/react-icons';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { chart_color_blue_300 as blueColor } from '@patternfly/react-tokens';
+import { chart_color_blue_300 as blueColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
 import { BUILDER_NODE_ADD_RADIUS } from './const';
 
 import './PlusNodeDecorator.scss';

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/WhenExpressionDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/WhenExpressionDecorator.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@patternfly/react-core';
-import { global_BorderColor_100 as lightBorderColor } from '@patternfly/react-tokens';
+import { global_BorderColor_100 as lightBorderColor } from '@patternfly/react-tokens/dist/js/global_BorderColor_100';
 import { runStatus } from '../../../utils/pipeline-augment';
 import { NODE_HEIGHT } from './const';
 

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -1,12 +1,12 @@
 import { TFunction } from 'i18next';
-import {
-  chart_color_green_400 as successColor,
-  chart_color_blue_300 as runningColor,
-  global_danger_color_100 as failureColor,
-  chart_color_blue_100 as pendingColor,
-  chart_color_black_400 as skippedColor,
-  chart_color_black_500 as cancelledColor,
-} from '@patternfly/react-tokens';
+
+import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import { chart_color_blue_300 as runningColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import { global_danger_color_100 as failureColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
+import { chart_color_blue_100 as pendingColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import { chart_color_black_400 as skippedColor } from '@patternfly/react-tokens/dist/js/chart_color_black_400';
+import { chart_color_black_500 as cancelledColor } from '@patternfly/react-tokens/dist/js/chart_color_black_500';
+
 import {
   K8sKind,
   referenceForModel,

--- a/frontend/public/components/graphs/utils.ts
+++ b/frontend/public/components/graphs/utils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { chart_color_orange_300 as requestedColor } from '@patternfly/react-tokens';
+import { chart_color_orange_300 as requestedColor } from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
 
 import { PrometheusResponse, DataPoint, PrometheusResult } from '.';
 import { Humanize } from '../utils';


### PR DESCRIPTION
In many files we are importing from @patternfly/react-tokens using a format like:

  `import { something } from '@patternfly/react-tokens' ` 

Whenever we do that, webpack has to parse 12k different token files. This caused a build failure in recent PF latest smoketesting.  It also increases build time.  

It's much better to import a specific file, like: 

  `import something from '@patternfly/react-tokens/dist/esm/something'`

Ex. 

Replace:

  `import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';`

With

  `import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/esm/global_warning_color_100'`