### PR TITLE
Bug 1941801: Role bind toolbar dropdowns haven't been internationalized

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -292,7 +292,7 @@ export const RoleBindingsPage = ({
   const { t } = useTranslation();
   const rowFilters = [
     {
-      filterGroupName: 'Kind',
+      filterGroupName: t('bindings~Kind'),
       type: 'role-binding-kind',
       reducer: bindingType,
       itemsGenerator: ({ ClusterRoleBinding: data }) => {

--- a/frontend/public/locales/en/bindings.json
+++ b/frontend/public/locales/en/bindings.json
@@ -14,6 +14,7 @@
   "No RoleBindings found": "No RoleBindings found",
   "Roles grant access to types of objects in the cluster. Roles are applied to a group or user via a RoleBinding.": "Roles grant access to types of objects in the cluster. Roles are applied to a group or user via a RoleBinding.",
   "RoleBindings": "RoleBindings",
+  "Kind": "Kind",
   "Namespace RoleBindings": "Namespace RoleBindings",
   "System RoleBindings": "System RoleBindings",
   "Cluster-wide RoleBindings": "Cluster-wide RoleBindings",


### PR DESCRIPTION
Fixes issue where role bindings filter dropdown group was not
translated. Specifically "Kind" in the first filter dropdown. Other
filter dropdowns seem fine.

<img width="1185" alt="Screen Shot 2021-04-26 at 1 43 37 PM" src="https://user-images.githubusercontent.com/21317056/116129902-9fbaee80-a698-11eb-8aed-e0d68cce3135.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1941801