### PR TITLE
ODC-5786: suppress focus outline on topology group elements

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/Topology.scss
+++ b/frontend/packages/topology/src/components/graph-view/Topology.scss
@@ -18,4 +18,11 @@
     width: 100%;
     height: 100%;
   }
+
+  // Some `g` elements such as layers are accepting focus.
+  // Suppress the outline style on these elements until we can determine
+  // what causes them to accept focus.
+  g:focus {
+    outline: none;
+  }
 }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5786

**Analysis / Root cause**: 
There are some `g` elements in the topology which are accepting focus. The reason for this is still TBD. Elements with focus get the browser default outline which is a blue box in chrome.

**Solution Description**: 
Hide outline focus style on topology `g` elements.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![topology-focus](https://user-images.githubusercontent.com/14068621/116143167-cb45d500-a6a8-11eb-9477-8b2b076d2648.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge