### PR TITLE
Allow focus on all alerts in modals

### DIFF
--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -25,16 +25,17 @@ const ErrorMessage = ({ message }) => {
       className="co-alert co-alert--scrollable"
       variant="danger"
       title={t('public~An error occurred')}
+      tabIndex={0}
     >
       <div className="co-pre-line">{message}</div>
     </Alert>
   );
 };
 const InfoMessage = ({ message }) => (
-  <Alert isInline className="co-alert" variant="info" title={message} />
+  <Alert isInline className="co-alert" variant="info" title={message} tabIndex={0} />
 );
 const SuccessMessage = ({ message }) => (
-  <Alert isInline className="co-alert" variant="success" title={message} />
+  <Alert isInline className="co-alert" variant="success" title={message} tabIndex={0} />
 );
 
 // NOTE: DO NOT use <a> elements within a ButtonBar.


### PR DESCRIPTION
This came up as a screen reader user typed in an upper case char during project creation displaying an error alert in the create project modal. 
The alert does not allow focus, so that was added by this pr as well as info and success alerts.

This needs more discussion with @jessiehuff before merging.

Before:
![no-focus](https://user-images.githubusercontent.com/35978579/116153826-ee2ab600-a6b5-11eb-9a4a-49fbc6c0b760.gif)

After:
![focus](https://user-images.githubusercontent.com/35978579/116153827-ee2ab600-a6b5-11eb-9b6c-65d9c5eb786f.gif)
