### PR TITLE
Use latest WebTerminal plugin instead of 4.5.0

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -57,7 +57,7 @@ export const newCloudShellWorkSpace = (name: string, namespace: string): CloudSh
         {
           plugin: {
             name: 'web-terminal',
-            id: 'redhat-developer/web-terminal/4.5.0',
+            id: 'redhat-developer/web-terminal/latest',
           },
         },
       ],


### PR DESCRIPTION
Initially, it was thought openshift console will use a different terminal plugin version to let the operator know which tooling is needed. But then the stuff changed and we just have 4.5.0 web terminal plugin which is used for every OpenShift plugin, which is a bit confusing.
So, WTO 1.3(Unreleased for OpenShift 4.8), 1.2.1(OpenShift 4.7) and 1.1.1(OpenShift 4.6) embed `latest` terminal plugin version, and OpenShift console should use it instead.

`4.5.0` is not removed as well just for backward compatibility, so, all previously created CRs should work as well.