### PR TITLE
Bug 1930007: Filter dropdown doesn’t support multi selection

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -129,7 +129,7 @@ export const deleteRow = (kind: string) => (name: string) => {
   });
 };
 
-export const rowFiltersButton = $('[data-test-id="filter-dropdown-toggle"]');
+export const rowFiltersButton = $('[data-test-id="filter-dropdown-toggle"] button');
 export const rowFiltersPresent = () => browser.wait(until.presenceOf(rowFiltersButton));
 export const rowFilterFor = (name: string) => $(`[data-test-row-filter="${name}"]`);
 

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -7,7 +7,7 @@ export const helmPO = {
   resourcesTab: '[data-test-id="horizontal-link-Resources"]',
   revisionHistoryTab: '[data-test-id="horizontal-link-Revision History"]',
   releaseNotesTab: '[data-test-id="horizontal-link-Release Notes"]',
-  filterDropdown: 'button[data-test-id="filter-dropdown-toggle"]',
+  filterDropdown: '[data-test-id="filter-dropdown-toggle"] button',
   filterDropdownDialog: '.pf-c-dropdown__group.co-filter-dropdown-group',
   filterToolBar: '#filter-toolbar',
   clearAllFilter: '.pf-c-button.pf-m-link.pf-m-inline',

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/monitoring-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/monitoring-po.ts
@@ -37,7 +37,7 @@ export const monitoringPO = {
     types: '[data-test-id="dropdown-button"]',
   },
   alertsTab: {
-    filter: 'button[data-test-id="filter-dropdown-toggle"]',
+    filter: '[data-test-id="filter-dropdown-toggle"] button',
     search: 'input[data-test-id="item-filter"]',
     table: '[role="grid"]',
     alertsTable: {

--- a/frontend/packages/dev-console/integration-tests/support/pages/monitoring/monitoring-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/monitoring/monitoring-page.ts
@@ -48,12 +48,18 @@ export const monitoringPage = {
       alertState: string[] = new Array('firing'),
       severity: string[] = new Array('Critical'),
     ) => {
-      cy.byLegacyTestID('filter-dropdown-toggle').click();
+      cy.byLegacyTestID('filter-dropdown-toggle')
+        .find('button')
+        .click();
       cy.get(`[data-test-row-filter="${alertState}"]`).click();
       //  To Do
       cy.byLegacyTestID(`[data-test-row-filter="${severity}"]`).click();
     },
-    clickFilter: () => cy.byLegacyTestID('filter-dropdown-toggle').click(),
+    clickFilter: () =>
+      cy
+        .byLegacyTestID('filter-dropdown-toggle')
+        .find('button')
+        .click(),
   },
   events: {
     selectResources: (resourceName: string) => {

--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -28,7 +28,9 @@ export const listPage = {
     },
     by: (rowFilter: string) => {
       cy.get('.pf-c-toolbar__content-section').within(() => {
-        cy.byLegacyTestID('filter-dropdown-toggle').click();
+        cy.byLegacyTestID('filter-dropdown-toggle')
+          .find('button')
+          .click();
         /* PF Filter dropdown menu items are:
            <li id="cluster">
              <a data-test-row-filter="cluster">

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/vms.list.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/vms.list.view.ts
@@ -11,7 +11,7 @@ export const vmLinkByName = (vmName) => $(`[data-test-id="${vmName}"]`);
 export const restrictedAccessBlock = $('.cos-status-box__title');
 export const hintBlockTitle = $('.co-hint-block__title.h4');
 
-export const filterToggle = $('[data-test-id="filter-dropdown-toggle"]');
+export const filterToggle = $('[data-test-id="filter-dropdown-toggle"] button');
 
 const filterItem = async (status: Status) => {
   const statusElement = $(`#${status}`);

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineRun-details-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineRun-details-page.ts
@@ -126,7 +126,9 @@ export const pipelineRunsPage = {
   verifyPipelineRunsTableDisplay: () =>
     cy.get(pipelineRunsPO.pipelineRunsTable.table).should('be.visible'),
   filterByStatus: (status: string = 'Succeeded') => {
-    cy.byLegacyTestID('filter-dropdown-toggle').click();
+    cy.byLegacyTestID('filter-dropdown-toggle')
+      .find('button')
+      .click();
     switch (status) {
       case 'Succeeded': {
         cy.get('#Succeeded').click();

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -5,11 +5,10 @@ import { connect } from 'react-redux';
 import {
   Badge,
   Button,
-  Checkbox,
-  Dropdown,
-  DropdownGroup,
-  DropdownItem,
-  DropdownToggle,
+  Select,
+  SelectGroup,
+  SelectOption,
+  SelectVariant,
   Toolbar,
   ToolbarChip,
   ToolbarContent,
@@ -17,7 +16,7 @@ import {
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
-import { CaretDownIcon, FilterIcon, ColumnsIcon } from '@patternfly/react-icons';
+import { FilterIcon, ColumnsIcon } from '@patternfly/react-icons';
 import { Dropdown as DropdownInternal } from '@console/internal/components/utils';
 import { useTranslation } from 'react-i18next';
 
@@ -54,33 +53,25 @@ const getDropdownItems = (rowFilters: RowFilter[], selectedItems, data, props) =
   rowFilters.map((grp) => {
     const items = grp.itemsGenerator ? grp.itemsGenerator(props, props.kind) : grp.items;
     return (
-      <DropdownGroup
-        key={grp.filterGroupName}
-        label={grp.filterGroupName}
-        className="co-filter-dropdown-group"
-      >
-        {_.map(items, (item) => (
-          <DropdownItem
-            data-test-row-filter={item.id}
-            key={item.id}
-            id={item.id}
-            className="co-filter-dropdown__item"
-            listItemClassName="co-filter-dropdown__list-item"
-          >
-            <div className="co-filter-dropdown-item">
-              <span className="co-filter-dropdown-item__checkbox">
-                <Checkbox isChecked={selectedItems.includes(item.id)} id={`${item.id}-checkbox`} />
-              </span>
+      <SelectGroup key={grp.filterGroupName} label={grp.filterGroupName}>
+        {_.map(items, (item) => {
+          return (
+            <SelectOption
+              data-test-row-filter={item.id}
+              key={item.id}
+              inputId={item.id}
+              value={item.id}
+            >
               <span className="co-filter-dropdown-item__name">{item.title}</span>
               <Badge key={item.id} isRead>
                 {grp.isMatch
                   ? _.filter(data, (d) => grp.isMatch(d, item.id)).length
                   : _.countBy(data, grp.reducer)?.[item.id] ?? '0'}
               </Badge>
-            </div>
-          </DropdownItem>
-        ))}
-      </DropdownGroup>
+            </SelectOption>
+          );
+        })}
+      </SelectGroup>
     );
   });
 
@@ -241,7 +232,6 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     const selectedNew = _.xor(selectedRowFilters, id);
     applyRowFilter(selectedNew);
     setQueryParameters(selectedNew);
-    setOpen(false);
   };
 
   const clearAllRowFilter = (f: string) => {
@@ -249,7 +239,6 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   };
 
   const onRowFilterSelect = (event) => {
-    event.preventDefault();
     updateRowFilterSelected([event?.target?.id]);
   };
 
@@ -321,21 +310,27 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
                   {acc}
                 </ToolbarFilter>
               ),
-              <Dropdown
-                dropdownItems={dropdownItems}
-                onSelect={onRowFilterSelect}
-                isOpen={isOpen}
-                toggle={
-                  <DropdownToggle
-                    data-test-id="filter-dropdown-toggle"
-                    onToggle={() => setOpen(!isOpen)}
-                    toggleIndicator={CaretDownIcon}
-                  >
-                    <FilterIcon className="span--icon__right-margin" />
-                    {t('public~Filter')}
-                  </DropdownToggle>
-                }
-              />,
+              <div data-test-id="filter-dropdown-toggle">
+                <Select
+                  placeholderText={
+                    <span>
+                      <FilterIcon className="span--icon__right-margin" />
+                      {t('public~Filter')}
+                    </span>
+                  }
+                  isOpen={isOpen}
+                  onToggle={() => {
+                    setOpen(!isOpen);
+                  }}
+                  onSelect={onRowFilterSelect}
+                  variant={SelectVariant.checkbox}
+                  selections={selectedRowFilters}
+                  isCheckboxSelectionBadgeHidden
+                  isGrouped
+                >
+                  {dropdownItems}
+                </Select>
+              </div>,
             )}
           </ToolbarItem>
         )}


### PR DESCRIPTION
This addresses [bug 1930007](https://bugzilla.redhat.com/show_bug.cgi?id=1930007)

The filter dropdown/select will remain open so the user can make multiple selections.  The filter/select dropdown can be closed by clicking on the filter button again or by clicking an item outside the filter dropdown/select.

https://user-images.githubusercontent.com/82059948/116313777-d0238b00-a773-11eb-9d95-e9cec776ea0f.mov

