### PR TITLE
Bug 2009420: Use live regions for alerts in modals

### DIFF
--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -25,16 +25,35 @@ const ErrorMessage = ({ message }) => {
       className="co-alert co-alert--scrollable"
       variant="danger"
       title={t('public~An error occurred')}
+      isLiveRegion
+      aria-live="assertive"
+      aria-atomic="true"
     >
       <div className="co-pre-line">{message}</div>
     </Alert>
   );
 };
 const InfoMessage = ({ message }) => (
-  <Alert isInline className="co-alert" variant="info" title={message} />
+  <Alert
+    isInline
+    className="co-alert"
+    variant="info"
+    title={message}
+    isLiveRegion
+    aria-live="polite"
+    aria-atomic="true"
+  />
 );
 const SuccessMessage = ({ message }) => (
-  <Alert isInline className="co-alert" variant="success" title={message} />
+  <Alert
+    isInline
+    className="co-alert"
+    variant="success"
+    title={message}
+    isLiveRegion
+    aria-live="polite"
+    aria-atomic="true"
+  />
 );
 
 // NOTE: DO NOT use <a> elements within a ButtonBar.

--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import * as PropTypes from 'prop-types';
-import { Alert } from '@patternfly/react-core';
+import { Alert, AlertGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 
 import { LoadingInline } from './status-box';
@@ -25,35 +25,16 @@ const ErrorMessage = ({ message }) => {
       className="co-alert co-alert--scrollable"
       variant="danger"
       title={t('public~An error occurred')}
-      isLiveRegion
-      aria-live="assertive"
-      aria-atomic="true"
     >
       <div className="co-pre-line">{message}</div>
     </Alert>
   );
 };
 const InfoMessage = ({ message }) => (
-  <Alert
-    isInline
-    className="co-alert"
-    variant="info"
-    title={message}
-    isLiveRegion
-    aria-live="polite"
-    aria-atomic="true"
-  />
+  <Alert isInline className="co-alert" variant="info" title={message} />
 );
 const SuccessMessage = ({ message }) => (
-  <Alert
-    isInline
-    className="co-alert"
-    variant="success"
-    title={message}
-    isLiveRegion
-    aria-live="polite"
-    aria-atomic="true"
-  />
+  <Alert isInline className="co-alert" variant="success" title={message} />
 );
 
 // NOTE: DO NOT use <a> elements within a ButtonBar.
@@ -70,11 +51,18 @@ export const ButtonBar = ({
 }) => {
   return (
     <div className={classNames(className, 'co-m-btn-bar')}>
-      {successMessage && <SuccessMessage message={successMessage} />}
-      {errorMessage && <ErrorMessage message={errorMessage} />}
-      {injectDisabled(children, inProgress)}
-      {inProgress && <LoadingInline />}
-      {infoMessage && <InfoMessage message={infoMessage} />}
+      <AlertGroup
+        isLiveRegion
+        aria-live="polite"
+        aria-atomic="false"
+        aria-relevant="additions text"
+      >
+        {successMessage && <SuccessMessage message={successMessage} />}
+        {errorMessage && <ErrorMessage message={errorMessage} />}
+        {injectDisabled(children, inProgress)}
+        {inProgress && <LoadingInline />}
+        {infoMessage && <InfoMessage message={infoMessage} />}
+      </AlertGroup>
     </div>
   );
 };


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2009420

This came up as a screen reader user typed in an upper case char during project creation displaying an error alert in the create project modal.
The alert does not get announced by the screen reader. Creating a liveRegion is a way to announce errors for screen readers. 

This is a pr to test with the jaws screen reader.

cc: @jessiehuff 

Before:

https://user-images.githubusercontent.com/35978579/135485341-0c32508b-d6c6-4715-8eeb-4056d77d2843.mov

After:


https://user-images.githubusercontent.com/35978579/135485565-1afa76d3-8b3a-4424-8dc3-f78f21ab23aa.mov

