### PR TITLE
Bug 1952214: Save additional Devfile container parameters from build guidance container and drop it to fix ImagePullBackOff

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
@@ -492,3 +492,372 @@ export const nodeJsBuilderImage = {
   },
   imageStreamNamespace: 'openshift',
 };
+
+export const defaultDevfileFormData: GitImportFormData = {
+  name: '',
+  project: {
+    name: 'gijohn',
+    displayName: '',
+    description: '',
+  },
+  application: {
+    initial: '',
+    name: '',
+    selectedKey: '',
+    isInContext: false,
+  },
+  image: {
+    selected: '',
+    recommended: '',
+    tag: '',
+    tagObj: {},
+    ports: [],
+    isRecommending: false,
+    couldNotRecommend: false,
+  },
+  serverless: {
+    scaling: {
+      minpods: '',
+      maxpods: '',
+      concurrencytarget: 100,
+      concurrencylimit: '',
+      autoscale: {
+        autoscalewindow: 60,
+        autoscalewindowUnit: 's',
+        defaultAutoscalewindowUnit: 's',
+      },
+      concurrencyutilization: 70,
+    },
+  },
+  route: {
+    disable: false,
+    create: true,
+    targetPort: '',
+    unknownTargetPort: '',
+    defaultUnknownPort: 8080,
+    path: '',
+    hostname: '',
+    secure: false,
+    tls: {
+      termination: '',
+      insecureEdgeTerminationPolicy: '',
+      caCertificate: '',
+      certificate: '',
+      destinationCACertificate: '',
+      privateKey: '',
+    },
+  },
+  resources: Resources.Kubernetes,
+  build: {
+    env: [],
+    triggers: {
+      webhook: true,
+      image: true,
+      config: true,
+    },
+    strategy: 'Devfile',
+  },
+  deployment: {
+    env: [],
+    triggers: {
+      image: true,
+      config: true,
+    },
+    replicas: 1,
+  },
+  labels: {},
+  limits: {
+    cpu: {
+      request: '',
+      requestUnit: 'm',
+      defaultRequestUnit: 'm',
+      limit: '',
+      limitUnit: 'm',
+      defaultLimitUnit: 'm',
+    },
+    memory: {
+      request: '',
+      requestUnit: 'Mi',
+      defaultRequestUnit: 'Mi',
+      limit: '',
+      limitUnit: 'Mi',
+      defaultLimitUnit: 'Mi',
+    },
+  },
+  healthChecks: {
+    readinessProbe: {
+      showForm: false,
+      enabled: false,
+      modified: false,
+      data: {
+        failureThreshold: 3,
+        requestType: 'httpGet',
+        httpGet: {
+          scheme: 'HTTP',
+          path: '/',
+          port: 8080,
+          httpHeaders: [],
+        },
+        tcpSocket: {
+          port: 8080,
+        },
+        exec: {
+          command: [''],
+        },
+        initialDelaySeconds: 0,
+        periodSeconds: 10,
+        timeoutSeconds: 1,
+        successThreshold: 1,
+      },
+    },
+    livenessProbe: {
+      showForm: false,
+      enabled: false,
+      modified: false,
+      data: {
+        failureThreshold: 3,
+        requestType: 'httpGet',
+        httpGet: {
+          scheme: 'HTTP',
+          path: '/',
+          port: 8080,
+          httpHeaders: [],
+        },
+        tcpSocket: {
+          port: 8080,
+        },
+        exec: {
+          command: [''],
+        },
+        initialDelaySeconds: 0,
+        periodSeconds: 10,
+        timeoutSeconds: 1,
+        successThreshold: 1,
+      },
+    },
+    startupProbe: {
+      showForm: false,
+      enabled: false,
+      modified: false,
+      data: {
+        failureThreshold: 3,
+        requestType: 'httpGet',
+        httpGet: {
+          scheme: 'HTTP',
+          path: '/',
+          port: 8080,
+          httpHeaders: [],
+        },
+        tcpSocket: {
+          port: 8080,
+        },
+        exec: {
+          command: [''],
+        },
+        initialDelaySeconds: 0,
+        periodSeconds: 10,
+        timeoutSeconds: 1,
+        successThreshold: 1,
+      },
+    },
+  },
+  resourceTypesNotValid: [],
+  pipeline: {
+    enabled: false,
+  },
+  git: {
+    url: '',
+    type: '',
+    ref: '',
+    dir: '',
+    showGitType: false,
+    secret: '',
+    isUrlValidating: false,
+  },
+  docker: {
+    dockerfilePath: './Dockerfile',
+  },
+  devfile: {
+    devfileHasError: false,
+    devfilePath: './devfile.yaml',
+  },
+};
+
+export const sampleDevfileFormData: GitImportFormData = {
+  ...defaultDevfileFormData,
+  name: 'devfile-sample',
+  application: {
+    initial: '',
+    name: 'devfile-sample-app',
+    selectedKey: 'devfile-sample-app',
+  },
+  git: {
+    url: 'https://github.com/redhat-developer/devfile-sample',
+    type: 'github',
+    ref: 'master',
+    dir: './',
+    showGitType: false,
+    secret: '',
+    isUrlValidating: false,
+  },
+  image: {
+    ...defaultDevfileFormData.image,
+    ports: [
+      {
+        protocol: 'TCP',
+        name: 'http-3001',
+        containerPort: 3001,
+      },
+    ],
+  },
+  deployment: {
+    ...defaultDevfileFormData.deployment,
+    env: [
+      {
+        name: 'PROJECTS_ROOT',
+        value: '/projects',
+      },
+      {
+        name: 'PROJECT_SOURCE',
+        value: '/projects',
+      },
+    ],
+  },
+  limits: {
+    cpu: {
+      request: '',
+      requestUnit: '',
+      defaultRequestUnit: '',
+      limit: '',
+      limitUnit: '',
+      defaultLimitUnit: '',
+    },
+    memory: {
+      request: '',
+      requestUnit: 'Mi',
+      defaultRequestUnit: 'Mi',
+      limit: '1',
+      limitUnit: 'Gi',
+      defaultLimitUnit: 'Gi',
+    },
+  },
+  devfile: {
+    devfileHasError: false,
+    devfilePath: './devfile.yaml',
+    devfileContent: 'SKIPPED',
+    devfileSuggestedResources: {
+      imageStream: {
+        kind: 'ImageStream',
+        apiVersion: 'image.openshift.io/v1',
+        metadata: {
+          creationTimestamp: null,
+        },
+        spec: {
+          lookupPolicy: {
+            local: false,
+          },
+        },
+        status: {
+          dockerImageRepository: '',
+        },
+      },
+      buildResource: {
+        kind: 'BuildConfig',
+        apiVersion: 'build.openshift.io/v1',
+        metadata: {
+          creationTimestamp: null,
+        },
+        spec: {
+          source: {
+            type: 'Git',
+            git: {
+              uri: 'https://github.com/redhat-developer/devfile-sample',
+              ref: 'master',
+            },
+            contextDir: 'src',
+          },
+          strategy: {
+            type: 'Docker',
+            dockerStrategy: {
+              dockerfilePath: 'Dockerfile',
+            },
+          },
+          output: {
+            to: {
+              kind: 'ImageStreamTag',
+              name: 'devfile-sample:latest:latest',
+            },
+          },
+          resources: {},
+          postCommit: {},
+          nodeSelector: null,
+        },
+        status: {
+          lastVersion: 0,
+        },
+      },
+      deployResource: {
+        kind: 'Deployment',
+        apiVersion: 'apps/v1',
+        metadata: {
+          creationTimestamp: null,
+        },
+        spec: {
+          selector: {
+            matchLabels: {
+              app: 'devfile-sample',
+            },
+          },
+          template: {
+            metadata: {
+              creationTimestamp: null,
+            },
+            spec: {},
+          },
+          strategy: {
+            type: 'Recreate',
+          },
+        },
+        status: {},
+      },
+      service: {
+        kind: 'Service',
+        apiVersion: 'v1',
+        metadata: {
+          creationTimestamp: null,
+        },
+        spec: {
+          ports: [
+            {
+              name: 'port-3001',
+              port: 3001,
+              targetPort: 3001,
+            },
+          ],
+        },
+        status: {
+          loadBalancer: {},
+        },
+      },
+      route: {
+        kind: 'Route',
+        apiVersion: 'route.openshift.io/v1',
+        metadata: {
+          creationTimestamp: null,
+        },
+        spec: {
+          path: '/',
+          to: {
+            kind: 'Service',
+            name: 'devfile-sample',
+            weight: null,
+          },
+          port: {
+            targetPort: 3001,
+          },
+        },
+        status: {},
+      },
+    },
+  },
+};

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -13,9 +13,13 @@ import * as pipelineUtils from '@console/pipelines-plugin/src/components/import/
 import { PipelineModel } from '@console/pipelines-plugin/src/models';
 import { Resources } from '../import-types';
 import * as submitUtils from '../import-submit-utils';
-import { defaultData, nodeJsBuilderImage as buildImage } from './import-submit-utils-data';
+import {
+  defaultData,
+  nodeJsBuilderImage as buildImage,
+  sampleDevfileFormData,
+} from './import-submit-utils-data';
 
-const { createOrUpdateDeployment, createOrUpdateResources } = submitUtils;
+const { createOrUpdateDeployment, createOrUpdateResources, createDevfileResources } = submitUtils;
 
 describe('Import Submit Utils', () => {
   const t = jest.fn();
@@ -284,6 +288,103 @@ describe('Import Submit Utils', () => {
       const models = returnValue.map((data) => _.get(data, 'model.kind'));
       expect(models.includes(PipelineModel.kind)).toEqual(false);
       done();
+    });
+  });
+
+  describe('createDevfileResources', () => {
+    beforeAll(() => {
+      jest
+        .spyOn(k8s, 'k8sCreate')
+        .mockImplementation((model, data, dryRun) => Promise.resolve({ model, data, dryRun }));
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('return a Deployment with just one container which includes ports, env from Devfile container ', async () => {
+      const formData = sampleDevfileFormData;
+      const returnValue = await createDevfileResources(formData, false, {}, '');
+
+      const deployment = returnValue.find((resource) => resource.data.kind === 'Deployment').data;
+
+      expect(deployment).toEqual({
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          annotations: {
+            'alpha.image.policy.openshift.io/resolve-names': '*',
+            'app.openshift.io/vcs-ref': 'master',
+            'app.openshift.io/vcs-uri': 'https://github.com/redhat-developer/devfile-sample',
+            'image.openshift.io/triggers':
+              '[{"from":{"kind":"ImageStreamTag","name":"devfile-sample:latest","namespace":"gijohn"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"devfile-sample\\")].image","pause":"false"}]',
+            isFromDevfile: 'true',
+            'openshift.io/generated-by': 'OpenShiftWebConsole',
+          },
+          creationTimestamp: null,
+          labels: {
+            app: 'devfile-sample',
+            'app.kubernetes.io/component': 'devfile-sample',
+            'app.kubernetes.io/instance': 'devfile-sample',
+            'app.kubernetes.io/name': 'devfile-sample',
+            'app.kubernetes.io/part-of': 'devfile-sample-app',
+            'app.openshift.io/runtime': 'devfile-sample',
+          },
+          name: 'devfile-sample',
+          namespace: 'gijohn',
+        },
+        spec: {
+          replicas: 1,
+          selector: {
+            matchLabels: {
+              app: 'devfile-sample',
+            },
+          },
+          strategy: {
+            type: 'Recreate',
+          },
+          template: {
+            metadata: {
+              creationTimestamp: null,
+              labels: {
+                app: 'devfile-sample',
+                deploymentconfig: 'devfile-sample',
+              },
+            },
+            spec: {
+              containers: [
+                {
+                  env: [
+                    {
+                      name: 'PROJECTS_ROOT',
+                      value: '/projects',
+                    },
+                    {
+                      name: 'PROJECT_SOURCE',
+                      value: '/projects',
+                    },
+                  ],
+                  image: 'devfile-sample:latest',
+                  name: 'devfile-sample',
+                  ports: [
+                    {
+                      protocol: 'TCP',
+                      containerPort: 3001,
+                      name: 'http-3001',
+                    },
+                  ],
+                  resources: {
+                    limits: {
+                      memory: '1Gi',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        status: {},
+      });
     });
   });
 });

--- a/frontend/packages/dev-console/src/components/import/devfile/DevfileImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/devfile/DevfileImportForm.tsx
@@ -7,7 +7,7 @@ import { FormFooter, FormBody } from '@console/shared/src/components/form-utils'
 import { DevfileImportFormProps } from '../import-types';
 import GitSection from '../git/GitSection';
 import AppSection from '../app/AppSection';
-import { useDefileServer, useDevfileDirectoryWatcher } from './devfileHooks';
+import { useDevfileServer, useDevfileDirectoryWatcher } from './devfileHooks';
 
 const DevfileImportForm: React.FC<FormikProps<FormikValues> & DevfileImportFormProps> = ({
   values,
@@ -22,7 +22,7 @@ const DevfileImportForm: React.FC<FormikProps<FormikValues> & DevfileImportFormP
   setFieldValue,
 }) => {
   const { t } = useTranslation();
-  const [, devfileParseError] = useDefileServer(values, setFieldValue);
+  const [, devfileParseError] = useDevfileServer(values, setFieldValue);
   useDevfileDirectoryWatcher(values, setFieldValue);
 
   return (


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1952214
#8729

**Analysis / Root cause**: 
When importing the sample Devfile from git repo https://github.com/redhat-developer/devfile-sample the new Deployment doens't start successfully. The Pod fails to start because the container image "buildguidanceimage-placeholder" could not be fetched.

The reason is that the [devfile.yaml](https://github.com/redhat-developer/devfile-sample/blob/5ffa4845474ed8321cba9b69f47f02ca16210334/devfile.yaml#L9-L17) contains a "build guidance" container which should be dropped. The console should only keep the configure from this container, like the right ports, environment variables and resource limits.

**Solution Description**: 
When submitting the `DevfileImportForm` it calls `createDevfileResources` which then calls `createOrUpdateDeployment` with the `formData` and the parsed `devfileResourceObjects.deployResource`. See [import-submit-utils.ts](https://github.com/openshift/console/blob/master/frontend/packages/dev-console/src/components/import/import-submit-utils.ts#L510-L516)

Because `createOrUpdateDeployment` loads the ports, environment variables and limits from the `formData` it is required to change it before that. It's also required to remove the "placeholder" container from the parsed `deployResource`.

I decided to do this in the form right after parsing the Devfile. This will allow us to validate or maybe provide additional fields for these parameters later.

Created Deployment without this PR:

```yaml
kind: Deployment
spec:
  template:
    spec:
      containers:
        - name: buildguidance
          image: buildguidanceimage-placeholder
          ports:
            - name: http-3001
              containerPort: 3001
              protocol: TCP
          env:
            - name: PROJECTS_ROOT
              value: /projects
            - name: PROJECT_SOURCE
              value: /projects
          resources:
            limits:
              memory: 1Gi
        - name: devfile-sample
          image: >-
            image-registry.openshift-image-registry.svc:5000/christoph/devfile-sample@sha256:3bafb69d0c1757b0e7db139ecf5d12812b56d584de940dbb6ac2065b62097de4
          resources: {}
```

Created Deployment with this PR:

```yaml
kind: Deployment
spec:
  template:
    spec:
      containers:
        - name: devfile-sample9
          image: >-
            image-registry.openshift-image-registry.svc:5000/christoph/devfile-sample9@sha256:25bc781ebdabd2602549e2ce0d1f40ae217889156a6c333be46b7d6c135475ed
          ports:
            - name: http-3001
              containerPort: 3001
              protocol: TCP
          env:
            - name: PROJECTS_ROOT
              value: /projects
            - name: PROJECT_SOURCE
              value: /projects
          resources:
            limits:
              memory: 1Gi
```

**Screen shots / Gifs for design review**: 
UI does not change.

Created deployment without this PR:
![image](https://user-images.githubusercontent.com/139310/116327281-be1f0800-a7c6-11eb-96ef-5b8711664a05.png)

Created deployment with this PR:
![image](https://user-images.githubusercontent.com/139310/116327509-3259ab80-a7c7-11eb-95ea-bc2e6e47c98c.png)

**Unit test coverage report**: 
Created a new unit test `createDevfileResources` before I decided to move this changes "up" from this function to the form hook. I kept the new tests also if it doesn't verify the build guidance container change here... :-/

```
    createDevfileResources
      ✓ return a Deployment with just one container which includes ports, env from Devfile container  (3ms)
```

**Test setup:**
1. Open the Developer perspective
2. Open Add > "From Devfile"
3. Press "Try sample" to import the Devfile from `https://github.com/redhat-developer/devfile-sample`
4. Create the Deployment and verify if the pods starts successfully.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
/assign @andrewballantyne 
/cc @andrewballantyne @maysunfaisal @elsony