### PR TITLE
Bug 1952635: fixes: Web console displays a blank page- white space instead of cluster information

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -159,7 +159,7 @@ class App_ extends React.PureComponent {
       <>
         <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
         <QuickStartDrawer>
-          <div id="app-content" className="co-m-page__body">
+          <div id="app-content" className="co-m-app__content">
             <ConsoleNotifier location="BannerTop" />
             <Page
               header={<Masthead onNavToggle={this._onNavToggle} />}

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -32,6 +32,13 @@ body,
   flex-direction: column;
 }
 
+.co-m-app__content {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  height: 100% // doesn't work on safari without height 
+}
+
 .co-p-has-sidebar {
   position: relative;
   display: flex;


### PR DESCRIPTION

This PR fixes the blank page issue  with safari https://bugzilla.redhat.com/show_bug.cgi?id=1952635

<img width="1773" alt="Screenshot 2021-04-28 at 1 37 51 PM" src="https://user-images.githubusercontent.com/9278015/116369394-f6563300-a826-11eb-9e84-754fa7d6f741.png">
