### PR TITLE
Query Browser: Add seconds back to query browser tooltips

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -50,7 +50,7 @@ import {
 } from '../utils';
 import {
   dateFormatterNoYear,
-  dateTimeFormatter,
+  dateTimeFormatterWithSeconds,
   formatPrometheusDuration,
   parsePrometheusDuration,
   timeFormatter,
@@ -198,7 +198,9 @@ const Tooltip_: React.FC<TooltipProps> = ({ activePoints, center, height, style,
             <div className="query-browser__tooltip-arrow" />
             <div className="query-browser__tooltip">
               <div className="query-browser__tooltip-group">
-                <div className="query-browser__tooltip-time">{dateTimeFormatter.format(time)}</div>
+                <div className="query-browser__tooltip-time">
+                  {dateTimeFormatterWithSeconds.format(time)}
+                </div>
               </div>
               {allSeries.map((s, i) => (
                 <div className="query-browser__tooltip-group" key={i}>

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -37,6 +37,15 @@ export const dateTimeFormatter = new Intl.DateTimeFormat(getLocale() || undefine
   year: 'numeric',
 });
 
+export const dateTimeFormatterWithSeconds = new Intl.DateTimeFormat(getLocale() || undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  year: 'numeric',
+});
+
 export const utcDateTimeFormatter = new Intl.DateTimeFormat(getLocale() || undefined, {
   month: 'short',
   day: 'numeric',


### PR DESCRIPTION
These were accidentally removed during the Console wide date format rework (https://github.com/openshift/console/pull/8490).

/cc @spadgett 

FYI @sichvoge, @cshinn 

![screenshot](https://user-images.githubusercontent.com/460802/116398340-a301d600-a862-11eb-9d83-cd058be661de.png)
![screenshot-1](https://user-images.githubusercontent.com/460802/116398345-a4cb9980-a862-11eb-8c8a-a7f2dfa5340f.png)
