### PR TITLE
CONSOLE-2508: Memsource automation

### DIFF
--- a/frontend/i18n-scripts/README.md
+++ b/frontend/i18n-scripts/README.md
@@ -1,0 +1,53 @@
+# i18n-scripts
+
+The i18n-scripts folder contains all homebrewed scripts for i18n workflow automation
+in OpenShift.
+
+## Languages
+The list of languages we're using are stored in `languages.sh`. All scripts
+that rely on language information import this variable, and it should be updated
+whenever OpenShift gains support for an additional language.
+
+## Memsource Automation
+We have created two scripts to handle pushing and pulling translations to/from
+Memsource, the tool the Red Hat Globalization team uses for translation jobs.
+
+Before running either tool, you must first install the [unofficial Memsource CLI client](https://github.com/unofficial-memsource/memsource-cli-client#pip-install).
+You also have to [configure it with your Memsource login info](https://github.com/unofficial-memsource/memsource-cli-client#configuration-red-hat-enterprise-linux-derivatives).
+
+Example CLI usage for upload script: `yarn memsource-upload -v 4.8 -s "200"`
+* -v is the current OpenShift version
+* -s is the current sprint number
+
+Example CLI usage for download script: `yarn memsource-download -p 6sB6qwpbRkGCeBQq4hUyK1`
+* -p is the project ID in Memsource. The project ID can be obtained from the Memsource project URL (it's the series of numbers and letters after /show/, i.e. https://cloud.memsource.com/web/project2/show/FBfZeTEWPYaC4VXhgrW0R2).
+
+## Build
+`build-i18n.sh` runs as part of the general `yarn i18n` command workflow. This script
+runs the i18next parser across the entire codebase and generates json files based on
+the marked keys in the application.
+
+## Folder Consolidation
+`consolidate-public-folders.js` runs as part of the general `yarn i18n` command workflow.
+The goal of the script is to consolidate all json files across the application with the name
+"public" into a single json file in the public folder. This is required to avoid namespace conflicts,
+as i18next requires unique namespaces.
+
+## English Defaults
+`set-english-defaults.js` runs as part of the general `yarn i18n` command workflow.
+This script programmatically adds values for each new key in a json file after the parser is run.
+The goal of this script was to save developers time and minimize errors, as it saves developers
+from having to manually edit json files most of the time. In some cases, such as complex pluralization,
+manual edits will be required.
+
+## Export
+`export-pos.sh` is a utility for Memsource automation. It exports all i18next json files
+in PO format in all the languages we currently support, so we can hand them off to the translation team.
+
+## i18n-to-PO
+`i18n-to-po.js` is a utility for Memsource automation. It is used by `export-pos.sh` to
+export individual files.
+
+## PO-to-i18n
+`po-to-i18n.js` is a utility for Memsource automation. It is used by the download script to
+correctly sort files into their original locations and convert them back into json format.

--- a/frontend/i18n-scripts/export-pos.sh
+++ b/frontend/i18n-scripts/export-pos.sh
@@ -2,22 +2,24 @@
 
 set -exuo pipefail
 
+source ./i18n-scripts/languages.sh
+
 for f in public/locales/en/* ; do
-  yarn i18n-to-po -f $(basename "$f" .json) -l zh-cn
-  yarn i18n-to-po -f $(basename "$f" .json) -l zh-tw
-  yarn i18n-to-po -f $(basename "$f" .json) -l ja
-  yarn i18n-to-po -f $(basename "$f" .json) -l ko
+  for i in "${LANGUAGES[@]}"
+  do
+  yarn i18n-to-po -f "$(basename "$f" .json)" -l "$i"
+  done
 done
 
 cd packages
 for d in */ ; do
   if [ -d "$d/locales/en" ]
   then
-    for f in $d/locales/en/* ; do
-      yarn i18n-to-po -p "$d" -f $(basename "$f" .json) -l zh-cn
-      yarn i18n-to-po -p "$d" -f $(basename "$f" .json) -l zh-tw
-      yarn i18n-to-po -p "$d" -f $(basename "$f" .json) -l ja
-      yarn i18n-to-po -p "$d" -f $(basename "$f" .json) -l ko
+    for f in "$d"/locales/en/* ; do
+      for i in "${LANGUAGES[@]}"
+      do
+        yarn i18n-to-po -p "$d" -f "$(basename "$f" .json)" -l "$i"
+      done
     done
   fi
 done

--- a/frontend/i18n-scripts/i18n-to-po.js
+++ b/frontend/i18n-scripts/i18n-to-po.js
@@ -61,57 +61,72 @@ function processFile(fileName, packageDir, language) {
       `./../packages/${packageDir}/locales/en/${fileName}.json`,
     );
 
-    fs.mkdirSync(path.join(__dirname, `./../packages/${packageDir}/locales/tmp`), {
-      recursive: true,
-    });
+    try {
+      if (fs.existsSync(i18nFile)) {
+        fs.mkdirSync(path.join(__dirname, `./../packages/${packageDir}/locales/tmp`), {
+          recursive: true,
+        });
 
-    tmpFile = path.join(__dirname, `./../packages/${packageDir}/locales/tmp/${fileName}.json`);
+        tmpFile = path.join(__dirname, `./../packages/${packageDir}/locales/tmp/${fileName}.json`);
 
-    removeValues(i18nFile, tmpFile);
-    consolidateWithExistingTranslations(tmpFile, fileName, language, packageDir);
+        removeValues(i18nFile, tmpFile);
+        consolidateWithExistingTranslations(tmpFile, fileName, language, packageDir);
 
-    fs.mkdirSync(path.join(__dirname, `./../po-files/${language}`), {
-      recursive: true,
-    });
-    i18nextToPo(language, fs.readFileSync(tmpFile), {
-      language,
-      foldLength: 0,
-      ctxSeparator: '~',
-    })
-      .then(
-        save(
-          path.join(
-            __dirname,
-            `./../po-files/${language}/${path.basename(fileName)}_package=${
-              packageDir.split('/')[0]
-            }.po`,
-          ),
-        ),
-      )
-      .catch((e) => console.error(fileName, e));
+        fs.mkdirSync(path.join(__dirname, `./../po-files/${language}`), {
+          recursive: true,
+        });
+        i18nextToPo(language, fs.readFileSync(tmpFile), {
+          language,
+          foldLength: 0,
+          ctxSeparator: '~',
+        })
+          .then(
+            save(
+              path.join(
+                __dirname,
+                `./../po-files/${language}/${packageDir.split('/')[0]}__${path.basename(
+                  fileName,
+                )}.po`,
+              ),
+            ),
+          )
+          .catch((e) => console.error(fileName, e));
+      }
+    } catch (err) {
+      console.error(err);
+    }
   } else {
     const i18nFile = path.join(__dirname, `./../public/locales/en/${fileName}.json`);
 
-    fs.mkdirSync(path.join(__dirname, './../public/locales/tmp'), { recursive: true });
+    try {
+      if (fs.existsSync(i18nFile)) {
+        fs.mkdirSync(path.join(__dirname, './../public/locales/tmp'), { recursive: true });
 
-    tmpFile = path.join(__dirname, `./../public/locales/tmp/${fileName}.json`);
+        tmpFile = path.join(__dirname, `./../public/locales/tmp/${fileName}.json`);
 
-    removeValues(i18nFile, tmpFile);
-    consolidateWithExistingTranslations(tmpFile, fileName, language);
+        removeValues(i18nFile, tmpFile);
+        consolidateWithExistingTranslations(tmpFile, fileName, language);
 
-    fs.mkdirSync(path.join(__dirname, `./../po-files/${language}`), { recursive: true });
-    i18nextToPo(language, fs.readFileSync(tmpFile), {
-      language,
-      foldLength: 0,
-      ctxSeparator: '~',
-    })
-      .then(
-        save(
-          path.join(__dirname, `./../po-files/${language}/${path.basename(fileName)}.po`),
+        fs.mkdirSync(path.join(__dirname, `./../po-files/${language}`), { recursive: true });
+        i18nextToPo(language, fs.readFileSync(tmpFile), {
           language,
-        ),
-      )
-      .catch((e) => console.error(fileName, e));
+          foldLength: 0,
+          ctxSeparator: '~',
+        })
+          .then(
+            save(
+              path.join(
+                __dirname,
+                `./../po-files/${language}/public__${path.basename(fileName)}.po`,
+              ),
+              language,
+            ),
+          )
+          .catch((e) => console.error(fileName, e));
+      }
+    } catch (err) {
+      console.error(err);
+    }
   }
   common.deleteFile(tmpFile);
   console.log(`Processed ${fileName}`);

--- a/frontend/i18n-scripts/languages.sh
+++ b/frontend/i18n-scripts/languages.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export LANGUAGES=( 'ja' 'zh-cn' 'ko')

--- a/frontend/i18n-scripts/memsource-download.sh
+++ b/frontend/i18n-scripts/memsource-download.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+source ./i18n-scripts/languages.sh
+
+while getopts p: flag
+do
+  case "${flag}" in
+      p) PROJECT_ID=${OPTARG};;
+      *) echo "usage: $0 [-p]" >&2
+      exit 1;;
+  esac
+done
+
+echo "Checking if git workspace is clean"
+GIT_STATUS="$(git status --short --untracked-files -- public/locales packages/**/locales)"
+if [ -n "$GIT_STATUS" ]; then
+  echo "There are uncommitted files in public or package locales folders. Remove or commit the files, then run this script again."
+  git diff
+  exit 1
+fi
+
+echo "Downloading PO files from Project ID \"$PROJECT_ID\""
+
+DOWNLOAD_PATH="$(mktemp -d)" || { echo "Failed to create temp folder"; exit 1; }
+
+# Memsource job listing is limited to 50 jobs per page
+# We need to pull all the files down by page and stop when we reach a page with no data
+for i in "${LANGUAGES[@]}"
+do
+  COUNTER=0
+  CURRENT_PAGE=$(memsource job list --project-id "$PROJECT_ID" --target-lang "$i" -f value --page-number 0 -c uid | tr '\n' ' ')
+  until [ -z "$CURRENT_PAGE" ]
+  do
+    ((COUNTER++))
+    echo Downloading page "$COUNTER"
+    memsource job download --project-id "$PROJECT_ID" --output-dir "$DOWNLOAD_PATH/$i" --job-id "$CURRENT_PAGE"
+    CURRENT_PAGE=$(memsource job list --project-id "$PROJECT_ID" --target-lang "$i" -f value --page-number "$COUNTER" -c uid | tr '\n' ' ')
+  done
+done
+
+echo Importing downloaded PO files into OpenShift
+for i in "${LANGUAGES[@]}"
+do
+  # We don't treat zh-cn as a dialect in i18next right now, so we need to alter it to zh
+  if [ "$i" == 'zh-cn' ]
+  then
+    yarn po-to-i18n -d "$DOWNLOAD_PATH/$i" -l 'zh'
+  else
+    yarn po-to-i18n -d "$DOWNLOAD_PATH/$i" -l "$i"
+  fi
+done
+
+echo Creating commit
+git add public/locales
+git add packages/**/locales
+git commit -m "chore(i18n): update translations
+
+Adding latest translations from Memsource project #$PROJECT_ID"

--- a/frontend/i18n-scripts/memsource-upload.sh
+++ b/frontend/i18n-scripts/memsource-upload.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+source ./i18n-scripts/languages.sh
+
+while getopts v:s: flag
+do
+  case "${flag}" in
+      v) VERSION=${OPTARG};;
+      s) SPRINT=${OPTARG};;
+      *) echo "usage: $0 [-v] [-s]" >&2
+      exit 1;;
+  esac
+done
+
+BRANCH=$(git branch  --show-current)
+
+echo "Creating project with title \"[OCP $VERSION] UI Localization - Sprint $SPRINT/Branch $BRANCH\""
+
+PROJECT_INFO=$(memsource project create --name "[OCP $VERSION] UI Localization - Sprint $SPRINT/Branch $BRANCH" --template-id 169304 -f json)
+PROJECT_ID=$(echo "$PROJECT_INFO" | jq -r '.uid')
+
+echo "Exporting PO files"
+yarn export-pos
+echo "Exported all PO files"
+
+echo "Creating jobs for exported PO files"
+for i in "${LANGUAGES[@]}"
+do
+  memsource job create --filenames po-files/"$i"/*.po --target-langs "$i" --project-id "${PROJECT_ID}"
+done
+
+echo "Uploaded PO files to Memsource"
+
+# Clean up PO file directory
+rm -rf po-files

--- a/frontend/i18n-scripts/po-to-i18n.js
+++ b/frontend/i18n-scripts/po-to-i18n.js
@@ -10,13 +10,12 @@ function save(target) {
 }
 
 function processFile(fileName, language) {
+  if (fileName.includes('.DS_Store')) {
+    return;
+  }
   let newFilePath;
-  const packageDir =
-    fileName.includes('_package=') && path.basename(fileName, '.po').split('_package=')[1];
-  const newFileName = packageDir
-    ? path.basename(fileName, '.po').split('_package=')[0]
-    : path.basename(fileName, '.po');
-  if (packageDir) {
+  const [packageDir, newFileName] = path.basename(fileName, '.po').split('__');
+  if (packageDir !== 'public') {
     if (!fs.existsSync(path.join(__dirname, `./../packages/${packageDir}/locales/${language}`))) {
       fs.mkdirSync(path.join(__dirname, `./../packages/${packageDir}/locales/${language}`), {
         recursive: true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,9 @@
     "i18n-to-po": "node ./i18n-scripts/i18n-to-po.js",
     "po-to-i18n": "node ./i18n-scripts/po-to-i18n.js",
     "i18n": "./i18n-scripts/build-i18n.sh && node ./i18n-scripts/consolidate-public-folders && node ./i18n-scripts/set-english-defaults.js",
-    "export-pos": "./i18n-scripts/export-pos.sh"
+    "export-pos": "./i18n-scripts/export-pos.sh",
+    "memsource-upload": "./i18n-scripts/memsource-upload.sh",
+    "memsource-download": "./i18n-scripts/memsource-download.sh"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
Added one script to handle project creation, file generation, and file upload for Memsource and a second to handle download and file import into OpenShift.

I used https://github.com/unofficial-memsource/memsource-cli-client instead of the Ansible collection because I couldn't get the collection to work. We can always circle back and switch to that later.

Documentation is in the files themselves; installing the memsource cli client and providing credentials is required for use. One script also requires the rename utility.

I also made some revisions to the other scripts in our little tool chain here.

Fixes https://issues.redhat.com/projects/CONSOLE/issues/CONSOLE-2508.