### PR TITLE
Bug 1897621: Auth test.Login times out - Wait for Cluster Auth Operator to start and finish Progressing 'test' IDP before e2e tests starts

### DIFF
--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -12,7 +12,7 @@ const { BRIDGE_KUBEADMIN_PASSWORD } = process.env;
 describe('Auth test', () => {
   beforeAll(async () => {
     await browser.get(appHost);
-    await browser.sleep(6000); // Wait long enough for the login redirect to complete
+    await browser.sleep(10000); // Wait long enough for the login redirect to complete
   });
 
   describe('Login test', async () => {

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -13,6 +13,32 @@ function copyArtifacts {
   fi
 }
 
+function waitForAuthOperatorProgressing {
+  output=''
+  count=0
+  sleepDuration=15
+  maxRetries=40  #10 minutes
+  action="started"
+  if [ "$1" == "False" ]; then
+    action="finished"
+  fi
+
+  until [ "$output" == "$1" ] || [ $count -gt $maxRetries ]; do
+    output=$(oc get co/authentication -o 'jsonpath={.status.conditions[?(@.type=="Progressing")].status}')
+    ((count=count+1))
+    sleep $sleepDuration
+  done
+
+  secs=$((count*sleepDuration));
+  printf -v durationStr '%dm:%ds' $((secs%3600/60)) $((secs%60))
+  if [ "$output" == "$1" ]; then
+    echo "authentication operator $action Progressing 'test' idp (duration: $durationStr)"
+  else
+    echo "authentication operator: maximum retries reached (duration: $durationStr)"
+    exit 1
+  fi
+}
+
 trap copyArtifacts EXIT
 
 # don't log kubeadmin-password
@@ -26,6 +52,12 @@ export BRIDGE_BASE_ADDRESS
 # Add htpasswd IDP
 oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
 oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
+set +x
+echo "waiting for authentication operator to start Progressing 'test' idp..."
+waitForAuthOperatorProgressing "True"
+echo "waiting for authentication operator to finish Progressing 'test' idp..."
+waitForAuthOperatorProgressing "False"
+set -x
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87


### PR DESCRIPTION
We’re not waiting long enough for the 'test' IDP to be available for the e2e tests.
Updated `test-prow-e2e.sh` to wait for Cluster Auth Operator to go into Progressing state, then wait for it to finish Progressing.

@stlaz wrote: "the rollout can take from 5 to 10 minutes btw"

Sample output of `test-prow-e2e.sh`
```
console>./test-prow-e2e.sh login
...
+ oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
++ cat ./frontend/integration-tests/data/patch-htpasswd.yaml
+ oc patch oauths cluster --patch 'spec:
...
oauth.config.openshift.io/cluster patched
+ set +x
waiting for authentication operator to start Progressing 'test' idp...
authentication operator started Progressing 'test' idp (duration: 0m:45s)
waiting for authentication operator to finish Progressing 'test' idp...
authentication operator finished Progressing 'test' idp (duration: 2m:15s)
+ set -x
...
...
Running:  app/auth-multiuser-login.spec.ts                                                (1 of 1)
  Auth test
  Logging in as test
      switches from dev to admin perspective
      does not show admin nav items in Administration to test user
      does not show admin nav items in Operators to test user
      does not show admin nav items in Storage to test user
      does not show Compute or Monitoring to test user
  Logging out
    ✓ logs in as 'test' user via htpasswd identity provider (18877ms)
  Logging in as kubeadmin
      verify sidenav menus and Administration menu access for cluster admin user
  Logging out
    ✓ log in as 'kubeadmin' user (10262ms)
  2 passing (33s)
```