### PR TITLE
[release-4.7] Bug 1954962: removes extra annotations form spec template for ksvc

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -86,7 +86,6 @@ export const getKnativeServiceDepResource = (
             }),
             ...(minpods && { 'autoscaling.knative.dev/minScale': `${minpods}` }),
             ...(maxpods && { 'autoscaling.knative.dev/maxScale': `${maxpods}` }),
-            ...annotations,
           },
         },
         spec: {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/8607