### PR TITLE
Revert "Disable Alertmanager e2e tests"

### DIFF
--- a/frontend/integration-tests/tests/alertmanager.scenario.ts
+++ b/frontend/integration-tests/tests/alertmanager.scenario.ts
@@ -24,7 +24,7 @@ const getGlobalsAndReceiverConfig = (configName: string, yamlStr: string) => {
   };
 };
 
-xdescribe('Alertmanager: PagerDuty Receiver Form', () => {
+describe('Alertmanager: PagerDuty Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -203,7 +203,7 @@ xdescribe('Alertmanager: PagerDuty Receiver Form', () => {
   });
 });
 
-xdescribe('Alertmanager: Email Receiver Form', () => {
+describe('Alertmanager: Email Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -327,7 +327,7 @@ xdescribe('Alertmanager: Email Receiver Form', () => {
   });
 });
 
-xdescribe('Alertmanager: Slack Receiver Form', () => {
+describe('Alertmanager: Slack Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -440,7 +440,7 @@ xdescribe('Alertmanager: Slack Receiver Form', () => {
   });
 });
 
-xdescribe('Alertmanager: Webhook Receiver Form', () => {
+describe('Alertmanager: Webhook Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -9,7 +9,7 @@ import * as sidenavView from '../views/sidenav.view';
 import * as horizontalnavView from '../views/horizontal-nav.view';
 import { execSync } from 'child_process';
 
-xdescribe('Alertmanager: YAML', () => {
+describe('Alertmanager: YAML', () => {
   afterEach(() => {
     checkLogs();
     checkErrors();
@@ -37,7 +37,7 @@ xdescribe('Alertmanager: YAML', () => {
   });
 });
 
-xdescribe('Alertmanager: Configuration', () => {
+describe('Alertmanager: Configuration', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,

--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -24,7 +24,7 @@ const shouldBeWatchdogSilencePage = () => {
   detailsPage.labelShouldExist('alertname=Watchdog');
 };
 
-xdescribe('Monitoring: Alerts', () => {
+describe('Monitoring: Alerts', () => {
   before(() => {
     cy.login();
     cy.createProject(testName);


### PR DESCRIPTION
Reverts openshift/console#8801

We should be able to reenable the tests after https://github.com/openshift/prometheus-operator/pull/116

/assign @dtaylor113 @kyoto 