### PR TITLE
adding sdk support for dynamic page extensions

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -49,6 +49,10 @@ import {
   setQueryArgument,
 } from './utils';
 import { isResourceListPage, useExtensions, ResourceListPage } from '@console/plugin-sdk';
+import {
+  ResourceListPage as DynamicResourceListPage,
+  isResourceListPage as isDynamicResourceListPage,
+} from '@console/dynamic-plugin-sdk';
 
 const mapStateToProps = (state: RootState): APIResourceLinkStateProps => {
   return {
@@ -417,10 +421,13 @@ const APIResourceInstances: React.FC<APIResourceTabProps> = ({
   customData: { kindObj, namespace },
 }) => {
   const resourceListPageExtensions = useExtensions<ResourceListPage>(isResourceListPage);
-  const componentLoader = getResourceListPages(resourceListPageExtensions).get(
-    referenceForModel(kindObj),
-    () => Promise.resolve(DefaultPage),
+  const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
+    isDynamicResourceListPage,
   );
+  const componentLoader = getResourceListPages(
+    resourceListPageExtensions,
+    dynamicResourceListPageExtensions,
+  ).get(referenceForModel(kindObj), () => Promise.resolve(DefaultPage));
   const ns = kindObj.namespaced ? namespace : undefined;
 
   return (

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -40,7 +40,10 @@ import { getResourceListPages } from './resource-pages';
 import { DefaultPage } from './default-resource';
 import { GreenCheckCircleIcon } from '@console/shared';
 import { useExtensions, isResourceListPage, ResourceListPage } from '@console/plugin-sdk';
-
+import {
+  ResourceListPage as DynamicResourceListPage,
+  isResourceListPage as isDynamicResourceListPage,
+} from '@console/dynamic-plugin-sdk';
 const { common } = Kebab.factory;
 
 const crdInstancesPath = (crd: CustomResourceDefinitionKind) =>
@@ -194,10 +197,14 @@ const Details: React.FC<{ obj: CustomResourceDefinitionKind }> = ({ obj: crd }) 
 
 const Instances: React.FC<InstancesProps> = ({ obj, namespace }) => {
   const resourceListPageExtensions = useExtensions<ResourceListPage>(isResourceListPage);
-  const crdKind = referenceForCRD(obj);
-  const componentLoader = getResourceListPages(resourceListPageExtensions).get(crdKind, () =>
-    Promise.resolve(DefaultPage),
+  const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
+    isDynamicResourceListPage,
   );
+  const crdKind = referenceForCRD(obj);
+  const componentLoader = getResourceListPages(
+    resourceListPageExtensions,
+    dynamicResourceListPageExtensions,
+  ).get(crdKind, () => Promise.resolve(DefaultPage));
   return (
     <AsyncComponent
       loader={componentLoader}

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -24,6 +24,12 @@ import {
   ResourceListPage as ResourceListPageExt,
   isResourceListPage,
 } from '@console/plugin-sdk';
+import {
+  ResourceDetailsPage as DynamicResourceDetailsPage,
+  isResourceDetailsPage as isDynamicResourceDetailsPage,
+  ResourceListPage as DynamicResourceListPage,
+  isResourceListPage as isDynamicResourceListPage,
+} from '@console/dynamic-plugin-sdk';
 
 // Parameters can be in pros.params (in URL) or in props.route (attribute of Route tag)
 const allParams = (props) => Object.assign({}, _.get(props, 'match.params'), props);
@@ -31,6 +37,9 @@ const allParams = (props) => Object.assign({}, _.get(props, 'match.params'), pro
 export const ResourceListPage = connectToPlural(
   withStartGuide((props: ResourceListPageProps) => {
     const resourceListPageExtensions = useExtensions<ResourceListPageExt>(isResourceListPage);
+    const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
+      isDynamicResourceListPage,
+    );
     const { kindObj, kindsInFlight, modelRef, noProjectsAvailable, ns, plural } = allParams(props);
 
     if (!kindObj) {
@@ -47,9 +56,10 @@ export const ResourceListPage = connectToPlural(
       );
     }
     const ref = referenceForModel(kindObj);
-    const componentLoader = getResourceListPages(resourceListPageExtensions).get(ref, () =>
-      Promise.resolve(DefaultPage),
-    );
+    const componentLoader = getResourceListPages(
+      resourceListPageExtensions,
+      dynamicResourceListPageExtensions,
+    ).get(ref, () => Promise.resolve(DefaultPage));
 
     return (
       <div className="co-m-list">
@@ -72,6 +82,9 @@ export const ResourceListPage = connectToPlural(
 
 export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPageProps) => {
   const detailsPageExtensions = useExtensions<ResourceDetailsPageExt>(isResourceDetailsPage);
+  const dynamicResourceListPageExtensions = useExtensions<DynamicResourceDetailsPage>(
+    isDynamicResourceDetailsPage,
+  );
   const { name, ns, kindObj, kindsInFlight } = allParams(props);
   const decodedName = decodeURIComponent(name);
 
@@ -86,9 +99,10 @@ export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPagePr
     props.match.path.indexOf('customresourcedefinitions') === -1
       ? referenceForModel(kindObj)
       : null;
-  const componentLoader = getResourceDetailsPages(detailsPageExtensions).get(ref, () =>
-    Promise.resolve(DefaultDetailsPage),
-  );
+  const componentLoader = getResourceDetailsPages(
+    detailsPageExtensions,
+    dynamicResourceListPageExtensions,
+  ).get(ref, () => Promise.resolve(DefaultDetailsPage));
 
   return (
     <>

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -41,17 +41,24 @@ import {
 import confirmNavUnpinModal from './nav/confirmNavUnpinModal';
 import { SearchFilterDropdown, searchFilterValues } from './search-filter-dropdown';
 import { useExtensions, isResourceListPage, ResourceListPage } from '@console/plugin-sdk';
+import {
+  ResourceListPage as DynamicResourceListPage,
+  isResourceListPage as isDynamicResourceListPage,
+} from '@console/dynamic-plugin-sdk';
 
 const ResourceList = connectToModel(({ kindObj, mock, namespace, selector, nameFilter }) => {
   const resourceListPageExtensions = useExtensions<ResourceListPage>(isResourceListPage);
+  const dynamicResourceListPageExtensions = useExtensions<DynamicResourceListPage>(
+    isDynamicResourceListPage,
+  );
   if (!kindObj) {
     return <LoadingBox />;
   }
 
-  const componentLoader = getResourceListPages(resourceListPageExtensions).get(
-    referenceForModel(kindObj),
-    () => Promise.resolve(DefaultPage),
-  );
+  const componentLoader = getResourceListPages(
+    resourceListPageExtensions,
+    dynamicResourceListPageExtensions,
+  ).get(referenceForModel(kindObj), () => Promise.resolve(DefaultPage));
   const ns = kindObj.namespaced ? namespace : undefined;
 
   return (

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash-es';
+import { ExtensionK8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
 
 import {
   CustomResourceDefinitionKind,
@@ -112,6 +113,9 @@ export const referenceForOwnerRef = (ownerRef: OwnerReference): GroupVersionKind
 
 export const referenceForModel = (model: K8sKind): GroupVersionKind =>
   referenceForGroupVersionKind(model.apiGroup || 'core')(model.apiVersion)(model.kind);
+
+export const referenceForExtensionModel = (model: ExtensionK8sModel): GroupVersionKind =>
+  referenceForGroupVersionKind(model?.group || 'core')(model?.version)(model?.kind);
 
 export const referenceFor = ({ kind, apiVersion }: K8sResourceCommon): GroupVersionKind => {
   if (!kind) {


### PR DESCRIPTION
blocked by https://github.com/openshift/console/pull/8818

This is the first and I suppose the last extension which I don't migrate all consumings to use the new dynamic extensions because there are so many. So we now support both Static and Dynamic page extensions