### PR TITLE
Bump SDK dependencies: ts-json-schema-generator, typescript

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -320,7 +320,6 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.10"
-
   },
   "husky": {
     "hooks": {

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -20,9 +20,9 @@
     "@types/fs-extra": "9.x",
     "ejs": "3.x",
     "fs-extra": "9.x",
-    "ts-json-schema-generator": "0.89.0",
+    "ts-json-schema-generator": "0.91.0",
     "tsutils": "3.x",
-    "typescript": "4.2.x",
+    "typescript": "~4.2.3",
     "webpack": "5.0.0-beta.16"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5542,10 +5542,15 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
-commander@^7.0.0, commander@^7.1.0:
+commander@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
   integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@~2.1.0:
   version "2.1.0"
@@ -18356,17 +18361,17 @@ ts-jest@21.x:
     source-map-support "^0.5.0"
     yargs "^10.0.3"
 
-ts-json-schema-generator@0.89.0:
-  version "0.89.0"
-  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-0.89.0.tgz#3335c9a9b337427f7354dcee1e0ffcfad2d9e90e"
-  integrity sha512-1jmG5toW9CeswDbcYUwg9Z0bi9ZQtO/Dg9eJd7TxJgZWgj0bPxGZahkyoqomDrN0CruVNgquB2Y2wNDcVUO7qQ==
+ts-json-schema-generator@0.91.0:
+  version "0.91.0"
+  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-0.91.0.tgz#93ecf4f7122ad7dbe67f6c6175f7c5ba0a547a48"
+  integrity sha512-+B0By9MyPFA7zQjPt/UgJkY+HuoiIawy5WTdH/Vss21qvvBlOhx3tlGWfu/cQhN2qfVohsfyMa3YFCaUArxyzg==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    commander "^7.1.0"
+    commander "^7.2.0"
     fast-json-stable-stringify "^2.1.0"
     glob "^7.1.6"
     json-stable-stringify "^1.0.1"
-    typescript "~4.2.2"
+    typescript "~4.2.3"
 
 ts-loader@^6.2.2:
   version "6.2.2"
@@ -18546,10 +18551,10 @@ typescript@3.8.3, typescript@^3.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
-typescript@4.2.x, typescript@~4.2.2:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@~4.2.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.24:
   version "0.7.26"


### PR DESCRIPTION
- bump `ts-json-schema-generator` to `0.91.0` for better JSON schema stability
- bump `typescript` to `4.2.4` and align semver range with ^^