### PR TITLE
Improve form validation and allow optional resources and workspaces

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -166,6 +166,7 @@
   "Output resources": "Output resources",
   "Display Name": "Display Name",
   "Name is already in use": "Name is already in use",
+  "No {{resourceType}} resource": "No {{resourceType}} resource",
   "Select {{resourceType}} resource...": "Select {{resourceType}} resource...",
   "Only showing resources for this type ({{resourceType}}).": "Only showing resources for this type ({{resourceType}}).",
   "View shortcuts": "View shortcuts",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/validation-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/validation-utils.spec.ts
@@ -541,6 +541,204 @@ describe('Pipeline Build validation schema', () => {
           );
       });
 
+      it('should pass if the task does not contain the optional resources', async () => {
+        const clusterTask = {
+          ...resourceTask,
+          spec: {
+            ...resourceTask.spec,
+            resources: {
+              inputs: [{ name: 'optional-input', type: 'git', optional: true }],
+              outputs: [{ name: 'optional-output', type: 'image', optional: true }],
+            },
+          },
+        };
+        await withFormData(
+          {
+            ...initialPipelineFormData,
+            tasks: [
+              {
+                name: 'test-task',
+                taskRef: { name: 'external-task-with-resources', kind: 'ClusterTask' },
+                resources: {
+                  inputs: [],
+                  outputs: [],
+                },
+              },
+            ],
+          },
+          {
+            clusterTasks: [clusterTask],
+          },
+        )
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task contain the optional resources', async () => {
+        const clusterTask = {
+          ...resourceTask,
+          spec: {
+            ...resourceTask.spec,
+            resources: {
+              inputs: [{ name: 'optional-input', type: 'git', optional: true }],
+              outputs: [{ name: 'optional-output', type: 'image', optional: true }],
+            },
+          },
+        };
+        await withFormData(
+          {
+            ...initialPipelineFormData,
+            resources: [
+              { name: 'git-resource', type: 'git' },
+              { name: 'image-resource', type: 'image' },
+            ],
+            tasks: [
+              {
+                name: 'test-task',
+                taskRef: { name: 'external-task-with-resources', kind: 'ClusterTask' },
+                resources: {
+                  inputs: [{ name: 'optional-input', resource: 'git-resource' }],
+                  outputs: [{ name: 'optional-output', resource: 'image-resource' }],
+                },
+              },
+            ],
+          },
+          {
+            clusterTasks: [clusterTask],
+          },
+        )
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task contain the optional resources with an empty string', async () => {
+        const clusterTask = {
+          ...resourceTask,
+          spec: {
+            ...resourceTask.spec,
+            resources: {
+              inputs: [{ name: 'optional-input', type: 'git', optional: true }],
+              outputs: [{ name: 'optional-output', type: 'image', optional: true }],
+            },
+          },
+        };
+        await withFormData(
+          {
+            ...initialPipelineFormData,
+            resources: [
+              { name: 'git-resource', type: 'git' },
+              { name: 'image-resource', type: 'image' },
+            ],
+            tasks: [
+              {
+                name: 'test-task',
+                taskRef: { name: 'external-task-with-resources', kind: 'ClusterTask' },
+                resources: {
+                  inputs: [{ name: 'optional-input', resource: '' }],
+                  outputs: [{ name: 'optional-output', resource: '' }],
+                },
+              },
+            ],
+          },
+          {
+            clusterTasks: [clusterTask],
+          },
+        )
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task contains the required but not the optional resources', async () => {
+        const clusterTask = {
+          ...resourceTask,
+          spec: {
+            ...resourceTask.spec,
+            resources: {
+              inputs: [
+                { name: 'required-input', type: 'git' },
+                { name: 'optional-input', type: 'git', optional: true },
+              ],
+              outputs: [
+                { name: 'required-output', type: 'image' },
+                { name: 'optional-output', type: 'image', optional: true },
+              ],
+            },
+          },
+        };
+        await withFormData(
+          {
+            ...initialPipelineFormData,
+            resources: [
+              { name: 'git-resource', type: 'git' },
+              { name: 'image-resource', type: 'image' },
+            ],
+            tasks: [
+              {
+                name: 'test-task',
+                taskRef: { name: 'external-task-with-resources', kind: 'ClusterTask' },
+                resources: {
+                  inputs: [{ name: 'required-input', resource: 'git-resource' }],
+                  outputs: [{ name: 'required-output', resource: 'image-resource' }],
+                },
+              },
+            ],
+          },
+          {
+            clusterTasks: [clusterTask],
+          },
+        )
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should fail if the task contains the optional but not the required resources', async () => {
+        const clusterTask = {
+          ...resourceTask,
+          spec: {
+            ...resourceTask.spec,
+            resources: {
+              inputs: [
+                { name: 'required-input', type: 'git' },
+                { name: 'optional-input', type: 'git', optional: true },
+              ],
+              outputs: [
+                { name: 'required-output', type: 'image' },
+                { name: 'optional-output', type: 'image', optional: true },
+              ],
+            },
+          },
+        };
+        await withFormData(
+          {
+            ...initialPipelineFormData,
+            resources: [
+              { name: 'git-resource', type: 'git' },
+              { name: 'image-resource', type: 'image' },
+            ],
+            tasks: [
+              {
+                name: 'test-task',
+                taskRef: { name: 'external-task-with-resources', kind: 'ClusterTask' },
+                resources: {
+                  inputs: [{ name: 'optional-input', resource: 'git-resource' }],
+                  outputs: [{ name: 'optional-output', resource: 'image-resource' }],
+                },
+              },
+            ],
+          },
+          {
+            clusterTasks: [clusterTask],
+          },
+        )
+          .then(shouldHaveFailed)
+          .catch(
+            hasError(
+              'formData.tasks[0].resources',
+              TASK_ERROR_STRINGS[TaskErrorType.MISSING_RESOURCES],
+            ),
+          );
+      });
+
       it('should pass if the task contains all of the required resources', async () => {
         await withFormData(
           {
@@ -763,6 +961,70 @@ describe('Pipeline Build validation schema', () => {
         )
           .then(hasResults)
           .catch(shouldHavePassed);
+      });
+
+      it('should pass if the task does not contain an optional workspaces', async () => {
+        const clusterTask = {
+          ...workspaceTask,
+          spec: {
+            ...workspaceTask.spec,
+            workspaces: [{ name: 'optional-workspace', optional: true }],
+          },
+        };
+        await withFormData(
+          {
+            ...initialPipelineFormData,
+            workspaces: [],
+            tasks: [
+              {
+                name: 'test-task',
+                taskRef: { name: 'external-task-with-workspace', kind: 'ClusterTask' },
+                workspaces: [],
+              },
+            ],
+          },
+          {
+            clusterTasks: [clusterTask],
+          },
+        )
+          .then(hasResults)
+          .catch(shouldHavePassed);
+      });
+
+      it('should fail if the task has a optional workspace but miss a required workspaces', async () => {
+        const clusterTask = {
+          ...workspaceTask,
+          spec: {
+            ...workspaceTask.spec,
+            workspaces: [
+              { name: 'optional-workspace', optional: true },
+              { name: 'required-workspace' },
+            ],
+          },
+        };
+        await withFormData(
+          {
+            ...initialPipelineFormData,
+            workspaces: [{ name: 'workspace' }],
+            tasks: [
+              {
+                name: 'test-task',
+                taskRef: { name: 'external-task-with-workspace', kind: 'ClusterTask' },
+                workspaces: [{ name: 'optional-workspace', workspace: 'workspace' }],
+              },
+            ],
+          },
+          {
+            clusterTasks: [clusterTask],
+          },
+        )
+          .then(shouldHaveFailed)
+          .catch(
+            hasError(
+              'formData.tasks[0].workspaces',
+              TASK_ERROR_STRINGS[TaskErrorType.MISSING_WORKSPACES],
+            ),
+          );
       });
 
       it('should fail if the task contains all the required workspaces but a mismatch in name occurs', async () => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
@@ -19,7 +19,7 @@ const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
     availableResources,
     hasResource,
     name,
-    resource: { name: resourceName, type: resourceType },
+    resource: { name: resourceName, type: resourceType, optional = false },
   } = props;
 
   const dropdownResources = availableResources.filter(
@@ -30,7 +30,6 @@ const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
       label: t('pipelines-plugin~Select {{resourceType}} resource...', { resourceType }),
       value: '',
       isPlaceholder: true,
-      isDisabled: true,
     },
     ...dropdownResources.map((resource) => ({ label: resource.name, value: resource.name })),
   ];
@@ -49,7 +48,7 @@ const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
           setFieldValue(name, { name: resourceName, resource: selectedResource });
         }
       }}
-      required
+      required={!optional}
     />
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWorkspace.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWorkspace.tsx
@@ -28,7 +28,6 @@ const TaskSidebarWorkspace: React.FC<TaskSidebarWorkspaceProps> = (props) => {
     {
       label: t('pipelines-plugin~Select workspace...'),
       value: '',
-      isDisabled: true,
       isPlaceholder: true,
     },
     ...dropdownWorkspaces.map((workspace) => ({

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWorkspace.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarWorkspace.tsx
@@ -12,6 +12,11 @@ type TaskSidebarWorkspaceProps = {
   resourceWorkspace: TektonWorkspace;
 };
 
+interface WorkspaceLink {
+  name: string;
+  workspace: string;
+}
+
 const TaskSidebarWorkspace: React.FC<TaskSidebarWorkspaceProps> = (props) => {
   const {
     availableWorkspaces,
@@ -20,27 +25,44 @@ const TaskSidebarWorkspace: React.FC<TaskSidebarWorkspaceProps> = (props) => {
     resourceWorkspace: { name: workspaceName, optional = false },
   } = props;
   const { t } = useTranslation();
-  const { setFieldValue } = useFormikContext<PipelineBuilderFormikValues>();
+  const { getFieldMeta, setFieldValue } = useFormikContext<PipelineBuilderFormikValues>();
 
   const dropdownWorkspaces = availableWorkspaces.filter((workspace) => !!workspace.name?.trim());
 
+  const currentLinkedWorkspaceName = getFieldMeta<WorkspaceLink>(name).value?.workspace;
+  const currentLinkedWorkspaceSelectable =
+    currentLinkedWorkspaceName &&
+    dropdownWorkspaces.some((resource) => resource.name === currentLinkedWorkspaceName);
+
   const options: FormSelectFieldOption[] = [
     {
-      label: t('pipelines-plugin~Select workspace...'),
+      label: optional
+        ? t('pipelines-plugin~No workspace')
+        : t('pipelines-plugin~Select workspace...'),
       value: '',
       isPlaceholder: true,
+      isDisabled: !optional,
     },
+  ];
+  if (currentLinkedWorkspaceName && !currentLinkedWorkspaceSelectable) {
+    options.push({
+      label: currentLinkedWorkspaceName,
+      value: currentLinkedWorkspaceName,
+      isDisabled: true,
+    });
+  }
+  options.push(
     ...dropdownWorkspaces.map((workspace) => ({
       value: workspace.name,
       label: workspace.name,
     })),
-  ];
+  );
 
   return (
     <FormSelectField
       name={`${name}.workspace`}
       label={workspaceName}
-      isDisabled={dropdownWorkspaces.length === 0}
+      isDisabled={options.length === 1}
       options={options}
       onChange={(selectedWorkspace: string) => {
         if (!hasWorkspace) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5804

**Analysis / Root cause**: 
After importing a Deployment from Git with enabled Pipelines option, the automatically copied Pipeline could not be opened and saved in the Pipeline builder without fixing a validation error. This happen because there are optional fields in this copied Pipeline which are not supported by the Pipeline builder.

The Pipeline builder expected that all defined resources and workspaces of a task are mandatory, but for the resource "source" of the task "openshift-client" there resource defined in the Pipeline:

![Screenshot from 2021-05-04 19-48-43](https://user-images.githubusercontent.com/139310/117047171-dab0c800-ad11-11eb-84e1-e7d991eb0ee1.png)

**Solution Description**: 
This change removes the form (formik + yup) "required" check for all resources and workspaces. Instead of a static check it now requires such a link to a Pipeline resource or workspace only if the linked task resource or workspace is mandatory. The form also shows the mandatory asterisk depending on this flag. You can see this change in the first two gifs below.

But while testing this I noticed some other "new" issues with the optional fields:

1. When the user changed a resource or workspace name in the pipeline, the task which refers such a resource or workspace need to be updated similar to required fields. This shows the user which tasks are affected by his change. So that's fine. But there is no option to de-select a resource or workspace again. The dropdown shows just the option "Select resource...." which is disabled and the other resources.
2. When the user removes a resource or workspace which is used in a task, and there is no other resource or workspace defined, the task is in a state where the user could not fix it anymore. The dropdown in the sidebar is completely disabled (because there is nothing to select) and it shows one an error that the user should change it ("Resource name has changed, reselect", or "Workspace name has changed, reselect").

To fix this I made an UI change which:

1. If the previously linked resource name could not be found anymore shows an additional option in the Dropdown which could not be selected anymore.
2. Enable the Dropdown if this option is shown or if there is any other resource is available. (It is still disabled if there is no resource is selected and there is no other resource available.)

Finally if this PR removes not linked resources and workspaces before it sends them to the backend. Otherwise the admission controller don't accept these optional fields.

**Screen shots / Gifs for design review**: 
Origin bug BEFORE this change:
![odc-5804-before](https://user-images.githubusercontent.com/139310/117051981-72fd7b80-ad17-11eb-8e70-e129b121bc08.gif)

Origin bug AFTER this change:
![odc-5804-after](https://user-images.githubusercontent.com/139310/117051990-76910280-ad17-11eb-86be-af6584dd77ea.gif)

FULL recording of the new bahaviour and how the user can solve the issue when she / he removes a resource or workspace now:
![option-to-unselect-optional-fields](https://user-images.githubusercontent.com/139310/117052228-c5d73300-ad17-11eb-8031-764cf8c1e457.gif)

Notice that the previously selected option automatically disappear as soon as the user switches to another option:
![Peek 2021-05-04 20-28](https://user-images.githubusercontent.com/139310/117052308-dedfe400-ad17-11eb-9db3-8f15065ef513.gif)

**Unit test coverage report**:
Additional tests for PipelineBuilder `pipeline-builder/validation-utils.ts`:

```
      Validate Resources
        ✓ should pass if the task does not contain the optional resources (7ms)
        ✓ should pass if the task contain the optional resources (9ms)
        ✓ should pass if the task contain the optional resources with an empty string (6ms)
        ✓ should pass if the task contains the required but not the optional resources (5ms)
        ✓ should fail if the task contains the optional but not the required resources (7ms)
      Validate Workspaces
        ✓ should pass if the task does not contain an optional workspaces (6ms)
        ✓ should fail if the task has a optional workspace but miss a required workspaces (7ms)
```

New unit test for `pipeline-builder/utils.ts`

```
  removeEmptyFormFields
    ✓ should not fail without any additional data
    ✓ should drop empty parameter values (1ms)
    ✓ should drop unlinked resources
    ✓ should drop unlinked workspaces
    ✓ should drop all optional or unlinked parameters
```

**Test setup:**
In general:
1. Install the OpenShift Pipelines operator (tested with version 1.4)

For the initial bug:
1. Import a Deployment from git. As repo you can use `https://github.com/jerolimov/nodeinfo` but this should fail also with others. Enable the "Add pipeline" option.
2. Open the Pipelines list
3. Select for your new pipeline the action "Edit pipeline"
4. Try to save this pipeline (previously it should an error and could not be saved)

For additional tests:
1. Create a task with optional resources and an optional workspace:
```yaml
apiVersion: tekton.dev/v1beta1
kind: Task
metadata:
  name: example-task
spec:
  resources:
    inputs:
      - name: input-resource
        optional: true
        type: git
    outputs:
      - name: output-resource
        optional: true
        type: image
  steps:
    - command:
        - /bin/bash
        - '-c'
        - echo
        - $(inputs.params.appName)
      image: registry.redhat.io/ubi7/ubi-minimal
      name: ''
      resources: {}
  workspaces:
    - name: a-workspace
      optional: true
```

2. Create a new Pipeline with the Pipeline builder
3. Add a resource / workspace, use them in your task, remove the resource / workspace from the Pipeline
4. Mix this with some more edge cases of adding and removing the data and try to save the pipeline when its possible.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/assign @andrewballantyne 
/cc @andrewballantyne @karthikjeeyar 