### PR TITLE
Bug 1954566: Cannot update a component (`UtilizationCard`) error

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -135,9 +135,11 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
       trimSecondsXMutator,
     );
     const [utilizationData, limitData, requestedData] = data;
-    setTimestamps &&
-      utilizationData &&
-      setTimestamps(utilizationData.map((datum) => datum.x as Date));
+    React.useEffect(() => {
+      setTimestamps &&
+        utilizationData &&
+        setTimestamps(utilizationData.map((datum) => datum.x as Date));
+    }, [setTimestamps, utilizationData]);
     const current = utilizationData?.length ? utilizationData[utilizationData.length - 1].y : null;
 
     let humanMax: string;


### PR DESCRIPTION
Relates to [Bug 1954566](https://bugzilla.redhat.com/show_bug.cgi?id=1954566)

Prevents the ```Warning: Cannot update a component (`UtilizationCard`) while rendering a different component (`Unknown`)``` error in the browser console.  See the bug for the exact error and trace.

The fix will only set a parent's state when the data in the child component changes by using the useEffect hook.


**Notes:**
This is a new React error that was introduced in recent versions of React.  So the appearance of this error may have started when new version of React was introduced.  In addition, the appearance of this error, may depend on the build and/or bridge connection.  For example the error may show on every page refresh, but once bridge is stopped and re-started, the error may no longer display.

Lastly, the pattern of calling a function passed as a prop that will change state of a parent is known to elicit this error.  Recommend always wrapping these prop based functions in a `useEffect` hook to prevent the state from being updated if the child component is immediately re-rendered without a data change.