### PR TITLE
[release-4.7] Bug 1956336: Fix Triggers section in eventlistener details page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
@@ -11,7 +11,10 @@ export interface EventListenerDetailsProps {
 
 const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventListener }) => {
   const { t } = useTranslation();
-  const triggers = eventListener.spec.triggers?.filter((trigger) => trigger.template?.name) || [];
+  const triggers =
+    eventListener.spec.triggers?.filter(
+      (trigger) => trigger.template?.ref || trigger.template?.name,
+    ) || [];
   return (
     <div className="co-m-pane__body">
       <SectionHeading text={t('pipelines-plugin~Event Listener details')} />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerTriggers.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerTriggers.tsx
@@ -18,7 +18,7 @@ interface EventListenerTriggersProps {
 
 const EventListenerTriggers: React.FC<EventListenerTriggersProps> = ({ namespace, triggers }) => {
   const { t } = useTranslation();
-  const triggerTemplates = triggers.filter((tr) => tr.template?.name);
+  const triggerTemplates = triggers.filter((tr) => tr.template?.ref || tr.template?.name);
   if (triggerTemplates.length === 0) {
     return null;
   }
@@ -28,7 +28,7 @@ const EventListenerTriggers: React.FC<EventListenerTriggersProps> = ({ namespace
       <dd>
         {triggerTemplates.map((trigger) => {
           const triggerTemplateKind = referenceForModel(TriggerTemplateModel);
-          const triggerTemplateName = trigger.template.name;
+          const triggerTemplateName = trigger.template?.ref || trigger.template?.name;
           const bindings: ResourceModelLink[] = getEventListenerTriggerBindingNames(
             trigger.bindings,
           );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/EventListenerDetails.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/__tests__/EventListenerDetails.spec.tsx
@@ -28,9 +28,14 @@ describe('EventListener Details', () => {
     );
   });
 
-  it('should not render EventListenerTriggers section if the trigger contains binding ref', () => {
+  it('should render EventListenerTriggers section if the trigger contains binding & template.name', () => {
+    wrapper.setProps({ obj: EventlistenerTestData[EventlistenerTypes.BINDINGS_TEMPLATE_NAME] });
+    expect(wrapper.find(EventListenerTriggers).exists()).toBe(true);
+  });
+
+  it('should render EventListenerTriggers section if the trigger contains binding & template.ref', () => {
     wrapper.setProps({ obj: EventlistenerTestData[EventlistenerTypes.BINDINGS_TEMPLATE_REF] });
-    expect(wrapper.find(EventListenerTriggers).exists()).toBe(false);
+    expect(wrapper.find(EventListenerTriggers).exists()).toBe(true);
   });
 
   it('should not render EventListenerTriggers section if triggers contains triggerRef', () => {


### PR DESCRIPTION
This is a manual cherry pick from 4.8 bug https://github.com/openshift/console/pull/8521
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5762

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
In Eventlistener details page, The triggers section supports only the `template.ref` but it should support `template.name` instead, for GA(1.4) pipelines operator.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Add `template.name` path to resolve and show the triggers section in the eventlistener page.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/9964343/116882708-622f0600-ac42-11eb-91d3-1eed2fbf6b76.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->
 EventListener Details
    ✓ should render EventListenerTriggers section if the trigger contains binding & template.name (15ms)
    ✓ should render EventListenerTriggers section if the trigger contains binding & template.ref (6ms)

**Test Setup**
1. Add a pipeline and add the trigger through the UI
2. Now visit the recently created eventlistener's details page
3. Trigger section should be shown on the right pane, under the URL. 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge