### PR TITLE
Bug 1955803: OperatorHub - console accepts any value for infraFeatures

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -15,8 +15,14 @@ export enum CapabilityLevel {
 
 export enum InfraFeatures {
   Disconnected = 'Disconnected',
-  Proxy = 'Proxy',
+  disconnected = 'Disconnected',
+  Proxy = 'Proxy-aware',
+  'proxy-aware' = 'Proxy-aware',
   FipsMode = 'FIPS Mode',
+  fips = 'FIPS Mode',
+  cnf = 'Cloud-Native Network Function',
+  cni = 'Container Network Interface',
+  csi = 'Container Storage Interface',
 }
 
 export type OperatorHubItem = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -27,6 +27,7 @@ import {
   OperatorHubCSVAnnotations,
   InstalledState,
   OperatorHubCSVAnnotationKey,
+  InfraFeatures,
 } from './index';
 import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
 import { Trans, useTranslation } from 'react-i18next';
@@ -71,12 +72,17 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
           const { currentCSVDesc } = (channels || []).find(({ name }) => name === defaultChannel);
           const currentCSVAnnotations: OperatorHubCSVAnnotations =
             currentCSVDesc?.annotations ?? {};
-          const [infraFeatures, validSubscription] = ANNOTATIONS_WITH_JSON.map((annotationKey) => {
-            return parseJSONAnnotation(currentCSVAnnotations, annotationKey, () =>
-              // eslint-disable-next-line no-console
-              console.warn(`Error parsing annotation in PackageManifest ${pkg.metadata.name}`),
-            );
-          });
+          const [parsedInfraFeatures = [], validSubscription] = ANNOTATIONS_WITH_JSON.map(
+            (annotationKey) => {
+              return parseJSONAnnotation(currentCSVAnnotations, annotationKey, () =>
+                // eslint-disable-next-line no-console
+                console.warn(`Error parsing annotation in PackageManifest ${pkg.metadata.name}`),
+              );
+            },
+          );
+          const filteredInfraFeatures = _.compact(
+            _.map(parsedInfraFeatures, (key) => InfraFeatures[key]),
+          );
 
           const {
             certifiedLevel,
@@ -131,7 +137,7 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
             marketplaceRemoteWorkflow,
             marketplaceSupportWorkflow,
             validSubscription,
-            infraFeatures,
+            infraFeatures: filteredInfraFeatures,
             keywords: currentCSVDesc?.keywords ?? [],
           };
         },


### PR DESCRIPTION
Fixes bug where the console UI is showing separate filters for a custom
catalog resource with supported infrastructure features annotation.
IE: `proxy` vs `proxy-aware` (both should map to the same UI filter)

See https://github.com/openshift/openshift-docs/pull/29511/files?short_path=15febe7#diff-15febe7334e281a679b50f39acc4f828f19f7c0efcd3e5033ed2db30c602a1d0 for new supported values versus old.

Also fixes bug where unsupported annotation values are shown in the UI.
IE: `bacon` 🥓

https://bugzilla.redhat.com/show_bug.cgi?id=1955803

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/21317056/116909140-c5ed0b00-ac11-11eb-88a2-0efb328169a2.png)
![image](https://user-images.githubusercontent.com/21317056/116909075-aeae1d80-ac11-11eb-95e2-ac0fd3b3a739.png)

### After
![image](https://user-images.githubusercontent.com/21317056/116909432-34ca6400-ac12-11eb-8813-9a700664ebbc.png)
<img width="1792" alt="Screen Shot 2021-05-03 at 12 54 47 PM" src="https://user-images.githubusercontent.com/21317056/116908581-14e67080-ac11-11eb-8b49-cd6979c36903.png">
<img width="1791" alt="Screen Shot 2021-05-03 at 12 58 26 PM" src="https://user-images.githubusercontent.com/21317056/116908582-14e67080-ac11-11eb-8955-b829bb8e43e4.png">
<img width="1792" alt="Screen Shot 2021-05-03 at 1 04 52 PM" src="https://user-images.githubusercontent.com/21317056/116908578-14e67080-ac11-11eb-8937-df391c2133b8.png">
