### PR TITLE
Bug 1935814: Fix row heights when additional columns in the pod & node list page have long text

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -18,7 +18,6 @@ import {
   withUserSettingsCompatibility,
   COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
   COLUMN_MANAGEMENT_CONFIGMAP_KEY,
-  useUserSettingsCompatibility,
 } from '@console/shared';
 import { NodeModel, MachineModel } from '@console/internal/models';
 import { NodeKind, referenceForModel } from '@console/internal/module/k8s';
@@ -250,13 +249,8 @@ const NodesTableRow = connect<NodesRowMapFromStateProps, null, NodesTableRowProp
     rowKey,
     style,
     metrics,
+    tableColumns,
   }: NodesTableRowProps & NodesRowMapFromStateProps) => {
-    const [tableColumns, , loaded] = useUserSettingsCompatibility(
-      COLUMN_MANAGEMENT_CONFIGMAP_KEY,
-      COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
-      undefined,
-      true,
-    );
     const nodeName = getName(node);
     const nodeUID = getUID(node);
     const usedMem = metrics?.usedMemory?.[nodeName];
@@ -283,9 +277,7 @@ const NodesTableRow = connect<NodesRowMapFromStateProps, null, NodesTableRowProp
     const labels = getLabels(node);
     const zone = node.metadata.labels?.['topology.kubernetes.io/zone'];
     const columns: Set<string> =
-      loaded && tableColumns?.[columnManagementID]?.length > 0
-        ? new Set(tableColumns[columnManagementID])
-        : getSelectedColumns();
+      tableColumns?.length > 0 ? new Set(tableColumns) : getSelectedColumns();
     return (
       <TableRow id={nodeUID} index={index} trKey={rowKey} style={style}>
         <TableData className={nodeColumnInfo.name.classes}>
@@ -398,6 +390,7 @@ type NodesTableRowProps = {
   index: number;
   rowKey: string;
   style: object;
+  tableColumns: string[];
 };
 
 const NodesTable: React.FC<NodesTableProps &
@@ -410,6 +403,7 @@ const NodesTable: React.FC<NodesTableProps &
           index={rowArgs.index}
           rowKey={rowArgs.key}
           style={rowArgs.style}
+          tableColumns={rowArgs.customData?.tableColumns}
         />
       ),
       [],
@@ -428,6 +422,7 @@ const NodesTable: React.FC<NodesTableProps &
         showNamespaceOverride
         Header={NodeTableHeader}
         Row={Row}
+        customData={{ tableColumns: tableColumns?.[columnManagementID] }}
         virtualize
       />
     );

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -29,7 +29,6 @@ import {
   COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
   useActiveNamespace,
   withLastNamespace,
-  useUserSettingsCompatibility,
 } from '@console/shared';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
@@ -274,13 +273,7 @@ const namespacesRowStateToProps = ({ UI }) => ({
 });
 
 const NamespacesTableRow = connect(namespacesRowStateToProps)(
-  withTranslation()(({ obj: ns, index, key, style, metrics, t }) => {
-    const [tableColumns, , loaded] = useUserSettingsCompatibility(
-      COLUMN_MANAGEMENT_CONFIGMAP_KEY,
-      COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
-      undefined,
-      true,
-    );
+  withTranslation()(({ obj: ns, index, key, style, metrics, tableColumns, t }) => {
     const name = getName(ns);
     const requester = getRequester(ns);
     const bytes = metrics?.memory?.[name];
@@ -288,9 +281,7 @@ const NamespacesTableRow = connect(namespacesRowStateToProps)(
     const description = getDescription(ns);
     const labels = ns.metadata.labels;
     const columns =
-      loaded && tableColumns?.[NamespacesColumnManagementID]?.length > 0
-        ? new Set(tableColumns[NamespacesColumnManagementID])
-        : getNamespacesSelectedColumns();
+      tableColumns?.length > 0 ? new Set(tableColumns) : getNamespacesSelectedColumns();
     return (
       <TableRow id={ns.metadata.uid} index={index} trKey={key} style={style}>
         <TableData className={namespaceColumnInfo.name.classes}>
@@ -372,6 +363,7 @@ const NamespacesRow = (rowArgs) => (
     index={rowArgs.index}
     rowKey={rowArgs.key}
     style={rowArgs.style}
+    tableColumns={rowArgs.customData?.tableColumns}
   />
 );
 
@@ -409,6 +401,7 @@ export const NamespacesList = connect(
         aria-label={t('public~Namespaces')}
         Header={NamespacesTableHeader}
         Row={NamespacesRow}
+        customData={{ tableColumns: tableColumns?.[NamespacesColumnManagementID] }}
         virtualize
       />
     );
@@ -568,12 +561,6 @@ const projectRowStateToProps = ({ UI }) => ({
 
 const ProjectTableRow = connect(projectRowStateToProps)(
   withTranslation()(({ obj: project, index, rowKey, style, customData = {}, metrics, t }) => {
-    const [tableColumns, , loaded] = useUserSettingsCompatibility(
-      COLUMN_MANAGEMENT_CONFIGMAP_KEY,
-      COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
-      undefined,
-      true,
-    );
     const name = getName(project);
     const requester = getRequester(project);
     const {
@@ -582,14 +569,15 @@ const ProjectTableRow = connect(projectRowStateToProps)(
       showMetrics,
       showActions,
       isColumnManagementEnabled = true,
+      tableColumns,
     } = customData;
     const bytes = metrics?.memory?.[name];
     const cores = metrics?.cpu?.[name];
     const description = getDescription(project);
     const labels = project.metadata.labels;
     const columns = isColumnManagementEnabled
-      ? loaded && tableColumns?.[projectColumnManagementID]?.length > 0
-        ? new Set(tableColumns[projectColumnManagementID])
+      ? tableColumns?.length > 0
+        ? new Set(tableColumns)
         : getProjectSelectedColumns({ showMetrics, showActions })
       : null;
     return (
@@ -769,7 +757,7 @@ const ProjectList_ = connectToFlags(
         Header={showMetrics ? headerWithMetrics : headerNoMetrics}
         Row={ProjectRow}
         EmptyMsg={data.length > 0 ? ProjectNotFoundMessage : ProjectEmptyMessage}
-        customData={{ showMetrics }}
+        customData={{ showMetrics, tableColumns: tableColumns?.[projectColumnManagementID] }}
         virtualize
       />
     );

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -10,7 +10,7 @@ import i18next from 'i18next';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Button, Popover } from '@patternfly/react-core';
-import { Status, TableColumnsType, useUserSettingsCompatibility } from '@console/shared';
+import { Status, TableColumnsType } from '@console/shared';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import {
   withUserSettingsCompatibility,
@@ -313,13 +313,8 @@ const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(p
     metrics,
     showNodes,
     showNamespaceOverride,
+    tableColumns,
   }: PodTableRowProps & PodTableRowPropsFromState) => {
-    const [tableColumns, , loaded] = useUserSettingsCompatibility(
-      COLUMN_MANAGEMENT_CONFIGMAP_KEY,
-      COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
-      undefined,
-      true,
-    );
     const { name, namespace, creationTimestamp, labels } = pod.metadata;
     const { readyCount, totalContainers } = podReadiness(pod);
     const phase = podPhase(pod);
@@ -327,9 +322,7 @@ const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(p
     const bytes: number = _.get(metrics, ['memory', namespace, name]);
     const cores: number = _.get(metrics, ['cpu', namespace, name]);
     const columns: Set<string> =
-      loaded && tableColumns?.[columnManagementID]?.length > 0
-        ? new Set(tableColumns[columnManagementID])
-        : getSelectedColumns(showNodes);
+      tableColumns?.length > 0 ? new Set(tableColumns) : getSelectedColumns(showNodes);
     const { t } = useTranslation();
     return (
       <TableRow id={pod.metadata.uid} index={index} trKey={rowKey} style={style}>
@@ -805,6 +798,7 @@ const getRow = (showNodes, showNamespaceOverride) => {
       style={rowArgs.style}
       showNodes={showNodes}
       showNamespaceOverride={showNamespaceOverride}
+      tableColumns={rowArgs.customData?.tableColumns}
     />
   );
 };
@@ -834,6 +828,7 @@ export const PodList: React.FC<PodListProps> = withUserSettingsCompatibility<
       aria-label={t('public~Pods')}
       Header={getHeader(showNodes)}
       Row={getRow(showNodes, showNamespaceOverride)}
+      customData={{ tableColumns: tableColumns?.[columnManagementID] }}
       virtualize
     />
   );
@@ -986,6 +981,7 @@ type PodTableRowProps = {
   index: number;
   rowKey: string;
   style: object;
+  tableColumns: string[];
   showNodes?: boolean;
   showNamespaceOverride?: boolean;
 };


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1935814

**Solution description:**
removed the usage of `useUserSettingsCompatibility` from the table row components and using `customData` prop of the Table component to pass the tablecolumn information

**GIF:**
![listpage](https://user-images.githubusercontent.com/22490998/117002585-5d7d5700-ad01-11eb-956b-a9cede410db8.gif)

**Test setup:**
To test this PR:
- In the `oc-environment.sh` change `BRIDGE_USER_SETTINGS_LOCATION="localstorage"` to `BRIDGE_USER_SETTINGS_LOCATION="configmap"`
- run the bridge again

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
