### PR TITLE
Bug 1956920: can't open terminal for pods that have more than one co…

### DIFF
--- a/frontend/public/components/terminal.jsx
+++ b/frontend/public/components/terminal.jsx
@@ -68,7 +68,7 @@ class Terminal_ extends React.Component {
     terminal.write(`\x1b[31m${reason || 'disconnected'}\x1b[m\r\n`);
     terminal.cursorHidden = true;
     terminal.setOption('disableStdin', true);
-    terminal.refresh(terminal.y, terminal.y);
+    terminal.refresh(0, terminal.rows - 1);
   }
 
   componentDidMount() {


### PR DESCRIPTION
…ntainer running

This fix uses a valid range for the refresh function of xterm, starting with row 0 and ending at rows-1.

Invalid start and end parameters were being passed to the refresh function of xterm during the switching of container terminals.  This caused an exception when attempting to switch container terminals.

Per the xterm code:

    /**
     * Tells the renderer to refresh terminal content between two rows
     * (inclusive) at the next opportunity.
     * @param start The row to start from (between 0 and this.rows - 1).
     * @param end The row to end at (between start and this.rows - 1).
     */

Fixes #8762