### PR TITLE
give feedback when modal submit is clicked

### DIFF
--- a/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
@@ -63,7 +63,7 @@ const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceMod
       </ModalBody>
       <ModalSubmitFooter
         submitText={submitLabel}
-        submitDisabled={(status && !!status.submitError) || !isValid}
+        submitDisabled={(status && !!status.submitError) || !isValid || isSubmitting}
         cancel={cancel}
         inProgress={isSubmitting}
         submitDanger
@@ -78,19 +78,18 @@ class DeleteResourceModal extends PromiseComponent<
   DeleteResourceModalState
 > {
   private handleSubmit = (values, actions) => {
-    actions.setSubmitting(true);
     const { onSubmit, close, redirect } = this.props;
-    onSubmit &&
+    return (
+      onSubmit &&
       this.handlePromise(onSubmit(values))
         .then(() => {
-          actions.setSubmitting(false);
           close();
           redirect && history.push(redirect);
         })
         .catch((errorMessage) => {
-          actions.setSubmitting(false);
           actions.setStatus({ submitError: errorMessage });
-        });
+        })
+    );
   };
 
   render() {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5799

**Root analysis:**
The submit status information is not sent to the modal submit footer

**Solution description:**
The submit status information is sent to the `submitDisabled` & `inProgress` props of the ModalSubmitFooter

**GIF:**
![modal-submit](https://user-images.githubusercontent.com/22490998/117028673-8f031c00-ad1b-11eb-93f8-90d5bd956b3b.gif)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge