### PR TITLE
Bug 1957756: Device Replacemet UI, The status of the disk is "replacement ready" before I clicked on "start replacement"

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/ocs-kebab-options.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/ocs-kebab-options.tsx
@@ -6,7 +6,7 @@ import { OCSDiskList, OCSColumnStateAction } from './state-reducer';
 import { diskReplacementModal } from '../modals/disk-replacement-modal';
 
 export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
-  ({ diskName, alertsMap, replacementMap, isRebalancing, dispatch }) => {
+  ({ nodeName, diskName, alertsMap, replacementMap, isRebalancing, dispatch }) => {
     const { t } = useTranslation();
 
     const kebabOptions: KebabOption[] = [
@@ -15,6 +15,7 @@ export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
         labelKey: t('ceph-storage-plugin~Start Disk Replacement'),
         callback: () =>
           diskReplacementModal({
+            nodeName,
             diskName,
             alertsMap,
             replacementMap,
@@ -34,6 +35,7 @@ export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
 );
 
 type OCSKebabOptionsProps = {
+  nodeName: string;
   diskName: string;
   alertsMap: OCSDiskList;
   replacementMap: OCSDiskList;

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/disk-replacement-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/disk-replacement-modal.tsx
@@ -46,6 +46,7 @@ const createTemplateInstance = async (
   template: TemplateKind,
   osd: string,
   disk: string,
+  nodeName: string,
 ) => {
   const templateInstance: TemplateInstanceKind = {
     apiVersion: apiVersionForModel(TemplateInstanceModel),
@@ -56,6 +57,7 @@ const createTemplateInstance = async (
       annotations: {
         disk,
         osd,
+        nodeName,
       },
     },
     spec: {
@@ -68,20 +70,29 @@ const createTemplateInstance = async (
   return k8sCreate(TemplateInstanceModel, templateInstance);
 };
 
-const instantiateTemplate = async (osdId: string, diskName: string) => {
+const instantiateTemplate = async (osdId: string, diskName: string, nodeName: string) => {
   const osdRemovalTemplate = await k8sGet(
     TemplateModel,
     OSD_REMOVAL_TEMPLATE,
     CEPH_STORAGE_NAMESPACE,
   );
   const templateSecret = await createTemplateSecret(osdRemovalTemplate, osdId);
-  await createTemplateInstance(templateSecret, osdRemovalTemplate, osdId, diskName);
+  await createTemplateInstance(templateSecret, osdRemovalTemplate, osdId, diskName, nodeName);
 };
 
 const DiskReplacementAction = (props: DiskReplacementActionProps) => {
   const { t } = useTranslation();
 
-  const { diskName, alertsMap, replacementMap, isRebalancing, dispatch, cancel, close } = props;
+  const {
+    diskName,
+    alertsMap,
+    nodeName,
+    replacementMap,
+    isRebalancing,
+    dispatch,
+    cancel,
+    close,
+  } = props;
 
   const [inProgress, setProgress] = React.useState(false);
   const [errorMessage, setError] = React.useState('');
@@ -103,7 +114,7 @@ const DiskReplacementAction = (props: DiskReplacementActionProps) => {
           ),
         );
       else {
-        instantiateTemplate(osd, diskName);
+        instantiateTemplate(osd, diskName, nodeName);
         dispatch({
           type: ActionType.SET_REPLACEMENT_MAP,
           payload: { [diskName]: { osd, status: Status.PreparingToReplace } },
@@ -157,5 +168,6 @@ export type DiskReplacementActionProps = {
   isRebalancing: boolean;
   alertsMap: OCSDiskList;
   replacementMap: OCSDiskList;
+  nodeName: string;
   dispatch: React.Dispatch<OCSColumnStateAction>;
 } & ModalComponentProps;


### PR DESCRIPTION
Added check for same node and same disk name to avoid collisions.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1957756

Signed-off-by: Afreen Rahman <afrahman@redhat.com>