### PR TITLE
Bug 1957967: Increase specificity of listPage.row.clickRowByName

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -75,10 +75,7 @@ export const listPage = {
     shouldExist: (resourceName: string) =>
       cy.get(`[data-test-rows="resource-row"]`).contains(resourceName),
     clickRowByName: (resourceName: string) =>
-      cy
-        .get(`[data-test-rows="resource-row"]`)
-        .contains(resourceName)
-        .click({ force: true }), // after applying row filter, resource rows detached from DOM according to cypress, need to force the click
+      cy.get(`a[data-test-id="${resourceName}"]`).click({ force: true }), // after applying row filter, resource rows detached from DOM according to cypress, need to force the click
     shouldNotExist: (resourceName: string) =>
       cy.get(`[data-test-id="${resourceName}"]`, { timeout: 90000 }).should('not.exist'),
   },


### PR DESCRIPTION
The selector used in the Cypress listPage.row.clickRowByName helper is not specific enough and could lead to flakes in some cases. Updating to use data attribute to specifically click the resource name link, since this should be consistent across all list pages.