### PR TITLE
Fix tooltip on pipelineRunCount and TaskRunDuration graphs based of P…

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -198,6 +198,7 @@
   "Refresh Interval": "Refresh Interval",
   "Time Range": "Time Range",
   "Pipeline run count chart": "Pipeline run count chart",
+  "Pipeline Runs": "Pipeline Runs",
   "Average PipelineRun duration": "Average PipelineRun duration",
   "Pipeline run duration chart": "Pipeline run duration chart",
   "Pipeline task run duration chart": "Pipeline task run duration chart",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
@@ -37,15 +37,15 @@ const PipelineRunCount: React.FC<PipelineMetricsGraphProps> = ({
   });
   const pipelineRunResultData = pipelineRunResult?.data?.result ?? [];
 
+  React.useEffect(() => {
+    if (!loaded && onInitialLoad) {
+      onInitialLoad({ chartName: 'pipelineRunCount', hasData: !!pipelineRunResultData.length });
+    }
+  }, [loaded, onInitialLoad, pipelineRunResultData]);
+
   if (loading) {
     return <LoadingInline />;
   }
-
-  if (!loaded) {
-    onInitialLoad &&
-      onInitialLoad({ chartName: 'pipelineRunCount', hasData: !!pipelineRunResultData.length });
-  }
-
   if ((!loaded && pipelineRunResultData.length) || error || pipelineRunResultData.length === 0) {
     return <GraphEmpty height={DEFAULT_CHART_HEIGHT} />;
   }
@@ -70,7 +70,7 @@ const PipelineRunCount: React.FC<PipelineMetricsGraphProps> = ({
                 labels={({ datum }) =>
                   datum.childName.includes('bar-') && datum.y !== null
                     ? `${formatDate(datum.x)}
-              ${datum.y}`
+                    ${t('pipelines-plugin~Pipeline Runs')}: ${datum.y}`
                     : null
                 }
               />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunDurationGraph.tsx
@@ -35,18 +35,19 @@ const PipelineRunDurationGraph: React.FC<PipelineMetricsGraphProps> = ({
   const pipelineRunDurationData = runData?.data?.result ?? [];
 
   const chartHeight = DEFAULT_LEGEND_CHART_HEIGHT;
-  if (runDataLoading) {
-    return <LoadingInline />;
-  }
 
-  if (!loaded) {
-    onInitialLoad &&
+  React.useEffect(() => {
+    if (!loaded && onInitialLoad) {
       onInitialLoad({
         chartName: 'pipelineRunDuration',
         hasData: !!pipelineRunDurationData.length,
       });
-  }
+    }
+  }, [loaded, onInitialLoad, pipelineRunDurationData]);
 
+  if (runDataLoading) {
+    return <LoadingInline />;
+  }
   if (
     (!loaded && pipelineRunDurationData.length) ||
     runDataError ||

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
@@ -39,17 +39,19 @@ const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
   });
   const pipelineSuccessData = runData?.data?.result ?? [];
 
-  if (runDataLoading) {
-    return <LoadingInline />;
-  }
-
-  if (!loaded) {
-    onInitialLoad &&
+  React.useEffect(() => {
+    if (!loaded && onInitialLoad) {
       onInitialLoad({
         chartName: 'pipelineSuccessRatio',
         hasData: !!pipelineSuccessData.length,
       });
+    }
+  }, [loaded, onInitialLoad, pipelineSuccessData]);
+
+  if (runDataLoading) {
+    return <LoadingInline />;
   }
+
   if ((!loaded && pipelineSuccessData.length) || runDataError || pipelineSuccessData.length === 0) {
     return <GraphEmpty height={DEFAULT_CHART_HEIGHT} />;
   }


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5763

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Follow the PF guidelines and include the design change outlined in the JIRA ticket.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

1.  Included the `PipelineRuns: ` label for the second row in the pipeline Run count graph.
2.  Included the `chartLegendTooltip` to show all the data points in a single tooltip based on the cursor movement in the chart.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
1. Pipeline Run count graph:

![image](https://user-images.githubusercontent.com/9964343/117412276-39548c80-af32-11eb-81b9-436dd4798d97.png)

2. TaskRun Duration graph:
![image](https://user-images.githubusercontent.com/9964343/117412475-7587ed00-af32-11eb-88cb-5ca1830be8c7.png)


![metrics-tooltips](https://user-images.githubusercontent.com/9964343/117413186-4920a080-af33-11eb-9b2c-fda1e7f89e65.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
cc: @bgliwa01 @andrewballantyne 