### PR TITLE
Bug 1961064: Fix documentation link to network policies

### DIFF
--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
@@ -198,14 +198,16 @@ const Details_ = ({ obj: np, flags }) => {
       <div className="co-m-pane__body">
         <SectionHeading text={t('public~Ingress rules')} />
         <p className="co-m-pane__explanation">
-          {t(
-            'public~Pods accept all traffic by default. They can be isolated via NetworkPolicies which specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will reject all traffic not explicitly allowed via a NetworkPolicy. See more details in:',
-          )}
-          <ExternalLink
-            href={getNetworkPolicyDocLink(flags[FLAGS.OPENSHIFT])}
-            text={t('public~NetworkPolicies documentation')}
-          />
-          .
+          <Trans ns="public">
+            Pods accept all traffic by default. They can be isolated via NetworkPolicies which
+            specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will
+            reject all traffic not explicitly allowed via a NetworkPolicy. See more details in:{' '}
+            <ExternalLink
+              href={getNetworkPolicyDocLink(flags[FLAGS.OPENSHIFT])}
+              text={t('public~NetworkPolicies documentation')}
+            />
+            .
+          </Trans>
         </p>
         {_.isEmpty(_.get(np, 'spec.ingress[0]', [])) ? (
           t('public~All traffic is allowed to Pods in {{namespace}}', {

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -4,6 +4,6 @@ export const openshiftHelpBase =
 
 export const getNetworkPolicyDocLink = (openshiftFlag: boolean) => {
   return openshiftFlag
-    ? `${openshiftHelpBase}networking/configuring-networkpolicy.html`
+    ? `${openshiftHelpBase}networking/network_policy/about-network-policy.html`
     : 'https://kubernetes.io/docs/concepts/services-networking/network-policies/';
 };

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1013,7 +1013,7 @@
   "To ports": "To ports",
   "NS selector": "NS selector",
   "Network policy details": "Network policy details",
-  "Pods accept all traffic by default. They can be isolated via NetworkPolicies which specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will reject all traffic not explicitly allowed via a NetworkPolicy. See more details in:": "Pods accept all traffic by default. They can be isolated via NetworkPolicies which specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will reject all traffic not explicitly allowed via a NetworkPolicy. See more details in:",
+  "Pods accept all traffic by default. They can be isolated via NetworkPolicies which specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will reject all traffic not explicitly allowed via a NetworkPolicy. See more details in: <2></2>.": "Pods accept all traffic by default. They can be isolated via NetworkPolicies which specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will reject all traffic not explicitly allowed via a NetworkPolicy. See more details in: <2></2>.",
   "NetworkPolicies documentation": "NetworkPolicies documentation",
   "All traffic is allowed to Pods in {{namespace}}": "All traffic is allowed to Pods in {{namespace}}",
   "Alerts could not be loaded": "Alerts could not be loaded",


### PR DESCRIPTION
Also fix missing space in english text

![Capture d’écran de 2021-05-07 11-40-08](https://user-images.githubusercontent.com/2153442/117431205-428d2b80-af29-11eb-970a-fc5b6b358f98.png)

The link was outdated, leading to 404. (I'm not sure since which version it changed)