### PR TITLE
Bug 1958868: Depracte isvmready

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHDetailsPage/SSHDetailsPage.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/ssh-service/SSHDetailsPage/SSHDetailsPage.tsx
@@ -13,10 +13,10 @@ import './ssh-details-page.scss';
 
 type SSHDetailsPageProps = {
   vm: VMKind | VMIKind;
-  isVMReady: boolean;
+  isVMIReady: boolean;
 };
 
-const SSHDetailsPage: React.FC<SSHDetailsPageProps> = ({ vm, isVMReady }) => {
+const SSHDetailsPage: React.FC<SSHDetailsPageProps> = ({ vm, isVMIReady }) => {
   const { sshServices } = useSSHService(vm);
   const { command, user } = useSSHCommand(vm);
 
@@ -25,7 +25,7 @@ const SSHDetailsPage: React.FC<SSHDetailsPageProps> = ({ vm, isVMReady }) => {
     <>
       <Stack hasGutter>
         <StackItem>
-          {isVMReady ? (
+          {isVMIReady ? (
             <>
               <Text component={TextVariants.p} data-test="SSHDetailsPage-user">
                 {t('kubevirt-plugin~user: {{user}}', { user })}
@@ -52,11 +52,11 @@ const SSHDetailsPage: React.FC<SSHDetailsPageProps> = ({ vm, isVMReady }) => {
             <b>{t('kubevirt-plugin~SSH Access ')}</b>
             <EditButton
               id="SSHDetailsPage-service-modal"
-              canEdit={isVMReady}
+              canEdit={isVMIReady}
               onClick={() => SSHModal({ vm })}
             />
           </div>
-          {isVMReady ? (
+          {isVMIReady ? (
             <Text component={TextVariants.p} data-test="SSHDetailsPage-port">
               {sshServices?.running
                 ? t('kubevirt-plugin~port: {{port}}', { port: sshServices?.port })

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -20,7 +20,7 @@ import { getDescription } from '../../selectors/selectors';
 import { getOperatingSystem, getOperatingSystemName, getVMLikeModel } from '../../selectors/vm';
 import { isBootOrderChanged, isFlavorChanged } from '../../selectors/vm-like/next-run-changes';
 import { getFlavorData } from '../../selectors/vm/flavor-data';
-import { isVMReady, isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
+import { isVMIReady, isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
 import { getVMINodeName, isVMIPaused } from '../../selectors/vmi';
 import { getVmiIpAddresses } from '../../selectors/vmi/ip-address';
 import { VMStatusBundle } from '../../statuses/vm/types';
@@ -217,7 +217,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         title={t('kubevirt-plugin~User credentials')}
         idValue={prefixedID(id, 'authorized-ssh-key')}
       >
-        <SSHDetailsPage vm={vmiLike} isVMReady={isVMReady(vm)} />
+        <SSHDetailsPage vm={vmiLike} isVMIReady={isVMIReady(vmi)} />
       </VMDetailsItem>
     </dl>
   );

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -91,7 +91,7 @@ export const getWorkloadProfile = (vm: VMGenericLikeEntityKind) =>
 export const getFlavor = (vmLike: VMGenericLikeEntityKind) =>
   findKeySuffixValue(getLabels(vmLike), TEMPLATE_FLAVOR_LABEL);
 
-export const isVMReady = (vm: VMKind) => !!vm?.status?.ready;
+export const isVMIReady = (vmi: VMIKind) => getStatusPhase(vmi) === VMIPhase.Running;
 
 export const isVMCreated = (vm: VMKind) => !!vm?.status?.created;
 


### PR DESCRIPTION
`vm?.status?.ready` is depracted, using vmi status instead.

Screenshots:
before:
![screenshot-localhost_9000-2021 05 10-13_39_16(1)](https://user-images.githubusercontent.com/2181522/117648002-5db0a300-b196-11eb-81cc-a967c208f5da.png)

after:
![screenshot-localhost_9000-2021 05 10-13_44_27](https://user-images.githubusercontent.com/2181522/117647973-58535880-b196-11eb-832c-b1df754c1c53.png)


Signed-off-by: yaacov <kobi.zamir@gmail.com>