### PR TITLE
Bug 1930007: Allow multiple selection on resources drop down

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -55,6 +55,7 @@
 
 .co-search-group__resource {
   margin: 0 15px 15px 0;
+  width: auto !important;
 }
 
 .co-search-input.pf-c-form-control {


### PR DESCRIPTION
Addresses [Bug 1930007](https://bugzilla.redhat.com/show_bug.cgi?id=1930007)

This allows the user to select multiple options without closing the drop down for the Resources drop down on the Events and Search pages.

This swapped out the custom Dropdown component with the PatternFly Select component.

NOTE:  The Workloads -> Pods page, click 'Filter' dropdown was resolved as part of another PR.  This PR only applies to the Events and Search pages.


https://user-images.githubusercontent.com/82059948/117692759-f2a9a100-b182-11eb-9862-f221cabda1a5.mov



