### PR TITLE
Bug 1957895: Cypress helper projectDropdown.shouldContain is not an assertion

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/common.ts
+++ b/frontend/packages/integration-tests-cypress/views/common.ts
@@ -19,7 +19,11 @@ export const projectDropdown = {
       .contains(projectName)
       .click();
   },
-  shouldContain: (name: string) => cy.byLegacyTestID('namespace-bar-dropdown').contains(name),
+  shouldContain: (name: string) =>
+    cy
+      .byLegacyTestID('namespace-bar-dropdown')
+      .contains(name)
+      .should('exist'),
   shouldNotContain: (name: string) =>
     cy.byLegacyTestID('namespace-bar-dropdown').should('not.contain', name),
   shouldNotExist: () => cy.byLegacyTestID('namespace-bar-dropdown').should('not.exist'),


### PR DESCRIPTION
The test would still fail with `.contains()` since the element would not be found, but we should probably use an assertion when the helper name starts with "should".

Added `contains().should('exist')` for readability