### PR TITLE
Bug 1943238: Display olm conditions descriptors in their own page section on operand details pages

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -119,7 +119,6 @@
   "Storage": "Storage",
   "Define the resource {{type}} for this {{kind}} instance.": "Define the resource {{type}} for this {{kind}} instance.",
   "No members": "No members",
-  "No conditions present": "No conditions present",
   "operator": "operator",
   "operator_plural": "operators",
   "Installation namespace <1>{{namespace}}</1> contains <4></4> installed with manual approval, and all operators installed in the same namespace will function as manual approval strategy. To allow automatic approval, all operators installed in the namespace must use automatic approval strategy.": "Installation namespace <1>{{namespace}}</1> contains <4></4> installed with manual approval, and all operators installed in the same namespace will function as manual approval strategy. To allow automatic approval, all operators installed in the namespace must use automatic approval strategy.",

--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -26,6 +26,13 @@ const prefixedCapabilities = new Set([
   StatusCapability.k8sResourcePrefix,
 ]);
 
+export const testConditionsDescriptor = {
+  path: 'testCondtions',
+  displayName: 'Test Condtions',
+  description: '',
+  'x-descriptors': [StatusCapability.conditions],
+};
+
 export const testClusterServiceVersion: ClusterServiceVersionKind = {
   apiVersion: 'operators.coreos.com/v1alpha1',
   kind: 'ClusterServiceVersion',
@@ -98,6 +105,7 @@ export const testClusterServiceVersion: ClusterServiceVersionKind = {
               'x-descriptors': [SpecCapability[capability]],
             })),
           statusDescriptors: [
+            testConditionsDescriptor,
             {
               path: 'podStatusus',
               displayName: 'Member Status',
@@ -202,6 +210,31 @@ export const testResourceInstance: K8sResourceKind = {
   },
   status: {
     'some-filled-path': 'this is filled!',
+    conditions: [
+      {
+        lastTransitionTime: '2017-10-16 12:00:00',
+        message: 'Condition message',
+        reason: 'CondtionReason',
+        status: 'True',
+        type: 'ConditionType',
+      },
+    ],
+    testConditions: [
+      {
+        lastTransitionTime: '2017-10-16 12:00:00',
+        message: 'Foo message',
+        reason: 'FooReason',
+        status: 'True',
+        type: 'FooType',
+      },
+      {
+        lastTransitionTime: '2017-10-16 12:01:00',
+        message: 'Bar message',
+        reason: 'BarReason',
+        status: 'True',
+        type: 'BarType',
+      },
+    ],
   },
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/index.tsx
@@ -8,19 +8,21 @@ import { JSONSchema6 } from 'json-schema';
 import { SpecDescriptorDetailsItem } from './spec';
 import { StatusDescriptorDetailsItem } from './status';
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
-import { DescriptorGroup, groupDescriptorDetails } from './utils';
+import {
+  DescriptorGroup,
+  groupDescriptorDetails,
+  useCalculatedDescriptorProperties,
+} from './utils';
 import { useTranslation } from 'react-i18next';
 
 export const DescriptorDetailsItem = withFallback<DescriptorDetailsItemProps>(
   ({ descriptor, model, obj, onError, schema, type }) => {
-    const propertySchema = getSchemaAtPath(schema, `${type}.${descriptor.path}`);
-    const fullPath = [type, ..._.toPath(descriptor.path)];
-    const label =
-      descriptor.displayName ||
-      propertySchema?.title ||
-      _.startCase(_.last(descriptor.path.split('.')));
-    const description = descriptor?.description || propertySchema?.description;
-    const value = _.get(obj, fullPath, descriptor.value);
+    const { displayName: label, description, value, fullPath } = useCalculatedDescriptorProperties(
+      type,
+      descriptor,
+      schema,
+      obj,
+    );
     const descriptorProps = {
       description,
       descriptor,

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/conditions.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/conditions.spec.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { Router } from 'react-router';
+import { Provider } from 'react-redux';
+import { StatusCapability } from '../types';
+import { DescriptorConditions } from './conditions';
+import { testResourceInstance } from '../../../../mocks';
+import { history, SectionHeading } from '@console/internal/components/utils';
+import store from '@console/internal/redux';
+
+describe('Conditions descriptor', () => {
+  it('Renders a conditions table for conditions status descriptor', () => {
+    const descriptor = {
+      path: 'testConditions',
+      displayName: 'Test Conditions',
+      description: '',
+      'x-descriptors': [StatusCapability.conditions],
+    };
+    const wrapper = mount(
+      <DescriptorConditions descriptor={descriptor} obj={testResourceInstance} schema={{}} />,
+      {
+        wrappingComponent: (props) => (
+          <Router history={history}>
+            <Provider store={store} {...props} />,
+          </Router>
+        ),
+      },
+    );
+
+    expect(wrapper.find(SectionHeading).text()).toEqual('Test Conditions');
+    expect(wrapper.find('[data-test="condition[0].type"]').text()).toEqual('FooType');
+    expect(wrapper.find('[data-test="condition[0].lastTransitionTime"]').text()).toEqual(
+      'Oct 16, 2017, 12:00 PM',
+    );
+    expect(wrapper.find('[data-test="condition[0].message"]').text()).toEqual('Foo message');
+    expect(wrapper.find('[data-test="condition[0].reason"]').text()).toEqual('FooReason');
+    expect(wrapper.find('[data-test="condition[0].status"]').text()).toEqual('True');
+    expect(wrapper.find('[data-test="condition[0].type"]').text()).toEqual('FooType');
+    expect(wrapper.find('[data-test="condition[1].type"]').text()).toEqual('BarType');
+    expect(wrapper.find('[data-test="condition[1].lastTransitionTime"]').text()).toEqual(
+      'Oct 16, 2017, 12:01 PM',
+    );
+    expect(wrapper.find('[data-test="condition[1].message"]').text()).toEqual('Bar message');
+    expect(wrapper.find('[data-test="condition[1].reason"]').text()).toEqual('BarReason');
+    expect(wrapper.find('[data-test="condition[1].status"]').text()).toEqual('True');
+    expect(wrapper.find('[data-test="condition[1].type"]').text()).toEqual('BarType');
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/conditions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/conditions.tsx
@@ -1,0 +1,52 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import { Conditions } from '@console/internal/components/conditions';
+import { useCalculatedDescriptorProperties } from '../utils';
+import { DescriptorType, StatusDescriptor } from '../types';
+import { SectionHeading } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { JSONSchema6 } from 'json-schema';
+
+// Determines if the descriptor points to an array value.
+const validateConditionsDescriptor = (descriptor: StatusDescriptor, value: any): boolean => {
+  if (!_.isArray(value)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[Invalid x-descriptor] 'urn:alm:descriptor:io.kubernetes.conditions' is incompatible with ${descriptor.path} and will have no effect`,
+      descriptor,
+    );
+    return false;
+  }
+  return true;
+};
+
+export const DescriptorConditions: React.FC<ConditionsDescriptorProps> = ({
+  descriptor,
+  obj,
+  schema,
+}) => {
+  const { displayName, value } = useCalculatedDescriptorProperties(
+    DescriptorType.status,
+    descriptor,
+    schema,
+    obj,
+  );
+
+  if (!validateConditionsDescriptor(descriptor, value)) {
+    return null;
+  }
+
+  return (
+    <div className="co-m-pane__body">
+      <SectionHeading text={displayName} />
+      <Conditions conditions={value} />
+    </div>
+  );
+};
+DescriptorConditions.displayName = 'DescriptorConditions';
+
+type ConditionsDescriptorProps = {
+  descriptor: StatusDescriptor;
+  obj: K8sResourceKind;
+  schema: JSONSchema6;
+};

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.spec.tsx
@@ -6,7 +6,6 @@ import { mount, ReactWrapper } from 'enzyme';
 import { Descriptor, StatusCapability, SpecCapability, DescriptorType } from '../types';
 import { testModel, testResourceInstance } from '../../../../mocks';
 import { ResourceLink, history } from '@console/internal/components/utils';
-import { Conditions } from '@console/internal/components/conditions';
 import { DescriptorDetailsItem, DescriptorDetailsItemProps } from '..';
 
 jest.mock('react-i18next', () => {
@@ -22,12 +21,6 @@ const OBJ = {
   status: {
     link: 'https://example.com',
     service: 'someservice',
-    conditions: [
-      {
-        lastUpdateTime: '2017-10-16 12:00:00',
-        type: 'SomeType',
-      },
-    ],
   },
 };
 
@@ -39,7 +32,7 @@ jest.mock('react-i18next', () => {
   };
 });
 
-describe('Status descriptors', () => {
+describe('Status descriptor details items', () => {
   let wrapper: ReactWrapper<DescriptorDetailsItemProps>;
   let descriptor: Descriptor;
 
@@ -71,14 +64,6 @@ describe('Status descriptors', () => {
   it('renders status value as text if no matching capability component', () => {
     expect(wrapper.find('dt').text()).toEqual(descriptor.displayName);
     expect(wrapper.find('dd .text-muted').text()).toEqual('public~None');
-  });
-
-  it('renders a conditions status', () => {
-    descriptor['x-descriptors'] = [StatusCapability.conditions];
-    descriptor.path = 'conditions';
-    wrapper.setProps({ descriptor });
-
-    expect(wrapper.find(Conditions).exists()).toBe(true);
   });
 
   it('renders a link status', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -4,7 +4,6 @@ import { Button } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 import { Status, SuccessStatus } from '@console/shared';
 import { DetailsItem } from '@console/internal/components/utils';
-import { Conditions } from '@console/internal/components/conditions';
 import { SecretValue } from '@console/internal/components/configmap-and-secret-data';
 import { CapabilityProps, StatusCapability } from '../types';
 import { Phase } from './phase';
@@ -37,30 +36,6 @@ const PodStatuses: React.FC<StatusCapabilityProps> = ({
         {detail}
       </DetailsItem>
     </div>
-  );
-};
-
-const StatusConditions: React.FC<StatusCapabilityProps> = ({
-  description,
-  descriptor,
-  fullPath,
-  label,
-  obj,
-  value,
-}) => {
-  const { t } = useTranslation();
-  const detail = React.useMemo(() => {
-    return (
-      (!_.isArray(value) && <Invalid path={descriptor.path} />) ||
-      (value.length === 0 && (
-        <span className="text-muted">{t('olm~No conditions present')}</span>
-      )) || <Conditions conditions={value} />
-    );
-  }, [descriptor.path, t, value]);
-  return (
-    <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
-      {detail}
-    </DetailsItem>
   );
 };
 
@@ -163,8 +138,6 @@ export const StatusDescriptorDetailsItem: React.FC<StatusCapabilityProps> = (pro
   switch (capability) {
     case StatusCapability.podStatuses:
       return <PodStatuses {...props} />;
-    case StatusCapability.conditions:
-      return <StatusConditions {...props} />;
     case StatusCapability.w3Link:
       return <Link {...props} />;
     case StatusCapability.k8sPhase:
@@ -196,7 +169,6 @@ type StatusCapabilityProps = CapabilityProps<StatusCapability>;
 Phase.displayName = 'Phase';
 Invalid.displayName = 'Invalid';
 PodStatuses.displayName = 'PodStatuses';
-StatusConditions.displayName = 'StatusConditions';
 Link.displayName = 'Link';
 K8sPhase.displayName = 'K8sPhase';
 K8sPhaseReason.displayName = 'K8sPhaseReason';

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
@@ -11,6 +11,23 @@ import {
   REGEXP_NESTED_ARRAY_PATH,
 } from './const';
 import { Descriptor, SpecCapability, StatusCapability } from './types';
+import { getSchemaAtPath } from '@console/shared';
+
+export const useCalculatedDescriptorProperties = (descriptorType, descriptor, schema, obj) => {
+  const propertySchema = getSchemaAtPath(schema, `${descriptorType}.${descriptor.path}`);
+  const fullPath = [descriptorType, ..._.toPath(descriptor.path)];
+  const displayName =
+    descriptor.displayName || propertySchema?.title || _.startCase(_.last(fullPath));
+  const description = descriptor?.description || propertySchema?.description || '';
+  const value = _.get(obj, fullPath, descriptor.value);
+  return {
+    description,
+    displayName,
+    fullPath,
+    propertySchema,
+    value,
+  };
+};
 
 // Creates a structure for rendering grouped descriptors on the operand details page.
 export const groupDescriptorDetails = (

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -15,6 +15,7 @@ import {
   testClusterServiceVersion,
   testOwnedResourceInstance,
   testModel,
+  testConditionsDescriptor,
 } from '../../../mocks';
 import { ClusterServiceVersionModel } from '../../models';
 import {
@@ -196,7 +197,10 @@ describe(OperandDetails.displayName, () => {
   });
 
   it('renders description title', () => {
-    const title = wrapper.find('SectionHeading').prop('text');
+    const title = wrapper
+      .find('SectionHeading')
+      .first()
+      .prop('text');
     expect(title).toEqual('olm~{{kind}} overview');
   });
 
@@ -253,6 +257,27 @@ describe(OperandDetails.displayName, () => {
         .shallow()
         .find(DescriptorDetailsItem).length,
     ).toEqual(csv.spec.customresourcedefinitions.required[0].specDescriptors.length);
+  });
+
+  it('renders a Condtions table', () => {
+    expect(
+      wrapper
+        .find('SectionHeading')
+        .at(1)
+        .prop('text'),
+    ).toEqual('public~Conditions');
+
+    expect(wrapper.find('Conditions').prop('conditions')).toEqual(
+      testResourceInstance.status.conditions,
+    );
+  });
+
+  it('renders a DescriptorConditions component for conditions descriptor', () => {
+    expect(wrapper.find('DescriptorConditions').prop('descriptor')).toEqual(
+      testConditionsDescriptor,
+    );
+    expect(wrapper.find('DescriptorConditions').prop('obj')).toEqual(testResourceInstance);
+    expect(wrapper.find('DescriptorConditions').prop('schema')).toEqual({});
   });
 });
 

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -19,21 +19,27 @@ export const Conditions: React.FC<ConditionsProps> = ({ conditions }) => {
   };
 
   const rows = conditions?.map?.((condition: K8sResourceCondition, i: number) => (
-    <div className="row" data-test-id={condition.type} key={i}>
-      <div className="col-xs-4 col-sm-2 col-md-2">
+    <div className="row" data-test={condition.type} key={i}>
+      <div className="col-xs-4 col-sm-2 col-md-2" data-test={`condition[${i}].type`}>
         <CamelCaseWrap value={condition.type} />
       </div>
-      <div className="col-xs-4 col-sm-2 col-md-2" data-test-id="status">
+      <div className="col-xs-4 col-sm-2 col-md-2" data-test={`condition[${i}].status`}>
         {getStatusLabel(condition.status)}
       </div>
-      <div className="hidden-xs hidden-sm col-md-2">
+      <div
+        className="hidden-xs hidden-sm col-md-2"
+        data-test={`condition[${i}].lastTransitionTime`}
+      >
         <Timestamp timestamp={condition.lastTransitionTime} />
       </div>
-      <div className="col-xs-4 col-sm-3 col-md-2">
+      <div className="col-xs-4 col-sm-3 col-md-2" data-test={`condition[${i}].reason`}>
         <CamelCaseWrap value={condition.reason} />
       </div>
       {/* remove initial newline which appears in route messages */}
-      <div className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line co-conditions__message">
+      <div
+        className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line co-conditions__message"
+        data-test={`condition[${i}].message`}
+      >
         {condition.message?.trim() || '-'}
       </div>
     </div>
@@ -60,6 +66,7 @@ export const Conditions: React.FC<ConditionsProps> = ({ conditions }) => {
     </>
   );
 };
+Conditions.displayName = 'Conditions';
 
 export type ConditionsProps = {
   conditions: K8sResourceCondition[];


### PR DESCRIPTION
Update condition descriptors to be rendered in separate, full width tables like the standard status.conditions table.

### Before
![before](https://user-images.githubusercontent.com/22625502/117719037-e9ccc580-b1aa-11eb-8413-5f92e4939962.png)

### After
![after](https://user-images.githubusercontent.com/22625502/117719072-ee917980-b1aa-11eb-82f6-1be2cb46f9d4.png)
