### PR TITLE
Topology List View Automation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,8 @@
     "test-cypress-knative": "cd packages/knative-plugin/integration-tests && yarn run test-cypress",
     "test-cypress-knative-headless": "cd packages/knative-plugin/integration-tests && yarn run test-cypress-headless",
     "test-cypress-helm": "cd packages/helm-plugin/integration-tests && yarn run test-cypress",
+    "test-cypress-topology": "cd packages/topology/integration-tests && yarn run test-cypress",
+    "test-cypress-topology-headless": "cd packages/topology/integration-tests && yarn run test-cypress-headless",
     "test-cypress-helm-headless": "cd packages/helm-plugin/integration-tests && yarn run test-cypress-headless",
     "cypress-merge": "mochawesome-merge ./gui_test_screenshots/cypress_report*.json > ./gui_test_screenshots/cypress.json",
     "cypress-generate": "marge -o ./gui_test_screenshots/ -f cypress-report -t 'OpenShift Console Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ./gui_test_screenshots/cypress/assets ./gui_test_screenshots/cypress.json",

--- a/frontend/packages/topology/integration-tests/features/topology/topology-list-view.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-list-view.feature
@@ -4,27 +4,15 @@ Feature: List view in topology
 
         Background:
             Given user is at developer perspective
-              And user has selected namespace "aut-topology-list-view"
+              And user has created or selected namespace "aut-topology-list-view"
+              And user is at Add page
 
 
         @smoke
         Scenario: Topology List view : T-07-TC05
-            Given user created workload "nodejs-ex-git" with resource type "Deployment"
+            Given user has created workload "nodejs-ex-git-d" with resource type "Deployment"
              When user clicks on List view button
-              And user verifies the filter by resource on top
              Then user will see workloads are segregated by applications groupings
-
-
-        @regression
-        Scenario: Topology filter by resource: T-07-TC06, T-07-TC07
-            Given user created two workloads with resource type "Deployment" and "Deployment-Config"
-             When user clicks on List view button
-              And user clicks the filter by resource on top
-              And user will see "Deployment" and "Deployment-Config" options with '1' associated with it
-              And user clicks on Deployment
-              And user can see only the deployment workload
-              And user clicks on Deployment-Config
-             Then user can see only the deployment-config workload
 
 
         @regression @manual

--- a/frontend/packages/topology/integration-tests/features/topology/topology-toolbar-filter.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-toolbar-filter.feature
@@ -1,0 +1,17 @@
+@topology
+Feature: Topology Toolbar Filter Group
+              As a user, I should be able to use the Filter Groups on Topology page
+
+        Background:
+            Given user is at developer perspective
+              And user has created or selected namespace "aut-tp-toolbar"
+              And user is at Add page
+
+        @regression
+        Scenario: Topology filter by resource: T-07-TC06, T-07-TC07
+            Given user has created workload "nodejs-ex-git-dc" with resource type "Deployment Config"
+             When user clicks on List view button
+              And user clicks the filter by resource on top
+             Then user will see Deployment and DeploymentConfig options with 1 associated with it
+              And user clicks on Deployment checkbox to see only the deployment type workload
+              And user clicks on DeploymentConfig checkbox to see only the deploymentconfig type workload

--- a/frontend/packages/topology/integration-tests/package.json
+++ b/frontend/packages/topology/integration-tests/package.json
@@ -5,5 +5,9 @@
   "private": true,
   "cypress-cucumber-preprocessor": {
     "step_definitions": "support/step-definitions/*/"
+  },
+  "scripts": {
+    "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/topology/*.feature\";"
   }
 }

--- a/frontend/packages/topology/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/topology/integration-tests/support/commands/hooks.ts
@@ -1,0 +1,13 @@
+before(() => {
+  cy.login();
+  cy.document()
+    .its('readyState')
+    .should('eq', 'complete');
+});
+
+after(() => {
+  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE')}`, {
+    failOnNonZeroExit: false,
+    timeout: 180000,
+  });
+});

--- a/frontend/packages/topology/integration-tests/support/commands/index.ts
+++ b/frontend/packages/topology/integration-tests/support/commands/index.ts
@@ -6,3 +6,4 @@ import '../../../../integration-tests-cypress/support/project';
 import '../../../../integration-tests-cypress/support/index';
 import '../../../../dev-console/integration-tests/support/commands/app';
 import './app';
+import './hooks';

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -19,6 +19,12 @@ export const topologyPO = {
     node: '[data-test-id="base-node-handler"]',
     workload: '[data-type="workload"]',
     eventSourceWorkload: '[data-type="event-source"]',
+    applicationGroupingTitle: '.odc-topology-list-view__application-label',
+    filterByResource: {
+      filterByResourceDropDown: '.pf-c-select__toggle-text',
+      deploymentResource: '.co-m-resource-icon.co-m-resource-deployment',
+      deploymentConfigResource: '.co-m-resource-icon.co-m-resource-deploymentconfig',
+    },
     contextMenuOptions: {
       addToProject: '.pf-topology-context-sub-menu',
     },
@@ -26,6 +32,7 @@ export const topologyPO = {
   list: {
     appName: '#HelmRelease ul li div',
     nodeName: '#HelmRelease ul li div',
+    resourceTitle: 'pf-c-data-list__cell.odc-topology-list-view__kind-label',
   },
   sidePane: {
     actionsDropDown: '[data-test-id="actions-menu-button"]',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -20,6 +20,9 @@ export const topologyPage = {
     app.waitForDocumentLoad();
     cy.url().should('include', 'topology');
   },
+  verifyTopologyGraphView: () => {
+    return cy.get(topologyPO.graph.emptyGraph);
+  },
   verifyContextMenu: () => cy.get(topologyPO.graph.contextMenu).should('be.visible'),
   verifyNoWorkLoadsText: (text: string) =>
     cy.get('h3.pf-c-title.pf-m-lg').should('contain.text', text),

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/list-view.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/list-view.ts
@@ -1,0 +1,17 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { navigateTo } from '@console/dev-console/integration-tests/support/pages/app';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
+import { topologyPO } from '../../page-objects/topology-po';
+
+When('user clicks on List view button', () => {
+  navigateTo(devNavigationMenu.Topology);
+  if (cy.get(topologyPO.graph.emptyGraph)) {
+    cy.get(topologyPO.switcher).click();
+  } else {
+    cy.log('You are already on List View');
+  }
+});
+
+Then('user will see workloads are segregated by applications groupings', () => {
+  cy.get(topologyPO.graph.applicationGroupingTitle).should('be.visible');
+});

--- a/frontend/packages/topology/integration-tests/tsconfig.json
+++ b/frontend/packages/topology/integration-tests/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../dev-console/integration-tests/tsconfig.json",
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/ODC-5576

**Problem:** Automation to open the list view of the Topology page

**Solution:** This script will open list view of topology page and will check the workload deployed

**Test Setup:**
1. Run `yarn run test-cypress-topology` in frontend
2. Execute feature file: `frontend/packages/topology/integration-tests/features/topology/topology-list-view.feature`

**Test Execution Screenshot:**
![Screenshot from 2021-05-11 09-52-41](https://user-images.githubusercontent.com/17041173/117758697-1ed72780-b240-11eb-9dbd-5d17cd037a8f.png)
