### PR TITLE
Fix that boolean values (esp. false) are not loaded and synced correctly

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useUserSettingsLocalStorage.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettingsLocalStorage.ts
@@ -14,7 +14,8 @@ export const useUserSettingsLocalStorage = <T>(
   const [data, setData] = React.useState(() => {
     const valueInStorage =
       storage.getItem(storageKey) !== null && deseralizeData(storage.getItem(storageKey));
-    return valueInStorage?.hasOwnProperty(keyRef.current) && valueInStorage[keyRef.current]
+    return valueInStorage?.hasOwnProperty(keyRef.current) &&
+      valueInStorage[keyRef.current] !== undefined
       ? valueInStorage[keyRef.current]
       : defaultValueRef.current;
   });
@@ -27,7 +28,7 @@ export const useUserSettingsLocalStorage = <T>(
         const configMapData = deseralizeData(event.newValue);
         const newData = configMapData?.[keyRef.current];
 
-        if (newData && seralizeData(newData) !== seralizeData(dataRef.current)) {
+        if (newData !== undefined && seralizeData(newData) !== seralizeData(dataRef.current)) {
           setData(newData);
         }
       }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5820

**Analysis / Root cause**: 
This issue happen only when user settings are saved in local storage. Which is commonly used in local development.

The value is not loaded and synced because of two truthy checks.

**Solution Description**: 
While loading the data from local storage, accept also `false` values and replace the truthy check with an not undefined check.

Do this as well when a sync event was received to update `false` values between browser tabs and windows.

**Screen shots / Gifs for design review**: 
Before:
![odc-5820-before](https://user-images.githubusercontent.com/139310/117769737-5e981200-b234-11eb-854c-858801d29453.gif)

After:
![odc-5820-after](https://user-images.githubusercontent.com/139310/117769742-60fa6c00-b234-11eb-925d-67c29369e4fe.gif)

**Unit test coverage report**: 
Not changed as there are no breaking test.

**Test setup:**
Add the following code to a functional component:

```tsx
import { Switch } from '@patternfly/react-core';
import { useUserSettings } from '@console/shared/src';

...

const [value, setValue] = useUserSettings('test', true, true);

...

<Switch
  isChecked={value || false}
  onChange={(changedValue) => setValue(changedValue)}
  value={JSON.stringify(value)}
/>
```

JS snippet to remove the test user settings:

```js
us = JSON.parse(window.localStorage.getItem('console-user-settings')); delete us.test; window.localStorage.setItem('console-user-settings', JSON.stringify(us))
```

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
