### PR TITLE
Added missing icons to VM states and removing popup when no actual message available

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -359,7 +359,6 @@
   "Guest agent status": "Guest agent status",
   "Virtual Machine": "Virtual Machine",
   "Virtual Machine Status": "Virtual Machine Status",
-  "Not Available": "Not Available",
   "Events": "Events",
   "View all": "View all",
   "Created": "Created",

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/status/GuestAgentStatusHealth.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/status/GuestAgentStatusHealth.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { VMIKind } from '@console/kubevirt-plugin/src/types';
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
 import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
+import { OffIcon } from '@patternfly/react-icons';
 
 import {
   isGuestAgentInstalled,
@@ -50,6 +51,7 @@ const GuestAgentStatusHealth: React.FC<GuestAgentProps> = ({ vmi }) => {
       title={t('kubevirt-plugin~Guest Agent')}
       state={state}
       details={details}
+      icon={!vmi?.status && <OffIcon />}
       popupTitle={t('kubevirt-plugin~Guest agent status')}
     >
       {guestAgentNotInstalledMessage || guestAgentNotSupportedMessage}

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/status/VMStatusHealth.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/status/VMStatusHealth.tsx
@@ -1,8 +1,10 @@
+import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
 import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
+import { HourglassHalfIcon, OffIcon } from '@patternfly/react-icons';
 
 import { VMStatusBundle } from '../../../../statuses/vm/types';
 import { ImporterPods } from '../../../vm-status/vm-status';
@@ -11,37 +13,44 @@ type VMStatusHealthProps = {
   vmStatusBundle: VMStatusBundle;
 };
 
+const stateMapper = {
+  Error: HealthState.ERROR,
+  Running: HealthState.OK,
+  Completed: HealthState.OK,
+  Pending: HealthState.PROGRESS,
+  Importing: HealthState.PROGRESS,
+  Deleting: HealthState.PROGRESS,
+  InProgress: HealthState.PROGRESS,
+  Starting: HealthState.PROGRESS,
+  Off: HealthState.PROGRESS,
+  Other: HealthState.UNKNOWN,
+};
+
+const customIconMapper = {
+  Pending: <HourglassHalfIcon />,
+  Off: <OffIcon />,
+};
+
 const VMStatusHealth: React.FC<VMStatusHealthProps> = ({ vmStatusBundle }) => {
   const { t } = useTranslation();
 
   const { status, importerPodsStatuses } = vmStatusBundle;
   const message = vmStatusBundle?.message || vmStatusBundle?.detailedMessage;
 
-  const stateMapper = (statusLabel: string) => {
-    const mapper = {
-      Error: HealthState.ERROR,
-      Running: HealthState.OK,
-      Completed: HealthState.OK,
-      Pending: HealthState.PROGRESS,
-      Importing: HealthState.PROGRESS,
-      InProgress: HealthState.PROGRESS,
-      Starting: HealthState.PROGRESS,
-      Off: HealthState.NOT_AVAILABLE,
-      Other: HealthState.UNKNOWN,
-    };
+  const simpleLabel = status.getSimpleLabel();
 
-    return mapper[statusLabel];
-  };
+  const state = stateMapper[simpleLabel];
 
   return (
     <HealthItem
       title={t('kubevirt-plugin~Virtual Machine')}
-      state={stateMapper(status.getSimpleLabel())}
-      details={status.getSimpleLabel()}
+      state={state}
+      details={simpleLabel}
+      icon={customIconMapper[simpleLabel]}
       popupTitle={t('kubevirt-plugin~Virtual Machine Status')}
     >
-      {message || t('kubevirt-plugin~Not Available')}
-      <ImporterPods key="importerPods" statuses={importerPodsStatuses} />
+      {!isEmpty(message) && message}
+      {importerPodsStatuses && <ImporterPods key="importerPods" statuses={importerPodsStatuses} />}
     </HealthItem>
   );
 };


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Analysis / Root cause**: 
HelthItem component didn't support custom icon

**Solution Description**: 
A fix was made for HealthItem component to support custom icon

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/117788612-36b6a780-b250-11eb-9906-5efa441fd36d.png)
Before:
![image](https://user-images.githubusercontent.com/14824964/117788790-61a0fb80-b250-11eb-8f55-de99f1bba2eb.png)
