### PR TITLE
Bug 1958439: fixes issue with html5 required validation for dynamic forms

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
@@ -18,7 +18,6 @@ export const TextWidget: React.FC<WidgetProps> = (props) => {
     onChange,
     onFocus,
     readonly = false,
-    required = false,
     schema = {},
     value = '',
   } = props;
@@ -35,7 +34,6 @@ export const TextWidget: React.FC<WidgetProps> = (props) => {
       onChange={({ currentTarget }) => onChange(currentTarget.value)}
       onFocus={onFocus && ((event) => onFocus(id, event.target.value))}
       readOnly={readonly}
-      required={required}
       type="text"
       value={value}
     />
@@ -71,20 +69,13 @@ export const PasswordWidget: React.FC<WidgetProps> = ({ value = '', id, onChange
   );
 };
 
-export const CheckboxWidget: React.FC<WidgetProps> = ({
-  value = false,
-  id,
-  label,
-  onChange,
-  required,
-}) => {
+export const CheckboxWidget: React.FC<WidgetProps> = ({ value = false, id, label, onChange }) => {
   return (
     <Checkbox
       id={id}
       key={id}
       isChecked={value}
       label={label}
-      required={required}
       onChange={(checked) => onChange(checked)}
     />
   );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1958439

**Analysis / Root cause**: 
If a field has required attribute and is hidden in DOM (if the accordion is closed which is holding it) html5validation kicks in as `CheckboxWidget` has required prop unlike `SwitchWidget`  and in console can see below error

```
An invalid form control with name='' is not focusable.
```

**Solution Description**: 
removed html5 required attribute from `CheckboxWidget` and `TextWidget`.


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
