### PR TITLE
Navigate user to respective catalog-page on pressing enter while focused on quick-add view-all link

### DIFF
--- a/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchList.tsx
@@ -117,6 +117,7 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
       <div className="odc-quick-search-list__all-items-link">
         {viewAll?.map((catalogLink) => (
           <Link
+            id={catalogLink.catalogType}
             to={catalogLink.to}
             key={catalogLink.catalogType}
             style={{ fontSize: 'var(--pf-global--FontSize--sm)' }}

--- a/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/topology/src/components/quick-search/QuickSearchModalBody.tsx
@@ -5,6 +5,7 @@ import {
   getQueryArgument,
   removeQueryArgument,
   setQueryArgument,
+  history,
 } from '@console/internal/components/utils';
 import QuickSearchBar from './QuickSearchBar';
 import QuickSearchContent from './QuickSearchContent';
@@ -93,11 +94,15 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
 
   const onEnter = React.useCallback(
     (e) => {
-      if (selectedItem) {
+      const { id } = document.activeElement;
+      const activeViewAllLink = viewAll?.find((link) => link.catalogType === id);
+      if (activeViewAllLink) {
+        history.push(activeViewAllLink.to);
+      } else if (selectedItem) {
         handleCta(e, selectedItem, closeModal, fireTelemetryEvent);
       }
     },
-    [closeModal, fireTelemetryEvent, selectedItem],
+    [closeModal, fireTelemetryEvent, selectedItem, viewAll],
   );
 
   const selectPrevious = React.useCallback(() => {


### PR DESCRIPTION
**Fixes:** [Clicking enter when focused on QuickSearch viewAll link navigates the user to the selectedItem](https://issues.redhat.com/browse/ODC-5609)

https://user-images.githubusercontent.com/20724543/117848567-0cd9a100-b2a1-11eb-9db3-1d874978674d.mov




/kind bug