### PR TITLE
Fix node-v15 pipeline test failures

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -409,6 +409,8 @@ export const managePipelineResources = async (
   formData: GitImportFormData,
   pipelineData: PipelineKind,
 ) => {
+  if (!formData) return;
+
   const { name, git, pipeline, project, docker, image } = formData;
   let managedPipeline: PipelineKind;
   const pipelineName = pipelineData?.metadata?.name;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
@@ -110,8 +110,14 @@ describe('getPipelineName', () => {
 
 describe('PipelineAction testing getPipelineRunData', () => {
   it('expect null to be returned when no arguments are passed', () => {
+    // Suppress the error log when we don't have pipeline or pipeline run
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
     const runData = getPipelineRunData();
     expect(runData).toBeNull();
+
+    // eslint-disable-next-line no-console
+    (console.error as any).mockRestore();
   });
 
   it('expect pipeline run data to be returned when only Pipeline argument is passed', () => {


### PR DESCRIPTION
https://issues.redhat.com/browse/ODC-5824

Does two things:

1. Cleans up logs so the pipeline tests run without spewing run-time console logs
2. Fixes up a couple tests so they can work with node-v15 -- `jest.spyOn` invokes the method with no arguments and one of our methods was incorrectly trying to test that a try/catch caught errors and mocked a situation where an undefined Pipeline object was being invoked for `.metadata.name`

Best guess why this is happening is this is somehow in the Node code on how to swallow some errors that jest is creating (maybe in a worker thread?) and thus when upgraded to v15 it exposes this issue instead of hiding it. There is a slack thread of others on the team testing on v14 of node and it passes as it always has -- see the ticket for that thread.