### PR TITLE
Bug 1959519: Fix typo in OperandDetails components

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -502,7 +502,7 @@ export const OperandDetails = connectToModel(({ crd, csv, kindObj, obj }: Operan
     if (descriptor['x-descriptors']?.includes(StatusCapability.podStatuses)) {
       return {
         ...acc,
-        podStatuses: [...(acc.PodStatuses ?? []), descriptor],
+        podStatuses: [...(acc.podStatuses ?? []), descriptor],
       };
     }
 


### PR DESCRIPTION
Fix typo that was causing podStatuses descriptors to be incorrectly aggregated leading to only the last one being rendered on the details page.