### PR TITLE
Bug 1958679: Disable pool compression via UI

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/update-block-pool-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/update-block-pool-modal.tsx
@@ -87,12 +87,12 @@ const UpdateBlockPoolModal = withHandlePromise((props: UpdateBlockPoolModalProps
       {
         op: 'replace',
         path: '/spec/compressionMode',
-        value: state.isCompressed ? COMPRESSION_ON : '',
+        value: state.isCompressed ? COMPRESSION_ON : 'none',
       },
       {
         op: 'replace',
         path: '/spec/parameters/compression_mode',
-        value: state.isCompressed ? COMPRESSION_ON : '',
+        value: state.isCompressed ? COMPRESSION_ON : 'none',
       },
     ];
 

--- a/frontend/packages/ceph-storage-plugin/src/utils/block-pool.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/block-pool.tsx
@@ -201,11 +201,11 @@ export const getPoolKindObj = (state: BlockPoolState): StoragePoolKind => ({
     namespace: CEPH_STORAGE_NAMESPACE,
   },
   spec: {
-    compressionMode: state.isCompressed ? COMPRESSION_ON : '',
+    compressionMode: state.isCompressed ? COMPRESSION_ON : 'none',
     deviceClass: state.volumeType || '',
     failureDomain: state.failureDomain,
     parameters: {
-      compression_mode: state.isCompressed ? COMPRESSION_ON : '', // eslint-disable-line @typescript-eslint/camelcase
+      compression_mode: state.isCompressed ? COMPRESSION_ON : 'none', // eslint-disable-line @typescript-eslint/camelcase
     },
     replicated: {
       size: Number(state.replicaSize),


### PR DESCRIPTION
CephBlockPool CR needs to have the following instead of the empty string, to avoid ceph hitting `Error EINVAL: unrecognized compression mode ''` error:
```
parameters:
  compression_mode: none
```

**Earlier:** (Edit Block Pool --> Disabling compression)
![Screenshot from 2021-05-11 23-55-14](https://user-images.githubusercontent.com/39404641/117866577-f0dffa80-b2b4-11eb-9fdc-1d7f2ee618ac.png)

**After:** (Edit Block Pool --> Disabling compression)
![Screenshot from 2021-05-11 23-54-52](https://user-images.githubusercontent.com/39404641/117866770-24228980-b2b5-11eb-9a88-cd80e0878d4f.png)

