### PR TITLE
Bug 1959041: "Troubleshoot" link doesn't exist after scaling down OSD pod

### DIFF
--- a/frontend/packages/ceph-storage-plugin/console-extensions.json
+++ b/frontend/packages/ceph-storage-plugin/console-extensions.json
@@ -13,7 +13,7 @@
   {
     "type": "console.alert-action",
     "properties": {
-      "alert": "CephOSDDiskUnavailable",
+      "alert": "CephOSDDiskNotResponding",
       "text": "%ceph-storage-plugin~Troubleshoot%",
       "action": { "$codeRef": "alert.getAlertActionPath" }
     },


### PR DESCRIPTION
Replaced duplicate alert "CephOSDDiskUnavailable" to "CephOSDDiskNotResponding" for "console.alert-action" type.