### PR TITLE
Bug 1959550: Overly generic CSS rules for dd and dt elements breaks styling elsewhere in console

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/review-tab.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/review-tab.scss
@@ -23,30 +23,29 @@
     grid-column-gap: var(--pf-global--spacer--2xl);
     grid-row-gap: var(--pf-global--spacer--sm);
   }
-}
-
-dt {
-  font-weight: var(--pf-global--FontWeight--semi-bold);
-
-  &:not(:first-child) {
-    margin-top: var(--pf-global--spacer--md);
-
+  dt {
+    font-weight: var(--pf-global--FontWeight--semi-bold);
+  
+    &:not(:first-child) {
+      margin-top: var(--pf-global--spacer--md);
+  
+      @media screen and (min-width: $pf-global--breakpoint--sm) {
+        margin-top: 0;
+      }
+    }
+  
     @media screen and (min-width: $pf-global--breakpoint--sm) {
-      margin-top: 0;
+      grid-column: 1;
     }
   }
-
-  @media screen and (min-width: $pf-global--breakpoint--sm) {
-    grid-column: 1;
+  
+  dd {
+    @media screen and (min-width: $pf-global--breakpoint--sm) {
+      grid-column: 2;
+    }
+  
+    margin: 0;
   }
-}
-
-dd {
-  @media screen and (min-width: $pf-global--breakpoint--sm) {
-    grid-column: 2;
-  }
-
-  margin: 0;
 }
 
 .kubevirt-create-vm-modal__review-tab__footer {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1959550

**Analysis / Root cause**: 
root cause is explained in BZ above

**Solution Description**: 
inserted generic CSS rules to it's specific intended class, so it affects only the correct CSS class.

**Screen shots / Gifs for design review**: 

Before:

![bz_1959550_before](https://user-images.githubusercontent.com/67270715/117959734-fa08b000-b324-11eb-9d3b-38394d736ee3.png)

After:

![bz_1959550_after](https://user-images.githubusercontent.com/67270715/117959767-00972780-b325-11eb-9fc4-7270ede059d0.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>