### PR TITLE
Bug 1926776: "Template support" modal appears when select the RHEL6 common template

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -567,7 +567,7 @@
   "Restore": "Restore",
   "Support for this template is provided through the OS community Red Hat participates in and contributes to.": "Support for this template is provided through the OS community Red Hat participates in and contributes to.",
   "Learn more about the community": "Learn more about the community",
-  "This template is provided by Red Hat, But is not supported ": "This template is provided by Red Hat, But is not supported ",
+  "This template is provided by Red Hat, but is not supported ": "This template is provided by Red Hat, but is not supported ",
   "The support level is not defined in the template yaml. To mark this template as supported, add these two annotations in the template details:": "The support level is not defined in the template yaml. To mark this template as supported, add these two annotations in the template details:",
   "Do not show this message again": "Do not show this message again",
   "Continue": "Continue",

--- a/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
@@ -57,7 +57,7 @@ const SupportModal: React.FC<SupportModalProps> = ({
           ) : isCommonTemplate ? (
             <>
               <StackItem>
-                {t('kubevirt-plugin~This template is provided by Red Hat, But is not supported ')}
+                {t('kubevirt-plugin~This template is provided by Red Hat, but is not supported ')}
                 <ExternalLink href={SUPPORT_URL} text={t('kubevirt-plugin~Learn more')} />
               </StackItem>
             </>


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1926776

**Analysis / Root cause**: 
Typo in support modal message, for more info please follow [this link](https://bugzilla.redhat.com/show_bug.cgi?id=1926776#c5) 

**Screen shots / Gifs for design review**: 

Before:

![bz_1926776_before_new](https://user-images.githubusercontent.com/67270715/117984840-d9e6ea00-b340-11eb-8af4-d2e0dbea827a.png)

After:

![bz_1926776_after_new](https://user-images.githubusercontent.com/67270715/117984898-e8350600-b340-11eb-9e40-6ff46232f3df.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>