### PR TITLE
Fix pipelinerun and taskrun log snippet message for timeout issue

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/__tests__/pipelineRunLogSnippet.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/__tests__/pipelineRunLogSnippet.spec.ts
@@ -6,32 +6,51 @@ import {
   DataState,
 } from '../../../../test-data/pipeline-data';
 
-const PipelineRunMock =
+const pipelineRunMock =
   pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.SUCCESS];
-const PipelineRunMockFailed =
+const pipelineRunMockFailed =
   pipelineTestData[PipelineExampleNames.BROKEN_MOCK_APP].pipelineRuns[DataState.FAILED1];
+const pipelineRunTimeoutError =
+  pipelineTestData[PipelineExampleNames.BROKEN_MOCK_APP].pipelineRuns[DataState.FAILED2];
 
 describe('PipelineRunLogSnippet test', () => {
   it('should return null for successful PLR', () => {
-    const msg = getPLRLogSnippet(PipelineRunMock);
+    const msg = getPLRLogSnippet(pipelineRunMock);
     expect(msg).toEqual(null);
   });
+
+  it('should return null if PLR value is null', () => {
+    const msg = getPLRLogSnippet(null);
+    expect(msg).toEqual(null);
+  });
+
   it('should return a Log message for failed PLR with task container', () => {
     const { title, containerName, podName } = getPLRLogSnippet(
-      PipelineRunMockFailed,
+      pipelineRunMockFailed,
     ) as ErrorDetailsWithLogName;
     expect(title).toEqual('Failure on task {{taskName}} - check logs for details.');
     expect(containerName).toEqual('step-build');
     expect(podName).toEqual('broken-app-pipeline-j2nxzm-x-compile-8mq2h-pod-b9gsg');
   });
+
+  it('should return a Log message for PLR with PipelineRunTimeout reason', () => {
+    const { title, staticMessage } = getPLRLogSnippet(
+      pipelineRunTimeoutError,
+    ) as ErrorDetailsWithStaticLog;
+    expect(title).toEqual('Failure - check logs for details.');
+    expect(staticMessage).toEqual(
+      'PipelineRun "fetch-and-print-recipe-test" failed to finish within "5s"',
+    );
+  });
+
   it('should return a static message', () => {
     const { title, staticMessage } = getPLRLogSnippet({
-      ...PipelineRunMock,
+      ...pipelineRunMock,
       status: {
-        ...PipelineRunMock.status,
+        ...pipelineRunMock.status,
         conditions: [
           {
-            ...PipelineRunMock.status.conditions[0],
+            ...pipelineRunMock.status.conditions[0],
             status: 'False',
             message: '',
           },

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/logs/pipelineRunLogSnippet.ts
@@ -29,10 +29,15 @@ export const getPLRLogSnippet = (pipelineRun: PipelineRunKind): CombinedErrorDet
       (condition) => condition.type === 'Succeeded' && condition.status === 'False',
     ),
   );
+  const isKnownReason = (reason: string): boolean => {
+    // known reasons https://tekton.dev/vault/pipelines-v0.21.0/pipelineruns/#monitoring-execution-status
+    return ['PipelineRunCancelled', 'PipelineRunTimeout'].includes(reason);
+  };
+
   // We're intentionally looking at the first failure because we have to start somewhere - they have the YAML still
   const failedTaskRun = failedTaskRuns[0];
 
-  if (!failedTaskRun) {
+  if (!failedTaskRun || isKnownReason(succeededCondition?.reason)) {
     // No specific task run failure information, just print pipeline run status
     return {
       staticMessage:

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/logs/__tests__/taskRunLogSnippet.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/logs/__tests__/taskRunLogSnippet.spec.ts
@@ -1,0 +1,85 @@
+import { getTRLogSnippet } from '../taskRunLogSnippet';
+import {
+  pipelineTestData,
+  PipelineExampleNames,
+  DataState,
+} from '../../../../test-data/pipeline-data';
+import {
+  ErrorDetailsWithStaticLog,
+  ErrorDetailsWithLogName,
+} from '../../../pipelineruns/logs/log-snippet-types';
+import { PipelineRunKind } from 'packages/pipelines-plugin/src/types';
+
+const taskRunMock = pipelineTestData[PipelineExampleNames.WORKSPACE_PIPELINE].taskRuns[0];
+const plrWithFailedTaskRun =
+  pipelineTestData[PipelineExampleNames.BROKEN_MOCK_APP].pipelineRuns[DataState.FAILED1];
+const plrWithTaskRunTimeoutError =
+  pipelineTestData[PipelineExampleNames.BROKEN_MOCK_APP].pipelineRuns[DataState.FAILED2];
+
+const getFailedTaskRunStatus = (plr: PipelineRunKind) => {
+  const [taskRunStatus] = Object.values(plr.status.taskRuns).filter((tr) =>
+    tr?.status?.conditions?.find(
+      (condition) => condition.type === 'Succeeded' && condition.status === 'False',
+    ),
+  );
+  return taskRunStatus?.status;
+};
+
+describe('TaskRunLogSnippet test', () => {
+  it('should return null for successful TaskRun', () => {
+    const msg = getTRLogSnippet(taskRunMock);
+    expect(msg).toEqual(null);
+  });
+
+  it('should return null if TaskRun value is null', () => {
+    const msg = getTRLogSnippet(null);
+    expect(msg).toEqual(null);
+  });
+
+  it('should return a Log message for failed TaskRun with task container', () => {
+    const taskRunWithContainer = {
+      ...taskRunMock,
+      status: { ...getFailedTaskRunStatus(plrWithFailedTaskRun) },
+    };
+    const { title, containerName, podName } = getTRLogSnippet(
+      taskRunWithContainer,
+    ) as ErrorDetailsWithLogName;
+    expect(title).toEqual('Failure on task {{taskName}} - check logs for details.');
+    expect(containerName).toEqual('step-build');
+    expect(podName).toEqual('broken-app-pipeline-j2nxzm-x-compile-8mq2h-pod-b9gsg');
+  });
+
+  it('should return a Log message for TaskRun with TaskRunTimeout reason', () => {
+    const timeOutTaskRun = {
+      ...taskRunMock,
+      status: { ...getFailedTaskRunStatus(plrWithTaskRunTimeoutError) },
+    };
+    const { title, staticMessage } = getTRLogSnippet(timeOutTaskRun) as ErrorDetailsWithStaticLog;
+    expect(title).toEqual('Failure on task {{taskName}} - check logs for details.');
+    expect(staticMessage).toEqual(
+      'TaskRun "fetch-and-print-recipe-test-fetch-the-recipe-5pb9p" failed to finish within "5s"',
+    );
+  });
+
+  it('should return a static message', () => {
+    const failedTaskRun = {
+      ...taskRunMock,
+      status: { ...getFailedTaskRunStatus(plrWithTaskRunTimeoutError) },
+    };
+    const { title, staticMessage } = getTRLogSnippet({
+      ...taskRunMock,
+      status: {
+        ...failedTaskRun.status,
+        conditions: [
+          {
+            ...failedTaskRun.status.conditions[0],
+            status: 'False',
+            message: '',
+          },
+        ],
+      },
+    }) as ErrorDetailsWithStaticLog;
+    expect(title).toEqual('Failure on task {{taskName}} - check logs for details.');
+    expect(staticMessage).toEqual('Unknown failure condition');
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -1584,7 +1584,190 @@ export const pipelineTestData: PipelineTestData = {
           },
         },
       },
+      [DataState.FAILED2]: {
+        apiVersion: 'tekton.dev/v1beta1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'broken-app-pipeline-failed',
+          labels: {
+            'pipeline.openshift.io/started-by': 'kubeadmin',
+            'tekton.dev/pipeline': 'broken-app-pipeline',
+          },
+          uid: '27a7fcad-8711-48df-8135-8e856f997e60',
+        },
+        spec: {
+          pipelineRef: {
+            name: 'fetch-and-print-recipe',
+          },
+          serviceAccountName: 'pipeline',
+          timeout: '5s',
+          workspaces: [
+            {
+              name: 'password-vault',
+              secret: {
+                secretName: 'secret-password',
+              },
+            },
+            {
+              configMap: {
+                items: [
+                  {
+                    key: 'brownies',
+                    path: 'recipe.txt',
+                  },
+                ],
+                name: 'sensitive-recipe-storage',
+              },
+              name: 'recipe-store',
+            },
+            {
+              name: 'shared-data',
+              persistentVolumeClaim: {
+                claimName: 'shared-task-storage',
+              },
+            },
+          ],
+        },
+        status: {
+          completionTime: '2021-05-12T11:37:31Z',
+          conditions: [
+            {
+              lastTransitionTime: '2021-05-12T11:37:31Z',
+              message: 'PipelineRun "fetch-and-print-recipe-test" failed to finish within "5s"',
+              reason: 'PipelineRunTimeout',
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+          pipelineSpec: pipelineSpec[PipelineExampleNames.BROKEN_MOCK_APP],
+          startTime: '2021-05-12T11:37:26Z',
+          taskRuns: {
+            'fetch-and-print-recipe-test-fetch-the-recipe-5pb9p': {
+              pipelineTaskName: 'fetch-the-recipe',
+              status: {
+                completionTime: '2021-05-12T11:37:32Z',
+                conditions: [
+                  {
+                    lastTransitionTime: '2021-05-12T11:37:32Z',
+                    message:
+                      'TaskRun "fetch-and-print-recipe-test-fetch-the-recipe-5pb9p" failed to finish within "5s"',
+                    reason: 'TaskRunTimeout',
+                    status: 'False',
+                    type: 'Succeeded',
+                  },
+                ],
+                podName: 'fetch-and-print-recipe-test-fetch-the-recipe-5pb9p-pod-ksbnx',
+                startTime: '2021-05-12T11:37:27Z',
+                steps: [
+                  {
+                    container: 'step-fetch-and-write',
+                    name: 'fetch-and-write',
+                  },
+                ],
+                taskSpec: {
+                  steps: [
+                    {
+                      image: 'ubuntu',
+                      name: 'fetch-and-write',
+                      resources: {},
+                    },
+                  ],
+                  workspaces: [
+                    {
+                      name: 'super-secret-password',
+                    },
+                    {
+                      name: 'secure-store',
+                    },
+                    {
+                      name: 'filedrop',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
     },
+    taskRuns: [
+      {
+        apiVersion: 'tekton.dev/v1beta1',
+        kind: 'TaskRun',
+        metadata: {
+          annotations: {
+            'pipeline.tekton.dev/release': 'v0.22.0',
+          },
+          name: 'recipe-time-hwtzt-fetch-the-recipe-x2b4n',
+          ownerReferences: [
+            {
+              apiVersion: 'tekton.dev/v1beta1',
+              blockOwnerDeletion: true,
+              controller: true,
+              kind: 'PipelineRun',
+              name: 'recipe-time-hwtzt',
+              uid: '6308f220-4da5-4d1a-9240-9a032fa1e56a',
+            },
+          ],
+          labels: {
+            'app.kubernetes.io/managed-by': 'tekton-pipelines',
+            'tekton.dev/pipeline': 'fetch-and-print-recipe',
+            'tekton.dev/pipelineRun': 'recipe-time-hwtzt',
+            'tekton.dev/pipelineTask': 'fetch-the-recipe',
+            'tekton.dev/task': 'fetch-secure-data',
+          },
+        },
+        spec: {
+          serviceAccountName: 'pipeline',
+          taskRef: {
+            kind: 'Task',
+            name: 'fetch-secure-data',
+          },
+          timeout: '5s',
+          workspaces: [
+            {
+              name: 'super-secret-password',
+              secret: {
+                secretName: 'secret-password',
+              },
+            },
+            {
+              configMap: {
+                items: [
+                  {
+                    key: 'brownies',
+                    path: 'recipe.txt',
+                  },
+                ],
+                name: 'sensitive-recipe-storage',
+              },
+              name: 'secure-store',
+            },
+            {
+              name: 'filedrop',
+              persistentVolumeClaim: {
+                claimName: 'shared-task-storage',
+              },
+            },
+          ],
+        },
+        status: {
+          completionTime: '2021-05-12T13:23:59Z',
+          conditions: [
+            {
+              lastTransitionTime: '2021-05-12T13:23:59Z',
+              message:
+                'TaskRun "recipe-time-hwtzt-fetch-the-recipe-x2b4n" failed to finish within "5s"',
+              reason: 'TaskRunTimeout',
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+          podName: 'recipe-time-hwtzt-fetch-the-recipe-x2b4n-pod-v4wzv',
+          startTime: '2021-05-12T13:23:53Z',
+        },
+      },
+    ],
   },
   [PipelineExampleNames.INVALID_PIPELINE_MISSING_TASK]: {
     dataSource: 'missing-task-reference',


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5702

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When a pipelinerun/taskrun fails due to a timeout issue, then the reason for failure is not shown in the pipelinerun/taskrun details page

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Show the message for the know reasons like PipelineRunTimeout and TaskRunTimeout
known reasons are mentioned in the docs:
https://tekton.dev/vault/pipelines-v0.21.0/pipelineruns/#monitoring-execution-status
https://tekton.dev/vault/pipelines-v0.21.0/taskruns/#monitoring-execution-status

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
**PipelineRun Details page:**
Before fix:
![image](https://user-images.githubusercontent.com/9964343/117991797-02301200-b35c-11eb-9cba-449a17c76803.png)
After fix:
![image](https://user-images.githubusercontent.com/9964343/117991851-0e1bd400-b35c-11eb-871b-5dfa3aab825c.png)

**Taskruns Details page**
![image](https://user-images.githubusercontent.com/9964343/117992176-563af680-b35c-11eb-9da1-b0f054711868.png)



**Unit test coverage report**: 
<!-- Attach test coverage report -->
PipelineRunLogSnippet test
```
 ✓ should return null if PLR value is null
✓ should return a Log message for PLR with PipelineRunTimeout reason
```
  TaskRunLogSnippet test
  ```
    ✓ should return null for successful TaskRun (2ms)
    ✓ should return null if TaskRun value is null
    ✓ should return a Log message for failed TaskRun with task container (1ms)
    ✓ should return a Log message for TaskRun with TaskRunTimeout reason
    ✓ should return a static message (1ms)
   ```

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Create the following resources:
**pipeline:**
```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: new-pipeline
spec:
  tasks:
    - name: kn
      params:
        - name: kn-image
          value: >-
            registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:efb51d4a337566ca8532073cd598cc2cfbbec260f037ce4de19d4c67ee411358
        - name: ARGS
          value:
            - help
      taskRef:
        kind: ClusterTask
        name: kn
```
**PipelineRun:**
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: new-pipelinerun-
  labels:
    tekton.dev/pipeline: new-pipeline
spec:
  pipelineRef:
    name: new-pipeline
  serviceAccountName: pipeline
  timeout: 4s
 ```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
cc: @andrewballantyne @VeereshAradhya 