### PR TITLE
Updated helm chart annotations namespace

### DIFF
--- a/frontend/packages/helm-plugin/src/catalog/utils/const.ts
+++ b/frontend/packages/helm-plugin/src/catalog/utils/const.ts
@@ -1,7 +1,7 @@
 // Annotation for human readable chart name, ready to be displayed in UI
-export const CHART_NAME_ANNOTATION = 'helm-chart.openshift.io/name';
+export const CHART_NAME_ANNOTATION = 'charts.openshift.io/name';
 // Annotation for chart category, e.g. redhat, partner, community
-export const PROVIDER_TYPE_ANNOTATION = 'helm-chart.openshift.io/providerType';
+export const PROVIDER_TYPE_ANNOTATION = 'charts.openshift.io/providerType';
 
 export enum PROVIDER_TYPE {
   redhat = 'redhat',


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5833
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Related to**: https://github.com/openshift/console/pull/8662

**Analysis / Root cause**: The namespace for the helm chart annotations used by helm plugin has been updated.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Update the annotations that we use in code.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No UI change.
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Test setup:**
- Add a new helm chart repo that contains `providerType` annotations in `index.yaml`.
```yaml
apiVersion: helm.openshift.io/v1beta1
kind: HelmChartRepository
metadata:
  name: redhat-certified
spec:
  connectionConfig:
    url: >-
      https://raw.githubusercontent.com/rohitkrai03/redhat-helm-charts/certification
  name: Red Hat Certification Charts
```
- Disable the default Red Hat helm chart repo.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
