### PR TITLE
Bug 1940318: Monitoring dashboards: Support colored text for single values

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -401,7 +401,7 @@ const Card: React.FC<CardProps> = ({ panel }) => {
     );
   }
 
-  if (!['grafana-piechart-panel', 'graph', 'singlestat', 'table'].includes(panel.type)) {
+  if (!['gauge', 'grafana-piechart-panel', 'graph', 'singlestat', 'table'].includes(panel.type)) {
     return null;
   }
 
@@ -442,7 +442,7 @@ const Card: React.FC<CardProps> = ({ panel }) => {
                   queries={queries}
                 />
               )}
-              {panel.type === 'singlestat' && (
+              {(panel.type === 'singlestat' || panel.type === 'gauge') && (
                 <SingleStat panel={panel} pollInterval={pollInterval} query={queries[0]} />
               )}
               {panel.type === 'table' && (

--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -10,6 +10,47 @@ import { PrometheusResponse } from '../../graphs';
 import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';
 import { LoadingInline, usePoll, useSafeFetch } from '../../utils';
 
+const colorMap = {
+  'super-light-blue': 'blue-100',
+  'light-blue': 'blue-200',
+  blue: 'blue-300',
+  'semi-dark-blue': 'blue-400',
+  'dark-blue': 'blue-500',
+
+  'super-light-green': 'green-100',
+  'light-green': 'green-200',
+  green: 'green-300',
+  'semi-dark-green': 'green-400',
+  'dark-green': 'green-500',
+
+  'super-light-orange': 'orange-100',
+  'light-orange': 'orange-200',
+  orange: 'orange-300',
+  'semi-dark-orange': 'orange-400',
+  'dark-orange': 'orange-500',
+
+  'super-light-purple': 'purple-100',
+  'light-purple': 'purple-200',
+  purple: 'purple-300',
+  'semi-dark-purple': 'purple-400',
+  'dark-purple': 'purple-500',
+
+  'super-light-red': 'red-100',
+  'light-red': 'red-200',
+  red: 'red-300',
+  'semi-dark-red': 'red-400',
+  'dark-red': 'red-500',
+
+  'super-light-yellow': 'gold-100',
+  'light-yellow': 'gold-200',
+  yellow: 'gold-300',
+  'semi-dark-yellow': 'gold-400',
+  'dark-yellow': 'gold-500',
+};
+
+const getColorCSS = (colorName: string): string =>
+  colorMap[colorName] ? `var(--pf-chart-color-${colorMap[colorName]})` : undefined;
+
 const Body: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <Bullseye className="monitoring-dashboards__single-stat query-browser__wrapper">
     {children}
@@ -20,6 +61,7 @@ const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
   const {
     decimals,
     format,
+    options,
     postfix,
     postfixFontSize,
     prefix,
@@ -64,13 +106,21 @@ const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
     return <ErrorAlert message={error} />;
   }
 
+  let color;
+  const thresholds = options?.fieldOptions?.thresholds;
+  if (thresholds && value !== undefined) {
+    const thresholdIndex =
+      _.sortedIndexBy(thresholds, { value: Number(value) }, (t) => Number(t.value)) - 1;
+    color = getColorCSS(thresholds[thresholdIndex]?.color);
+  }
+
   return (
     <Body>
-      {prefix && <span style={{ fontSize: prefixFontSize }}>{prefix}</span>}
-      <span style={{ fontSize: valueFontSize }}>
+      {prefix && <span style={{ color, fontSize: prefixFontSize }}>{prefix}</span>}
+      <span style={{ color, fontSize: valueFontSize }}>
         {valueMap ? valueMap.text : formatNumber(value, decimals, format)}
       </span>
-      {postfix && <span style={{ fontSize: postfixFontSize }}>{postfix}</span>}
+      {postfix && <span style={{ color, fontSize: postfixFontSize }}>{postfix}</span>}
     </Body>
   );
 };

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -28,6 +28,14 @@ export type Panel = {
   legend?: {
     show: boolean;
   };
+  options?: {
+    fieldOptions: {
+      thresholds: {
+        color?: string;
+        value: number;
+      }[];
+    };
+  };
   panels: Panel[];
   postfix?: string;
   postfixFontSize?: string;


### PR DESCRIPTION
Support the `thresholds` object, which specifies colors for single stats
depending on their value.

Color names are defined by the Grafana dashboard definition format. They
are mapped to PatternFly chart colors to be consistent with the graph
colors on the same page.

Also adds support for `gauge` panels, but just renders them as single
values (with support for threshold colors).

PatternFly colors are from https://www.patternfly.org/v4/guidelines/colors-for-charts

FYI @cshinn 

![screenshot](https://user-images.githubusercontent.com/460802/118142206-1f8cdb00-b445-11eb-8006-ffa80fd6ad68.png)