### PR TITLE
Adding support to consume latest stable images of ocs operator

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/mocks/install.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/mocks/install.ts
@@ -1,0 +1,26 @@
+export const PULL_SECRET_PATH = '/var/run/operator-secret/dockerconfig';
+
+export const CATALOG = {
+  NAMESPACE: 'openshift-marketplace',
+  SECRET: 'ocs-secret',
+  IMAGE: 'quay.io/rhceph-dev/ocs-registry:latest-stable-4.8',
+};
+
+export const ocsCatalogSource = {
+  apiVersion: 'operators.coreos.com/v1alpha1',
+  kind: 'CatalogSource',
+  metadata: {
+    labels: {
+      'ocs-operator-internal': 'true',
+    },
+    namespace: CATALOG.NAMESPACE,
+    name: 'ocs-catalogsource',
+  },
+  spec: {
+    sourceType: 'grpc',
+    image: CATALOG.IMAGE,
+    secrets: [CATALOG.SECRET],
+    displayName: 'OpenShift Container Storage',
+    publisher: 'Red Hat',
+  },
+};

--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/support/index.ts
@@ -1,106 +1,55 @@
-import * as _ from 'lodash';
+import { NS } from '../utils/consts';
 import '../../../integration-tests-cypress/support/index.ts';
-import { wizard } from '../../../integration-tests-cypress/views/wizard';
-import { commonFlows } from '../views/common';
+import { CATALOG } from '../mocks/install';
+import { OCS_OP } from '../consts';
+import {
+  createImagePullSecret,
+  createCustomCatalogSource,
+  subscribeToOperator,
+  linkPullSecretToPods,
+  createInternalStorageCluster,
+  verifyMonitoring,
+  verifyNodeLabels,
+  verifyClusterReadiness,
+} from '../views/install';
 
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
-      install(mode?: 'Internal' | 'Attached', encrypted?: boolean): Chainable<Element>;
+      install(encrypted?: boolean): Chainable<Element>;
     }
   }
 }
 
-Cypress.Commands.add('install', (mode: 'Internal' | 'Attached' = 'Internal', encrypted = false) => {
-  cy.exec('oc get storagecluster ocs-storagecluster -n openshift-storage', {
+Cypress.Commands.add('install', (encrypted = false) => {
+  cy.exec(`oc get storagecluster ocs-storagecluster -n ${NS}`, {
     failOnNonZeroExit: false,
   }).then(({ code }) => {
     // Only run Installation if the Storage Cluster doesn't already exist
     if (code !== 0) {
-      cy.log('Perform OCS Installation and cluster creation');
-      cy.log('Search in Operator Hub');
-      cy.clickNavLink(['Operators', 'OperatorHub']);
-      cy.byTestID('search-operatorhub').type('Openshift Container Storage');
-      cy.byTestID('ocs-operator-redhat-operators-openshift-marketplace').click();
-
-      cy.log('Subscribe to OCS Operator');
-      cy.byLegacyTestID('operator-install-btn').click({ force: true });
-      cy.byTestID('Operator recommended Namespace:-radio-input').should('be.checked');
-      cy.byTestID('enable-monitoring').click();
-      cy.byTestID('install-operator').click();
-      cy.byTestID('success-icon', { timeout: 180000 }).should('be.visible');
-      cy.exec('oc get project openshift-storage -o json').then((res) => {
-        const obj = JSON.parse(res.stdout);
-        expect(obj.metadata.labels?.['openshift.io/cluster-monitoring']).toEqual('true');
-      });
-
-      // Rook, Noobaa and OCS pod should come up after installation.
-      cy.exec('oc get po -n openshift-storage -o json').then((res) => {
-        const { items } = JSON.parse(res.stdout);
-        expect(
-          items.find((item) => _.startsWith(item.metadata.name, 'noobaa-operator')),
-        ).toBeDefined();
-        expect(
-          items.find((item) => _.startsWith(item.metadata.name, 'ocs-operator')),
-        ).toBeDefined();
-        expect(
-          items.find((item) => _.startsWith(item.metadata.name, 'rook-ceph-operator')),
-        ).toBeDefined();
-      });
-
-      // Make changes to this once we add annotation
-      cy.log(`Install OCS in ${mode} Mode`);
-      // Reload because StorageCluster CRD is not registered in the UI; hence getting 404 Error
-      cy.visit('/');
-      cy.reload(true);
-      commonFlows.navigateToOCS();
-      cy.byLegacyTestID('horizontal-link-Storage Cluster').click();
-      cy.byTestID('item-create').click();
-
-      cy.log(`Select ${mode}`);
-      cy.byTestID('Internal-radio-input').should('be.checked');
-
-      // Step 1
-      // Select all worker Nodes
-      commonFlows.checkAll().check();
-      commonFlows.checkAll().should('be.checked');
-      // Two dropdowns in the same page.
-      // (Todo: )make dropdown data-test-id be something that can be passed as a prop
-      cy.byLegacyTestID('dropdown-button')
-        .first()
-        .click();
-      cy.byTestDropDownMenu('512Gi').click();
-      wizard.next();
-
-      // Step 2
-      if (encrypted) {
-        cy.log('Enabling Encryption');
-        cy.byTestID('encryption-checkbox').click();
-      }
-      wizard.next();
-
-      // Final Step
-      wizard.create();
-
-      cy.log('Verify all worker nodes are labelled');
-      cy.exec('oc get nodes -o json').then((res) => {
-        const { items } = JSON.parse(res.stdout);
-        items
-          .map((item) => item.metadata.labels)
-          .filter((item) => item.hasOwnProperty('node-role.kubernetes.io/worker'))
-          .forEach((item) =>
-            expect(item.hasOwnProperty('cluster.ocs.openshift.io/openshift-storage')).toBeTruthy(),
-          );
-      });
-
-      // Wait for the storage cluster to reach Ready
-      // Storage Cluster CR flickers so wait for 10 seconds
-      // Disablng until ocs-operator fixes above issue
+      cy.log('Perform OCS Operator installation and StoargeCluster creation');
+      createImagePullSecret(CATALOG.NAMESPACE);
+      createCustomCatalogSource();
+      subscribeToOperator();
+      cy.byTestID('view-installed-operators-btn').click();
+      cy.log('Wait for operator phase to be `Installing`');
+      cy.byLegacyTestID('item-filter').type(`${OCS_OP}`);
+      cy.byTestID('status-text', { timeout: 120000 }).should('have.text', 'Installing');
+      /**
+       * Waiting for 30 seconds to make sure service accounts are loaded by the operator.
+       * It is a safer time lapse to ensure everything is ready for next step.
+       * */
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(10000);
-      cy.byTestID('resource-status').contains('Ready', { timeout: 900000 });
+      cy.wait(30000);
+      linkPullSecretToPods();
+      cy.log('Check operator installation to be successful');
+      cy.byTestID('success-icon', { timeout: 180000 }).should('be.visible');
+      createInternalStorageCluster(encrypted);
+      verifyNodeLabels();
+      verifyMonitoring();
+      verifyClusterReadiness();
     } else {
-      cy.log('OCS Storage Cluster is already Installed. Proceeding without installation');
+      cy.log('OCS Storage Cluster is already Installed. Proceeding without installation.');
     }
   });
 });

--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/obc-test.spec.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/obc-test.spec.ts
@@ -109,7 +109,7 @@ describe('Test Object Bucket Claim resource', () => {
     cy.byLegacyTestID('openshift-storage.noobaa.io').contains(OBC_STORAGE_CLASS_EXACT);
 
     cy.log('Test if Object Bucket is created');
-    cy.byTestID('obc-link').click();
+    cy.byTestID('ob-link').click();
     detailsPage.isLoaded();
     cy.byLegacyTestID('resource-title').should('be.visible');
     cy.byTestID('resource-status').contains(BOUND);

--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/views/bc.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/views/bc.ts
@@ -15,6 +15,9 @@ const TierCountMap = Object.freeze({
 export const cleanup = () => {
   cy.exec(
     'oc delete backingstore test-store1 test-store2 test-store3 test-store4 -n openshift-storage',
+    {
+      timeout: 60000,
+    },
   );
 };
 

--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/views/install.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/views/install.ts
@@ -1,0 +1,119 @@
+import { ServiceAccountKind } from '@console/internal/module/k8s';
+import '../../../integration-tests-cypress/support/index.ts';
+import { wizard } from '@console/cypress-integration-tests/views/wizard';
+import { CATALOG, PULL_SECRET_PATH, ocsCatalogSource } from '../mocks/install';
+import { commonFlows } from './common';
+import { NS } from '../utils/consts';
+
+export const createImagePullSecret = (namespace: string) => {
+  cy.log(`Create ${CATALOG.SECRET} in ${namespace}`);
+  cy.exec(
+    `oc create secret generic ocs-secret --from-file=.dockerconfigjson=${PULL_SECRET_PATH} --type=kubernetes.io/dockerconfigjson -n ${namespace}`,
+  );
+};
+
+export const createCustomCatalogSource = () => {
+  cy.log('Create custom catalog source with latest stable image of OCS');
+  cy.exec(`echo '${JSON.stringify(ocsCatalogSource)}' | kubectl apply -f -`);
+};
+
+export const subscribeToOperator = () => {
+  cy.log('Search in Operator Hub');
+  cy.clickNavLink(['Operators', 'OperatorHub']);
+  cy.byTestID('search-operatorhub').type('Openshift Container Storage');
+  cy.byTestID('ocs-operator-ocs-catalogsource-openshift-marketplace', { timeout: 120000 }).click();
+  cy.log('Subscribe to OCS Operator');
+  cy.byLegacyTestID('operator-install-btn').click({ force: true });
+  cy.byTestID('Operator recommended Namespace:-radio-input').should('be.checked');
+  cy.byTestID('install-operator').click();
+};
+
+export const linkPullSecretToPods = () => {
+  createImagePullSecret(NS);
+  cy.log(`Add ${CATALOG.SECRET} to all service accounts in ${NS} namespace`);
+  cy.exec(`oc get serviceaccounts -n ${NS} -o json`).then((res) => {
+    const { items: saList } = JSON.parse(res.stdout);
+    saList.forEach((sa: ServiceAccountKind) => {
+      cy.log(`Linking ${CATALOG.SECRET} to ${sa.metadata.name}`);
+      cy.exec(`oc secrets link ${sa.metadata.name} ${CATALOG.SECRET} -n ${NS} --for=pull`);
+    });
+  });
+  cy.log(`Rolling out secret update to pods`);
+  cy.exec(`oc delete pods --all -n ${NS}`);
+};
+
+export const verifyMonitoring = () => {
+  cy.log(`Verify monitoring enablement in ${NS} namespace`);
+  cy.exec(`oc get project ${NS} -o json`).then((res) => {
+    const obj = JSON.parse(res.stdout);
+    expect(obj.metadata.labels?.['openshift.io/cluster-monitoring']).toEqual('true');
+  });
+};
+
+export const verifyNodeLabels = () => {
+  cy.log('Verify all worker nodes are labelled');
+  cy.exec('oc get nodes -o json').then((res) => {
+    const { items } = JSON.parse(res.stdout);
+    items
+      .map((item) => item.metadata.labels)
+      .filter((item) => item.hasOwnProperty('node-role.kubernetes.io/worker'))
+      .forEach((item) =>
+        expect(item.hasOwnProperty('cluster.ocs.openshift.io/openshift-storage')).toBeTruthy(),
+      );
+  });
+};
+
+export const verifyClusterReadiness = () => {
+  // Wait for the storage cluster to reach Ready
+  // Storage Cluster CR flickers so wait for 10 seconds
+  // Disablng until ocs-operator fixes above issue
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(10000);
+  cy.log('Verify Storage cluster is `Ready`');
+  cy.byTestID('resource-status').contains('Ready', { timeout: 900000 });
+  cy.byLegacyTestID('horizontal-link-Resources').click();
+  cy.log('Verify ceph cluster is `Ready`');
+  cy.byTestOperandLink('ocs-storagecluster-cephcluster').click();
+  cy.byTestID('resource-status').contains('Ready', { timeout: 900000 });
+  cy.go('back');
+  cy.log('Verify noobaa system is `Ready`');
+  cy.byTestOperandLink('noobaa').click();
+  cy.byTestID('resource-status').contains('Ready', { timeout: 900000 });
+};
+
+export const createInternalStorageCluster = (encrypted: boolean) => {
+  const mode = 'Internal';
+  // Make changes to this once we add annotation
+  cy.log(`Install OCS in ${mode} Mode`);
+  // Reload because StorageCluster CRD is not registered in the UI; hence getting 404 Error
+  cy.visit('/');
+  cy.reload(true);
+  commonFlows.navigateToOCS();
+  cy.byLegacyTestID('horizontal-link-Storage Cluster').click();
+  cy.byTestID('item-create').click();
+
+  cy.log(`Select ${mode}`);
+  cy.byTestID('Internal-radio-input').should('be.checked');
+
+  // Step 1
+  // Select all worker Nodes
+  commonFlows.checkAll().check();
+  commonFlows.checkAll().should('be.checked');
+  // Two dropdowns in the same page.
+  // (Todo: )make dropdown data-test-id be something that can be passed as a prop
+  cy.byLegacyTestID('dropdown-button')
+    .first()
+    .click();
+  cy.byTestDropDownMenu('512Gi').click();
+  wizard.next();
+
+  // Step 2
+  if (encrypted) {
+    cy.log('Enabling Encryption');
+    cy.byTestID('encryption-checkbox').click();
+  }
+  wizard.next();
+
+  // Final Step
+  wizard.create();
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
@@ -130,9 +130,9 @@ const Details: React.FC<DetailsProps> = ({ obj }) => {
                 <dt>{t('ceph-storage-plugin~Object Bucket')}</dt>
                 <dd>
                   <ResourceLink
-                    dataTest="obc-link"
+                    dataTest="ob-link"
                     kind={referenceForModel(NooBaaObjectBucketModel)}
-                    name={obj.spec.ObjectBucketName}
+                    name={obj.spec.objectBucketName}
                   />
                 </dd>
               </>


### PR DESCRIPTION
- Plugin tests can consume the latest stable image
- We adopted the methodology of linking the private repo secret to all service accounts in order to be consumed by pods.
- The secret is created in `openshift-storage namespace` to be consumed by all pods for pulling their bundles
- The secret is created in `openshift-marketplace` in order to create a custom catalog source

Fixes https://issues.redhat.com/browse/RHSTOR-1835

Update:

Some issues that kept us blocking now fixed.
- In 4.8 a change in  obc spec  to use `spec.objectBucketName` instead of `spec.ObjectBucketName`
- backing store deletion gets flaky at times (seen generally as well irrespective of ocs version/build). There are a lot of resources deleted at once in a single exec command. It takes sometime hence to delete the resources. The default 30s timeout for which does not seems enough sometimes.
- cluster readiness checks for noobaa, ceph cluster readiness too before proceeding ahead to ensure the following tests won't fail which are dependent on ceph cluster and noobaa system availability.

Signed-off-by: Afreen Rahman <afrahman@redhat.com>