### PR TITLE
fixes monitoring nav route for dev perspective

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -291,7 +291,7 @@
       "perspective": "dev",
       "section": "top",
       "name": "%devconsole~Monitoring%",
-      "href": "/monitoring",
+      "href": "/dev-monitoring",
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-monitoring",
         "data-tour-id": "tour-monitoring-nav",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5836

**Analysis / Root cause**: 
Monitoring in devPerspective take the user to the alerts page

**Solution Description**: 
Monitoring in devPerspective take the user to the monitoring view for dev perspective

**Screen shots / Gifs for design review**: 
- Before:

![image](https://user-images.githubusercontent.com/5129024/118274160-68df3800-b4e2-11eb-8113-e1043d50e5a0.png)


- After:

![image](https://user-images.githubusercontent.com/5129024/118274258-87453380-b4e2-11eb-833d-286eb7cd3f37.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
