### PR TITLE
 Bug 1960686: Fix hot loop in global config page

### DIFF
--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -57,12 +57,11 @@ const GlobalConfigPage_: React.FC<GlobalConfigPageProps & GlobalConfigPageExtens
   const [textFilter, setTextFilter] = React.useState('');
   const { t } = useTranslation();
 
-  const oauthMenuItems = _.map(addIDPItems, (label: string, id: string) => ({
-    label: t('public~{{label}}', { label }),
-    href: `/settings/idp/${id}`,
-  }));
-
   React.useEffect(() => {
+    const oauthMenuItems = _.map(addIDPItems, (label: string, id: string) => ({
+      label: t('public~{{label}}', { label }),
+      href: `/settings/idp/${id}`,
+    }));
     const editYAMLMenuItem = (name: string, resourceLink: string) => ({
       label: t('global-config~Edit {{name}} resource', { name }),
       href: `${resourceLink}/yaml`,
@@ -134,7 +133,7 @@ const GlobalConfigPage_: React.FC<GlobalConfigPageProps & GlobalConfigPageExtens
       }
     });
     return () => (isSubscribed = false);
-  }, [configResources, errors, globalConfigs, oauthMenuItems, t]);
+  }, [configResources, globalConfigs, t]);
   const visibleItems = items.filter(({ label, description = '' }) => {
     return (
       fuzzyCaseInsensitive(textFilter, label) ||


### PR DESCRIPTION
Manual 4.7 backport of #8934

`oauthMenuItems` was initialized to a different value on every render,
and it was included in the dependency list of the `useEffect` hook. This
caused the hook to hot loop. Initialize `oauthMenuItems` inside
`useEffect` instead since it's only used in that block. Also remove
`errors` from the dependency list since it wasn't referenced inside
the hook.

/assign @rhamilto 