### PR TITLE
Bug 1917328: Default to current namespace for non-common templates

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
@@ -117,6 +117,7 @@ export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (prop
         withCreate: true,
         withCustomizeModal,
         isCommonTemplate: isCommon,
+        namespace,
       }}
     />
   );


### PR DESCRIPTION
When the VM wizard is started from the "Create Virtual Machine" button in the Actions dropdown of the VM templates details page, the Project field should be populated with the current namespace for all non-common templates.