### PR TITLE
[WIP] Fix Cypress role binding test flake

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -27,10 +27,11 @@ export const listPage = {
       });
     },
     by: (rowFilter: string) => {
+      cy.byLegacyTestID('filter-dropdown-toggle')
+        .find('button')
+        .as('filterDropdownBtn');
       cy.get('.pf-c-toolbar__content-section').within(() => {
-        cy.byLegacyTestID('filter-dropdown-toggle')
-          .find('button')
-          .click();
+        cy.get('@filterDropdownBtn').click(); // open filter dropdown
         /* PF Filter dropdown menu items are:
            <li id="cluster">
              <a data-test-row-filter="cluster">
@@ -39,6 +40,7 @@ export const listPage = {
            '?rowFilter=...'.
          */
         cy.get(`#${rowFilter}`).click(); // clicking on the <li /> works!
+        cy.get('@filterDropdownBtn').click(); // close filter dropdown
         cy.url().should('include', '?rowFilter');
       });
     },


### PR DESCRIPTION
Seems like clicking on Filter button opens filter dropdown, check's an item correctly, but dropdown stays open.  The attempt to type into filter input box closes open filter dropdown, but doesn't return focus for typing.

Added open and close filter dropdown commands before typing.