### PR TITLE
Topology - Delete Workload

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
@@ -19,6 +19,7 @@ export enum nodeActions {
   EditLabels = 'Edit labels',
   EditDeployment = 'Edit Deployment',
   DeleteDeployment = 'Delete Deployment',
+  DeleteDeploymentConfig = 'Delete DeploymentConfig',
   EditAnnotations = 'Edit annotations',
   MoveSink = 'Move sink',
   EditSinkBinding = 'Edit SinkBinding',

--- a/frontend/packages/topology/integration-tests/features/topology/topoplogy-delete-workload.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topoplogy-delete-workload.feature
@@ -4,26 +4,23 @@ Feature: Deleteing an application node
 
         Background:
             Given user is at developer perspective
-              And user has selected namespace "aut-topology-delete-workload"
+              And user has created or selected namespace "aut-topology-delete-workload"
+              And user is at Add page
 
         @regression
         Scenario: Deleting a workload through Action menu : T-09-TC01
-            Given user created workload "nodejs-ex-git" with resource type "Deployment"
-             When user clicks on workload to open sidebar
+            Given user has created workload "nodejs-ex-git-d" with resource type "Deployment"
+             When user clicks on workload "nodejs-ex-git-d"
               And user clicks on Action menu
-              And user clicks delete workload
-              And user sees "Delete" modal box to open
-              And user checks Delete dependent objects of this resource to be checked
-              And user clicks on "Delete"
-             Then workload "nodejs-ex-git" disappeared from topology
+              And user clicks "Delete Deployment" from action menu
+              And user clicks on Delete button from modal
+             Then user will see workload disappeared from topology
 
 
-        @smoke
+        @regression
         Scenario: Deleting a workload through context menu : T-06-TC16
-            Given user created workload "nodejs-ex-git" with resource type "Deployment"
-             When user right clicks on the node "nodejs-ex-git"
-              And user selects "Delete Deployment" from the context menu
-              And user sees "Delete" modal box to open
-              And user checks Delete dependent objects of this resource to be checked
-              And user clicks on "Delete"
-             Then workload "nodejs-ex-git" disappeared from topology
+            Given user has created workload "nodejs-ex-git-dc" with resource type "Deployment Config"
+             When user right clicks on the workload "nodejs-ex-git-dc" to open the Context Menu
+              And user clicks "Delete DeploymentConfig" from action menu
+              And user clicks on Delete button from modal
+             Then user will see workload disappeared from topology

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -18,6 +18,7 @@ export const topologyPO = {
     workloads: 'g[data-surface="true"]',
     node: '[data-test-id="base-node-handler"]',
     workload: '[data-type="workload"]',
+    deleteWorkload: '[data-test="confirm-action"]',
     eventSourceWorkload: '[data-type="event-source"]',
     applicationGroupingTitle: '.odc-topology-list-view__application-label',
     filterByResource: {

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
@@ -50,6 +50,13 @@ export const topologyActions = {
           .click();
         break;
       }
+      case 'Delete DeploymentConfig':
+      case nodeActions.DeleteDeploymentConfig: {
+        cy.byTestActionID(action)
+          .should('be.visible')
+          .click();
+        break;
+      }
       case 'Delete SinkBinding':
       case nodeActions.DeleteSinkBinding: {
         cy.byTestActionID(action)

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
@@ -12,4 +12,7 @@ export const topologyHelper = {
     cy.get(topologyPO.highlightNode).should('be.visible');
     app.waitForDocumentLoad();
   },
+  verifyWorkloadDeleted: (workloadName: string) => {
+    topologyHelper.search(workloadName).should('not.be.visible');
+  },
 };

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-side-pane-page.ts
@@ -18,6 +18,7 @@ export const topologySidePane = {
       .contains(tabName)
       .should('be.visible'),
   verifyActionsDropDown: () => cy.get(topologyPO.sidePane.actionsDropDown).should('be.visible'),
+  clickActionsDropDown: () => cy.get(topologyPO.sidePane.actionsDropDown).click(),
   selectTab: (tabName: string) =>
     cy
       .get(topologyPO.sidePane.tabName)

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -16,6 +16,7 @@ import {
   createGitWorkload,
   topologyHelper,
 } from '@console/dev-console/integration-tests/support/pages';
+import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
 
 Given('user is at the Topology page', () => {
   navigateTo(devNavigationMenu.Topology);
@@ -114,4 +115,15 @@ Given(
 
 Given('user is at Add page', () => {
   navigateTo(devNavigationMenu.Add);
+});
+
+When(
+  'user right clicks on the workload {string} to open the Context Menu',
+  (workloadName: string) => {
+    topologyPage.rightClickOnNode(workloadName);
+  },
+);
+
+Then('user will see workload disappeared from topology', () => {
+  cy.get(topologyPO.emptyStateIcon).should('be.visible');
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/delete-workload.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/delete-workload.ts
@@ -1,0 +1,16 @@
+import { When } from 'cypress-cucumber-preprocessor/steps';
+import { topologySidePane } from '@console/topology/integration-tests/support/pages/topology/topology-side-pane-page';
+import { topologyActions } from '@console/topology/integration-tests/support/pages/topology/topology-actions-page';
+import { topologyPO } from '../../page-objects/topology-po';
+
+When('user clicks on Action menu', () => {
+  topologySidePane.clickActionsDropDown();
+});
+
+When('user clicks {string} from action menu', (actionItem: string) => {
+  topologyActions.selectAction(actionItem);
+});
+
+When('user clicks on Delete button from modal', () => {
+  cy.get(topologyPO.graph.deleteWorkload).click();
+});


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/ODC-5582

**Problem:** Automation to delete the workload

**Solution:** This script will delete the already created workload using the Actions dropdown menu and Context Menu

**Test Setup:**
1. Replace `"TAGS": "@smoke and not @manual and not @to-do",` with `"TAGS": "@smoke or @regression and not @manual and not @to-do",` in topology/cypress.json under `env`
2. Run `yarn run test-cypress-topology` in frontend
3. Execute feature file: `frontend/packages/topology/integration-tests/features/topology/topology-delete-workload.feature`

**Test Execution Screenshot:**
![Screenshot from 2021-05-17 09-25-39](https://user-images.githubusercontent.com/17041173/118431423-f5147980-b6f3-11eb-970c-62db49570b1f.png)
