### PR TITLE
Bug 1960531: Monitoring dashboards: Fix bug where panels could be duplicated

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -601,7 +601,7 @@ const MonitoringDashboardsPage: React.FC<MonitoringDashboardsPageProps> = ({ mat
     ? data.rows
     : data?.panels?.reduce((acc, panel) => {
         if (panel.type === 'row' || acc.length === 0) {
-          acc.push(panel);
+          acc.push(_.cloneDeep(panel));
         } else {
           const row = acc[acc.length - 1];
           if (_.isNil(row.panels)) {


### PR DESCRIPTION
We should clone the panel so that the `row.panels.push` action isn't
altering the original panel's rows.