### PR TITLE
Bug 1961336: Remove the broken Devfile Sample for BuildConfigs

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -140,8 +140,6 @@
   "This \"ClusterRole\" is allowed to \"GET\" and \"POST\" requests to the non-resource endpoint \"/healthz\" and all subpaths (must be in the \"ClusterRole\" bound with a \"ClusterRoleBinding\" to be effective).": "This \"ClusterRole\" is allowed to \"GET\" and \"POST\" requests to the non-resource endpoint \"/healthz\" and all subpaths (must be in the \"ClusterRole\" bound with a \"ClusterRoleBinding\" to be effective).",
   "Build from Dockerfile": "Build from Dockerfile",
   "A Dockerfile build performs an image build using a Dockerfile in the source repository or specified in build configuration.": "A Dockerfile build performs an image build using a Dockerfile in the source repository or specified in build configuration.",
-  "Build from Devfile": "Build from Devfile",
-  "A Devfile build performs an image build using a devfile in the source repository or specified in build configuration.": "A Devfile build performs an image build using a devfile in the source repository or specified in build configuration.",
   "Source-to-Image (S2I) build": "Source-to-Image (S2I) build",
   "S2I is a tool for building reproducible container images. It produces ready-to-run images by injecting the application source into a container image and assembling a new image.": "S2I is a tool for building reproducible container images. It produces ready-to-run images by injecting the application source into a container image and assembling a new image.",
   "Limit": "Limit",

--- a/frontend/packages/console-shared/src/utils/sample-utils.ts
+++ b/frontend/packages/console-shared/src/utils/sample-utils.ts
@@ -91,14 +91,6 @@ const defaultSamples = (t: TFunction) =>
           targetResource: getTargetResource(BuildConfigModel),
         },
         {
-          title: t('console-shared~Build from Devfile'),
-          description: t(
-            'console-shared~A Devfile build performs an image build using a devfile in the source repository or specified in build configuration.',
-          ),
-          id: 'devfile-build',
-          targetResource: getTargetResource(BuildConfigModel),
-        },
-        {
           title: t('console-shared~Source-to-Image (S2I) build'),
           description: t(
             'console-shared~S2I is a tool for building reproducible container images. It produces ready-to-run images by injecting the application source into a container image and assembling a new image.',


### PR DESCRIPTION
**Analysis / Root cause**: 
During 4.7's https://github.com/openshift/console/pull/7299 there was a partial implementation of a sample that just didn't work.

**Solution Description**: 
Remove it. It was never part of the design and slipped through during the work handoff in 4.7.

**Screen shots / Gifs for design review**: 

Before:
![image](https://user-images.githubusercontent.com/8126518/118543313-1db36800-b722-11eb-9e98-9c6768864526.png)

After:
![Screen Shot 2021-05-17 at 3 05 25 PM](https://user-images.githubusercontent.com/8126518/118543299-15f3c380-b722-11eb-9460-8823b86d751c.png)

**Test setup:**

Dev Perspective => Builds => Create BuildConfig => "Samples" sidebar tab.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge