### PR TITLE
[release-4.7] Bug 1963025: Fix documentation link to network policies

### DIFF
--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
@@ -198,14 +198,17 @@ const Details_ = ({ obj: np, flags }) => {
       <div className="co-m-pane__body">
         <SectionHeading text={t('network-policy~Ingress rules')} />
         <p className="co-m-pane__explanation">
-          {t(
-            'network-policy~Pods accept all traffic by default. They can be isolated via Network Policies which specify a whitelist of ingress rules. When a Pod is selected by a Network Policy, it will reject all traffic not explicitly allowed via a Network Policy. See more details in:',
-          )}
-          <ExternalLink
-            href={getNetworkPolicyDocLink(flags[FLAGS.OPENSHIFT])}
-            text={t('network-policy~Network Policies documentation')}
-          />
-          .
+          <Trans ns="network-policy">
+            Pods accept all traffic by default. They can be isolated via Network Policies which
+            specify a whitelist of ingress rules. When a Pod is selected by a Network Policy, it
+            will reject all traffic not explicitly allowed via a Network Policy. See more details
+            in:{' '}
+            <ExternalLink
+              href={getNetworkPolicyDocLink(flags[FLAGS.OPENSHIFT])}
+              text={t('network-policy~Network Policies documentation')}
+            />
+            .
+          </Trans>
         </p>
         {_.isEmpty(_.get(np, 'spec.ingress[0]', [])) ? (
           t('network-policy~All traffic is allowed to Pods in {{namespace}}', {

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -4,6 +4,6 @@ export const openshiftHelpBase =
 
 export const getNetworkPolicyDocLink = (openshiftFlag: boolean) => {
   return openshiftFlag
-    ? `${openshiftHelpBase}networking/configuring-networkpolicy.html`
+    ? `${openshiftHelpBase}networking/network_policy/about-network-policy.html`
     : 'https://kubernetes.io/docs/concepts/services-networking/network-policies/';
 };

--- a/frontend/public/locales/en/network-policy.json
+++ b/frontend/public/locales/en/network-policy.json
@@ -9,7 +9,7 @@
   "NS selector": "NS selector",
   "Network policy details": "Network policy details",
   "Ingress rules": "Ingress rules",
-  "Pods accept all traffic by default. They can be isolated via Network Policies which specify a whitelist of ingress rules. When a Pod is selected by a Network Policy, it will reject all traffic not explicitly allowed via a Network Policy. See more details in:": "Pods accept all traffic by default. They can be isolated via Network Policies which specify a whitelist of ingress rules. When a Pod is selected by a Network Policy, it will reject all traffic not explicitly allowed via a Network Policy. See more details in:",
+  "Pods accept all traffic by default. They can be isolated via Network Policies which specify a whitelist of ingress rules. When a Pod is selected by a Network Policy, it will reject all traffic not explicitly allowed via a Network Policy. See more details in: <2></2>.": "Pods accept all traffic by default. They can be isolated via Network Policies which specify a whitelist of ingress rules. When a Pod is selected by a Network Policy, it will reject all traffic not explicitly allowed via a Network Policy. See more details in: <2></2>.",
   "Network Policies documentation": "Network Policies documentation",
   "All traffic is allowed to Pods in {{namespace}}": "All traffic is allowed to Pods in {{namespace}}"
 }


### PR DESCRIPTION
Also fix missing space in english text

i18n network-policy with link: use Trans

4.7 backport for https://github.com/openshift/console/pull/8869