### PR TITLE
Bug 1961675: Hide TaskRun edit actions for rows in Pipelinerun's TaskRun tab

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
-import { ResourceLink, Timestamp, Kebab, ResourceKebab } from '@console/internal/components/utils';
+import { ResourceLink, Timestamp, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskRunKind } from '../../../types';
 import { getModelReferenceFromTaskKind } from '../../../utils/pipeline-augment';
+import { getTaskRunKebabActions } from '../../../utils/pipeline-actions';
 import { TaskRunModel, PipelineModel } from '../../../models';
 import { tableColumnClasses } from './taskruns-table';
 import { taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
@@ -66,7 +67,7 @@ const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...prop
       <Timestamp timestamp={obj?.status?.startTime} />
     </TableData>
     <TableData className={tableColumnClasses[7]}>
-      <ResourceKebab actions={Kebab.factory.common} kind={taskRunsReference} resource={obj} />
+      <ResourceKebab actions={getTaskRunKebabActions()} kind={taskRunsReference} resource={obj} />
     </TableData>
   </TableRow>
 );

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -265,3 +265,5 @@ export const getPipelineRunKebabActions = (redirectReRun?: boolean): KebabAction
   (model, pipelineRun) => stopPipelineRun(model, pipelineRun),
   Kebab.factory.Delete,
 ];
+
+export const getTaskRunKebabActions = (): KebabAction[] => [Kebab.factory.Delete];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5736
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
User should only be able to Delete a taskrun, but the taskrun kebab menu includes options to Edit lable, annotation, and taskrun.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Hide taskrun edit actions for rows in pipelinerun's taskrun tab.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
![0](https://user-images.githubusercontent.com/20013884/118658761-52025380-b80a-11eb-9b95-41b63f45c90a.png)

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
