### PR TITLE
Bug 1932472: Allow ManagedFields Code Folding on Form/YAML Switcher

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/YAMLEditor.tsx
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditor.tsx
@@ -28,15 +28,16 @@ const YAMLEditor = React.forwardRef<MonacoEditor, YAMLEditorProps>((props, ref) 
     onSave,
   } = props;
 
+  const [usesValue] = React.useState<boolean>(value !== undefined);
   const editorDidMount = React.useCallback(
     (editor, monaco) => {
       editor.layout();
       editor.focus();
-      registerYAMLinMonaco(editor, monaco);
+      registerYAMLinMonaco(editor, monaco, usesValue);
       monaco.editor.getModels()[0].updateOptions({ tabSize: 2 });
       onSave && editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, onSave); // eslint-disable-line no-bitwise
     },
-    [onSave],
+    [onSave, usesValue],
   );
 
   return (


### PR DESCRIPTION
**Analysis / Root cause**: 
When we get a MonacoEditor instance back from the `editorDidMount` prop we create listeners off of the provided instance to do many things. Among them, code fold the ManagedFields metadata chunk.

The two ways the Editor is currently used is via the Form/YAML switcher which uses prop `value` and the Edit YAML views which uses a reference to update the state. Essentially controlled and uncontrolled (respectively).

If you use the `value` prop, the editor gets your value before the listeners are setup. Thus preventing our code folding ability to kick in for the first rendered content. If you use the reference the listeners are setup before you `setValue` on the instance (since you need the instance to set it). 

**Solution Description**: 
Pass an additional prop to the setup utilities to say it's not needing to wait. `alreadyInUse` is a prop that (today) only invokes the code folding utility immediately rather than waiting on the next edit.

**Screen shots / Gifs for design review**: 
![CodeFoldYAMLFormSwitcher](https://user-images.githubusercontent.com/8126518/118693041-b3a9ca00-b7d8-11eb-9074-5fb545bea87d.gif)

**Test setup:**

1. View a YAML tab of any created component and see the `managedFields` fold immediately (before and after this fix)
2. View a Form/YAML switcher of an already created component and see the `managedFields` fold immediately (after this fix)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge