### PR TITLE
fix dev-catalog type tooltip

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
@@ -21,7 +21,12 @@ const CatalogTypeSelector: React.FC<CatalogTypeSelectorProps> = ({
 
   const typeDescriptions = React.useMemo(
     () =>
-      catalogTypes.map((type) => <SyncMarkdownView key={type.value} content={type.description} />),
+      catalogTypes.map(
+        (type) =>
+          type.description && (
+            <SyncMarkdownView key={type.value} content={type.description} inline />
+          ),
+      ),
     [catalogTypes],
   );
 
@@ -29,7 +34,7 @@ const CatalogTypeSelector: React.FC<CatalogTypeSelectorProps> = ({
     <>
       <Title headingLevel="h4" style={{ marginLeft: '14px' }}>
         {t('devconsole~Type')}
-        <FieldLevelHelp popoverHasAutoWidth>{typeDescriptions}</FieldLevelHelp>
+        <FieldLevelHelp>{typeDescriptions}</FieldLevelHelp>
       </Title>
       <VerticalTabs>
         {catalogTypes.map((type) => {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5819

**Root analysis:**
The tooltip displays off the screen so text cannot be read. There is no way to scroll to see the unreadable text.

**Solution description:**
- passed `inline` property to `SyncMarkdownView`
- showing the description of the catalog item only if it's available

**GIF:**
![dev-cat](https://user-images.githubusercontent.com/22490998/118857037-3b84f680-b8f5-11eb-94dd-c3d618924ec4.gif)

**Browser conformance:**
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge