### PR TITLE
Add useDynamicPluginInfo hook

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/.gitignore
+++ b/frontend/packages/console-dynamic-plugin-sdk/.gitignore
@@ -1,1 +1,1 @@
-schema
+/schema

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
@@ -132,7 +132,7 @@ describe('loadDynamicPlugin', () => {
 
 describe('registerPluginEntryCallback', () => {
   it('adds loadPluginEntry function to window global object', () => {
-    const pluginStore = new PluginStore([]);
+    const pluginStore = new PluginStore();
     expect(window.loadPluginEntry).toBeUndefined();
 
     registerPluginEntryCallback(pluginStore);
@@ -142,7 +142,7 @@ describe('registerPluginEntryCallback', () => {
 
 describe('window.loadPluginEntry', () => {
   it('marks the plugin as loaded, resolves its extensions and adds it to plugin store', () => {
-    const pluginStore = new PluginStore([]);
+    const pluginStore = new PluginStore();
     const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
 
     const extensions: Extension[] = [
@@ -196,7 +196,7 @@ describe('window.loadPluginEntry', () => {
   });
 
   it('does nothing if the plugin ID is not registered', () => {
-    const pluginStore = new PluginStore([]);
+    const pluginStore = new PluginStore();
     const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
 
     const [, entryModule] = getEntryModuleMocks({});
@@ -218,7 +218,7 @@ describe('window.loadPluginEntry', () => {
   });
 
   it('does nothing if called a second time for the same plugin', () => {
-    const pluginStore = new PluginStore([]);
+    const pluginStore = new PluginStore();
     const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
 
     const manifest = getPluginManifest('Test', '1.2.3');
@@ -249,7 +249,7 @@ describe('window.loadPluginEntry', () => {
   });
 
   it('does nothing if overriding shared modules throws an error', () => {
-    const pluginStore = new PluginStore([]);
+    const pluginStore = new PluginStore();
     const addDynamicPlugin = jest.spyOn(pluginStore, 'addDynamicPlugin');
 
     const manifest = getPluginManifest('Test', '1.2.3');
@@ -295,7 +295,7 @@ describe('loadAndEnablePlugin', () => {
   let setDynamicPluginEnabled: jest.SpyInstance<typeof pluginStore.setDynamicPluginEnabled>;
 
   beforeEach(() => {
-    pluginStore = new PluginStore([]);
+    pluginStore = new PluginStore();
     setDynamicPluginEnabled = jest.spyOn(pluginStore, 'setDynamicPluginEnabled');
     setDynamicPluginEnabled.mockImplementation(() => {});
   });
@@ -329,6 +329,6 @@ describe('loadAndEnablePlugin', () => {
     await loadAndEnablePlugin('Test', pluginStore, onError);
 
     expect(setDynamicPluginEnabled).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith(new Error('boom'));
+    expect(onError).toHaveBeenCalledWith();
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-manifest.spec.ts
@@ -3,14 +3,14 @@ import { getPluginManifest } from '../../utils/test-utils';
 import { SchemaValidator } from '../../validation/SchemaValidator';
 import * as pluginManifestModule from '../plugin-manifest';
 
+const { fetchPluginManifest } = pluginManifestModule;
+
 const coFetch = jest.spyOn(coFetchModule, 'coFetch');
 
 const validatePluginManifestSchema = jest.spyOn(
   pluginManifestModule,
   'validatePluginManifestSchema',
 );
-
-const { fetchPluginManifest } = pluginManifestModule;
 
 beforeEach(() => {
   [coFetch, validatePluginManifestSchema].forEach((mock) => mock.mockReset());

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { Store } from 'redux';
 import { RootState } from '@console/internal/redux';
-import { initSubscriptionService } from '@console/plugin-sdk/src/api/subscribeToExtensions';
+import { initSubscriptionService } from '@console/plugin-sdk/src/api/pluginSubscriptionService';
 import { PluginStore } from '@console/plugin-sdk/src/store';
 import { exposePluginAPI } from './plugin-api';
 import { registerPluginEntryCallback, loadAndEnablePlugin } from './plugin-loader';
@@ -14,8 +14,10 @@ export const initConsolePlugins = _.once(
 
     // Load all dynamic plugins which are currently enabled on the cluster
     window.SERVER_FLAGS.consolePlugins.forEach((pluginName) => {
-      // TODO(vojtech): use error handler that adds new entry into the notification drawer
-      loadAndEnablePlugin(pluginName, pluginStore);
+      loadAndEnablePlugin(pluginName, pluginStore, () => {
+        // TODO(vojtech): add new entry into the notification drawer
+        pluginStore.registerFailedDynamicPlugin(pluginName);
+      });
     });
   },
 );

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-loader.ts
@@ -93,7 +93,10 @@ export const getPluginEntryCallback = (
     pluginData.manifest.extensions,
     entryModule,
     pluginID,
-    () => pluginStore.setDynamicPluginEnabled(pluginID, false),
+    () => {
+      console.error(`Code reference resolution failed for plugin ${pluginID}`);
+      pluginStore.setDynamicPluginEnabled(pluginID, false);
+    },
   );
 
   pluginStore.addDynamicPlugin(pluginID, pluginData.manifest, resolvedExtensions);
@@ -115,7 +118,7 @@ export const loadPluginFromURL = async (baseURL: string) => {
 export const loadAndEnablePlugin = async (
   pluginName: string,
   pluginStore: PluginStore,
-  onError: (error: any) => void = _.noop,
+  onError: VoidFunction = _.noop,
 ) => {
   const url = `${window.SERVER_FLAGS.basePath}api/plugins/${pluginName}/`;
 
@@ -123,8 +126,8 @@ export const loadAndEnablePlugin = async (
     const pluginID = await loadPluginFromURL(url);
     pluginStore.setDynamicPluginEnabled(pluginID, true);
   } catch (e) {
-    onError(e);
     console.error(`Error while loading plugin from ${url}`, e);
+    onError();
   }
 };
 

--- a/frontend/packages/console-plugin-sdk/src/api/useDynamicPluginInfo.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useDynamicPluginInfo.ts
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { useForceRender } from '@console/shared/src/hooks/useForceRender';
+import { DynamicPluginInfo } from '../store';
+import { subscribeToDynamicPlugins } from './pluginSubscriptionService';
+
+/**
+ * React hook for consuming Console dynamic plugin runtime information.
+ *
+ * When the runtime status of a dynamic plugin changes, the React component
+ * is re-rendered with the hook returning an up-to-date plugin information.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * const Example = () => {
+ *   const pluginEntries = useDynamicPluginInfo();
+ *   // process plugin entries and render your component
+ * };
+ * ```
+ *
+ * The hook's result is guaranteed to be referentially stable across re-renders.
+ *
+ * @returns Console dynamic plugin runtime information.
+ */
+export const useDynamicPluginInfo = (): DynamicPluginInfo[] => {
+  const forceRender = useForceRender();
+
+  const isMountedRef = React.useRef(true);
+  const unsubscribeRef = React.useRef<VoidFunction>(null);
+  const pluginEntriesRef = React.useRef<DynamicPluginInfo[]>([]);
+
+  const trySubscribe = React.useCallback(() => {
+    if (unsubscribeRef.current === null) {
+      unsubscribeRef.current = subscribeToDynamicPlugins((pluginEntries) => {
+        pluginEntriesRef.current = pluginEntries;
+        isMountedRef.current && forceRender();
+      });
+    }
+  }, [forceRender]);
+
+  const tryUnsubscribe = React.useCallback(() => {
+    if (unsubscribeRef.current !== null) {
+      unsubscribeRef.current();
+      unsubscribeRef.current = null;
+    }
+  }, []);
+
+  trySubscribe();
+
+  React.useEffect(
+    () => () => {
+      isMountedRef.current = false;
+      tryUnsubscribe();
+    },
+    [tryUnsubscribe],
+  );
+
+  return pluginEntriesRef.current;
+};

--- a/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
@@ -4,7 +4,7 @@ import { mergeExtensionProperties } from '@console/dynamic-plugin-sdk/src/utils/
 import { useForceRender } from '@console/shared/src/hooks/useForceRender';
 import { Extension, ExtensionTypeGuard, LoadedExtension } from '../typings';
 import useTranslationExt from '../utils/useTranslationExt';
-import { subscribeToExtensions } from './subscribeToExtensions';
+import { subscribeToExtensions } from './pluginSubscriptionService';
 
 const translate = (obj: any, t: (str: string) => string): typeof obj => {
   if (typeof obj === 'string') {
@@ -38,7 +38,7 @@ const translate = (obj: any, t: (str: string) => string): typeof obj => {
  *   values
  *
  * When the list of matching extensions changes, the React component is re-rendered
- * with the hook returning an updated list of extensions.
+ * with the hook returning an up-to-date list of extensions.
  *
  * Example usage:
  *

--- a/frontend/packages/console-plugin-sdk/src/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/index.ts
@@ -5,3 +5,4 @@ export * from './store';
 // React integrations
 export * from './api/useExtensions';
 export * from './api/withExtensions';
+export * from './api/useDynamicPluginInfo';

--- a/frontend/packages/console-shared/src/utils/sample-utils.ts
+++ b/frontend/packages/console-shared/src/utils/sample-utils.ts
@@ -30,7 +30,7 @@ import {
   referenceForModel,
 } from '@console/internal/module/k8s';
 import { LoadedExtension } from '@console/plugin-sdk/src';
-import { subscribeToExtensions } from '@console/plugin-sdk/src/api/subscribeToExtensions';
+import { subscribeToExtensions } from '@console/plugin-sdk/src/api/pluginSubscriptionService';
 
 export type Sample = {
   highlightText?: string;

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -7,7 +7,7 @@ import { isCustomFeatureFlag, CustomFeatureFlag } from '@console/plugin-sdk/src/
 import {
   subscribeToExtensions,
   extensionDiffListener,
-} from '@console/plugin-sdk/src/api/subscribeToExtensions';
+} from '@console/plugin-sdk/src/api/pluginSubscriptionService';
 import {
   FeatureFlag as DynamicFeatureFlag,
   isFeatureFlag as isDynamicFeatureFlag,

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -22,11 +22,11 @@ import { NamespaceRedirect } from './utils/namespace-redirect';
 //PF4 Imports
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 import {
-  useExtensions,
-  isPerspective,
   Perspective,
   RoutePage,
+  isPerspective,
   isRoutePage,
+  useExtensions,
 } from '@console/plugin-sdk';
 import {
   RoutePage as DynamicRoutePage,

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { KEY_CODES, Tooltip, FocusTrap } from '@patternfly/react-core';
 import { AngleRightIcon, EllipsisVIcon } from '@patternfly/react-icons';
-import { subscribeToExtensions } from '@console/plugin-sdk/src/api/subscribeToExtensions';
+import { subscribeToExtensions } from '@console/plugin-sdk/src/api/pluginSubscriptionService';
 import { KebabActions, isKebabActions } from '@console/plugin-sdk/src/typings/kebab-actions';
 import Popper from '@console/shared/src/components/popper/Popper';
 import {

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -9,7 +9,10 @@ const activePlugins =
     ? (require('@console/active-plugins').default as ActivePlugin[])
     : [];
 
-export const pluginStore = new PluginStore(activePlugins);
+export const pluginStore = new PluginStore(
+  activePlugins,
+  new Set(window.SERVER_FLAGS.consolePlugins),
+);
 
 if (process.env.NODE_ENV !== 'production') {
   // Expose Console plugin store for debugging

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -7,7 +7,7 @@ import { isModelFeatureFlag } from '@console/plugin-sdk/src/typings';
 import {
   subscribeToExtensions,
   extensionDiffListener,
-} from '@console/plugin-sdk/src/api/subscribeToExtensions';
+} from '@console/plugin-sdk/src/api/pluginSubscriptionService';
 import {
   ModelFeatureFlag as DynamicModelFeatureFlag,
   isModelFeatureFlag as isDynamicModelFeatureFlag,


### PR DESCRIPTION
This PR adds new React hook `useDynamicPluginInfo` which allows consuming Console [dynamic plugin](https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk) runtime information.

This hook re-renders the given component in any of the following cases:
- dynamic plugin(s) finished loading - status change `Pending` :arrow_forward: `Loaded`
- dynamic plugin(s) failed to load - status change `Pending` :arrow_forward: `Failed`

Hook return type is `DynamicPluginInfo[]` with `status: 'Pending' | 'Loaded' | 'Failed'` element property as the common denominator. Plugin metadata & enabled flag is available only for loaded plugins.

@spadgett FYI, this modifies `PluginStore` to allow loading only dynamic plugins listed via `SERVER_FLAGS.consolePlugins`.