### PR TITLE
Bug 1957457: Support secondary text in ResourceDropdown

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-wizard/configure.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import * as fuzzy from 'fuzzysearch';
 import { FormGroup, Checkbox, Radio } from '@patternfly/react-core';
 import { FieldLevelHelp, Firehose } from '@console/internal/components/utils';
 import { getName, ResourceDropdown, useFlag } from '@console/shared';
@@ -219,6 +220,10 @@ export const NetworkFormGroup: React.FC<NetworkFormGroupProps> = ({
     (device: NetworkAttachmentDefinitionKind) => publicNetworkName !== getName(device),
     [publicNetworkName],
   );
+
+  const autoCompleteFilter = (strText: string, item: React.ReactElement): boolean =>
+    fuzzy(strText, item?.props?.name);
+
   return (
     <>
       <FormGroup
@@ -269,6 +274,7 @@ export const NetworkFormGroup: React.FC<NetworkFormGroupProps> = ({
                   setNetwork(NADSelectorType.PUBLIC, selectedResource)
                 }
                 resourceFilter={filterForPublicDevices}
+                autocompleteFilter={autoCompleteFilter}
                 showBadge
               />
             </Firehose>
@@ -288,6 +294,7 @@ export const NetworkFormGroup: React.FC<NetworkFormGroupProps> = ({
                   setNetwork(NADSelectorType.CLUSTER, selectedResource)
                 }
                 resourceFilter={filterForClusterDevices}
+                autocompleteFilter={autoCompleteFilter}
                 showBadge
               />
             </Firehose>

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -91,7 +91,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
       color: inherit;
       padding: 4px 0 2px !important;
 
-      @media(min-width: $grid-float-breakpoint) {
+      @media (min-width: $grid-float-breakpoint) {
         padding-bottom: 10px !important;
         padding-top: 11px !important;
       }
@@ -128,7 +128,6 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
   }
 }
 
-
 // Custom dropdown menu rules for namespace-selector & resource-item that don't use the default pf4 styles
 .co-namespace-selector .dropdown-menu__autocomplete-filter {
   li {
@@ -156,7 +155,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
         }
       }
       &.next-to-bookmark {
-        padding-left: 5px
+        padding-left: 5px;
       }
     }
   }
@@ -241,7 +240,6 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
     &.pf-m-align-right-on-md {
       right: 0;
     }
-
   }
 }
 
@@ -260,5 +258,8 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
   .co-resource-item__resource-name {
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  .co-resource-item__resource-namespace {
+    display: none !important;
   }
 }


### PR DESCRIPTION
Add namespace in Multus Dropdown
Before:
![Screenshot from 2021-05-19 13-13-38](https://user-images.githubusercontent.com/54092533/118776775-f71e3a00-b8a5-11eb-86ac-be3f6af9d96e.png)
After:
![Screenshot from 2021-05-22 01-28-09](https://user-images.githubusercontent.com/54092533/119192097-32368e00-ba9d-11eb-89af-56010a8dd931.png)
