### PR TITLE
Bug 1960612: Make filesystem queries use all devices

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -456,11 +456,12 @@ const fetchNodeMetrics = (): Promise<NodeMetrics> => {
     {
       key: 'usedStorage',
       query:
-        'sum by (instance) (node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_free_bytes{mountpoint="/"})',
+        'sum by (instance) ((max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"})) - (max by (device, instance) (node_filesystem_free_bytes{device=~"/.*"})))',
     },
     {
       key: 'totalStorage',
-      query: 'sum by (instance) (node_filesystem_size_bytes{mountpoint="/"})',
+      query:
+        'sum by (instance) (max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"}))',
     },
     {
       key: 'cpu',

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
@@ -37,10 +37,10 @@ const queries = {
   [NodeQueries.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance='<%= node %>'}`),
   [NodeQueries.POD_COUNT]: _.template(`kubelet_running_pods{instance=~'<%= ipAddress %>:.*'}`),
   [NodeQueries.FILESYSTEM_USAGE]: _.template(
-    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/"})`,
+    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"})) - sum(max by (device) (node_filesystem_avail_bytes{instance='<%= node %>', device=~"/.*"}))`,
   ),
   [NodeQueries.FILESYSTEM_TOTAL]: _.template(
-    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/"})`,
+    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"}))`,
   ),
   [NodeQueries.NETWORK_IN_UTILIZATION]: _.template(
     `instance:node_network_receive_bytes:rate:sum{instance='<%= node %>'}`,

--- a/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
@@ -46,7 +46,7 @@ const top25Queries = {
   [OverviewQuery.NODES_BY_MEMORY]:
     'topk(25, sort_desc(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes))',
   [OverviewQuery.NODES_BY_STORAGE]:
-    'topk(25, sort_desc(sum(node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_avail_bytes{instance=~".*",mountpoint="/"}) BY (instance)))',
+    'topk(25, sort_desc(sum by (instance) (max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"})) - sum by (instance) (max by (device, instance) (node_filesystem_avail_bytes{device=~"/.*"}))))',
   [OverviewQuery.NODES_BY_PODS]:
     'topk(25, sort_desc(sum(avg_over_time(kubelet_running_pods[5m])) BY (node)))',
   [OverviewQuery.NODES_BY_NETWORK_IN]:
@@ -78,8 +78,9 @@ const overviewQueries = {
   [OverviewQuery.CPU_TOTAL]: 'sum(cluster:capacity_cpu_cores:sum)',
   [OverviewQuery.CPU_REQUESTS]: 'sum(kube_pod_resource_request{resource="cpu"})',
   [OverviewQuery.STORAGE_UTILIZATION]:
-    '(sum(node_filesystem_size_bytes{mountpoint="/"}) - sum(node_filesystem_free_bytes{mountpoint="/"}))',
-  [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes{mountpoint="/"})',
+    'sum(max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"}) - max by (device, instance) (node_filesystem_free_bytes{device=~"/.*"}))',
+  [OverviewQuery.STORAGE_TOTAL]:
+    'sum(max by (device, instance) (node_filesystem_size_bytes{device=~"/.*"}))',
   [OverviewQuery.POD_UTILIZATION]: 'count(kube_running_pod_ready)',
   [OverviewQuery.NETWORK_IN_UTILIZATION]:
     'sum(instance:node_network_receive_bytes_excluding_lo:rate1m)',

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/queries.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/queries.ts
@@ -28,10 +28,10 @@ const nodeQueriesByNodeName = {
   [HostQuery.MEMORY_UTILIZATION]: _.template(`node_memory_Active_bytes{instance=~'<%= node %>'}`),
   [HostQuery.MEMORY_TOTAL]: _.template(`node_memory_MemTotal_bytes{instance=~'<%= node %>'}`),
   [HostQuery.STORAGE_UTILIZATION]: _.template(
-    `sum(node_filesystem_size_bytes{instance="<%= node %>",mountpoint="/"} - node_filesystem_avail_bytes{instance="<%= node %>",mountpoint="/"})`,
+    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"})) - sum(max by (device) (node_filesystem_avail_bytes{instance='<%= node %>', device=~"/.*"}))`,
   ),
   [HostQuery.STORAGE_TOTAL]: _.template(
-    `sum(node_filesystem_size_bytes{instance='<%= node %>',mountpoint="/"})`,
+    `sum(max by (device) (node_filesystem_size_bytes{instance='<%= node %>', device=~"/.*"}))`,
   ),
   [HostQuery.NETWORK_IN_UTILIZATION]: _.template(
     `instance:node_network_receive_bytes:rate:sum{instance=~'<%= node %>'}`,


### PR DESCRIPTION
When node has more then one disk the filesystem total is wrong (only show the disk mount in /)

This PR change query to sum by device instead of using mount point.

Screenshots:
Before:
![screenshot-localhost_9000-2021 05 19-14_32_17](https://user-images.githubusercontent.com/2181522/118806524-de1a8680-b8af-11eb-96fb-d2b58d9b4791.png)

After:
![screenshot-localhost_9000-2021 05 19-14_34_09](https://user-images.githubusercontent.com/2181522/118806517-dbb82c80-b8af-11eb-9f68-995237852429.png)

Disks:
![screenshot-localhost_9000-2021 05 19-14_32_37(1)](https://user-images.githubusercontent.com/2181522/118806508-d8bd3c00-b8af-11eb-9ea8-930e36ca5fd7.png)

Signed-off-by: yaacov <kobi.zamir@gmail.com>