### PR TITLE
Bug 1962153: fix VolumeSnapshot routes

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -44,7 +44,7 @@
   "PersistentVolumeClaim details": "PersistentVolumeClaim details",
   "StorageClass": "StorageClass",
   "Create VolumeSnapshot": "Create VolumeSnapshot",
-  "Creating snapshot for claim <1>{resourceName}</1>": "Creating snapshot for claim <1>{resourceName}</1>",
+  "Creating snapshot for claim <1>{pvcName}</1>": "Creating snapshot for claim <1>{pvcName}</1>",
   "PersistentVolumeClaim": "PersistentVolumeClaim",
   "Snapshot Class": "Snapshot Class",
   "Create": "Create",

--- a/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
@@ -7,7 +7,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Grid, GridItem, ActionGroup, Button, Alert } from '@patternfly/react-core';
 
 import {
-  LoadingBox,
   ListDropdown,
   ButtonBar,
   history,
@@ -19,7 +18,6 @@ import {
   humanizeBinaryBytes,
 } from '@console/internal/components/utils';
 import {
-  K8sKind,
   referenceForModel,
   k8sCreate,
   referenceFor,
@@ -30,7 +28,6 @@ import {
   apiVersionForModel,
   ListKind,
 } from '@console/internal/module/k8s';
-import { connectToPlural } from '@console/internal/kinds';
 import {
   PersistentVolumeClaimModel,
   VolumeSnapshotModel,
@@ -133,18 +130,10 @@ const isDefaultSnapshotClass = (volumeSnapshotClass: VolumeSnapshotClassKind) =>
   ] === 'true';
 
 const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
-  const {
-    resourceName,
-    plural,
-    namespace,
-    kindObj,
-    handlePromise,
-    inProgress,
-    errorMessage,
-  } = props;
+  const { pvcName, namespace, handlePromise, inProgress, errorMessage } = props;
 
   const { t } = useTranslation();
-  const [pvcName, setPVCName] = React.useState(resourceName);
+  const [statePvcName, setPVCName] = React.useState(pvcName);
   const [pvcObj, setPVCObj] = React.useState<PersistentVolumeClaimKind>(null);
   const [snapshotName, setSnapshotName] = React.useState(`${pvcName || 'pvc'}-snapshot`);
   const [snapshotClassName, setSnapshotClassName] = React.useState('');
@@ -162,9 +151,9 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
         namespace,
         isList: true,
       },
-      pvcName ? { name: pvcName } : null,
+      statePvcName ? { name: statePvcName } : null,
     );
-  }, [namespace, pvcName]);
+  }, [namespace, statePvcName]);
 
   const [data, loaded, loadError] = useK8sWatchResource<PersistentVolumeClaimKind[]>(resourceWatch);
   const scList = scObjListLoaded ? scObjList.items : [];
@@ -174,7 +163,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
     (snapshotClass: VolumeSnapshotClassKind) => provisioner?.includes(snapshotClass?.driver),
     [provisioner],
   );
-  const vscList = vscLoaded ? vscObj.items : [];
+  const vscList = vscLoaded && vscObj ? vscObj.items : [];
   const getDefaultItem = React.useCallback(
     (snapFilter) => {
       const filteredVSC = vscList.filter(snapFilter);
@@ -187,10 +176,10 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
   );
 
   React.useEffect(() => {
-    const currentPVC = data.find((pvc) => pvc.metadata.name === pvcName);
+    const currentPVC = data.find((pvc) => pvc.metadata.name === statePvcName);
     setPVCObj(currentPVC);
     setSnapshotClassName(getDefaultItem(snapshotClassFilter));
-  }, [data, pvcName, namespace, loadError, snapshotClassFilter, getDefaultItem]);
+  }, [data, statePvcName, namespace, loadError, snapshotClassFilter, getDefaultItem]);
 
   const handleSnapshotName: React.ReactEventHandler<HTMLInputElement> = (event) =>
     setSnapshotName(event.currentTarget.value);
@@ -219,7 +208,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
       spec: {
         volumeSnapshotClassName: snapshotClassName,
         source: {
-          persistentVolumeClaimName: pvcName,
+          persistentVolumeClaimName: statePvcName,
         },
       },
     };
@@ -230,6 +219,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
   };
 
   const isBound = (pvc: PersistentVolumeClaimKind) => pvc?.status?.phase === 'Bound';
+  const kindId = `${VolumeSnapshotModel.apiGroup}~${VolumeSnapshotModel.apiVersion}~${VolumeSnapshotModel.kind}`;
 
   return (
     <div className="co-volume-snapshot__body">
@@ -241,7 +231,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
           <div className="co-m-pane__name">{title}</div>
           <div className="co-m-pane__heading-link">
             <Link
-              to={`/k8s/ns/${namespace || 'default'}/${plural}/~new`}
+              to={`/k8s/ns/${namespace || 'default'}/${kindId}/~new`}
               id="yaml-link"
               data-test="yaml-link"
               replace
@@ -251,14 +241,13 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
           </div>
         </h1>
         <form className="co-m-pane__body-group" onSubmit={create}>
-          {kindObj.kind === PersistentVolumeClaimModel.kind && (
+          {pvcName ? (
             <p>
               <Trans ns="console-app">
-                Creating snapshot for claim <strong>{resourceName}</strong>
+                Creating snapshot for claim <strong>{pvcName}</strong>
               </Trans>
             </p>
-          )}
-          {kindObj.kind === VolumeSnapshotModel.kind && (
+          ) : (
             /* eslint-disable jsx-a11y/label-has-associated-control */
             <>
               <label className="control-label co-required" html-for="claimName">
@@ -268,7 +257,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
                 dataTest="pvc-dropdown"
                 namespace={namespace}
                 onChange={handlePVCName}
-                selectedKey={pvcName}
+                selectedKey={statePvcName}
                 dataFilter={isBound}
                 desc={`Persistent Volume Claim in ${namespace} namespace`}
               />
@@ -316,7 +305,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
                 type="submit"
                 variant="primary"
                 id="save-changes"
-                isDisabled={!snapshotClassName || !snapshotName || !pvcName}
+                isDisabled={!snapshotClassName || !snapshotName || !statePvcName}
               >
                 {t('console-app~Create')}
               </Button>
@@ -331,7 +320,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
         <Grid hasGutter>
           <GridItem span={1} />
           <GridItem span={10}>
-            {pvcName && pvcObj && loaded && <PVCSummary persistentVolumeClaim={pvcObj} />}
+            {statePvcName && pvcObj && loaded && <PVCSummary persistentVolumeClaim={pvcObj} />}
             {!loaded && <LoadingComponent />}
           </GridItem>
           <GridItem span={1} />
@@ -341,26 +330,12 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
   );
 });
 
-const VolumeSnapshotComponent: React.FC<VolumeSnapshotComponentProps> = (props) => {
+export const VolumeSnapshot: React.FC<VolumeSnapshotComponentProps> = (props) => {
   const {
-    kindObj,
-    kindsInFlight,
     match: { params },
   } = props;
-  if (!kindObj && kindsInFlight) {
-    return <LoadingBox />;
-  }
-  return (
-    <CreateSnapshotForm
-      plural={params.plural}
-      namespace={params.ns}
-      resourceName={params.name}
-      kindObj={kindObj}
-    />
-  );
+  return <CreateSnapshotForm namespace={params.ns} pvcName={params.pvcName} />;
 };
-
-export const VolumeSnapshot = connectToPlural(VolumeSnapshotComponent);
 
 type SnapshotClassDropdownProps = {
   selectedKey: string;
@@ -372,9 +347,7 @@ type SnapshotClassDropdownProps = {
 
 type SnapshotResourceProps = HandlePromiseProps & {
   namespace: string;
-  resourceName: string;
-  kindObj: K8sKind;
-  plural: string;
+  pvcName?: string;
 };
 
 type PVCSummaryProps = {
@@ -382,7 +355,5 @@ type PVCSummaryProps = {
 };
 
 type VolumeSnapshotComponentProps = {
-  kindObj: K8sKind;
-  kindsInFlight: boolean;
-  match: match<{ ns?: string; plural?: string; name?: string }>;
+  match: match<{ ns: string; pvcName?: string }>;
 };

--- a/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/volume-snapshot.tsx
@@ -196,7 +196,7 @@ const VolumeSnapshotPage: React.FC<VolumeSnapshotPageProps> = (props) => {
   const namespace = props.namespace || props.match?.params?.ns || 'all-namespaces';
   const createProps = {
     to: `/k8s/${namespace === 'all-namespaces' ? namespace : `ns/${namespace}`}/${
-      props.match?.params?.plural
+      VolumeSnapshotModel.plural
     }/~new/form`,
   };
   return (

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -449,16 +449,6 @@ const AppContents: React.FC<{}> = () => {
             />
 
             <LazyRoute
-              path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/pvc/:pvcName/~new/form`}
-              exact
-              loader={() =>
-                import(
-                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
-                ).then((m) => m.VolumeSnapshot)
-              }
-            />
-
-            <LazyRoute
               path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
               exact
               loader={() =>

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -449,7 +449,7 @@ const AppContents: React.FC<{}> = () => {
             />
 
             <LazyRoute
-              path={`/k8s/ns/:ns/:plural/:name/${VolumeSnapshotModel.plural}/~new/form`}
+              path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/pvc/:pvcName/~new/form`}
               exact
               loader={() =>
                 import(
@@ -459,7 +459,7 @@ const AppContents: React.FC<{}> = () => {
             />
 
             <LazyRoute
-              path="/k8s/ns/:ns/:plural/~new/form"
+              path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
               exact
               loader={() =>
                 import(
@@ -469,7 +469,7 @@ const AppContents: React.FC<{}> = () => {
             />
 
             <LazyRoute
-              path="/k8s/all-namespaces/:plural/~new/form"
+              path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
               exact
               loader={() =>
                 import(

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -362,7 +362,7 @@ const kebabFactory: KebabFactory = {
     labelKey: 'public~Create snapshot',
     isDisabled: obj?.status?.phase !== 'Bound',
     tooltip: obj?.status?.phase !== 'Bound' ? 'PVC is not Bound' : '',
-    href: `/k8s/ns/${obj.metadata.namespace}/${VolumeSnapshotModel.plural}/pvc/${obj.metadata.name}/~new/form`,
+    href: `/k8s/ns/${obj.metadata.namespace}/${VolumeSnapshotModel.plural}/~new/form?pvc=${obj.metadata.name}`,
     accessReview: asAccessReview(kind, obj, 'create'),
   }),
   ClonePVC: (kind, obj) => ({

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -362,9 +362,7 @@ const kebabFactory: KebabFactory = {
     labelKey: 'public~Create snapshot',
     isDisabled: obj?.status?.phase !== 'Bound',
     tooltip: obj?.status?.phase !== 'Bound' ? 'PVC is not Bound' : '',
-    href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/${
-      VolumeSnapshotModel.plural
-    }/~new/form`,
+    href: `/k8s/ns/${obj.metadata.namespace}/${VolumeSnapshotModel.plural}/pvc/${obj.metadata.name}/~new/form`,
     accessReview: asAccessReview(kind, obj, 'create'),
   }),
   ClonePVC: (kind, obj) => ({


### PR DESCRIPTION
- Fix routes so that they're not ambiguous
- Fix Edit YAML link in case we're coming from a PVC page
- Simplify create-volume-snapshot:
    - async loading of kind data shouldn't be necessary
    - rename "resourceName" to "pvcName", more explicit
    - absence/presence of pvcName props is sufficient to decide conditional
      display of the PVC dropdown