### PR TITLE
Bug 1962256: virt: use the new rhel8 image as an example

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -22,7 +22,7 @@ export const READY = 'Ready';
 export const CLOUD = 'cloud';
 export const SSH = 'ssh';
 
-export const EXAMPLE_CONTAINER = 'kubevirt/fedora-cloud-container-disk-demo';
+export const EXAMPLE_CONTAINER = 'registry.redhat.io/rhel8/rhel-guest-image';
 export const FEDORA_IMAGE_LINK = 'https://alt.fedoraproject.org/cloud/';
 export const RHEL_IMAGE_LINK =
   'https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.2/x86_64/product-software';


### PR DESCRIPTION
For downtream it would be better than Fedora

Signed-off-by: Dan Kenigsberg <danken@redhat.com>