### PR TITLE
Fix duplicate helm charts not showing up in catalog

### DIFF
--- a/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
@@ -107,7 +107,7 @@ export const normalizeHelmCharts = (
         ];
 
         const helmChart = {
-          uid: digest,
+          uid: `${chartRepoName}--${digest}`,
           type: 'HelmChart',
           name: displayName,
           title,


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5853
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Duplicate helm charts coming from two different helm chart repositories were not shown. UIDs of the charts remained same which caused the catalog to remove duplicates.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Create UIDs of the charts using both helm repo name and digest of the chart.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No UI Change per say.
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/118846177-1474f780-b8ea-11eb-81fe-2473ced90e19.mov

**Test setup:**
- Add a new helm chart repo that contains providerType annotations in index.yaml.

```yaml
apiVersion: helm.openshift.io/v1beta1
kind: HelmChartRepository
metadata:
  name: redhat-certified
spec:
  connectionConfig:
    url: >-
      https://raw.githubusercontent.com/rohitkrai03/redhat-helm-charts/certification
  name: Red Hat Certification Charts
``` 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
