### PR TITLE
Fix isSubmitting logic of formik forms

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
@@ -37,7 +37,6 @@ const CloudShellDeveloperSetup: React.FunctionComponent<Props> = ({
   const { t } = useTranslation();
 
   const handleSubmit = async (values: CloudShellSetupFormData, actions) => {
-    actions.setSubmitting(true);
     const createNamespace = values.namespace === CREATE_NAMESPACE_KEY;
     const namespace = createNamespace ? values.newNamespace : values.namespace;
 
@@ -57,7 +56,6 @@ const CloudShellDeveloperSetup: React.FunctionComponent<Props> = ({
     } catch (err) {
       actions.setStatus({ submitError: err.message });
     }
-    actions.setSubmitting(false);
   };
 
   return (

--- a/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModal.tsx
+++ b/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModal.tsx
@@ -30,9 +30,9 @@ const ResourceLimitsModal: React.FC<Props> = ({
         <ResourceLimitSection hideTitle />
       </ModalBody>
       <ModalSubmitFooter
-        submitDisabled={!_.isEmpty(errors)}
+        submitDisabled={!_.isEmpty(errors) || isSubmitting}
         inProgress={isSubmitting}
-        errorMessage={status && status.submitError}
+        errorMessage={status?.submitError}
         submitText={t('console-app~Save')}
         cancel={cancel}
       />

--- a/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModalLauncher.tsx
+++ b/frontend/packages/console-app/src/components/modals/resource-limits/ResourceLimitsModalLauncher.tsx
@@ -28,7 +28,8 @@ const ResourceLimitsModalLauncher: React.FC<ResourceLimitsModalLauncherProps> = 
       limits: { cpu, memory },
     } = values;
     const resources = getResourceLimitsData({ cpu, memory });
-    k8sPatch(props.model, props.resource, [
+
+    return k8sPatch(props.model, props.resource, [
       {
         op: 'replace',
         path: `/spec/template/spec/containers/0/resources`,
@@ -36,11 +37,9 @@ const ResourceLimitsModalLauncher: React.FC<ResourceLimitsModalLauncherProps> = 
       },
     ])
       .then(() => {
-        actions.setSubmitting(false);
         props.close();
       })
       .catch((error) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: error });
       });
   };

--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
@@ -105,7 +105,9 @@ const EditDeploymentForm: React.FC<FormikProps<FormikValues> & {
         infoMessage={t('devconsole~Click reload to see the new version.')}
         isSubmitting={isSubmitting}
         submitLabel={t('devconsole~Save')}
-        disableSubmit={editorType === EditorType.YAML ? !dirty : !dirty || !_.isEmpty(errors)}
+        disableSubmit={
+          (editorType === EditorType.YAML ? !dirty : !dirty || !_.isEmpty(errors)) || isSubmitting
+        }
         handleCancel={history.goBack}
         handleDownload={editorType === EditorType.YAML && (() => downloadYaml(yamlData))}
         sticky

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -125,7 +125,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
             errorMessage={status && status?.errors?.json?.message}
             isSubmitting={isSubmitting}
             submitLabel={healthCheckAdded ? t('devconsole~Save') : t('devconsole~Add')}
-            disableSubmit={isFormClean || !dirty || !_.isEmpty(errors)}
+            disableSubmit={isFormClean || !dirty || !_.isEmpty(errors) || isSubmitting}
             resetLabel={t('devconsole~Cancel')}
             hideSubmit={viewOnly}
           />

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecksForm.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecksForm.tsx
@@ -41,14 +41,12 @@ const AddHealthChecksForm: React.FC<AddHealthChecksFormProps> = ({
   const handleSubmit = (values, actions) => {
     const updatedResource = updateHealthChecksProbe(values, resource.data, container);
 
-    k8sUpdate(modelFor(referenceFor(resource.data)), updatedResource)
+    return k8sUpdate(modelFor(referenceFor(resource.data)), updatedResource)
       .then(() => {
-        actions.setSubmitting(false);
         actions.setStatus({ error: '' });
         history.goBack();
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ errors: err });
       });
   };

--- a/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
@@ -68,7 +68,7 @@ const HPAForm: React.FC<FormikProps<HPAFormValues> & HPAFormProps> = ({
         errorMessage={status?.submitError}
         isSubmitting={isSubmitting}
         submitLabel={t('devconsole~Save')}
-        disableSubmit={isForm && !isEmpty(errors)}
+        disableSubmit={(isForm && !isEmpty(errors)) || isSubmitting}
         resetLabel={t('devconsole~Cancel')}
         sticky
       />

--- a/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
@@ -52,18 +52,16 @@ const HPAFormikForm: React.FC<HPAFormikFormProps> = ({ existingHPA, targetResour
     const invalidUsageError = getInvalidUsageError(hpa, values);
     if (invalidUsageError) {
       helpers.setStatus({ submitError: invalidUsageError });
-      return;
+      return Promise.reject();
     }
 
-    helpers.setSubmitting(true);
     const method = existingHPA ? k8sUpdate : k8sCreate;
-    method(HorizontalPodAutoscalerModel, hpa)
+
+    return method(HorizontalPodAutoscalerModel, hpa)
       .then(() => {
-        helpers.setSubmitting(false);
         history.goBack();
       })
       .catch((error) => {
-        helpers.setSubmitting(false);
         helpers.setStatus({
           submitError: error?.message || t('devconsole~Unknown error submitting'),
         });

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -79,7 +79,6 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
       return true;
     });
 
-    actions.setSubmitting(true);
     if (!_.isEmpty(updateRoles)) {
       roleBindingRequests.push(...sendRoleBindingRequest(Verb.Patch, updateRoles, roleBinding));
     }
@@ -90,9 +89,8 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
       roleBindingRequests.push(...sendRoleBindingRequest(Verb.Create, newRoles, roleBinding));
     }
 
-    Promise.all(roleBindingRequests)
+    return Promise.all(roleBindingRequests)
       .then(() => {
-        actions.setSubmitting(false);
         actions.resetForm({
           values: {
             projectAccess: values.projectAccess,
@@ -101,7 +99,6 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({
         });
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccessForm.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccessForm.tsx
@@ -18,7 +18,7 @@ const ProjectAccessForm: React.FC<ProjectAccessFormProps> = ({
   roles,
 }) => {
   const { t } = useTranslation();
-  const disableSubmit = !dirty || !_.isEmpty(errors);
+  const disableSubmit = !dirty || !_.isEmpty(errors) || isSubmitting;
   return (
     <Form onSubmit={handleSubmit}>
       <div className="co-m-pane__form">

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -48,7 +48,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
 
   const isSubmitDisabled =
     (helmAction === HelmActionType.Upgrade && !dirty) ||
-    status?.isSubmitting ||
+    isSubmitting ||
     !_.isEmpty(errors) ||
     !!chartError;
 
@@ -144,8 +144,8 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
       </FormBody>
       <FormFooter
         handleReset={handleReset}
-        errorMessage={status && status.submitError}
-        isSubmitting={status?.isSubmitting || isSubmitting}
+        errorMessage={status?.submitError}
+        isSubmitting={isSubmitting}
         submitLabel={helmActionString(t)[helmAction]}
         disableSubmit={isSubmitDisabled}
         resetLabel={t('helm-plugin~Cancel')}

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -141,7 +141,6 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
   };
 
   const handleSubmit = (values, actions) => {
-    actions.setStatus({ isSubmitting: true });
     const {
       releaseName,
       chartURL,
@@ -164,14 +163,14 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
             errorsText: ajv.errorsText(),
           }),
         });
-        return;
+        return Promise.reject();
       }
     } else if (yamlData) {
       try {
         valuesObj = safeLoad(yamlData);
       } catch (err) {
         actions.setStatus({ submitError: t('helm-plugin~Invalid YAML - {{err}}', { err }) });
-        return;
+        return Promise.reject();
       }
     }
 
@@ -185,7 +184,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
     const isGoingToTopology =
       helmAction === HelmActionType.Install || helmActionOrigin === HelmActionOrigins.topology;
 
-    config
+    return config
       .fetch('/api/helm/release', payload, null, -1)
       .then(async (res: HelmRelease) => {
         let redirect = config.redirectURL;
@@ -206,12 +205,10 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
           }
         }
 
-        actions.setStatus({ isSubmitting: false });
         history.push(redirect);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
-        actions.setStatus({ submitError: err.message, isSubmitting: false });
+        actions.setStatus({ submitError: err.message });
       });
   };
 

--- a/frontend/packages/helm-plugin/src/components/forms/rollback/HelmReleaseRollbackForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/rollback/HelmReleaseRollbackForm.tsx
@@ -65,9 +65,9 @@ const HelmReleaseRollbackForm: React.FC<Props> = ({
       <FormFooter
         handleReset={handleReset}
         errorMessage={status?.submitError}
-        isSubmitting={status?.isSubmitting || isSubmitting}
+        isSubmitting={isSubmitting}
         submitLabel={helmActionString(t)[helmAction]}
-        disableSubmit={status?.isSubmitting || !dirty || !_.isEmpty(errors)}
+        disableSubmit={isSubmitting || !dirty || !_.isEmpty(errors)}
         resetLabel={t('helm-plugin~Cancel')}
         sticky
       />

--- a/frontend/packages/helm-plugin/src/components/forms/rollback/HelmReleaseRollbackPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/rollback/HelmReleaseRollbackPage.tsx
@@ -58,21 +58,18 @@ const HelmReleaseRollbackPage: React.FC<HelmReleaseRollbackPageProps> = ({ match
   };
 
   const handleSubmit = (values, actions) => {
-    actions.setStatus({ isSubmitting: true });
     const payload = {
       namespace,
       name: releaseName,
       version: values.revision,
     };
 
-    config
+    return config
       .fetch('/api/helm/release', payload, null, -1)
       .then(() => {
-        actions.setStatus({ isSubmitting: false });
         history.push(config.redirectURL);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -142,13 +142,12 @@ export const EventSource: React.FC<Props> = ({
       },
     } = values;
     const eventSrcRequest: Promise<K8sResourceKind> = createResources(values);
-    eventSrcRequest
+
+    return eventSrcRequest
       .then(() => {
-        actions.setSubmitting(false);
         handleRedirect(projectName, perspective, perpectiveExtension);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/knative-plugin/src/components/add/EventSourceForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourceForm.tsx
@@ -92,7 +92,8 @@ const EventSourceForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
         isSubmitting={isSubmitting}
         submitLabel={t('knative-plugin~Create')}
         disableSubmit={
-          values.editorType === EditorType.YAML ? !dirty : !dirty || !_.isEmpty(errors)
+          (values.editorType === EditorType.YAML ? !dirty : !dirty || !_.isEmpty(errors)) ||
+          isSubmitting
         }
         resetLabel={t('knative-plugin~Cancel')}
         sticky

--- a/frontend/packages/knative-plugin/src/components/add/channels/AddChannel.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/AddChannel.tsx
@@ -60,13 +60,11 @@ const AddChannel: React.FC<Props> = ({ namespace, channels, activeApplication })
   };
 
   const handleSubmit = (values, actions) => {
-    createResources(values)
+    return createResources(values)
       .then(() => {
-        actions.setSubmitting(false);
         handleRedirect(values.namespace, perspective, perspectiveExtension);
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/knative-plugin/src/components/add/channels/ChannelForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/ChannelForm.tsx
@@ -99,7 +99,7 @@ const ChannelForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
         errorMessage={status && status.submitError}
         isSubmitting={isSubmitting}
         submitLabel={t('knative-plugin~Create')}
-        disableSubmit={!dirty || !_.isEmpty(errors)}
+        disableSubmit={!dirty || !_.isEmpty(errors) || isSubmitting}
         resetLabel={t('knative-plugin~Cancel')}
         sticky
       />

--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSub.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSub.tsx
@@ -65,9 +65,8 @@ const PubSub: React.FC<PubSubProps> = ({
     },
   };
   const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {
-    k8sCreate(getResourceModel(), values)
+    return k8sCreate(getResourceModel(), values)
       .then(() => {
-        action.setSubmitting(false);
         action.setStatus({ subscriberAvailable: true, error: '' });
         close();
       })

--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSubModal.tsx
@@ -52,7 +52,7 @@ const PubSubModal: React.FC<Props> = ({
         inProgress={isSubmitting}
         submitText={t('knative-plugin~Add')}
         cancelText={t('knative-plugin~Cancel')}
-        submitDisabled={!dirty || !_.isEmpty(errors)}
+        submitDisabled={!dirty || !_.isEmpty(errors) || isSubmitting}
         cancel={cancel}
         errorMessage={status.error}
       />

--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModal.tsx
@@ -61,6 +61,7 @@ const DeleteRevisionModal: React.FC<Props> = (props) => {
         cancelText={t('knative-plugin~Cancel')}
         cancel={cancel}
         errorMessage={status.error}
+        submitDisabled={isSubmitting}
         submitDanger
       />
     </form>

--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
@@ -122,7 +122,7 @@ const Controller: React.FC<ControllerProps> = ({ loaded, resources, revision, ca
   }
 
   const deleteRevision = (action: FormikHelpers<FormikValues>) => {
-    k8sKill(RevisionModel, revision)
+    return k8sKill(RevisionModel, revision)
       .then(() => {
         close();
         // If we are currently on the deleted revision's page, redirect to the list page
@@ -140,11 +140,10 @@ const Controller: React.FC<ControllerProps> = ({ loaded, resources, revision, ca
   const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {
     const obj = constructObjForUpdate(values.trafficSplitting, service);
     if (!deleteTraffic || deleteTraffic.percent === 0) {
-      deleteRevision(action);
-      return;
+      return deleteRevision(action);
     }
 
-    k8sUpdate(ServiceModel, obj)
+    return k8sUpdate(ServiceModel, obj)
       .then(() => {
         deleteRevision(action);
       })

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsub.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsub.tsx
@@ -37,9 +37,8 @@ const SinkPubsub: React.FC<SinkPubsubProps> = ({ source, cancel, close }) => {
         spec: { ...source.spec, subscriber: { ...values } },
       }),
     };
-    k8sUpdate(modelFor(referenceFor(source)), updatePayload)
+    return k8sUpdate(modelFor(referenceFor(source)), updatePayload)
       .then(() => {
-        action.setSubmitting(false);
         action.setStatus({ error: '' });
         close();
       })

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSource.tsx
@@ -57,9 +57,8 @@ const SinkSource: React.FC<SinkSourceProps> = ({ source, cancel, close }) => {
           }
         : { spec: { ...source.spec, sink: { uri: sink?.uri } } }),
     };
-    k8sUpdate(modelFor(referenceFor(source)), updatePayload)
+    return k8sUpdate(modelFor(referenceFor(source)), updatePayload)
       .then(() => {
-        action.setSubmitting(false);
         action.setStatus({ error: '' });
         close();
       })

--- a/frontend/packages/knative-plugin/src/components/sink-uri/SinkUri.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-uri/SinkUri.tsx
@@ -26,9 +26,8 @@ const SinkUri: React.FC<SinkUriProps> = ({ source, eventSourceList, cancel, clos
       };
       requests.push(k8sUpdate(modelFor(referenceFor(evSrc)), updatePayload));
     });
-    Promise.race(requests)
+    return Promise.race(requests)
       .then(() => {
-        action.setSubmitting(false);
         action.setStatus({ error: '' });
         close();
       })

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -47,9 +47,8 @@ const TrafficSplitting: React.FC<TrafficSplittingProps> = ({
   };
   const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {
     const obj = constructObjForUpdate(values.trafficSplitting, service);
-    k8sUpdate(ServiceModel, obj)
+    return k8sUpdate(ServiceModel, obj)
       .then(() => {
-        action.setSubmitting(false);
         action.setStatus({ error: '' });
         close();
       })

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
@@ -30,6 +30,7 @@ const TrafficSplittingModal: React.FC<Props> = (props) => {
       </ModalBody>
       <ModalSubmitFooter
         inProgress={isSubmitting}
+        submitDisabled={isSubmitting}
         submitText={t('knative-plugin~Save')}
         cancelText={t('knative-plugin~Cancel')}
         cancel={cancel}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHost.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHost.tsx
@@ -169,13 +169,11 @@ const AddBareMetalHost: React.FC<AddBareMetalHostProps> = ({
         )
       : createBareMetalHost(opts);
 
-    promise
+    return promise
       .then(() => {
-        actions.setSubmitting(false);
         history.push(resourcePathFromModel(BareMetalHostModel, values.name, namespace));
       })
       .catch((error) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: error.message });
       });
   };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
@@ -26,9 +26,7 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
   };
 
   const handleSubmit = (values, actions) => {
-    actions.setSubmitting(true);
-
-    k8sUpdate(
+    return k8sUpdate(
       PipelineModel,
       {
         ...obj,
@@ -42,7 +40,6 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
       obj.metadata.name,
     )
       .then((newObj) => {
-        actions.setSubmitting(false);
         actions.resetForm({
           values: {
             parameters: _.get(newObj.spec, 'params', []),
@@ -56,7 +53,6 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
         });
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/ModalStructure.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/ModalStructure.tsx
@@ -44,7 +44,7 @@ const ModalStructure: React.FC<ModalStructureCombinedProps> = (props) => {
           errorMessage={status?.submitError}
           inProgress={isSubmitting}
           submitText={submitBtnText}
-          submitDisabled={!_.isEmpty(errors)}
+          submitDisabled={!_.isEmpty(errors) || isSubmitting}
           submitDanger={submitDanger}
           cancel={close}
         />

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineSecretSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineSecretSection.tsx
@@ -35,7 +35,6 @@ const PipelineSecretSection: React.FC = () => {
   } = useFormikContext<CommonPipelineModalFormikValues>();
 
   const handleSubmit = (values, actions) => {
-    actions.setSubmitting(true);
     const newSecret = {
       apiVersion: SecretModel.apiVersion,
       kind: SecretModel.kind,
@@ -47,9 +46,8 @@ const PipelineSecretSection: React.FC = () => {
       type: values.type,
       stringData: values.formData,
     };
-    k8sCreate(SecretModel, newSecret)
+    return k8sCreate(SecretModel, newSecret)
       .then((resp) => {
-        actions.setSubmitting(false);
         setFieldValue(secretOpenField.name, false);
         associateServiceAccountToSecret(
           resp,
@@ -58,7 +56,6 @@ const PipelineSecretSection: React.FC = () => {
         );
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -42,17 +42,13 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
     secretOpen: false,
   };
 
-  const handleSubmit = (values: StartPipelineFormValues, actions): void => {
-    actions.setSubmitting(true);
-
-    submitStartPipeline(values, pipeline, null, userStartedAnnotation)
+  const handleSubmit = (values: StartPipelineFormValues, actions) => {
+    return submitStartPipeline(values, pipeline, null, userStartedAnnotation)
       .then((res) => {
-        actions.setSubmitting(false);
         onSubmit && onSubmit(res);
         close();
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err.message });
         errorModal({ error: err.message });
         close();

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
@@ -39,11 +39,8 @@ const AddTriggerModal: React.FC<AddTriggerModalProps> = ({ pipeline, close }) =>
   };
 
   const handleSubmit = (values: AddTriggerFormValues, actions) => {
-    actions.setSubmitting(true);
-
-    submitTrigger(pipeline, values)
+    return submitTrigger(pipeline, values)
       .then(() => {
-        actions.setSubmitting(false);
         close();
       })
       .catch((error) => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/RemoveTriggerModal.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/RemoveTriggerModal.tsx
@@ -23,15 +23,11 @@ const RemoveTriggerModal: React.FC<RemoveTriggerModalProps> = ({ pipeline, close
     values: RemoveTriggerFormValues,
     actions: FormikHelpers<RemoveTriggerFormValues>,
   ) => {
-    actions.setSubmitting(true);
-
-    removeTrigger(values, pipeline)
+    return removeTrigger(values, pipeline)
       .then(() => {
-        actions.setSubmitting(false);
         close();
       })
       .catch((e) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: e.message });
       });
   };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
@@ -72,7 +72,6 @@ const PipelineBuilderPage: React.FC<PipelineBuilderPageProps> = (props) => {
 
     return resourceCall
       .then(() => {
-        actions.setSubmitting(false);
         history.push(`/k8s/ns/${ns}/${referenceForModel(PipelineModel)}/${pipeline.metadata.name}`);
       })
       .catch((e) => {

--- a/frontend/packages/topology/src/components/modals/EditApplicationModal.tsx
+++ b/frontend/packages/topology/src/components/modals/EditApplicationModal.tsx
@@ -58,7 +58,7 @@ const EditApplicationForm: React.FC<FormikProps<FormikValues> & EditApplicationF
       </ModalBody>
       <ModalSubmitFooter
         submitText={t('topology~Save')}
-        submitDisabled={!dirty}
+        submitDisabled={!dirty || isSubmitting}
         cancel={cancel}
         inProgress={isSubmitting}
         errorMessage={status && status.submitError}
@@ -76,13 +76,11 @@ class EditApplicationModal extends PromiseComponent<
     const applicationKey = values.application.selectedKey;
     const application = applicationKey === UNASSIGNED_KEY ? undefined : values.application.name;
 
-    this.handlePromise(updateResourceApplication(resourceKind, resource, application))
+    return this.handlePromise(updateResourceApplication(resourceKind, resource, application))
       .then(() => {
-        actions.setSubmitting(false);
         this.props.close();
       })
       .catch((errorMessage) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: errorMessage });
       });
   };

--- a/frontend/packages/topology/src/components/modals/MoveConnectionModal.tsx
+++ b/frontend/packages/topology/src/components/modals/MoveConnectionModal.tsx
@@ -108,7 +108,7 @@ const MoveConnectionForm: React.FC<FormikProps<FormikValues> &
       </ModalBody>
       <ModalSubmitFooter
         submitText={t('topology~Move')}
-        submitDisabled={!isDirty}
+        submitDisabled={!isDirty || isSubmitting}
         cancel={cancel}
         inProgress={isSubmitting}
         errorMessage={status && status.submitError}
@@ -146,15 +146,12 @@ class MoveConnectionModal extends PromiseComponent<
   };
 
   private handleSubmit = (values, actions) => {
-    actions.setSubmitting(true);
     const { close } = this.props;
-    this.handlePromise(this.onSubmit(values.target))
+    return this.handlePromise(this.onSubmit(values.target))
       .then(() => {
-        actions.setSubmitting(false);
         close();
       })
       .catch((err) => {
-        actions.setSubmitting(false);
         actions.setStatus({ submitError: err });
       });
   };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3617
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: In our use of Formik we are always manually calling actions.setSubmitting(true | false) for our async submit handlers. But this is not needed because formik handles that logic internally if a promise is returned from the submit handler.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Cleanup the use of `setSubmitting` to manually handle the submitting state.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No design changes.
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
