### PR TITLE
Bug 1962256: Use shiny new rhel8 image in yaml

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { isUpstream } from '../../../utils/common';
 
-import { EXAMPLE_CONTAINER } from '../../../utils/strings';
+import { EXAMPLE_CONTAINER, FEDORA_EXAMPLE_CONTAINER } from '../../../utils/strings';
 
 export const ContainerSourceHelp: React.FC = () => {
   const { t } = useTranslation();
+  const container = isUpstream() ? FEDORA_EXAMPLE_CONTAINER : EXAMPLE_CONTAINER;
+
   return (
     <div className="pf-c-form__helper-text" aria-live="polite" data-test="ContainerSourceHelp">
-      {t('kubevirt-plugin~Example: {{container}}', { container: EXAMPLE_CONTAINER })}
+      {t('kubevirt-plugin~Example: {{container}}', { container })}
     </div>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/default-os-selection.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/default-os-selection.ts
@@ -1,14 +1,17 @@
 import { TemplateKind } from '@console/internal/module/k8s';
 import { getName } from '@console/shared/src';
 import { ObjectEnum } from '@console/shared/src/constants/object-enum';
+import { isUpstream } from '../../utils/common';
 
 export class OSSelection extends ObjectEnum<string> {
   static readonly FEDORA = new OSSelection(
     'fedora',
-    'kubevirt/fedora-cloud-container-disk-demo:latest',
+    'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest',
   );
 
   static readonly CENTOS = new OSSelection('centos', 'centos:latest');
+
+  static readonly RHEL8 = new OSSelection('rhel8', 'registry.redhat.io/rhel8/rhel-guest-image');
 
   private readonly image: string;
 
@@ -19,7 +22,10 @@ export class OSSelection extends ObjectEnum<string> {
 
   public getContainerImage = () => this.image;
 
-  static getAll = () => [OSSelection.FEDORA, OSSelection.CENTOS];
+  static getAll = () =>
+    isUpstream()
+      ? [OSSelection.FEDORA, OSSelection.RHEL8, OSSelection.CENTOS]
+      : [OSSelection.RHEL8, OSSelection.FEDORA, OSSelection.CENTOS];
 
   static findSuitableOSAndTemplate = (templates: TemplateKind[]) => {
     const sortedTemplates = [...templates].sort((a, b) => getName(b).localeCompare(getName(a)));

--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-template-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-template-yaml.ts
@@ -59,7 +59,7 @@ objects:
           volumes:
             - name: containerdisk
               containerDisk:
-                image: 'kubevirt/fedora-cloud-container-disk-demo:latest'
+                image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest'
             - cloudInitNoCloud:
                 userData: |-
                   #cloud-config

--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: 'kubevirt/fedora-cloud-container-disk-demo:latest'
+            image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest'
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-

--- a/frontend/packages/kubevirt-plugin/src/topology/__tests__/topology-kubevirt-test-data.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/__tests__/topology-kubevirt-test-data.ts
@@ -754,7 +754,7 @@ const pods = {
               },
             ],
             terminationMessagePolicy: 'File',
-            image: 'kubevirt/fedora-cloud-container-disk-demo:latest',
+            image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest',
             args: [
               '--copy-path',
               '/var/run/kubevirt-ephemeral-disks/container-disk-data/e2ec8a25-ef0c-47a0-8afe-5b58570f97b0/disk_0',
@@ -2157,7 +2157,7 @@ const virtualmachines = {
             volumes: [
               {
                 containerDisk: {
-                  image: 'kubevirt/fedora-cloud-container-disk-demo:latest',
+                  image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest',
                 },
                 name: 'containerdisk',
               },
@@ -2272,7 +2272,7 @@ const virtualmachines = {
             volumes: [
               {
                 containerDisk: {
-                  image: 'kubevirt/fedora-cloud-container-disk-demo:latest',
+                  image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest',
                 },
                 name: 'containerdisk',
               },
@@ -2399,7 +2399,7 @@ const virtualmachineinstances = {
         volumes: [
           {
             containerDisk: {
-              image: 'kubevirt/fedora-cloud-container-disk-demo:latest',
+              image: 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest',
               imagePullPolicy: 'Always',
             },
             name: 'containerdisk',

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -23,6 +23,7 @@ export const CLOUD = 'cloud';
 export const SSH = 'ssh';
 
 export const EXAMPLE_CONTAINER = 'registry.redhat.io/rhel8/rhel-guest-image';
+export const FEDORA_EXAMPLE_CONTAINER = 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest';
 export const FEDORA_IMAGE_LINK = 'https://alt.fedoraproject.org/cloud/';
 export const RHEL_IMAGE_LINK =
   'https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.2/x86_64/product-software';


### PR DESCRIPTION
use the new rhel8 image as an example

When upstream using fedora
When downstream using rhel

Screenshots:
cloudinit injection works:
![screenshot-localhost_9000-2021 05 20-09_00_08](https://user-images.githubusercontent.com/2181522/118927425-72392c00-b94a-11eb-86f7-27ed311cfcd9.png)

default image is rhel8:
![screenshot-localhost_9000-2021 05 20-09_00_53](https://user-images.githubusercontent.com/2181522/118927430-736a5900-b94a-11eb-8367-861b68b027c3.png)

help string change:
![screenshot-localhost_9000-2021 05 20-09_54_52](https://user-images.githubusercontent.com/2181522/118933224-9ea47680-b951-11eb-9659-7f77cf4c77f3.png)

Signed-off-by: yaacov <kobi.zamir@gmail.com>