### PR TITLE
Bug 1960534: Monitoring dashboards: Always allow custom format for tooltip entries

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -59,7 +59,8 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
             isStack={graphType === GraphTypes.area}
             timespan={timespan}
             pollInterval={pollInterval}
-            formatLegendLabel={(labels) => labels.pod}
+            formatSeriesTitle={(labels) => labels.pod}
+            showLegend
           />
         </PrometheusGraphLink>
       </DashboardCardBody>

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -48,7 +48,7 @@ import { AlertmanagerYAMLEditorWrapper } from './alert-manager-yaml-editor';
 import { AlertmanagerConfigWrapper } from './alert-manager-config';
 import MonitoringDashboardsPage from './dashboards';
 import { QueryBrowserPage, ToggleGraph } from './metrics';
-import { FormatLegendLabel, QueryBrowser } from './query-browser';
+import { FormatSeriesTitle, QueryBrowser } from './query-browser';
 import { CreateSilence, EditSilence } from './silence-form';
 import {
   Alert,
@@ -447,7 +447,7 @@ const queryBrowserURL = (query: string, namespace: string) =>
 
 const Graph: React.FC<GraphProps> = ({
   filterLabels = undefined,
-  formatLegendLabel,
+  formatSeriesTitle,
   namespace,
   query,
   ruleDuration,
@@ -469,7 +469,7 @@ const Graph: React.FC<GraphProps> = ({
       namespace={namespace}
       defaultTimespan={timespan}
       filterLabels={filterLabels}
-      formatLegendLabel={formatLegendLabel}
+      formatSeriesTitle={formatSeriesTitle}
       GraphLink={GraphLink}
       pollInterval={Math.round(timespan / 120)}
       queries={[query]}
@@ -925,7 +925,7 @@ export const AlertRulesDetailsPage = withFallback(
 
     const { t } = useTranslation();
 
-    const formatLegendLabel = (alertLabels) => {
+    const formatSeriesTitle = (alertLabels) => {
       const nameLabel = alertLabels.__name__ ?? '';
       const otherLabels = _.omit(alertLabels, '__name__');
       return `${nameLabel}{${_.map(otherLabels, (v, k) => `${k}="${v}"`).join(',')}}`;
@@ -1033,10 +1033,11 @@ export const AlertRulesDetailsPage = withFallback(
               <div className="row">
                 <div className="col-sm-12">
                   <Graph
-                    formatLegendLabel={formatLegendLabel}
+                    formatSeriesTitle={formatSeriesTitle}
                     namespace={namespace}
                     query={rule?.query}
                     ruleDuration={rule?.duration}
+                    showLegend
                   />
                 </div>
               </div>
@@ -1822,10 +1823,11 @@ type AlertingPageProps = {
 
 type GraphProps = {
   filterLabels?: PrometheusLabels;
-  formatLegendLabel?: FormatLegendLabel;
+  formatSeriesTitle?: FormatSeriesTitle;
   namespace?: string;
   query: string;
   ruleDuration: number;
+  showLegend?: boolean;
 };
 
 type MonitoringResourceIconProps = {

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -8,16 +8,23 @@ import {
   monitoringDashboardsSetTimespan,
 } from '../../../actions/ui';
 import { RootState } from '../../../redux';
-import { FormatLegendLabel, QueryBrowser } from '../query-browser';
+import { FormatSeriesTitle, QueryBrowser } from '../query-browser';
 
 type Props = {
-  formatLegendLabel?: FormatLegendLabel;
+  formatSeriesTitle?: FormatSeriesTitle;
   isStack: boolean;
   pollInterval: number;
   queries: string[];
+  showLegend?: boolean;
 };
 
-const Graph: React.FC<Props> = ({ formatLegendLabel, isStack, pollInterval, queries }) => {
+const Graph: React.FC<Props> = ({
+  formatSeriesTitle,
+  isStack,
+  pollInterval,
+  queries,
+  showLegend,
+}) => {
   const dispatch = useDispatch();
   const endTime = useSelector(({ UI }: RootState) => UI.getIn(['monitoringDashboards', 'endTime']));
   const timespan = useSelector(({ UI }: RootState) =>
@@ -36,12 +43,13 @@ const Graph: React.FC<Props> = ({ formatLegendLabel, isStack, pollInterval, quer
     <QueryBrowser
       defaultSamples={30}
       fixedEndTime={endTime}
-      formatLegendLabel={formatLegendLabel}
+      formatSeriesTitle={formatSeriesTitle}
       hideControls
       isStack={isStack}
       onZoom={onZoom}
       pollInterval={pollInterval}
       queries={queries}
+      showLegend={showLegend}
       timespan={timespan}
     />
   );

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -378,7 +378,7 @@ const Card: React.FC<CardProps> = ({ panel }) => {
     UI.getIn(['monitoringDashboards', 'variables']),
   );
 
-  const formatLegendLabel = React.useCallback(
+  const formatSeriesTitle = React.useCallback(
     (labels, i) => {
       const legendFormat = panel.targets?.[i]?.legendFormat;
       const compiled = _.template(legendFormat, legendTemplateOptions);
@@ -438,10 +438,11 @@ const Card: React.FC<CardProps> = ({ panel }) => {
               )}
               {panel.type === 'graph' && (
                 <Graph
-                  formatLegendLabel={panel.legend?.show ? formatLegendLabel : undefined}
+                  formatSeriesTitle={formatSeriesTitle}
                   isStack={panel.stack}
                   pollInterval={pollInterval}
                   queries={queries}
+                  showLegend={panel.legend?.show}
                 />
               )}
               {(panel.type === 'singlestat' || panel.type === 'gauge') && (
@@ -564,7 +565,7 @@ const MonitoringDashboardsPage: React.FC<MonitoringDashboardsPageProps> = ({ mat
             // Look for an option that should be selected by default
             let value = _.find(v.options, { selected: true })?.value;
 
-            // If no default option was found, see if the "All" option should be the by default
+            // If no default option was found, see if the "All" option should be the default
             if (
               value === undefined &&
               v.includeAll &&

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -258,7 +258,16 @@ type GraphSeries = GraphDataPoint[] | null;
 const getXDomain = (endTime: number, span: number): AxisDomain => [endTime - span, endTime];
 
 const Graph: React.FC<GraphProps> = React.memo(
-  ({ allSeries, disabledSeries, formatLegendLabel, isStack, span, width, fixedXDomain }) => {
+  ({
+    allSeries,
+    disabledSeries,
+    fixedXDomain,
+    formatSeriesTitle,
+    isStack,
+    showLegend,
+    span,
+    width,
+  }) => {
     const data: GraphSeries[] = [];
     const tooltipSeriesNames: string[] = [];
     const legendData: { name: string }[] = [];
@@ -277,8 +286,8 @@ const Graph: React.FC<GraphProps> = React.memo(
       _.each(series, ([metric, values]) => {
         // Ignore any disabled series
         data.push(_.some(disabledSeries[i], (s) => _.isEqual(s, metric)) ? null : values);
-        if (formatLegendLabel) {
-          const name = formatLegendLabel(metric, i);
+        if (formatSeriesTitle) {
+          const name = formatSeriesTitle(metric, i);
           legendData.push({ name });
           tooltipSeriesNames.push(name);
         } else {
@@ -381,7 +390,7 @@ const Graph: React.FC<GraphProps> = React.memo(
             );
           })}
         </GroupComponent>
-        {!_.isEmpty(legendData) && (
+        {showLegend && !_.isEmpty(legendData) && (
           <ChartLegend
             data={legendData}
             groupComponent={<LegendContainer />}
@@ -457,9 +466,10 @@ const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
   allSeries,
   disabledSeries,
   fixedXDomain,
-  formatLegendLabel,
+  formatSeriesTitle,
   isStack,
   onZoom,
+  showLegend,
   span,
   width,
 }) => {
@@ -528,8 +538,9 @@ const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
         allSeries={allSeries}
         disabledSeries={disabledSeries}
         fixedXDomain={fixedXDomain}
-        formatLegendLabel={formatLegendLabel}
+        formatSeriesTitle={formatSeriesTitle}
         isStack={isStack}
+        showLegend={showLegend}
         span={span}
         width={width}
       />
@@ -553,7 +564,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   disableZoom,
   filterLabels,
   fixedEndTime,
-  formatLegendLabel,
+  formatSeriesTitle,
   GraphLink,
   hideControls,
   isStack = false,
@@ -561,6 +572,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   onZoom,
   pollInterval,
   queries,
+  showLegend,
   showStackedControl = false,
   timespan,
 }) => {
@@ -813,7 +825,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
           )}
           <div
             className={classNames('graph-wrapper graph-wrapper--query-browser', {
-              'graph-wrapper--query-browser--with-legend': !!formatLegendLabel,
+              'graph-wrapper--query-browser--with-legend': showLegend && !!formatSeriesTitle,
             })}
           >
             <div ref={containerRef} style={{ width: '100%' }}>
@@ -824,8 +836,9 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                       allSeries={graphData}
                       disabledSeries={disabledSeries}
                       fixedXDomain={xDomain}
-                      formatLegendLabel={formatLegendLabel}
+                      formatSeriesTitle={formatSeriesTitle}
                       isStack={canStack && isStacked}
+                      showLegend={showLegend}
                       span={span}
                       width={width}
                     />
@@ -834,9 +847,10 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                       allSeries={graphData}
                       disabledSeries={disabledSeries}
                       fixedXDomain={xDomain}
-                      formatLegendLabel={formatLegendLabel}
+                      formatSeriesTitle={formatSeriesTitle}
                       isStack={canStack && isStacked}
                       onZoom={zoomableGraphOnZoom}
+                      showLegend={showLegend}
                       span={span}
                       width={width}
                     />
@@ -870,7 +884,7 @@ export type QueryObj = {
   text?: string;
 };
 
-export type FormatLegendLabel = (labels: PrometheusLabels, i?: number) => string;
+export type FormatSeriesTitle = (labels: PrometheusLabels, i?: number) => string;
 
 type ErrorProps = {
   error: PrometheusAPIError;
@@ -886,8 +900,9 @@ type GraphProps = {
   allSeries: Series[][];
   disabledSeries?: PrometheusLabels[][];
   fixedXDomain?: AxisDomain;
-  formatLegendLabel?: FormatLegendLabel;
+  formatSeriesTitle?: FormatSeriesTitle;
   isStack?: boolean;
+  showLegend?: boolean;
   span: number;
   width: number;
 };
@@ -903,7 +918,7 @@ export type QueryBrowserProps = {
   disableZoom?: boolean;
   filterLabels?: PrometheusLabels;
   fixedEndTime?: number;
-  formatLegendLabel?: FormatLegendLabel;
+  formatSeriesTitle?: FormatSeriesTitle;
   GraphLink?: React.ComponentType<{}>;
   hideControls?: boolean;
   isStack?: boolean;
@@ -911,6 +926,7 @@ export type QueryBrowserProps = {
   onZoom?: GraphOnZoom;
   pollInterval?: number;
   queries: string[];
+  showLegend?: boolean;
   showStackedControl?: boolean;
   timespan?: number;
 };


### PR DESCRIPTION
The `legendFormat` function is used for formatting the legend entries
both below the graph and in the graph tooltip. However, we were ignoring
it when `panel.legend.show` isn't `true`. This changes the tooltips to
always use `legendFormat` when it is provided.

| Before | After |
|-|-|
| ![before](https://user-images.githubusercontent.com/460802/118934837-c6adcd00-b985-11eb-918a-71ceb328de9b.png) | ![after](https://user-images.githubusercontent.com/460802/118934848-ca415400-b985-11eb-91d5-8e94d5425514.png)

