### PR TITLE
[release-4.7] Bug 1962493: Hide TaskRun edit actions for rows in Pipelinerun's TaskRun tab

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
-import { ResourceLink, Timestamp, Kebab, ResourceKebab } from '@console/internal/components/utils';
+import { ResourceLink, Timestamp, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { TaskRunKind, getModelReferenceFromTaskKind } from '../../../utils/pipeline-augment';
+import { getTaskRunKebabActions } from '../../../utils/pipeline-actions';
 import { TaskRunModel, PipelineModel } from '../../../models';
 import { tableColumnClasses } from './taskruns-table';
 import { taskRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
@@ -65,7 +66,7 @@ const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...prop
       <Timestamp timestamp={obj?.status?.startTime} />
     </TableData>
     <TableData className={tableColumnClasses[7]}>
-      <ResourceKebab actions={Kebab.factory.common} kind={taskRunsReference} resource={obj} />
+      <ResourceKebab actions={getTaskRunKebabActions()} kind={taskRunsReference} resource={obj} />
     </TableData>
   </TableRow>
 );

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -258,3 +258,5 @@ export const getPipelineRunKebabActions = (redirectReRun?: boolean): KebabAction
   (model, pipelineRun) => stopPipelineRun(model, pipelineRun),
   Kebab.factory.Delete,
 ];
+
+export const getTaskRunKebabActions = (): KebabAction[] => [Kebab.factory.Delete];


### PR DESCRIPTION
This is a manual cherry pick of #8960