### PR TITLE
Topology-Edit Workload and Resource Type

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
@@ -18,6 +18,8 @@ export enum nodeActions {
   EditUpdateStrategy = 'Edit update strategy',
   EditLabels = 'Edit labels',
   EditDeployment = 'Edit Deployment',
+  EditDeploymentConfig = 'Edit DeploymentConfig',
+  EditResourceLimits = 'Edit resource limits',
   DeleteDeployment = 'Delete Deployment',
   DeleteDeploymentConfig = 'Delete DeploymentConfig',
   EditAnnotations = 'Edit annotations',
@@ -34,4 +36,9 @@ export enum nodeActions {
   DeleteInMemoryChannel = 'Delete InMemoryChannel',
   EditRevision = 'Edit Revision',
   DeleteRevision = 'Delete Revision',
+}
+
+export enum authenticationTypes {
+  ImageRegistryCredentials = 'Image registry credentials',
+  UploadConfigurationFile = 'Upload configuration file',
 }

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -7,6 +7,8 @@ export const gitPO = {
   builderImageCard: '.odc-selector-card',
   nodeName: '[data-test-id="application-form-app-name"]',
   appName: '[id$=application-name-field]',
+  createNewApp: '[data-test-id="dropdown-menu"]',
+  newAppName: '[data-test-id="application-form-app-input"]',
   create: '[data-test-id="submit-button"]',
   cancel: '[data-test-id="reset-button"]',
   gitSection: {

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -62,6 +62,15 @@ export const gitPage = {
     });
     // cy.get(gitPO.appName).should('have.value', nodeName)
   },
+  editAppName: (newAppName: string) => {
+    cy.get(gitPO.appName).click();
+    cy.get(gitPO.createNewApp)
+      .first()
+      .click();
+    cy.get(gitPO.newAppName)
+      .clear()
+      .type(newAppName);
+  },
   enterComponentName: (name: string) => {
     cy.get(gitPO.nodeName)
       .scrollIntoView()

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -44,6 +44,7 @@ export const perspective = {
 export const navigateTo = (opt: devNavigationMenu) => {
   switch (opt) {
     case devNavigationMenu.Add: {
+      perspective.switchTo(switchPerspective.Developer);
       cy.get(devNavigationMenuPO.add)
         .click()
         .then(() => {

--- a/frontend/packages/topology/integration-tests/features/topology/topology-editing-app-node.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-editing-app-node.feature
@@ -4,40 +4,99 @@ Feature: Editing an application
 
         Background:
             Given user is at developer perspective
-              And user has created or selected namespace "aut-topology-editing-app-node"
+              And user has created or selected namespace "aut-topology-edit-node-resource"
+              And user is at Add page
 
 
         @smoke
         Scenario Outline: Editing a workload : T-06-TC14, T-06-TC15
-            Given user has created workload "<workload_name>"  with resource type "<resource_type>"
-              And user is at the Topology page
-             When user right clicks on the node "<workload_name>" to open context menu
-              And user selects option "Edit <workload_name>" from context menu
-              And user can see Edit form
-              And user verifies that name of the node and route option is not editable
-              And user verifies that Application grouping, git url, builder image version and advanced option can be edited
-              And user edits Application name as "nodejs-ex-git-app-1"
-              And user clicks on save
-             Then user can see the change of node to the new Application "nodejs-ex-git-app-1"
+            Given user has created workload "<workload_name>" with resource type "<resource_type>"
+             When user right clicks on the workload "<workload_name>" to open the Context Menu
+              And user clicks on "Edit <workload_name>" from context action menu
+              And user edits application groupings to "<application_groupings>"
+              And user saves the changes
+             Then user can see application groupings updated to "<application_groupings>"
 
         Examples:
-                  | resource_type     | workload_name   |
-                  | deployment        | nodejs-ex-git   |
-                  | deployment config | dancer-ex-git-1 |
+                  | resource_type     | workload_name   | application_groupings |
+                  | Deployment        | nodejs-ex-git   | app1                  |
+                  | Deployment Config | dancer-ex-git-1 | app2                  |
 
 
-        @regression
+        @smoke
         Scenario: Editing a knative service : T-06-TC14, T-06-TC15
-            Given user has created knative workload "nodejs-ex-git"
-              And user is at the Topology page
-             When user right clicks on the node "nodejs-ex-git" to open context menu
-              And user selects option "Edit Service" from context menu
-              And user can see Edit form
-              And user verifies that name of service and route option is not editable
-              And user verifies that Application grouping, git url, builder image version and advanced option can be edited
-              And user edits Application name as "nodejs-ex-git-app-1"
-              And user clicks on save
-             Then user can see the change of knative service to the new Application defined above
+            Given user has installed OpenShift Serverless Operator
+              And user is at Add page
+              And user has created or selected namespace "aut-topology-edit-resource"
+              And user has created workload "nodejs-ex-git-kn" with resource type "Knative Service"
+             When user right clicks on the workload "nodejs-ex-git-kn" to open the Context Menu
+              And user clicks on "Edit nodejs-ex-git-kn" from context action menu
+              And user edits application groupings to "new-app"
+              And user saves the changes
+             Then user can see application groupings updated to "new-app"
+
+
+        @smoke
+        Scenario: Advanced image options in Edit deployment/deployment config form
+            Given user has created workload "nodejs-advanced" with resource type "Deployment"
+             When user right clicks on the workload "nodejs-advanced" to open the Context Menu
+              And user clicks "Edit Deployment" from action menu
+              And user clicks on Show advanced image options
+              And user clicks on Create new secret
+              And user creates a new secret "new-secret"
+             Then user will see "new-secret" in secret name dropdown under Pull secret
+
+
+        @smoke
+        Scenario: Editing deployment resource limits through form view
+            Given user has created workload "resource-limit" with resource type "Deployment Config"
+             When user right clicks on the workload "resource-limit" to open the Context Menu
+              And user clicks "Edit resource limits" from action menu
+              And user enters value of CPU Request as "250"
+              And user enters value of CPU Limit as "500"
+              And user enters value of Memory Request as "64"
+              And user enters value of Memory Limit as "128"
+              And user clicks on Save
+             Then user will be redirected to Topology with the updated resource limits
+
+
+        @smoke
+        Scenario: Editing deployment using form view
+            Given user has created workload "rolling-update" with resource type "Deployment"
+             When user right clicks on the workload "rolling-update" to open the Context Menu
+              And user clicks "Edit Deployment" from action menu
+              And user selects "Rolling Update" Strategy type under Deployment Strategy
+              And user enters value of Maximum number of unavailable Pods and Maximum number of surge Pods as "25%"
+              And user selects value of project, image stream and tag section under images as "openshift", "golang" and "latest" respectively
+              And user enters NAME as "DEMO_GREETING" and VALUE as "Hello from the environment"
+              And user clicks on Show advanced image options
+              And user clicks on Create new secret
+              And user creates a new secret "new-secret1"
+              And user selects secret "new-secret1" from Pull secret dropdown
+              And user selects the Pause rollouts check box under advanced options section
+              And user saves the changes
+             Then user will be redirected to Topology with the updated deployment
+
+
+        @smoke
+        Scenario Outline: Editing deployment config using form view
+            Given user has created workload "recreate-update" with resource type "Deployment Config"
+             When user right clicks on the workload "recreate-update" to open the Context Menu
+              And user clicks "Edit DeploymentConfig" from action menu
+              And user selects "Recreate" Strategy type under Deployment Strategy
+              And user enters Timeout value as "600"
+              And user clicks on Show additional parameters and lifcycle hooks
+              And user adds Pre Cycle Hook for workload "recreate-update" with failure policy "Abort"
+              And user adds Mid Cycle Hook for workload "recreate-update" with failure policy "Retry"
+              And user adds Post Cycle Hook for workload "recreate-update" with failure policy "Ignore"
+              And user unchecks Deploy image from an image stream tag checkbox
+              And user enters value of Image name as "<image_value>"
+              And user saves the changes
+             Then user will be redirected to Topology with the updated deployment
+
+        Examples:
+                  | image_value                                                                                                            | replica |
+                  | quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:51435011b4f381e292cd70c231d45a35add8b2d28ccac707c52802c143604630 | 4       |
 
 
         @regression @manual
@@ -50,37 +109,6 @@ Feature: Editing an application
               And user clicks on Save
              Then user is redirected to topology
               And user can see a toast notification of JAR file uploading with link to build logs
-
-
-        @regression @manual
-        Scenario: Edit form for deployment
-            Given user has created deployment workload
-              And user is at the Topology page
-             When user right clicks on the node to open context menu
-              And user selects option "Edit Deployment" from context menu
-             Then user will see option to switch between YAML view and Form view
-              And user will see Recreate Strategy type under Deployment Strategy selected by default
-              And user will see "Maximum number of unavailable Pods" and "Maximum number of surge Pods" sections for Strategy type RollingUpdate under Deployment Strategy
-              And user will see "Deploy image from an image stream tag" checkbox under Images with project, image stream and tag section associated with it
-              And user will see Image name section under Images with checkbox "Deploy image from an image stream tag" unchecked
-              And user will see "Show advanced image options" and "Show advanced container options" in case of image stream option
-              And user will see advanced option for "Pause rollouts" and "Scaling"
-
-
-        @regression @manual
-        Scenario: Edit form for deployment config
-            Given user has created deployment config workload
-              And user is at the Topology page
-             When user right clicks on the node to open context menu
-              And user selects option "Edit DeploymentConfig" from context menu
-             Then user will see option to switch between YAML view and Form view
-              And user will see "Timeout" section assciated with Recreate Strategy type under Deployment Strategy selected by default
-              And user will see "Timeout", "Maximum number of unavailable Pods" and "Maximum number of surge Pods" sections for Strategy type RollingUpdate under Deployment Strategy
-              And user will see "Image name", "Command" and "Environment variables(runtime only)" sections for Strategy type Custom under Deployment Strategy
-              And user will see "Deploy image from an image stream tag" checkbox under Images with project, image stream and tag section associated with it
-              And user will see Image name section under Images with checkbox "Deploy image from an image stream tag" unchecked
-              And user will see "Show additional parameters and lifecycle hooks", "Show advanced image options" and "Show advanced container options" in case of image stream option
-              And user will see advanced option for "Pause rollouts" and "Scaling"
 
 
         @regression @manual
@@ -109,26 +137,6 @@ Feature: Editing an application
                   | DeploymentConfig |
 
 
-        @regression @to-do
-        Scenario Outline: Advanced image options in Edit deployment/deployment config form
-            Given user has "<resource>" workload "workload-d"
-              And user is on Edit "<resource>" page
-             When user clicks on "Show advanced image options" option
-              And user clicks on Create new secret
-              And user enters Secret name as "new-secret1"
-              And user selects Authentication type as "Image registry credentiials"
-              And user enters Image registry server address as "https://quay.io/repository/kubernetes-ingress-controller/nginx-ingress-controller?tag=latest&tab=tags"
-              And user enters Username and Password as "test1" and "test" respectively
-              And user enters Email as "test1@redhat.com"
-              And user clicks on Create button
-             Then user will see "new-secret1" in secret name dropdown under Pull secret
-
-        Examples:
-                  | resource         |
-                  | Deployment       |
-                  | DeploymentConfig |
-
-
         @regression @manual
         Scenario Outline: Additional advanced sections in Edit deployment/deployment config form
             Given user has "<resource>" workload "workload-d"
@@ -142,71 +150,3 @@ Feature: Editing an application
                   | resource         | value             |
                   | Deployment       | deployment        |
                   | DeploymentConfig | deployment config |
-
-
-        @regression @todo
-        Scenario Outline: Editing deployment through form view
-            Given user has created deployment workload "workload-ad"
-              And user is at the Topology page
-             When user right clicks on the node "workload-ad" to open context menu
-              And user selects option "Edit Deployment" option from context menu
-              And user selects "RollingUpdate" Strategy type under Deployment Strategy
-              And user enters value of Maximum number of unavailable Pods and Maximum number of surge Pods as "25%"
-              And user selects value of project, image stream and tag section under images as "<Openshift>", "<image_stream>" and "<latest>" respectively
-              And user clicks on "Show advanced container options"
-              And user enters NAME as "<env_name>" and VALUE as "<env_value>"
-              And user clicks on "Show advanced image options"
-              And user creates a secret "new-secret1"
-              And user selects secret "new-secret1" from Pull secret dropdown
-              And user selects the "Pause rollouts" check box under advanced options section
-              And user enters Replicas as "<replica>" under Scaling section
-              And user clicks on Save
-             Then user will be redirected to Topology with the updated deployment
-
-        Examples:
-                  | project   | image_stream    | tag    | env_name      | env_value                    | replica |
-                  | Openshift | hello-openshift | latest | DEMO_GREETING | "Hello from the environment" | 2       |
-
-
-        @regression @todo
-        Scenario Outline: Editing deployment config through form view
-            Given user has created deployment config workload "workload-adc"
-              And user is at the Topology page
-             When user right clicks on the node "workload-adc" to open context menu
-              And user selects option "Edit DeploymentConfig" option from context menu
-              And user selects "Recreate" Strategy type under Deployment Strategy
-              And user enters Timeout value as "600"
-              And user clicks on "Show additional parameters and lifcycle hooks"
-              And user clicks on "Add Pre Cycle Hook"
-              And user clicks on tick button
-              And user clicks on "Add Mid Cycle Hook"
-              And user clicks on tick button
-              And user clicks on "Add Post Cycle Hook"
-              And user clicks on tick button
-              And user unchecks "Deploy image from an image stream tag" checkbox
-              And user enters value of Image name as "<image_value>"
-              And user clicks on "Show advanced image options"
-              And user creates a secret "new-secret1"
-              And user selects secret "new-secret1" from Pull secret dropdown
-              And user selects the "Pause rollouts" check box under advanced options section
-              And user enters Replicas as "<replica>" under Scaling section
-              And user clicks on Save
-             Then user will be redirected to Topology with the updated deployment config
-
-        Examples:
-                  | image_value                                                                                                            | replica |
-                  | quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:51435011b4f381e292cd70c231d45a35add8b2d28ccac707c52802c143604630 | 4       |
-
-
-        @regression @todo
-        Scenario: Editing deployment resource limits through form view
-            Given user has created deployment workload "workload-ad"
-              And user is at the Topology page
-             When user right clicks on the node "workload-ad" to open context menu
-              And user selects option "Edit resource limits" from context menu
-              And user enters value of CPU Request as "250"
-              And user enters value of CPU Limit as "500"
-              And user enters value of Memory Request as "64"
-              And user enters value of Memory Limit as "128"
-              And user clicks on Save
-             Then user will be redirected to Topology with the updated resource limits

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -103,4 +103,114 @@ export const topologyPO = {
     },
   },
   highlightNode: '.is-filtered',
+  createSecret: {
+    advancedOptions: '.pf-c-expandable-section__toggle-text',
+    secretForm: '.co-create-secret-form.modal-content',
+    createSecretButton: 'button.pf-c-button.pf-m-link.pf-m-link--align-left',
+    secretDropDown: '[id="form-ns-dropdown-formData-imagePullSecret-field"]',
+    secretDropDownItem: '[data-test="dropdown-menu-item-link"]',
+    formInputs: {
+      secretFormTitle: '[data-test-id="modal-title"]',
+      secretName: '[id="secret-name"]',
+      authenticationType: '[data-test-id="dropdown-button"]',
+      imageRegistryCredentials: '[data-test-dropdown-menu="credentials"]',
+      uploadConfigurationFile: '[data-test-dropdown-menu="config-file"]',
+      registryServerAddress: 'input[name="address"]',
+      userName: 'input[name="username"]',
+      password: 'input[name="password"]',
+      email: 'input[name="email"]',
+      saveSecret: '[data-test="confirm-action"]',
+      reloadForm: '[data-test-id="reset-button"]',
+      cancelAction: '[data-test-id="cancel-button"]',
+    },
+  },
+  resourceLimits: {
+    requestCPU: 'input[name="limits.cpu.requestValue"]',
+    limitCPU: 'input[name="limits.cpu.limitValue"]',
+    requestMemory: 'input[name="limits.memory.requestValue"]',
+    limitMemory: 'input[name="limits.memory.limitValue"]',
+  },
+  deploymentStrategy: {
+    strategyTypeDropDown: 'button[id="form-dropdown-formData-deploymentStrategy-type-field"]',
+    recreateStrategy: 'button[id="Recreate-link"]',
+    rollingUpdate: 'button[id="RollingUpdate-link"]',
+    customUpdate: 'button[id="Custom-link"]',
+    maxUnavailablePods: 'input[name="formData.deploymentStrategy.rollingUpdate.maxUnavailable"]',
+    maxSurgePods: 'input[name="formData.deploymentStrategy.rollingUpdate.maxSurge"]',
+    projectDropDown: '[id="form-ns-dropdown-formData-imageStream-namespace-field"]',
+    imageStream: '[id="form-ns-dropdown-formData-imageStream-image-field"]',
+    tag: '[id="form-dropdown-formData-imageStream-tag-field"]',
+    envName: '[data-test="pairs-list-name"]',
+    envValue: '[data-test="pairs-list-value"]',
+    advancedOptions: 'button.pf-c-button.pf-m-link.pf-m-inline',
+    pauseRolloutsCheckbox: '[id="form-checkbox-formData-paused-field"]',
+    enterReplica: 'input[id="form-number-spinner-formData-replicas-field"]',
+    saveEdit: '[data-test-id="submit-button"]',
+    selectSecret: '[id="form-ns-dropdown-formData-imagePullSecret-field"]',
+    timeout:
+      'input[id="form-input-formData-deploymentStrategy-recreateParams-timeoutSeconds-field"]',
+    deployImageCheckbox: 'input[name="formData.fromImageStreamTag"]',
+    imageName: 'input[name="formData.imageName"]',
+    preLifecycleHook: {
+      preExecNewPod:
+        'input[id="form-radiobutton-formData-deploymentStrategy-recreateParams-pre-action-execNewPod-field"]',
+      preExecNewPodContainerDD:
+        '[id="form-dropdown-formData-deploymentStrategy-recreateParams-pre-lch-execNewPod-containerName-field"]',
+      runCommand:
+        '[id="form-input-formData-deploymentStrategy-recreateParams-pre-lch-execNewPod-command-0-field"]',
+      preTagImagesField:
+        'input[id="form-radiobutton-formData-deploymentStrategy-recreateParams-pre-action-tagImages-field"]',
+      preTagImagesFieldContainerDD:
+        '[id="form-dropdown-formData-deploymentStrategy-imageStreamData-pre-containerName-field"]',
+      projectDropDown:
+        'button[id="form-ns-dropdown-formData-deploymentStrategy-imageStreamData-pre-imageStream-namespace-field"]',
+      imageStream:
+        'button[id="form-ns-dropdown-formData-deploymentStrategy-imageStreamData-pre-imageStream-image-field"]',
+      imageStreamTag:
+        'button[id="form-dropdown-formData-deploymentStrategy-imageStreamData-pre-imageStream-tag-field"]',
+      failurePolicy:
+        'button[id="form-dropdown-formData-deploymentStrategy-recreateParams-pre-lch-failurePolicy-field"]',
+    },
+    postLifecycleHook: {
+      postExecNewPod:
+        'input[id="form-radiobutton-formData-deploymentStrategy-recreateParams-post-action-execNewPod-field"]',
+      postExecNewPodContainerNameDD:
+        '[id="form-dropdown-formData-deploymentStrategy-recreateParams-post-lch-execNewPod-containerName-field"]',
+      runCommand:
+        'input[id="form-input-formData-deploymentStrategy-recreateParams-post-lch-execNewPod-command-0-field"]',
+      postTagImagesField:
+        'input[id="form-radiobutton-formData-deploymentStrategy-recreateParams-post-action-tagImages-field"]',
+      postTagImagesFieldContainerDD:
+        'button[id="form-dropdown-formData-deploymentStrategy-imageStreamData-post-containerName-field"]',
+      projectDropDown:
+        'button[id="form-ns-dropdown-formData-deploymentStrategy-imageStreamData-post-imageStream-namespace-field"]',
+      imageStream:
+        'button[id="form-ns-dropdown-formData-deploymentStrategy-imageStreamData-post-imageStream-image-field"]',
+      imageStreamTag:
+        'button[id="form-dropdown-formData-deploymentStrategy-imageStreamData-post-imageStream-tag-field"]',
+      failurePolicy:
+        'button[id="form-dropdown-formData-deploymentStrategy-recreateParams-post-lch-failurePolicy-field"]',
+    },
+    midLifecycleHook: {
+      midExecNewPod:
+        'input[id="form-radiobutton-formData-deploymentStrategy-recreateParams-mid-action-execNewPod-field"]',
+      midContainerNameDropDown:
+        'button[id="form-dropdown-formData-deploymentStrategy-recreateParams-mid-lch-execNewPod-containerName-field"]',
+      runCommand:
+        'id="form-input-formData-deploymentStrategy-recreateParams-mid-lch-execNewPod-command-0-field"',
+      midTagImagesField:
+        'input[id="form-radiobutton-formData-deploymentStrategy-recreateParams-mid-action-tagImages-field"]',
+      midTagImagesFieldContainerDD:
+        'button[id="form-dropdown-formData-deploymentStrategy-imageStreamData-mid-containerName-field"]',
+      projectDropDown:
+        'button[id="form-ns-dropdown-formData-deploymentStrategy-imageStreamData-mid-imageStream-namespace-field"]',
+      imageStream:
+        'button[id="form-ns-dropdown-formData-deploymentStrategy-imageStreamData-mid-imageStream-image-field"]',
+      imageStreamTag:
+        'button[id="form-dropdown-formData-deploymentStrategy-imageStreamData-mid-imageStream-tag-field"]',
+      failurePolicy:
+        'button[id="form-dropdown-formData-deploymentStrategy-recreateParams-mid-lch-failurePolicy-field"]',
+    },
+    tickButton: '[data-test-id="check-icon"]',
+  },
 };

--- a/frontend/packages/topology/integration-tests/support/pages/functions/add-secret.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/functions/add-secret.ts
@@ -1,0 +1,17 @@
+import { editDeployment } from '@console/topology/integration-tests/support/pages/topology/topology-edit-deployment';
+
+export const addSecret = (
+  secretName: string = 'newSecret 1',
+  serverUrl: string = 'https://quay.io/repository/kubernetes-ingress-controller/nginx-ingress-controller?tag=latest&tab=tags',
+  username: string = 'test1',
+  password: string = 'test',
+  email: string = 'test1@redhat.com',
+) => {
+  editDeployment.verifyModalTitle();
+  editDeployment.addSecretName(secretName);
+  editDeployment.addServerAddress(serverUrl);
+  editDeployment.enterUsername(username);
+  editDeployment.enterPassword(password);
+  editDeployment.enterEmail(email);
+  editDeployment.saveSecret();
+};

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
@@ -11,6 +11,20 @@ export const topologyActions = {
           .click();
         break;
       }
+      case 'Edit Deployment':
+      case nodeActions.EditDeployment: {
+        cy.byTestActionID(action)
+          .should('be.visible')
+          .click();
+        break;
+      }
+      case 'Edit DeploymentConfig':
+      case nodeActions.EditDeploymentConfig: {
+        cy.byTestActionID(action)
+          .should('be.visible')
+          .click();
+        break;
+      }
       case 'Edit Pod Count':
       case nodeActions.EditPodCount: {
         cy.byTestActionID(action)
@@ -66,6 +80,13 @@ export const topologyActions = {
       }
       case 'Edit SinkBinding':
       case nodeActions.EditSinkBinding: {
+        cy.byTestActionID(action)
+          .should('be.visible')
+          .click();
+        break;
+      }
+      case 'Edit resource limits':
+      case nodeActions.EditResourceLimits: {
         cy.byTestActionID(action)
           .should('be.visible')
           .click();

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-edit-deployment.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-edit-deployment.ts
@@ -1,0 +1,126 @@
+import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
+import { authenticationTypes } from '@console/dev-console/integration-tests/support/constants';
+
+export const editDeployment = {
+  verifyModalTitle: () => {
+    cy.get(topologyPO.createSecret.formInputs.secretFormTitle).should('be.visible');
+  },
+  addSecretName: (secretName: string) => {
+    cy.get(topologyPO.createSecret.formInputs.secretName)
+      .clear()
+      .type(secretName);
+  },
+  selectAuthenticationType: (authenticationType: authenticationTypes | string) => {
+    cy.get(topologyPO.createSecret.formInputs.authenticationType).click();
+    switch (authenticationType) {
+      case 'Image registry credentials':
+      case authenticationTypes.ImageRegistryCredentials: {
+        cy.byTestActionID(authenticationType)
+          .should('be.visible')
+          .click();
+        break;
+      }
+      case 'Upload configuration file':
+      case authenticationTypes.UploadConfigurationFile: {
+        cy.byTestActionID(authenticationType)
+          .should('be.visible')
+          .click();
+        break;
+      }
+      default: {
+        throw new Error(`${authenticationType} is not available in action menu`);
+      }
+    }
+  },
+  addServerAddress: (serverUrl: string) => {
+    cy.get(topologyPO.createSecret.formInputs.registryServerAddress)
+      .clear()
+      .type(serverUrl);
+  },
+  enterUsername: (username: string) => {
+    cy.get(topologyPO.createSecret.formInputs.userName)
+      .clear()
+      .type(username);
+  },
+  enterPassword: (password: string) => {
+    cy.get(topologyPO.createSecret.formInputs.password)
+      .clear()
+      .type(password);
+  },
+  enterEmail: (email: string) => {
+    cy.get(topologyPO.createSecret.formInputs.email)
+      .clear()
+      .type(email);
+  },
+  saveSecret: () => {
+    cy.get(topologyPO.createSecret.formInputs.saveSecret).click();
+  },
+  selectDeploymentStrategyType: (strategyType: string) => {
+    cy.get(topologyPO.deploymentStrategy.strategyTypeDropDown).click();
+
+    if (strategyType === 'Rolling Update') {
+      cy.get(topologyPO.deploymentStrategy.rollingUpdate).click();
+    } else if (strategyType === 'Recreate') {
+      cy.get(topologyPO.deploymentStrategy.recreateStrategy).click();
+    } else if (strategyType === 'Custom') {
+      cy.get(topologyPO.deploymentStrategy.customUpdate).click();
+    }
+  },
+  selectProjectName: (projectName: string) => {
+    cy.get(topologyPO.deploymentStrategy.projectDropDown).click();
+    cy.get(`[id="${projectName}-link"]`).click();
+  },
+  selectImageStream: (imageStream: string) => {
+    cy.get(topologyPO.deploymentStrategy.imageStream).click();
+    cy.get(`[id="${imageStream}-link"]`).click();
+  },
+  selectImageStreamTag: (tag: string) => {
+    cy.get(topologyPO.deploymentStrategy.tag).click();
+    cy.get(`[id="${tag}-link"]`).click();
+  },
+  addPreCycleHook: (workloadName: string, failurePolicy: string) => {
+    cy.get(topologyPO.deploymentStrategy.preLifecycleHook.preExecNewPod).click();
+    cy.get(topologyPO.deploymentStrategy.preLifecycleHook.preExecNewPodContainerDD).click();
+    cy.get(`[id="${workloadName}-link"]`).click();
+    cy.get(topologyPO.deploymentStrategy.preLifecycleHook.runCommand)
+      .clear()
+      .type('echo "PreLifeCycle Hook"');
+    cy.get(topologyPO.deploymentStrategy.preLifecycleHook.failurePolicy).click();
+    cy.get(`[id="${failurePolicy}-link"]`).click();
+    cy.get(topologyPO.deploymentStrategy.tickButton).click();
+  },
+  selectProject: (projectName: string) => {
+    cy.get(`[id="${projectName}-link"]`).click();
+  },
+  selectImage: (imageStream: string) => {
+    cy.get(`[id="${imageStream}-link"]`).click();
+  },
+  selectImageTag: (tag: string) => {
+    cy.get(`[id="${tag}-link"]`).click();
+  },
+  addMidCycleHook: (workloadName: string, failurePolicy: string) => {
+    cy.get(topologyPO.deploymentStrategy.midLifecycleHook.midTagImagesField).click();
+    cy.get(topologyPO.deploymentStrategy.midLifecycleHook.midTagImagesFieldContainerDD).click();
+    cy.get(`[id="${workloadName}-link"]`).click();
+    cy.get(topologyPO.deploymentStrategy.midLifecycleHook.projectDropDown).click();
+    editDeployment.selectProject('openshift');
+    cy.get(topologyPO.deploymentStrategy.midLifecycleHook.imageStream).click();
+    editDeployment.selectImage('golang');
+    cy.get(topologyPO.deploymentStrategy.midLifecycleHook.imageStreamTag).click();
+    editDeployment.selectImageTag('latest');
+    cy.get(topologyPO.deploymentStrategy.midLifecycleHook.failurePolicy).click();
+    cy.get(`[id="${failurePolicy}-link"]`).click();
+    cy.get(topologyPO.deploymentStrategy.tickButton).click();
+  },
+  addPostCycleHook: (workloadName: string, failurePolicy: string) => {
+    cy.get(topologyPO.deploymentStrategy.postLifecycleHook.postExecNewPod).click();
+    cy.get(topologyPO.deploymentStrategy.postLifecycleHook.postExecNewPodContainerNameDD).click();
+    cy.get(`[id="${workloadName}-link"]`).click();
+    cy.get(topologyPO.deploymentStrategy.postLifecycleHook.runCommand)
+      .clear()
+      .type('echo "PostLifeCycle Hook"');
+    cy.get(topologyPO.deploymentStrategy.postLifecycleHook.failurePolicy).click();
+    cy.get(`[id="${failurePolicy}-link"]`).click();
+    cy.get(topologyPO.deploymentStrategy.tickButton).click();
+  },
+};

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -17,6 +17,7 @@ import {
   topologyHelper,
 } from '@console/dev-console/integration-tests/support/pages';
 import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
+import { verifyAndInstallKnativeOperator } from '@console/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster';
 
 Given('user is at the Topology page', () => {
   navigateTo(devNavigationMenu.Topology);
@@ -126,4 +127,8 @@ When(
 
 Then('user will see workload disappeared from topology', () => {
   cy.get(topologyPO.emptyStateIcon).should('be.visible');
+});
+
+Given('user has installed OpenShift Serverless Operator', () => {
+  verifyAndInstallKnativeOperator();
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/delete-workload.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/delete-workload.ts
@@ -2,12 +2,14 @@ import { When } from 'cypress-cucumber-preprocessor/steps';
 import { topologySidePane } from '@console/topology/integration-tests/support/pages/topology/topology-side-pane-page';
 import { topologyActions } from '@console/topology/integration-tests/support/pages/topology/topology-actions-page';
 import { topologyPO } from '../../page-objects/topology-po';
+import { app } from '@console/dev-console/integration-tests/support/pages';
 
 When('user clicks on Action menu', () => {
   topologySidePane.clickActionsDropDown();
 });
 
 When('user clicks {string} from action menu', (actionItem: string) => {
+  app.waitForLoad();
   topologyActions.selectAction(actionItem);
 });
 

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/edit-workload.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/edit-workload.ts
@@ -1,0 +1,190 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { topologyPO } from '../../page-objects/topology-po';
+import { gitPage } from '@console/dev-console/integration-tests/support/pages/add-flow';
+import { addSecret } from '@console/topology/integration-tests/support/pages/functions/add-secret';
+import { topologyHelper } from '@console/topology/integration-tests/support/pages/topology/topology-helper-page';
+import { editDeployment } from '../../pages/topology/topology-edit-deployment';
+
+When('user edits application groupings to {string}', (newAppName: string) => {
+  gitPage.editAppName(newAppName);
+});
+
+When('user saves the new changes', () => {
+  cy.get(topologyPO.createSecret.formInputs.saveSecret).click();
+});
+
+Then('user can see application groupings updated to {string}', (newAppName: string) => {
+  topologyHelper.verifyWorkloadInTopologyPage(newAppName);
+});
+
+When('user clicks on Show advanced image options', () => {
+  if (cy.get(topologyPO.createSecret.advancedOptions).contains('Show advanced image options')) {
+    cy.get(topologyPO.createSecret.advancedOptions).click();
+  } else {
+    cy.log('You have already opened advanced options');
+  }
+});
+
+When('user clicks on Create new secret', () => {
+  cy.get(topologyPO.createSecret.createSecretButton)
+    .contains('Create new Secret')
+    .click();
+});
+
+When('user creates a new secret {string}', (secretName: string) => {
+  addSecret(secretName);
+});
+
+When('user clicks on {string} from context action menu', (actionItem: string) => {
+  cy.byTestActionID(actionItem)
+    .should('be.visible')
+    .click();
+});
+
+Then('user will see {string} in secret name dropdown under Pull secret', (secretName: string) => {
+  cy.get(topologyPO.createSecret.secretDropDown).click();
+  cy.get(topologyPO.createSecret.secretDropDownItem).should('contain', secretName);
+  cy.get(topologyPO.createSecret.formInputs.cancelAction).click();
+});
+
+When('user enters value of CPU Request as {string}', (requestCPU: string) => {
+  cy.get(topologyPO.resourceLimits.requestCPU)
+    .clear()
+    .type(requestCPU);
+});
+
+When('user enters value of CPU Limit as {string}', (limitCPU: string) => {
+  cy.get(topologyPO.resourceLimits.limitCPU)
+    .clear()
+    .type(limitCPU);
+});
+
+When('user enters value of Memory Request as {string}', (requestMemory: string) => {
+  cy.get(topologyPO.resourceLimits.requestMemory)
+    .clear()
+    .type(requestMemory);
+});
+
+When('user enters value of Memory Limit as {string}', (limitMemory: string) => {
+  cy.get(topologyPO.resourceLimits.limitMemory)
+    .clear()
+    .type(limitMemory);
+});
+
+When('user clicks on Save', () => {
+  cy.get(topologyPO.createSecret.formInputs.saveSecret).click();
+});
+
+Then('user will be redirected to Topology with the updated resource limits', () => {
+  cy.get(topologyPO.graph.emptyGraph).should('be.visible');
+});
+
+When('user selects {string} Strategy type under Deployment Strategy', (strategyType: string) => {
+  editDeployment.selectDeploymentStrategyType(strategyType);
+});
+
+When(
+  'user enters value of Maximum number of unavailable Pods and Maximum number of surge Pods as {string}',
+  (podPercentage: string) => {
+    cy.get(topologyPO.deploymentStrategy.maxUnavailablePods)
+      .clear()
+      .type(podPercentage);
+    cy.get(topologyPO.deploymentStrategy.maxSurgePods)
+      .clear()
+      .type(podPercentage);
+  },
+);
+
+When(
+  'user selects value of project, image stream and tag section under images as {string}, {string} and {string} respectively',
+  (projectName: string, imageStream: string, tag: string) => {
+    editDeployment.selectProjectName(projectName);
+    editDeployment.selectImageStream(imageStream);
+    editDeployment.selectImageStreamTag(tag);
+  },
+);
+
+When('user enters NAME as {string} and VALUE as {string}', (envName: string, envValue: string) => {
+  cy.get(topologyPO.deploymentStrategy.envName)
+    .clear()
+    .type(envName);
+  cy.get(topologyPO.deploymentStrategy.envValue)
+    .clear()
+    .type(envValue);
+});
+
+When('user selects secret {string} from Pull secret dropdown', (secretName: string) => {
+  cy.get(topologyPO.deploymentStrategy.selectSecret).click();
+  const CSSSelector = `[id="${secretName}-link"]`;
+  cy.get(CSSSelector).click();
+});
+
+When('user selects the Pause rollouts check box under advanced options section', () => {
+  cy.get(topologyPO.deploymentStrategy.advancedOptions)
+    .eq(0)
+    .click();
+  cy.get(topologyPO.deploymentStrategy.pauseRolloutsCheckbox).click();
+});
+
+When('user enters Replicas as {string} under Scaling section', (replicaCount: string) => {
+  cy.get(topologyPO.deploymentStrategy.advancedOptions)
+    .find('Scaling')
+    .click();
+  cy.get(topologyPO.deploymentStrategy.enterReplica)
+    .clear()
+    .type(replicaCount);
+});
+
+When('user will be redirected to Topology with the updated deployment', () => {
+  cy.get(topologyPO.graph.emptyGraph).should('be.visible');
+});
+
+When('user saves the changes', () => {
+  cy.get(topologyPO.deploymentStrategy.saveEdit).click();
+});
+
+When('user enters Timeout value as {string}', (timeoutValue: string) => {
+  cy.get(topologyPO.deploymentStrategy.timeout)
+    .clear()
+    .type(timeoutValue);
+});
+
+When('user clicks on Show additional parameters and lifcycle hooks', () => {
+  cy.get(topologyPO.createSecret.advancedOptions)
+    .eq(0)
+    .click();
+});
+
+When(
+  'user adds Pre Cycle Hook for workload {string} with failure policy {string}',
+  (workloadName: string, failurePolicy: string) => {
+    cy.contains('Add pre lifecycle hook').click();
+    editDeployment.addPreCycleHook(workloadName, failurePolicy);
+  },
+);
+
+When(
+  'user adds Mid Cycle Hook for workload {string} with failure policy {string}',
+  (workloadName: string, failurePolicy: string) => {
+    cy.contains('Add mid lifecycle hook').click();
+    editDeployment.addMidCycleHook(workloadName, failurePolicy);
+  },
+);
+
+When(
+  'user adds Post Cycle Hook for workload {string} with failure policy {string}',
+  (workloadName: string, failurePolicy: string) => {
+    cy.contains('Add post lifecycle hook').click();
+    editDeployment.addPostCycleHook(workloadName, failurePolicy);
+  },
+);
+
+When('user unchecks Deploy image from an image stream tag checkbox', () => {
+  cy.get(topologyPO.deploymentStrategy.deployImageCheckbox).click();
+});
+
+When('user enters value of Image name as {string}', (imageLink: string) => {
+  cy.get(topologyPO.deploymentStrategy.imageName)
+    .clear()
+    .type(imageLink);
+});


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/ODC-5583 

**Problem:** Automation to edit workload and edit resource types of workload

**Solution:** This script will delete the already created workload using the Actions dropdown menu and Context Menu

**Cluster Setup:**
```

- export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
- BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
- BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
- export BRIDGE_KUBEADMIN_PASSWORD
- export BRIDGE_BASE_ADDRESS
- oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
- oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
- oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
- ./test-cypress.sh -p topology

```

**Test Setup:**
1. Replace `"TAGS": "@smoke and not @manual and not @to-do"`, with ` "@Topology and (@smoke or @regression) and not (@Manual or @to-do)",` in `topology/cypress.json` under `env`
2. Run `yarn run test-cypress-topology` in frontend
3. Execute feature file: `frontend/packages/topology/integration-tests/features/topology/topology-editing-app-node.feature`

**Test Execution Screenshot:**

![Screenshot from 2021-05-21 12-42-57](https://user-images.githubusercontent.com/17041173/119097203-15b13c00-ba32-11eb-9f02-293f016252af.png)
