### PR TITLE
Bug 1949338: show the content of Insights widget when there are 0 recommendations for cluster

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -29,7 +29,6 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
     ([k1], [k2]) => riskSorting[k1] - riskSorting[k2],
   );
   const numberOfIssues = Object.values(metrics).reduce((acc, cur) => acc + cur, 0);
-  const hasIssues = riskEntries.length > 0 && numberOfIssues > 0;
 
   const isWaitingOrDisabled = _isWaitingOrDisabled(metrics);
   const isError = _isError(metrics);
@@ -58,7 +57,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         </div>
       )}
       <div className="co-status-popup__section">
-        {hasIssues && !isWaitingOrDisabled && !isError && (
+        {!isWaitingOrDisabled && !isError && (
           <div>
             <ChartDonut
               data={riskEntries.map(([k, v]) => ({
@@ -99,7 +98,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         )}
       </div>
       <div className="co-status-popup__section">
-        {hasIssues && !isWaitingOrDisabled && !isError && (
+        {!isWaitingOrDisabled && !isError && (
           <>
             <h6 className="pf-c-title pf-m-md">{t('insights-plugin~Fixable issues')}</h6>
             <div>
@@ -110,7 +109,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
             </div>
           </>
         )}
-        {!hasIssues && (isWaitingOrDisabled || isError) && (
+        {(isWaitingOrDisabled || isError) && (
           <ExternalLink
             href={`${openshiftHelpBase}support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html`}
             text={t('insights-plugin~More about Insights')}


### PR DESCRIPTION
The patch solves the bug when no recommendations hit a cluster, but the widget has no content inside.

Before: 
![Screenshot from 2021-05-20 15-49-25](https://user-images.githubusercontent.com/31385370/118990666-5ef68280-b983-11eb-9661-769848a28494.png)

After:
![Screenshot from 2021-05-20 15-51-54](https://user-images.githubusercontent.com/31385370/118990688-63bb3680-b983-11eb-9e23-ee91c15d43e2.png)

