### PR TITLE
Rename 'Insights' to 'Insights Advisor'

### DIFF
--- a/frontend/packages/insights-plugin/locales/en/insights-plugin.json
+++ b/frontend/packages/insights-plugin/locales/en/insights-plugin.json
@@ -15,5 +15,5 @@
   "{{issuesNumber}} issue found": "{{issuesNumber}} issue found",
   "{{issuesNumber}} issues found": "{{issuesNumber}} issues found",
   "Insights": "Insights",
-  "Insights status": "Insights status"
+  "Insights Advisor status": "Insights Advisor status"
 }

--- a/frontend/packages/insights-plugin/locales/ja/insights-plugin.json
+++ b/frontend/packages/insights-plugin/locales/ja/insights-plugin.json
@@ -15,5 +15,5 @@
   "{{issuesNumber}} issue found": "{{issuesNumber}} 件の問題が見つかりました",
   "{{issuesNumber}} issues found": "{{issuesNumber}} 件の問題が見つかりました",
   "Insights": "Insights",
-  "Insights status": "Insights のステータス"
+  "Insights Advisor status": "Insights Advisor のステータス"
 }

--- a/frontend/packages/insights-plugin/locales/ko/insights-plugin.json
+++ b/frontend/packages/insights-plugin/locales/ko/insights-plugin.json
@@ -15,5 +15,5 @@
   "{{issuesNumber}} issue found": "{{issuesNumber}} 문제 발견",
   "{{issuesNumber}} issues found": "{{issuesNumber}} 문제 발견",
   "Insights": "Insights",
-  "Insights status": "Insights 상태"
+  "Insights Advisor status": "Insights Advisor 상태"
 }

--- a/frontend/packages/insights-plugin/locales/zh/insights-plugin.json
+++ b/frontend/packages/insights-plugin/locales/zh/insights-plugin.json
@@ -14,5 +14,5 @@
   "{{issuesNumber}} issue found": "{{issuesNumber}} 个发现的问题",
   "{{issuesNumber}} issues found": "{{issuesNumber}} 个发现的问题",
   "Insights": "Insights",
-  "Insights status": "Insights 状态"
+  "Insights Advisor status": "Insights Advisor 状态"
 }

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -46,13 +46,17 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
 
   return (
     <div className="co-insights__box">
+      <p>
+        Insights Advisor identifies and prioritizes risks to security, performance, availability,
+        and stability of your clusters.
+      </p>
       {isError && (
-        <div className="co-status-popup__section">
+        <div className="co-status-popup__section text-secondary">
           {t('insights-plugin~Temporary unavailable.')}
         </div>
       )}
       {isWaitingOrDisabled && (
-        <div className="co-status-popup__section">
+        <div className="co-status-popup__section text-secondary">
           {t('insights-plugin~Disabled or waiting for results.')}
         </div>
       )}

--- a/frontend/packages/insights-plugin/src/plugin.tsx
+++ b/frontend/packages/insights-plugin/src/plugin.tsx
@@ -28,7 +28,7 @@ const plugin: Plugin<ConsumedExtensions> = [
           (m) => m.InsightsPopup,
         ),
       // t('insights-plugin~Insights status')
-      popupTitle: '%insights-plugin~Insights status%',
+      popupTitle: '%insights-plugin~Insights Advisor status%',
     },
   },
 ];

--- a/frontend/packages/insights-plugin/src/plugin.tsx
+++ b/frontend/packages/insights-plugin/src/plugin.tsx
@@ -27,7 +27,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/InsightsPopup/index' /* webpackChunkName: "insights-plugin" */).then(
           (m) => m.InsightsPopup,
         ),
-      // t('insights-plugin~Insights status')
+      // t('insights-plugin~Insights Advisor status')
       popupTitle: '%insights-plugin~Insights Advisor status%',
     },
   },


### PR DESCRIPTION
- [x] Replace `Insights` occurrences with `Insights Advisor` in the Insights widget (but some spots should be left as `Insights` after the request from PMs).
- [x] Add missing paragraph to the content of Insights widget.

Before:
![Screenshot from 2021-05-20 16-28-57](https://user-images.githubusercontent.com/31385370/118996898-87cd4680-b988-11eb-983d-17b02df07e62.png)
After:
![Screenshot from 2021-05-20 16-26-50](https://user-images.githubusercontent.com/31385370/118996927-8c91fa80-b988-11eb-9ac6-b8daec95a9ec.png)
