### PR TITLE
Bug 1961829: Fix quick start prerequisites getting truncated

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.tsx
@@ -40,10 +40,9 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
       featured={isActive}
       title={<QuickStartTileHeader name={displayName} status={status} duration={durationMinutes} />}
       onClick={onClick}
-      description={
-        <QuickStartTileDescription description={description} prerequisites={prerequisites} />
-      }
-    />
+    >
+      <QuickStartTileDescription description={description} prerequisites={prerequisites} />
+    </CatalogTile>
   );
 };
 

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.scss
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.scss
@@ -1,6 +1,9 @@
 .co-quick-start-tile {
   &-description {
-    margin: 0 0 var(--pf-global--spacer--md) 0;
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
   }
 
   &-prerequisites {

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileDescription.tsx
@@ -25,7 +25,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
   const prereqs = prerequisites?.filter((p) => p);
   return (
     <>
-      <Text component={TextVariants.p} className="oc-quick-start-tile-description">
+      <Text component={TextVariants.p} className="co-quick-start-tile-description">
         {description}
       </Text>
       {prereqs?.length > 0 && (


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-29337
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Catalog tiles truncate the description if it iss more than 3 lines. We send the prerequisites along with description to the tile and that is why it was not being shown for long description.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: `CatalogTile` has an option to send children for the body which doesn't get truncated. So sending the description as children solves the truncation issue.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux @bmignano 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/119015191-523f5200-b9b6-11eb-8405-ba668ee5334b.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
