### PR TITLE
Auto focus first input field of import forms

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -38,6 +38,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   builderImages,
 }) => {
   const { t } = useTranslation();
+  const inputRef = React.useRef<HTMLInputElement>();
   const { values, setFieldValue, setFieldTouched, touched, dirty } = useFormikContext<
     FormikValues
   >();
@@ -267,9 +268,15 @@ const GitSection: React.FC<GitSectionProps> = ({
   };
 
   useFormikValidationFix(values.git.url);
+
+  React.useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
   return (
     <FormSection title={t('devconsole~Git')}>
       <InputField
+        ref={inputRef}
         type={TextInputTypes.text}
         name="git.url"
         label={t('devconsole~Git Repo URL')}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -20,6 +20,7 @@ import './ImageSearch.scss';
 
 const ImageSearch: React.FC = () => {
   const { t } = useTranslation();
+  const inputRef = React.useRef<HTMLInputElement>();
   const { values, setFieldValue, dirty, initialValues, touched } = useFormikContext<FormikValues>();
   const [newImageSecret, setNewImageSecret] = React.useState('');
   const [alertVisible, shouldHideAlert] = React.useState(true);
@@ -163,9 +164,14 @@ const ImageSearch: React.FC = () => {
     values.searchTerm,
   ]);
 
+  React.useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
   return (
     <>
       <InputField
+        ref={inputRef}
         type={TextInputTypes.text}
         name="searchTerm"
         placeholder={t('devconsole~Enter an Image name')}


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3252
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Import forms don't focus the first fields which can lead to undesired behaviours like going back to a focus nav item when clicking enter.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Focus first field of the import forms. Adding auto focus to git section and image search input fields cover all of the import forms for us as these are re-used.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/119029699-963a5300-b9c6-11eb-9840-7f3836142464.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
