### PR TITLE
Supplement: Add and update data-test for new add page

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
@@ -17,7 +17,7 @@ import { ArrowRightIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import './GettingStartedCard.scss';
 
 export interface GettingStartedLink {
-  key: string;
+  id: string;
   loading?: boolean;
 
   title?: string;
@@ -30,6 +30,7 @@ export interface GettingStartedLink {
 }
 
 export interface GettingStartedCardProps {
+  id: string;
   icon?: React.ReactElement;
   title: string;
   titleColor?: string;
@@ -39,6 +40,7 @@ export interface GettingStartedCardProps {
 }
 
 export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
+  id,
   icon,
   title,
   titleColor,
@@ -51,30 +53,43 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
       direction={{ default: 'column' }}
       grow={{ default: 'grow' }}
       className="ocs-getting-started-card"
+      data-test={`card ${id}`}
     >
-      <Title headingLevel="h3" size={TitleSizes.md} style={{ color: titleColor }}>
+      <Title headingLevel="h3" size={TitleSizes.md} style={{ color: titleColor }} data-test="title">
         {icon ? <span className="ocs-getting-started-card__title-icon">{icon}</span> : null}
         {title}
       </Title>
 
-      {description ? <Text component={TextVariants.small}>{description}</Text> : null}
+      {description ? (
+        <Text component={TextVariants.small} data-test="description">
+          {description}
+        </Text>
+      ) : null}
 
       <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
         {links?.length > 0 ? (
           <SimpleList isControlled={false} className="ocs-getting-started-card__list">
             {links.map((link) =>
               link.loading ? (
-                <li key={link.key}>
+                <li key={link.id}>
                   <Skeleton fontSize="sm" />
                 </li>
               ) : (
                 <SimpleListItem
-                  key={link.key}
+                  key={link.id}
                   component={link.href ? (link.external ? 'a' : (Link as any)) : 'button'}
                   componentProps={
                     link.external
-                      ? { href: link.href, target: '_blank', rel: 'noopener noreferrer' }
-                      : { to: link.href }
+                      ? {
+                          href: link.href,
+                          target: '_blank',
+                          rel: 'noopener noreferrer',
+                          'data-test': `item ${link.id}`,
+                        }
+                      : {
+                          to: link.href,
+                          'data-test': `item ${link.id}`,
+                        }
                   }
                   onClick={link.onClick}
                 >
@@ -94,16 +109,28 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
       {moreLink ? (
         <FlexItem>
           {moreLink.onClick ? (
-            <Button onClick={moreLink.onClick} isInline variant="link">
+            <Button
+              onClick={moreLink.onClick}
+              isInline
+              variant="link"
+              data-test={`item ${moreLink.id}`}
+            >
               {moreLink.title}
             </Button>
           ) : moreLink.external ? (
-            <a href={moreLink.href} target="_blank" rel="noopener noreferrer">
+            <a
+              href={moreLink.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-test={`item ${moreLink.id}`}
+            >
               {moreLink.title}
               <ExternalLinkAltIcon />
             </a>
           ) : (
-            <Link to={moreLink.href}>{moreLink.title}</Link>
+            <Link to={moreLink.href} data-test={`item ${moreLink.id}`}>
+              {moreLink.title}
+            </Link>
           )}
         </FlexItem>
       ) : null}

--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedGrid.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedGrid.tsx
@@ -39,6 +39,7 @@ export const GettingStartedGrid: React.FC<GettingStartedGridProps> = ({ onHide, 
           'console-shared~You can always bring these getting started resources back into view by clicking Show getting started resources in the page heading.',
         )}
         onClick={onHide}
+        data-test="hide"
       >
         {t('console-shared~Hide from view')}
       </DropdownItem>,
@@ -55,10 +56,10 @@ export const GettingStartedGrid: React.FC<GettingStartedGridProps> = ({ onHide, 
   );
 
   return (
-    <Card className="ocs-getting-started-grid">
+    <Card className="ocs-getting-started-grid" data-test="getting-started">
       <CardHeader className="ocs-getting-started-grid__header">
         <CardTitle>
-          <Title headingLevel="h2" size={TitleSizes.lg}>
+          <Title headingLevel="h2" size={TitleSizes.lg} data-test="title">
             {title}{' '}
             <Popover bodyContent={titleTooltip}>
               <span
@@ -75,7 +76,7 @@ export const GettingStartedGrid: React.FC<GettingStartedGridProps> = ({ onHide, 
             <Dropdown
               isOpen={menuIsOpen}
               isPlain
-              toggle={<KebabToggle onToggle={onToggle} />}
+              toggle={<KebabToggle onToggle={onToggle} data-test="actions" />}
               position="right"
               dropdownItems={actionDropdownItem}
               className="ocs-getting-started-grid__action-dropdown"

--- a/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/QuickStartGettingStartedCard.tsx
@@ -86,25 +86,26 @@ export const QuickStartGettingStartedCard: React.FC<QuickStartGettingStartedCard
 
         const links: GettingStartedLink[] = loaded
           ? slicedQuickStarts.map((quickStart: QuickStart) => ({
-              key: quickStart.metadata.name,
+              id: quickStart.metadata.name,
               title: quickStart.spec.displayName,
               onClick: () => {
                 setActiveQuickStart(quickStart.metadata.name, quickStart.spec.tasks.length);
               },
             }))
           : featured?.map((name) => ({
-              key: name,
+              id: name,
               loading: true,
             }));
 
         const moreLink: GettingStartedLink = {
-          key: 'quick-starts',
+          id: 'all-quick-starts',
           title: t('console-shared~View all quick starts'),
           href: '/quickstart',
         };
 
         return (
           <GettingStartedCard
+            id="quick-start"
             icon={<RouteIcon color="var(--pf-global--palette--purple-600)" aria-hidden="true" />}
             title={t('console-shared~Build with guided documentation')}
             titleColor={'var(--pf-global--palette--purple-700)'}

--- a/frontend/packages/console-shared/src/components/getting-started/RestoreGettingStartedButton.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/RestoreGettingStartedButton.tsx
@@ -30,6 +30,7 @@ export const RestoreGettingStartedButton: React.FC<RestoreGettingStartedButtonPr
         setShowState(GettingStartedShowState.DISAPPEAR);
       }}
       style={{ cursor: 'pointer' }}
+      data-test="restore-getting-started"
     >
       {t('console-shared~Show getting started resources')}
     </Label>

--- a/frontend/packages/console-shared/src/components/getting-started/__tests__/GettingStartedCard.spec.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/__tests__/GettingStartedCard.spec.tsx
@@ -13,14 +13,19 @@ describe('GettingStartedCard', () => {
   });
 
   it('should render the title', () => {
-    const wrapper = shallow(<GettingStartedCard title="Card title" links={[]} />);
+    const wrapper = shallow(<GettingStartedCard id="card" title="Card title" links={[]} />);
 
     expect(wrapper.render().text()).toContain('Card title');
   });
 
   it('should render the title and description', () => {
     const wrapper = shallow(
-      <GettingStartedCard title="Card title" description="Some more details..." links={[]} />,
+      <GettingStartedCard
+        id="card"
+        title="Card title"
+        description="Some more details..."
+        links={[]}
+      />,
     );
 
     expect(wrapper.render().text()).toContain('Card title');
@@ -29,25 +34,25 @@ describe('GettingStartedCard', () => {
 
   it('should render all link as button or link', () => {
     const links: GettingStartedLink[] = [
-      { key: 'button', title: 'Button', onClick: () => null },
-      { key: 'internallink', title: 'Internal link', href: '/' },
+      { id: 'button', title: 'Button', onClick: () => null },
+      { id: 'internallink', title: 'Internal link', href: '/' },
       {
-        key: 'externallink',
+        id: 'externallink',
         title: 'External link',
         href: 'https://www.openshift.com/',
         external: true,
       },
     ];
-    const wrapper = shallow(<GettingStartedCard title="Card title" links={links} />);
+    const wrapper = shallow(<GettingStartedCard id="card" title="Card title" links={links} />);
 
     expect(wrapper.find('SimpleListItem')).toHaveLength(3);
   });
 
   it('should render internal more link', () => {
-    const moreLink: GettingStartedLink = { key: 'moreLink', title: 'Another link', href: '/' };
+    const moreLink: GettingStartedLink = { id: 'moreLink', title: 'Another link', href: '/' };
 
     const wrapper = shallow(
-      <GettingStartedCard title="Card title" links={[]} moreLink={moreLink} />,
+      <GettingStartedCard id="card" title="Card title" links={[]} moreLink={moreLink} />,
     );
 
     expect(wrapper.find('Link')).toHaveLength(1);
@@ -56,14 +61,14 @@ describe('GettingStartedCard', () => {
 
   it('should render external more link', () => {
     const moreLink: GettingStartedLink = {
-      key: 'moreLink',
+      id: 'moreLink',
       title: 'OpenShift',
       href: 'https://www.openshift.com/',
       external: true,
     };
 
     const wrapper = shallow(
-      <GettingStartedCard title="Card title" links={[]} moreLink={moreLink} />,
+      <GettingStartedCard id="card" title="Card title" links={[]} moreLink={moreLink} />,
     );
 
     expect(wrapper.find('a')).toHaveLength(1);

--- a/frontend/packages/console-shared/src/components/getting-started/__tests__/QuickStartGettingStartedCard.spec.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/__tests__/QuickStartGettingStartedCard.spec.tsx
@@ -42,11 +42,11 @@ describe('QuickStartGettingStartedCard', () => {
       'Build with guided documentation',
     );
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
-      { key: 'quarkus-with-s2i', loading: true },
-      { key: 'spring-with-s2i', loading: true },
+      { id: 'quarkus-with-s2i', loading: true },
+      { id: 'spring-with-s2i', loading: true },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'quick-starts',
+      id: 'all-quick-starts',
       title: 'View all quick starts',
       href: '/quickstart',
     });
@@ -65,18 +65,18 @@ describe('QuickStartGettingStartedCard', () => {
     );
     expect(wrapper.find(GettingStartedCard).props().links).toMatchObject([
       {
-        key: 'quarkus-with-s2i',
+        id: 'quarkus-with-s2i',
         title: 'Get started with Quarkus using s2i',
         onClick: expect.any(Function),
       },
       {
-        key: 'spring-with-s2i',
+        id: 'spring-with-s2i',
         title: 'Get started with Spring',
         onClick: expect.any(Function),
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'quick-starts',
+      id: 'all-quick-starts',
       title: 'View all quick starts',
       href: '/quickstart',
     });
@@ -93,18 +93,18 @@ describe('QuickStartGettingStartedCard', () => {
     );
     expect(wrapper.find(GettingStartedCard).props().links).toMatchObject([
       {
-        key: 'spring-with-s2i',
+        id: 'spring-with-s2i',
         title: 'Get started with Spring',
         onClick: expect.any(Function),
       },
       {
-        key: 'monitor-sampleapp',
+        id: 'monitor-sampleapp',
         title: 'Monitor your sample application',
         onClick: expect.any(Function),
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'quick-starts',
+      id: 'all-quick-starts',
       title: 'View all quick starts',
       href: '/quickstart',
     });

--- a/frontend/packages/dev-console/integration-tests/features/healthChecks/add-health-checks-git-form.feature
+++ b/frontend/packages/dev-console/integration-tests/features/healthChecks/add-health-checks-git-form.feature
@@ -11,7 +11,7 @@ Feature: Health Checks
     # Git URL: https://github.com/openshift-roadshow/nationalparks-py
     # This is already covered as part of A-04-TC12
         @smoke @to-do
-        Scenario: Health Checks option in Advanced Options: HC-01-TC01
+        Scenario Outline: Health Checks option in Advanced Options: HC-01-TC01
             Given user is at Import from Git page
              When user enters Git Repo url as "https://github.com/openshift-roadshow/nationalparks-py"
               And user enters Application name as "national-parks-demo"

--- a/frontend/packages/dev-console/integration-tests/features/healthChecks/add-health-checks-topology-sidebar.feature
+++ b/frontend/packages/dev-console/integration-tests/features/healthChecks/add-health-checks-topology-sidebar.feature
@@ -17,7 +17,7 @@ Feature: Health Checks
 
 
         @smoke @to-do
-        Scenario: Add Health Checks to Deployments from Sidebar: HC-02-TC02
+        Scenario Outline: Add Health Checks to Deployments from Sidebar: HC-02-TC02
             Given workload "health-checks-d" with resource type "Deployment" is present in topology page
              When user clicks on the workload "health-checks-d" to open the sidebar
               And user selects "Add Health Checks" from topology sidebar Actions dropdown
@@ -43,6 +43,7 @@ Feature: Health Checks
 
         @smoke @to-do
         Scenario: Add Health Checks to Deployment Configs from Actions dropdown Sidebar: HC-02-TC03
+        Scenario Outline: Add Health Checks to Deployment Configs from Actions dropdown Sidebar: HC-02-TC03
             Given workload "health-checks-dc" with resource type "Deployment Config" is present in topology page
              When user clicks on the workload "health-checks-dc" to open the sidebar
               And user selects "Add Health Checks" from topology sidebar Actions dropdown
@@ -67,7 +68,7 @@ Feature: Health Checks
 
 
         @regression @to-do
-        Scenario: Add Health Check to Deployments from Context Menu: HC-02-TC04
+        Scenario Outline: Add Health Check to Deployments from Context Menu: HC-02-TC04
             Given workload "health-checks-d" with resource type "Deployment" is present in topology page
              When user right clicks on the workload "health-checks-d" to open the Context Menu
               And user selects "Add Health Checks" from Context Menu
@@ -92,7 +93,7 @@ Feature: Health Checks
 
 
         @regression @to-do
-        Scenario: Edit Health Checks option for Knative Service through Context Menu: HC-02-TC04
+        Scenario Outline: Edit Health Checks option for Knative Service through Context Menu: HC-02-TC04
             Given workload "health-checks-kn" with resource type "Knative Service" is present in topology page
              When user right clicks on the Service "health-checks-kn" to open the Context Menu
               And user selects "Edit Health Checks" from Context Menu

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -10,21 +10,21 @@ export const addPage = {
     switch (card) {
       case 'Git':
       case addOptions.Git:
-        cy.byLegacyTestID('odc-add-card-item-import-from-git').click();
+        cy.byTestID('item import-from-git').click();
         // Bug: 1890678 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
         // cy.testA11y('Import from Git Page');
         detailsPage.titleShouldContain(pageTitle.Git);
         break;
       case 'Deploy Image':
       case addOptions.ContainerImage:
-        cy.byLegacyTestID('odc-add-card-item-deploy-image').click();
+        cy.byTestID('item deploy-image').click();
         // Bug: 1890678 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
         // cy.testA11y('Deploy Page');
         detailsPage.titleShouldContain(pageTitle.ContainerImage);
         break;
       case 'Import from Dockerfile':
       case addOptions.DockerFile:
-        cy.byLegacyTestID('odc-add-card-item-import-from-dockerfile').click();
+        cy.byTestID('item import-from-dockerfile').click();
         // Bug: 1890678 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
         // cy.testA11y('Import from Docker file');
         detailsPage.titleShouldContain(pageTitle.DockerFile);
@@ -32,39 +32,39 @@ export const addPage = {
       case 'Developer Catalog':
       case 'From Catalog':
       case addOptions.DeveloperCatalog:
-        cy.byLegacyTestID('odc-add-card-item-dev-catalog').click();
+        cy.byTestID('item dev-catalog').click();
         app.waitForDocumentLoad();
         detailsPage.titleShouldContain(pageTitle.DeveloperCatalog);
         cy.testA11y(pageTitle.DeveloperCatalog);
         break;
       case 'Database':
       case addOptions.Database:
-        cy.byLegacyTestID('odc-add-card-item-dev-catalog-databases').click();
+        cy.byTestID('item dev-catalog-databases').click();
         detailsPage.titleShouldContain(pageTitle.DeveloperCatalog);
         cy.testA11y(pageTitle.DeveloperCatalog);
         break;
       case 'Event Source':
       case addOptions.EventSource:
-        cy.byLegacyTestID('odc-add-card-item-knative-event-source').click();
+        cy.byTestID('item knative-event-source').click();
         detailsPage.titleShouldContain(pageTitle.EventSource);
         // Bug: ODC 5719 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
         // cy.testA11y(pageTitle.EventSource);
         break;
       case 'Helm Chart':
       case addOptions.HelmChart:
-        cy.byLegacyTestID('odc-add-card-item-helm').click({ force: true });
+        cy.byTestID('item helm').click({ force: true });
         detailsPage.titleShouldContain(pageTitle.HelmCharts);
         cy.testA11y(pageTitle.HelmCharts);
         break;
       case 'Operator Backed':
       case addOptions.OperatorBacked:
-        cy.byLegacyTestID('odc-add-card-item-operator-backed').click();
+        cy.byTestID('item operator-backed').click();
         detailsPage.titleShouldContain(pageTitle.OperatorBacked);
         cy.testA11y(pageTitle.OperatorBacked);
         break;
       case 'Pipeline':
       case addOptions.Pipeline:
-        cy.byLegacyTestID('odc-add-card-item-pipeline').click();
+        cy.byTestID('item pipeline').click();
         cy.get('.odc-pipeline-builder-header__title').should(
           'have.text',
           pageTitle.PipelineBuilder,
@@ -73,24 +73,24 @@ export const addPage = {
         break;
       case 'Yaml':
       case addOptions.YAML:
-        cy.byLegacyTestID('odc-add-card-item-import-yaml').click();
+        cy.byTestID('item import-yaml').click();
         cy.get('[data-mode-id="yaml"]').should('be.visible');
         cy.testA11y(pageTitle.YAML);
         break;
       case 'Channel':
       case addOptions.Channel:
-        cy.byLegacyTestID('odc-add-card-item-knative-eventing-channel').click();
+        cy.byTestID('item knative-eventing-channel').click();
         detailsPage.titleShouldContain(pageTitle.Channel);
         cy.testA11y(pageTitle.Channel);
         break;
       case addOptions.DevFile:
-        cy.byLegacyTestID('odc-add-card-item-import-from-devfile').click();
+        cy.byTestID('item import-from-devfile').click();
         detailsPage.titleShouldContain(pageTitle.DevFile);
         // Below line is commented due to Bug: ODC-5832
         // cy.testA11y(pageTitle.DevFile);
         break;
       case addOptions.UploadJARFile:
-        cy.byLegacyTestID('odc-add-card-item-upload-jar').click();
+        cy.byTestID('item upload-jar').click();
         detailsPage.titleShouldContain(pageTitle.UploadJarFile);
         // Below line is commented due to Bug: ODC-5832
         // cy.testA11y(pageTitle.UploadJarFile);

--- a/frontend/packages/dev-console/src/components/add/AddCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddCard.tsx
@@ -4,18 +4,19 @@ import { ResolvedExtension, AddAction } from '@console/dynamic-plugin-sdk';
 import AddCardItem from './AddCardItem';
 import './AddCard.scss';
 
-type AddCardProps = { title: string; items: ResolvedExtension<AddAction>[]; namespace: string };
-const AddCard: React.FC<AddCardProps> = ({ title, items, namespace }) => {
+type AddCardProps = {
+  id: string;
+  title: string;
+  items: ResolvedExtension<AddAction>[];
+  namespace: string;
+};
+
+const AddCard: React.FC<AddCardProps> = ({ id, title, items, namespace }) => {
   const isTitleFromItem: boolean = items?.length === 1 && items[0].properties.label === title;
   return items?.length > 0 ? (
-    <Card key={title} className="odc-add-card">
+    <Card key={title} className="odc-add-card" data-test={`card ${id}`}>
       {!isTitleFromItem && (
-        <Title
-          size="lg"
-          headingLevel="h4"
-          className="odc-add-card__title"
-          data-test-id="odc-add-card-title"
-        >
+        <Title size="lg" headingLevel="h2" className="odc-add-card__title" data-test="title">
           {title}
         </Title>
       )}

--- a/frontend/packages/dev-console/src/components/add/AddCardItem.scss
+++ b/frontend/packages/dev-console/src/components/add/AddCardItem.scss
@@ -6,40 +6,35 @@
   }
 
   margin-top: var(--pf-global--spacer--lg);
+  margin-left: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--sm));
 
-  &__header {
-    margin-left: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--sm));
+  &__icon {
+    height: var(--pf-global--FontSize--lg);
+    max-width: var(--pf-global--spacer--lg);
+    min-width: var(--pf-global--spacer--md);
+    color: var(--pf-global--Color--100) !important;
+    // temporary fix since --pf-global--FontSize--md is being computed to 14px instead of 16px
+    font-size: var(--pf-global--FontSize--md);
+    margin-right: var(--pf-global--spacer--sm);
+  }
 
-    &__icon {
-      display: inline;
-      vertical-align: middle;
-      height: var(--pf-global--FontSize--lg);
-      max-width: var(--pf-global--spacer--lg);
-      min-width: var(--pf-global--spacer--md);
-      color: var(--pf-global--Color--100) !important;
-      // temporary fix since --pf-global--FontSize--md is being computed to 14px instead of 16px
-      font-size: var(--pf-global--FontSize--md);
-      margin-left: var(--pf-global--spacer--sm);
+  &__title {
+    display: inline;
+    vertical-align: middle;
+    margin-left: var(--pf-global--spacer--sm);
+    // temporary fix since --pf-global--FontSize--md is being computed to 14px instead of 16px
+    font-size: var(--pf-global--spacer--md) !important;
+  }
+
+  a.pf-c-simple-list__item-link {
+    &:hover .odc-add-card-item__title {
+      color: var(--pf-c-simple-list__item-link--hover--Color);
     }
-
-    &__title {
-      display: inline;
-      vertical-align: middle;
-      margin-left: var(--pf-global--spacer--sm);
-      // temporary fix since --pf-global--FontSize--md is being computed to 14px instead of 16px
-      font-size: var(--pf-global--spacer--md) !important;
+    &:focus .odc-add-card-item__title {
+      color: var(--pf-c-simple-list__item-link--focus--Color);
     }
-
-    a.pf-c-simple-list__item-link {
-      &:hover .odc-add-card-item__header__title {
-        color: var(--pf-c-simple-list__item-link--hover--Color);
-      }
-      &:focus .odc-add-card-item__header__title {
-        color: var(--pf-c-simple-list__item-link--focus--Color);
-      }
-      &:active .odc-add-card-item__header__title {
-        color: var(--pf-c-simple-list__item-link--active--Color);
-      }
+    &:active .odc-add-card-item__title {
+      color: var(--pf-c-simple-list__item-link--active--Color);
     }
   }
 

--- a/frontend/packages/dev-console/src/components/add/AddCardItem.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddCardItem.tsx
@@ -22,18 +22,11 @@ const AddCardItem: React.FC<AddCardItemProps> = ({
 
   const actionIcon = (): JSX.Element => {
     if (typeof icon === 'string') {
-      return (
-        <img
-          className="odc-add-card-item__header__icon"
-          src={icon}
-          alt={label}
-          aria-hidden="true"
-        />
-      );
+      return <img className="odc-add-card-item__icon" src={icon} alt={label} aria-hidden="true" />;
     }
     if (typeof icon !== 'string' && React.isValidElement(icon)) {
       return (
-        <span className="odc-add-card-item__header__icon" aria-hidden="true">
+        <span className="odc-add-card-item__icon" aria-hidden="true">
           {icon}
         </span>
       );
@@ -42,31 +35,31 @@ const AddCardItem: React.FC<AddCardItemProps> = ({
   };
 
   return (
-    <div className="odc-add-card-item" data-test-id={`odc-add-card-item-${id}`}>
-      <SimpleListItem
-        component="a"
-        onClick={(e: React.SyntheticEvent) => {
-          fireTelemetryEvent('Add Item Selected', {
-            id,
-            name: label,
-          });
-          navigateTo(e, resolvedHref(href, namespace));
-        }}
-        href={resolvedHref(href, namespace)}
-        data-test-id="odc-add-card-link"
-        className="odc-add-card-item__header"
-      >
+    <SimpleListItem
+      component="a"
+      componentProps={{
+        'data-test': `item ${id}`,
+      }}
+      href={resolvedHref(href, namespace)}
+      onClick={(e: React.SyntheticEvent) => {
+        fireTelemetryEvent('Add Item Selected', {
+          id,
+          name: label,
+        });
+        navigateTo(e, resolvedHref(href, namespace));
+      }}
+      className="odc-add-card-item"
+    >
+      <Title headingLevel="h3" size="md" className="odc-add-card-item__title" data-test="title">
         {actionIcon()}
-        <Title headingLevel="h5" size="md" className="odc-add-card-item__header__title">
-          {label}
-        </Title>
-        {showDetails && (
-          <Text className="odc-add-card-item__description" data-test-id="odc-add-card-item-desc">
-            {description}
-          </Text>
-        )}
-      </SimpleListItem>
-    </div>
+        {label}
+      </Title>
+      {showDetails && (
+        <Text className="odc-add-card-item__description" data-test="description">
+          {description}
+        </Text>
+      )}
+    </SimpleListItem>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/add/AddCardSection.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddCardSection.tsx
@@ -8,7 +8,7 @@ import AddCardSectionSkeleton from './AddCardSectionSkeleton';
 import AddCardSectionEmptyState from './AddCardSectionEmptyState';
 import { MasonryLayout } from './layout/MasonryLayout';
 
-type AddCardsSectionProps = {
+type AddCardSectionProps = {
   namespace: string;
   addActionExtensions: ResolvedExtension<AddAction>[];
   addActionGroupExtensions: LoadedExtension<AddActionGroup>[];
@@ -19,7 +19,7 @@ type AddCardsSectionProps = {
 
 const COLUMN_WIDTH = 300;
 
-const AddCardsSection: React.FC<AddCardsSectionProps> = ({
+const AddCardSection: React.FC<AddCardSectionProps> = ({
   namespace,
   addActionExtensions,
   addActionGroupExtensions,
@@ -41,24 +41,20 @@ const AddCardsSection: React.FC<AddCardsSectionProps> = ({
     const addGroups: AddGroup[] = getAddGroups(addActionExtensions, sortedActionGroup);
 
     return addGroups.map(({ id, name, items }) => (
-      <AddCard
-        key={id}
-        title={name}
-        items={items}
-        namespace={namespace}
-        data-test-id={`odc-add-card-${id}`}
-      />
+      <AddCard key={id} id={id} title={name} items={items} namespace={namespace} />
     ));
   };
 
   return (
-    <MasonryLayout
-      columnWidth={COLUMN_WIDTH}
-      loading={!extensionsLoaded}
-      LoadingComponent={AddCardSectionSkeleton}
-    >
-      {getAddCards()}
-    </MasonryLayout>
+    <div data-test="add-cards">
+      <MasonryLayout
+        columnWidth={COLUMN_WIDTH}
+        loading={!extensionsLoaded}
+        LoadingComponent={AddCardSectionSkeleton}
+      >
+        {getAddCards()}
+      </MasonryLayout>
+    </div>
   );
 };
-export default AddCardsSection;
+export default AddCardSection;

--- a/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
@@ -61,6 +61,7 @@ const AddPageLayout: React.FC<AddPageLayoutProps> = ({ title, hintBlock: additio
               className={cx('odc-add-page-layout__hint-block__details-switch', {
                 'odc-add-page-layout__hint-block__details-switch__loading-state': !extensionsLoaded,
               })}
+              data-test="details-switch"
             >
               {extensionsLoaded ? (
                 <Tooltip
@@ -77,13 +78,16 @@ const AddPageLayout: React.FC<AddPageLayoutProps> = ({ title, hintBlock: additio
                     onChange={(checked) => {
                       setShowDetails(checked);
                     }}
-                    data-test-id="odc-add-page-details-switch"
+                    data-test="switch"
                   />
                 </Tooltip>
               ) : (
                 <Skeleton shape="circle" width="24px" />
               )}
-              <span className="odc-add-page-layout__hint-block__details-switch__text">
+              <span
+                className="odc-add-page-layout__hint-block__details-switch__text"
+                data-test="label"
+              >
                 {extensionsLoaded ? switchText : <Skeleton height="100%" width="64px" />}
               </span>
             </div>
@@ -97,7 +101,7 @@ const AddPageLayout: React.FC<AddPageLayoutProps> = ({ title, hintBlock: additio
   };
 
   return (
-    <div className="odc-add-page-layout">
+    <div className="odc-add-page-layout" data-test="add-page">
       <PageLayout title={title} hint={getHint()}>
         <GettingStartedSection />
         <AddCardSection

--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -19,7 +19,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
 
   const links: GettingStartedLink[] = [
     {
-      key: 'helm-charts',
+      id: 'helm-charts',
       title: t('devconsole~Discover certified Helm Charts'),
       href:
         activeNamespace && activeNamespace !== ALL_NAMESPACES_KEY
@@ -27,7 +27,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
           : '/catalog/all-namespaces?catalogType=HelmChart',
     },
     {
-      key: 'topology',
+      id: 'topology',
       title: t('devconsole~Start building your application quickly in topology'),
       href:
         activeNamespace && activeNamespace !== ALL_NAMESPACES_KEY
@@ -37,7 +37,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
   ];
 
   const moreLink: GettingStartedLink = {
-    key: 'whats-new',
+    id: 'whats-new',
     title: t("devconsole~What's new in OpenShift {{version}}", { version }),
     href: 'https://developers.redhat.com/products/openshift/getting-started',
     external: true,
@@ -45,6 +45,7 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
 
   return (
     <GettingStartedCard
+      id="developer-features"
       icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
       title={t('devconsole~Explore new developer features')}
       titleColor={'var(--pf-global--palette--gold-700)'}

--- a/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
@@ -47,7 +47,7 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
   const [activeNamespace] = useActiveNamespace();
 
   const moreLink: GettingStartedLink = {
-    key: 'all-samples',
+    id: 'all-samples',
     title: t('devconsole~View all samples'),
     href:
       activeNamespace && activeNamespace !== ALL_NAMESPACES_KEY
@@ -64,7 +64,7 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
         const links: GettingStartedLink[] = service.loaded
           ? slicedCatalogItems.map((item) => {
               return {
-                key: item.uid,
+                id: item.uid,
                 title: item.name,
                 href: item.cta?.href,
                 onClick: item.cta?.callback,
@@ -72,13 +72,14 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
             })
           : featured.map((uid) => {
               return {
-                key: uid,
+                id: uid,
                 loading: true,
               };
             });
 
         return (
           <GettingStartedCard
+            id="samples"
             icon={<CatalogIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
             title={t('devconsole~Create applications using samples')}
             titleColor={'var(--pf-global--palette--blue-600)'}

--- a/frontend/packages/dev-console/src/components/add/__tests__/AddCard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/AddCard.spec.tsx
@@ -11,7 +11,8 @@ describe('AddCard', () => {
 
   beforeEach(() => {
     props = {
-      title: 'title',
+      id: 'id',
+      title: 'Title',
       items: addActionExtensions,
       namespace: 'ns',
     };

--- a/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
@@ -46,18 +46,18 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
     );
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
       {
-        key: 'helm-charts',
+        id: 'helm-charts',
         title: 'Discover certified Helm Charts',
         href: '/catalog/ns/active-namespace?catalogType=HelmChart',
       },
       {
-        key: 'topology',
+        id: 'topology',
         title: 'Start building your application quickly in topology',
         href: '/topology/ns/active-namespace?catalogSearch=',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'whats-new',
+      id: 'whats-new',
       title: "What's new in OpenShift x.y",
       href: 'https://developers.redhat.com/products/openshift/getting-started',
       external: true,
@@ -74,18 +74,18 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
     );
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
       {
-        key: 'helm-charts',
+        id: 'helm-charts',
         title: 'Discover certified Helm Charts',
         href: '/catalog/all-namespaces?catalogType=HelmChart',
       },
       {
-        key: 'topology',
+        id: 'topology',
         title: 'Start building your application quickly in topology',
         href: '/topology/all-namespaces?catalogSearch=',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'whats-new',
+      id: 'whats-new',
       title: "What's new in OpenShift x.y",
       href: 'https://developers.redhat.com/products/openshift/getting-started',
       external: true,

--- a/frontend/packages/dev-console/src/components/add/__tests__/SampleGettingStartedCard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/SampleGettingStartedCard.spec.tsx
@@ -51,11 +51,11 @@ describe('SampleGettingStartedCard', () => {
       'Create applications using samples',
     );
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
-      { key: 'code-with-quarkus', loading: true },
-      { key: 'java-springboot-basic', loading: true },
+      { id: 'code-with-quarkus', loading: true },
+      { id: 'java-springboot-basic', loading: true },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'all-samples',
+      id: 'all-samples',
       title: 'View all samples',
       href: '/samples/ns/active-namespace',
     });
@@ -74,20 +74,20 @@ describe('SampleGettingStartedCard', () => {
     );
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
       {
-        key: 'code-with-quarkus',
+        id: 'code-with-quarkus',
         title: 'Basic Quarkus',
         href:
           '/import?importType=devfile&formType=sample&devfileName=code-with-quarkus&gitRepo=https://github.com/elsony/devfile-sample-code-with-quarkus.git',
       },
       {
-        key: 'java-springboot-basic',
+        id: 'java-springboot-basic',
         title: 'Basic Spring Boot',
         href:
           '/import?importType=devfile&formType=sample&devfileName=java-springboot-basic&gitRepo=https://github.com/elsony/devfile-sample-java-springboot-basic.git',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'all-samples',
+      id: 'all-samples',
       title: 'View all samples',
       href: '/samples/ns/active-namespace',
     });
@@ -104,19 +104,19 @@ describe('SampleGettingStartedCard', () => {
     );
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
       {
-        key: 'Sample-7755a465-a923-4393-a102-9876c110dbb4',
+        id: 'Sample-7755a465-a923-4393-a102-9876c110dbb4',
         title: '.NET Core',
         href: '/samples/ns/active-namespace/dotnet/openshift',
       },
       {
-        key: 'nodejs-basic',
+        id: 'nodejs-basic',
         title: 'Basic NodeJS',
         href:
           '/import?importType=devfile&formType=sample&devfileName=nodejs-basic&gitRepo=https://github.com/redhat-developer/devfile-sample.git',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'all-samples',
+      id: 'all-samples',
       title: 'View all samples',
       href: '/samples/ns/active-namespace',
     });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-alert-receiver-link.spec.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-alert-receiver-link.spec.ts
@@ -172,7 +172,7 @@ describe('useAlertReceiverLink', () => {
     const { result } = testHook(() => useAlertReceiverLink());
 
     expect(result.current).toEqual({
-      key: 'alert-receivers',
+      id: 'alert-receivers',
       title: 'Configure alert receivers',
       href: '/monitoring/alertmanagerconfig',
     });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-getting-started-card.spec.tsx
@@ -44,12 +44,12 @@ const useAlertReceiverLinkMock = useAlertReceiverLink as jest.Mock;
 describe('ClusterSetupGettingStartedCard', () => {
   it('should render links if hooks provide them', () => {
     useIdentityProviderLinkMock.mockReturnValue({
-      key: 'identity-providers',
+      id: 'identity-providers',
       title: 'Add identity providers',
       href: 'cluster',
     });
     useAlertReceiverLinkMock.mockReturnValue({
-      key: 'alert-receivers',
+      id: 'alert-receivers',
       title: 'Configure alert receivers',
       href: '/monitoring/alertmanagerconfig',
     });
@@ -59,18 +59,18 @@ describe('ClusterSetupGettingStartedCard', () => {
     expect(wrapper.find(GettingStartedCard).props().title).toEqual('Set up your cluster');
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
       {
-        key: 'identity-providers',
+        id: 'identity-providers',
         title: 'Add identity providers',
         href: 'cluster',
       },
       {
-        key: 'alert-receivers',
+        id: 'alert-receivers',
         title: 'Configure alert receivers',
         href: '/monitoring/alertmanagerconfig',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'quick-starts',
+      id: 'machine-configuration',
       title: 'View all steps in documentation',
       href:
         'https://docs.okd.io/latest/post_installation_configuration/machine-configuration-tasks.html',

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-identity-provider-link.spec.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/cluster-setup-identity-provider-link.spec.ts
@@ -66,7 +66,7 @@ describe('useIdentityProviderLink', () => {
     const { result } = testHook(() => useIdentityProviderLink());
 
     expect(result.current).toEqual({
-      key: 'identity-providers',
+      id: 'identity-providers',
       title: 'Add identity providers',
       href: '/k8s/cluster/config.openshift.io~v1~OAuth/cluster',
     });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
@@ -43,18 +43,18 @@ describe('ExploreAdminFeaturesGettingStartedCard', () => {
     expect(wrapper.find(GettingStartedCard).props().title).toEqual('Explore new admin features');
     expect(wrapper.find(GettingStartedCard).props().links).toEqual([
       {
-        key: 'api-explorer',
+        id: 'api-explorer',
         title: 'API Explorer',
         href: '/api-explorer',
       },
       {
-        key: 'console-customizations',
+        id: 'console-customizations',
         title: 'Console customizations',
         href: '/k8s/cluster/customresourcedefinitions?name=console',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
-      key: 'whats-new',
+      id: 'whats-new',
       title: "See what's new in OpenShift x.y",
       href: 'https://www.openshift.com/learn/whats-new',
       external: true,

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-alert-receiver-link.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-alert-receiver-link.ts
@@ -44,7 +44,7 @@ export const useAlertReceiverLink = (): GettingStartedLink | null => {
 
   if (canEdit && hasIncompleteReceivers) {
     return {
-      key: 'alert-receivers',
+      id: 'alert-receivers',
       title: t('public~Configure alert receivers'),
       href: '/monitoring/alertmanagerconfig',
     };

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-getting-started-card.tsx
@@ -25,7 +25,7 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
   const moreLinkBaseURL = window.SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';
   const moreLinkURL = `${moreLinkBaseURL}post_installation_configuration/machine-configuration-tasks.html`;
   const moreLink: GettingStartedLink = {
-    key: 'quick-starts',
+    id: 'machine-configuration',
     title: t('public~View all steps in documentation'),
     href: moreLinkURL,
     external: true,
@@ -33,6 +33,7 @@ export const ClusterSetupGettingStartedCard: React.FC = () => {
 
   return (
     <GettingStartedCard
+      id="cluster-setup"
       icon={<ClipboardCheckIcon color="var(--pf-global--primary-color--100)" aria-hidden="true" />}
       title={t('public~Set up your cluster')}
       titleColor={'var(--pf-global--palette--blue-600)'}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-identity-provider-link.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/cluster-setup-identity-provider-link.ts
@@ -43,7 +43,7 @@ export const useIdentityProviderLink = (): GettingStartedLink | null => {
   }
 
   return {
-    key: 'identity-providers',
+    id: 'identity-providers',
     title: t('public~Add identity providers'),
     href: resourcePathFromModel(OAuthModel, 'cluster'),
   };

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -18,19 +18,19 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
 
   const links: GettingStartedLink[] = [
     {
-      key: 'api-explorer',
+      id: 'api-explorer',
       title: t('public~API Explorer'),
       href: '/api-explorer',
     },
     {
-      key: 'console-customizations',
+      id: 'console-customizations',
       title: t('public~Console customizations'),
       href: '/k8s/cluster/customresourcedefinitions?name=console',
     },
   ];
 
   const moreLink: GettingStartedLink = {
-    key: 'whats-new',
+    id: 'whats-new',
     title: t("public~See what's new in OpenShift {{version}}", { version }),
     href: 'https://www.openshift.com/learn/whats-new',
     external: true,
@@ -38,6 +38,7 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
 
   return (
     <GettingStartedCard
+      id="admin-features"
       icon={<FlagIcon color="var(--pf-global--palette--orange-300)" aria-hidden="true" />}
       title={t('public~Explore new admin features')}
       titleColor={'var(--pf-global--palette--gold-700)'}


### PR DESCRIPTION
**Fixes**: 
Epic: https://issues.redhat.com/browse/ODC-5013

**Analysis / Root cause**:
Data-test attributes are missed for getting started card and items.

**Solution Description**: 
* Update add card `data-test-id`s to hierarchy-based `data-test` attributes.
* Add missing `data-test` attributes to new getting started section.
* Updated `packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts` with new data-test checks

**Screen shots**: 
Some `data-test` query examples:

```js
// Remove outlines for all data-test and data-test-id entries
document.querySelectorAll('[data-test],[data-test-id]').forEach(e => e.style.outline = '')
// Add outline to all add-page data-test elements
document.querySelectorAll('[data-test=add-page] [data-test]').forEach(e => e.style.outline = '1px solid red')
```
![image](https://user-images.githubusercontent.com/139310/119571131-45a16c00-bdb1-11eb-8733-d1036bc35021.png)

```js
// Remove outlines for all data-test and data-test-id entries
document.querySelectorAll('[data-test],[data-test-id]').forEach(e => e.style.outline = '')
// Add outline to all add-page titles
document.querySelectorAll('[data-test=add-page] [data-test~=title]').forEach(e => e.style.outline = '1px solid red')
```
![image](https://user-images.githubusercontent.com/139310/119570928-0246fd80-bdb1-11eb-963f-c7ea2326673a.png)


**Unit test coverage report**: 
* Updated existing tests. Don't added any `data-test` tests.

**Test setup:**
* Open Add page and check rendered elements.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge