### PR TITLE
Add support for default repo overwrites

### DIFF
--- a/pkg/helm/actions/fake/helmcrconfigs.go
+++ b/pkg/helm/actions/fake/helmcrconfigs.go
@@ -59,6 +59,17 @@ func K8sDynamicClient(indexFiles ...string) dynamic.Interface {
 	return fake.NewSimpleDynamicClient(newScheme(), objs...)
 }
 
+func K8sDynamicClientWithRepoNames(repoNames []string, indexFiles ...string) dynamic.Interface {
+	var objs []runtime.Object
+
+	for i, indexFile := range indexFiles {
+		fakeCr := fakeHelmCR(indexFile, repoNames[i])
+		objs = append(objs, fakeCr)
+	}
+
+	return fake.NewSimpleDynamicClient(newScheme(), objs...)
+}
+
 func K8sDynamicClientFromCRs(crs ...*unstructured.Unstructured) dynamic.Interface {
 	var objs []runtime.Object
 

--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -52,6 +52,13 @@ func httpClient(tlsConfig *tls.Config) (*http.Client, error) {
 	return client, nil
 }
 
+func (hr helmRepo) OverwrittenRepoName() string {
+	if hr.Name == "openshift-helm-charts" {
+		return "redhat-helm-repo"
+	}
+	return ""
+}
+
 func (hr helmRepo) IndexFile() (*repo.IndexFile, error) {
 	var indexFile repo.IndexFile
 	httpClient, err := hr.httpClient()

--- a/pkg/helm/chartproxy/testdata/mergedRepoOverwriteNoDups.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedRepoOverwriteNoDups.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+entries:
+  psql-service--redhat-helm-repo:
+  - annotations:
+      charts.openshift.io/archs: x86_64
+      charts.openshift.io/name: PSQL RedHat Demo Chart
+      charts.openshift.io/provider: RedHat
+      charts.openshift.io/supportURL: https://github.com/dperaza4dustbit/helm-chart
+    apiVersion: v2
+    appVersion: 10.0.0
+    created: "2021-05-20T17:02:54.537383-04:00"
+    description: A Helm chart for a RedHat Certified PSQL
+    digest: 7b62635ea789ce8e6c43b007228b5ed030868d92efb1ba8a66a47d27acd619a9
+    kubeVersion: 1.20.0
+    name: psql-service
+    type: application
+    urls:
+    - https://dperaza4dustbit.github.io/helm-chart/psql-service-0.1.8.tgz
+    version: 0.1.8
+  ssm-service--redhat-helm-repo:
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2021-05-20T17:02:54.541213-04:00"
+    description: A Helm chart for a Software Security Module
+    digest: 787dae187f2bda7d20cb1c2fd50ad9ff5a8d8e4fb614a6b9aa4b25921d590b74
+    name: ssm-service
+    type: application
+    urls:
+    - https://dperaza4dustbit.github.io/helm-chart/ssm-service-0.1.2.tgz
+    version: 0.1.2
+  ibm-mongodb-enterprise-helm--openshift-helm-charts:
+  - apiVersion: v2
+    appVersion: 4.4.0
+    created: "2021-05-18T16:18:54.788708+02:00"
+    description: 'IBM Helm Chart to deploy MongoDB Enterprise on OpenShift Container Platform hosted on IBM Power systems.  Documentation For additional details regarding install parameters see here https://docs.mongodb.com/manual/administration/install-enterprise/  License By installing this product you accept the license terms. https://www.mongodb.com/community/licensing '
+    digest: 6727fe960ea49f9fa1e6c5c36f1d4190b1ca12ce82b11c290b6150f34a48560b
+    keywords:
+    - IBM
+    - ppc64le
+    - Enterprise MongoDB
+    - RHOCP
+    - Database
+    - Other
+    kubeVersion: '>=1.16.0-0'
+    maintainers:
+    - name: IBM
+    name: ibm-mongodb-enterprise-helm
+    urls:
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-mongodb-enterprise-helm-0.2.0.tgz
+    version: 0.2.0
+  quarkus--openshift-helm-charts:
+  - apiVersion: v2
+    created: "2021-05-18T16:18:54.895387+02:00"
+    description: A Helm chart to build and deploy Quarkus applications
+    digest: 6d8f1b945c037f1f252e532430c21ef723bc11fab369ef26d316fff69c4ffade
+    keywords:
+    - runtimes
+    - quarkus
+    name: quarkus
+    urls:
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.3.tgz
+    version: 0.0.3
+  wildfly--openshift-helm-charts:
+  - apiVersion: v2
+    appVersion: "23.0"
+    created: "2021-05-18T16:18:54.896136+02:00"
+    dependencies:
+    - name: wildfly-common
+      repository: file://../wildfly-common
+      version: 1.3.0
+    description: Build and Deploy WildFly applications on OpenShift
+    digest: c9d05d87d566da2fe8ee041dbf6e0b4cb6614e138edbecac09b510cb68ccf4e2
+    icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark_256px.png
+    maintainers:
+    - email: wildfly-dev@lists.jboss.org
+      name: WildFly
+      url: https://wildfly.org
+    name: wildfly
+    type: application
+    urls:
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/wildfly-1.3.0.tgz
+    version: 1.3.0
+generated: "2021-05-18T16:18:54.729134+02:00"

--- a/pkg/helm/chartproxy/testdata/sampleOverwrite1.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleOverwrite1.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+entries:
+  ibm-mongodb-enterprise-helm:
+  - apiVersion: v2
+    appVersion: 4.4.0
+    created: "2021-05-20T17:02:54.533247-04:00"
+    description: 'IBM Helm Chart to deploy MongoDB Enterprise on OpenShift Container
+      Platform hosted on IBM Power systems.  Documentation For additional details
+      regarding install parameters see here https://docs.mongodb.com/manual/administration/install-enterprise/  License
+      By installing this product you accept the license terms. https://www.mongodb.com/community/licensing '
+    digest: 6727fe960ea49f9fa1e6c5c36f1d4190b1ca12ce82b11c290b6150f34a48560b
+    keywords:
+    - IBM
+    - ppc64le
+    - Enterprise MongoDB
+    - RHOCP
+    - Database
+    - Other
+    kubeVersion: '>=1.16.0-0'
+    maintainers:
+    - name: IBM
+    name: ibm-mongodb-enterprise-helm
+    urls:
+    - https://dperaza4dustbit.github.io/helm-chart/ibm-mongodb-enterprise-helm-0.2.0.tgz
+    version: 0.2.0
+  psql-service:
+  - annotations:
+      charts.openshift.io/archs: x86_64
+      charts.openshift.io/name: PSQL RedHat Demo Chart
+      charts.openshift.io/provider: RedHat
+      charts.openshift.io/supportURL: https://github.com/dperaza4dustbit/helm-chart
+    apiVersion: v2
+    appVersion: 10.0.0
+    created: "2021-05-20T17:02:54.537383-04:00"
+    description: A Helm chart for a RedHat Certified PSQL
+    digest: 7b62635ea789ce8e6c43b007228b5ed030868d92efb1ba8a66a47d27acd619a9
+    kubeVersion: 1.20.0
+    name: psql-service
+    type: application
+    urls:
+    - https://dperaza4dustbit.github.io/helm-chart/psql-service-0.1.8.tgz
+    version: 0.1.8
+  quarkus:
+  - apiVersion: v2
+    created: "2021-05-20T17:02:54.538296-04:00"
+    description: A Helm chart to build and deploy Quarkus applications
+    digest: 1d6a88bc9d9a7dfa6eb02b9dc70242a0fc292e48da5ef922c3ec9e61ebad3dec
+    keywords:
+    - runtimes
+    - quarkus
+    name: quarkus
+    urls:
+    - https://dperaza4dustbit.github.io/helm-chart/quarkus-0.0.3.tgz
+    version: 0.0.3
+  ssm-service:
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2021-05-20T17:02:54.541213-04:00"
+    description: A Helm chart for a Software Security Module
+    digest: 787dae187f2bda7d20cb1c2fd50ad9ff5a8d8e4fb614a6b9aa4b25921d590b74
+    name: ssm-service
+    type: application
+    urls:
+    - https://dperaza4dustbit.github.io/helm-chart/ssm-service-0.1.2.tgz
+    version: 0.1.2
+generated: "2021-05-20T17:02:54.531906-04:00"

--- a/pkg/helm/chartproxy/testdata/sampleOverwrite2.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleOverwrite2.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+entries:
+  ibm-mongodb-enterprise-helm:
+  - apiVersion: v2
+    appVersion: 4.4.0
+    created: "2021-05-18T16:18:54.788708+02:00"
+    description: 'IBM Helm Chart to deploy MongoDB Enterprise on OpenShift Container Platform hosted on IBM Power systems.  Documentation For additional details regarding install parameters see here https://docs.mongodb.com/manual/administration/install-enterprise/  License By installing this product you accept the license terms. https://www.mongodb.com/community/licensing '
+    digest: 6727fe960ea49f9fa1e6c5c36f1d4190b1ca12ce82b11c290b6150f34a48560b
+    keywords:
+    - IBM
+    - ppc64le
+    - Enterprise MongoDB
+    - RHOCP
+    - Database
+    - Other
+    kubeVersion: '>=1.16.0-0'
+    maintainers:
+    - name: IBM
+    name: ibm-mongodb-enterprise-helm
+    urls:
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-mongodb-enterprise-helm-0.2.0.tgz
+    version: 0.2.0
+  quarkus:
+  - apiVersion: v2
+    created: "2021-05-18T16:18:54.895387+02:00"
+    description: A Helm chart to build and deploy Quarkus applications
+    digest: 6d8f1b945c037f1f252e532430c21ef723bc11fab369ef26d316fff69c4ffade
+    keywords:
+    - runtimes
+    - quarkus
+    name: quarkus
+    urls:
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.3.tgz
+    version: 0.0.3
+  wildfly:
+  - apiVersion: v2
+    appVersion: "23.0"
+    created: "2021-05-18T16:18:54.896136+02:00"
+    dependencies:
+    - name: wildfly-common
+      repository: file://../wildfly-common
+      version: 1.3.0
+    description: Build and Deploy WildFly applications on OpenShift
+    digest: c9d05d87d566da2fe8ee041dbf6e0b4cb6614e138edbecac09b510cb68ccf4e2
+    icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark_256px.png
+    maintainers:
+    - email: wildfly-dev@lists.jboss.org
+      name: WildFly
+      url: https://wildfly.org
+    name: wildfly
+    type: application
+    urls:
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/wildfly-1.3.0.tgz
+    version: 1.3.0
+generated: "2021-05-18T16:18:54.729134+02:00"


### PR DESCRIPTION
Adding support for default repo openshift-helm-charts to overwrite
charts in previous default repo redhat-helm-repo to avoid duplicates in
the catalog. This PR is a follow up to this PR already merged:

https://github.com/openshift/console-operator/pull/545

The story for this requirement is described here: 
https://issues.redhat.com/browse/HELM-185