### PR TITLE
Bug 1945312: Fix project deletion issue and reset active namespace

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/namespace.ts
@@ -8,9 +8,10 @@ import { useUserSettingsCompatibility } from '@console/shared/src/hooks/useUserS
 import { setActiveNamespace } from '@console/internal/actions/ui';
 import {
   ALL_NAMESPACES_KEY,
-  USERSETTINGS_PREFIX,
   NAMESPACE_USERSETTINGS_PREFIX,
   NAMESPACE_LOCAL_STORAGE_KEY,
+  LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
+  LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
 } from '@console/shared/src/constants';
 import { k8sGet, K8sKind } from '@console/internal/module/k8s';
 import { NamespaceModel, ProjectModel } from '@console/internal/models';
@@ -25,9 +26,6 @@ type NamespaceContextType = {
 
 const FAVORITE_NAMESPACE_NAME_USERSETTINGS_KEY = `${NAMESPACE_USERSETTINGS_PREFIX}.favorite`;
 const FAVORITE_NAMESPACE_NAME_LOCAL_STORAGE_KEY = NAMESPACE_LOCAL_STORAGE_KEY;
-
-const LAST_NAMESPACE_NAME_USER_SETTINGS_KEY = `${USERSETTINGS_PREFIX}.lastNamespace`;
-const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `bridge/last-namespace-name`;
 
 export const NamespaceContext = React.createContext<NamespaceContextType>({});
 

--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -37,6 +37,7 @@ export const NAMESPACE_USERSETTINGS_PREFIX = `${USERSETTINGS_PREFIX}.namespace`;
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const APPLICATION_USERSETTINGS_PREFIX = `${USERSETTINGS_PREFIX}.applications`;
 export const APPLICATION_LOCAL_STORAGE_KEY = 'dropdown-storage-applications';
+export const LAST_NAMESPACE_NAME_USER_SETTINGS_KEY = `${USERSETTINGS_PREFIX}.lastNamespace`;
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
+// FIXME upgrading redux types is causing many errors at this time
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@console/internal/redux';
 import { k8sKill, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import {
   createModalLauncher,
@@ -11,10 +16,14 @@ import {
 import { history } from '@console/internal/components/utils';
 import {
   ALL_NAMESPACES_KEY,
-  useActiveNamespace,
+  LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
+  LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
+  useUserSettingsCompatibility,
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
+import { getActiveNamespace } from '../../reducers/ui';
+import { setActiveNamespace } from '../../actions/ui';
 
 export const DeleteNamespaceModal: React.FC<DeleteNamespaceModalProps> = ({
   cancel,
@@ -23,15 +32,27 @@ export const DeleteNamespaceModal: React.FC<DeleteNamespaceModalProps> = ({
   resource,
 }) => {
   const { t } = useTranslation();
-  const [activeNamespace, setActiveNamespace] = useActiveNamespace();
   const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
   const [confirmed, setConfirmed] = React.useState(false);
+
+  /**
+   * This is a workaround because modal launcher renders all modals outside of main app context.
+   * This leads to namespace context not being available in modal so we access the redux store and use settings directly as a workaround.
+   *  */
+  const dispatch = useDispatch();
+  const activeNamespace = useSelector((state: RootState) => getActiveNamespace(state));
+  const [, setLastNamespace] = useUserSettingsCompatibility<string>(
+    LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
+    LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
+  );
+
   const onSubmit = (event) => {
     event.preventDefault();
     handlePromise(k8sKill(kind, resource))
       .then(() => {
         if (resource.metadata.name === activeNamespace) {
-          setActiveNamespace(ALL_NAMESPACES_KEY);
+          dispatch(setActiveNamespace(ALL_NAMESPACES_KEY));
+          setLastNamespace(ALL_NAMESPACES_KEY);
         }
         close?.();
         history.push(`/k8s/cluster/${kind.plural}`);


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-27202
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: When `activeNamespace`was moved to `userSettings` in https://github.com/openshift/console/pull/7433, it was refactored to use a global namespace context. Since modals created by `createModalLauncher` uses `ReactDOM.render` to render the modal in a new context, `delete-namespace-modal` was unable to get the namespace context.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: There's no way to get the actual global `Namespace` context unless we refactor the way modal are being created by `createModalLauncher`. As a workaround, directly fetch `activeNamespace` from redux store and set a new namespace after deletion in redux and user settings.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/119167965-0ce65780-ba7e-11eb-926e-063b2bac8d98.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
