### PR TITLE
Bug 1955803: OperatorHub duplicate item details and empty infraFeatures

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -217,7 +217,7 @@ export const OperatorHubItemDetails: React.FC<OperatorHubItemDetailsProps> = ({
                 value={catalogSourceDisplayName || notAvailable}
               />
               <PropertyItem label={t('olm~Provider')} value={provider || notAvailable} />
-              {infraFeatures && (
+              {!_.isEmpty(infraFeatures) && (
                 <PropertyItem
                   label={t('olm~Infrastructure features')}
                   value={mappedInfraFeatures}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -80,8 +80,8 @@ export const OperatorHubList: React.FC<OperatorHubListProps> = ({
               );
             },
           );
-          const filteredInfraFeatures = _.compact(
-            _.map(parsedInfraFeatures, (key) => InfraFeatures[key]),
+          const filteredInfraFeatures = _.uniq(
+            _.compact(_.map(parsedInfraFeatures, (key) => InfraFeatures[key])),
           );
 
           const {


### PR DESCRIPTION
As pointed out by @yapei on the support release-4.7 PR, there are
two remaining issues with the infrastructure features filter and display
values:

1. There are duplicate items listed under `Infrastructure Features` on the operator item details page
2. For operators with no infrastructure features (such as `Kubestone`), we need to hide the section

Follow up to original PR in master: https://github.com/openshift/console/pull/8844

https://bugzilla.redhat.com/show_bug.cgi?id=1955803

### Before:
<img width="274" alt="before1" src="https://user-images.githubusercontent.com/21317056/119191141-43a37a00-ba4c-11eb-83a6-0bb87dc01b4d.png">
<img width="712" alt="before" src="https://user-images.githubusercontent.com/21317056/119191127-400ff300-ba4c-11eb-82c9-7135e61a3a14.png">

### After:
<img width="1788" alt="Screen Shot 2021-05-21 at 3 30 25 PM" src="https://user-images.githubusercontent.com/21317056/119191230-58800d80-ba4c-11eb-80db-b6f9d9161add.png">
<img width="1792" alt="Screen Shot 2021-05-21 at 3 32 35 PM" src="https://user-images.githubusercontent.com/21317056/119191233-59b13a80-ba4c-11eb-9a5f-ed13f574f39e.png">
