### PR TITLE
adjust styles of add page and getting started to align with UX

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.scss
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.scss
@@ -1,4 +1,10 @@
 .ocs-getting-started-card {
+  .pf-c-simple-list__item-link {
+    --pf-c-simple-list__item-link--focus--FontWeight: normal;
+    --pf-c-simple-list__item-link--active--FontWeight: normal;
+    --pf-c-simple-list__item-link--hover--FontWeight: normal;
+  }
+
   &__title-icon {
     margin-right: var(--pf-global--spacer--sm);
   }
@@ -18,11 +24,14 @@
       > li {
         // Add spacing to the skeleton similar to the SimpleListItem
         .pf-c-skeleton {
-          margin:
-              var(--pf-c-simple-list__item-link--PaddingTop)
-              var(--pf-c-simple-list__item-link--PaddingRight)
-              var(--pf-c-simple-list__item-link--PaddingBottom)
-              var(--pf-c-simple-list__item-link--PaddingLeft);
+          margin: var(--pf-c-simple-list__item-link--PaddingTop)
+            var(--pf-c-simple-list__item-link--PaddingRight)
+            var(--pf-c-simple-list__item-link--PaddingBottom)
+            var(--pf-c-simple-list__item-link--PaddingLeft);
+        }
+
+        a {
+          text-decoration: none;
         }
 
         // Override default style for a:hover, a:focus from scaffolding.scss
@@ -39,7 +48,8 @@
     }
   }
 
-  a > svg, button > svg {
+  a > svg,
+  button > svg {
     margin-left: var(--pf-global--spacer--sm);
   }
 }

--- a/frontend/packages/dev-console/src/components/add/AddCardItem.scss
+++ b/frontend/packages/dev-console/src/components/add/AddCardItem.scss
@@ -1,7 +1,15 @@
 .odc-add-card-item {
+  .pf-c-simple-list__item-link {
+    --pf-c-simple-list__item-link--focus--FontWeight: normal;
+    --pf-c-simple-list__item-link--active--FontWeight: normal;
+    --pf-c-simple-list__item-link--hover--FontWeight: normal;
+  }
+
   margin-top: var(--pf-global--spacer--lg);
+
   &__header {
     margin-left: calc(var(--pf-global--spacer--lg) - var(--pf-global--spacer--sm));
+
     &__icon {
       display: inline;
       vertical-align: middle;
@@ -13,6 +21,7 @@
       font-size: var(--pf-global--FontSize--md);
       margin-left: var(--pf-global--spacer--sm);
     }
+
     &__title {
       display: inline;
       vertical-align: middle;
@@ -20,21 +29,29 @@
       // temporary fix since --pf-global--FontSize--md is being computed to 14px instead of 16px
       font-size: var(--pf-global--spacer--md) !important;
     }
-    &:hover {
-      color: var(--pf-global--link--Color);
-      .odc-add-card-item__header__title {
-        color: var(--pf-global--link--Color);
+
+    a.pf-c-simple-list__item-link {
+      &:hover .odc-add-card-item__header__title {
+        color: var(--pf-c-simple-list__item-link--hover--Color);
+      }
+      &:focus .odc-add-card-item__header__title {
+        color: var(--pf-c-simple-list__item-link--focus--Color);
+      }
+      &:active .odc-add-card-item__header__title {
+        color: var(--pf-c-simple-list__item-link--active--Color);
       }
     }
   }
+
   &__description {
-    margin: var(--pf-global--spacer--sm) 0px 0px var(--pf-global--spacer--lg);
+    margin: var(--pf-global--spacer--sm) 0 0 var(--pf-global--spacer--sm);
     color: var(--pf-global--Color--200);
     // temporary fix since --pf-global--FontSize--sm is being computed to 13px instead of 14px
     font-size: var(--pf-global--FontSize--md);
   }
 
   a {
-    padding-left: 0px;
+    padding-left: 0;
+    text-decoration: none;
   }
 }

--- a/frontend/packages/dev-console/src/components/add/AddCardItem.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddCardItem.tsx
@@ -60,12 +60,12 @@ const AddCardItem: React.FC<AddCardItemProps> = ({
         <Title headingLevel="h5" size="md" className="odc-add-card-item__header__title">
           {label}
         </Title>
+        {showDetails && (
+          <Text className="odc-add-card-item__description" data-test-id="odc-add-card-item-desc">
+            {description}
+          </Text>
+        )}
       </SimpleListItem>
-      {showDetails && (
-        <Text className="odc-add-card-item__description" data-test-id="odc-add-card-item-desc">
-          {description}
-        </Text>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
**Fixes**: 
Addresses UX changes related to story: https://issues.redhat.com/browse/ODC-5561
and PF issue: https://github.com/patternfly/patternfly/issues/4085

**Analysis / Root cause**: 
UX change request to include details in add page cards on hover.
Also addresses styling issue in PF related to https://github.com/patternfly/patternfly/issues/4085

**Solution Description**: 
Override styles.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Focus and hover states:
![image](https://user-images.githubusercontent.com/14068621/119202571-17452900-ba5f-11eb-9373-39e40750d86c.png)
![image](https://user-images.githubusercontent.com/14068621/119202594-21672780-ba5f-11eb-8b9f-7e0020ff11a9.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [x] Safari
- [x] Edge

cc @nemesis09 @jerolimov 

@gdoyle1 please approve UX