### PR TITLE
Bug 1963211: Kubevirt i18n typo

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -565,7 +565,7 @@
   "Restore": "Restore",
   "Support for this template is provided through the OS community Red Hat participates in and contributes to.": "Support for this template is provided through the OS community Red Hat participates in and contributes to.",
   "Learn more about the community": "Learn more about the community",
-  "This template is provided by Red Hat, but is not supported ": "This template is provided by Red Hat, but is not supported ",
+  "This template is provided by Red Hat, but is not supported": "This template is provided by Red Hat, but is not supported",
   "The support level is not defined in the template yaml. To mark this template as supported, add these two annotations in the template details:": "The support level is not defined in the template yaml. To mark this template as supported, add these two annotations in the template details:",
   "Do not show this message again": "Do not show this message again",
   "Continue": "Continue",

--- a/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/support-modal/support-modal.tsx
@@ -57,7 +57,7 @@ const SupportModal: React.FC<SupportModalProps> = ({
           ) : isCommonTemplate ? (
             <>
               <StackItem>
-                {t('kubevirt-plugin~This template is provided by Red Hat, but is not supported ')}
+                {t('kubevirt-plugin~This template is provided by Red Hat, but is not supported')}{' '}
                 <ExternalLink href={SUPPORT_URL} text={t('kubevirt-plugin~Learn more')} />
               </StackItem>
             </>


### PR DESCRIPTION
"This template is provided by Red Hat, But is not supported " should be "This template is provided by Red Hat, but is not supported"

Signed-off-by: yaacov <kobi.zamir@gmail.com>