### PR TITLE
Bug 1963676: Vm wizard choose os not template

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -334,8 +334,6 @@
   "Start this virtual machine after creation": "Start this virtual machine after creation",
   "This template does not have a boot source. Provide a custom boot source for this <2>{{name}}</2> virtual machine.": "This template does not have a boot source. Provide a custom boot source for this <2>{{name}}</2> virtual machine.",
   "Project ": "Project ",
-  "Type ": "Type ",
-  "Flavor ": "Flavor ",
   "Storage ": "Storage ",
   "All projects": "All projects",
   "Select a template": "Select a template",

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/tabs/select-template.tsx
@@ -33,9 +33,7 @@ import { SearchIcon } from '@patternfly/react-icons';
 import { createProjectModal } from '@console/internal/components/modals';
 import { BOOT_SOURCE_AVAILABLE, BOOT_SOURCE_REQUIRED } from '../../../constants';
 import { usePinnedTemplates } from '../../../hooks/use-pinned-templates';
-import { getWorkloadProfile } from '../../../selectors/vm';
 import {
-  getTemplateFlavorData,
   getTemplateOperatingSystems,
   getTemplateSizeRequirementInBytes,
 } from '../../../selectors/vm-template/advanced';
@@ -78,7 +76,6 @@ export const TemplateTile: React.FC<TemplateTileProps> = ({
   const [template] = templateItem.variants;
 
   const osName = getTemplateOperatingSystems(templateItem.variants)?.[0]?.name;
-  const workloadProfile = getWorkloadProfile(template) || t('kubevirt-plugin~Not available');
   const provider = getTemplateProvider(t, template, true);
   const storage = getTemplateSizeRequirementInBytes(template, sourceStatus);
   const storageLable = storage
@@ -118,17 +115,6 @@ export const TemplateTile: React.FC<TemplateTileProps> = ({
             <StackItem>
               <b>{t('kubevirt-plugin~Project ')}</b>
               {template.metadata.namespace}
-            </StackItem>
-            <StackItem>
-              <b>{t('kubevirt-plugin~Type ')}</b>
-              {workloadProfile}
-            </StackItem>
-            <StackItem>
-              <b>{t('kubevirt-plugin~Flavor ')}</b>
-              {t(
-                'kubevirt-plugin~{{flavor}}: {{count}} CPU | {{memory}} Memory',
-                getTemplateFlavorData(template),
-              )}
             </StackItem>
             <StackItem>
               <b>{t('kubevirt-plugin~Storage ')}</b>


### PR DESCRIPTION
Problem:
In current flow, user choose the template + flavor in the first step
but are only given one flavor for each template family, users don't
know they can choose the flavor in the next step.

Solution:
Let user only select the template in the first step and choose the flavor in the next step.

Screenshots:
Before
![screenshot-localhost_9000-2021 05 23-15_30_10](https://user-images.githubusercontent.com/2181522/119260935-babc4800-bbdd-11eb-9edc-11d7c3d941a2.png)

After
![screenshot-localhost_9000-2021 05 23-15_29_33](https://user-images.githubusercontent.com/2181522/119260934-b98b1b00-bbdd-11eb-91e2-1e0a6f3f7ae2.png)

Signed-off-by: yaacov <kobi.zamir@gmail.com>