### PR TITLE
Bug 1957982: Make disabled action items not clickable and focusable

### DIFF
--- a/frontend/packages/console-shared/src/components/kebab/KebabItem.tsx
+++ b/frontend/packages/console-shared/src/components/kebab/KebabItem.tsx
@@ -35,6 +35,7 @@ const KebabItemButton: React.FC<KebabItemProps & { isAllowed: boolean }> = ({
       // eslint-disable-next-line jsx-a11y/no-autofocus
       autoFocus={autoFocus}
       onKeyDown={onEscape && handleEscape}
+      disabled={disabled}
       data-test-action={option.id}
     >
       {option.icon && <span className="oc-kebab__icon">{option.icon}</span>}

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -92,6 +92,7 @@ const KebabItem_: React.FC<KebabItemProps & { isAllowed: boolean }> = ({
       onClick={(e) => !disabled && onClick(e, option)}
       autoFocus={autoFocus}
       onKeyDown={onEscape && handleEscape}
+      disabled={disabled}
       data-test-action={option.labelKey ? t(option.labelKey, option.labelKind) : option.label}
     >
       {option.icon && <span className="oc-kebab__icon">{option.icon}</span>}
@@ -159,11 +160,17 @@ const KebabSubMenu: React.FC<KebabSubMenuProps> = ({ option, onClick }) => {
         }}
         reference={referenceCb}
       >
-        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+        <FocusTrap
+          focusTrapOptions={{
+            clickOutsideDeactivates: true,
+            fallbackFocus: () => subMenuRef.current, // fallback to popover content wrapper div if there are no tabbable elements
+          }}
+        >
           <div
             ref={subMenuCbRef}
             role="presentation"
             className="pf-c-dropdown pf-m-expanded"
+            tabIndex={-1}
             onMouseLeave={(e) => {
               // only close the sub menu if the mouse does not enter the item
               if (!nodeRef.current || !nodeRef.current.contains(e.relatedTarget as Node)) {
@@ -445,6 +452,8 @@ export class Kebab extends React.Component<any, { active: boolean }> {
 
   private dropdownElement = React.createRef<HTMLButtonElement>();
 
+  private divElement = React.createRef<HTMLDivElement>();
+
   constructor(props) {
     super(props);
     this.state = {
@@ -497,6 +506,8 @@ export class Kebab extends React.Component<any, { active: boolean }> {
 
   getPopperReference = () => this.dropdownElement.current;
 
+  getDivReference = () => this.divElement.current;
+
   render() {
     const { options, isDisabled } = this.props;
 
@@ -533,9 +544,13 @@ export class Kebab extends React.Component<any, { active: boolean }> {
           reference={this.getPopperReference}
         >
           <FocusTrap
-            focusTrapOptions={{ clickOutsideDeactivates: true, returnFocusOnDeactivate: false }}
+            focusTrapOptions={{
+              clickOutsideDeactivates: true,
+              returnFocusOnDeactivate: false,
+              fallbackFocus: this.getDivReference, // fallback to popover content wrapper div if there are no tabbable elements
+            }}
           >
-            <div className="pf-c-dropdown pf-m-expanded">
+            <div ref={this.divElement} className="pf-c-dropdown pf-m-expanded" tabIndex={-1}>
               <KebabMenuItems
                 options={menuOptions}
                 onClick={this.onClick}


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/ODC-3045
- https://issues.redhat.com/browse/OCPBUGSM-28886
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The disabled action items in action menus were still clickable and focusable which gave a false sense that clicking on the action would work. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Disable the action item button so that it is not clickable or focusable.
- Send a fallback element to the focus trap when there are no tabbable elements. 
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Before - 

https://user-images.githubusercontent.com/6041994/119333445-7d23f180-bca7-11eb-92ff-c652a32c2f85.mov

After - 

https://user-images.githubusercontent.com/6041994/119333460-82813c00-bca7-11eb-80e9-55fad2094224.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
