### PR TITLE
Fix scrollbar height issue in pod terminal

### DIFF
--- a/frontend/public/components/_terminal.scss
+++ b/frontend/public/components/_terminal.scss
@@ -1,4 +1,4 @@
-@import "~xterm/css/xterm.css";
+@import '~xterm/css/xterm.css';
 
 $console-z-index: $zindex-navbar-fixed + 20;
 $console-collapse-link-z-index: $console-z-index + 20;
@@ -19,15 +19,18 @@ $console-collapse-link-z-index: $console-z-index + 20;
   padding: 0;
   background-color: $color-pf-black;
   position: relative;
+  > .terminal {
+    height: 100%;
+  }
 }
 
 .console-collapse-link.pf-c-button {
-  background:rgba(0, 0, 0, 0.75) !important;
+  background: rgba(0, 0, 0, 0.75) !important;
   color: $color-pf-blue-300;
   position: fixed;
   right: 18px;
   top: 4px;
-  z-index: $console-collapse-link-z-index;  // in fullscreen mode, to get above console's z-index
+  z-index: $console-collapse-link-z-index; // in fullscreen mode, to get above console's z-index
 }
 
 .default-overflow {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5631
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Scrollbar height in pod terminal didn't match the height of the terminal.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Override the xterm terminal height to always be 100% of the terminal wrapper.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Before -

https://user-images.githubusercontent.com/6041994/119336309-24eeee80-bcab-11eb-84ce-3e8ee3bd96b2.mov

After -

https://user-images.githubusercontent.com/6041994/119336363-37692800-bcab-11eb-8800-d5d5de36320e.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
