### PR TITLE
Bug 1963896: Add PVC link to disk table

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -6,8 +6,9 @@ import {
   Kebab,
   KebabOption,
   LoadingInline,
+  ResourceLink,
 } from '@console/internal/components/utils';
-import { TemplateModel } from '@console/internal/models';
+import { TemplateModel, PersistentVolumeClaimModel } from '@console/internal/models';
 import { DASH, dimensifyRow, getDeletetionTimestamp } from '@console/shared';
 
 import { PENDING_RESTART_LABEL } from '../../constants';
@@ -108,7 +109,7 @@ export type VMDiskSimpleRowProps = {
 };
 
 export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
-  data: { name, source, size, diskInterface, storageClass, type },
+  data: { name, source, size, diskInterface, storageClass, type, disk },
   validation = {},
   columnClasses,
   actionsComponent,
@@ -120,6 +121,17 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
 
   const isSizeLoading = size === undefined;
   const isStorageClassLoading = size === undefined;
+  const pvcName = disk?.persistentVolumeClaimWrapper?.getName();
+  const pvcNamespace = disk?.persistentVolumeClaimWrapper?.getNamespace();
+  const pvcLink = pvcName && pvcNamespace && (
+    <ResourceLink
+      inline
+      kind={PersistentVolumeClaimModel.kind}
+      name={pvcName}
+      namespace={pvcNamespace}
+    />
+  );
+
   return (
     <TableRow id={name} index={index} trKey={name} style={style}>
       <TableData className={dimensify()}>
@@ -131,7 +143,7 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
         </ValidationCell>
       </TableData>
       <TableData className={dimensify()}>
-        <ValidationCell validation={validation.source}>{source || DASH}</ValidationCell>
+        <ValidationCell validation={validation.source}>{pvcLink || source || DASH}</ValidationCell>
       </TableData>
       <TableData className={dimensify()}>
         {isSizeLoading && <LoadingInline />}
@@ -182,7 +194,7 @@ export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
   const isPendingRestart = !!pendingChangesDisks?.has(restData.name);
   return (
     <DiskSimpleRow
-      data={restData}
+      data={{ disk, ...restData }}
       validation={
         diskValidations && {
           name: diskValidations.validations.name,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -8,6 +8,7 @@ import { VMLikeEntityKind } from '../../types/vmLike';
 import { TemplateValidations } from '../../utils/validations/template/template-validations';
 
 export type StorageSimpleData = {
+  disk?: CombinedDisk;
   name?: string;
   content?: string;
   source?: string;
@@ -28,7 +29,6 @@ export type StorageSimpleDataValidation = {
 };
 
 export type StorageBundle = StorageSimpleData & {
-  disk: CombinedDisk;
   templateValidations?: TemplateValidations;
   diskValidations?: UIStorageValidation;
   type?: DiskType;


### PR DESCRIPTION
Problem:
No quick way to get the PVC from the VM disks table

Solution:
Add a link to PVC when applicatble

Screenshots:
Before
![screenshot-console-openshift-console apps uit-01 cnv-qe rhcloud com-2021 05 24-13_46_42](https://user-images.githubusercontent.com/2181522/119336796-bd2ea880-bc96-11eb-9497-e82850679141.png)

After
![screenshot-localhost_9000-2021 05 24-13_46_29](https://user-images.githubusercontent.com/2181522/119336798-be5fd580-bc96-11eb-8319-c1c41bc8814c.png)


Signed-off-by: yaacov <kobi.zamir@gmail.com>