### PR TITLE
Fix the alignment of success ratio and pipeline run count chart

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineSuccessRatioDonut.tsx
@@ -99,10 +99,16 @@ const PipelineSuccessRatioDonut: React.FC<PipelineMetricsGraphProps> = ({
   }
   const successValue = _.find(finalArray, { x: 'success' })?.['count'] ?? 0;
   const successData = _.sortBy(finalArray, 'sortOrder');
+  const OVERLAP = 20;
   return (
     <Grid hasGutter>
       <GridItem xl2={3} xl={3} lg={3} md={3} sm={3}>
-        <div style={{ height: DEFAULT_CHART_HEIGHT }}>
+        <div
+          style={{
+            height: DEFAULT_CHART_HEIGHT,
+            marginTop: OVERLAP * -1,
+          }}
+        >
           <SuccessRatioDonut
             data={successData}
             successValue={successValue}


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5627

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
The number of pipeline runs graph shrinks so it isn't aligned with pipeline success ratio graph once there are data points.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added a missing negative margin in donut chart which is present in the adjacent chart (success percentage chart) in the first card.
 
**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/9964343/119354392-acdff300-bcc1-11eb-855f-82d7a23dec6c.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @bgliwa01 @andrewballantyne 