### PR TITLE
Bug 1963213: Fixed bug in Memsource download script

### DIFF
--- a/frontend/i18n-scripts/README.md
+++ b/frontend/i18n-scripts/README.md
@@ -15,7 +15,7 @@ Memsource, the tool the Red Hat Globalization team uses for translation jobs.
 Before running either tool, you must first install the [unofficial Memsource CLI client](https://github.com/unofficial-memsource/memsource-cli-client#pip-install).
 You also have to [configure it with your Memsource login info](https://github.com/unofficial-memsource/memsource-cli-client#configuration-red-hat-enterprise-linux-derivatives).
 
-Example CLI usage for upload script: `yarn memsource-upload -v 4.8 -s "200"`
+Example CLI usage for upload script: `yarn memsource-upload -v 4.8 -s 200`
 * -v is the current OpenShift version
 * -s is the current sprint number
 

--- a/frontend/i18n-scripts/memsource-download.sh
+++ b/frontend/i18n-scripts/memsource-download.sh
@@ -30,12 +30,12 @@ DOWNLOAD_PATH="$(mktemp -d)" || { echo "Failed to create temp folder"; exit 1; }
 for i in "${LANGUAGES[@]}"
 do
   COUNTER=0
-  CURRENT_PAGE=$(memsource job list --project-id "$PROJECT_ID" --target-lang "$i" -f value --page-number 0 -c uid | tr '\n' ' ')
+  CURRENT_PAGE=( $(memsource job list --project-id "$PROJECT_ID" --target-lang "$i" -f value --page-number 0 -c uid) )
   until [ -z "$CURRENT_PAGE" ]
   do
     ((COUNTER++))
     echo Downloading page "$COUNTER"
-    memsource job download --project-id "$PROJECT_ID" --output-dir "$DOWNLOAD_PATH/$i" --job-id "$CURRENT_PAGE"
+    memsource job download --project-id "$PROJECT_ID" --output-dir "$DOWNLOAD_PATH/$i" --job-id "${CURRENT_PAGE[@]}"
     CURRENT_PAGE=$(memsource job list --project-id "$PROJECT_ID" --target-lang "$i" -f value --page-number "$COUNTER" -c uid | tr '\n' ' ')
   done
 done
@@ -57,4 +57,4 @@ git add public/locales
 git add packages/**/locales
 git commit -m "chore(i18n): update translations
 
-Adding latest translations from Memsource project #$PROJECT_ID"
+Adding latest translations from Memsource project https://cloud.memsource.com/web/project2/show/$PROJECT_ID"


### PR DESCRIPTION
Quotes prevented the Memsource CLI tool from correctly reading the job information, leading to an API error. I also made a tiny docs update.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1963213.