### PR TITLE
Bug 1957756: Missing already replaced condition in disk modal

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -310,6 +310,7 @@
   "Go To Pvc List": "Go To Pvc List",
   "Edit Block Pool": "Edit Block Pool",
   "Block Pool Update Form": "Block Pool Update Form",
+  "replacement disallowed: disk {{diskName}} is {{replacingDiskStatus}}": "replacement disallowed: disk {{diskName}} is {{replacingDiskStatus}}",
   "replacement disallowed: disk {{diskName}} is {{replacementStatus}}": "replacement disallowed: disk {{diskName}} is {{replacementStatus}}",
   "Disk Replacement": "Disk Replacement",
   "This action will start preparing the disk for replacement.": "This action will start preparing the disk for replacement.",

--- a/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/ocs-kebab-options.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/ocs-kebab-options.tsx
@@ -3,12 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { TableData } from '@console/internal/components/factory';
 import { KebabOption, Kebab } from '@console/internal/components/utils';
 import { DiskMetadata } from 'packages/local-storage-operator-plugin/src/components/disks-list/types';
-import { OCSDiskList, OCSColumnStateAction } from './state-reducer';
+import { OCSColumnStateAction, OCSColumnState } from './state-reducer';
 import { diskReplacementModal } from '../modals/disk-replacement-modal';
 
 export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
-  ({ nodeName, disk, alertsMap, replacementMap, isRebalancing, dispatch }) => {
+  ({ nodeName, disk, ocsState, dispatch }) => {
     const { t } = useTranslation();
+
+    const { alertsMap } = ocsState;
 
     const kebabOptions: KebabOption[] = [
       {
@@ -18,9 +20,7 @@ export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
           diskReplacementModal({
             nodeName,
             disk,
-            alertsMap,
-            replacementMap,
-            isRebalancing,
+            ocsState,
             dispatch,
           }),
       },
@@ -29,7 +29,7 @@ export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
     return (
       <TableData className={Kebab.columnClass}>
         {/* Enables the options for the disk with failures */}
-        <Kebab options={kebabOptions} isDisabled={!alertsMap[disk.path]} />
+        <Kebab options={kebabOptions} isDisabled={alertsMap?.[disk.path]?.node !== nodeName} />
       </TableData>
     );
   },
@@ -38,8 +38,6 @@ export const OCSKebabOptions: React.FC<OCSKebabOptionsProps> = React.memo(
 type OCSKebabOptionsProps = {
   disk: DiskMetadata;
   nodeName: string;
-  alertsMap: OCSDiskList;
-  replacementMap: OCSDiskList;
-  isRebalancing: boolean;
+  ocsState: OCSColumnState;
   dispatch: React.Dispatch<OCSColumnStateAction>;
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/state-reducer.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/disk-inventory/state-reducer.ts
@@ -5,7 +5,8 @@ export enum ActionType {
   SET_TEMPLATES_MAP = 'SET_TEMPLATES_MAP',
   SET_METRICS_MAP = 'SET_METRICS_MAP',
   SET_IS_REBALANCING = 'SET_IS_REBALANCING',
-  SET_REPLACEMENT_MAP = 'SET_REPLACEMENT_MAP',
+  SET_REPLACED_DISK_LIST = 'SET_REPLACED_DISK_LIST',
+  SET_REPLACING_DISK_LIST = 'SET_REPLACING_DISK_LIST',
 }
 
 export enum Status {
@@ -43,7 +44,8 @@ export const initialState: OCSColumnState = {
   metricsMap: {},
   alertsMap: {},
   isRebalancing: false,
-  replacementMap: {},
+  replacedDiskList: [],
+  replacingDiskList: [],
 };
 
 export const reducer = (state: OCSColumnState, action: OCSColumnStateAction) => {
@@ -60,16 +62,22 @@ export const reducer = (state: OCSColumnState, action: OCSColumnStateAction) => 
         metricsMap: action.payload,
       };
     }
-    case ActionType.SET_REPLACEMENT_MAP: {
+    case ActionType.SET_REPLACED_DISK_LIST: {
       return {
         ...state,
-        replacementMap: action.payload,
+        replacedDiskList: action.payload,
       };
     }
     case ActionType.SET_IS_REBALANCING: {
       return {
         ...state,
         isRebalancing: action.payload,
+      };
+    }
+    case ActionType.SET_REPLACING_DISK_LIST: {
+      return {
+        ...state,
+        replacingDiskList: action.payload,
       };
     }
     default:
@@ -80,22 +88,34 @@ export const reducer = (state: OCSColumnState, action: OCSColumnStateAction) => 
 export type OCSColumnStateAction =
   | { type: ActionType.SET_ALERTS_MAP; payload: OCSDiskList }
   | { type: ActionType.SET_METRICS_MAP; payload: OCSDiskList }
-  | { type: ActionType.SET_REPLACEMENT_MAP; payload: OCSDiskList }
-  | { type: ActionType.SET_IS_REBALANCING; payload: boolean };
+  | { type: ActionType.SET_REPLACED_DISK_LIST; payload: ReplacedDisk[] }
+  | { type: ActionType.SET_IS_REBALANCING; payload: boolean }
+  | {
+      type: ActionType.SET_REPLACING_DISK_LIST;
+      payload: {
+        id: string;
+        path: string;
+        serial: string;
+      }[];
+    };
 
 export type OCSColumnState = {
   metricsMap: OCSDiskList;
   alertsMap: OCSDiskList;
   isRebalancing: boolean;
-  replacementMap: ReplacementMap;
+  replacedDiskList: ReplacedDisk[];
+  replacingDiskList: {
+    id: string;
+    path: string;
+    serial: string;
+  }[];
 };
 
-export type ReplacementMap = OCSDiskList & {
-  [diskName: string]: OCSDiskMetadata & {
-    disk: {
-      id: string;
-      serial: string;
-    };
+export type ReplacedDisk = OCSDiskMetadata & {
+  disk: {
+    id: string;
+    path: string;
+    serial: string;
   };
 };
 
@@ -105,7 +125,7 @@ export type OCSDiskList = {
 
 export type OCSDiskStatus = keyof typeof Status;
 
-export type OCSDiskMetadata = { osd: string; status: OCSDiskStatus };
+export type OCSDiskMetadata = { osd: string; status: OCSDiskStatus; node: string };
 
 export type AlertsDiskMap = {
   [disk: string]: string;


### PR DESCRIPTION
The PR #8880 added checking for a replaced disk in list page but we missed out adding in disk replacement modal as well.
This PR adds that  same condition only.
Edit:

While fixing this I found on the test setup we can have more templates on same node, hence changed existing data structure from map (`replacementMap`) to array (`replacedDiskList`)