### PR TITLE
fixes terminal loading screen height on safari

### DIFF
--- a/frontend/packages/console-shared/src/components/drawer/Drawer.scss
+++ b/frontend/packages/console-shared/src/components/drawer/Drawer.scss
@@ -31,6 +31,7 @@
     position: relative;
     flex-grow: 1;
     overflow: auto;
+    height: 100%;
   }
 
   &-appear {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4128

**Solution Description**: 
on safari loading screen height for web terminal was not full, added 100% height to the parent to fix it.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/5129024/119456573-6d181a80-bd58-11eb-9625-47c14c41a430.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge
