### PR TITLE
Bug 1908169: The example of Import URL is "Fedora cloud image list" for all templates.

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -387,6 +387,7 @@
   "Example: {{container}}": "Example: {{container}}",
   "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image": "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image",
   "Example: For Windows, visit the <2><0>Windows 10 cloud image</0></2> and copy the download link URL for the cloud base image": "Example: For Windows, visit the <2><0>Windows 10 cloud image</0></2> and copy the download link URL for the cloud base image",
+  "Example: For Centos, visit the <2><0>Centos cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For Centos, visit the <2><0>Centos cloud image list</0></2> and copy the download link URL for the cloud base image",
   "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image",
   "Selected {{name}} is not available": "Selected {{name}} is not available",
   "{{title}} size": "{{title}} size",

--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { FEDORA_IMAGE_LINK, RHEL_IMAGE_LINK, WINDOWS_IMAGE_LINK } from '../../../utils/strings';
+import {
+  CENTOS_IMAGE_LINK,
+  FEDORA_IMAGE_LINK,
+  RHEL_IMAGE_LINK,
+  WINDOWS_IMAGE_LINK,
+} from '../../../utils/strings';
 
 type URLSourceHelpProps = {
   baseImageName: string;
@@ -26,6 +31,16 @@ export const URLSourceHelp: React.FC<URLSourceHelpProps> = ({ baseImageName }) =
       <strong>
         <a href={WINDOWS_IMAGE_LINK} rel="noopener noreferrer" target="_blank">
           Windows 10 cloud image
+        </a>
+      </strong>{' '}
+      and copy the download link URL for the cloud base image
+    </Trans>
+  ) : baseImageName?.includes('centos') ? (
+    <Trans t={t} ns="kubevirt-plugin">
+      Example: For Centos, visit the{' '}
+      <strong>
+        <a href={CENTOS_IMAGE_LINK} rel="noopener noreferrer" target="_blank">
+          Centos cloud image list
         </a>
       </strong>{' '}
       and copy the download link URL for the cloud base image

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -24,6 +24,7 @@ export const SSH = 'ssh';
 
 export const EXAMPLE_CONTAINER = 'registry.redhat.io/rhel8/rhel-guest-image';
 export const FEDORA_EXAMPLE_CONTAINER = 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest';
+export const CENTOS_IMAGE_LINK = 'https://cloud.centos.org/centos/';
 export const FEDORA_IMAGE_LINK = 'https://alt.fedoraproject.org/cloud/';
 export const RHEL_IMAGE_LINK =
   'https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.2/x86_64/product-software';


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1908169#c16

**Analysis / Root cause**: 
Centos templates shows "Fedora cloud image list" link instead of "Centos cloud image list" when boot source is "import via URL"

**Solution Description**: 
Adding Centos cloud image list

**Screen shots / Gifs for design review**: 
Before:

![Screenshot from 2021-05-25 12-13-17](https://user-images.githubusercontent.com/67270715/119472202-b5343e80-bd52-11eb-8beb-89f6f6cd2536.png)

After:

![Screenshot from 2021-05-25 11-40-58](https://user-images.githubusercontent.com/67270715/119472215-b7969880-bd52-11eb-8161-821950fd66f4.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>