### PR TITLE
fix kafka connections topology sidebar heading

### DIFF
--- a/frontend/packages/rhoas-plugin/locales/en/rhoas-plugin.json
+++ b/frontend/packages/rhoas-plugin/locales/en/rhoas-plugin.json
@@ -50,7 +50,6 @@
   "Create a Kafka connector": "Create a Kafka connector",
   "Create a binding connector": "Create a binding connector",
   "No data": "No data",
-  "Kafka Connection": "Kafka Connection",
   "Cloud Service": "Cloud Service",
   "This resource represents service that exist outside your cluster": "This resource represents service that exist outside your cluster",
   "Details": "Details",

--- a/frontend/packages/rhoas-plugin/src/topology/components/KafkaNode.tsx
+++ b/frontend/packages/rhoas-plugin/src/topology/components/KafkaNode.tsx
@@ -12,6 +12,7 @@ import {
 import { calculateRadius } from '@console/shared';
 import { RootState } from '@console/internal/redux';
 import { getServiceBindingStatus } from '@console/topology/src/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
 import { KafkaConnectionModel } from '../../models';
 import { kafkaIcon } from '../../const';
 import TrapezoidBaseNode from './TrapezoidBaseNode';
@@ -57,7 +58,7 @@ const KafkaNode: React.FC<KafkaNodeProps> = ({
       icon={kafkaIcon}
       innerRadius={iconRadius}
       selected={selected}
-      kind={KafkaConnectionModel.kind}
+      kind={referenceForModel(KafkaConnectionModel)}
       element={element}
       outerRadius={radius}
       {...props}

--- a/frontend/packages/rhoas-plugin/src/topology/components/TopologyKafkaPanel.tsx
+++ b/frontend/packages/rhoas-plugin/src/topology/components/TopologyKafkaPanel.tsx
@@ -1,10 +1,17 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 import { Node } from '@patternfly/react-topology';
 import * as UIActions from '@console/internal/actions/ui';
-import { navFactory, SimpleTabNav } from '@console/internal/components/utils';
+import {
+  navFactory,
+  ResourceIcon,
+  resourcePath,
+  SimpleTabNav,
+} from '@console/internal/components/utils';
 import { ResourcesComponent } from './ResourceComponent';
 import { DetailsComponent } from './DetailsComponent';
 
@@ -49,12 +56,25 @@ export const ConnectedTopologyRhoasPanel: React.FC<TopologyRhoasPanelProps> = ({
     setShowAlert(false);
   };
 
+  const kindRef = referenceFor(akc);
+  const kindObj = modelFor(kindRef);
+
   return (
     <div className="overview__sidebar-pane resource-overview">
       <div className="overview__sidebar-pane-head resource-overview__heading">
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name co-resource-item">
-            <h3>{t('rhoas-plugin~Kafka Connection')}</h3>
+            <ResourceIcon className="co-m-resource-icon--lg" kind={kindRef} />
+            <Link
+              to={resourcePath(
+                kindObj.crd ? kindRef : akc.kind,
+                akc.metadata.name,
+                akc.metadata.namespace,
+              )}
+              className="co-resource-item__resource-name"
+            >
+              {akc.metadata.name}
+            </Link>
           </div>
         </h1>
         {showAlert && (


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-5848

This PR fixes the topology sidebar heading for the Kafka connection. Added ResourceIcon and Link for resource in the heading that was missing earlier.

Screenshot:
<img width="1115" alt="Screenshot 2021-05-25 at 4 53 23 PM" src="https://user-images.githubusercontent.com/9278015/119490089-0dcb0200-bd7a-11eb-846e-1554af8ccc11.png">
