### PR TITLE
Bug 1964997: Removing library charts from the merged helm repo index entries.

### DIFF
--- a/pkg/helm/chartproxy/proxy.go
+++ b/pkg/helm/chartproxy/proxy.go
@@ -87,12 +87,14 @@ func (p *proxy) IndexFile(onlyCompatible bool) (*repo.IndexFile, error) {
 			}
 
 			for key, entry := range idxFile.Entries {
-				if onlyCompatible {
-					for i := len(entry) - 1; i >= 0; i-- {
-						if entry[i].Metadata.KubeVersion != "" && p.kubeVersion != "" {
-							if !chartutil.IsCompatibleRange(entry[i].Metadata.KubeVersion, p.kubeVersion) {
-								entry = append(entry[:i], entry[i+1:]...)
-							}
+				for i := len(entry) - 1; i >= 0; i-- {
+					if entry[i].Type == "library" {
+						entry = append(entry[:i], entry[i+1:]...)
+						continue
+					}
+					if onlyCompatible && entry[i].Metadata.KubeVersion != "" && p.kubeVersion != "" {
+						if !chartutil.IsCompatibleRange(entry[i].Metadata.KubeVersion, p.kubeVersion) {
+							entry = append(entry[:i], entry[i+1:]...)
 						}
 					}
 				}

--- a/pkg/helm/chartproxy/proxy_test.go
+++ b/pkg/helm/chartproxy/proxy_test.go
@@ -91,6 +91,11 @@ func TestProxy_IndexFile(t *testing.T) {
 			mergedFile: "testdata/mergedRepoIndex.yaml",
 		},
 		{
+			name:       "returned merged index file without library chart entries",
+			indexFiles: []string{"testdata/sampleRepoLibrary.yaml"},
+			mergedFile: "testdata/mergedRepoLibrary.yaml",
+		},
+		{
 			name:       "returned merged index contains all entries from source repos - helm names are appended with repo names to avoid duplicate removal",
 			indexFiles: []string{"testdata/sampleRepoIndex2.yaml", "testdata/sampleRepoIndex2.yaml"},
 			mergedFile: "testdata/mergedRepoIndexWithDuplicates.yaml",

--- a/pkg/helm/chartproxy/testdata/mergedRepoLibrary.yaml
+++ b/pkg/helm/chartproxy/testdata/mergedRepoLibrary.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+entries:
+  wildfly--sample-repo-1:
+  - apiVersion: v2
+    appVersion: "23.0"
+    created: "2021-05-03T12:57:36.212993032Z"
+    dependencies:
+    - name: wildfly-common
+      repository: file://../wildfly-common
+      version: 1.3.0
+    description: Build and Deploy WildFly applications on OpenShift
+    digest: e51327acdae164b4a7b940fd97c70e4257e7f26bf40fe4e687a0c6777056b1a3
+    icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark_256px.png
+    maintainers:
+    - email: wildfly-dev@lists.jboss.org
+      name: WildFly
+      url: https://wildfly.org
+    name: wildfly
+    type: application
+    urls:
+    - https://github.com/wildfly/wildfly-charts/releases/download/wildfly-1.3.0/wildfly-1.3.0.tgz
+    version: 1.3.0
+generated: "2021-03-09T10:42:06.703995832Z"

--- a/pkg/helm/chartproxy/testdata/sampleRepoLibrary.yaml
+++ b/pkg/helm/chartproxy/testdata/sampleRepoLibrary.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+entries:
+  wildfly:
+  - apiVersion: v2
+    appVersion: "23.0"
+    created: "2021-05-03T12:57:36.212993032Z"
+    dependencies:
+    - name: wildfly-common
+      repository: file://../wildfly-common
+      version: 1.3.0
+    description: Build and Deploy WildFly applications on OpenShift
+    digest: e51327acdae164b4a7b940fd97c70e4257e7f26bf40fe4e687a0c6777056b1a3
+    icon: https://design.jboss.org/wildfly/logo/final/wildfly_logomark_256px.png
+    maintainers:
+    - email: wildfly-dev@lists.jboss.org
+      name: WildFly
+      url: https://wildfly.org
+    name: wildfly
+    type: application
+    urls:
+    - https://github.com/wildfly/wildfly-charts/releases/download/wildfly-1.3.0/wildfly-1.3.0.tgz
+    version: 1.3.0
+  wildfly-common:
+  - apiVersion: v2
+    appVersion: 1.0.0
+    created: "2021-05-03T12:57:36.326743726Z"
+    description: A library chart for WildFly-based applications
+    digest: 2d843abd1efd54977eabbeb7e14f78b301b5a3bd5100be2c2c1b51c941b9c349
+    name: wildfly-common
+    type: library
+    urls:
+    - https://github.com/wildfly/wildfly-charts/releases/download/wildfly-common-1.3.0/wildfly-common-1.3.0.tgz
+    version: 1.3.0
+generated: "2021-03-09T10:42:06.703995832Z"


### PR DESCRIPTION
Library charts are not installable, removing from the list of charts
available in the catalog.

Partially addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1933101