### PR TITLE
Add tooltips to masthead icons and remove hover state from notification

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
@@ -34,7 +34,7 @@ const ClouldShellMastheadButton: React.FC<Props> = ({ onClick, open }) => {
             ? t('cloudshell~Close command line terminal')
             : t('cloudshell~Open command line terminal')
         }
-        position={TooltipPosition.bottom}
+        position={TooltipPosition.auto}
       >
         <Button
           variant="plain"

--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -6,13 +6,13 @@
   max-width: 140px !important; // PF4 does not limit username length (upstream bug)
   overflow-x: hidden;
   text-overflow: ellipsis;
-  @media(min-width: 855px) {
+  @media (min-width: 855px) {
     max-width: 225px !important;
   }
-  @media(min-width: $screen-md-min) {
+  @media (min-width: $screen-md-min) {
     max-width: 275px !important;
   }
-  @media(min-width: $screen-lg-min) {
+  @media (min-width: $screen-lg-min) {
     max-width: 300px !important;
   }
 }
@@ -33,4 +33,8 @@
     opacity: 1;
     color: var(--pf-global--icon--Color--light);
   }
+}
+
+.pf-c-page__header-tools-item .pf-c-notification-badge.pf-m-read:hover {
+  background-color: transparent;
 }

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -44,15 +44,17 @@ const SystemStatusButton = ({ statuspageData, className }) => {
   const { t } = useTranslation();
   return !_.isEmpty(_.get(statuspageData, 'incidents')) ? (
     <PageHeaderToolsItem className={className}>
-      <a
-        className="pf-c-button pf-m-plain"
-        aria-label={t('public~System status')}
-        href={statuspageData.page.url}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <YellowExclamationTriangleIcon className="co-masthead-icon" />
-      </a>
+      <Tooltip content={t('public~System status')} position={TooltipPosition.auto}>
+        <a
+          className="pf-c-button pf-m-plain"
+          aria-label={t('public~System status')}
+          href={statuspageData.page.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <YellowExclamationTriangleIcon className="co-masthead-icon" />
+        </a>
+      </Tooltip>
     </PageHeaderToolsItem>
   ) : null;
 };
@@ -588,35 +590,39 @@ class MastheadToolbarContents_ extends React.Component {
             {/* desktop -- (application launcher dropdown), import yaml, help dropdown [documentation, about] */}
             {!_.isEmpty(launchActions) && (
               <PageHeaderToolsItem>
-                <ApplicationLauncher
-                  className="co-app-launcher"
-                  data-test-id="application-launcher"
-                  onSelect={this._onApplicationLauncherDropdownSelect}
-                  onToggle={this._onApplicationLauncherDropdownToggle}
-                  isOpen={isApplicationLauncherDropdownOpen}
-                  items={this._renderApplicationItems(this._launchActions())}
-                  data-quickstart-id="qs-masthead-applications"
-                  position="right"
-                  isGrouped
-                />
+                <Tooltip content={t('public~Application launcher')} position={TooltipPosition.auto}>
+                  <ApplicationLauncher
+                    className="co-app-launcher"
+                    data-test-id="application-launcher"
+                    onSelect={this._onApplicationLauncherDropdownSelect}
+                    onToggle={this._onApplicationLauncherDropdownToggle}
+                    isOpen={isApplicationLauncherDropdownOpen}
+                    items={this._renderApplicationItems(this._launchActions())}
+                    data-quickstart-id="qs-masthead-applications"
+                    position="right"
+                    isGrouped
+                  />
+                </Tooltip>
               </PageHeaderToolsItem>
             )}
             {/* desktop -- (notification drawer button) */
             alertAccess && (
               <PageHeaderToolsItem>
-                <NotificationBadge
-                  aria-label={t('public~Notification drawer')}
-                  onClick={drawerToggle}
-                  isRead
-                  count={notificationAlerts?.data?.length || 0}
-                  data-quickstart-id="qs-masthead-notifications"
-                >
-                  <BellIcon alt="" />
-                </NotificationBadge>
+                <Tooltip content={t('public~Notification drawer')} position={TooltipPosition.auto}>
+                  <NotificationBadge
+                    aria-label={t('public~Notification drawer')}
+                    onClick={drawerToggle}
+                    variant="read"
+                    count={notificationAlerts?.data?.length || 0}
+                    data-quickstart-id="qs-masthead-notifications"
+                  >
+                    <BellIcon alt="" />
+                  </NotificationBadge>
+                </Tooltip>
               </PageHeaderToolsItem>
             )}
             <PageHeaderToolsItem>
-              <Tooltip content={t('public~Import YAML')} position={TooltipPosition.bottom}>
+              <Tooltip content={t('public~Import YAML')} position={TooltipPosition.auto}>
                 <Link
                   to={this._getImportYAMLPath()}
                   className="pf-c-button pf-m-plain"
@@ -629,41 +635,45 @@ class MastheadToolbarContents_ extends React.Component {
             </PageHeaderToolsItem>
             <CloudShellMastheadButton />
             <PageHeaderToolsItem>
-              <ApplicationLauncher
-                aria-label={t('public~Help menu')}
-                className="co-app-launcher"
-                data-test="help-dropdown-toggle"
-                data-tour-id="tour-help-button"
-                data-quickstart-id="qs-masthead-help"
-                onSelect={this._onHelpDropdownSelect}
-                onToggle={this._onHelpDropdownToggle}
-                isOpen={isHelpDropdownOpen}
-                items={this._renderApplicationItems(
-                  this._helpActions(
-                    this._getAdditionalActions(
-                      this._getAdditionalLinks(consoleLinks?.data, 'HelpMenu'),
+              <Tooltip content={t('public~Help menu')} position={TooltipPosition.auto}>
+                <ApplicationLauncher
+                  aria-label={t('public~Help menu')}
+                  className="co-app-launcher"
+                  data-test="help-dropdown-toggle"
+                  data-tour-id="tour-help-button"
+                  data-quickstart-id="qs-masthead-help"
+                  onSelect={this._onHelpDropdownSelect}
+                  onToggle={this._onHelpDropdownToggle}
+                  isOpen={isHelpDropdownOpen}
+                  items={this._renderApplicationItems(
+                    this._helpActions(
+                      this._getAdditionalActions(
+                        this._getAdditionalLinks(consoleLinks?.data, 'HelpMenu'),
+                      ),
                     ),
-                  ),
-                )}
-                position="right"
-                toggleIcon={<QuestionCircleIcon alt="" />}
-                isGrouped
-              />
+                  )}
+                  position="right"
+                  toggleIcon={<QuestionCircleIcon alt="" />}
+                  isGrouped
+                />
+              </Tooltip>
             </PageHeaderToolsItem>
           </PageHeaderToolsGroup>
           <PageHeaderToolsGroup>
             {/* mobile -- (notification drawer button) */
             alertAccess && notificationAlerts?.data?.length > 0 && (
               <PageHeaderToolsItem className="visible-xs-block">
-                <NotificationBadge
-                  aria-label={t('public~Notification drawer')}
-                  onClick={drawerToggle}
-                  isRead
-                  count={notificationAlerts?.data?.length}
-                  data-quickstart-id="qs-masthead-notifications"
-                >
-                  <BellIcon />
-                </NotificationBadge>
+                <Tooltip content={t('public~Notification drawer')} position={TooltipPosition.auto}>
+                  <NotificationBadge
+                    aria-label={t('public~Notification drawer')}
+                    onClick={drawerToggle}
+                    variant="read"
+                    count={notificationAlerts?.data?.length}
+                    data-quickstart-id="qs-masthead-notifications"
+                  >
+                    <BellIcon />
+                  </NotificationBadge>
+                </Tooltip>
               </PageHeaderToolsItem>
             )}
             {/* mobile -- (system status button) */}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -613,6 +613,7 @@
   "Import YAML": "Import YAML",
   "Utility menu": "Utility menu",
   "User menu": "User menu",
+  "Application launcher": "Application launcher",
   "Notification drawer": "Notification drawer",
   "Help menu": "Help menu",
   "Add new Users to Group {{name}}.": "Add new Users to Group {{name}}.",


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5746
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Not all the icons in the msthead have tooltips and the notification badge has a hover state..
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Add consistent tooltips to all masthead icons and remove hover state from notification badge.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux @bgliwa01 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/119515185-41feec80-bd93-11eb-98f8-6bdbaa0e2f1d.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
