### PR TITLE
Fix git type dropdown showing while form is submitting 

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -39,7 +39,7 @@ const GitSection: React.FC<GitSectionProps> = ({
 }) => {
   const { t } = useTranslation();
   const inputRef = React.useRef<HTMLInputElement>();
-  const { values, setFieldValue, setFieldTouched, touched, dirty } = useFormikContext<
+  const { values, setFieldValue, setFieldTouched, touched, dirty, isSubmitting } = useFormikContext<
     FormikValues
   >();
   const { url: defaultSampleURL, dir: defaultSampleDir, ref: defaultSampleRef } =
@@ -75,7 +75,7 @@ const GitSection: React.FC<GitSectionProps> = ({
 
       const gitType = gitTypeTouched ? values.git.type : detectGitType(url);
       const gitRepoName = detectGitRepoName(url);
-      const showGitType = gitType === GitTypes.unsure || gitTypeTouched;
+      const showGitType = gitType === GitTypes.unsure || (gitTypeTouched && !isSubmitting);
 
       setFieldValue('git.type', gitType);
       setFieldValue('git.showGitType', showGitType);
@@ -119,17 +119,18 @@ const GitSection: React.FC<GitSectionProps> = ({
       }
     },
     [
-      buildStrategy,
-      gitTypeTouched,
-      nameTouched,
-      setFieldTouched,
       setFieldValue,
-      values.application.name,
-      values.application.selectedKey,
-      values.formType,
+      gitTypeTouched,
       values.git.type,
       values.name,
+      values.formType,
+      values.application.name,
+      values.application.selectedKey,
       values.devfile,
+      isSubmitting,
+      setFieldTouched,
+      nameTouched,
+      buildStrategy,
     ],
   );
 


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5826
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Git type field visibility depends on its touched state. When form is submitted, formik makrs all fields as touched and that is why the git type field is shown momentarily. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Check for `isSubmitting` property of the form while setting visibility of git type field.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/119536687-f8b89800-bda6-11eb-9a66-4e95fb0e32c0.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
