### PR TITLE
Change alignment of actions on the add page on small screens

### DIFF
--- a/frontend/packages/dev-console/src/components/add/AddPageLayout.scss
+++ b/frontend/packages/dev-console/src/components/add/AddPageLayout.scss
@@ -8,26 +8,27 @@
   // Drop padding below the hint to add this gap between hint and actions below.
   .ocs-page-layout__hint {
     padding-bottom: 0; /* override var(--pf-global--spacer--md) */
+    padding-right: 0;
   }
 
   &__hint-block {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     flex-wrap: wrap;
 
     &__text {
+      margin-right: var(--pf-global--spacer--lg);
       margin-bottom: var(--pf-global--spacer--md);
     }
 
     &__actions {
-      flex: 1;
       display: flex;
       align-items: center;
-      justify-content: flex-end;
       flex-wrap: wrap;
   
       > * {
-        margin-left: var(--pf-global--spacer--md);
+        margin-right: var(--pf-global--spacer--lg);
         margin-bottom: var(--pf-global--spacer--md);
       }
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5891

**Analysis / Root cause**: 
Add page details switch and getting started label is different aligned then in the designs.

They should be left aligned when they break into a new line.

**Solution Description**: 
Changed CSS rules to align the items on the left hand side when the actions wraps into the next line.

**Screen shots / Gifs for design review**: 
cc @openshift/team-devconsole-ux @gdoyle1 

Before:
![odc-5891-before](https://user-images.githubusercontent.com/139310/119562250-67e1bc80-bda6-11eb-873b-5225324e5139.gif)

After:
![odc-5891-after](https://user-images.githubusercontent.com/139310/119562265-6c0dda00-bda6-11eb-99fa-afec7ed30505.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Open the add page
2. Resize the window and watch the details switch
3. Test it with hidden getting started section

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge