### PR TITLE
remove visual fix that was breaking patternfly table

### DIFF
--- a/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.scss
+++ b/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.scss
@@ -1,3 +1,0 @@
-.rhoas-service-instance-table tr>*:empty {
-  width: 45px; /* Match width of PF React Table until solution is figured out */
-}

--- a/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.tsx
+++ b/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.tsx
@@ -23,7 +23,6 @@ import {
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import { Timestamp } from '@console/internal/components/utils';
 import { CloudKafka } from '../../utils/rhoas-types';
-import './ServiceInstanceTable.scss';
 import ServiceIconStatus from './ServiceIconStatus';
 
 type FormattedKafkas = {


### PR DESCRIPTION
I'm removing CCS override added by @christiemolloy to fix some visual problems with Patternfly Table.
This fix was working fine on chrome but was causing problems on firefox (checkbox was under the text).
Looks like firefox doesn't particularly like setting fixed width on table columns

![image](https://user-images.githubusercontent.com/981838/119631721-123dfc00-be08-11eb-9e57-5404db743715.png)

After discussion with @christianvogt I went to:

- Remove override that was causing issue on firefox
- Logged issue in patternfly https://github.com/patternfly/patternfly-react/issues/5835

The drawback of this is that on both chrome and firefox radio column will be extremely long right now. 
I have spent some time trying to figure out some nice hack but that was above level of my basic understanding of PF CSS

