### PR TITLE
Bug 1962814: Add tooltip for Raw Capacity card

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -51,6 +51,7 @@
   "Version": "Version",
   "Inventory": "Inventory",
   "Raw Capacity": "Raw Capacity",
+  "Raw capacity is the absolute total disk space available to the array subsystem.": "Raw capacity is the absolute total disk space available to the array subsystem.",
   "Used": "Used",
   "Available versus Used Capacity": "Available versus Used Capacity",
   "Used of {{capacity}}": "Used of {{capacity}}",

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/raw-capacity-card/raw-capacity-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/raw-capacity-card/raw-capacity-card.tsx
@@ -8,7 +8,7 @@ import DashboardCard from '@console/shared/src/components/dashboard/dashboard-ca
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
-import { humanizeBinaryBytes } from '@console/internal/components/utils';
+import { humanizeBinaryBytes, FieldLevelHelp } from '@console/internal/components/utils';
 import { getInstantVectorStats } from '@console/internal/components/graphs/utils';
 import { CAPACITY_INFO_QUERIES } from '../../../../constants/queries';
 import './raw-capacity-card.scss';
@@ -51,7 +51,14 @@ const RawCapacityCard: React.FC = React.memo(() => {
   return (
     <DashboardCard>
       <DashboardCardHeader>
-        <DashboardCardTitle>{t('ceph-storage-plugin~Raw Capacity')}</DashboardCardTitle>
+        <DashboardCardTitle>
+          {t('ceph-storage-plugin~Raw Capacity')}
+          <FieldLevelHelp>
+            {t(
+              'ceph-storage-plugin~Raw capacity is the absolute total disk space available to the array subsystem.',
+            )}
+          </FieldLevelHelp>
+        </DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody className="ceph-raw-usage__container">
         {!loading && !loadError && (


### PR DESCRIPTION
Added tooltip for the Raw Capacity card in the Persistent Storage tab.

![raw-cap-ss](https://user-images.githubusercontent.com/33557095/119644041-13881c80-be3a-11eb-8db8-48b9344137ec.png)
