### PR TITLE
Force en_US locale for jest tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx,.json,.gql,.graphql --color",
     "lint": "NODE_OPTIONS=--max-old-space-size=4096 yarn eslint .",
     "gherkin-lint": "./node_modules/.bin/gherkin-lint -c ./.gherkin-lintrc ./packages/*/integration-tests/features",
-    "test": "jest",
+    "test": "LANG=en_US.UTF-8 jest",
     "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "webdriver-update": "webdriver-manager update",
     "webdriver-update-macos": "CHROME_VERSION=$(/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version) && yarn webdriver-update --versions.chrome=\"${CHROME_VERSION}\"",


### PR DESCRIPTION
Jest could fail when a locale different from en_US was used (e.g.
fr_FR.UTF-8)

In particular there was failures in `packages/operator-lifecycle-manager/src/components/descriptors/status/conditions.spec.tsx`
and `__tests__/units.spec.js`

E.g.
```
    Expected value to equal:
      "10.23 KiB"
    Received:
      "10,23 KiB"
```

(notice the dot notation versus coma)