### PR TITLE
Update table classes for kube-virt, ceph-storage, bare-metal and network attachment

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
@@ -34,11 +34,11 @@ const kind = referenceForModel(NooBaaObjectBucketClaimModel);
 export const OBCStatus: React.FC<OBCStatusProps> = ({ obc }) => <Status status={getPhase(obc)} />;
 
 const tableColumnClasses = [
-  classNames('col-lg-3', 'col-md-2', 'col-sm-4', 'col-xs-6'),
-  classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'col-xs-6'),
-  classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'hidden-xs'),
-  classNames('col-lg-2', 'col-md-3', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-3', 'col-md-3', 'hidden-sm', 'hidden-xs'),
+  'pf-u-w-25-on-xl',
+  '',
+  'pf-m-hidden pf-m-visible-on-md',
+  'pf-m-hidden pf-m-visible-on-lg',
+  'pf-m-hidden pf-m-visible-on-lg pf-u-w-25-on-xl',
   Kebab.columnClass,
 ];
 

--- a/frontend/packages/ceph-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
@@ -32,9 +32,9 @@ const menuActions = [...Kebab.factory.common];
 const OBStatus: React.FC<OBStatusProps> = ({ ob }) => <Status status={getPhase(ob)} />;
 
 const tableColumnClasses = [
-  classNames('col-lg-4', 'col-md-4', 'col-sm-6', 'col-xs-6'),
-  classNames('col-lg-3', 'col-md-3', 'col-sm-6', 'hidden-xs'),
-  classNames('col-lg-4', 'col-md-4', 'hidden-sm', 'hidden-xs'),
+  '',
+  'pf-m-hidden pf-m-visible-on-md pf-u-w-25-on-md',
+  'pf-m-hidden pf-m-visible-on-lg',
   Kebab.columnClass,
 ];
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
@@ -1,20 +1,19 @@
-import * as classNames from 'classnames';
 import { Kebab } from '@console/internal/components/utils';
 
 export const diskTableColumnClasses = [
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
+  '',
+  '',
+  'pm-m-hidden pf-m-visible-on-sm',
+  'pm-m-hidden pf-m-visible-on-md',
+  'pm-m-hidden pf-m-visible-on-lg',
+  'pm-m-hidden pf-m-visible-on-lg',
   Kebab.columnClass,
 ];
 
 export const cdTableColumnClasses = [
-  classNames('col-lg-3'),
-  classNames('col-lg-3'),
-  classNames('col-lg-3'),
-  classNames('col-lg-3'),
+  '',
+  '',
+  'pm-m-hidden pf-m-visible-on-md',
+  'pm-m-hidden pf-m-visible-on-lg',
   Kebab.columnClass,
 ];

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/utils.ts
@@ -1,11 +1,10 @@
-import * as classNames from 'classnames';
 import { Kebab } from '@console/internal/components/utils';
 
 export const nicTableColumnClasses = [
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
+  '',
+  '',
+  '',
+  'pf-m-hidden pf-m-visible-on-lg',
+  'pf-m-hidden pf-m-visible-on-xl',
   Kebab.columnClass,
 ];

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/utils.ts
@@ -1,11 +1,3 @@
-import * as classNames from 'classnames';
 import { Kebab } from '@console/internal/components/utils';
 
-export const snapshotsTableColumnClasses = [
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  classNames('col-lg-2'),
-  Kebab.columnClass,
-];
+export const snapshotsTableColumnClasses = ['', '', '', '', '', Kebab.columnClass];

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-users.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-users.tsx
@@ -13,12 +13,7 @@ import { VMIKind } from '../../types';
 import { getGuestAgentFieldNotAvailMsg } from '../../utils/guest-agent-strings';
 import { isGuestAgentInstalled } from '../../utils/guest-agent-utils';
 
-const tableColumnClasses = [
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
-  classNames('col-lg-3', 'col-md-3', 'hidden-sm', 'hidden-xs'),
-];
+const tableColumnClasses = ['', '', '', 'pf-m-hidden pf-m-visible-on-lg'];
 
 const UsersTableHeader = (t: TFunction) => () => {
   return [

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -9,7 +9,6 @@ import {
 } from '@patternfly/react-core';
 import { RocketIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
@@ -86,12 +85,12 @@ import VMIP from './VMIP';
 import './vm.scss';
 
 const tableColumnClasses = [
-  classNames('col-lg-2', 'col-md-2', 'col-sm-6', 'col-xs-6'),
-  classNames('col-lg-2', 'col-md-2', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-2', 'col-md-2', 'col-sm-3', 'col-xs-3'),
-  classNames('col-lg-2', 'col-md-2', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-2', 'col-md-2', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-2', 'col-md-2', 'col-sm-3', 'col-xs-3'),
+  'pf-u-w-16-on-xl pf-u-w-50-on-xs',
+  'pf-m-hidden pf-m-visible-on-lg',
+  '',
+  'pf-m-hidden pf-m-visible-on-xl',
+  'pf-m-hidden pf-m-visible-on-lg',
+  '',
   Kebab.columnClass,
 ];
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import {
@@ -26,12 +25,12 @@ import { menuActions } from './host-menu-actions';
 import NodeLink from './NodeLink';
 
 const tableColumnClasses = {
-  name: classNames('col-lg-2', 'col-md-4', 'col-sm-12', 'col-xs-12'),
-  status: classNames('col-lg-2', 'col-md-4', 'col-sm-6', 'hidden-xs'),
-  node: classNames('col-lg-2', 'col-md-4', 'hidden-sm', 'hidden-xs'),
-  role: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
-  address: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
-  serialNumber: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  name: '',
+  status: 'pf-m-hidden pf-m-visible-on-sm',
+  node: 'pf-m-hidden pf-m-visible-on-md',
+  role: 'pf-m-hidden pf-m-visible-on-lg',
+  address: 'pf-m-hidden pf-m-visible-on-lg',
+  serialNumber: 'pf-m-hidden pf-m-visible-on-lg',
   kebab: Kebab.columnClass,
 };
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import NodeRoles from '@console/app/src/components/nodes/NodeRoles';
@@ -21,11 +20,11 @@ import { menuActions } from './menu-actions';
 import './baremetal-nodes-table.scss';
 
 const tableColumnClasses = {
-  name: classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
-  status: classNames('col-lg-3', 'col-md-4', 'col-sm-6', 'hidden-xs'),
-  role: classNames('col-lg-2', 'col-md-4', 'hidden-sm', 'hidden-xs'),
-  machine: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
-  address: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  name: '',
+  status: 'pf-m-hidden pf-m-visible-on-sm',
+  role: 'pf-m-hidden pf-m-visible-on-md pf-u-w-16-on-lg',
+  machine: 'pf-m-hidden pf-m-visible-on-lg pf-u-w-16-on-lg',
+  address: 'pf-m-hidden pf-m-visible-on-lg pf-u-w-16-on-lg',
   kebab: Kebab.columnClass,
 };
 

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Button, EmptyState, EmptyStateSecondaryActions, Title } from '@patternfly/react-core';
 import { RocketIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { QuickStart } from '@console/app/src/components/quick-starts/utils/quick-start-types';
 import { QuickStartModel } from '@console/app/src/models';
@@ -36,12 +35,7 @@ import './NetworkAttachmentDefinition.scss';
 const { common } = Kebab.factory;
 const menuActions = [...common];
 
-const tableColumnClasses = [
-  classNames('col-lg-4', 'col-md-4', 'col-sm-6', 'col-xs-6'),
-  classNames('col-lg-4', 'col-md-4', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-4', 'col-md-4', 'col-sm-6', 'col-xs-6'),
-  Kebab.columnClass,
-];
+const tableColumnClasses = ['', 'pf-m-hidden pf-m-visible-on-md', '', Kebab.columnClass];
 
 const NetworkAttachmentDefinitionsHeader = () =>
   dimensifyHeader(


### PR DESCRIPTION
# Addresses

https://issues.redhat.com/browse/ODC-5816

# Screenshots
Ceph
![ceph](https://user-images.githubusercontent.com/24852534/119862408-19fbbe80-bf36-11eb-98fa-96938920f889.gif)

Kubevirt

![vm-layout](https://user-images.githubusercontent.com/24852534/119863015-c2aa1e00-bf36-11eb-90b8-62de225996c0.gif)
![vm-nic](https://user-images.githubusercontent.com/24852534/119863032-c8076880-bf36-11eb-871b-e2054e2b051e.gif)
![vm-wizard](https://user-images.githubusercontent.com/24852534/119863036-c9389580-bf36-11eb-95b5-846066416f18.gif)

# Tests 
None change

# Broswer conformance

Chrome