### PR TITLE
Fix to disable submit button when yaml editor is empty

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -85,6 +85,7 @@ export const EditYAML_ = connect(stateToProps)(
             fileUpload: props.fileUpload,
             showSidebar: !!props.create,
             owner: null,
+            isSaveOrCreateDisabled: true,
           };
           this.monacoRef = React.createRef();
           // k8s uses strings for resource versions
@@ -517,7 +518,10 @@ export const EditYAML_ = connect(stateToProps)(
                         showShortcuts={!genericYAML}
                         minHeight="100px"
                         toolbarLinks={sidebarLink ? [sidebarLink] : []}
-                        onChange={onChange}
+                        onChange={(newValue) => {
+                          this.setState({ isSaveOrCreateDisabled: !newValue });
+                          onChange;
+                        }}
                         onSave={() => this.save()}
                       />
                       <div className="yaml-editor__buttons" ref={(r) => (this.buttons = r)}>
@@ -553,6 +557,7 @@ export const EditYAML_ = connect(stateToProps)(
                               id="save-changes"
                               data-test="save-changes"
                               onClick={() => this.save()}
+                              isDisabled={this.state.isSaveOrCreateDisabled}
                             >
                               {t('public~Create')}
                             </Button>
@@ -564,6 +569,7 @@ export const EditYAML_ = connect(stateToProps)(
                               id="save-changes"
                               data-test="save-changes"
                               onClick={() => this.save()}
+                              isDisabled={this.state.isSaveOrCreateDisabled}
                             >
                               {t('public~Save')}
                             </Button>


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-5629

**Root cause/Analysis:**
Even when YAML editor is empty create/save buttons are clickable.

**Solution:**
Disable create/save buttons when YAML editor is empty.

**ScreenRecording:**

https://user-images.githubusercontent.com/20724543/119669545-c4e87b80-be55-11eb-8fdc-386d765c73d9.mov

/kind bug

cc: @openshift/team-devconsole-ux 