### PR TITLE
fix terminal new tab redirect

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
@@ -10,7 +10,7 @@ const CloudShellTab: React.FC = () => {
   const { t } = useTranslation();
   const devWorkspaceFlag = useFlag(FLAG_DEVWORKSPACE);
 
-  if (!devWorkspaceFlag) return <Redirect to="/" />;
+  if (devWorkspaceFlag === false) return <Redirect to="/" />;
 
   return (
     <>

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
@@ -20,8 +20,14 @@ describe('CloudShellTab', () => {
     expect(cloudShellTabWrapper.find(CloudShellTerminal).exists()).toBe(true);
   });
 
-  it('should render redirect component if terminal operator is not installed', () => {
+  it('should not render redirect component if flag check is pending', () => {
     spyOn(shared, 'useFlag').and.returnValue(undefined);
+    const cloudShellTabWrapper = shallow(<CloudShellTab />);
+    expect(cloudShellTabWrapper.find(Redirect).exists()).toBe(false);
+  });
+
+  it('should render redirect component if terminal operator is not installed', () => {
+    spyOn(shared, 'useFlag').and.returnValue(false);
     const cloudShellTabWrapper = shallow(<CloudShellTab />);
     expect(cloudShellTabWrapper.find(Redirect).exists()).toBe(true);
   });


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-5885

This PR fixes the flag check for DevWorkspace. `useFlag` returns undefined which means the flag check is pending and we redirect to the `/`. Check for `false` while doing flag check.

![new-tab](https://user-images.githubusercontent.com/9278015/119693063-91175100-be69-11eb-840c-8c42ad5d3057.gif)
