### PR TITLE
Bug 1965116: Add max height to resource and filter drop downs

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -327,6 +327,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
                   selections={selectedRowFilters}
                   isCheckboxSelectionBadgeHidden
                   isGrouped
+                  maxHeight="60vh"
                 >
                   {dropdownItems}
                 </Select>

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -134,6 +134,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
       hasInlineFilter
       customBadgeText={selected.length}
       className={classNames('co-type-selector', className)}
+      maxHeight="60vh"
     >
       {items}
     </Select>


### PR DESCRIPTION
The CSS for the newly added PatternFly Select does not have a default max-height.   Add the max-height setting from the removed custom drop down component CSS to the the PatternFly select.

Fixes an issue introduced as part of the following PRs:
 - https://github.com/openshift/console/pull/8877
 - https://github.com/openshift/console/pull/8802