### PR TITLE
PR 9051 review: Replace "RAW" by "Raw" in "Raw Capacity" card.

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -234,7 +234,7 @@
   "Error": "Error",
   "Warning": "Warning",
   "Raw Capacity": "Raw Capacity",
-  "RAW capacity is the absolute total disk space available to the array subsystem.": "RAW capacity is the absolute total disk space available to the array subsystem.",
+  "Raw capacity is the absolute total disk space available to the array subsystem.": "Raw capacity is the absolute total disk space available to the array subsystem.",
   "Used": "Used",
   "Available versus Used Capacity": "Available versus Used Capacity",
   "Used of {{capacity}}": "Used of {{capacity}}",

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/raw-capacity-card/raw-capacity-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/raw-capacity-card/raw-capacity-card.tsx
@@ -85,7 +85,7 @@ const RawCapacityCard: React.FC = React.memo(() => {
           {t('ceph-storage-plugin~Raw Capacity')}
           <FieldLevelHelp>
             {t(
-              'ceph-storage-plugin~RAW capacity is the absolute total disk space available to the array subsystem.',
+              'ceph-storage-plugin~Raw capacity is the absolute total disk space available to the array subsystem.',
             )}
           </FieldLevelHelp>
         </DashboardCardTitle>


### PR DESCRIPTION
Fixed the "RAW Capacity" spelling error originally introduced in #8590 for the "Raw Capacity" card.