### PR TITLE
[WIP] Bug 1965212: Query Browser: Fix aria title being visible

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -271,7 +271,6 @@ const Graph: React.FC<GraphProps> = React.memo(
     const data: GraphSeries[] = [];
     const tooltipSeriesNames: string[] = [];
     const legendData: { name: string }[] = [];
-    const { t } = useTranslation();
 
     const [xDomain, setXDomain] = React.useState(fixedXDomain || getXDomain(Date.now(), span));
 
@@ -350,8 +349,8 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     return (
       <Chart
+        ariaTitle=""
         containerComponent={graphContainer}
-        ariaTitle={t('public~query browser chart')}
         domain={domain}
         domainPadding={{ y: 1 }}
         height={200}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -915,7 +915,6 @@
   "{{count}} day": "{{count}} day",
   "{{count}} day_plural": "{{count}} days",
   "Reset zoom": "Reset zoom",
-  "query browser chart": "query browser chart",
   "Ungraphable results": "Ungraphable results",
   "Query results include range vectors, which cannot be graphed. Try adding a function to transform the data.": "Query results include range vectors, which cannot be graphed. Try adding a function to transform the data.",
   "Query result is a string, which cannot be graphed.": "Query result is a string, which cannot be graphed.",


### PR DESCRIPTION
The title was visible, which partially obscured the tooltip.

Using `ariaDesc` instead of `ariaTitle` prevents it being displayed.

### Before
![screenshot](https://user-images.githubusercontent.com/460802/119786783-7e555880-bf0b-11eb-8e4e-57e410bbfa0a.png)
