### PR TITLE
Fix keyboard scroll issue of namespaced pages

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -1,7 +1,6 @@
 .odc-namespaced-page {
-  height: 100%;
-  max-height: 100%;
   display: flex;
+  flex: 1;
   flex-direction: column;
 
   &__content {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5514
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The `NamespacedPage` component that is used by all dev console pages had `height: 100%` which caused issues with scroll.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Removed `height: 100%` and add `flex: 1`.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/119853432-d3a26180-bf2d-11eb-832b-080d0132aeb9.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
