### PR TITLE
Bug 1951043: Fix Pipeline Parameters in Modals accept empty string defaults

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineParameterSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineParameterSection.tsx
@@ -4,22 +4,21 @@ import { useTranslation } from 'react-i18next';
 import { TextInputTypes } from '@patternfly/react-core';
 import { InputField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
+import { paramIsRequired } from '../../../../utils/common';
 import AutoCompletePopover from '../../../shared/common/auto-complete/AutoCompletePopover';
-import { TektonParam } from '../../../../types';
-import { AddTriggerFormValues } from '../triggers/types';
+import { CommonPipelineModalFormikValues, ModalParameter } from './types';
 
 type ParametersSectionProps = {
   autoCompleteValues?: string[];
-  parameters: TektonParam[];
 };
 
-const PipelineParameterSection: React.FC<ParametersSectionProps> = ({
-  autoCompleteValues,
-  parameters,
-}) => {
+const PipelineParameterSection: React.FC<ParametersSectionProps> = ({ autoCompleteValues }) => {
   const { t } = useTranslation();
 
-  const { setFieldValue } = useFormikContext<AddTriggerFormValues>();
+  const {
+    setFieldValue,
+    values: { parameters },
+  } = useFormikContext<CommonPipelineModalFormikValues>();
 
   return (
     <FieldArray
@@ -28,32 +27,35 @@ const PipelineParameterSection: React.FC<ParametersSectionProps> = ({
       render={() =>
         parameters.length > 0 && (
           <FormSection title={t('pipelines-plugin~Parameters')} fullWidth>
-            {parameters.map((parameter, index) => {
-              const name = `parameters.${index}.default`;
+            {parameters.map((parameter: ModalParameter, index) => {
+              const name = `parameters.${index}.value`;
+              const isRequired = paramIsRequired(parameter);
 
               const input = (ref?) => (
                 <InputField
                   ref={ref}
-                  key={parameter.name}
                   name={name}
                   type={TextInputTypes.text}
                   label={parameter.name}
                   helpText={parameter.description}
-                  placeholder={t('pipelines-plugin~Name')}
-                  required
+                  required={isRequired}
                   autoComplete="off"
                 />
               );
 
-              return autoCompleteValues ? (
-                <AutoCompletePopover
-                  autoCompleteValues={autoCompleteValues}
-                  onAutoComplete={(value: string) => setFieldValue(name, value)}
-                >
-                  {(callbackRef) => input(callbackRef)}
-                </AutoCompletePopover>
-              ) : (
-                input()
+              return (
+                <React.Fragment key={parameter.name}>
+                  {autoCompleteValues ? (
+                    <AutoCompletePopover
+                      autoCompleteValues={autoCompleteValues}
+                      onAutoComplete={(value: string) => setFieldValue(name, value)}
+                    >
+                      {(callbackRef) => input(callbackRef)}
+                    </AutoCompletePopover>
+                  ) : (
+                    input()
+                  )}
+                </React.Fragment>
               );
             })}
           </FormSection>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineSecretSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineSecretSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Formik, useField, useFormikContext, FormikValues } from 'formik';
+import { Formik, useField, useFormikContext } from 'formik';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { Button } from '@patternfly/react-core';
 import { ExpandCollapse } from '@console/internal/components/utils';
@@ -15,6 +15,7 @@ import { SecretAnnotationId } from '../../const';
 import { advancedSectionValidationSchema } from './validation-utils';
 import SecretForm from './SecretForm';
 import SecretsList from './SecretsList';
+import { CommonPipelineModalFormikValues } from './types';
 
 import './PipelineSecretSection.scss';
 
@@ -25,14 +26,13 @@ const initialValues = {
   formData: {},
 };
 
-type PipelineSecretSectionProps = {
-  namespace: string;
-};
-
-const PipelineSecretSection: React.FC<PipelineSecretSectionProps> = ({ namespace }) => {
+const PipelineSecretSection: React.FC = () => {
   const { t } = useTranslation();
   const [secretOpenField] = useField<boolean>('secretOpen');
-  const { setFieldValue } = useFormikContext<FormikValues>();
+  const {
+    setFieldValue,
+    values: { namespace },
+  } = useFormikContext<CommonPipelineModalFormikValues>();
 
   const handleSubmit = (values, actions) => {
     actions.setSubmitting(true);

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/__tests__/utils.spec.ts
@@ -253,6 +253,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
           name: 'ParameterA',
           default: 'Default value',
           description: 'Description',
+          value: 'Updated value',
         },
       ],
       resources: [],
@@ -273,7 +274,7 @@ describe('PipelineAction testing getPipelineRunFromForm', () => {
         params: [
           {
             name: 'ParameterA',
-            value: 'Default value',
+            value: 'Updated value',
           },
         ],
         resources: [],

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/types.ts
@@ -57,9 +57,13 @@ export type PipelineModalFormWorkspaceStructure =
 
 export type PipelineModalFormWorkspace = TektonWorkspace & PipelineModalFormWorkspaceStructure;
 
+export type ModalParameter = TektonParam & {
+  value?: string | string[];
+};
+
 export type CommonPipelineModalFormikValues = FormikValues & {
   namespace: string;
-  parameters: TektonParam[];
+  parameters: ModalParameter[];
   resources: PipelineModalFormResource[];
   workspaces: PipelineModalFormWorkspace[];
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/utils.ts
@@ -11,6 +11,7 @@ import {
   PipelineRunResource,
   VolumeClaimTemplateType,
   TektonWorkspace,
+  PipelineRunParam,
 } from '../../../../types';
 import { getPipelineRunParams, getPipelineRunWorkspaces } from '../../../../utils/pipeline-utils';
 import { TektonResourceLabel, VolumeTypes, preferredNameAnnotation } from '../../const';
@@ -192,7 +193,10 @@ export const convertPipelineToModalData = (
 
   return {
     namespace,
-    parameters: params || [],
+    parameters: (params || []).map((param) => ({
+      ...param,
+      value: param.default, // setup the default if it exists
+    })),
     resources: (resources || []).map((resource: TektonResource) => ({
       name: resource.name,
       selection: alwaysCreateResources ? CREATE_PIPELINE_RESOURCE : '',
@@ -251,7 +255,7 @@ export const getPipelineRunFromForm = (
       pipelineRef: {
         name: pipeline.metadata.name,
       },
-      params: getPipelineRunParams(parameters),
+      params: parameters.map(({ name, value }): PipelineRunParam => ({ name, value })),
       resources: resources.map(convertResources),
       workspaces: getPipelineRunWorkspaces(workspaces),
     },

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/validation-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/validation-utils.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 import * as yup from 'yup';
+import { paramIsRequired } from '../../../../utils/common';
 import { PipelineResourceType, VolumeTypes } from '../../const';
 import { CREATE_PIPELINE_RESOURCE } from './const';
 
@@ -124,8 +125,15 @@ const commonPipelineSchema = () =>
     parameters: yup.array().of(
       yup.object().shape({
         name: yup.string().required(i18next.t('pipelines-plugin~Required')),
+        default: yup.string(),
         description: yup.string(),
-        default: yup.string().required(i18next.t('pipelines-plugin~Required')),
+        value: yup
+          .string()
+          .test('test-if-param-can-be-empty', i18next.t('pipelines-plugin~Required'), function(
+            value: string,
+          ) {
+            return paramIsRequired(this.parent) ? !!value : true;
+          }),
       }),
     ),
     resources: formResources(),

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/start-pipeline/StartPipelineForm.tsx
@@ -1,21 +1,22 @@
 import * as React from 'react';
-import { FormikValues } from 'formik';
+import { FormikProps } from 'formik';
 import { useTranslation } from 'react-i18next';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 import PipelineParameterSection from '../common/PipelineParameterSection';
 import PipelineResourceSection from '../common/PipelineResourceSection';
 import PipelineWorkspacesSection from '../common/PipelineWorkspacesSection';
 import PipelineSecretSection from '../common/PipelineSecretSection';
+import { StartPipelineFormValues } from './types';
 
-const StartPipelineForm: React.FC<FormikValues> = ({ values }) => {
+const StartPipelineForm: React.FC<FormikProps<StartPipelineFormValues>> = () => {
   const { t } = useTranslation();
   return (
     <>
-      <PipelineParameterSection parameters={values.parameters} />
+      <PipelineParameterSection />
       <PipelineResourceSection />
       <PipelineWorkspacesSection />
       <FormSection title={t('pipelines-plugin~Advanced options')} fullWidth>
-        <PipelineSecretSection namespace={values.namespace} />
+        <PipelineSecretSection />
       </FormSection>
     </>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/triggers/AddTriggerForm.tsx
@@ -7,20 +7,13 @@ import PipelineWorkspacesSection from '../common/PipelineWorkspacesSection';
 import TriggerBindingSection from './TriggerBindingSection';
 import { AddTriggerFormValues } from './types';
 
-type AddTriggerFormProps = FormikProps<AddTriggerFormValues>;
-
-const AddTriggerForm: React.FC<AddTriggerFormProps> = (props) => {
-  const { values } = props;
-
+const AddTriggerForm: React.FC<FormikProps<AddTriggerFormValues>> = () => {
   const autoCompleteValues: string[] = useAddTriggerParams();
 
   return (
     <>
       <TriggerBindingSection />
-      <PipelineParameterSection
-        autoCompleteValues={autoCompleteValues}
-        parameters={values.parameters}
-      />
+      <PipelineParameterSection autoCompleteValues={autoCompleteValues} />
       <PipelineResourceSection />
       <PipelineWorkspacesSection />
     </>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
-import { PipelineTask, TaskKind, TektonParam } from '../../../../types';
+import { PipelineTask, TaskKind } from '../../../../types';
 import { initialPipelineFormData } from '../const';
 import { PipelineBuilderFormikValues, PipelineBuilderTaskBase } from '../types';
 import {
@@ -12,38 +12,9 @@ import {
   mapReplaceRelatedInOthers,
   mapStitchReplaceInOthers,
   safeName,
-  taskParamIsRequired,
   removeEmptyFormFields,
 } from '../utils';
 import { externalTask, externalTaskWithVarietyParams } from './validation-utils-data';
-
-describe('taskParamIsRequired properly detects what is required', () => {
-  const structure: TektonParam = {
-    name: 'test-param',
-    description: 'some description',
-    type: 'string',
-  };
-
-  it('expect an empty param to result in needing a default', () => {
-    expect(taskParamIsRequired({} as any)).toBe(true);
-  });
-
-  it('expect no default property to mean required', () => {
-    expect(taskParamIsRequired(structure)).toBe(true);
-  });
-
-  it('expect a string default of a truthy value to mean not required', () => {
-    expect(taskParamIsRequired({ ...structure, default: 'truthy' })).toBe(false);
-  });
-
-  it('expect an empty string default to mean not required', () => {
-    expect(taskParamIsRequired({ ...structure, default: '' })).toBe(false);
-  });
-
-  it('expect an array default to always be not required', () => {
-    expect(taskParamIsRequired({ ...structure, type: 'array', default: [] })).toBe(false);
-  });
-});
 
 describe('findTaskFromFormikData / findTask', () => {
   const createFormValues = (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useFormikContext } from 'formik';
-import { TektonParam } from '../../../../types';
-import { taskParamIsRequired } from '../utils';
 import { TextAreaField, TextColumnField, MergeNewValueUtil } from '@console/shared';
-import { PipelineBuilderFormikValues, SelectedBuilderTask } from '../types';
+import { TektonParam } from '../../../../types';
+import { paramIsRequired } from '../../../../utils/common';
 import AutoCompletePopover from '../../../shared/common/auto-complete/AutoCompletePopover';
 import { useBuilderParams } from '../../../shared/common/auto-complete/autoCompleteValueParsers';
+import { PipelineBuilderFormikValues, SelectedBuilderTask } from '../types';
 
 import './TaskSidebarParam.scss';
 
@@ -21,7 +21,7 @@ const TaskSidebarParam: React.FC<TaskSidebarParamProps> = (props) => {
   const { hasParam, name, resourceParam, selectedData } = props;
   const autoCompleteOptions = useBuilderParams(selectedData);
 
-  const emptyIsInvalid = taskParamIsRequired(resourceParam);
+  const emptyIsInvalid = paramIsRequired(resourceParam);
 
   const resourceParamName = resourceParam.name;
   const fieldName = `${name}.value`;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/utils.ts
@@ -209,10 +209,6 @@ export const mapAddRelatedToOthers = <TaskType extends PipelineBuilderTaskBase>(
   };
 };
 
-export const taskParamIsRequired = (param: TektonParam): boolean => {
-  return !('default' in param);
-};
-
 export const safeName = (reservedNames: string[], desiredName: string): string => {
   if (reservedNames.includes(desiredName)) {
     const newName = `${desiredName}-${getRandomChars(3)}`;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/validation-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/validation-utils.ts
@@ -3,10 +3,6 @@ import * as yup from 'yup';
 import i18n from 'i18next';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
 import { nameValidationSchema } from '@console/shared';
-import { TASK_ERROR_STRINGS, TaskErrorType } from './const';
-import { findTaskFromFormikData, taskParamIsRequired } from './utils';
-import { PipelineBuilderFormYamlValues, TaskType } from './types';
-import { getTaskParameters, getTaskResources } from '../resource-utils';
 import {
   PipelineTaskResource,
   PipelineTask,
@@ -18,7 +14,12 @@ import {
   TektonResourceGroup,
   WhenExpression,
 } from '../../../types';
+import { paramIsRequired } from '../../../utils/common';
 import { PipelineResourceType } from '../const';
+import { getTaskParameters, getTaskResources } from '../resource-utils';
+import { TASK_ERROR_STRINGS, TaskErrorType } from './const';
+import { PipelineBuilderFormYamlValues, TaskType } from './types';
+import { findTaskFromFormikData } from './utils';
 
 /**
  * Checks to see if the params without a default have a value
@@ -34,7 +35,7 @@ const areRequiredParamsAdded = (
     return true;
   }
 
-  const requiredTaskParams = getTaskParameters(task).filter(taskParamIsRequired);
+  const requiredTaskParams = getTaskParameters(task).filter(paramIsRequired);
   if (requiredTaskParams.length === 0) {
     // No required params, no issue
     return true;

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/common.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/common.spec.ts
@@ -1,0 +1,30 @@
+import { TektonParam } from '../../types';
+import { paramIsRequired } from '../common';
+
+describe('taskParamIsRequired properly detects what is required', () => {
+  const structure: TektonParam = {
+    name: 'test-param',
+    description: 'some description',
+    type: 'string',
+  };
+
+  it('expect an empty param to result in needing a default', () => {
+    expect(paramIsRequired({} as any)).toBe(true);
+  });
+
+  it('expect no default property to mean required', () => {
+    expect(paramIsRequired(structure)).toBe(true);
+  });
+
+  it('expect a string default of a truthy value to mean not required', () => {
+    expect(paramIsRequired({ ...structure, default: 'truthy' })).toBe(false);
+  });
+
+  it('expect an empty string default to mean not required', () => {
+    expect(paramIsRequired({ ...structure, default: '' })).toBe(false);
+  });
+
+  it('expect an array default to always be not required', () => {
+    expect(paramIsRequired({ ...structure, type: 'array', default: [] })).toBe(false);
+  });
+});

--- a/frontend/packages/pipelines-plugin/src/utils/common.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/common.ts
@@ -1,0 +1,5 @@
+import { TektonParam } from '../types';
+
+export const paramIsRequired = (param: TektonParam): boolean => {
+  return !('default' in param);
+};


### PR DESCRIPTION
**Analysis / Root cause**:
All parameters were always required. Empty string parameter defaults were not recognized as a valid default by our validation schema.

**Solution Description**:
Allow any parameter that has a default property to accept an empty string.

Caveat is empty string support for required (aka no `default` property) params is not supported. This would require a fundamental UX change in the way the console inputs work today. (no way to determine if you want empty string or an empty field).

**Screen shots / Gifs for design review**:
Changes to the UI are the omission of the `*` on any parameter with a `default` property -- effectively no change.

**Unit test coverage report**:
No change, tests moved around a bit though.

**Test setup:**

I used my [parameter echo example](https://github.com/andrewballantyne/pipeline-scratch-pad/tree/master/examples/param-echo) -- but any Pipeline that accepts at least 1 param can be modified to have or not have a default for that parameter.

- Test with `default == ‘test’`
- Test with `default == ‘’`
- Test with no `default`

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge