### PR TITLE
Missing parens in the Last deployment column (#5899)

### DIFF
--- a/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.tsx
+++ b/frontend/packages/gitops-plugin/src/components/list/GitOpsTableRow.tsx
@@ -122,7 +122,7 @@ const GitOpsTableRow: RowFunction<GitOpsAppGroupData> = (props) => {
                 <Timestamp timestamp={latestDeployedTime} />
               </span>
             </FlexItem>
-            <FlexItem>{latestDeployedEnv}</FlexItem>
+            <FlexItem>({latestDeployedEnv})</FlexItem>
           </Flex>
         ) : (
           <span>-</span>


### PR DESCRIPTION
This is a bug fix.  The brackets are missing around the environment.

See Jira 5899.