### PR TITLE
Bug 1965391: Skip to 3rd step when SC present

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
@@ -23,8 +23,6 @@ import { OCS_ATTACHED_DEVICES_FLAG } from '@console/local-storage-operator-plugi
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { resourcePathFromModel } from '@console/internal/components/utils';
 import { getName } from '@console/shared';
-import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
-import { StorageClassModel } from '@console/internal/models';
 import { initialState, reducer } from './reducer';
 import {
   DiscoverDisks,
@@ -34,7 +32,7 @@ import { CreateStorageClass } from './install-wizard-steps/create-storage-class/
 import { StorageAndNodes } from './install-wizard-steps/storage-and-nodes-step';
 import { ReviewAndCreate } from './install-wizard-steps/review-and-create-step';
 import { Configure } from './install-wizard-steps/configure-step';
-import { taintNodes, filterSCWithNoProv } from '../../../utils/install';
+import { taintNodes } from '../../../utils/install';
 import {
   CreateStepsSC,
   MINIMUM_NODES,
@@ -123,25 +121,11 @@ const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
   const [showInfoAlert, setShowInfoAlert] = React.useState(true);
   const [inProgress, setInProgress] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
-  const [isForceNavigated, setForceNavigated] = React.useState(false);
   const flagDispatcher = useDispatch();
 
   const discoveryNodes = state.lvdIsSelectNodes ? state.lvdSelectNodes : state.lvdAllNodes;
 
   const { getStep, getIndex, getAnchor } = navUtils;
-
-  const [hasNoProvSC, setHasNoProvSC] = React.useState(false);
-
-  const [storageClasses, isLoaded, err] = useK8sGet(StorageClassModel);
-
-  React.useEffect(() => {
-    if (!err && isLoaded) {
-      const filteredSCData = storageClasses['items'].filter(filterSCWithNoProv);
-      if (filteredSCData.length) {
-        setHasNoProvSC(true);
-      }
-    }
-  }, [appName, err, isLoaded, ns, storageClasses]);
 
   /**
    * This custom footer for wizard provides a control over the movement to next step.
@@ -301,7 +285,7 @@ const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
         <Wizard
           className="ocs-install-wizard"
           steps={steps}
-          startAtStep={getStep(0, hasNoProvSC, isForceNavigated, setForceNavigated)}
+          startAtStep={getStep()}
           onBack={() => {
             history.push(getAnchor(getStep() - 1, getIndex(MODES, MODES.ATTACHED_DEVICES)));
           }}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -62,16 +62,10 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
     null,
     CEPH_STORAGE_NAMESPACE,
   );
-  const [hasNoProvSC, setHasNoProvSC] = React.useState(false);
-  const [sc, isLoaded, err] = useK8sGet<ListKind<StorageClassResourceKind>>(StorageClassModel);
-  const memoizedCSV = useDeepCompareMemoize(csv, true);
 
-  React.useEffect(() => {
-    if (!err && isLoaded) {
-      const isSCWithNoProv = sc?.items?.some(filterSCWithNoProv);
-      setHasNoProvSC(isSCWithNoProv);
-    }
-  }, [appName, err, isLoaded, ns, sc]);
+  const memoizedCSV = useDeepCompareMemoize(csv, true);
+  const [sc] = useK8sGet<ListKind<StorageClassResourceKind>>(StorageClassModel);
+  const hasNoProvSC = sc?.items?.some(filterSCWithNoProv);
 
   React.useEffect(() => {
     if (csvLoaded && !csvError) {
@@ -131,8 +125,9 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
       case 2:
         if (hasNoProvSC) {
           history.push(getAnchor(3, 2));
+          break;
         }
-        break;
+      // eslint-disable-next-line no-fallthrough
       default:
         history.push(getAnchor(getIndex(CreateStepsSC, CreateStepsSC.DISCOVER), modeIndex));
     }

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -88,7 +88,7 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
   }, [infra, infraLoaded, infraError]);
 
   const getMode = () => {
-    const searchParams = new URLSearchParams(window.location.search.slice(1));
+    const searchParams = new URLSearchParams(window.location.search);
     const modeParam = parseInt(searchParams.get('mode'), 10) || 1;
     const sanitizedMode =
       modeParam && modeParam <= (!isIndepModeSupportedPlatform ? 2 : 3) && modeParam >= 1
@@ -98,7 +98,7 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
   };
 
   const getParamString = (step: number, mode: number) => {
-    const searchParams = new URLSearchParams(window.location.search.slice(1));
+    const searchParams = new URLSearchParams(window.location.search);
     searchParams.set('step', step.toString());
     searchParams.set('mode', mode.toString());
     return searchParams.toString();
@@ -106,10 +106,10 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
 
   const getAnchor = (step: number, mode: number) => `~new?${getParamString(step, mode)}`;
 
-  const getStep = (offset: number = 0) => {
-    const searchParams = new URLSearchParams(window.location.search.slice(1));
+  const getStep = (maxSteps: number = 5) => {
+    const searchParams = new URLSearchParams(window.location.search);
     const step = parseInt(searchParams.get('step'), 10) || 1;
-    const sanitizedStep = step && step <= 5 - offset && step >= 1 ? step : 1;
+    const sanitizedStep = step <= maxSteps && step >= 1 ? step : 1;
     return sanitizedStep;
   };
 
@@ -121,10 +121,9 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
   const handleModeChange = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;
     const modeIndex = getIndex(MODES, value);
-    // `modeIndex` can have one of the following numerical values:
-    // 1: INTERNAL
-    // 2: ATTACHED_DEVICES
-    // 3: EXTERNAL
+    // Set the currently active step in the wizard to "Storage and Nodes"
+    // when the currently active mode is set to "Internal - Attached Devices"
+    // and a "no-provisioner" storage class exists.
     if (modeIndex === 2 && hasNoProvSC) {
       history.push(getAnchor(3, 2));
     } else {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -90,13 +90,6 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
     return sanitizedMode;
   };
 
-  const getStep = (offset: number = 0) => {
-    const searchParams = new URLSearchParams(window.location.search.slice(1));
-    const step = parseInt(searchParams.get('step'), 10) || 1;
-    const sanitizedStep = step && step <= 5 - offset && step >= 1 ? step : 1;
-    return sanitizedStep;
-  };
-
   const getParamString = (step: number, mode: number) => {
     const searchParams = new URLSearchParams(window.location.search.slice(1));
     searchParams.set('step', step.toString());
@@ -104,12 +97,29 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
     return searchParams.toString();
   };
 
+  const getAnchor = (step: number, mode: number) => `~new?${getParamString(step, mode)}`;
+
+  const getStep = (
+    offset: number = 0,
+    forceNavigate: boolean = false,
+    isForceNavigated: boolean = false,
+    setForceNavigated: React.Dispatch<React.SetStateAction<boolean>> = null,
+  ) => {
+    const searchParams = new URLSearchParams(window.location.search.slice(1));
+    const step = parseInt(searchParams.get('step'), 10) || 1;
+    let sanitizedStep = step && step <= 5 - offset && step >= 1 ? step : 1;
+    if (forceNavigate && !isForceNavigated) {
+      history.push(getAnchor(3, 2));
+      sanitizedStep = 3;
+      setForceNavigated(true);
+    }
+    return sanitizedStep;
+  };
+
   const getIndex = (searchSpace: any, search: string, offset: number = 0) => {
     const index = Object.values(searchSpace).findIndex((el) => el === search);
     return index - offset + 1;
   };
-
-  const getAnchor = (step: number, mode: number) => `~new?${getParamString(step, mode)}`;
 
   const handleModeChange = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -121,15 +121,14 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
   const handleModeChange = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget;
     const modeIndex = getIndex(MODES, value);
-    switch (modeIndex) {
-      case 2:
-        if (hasNoProvSC) {
-          history.push(getAnchor(3, 2));
-          break;
-        }
-      // eslint-disable-next-line no-fallthrough
-      default:
-        history.push(getAnchor(getIndex(CreateStepsSC, CreateStepsSC.DISCOVER), modeIndex));
+    // `modeIndex` can have one of the following numerical values:
+    // 1: INTERNAL
+    // 2: ATTACHED_DEVICES
+    // 3: EXTERNAL
+    if (modeIndex === 2 && hasNoProvSC) {
+      history.push(getAnchor(3, 2));
+    } else {
+      history.push(getAnchor(getIndex(CreateStepsSC, CreateStepsSC.DISCOVER), modeIndex));
     }
   };
 

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/internal-mode/install-wizard.tsx
@@ -177,10 +177,10 @@ export const CreateInternalCluster: React.FC<CreateInternalClusterProps> = ({
           backButtonText={t('ceph-storage-plugin~Back')}
           startAtStep={getStep()}
           onBack={() => {
-            history.push(`~new?${getParamString(getStep(2) - 1, getIndex(MODES, MODES.INTERNAL))}`);
+            history.push(`~new?${getParamString(getStep(3) - 1, getIndex(MODES, MODES.INTERNAL))}`);
           }}
           onNext={() => {
-            history.push(`~new?${getParamString(getStep(2) + 1, getIndex(MODES, MODES.INTERNAL))}`);
+            history.push(`~new?${getParamString(getStep(3) + 1, getIndex(MODES, MODES.INTERNAL))}`);
           }}
           onClose={() =>
             history.push(resourcePathFromModel(ClusterServiceVersionModel, appName, ns))

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -287,7 +287,12 @@ export type DiscoveredDisk = {
 } & DiskMetadata;
 
 export type NavUtils = {
-  getStep: (offset?: number) => number;
+  getStep: (
+    offset?: number,
+    forceNavigate?: boolean,
+    isForceNavigated?: boolean,
+    setForceNavigated?: React.Dispatch<React.SetStateAction<boolean>>,
+  ) => number;
   getParamString: (step: number, mode: number) => string;
   getIndex: (searchSpace: any, search: string, offset?: number) => number;
   getAnchor: (step: number, mode: number) => string;

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -287,12 +287,7 @@ export type DiscoveredDisk = {
 } & DiskMetadata;
 
 export type NavUtils = {
-  getStep: (
-    offset?: number,
-    forceNavigate?: boolean,
-    isForceNavigated?: boolean,
-    setForceNavigated?: React.Dispatch<React.SetStateAction<boolean>>,
-  ) => number;
+  getStep: (offset?: number) => number;
   getParamString: (step: number, mode: number) => string;
   getIndex: (searchSpace: any, search: string, offset?: number) => number;
   getAnchor: (step: number, mode: number) => string;

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -287,7 +287,7 @@ export type DiscoveredDisk = {
 } & DiskMetadata;
 
 export type NavUtils = {
-  getStep: (offset?: number) => number;
+  getStep: (maxSteps?: number) => number;
   getParamString: (step: number, mode: number) => string;
   getIndex: (searchSpace: any, search: string, offset?: number) => number;
   getAnchor: (step: number, mode: number) => string;


### PR DESCRIPTION
Jump to the 3rd step in attached-devices mode when a no-provisioner
storage class has already been created. Also, keep the URL and wizard in
sync while doing so, for an overall better user experience (for
instance, if the user wants to bookmark the page they are currently on,
hence I felt that synchronization was necessary).

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>

https://user-images.githubusercontent.com/33557095/119907592-3f0c2380-bf6e-11eb-8087-9c4480118453.mp4
