### PR TITLE
Update OWNERS for Insights Advisor plugin

### DIFF
--- a/frontend/packages/insights-plugin/OWNERS
+++ b/frontend/packages/insights-plugin/OWNERS
@@ -1,8 +1,8 @@
 reviewers:
-  - bond95
+  - gkarat
   - tisnik
 approvers:
-  - bond95
+  - gkarat
   - tisnik
 labels:
   - component/insights


### PR DESCRIPTION
bond95 (Bohdan Iakymets) is no longer participating in the CCX team and Red Hat, and therefore should be removed from this list.
I added myself, as I assumed his position about 6 months ago.