### PR TITLE
show helptext for workspaces in start pipeline form

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineWorkspacesSection.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/PipelineWorkspacesSection.tsx
@@ -108,6 +108,7 @@ const PipelineWorkspacesSection: React.FC = () => {
                 }
                 fullWidth
                 required={!workspace.optional}
+                helpText={workspace.description}
               />
               {getVolumeTypeFields(workspace.type, index)}
             </div>


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5861

**Root analysis:**
Description of workspaces is not shown in the form

**Solution description:**
passed the value of workspace description in the `helptext` prop

**Screenshot:**
![Screenshot from 2021-05-31 16-36-10](https://user-images.githubusercontent.com/22490998/120184781-ff279380-c22e-11eb-8cd3-6715dcbd3272.png)
![start-pipeline](https://user-images.githubusercontent.com/22490998/120184785-0058c080-c22f-11eb-9c79-b05d1ba8d3c8.png)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge