### PR TITLE
Fix traffic splitting modal crashing UI with no revision loaded

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/traffic-splitting-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/traffic-splitting-utils.ts
@@ -9,6 +9,8 @@ import {
 export type RevisionItems = { [name: string]: string };
 
 export const getRevisionItems = (revisions: K8sResourceKind[]): RevisionItems => {
+  if (!revisions) return {} as RevisionItems;
+
   return revisions.reduce((acc, currValue) => {
     acc[currValue.metadata.name] = currValue.metadata.name;
     return acc;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5904
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Traffic splitting modal crashes the UI when there are no revisions loaded. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Turns out this only happens in rare cases when the revision is not created or takes time to get created. Added a check for handling this edge case.
<!-- Describe your code changes in detail and explain the solution -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
