### PR TITLE
Bug 1966520: Add button from ocs add capacity should not be enabled if there are no PV's

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
@@ -243,6 +243,7 @@ export const AddCapacityModal = (props: AddCapacityModalProps) => {
         errorMessage={errorMessage}
         submitText={t('ceph-storage-plugin~Add')}
         cancel={cancel}
+        submitDisabled={isNoProvionerSC && !availablePvsCount}
       />
     </Form>
   );

--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -63,7 +63,7 @@ export const getRack = (node: NodeKind) => node.metadata.labels?.[RACK_LABEL];
 export const getAssociatedNodes = (pvs: K8sResourceKind[]): string[] => {
   const nodes = pvs.reduce((res, pv) => {
     const matchExpressions: MatchExpression[] =
-      pv?.spec?.nodeAffinity?.required?.nodeSelectorTerms?.[0]?.matchExpressions;
+      pv?.spec?.nodeAffinity?.required?.nodeSelectorTerms?.[0]?.matchExpressions || [];
     matchExpressions.forEach(({ key, operator, values }) => {
       if (key === HOSTNAME_LABEL_KEY && operator === LABEL_OPERATOR) {
         values.forEach((value) => res.add(value));


### PR DESCRIPTION
Disabled the "add" button if no PVs are available.
![Screenshot from 2021-06-01 20-12-33](https://user-images.githubusercontent.com/39404641/120343489-653b1600-c316-11eb-8a93-ded5894fe74a.png)

Other add-capacity-modal validations were incorporated in https://github.com/openshift/console/pull/8754