### PR TITLE
Disable portworx operator Cypress test until upstream version change is merged

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -14,7 +14,8 @@ const operatorInstance = 'StorageCluster';
 const openshiftOperatorsNS = 'openshift-operators';
 const operandLink = 'portworx';
 
-describe(`Interacting with a global install mode Operator (${operatorName})`, () => {
+// TODO: Disable until https://github.com/libopenstorage/operator/pull/323 is merged
+xdescribe(`Interacting with a global install mode Operator (${operatorName})`, () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
Disable until [libopenstorage operator PR #323](https://github.com/libopenstorage/operator/pull/323 ) is merged