### PR TITLE
Bug 1965370: Update ZH translation for "Route"

### DIFF
--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -1427,7 +1427,7 @@
   "ProjectRequest": "ProjectRequest",
   "ProjectRequests": "ProjectRequests",
   "Ingress": "Ingress",
-  "Route": "Route",
+  "Route": "路由",
   "ConfigMap": "ConfigMap",
   "ClusterRoleBinding": "ClusterRoleBinding",
   "ClusterRoleBindings": "ClusterRoleBindings",


### PR DESCRIPTION
Updated ZH translation for "Route;" it's now consistent with "Routes" and other usages of "Route." Still waiting for confirmation on KO part of bug.

Fixes part of https://bugzilla.redhat.com/show_bug.cgi?id=1965370.