### PR TITLE
fixes: multiline code snippet buttons doesn't work properly

### DIFF
--- a/frontend/__tests__/components/markdown-view.spec.tsx
+++ b/frontend/__tests__/components/markdown-view.spec.tsx
@@ -52,7 +52,7 @@ describe('markdown-view', () => {
         .onLoad({} as React.SyntheticEvent);
     });
     expect(renderExtension).toHaveBeenCalledWith(
-      (v1.find('iframe').getDOMNode() as HTMLIFrameElement).contentDocument,
+      (v1.find('iframe').getDOMNode() as HTMLIFrameElement).contentDocument ?? document,
       '',
     );
 

--- a/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownCopyClipboard.tsx
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownCopyClipboard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useEventListener, useForceRender } from '../../hooks';
+import { useEventListener } from '../../hooks';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { MARKDOWN_COPY_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
 
@@ -62,19 +62,6 @@ const MarkdownCopyClipboard: React.FC<MarkdownCopyClipboardProps> = ({
   rootSelector,
 }) => {
   const elements = docContext.querySelectorAll(`${rootSelector} [${MARKDOWN_COPY_BUTTON_ID}]`);
-  const forceRender = useForceRender();
-  /**
-   * During the first render of component docContext is not updated with the latest copy of `document`
-   * because we use `dangerouslySetInnerHTML` to set the markdown markup to a div.
-   * So while react updates the dom with latest of markdown markup with `dangerouslySetInnerHTML`
-   * this component mounts and access the old copy of dom in which there are no elements present
-   * with querySelector.
-   * So using forceRender to rerender the component and access the `document` in which markdown markup is present.
-   */
-  React.useEffect(() => {
-    forceRender();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   return elements.length > 0 ? (
     <>
       {Array.from(elements).map((elm) => {

--- a/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownCopyClipboard.tsx
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownCopyClipboard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useEventListener } from '../../hooks';
+import { useEventListener, useForceRender } from '../../hooks';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { MARKDOWN_COPY_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
 
@@ -62,6 +62,19 @@ const MarkdownCopyClipboard: React.FC<MarkdownCopyClipboardProps> = ({
   rootSelector,
 }) => {
   const elements = docContext.querySelectorAll(`${rootSelector} [${MARKDOWN_COPY_BUTTON_ID}]`);
+  const forceRender = useForceRender();
+  /**
+   * During the first render of component docContext is not updated with the latest copy of `document`
+   * because we use `dangerouslySetInnerHTML` to set the markdown markup to a div.
+   * So while react updates the dom with latest of markdown markup with `dangerouslySetInnerHTML`
+   * this component mounts and access the old copy of dom in which there are no elements present
+   * with querySelector.
+   * So using forceRender to rerender the component and access the `document` in which markdown markup is present.
+   */
+  React.useEffect(() => {
+    forceRender();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return elements.length > 0 ? (
     <>
       {Array.from(elements).map((elm) => {

--- a/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownExecuteSnippet.tsx
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownExecuteSnippet.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import useCloudShellAvailable from '@console/app/src/components/cloud-shell/useCloudShellAvailable';
 import { useCloudShellCommandDispatch } from '@console/app/src/redux/actions/cloud-shell-dispatchers';
-import { useEventListener, useForceRender } from '../../hooks';
+import { useEventListener } from '../../hooks';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { MARKDOWN_EXECUTE_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
 
@@ -66,19 +66,6 @@ const MarkdownExecuteSnippet: React.FC<MarkdownExecuteCommandProps> = ({
 }) => {
   const elements = docContext.querySelectorAll(`${rootSelector} [${MARKDOWN_EXECUTE_BUTTON_ID}]`);
   const showExecuteButton = useCloudShellAvailable();
-  const forceRender = useForceRender();
-  /**
-   * During the first render of component docContext is not updated with the latest copy of `document`
-   * because we use `dangerouslySetInnerHTML` to set the markdown markup to a div.
-   * So while react updates the dom with latest of markdown markup with `dangerouslySetInnerHTML`
-   * this component mounts and access the old copy of dom in which there are no elements present
-   * with querySelector.
-   * So using forceRender to rerender the component and access the `document` in which markdown markup is present.
-   */
-  React.useEffect(() => {
-    forceRender();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   return elements.length > 0 && showExecuteButton ? (
     <>
       {Array.from(elements).map((elm) => {

--- a/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownExecuteSnippet.tsx
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/MarkdownExecuteSnippet.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import useCloudShellAvailable from '@console/app/src/components/cloud-shell/useCloudShellAvailable';
 import { useCloudShellCommandDispatch } from '@console/app/src/redux/actions/cloud-shell-dispatchers';
-import { useEventListener } from '../../hooks';
+import { useEventListener, useForceRender } from '../../hooks';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { MARKDOWN_EXECUTE_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
 
@@ -66,7 +66,19 @@ const MarkdownExecuteSnippet: React.FC<MarkdownExecuteCommandProps> = ({
 }) => {
   const elements = docContext.querySelectorAll(`${rootSelector} [${MARKDOWN_EXECUTE_BUTTON_ID}]`);
   const showExecuteButton = useCloudShellAvailable();
-
+  const forceRender = useForceRender();
+  /**
+   * During the first render of component docContext is not updated with the latest copy of `document`
+   * because we use `dangerouslySetInnerHTML` to set the markdown markup to a div.
+   * So while react updates the dom with latest of markdown markup with `dangerouslySetInnerHTML`
+   * this component mounts and access the old copy of dom in which there are no elements present
+   * with querySelector.
+   * So using forceRender to rerender the component and access the `document` in which markdown markup is present.
+   */
+  React.useEffect(() => {
+    forceRender();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return elements.length > 0 && showExecuteButton ? (
     <>
       {Array.from(elements).map((elm) => {

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -31,3 +31,4 @@ export * from './useBoundingClientRect';
 export * from './useScrollContainer';
 export * from './useEventListener';
 export * from './useTelemetry';
+export * from './useForceRender';

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -116,9 +116,15 @@ type RenderExtensionProps = {
   renderExtension: (contentDocument: HTMLDocument, rootSelector: string) => React.ReactNode;
   selector: string;
   markup: string;
+  docContext?: HTMLDocument;
 };
 
-const RenderExtension: React.FC<RenderExtensionProps> = ({ renderExtension, selector, markup }) => {
+const RenderExtension: React.FC<RenderExtensionProps> = ({
+  renderExtension,
+  selector,
+  markup,
+  docContext,
+}) => {
   const forceRender = useForceRender();
   const markupRef = React.useRef<string>(null);
   const shouldRenderExtension = React.useCallback(() => {
@@ -138,7 +144,9 @@ const RenderExtension: React.FC<RenderExtensionProps> = ({ renderExtension, sele
     renderExtension && forceRender();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [markup]);
-  return <>{shouldRenderExtension() ? renderExtension?.(document, selector) : null}</>;
+  return (
+    <>{shouldRenderExtension() ? renderExtension?.(docContext ?? document, selector) : null}</>
+  );
 };
 
 const InlineMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
@@ -241,7 +249,14 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
         ref={(r) => setFrame(r)}
         onLoad={() => onLoad()}
       />
-      {loaded && frame && renderExtension && renderExtension(frame.contentDocument, '')}
+      {loaded && frame && (
+        <RenderExtension
+          markup={markup}
+          selector={''}
+          renderExtension={renderExtension}
+          docContext={frame.contentDocument}
+        />
+      )}
     </>
   );
 };

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash-es';
 import { Converter } from 'showdown';
 import * as sanitizeHtml from 'sanitize-html';
 import { useTranslation } from 'react-i18next';
+import { useForceRender } from '@console/shared';
 
 import './_markdown-view.scss';
 
@@ -111,6 +112,27 @@ export const SyncMarkdownView: React.FC<SyncMarkdownProps> = ({
   return inline ? <InlineMarkdownView {...innerProps} /> : <IFrameMarkdownView {...innerProps} />;
 };
 
+type RenderExtensionProps = {
+  renderExtension: (contentDocument: HTMLDocument, rootSelector: string) => React.ReactNode;
+  selector: string;
+  markup: string;
+};
+
+const RenderExtension: React.FC<RenderExtensionProps> = ({ renderExtension, selector, markup }) => {
+  const forceRender = useForceRender();
+  /**
+   * During any render cycle renderExtension receives an old copy of document
+   * because react is still updating the dom using `dangerouslySetInnerHTML` with latest markdown markup
+   * which causes the component rendered by renderExtension to receive old copy of document
+   * use forceRender to delay the rendering of extension by one render cycle
+   */
+  React.useEffect(() => {
+    renderExtension && forceRender();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [markup]);
+  return <>{renderExtension?.(document, selector)}</>;
+};
+
 const InlineMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   markup,
   isEmpty,
@@ -120,7 +142,7 @@ const InlineMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   return (
     <div className={cx('co-markdown-view', { ['is-empty']: isEmpty })} id={id}>
       <div dangerouslySetInnerHTML={{ __html: markup }} />
-      {renderExtension && renderExtension(document, `#${id}`)}
+      <RenderExtension renderExtension={renderExtension} selector={`#${id}`} markup={markup} />
     </div>
   );
 };

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -120,8 +120,16 @@ type RenderExtensionProps = {
 
 const RenderExtension: React.FC<RenderExtensionProps> = ({ renderExtension, selector, markup }) => {
   const forceRender = useForceRender();
+  const markupRef = React.useRef<string>(null);
+  const shouldRenderExtension = React.useCallback(() => {
+    if (markupRef.current === markup) {
+      return true;
+    }
+    markupRef.current = markup;
+    return false;
+  }, [markup]);
   /**
-   * During any render cycle renderExtension receives an old copy of document
+   * During a render cycle in which markup changes, renderExtension receives an old copy of document
    * because react is still updating the dom using `dangerouslySetInnerHTML` with latest markdown markup
    * which causes the component rendered by renderExtension to receive old copy of document
    * use forceRender to delay the rendering of extension by one render cycle
@@ -130,7 +138,7 @@ const RenderExtension: React.FC<RenderExtensionProps> = ({ renderExtension, sele
     renderExtension && forceRender();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [markup]);
-  return <>{renderExtension?.(document, selector)}</>;
+  return <>{shouldRenderExtension() ? renderExtension?.(document, selector) : null}</>;
 };
 
 const InlineMarkdownView: React.FC<InnerSyncMarkdownProps> = ({


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-5896

This PR fixes the issue of the multiline/single line code snippets where the event listeners were not attached which made both `copy to clipboard` and `execute in terminal` buttons unresponsive.

![Kapture 2021-06-01 at 22 20 01](https://user-images.githubusercontent.com/9278015/120361597-a2f46a80-c327-11eb-9dde-e197a54a72e7.gif)
