### PR TITLE
ODC-5919-Pipeline Actions script fixes

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
@@ -20,7 +20,7 @@ export const pageTitle = {
   Project: 'Project Details',
   ConfigMaps: 'Config Maps',
   Secrets: 'Secrets',
-  PipelineRunDetails: 'Pipeline Run details',
+  PipelineRunDetails: 'PipelineRun details',
   PipelineDetails: 'Pipeline details',
   TriggerTemplateDetails: 'Trigger Template details',
   EventListenerDetails: 'Event Listener details',

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-actions.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-actions.feature
@@ -143,7 +143,7 @@ Feature: Perform the actions on Pipelines page
         @regression
         Scenario: Start Last Run for the basic pipeline from pipelines page: P-06-TC13
             Given pipeline run is displayed for "pipeline-fff" with resource
-             When user selects "Start Last Run" from the kebab menu for "pipeline-fff"
+             When user selects "Start last run" from the kebab menu for "pipeline-fff"
              Then user will be redirected to Pipeline Run Details page
 
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/constants/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/constants/pipelines.ts
@@ -8,5 +8,5 @@ export enum pipelineActions {
   DeletePipeline = 'Delete Pipeline',
   StartLastRun = 'Start Last Run',
   Rerun = 'Rerun',
-  DeletePipelineRun = 'Delete Pipeline Run',
+  DeletePipelineRun = 'Delete PipelineRun',
 }

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -79,7 +79,7 @@ export const pipelineDetailsPO = {
   detailsTab: '[data-test-id$="Details"]',
   metricsTab: '[data-test-id="horizontal-link-Metrics"]',
   yamlTab: '[data-test-id$="YAML"]',
-  pipelineRunsTab: '[data-test-id="horizontal-link-Pipeline Runs"]',
+  pipelineRunsTab: '[data-test-id="horizontal-link-PipelineRuns"]',
   parametersTab: '[data-test-id="horizontal-link-Parameters"]',
   resourcesTab: '[data-test-id="horizontal-link-Resources"]',
   details: {


### PR DESCRIPTION
Jira Id : https://issues.redhat.com/browse/ODC-5919

**Description**:
Pipeline action names text format got changed, due to that script failures are occurred. Fixing them by updating text and page objects

NOTE: one test case is not fixed related to adding task by editing pipeline []- will handle it [ODC-5918](https://issues.redhat.com/browse/ODC-5918)

Browser & its version : Chrome 89

Setup:
Update the script in package.json as "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/*/pipelines-actions.feature\";" in

Execution Commands:
In below commands, please update url and password based on the cluster

```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
./test-cypress.sh -p pipelines -h true
```
Execute all feature files

**Screenshots**
![image](https://user-images.githubusercontent.com/61005404/120377050-3c2c7c80-c33a-11eb-9a15-205d5c71a714.png)

