### PR TITLE
Omit bitbucket branch in URL if it contains slash

### DIFF
--- a/frontend/packages/topology/src/utils/topology-utils.ts
+++ b/frontend/packages/topology/src/utils/topology-utils.ts
@@ -55,7 +55,9 @@ const getFullGitURL = (gitUrl: GitUrlParse.GitUrl, branch?: string) => {
   if (gitUrl.resource.includes('gitlab')) {
     return `${baseUrl}/-/tree/${branch}`;
   }
-  if (gitUrl.resource.includes('bitbucket')) {
+  // Branch names containing '/' do not work with bitbucket src URLs
+  // https://jira.atlassian.com/browse/BCLOUD-9969
+  if (gitUrl.resource.includes('bitbucket') && !branch.includes('/')) {
     return `${baseUrl}/src/${branch}`;
   }
   return baseUrl;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5901
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Bitbucket URLs created using the format `{repo}/src/{branch}` do not work if there is a slash(`/`) in the branch name.
(Source: https://jira.atlassian.com/browse/BCLOUD-9969)
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Do not add branch name to git icon URL if it contains a `/`.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
(No UI change)
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Test setup:**
- Create a deployment with git import flow using any bitbucket repository.
- Update the deployment annotation `app.openshift.io/vcs-ref` to contain one or more `/`s
- GIt icon URL should not contain branch name
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug