### PR TITLE
handles check for kafkasource update with managed kafka

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -194,5 +194,6 @@
   "Move sink to {{resourceObjKind}}": "Move sink to {{resourceObjKind}}",
   "Move sink to URI": "Move sink to URI",
   "Open URI": "Open URI",
+  "Unable to create kafka connector as bootstrapServerHost or secret is not available in target resource.": "Unable to create kafka connector as bootstrapServerHost or secret is not available in target resource.",
   "Knative Services": "Knative Services"
 }

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
@@ -203,7 +203,7 @@ export const eventSourceKafkaLinkDragSourceSpec = (): DragSourceSpec<
       createEventSourceKafkaConnection(props.element.getSource(), dropResult).catch((error) => {
         errorModal({
           title: i18next.t('knative-plugin~Error moving event source kafka connector'),
-          error: error.message,
+          error: error?.message,
           showIcon: true,
         });
       });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5902

**Analysis / Root cause**: 
on updating `kafkaSource` with drag and drop to an invalid managed kafka connection resource (by invalid mean does not have `bootstrapServerHost` or secrets) form topology the connectors were not updating neither any err/info was shown to the user.

**Solution Description**: 
while updating `kafkaSource` with drag and drop to a managed kafka connection resource then added a check to validate if `KC` has `bootstrapServerHost` and `secrets`. In case of invalid show appropriate message to the user and don't update `kafkaSource` otherwise update it.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/5129024/120480566-ce7d6080-c3cc-11eb-943f-459ef90a7b7a.png)


![Kapture 2021-06-02 at 18 02 29](https://user-images.githubusercontent.com/5129024/120480597-d937f580-c3cc-11eb-9e35-d32a36d13dc4.gif)




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
