### PR TITLE
Bug 1967207: Update "Getting started resources" links

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
@@ -48,9 +48,9 @@ describe('ExploreAdminFeaturesGettingStartedCard', () => {
         href: '/api-explorer',
       },
       {
-        id: 'console-customizations',
-        title: 'Console customizations',
-        href: '/k8s/cluster/customresourcedefinitions?name=console',
+        id: 'operatorhub',
+        title: 'OperatorHub',
+        href: '/operatorhub',
       },
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -22,9 +22,9 @@ export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
       href: '/api-explorer',
     },
     {
-      id: 'console-customizations',
-      title: t('public~Console customizations'),
-      href: '/k8s/cluster/customresourcedefinitions?name=console',
+      id: 'operatorhub',
+      title: t('public~OperatorHub'),
+      href: '/operatorhub',
     },
   ];
 

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -344,7 +344,7 @@
   "Set up your cluster": "Set up your cluster",
   "Finish setting up your cluster with recommended configurations.": "Finish setting up your cluster with recommended configurations.",
   "Add identity providers": "Add identity providers",
-  "Console customizations": "Console customizations",
+  "OperatorHub": "OperatorHub",
   "See what's new in OpenShift {{version}}": "See what's new in OpenShift {{version}}",
   "Explore new admin features": "Explore new admin features",
   "Explore new features and resources within the admin perspective.": "Explore new features and resources within the admin perspective.",


### PR DESCRIPTION
Show "OperatorHub" in place of "Console customizations" in the Administrator perspective "Getting started resources" card.