### PR TITLE
Bug 1967208: Use semver to parse version for "Getting started" card

### DIFF
--- a/frontend/packages/console-shared/src/hooks/version.ts
+++ b/frontend/packages/console-shared/src/hooks/version.ts
@@ -20,12 +20,12 @@ export const useClusterVersion = (): ClusterVersionKind => {
   return cvLoaded && !cvLoadError ? cvData : null;
 };
 
-export const useOpenshiftVersion = (): string => {
-  const [openshiftVersion, setOpenshiftVersion] = useState<string>();
+export const useOpenShiftVersion = (): string => {
+  const [openshiftVersion, setOpenShiftVersion] = useState<string>();
   const clusterVersion = useClusterVersion();
   const version = clusterVersion?.status?.history?.[0]?.version;
   useEffect(() => {
-    setOpenshiftVersion(version);
+    setOpenShiftVersion(version);
   }, [version]);
   return openshiftVersion;
 };

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -165,7 +165,7 @@
   "Pause rollouts for this {{resourceLabel}}": "Pause rollouts for this {{resourceLabel}}",
   "Pausing lets you make changes without triggering a rollout. You can resume rollouts at any time.": "Pausing lets you make changes without triggering a rollout. You can resume rollouts at any time.",
   "Required": "Required",
-  "Get started with a tour of some of the key areas in OpenShift {{version}} Developer perspective that can help you complete workflows and be more productive.": "Get started with a tour of some of the key areas in OpenShift {{version}} Developer perspective that can help you complete workflows and be more productive.",
+  "Get started with a tour of some of the key areas in OpenShift {{version}}'s Developer perspective that can help you complete workflows and be more productive.": "Get started with a tour of some of the key areas in OpenShift {{version}}'s Developer perspective that can help you complete workflows and be more productive.",
   "Switch between the Developer and Administrator perspectives.": "Switch between the Developer and Administrator perspectives.",
   "Use the Administrator perspective to manage workload storage, networking, cluster settings, and more. This may require additional user access.": "Use the Administrator perspective to manage workload storage, networking, cluster settings, and more. This may require additional user access.",
   "Use the Developer perspective to build applications and associated components and services, define how they work together, and monitor their health over time.": "Use the Developer perspective to build applications and associated components and services, define how they work together, and monitor their health over time.",

--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import * as semver from 'semver';
 import { useTranslation } from 'react-i18next';
 import { FlagIcon } from '@patternfly/react-icons';
 
-import { ALL_NAMESPACES_KEY, useActiveNamespace, useOpenshiftVersion } from '@console/shared/src';
+import { ALL_NAMESPACES_KEY, useActiveNamespace, useOpenShiftVersion } from '@console/shared/src';
 import {
   GettingStartedLink,
   GettingStartedCard,
@@ -11,11 +12,9 @@ import {
 export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
+  const parsed = semver.parse(useOpenShiftVersion());
   // Show only major and minor version.
-  const version = (useOpenshiftVersion() || '')
-    .split('.')
-    .slice(0, 2)
-    .join('.');
+  const version = parsed ? `${parsed.major}.${parsed.minor}` : '';
 
   const links: GettingStartedLink[] = [
     {

--- a/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('react-i18next', () => ({
 jest.mock('@console/shared/src', () => ({
   ...require.requireActual('@console/shared/src'),
   useActiveNamespace: jest.fn(),
-  useOpenshiftVersion: () => 'x.y.z',
+  useOpenShiftVersion: () => '4.8.0',
 }));
 
 // Workaround because getting-started exports also useGettingStartedShowState
@@ -58,7 +58,7 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
       id: 'whats-new',
-      title: "What's new in OpenShift x.y",
+      title: "What's new in OpenShift 4.8",
       href: 'https://developers.redhat.com/products/openshift/getting-started',
       external: true,
     });
@@ -86,7 +86,7 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
       id: 'whats-new',
-      title: "What's new in OpenShift x.y",
+      title: "What's new in OpenShift 4.8",
       href: 'https://developers.redhat.com/products/openshift/getting-started',
       external: true,
     });

--- a/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
+++ b/frontend/packages/dev-console/src/components/guided-tour/GuidedTourText.tsx
@@ -1,19 +1,23 @@
 import * as React from 'react';
+import * as semver from 'semver';
 import { Trans, useTranslation } from 'react-i18next';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { useOpenshiftVersion } from '@console/shared/src/hooks/version';
+import { useOpenShiftVersion } from '@console/shared/src/hooks/version';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ConsoleLinkModel } from '@console/internal/models';
 
 const DevPerspectiveTourText: React.FC = () => {
   const { t } = useTranslation();
-  const openshiftVersion = useOpenshiftVersion();
+  const fullVersion = useOpenShiftVersion();
+  const parsed = semver.parse(fullVersion);
+  // Show only major and minor version.
+  const version = parsed ? `${parsed.major}.${parsed.minor}` : '4.x';
   return (
     <>
       {t(
-        'devconsole~Get started with a tour of some of the key areas in OpenShift {{version}} Developer perspective that can help you complete workflows and be more productive.',
-        { version: openshiftVersion ? [openshiftVersion?.slice(0, 3), "'s"].join('') : '4.x' },
+        "devconsole~Get started with a tour of some of the key areas in OpenShift {{version}}'s Developer perspective that can help you complete workflows and be more productive.",
+        { version },
       )}
     </>
   );

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/__tests__/explore-admin-features-getting-started-card.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('@console/shared/src', () => ({
   ...require.requireActual('@console/shared/src'),
-  useOpenshiftVersion: () => 'x.y.z',
+  useOpenShiftVersion: () => '4.8.0',
 }));
 
 // Workaround because getting-started exports also RestoreGettingStartedButton
@@ -55,7 +55,7 @@ describe('ExploreAdminFeaturesGettingStartedCard', () => {
     ]);
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
       id: 'whats-new',
-      title: "See what's new in OpenShift x.y",
+      title: "See what's new in OpenShift 4.8",
       href: 'https://www.openshift.com/learn/whats-new',
       external: true,
     });

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/getting-started/explore-admin-features-getting-started-card.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import * as semver from 'semver';
 import { useTranslation } from 'react-i18next';
 import { FlagIcon } from '@patternfly/react-icons';
 
-import { useOpenshiftVersion } from '@console/shared/src';
+import { useOpenShiftVersion } from '@console/shared/src';
 import {
   GettingStartedCard,
   GettingStartedLink,
@@ -10,11 +11,9 @@ import {
 
 export const ExploreAdminFeaturesGettingStartedCard: React.FC = () => {
   const { t } = useTranslation();
+  const parsed = semver.parse(useOpenShiftVersion());
   // Show only major and minor version.
-  const version = (useOpenshiftVersion() || '')
-    .split('.')
-    .slice(0, 2)
-    .join('.');
+  const version = parsed ? `${parsed.major}.${parsed.minor}` : '';
 
   const links: GettingStartedLink[] = [
     {


### PR DESCRIPTION
Using the semver library is more robust than manually parsing the
string. Also fix the typo the hook name `useOpenshiftVersion` ->
`useOpenShiftVersion`.

/assign @jerolimov