### PR TITLE
Update the name and value titles to primary texts

### DIFF
--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -120,8 +120,8 @@ const NameValueEditor_ = withDragDropContext(
         <>
           <div className="row pairs-list__heading">
             {!readOnly && allowSorting && <div className="col-xs-1 co-empty__header" />}
-            <div className="col-xs-5 text-secondary text-uppercase">{nameString}</div>
-            <div className="col-xs-5 text-secondary text-uppercase">{valueString}</div>
+            <div className="col-xs-5">{nameString}</div>
+            <div className="col-xs-5">{valueString}</div>
             <div className="col-xs-1 co-empty__header" />
           </div>
           {pairElems}


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3945
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: The name and value titles in name value editor can become confusing because of secondary text styling and a placeholder in the input field.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Update. the name and value titles to primary text styles to make it distinct from placeholder texts.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux @lwrigh 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

Before - 
<img width="1268" alt="Screenshot 2021-06-03 at 7 22 28 PM" src="https://user-images.githubusercontent.com/6041994/120656211-0bb32280-c4a1-11eb-881c-c9589239afb1.png">


After -
<img width="1258" alt="Screenshot 2021-06-03 at 7 16 02 PM" src="https://user-images.githubusercontent.com/6041994/120656262-18d01180-c4a1-11eb-9cc2-0f4de0532494.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
