### PR TITLE
Gherkin: customization of available roles in project membership 

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/project/project-access.feature
+++ b/frontend/packages/dev-console/integration-tests/features/project/project-access.feature
@@ -1,0 +1,39 @@
+@project-access
+Feature: Project Access page
+              As a administrator, I want to customize the roles which are being shown in the Project Access tab in the Developer console, this includes removing default roles as well as adding custom roles.
+
+
+        Background:
+            Given user is at developer perspective
+              And user has created or selected namespace "aut-project-access"
+
+
+        @regression @odc-4650 @manual
+        Scenario: Adding Custom role in project membership: PA-01-TC01
+            Given user has cluster role basic-user created
+             When user clicks on Search tab in navigation menu
+              And user searches console in Resources dropdown
+              And user selects Console with apiVersion operator.openshift.io/v1 option from Resources dropdown
+              And user clicks on "cluster" Name in Consoles
+              And user switches to YAML tab
+              And user adds spec.customization.projectAccess section
+              And user inserts Add project access roles Snippet from the Sidebar under spec.customization.projectAccess section
+              And user adds "- basic-user" under the other three role added from Snippet
+              And user clicks on Save button
+              And user clicks on Project tab in navigation menu
+              And user clicks Project access tab
+              And user clicks on Role dropdown for kube:admin Name
+             Then user will see "basic-user" option in the dropdown
+
+
+
+        @regression @odc-4650 @manual
+        Scenario: Removing Custom role in project membership: PA-01-TC02
+            Given user has added custom role "basic-user" in console YAML
+              And user is at cluster YAML of "operator.openshift.io/v1" console
+             When user removes "- view" from spec.customization.projectAccess.availableClusterRoles
+              And user clicks on Save button
+              And user clicks on Project tab in navigation menu
+              And user clicks Project access tab
+              And user clicks on Role dropdown for kube:admin Name
+             Then user will not see "view" option in the dropdown


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-4650
Story: https://issues.redhat.com/browse/ODC-5438

Acceptance criteria:

- As an administrator, I want to customize the roles which are being shown in the Project Access tab in the Developer console.  This includes removing default roles as well as adding custom roles. 

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]