### PR TITLE
Bug 1967276: Remove tooltips from masthead toolbar

### DIFF
--- a/frontend/packages/console-app/locales/en/cloudshell.json
+++ b/frontend/packages/console-app/locales/en/cloudshell.json
@@ -14,8 +14,6 @@
   "Reconnect to terminal": "Reconnect to terminal",
   "Restart terminal": "Restart terminal",
   "OpenShift command line": "OpenShift command line",
-  "Close command line terminal": "Close command line terminal",
-  "Open command line terminal": "Open command line terminal",
   "OpenShift command line terminal": "OpenShift command line terminal",
   "Failed to connect to your OpenShift command line terminal": "Failed to connect to your OpenShift command line terminal",
   "Initialize terminal": "Initialize terminal",

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { RootState } from '@console/internal/redux';
 import { TerminalIcon } from '@patternfly/react-icons';
-import { Button, PageHeaderToolsItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Button, PageHeaderToolsItem } from '@patternfly/react-core';
 import { isCloudShellExpanded } from '../../redux/reducers/cloud-shell-selectors';
 import { toggleCloudShellExpanded } from '../../redux/actions/cloud-shell-actions';
 import useCloudShellAvailable from './useCloudShellAvailable';
@@ -28,25 +28,16 @@ const ClouldShellMastheadButton: React.FC<Props> = ({ onClick, open }) => {
 
   return (
     <PageHeaderToolsItem>
-      <Tooltip
-        content={
-          open
-            ? t('cloudshell~Close command line terminal')
-            : t('cloudshell~Open command line terminal')
-        }
-        position={TooltipPosition.auto}
+      <Button
+        variant="plain"
+        aria-label={t('cloudshell~Command line terminal')}
+        onClick={onClick}
+        className={open ? 'pf-m-selected' : undefined}
+        data-tour-id="tour-cloud-shell-button"
+        data-quickstart-id="qs-masthead-cloudshell"
       >
-        <Button
-          variant="plain"
-          aria-label={t('cloudshell~Command line terminal')}
-          onClick={onClick}
-          className={open ? 'pf-m-selected' : undefined}
-          data-tour-id="tour-cloud-shell-button"
-          data-quickstart-id="qs-masthead-cloudshell"
-        >
-          <TerminalIcon className="co-masthead-icon" />
-        </Button>
-      </Tooltip>
+        <TerminalIcon className="co-masthead-icon" />
+      </Button>
     </PageHeaderToolsItem>
   );
 };

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -18,8 +18,6 @@ import {
   PageHeaderTools,
   PageHeaderToolsGroup,
   PageHeaderToolsItem,
-  TooltipPosition,
-  Tooltip,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { FLAGS, YellowExclamationTriangleIcon, ACM_LINK_ID } from '@console/shared';
@@ -44,17 +42,15 @@ const SystemStatusButton = ({ statuspageData, className }) => {
   const { t } = useTranslation();
   return !_.isEmpty(_.get(statuspageData, 'incidents')) ? (
     <PageHeaderToolsItem className={className}>
-      <Tooltip content={t('public~System status')} position={TooltipPosition.auto}>
-        <a
-          className="pf-c-button pf-m-plain"
-          aria-label={t('public~System status')}
-          href={statuspageData.page.url}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <YellowExclamationTriangleIcon className="co-masthead-icon" />
-        </a>
-      </Tooltip>
+      <a
+        className="pf-c-button pf-m-plain"
+        aria-label={t('public~System status')}
+        href={statuspageData.page.url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <YellowExclamationTriangleIcon className="co-masthead-icon" />
+      </a>
     </PageHeaderToolsItem>
   ) : null;
 };
@@ -590,90 +586,81 @@ class MastheadToolbarContents_ extends React.Component {
             {/* desktop -- (application launcher dropdown), import yaml, help dropdown [documentation, about] */}
             {!_.isEmpty(launchActions) && (
               <PageHeaderToolsItem>
-                <Tooltip content={t('public~Application launcher')} position={TooltipPosition.auto}>
-                  <ApplicationLauncher
-                    className="co-app-launcher"
-                    data-test-id="application-launcher"
-                    onSelect={this._onApplicationLauncherDropdownSelect}
-                    onToggle={this._onApplicationLauncherDropdownToggle}
-                    isOpen={isApplicationLauncherDropdownOpen}
-                    items={this._renderApplicationItems(this._launchActions())}
-                    data-quickstart-id="qs-masthead-applications"
-                    position="right"
-                    isGrouped
-                  />
-                </Tooltip>
+                <ApplicationLauncher
+                  aria-label={t('public~Application launcher')}
+                  className="co-app-launcher"
+                  data-test-id="application-launcher"
+                  onSelect={this._onApplicationLauncherDropdownSelect}
+                  onToggle={this._onApplicationLauncherDropdownToggle}
+                  isOpen={isApplicationLauncherDropdownOpen}
+                  items={this._renderApplicationItems(this._launchActions())}
+                  data-quickstart-id="qs-masthead-applications"
+                  position="right"
+                  isGrouped
+                />
               </PageHeaderToolsItem>
             )}
             {/* desktop -- (notification drawer button) */
             alertAccess && (
               <PageHeaderToolsItem>
-                <Tooltip content={t('public~Notification drawer')} position={TooltipPosition.auto}>
-                  <NotificationBadge
-                    aria-label={t('public~Notification drawer')}
-                    onClick={drawerToggle}
-                    variant="read"
-                    count={notificationAlerts?.data?.length || 0}
-                    data-quickstart-id="qs-masthead-notifications"
-                  >
-                    <BellIcon alt="" />
-                  </NotificationBadge>
-                </Tooltip>
+                <NotificationBadge
+                  aria-label={t('public~Notification drawer')}
+                  onClick={drawerToggle}
+                  variant="read"
+                  count={notificationAlerts?.data?.length || 0}
+                  data-quickstart-id="qs-masthead-notifications"
+                >
+                  <BellIcon alt="" />
+                </NotificationBadge>
               </PageHeaderToolsItem>
             )}
             <PageHeaderToolsItem>
-              <Tooltip content={t('public~Import YAML')} position={TooltipPosition.auto}>
-                <Link
-                  to={this._getImportYAMLPath()}
-                  className="pf-c-button pf-m-plain"
-                  aria-label={t('public~Import YAML')}
-                  data-quickstart-id="qs-masthead-import"
-                >
-                  <PlusCircleIcon className="co-masthead-icon" alt="" />
-                </Link>
-              </Tooltip>
+              <Link
+                to={this._getImportYAMLPath()}
+                className="pf-c-button pf-m-plain"
+                aria-label={t('public~Import YAML')}
+                data-quickstart-id="qs-masthead-import"
+              >
+                <PlusCircleIcon className="co-masthead-icon" alt="" />
+              </Link>
             </PageHeaderToolsItem>
             <CloudShellMastheadButton />
             <PageHeaderToolsItem>
-              <Tooltip content={t('public~Help menu')} position={TooltipPosition.auto}>
-                <ApplicationLauncher
-                  aria-label={t('public~Help menu')}
-                  className="co-app-launcher"
-                  data-test="help-dropdown-toggle"
-                  data-tour-id="tour-help-button"
-                  data-quickstart-id="qs-masthead-help"
-                  onSelect={this._onHelpDropdownSelect}
-                  onToggle={this._onHelpDropdownToggle}
-                  isOpen={isHelpDropdownOpen}
-                  items={this._renderApplicationItems(
-                    this._helpActions(
-                      this._getAdditionalActions(
-                        this._getAdditionalLinks(consoleLinks?.data, 'HelpMenu'),
-                      ),
+              <ApplicationLauncher
+                aria-label={t('public~Help menu')}
+                className="co-app-launcher"
+                data-test="help-dropdown-toggle"
+                data-tour-id="tour-help-button"
+                data-quickstart-id="qs-masthead-help"
+                onSelect={this._onHelpDropdownSelect}
+                onToggle={this._onHelpDropdownToggle}
+                isOpen={isHelpDropdownOpen}
+                items={this._renderApplicationItems(
+                  this._helpActions(
+                    this._getAdditionalActions(
+                      this._getAdditionalLinks(consoleLinks?.data, 'HelpMenu'),
                     ),
-                  )}
-                  position="right"
-                  toggleIcon={<QuestionCircleIcon alt="" />}
-                  isGrouped
-                />
-              </Tooltip>
+                  ),
+                )}
+                position="right"
+                toggleIcon={<QuestionCircleIcon alt="" />}
+                isGrouped
+              />
             </PageHeaderToolsItem>
           </PageHeaderToolsGroup>
           <PageHeaderToolsGroup>
             {/* mobile -- (notification drawer button) */
             alertAccess && notificationAlerts?.data?.length > 0 && (
               <PageHeaderToolsItem className="visible-xs-block">
-                <Tooltip content={t('public~Notification drawer')} position={TooltipPosition.auto}>
-                  <NotificationBadge
-                    aria-label={t('public~Notification drawer')}
-                    onClick={drawerToggle}
-                    variant="read"
-                    count={notificationAlerts?.data?.length}
-                    data-quickstart-id="qs-masthead-notifications"
-                  >
-                    <BellIcon />
-                  </NotificationBadge>
-                </Tooltip>
+                <NotificationBadge
+                  aria-label={t('public~Notification drawer')}
+                  onClick={drawerToggle}
+                  variant="read"
+                  count={notificationAlerts?.data?.length}
+                  data-quickstart-id="qs-masthead-notifications"
+                >
+                  <BellIcon />
+                </NotificationBadge>
               </PageHeaderToolsItem>
             )}
             {/* mobile -- (system status button) */}


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-29935
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Having tooltips on masthead toolbar overlays on dropdown. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Remove all the tooltips from the masthead toolbar.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux @bgliwa01 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/120664621-b67b0f00-c4a8-11eb-9dd0-11d3102650f7.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
