### PR TITLE
Bug 1967713: Show link to the OCM landing page when cluster ID is missing

### DIFF
--- a/frontend/packages/insights-plugin/locales/en/insights-plugin.json
+++ b/frontend/packages/insights-plugin/locales/en/insights-plugin.json
@@ -10,6 +10,7 @@
   "Total Risk": "Total Risk",
   "Fixable issues": "Fixable issues",
   "View all in OpenShift Cluster Manager": "View all in OpenShift Cluster Manager",
+  "Go to OpenShift Cluster Manager": "Go to OpenShift Cluster Manager",
   "More about Insights": "More about Insights",
   "Not available": "Not available",
   "{{issuesNumber}} issue found": "{{issuesNumber}} issue found",

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -98,7 +98,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         )}
       </div>
       <div className="co-status-popup__section">
-        {!isWaitingOrDisabled && !isError && (
+        {!isWaitingOrDisabled && !isError && clusterID && (
           <>
             <h6 className="pf-c-title pf-m-md">{t('insights-plugin~Fixable issues')}</h6>
             <div>
@@ -108,6 +108,14 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
               />
             </div>
           </>
+        )}
+        {!isWaitingOrDisabled && !isError && !clusterID && (
+          <div>
+            <ExternalLink
+              href={`https://cloud.redhat.com/openshift/`}
+              text={t('insights-plugin~Go to OpenShift Cluster Manager')}
+            />
+          </div>
         )}
         {(isWaitingOrDisabled || isError) && (
           <ExternalLink


### PR DESCRIPTION
The Insights widget referred to the wrong Cluster Details page when the external cluster-ID was unavailable for some reason.

The patch replaces that link to redirect the OCM landing page. 