### PR TITLE
Bug 1967717: Rename Insights to Insights Advisor and add missing paragraph

### DIFF
--- a/frontend/packages/insights-plugin/locales/en/insights-plugin.json
+++ b/frontend/packages/insights-plugin/locales/en/insights-plugin.json
@@ -3,6 +3,7 @@
   "moderate": "moderate",
   "important": "important",
   "critical": "critical",
+  "Insights Advisor identifies and prioritizes risks to security, performance, availability, and stability of your clusters.": "Insights Advisor identifies and prioritizes risks to security, performance, availability, and stability of your clusters.",
   "Temporary unavailable.": "Temporary unavailable.",
   "Disabled or waiting for results.": "Disabled or waiting for results.",
   "Total issue": "Total issue",
@@ -15,5 +16,5 @@
   "{{issuesNumber}} issue found": "{{issuesNumber}} issue found",
   "{{issuesNumber}} issues found": "{{issuesNumber}} issues found",
   "Insights": "Insights",
-  "Insights status": "Insights status"
+  "Insights Advisor status": "Insights Advisor status"
 }

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -46,6 +46,11 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
 
   return (
     <div className="co-insights__box">
+      <p>
+        {t(
+          'insights-plugin~Insights Advisor identifies and prioritizes risks to security, performance, availability, and stability of your clusters.',
+        )}
+      </p>
       {isError && (
         <div className="co-status-popup__section">
           {t('insights-plugin~Temporary unavailable.')}

--- a/frontend/packages/insights-plugin/src/plugin.tsx
+++ b/frontend/packages/insights-plugin/src/plugin.tsx
@@ -27,8 +27,8 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/InsightsPopup/index' /* webpackChunkName: "insights-plugin" */).then(
           (m) => m.InsightsPopup,
         ),
-      // t('insights-plugin~Insights status')
-      popupTitle: '%insights-plugin~Insights status%',
+      // t('insights-plugin~Insights Advisor status')
+      popupTitle: '%insights-plugin~Insights Advisor status%',
     },
   },
 ];


### PR DESCRIPTION
The patch changes naming from Insights to Insights Advisor in several places of the related widget. Furthermore, it appeared we are missing one important paragraph there. The patch also adds it.

Before:
![Screenshot from 2021-06-03 18-51-34](https://user-images.githubusercontent.com/31385370/120682426-bbd25c80-c49c-11eb-9a32-54097765baa3.png)
After:
![Screenshot from 2021-06-03 18-50-57](https://user-images.githubusercontent.com/31385370/120682443-bf65e380-c49c-11eb-97b1-cbcfed47ba42.png)
