### PR TITLE
Remove tabIndex from scrollable containers to fix keyboard scroll issue

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -1,7 +1,8 @@
 .odc-namespaced-page {
   display: flex;
-  flex: 1;
   flex-direction: column;
+  height: 100%;
+  max-height: 100%;
 
   &__content {
     display: flex;

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -171,8 +171,7 @@ const AppContents: React.FC<{}> = () => {
       <div id="content">
         <GlobalNotifications />
         <Route path={namespacedRoutes} component={NamespaceBar} />
-        {/* tabIndex is necessary to restore keyboard scrolling as a result of PatternFly's <Page> having a hard-coded tabIndex.  See https://github.com/patternfly/patternfly-react/issues/4180 */}
-        <div id="content-scrollable" tabIndex={-1}>
+        <div id="content-scrollable">
           <Switch>
             {pluginPageRoutes}
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -163,6 +163,8 @@ class App_ extends React.PureComponent {
           <div id="app-content" className="co-m-app__content">
             <ConsoleNotifier location="BannerTop" />
             <Page
+              // Need to pass mainTabIndex=null to enable keyboard scrolling as default tabIndex is set to -1 by patternfly
+              mainTabIndex={null}
               header={<Masthead onNavToggle={this._onNavToggle} />}
               sidebar={
                 <Navigation

--- a/frontend/public/components/sidebars/resource-sidebar.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar.tsx
@@ -22,8 +22,7 @@ const ResourceSidebarWrapper = (props) => {
       className="co-p-has-sidebar__sidebar co-p-has-sidebar__sidebar--bordered hidden-sm hidden-xs"
       data-test="resource-sidebar"
     >
-      {/* tabIndex is necessary to restore keyboard scrolling as a result of PatternFly's <Page> having a hard-coded tabIndex.  See https://github.com/patternfly/patternfly-react/issues/4180 */}
-      <div className="co-m-pane__body co-p-has-sidebar__sidebar-body" tabIndex={-1}>
+      <div className="co-m-pane__body co-p-has-sidebar__sidebar-body">
         <Button
           type="button"
           className="co-p-has-sidebar__sidebar-close"


### PR DESCRIPTION
**Analysis / Root cause**:
- To fix the keyboard scroll issue https://github.com/openshift/console/pull/9068 changed the layout to flex and removed `max-height` from the container. 
- But this caused another issue where cypress test started failing because `scrollTo` wouldn't work anymore.
- Turns out it was an old issue because of PF setting `tabIndex=-1` on `Page` component mentioned in https://github.com/patternfly/patternfly-react/issues/4180. This caused all the child containers to explicitly set `tabIndex={-1}` in order to enable keyboard scrolling. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Revert back the changes from https://github.com/openshift/console/pull/9068.
- Remove explicit `tabIndex={-1}` from scrollable container.
- Pass explicit `mainTabIndex={null}` to `Page` component.
<!-- Describe your code changes in detail and explain the solution -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
