### PR TITLE
Bug 1967639: fixes: console whitescreens if user settings fails to load

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useUserSettingsLocalStorage.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettingsLocalStorage.ts
@@ -76,8 +76,13 @@ export const useUserSettingsLocalStorage = <T>(
           url: window.location.toString(),
         });
 
-        // update storage
-        storage.setItem(storageKey, newValue);
+        try {
+          // update storage
+          storage.setItem(storageKey, newValue);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error(`Error while updating local storage for key ${storageKey}`, err);
+        }
 
         // dispatch storage event
         window.dispatchEvent(event);


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/OCPBUGSM-29992

Whenever user settings fail to load console breaks.
This PR fixes:

- Make sure a new config map is created only when K8sWatchResource fails with 404, else fallback to local storage
- If create config map request fails, fallback to local storage.