### PR TITLE
update eventsources static model version to latest supported

### DIFF
--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -142,7 +142,7 @@ export const EventSourceCronJobModel: K8sKind = {
 
 export const EventSourcePingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   kind: 'PingSource',
   label: 'PingSource',
   // t('knative-plugin~PingSource')
@@ -160,7 +160,7 @@ export const EventSourcePingModel: K8sKind = {
 
 export const EventSourceContainerModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'ContainerSource',
   label: 'ContainerSource',
   // t('knative-plugin~ContainerSource')
@@ -178,7 +178,7 @@ export const EventSourceContainerModel: K8sKind = {
 
 export const EventSourceApiServerModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'ApiServerSource',
   label: 'ApiServerSource',
   // t('knative-plugin~ApiServerSource')
@@ -232,7 +232,7 @@ export const EventSourceKafkaModel: K8sKind = {
 
 export const EventSourceSinkBindingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
-  apiVersion: 'v1beta1',
+  apiVersion,
   kind: 'SinkBinding',
   label: 'SinkBinding',
   // t('knative-plugin~SinkBinding')

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
@@ -1,16 +1,14 @@
 export const mockEventSourcCRDData = {
   kind: 'CustomResourceDefinitionList',
   apiVersion: 'apiextensions.k8s.io/v1',
-  metadata: {
-    resourceVersion: '471070',
-  },
+  metadata: { resourceVersion: '195307' },
   items: [
     {
       metadata: {
         name: 'apiserversources.sources.knative.dev',
         labels: {
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.17.2',
+          'eventing.knative.dev/release': 'v0.20.0',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -25,33 +23,11 @@ export const mockEventSourcCRDData = {
           categories: ['all', 'knative', 'sources'],
         },
         versions: [
-          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1alpha1', served: true, storage: false },
           { name: 'v1alpha2', served: true, storage: false },
           { name: 'v1beta1', served: true, storage: false },
+          { name: 'v1', served: true, storage: true },
         ],
-      },
-    },
-    {
-      metadata: {
-        name: 'camelsources.sources.knative.dev',
-        labels: {
-          'contrib.eventing.knative.dev/release': 'v0.15.1',
-          'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/source': 'true',
-          'knative.dev/crd-install': 'true',
-          'operators.coreos.com/knative-camel-operator.openshift-operators': '',
-        },
-      },
-      spec: {
-        group: 'sources.knative.dev',
-        names: {
-          plural: 'camelsources',
-          singular: 'camelsource',
-          kind: 'CamelSource',
-          listKind: 'CamelSourceList',
-          categories: ['all', 'knative', 'eventing', 'sources'],
-        },
-        versions: [{ name: 'v1alpha1', served: true, storage: true }],
       },
     },
     {
@@ -59,7 +35,7 @@ export const mockEventSourcCRDData = {
         name: 'containersources.sources.knative.dev',
         labels: {
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.17.2',
+          'eventing.knative.dev/release': 'v0.20.0',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -74,7 +50,33 @@ export const mockEventSourcCRDData = {
           categories: ['all', 'knative', 'sources'],
         },
         versions: [
-          { name: 'v1alpha2', served: true, storage: true },
+          { name: 'v1alpha2', served: true, storage: false },
+          { name: 'v1beta1', served: true, storage: false },
+          { name: 'v1', served: true, storage: true },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'kafkasources.sources.knative.dev',
+        labels: {
+          'duck.knative.dev/source': 'true',
+          'eventing.knative.dev/source': 'true',
+          'kafka.eventing.knative.dev/release': 'v0.20.0',
+          'knative.dev/crd-install': 'true',
+        },
+      },
+      spec: {
+        group: 'sources.knative.dev',
+        names: {
+          plural: 'kafkasources',
+          singular: 'kafkasource',
+          kind: 'KafkaSource',
+          listKind: 'KafkaSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          { name: 'v1alpha1', served: true, storage: true },
           { name: 'v1beta1', served: true, storage: false },
         ],
       },
@@ -84,7 +86,7 @@ export const mockEventSourcCRDData = {
         name: 'pingsources.sources.knative.dev',
         labels: {
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.17.2',
+          'eventing.knative.dev/release': 'v0.20.0',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -99,8 +101,9 @@ export const mockEventSourcCRDData = {
           categories: ['all', 'knative', 'sources'],
         },
         versions: [
-          { name: 'v1alpha2', served: true, storage: true },
-          { name: 'v1beta1', served: true, storage: false },
+          { name: 'v1alpha2', served: true, storage: false },
+          { name: 'v1beta1', served: true, storage: true },
+          { name: 'v1beta2', served: true, storage: false },
         ],
       },
     },
@@ -110,7 +113,7 @@ export const mockEventSourcCRDData = {
         labels: {
           'duck.knative.dev/binding': 'true',
           'duck.knative.dev/source': 'true',
-          'eventing.knative.dev/release': 'v0.17.2',
+          'eventing.knative.dev/release': 'v0.20.0',
           'eventing.knative.dev/source': 'true',
           'knative.dev/crd-install': 'true',
         },
@@ -125,9 +128,10 @@ export const mockEventSourcCRDData = {
           categories: ['all', 'knative', 'sources', 'bindings'],
         },
         versions: [
-          { name: 'v1alpha1', served: true, storage: true },
+          { name: 'v1alpha1', served: true, storage: false },
           { name: 'v1alpha2', served: true, storage: false },
           { name: 'v1beta1', served: true, storage: false },
+          { name: 'v1', served: true, storage: true },
         ],
       },
     },


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5932

**Analysis / Root cause**: 
the color for event sources where shown with default blue color not as expected custom color

**Solution Description**: 
updated apiVersion for static models for  eventsources to latest supported based on respective CRDs for
- PingSource
- ApiServerSource
- ContainerSource
- SinkBinding

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/5129024/120984753-91ccb300-c798-11eb-8ebd-eb49cc870296.png)



**Unit test coverage report**: 
Updated


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
