### PR TITLE
No color change on Add card hover

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.scss
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.scss
@@ -34,15 +34,14 @@
           text-decoration: none;
         }
 
-        // Override default style for a:hover, a:focus from scaffolding.scss
-        a.pf-c-simple-list__item-link:hover {
-          --pf-global--link--Color--hover: var(--pf-c-simple-list__item-link--hover--Color);
-        }
-        a.pf-c-simple-list__item-link:focus {
-          --pf-global--link--Color--hover: var(--pf-c-simple-list__item-link--focus--Color);
-        }
-        a.pf-c-simple-list__item-link:active {
-          --pf-global--link--Color--hover: var(--pf-c-simple-list__item-link--active--Color);
+        // Override default style for button and a:hover, focus from scaffolding.scss
+        a.pf-c-simple-list__item-link:hover,
+        a.pf-c-simple-list__item-link:focus,
+        a.pf-c-simple-list__item-link:active,
+        button.pf-c-simple-list__item-link:hover,
+        button.pf-c-simple-list__item-link:focus,
+        button.pf-c-simple-list__item-link:active {
+          color: var(--pf-global--Color--100);
         }
       }
     }

--- a/frontend/packages/dev-console/src/components/add/AddCardItem.scss
+++ b/frontend/packages/dev-console/src/components/add/AddCardItem.scss
@@ -26,18 +26,6 @@
     font-size: var(--pf-global--spacer--md) !important;
   }
 
-  a.pf-c-simple-list__item-link {
-    &:hover .odc-add-card-item__title {
-      color: var(--pf-c-simple-list__item-link--hover--Color);
-    }
-    &:focus .odc-add-card-item__title {
-      color: var(--pf-c-simple-list__item-link--focus--Color);
-    }
-    &:active .odc-add-card-item__title {
-      color: var(--pf-c-simple-list__item-link--active--Color);
-    }
-  }
-
   &__description {
     margin: var(--pf-global--spacer--sm) 0 0 var(--pf-global--spacer--sm);
     color: var(--pf-global--Color--200);


### PR DESCRIPTION
# Addresses
https://issues.redhat.com/browse/ODC-5887

# Issue
Add card items change color on hover, active 

# Screenshot
![addcardhover (1)](https://user-images.githubusercontent.com/24852534/121020370-f1898500-c7bd-11eb-80bb-47fe9ac44f91.gif)

![Screencast from 06-11-2021 03_54_57 PM (1)](https://user-images.githubusercontent.com/24852534/121674903-47b53b80-cad0-11eb-82fa-9f28c1a5a20e.gif)


# Tests
No change

# Briwser conformance
Chrome