### PR TITLE
Resized Perspective Switcher to match height of side Nav Items

### DIFF
--- a/frontend/public/components/nav/_nav-header.scss
+++ b/frontend/public/components/nav/_nav-header.scss
@@ -1,5 +1,6 @@
 .oc-nav-header {
-  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--sm);
+  border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
+  padding: 0.6rem var(--pf-global--spacer--sm);
 
   @media screen and (min-width: $grid-float-breakpoint) {
     padding-left: var(--pf-global--spacer--md);

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownToggle,
-  NavItemSeparator,
-  Title,
-} from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownToggle, Title } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { Perspective, useExtensions, isPerspective } from '@console/plugin-sdk';
 import { history } from '../utils';
@@ -112,21 +106,18 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
   );
 
   return (
-    <>
-      <div
-        className="oc-nav-header"
-        data-tour-id="tour-perspective-dropdown"
-        data-quickstart-id="qs-perspective-switcher"
-      >
-        <Dropdown
-          isOpen={isPerspectiveDropdownOpen}
-          toggle={renderToggle(icon, name)}
-          dropdownItems={perspectiveItems}
-          data-test-id="perspective-switcher-menu"
-        />
-      </div>
-      <NavItemSeparator key={`separator-nav-header`} inset={{ default: 'insetNone' }} />
-    </>
+    <div
+      className="oc-nav-header"
+      data-tour-id="tour-perspective-dropdown"
+      data-quickstart-id="qs-perspective-switcher"
+    >
+      <Dropdown
+        isOpen={isPerspectiveDropdownOpen}
+        toggle={renderToggle(icon, name)}
+        dropdownItems={perspectiveItems}
+        data-test-id="perspective-switcher-menu"
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
After initial ACM phase 1 changes, perspective switcher w/ bottom divider padding was larger in height than other side nav items:

![image](https://user-images.githubusercontent.com/12733153/121034622-258f8680-c77b-11eb-9be7-473683b5cf7b.png)

This PR restores some previous css and removes `NavItemSeparator`.   Perspective switcher is now the same height as other side nav menu items:

![image](https://user-images.githubusercontent.com/12733153/121034752-4526af00-c77b-11eb-8f71-47115b28ae76.png)
