### PR TITLE
Allow passing additional arguments to run-bridge.sh

### DIFF
--- a/examples/run-bridge.sh
+++ b/examples/run-bridge.sh
@@ -16,4 +16,5 @@ set -exuo pipefail
     --user-auth-oidc-client-secret-file=examples/console-client-secret \
     --user-auth-oidc-ca-file=examples/ca.crt \
     --k8s-mode-off-cluster-alertmanager="$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')" \
-    --k8s-mode-off-cluster-thanos="$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')"
+    --k8s-mode-off-cluster-thanos="$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')" \
+    $@


### PR DESCRIPTION
Signed-off-by: Tim Etchells <tetchel@gmail.com>

I wanted to be able to [run the console with authentication enabled](https://github.com/openshift/console/#openshift-with-authentication), and also [tell it to load my dynamic plugin](https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk#plugin-development).

So, I added `$@` to the `bin/bridge` invocation in `run-bridge.sh` so I could pass additional arguments to `bridge`:

`./examples/run-bridge.sh -plugins github-connector=https://localhost:3001`
leads to..
```
+ ./bin/bridge --base-address=http://localhost:9000 --ca-file=examples/ca.crt --k8s-auth=openshift --k8s-mode=off-cluster --k8s-mode-off-cluster-endpoint=https://api.crc.testing:6443 --k8s-mode-off-cluster-skip-verify-tls=true --listen=http://127.0.0.1:9000 --public-dir=./frontend/public/dist --user-auth=openshift --user-auth-oidc-client-id=console-oauth-client --user-auth-oidc-client-secret-file=examples/console-client-secret --user-auth-oidc-ca-file=examples/ca.crt --k8s-mode-off-cluster-alertmanager= --k8s-mode-off-cluster-thanos= -plugins github-connector=https://localhost:3001
```

Let me know if this PR is not appropriate.
