### PR TITLE
Bug 1966684: Fix creating snapshot for claim <name> string

### DIFF
--- a/frontend/packages/console-app/locales/en/console-app.json
+++ b/frontend/packages/console-app/locales/en/console-app.json
@@ -45,7 +45,7 @@
   "PersistentVolumeClaim details": "PersistentVolumeClaim details",
   "StorageClass": "StorageClass",
   "Create VolumeSnapshot": "Create VolumeSnapshot",
-  "Creating snapshot for claim <1>{pvcName}</1>": "Creating snapshot for claim <1>{pvcName}</1>",
+  "Creating snapshot for claim <1>{{pvcName}}</1>": "Creating snapshot for claim <1>{{pvcName}}</1>",
   "PersistentVolumeClaim": "PersistentVolumeClaim",
   "Snapshot Class": "Snapshot Class",
   "Create": "Create",

--- a/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
+++ b/frontend/packages/console-app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot.tsx
@@ -244,7 +244,7 @@ const CreateSnapshotForm = withHandlePromise<SnapshotResourceProps>((props) => {
           {pvcName ? (
             <p>
               <Trans ns="console-app">
-                Creating snapshot for claim <strong>{pvcName}</strong>
+                Creating snapshot for claim <strong>{{ pvcName }}</strong>
               </Trans>
             </p>
           ) : (


### PR DESCRIPTION
This string is missing an additional bracket pair around the variable being substituted. While this appeared to work for English, when I set my browser to use Chinese I still see the English string.

## Before
<img width="1789" alt="Screen Shot 2021-06-07 at 10 48 32 AM" src="https://user-images.githubusercontent.com/21317056/121048262-a606b500-c784-11eb-8015-da8caa0f11e7.png">
<img width="1789" alt="Screen Shot 2021-06-07 at 11 36 59 AM" src="https://user-images.githubusercontent.com/21317056/121049012-52489b80-c785-11eb-89aa-77cce5fc3bb7.png">


## After (with mocked translation change to zh/console.json)
<img width="1792" alt="Screen Shot 2021-06-07 at 11 39 17 AM" src="https://user-images.githubusercontent.com/21317056/121048840-29c0a180-c785-11eb-99a0-d3d4a6d19eff.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1966684