### PR TITLE
ODC-5915-update create from git feature scripts

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -49,8 +49,8 @@ export const gitPO = {
       buildTriggerImage: 'input#form-checkbox-build-triggers-image-field',
       buildTriggerConfigField: 'input#form-checkbox-build-triggers-config-field',
       // Add Environment Value
-      envName: '[data-test=pairs-list-name]',
-      envValue: '[data-test=pairs-list-value]',
+      envName: 'input[data-test=pairs-list-name]',
+      envValue: 'input[data-test=pairs-list-value]',
       // Count for Rows in Environment Variables section
       envRows: 'div.row.pairs-list__row',
       deleteRowButton: 'button[data-test="delete-button"]',

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -28,23 +28,32 @@ export const gitPage = {
       .should('be.visible');
   },
   enterAppName: (appName: string) => {
-    cy.get(gitPO.appName).then(($el) => {
-      if ($el.prop('tagName').includes('button')) {
-        cy.get(gitPO.appName).click();
-        cy.get(`li #${appName}-link`).click();
-        cy.log(`Application Name "${appName}" is selected`);
-      } else if ($el.prop('tagName').includes('input')) {
-        cy.get(gitPO.appName)
+    cy.get('body').then(($body) => {
+      if ($body.find('#form-input-application-name-field').length) {
+        cy.get('#form-input-application-name-field')
           .scrollIntoView()
           .invoke('val')
           .should('not.be.empty');
-        cy.get(gitPO.appName).clear();
-        cy.get(gitPO.appName)
+        cy.get('#form-input-application-name-field')
+          .clear()
           .type(appName)
           .should('have.value', appName);
         cy.log(`Application Name "${appName}" is created`);
-      } else {
-        cy.log(`App name doesn't contain button or input tags`);
+      } else if ($body.find('#form-dropdown-application-name-field').length) {
+        cy.get(gitPO.appName).click();
+        cy.get('[data-test-id="dropdown-text-filter"]').type(appName);
+        cy.get('[role="listbox"]').then(($el) => {
+          if ($el.find('li[role="option"]').length === 0) {
+            cy.get('[data-test-dropdown-menu="#CREATE_APPLICATION_KEY#"]').click();
+            cy.get('#form-input-application-name-field')
+              .clear()
+              .type(appName)
+              .should('have.value', appName);
+          } else {
+            cy.get(`li #${appName}-link`).click();
+            cy.log(`Application Name "${appName}" is selected`);
+          }
+        });
       }
     });
   },
@@ -72,6 +81,7 @@ export const gitPage = {
       .type(newAppName);
   },
   enterComponentName: (name: string) => {
+    app.waitForLoad();
     cy.get(gitPO.nodeName)
       .scrollIntoView()
       .invoke('val')

--- a/frontend/packages/dev-console/integration-tests/support/pages/addHealthChecks-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/addHealthChecks-page.ts
@@ -20,28 +20,28 @@ export const addHealthChecksPage = {
       .scrollIntoView()
       .click(),
   addReadinessProbe: () => {
-    addHealthChecksPage.clickProbeLink('Add Readiness Probe');
+    addHealthChecksPage.clickProbeLink('Add Readiness probe');
     addHealthChecksPage.verifyHealthChecksForm();
     addHealthChecksPage.clickCheckIcon();
-    addHealthChecksPage.verifySuccessText('Readiness Probe Added');
+    addHealthChecksPage.verifySuccessText('Readiness probe added');
   },
   removeReadinessProbe: () => {
     cy.get(addHealthChecksPO.removeReadinessProbeIcon).click();
   },
   addLivenessProbe: () => {
-    cy.byButtonText('Add Liveness Probe')
+    cy.byButtonText('Add Liveness probe')
       .scrollIntoView()
       .click();
     cy.get('div.odc-heath-check-probe-form').should('be.visible');
     addHealthChecksPage.clickCheckIcon();
-    addHealthChecksPage.verifySuccessText('Liveness Probe Added');
+    addHealthChecksPage.verifySuccessText('Liveness probe added');
   },
   addStartupProbe: () => {
-    cy.byButtonText('Add Startup Probe')
+    cy.byButtonText('Add Startup probe')
       .scrollIntoView()
       .click();
     cy.get('div.odc-heath-check-probe-form').should('be.visible');
     addHealthChecksPage.clickCheckIcon();
-    addHealthChecksPage.verifySuccessText('Startup Probe Added');
+    addHealthChecksPage.verifySuccessText('Startup probe added');
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -15,6 +15,7 @@ export const app = {
   waitForLoad: (timeout: number = 80000) => {
     cy.get('.co-m-loader', { timeout }).should('not.exist');
     cy.get('.pf-c-spinner', { timeout }).should('not.exist');
+    cy.get('.skeleton-catalog--grid').should('not.exist');
     app.waitForDocumentLoad();
   },
   waitForNameSpacesToLoad: () => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
@@ -180,7 +180,7 @@ Then('public url is not created for node {string} in the workload sidebar', (nod
   topologyPage.verifyWorkloadInTopologyPage(nodeName);
   topologyPage.componentNode(nodeName).click({ force: true });
   topologySidePane.selectTab('Resources');
-  topologySidePane.verifySection('Routes').should('be.visible');
+  topologySidePane.verifySection('Routes');
   cy.get('[role="dialog"] h2')
     .contains('Routes')
     .next('span')
@@ -188,16 +188,13 @@ Then('public url is not created for node {string} in the workload sidebar', (nod
 });
 
 Then(
-  'the route of application {string} contains {string}',
+  'the route of application {string} contains {string} in the Routes section of the workload sidebar',
   (nodeName: string, routeName: string) => {
     topologyPage.verifyWorkloadInTopologyPage(nodeName);
     topologyPage.componentNode(nodeName).click({ force: true });
     topologySidePane.selectTab('Resources');
-    topologySidePane.verifySection('Routes').should('be.visible');
-    cy.get('[role="dialog"] h2')
-      .contains('Routes')
-      .next('span')
-      .should('contain.text', routeName);
+    topologySidePane.verifySection('Routes');
+    cy.get('a.co-external-link.co-external-link--block').should('contain.text', routeName);
   },
 );
 


### PR DESCRIPTION
**Jira Id**: https://issues.redhat.com/browse/ODC-5915

**Description**:
Script fixes for Add flow

**Browser & its version** : Chrome 89

**Setup**:
Update the [script](https://github.com/openshift/console/blob/master/frontend/packages/dev-console/integration-tests/package.json#L14) in package.json as `'test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec "features/*/create-from-git.feature";'`

update the TAGS in dev-console/integration-tests/cypress.json as `"@add-flow and not (@manual or @to-do)"`,

**Execution Commands**:
In below commands, please update url and password based on the cluster
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD https://api.gamore48installer7thjune001.devcluster.openshift.com:6443  --insecure-skip-tls-verify
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
./test-cypress.sh -p devconsole
```
Execute the Create-from-git.feature file
**Screenshots**
![image](https://user-images.githubusercontent.com/61005404/121125290-f4c75400-c843-11eb-8ce7-2a14f77d3b64.png)
