### PR TITLE
Inline Event Listener URL

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerURL.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/EventListenerURL.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ClipboardCopy } from '@patternfly/react-core';
+import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 import { EventListenerKind } from '../resource-types';
 import { useEventListenerURL } from '../utils/triggers';
 
@@ -20,7 +20,7 @@ const EventListenerURL: React.FC<EventListenerURLProps> = ({ eventListener, name
         <dl>
           <dt>{t('pipelines-plugin~URL')}</dt>
           <dd>
-            <ClipboardCopy isReadOnly>{routeURL}</ClipboardCopy>
+            <ClipboardCopy variant={ClipboardCopyVariant.inlineCompact}>{routeURL}</ClipboardCopy>
           </dd>
         </dl>
       </div>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResourceLink } from '@console/internal/components/utils';
 import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
-import { ClipboardCopy } from '@patternfly/react-core';
+import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 import { RouteTemplate } from '../utils/triggers';
 import './TriggerTemplateResourceLink.scss';
 
@@ -37,7 +37,13 @@ const TriggerTemplateResourceLink: React.FC<TriggerTemplateResourceLinkProps> = 
                 title={triggerTemplateName}
                 inline
               />
-              {routeURL && <ClipboardCopy isReadOnly>{routeURL}</ClipboardCopy>}
+              {routeURL && (
+                <div>
+                  <ClipboardCopy variant={ClipboardCopyVariant.inlineCompact}>
+                    {routeURL}
+                  </ClipboardCopy>
+                </div>
+              )}
             </dd>
           );
         })}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5936

**Analysis / Root cause**: 
Using a blocky version of the Copy URL component, looks ugly 🙂 

**Solution Description**: 
Using a more streamlined/inline version of Copy URL component, looks better 🙂 

**Screen shots / Gifs for design review**: 
cc @bgliwa01 
![Screen Shot 2021-06-07 at 1 03 07 PM](https://user-images.githubusercontent.com/8126518/121060954-44007c80-c791-11eb-9219-0da69af56c9c.png)
![Screen Shot 2021-06-07 at 1 03 20 PM](https://user-images.githubusercontent.com/8126518/121060959-44991300-c791-11eb-933b-eb9792dc8a47.png)
![Screen Shot 2021-06-07 at 1 03 33 PM](https://user-images.githubusercontent.com/8126518/121060962-4531a980-c791-11eb-90a0-77d4dd92f454.png)
![Screen Shot 2021-06-07 at 1 03 46 PM](https://user-images.githubusercontent.com/8126518/121060964-45ca4000-c791-11eb-962b-0eaf716412f5.png)

**Unit test coverage report**: 
None, no test related impacts.

**Test setup:**
* Have a Pipeline
* Add a trigger
    * View Event Listener Details Page
    * View Pipeline Details Page

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge