### PR TITLE
Add error boundary to topology page

### DIFF
--- a/frontend/packages/topology/src/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/topology/src/__tests__/TopologyPage.spec.tsx
@@ -58,38 +58,45 @@ describe('Topology page tests', () => {
   });
 
   it('should render topology page', () => {
-    const wrapper = shallow(<TopologyPage match={match} hideProjects={false} />);
+    const wrapperWithFallback = shallow(<TopologyPage match={match} hideProjects={false} />);
+    const wrapper = wrapperWithFallback.find('TopologyPage').shallow();
     expect(wrapper.find(NamespacedPage).exists()).toBe(true);
   });
 
   it('should default to graph view', () => {
     (useUserSettingsCompatibility as jest.Mock).mockReturnValue(['', () => {}, true]);
-    const wrapper = shallow(<TopologyPage match={match} hideProjects={false} />);
+    const wrapperWithFallback = shallow(<TopologyPage match={match} hideProjects={false} />);
+    const wrapper = wrapperWithFallback.find('TopologyPage').shallow();
     expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(false);
   });
 
   it('should allow setting default to list view', () => {
-    const wrapper = shallow(
+    const wrapperWithFallback = shallow(
       <TopologyPage match={match} hideProjects={false} defaultViewType={TopologyViewType.list} />,
     );
+    const wrapper = wrapperWithFallback.find('TopologyPage').shallow();
     expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(true);
   });
 
-  it('should use useUserSettingsCompatibility setting', () => {
+  it('should render graph if useUserSettingsCompatibility setting returns that', () => {
     (useUserSettingsCompatibility as jest.Mock).mockReturnValue(['graph', () => {}, true]);
-    let wrapper = shallow(
+    const wrapperWithFallback = shallow(
       <TopologyPage match={match} hideProjects={false} activeViewStorageKey="fake-key" />,
     );
+    const wrapper = wrapperWithFallback.find('TopologyPage').shallow();
     expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(false);
+  });
 
+  it('should render list if useUserSettingsCompatibility setting returns that', () => {
     (useUserSettingsCompatibility as jest.Mock).mockReturnValue(['list', () => {}, true]);
-    wrapper = shallow(
+    const wrapperWithFallback = shallow(
       <TopologyPage match={match} hideProjects={false} activeViewStorageKey="fake-key" />,
     );
+    const wrapper = wrapperWithFallback.find('TopologyPage').shallow();
     expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(true);
   });
 
-  it('should continue to support URL view path', () => {
+  it('should continue to support URL view path for graph', () => {
     (useUserSettingsCompatibility as jest.Mock).mockReturnValue(['', () => {}, true]);
     const viewMatch = {
       params: { name: 'default' },
@@ -97,11 +104,20 @@ describe('Topology page tests', () => {
       path: '/topology/graph',
       url: '',
     };
-    let wrapper = shallow(<TopologyPage match={viewMatch} hideProjects={false} />);
+    const wrapperWithFallback = shallow(<TopologyPage match={viewMatch} hideProjects={false} />);
+    const wrapper = wrapperWithFallback.find('TopologyPage').shallow();
     expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(false);
+  });
 
-    viewMatch.path = '/topology/list';
-    wrapper = shallow(<TopologyPage match={viewMatch} hideProjects={false} />);
+  it('should continue to support URL view path for list', () => {
+    const viewMatch = {
+      params: { name: 'default' },
+      isExact: true,
+      path: '/topology/list',
+      url: '',
+    };
+    const wrapperWithFallback = shallow(<TopologyPage match={viewMatch} hideProjects={false} />);
+    const wrapper = wrapperWithFallback.find('TopologyPage').shallow();
     expect(wrapper.find('[data-test-id="topology-list-page"]').exists()).toBe(true);
   });
 });

--- a/frontend/packages/topology/src/components/graph-view/Topology.tsx
+++ b/frontend/packages/topology/src/components/graph-view/Topology.tsx
@@ -27,6 +27,8 @@ import {
   withUserSettingsCompatibility,
   WithUserSettingsCompatibilityProps,
 } from '@console/shared';
+import { withFallback } from '@console/shared/src/components/error/error-boundary';
+import { ErrorBoundaryFallback } from '@console/internal/components/error';
 import { useExtensions } from '@console/plugin-sdk';
 import { RootState } from '@console/internal/redux';
 import { isTopologyComponentFactory, TopologyComponentFactory } from '../../extensions/topology';
@@ -321,13 +323,19 @@ const TopologyDispatchToProps = (dispatch): DispatchProps => ({
   },
 });
 
-export default connect<StateProps, DispatchProps, TopologyProps>(
-  TopologyStateToProps,
-  TopologyDispatchToProps,
-)(
-  withUserSettingsCompatibility<TopologyProps & WithUserSettingsCompatibilityProps<object>, object>(
-    TOPOLOGY_LAYOUT_CONFIG_STORAGE_KEY,
-    TOPOLOGY_LAYOUT_LOCAL_STORAGE_KEY,
-    {},
-  )(React.memo(Topology)),
+export default withFallback(
+  connect<StateProps, DispatchProps, TopologyProps>(
+    TopologyStateToProps,
+    TopologyDispatchToProps,
+  )(
+    withUserSettingsCompatibility<
+      TopologyProps & WithUserSettingsCompatibilityProps<object>,
+      object
+    >(
+      TOPOLOGY_LAYOUT_CONFIG_STORAGE_KEY,
+      TOPOLOGY_LAYOUT_LOCAL_STORAGE_KEY,
+      {},
+    )(React.memo(Topology)),
+  ),
+  ErrorBoundaryFallback,
 );

--- a/frontend/packages/topology/src/components/list-view/TopologyListView.tsx
+++ b/frontend/packages/topology/src/components/list-view/TopologyListView.tsx
@@ -12,6 +12,8 @@ import {
 } from '@patternfly/react-topology';
 import { DataList } from '@patternfly/react-core';
 import { useQueryParams } from '@console/shared';
+import { withFallback } from '@console/shared/src/components/error/error-boundary';
+import { ErrorBoundaryFallback } from '@console/internal/components/error';
 import { OverviewMetrics } from '@console/internal/components/overview/metricUtils';
 import { Alert } from '@console/internal/components/monitoring/types';
 import * as UIActions from '@console/internal/actions/ui';
@@ -320,13 +322,12 @@ const dispatchToProps = (dispatch): TopologyListViewPropsFromDispatch => ({
     dispatch(UIActions.monitoringLoaded('devAlerts', alerts, 'dev')),
 });
 
-const TopologyListView = connect<
-  TopologyListViewPropsFromState,
-  TopologyListViewPropsFromDispatch,
-  TopologyListViewProps
->(
-  stateToProps,
-  dispatchToProps,
-)(React.memo(ConnectedTopologyListView));
+const TopologyListView = withFallback(
+  connect<TopologyListViewPropsFromState, TopologyListViewPropsFromDispatch, TopologyListViewProps>(
+    stateToProps,
+    dispatchToProps,
+  )(React.memo(ConnectedTopologyListView)),
+  ErrorBoundaryFallback,
+);
 
 export default TopologyListView;

--- a/frontend/packages/topology/src/components/page/TopologyPage.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyPage.tsx
@@ -12,6 +12,8 @@ import NamespacedPage, {
 } from '@console/dev-console/src/components/NamespacedPage';
 import ProjectsExistWrapper from '@console/dev-console/src/components/ProjectsExistWrapper';
 import CreateProjectListPage from '@console/dev-console/src/components/projects/CreateProjectListPage';
+import { withFallback } from '@console/shared/src/components/error/error-boundary';
+import { ErrorBoundaryFallback } from '@console/internal/components/error';
 import TopologyDataRenderer from './TopologyDataRenderer';
 import {
   LAST_TOPOLOGY_VIEW_LOCAL_STORAGE_KEY,
@@ -123,4 +125,4 @@ const TopologyPage: React.FC<TopologyPageProps> = ({
   );
 };
 
-export default TopologyPage;
+export default withFallback(TopologyPage, ErrorBoundaryFallback);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5809

**Analysis / Root cause**: 
We had different errors in topology when data are missed or new operator versions provide unexpected data to the topology. The current error boundary is part of each individual content page as `ListPage` and `DetailPage` and was not part of `TopologyPage`.

**Solution Description**: 
Added `withFallback` which is used in [ListPage](https://github.com/openshift/console/blob/master/frontend/public/components/factory/list-page.jsx#L317), DetailPage and other components to topology page.

Add this on two different levels to catch errors in topology graph visualization or list and topology at all. The second error boundary on the graph visualization and list allows the user to switch between both topology view types if only the other one iis broken. See screenshots below.

**Screen shots / Gifs for design review**: 
Without error boundary:
White screen and complete console is crashing.

Without the additional error boundary the content block shows an error, but the user can not switch between the graph and list view:
![Screenshot from 2021-06-07 18-56-29](https://user-images.githubusercontent.com/139310/121065019-95782e00-c7c8-11eb-9514-52f575b46a79.png)
![Screenshot from 2021-06-07 19-02-30](https://user-images.githubusercontent.com/139310/121065028-97da8800-c7c8-11eb-8b9a-3aa3ccf5e314.png)

With the additional error boundary the user can still switch between the graph and list view:
![Screenshot from 2021-06-07 19-04-43](https://user-images.githubusercontent.com/139310/121065037-9a3ce200-c7c8-11eb-9de4-4a90c015d05f.png)
![Screenshot from 2021-06-07 19-05-47](https://user-images.githubusercontent.com/139310/121065048-9c9f3c00-c7c8-11eb-8d4c-6f7774c1be90.png)

**Unit test coverage report**: 
Only change `TopologyPage` unit tests to find the right view after adding new component hierarchy level.

**Test setup:**
Manually added a crash in `UrlDecorator` by throwing an error. At the moment I don't see an option to test this on a cluster.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge