### PR TITLE
Bug 1966077: Don't show empty hidden fields on operand details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
@@ -14,7 +14,6 @@ export enum SpecCapability {
   namespaceSelector = 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector',
   k8sResourcePrefix = 'urn:alm:descriptor:io.kubernetes:',
   booleanSwitch = 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch',
-
   password = 'urn:alm:descriptor:com.tectonic.ui:password',
   checkbox = 'urn:alm:descriptor:com.tectonic.ui:checkbox',
   imagePullPolicy = 'urn:alm:descriptor:com.tectonic.ui:imagePullPolicy',
@@ -45,6 +44,13 @@ export enum StatusCapability {
   // Prefix for all kubernetes resource status descriptors.
   k8sResourcePrefix = 'urn:alm:descriptor:io.kubernetes:',
   hidden = 'urn:alm:descriptor:com.tectonic.ui:hidden',
+}
+
+export enum CommonCapability {
+  podCount = 'urn:alm:descriptor:com.tectonic.ui:podCount',
+  k8sResourcePrefix = 'urn:alm:descriptor:io.kubernetes:',
+  hidden = 'urn:alm:descriptor:com.tectonic.ui:hidden',
+  password = 'urn:alm:descriptor:com.tectonic.ui:password',
 }
 
 export type Descriptor<T = any> = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
@@ -10,7 +10,7 @@ import {
   REGEXP_CAPTURE_GROUP_SUBGROUP,
   REGEXP_NESTED_ARRAY_PATH,
 } from './const';
-import { Descriptor, SpecCapability, StatusCapability } from './types';
+import { Descriptor, SpecCapability, StatusCapability, CommonCapability } from './types';
 import { getSchemaAtPath } from '@console/shared';
 
 export const useCalculatedDescriptorProperties = (descriptorType, descriptor, schema, obj) => {
@@ -78,8 +78,11 @@ export const groupDescriptorDetails = (
           };
     };
 
-    // Nested arrays are not supported
-    if (REGEXP_NESTED_ARRAY_PATH.test(descriptor.path)) {
+    // Ignore nested arrays and hidden descriptors.
+    if (
+      REGEXP_NESTED_ARRAY_PATH.test(descriptor.path) ||
+      descriptor?.['x-descriptors']?.includes(CommonCapability.hidden)
+    ) {
       return acc;
     }
 


### PR DESCRIPTION
If a hidden descriptor is applied to an object or all of it's children, hide it on the details page.