### PR TITLE
Bug 1967234: Console is continuously polling for ConsoleLink acm-link

### DIFF
--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -25,11 +25,15 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
   const [activePerspective, setActivePerspective] = useActivePerspective();
   const [isPerspectiveDropdownOpen, setPerspectiveDropdownOpen] = React.useState(false);
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
-  const [acmLink] = useK8sWatchResource<K8sResourceKind>({
+  const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
+    isList: true,
     kind: referenceForModel(ConsoleLinkModel),
-    name: ACM_LINK_ID,
     optional: true,
   });
+  const acmLink = consoleLinks.find(
+    (link: K8sResourceKind) =>
+      link.spec.location === 'ApplicationMenu' && link.metadata.name === ACM_LINK_ID,
+  );
   const { t } = useTranslation();
   const togglePerspectiveOpen = React.useCallback(() => {
     setPerspectiveDropdownOpen(!isPerspectiveDropdownOpen);


### PR DESCRIPTION
**Previously, K8sWatchResource was watching for the specific acm-console-link, which when not installed results in a 404 errors:**

![image](https://user-images.githubusercontent.com/12733153/121080004-dd875880-c7a8-11eb-8525-f1e9340cb8da.png)

**This PR updates K8sWatchResource to watch ConsoleLinks and find the acm-console-link from that collection.**