### PR TITLE
Bug 1968525: Warning - Operator Details page duplicate keys

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -431,6 +431,44 @@ describe(ClusterServiceVersionDetails.displayName, () => {
         .props().text,
     ).toEqual('olm~Conditions');
   });
+
+  it('does not render service accounts section if empty', () => {
+    const emptyTestClusterServiceVersion = _.cloneDeep(testClusterServiceVersion);
+    emptyTestClusterServiceVersion.spec.install.spec.permissions = [];
+    wrapper = shallow(
+      <ClusterServiceVersionDetails
+        obj={emptyTestClusterServiceVersion}
+        subscriptions={testSubscriptions}
+      />,
+    );
+    expect(emptyTestClusterServiceVersion.spec.install.spec.permissions.length).toEqual(0);
+    expect(
+      wrapper.findWhere(
+        (node) => node.type() === 'dt' && node.text() === 'olm~Operator ServiceAccounts',
+      ).length,
+    ).toEqual(0);
+  });
+
+  it('does not render duplicate service accounts', () => {
+    const duplicateTestClusterServiceVersion = _.cloneDeep(testClusterServiceVersion);
+    const permission = duplicateTestClusterServiceVersion.spec.install.spec.permissions[0];
+    duplicateTestClusterServiceVersion.spec.install.spec.permissions.push(permission);
+    wrapper = shallow(
+      <ClusterServiceVersionDetails
+        obj={duplicateTestClusterServiceVersion}
+        subscriptions={testSubscriptions}
+      />,
+    );
+    expect(duplicateTestClusterServiceVersion.spec.install.spec.permissions.length).toEqual(2);
+    expect(
+      wrapper.findWhere(
+        (node) => node.type() === 'dt' && node.text() === 'olm~Operator ServiceAccounts',
+      ).length,
+    ).toEqual(1);
+    expect(
+      wrapper.find(`[data-service-account-name="${permission.serviceAccountName}"]`).length,
+    ).toEqual(1);
+  });
 });
 
 describe(CSVSubscription.displayName, () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -973,6 +973,7 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
 
   const csvPlugins = getClusterServiceVersionPlugins(metadata?.annotations);
   const subscription = subscriptionForCSV(props.subscriptions, props.obj);
+  const permissions = _.uniqBy(spec?.install?.spec?.permissions, 'serviceAccountName');
 
   return (
     <>
@@ -1110,11 +1111,11 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
                   />
                 </dd>
               ))}
-              {spec?.install?.spec?.permissions && (
+              {!_.isEmpty(permissions) && (
                 <>
                   <dt>{t('olm~Operator ServiceAccounts')}</dt>
-                  {spec.install.spec.permissions.map(({ serviceAccountName }) => (
-                    <dd key={serviceAccountName}>
+                  {permissions.map(({ serviceAccountName }) => (
+                    <dd key={serviceAccountName} data-service-account-name={serviceAccountName}>
                       <ResourceLink
                         name={serviceAccountName}
                         kind="ServiceAccount"


### PR DESCRIPTION
We noticed an issue on the gitops operator details page in the browser console where React claims 2 elements on the page have the same key. I've tracked the issue down to the service accounts for the gitops operator. There are 3 service accounts with the same `serviceAccountName` that the UI looks up under `.spec.install.spec.permissions[]` with the value of `gitops-operator`. See screenshots.

## Issue
<img width="1792" alt="Screen Shot 2021-06-07 at 5 45 45 PM" src="https://user-images.githubusercontent.com/21317056/121095013-8770e000-c7bd-11eb-94f9-80f7367763a3.png">

### Note there are no unique identifier on each service account permission in gitops operator object:
<img width="521" alt="Screen Shot 2021-06-07 at 5 52 10 PM" src="https://user-images.githubusercontent.com/21317056/121095076-a4a5ae80-c7bd-11eb-9f1c-f57665860895.png">

@cyril-ui-developer @jhadvig @spadgett ~~this change is not pretty and probably shouldn't be delivered (though it removes the errors)~~ From the 4.7 doc, nothing indicates that `serviceAccountName` in `.spec.install.spec.permissions[]` needs to be unique (see below). I'm wondering if we need to pull these service accounts from somewhere else? 

<img width="979" alt="Screen Shot 2021-06-07 at 6 35 22 PM" src="https://user-images.githubusercontent.com/21317056/121096105-85a81c00-c7bf-11eb-8a86-be8a728966b6.png">

https://docs.openshift.com/container-platform/4.7/rest_api/operatorhub_apis/clusterserviceversion-operators-coreos-com-v1alpha1.html


https://bugzilla.redhat.com/show_bug.cgi?id=1968525