### PR TITLE
Topology - Connecting Workloads using Edit Annotations

### DIFF
--- a/frontend/packages/topology/integration-tests/features/topology/topology-connecting-workloads.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-connecting-workloads.feature
@@ -4,18 +4,20 @@ Feature: Connecting nodes
 
         Background:
             Given user is at developer perspective
-              And user has created or selected namespace "aut-topology-connecting-nodes"
+              And user has created or selected namespace "aut-tp-connect-workloads"
+              And user has created workload "nodejs-ex-git" with resource type "Deployment"
+              And user is at Add page
 
 
-        @smoke @to-do
+        @smoke
         Scenario: Create visual connection between two nodes using Annotations: T-07-TC01
-            Given user has creaeted two worloads "nodejs-ex-git" and "dancer-ex-git"
-              And user is at the Topolgy page
-             When user clicks node "nodejs-ex-git" to open the side bar
-              And user selects "Edit Annotations" option from Actions menu
+            Given user has created workload "dancer-ex-git" with resource type "Deployment Config"
+             When user clicks on workload "nodejs-ex-git"
+              And user clicks on Action menu
+              And user clicks "Edit annotations" from action menu
               And user enters key as "app.openshift.io/connects-to"
-              And user enters value as name of the node "dancer-ex-git" to which it will be associated
-             Then user can see that two nodes are connected with dotted arrow
+              And user enters value as "dancer-ex-git" to which it will be connected
+             Then user can see that two workloads are connected with arrow
 
 
         @regression @manual

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -21,6 +21,8 @@ export const topologyPO = {
     deleteWorkload: '[data-test="confirm-action"]',
     eventSourceWorkload: '[data-type="event-source"]',
     applicationGroupingTitle: '.odc-topology-list-view__application-label',
+    addNewAnnotations: '[data-test="add-button"]',
+    connector: '[data-test-id="edge-handler"]',
     filterByResource: {
       filterByResourceDropDown: '.pf-c-select__toggle-text',
       deploymentResource: '.co-m-resource-icon.co-m-resource-deployment',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-actions-page.ts
@@ -5,6 +5,7 @@ export const topologyActions = {
   selectAction: (action: nodeActions | string) => {
     switch (action) {
       case 'Edit Application Grouping':
+      case 'Edit Application grouping':
       case nodeActions.EditApplicationGrouping: {
         cy.byTestActionID(action)
           .should('be.visible')
@@ -26,6 +27,7 @@ export const topologyActions = {
         break;
       }
       case 'Edit Pod Count':
+      case 'Edit Pod count':
       case nodeActions.EditPodCount: {
         cy.byTestActionID(action)
           .should('be.visible')
@@ -33,21 +35,23 @@ export const topologyActions = {
         break;
       }
       case 'Edit Labels':
+      case 'Edit labels':
       case nodeActions.EditLabels: {
         cy.byTestActionID(action)
           .should('be.visible')
           .click();
         cy.get('form').should('be.visible');
-        modal.modalTitleShouldContain('Edit Labels');
+        modal.modalTitleShouldContain('Edit labels');
         break;
       }
       case 'Edit Annotations':
+      case 'Edit annotations':
       case nodeActions.EditAnnotations: {
         cy.byTestActionID(action)
           .should('be.visible')
           .click();
         cy.get('form').should('be.visible');
-        modal.modalTitleShouldContain('Edit Annotations');
+        modal.modalTitleShouldContain('Edit annotations');
         break;
       }
       case 'Edit Update Strategy':

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/edit-workload.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/edit-workload.ts
@@ -188,3 +188,23 @@ When('user enters value of Image name as {string}', (imageLink: string) => {
     .clear()
     .type(imageLink);
 });
+
+When('user enters key as {string}', (annotationKey: string) => {
+  cy.get(topologyPO.graph.addNewAnnotations).click();
+  cy.get(topologyPO.deploymentStrategy.envName)
+    .last()
+    .clear()
+    .type(annotationKey);
+});
+
+When('user enters value as {string} to which it will be connected', (annotationValue: string) => {
+  cy.get(topologyPO.deploymentStrategy.envValue)
+    .last()
+    .clear()
+    .type(annotationValue);
+  cy.get(topologyPO.graph.deleteWorkload).click();
+});
+
+Then('user can see that two workloads are connected with arrow', () => {
+  cy.get(topologyPO.graph.connector).should('be.visible');
+});


### PR DESCRIPTION
**Fix:** https://issues.redhat.com/browse/ODC-5580

**Problem:** Automation to connect workload using Edit Annotation action.

**Solution:** This script will edit the Annotations and will add new annotations to connect the workload with another workload.

**Cluster Setup:**
```
- export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
- BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
- BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
- export BRIDGE_KUBEADMIN_PASSWORD
- export BRIDGE_BASE_ADDRESS
- oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
- oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
- oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
```

**Test Setup:**
1. Replace `"TAGS": "@smoke and not @manual and not @to-do",` with `"@Topology and (@smoke or @regression) and not (@Manual or @to-do)",` in` topology/cypress.json` under `env`
2. Run `./test-cypress.sh -p topology` in console
3. Execute feature file: `frontend/packages/topology/integration-tests/features/topology/topology-connecting-workloads.feature`

**Test Execution Screenshot:**
![Screenshot from 2021-06-08 14-51-55](https://user-images.githubusercontent.com/17041173/121160515-c8bec980-c869-11eb-9c1c-3bf8c37e3f98.png)
