### PR TITLE
Bug 1969386: deprecated metric kubevirt_vmi_storage_traffic_bytes_total

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -376,7 +376,7 @@
   "Status": "Status",
   "Utilization": "Utilization",
   "CPU": "CPU",
-  "Filesystem": "Filesystem",
+  "Memory (RSS)": "Memory (RSS)",
   "Network Transfer": "Network Transfer",
   "Source uploading": "Source uploading",
   "View details": "View details",

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
@@ -4,6 +4,8 @@ export enum VMQueries {
   CPU_USAGE = 'CPU_USAGE',
   MEMORY_USAGE = 'MEMORY_USAGE',
   FILESYSTEM_USAGE = 'FILESYSTEM_USAGE',
+  FILESYSTEM_READ_USAGE = 'FILESYSTEM_READ_USAGE',
+  FILESYSTEM_WRITE_USAGE = 'FILESYSTEM_WRITE_USAGE',
   NETWORK_USAGE = 'NETWORK_USAGE',
   NETWORK_IN_USAGE = 'NETWORK_IN_USAGE',
   NETWORK_OUT_USAGE = 'NETWORK_OUT_USAGE',
@@ -18,8 +20,11 @@ const queries = {
     `pod:container_cpu_usage:sum{pod='<%= launcherPodName %>'}`,
   ),
   [VMQueries.MEMORY_USAGE]: _.template(`kubevirt_vmi_memory_resident_bytes{name='<%= vmName %>'}`),
-  [VMQueries.FILESYSTEM_USAGE]: _.template(
-    `sum(kubevirt_vmi_storage_traffic_bytes_total{name='<%= vmName %>'})`,
+  [VMQueries.FILESYSTEM_READ_USAGE]: _.template(
+    `sum(kubevirt_vmi_storage_read_traffic_bytes_total{name='<%= vmName %>'})`,
+  ),
+  [VMQueries.FILESYSTEM_WRITE_USAGE]: _.template(
+    `sum(kubevirt_vmi_storage_write_traffic_bytes_total{name='<%= vmName %>'})`,
   ),
   [VMQueries.NETWORK_IN_USAGE]: _.template(
     `sum(kubevirt_vmi_network_receive_bytes_total{name='<%= vmName %>'})`,
@@ -32,13 +37,22 @@ const queries = {
 export const getUtilizationQueries = (props: { vmName: string; launcherPodName?: string }) => ({
   [VMQueries.CPU_USAGE]: queries[VMQueries.CPU_USAGE](props),
   [VMQueries.MEMORY_USAGE]: queries[VMQueries.MEMORY_USAGE](props),
-  [VMQueries.FILESYSTEM_USAGE]: queries[VMQueries.FILESYSTEM_USAGE](props),
 });
 
 export const getMultilineUtilizationQueries = (props: {
   vmName: string;
   launcherPodName?: string;
 }) => ({
+  [VMQueries.FILESYSTEM_USAGE]: [
+    {
+      query: queries[VMQueries.FILESYSTEM_READ_USAGE](props),
+      desc: 'read',
+    },
+    {
+      query: queries[VMQueries.FILESYSTEM_WRITE_USAGE](props),
+      desc: 'write',
+    },
+  ],
   [VMQueries.NETWORK_USAGE]: [
     {
       query: queries[VMQueries.NETWORK_IN_USAGE](props),

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -103,7 +103,7 @@ export const VMUtilizationCard: React.FC = () => {
           isDisabled={!vmiIsRunning}
         />
         <PrometheusUtilizationItem
-          title={t('kubevirt-plugin~Memory')}
+          title={t('kubevirt-plugin~Memory (RSS)')}
           utilizationQuery={queries[VMQueries.MEMORY_USAGE]}
           humanizeValue={humanizeBinaryBytes}
           byteDataType={ByteDataTypes.BinaryBytes}
@@ -112,9 +112,9 @@ export const VMUtilizationCard: React.FC = () => {
           adjustDuration={adjustDuration}
           isDisabled={!vmiIsRunning}
         />
-        <PrometheusUtilizationItem
-          title={t('kubevirt-plugin~Filesystem')}
-          utilizationQuery={queries[VMQueries.FILESYSTEM_USAGE]}
+        <PrometheusMultilineUtilizationItem
+          title={t('kubevirt-plugin~Storage')}
+          queries={multilineQueries[VMQueries.FILESYSTEM_USAGE]}
           humanizeValue={humanizeBinaryBytes}
           byteDataType={ByteDataTypes.BinaryBytes}
           duration={duration}


### PR DESCRIPTION
Prometheus metrics deprecated:
`kubevirt_vmi_storage_traffic_bytes_total` is now `kubevirt_vmi_storage_write_traffic_bytes_total` and `kubevirt_vmi_storage_read_traffic_bytes_total`

Screenshot:
Before:
![screenshot-localhost_9000-2021 06 08-20_42_54](https://user-images.githubusercontent.com/2181522/121232304-210dbf80-c89a-11eb-97e7-a72f0e0ac2b9.png)

After:
![screenshot-localhost_9000-2021 06 08-20_42_00](https://user-images.githubusercontent.com/2181522/121232221-09363b80-c89a-11eb-9fea-c3b62df80d08.png)


Signed-off-by: yaacov <kobi.zamir@gmail.com>