### PR TITLE
Bug 1967275: Prevent awkward wrap of icons with getting started links and buttons

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
@@ -12,7 +12,6 @@ import {
   Skeleton,
   SimpleListItem,
 } from '@patternfly/react-core';
-import { ArrowRightIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import './GettingStartedCard.scss';
 
@@ -78,6 +77,7 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
                 <SimpleListItem
                   key={link.id}
                   component={link.href ? (link.external ? 'a' : (Link as any)) : 'button'}
+                  componentClassName={link.external ? 'co-external-link' : 'co-goto-arrow'}
                   componentProps={
                     link.external
                       ? {
@@ -94,11 +94,7 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
                   onClick={link.onClick}
                 >
                   {link.title}
-                  {link.external ? (
-                    <ExternalLinkAltIcon aria-hidden="true" />
-                  ) : (
-                    <ArrowRightIcon aria-hidden="true" />
-                  )}
+                  {link.external}
                 </SimpleListItem>
               ),
             )}
@@ -121,11 +117,11 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
             <a
               href={moreLink.href}
               target="_blank"
+              className="co-external-link"
               rel="noopener noreferrer"
               data-test={`item ${moreLink.id}`}
             >
               {moreLink.title}
-              <ExternalLinkAltIcon />
             </a>
           ) : (
             <Link to={moreLink.href} data-test={`item ${moreLink.id}`}>

--- a/frontend/packages/console-shared/src/components/getting-started/__tests__/GettingStartedCard.spec.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/__tests__/GettingStartedCard.spec.tsx
@@ -56,7 +56,7 @@ describe('GettingStartedCard', () => {
     );
 
     expect(wrapper.find('Link')).toHaveLength(1);
-    expect(wrapper.find('ExternalLinkAltIcon')).toHaveLength(0);
+    expect(wrapper.find('.co-external-link')).toHaveLength(0);
   });
 
   it('should render external more link', () => {
@@ -72,6 +72,6 @@ describe('GettingStartedCard', () => {
     );
 
     expect(wrapper.find('a')).toHaveLength(1);
-    expect(wrapper.find('ExternalLinkAltIcon')).toHaveLength(1);
+    expect(wrapper.find('.co-external-link')).toHaveLength(1);
   });
 });

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -253,7 +253,7 @@ dl.co-inline {
 
 // append external-link icon to <a> so that it doesn't wrap without text
 // there must be no white space between the text and the closing </a> tag holding the pseudo element
-.co-external-link:after {
+.co-external-link::after {
   @include font-awesome-free-solid;
   content: fa-content($fa-var-external-link-alt);
   font-size: 75%;
@@ -279,6 +279,18 @@ dl.co-inline {
 // Enable break word within co-m-table-grid
 .co-external-link--block {
   display: block;
+}
+
+.co-goto-arrow::after {
+  @include font-awesome-free-solid;
+  content: fa-content($fa-var-arrow-right);
+  font-size: 75%;
+  height: 16px;
+  margin-left: 3px;
+  margin-right: -15px; // width + margin-left
+  position: relative;
+  top: 0;
+  width: 12px;
 }
 
 .co-icon-flex-child {


### PR DESCRIPTION
Fixes bug https://bugzilla.redhat.com/show_bug.cgi?id=1967275

Note: I had to switch the icons to display as appended Pseudo-class `:after` elements in order to keep them from wrapping within their parent elements that are displayed as flex containers.

<img width="763" alt="Screen Shot 2021-06-08 at 2 53 48 PM" src="https://user-images.githubusercontent.com/1874151/121255443-6b327900-c879-11eb-91e5-f6d27a88e84d.png">
 

