### PR TITLE
CONSOLE-2425: Support localization of dynamic plugins

### DIFF
--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -23,7 +23,7 @@ i18n
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
     backend: {
-      loadPath: 'static/locales/{{lng}}/{{ns}}.json',
+      loadPath: '/locales/resource.json?lng={{lng}}&ns={{ns}}',
     },
     lng: localStorage.getItem('bridge/language'),
     fallbackLng: 'en',


### PR DESCRIPTION
Implementing additional endpoint for handling locales. The endpoint has following format:
`api/locales/<language>/<plugin-locale-file>`
eg. `api/locales/en/olm.json`

When the request hits the endpoint:
1. it will parse out language and plugin's locale file
2. then it will compare the plugin name against the list of enabled plugins
3. if it matches any of the enabled plugins, it will redirect to its service
4. if it doesn't match any of the enabled plugins, use redirect to `loadPath`, which is set to `static/locales/{{lng}}/{{ns}}.json`

Hopefully I understood the desired logic correctly.
@spadgett shall I also update the i18n enhancement ?

PTAL 