### PR TITLE
Bug 1969951: update cluster-local label for ksvc

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
@@ -218,7 +218,7 @@ describe('KSVC Route Data', () => {
       metadata: {
         ...knativeService.metadata,
         labels: {
-          'serving.knative.dev/visibility': 'cluster-local',
+          'networking.knative.dev/visibility': 'cluster-local',
         },
       },
       spec: {

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -316,7 +316,7 @@ export const getUserLabels = (resource: K8sResourceKind) => {
     'app.kubernetes.io/part-of',
     'app.openshift.io/runtime-version',
     'app.openshift.io/runtime-namespace',
-    'serving.knative.dev/visibility',
+    'networking.knative.dev/visibility',
   ];
   const allLabels = _.get(resource, 'metadata.labels', {});
   const userLabels = _.omit(allLabels, defaultLabels);

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-knative-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-knative-utils.spec.ts
@@ -63,7 +63,7 @@ describe('Create knative Utils', () => {
         'imgStream',
       );
       expect(
-        knDeploymentResource.metadata.labels['serving.knative.dev/visibility'],
+        knDeploymentResource.metadata.labels['networking.knative.dev/visibility'],
       ).toBeUndefined();
     });
 
@@ -73,8 +73,10 @@ describe('Create knative Utils', () => {
         defaultData,
         'imgStream',
       );
-      expect(knDeploymentResource.metadata.labels['serving.knative.dev/visibility']).toBeDefined();
-      expect(knDeploymentResource.metadata.labels['serving.knative.dev/visibility']).toEqual(
+      expect(
+        knDeploymentResource.metadata.labels['networking.knative.dev/visibility'],
+      ).toBeDefined();
+      expect(knDeploymentResource.metadata.labels['networking.knative.dev/visibility']).toEqual(
         'cluster-local',
       );
     });

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -91,7 +91,7 @@ export const getKnativeServiceDepResource = (
       labels: {
         ...defaultLabel,
         ...labels,
-        ...(!create && { 'serving.knative.dev/visibility': `cluster-local` }),
+        ...(!create && { 'networking.knative.dev/visibility': `cluster-local` }),
         ...((formData as GitImportFormData).pipeline?.enabled && {
           'app.kubernetes.io/name': name,
         }),


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1969951


**Solution Description**: 
updated `cluster-local` label  to `networking.knative.dev/visibility=cluster-local` over old one

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/5129024/121375503-68f61a80-c95e-11eb-932c-0cf5b9c724a8.png)

![image](https://user-images.githubusercontent.com/5129024/121375825-a78bd500-c95e-11eb-8414-b92ad44dfa85.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
