### PR TITLE
[release-4.6] Bug 1969878: fix resources fetched by firehose to show the correct Pod donut

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
@@ -3,13 +3,11 @@ import { Firehose, FirehoseResource } from '@console/internal/components/utils';
 import { PodRingResources, PodRingData } from '../../types';
 import { transformPodRingData, podRingFirehoseProps } from '../../utils';
 import {
-  DaemonSetModel,
   PodModel,
   ReplicaSetModel,
   ReplicationControllerModel,
   DeploymentModel,
   DeploymentConfigModel,
-  StatefulSetModel,
 } from '@console/internal/models';
 
 interface RenderPropsType {
@@ -46,21 +44,15 @@ const PodRingController: React.FC<PodRingDataControllerProps> = ({ namespace, ki
   const resources: FirehoseResource[] = [
     {
       isList: true,
+      kind,
+      namespace,
+      prop: podRingFirehoseProps[kind],
+    },
+    {
+      isList: true,
       kind: PodModel.kind,
       namespace,
       prop: podRingFirehoseProps[PodModel.kind],
-    },
-    {
-      isList: true,
-      kind: ReplicaSetModel.kind,
-      namespace,
-      prop: podRingFirehoseProps[ReplicaSetModel.kind],
-    },
-    {
-      isList: true,
-      kind: ReplicationControllerModel.kind,
-      namespace,
-      prop: podRingFirehoseProps[ReplicationControllerModel.kind],
     },
   ];
 
@@ -68,33 +60,17 @@ const PodRingController: React.FC<PodRingDataControllerProps> = ({ namespace, ki
     case DeploymentModel.kind:
       resources.push({
         isList: true,
-        kind,
+        kind: ReplicaSetModel.kind,
         namespace,
-        prop: podRingFirehoseProps[kind],
+        prop: podRingFirehoseProps[ReplicaSetModel.kind],
       });
       break;
     case DeploymentConfigModel.kind:
       resources.push({
         isList: true,
-        kind,
+        kind: ReplicationControllerModel.kind,
         namespace,
-        prop: podRingFirehoseProps[kind],
-      });
-      break;
-    case StatefulSetModel.kind:
-      resources.push({
-        isList: true,
-        kind,
-        namespace,
-        prop: podRingFirehoseProps[kind],
-      });
-      break;
-    case DaemonSetModel.kind:
-      resources.push({
-        isList: true,
-        kind,
-        namespace,
-        prop: podRingFirehoseProps[kind],
+        prop: podRingFirehoseProps[ReplicationControllerModel.kind],
       });
       break;
     default:


### PR DESCRIPTION
This PR fixes the issue with how we fetch the resource for pod donuts through firehose.

Issue: when we show the pod donut on a deployment config page it tries to fetch `deploymentconfigs`, `Pods`, `replicasets` and `replicationcontrollers`. If a user doesn't have access to deployments and replicasets firehose throws an error and pod donut doesn't show up on the deployment config page

Solution: only fetch resources related to them i.e. for a DC only fetch ReplicationControllers and Pods. We don't need to fetch replicasets when we need to show the pod donut for deployment config

<img width="802" alt="Screenshot 2021-06-09 at 8 40 19 PM" src="https://user-images.githubusercontent.com/9278015/121381544-6fd35c00-c963-11eb-94a3-9d348320223c.png">
