### PR TITLE
show `Stop` pipelinerun action if any of the tasks is running

### DIFF
--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-augment.spec.ts
@@ -15,6 +15,7 @@ import {
   totalPipelineRunTasks,
   getResourceModelFromTaskKind,
   getResourceModelFromBindingKind,
+  shouldHidePipelineRunStop,
 } from '../pipeline-augment';
 import {
   ClusterTaskModel,
@@ -219,6 +220,22 @@ describe('PipelineAugment test correct task status state is pulled from pipeline
       expect(sumInProgressTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
       expect(sumTaskStatuses(taskStatus)).toEqual(expectedTaskCount);
       expect(taskCount).toEqual(expectedTaskCount);
+    });
+
+    it('should not hide the pipelinerun stop action ', () => {
+      const pipelineRun =
+        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
+          DataState.IN_PROGRESS
+        ];
+      expect(shouldHidePipelineRunStop(pipelineRun)).toEqual(false);
+    });
+
+    it('should hide the pipelinerun stop action ', () => {
+      const pipelineRun =
+        pipelineTestData[PipelineExampleNames.EMBEDDED_TASK_SPEC_MOCK_APP].pipelineRuns[
+          DataState.SUCCESS
+        ];
+      expect(shouldHidePipelineRunStop(pipelineRun)).toEqual(true);
     });
   });
 

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-actions.tsx
@@ -17,7 +17,7 @@ import { getPipelineRunData } from '../components/pipelines/modals/common/utils'
 import { StartedByAnnotation } from '../components/pipelines/const';
 import { EventListenerModel, PipelineModel, PipelineRunModel } from '../models';
 import { PipelineKind, PipelineRunKind } from '../types';
-import { pipelineRunFilterReducer } from './pipeline-filter-reducer';
+import { shouldHidePipelineRunStop } from './pipeline-augment';
 
 export const handlePipelineRunSubmit = (pipelineRun: PipelineRunKind) => {
   history.push(
@@ -197,7 +197,7 @@ export const stopPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipelin
         ],
       );
     },
-    hidden: !(pipelineRun && pipelineRunFilterReducer(pipelineRun) === 'Running'),
+    hidden: shouldHidePipelineRunStop(pipelineRun),
     accessReview: {
       group: kind.apiGroup,
       resource: kind.plural,

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-augment.ts
@@ -322,3 +322,15 @@ export const getModelReferenceFromTaskKind = (kind: string): GroupVersionKind =>
   const model = getResourceModelFromTaskKind(kind);
   return referenceForModel(model);
 };
+
+export const countRunningTasks = (pipelineRun: PipelineRunKind): number => {
+  const taskStatuses = getTaskStatus(pipelineRun, undefined);
+  return taskStatuses.Running;
+};
+
+export const shouldHidePipelineRunStop = (pipelineRun: PipelineRunKind): boolean =>
+  !(
+    pipelineRun &&
+    (countRunningTasks(pipelineRun) > 0 ||
+      pipelineRunFilterReducer(pipelineRun) === runStatus.Running)
+  );


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5931

**Root analysis:**
- to show or not to show the stop action menu for Pipeline run is being decided only by the final pipeline run status

**Solution description:**
- added a check to see if any of the tasks is still running

**GIF:**
![pipelinerun-stop](https://user-images.githubusercontent.com/22490998/121400765-99957e80-c975-11eb-9451-9873df913e21.gif)

**Unit test coverage report:**
added tests

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

