### PR TITLE
Bug 1970381: Monitoring dashboards: Custom time range inputs should retain values

### DIFF
--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -176,6 +176,10 @@ export const parsePrometheusDuration = (duration: string): number => {
 
 const zeroPad = (number: number) => (number < 10 ? `0${number}` : number);
 
+// Get YYYY-MM-DD date string for a date object
+export const toISODateString = (date: Date): string =>
+  `${date.getFullYear()}-${zeroPad(date.getMonth() + 1)}-${zeroPad(date.getDate())}`;
+
 export const twentyFourHourTime = (date: Date, showSeconds?: boolean): string => {
   const hours = zeroPad(date.getHours() ?? 0);
   const minutes = `:${zeroPad(date.getMinutes() ?? 0)}`;


### PR DESCRIPTION
After setting a custom time range once and then opening the custom time
range modal again, the inputs should show the previously selected
values.