### PR TITLE
Add a11y label to Loading component, create non-a11y LoadingBoxWithoutAccessibility component for app.jsx

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -86,14 +86,12 @@ export const addPage = {
       case addOptions.DevFile:
         cy.byTestID('item import-from-devfile').click();
         detailsPage.titleShouldContain(pageTitle.DevFile);
-        // Below line is commented due to Bug: ODC-5832
-        // cy.testA11y(pageTitle.DevFile);
+        cy.testA11y(pageTitle.DevFile);
         break;
       case addOptions.UploadJARFile:
         cy.byTestID('item upload-jar').click();
         detailsPage.titleShouldContain(pageTitle.UploadJarFile);
-        // Below line is commented due to Bug: ODC-5832
-        // cy.testA11y(pageTitle.UploadJarFile);
+        cy.testA11y(pageTitle.UploadJarFile);
         break;
       default:
         throw new Error(`Unable to find the "${card}" card on Add page`);

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -16,7 +16,7 @@ import { getBrandingDetails, Masthead } from './masthead';
 import { ConsoleNotifier } from './console-notifier';
 import { ConnectedNotificationDrawer } from './notification-drawer';
 import { Navigation } from './nav';
-import { history, AsyncComponent, LoadingBox } from './utils';
+import { history, AsyncComponent, LoadingBoxWithoutAccessibility } from './utils';
 import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources } from '../module/k8s';
 import { receivedResources, watchAPIServices } from '../actions/k8s';
@@ -223,12 +223,12 @@ const AppWithExtensions = withTranslation()((props) => {
     return <App_ contextProviderExtensions={contextProviderExtensions} {...props} />;
   }
 
-  return <LoadingBox />;
+  return <LoadingBoxWithoutAccessibility />;
 });
 
 initConsolePlugins(pluginStore, store);
 
-render(<LoadingBox />, document.getElementById('app'));
+render(<LoadingBoxWithoutAccessibility />, document.getElementById('app'));
 
 const AppRouter = () => {
   const standaloneRouteExtensions = useExtensions(isStandaloneRoutePage);
@@ -356,7 +356,7 @@ graphQLReady.onReady(() => {
   }
 
   render(
-    <React.Suspense fallback={<LoadingBox />}>
+    <React.Suspense fallback={<LoadingBoxWithoutAccessibility />}>
       <Provider store={store}>
         <CaptureTelemetry />
         <ToastProvider>

--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -40,16 +40,20 @@ export const LoadError: React.FC<LoadErrorProps> = ({
 );
 LoadError.displayName = 'LoadError';
 
-export const Loading: React.FC<LoadingProps> = ({ className }) => (
-  <div
-    className={classNames('co-m-loader co-an-fade-in-out', className)}
-    data-test="loading-indicator"
-  >
-    <div className="co-m-loader-dot__one" />
-    <div className="co-m-loader-dot__two" />
-    <div className="co-m-loader-dot__three" />
-  </div>
-);
+export const Loading: React.FC<LoadingProps> = ({ className }) => {
+  const { t } = useTranslation();
+  return (
+    <div
+      className={classNames('co-m-loader co-an-fade-in-out', className)}
+      data-test="loading-indicator"
+      aria-label={t && t('public~Loading...')}
+    >
+      <div className="co-m-loader-dot__one" />
+      <div className="co-m-loader-dot__two" />
+      <div className="co-m-loader-dot__three" />
+    </div>
+  );
+};
 Loading.displayName = 'Loading';
 
 export const LoadingInline: React.FC<{}> = () => <Loading className="co-m-loader--inline" />;
@@ -62,6 +66,27 @@ export const LoadingBox: React.FC<LoadingBoxProps> = ({ className, message }) =>
   </Box>
 );
 LoadingBox.displayName = 'LoadingBox';
+
+/**
+ * Similar to LoadingBox but doesn't use useTranslation() to add an accessibility label.
+ * useTranslation requires a wrapping React.Suspense and could not be used as fallback
+ * in a suspense block. So it could not be used as initial loading indicator in app.jsx.
+ */
+export const LoadingBoxWithoutAccessibility: React.FC = () => (
+  <Box className="cos-status-box--loading">
+    <div
+      className="co-m-loader co-an-fade-in-out"
+      data-test="loading-indicator"
+      // Not translated as mentioned above.
+      aria-label="Loading..."
+    >
+      <div className="co-m-loader-dot__one" />
+      <div className="co-m-loader-dot__two" />
+      <div className="co-m-loader-dot__three" />
+    </div>
+  </Box>
+);
+LoadingBoxWithoutAccessibility.displayName = 'LoadingBoxWithoutAccessibility';
 
 export const EmptyBox: React.FC<EmptyBoxProps> = ({ label }) => {
   const { t } = useTranslation();

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1522,6 +1522,7 @@
   "The logs for this {{resourceKind}} may be stale.": "The logs for this {{resourceKind}} may be stale.",
   "Refresh": "Refresh",
   "No selector": "No selector",
+  "Loading...": "Loading...",
   "No {{label}} found": "No {{label}} found",
   "Not found": "Not found",
   "Restricted Access": "Restricted Access",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5832

**Analysis / Root cause**: 
Our cypress includes automatically accessibility checks via [cypress-axe](https://github.com/component-driven/cypress-axe). These checks found an issue when the application dropdown is shown with a loading indicator. This is independent from the `Devfile` or `UploadJarFile` tests. It happens if the add page was called when there is already an application available in the current namespace.

**Solution Description**: 
1. Re-enable a11y checks in devconsole add page test.
2. Add `aria-label={t('Loading...)}` to the `Loading` component.
3. Create a `LoadingBoxWithoutAccessibility` component for `app.jsx` which uses the `LoadingBox` as React.Suspend fallback which isn't possible with `useTranslation`

**Screen shots / Gifs for design review**: 
UI itself isn't changed.

The initial issue is about this application dropdown. But this PR adds the accessibility label for the Loading indicator in general:
![Screenshot from 2021-06-10 15-46-32](https://user-images.githubusercontent.com/139310/121536334-410cc280-ca03-11eb-8ccd-73c987bc4451.png)

New aria-label for the application dropdown (while showing the loading indicator):
![Screenshot from 2021-06-10 15-39-40](https://user-images.githubusercontent.com/139310/121535225-41f12480-ca02-11eb-8ed4-9339432a7a5e.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
To analyse application dropdown a11y label:
* Open `frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx` and comment line 121 and 124.

```diff
-    if (!loaded && !loadError) {
+    // if (!loaded && !loadError) {
      this.setState({ title: <LoadingInline /> });
      return;
-    }
+    // }
```

Cypress tests:
* `yarn test-cypress-devconsole` and run `create-from-devfile.feature`
* `yarn test-cypress-devconsole` and run `upload-jar-file.feature`

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge