### PR TITLE
Remove cy.wait from multiple-storageclass-selection tests

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/multiple-storageclass-selection.spec.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/multiple-storageclass-selection.spec.ts
@@ -35,11 +35,6 @@ const addCapacity = (uid: string, scName: string) => {
   cy.byTestID('dropdown-menu-item-link')
     .contains(scName)
     .click();
-
-  // wait for Pvs & Nodes data to load (used for validations)
-  // to-do (Sanjal): add a more robust way instead of wait by checking the currentCapacity/PVsAvailableCapacity components state
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(5000);
   cy.byTestID('confirm-action').click();
 };
 

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
@@ -55,7 +55,7 @@ export const AddCapacityModal = (props: AddCapacityModalProps) => {
 
   const [values, loading, loadError] = usePrometheusQueries(queries, parser as any);
   const [pvData, pvLoaded, pvLoadError] = useK8sWatchResource<K8sResourceKind[]>(pvResource);
-  const [nodesData] = useK8sWatchResource<NodeKind[]>(nodeResource);
+  const [nodesData, nodesLoaded, nodesLoadError] = useK8sWatchResource<NodeKind[]>(nodeResource);
   const [storageClass, setStorageClass] = React.useState<StorageClassResourceKind>(null);
   const [inProgress, setProgress] = React.useState(false);
   const [errorMessage, setError] = React.useState('');
@@ -76,6 +76,7 @@ export const AddCapacityModal = (props: AddCapacityModalProps) => {
   const totalCapacity = humanizeBinaryBytes(totalCapacityMetric);
   /** Name of the installation storageClass which will be the pre-selected value for the dropdown */
   const installStorageClass = deviceSets?.[0]?.dataPVCTemplate?.spec?.storageClassName;
+  const nodesError = nodesLoadError || !nodesData.length || !nodesLoaded;
 
   const validateSC = React.useCallback(() => {
     if (!selectedSCName) return t('ceph-storage-plugin~No StorageClass selected');
@@ -250,7 +251,7 @@ export const AddCapacityModal = (props: AddCapacityModalProps) => {
           errorMessage={errorMessage}
           submitText={t('ceph-storage-plugin~Add')}
           cancel={cancel}
-          submitDisabled={isNoProvionerSC && !availablePvsCount}
+          submitDisabled={isNoProvionerSC && (!availablePvsCount || nodesError)}
         />
       </div>
     </form>


### PR DESCRIPTION
`multiple-storageclass-selection` tests --> `Add capacity with a new storage class having NO-PROVISIONER as provisioner` --> We only want to click the add capacity button once both "pvData" and "nodesData" gets loaded, hence cy.wait was added earlier.

Now, removed cy.wait condition. Add capacity button will be disabled if there are any errors or data is not completely loaded.