### PR TITLE
handles route decorator for revision

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/components/decorators/RevisionRouteDecorator.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/RevisionRouteDecorator.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Node } from '@patternfly/react-topology';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Decorator } from '@console/topology/src/components/graph-view';
+import { getResource } from '@console/topology/src/utils';
+import { useRoutesURL } from '../../../utils/useRoutesURL';
+
+interface RevisionRouteDecoratorProps {
+  element: Node;
+  radius: number;
+  x: number;
+  y: number;
+}
+
+const RevisionRouteDecorator: React.FC<RevisionRouteDecoratorProps> = ({
+  element,
+  radius,
+  x,
+  y,
+}) => {
+  const { t } = useTranslation();
+  const resourceObj = getResource(element);
+  const url = useRoutesURL(resourceObj);
+
+  if (!url) {
+    return null;
+  }
+  return (
+    <Tooltip key="route" content={t('knative-plugin~Open URL')} position={TooltipPosition.right}>
+      <Decorator x={x} y={y} radius={radius} href={url} external>
+        <g transform={`translate(-${radius / 2}, -${radius / 2})`}>
+          <ExternalLinkAltIcon style={{ fontSize: radius }} title={t('knative-plugin~Open URL')} />
+        </g>
+      </Decorator>
+    </Tooltip>
+  );
+};
+
+export default RevisionRouteDecorator;

--- a/frontend/packages/knative-plugin/src/topology/components/decorators/getRevisionRouteDecorator.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/getRevisionRouteDecorator.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { Node } from '@patternfly/react-topology';
+import RevisionRouteDecorator from './RevisionRouteDecorator';
+
+export const getRevisionRouteDecorator = (element: Node, radius: number, x: number, y: number) => {
+  return <RevisionRouteDecorator key="url" element={element} radius={radius} x={x} y={y} />;
+};

--- a/frontend/packages/knative-plugin/src/topology/components/decorators/index.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/index.ts
@@ -2,3 +2,8 @@ export const getServiceRouteDecorator = () =>
   import('./getServiceRouteDecorator' /* webpackChunkName: "knative-components" */).then(
     (m) => m.getServiceRouteDecorator,
   );
+
+export const getRevisionRouteDecorator = () =>
+  import('./getRevisionRouteDecorator' /* webpackChunkName: "revision-decorator" */).then(
+    (m) => m.getRevisionRouteDecorator,
+  );

--- a/frontend/packages/knative-plugin/src/topology/components/nodes/RevisionNode.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/nodes/RevisionNode.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { useAnchor, AnchorEnd, Node, observer } from '@patternfly/react-topology';
 import { getTopologyResourceObject } from '@console/topology/src/utils';
-import { useRoutesURL } from '@console/topology/src/data-transforms/useRoutesURL';
 import { WorkloadPodsNode } from '@console/topology/src/components/graph-view';
 import RevisionTrafficTargetAnchor from '../anchors/RevisionTrafficTargetAnchor';
 import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
+import { useRoutesURL } from '../../../utils/useRoutesURL';
 
 const DECORATOR_RADIUS = 13;
 const RevisionNode: React.FC<React.ComponentProps<typeof WorkloadPodsNode>> = (props) => {

--- a/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
@@ -41,7 +41,7 @@ import {
   fetchEventSourcesCrd,
   fetchChannelsCrd,
 } from '../utils/fetch-dynamic-eventsources-utils';
-import { getServiceRouteDecorator } from './components/decorators';
+import { getRevisionRouteDecorator, getServiceRouteDecorator } from './components/decorators';
 
 // Added it to perform discovery of Dynamic event sources on cluster on app load as kebab option needed models upfront
 fetchEventSourcesCrd();
@@ -141,6 +141,15 @@ export const topologyPlugin: Plugin<TopologyConsumedExtensions> = [
         FLAG_KNATIVE_SERVING_SERVICE,
         FLAG_KNATIVE_EVENTING,
       ],
+    },
+  },
+  {
+    type: 'Topology/Decorator',
+    properties: {
+      id: 'revision-url-decorator',
+      priority: 100,
+      quadrant: TopologyDecoratorQuadrant.upperRight,
+      decorator: applyCodeRefSymbol(getRevisionRouteDecorator),
     },
   },
 ];

--- a/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
+++ b/frontend/packages/knative-plugin/src/utils/useRoutesURL.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { getRouteData } from '../topology/knative-topology-utils';
+import { RouteModel } from '../models';
+
+export const useRoutesURL = (resource: K8sResourceKind): string => {
+  const { namespace } = resource.metadata;
+  const [allRoutes, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>({
+    isList: true,
+    kind: referenceForModel(RouteModel),
+    namespace,
+    optional: true,
+  });
+
+  const routes = loaded && !loadError ? allRoutes : [];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const url = React.useMemo(() => getRouteData(resource, routes), [routes]);
+
+  return url;
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5946

**Solution Description**: 
Handled route fetching logic, added  route decorator and contributed via plugin

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/5129024/121559756-82699600-ca34-11eb-8d0b-9c6205aa1bc3.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
- Create ksvc
- Edit ksvc to get another revision
- Do traffic split and tag for at least one revision

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
