### PR TITLE
Filter disabled add actions for topology menus

### DIFF
--- a/frontend/packages/dev-console/src/actions/add-resources.tsx
+++ b/frontend/packages/dev-console/src/actions/add-resources.tsx
@@ -13,84 +13,121 @@ import {
 import * as helmIcon from '@console/internal/imgs/logos/helm.svg';
 import { ImportOptions } from '../components/import/import-types';
 import { KebabAction, createKebabAction } from '../utils/add-resources-menu-utils';
+import { getDisabledAddActions } from '../utils/useAddActionExtensions';
 
 export const allImportResourceAccess = 'allImportResourceAccess';
 export const allCatalogImageResourceAccess = 'allCatalogImageResourceAccess';
 
-export const fromGit = createKebabAction(
-  // t('devconsole~From Git')
-  'devconsole~From Git',
-  <GitAltIcon />,
-  ImportOptions.GIT,
-  allImportResourceAccess,
-);
+type AddActionItem = { id: string; action: KebabAction };
 
-export const containerImage = createKebabAction(
-  // t('devconsole~Container Image')
-  'devconsole~Container Image',
-  <OsImageIcon />,
-  ImportOptions.CONTAINER,
-  allCatalogImageResourceAccess,
-);
+export const fromGit: AddActionItem = {
+  id: 'import-from-git',
+  action: createKebabAction(
+    // t('devconsole~From Git')
+    'devconsole~From Git',
+    <GitAltIcon />,
+    ImportOptions.GIT,
+    allImportResourceAccess,
+  ),
+};
 
-export const fromCatalog = createKebabAction(
-  // t('devconsole~From Catalog')
-  'devconsole~From Catalog',
-  <CatalogIcon />,
-  ImportOptions.CATALOG,
-);
+export const containerImage: AddActionItem = {
+  id: 'deploy-image',
+  action: createKebabAction(
+    // t('devconsole~Container Image')
+    'devconsole~Container Image',
+    <OsImageIcon />,
+    ImportOptions.CONTAINER,
+    allCatalogImageResourceAccess,
+  ),
+};
 
-export const fromDockerfile = createKebabAction(
-  // t('devconsole~From Dockerfile')
-  'devconsole~From Dockerfile',
-  <CubeIcon />,
-  ImportOptions.DOCKERFILE,
-  allImportResourceAccess,
-);
+export const fromCatalog: AddActionItem = {
+  id: 'dev-catalog',
+  action: createKebabAction(
+    // t('devconsole~From Catalog')
+    'devconsole~From Catalog',
+    <CatalogIcon />,
+    ImportOptions.CATALOG,
+  ),
+};
 
-export const fromDevfile = createKebabAction(
-  // t('devconsole~From Devfile')
-  'devconsole~From Devfile',
-  <LayerGroupIcon />,
-  ImportOptions.DEVFILE,
-  allImportResourceAccess,
-);
+export const fromDockerfile: AddActionItem = {
+  id: 'import-from-dockerfile',
+  action: createKebabAction(
+    // t('devconsole~From Dockerfile')
+    'devconsole~From Dockerfile',
+    <CubeIcon />,
+    ImportOptions.DOCKERFILE,
+    allImportResourceAccess,
+  ),
+};
 
-export const fromDatabaseCatalog = createKebabAction(
-  // t('devconsole~Database')
-  'devconsole~Database',
-  <DatabaseIcon />,
-  ImportOptions.DATABASE,
-);
+export const fromDevfile: AddActionItem = {
+  id: 'import-from-devfile',
+  action: createKebabAction(
+    // t('devconsole~From Devfile')
+    'devconsole~From Devfile',
+    <LayerGroupIcon />,
+    ImportOptions.DEVFILE,
+    allImportResourceAccess,
+  ),
+};
 
-export const fromSamples = createKebabAction(
-  // t('devconsole~Samples')
-  'devconsole~Samples',
-  <LaptopCodeIcon />,
-  ImportOptions.SAMPLES,
-);
+export const fromDatabaseCatalog: AddActionItem = {
+  id: 'dev-catalog-databases',
+  action: createKebabAction(
+    // t('devconsole~Database')
+    'devconsole~Database',
+    <DatabaseIcon />,
+    ImportOptions.DATABASE,
+  ),
+};
 
-export const fromOperatorBacked = createKebabAction(
-  // t('devconsole~Operator Backed')
-  'devconsole~Operator Backed',
-  <BoltIcon />,
-  ImportOptions.OPERATORBACKED,
-);
+export const fromSamples: AddActionItem = {
+  id: 'import-from-samples',
+  action: createKebabAction(
+    // t('devconsole~Samples')
+    'devconsole~Samples',
+    <LaptopCodeIcon />,
+    ImportOptions.SAMPLES,
+  ),
+};
 
-export const fromHelmCharts = createKebabAction(
-  // t('devconsole~Helm Charts')
-  'devconsole~Helm Charts',
-  <img style={{ height: '1em', width: '1em' }} src={helmIcon} alt="Helm Charts Logo" />,
-  ImportOptions.HELMCHARTS,
-);
+export const fromOperatorBacked: AddActionItem = {
+  id: 'operator-backed',
+  action: createKebabAction(
+    // t('devconsole~Operator Backed')
+    'devconsole~Operator Backed',
+    <BoltIcon />,
+    ImportOptions.OPERATORBACKED,
+  ),
+};
 
-export const uploadJarFile = createKebabAction(
-  // t('devconsole~Upload JAR file')
-  'devconsole~Upload JAR file',
-  <FileUploadIcon />,
-  ImportOptions.UPLOADJAR,
-  allCatalogImageResourceAccess,
-);
+export const fromHelmCharts: AddActionItem = {
+  id: 'helm',
+  action: createKebabAction(
+    // t('devconsole~Helm Charts')
+    'devconsole~Helm Charts',
+    <img style={{ height: '1em', width: '1em' }} src={helmIcon} alt="Helm Charts Logo" />,
+    ImportOptions.HELMCHARTS,
+  ),
+};
+
+export const uploadJarFile: AddActionItem = {
+  id: 'upload-jar',
+  action: createKebabAction(
+    // t('devconsole~Upload JAR file')
+    'devconsole~Upload JAR file',
+    <FileUploadIcon />,
+    ImportOptions.UPLOADJAR,
+    allCatalogImageResourceAccess,
+  ),
+};
+
+const disabledAddActions = getDisabledAddActions();
+export const disabledFilter = (item) => !disabledAddActions?.includes(item.id);
+export const actionMapper = (item) => item.action;
 
 export const addResourceMenu: KebabAction[] = [
   fromSamples,
@@ -103,7 +140,9 @@ export const addResourceMenu: KebabAction[] = [
   fromOperatorBacked,
   fromHelmCharts,
   uploadJarFile,
-];
+]
+  .filter(disabledFilter)
+  .map(actionMapper);
 
 export const addGroupResourceMenu: KebabAction[] = [
   fromGit,
@@ -111,7 +150,9 @@ export const addGroupResourceMenu: KebabAction[] = [
   fromDockerfile,
   fromDevfile,
   uploadJarFile,
-];
+]
+  .filter(disabledFilter)
+  .map(actionMapper);
 
 export const addResourceMenuWithoutCatalog: KebabAction[] = [
   fromGit,
@@ -120,4 +161,6 @@ export const addResourceMenuWithoutCatalog: KebabAction[] = [
   fromDevfile,
   fromOperatorBacked,
   uploadJarFile,
-];
+]
+  .filter(disabledFilter)
+  .map(actionMapper);

--- a/frontend/packages/dev-console/src/utils/useAddActionExtensions.ts
+++ b/frontend/packages/dev-console/src/utils/useAddActionExtensions.ts
@@ -9,7 +9,7 @@ interface AddPage {
   disabledActions?: string[];
 }
 
-const getDisabledAddActions = (): string[] | undefined => {
+export const getDisabledAddActions = (): string[] | undefined => {
   if (window.SERVER_FLAGS.addPage) {
     const addPage: AddPage = JSON.parse(window.SERVER_FLAGS.addPage);
     const { disabledActions } = addPage;

--- a/frontend/packages/knative-plugin/src/actions/add-channel.tsx
+++ b/frontend/packages/knative-plugin/src/actions/add-channel.tsx
@@ -14,9 +14,12 @@ const EventChannelIcon: React.FC = () => (
   <img style={eventChannelStyles} src={channelIcon} alt="" />
 );
 
-export const addChannels: KebabAction = createKebabAction(
-  // t('knative-plugin~Channel')
-  'knative-plugin~Channel',
-  <EventChannelIcon />,
-  ImportOptions.EVENTCHANNEL,
-);
+export const addChannels: { id: string; action: KebabAction } = {
+  id: 'knative-eventing-channel',
+  action: createKebabAction(
+    // t('knative-plugin~Channel')
+    'knative-plugin~Channel',
+    <EventChannelIcon />,
+    ImportOptions.EVENTCHANNEL,
+  ),
+};

--- a/frontend/packages/knative-plugin/src/actions/add-event-source.tsx
+++ b/frontend/packages/knative-plugin/src/actions/add-event-source.tsx
@@ -14,9 +14,12 @@ const EventSourceIcon: React.FC = () => {
   return <img style={eventSourceIconStyle} src={eventSourceImg} alt="" />;
 };
 
-export const addEventSource: KebabAction = createKebabAction(
-  // t('knative-plugin~Event Source')
-  'knative-plugin~Event Source',
-  <EventSourceIcon />,
-  ImportOptions.EVENTSOURCE,
-);
+export const addEventSource: { id: string; action: KebabAction } = {
+  id: 'knative-event-source',
+  action: createKebabAction(
+    // t('knative-plugin~Event Source')
+    'knative-plugin~Event Source',
+    <EventSourceIcon />,
+    ImportOptions.EVENTSOURCE,
+  ),
+};

--- a/frontend/packages/knative-plugin/src/topology/create-connector-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/create-connector-utils.ts
@@ -5,6 +5,8 @@ import {
   addResourceMenuWithoutCatalog,
   addResourceMenu,
   addGroupResourceMenu,
+  disabledFilter,
+  actionMapper,
 } from '@console/dev-console/src/actions/add-resources';
 import { GraphData } from '@console/topology/src/topology-types';
 import { getResource } from '@console/topology/src/utils';
@@ -34,14 +36,17 @@ export const getKnativeContextMenuAction = (
   if (connectorSource?.getData().type === TYPE_EVENT_SOURCE_KAFKA) {
     return [];
   }
+  const knativeActions = [addEventSource, addChannels].filter(disabledFilter).map(actionMapper);
+  const knativeConnectorActions = [addEventSource].filter(disabledFilter).map(actionMapper);
+
   if (!connectorSource && isGroupActions) {
     if (graphData.eventSourceEnabled) {
-      return [...addGroupResourceMenu, addEventSource, addChannels];
+      return [...addGroupResourceMenu, ...knativeActions];
     }
   }
   if (!connectorSource) {
     if (graphData.eventSourceEnabled) {
-      return [...addResourceMenu, addEventSource, addChannels];
+      return [...addResourceMenu, ...knativeActions];
     }
     return menu;
   }
@@ -52,9 +57,10 @@ export const getKnativeContextMenuAction = (
   switch (sourceKind) {
     case referenceForModel(ServiceModel):
       return graphData.eventSourceEnabled
-        ? isGroupActions
-          ? [...addGroupResourceMenu, addEventSource]
-          : [...addResourceMenuWithoutCatalog, addEventSource]
+        ? [
+            ...(isGroupActions ? addGroupResourceMenu : addResourceMenuWithoutCatalog),
+            ...knativeConnectorActions,
+          ]
         : menu;
     case referenceForModel(EventingBrokerModel):
       return [addTrigger(EventingTriggerModel, connectorSource.getData().resource)];


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-5949
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Topology add actions menu that are disabled still show up in the menu.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Filter out add actions that are disabled.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
https://user-images.githubusercontent.com/6041994/121564968-9f549800-ca39-11eb-8003-f37b038a42dc.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
