### PR TITLE
ODC-5918-fixed the create from builder image feature scripts

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/add-page.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/add-page.feature
@@ -9,7 +9,7 @@ Feature: Add page on Developer Console
               And user is at Add page
 
 
-        @regression
+        @regression @to-do
         Scenario: Getting started resources on Developer perspective: A-11-TC01
              Then user will see Getting started resources
               And user will see Create Application using Samples
@@ -26,7 +26,7 @@ Feature: Add page on Developer Console
               And user will see "From Local Machine" card
 
 
-        @regression
+        @regression @to-do
         Scenario: Developer Catalog option to create an Application, Component or Service: A-11-TC03
              Then user will see "All services" option
               And user will see "Database" option
@@ -34,14 +34,14 @@ Feature: Add page on Developer Console
               And user will see "Helm Chart" option
 
 
-        @regression
+        @regression @to-do
         Scenario: Git Repository option to create an Application, Component or Service: A-11-TC04
              Then user will see "From Git" option
               And user will see "From Devfile" option
               And user will see "From Dockerfile" option
 
 
-        @regression
+        @regression @to-do
         Scenario: From Local Machine option to create an Application, Component or Service: A-11-TC05
              Then user will see "Import YAML" option
               And user will see "Upload JAR file" option

--- a/frontend/packages/dev-console/integration-tests/features/monitoring/dashboard-display.feature
+++ b/frontend/packages/dev-console/integration-tests/features/monitoring/dashboard-display.feature
@@ -19,10 +19,10 @@ Feature: Monitoring Page
         Scenario: Dashboard tab on the Monitoring page for particular workload: M-02-TC02
             Given user is at Add page
               And user has created workload "parks-test" with resource type "Deployment"
-              And user opened the url of the workload "national-parks-test" in topology page
+              And user opened the url of the workload "parks-test" in topology page
               And user is on Monitoring page
              When user clicks on "Dashboard" tab
-              And user selects the workload "national-parks-test" from the dropdown
+              And user selects the workload "parks-test" from the dropdown
              Then user will see the CPU Usage on Dashboard tab
               And user will see the Memory Usage on Dashboard tab
               And user will see Receive Bandwidth on Dashboard tab
@@ -36,8 +36,8 @@ Feature: Monitoring Page
         @regression
         Scenario: Dashboard tab on the Monitoring page for all workloads: M-02-TC03
             Given user is at Add page
-              And user has created workload "national-parks-test-1" with resource type "Deployment"
-              And user opened the url of the workload "national-parks-test-1" in topology page
+              And user has created workload "parks-test-1" with resource type "Deployment"
+              And user opened the url of the workload "parks-test-1" in topology page
               And user is on Monitoring page
              When user clicks on "Dashboard" tab
              Then user will see the dropdown selected with All Workloads by default

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -89,7 +89,10 @@ Feature: Create the pipeline from builder page
              When user enters pipeline name as "pipeline-params"
               And user selects "s2i-nodejs" from Task drop down
               And user adds the parameter details like Name, Description and Default Value
+              And user clicks on Add workspace
+              And user adds the Workspace name as "empty"
               And user adds the image name to the pipeline task "s2i-nodejs"
+              And user adds the workspace "empty" to the pipeline task "s2i-nodejs"
               And user clicks Create button on Pipeline Builder page
              Then user will be redirected to Pipeline Details page with header name "pipeline-params"
 

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipeline-task-runs-display.feature
@@ -58,7 +58,7 @@ Feature: Display task runs page
               And user is at Task Runs tab of pipeline run with all kind of Workspaces
              When user clicks on a task run associated with "<workspace_name>" "<resource>" Resources
              Then user is redirected to Task Run Details tab
-              And user will see "<workspace_type>" label with "<workspace_name>" Workspace "shared-task-storage" mentioned in the "<resource>" Resources section of Task Run Details page
+              And user will see "<workspace_type>" label with "<workspace_name>" Workspace mentioned in the "<resource>" Resources section of Task Run Details page
 
         Examples:
                   | pipeline_name | workspace_type        | workspace_name      | resource            |

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -29,7 +29,7 @@ export const pipelineBuilderPO = {
     sidePane: {
       dialog: 'div.odc-sidebar',
       displayName: '#task-name',
-      inputResource: 'select[id*="tasks-0-resources-inputs-0-resource-field"]',
+      inputResource: 'select[id*="resources-inputs-0-resource-field"]',
       workSpace: '.odc-task-sidebar__workspace [data-test-id="dropdown-button"] span',
       parameterUrl: '[id$="tasks-0-params-0-value-field"]',
       parameterUrlHelper: '[id$="tasks-0-params-0-value-field-helper"]',

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/pipelines.ts
@@ -80,8 +80,7 @@ When('user adds another task {string} in parallel', (taskName: string) => {
   pipelineBuilderPage.selectParallelTask(taskName);
   pipelineBuilderPage.addResource('git resource');
   pipelineBuilderPage.clickOnTask(taskName);
-  cy.get(pipelineBuilderPO.formView.sidePane.inputResource).click();
-  cy.byTestDropDownMenu('git resource').click();
+  cy.get(pipelineBuilderPO.formView.sidePane.inputResource).select('git resource');
   pipelineBuilderPage.clickCreateButton();
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -85,8 +85,7 @@ When('user adds another task {string} in series', (taskName: string) => {
   pipelineBuilderPage.selectSeriesTask(taskName);
   pipelineBuilderPage.addResource('git resource');
   pipelineBuilderPage.clickOnTask(taskName);
-  cy.get(pipelineBuilderPO.formView.sidePane.inputResource).click();
-  cy.byTestDropDownMenu('git resource').click();
+  cy.get(pipelineBuilderPO.formView.sidePane.inputResource).select('git resource');
   pipelineBuilderPage.clickCreateButton();
 });
 
@@ -106,6 +105,15 @@ When('user adds the image name to the pipeline task {string}', (pipelineTaskName
   cy.get(pipelineBuilderPO.formView.sidePane.imageName).type('openshift/hello-openshift');
   sidePane.close();
 });
+
+When(
+  'user adds the workspace {string} to the pipeline task {string}',
+  (workspaceName: string, pipelineTaskName: string) => {
+    pipelineBuilderPage.clickOnTask(pipelineTaskName);
+    pipelineBuilderSidePane.selectWorkspace(workspaceName);
+    sidePane.close();
+  },
+);
 
 When('user selects YAML view', () => {
   pipelineBuilderPage.clickYaml();

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-workspaces.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-workspaces.ts
@@ -8,6 +8,7 @@ import {
   pipelinesPage,
   startPipelineInPipelinesPage,
 } from '../../pages';
+import { yamlEditor } from '@console/dev-console/integration-tests/support/pages';
 
 When('user enters yaml content {string} in editor', (pipelineYamlFile: string) => {
   cy.fixture(`pipelines/pipelines-workspaces/${pipelineYamlFile}`).then((yaml) => {
@@ -26,12 +27,12 @@ Given('user is at Edit Yaml page', () => {
 
 Given('user created pipeline with workspace', () => {
   pipelineBuilderPage.clickYaml();
-  pipelineBuilderPage.selectSampleInYamlView('s2i-build-and-deploy-pipeline-using-workspace');
-  // Instead of copy parseTwoDigitYear, we are using samples
-  // cy.fixture(`pipelines/pipelines-workspaces/pipeline-with-workspace.yaml`).then((yaml) => {
-  //   cy.log(yaml);
-  //   pipelineBuilderPage.enterYaml(yaml);
-  // });
+  yamlEditor.isLoaded();
+  pipelinesPage.clearYAMLEditor();
+  pipelinesPage.setEditorContent(
+    `testData/pipeline-workspaces/s2i-build-and-deploy-pipeline-using-workspace.yaml`,
+  );
+  cy.get(pipelineBuilderPO.create).click();
   cy.get(pipelineBuilderPO.yamlCreatePipeline.create).click();
 });
 

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/pipelines-workspaces/s2i-build-and-deploy-pipeline-using-workspace.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/pipelines-workspaces/s2i-build-and-deploy-pipeline-using-workspace.yaml
@@ -1,0 +1,59 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: s2i-build-and-deploy
+spec:
+  params:
+    - name: IMAGE_NAME
+      type: string
+    - name: GIT_REPO
+      type: string
+    - name: GIT_REVISION
+      type: string
+  workspaces:
+    - name: workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      workspaces:
+        - name: output
+          workspace: workspace
+      params:
+        - name: url
+          value: $(params.GIT_REPO)
+        - name: revision
+          value: $(params.GIT_REVISION)
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+
+    - name: build
+      taskRef:
+        name: s2i-java-8
+        kind: ClusterTask
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: workspace
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE_NAME)
+        - name: TLSVERIFY
+          value: "false"
+
+    - name: deploy
+      taskRef:
+        name: openshift-client
+        kind: ClusterTask
+      runAfter:
+        - build
+      params:
+        - name: ARGS
+          value:
+            - "new-app"
+            - "--docker-image"
+            - "$(params.IMAGE_NAME)"


### PR DESCRIPTION
**jira Id**: https://issues.redhat.com/browse/ODC-5918
**Description**: 
P-02-TC02 | Script fix required - unable to identify locators
P-02-TC03 | Script fix required - unable to identify locators
P-02-TC06 | Script fix required - unable to identify locators

**Browser & its version**: chrome 91

**Execution Commands**:
In below commands, please update url and password based on the cluster

```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD https://api.gamore48installer7thjune001.devcluster.openshift.com:6443  --insecure-skip-tls-verify
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
./test-cypress.sh -p pipelines
```
Select create-from-builder-page.feature file

**Screenshots**
![image](https://user-images.githubusercontent.com/61005404/121567169-e3489c80-ca3b-11eb-9371-60e5d662891a.png)



