### PR TITLE
Bug 1908772: Fix a11y violation: Dev Console Nav Menu UL contains non-LI elements

### DIFF
--- a/frontend/packages/integration-tests-cypress/support/a11y.ts
+++ b/frontend/packages/integration-tests-cypress/support/a11y.ts
@@ -41,7 +41,6 @@ Cypress.Commands.add('testA11y', (target: string, selector?: string) => {
       { id: 'color-contrast', enabled: false }, // seem to be somewhat inaccurate and has difficulty always picking up the correct colors, tons of open issues for it on axe-core
       { id: 'focusable-content', enabled: false }, // recently updated and need to give the PF team time to fix issues before enabling
       { id: 'scrollable-region-focusable', enabled: false }, // recently updated and need to give the PF team time to fix issues before enabling
-      { id: 'list', enabled: false }, // introduced in Cypress 6.0. fix devconsole's sidebar NavList UL to only have LI as direct child elements. see https://bugzilla.redhat.com/show_bug.cgi?id=1908772
     ],
   });
   a11yTestResults.numberChecks += 1;

--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -1,16 +1,15 @@
-.oc-nav-group.pf-c-nav__section {
-  margin-top: 0;
-  .pf-c-nav__section-title {
-    padding-bottom: 0;
-  }
-  &:first-of-type {
+.oc-perspective-nav {
+  .pf-c-nav__section:first-child {
     .pf-c-nav__section-title {
       padding-top: 0;
       border: none;
     }
   }
-  > ul {
-    padding-left: 0;
+  .pf-c-nav__section {
+    margin-top: 0;
+    .pf-c-nav__section-title {
+      padding-bottom: 0;
+    }
   }
 }
 

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { NavItemSeparator } from '@patternfly/react-core';
+import { NavList, NavItemSeparator } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 
 import { FLAGS, useActiveNamespace } from '@console/shared';
@@ -109,7 +109,7 @@ const AdminNav = () => {
   const machineNS = lastNamespace === ALL_NAMESPACES_KEY ? lastNamespace : 'openshift-machine-api';
   const { t } = useTranslation();
   return (
-    <>
+    <NavList>
       <NavSection id="home" title={t('public~Home')} data-quickstart-id="qs-nav-home">
         <HrefLink
           id="dashboards"
@@ -420,7 +420,7 @@ const AdminNav = () => {
           required={FLAGS.CAN_LIST_CRD}
         />
       </NavSection>
-    </>
+    </NavList>
   );
 };
 

--- a/frontend/public/components/nav/index.tsx
+++ b/frontend/public/components/nav/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Nav, NavProps, NavList, PageSidebar } from '@patternfly/react-core';
+import { Nav, NavProps, PageSidebar } from '@patternfly/react-core';
 import PerspectiveNav from './perspective-nav';
 import NavHeader from './nav-header';
 
@@ -15,9 +15,7 @@ export const Navigation: React.FC<NavigationProps> = React.memo(
       nav={
         <Nav aria-label="Nav" onSelect={onNavSelect} theme="dark">
           <NavHeader onPerspectiveSelected={onPerspectiveSelected} />
-          <NavList>
-            <PerspectiveNav />
-          </NavList>
+          <PerspectiveNav />
         </Nav>
       }
       isNavOpen={isNavOpen}

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -61,7 +61,7 @@ const PerspectiveNav: React.FC<{}> = () => {
     return '';
   };
 
-  const getPinnedItems = (rootNavLink: boolean = false): React.ReactElement[] =>
+  const getPinnedItems = (): React.ReactElement[] =>
     pinnedResourcesLoaded
       ? pinnedResources
           .map((resource) => {
@@ -92,7 +92,7 @@ const PerspectiveNav: React.FC<{}> = () => {
               </Button>
             );
 
-            return rootNavLink ? (
+            return (
               <RootNavLink
                 key={resource}
                 className="oc-nav-pinned-item"
@@ -101,17 +101,13 @@ const PerspectiveNav: React.FC<{}> = () => {
               >
                 {removeButton}
               </RootNavLink>
-            ) : (
-              <Component key={resource} className="oc-nav-pinned-item" {...props}>
-                {removeButton}
-              </Component>
             );
           })
           .filter((p) => p !== null)
       : [];
 
   return (
-    <>
+    <div className="oc-perspective-nav">
       {orderedNavItems.map((item, index) => {
         if (isNavSection(item)) {
           const { id, name } = item.properties;
@@ -120,14 +116,12 @@ const PerspectiveNav: React.FC<{}> = () => {
         if (isSeparator(item)) {
           return <NavItemSeparator key={`separator-${index}`} />;
         }
-        return createLink(item, true);
+        return <li key={item.uid}>{createLink(item, true)}</li>;
       })}
       {pinnedResourcesLoaded && pinnedResources?.length ? (
-        <NavGroup className="oc-nav-group" title="" key="group-pins">
-          {getPinnedItems(true)}
-        </NavGroup>
+        <NavGroup title="">{getPinnedItems()}</NavGroup>
       ) : null}
-    </>
+    </div>
   );
 };
 

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -218,7 +218,7 @@ export const NavSection = connect(navSectionStateToProps)(
 
           if (isGrouped) {
             return (
-              <NavGroup className="oc-nav-group" title="" data-quickstart-id={dataQuickStartId}>
+              <NavGroup title="" data-quickstart-id={dataQuickStartId}>
                 {children}
               </NavGroup>
             );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1908772

**Analysis / Root cause**: 
Dev Console Nav Menu UL contains non-LI elements

**Solution Description**: 
Add li elements.

**Screen shots / Gifs for design review**: 
UI looks like before!

Lists on both levels have now only li elements as child of the ul elements.

https://user-images.githubusercontent.com/139310/121612069-f8ccbf00-ca59-11eb-966a-768c2d89019c.mp4

**Unit test coverage report**: 
Untouched

**Test setup:**
* Open developer perspective
* Check rendered elements in browser
* run `yarn test-cypress-devconsole` `create-from-git.feature` successfully

![image](https://user-images.githubusercontent.com/139310/121612274-5f51dd00-ca5a-11eb-87f1-dec0a0cb0aa2.png)

* run `yarn test-cypress-console` and run `namespace-crud.spec.ts` successfully

![image](https://user-images.githubusercontent.com/139310/121612402-a2ac4b80-ca5a-11eb-8822-4e5e1fb40cd1.png)


**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge