### PR TITLE
Fix a11y issue in virtualized tables with sortable headers and redesigned add page

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedGrid.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedGrid.tsx
@@ -63,6 +63,7 @@ export const GettingStartedGrid: React.FC<GettingStartedGridProps> = ({ onHide, 
             {title}{' '}
             <Popover bodyContent={titleTooltip}>
               <span
+                role="button"
                 aria-label={t('console-shared~More info')}
                 className="ocs-getting-started-grid__tooltip-icon"
               >

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -792,7 +792,7 @@ export const Table = connect<
               role={virtualize ? 'presentation' : 'grid'}
               aria-label={virtualize ? null : ariaLabel}
             >
-              <TableHeader />
+              <TableHeader role="rowgroup" />
               {!virtualize && <TableBody />}
             </PfTable>
             {virtualize &&


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5119

**Analysis / Root cause**: 
1. When rendering a virtualized table with sortable headers, these generates some a11y issues. Could verify this with the axe devtools in Firefox as well with the accessibility debug tools in Chrome.
2. The popover icon in the title of the redesigned add page should have a role when defined an `aria-label` for the icon.

Firefox Axe DevTools before:
![image](https://user-images.githubusercontent.com/139310/121619019-21f44c00-ca68-11eb-95d9-82a376ba2b12.png)

Chrome DevTools before:
![image](https://user-images.githubusercontent.com/139310/121619144-5d8f1600-ca68-11eb-8809-0a7f582ac05c.png)

**Solution Description**: 
1. Force `rowgroup` `role` for `thead`for virtualized tables. This is the default for a `thead` when the table was not forced to `presentation`. This allows the aria-sort attribute on the th cell.
2. Added role="button" to the popover icon on the add page.

Firefox Axe DevTools after:
![image](https://user-images.githubusercontent.com/139310/121620538-cecfc880-ca6a-11eb-9679-48136b6bd908.png)

Chrome DevTools after:
![image](https://user-images.githubusercontent.com/139310/121619524-09386600-ca69-11eb-8705-374fa9666c21.png)

Other issues are not addressed in this issue. Some navigation issues are addressed in #9215

**Screen shots / Gifs for design review**: 
UI doesn't changed.

**Unit test coverage report**: 
Untouched

**Test setup:**
* Open add page and select "App projects"
* Run Axe DevTools

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge