### PR TITLE
Fix quick starts label text

### DIFF
--- a/frontend/packages/topology/locales/en/topology.json
+++ b/frontend/packages/topology/locales/en/topology.json
@@ -71,6 +71,7 @@
   "Quick search list": "Quick search list",
   "Quick search": "Quick search",
   "Prerequisites": "Prerequisites",
+  "Quick Starts": "Quick Starts",
   "Start": "Start",
   "Visual connector": "Visual connector",
   "Binding connector": "Binding connector",

--- a/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
+++ b/frontend/packages/topology/src/components/quick-search/utils/quick-search-utils.tsx
@@ -39,7 +39,7 @@ export const useTransformedQuickStarts = (quickStarts: QuickStart[]): CatalogIte
         );
         return {
           name: qs.spec.displayName,
-          type: 'Quick Start',
+          type: t('topology~Quick Starts'),
           uid: qs.metadata.uid,
           cta: {
             callback: () => setActiveQuickStart(qs.metadata.name, qs.spec.tasks?.length),


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-5953

This PR changes quick starts label text from `Quick Start` to `Quick Starts`.

**Screenshot:**
<img width="1791" alt="Screenshot 2021-06-11 at 1 20 59 PM" src="https://user-images.githubusercontent.com/20724543/121652445-49bfd000-cab9-11eb-9350-69b80b76ceb3.png">


/kind bug