### PR TITLE
adds feature flag for revision decorator plugin

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/components/decorators/getRevisionRouteDecorator.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/decorators/getRevisionRouteDecorator.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { Node } from '@patternfly/react-topology';
 import RevisionRouteDecorator from './RevisionRouteDecorator';
+import { TYPE_KNATIVE_REVISION } from '../../const';
 
 export const getRevisionRouteDecorator = (element: Node, radius: number, x: number, y: number) => {
+  if (element.getType() !== TYPE_KNATIVE_REVISION) {
+    return null;
+  }
   return <RevisionRouteDecorator key="url" element={element} radius={radius} x={x} y={y} />;
 };

--- a/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/knative-plugin/src/topology/topology-plugin.ts
@@ -151,5 +151,15 @@ export const topologyPlugin: Plugin<TopologyConsumedExtensions> = [
       quadrant: TopologyDecoratorQuadrant.upperRight,
       decorator: applyCodeRefSymbol(getRevisionRouteDecorator),
     },
+    flags: {
+      required: [
+        FLAG_KNATIVE_SERVING_CONFIGURATION,
+        FLAG_KNATIVE_SERVING,
+        FLAG_KNATIVE_SERVING_REVISION,
+        FLAG_KNATIVE_SERVING_ROUTE,
+        FLAG_KNATIVE_SERVING_SERVICE,
+        FLAG_KNATIVE_EVENTING,
+      ],
+    },
   },
 ];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5956


**Solution Description**: 
adds feature flag for revision decorator plugin and check if the resource is a revision in decorator provider

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
