### PR TITLE
(fix): Hide RGW storage class in add capacity modal

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -23,6 +23,7 @@ export const OCS_PROVISIONERS = [
   'cephfs.csi.ceph.com',
   'rbd.csi.ceph.com',
   'noobaa.io/obc',
+  'ceph.rook.io/bucket',
 ];
 
 export enum CLUSTER_STATUS {


### PR DESCRIPTION
Added rook bucket provisioner in the blacklist

Signed-off-by: Afreen Rahman <afrahman@redhat.com>