### PR TITLE
Bug 1971499: Do not render samples column and helm link when add page customization disabled them

### DIFF
--- a/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
+++ b/frontend/packages/console-shared/src/components/getting-started/GettingStartedCard.tsx
@@ -94,7 +94,6 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
                   onClick={link.onClick}
                 >
                   {link.title}
-                  {link.external}
                 </SimpleListItem>
               ),
             )}

--- a/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/DeveloperFeaturesGettingStartedCard.tsx
@@ -9,6 +9,9 @@ import {
   GettingStartedCard,
 } from '@console/shared/src/components/getting-started';
 
+import { getDisabledAddActions } from '../../utils/useAddActionExtensions';
+import { fromHelmCharts } from '../../actions/add-resources';
+
 export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
@@ -16,29 +19,33 @@ export const DeveloperFeaturesGettingStartedCard: React.FC = () => {
   // Show only major and minor version.
   const version = parsed ? `${parsed.major}.${parsed.minor}` : '';
 
-  const links: GettingStartedLink[] = [
-    {
+  const links: GettingStartedLink[] = [];
+
+  const disabledAddActions = getDisabledAddActions();
+  if (!disabledAddActions?.includes(fromHelmCharts.id)) {
+    links.push({
       id: 'helm-charts',
       title: t('devconsole~Discover certified Helm Charts'),
       href:
         activeNamespace && activeNamespace !== ALL_NAMESPACES_KEY
           ? `/catalog/ns/${activeNamespace}?catalogType=HelmChart`
           : '/catalog/all-namespaces?catalogType=HelmChart',
-    },
-    {
-      id: 'topology',
-      title: t('devconsole~Start building your application quickly in topology'),
-      href:
-        activeNamespace && activeNamespace !== ALL_NAMESPACES_KEY
-          ? `/topology/ns/${activeNamespace}?catalogSearch=`
-          : '/topology/all-namespaces?catalogSearch=',
-    },
-  ];
+    });
+  }
+
+  links.push({
+    id: 'topology',
+    title: t('devconsole~Start building your application quickly in topology'),
+    href:
+      activeNamespace && activeNamespace !== ALL_NAMESPACES_KEY
+        ? `/topology/ns/${activeNamespace}?catalogSearch=`
+        : '/topology/all-namespaces?catalogSearch=',
+  });
 
   const moreLink: GettingStartedLink = {
     id: 'whats-new',
     title: t("devconsole~What's new in OpenShift {{version}}", { version }),
-    href: 'https://developers.redhat.com/products/openshift/getting-started',
+    href: 'https://developers.redhat.com/products/openshift/whats-new',
     external: true,
   };
 

--- a/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
+++ b/frontend/packages/dev-console/src/components/add/SampleGettingStartedCard.tsx
@@ -11,6 +11,8 @@ import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
 
 import CatalogServiceProvider from '../catalog/service/CatalogServiceProvider';
+import { getDisabledAddActions } from '../../utils/useAddActionExtensions';
+import { fromSamples } from '../../actions/add-resources';
 
 interface SampleGettingStartedCardProps {
   featured?: string[];
@@ -45,6 +47,11 @@ export const SampleGettingStartedCard: React.FC<SampleGettingStartedCardProps> =
 }) => {
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
+
+  const disabledAddActions = getDisabledAddActions();
+  if (disabledAddActions?.includes(fromSamples.id)) {
+    return null;
+  }
 
   const moreLink: GettingStartedLink = {
     id: 'all-samples',

--- a/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/DeveloperFeaturesGettingStartedCard.spec.tsx
@@ -35,6 +35,10 @@ jest.mock(
 
 const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
 
+afterEach(() => {
+  delete window.SERVER_FLAGS.addPage;
+});
+
 describe('DeveloperFeaturesGettingStartedCard', () => {
   it('should contain links to current active namespace', () => {
     useActiveNamespaceMock.mockReturnValue(['active-namespace']);
@@ -59,7 +63,32 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
       id: 'whats-new',
       title: "What's new in OpenShift 4.8",
-      href: 'https://developers.redhat.com/products/openshift/getting-started',
+      href: 'https://developers.redhat.com/products/openshift/whats-new',
+      external: true,
+    });
+  });
+
+  it('should not show helm link when helm card is disabled', () => {
+    window.SERVER_FLAGS.addPage = '{ "disabledActions": "helm" }';
+
+    useActiveNamespaceMock.mockReturnValue(['active-namespace']);
+
+    const wrapper = shallow(<DeveloperFeaturesGettingStartedCard />);
+
+    expect(wrapper.find(GettingStartedCard).props().title).toEqual(
+      'Explore new developer features',
+    );
+    expect(wrapper.find(GettingStartedCard).props().links).toEqual([
+      {
+        id: 'topology',
+        title: 'Start building your application quickly in topology',
+        href: '/topology/ns/active-namespace?catalogSearch=',
+      },
+    ]);
+    expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
+      id: 'whats-new',
+      title: "What's new in OpenShift 4.8",
+      href: 'https://developers.redhat.com/products/openshift/whats-new',
       external: true,
     });
   });
@@ -87,7 +116,7 @@ describe('DeveloperFeaturesGettingStartedCard', () => {
     expect(wrapper.find(GettingStartedCard).props().moreLink).toEqual({
       id: 'whats-new',
       title: "What's new in OpenShift 4.8",
-      href: 'https://developers.redhat.com/products/openshift/getting-started',
+      href: 'https://developers.redhat.com/products/openshift/whats-new',
       external: true,
     });
   });

--- a/frontend/packages/dev-console/src/components/add/__tests__/SampleGettingStartedCard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/SampleGettingStartedCard.spec.tsx
@@ -38,7 +38,22 @@ jest.mock(
 const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
 const CatalogServiceProviderMock = CatalogServiceProvider as jest.Mock;
 
+afterEach(() => {
+  delete window.SERVER_FLAGS.addPage;
+});
+
 describe('SampleGettingStartedCard', () => {
+  it('should not render when Samples add card is disabled', () => {
+    window.SERVER_FLAGS.addPage = '{ "disabledActions": "import-from-samples" }';
+
+    useActiveNamespaceMock.mockReturnValue(['active-namespace']);
+    CatalogServiceProviderMock.mockImplementation((props) => props.children(loadedCatalogService));
+
+    const wrapper = shallow(<SampleGettingStartedCard />);
+
+    expect(wrapper.text()).toEqual('');
+  });
+
   it('should render loading links until catalog service is loaded', () => {
     useActiveNamespaceMock.mockReturnValue(['active-namespace']);
     CatalogServiceProviderMock.mockImplementation((props) => props.children(loadingCatalogService));


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1971499

**Analysis / Root cause**: 
The getting started section and helm link is shown on the add page but doesn't pay attention to the add card customization yet.

**Solution Description**: 
Check the list of disabled add cards and do not render the getting started samples or helm link when the these cards are disabled. See https://coreos.slack.com/archives/CHC2R6AGG/p1623439527043400

Also change link "What's new in OpenShift 4.8", see https://coreos.slack.com/archives/CHC2R6AGG/p1623638084044900

```diff
- from https://developers.redhat.com/products/openshift/getting-started
+  to  https://developers.redhat.com/products/openshift/whats-new
```

**Screen shots / Gifs for design review**: 
Before:
![before](https://user-images.githubusercontent.com/139310/121861083-cccf6900-ccf9-11eb-93b5-781a8aa032ab.png)

With this PR the sample column and helm link in "Explore new developer features" are not shown anymore:
![after](https://user-images.githubusercontent.com/139310/121859278-cd670000-ccf7-11eb-9d38-ecb9f3b5b244.png)

**Unit test coverage report**: 
Added new test for the cases where samples or helm cards are disabled.

**Test setup:**
1. Open cluster Console resource. Quick link in console: /k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml
2. Add customization:
```yaml
spec:
  customization:
    addPage:
      disabledActions:
        - import-from-samples
        - helm
```
3. Reload your browser tab on the add page

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge