### PR TITLE
Bug 1971667: Track and show error messages in modals

### DIFF
--- a/frontend/__tests__/components/utils/promise-component.spec.tsx
+++ b/frontend/__tests__/components/utils/promise-component.spec.tsx
@@ -8,6 +8,16 @@ import {
   HandlePromiseProps,
 } from '../../../public/components/utils/promise-component';
 
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+const i18nNS = 'public';
+
 describe('withHandlePromise', () => {
   type TestProps = {
     promise: Promise<any>;
@@ -49,7 +59,7 @@ describe('withHandlePromise', () => {
           .dive()
           .find('h1')
           .text(),
-      ).toEqual('An error occurred. Please try again.');
+      ).toEqual(`${i18nNS}~An error occurred. Please try again.`);
       done();
     }, 10);
   });

--- a/frontend/public/components/modals/delete-modal.tsx
+++ b/frontend/public/components/modals/delete-modal.tsx
@@ -27,7 +27,6 @@ import { ResourceLink } from '../utils/resource-link';
 const DeleteModal = withHandlePromise((props: DeleteModalProps) => {
   const [isChecked, setIsChecked] = React.useState(true);
   const [owner, setOwner] = React.useState(null);
-  const [errorMessage] = React.useState(null);
 
   const { t } = useTranslation();
 
@@ -72,7 +71,7 @@ const DeleteModal = withHandlePromise((props: DeleteModalProps) => {
       });
   });
 
-  const { kind, resource, message } = props;
+  const { kind, resource, message, errorMessage } = props;
   return (
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>

--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -16,7 +16,6 @@ import {
 
 const TaintsModal = withHandlePromise((props: TaintsModalProps) => {
   const [taints, setTaints] = React.useState(props.resource.spec.taints || []);
-  const [errorMessage] = React.useState<string>();
 
   const { t } = useTranslation();
 
@@ -62,6 +61,8 @@ const TaintsModal = withHandlePromise((props: TaintsModalProps) => {
     PreferNoSchedule: 'PreferNoSchedule',
     NoExecute: 'NoExecute',
   };
+
+  const { errorMessage } = props;
 
   return (
     <form

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -15,7 +15,6 @@ import {
 } from '../factory';
 
 const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
-  const [errorMessage] = React.useState();
   const getTolerationsFromResource = (): Toleration[] => {
     const { resource } = props;
     return props.resourceKind.kind === 'Pod'
@@ -100,6 +99,8 @@ const TolerationsModal = withHandlePromise((props: TolerationsModalProps) => {
   const isEditable = (toleration: TolerationModalItem) => {
     return props.resourceKind.kind !== 'Pod' || toleration.isNew;
   };
+
+  const { errorMessage } = props;
 
   return (
     <form

--- a/frontend/public/components/utils/promise-component.tsx
+++ b/frontend/public/components/utils/promise-component.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
+import i18next from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 export const withHandlePromise: WithHandlePromise = (Component) => (props) => {
   const [inProgress, setInProgress] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
+
+  const { t } = useTranslation();
 
   const handlePromise = (promise, onFulfill, onError) => {
     setInProgress(true);
@@ -13,7 +17,7 @@ export const withHandlePromise: WithHandlePromise = (Component) => (props) => {
         onFulfill && onFulfill(res);
       },
       (error) => {
-        const errorMsg = error.message || 'An error occurred. Please try again.';
+        const errorMsg = error.message || t('public~An error occurred. Please try again.');
         setInProgress(false);
         setErrorMessage(errorMsg);
         // eslint-disable-next-line no-console
@@ -60,7 +64,7 @@ export class PromiseComponent<P, S extends PromiseComponentState> extends React.
   }
 
   private catch(error) {
-    const errorMessage = error.message || 'An error occurred. Please try again.';
+    const errorMessage = error.message || i18next.t('public~An error occurred. Please try again.');
     this.setState({
       inProgress: false,
       errorMessage,

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -447,6 +447,7 @@
   "Non-printable file detected.": "Non-printable file detected.",
   "File contains non-printable characters. Preview is not available.": "File contains non-printable characters. Preview is not available.",
   "Select {{item}}": "Select {{item}}",
+  "An error occurred. Please try again.": "An error occurred. Please try again.",
   "Remove volume": "Remove volume",
   "Mount path": "Mount path",
   "SubPath": "SubPath",


### PR DESCRIPTION
Error messages weren't being passed to the footer in a few modals. I refactored them to catch and show the error messages.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1971667.