### PR TITLE
Bug 1967658: improve failure alert for copied CSV

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -56,6 +56,8 @@
   "Create instance": "Create instance",
   "{{initializationResourceKind}} required": "{{initializationResourceKind}} required",
   "Create a {{initializationResourceKind}} instance to use this Operator.": "Create a {{initializationResourceKind}} instance to use this Operator.",
+  "Operator failed": "Operator failed",
+  "This Operator was copied from another namespace. For the reason it failed, see ": "This Operator was copied from another namespace. For the reason it failed, see ",
   "Description": "Description",
   "Not available": "Not available",
   "Provider": "Provider",

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -87,6 +87,7 @@ import {
   ClusterServiceVersionKind,
   ClusterServiceVersionPhase,
   CRDDescription,
+  CSVConditionReason,
   InstallPlanKind,
   PackageManifestKind,
   SubscriptionKind,
@@ -987,8 +988,25 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
                   isInline
                   className="co-alert"
                   variant="danger"
-                  title={`${status.phase}: ${status.message}`}
-                />
+                  title={t('olm~Operator failed')}
+                >
+                  {status.reason === CSVConditionReason.CSVReasonCopied ? (
+                    <>
+                      {t(
+                        'olm~This Operator was copied from another namespace. For the reason it failed, see ',
+                      )}
+                      <ResourceLink
+                        name={metadata.name}
+                        kind={referenceForModel(ClusterServiceVersionModel)}
+                        namespace={operatorNamespaceFor(props.obj)}
+                        hideIcon
+                        inline
+                      />
+                    </>
+                  ) : (
+                    status.message
+                  )}
+                </Alert>
               )}
               {initializationResource && (
                 <InitializationResourceAlert


### PR DESCRIPTION
After:
If CSV is copied:
<img width="1420" alt="Screen Shot 2021-06-14 at 10 28 17 AM" src="https://user-images.githubusercontent.com/895728/121913261-3c942280-ccff-11eb-8f58-9097947accd7.png">
Otherwise:
<img width="1354" alt="Screen Shot 2021-06-14 at 11 45 32 AM" src="https://user-images.githubusercontent.com/895728/121920907-7c123d00-cd06-11eb-8076-436830832728.png">