### PR TITLE
Fix monitoring error box alignment

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -20,7 +20,7 @@ $tooltip-background-color: var(--pf-global--BackgroundColor--dark-100);
 .graph-empty-state {
   min-height: 310px;
   &__loaded {
-    align-items: center;
+    align-items: stretch;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5997

**Analysis / Root cause**: 
Error message is aligned with a flex layout to the center.

**Solution Description**: 
Stretch the content of the flex layout.

I tested also the admin monitoring area but didn't find any difference.

**Screen shots / Gifs for design review**: 
Before (in case of an error, for example with a local CRC):
![monitoring-error-before](https://user-images.githubusercontent.com/139310/122010075-0a47fb00-cdbb-11eb-9812-f8eb671889b2.png)

With this PR and an error (local CRC):
![with-pr-without-monitoring](https://user-images.githubusercontent.com/139310/122010109-12a03600-cdbb-11eb-812a-2e2e9c0a281b.png)

With this PR and installed monitoring (shared cluster):
![with-pr-with-monitoring](https://user-images.githubusercontent.com/139310/122010168-20ee5200-cdbb-11eb-9d00-6afb67c8bc02.png)

**Unit test coverage report**: 
Unchanged. CSS only change.

**Test setup:**
* To get the error use a CRC
* **Alternative:** switch to monitoring tab (to load the JS), switch back, disconnect from internet or stop a local bridge, and switch back to the monitoring tab

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge