### PR TITLE
Bug 1972016: Fix time range issue for devconsole monitoring dashboard

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
@@ -33,11 +33,17 @@ type MonitoringDashboardProps = {
 type StateProps = {
   timespan: number;
   pollInterval: number;
+  endTime: number;
 };
 
 type Props = MonitoringDashboardProps & StateProps;
 
-export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInterval }) => {
+export const MonitoringDashboard: React.FC<Props> = ({
+  match,
+  timespan,
+  pollInterval,
+  endTime,
+}) => {
   const { t } = useTranslation();
   const namespace = match.params.ns;
   const params = getURLSearchParams();
@@ -104,6 +110,7 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
               key={q.title}
               timespan={timespan}
               pollInterval={pollInterval}
+              endTime={endTime}
             />
           ))}
         </Dashboard>
@@ -115,6 +122,7 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
 const mapStateToProps = (state: RootState): StateProps => ({
   timespan: state.UI.getIn(['monitoringDashboards', 'timespan']),
   pollInterval: state.UI.getIn(['monitoringDashboards', 'pollInterval']),
+  endTime: state.UI.getIn(['monitoringDashboards', 'endTime']),
 });
 
 export default connect<StateProps, MonitoringDashboardProps>(mapStateToProps)(MonitoringDashboard);

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -24,6 +24,7 @@ type MonitoringDashboardGraphProps = {
   byteDataType: ByteDataTypes;
   timespan?: number;
   pollInterval?: number;
+  endTime?: number;
 };
 
 const DEFAULT_TIME_SPAN = 30 * 60 * 1000;
@@ -36,6 +37,7 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
   graphType = GraphTypes.area,
   timespan,
   pollInterval,
+  endTime,
 }) => {
   const { t } = useTranslation();
   return (
@@ -59,6 +61,7 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
             isStack={graphType === GraphTypes.area}
             timespan={timespan}
             pollInterval={pollInterval}
+            fixedEndTime={endTime}
             formatSeriesTitle={(labels) => labels.pod}
             showLegend
           />

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
@@ -37,6 +37,7 @@ describe('Monitoring Dashboard Tab', () => {
     },
     timespan: 1800000,
     pollInterval: 90000,
+    endTime: 1900000,
   };
 
   it('should render Monitoring Dashboard tab', () => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGSM-30921

**Analysis / Root cause**: 
Set a specific time range, but Dashboards display data with a different time range. `fixedEndTime` prop is missing from the `QueryBrowser` component and it is the cause of this issue.

**Solution Description**: 
 Passed the `endTime` prop to `QueryBrowser` component.

**Screen shots / Gifs for design review**: 
![Kapture 2021-06-15 at 14 53 55](https://user-images.githubusercontent.com/2561818/122028393-9f61e880-cde9-11eb-852e-a7ed6719b435.gif)

