### PR TITLE
Always use http protocol for gitlab host

### DIFF
--- a/frontend/packages/git-service/src/services/gitlab-service.ts
+++ b/frontend/packages/git-service/src/services/gitlab-service.ts
@@ -58,11 +58,9 @@ export class GitlabService extends BaseService {
   };
 
   getRepoMetadata(): RepoMetadata {
-    const { name, owner, protocol, resource, full_name: fullName } = GitUrlParse(
-      this.gitsource.url,
-    );
+    const { name, owner, resource, full_name: fullName } = GitUrlParse(this.gitsource.url);
     const contextDir = removeLeadingSlash(this.gitsource.contextDir);
-    const host = `${protocol}://${resource}`;
+    const host = `https://${resource}`;
     return {
       repoName: name,
       owner,
@@ -96,7 +94,7 @@ export class GitlabService extends BaseService {
       await this.getRepo();
       return RepoStatus.Reachable;
     } catch (e) {
-      if (e.response.status === 429) {
+      if (e.response?.status === 429) {
         return RepoStatus.RateLimitExceeded;
       }
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5993
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The gitlab API expects the host URL to always be https, even if the repo URL is SSH.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Always use the HTTP host URL for gitlab.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/122032902-b276b780-cded-11eb-809f-4f468e01015f.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug