### PR TITLE
fixes Loading indicator alignment on eventsources form

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
@@ -6,7 +6,7 @@ import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
 import { QUERY_PROPERTIES } from '@console/dev-console/src/const';
-import { LoadingInline, PageHeading } from '@console/internal/components/utils';
+import { LoadingBox, PageHeading } from '@console/internal/components/utils';
 import { TechPreviewBadge } from '@console/shared';
 import { useEventSourceStatus } from '../../hooks';
 import { CamelKameletBindingModel } from '../../models';
@@ -52,7 +52,7 @@ const EventSourcePage: React.FC<EventSourcePageProps> = ({ match, location }) =>
           createSourceAccess={createSourceAccess}
         />
       ) : (
-        <LoadingInline />
+        <LoadingBox />
       )}
       {loaded && isValidSource && !createSourceAccessLoading && createSourceAccess && (
         <ConnectedEventSource


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6028

**Analysis / Root cause**: 
Loading indicator is misaligned on Event sources form

**Solution Description**: 
Loading indicator is aligned to center on Event sources form

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![Kapture 2021-06-15 at 16 28 26](https://user-images.githubusercontent.com/5129024/122041734-e3a7b580-cdf6-11eb-8639-5d9bcf791fc4.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- Install Serverless & Red Hat Integration - Camel K operator
- Create a namespace and create CR for IP (integration platform) in that namespace
- go to devConsole => add => event source

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
