### PR TITLE
fixes kafka connection sidebar resource to show secret resource if exist

### DIFF
--- a/frontend/packages/rhoas-plugin/locales/en/rhoas-plugin.json
+++ b/frontend/packages/rhoas-plugin/locales/en/rhoas-plugin.json
@@ -47,6 +47,7 @@
   "Bootstrap Server": "Bootstrap Server",
   "URL": "URL",
   "Secret": "Secret",
+  "No Secret": "No Secret",
   "Create a Kafka connector": "Create a Kafka connector",
   "Create a binding connector": "Create a binding connector",
   "No data": "No data",

--- a/frontend/packages/rhoas-plugin/src/topology/components/ResourceComponent.tsx
+++ b/frontend/packages/rhoas-plugin/src/topology/components/ResourceComponent.tsx
@@ -21,11 +21,15 @@ export const ResourcesComponent: React.FC<{ obj: KafkaConnection }> = ({ obj }) 
   return (
     <ul>
       <h3>{t('rhoas-plugin~Secret')}</h3>
-      <li className="list-group-item container-fluid">
-        <div className="row">
-          <span className="col-xs-12">{link}</span>
-        </div>
-      </li>
+      {!serviceAccountSecretName ? (
+        <span className="text-muted">{t('rhoas-plugin~No Secret')}</span>
+      ) : (
+        <li className="list-group-item container-fluid">
+          <div className="row">
+            <span className="col-xs-12">{link}</span>
+          </div>
+        </li>
+      )}
     </ul>
   );
 };

--- a/frontend/packages/rhoas-plugin/src/topology/components/__mocks__/kafka-connection-mock.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/components/__mocks__/kafka-connection-mock.ts
@@ -1,0 +1,33 @@
+import { KafkaConnection } from '../../../utils/rhoas-types';
+
+export const mockKafkaConnection: KafkaConnection = {
+  apiVersion: 'rhoas.redhat.com/v1alpha1',
+  kind: 'KafkaConnection',
+  metadata: {
+    creationTimestamp: '2021-06-15T11:16:05Z',
+    finalizers: ['kafkaconnections.rhoas.redhat.com/finalizer'],
+    generation: 1,
+    name: 'example',
+    namespace: 'default',
+    resourceVersion: '481367',
+    uid: 'f41f7577-2eaa-428a-a600-04657cb0e9dc',
+  },
+  spec: {
+    accessTokenSecretName: 'accessTokenName',
+    credentials: {
+      serviceAccountSecretName: 'RH-service-account-secret',
+    },
+  },
+  status: {
+    bootstrapServerHost: 'bootstrapServerHost',
+    conditions: [
+      {
+        message: '',
+        reason: '',
+        status: 'True',
+        type: 'AcccesTokenSecretValid',
+      },
+    ],
+    metadata: {},
+  },
+};

--- a/frontend/packages/rhoas-plugin/src/topology/components/__tests__/ResourceComponent.spec.tsx
+++ b/frontend/packages/rhoas-plugin/src/topology/components/__tests__/ResourceComponent.spec.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { ResourceLink } from '@console/internal/components/utils';
+import { mockKafkaConnection } from '../__mocks__/kafka-connection-mock';
+import { ResourcesComponent } from '../ResourceComponent';
+
+jest.mock('react-i18next', () => {
+  const reactI18next = require.requireActual('react-i18next');
+  return {
+    ...reactI18next,
+    useTranslation: () => ({ t: (key) => key }),
+  };
+});
+
+describe('ResourceComponent', () => {
+  it('Should show secret if exists', () => {
+    const wrapper = shallow(<ResourcesComponent obj={mockKafkaConnection} />);
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+  });
+
+  it('Should not list secret if doesnot exists', () => {
+    const mockKcData = {
+      ...mockKafkaConnection,
+      spec: {
+        accessTokenSecretName: '',
+        credentials: {
+          serviceAccountSecretName: '',
+        },
+      },
+    };
+    const wrapper = shallow(<ResourcesComponent obj={mockKcData} />);
+    expect(wrapper.find(ResourceLink).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5995

**Analysis / Root cause**: 
kafka connection with no secret has an empty secret resource

**Solution Description**: 
fixes kafka connection sidebar resource to show secret resource if exist

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/5129024/122061326-042e3a80-ce0c-11eb-9505-75af41e75995.png)


![image](https://user-images.githubusercontent.com/5129024/122050381-09d25300-ce01-11eb-9495-6eade5c4ad37.png)


**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/5129024/122049514-2326cf80-ce00-11eb-8c91-e7c11b164f05.png)


**Test setup:**
- install RHOAS operator
- Create a kafka connection / link managed services with add flow from ODC

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
