### PR TITLE
Bug 1970466: Console's OperatorHub leads users to unrelated install plan, if subscription does not have its own

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -207,6 +207,7 @@
   "Deep Insights": "Deep Insights",
   "Auto Pilot": "Auto Pilot",
   "Checked": "Checked",
+  "A suitable CSV is not found.": "A suitable CSV is not found.",
   "Version <1>{{installedVersion}}</1> of this Operator has been installed on the cluster.": "Version <1>{{installedVersion}}</1> of this Operator has been installed on the cluster.",
   "This Operator has been installed on the cluster.": "This Operator has been installed on the cluster.",
   "View it here.": "View it here.",

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -75,6 +75,15 @@ const InstalledHintBlock: React.FC<OperatorHubItemDetailsHintBlockProps> = ({
     isList: false,
     namespaced: true,
   });
+
+  if (!subscription?.status?.installedCSV) {
+    return (
+      <HintBlock className="co-catalog-page__hint" title="Operator Not Yet Installed">
+        <p>{t('olm~A suitable CSV is not found.')}</p>
+      </HintBlock>
+    );
+  }
+
   const nsPath = `/k8s/${namespace ? `ns/${namespace}` : 'all-namespaces'}`;
   const to = installedCSV
     ? `${nsPath}/clusterserviceversions/${installedCSV?.metadata?.name ?? ''}`


### PR DESCRIPTION
Related to [Bug 1970466](https://bugzilla.redhat.com/show_bug.cgi?id=1970466)

When viewing an operator's detail information, a message is shown if the installed CSV(startingCSV) is not found instead of displaying that the operator has been installed.

<img width="550" alt="Bug 1970466" src="https://user-images.githubusercontent.com/82059948/122073371-fbaf1300-cdbd-11eb-9ec4-e2a6756e1f8b.png">


As coded, if a yaml contains an unknown starting CSV, when calling useK8sWatchResource, the name key is set to undefined.  This causes usek8sWatchResource to return a perviously installed operator to be returned causing incorrect information to be shown.