### PR TITLE
Fix catalog tile links and default behaviour with ctrl+click

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogController.tsx
@@ -16,6 +16,7 @@ import CatalogView from './catalog-view/CatalogView';
 import CatalogTile from './CatalogTile';
 import CatalogDetailsModal from './details/CatalogDetailsModal';
 import { CatalogService } from './service/CatalogServiceProvider';
+import { getURLWithParams } from './utils/catalog-utils';
 import { determineAvailableFilters } from './utils/filter-utils';
 import {
   CatalogCategory,
@@ -155,7 +156,11 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
             ? () => item.cta.callback()
             : null
         }
-        href={!enableDetailsPanel ? item.cta?.href : null}
+        href={
+          !enableDetailsPanel
+            ? item.cta?.href
+            : getURLWithParams(CatalogQueryParams.SELECTED_ID, item.uid)
+        }
       />
     ),
     [catalogTypes, openDetailsPanel, enableDetailsPanel],

--- a/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
 import { history } from '@console/internal/components/utils';
 import CatalogBadges from './CatalogBadges';
-import { getIconProps } from './utils/catalog-utils';
+import { getIconProps, isModifiedEvent } from './utils/catalog-utils';
 import { CatalogType } from './utils/types';
 
 import './CatalogTile.scss';
@@ -38,7 +38,8 @@ const CatalogTile: React.FC<CatalogTileProps> = ({ item, catalogTypes, onClick, 
   return (
     <PfCatalogTile
       className="odc-catalog-tile co-catalog-tile"
-      onClick={(e) => {
+      onClick={(e: React.MouseEvent<HTMLElement>) => {
+        if (isModifiedEvent(e)) return;
         e.preventDefault();
         if (onClick) {
           onClick(item);

--- a/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
@@ -51,6 +51,20 @@ export const updateURLParams = (paramName: string, value: string | string[]) => 
   setURLParams(params);
 };
 
+export const getURLWithParams = (paramName: string, value: string | string[]): string => {
+  const params = new URLSearchParams(window.location.search);
+  const url = new URL(window.location.href);
+
+  if (value) {
+    params.set(paramName, Array.isArray(value) ? JSON.stringify(value) : value);
+  } else {
+    params.delete(paramName);
+  }
+
+  const searchParams = `?${params.toString()}${url.hash}`;
+  return `${url.pathname}${searchParams}`;
+};
+
 export const getCatalogTypeCounts = (
   items: CatalogItem[],
   catalogTypes: CatalogType[],
@@ -63,4 +77,8 @@ export const getCatalogTypeCounts = (
   });
 
   return catalogTypeCounts;
+};
+
+export const isModifiedEvent = (event: React.MouseEvent<HTMLElement>) => {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6032
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
- Catalog tiles were only setting href property if there was explicit href available for that item. This resulted in `/#` as href.
- Catalog tiles add an `onClick` handler for each tile which prevents default. This disables the `Ctrl+Click` behaviour for links.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Set correct hrefs for every item in catalog tile.
- Add a check for modified clicks and do no prevent default in that case. This uses `isModified` check from `react-router` `Link` component.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/122077269-36926480-ce19-11eb-9809-031fa8498c22.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
