### PR TITLE
Use different suffix for pipeline secret if annotation already exists

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -456,12 +456,14 @@ export const managePipelineResources = async (
   if (git.secret) {
     const secret = await k8sGet(SecretModel, git.secret, project.name);
     const gitUrl = GitUrlParse(git.url);
-    const secretAnnotation = getSecretAnnotations({
-      key: 'git',
-      value:
-        gitUrl.protocol === 'ssh' ? gitUrl.resource : `${gitUrl.protocol}://${gitUrl.resource}`,
-    });
-    secret.metadata.annotations = _.merge(secret.metadata.annotations, secretAnnotation);
+    secret.metadata.annotations = getSecretAnnotations(
+      {
+        key: 'git',
+        value:
+          gitUrl.protocol === 'ssh' ? gitUrl.resource : `${gitUrl.protocol}://${gitUrl.resource}`,
+      },
+      secret.metadata.annotations,
+    );
     await k8sUpdate(SecretModel, secret, project.name);
 
     const pipelineServiceAccount = await k8sGet(

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/pipeline-utils.spec.ts
@@ -144,6 +144,55 @@ describe('pipeline-utils ', () => {
     });
   });
 
+  it('should have correct annotation key prefix when there are existing annotations', () => {
+    const existingAnnotations = {
+      'tekton.dev/git-0': 'gitlab.com',
+    };
+    const annotations = getSecretAnnotations(
+      {
+        key: SecretAnnotationId.Git,
+        value: 'github.com',
+      },
+      existingAnnotations,
+    );
+    expect(annotations).toEqual({
+      'tekton.dev/git-0': 'gitlab.com',
+      'tekton.dev/git-1': 'github.com',
+    });
+  });
+
+  it('should avoid adding duplicate annotations to secret', () => {
+    const existingAnnotations = {
+      'tekton.dev/git-0': 'github.com',
+    };
+    const annotations = getSecretAnnotations(
+      {
+        key: SecretAnnotationId.Git,
+        value: 'github.com',
+      },
+      existingAnnotations,
+    );
+    expect(annotations).toEqual({
+      'tekton.dev/git-0': 'github.com',
+    });
+  });
+
+  it('should return unmodified annotations if invalid key is provided', () => {
+    const existingAnnotations = {
+      'tekton.dev/git-0': 'gitlab.com',
+    };
+    const annotations = getSecretAnnotations(
+      {
+        key: 'invalid-type',
+        value: 'github.com',
+      },
+      existingAnnotations,
+    );
+    expect(annotations).toEqual({
+      'tekton.dev/git-0': 'gitlab.com',
+    });
+  });
+
   it('expected relative time should be "a few seconds"', () => {
     const relativeTime = calculateRelativeTime('2020-05-22T11:57:53Z', '2020-05-22T11:57:57Z');
     expect(relativeTime).toBe('a few seconds');

--- a/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/pipeline-utils.ts
@@ -383,15 +383,35 @@ type KeyValuePair = {
   key: string;
   value: string;
 };
-export const getSecretAnnotations = (annotation: KeyValuePair) => {
-  const annotations = {};
+
+const getAnnotationKey = (secretType: string, suffix: number) => {
   const annotationPrefix = 'tekton.dev';
-  if (annotation?.key === SecretAnnotationId.Git) {
-    annotations[`${annotationPrefix}/${SecretAnnotationId.Git}-0`] = annotation?.value;
-  } else if (annotation?.key === SecretAnnotationId.Image) {
-    annotations[`${annotationPrefix}/${SecretAnnotationId.Image}-0`] = annotation?.value;
+  if (secretType === SecretAnnotationId.Git) {
+    return `${annotationPrefix}/${SecretAnnotationId.Git}-${suffix}`;
   }
-  return annotations;
+  if (secretType === SecretAnnotationId.Image) {
+    return `${annotationPrefix}/${SecretAnnotationId.Image}-${suffix}`;
+  }
+  return null;
+};
+
+export const getSecretAnnotations = (
+  annotation: KeyValuePair,
+  existingAnnotations: { [key: string]: string } = {},
+) => {
+  let count = 0;
+  let annotationKey = getAnnotationKey(annotation?.key, count);
+  if (!annotationKey) {
+    return existingAnnotations;
+  }
+  while (
+    existingAnnotations[annotationKey] &&
+    existingAnnotations[annotationKey] !== annotation?.value
+  ) {
+    annotationKey = getAnnotationKey(annotation?.key, ++count);
+  }
+
+  return { ...existingAnnotations, [annotationKey]: annotation?.value };
 };
 
 export const pipelinesTab = (kindObj: K8sKind) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6003
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
In pipelines created by git import flow, annotations of a shared secret will get overridden when the git host is different.
For example: `tekton.dev/git-0: https://github.com` will get replaced by `tekton.dev/git-0: https://gitlab.com`, causing the previous pipeline to fail.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Use a different suffix and don't change existing annotations, ex. `tekton.dev/git-1: https://gitlab.com`.
<!-- Describe your code changes in detail and explain the solution -->

<!--**Screen shots / Gifs for design review**: -->
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Test setup:**
Requires two private repositories, hosted on different git services (example using github & gitlab each)
And sharing the same deploy key (ssh preferred) which can be used as secret.
1. Navigate to git import flow and create a deployment using the first repository, add the deploy key as secret and check the "add pipeline" option.
2. Create another deployment using the second repository, select the above created secret and check "add pipeline" option.
3. After both the pipelines have finished running, rerun the pipeline from the first deployment.
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug