### PR TITLE
Update ProjectsLink to use link instead of button

### DIFF
--- a/frontend/packages/console-shared/src/utils/utils.ts
+++ b/frontend/packages/console-shared/src/utils/utils.ts
@@ -71,3 +71,8 @@ export const toTitleCase = (title: string): string => {
     .map((w) => (w ? w[0].toUpperCase() + w.substr(1) : ''))
     .join(' ');
 };
+
+// Check for a modified mouse event. For example - Ctrl + Click
+export const isModifiedEvent = (event: React.MouseEvent<HTMLElement>) => {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+};

--- a/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/CatalogTile.tsx
@@ -8,8 +8,9 @@ import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
 import { history } from '@console/internal/components/utils';
+import { isModifiedEvent } from '@console/shared';
 import CatalogBadges from './CatalogBadges';
-import { getIconProps, isModifiedEvent } from './utils/catalog-utils';
+import { getIconProps } from './utils/catalog-utils';
 import { CatalogType } from './utils/types';
 
 import './CatalogTile.scss';

--- a/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/utils/catalog-utils.tsx
@@ -78,7 +78,3 @@ export const getCatalogTypeCounts = (
 
   return catalogTypeCounts;
 };
-
-export const isModifiedEvent = (event: React.MouseEvent<HTMLElement>) => {
-  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
-};

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -27,8 +27,11 @@ import {
   withUserSettingsCompatibility,
   COLUMN_MANAGEMENT_CONFIGMAP_KEY,
   COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY,
-  useActiveNamespace,
   withLastNamespace,
+  LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
+  LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
+  useUserSettingsCompatibility,
+  isModifiedEvent,
 } from '@console/shared';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
@@ -530,25 +533,43 @@ const getProjectSelectedColumns = ({ showMetrics, showActions }) => {
 const ProjectLink = connect(null, {
   filterList: k8sActions.filterList,
 })(({ project, filterList }) => {
-  const [, setActiveNamespace] = useActiveNamespace();
+  const [, setLastNamespace] = useUserSettingsCompatibility(
+    LAST_NAMESPACE_NAME_USER_SETTINGS_KEY,
+    LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
+  );
+  const url = new URL(window.location.href);
+  const params = new URLSearchParams(url.search);
+  const basePath = url.pathname;
+  if (params.has('project-name')) {
+    // clear project-name query param from the url
+    params.delete('project-name');
+  }
+  const newUrl = {
+    search: `?${params.toString()}`,
+    hash: url.hash,
+  };
+  const namespacedPath = UIActions.formatNamespaceRoute(project.metadata.name, basePath, newUrl);
+
+  const handleClick = (e) => {
+    // Don't set last namespace if its modified click (Ctrl+Click).
+    if (isModifiedEvent(e)) {
+      return;
+    }
+    setLastNamespace(project.metadata.name);
+    // update last namespace in session storage (persisted only for current browser tab). Used to remember/restore if
+    // "All Projects" was selected when returning to the list view (typically from details view) via breadcrumb or
+    // sidebar navigation
+    sessionStorage.setItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, project.metadata.name);
+    // clear project-name filter when active namespace is changed
+    filterList(referenceForModel(ProjectModel), 'project-name', '');
+  };
+
   return (
     <span className="co-resource-item co-resource-item--truncate">
       <ResourceIcon kind="Project" />
-      <Button
-        isInline
-        title={project.metadata.name}
-        type="button"
-        className="co-resource-item__resource-name"
-        onClick={() => {
-          setActiveNamespace(project.metadata.name);
-          removeQueryArgument('project-name');
-          // clear project-name filter when active namespace is changed
-          filterList(referenceForModel(ProjectModel), 'project-name', '');
-        }}
-        variant="link"
-      >
+      <Link to={namespacedPath} className="co-resource-item__resource-name" onClick={handleClick}>
         {project.metadata.name}
-      </Button>
+      </Link>
     </span>
   );
 });


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6001
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
- Project links in the project list page for all projects doesn't work as proper links.
- `ProjectLink` in `ProjectsTable` uses `button` instead of a link. 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
- Use `Link` instead of button for project links and simulate the same `onClick` behaviour.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/122255403-b1c44b00-ceeb-11eb-9769-f417b1e474a0.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
