### PR TITLE
Fix sample list flickering in the getting started card on the add page

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.data.ts
@@ -1,0 +1,116 @@
+import { CatalogItem } from '@console/dynamic-plugin-sdk/src';
+import { DevfileSample } from '../../../import/devfile/devfile-types';
+
+export const devfileSamples: DevfileSample[] = [
+  {
+    name: 'nodejs-basic',
+    displayName: 'Basic NodeJS',
+    description: 'A simple Hello world NodeJS application',
+    icon: 'trimmed',
+    tags: ['NodeJS', 'Express'],
+    projectType: 'nodejs',
+    language: 'nodejs',
+    git: {
+      remotes: {
+        origin: 'https://github.com/redhat-developer/devfile-sample.git',
+      },
+    },
+  },
+  {
+    name: 'code-with-quarkus',
+    displayName: 'Basic Quarkus',
+    description: 'A simple Hello World Java application using Quarkus',
+    icon: 'trimmed',
+    tags: ['Java', 'Quarkus'],
+    projectType: 'quarkus',
+    language: 'java',
+    git: {
+      remotes: {
+        origin: 'https://github.com/elsony/devfile-sample-code-with-quarkus.git',
+      },
+    },
+  },
+  {
+    name: 'java-springboot-basic',
+    displayName: 'Basic Spring Boot',
+    description: 'A simple Hello World Java Spring Boot application using Maven',
+    icon: 'trimmed',
+    tags: ['Java', 'Spring'],
+    projectType: 'springboot',
+    language: 'java',
+    git: {
+      remotes: {
+        origin: 'https://github.com/elsony/devfile-sample-java-springboot-basic.git',
+      },
+    },
+  },
+  {
+    name: 'python-basic',
+    displayName: 'Basic Python',
+    description: 'A simple Hello World application using Python',
+    icon: 'trimmed',
+    tags: ['Python'],
+    projectType: 'python',
+    language: 'python',
+    git: {
+      remotes: {
+        origin: 'https://github.com/elsony/devfile-sample-python-basic.git',
+      },
+    },
+  },
+];
+
+export const expectedCatalogItems: CatalogItem[] = [
+  {
+    uid: 'nodejs-basic',
+    type: 'Sample',
+    name: 'Basic NodeJS',
+    description: 'A simple Hello world NodeJS application',
+    tags: ['NodeJS', 'Express'],
+    cta: {
+      label: 'Create Devfile Sample',
+      href:
+        '/import?importType=devfile&formType=sample&devfileName=nodejs-basic&gitRepo=https://github.com/redhat-developer/devfile-sample.git',
+    },
+    icon: { url: 'data:image/png;base64,trimmed' },
+  },
+  {
+    uid: 'code-with-quarkus',
+    type: 'Sample',
+    name: 'Basic Quarkus',
+    description: 'A simple Hello World Java application using Quarkus',
+    tags: ['Java', 'Quarkus'],
+    cta: {
+      label: 'Create Devfile Sample',
+      href:
+        '/import?importType=devfile&formType=sample&devfileName=code-with-quarkus&gitRepo=https://github.com/elsony/devfile-sample-code-with-quarkus.git',
+    },
+    icon: { url: 'data:image/png;base64,trimmed' },
+  },
+  {
+    uid: 'java-springboot-basic',
+    type: 'Sample',
+    name: 'Basic Spring Boot',
+    description: 'A simple Hello World Java Spring Boot application using Maven',
+    tags: ['Java', 'Spring'],
+    cta: {
+      label: 'Create Devfile Sample',
+      href:
+        '/import?importType=devfile&formType=sample&devfileName=java-springboot-basic&gitRepo=https://github.com/elsony/devfile-sample-java-springboot-basic.git',
+    },
+    icon: { url: 'data:image/png;base64,trimmed' },
+  },
+  {
+    uid: 'python-basic',
+    type: 'Sample',
+    name: 'Basic Python',
+    description: 'A simple Hello World application using Python',
+    tags: ['Python'],
+    cta: {
+      label: 'Create Devfile Sample',
+      href:
+        '/import?importType=devfile&formType=sample&devfileName=python-basic&gitRepo=https://github.com/elsony/devfile-sample-python-basic.git',
+    },
+    icon: { url: 'data:image/png;base64,trimmed' },
+  },
+];

--- a/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.spec.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.spec.ts
@@ -1,0 +1,61 @@
+import { act } from 'react-dom/test-utils';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { testHook } from '../../../../../../../__tests__/utils/hooks-utils';
+import { DevfileSample } from '../../../import/devfile/devfile-types';
+import useDevfileSamples from '../useDevfileSamples';
+import { devfileSamples, expectedCatalogItems } from './useDevfileSamples.data';
+
+jest.mock('react-i18next', () => ({
+  ...require.requireActual('react-i18next'),
+  useTranslation: () => ({ t: (key) => key.split('~')[1] }),
+}));
+
+jest.mock('@console/internal/co-fetch', () => ({
+  coFetchJSON: {
+    put: jest.fn(),
+  },
+}));
+
+const putMock = coFetchJSON.put as jest.Mock;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('useDevfileSamples:', () => {
+  it('should return loaded false until data are loaded', async () => {
+    let resolver: (samples: DevfileSample[]) => void;
+    putMock.mockReturnValue(new Promise((resolve) => (resolver = resolve)));
+
+    const { result } = testHook(() => useDevfileSamples({}));
+
+    expect(putMock).toHaveBeenCalledTimes(1);
+    expect(putMock).toHaveBeenLastCalledWith('/api/devfile/samples', {
+      registry: 'sample-placeholder',
+    });
+
+    expect(result.current).toEqual([[], false, undefined]);
+
+    await act(async () => resolver(devfileSamples));
+
+    expect(result.current).toEqual([expectedCatalogItems, true, undefined]);
+  });
+
+  it('should return loaded false until fetch fails', async () => {
+    let rejector: (error: Error) => void;
+    putMock.mockReturnValue(new Promise((_, reject) => (rejector = reject)));
+
+    const { result } = testHook(() => useDevfileSamples({}));
+
+    expect(putMock).toHaveBeenCalledTimes(1);
+    expect(putMock).toHaveBeenLastCalledWith('/api/devfile/samples', {
+      registry: 'sample-placeholder',
+    });
+
+    expect(result.current).toEqual([[], false, undefined]);
+
+    await act(async () => rejector(new Error('API call failed')));
+
+    expect(result.current).toEqual([[], false, new Error('API call failed')]);
+  });
+});

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
@@ -35,7 +35,7 @@ const normalizeDevfileSamples = (devfileSamples: DevfileSample[], t: TFunction):
 
 const useDevfileSamples: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, any] => {
   const { t } = useTranslation();
-  const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>([]);
+  const [devfileSamples, setDevfileSamples] = React.useState<DevfileSample[]>();
   const [loadedError, setLoadedError] = React.useState<APIError>();
 
   React.useEffect(() => {
@@ -55,10 +55,10 @@ const useDevfileSamples: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], bool
     return () => (mounted = false);
   }, []);
 
-  const normalizedDevfileSamples = React.useMemo(() => normalizeDevfileSamples(devfileSamples, t), [
-    devfileSamples,
-    t,
-  ]);
+  const normalizedDevfileSamples = React.useMemo(
+    () => normalizeDevfileSamples(devfileSamples || [], t),
+    [devfileSamples, t],
+  );
 
   const loaded = !!devfileSamples;
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6024

**Analysis / Root cause**: 
`SampleGettingStartedCard` uses `CatalogServiceProvider` to load all samples. At the moment this loads samples with two extensions via `useDevfileSamples` and `useBuilderImageSamples`.

The sample card shows a loading indicator until the provider calls the inner children prop with `loaded=true`. And the `CatalogServiceProvider` returns loaded=true only if **all extensions** has fetched their data. See [CatalogServiceProvider.tsx#L47-L50](https://github.com/openshift/console/blob/master/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx#L47-L50)

While debugging the `onValueResolved` ([CatalogServiceProvider.tsx#L71-L73](https://github.com/openshift/console/blob/master/frontend/packages/dev-console/src/components/catalog/service/CatalogServiceProvider.tsx#L71-L73)) I noticed that this method was called for devfile already before the actual data are fetched.

And this happen finally because `useDevfileSamples` returns loaded true already before the API call was resolved.

**Solution Description**: 
`const loaded = !!devfileSamples;` returns true if the initial state is `[]`. Removed this state to return loaded=false until the API call was resolved.

**Screen shots / Gifs for design review**: 
Flickering on the getting started card disappear.

**Unit test coverage report**: 
Added new tests:
```
 PASS  packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.spec.ts
  useDevfileSamples:
    ✓ should return loaded false until data are loaded (22ms)
    ✓ should return loaded false until fetch fails (4ms)
```

**Test setup:**
Just refresh the add page again and again to check if the sample list in the getting started card flickers.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
