### PR TITLE
Fix override of the style in monitoring custom time range modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-expression-list/affinity-expression-row.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-expression-list/affinity-expression-row.scss
@@ -1,14 +1,16 @@
-.kv-affinity-expression-row__key-input {
-  min-height: 42px;
-}
-
-.kv-affinity-expression-row__operator-input {
-  min-height: 42px;
-}
-
-.pf-m-typeahead {
-  min-height: 42px;
-  .pf-c-select__toggle-button {
-    display: none;
+.kv-affinity-expression-row {
+  &__key-input {
+    min-height: 42px;
+  }
+  &__operator-input {
+    min-height: 42px;
+  }
+  &__values-input {
+    .pf-m-typeahead {
+      min-height: 42px;
+      .pf-c-select__toggle-button {
+        display: none;
+      }
+    }
   }
 }

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-expression-list/affinity-expression-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-expression-list/affinity-expression-row.tsx
@@ -65,6 +65,7 @@ export const AffinityExpressionRow = ({
       </GridItem>
       <GridItem span={5}>
         <Select
+          className="kv-affinity-expression-row__values-input"
           isDisabled={!enableValueField}
           variant={SelectVariant.typeaheadMulti}
           isOpen={isValuesExpanded}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6035

**Analysis / Root cause**: 
Override of the pf typeahead style in kubevirt-plugin affects the style of the component in other packages

**Solution Description**: 
Nested the class with the parent class.

**Screen shots / Gifs for design review**: 
![Kapture 2021-06-16 at 09 45 40](https://user-images.githubusercontent.com/2561818/122157030-c2db7080-ce87-11eb-80f4-489f28feea0a.gif)


![image](https://user-images.githubusercontent.com/2561818/122232079-9865d380-ced8-11eb-8fc8-adadd01b83ca.png)
