### PR TITLE
Bug 1972514: KSVC - adds check for status in ksvc in util logic

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewListItem.spec.tsx
@@ -9,6 +9,7 @@ import { usePodsForRevisions } from '../../../utils/usePodsForRevisions';
 import RevisionsOverviewListItem, {
   RevisionsOverviewListItemProps,
 } from '../RevisionsOverviewListItem';
+import RoutesUrlLink from '../RoutesUrlLink';
 
 jest.mock('../../../utils/usePodsForRevisions', () => ({
   usePodsForRevisions: jest.fn(),
@@ -154,5 +155,19 @@ describe('RevisionsOverviewListItem', () => {
           .props().title,
       ).toEqual(1);
     });
+  });
+
+  it('should not render RoutesUrlLink if status is not present', () => {
+    const mockKsvc = {
+      ...MockKnativeResources.ksservices.data[0],
+    };
+    delete mockKsvc.status;
+    wrapper = shallow(
+      <RevisionsOverviewListItem
+        revision={MockKnativeResources.revisions.data[0]}
+        service={mockKsvc}
+      />,
+    );
+    expect(wrapper.find(RoutesUrlLink).exists()).toBe(false);
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -17,6 +17,7 @@ import {
   CamelIntegrationModel,
   CamelKameletBindingModel,
 } from '../models';
+import { Traffic } from '../types';
 
 export type KnativeItem = {
   revisions?: K8sResourceKind[];
@@ -304,5 +305,27 @@ export const knativeCamelKameletBindingResourceWatchers = (
       namespace,
       optional: true,
     },
+  };
+};
+
+export const getTrafficByRevision = (revName: string, service: K8sResourceKind) => {
+  if (!service.status?.traffic?.length) {
+    return {};
+  }
+  const trafficPercent = service.status.traffic
+    .filter((t: Traffic) => t.revisionName === revName)
+    .reduce(
+      (acc, tr: Traffic) => {
+        acc.percent += tr.percent ? tr.percent : 0;
+        if (tr.url) {
+          acc.urls.push(tr.url);
+        }
+        return acc;
+      },
+      { urls: [], percent: 0 },
+    );
+  return {
+    ...trafficPercent,
+    percent: trafficPercent.percent ? `${trafficPercent.percent}%` : null,
   };
 };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
NPE is thrown in topology and err is shown in the error boundary and this happened on one of case where after creating knative service, the status field was not there in response.

**Solution Description**: 
- Status is usually there when any k8s resource is created, the same is the case for ksvc. Though status is an optional field and good to have a check added as part of this PR
- added specs


**Unit test coverage report**: 
<!-- Attach test coverage report -->

![image](https://user-images.githubusercontent.com/5129024/122179163-dfd26c80-cea4-11eb-9e25-63f7d2d6a3f3.png)

![image](https://user-images.githubusercontent.com/5129024/122179226-ef51b580-cea4-11eb-9e7f-aff3a4545f8c.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
