### PR TITLE
Update example placeholder for labels section of odc add flows

### DIFF
--- a/frontend/packages/dev-console/src/components/import/advanced/LabelSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/LabelSection.tsx
@@ -17,6 +17,7 @@ const LabelSection: React.FC = () => {
       <SelectorInput
         onChange={(val) => setFieldValue('labels', SelectorInput.objectify(val))}
         tags={labels}
+        placeholder="app.io/type=frontend"
       />
     </FormSection>
   );

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -96,7 +96,7 @@ export class SelectorInput extends React.Component {
       autoFocus: this.props.autoFocus,
       className: classNames('input', { 'invalid-tag': !isInputValid }),
       onChange: this.handleInputChange.bind(this),
-      placeholder: _.isEmpty(tags) ? 'app=frontend' : '',
+      placeholder: _.isEmpty(tags) ? this.props.placeholder || 'app=frontend' : '',
       spellCheck: 'false',
       value: inputValue,
       id: 'tags-input',


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6027

This PR updates example placeholder for labels section as `app` label can be misleading for the users since it is a default label and hence is added always when an app is created using add flows and also since only `user-labels` are editable via edit flows.

**Screenshot:**
<img width="778" alt="Screenshot 2021-06-16 at 5 54 22 PM" src="https://user-images.githubusercontent.com/20724543/122218475-1d96bb80-cecc-11eb-8f72-2f77de6abfd8.png">





cc: @openshift/team-devconsole-ux 

/kind bug