### PR TITLE
Fix for ConsoleExternalLogLink CRD protractor flake

### DIFF
--- a/frontend/integration-tests/tests/crd-extensions.scenario.ts
+++ b/frontend/integration-tests/tests/crd-extensions.scenario.ts
@@ -297,6 +297,7 @@ describe('CRD extensions', () => {
       const newContent = _.defaultsDeep({}, { spec: { namespaceFilter } }, safeLoad(content));
       await yamlView.setEditorContent(safeDump(newContent));
       expect(yamlView.getEditorContent()).toContain(`namespaceFilter: ${namespaceFilter}`);
+      expect(yamlView.saveButton.isPresent()).toBe(true);
       await yamlView.saveButton.click();
       await browser.wait(until.visibilityOf(crudView.successMessage));
       expect(crudView.successMessage.isPresent()).toBe(true);


### PR DESCRIPTION
Wait for existance of Save button before clicking.

Was able to reproduce this locally and fix.   

Note, this is a fix for a one of the several [CRD Extensions flakes](https://search.ci.openshift.org/?search=CRD+extensions.&maxAge=336h&context=1&type=junit&name=.*e2e.*console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) we're seeing.