### PR TITLE
fixes: Serverless deployments are not shown in topology Consumption mode

### DIFF
--- a/frontend/packages/topology/src/components/page/TopologyDataRenderer.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyDataRenderer.tsx
@@ -3,7 +3,6 @@ import { observer } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 import { StatusBox } from '@console/internal/components/utils';
 import { ModelContext, ExtensibleModel } from '../../data-transforms/ModelContext';
-import { FilterProvider } from '../../filters/FilterProvider';
 import { TopologyViewType } from '../../topology-types';
 import { DroppableTopologyComponent } from './DroppableTopologyComponent';
 
@@ -32,9 +31,7 @@ const TopologyDataRenderer: React.FC<TopologyDataRendererProps> = observer(({ vi
       loaded={loaded}
       loadError={loadError}
     >
-      <FilterProvider>
-        <DroppableTopologyComponent viewType={viewType} model={model} namespace={namespace} />
-      </FilterProvider>
+      <DroppableTopologyComponent viewType={viewType} model={model} namespace={namespace} />
     </StatusBox>
   );
 });

--- a/frontend/packages/topology/src/components/page/TopologyPage.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../const';
 import DataModelProvider from '../../data-transforms/DataModelProvider';
 import { TOPOLOGY_SEARCH_FILTER_KEY } from '../../filters';
+import { FilterProvider } from '../../filters/FilterProvider';
 import { TopologyViewType } from '../../topology-types';
 import TopologyDataRenderer from './TopologyDataRenderer';
 import TopologyPageToolbar from './TopologyPageToolbar';
@@ -86,42 +87,44 @@ const TopologyPage: React.FC<TopologyPageProps> = ({
   };
 
   return (
-    <DataModelProvider namespace={namespace}>
-      <Helmet>
-        <title>{t('topology~Topology')}</title>
-      </Helmet>
-      <NamespacedPage
-        variant={
-          viewType === TopologyViewType.graph
-            ? NamespacedPageVariants.default
-            : NamespacedPageVariants.light
-        }
-        onNamespaceChange={handleNamespaceChange}
-        hideProjects={hideProjects}
-        toolbar={<TopologyPageToolbar viewType={viewType} onViewChange={onViewChange} />}
-        data-test-id={
-          viewType === TopologyViewType.graph ? 'topology-graph-page' : 'topology-list-page'
-        }
-      >
-        <ProjectsExistWrapper title={t('topology~Topology')} projects={projects}>
-          {namespace ? (
-            <TopologyDataRenderer viewType={viewType} />
-          ) : (
-            <CreateProjectListPage title={t('topology~Topology')}>
-              {(openProjectModal) => (
-                <Trans t={t} ns="topology">
-                  Select a Project to view the topology or{' '}
-                  <Button isInline variant="link" onClick={openProjectModal}>
-                    create a Project
-                  </Button>
-                  .
-                </Trans>
-              )}
-            </CreateProjectListPage>
-          )}
-        </ProjectsExistWrapper>
-      </NamespacedPage>
-    </DataModelProvider>
+    <FilterProvider>
+      <DataModelProvider namespace={namespace}>
+        <Helmet>
+          <title>{t('topology~Topology')}</title>
+        </Helmet>
+        <NamespacedPage
+          variant={
+            viewType === TopologyViewType.graph
+              ? NamespacedPageVariants.default
+              : NamespacedPageVariants.light
+          }
+          onNamespaceChange={handleNamespaceChange}
+          hideProjects={hideProjects}
+          toolbar={<TopologyPageToolbar viewType={viewType} onViewChange={onViewChange} />}
+          data-test-id={
+            viewType === TopologyViewType.graph ? 'topology-graph-page' : 'topology-list-page'
+          }
+        >
+          <ProjectsExistWrapper title={t('topology~Topology')} projects={projects}>
+            {namespace ? (
+              <TopologyDataRenderer viewType={viewType} />
+            ) : (
+              <CreateProjectListPage title={t('topology~Topology')}>
+                {(openProjectModal) => (
+                  <Trans t={t} ns="topology">
+                    Select a Project to view the topology or{' '}
+                    <Button isInline variant="link" onClick={openProjectModal}>
+                      create a Project
+                    </Button>
+                    .
+                  </Trans>
+                )}
+              </CreateProjectListPage>
+            )}
+          </ProjectsExistWrapper>
+        </NamespacedPage>
+      </DataModelProvider>
+    </FilterProvider>
   );
 };
 


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-6009

Problem: Filter provider is not wrapping the DataModelProvider which uses the `useDisplayFilters` that why filter in DataModelProvider are undefined and connectivity/consumption mode are not updated properly

Solution: Wrap DataModelProvider with FilterProvider

Screenshots:
<img width="927" alt="Screenshot 2021-06-16 at 7 52 42 PM" src="https://user-images.githubusercontent.com/9278015/122238499-ce598680-cedd-11eb-8ae2-18028ff162bd.png">
<img width="1039" alt="Screenshot 2021-06-16 at 7 53 07 PM" src="https://user-images.githubusercontent.com/9278015/122238516-d1ed0d80-cedd-11eb-9592-a7e0e93c9f4f.png">
