### PR TITLE
Bug 1958088: show recently admitted ingress host as links and URLs in UI

### DIFF
--- a/frontend/__tests__/components/route-pages.spec.tsx
+++ b/frontend/__tests__/components/route-pages.spec.tsx
@@ -83,7 +83,7 @@ describe(RouteLocation.displayName, () => {
     expect(wrapper.find(ExternalLink).props().href).toContain('http:');
   });
 
-  it('renders oldest admitted ingress', () => {
+  it('renders recent admitted ingress', () => {
     const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
@@ -91,7 +91,7 @@ describe(RouteLocation.displayName, () => {
         name: 'example',
       },
       spec: {
-        host: 'www.example.com',
+        host: 'newer.example.com',
         path: '\\mypath',
         wildcardPolicy: 'None',
         to: {
@@ -128,7 +128,7 @@ describe(RouteLocation.displayName, () => {
 
     const wrapper = shallow(<RouteLocation obj={route} />);
     expect(wrapper.find(ExternalLink).exists()).toBe(true);
-    expect(wrapper.find(ExternalLink).props().href).toContain('http://www.example.com');
+    expect(wrapper.find(ExternalLink).props().href).toContain('http://newer.example.com');
   });
 
   it('renders additional path in url', () => {


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1958088

**Analysis / Root cause**: 
UI shows oldest admitted ingress host as links and URLs in UI.

**Solution Description**: 
made use of `lastTransitionTime` in status to show recently admitted ingress host as links and URLs in UI.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
