### PR TITLE
Bug 1969546: Set OLM install modal body padding to 0 so that our scroll shadows are positioned at the bottom of the modal

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -207,7 +207,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
       display: flex;
       flex-direction: column;
       margin: 0 !important;
-      padding: 0;
+      padding: 0 !important;
     }
 
     .modal-body-inner-shadow-covers {


### PR DESCRIPTION
This also prevents iframe description double scrollbar to appear on resize.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1969546

![scrollbar-shadow-bug](https://user-images.githubusercontent.com/1874151/122252652-87e23880-ce99-11eb-9e99-6228bd1d8828.gif)
