### PR TITLE
Fix flickering by reducing the column count update with a threshold

### DIFF
--- a/frontend/packages/dev-console/src/components/add/__tests__/MasonryLayout.spec.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/MasonryLayout.spec.tsx
@@ -1,49 +1,120 @@
 import * as React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
-import Measure, { BoundingRect } from 'react-measure';
+import { shallow } from 'enzyme';
+import Measure, { ContentRect } from 'react-measure';
 import AddCardSectionSkeleton from '../AddCardSectionSkeleton';
 import { Masonry } from '../layout/Masonry';
 import { MasonryLayout } from '../layout/MasonryLayout';
 
 describe('Masonry Layout', () => {
-  type MasonryLayoutProps = React.ComponentProps<typeof MasonryLayout>;
-  let wrapper: ShallowWrapper<MasonryLayoutProps>;
-  const bounds: BoundingRect = { width: 1200, height: 900, top: 0, left: 0, bottom: 0, right: 0 };
+  const getContentRect = (width: number, height: number): ContentRect => ({
+    bounds: { width, height, top: 0, left: 0, bottom: 0, right: 0 },
+  });
 
   it('should render loading component if loading is true and LoadingComponent is defined', () => {
-    wrapper = shallow(
+    const wrapper = shallow(
       <MasonryLayout columnWidth={300} loading LoadingComponent={AddCardSectionSkeleton}>
-        {[<div key="key" />]}
+        <div>Child 1</div>
+        <div>Child 2</div>
+        <div>Child 3</div>
+        <div>Child 4</div>
+        <div>Child 5</div>
       </MasonryLayout>,
     );
-    wrapper.find(Measure).prop('onResize')({
-      bounds,
-    });
+    wrapper.find(Measure).prop('onResize')(getContentRect(1400, 900));
+
+    // Should show 4 columns (Math.floor(1400 / 300))
     expect(
       wrapper
         .dive()
         .dive()
         .find(Masonry)
-        .find(AddCardSectionSkeleton)
-        .exists(),
-    ).toBe(true);
+        .prop('columnCount'),
+    ).toBe(4);
+    // Should render 4 placeholders
+    expect(
+      wrapper
+        .dive()
+        .dive()
+        .find(Masonry)
+        .find(AddCardSectionSkeleton),
+    ).toHaveLength(4);
   });
 
   it('should render children if loading is false', () => {
-    const TestChildren: React.FC = () => <div />;
-    wrapper = shallow(
-      <MasonryLayout columnWidth={300}>{[<TestChildren key="key" />]}</MasonryLayout>,
+    const wrapper = shallow(
+      <MasonryLayout columnWidth={300}>
+        <div>Child 1</div>
+        <div>Child 2</div>
+        <div>Child 3</div>
+        <div>Child 4</div>
+        <div>Child 5</div>
+      </MasonryLayout>,
     );
-    wrapper.find(Measure).prop('onResize')({
-      bounds,
-    });
+    wrapper.find(Measure).prop('onResize')(getContentRect(1400, 900));
+
+    // Should show 4 columns (Math.floor(1400 / 300))
     expect(
       wrapper
         .dive()
         .dive()
         .find(Masonry)
-        .find(TestChildren)
-        .exists(),
-    ).toBe(true);
+        .prop('columnCount'),
+    ).toBe(4);
+    // Should render all childrens
+    expect(
+      wrapper
+        .dive()
+        .dive()
+        .find(Masonry)
+        .find('div'),
+    ).toHaveLength(5);
+  });
+
+  it('should change columns if a resize event exceeds threshold', () => {
+    const wrapper = shallow(
+      <MasonryLayout columnWidth={300}>
+        <div>Child 1</div>
+        <div>Child 2</div>
+        <div>Child 3</div>
+        <div>Child 4</div>
+        <div>Child 5</div>
+      </MasonryLayout>,
+    );
+    wrapper.find(Measure).prop('onResize')(getContentRect(1200, 800));
+    // Should show 4 columns and all childrens, see test above.
+
+    wrapper.find(Measure).prop('onResize')(getContentRect(900, 800));
+    // Should show 3 columns now (Math.floor(900 / 300))
+    expect(
+      wrapper
+        .dive()
+        .dive()
+        .find(Masonry)
+        .prop('columnCount'),
+    ).toBe(3);
+  });
+
+  it('should not change columns if a resize event does not exceed threshold', () => {
+    const wrapper = shallow(
+      <MasonryLayout columnWidth={300}>
+        <div>Child 1</div>
+        <div>Child 2</div>
+        <div>Child 3</div>
+        <div>Child 4</div>
+        <div>Child 5</div>
+      </MasonryLayout>,
+    );
+    wrapper.find(Measure).prop('onResize')(getContentRect(1200, 800));
+    // Should show 4 columns and all childrens, see test above.
+
+    wrapper.find(Measure).prop('onResize')(getContentRect(1190, 800));
+    // Should still show 4 columns because new width does not exceed threshold
+    expect(
+      wrapper
+        .dive()
+        .dive()
+        .find(Masonry)
+        .prop('columnCount'),
+    ).toBe(4);
   });
 });

--- a/frontend/packages/dev-console/src/components/add/layout/Masonry.tsx
+++ b/frontend/packages/dev-console/src/components/add/layout/Masonry.tsx
@@ -4,13 +4,13 @@ import Measure from 'react-measure';
 import './MasonryLayout.scss';
 
 type MasonryProps = {
-  columnsCount: number;
+  columnCount: number;
   children: React.ReactElement[];
 };
 
-export const Masonry: React.FC<MasonryProps> = ({ columnsCount, children }) => {
+export const Masonry: React.FC<MasonryProps> = ({ columnCount, children }) => {
   const [heights, setHeights] = React.useState<Record<string, number>>({});
-  const columns = columnsCount || 1;
+  const columns = columnCount || 1;
   const setHeight = (key: string, height: number) => {
     setHeights((old) => ({ ...old, [key]: height }));
   };

--- a/frontend/packages/dev-console/src/components/add/layout/MasonryLayout.tsx
+++ b/frontend/packages/dev-console/src/components/add/layout/MasonryLayout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Measure from 'react-measure';
+import Measure, { ContentRect } from 'react-measure';
 import { Masonry } from './Masonry';
 import './MasonryLayout.scss';
 
@@ -8,6 +8,14 @@ type MasonryLayoutProps = {
   children: React.ReactElement[];
   loading?: boolean;
   LoadingComponent?: React.ComponentType<any>;
+  /**
+   * This threshold ensures that the resize doesn't happen to often.
+   * It is set to 30 pixels by default to ensure that the column count is not
+   * changed back and forward if a scrollbar appears or disappears depending on
+   * the content width and height. In some edge cases this could result in an
+   * endless rerendering (which is also visible to the user as a flickering UI).
+   */
+  resizeThreshold?: number;
 };
 
 export const MasonryLayout: React.FC<MasonryLayoutProps> = ({
@@ -15,8 +23,20 @@ export const MasonryLayout: React.FC<MasonryLayoutProps> = ({
   children,
   loading,
   LoadingComponent,
+  resizeThreshold = 30,
 }) => {
   const [width, setWidth] = React.useState<number>(0);
+  const onResize = React.useCallback(
+    (contentRect: ContentRect) => {
+      const newWidth = contentRect.bounds?.width;
+      if (newWidth) {
+        setWidth((oldWidth) =>
+          Math.abs(oldWidth - newWidth) < resizeThreshold ? oldWidth : newWidth,
+        );
+      }
+    },
+    [resizeThreshold],
+  );
   const columnCount = React.useMemo(() => (width ? Math.floor(width / columnWidth) || 1 : null), [
     columnWidth,
     width,
@@ -28,10 +48,10 @@ export const MasonryLayout: React.FC<MasonryLayoutProps> = ({
       : children;
 
   return (
-    <Measure bounds onResize={(contentRect) => setWidth(contentRect.bounds?.width)}>
+    <Measure bounds onResize={onResize}>
       {({ measureRef }) => (
         <div className="odc-masonry-container" ref={measureRef}>
-          {columnCount ? <Masonry columnsCount={columnCount}>{columns}</Masonry> : null}
+          {columnCount ? <Masonry columnCount={columnCount}>{columns}</Masonry> : null}
         </div>
       )}
     </Measure>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5855

**Analysis / Root cause**: 
There is an edge case which brings the masonry layout to an endless rerendering loop / flickering UI.

* The width of the content should be close to an area which changes the number of colums.
* The height of the content should be also close to an area where the content needs a scrollbar - or not.

When starting without a scrollbar:
1. When the number of columns is changed, the content height will change also in most cases.
2. If the layout change need more height so that the scrollbar appears...
3. this scrollbar reduce the available width again, so that the number of columns will be changed back.
4. Now the initial number of columns will not require a scrollbar anymore, which bring us back to step 1 where the layout will increase the number of columns again.

This might be also possible in the other direction.

This issue could only be reduced with browsers which resizes the browser content area depending on a scrollbar. Aka, don't use a scrollbar which overlays the content because it was only shown when the user scrolls. (As I remember Safari uses this behavior by default.)

**Solution Description**: 
Instead of recalculating the number of columns all the time, the code has now a threshold on the width state. Only if a resize will change with width over 30 pixels the numbers of columns will be recalculated.

So if the user resizes the window, show or hide the navigation, the number of columns will be calculated again and again (with this threshold).

Expecting that a scrollbar doesn't consume more then 30 pixels, the layout will not be touched anymore when a scrollbar appears or disappers.

**Screen shots / Gifs for design review**: 
Because it was tricky to reproduce I recorded a video which shows the issue on Firefox and then I applying the code change locally.

The video has a big size (in width and height) because this is required "sweet spot" where the page needs a scrollbar with five columns but not with four! (Depends on installed operators (shown cards), font size, etc.)

https://user-images.githubusercontent.com/139310/122264631-06f66180-ced8-11eb-898a-1a225d35cfee.mp4

**Unit test coverage report**: 
Extended `MasonryLayout.spec.tsx` to include a test for the threshold:

```
 PASS  packages/dev-console/src/components/add/__tests__/MasonryLayout.spec.tsx
  Masonry Layout
    ✓ should render loading component if loading is true and LoadingComponent is defined (8ms)
    ✓ should render children if loading is false (5ms)
    ✓ should change columns if a resize event exceeds threshold (3ms)
    ✓ should not change columns if a resize event does not exceed threshold (5ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.147s, estimated 2s
```

**Test setup:**
* Try to find the spot where the layout switches between 3 and 4 or 4 and 5 columns.
* Adjust your browser window height so that the scrollbar appears/disappears to change the number of columns.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
