### PR TITLE
convert intervalDropdown component to use patternfly dropdown component

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsRefreshDropdown.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetricsRefreshDropdown.tsx
@@ -14,8 +14,16 @@ const PipelineMetricsRefreshDropdown: React.FC<PipelineMetricsRefreshDropdownPro
   const { t } = useTranslation();
   return (
     <div className="form-group">
-      <label>{t('pipelines-plugin~Refresh Interval')}</label>
-      <IntervalDropdown interval={interval} setInterval={setInterval as never} />
+      <label htmlFor="pipeline-refresh-interval-dropdown">
+        {t('pipelines-plugin~Refresh Interval')}
+      </label>
+      <div>
+        <IntervalDropdown
+          id="pipeline-refresh-interval-dropdown"
+          interval={interval}
+          setInterval={setInterval}
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -44,6 +44,7 @@ import {
   MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY,
   Panel,
 } from './types';
+import { useBoolean } from '../hooks/useBoolean';
 
 const NUM_SAMPLES = 30;
 
@@ -92,14 +93,6 @@ const evaluateTemplate = (
   });
 
   return result;
-};
-
-const useBoolean = (initialValue: boolean): [boolean, () => void, () => void, () => void] => {
-  const [value, setValue] = React.useState(initialValue);
-  const toggle = React.useCallback(() => setValue((v) => !v), []);
-  const setTrue = React.useCallback(() => setValue(true), []);
-  const setFalse = React.useCallback(() => setValue(false), []);
-  return [value, toggle, setTrue, setFalse];
 };
 
 const VariableDropdown: React.FC<VariableDropdownProps> = ({

--- a/frontend/public/components/monitoring/hooks/useBoolean.ts
+++ b/frontend/public/components/monitoring/hooks/useBoolean.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export const useBoolean = (
+  initialValue: boolean,
+): [boolean, () => void, () => void, () => void] => {
+  const [value, setValue] = React.useState(initialValue);
+  const toggle = React.useCallback(() => setValue((v) => !v), []);
+  const setTrue = React.useCallback(() => setValue(true), []);
+  const setFalse = React.useCallback(() => setValue(false), []);
+  return [value, toggle, setTrue, setFalse];
+};

--- a/frontend/public/components/monitoring/poll-interval-dropdown.tsx
+++ b/frontend/public/components/monitoring/poll-interval-dropdown.tsx
@@ -1,8 +1,9 @@
+import * as _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-
-import { Dropdown } from '../utils/dropdown';
+import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import { formatPrometheusDuration, parsePrometheusDuration } from '../utils/datetime';
+import { useBoolean } from './hooks/useBoolean';
 
 const OFF_KEY = 'OFF_KEY';
 
@@ -13,6 +14,7 @@ type Props = {
 };
 
 const IntervalDropdown: React.FC<Props> = ({ id, interval, setInterval }) => {
+  const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
   const { t } = useTranslation();
 
   const onChange = React.useCallback(
@@ -33,12 +35,27 @@ const IntervalDropdown: React.FC<Props> = ({ id, interval, setInterval }) => {
     '1d': t('public~{{count}} day', { count: 1 }),
   };
 
+  const selectedKey = interval === null ? OFF_KEY : formatPrometheusDuration(interval);
+
   return (
     <Dropdown
-      id={id}
-      items={intervalOptions}
-      onChange={onChange}
-      selectedKey={interval === null ? OFF_KEY : formatPrometheusDuration(interval)}
+      dropdownItems={_.map(intervalOptions, (name, key) => (
+        <DropdownItem component="button" key={key} onClick={() => onChange(key)}>
+          {name}
+        </DropdownItem>
+      ))}
+      isOpen={isOpen}
+      onSelect={setClosed}
+      toggle={
+        <DropdownToggle
+          className="monitoring-dashboards__dropdown-button"
+          id={`${id}-dropdown`}
+          onToggle={toggleIsOpen}
+        >
+          {intervalOptions[selectedKey]}
+        </DropdownToggle>
+      }
+      className="monitoring-dashboards__variable-dropdown"
     />
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6000

**Analysis / Root cause**: 


**Solution Description**: 
converted `intervalDropdown` component to use patternfly dropdown component, all dropdown now in dashboard for monitoring in dev/admin side has similar experience with arrow keys on dropdown items. Same is the case with pipeline metrics dropdowns.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Kapture 2021-06-17 at 16 18 57](https://user-images.githubusercontent.com/5129024/122383038-17feab80-cf88-11eb-8367-58d77ef1d2d5.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
