### PR TITLE
add KindResourcePage dynamic extension

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
@@ -18,6 +18,12 @@ export type ExtensionK8sGroupModel = {
   kind?: string;
 };
 
+export type ExtensionK8sGroupKindModel = {
+  group: string;
+  version?: string;
+  kind: string;
+};
+
 export type K8sKind = {
   abbr: string;
   kind: string;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/pages.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/pages.ts
@@ -1,10 +1,11 @@
 import { RouteComponentProps } from 'react-router';
-import { ExtensionK8sModel } from '../api/common-types';
+import { ExtensionK8sGroupKindModel, ExtensionK8sModel } from '../api/common-types';
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
 
 type ResourcePageProperties = {
   /** The model for which this resource page links to. */
-  model: ExtensionK8sModel;
+  model: ExtensionK8sGroupKindModel;
+  /** The component to be rendered when the route matches. */
   component: CodeRef<
     React.ComponentType<{
       match: RouteComponentProps['match'];

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -88,11 +88,18 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
           component: (cProps) => renderAsyncComponent(p, cProps),
         })),
       ...dynamicResourcePageExtensions
-        .filter(
-          (p) =>
-            referenceForExtensionModel(p.properties.model) ===
-            (kindObj ? referenceFor(kindObj) : props.kind),
-        )
+        .filter((p) => {
+          if (p.properties.model.version) {
+            return (
+              referenceForExtensionModel(p.properties.model) ===
+              (kindObj ? referenceFor(kindObj) : props.kind)
+            );
+          }
+          return (
+            p.properties.model.group === kindObj.apiGroup &&
+            p.properties.model.kind === kindObj.kind
+          );
+        })
         .map(({ properties: { href, name, component: Component } }) => ({
           href,
           name,

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -15,6 +15,7 @@ import {
   K8sKind,
   K8sResourceKindReference,
   kindForReference,
+  referenceForExtensionModel,
   referenceForModel,
 } from '../module/k8s';
 import {
@@ -99,10 +100,15 @@ export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPagePr
     props.match.path.indexOf('customresourcedefinitions') === -1
       ? referenceForModel(kindObj)
       : null;
-  const componentLoader = getResourceDetailsPages(
-    detailsPageExtensions,
-    dynamicResourceListPageExtensions,
-  ).get(ref, () => Promise.resolve(DefaultDetailsPage));
+  const componentLoader =
+    getResourceDetailsPages(detailsPageExtensions, dynamicResourceListPageExtensions).get(ref) ||
+    getResourceDetailsPages(detailsPageExtensions, dynamicResourceListPageExtensions).get(
+      referenceForExtensionModel({
+        group: kindObj.apiGroup,
+        kind: kindObj.kind,
+      }),
+    );
+  const defaultPage = () => Promise.resolve(DefaultDetailsPage);
 
   return (
     <>
@@ -110,7 +116,7 @@ export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPagePr
         <title>{`${decodedName} · Details`}</title>
       </Helmet>
       <AsyncComponent
-        loader={componentLoader}
+        loader={componentLoader || defaultPage}
         match={props.match}
         namespace={ns}
         kind={props.modelRef}

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { ExtensionK8sModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
+import { ExtensionK8sGroupModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
 
 import {
   CustomResourceDefinitionKind,
@@ -114,7 +114,7 @@ export const referenceForOwnerRef = (ownerRef: OwnerReference): GroupVersionKind
 export const referenceForModel = (model: K8sKind): GroupVersionKind =>
   referenceForGroupVersionKind(model.apiGroup || 'core')(model.apiVersion)(model.kind);
 
-export const referenceForExtensionModel = (model: ExtensionK8sModel): GroupVersionKind =>
+export const referenceForExtensionModel = (model: ExtensionK8sGroupModel): GroupVersionKind =>
   referenceForGroupVersionKind(model?.group || 'core')(model?.version)(model?.kind);
 
 export const referenceFor = ({ kind, apiVersion }: K8sResourceCommon): GroupVersionKind => {


### PR DESCRIPTION
This allows the plugin UI to be dynamic and work with any version of an available CRD without hardcoding versions

e.g.
before
```JSON
  {
    "type": "console.page/route",
    "properties": {
      "path": [
        "/k8s/ns/:ns/kubevirt.io~v1~VirtualMachine/:name",
        "/k8s/ns/:ns/kubevirt.io~v1alpha3~VirtualMachine/:name"
      ],
      "component": {
        "$codeRef": "VirtualMachinesDetailsPage"
      }
    },
    "flags": {
      "required": ["KUBEVIRT"]
    }
  }
```
after
```JSON
{
    "type": "console.page/resource/kind/details",
    "properties": {
      "kind": "VirtualMachine",
      "preferredVersion": "v1",
      "component": {
        "$codeRef": "VirtualMachinesDetailsPage"
      }
    },
    "flags": {
      "required": ["KUBEVIRT"]
    }
  }
```

@rawagner @christianvogt @vojtechszocs please review