### PR TITLE
fixes Link `to` prop path for CatalogTypeSelector

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
@@ -44,7 +44,7 @@ const CatalogTypeSelector: React.FC<CatalogTypeSelectorProps> = ({
           queryParams.set(CatalogQueryParams.TYPE, type.value);
 
           const to = {
-            path: pathname,
+            pathname,
             search: `?${queryParams.toString()}`,
           };
 


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-6038

This PR fixes the path created for Link Component in the CatalogTypeSelector.

<img width="1501" alt="Screenshot 2021-06-17 at 5 30 25 PM" src="https://user-images.githubusercontent.com/9278015/122393848-f0f9a700-cf92-11eb-93a2-80bdb51376a0.png">
