### PR TITLE
Fix for protractor CRD ConsoleNotification & ConsoleExternalLogLink extensions test flakes

### DIFF
--- a/frontend/integration-tests/tests/crd-extensions.scenario.ts
+++ b/frontend/integration-tests/tests/crd-extensions.scenario.ts
@@ -205,6 +205,7 @@ describe('CRD extensions', () => {
       const newContent = _.defaultsDeep({}, { spec: { location, text } }, safeLoad(content));
       await yamlView.setEditorContent(safeDump(newContent));
       expect(yamlView.getEditorContent()).toContain(`location: ${location}`);
+      await browser.wait(until.elementToBeClickable(yamlView.saveButton));
       await yamlView.saveButton.click();
       await browser.wait(until.visibilityOf(crudView.successMessage));
       expect(crudView.successMessage.isPresent()).toBe(true);
@@ -297,7 +298,7 @@ describe('CRD extensions', () => {
       const newContent = _.defaultsDeep({}, { spec: { namespaceFilter } }, safeLoad(content));
       await yamlView.setEditorContent(safeDump(newContent));
       expect(yamlView.getEditorContent()).toContain(`namespaceFilter: ${namespaceFilter}`);
-      expect(yamlView.saveButton.isPresent()).toBe(true);
+      await browser.wait(until.elementToBeClickable(yamlView.saveButton));
       await yamlView.saveButton.click();
       await browser.wait(until.visibilityOf(crudView.successMessage));
       expect(crudView.successMessage.isPresent()).toBe(true);


### PR DESCRIPTION
#9273 fixed CRD ConsoleExternalLogLink extension test when running locally, PROW still showing flakes in CI.

Looked at several screenshoots, issue seems to be failing to click on YAML Editor's Save button.
Added `wait(until.elementToBeClickable..` to the two tests which have been failing.