### PR TITLE
fix invalid runafter breaking pipeline builder issue

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.tsx
@@ -47,12 +47,14 @@ const SyncedEditorField: React.FC<SyncedEditorFieldProps> = ({
 
   const handleToggleToForm = () => {
     const newFormData = safeYAMLToJS(yamlData);
-    if (!_.isEmpty(newFormData)) {
+    const santizedFormData =
+      !_.isEmpty(newFormData) && formContext.sanitizeTo
+        ? formContext.sanitizeTo(newFormData)
+        : newFormData;
+
+    if (!_.isEmpty(santizedFormData)) {
       changeEditorType(EditorType.Form);
-      setFieldValue(
-        formContext.name,
-        formContext.sanitizeTo ? formContext.sanitizeTo(newFormData) : newFormData,
-      );
+      setFieldValue(formContext.name, santizedFormData);
     } else {
       setYAMLWarning(true);
     }

--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -144,6 +144,7 @@
   "Missing Resources": "Missing Resources",
   "Missing Workspaces": "Missing Workspaces",
   "Invalid When Expressions": "Invalid When Expressions",
+  "Invalid RunAfter": "Invalid RunAfter",
   "Failed to load Tasks. {{error}}": "Failed to load Tasks. {{error}}",
   "Remove task": "Remove task",
   "Remove {{taskName}}?": "Remove {{taskName}}?",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -31,6 +31,7 @@ import {
 } from './types';
 import { applyChange } from './update-utils';
 import { convertBuilderFormToPipeline } from './utils';
+import { validationSchema } from './validation-utils';
 
 import './PipelineBuilderForm.scss';
 
@@ -121,6 +122,9 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
   );
 
   const sanitizeToForm = (yamlPipeline: PipelineKind) => {
+    if (!yamlPipeline.spec) {
+      return {};
+    }
     const { finally: finallyTasks, ...pipelineSpecProperties } = yamlPipeline.spec;
 
     const newFormData = {
@@ -129,6 +133,17 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
       name: yamlPipeline.metadata?.name,
       finallyTasks,
     };
+    try {
+      validationSchema(true).validateSync({
+        ...props.values,
+        editorType: EditorType.Form,
+        formData: newFormData,
+      });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('Validation error:', e);
+      return {};
+    }
     return _.merge({}, initialPipelineFormData, newFormData);
   };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/const.ts
@@ -18,6 +18,7 @@ export enum TaskErrorType {
   MISSING_RESOURCES = 'missingResources',
   MISSING_WORKSPACES = 'missingWorkspaces',
   MISSING_REQUIRED_WHEN_EXPRESSIONS = 'missingWhenExpressions',
+  INVALID_RUNAFTER = 'invalidRunAfter',
 }
 
 export const TASK_FIELD_ERROR_TYPE_MAPPING: { [key in TaskErrorType]: string[] } = {
@@ -25,6 +26,7 @@ export const TASK_FIELD_ERROR_TYPE_MAPPING: { [key in TaskErrorType]: string[] }
   [TaskErrorType.MISSING_RESOURCES]: ['resources'],
   [TaskErrorType.MISSING_WORKSPACES]: ['workspaces'],
   [TaskErrorType.MISSING_REQUIRED_WHEN_EXPRESSIONS]: ['when'],
+  [TaskErrorType.INVALID_RUNAFTER]: ['runAfter'],
 };
 
 export const TASK_ERROR_STRINGS: { [key in TaskErrorType]: string } = {
@@ -34,6 +36,7 @@ export const TASK_ERROR_STRINGS: { [key in TaskErrorType]: string } = {
   [TaskErrorType.MISSING_REQUIRED_WHEN_EXPRESSIONS]: i18n.t(
     'pipelines-plugin~Invalid When Expressions',
   ),
+  [TaskErrorType.INVALID_RUNAFTER]: i18n.t('pipelines-plugin~Invalid RunAfter'),
 };
 
 export enum WhenExpressionOperatorType {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/validation-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/validation-utils.ts
@@ -479,7 +479,7 @@ const pipelineBuilderFormSchema = (formValues: PipelineBuilderFormYamlValues) =>
   });
 };
 
-export const validationSchema = () =>
+export const validationSchema = (sync = false) =>
   yup.mixed().test({
     test(formValues: PipelineBuilderFormYamlValues) {
       const formYamlDefinition = yup.object({
@@ -491,6 +491,8 @@ export const validationSchema = () =>
         }),
       });
 
-      return formYamlDefinition.validate(formValues, { abortEarly: false });
+      return sync
+        ? formYamlDefinition.validateSync(formValues, { abortEarly: false })
+        : formYamlDefinition.validate(formValues, { abortEarly: false });
     },
   });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getFinallyTaskWidth,
   taskHasWhenExpression,
   nodesHasWhenExpression,
+  getEdgesFromNodes,
 } from '../utils';
 
 const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
@@ -137,5 +138,41 @@ describe('hasWhenExpression', () => {
 
   it('expect to return true if the finally tasks in the pipeline contains when expression', () => {
     expect(hasWhenExpression(pipelineWithWhenAndFinally)).toBe(true);
+  });
+});
+
+describe('getEdgesFromNodes', () => {
+  it('should contain correct number of edges based on the runAfters', () => {
+    const [task1, task2, task3, task4] = pipeline.spec.tasks;
+    const pipelineWithMultipleLastTasks = {
+      ...pipeline,
+      spec: {
+        ...pipeline.spec,
+        tasks: [task1, task2, task3, task4],
+      },
+    };
+    const { nodes } = getTopologyNodesEdges(pipelineWithMultipleLastTasks);
+    expect(getEdgesFromNodes(nodes)).toHaveLength(3);
+  });
+
+  it('should exclude the invalid runAfter names', () => {
+    const [task1, task2, task3, task4] = pipeline.spec.tasks;
+    const pipelineWithInvalidRunAfter = {
+      ...pipeline,
+      spec: {
+        ...pipeline.spec,
+        tasks: [
+          task1,
+          task2,
+          task3,
+          {
+            ...task4,
+            runAfter: [...task4.runAfter, 'fake-task-name'],
+          },
+        ],
+      },
+    };
+    const { nodes } = getTopologyNodesEdges(pipelineWithInvalidRunAfter);
+    expect(getEdgesFromNodes(nodes)).toHaveLength(3);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -225,8 +225,9 @@ export const tasksToBuilderNodes = (
   });
 };
 
-export const getEdgesFromNodes = (nodes: PipelineMixedNodeModel[]): PipelineEdgeModel[] =>
-  _.flatten(
+export const getEdgesFromNodes = (nodes: PipelineMixedNodeModel[]): PipelineEdgeModel[] => {
+  const regularNodeIds = nodes.map((n) => n.id);
+  return _.flatten(
     nodes.map((node) => {
       const {
         data: {
@@ -236,15 +237,17 @@ export const getEdgesFromNodes = (nodes: PipelineMixedNodeModel[]): PipelineEdge
 
       if (runAfter.length === 0) return null;
 
-      return runAfter.map((source) => ({
-        id: `${source}~to~${target}`,
-        type: 'edge',
-        source,
-        target,
-      }));
+      return runAfter
+        .filter((runAfterNode) => regularNodeIds.includes(runAfterNode))
+        .map((source) => ({
+          id: `${source}~to~${target}`,
+          type: 'edge',
+          source,
+          target,
+        }));
     }),
   ).filter((edgeList) => !!edgeList);
-
+};
 export const getFinallyTaskHeight = (allTasksLength: number, disableBuilder: boolean): number => {
   return (
     allTasksLength * NODE_HEIGHT +


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-5991

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
In yaml view, adding an non existent task name as a value to any task's `runafter` field and switching back to pipeline builder view forms an incorrect edge and topology layout fails to find the non existent node in the data model. 


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Filter out the invalid/non-existent node name from runAfter field and also surface the invalid runAfter error to the user so they can correct their mistake by going back to yaml view.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Invalid_runAfter](https://user-images.githubusercontent.com/9964343/122460513-d265d100-cfcf-11eb-9293-d6ec85b2ddaa.png)



**Unit test coverage report**: 
<!-- Attach test coverage report -->
```
 getEdgesFromNodes
    ✓ should contain correct number of edges based on the runAfters (1ms)
    ✓ should exclude the invalid runAfter names
 ```

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. In create pipelines page, switch to pipeline builder
2. Try out `docker-build-and-deploy-pipeline` sample and change the name the `fetch-reposistory` task **or** add any invalid in `build` tasks's runAfter value
3. Switch back to pipeline builder view

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @bgliwa01 
/assign @andrewballantyne 