### PR TITLE
Bug 1973338: Fix punctuation in pvc upload size warning

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -56,7 +56,7 @@
   "detected file extension is {{fileNameExtension}}": "detected file extension is {{fileNameExtension}}",
   "no file extention detected": "no file extention detected",
   "PVC size warning": "PVC size warning",
-  "PVC size is smaller than double the provided image, Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements": "PVC size is smaller than double the provided image, Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements",
+  "PVC size is smaller than double the provided image. Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements.": "PVC size is smaller than double the provided image. Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements.",
   "File type extension": "File type extension",
   "Based on the file extension it seems like you are trying to upload a file which is not supported ({{fileNameExtText}}).": "Based on the file extension it seems like you are trying to upload a file which is not supported ({{fileNameExtText}}).",
   "Learn more about supported formats": "Learn more about supported formats",

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -721,10 +721,8 @@ export const UploadPVCPage: React.FC<UploadPVCPageProps> = (props) => {
               <Alert variant="warning" isInline title={t('kubevirt-plugin~PVC size warning')}>
                 <p>
                   {t(
-                    'kubevirt-plugin~PVC size is smaller than double the provided image, Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements',
-                  )}
-                </p>
-                <p>
+                    'kubevirt-plugin~PVC size is smaller than double the provided image. Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements.',
+                  )}{' '}
                   <ExternalLink
                     text={t('kubevirt-plugin~Learn more')}
                     href="https://docs.openshift.com/container-platform/4.7/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.html"


### PR DESCRIPTION
When reviewing the files from the translators, we noticed "PVC size is smaller than double the provided image, Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements" in kubevirt-plugin.json needs a period instead of the comma.

It should be "PVC size is smaller than double the provided image. Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements."