### PR TITLE
Fix full screen loading indicator when routes are loaded lazy (or components uses React.Suspense)

### DIFF
--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -171,521 +171,524 @@ const AppContents: React.FC<{}> = () => {
       <div id="content">
         <GlobalNotifications />
         <Route path={namespacedRoutes} component={NamespaceBar} />
+
         <div id="content-scrollable">
-          <Switch>
-            {pluginPageRoutes}
+          <React.Suspense fallback={<LoadingBox />}>
+            <Switch>
+              {pluginPageRoutes}
 
-            <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
-            <LazyRoute
-              path="/dashboards"
-              loader={() =>
-                import(
-                  './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
-                ).then((m) => m.DashboardsPage)
-              }
-            />
+              <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
+              <LazyRoute
+                path="/dashboards"
+                loader={() =>
+                  import(
+                    './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
+                  ).then((m) => m.DashboardsPage)
+                }
+              />
 
-            {/* Redirect legacy routes to avoid breaking links */}
-            <Redirect from="/cluster-status" to="/dashboards" />
-            <Redirect from="/status/all-namespaces" to="/dashboards" />
-            <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
-            <Route path="/status" exact component={NamespaceRedirect} />
-            <Redirect from="/overview/all-namespaces" to="/dashboards" />
-            <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
-            <Route path="/overview" exact component={NamespaceRedirect} />
+              {/* Redirect legacy routes to avoid breaking links */}
+              <Redirect from="/cluster-status" to="/dashboards" />
+              <Redirect from="/status/all-namespaces" to="/dashboards" />
+              <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
+              <Route path="/status" exact component={NamespaceRedirect} />
+              <Redirect from="/overview/all-namespaces" to="/dashboards" />
+              <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
+              <Route path="/overview" exact component={NamespaceRedirect} />
 
-            <LazyRoute
-              path="/api-explorer"
-              exact
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                  (m) => m.APIExplorerPage,
-                )
-              }
-            />
-            <LazyRoute
-              path="/api-resource/cluster/:plural"
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                  (m) => m.APIResourcePage,
-                )
-              }
-            />
-            <LazyRoute
-              path="/api-resource/all-namespaces/:plural"
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                  NamespaceFromURL(m.APIResourcePage),
-                )
-              }
-            />
-            <LazyRoute
-              path="/api-resource/ns/:ns/:plural"
-              loader={() =>
-                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                  NamespaceFromURL(m.APIResourcePage),
-                )
-              }
-            />
+              <LazyRoute
+                path="/api-explorer"
+                exact
+                loader={() =>
+                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+                    (m) => m.APIExplorerPage,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/api-resource/cluster/:plural"
+                loader={() =>
+                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+                    (m) => m.APIResourcePage,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/api-resource/all-namespaces/:plural"
+                loader={() =>
+                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+                    NamespaceFromURL(m.APIResourcePage),
+                  )
+                }
+              />
+              <LazyRoute
+                path="/api-resource/ns/:ns/:plural"
+                loader={() =>
+                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+                    NamespaceFromURL(m.APIResourcePage),
+                  )
+                }
+              />
 
-            <LazyRoute
-              path="/command-line-tools"
-              exact
-              loader={() =>
-                import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
-                  (m) => m.CommandLineToolsPage,
-                )
-              }
-            />
+              <LazyRoute
+                path="/command-line-tools"
+                exact
+                loader={() =>
+                  import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
+                    (m) => m.CommandLineToolsPage,
+                  )
+                }
+              />
 
-            <Route path="/operatorhub" exact component={NamespaceRedirect} />
-            <LazyRoute
-              path="/provisionedservices/all-namespaces"
-              loader={() =>
-                import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
-                  (m) => m.ProvisionedServicesPage,
-                )
-              }
-            />
-            <LazyRoute
-              path="/provisionedservices/ns/:ns"
-              loader={() =>
-                import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
-                  (m) => m.ProvisionedServicesPage,
-                )
-              }
-            />
-            <Route path="/provisionedservices" component={NamespaceRedirect} />
+              <Route path="/operatorhub" exact component={NamespaceRedirect} />
+              <LazyRoute
+                path="/provisionedservices/all-namespaces"
+                loader={() =>
+                  import(
+                    './provisioned-services' /* webpackChunkName: "provisionedservices" */
+                  ).then((m) => m.ProvisionedServicesPage)
+                }
+              />
+              <LazyRoute
+                path="/provisionedservices/ns/:ns"
+                loader={() =>
+                  import(
+                    './provisioned-services' /* webpackChunkName: "provisionedservices" */
+                  ).then((m) => m.ProvisionedServicesPage)
+                }
+              />
+              <Route path="/provisionedservices" component={NamespaceRedirect} />
 
-            <LazyRoute
-              path="/brokermanagement"
-              loader={() =>
-                import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
-                  (m) => m.BrokerManagementPage,
-                )
-              }
-            />
+              <LazyRoute
+                path="/brokermanagement"
+                loader={() =>
+                  import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
+                    (m) => m.BrokerManagementPage,
+                  )
+                }
+              />
 
-            <LazyRoute
-              path="/catalog/instantiate-template"
-              exact
-              loader={() =>
-                import(
-                  './instantiate-template' /* webpackChunkName: "instantiate-template" */
-                ).then((m) => m.InstantiateTemplatePage)
-              }
-            />
+              <LazyRoute
+                path="/catalog/instantiate-template"
+                exact
+                loader={() =>
+                  import(
+                    './instantiate-template' /* webpackChunkName: "instantiate-template" */
+                  ).then((m) => m.InstantiateTemplatePage)
+                }
+              />
 
-            <Route
-              path="/k8s/ns/:ns/alertmanagers/:name"
-              exact
-              render={({ match }) => (
-                <Redirect
-                  to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
-                    match.params.name
-                  }`}
-                />
-              )}
-            />
+              <Route
+                path="/k8s/ns/:ns/alertmanagers/:name"
+                exact
+                render={({ match }) => (
+                  <Redirect
+                    to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
+                      match.params.name
+                    }`}
+                  />
+                )}
+              />
 
-            <LazyRoute
-              path="/k8s/all-namespaces/events"
-              exact
-              loader={() =>
-                import('./events' /* webpackChunkName: "events" */).then((m) =>
-                  NamespaceFromURL(m.EventStreamPage),
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/events"
-              exact
-              loader={() =>
-                import('./events' /* webpackChunkName: "events" */).then((m) =>
-                  NamespaceFromURL(m.EventStreamPage),
-                )
-              }
-            />
-            <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
-            <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
-            <Route path="/search" exact component={NamespaceRedirect} />
+              <LazyRoute
+                path="/k8s/all-namespaces/events"
+                exact
+                loader={() =>
+                  import('./events' /* webpackChunkName: "events" */).then((m) =>
+                    NamespaceFromURL(m.EventStreamPage),
+                  )
+                }
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/events"
+                exact
+                loader={() =>
+                  import('./events' /* webpackChunkName: "events" */).then((m) =>
+                    NamespaceFromURL(m.EventStreamPage),
+                  )
+                }
+              />
+              <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
+              <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
+              <Route path="/search" exact component={NamespaceRedirect} />
 
-            <LazyRoute
-              path="/k8s/all-namespaces/import"
-              exact
-              loader={() =>
-                import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                  NamespaceFromURL(m.ImportYamlPage),
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/import/"
-              exact
-              loader={() =>
-                import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                  NamespaceFromURL(m.ImportYamlPage),
-                )
-              }
-            />
+              <LazyRoute
+                path="/k8s/all-namespaces/import"
+                exact
+                loader={() =>
+                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                    NamespaceFromURL(m.ImportYamlPage),
+                  )
+                }
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/import/"
+                exact
+                loader={() =>
+                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                    NamespaceFromURL(m.ImportYamlPage),
+                  )
+                }
+              />
 
-            {
-              // These pages are temporarily disabled. We need to update the safe resources list.
-              // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-              // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-            }
+              {
+                // These pages are temporarily disabled. We need to update the safe resources list.
+                // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+                // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+              }
 
-            {
-              // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-              // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-            }
+              {
+                // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+                // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+              }
 
-            <LazyRoute
-              path="/k8s/ns/:ns/secrets/~new/:type"
-              exact
-              kind="Secret"
-              loader={() =>
-                import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                  (m) => m.CreateSecret,
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/secrets/:name/edit"
-              exact
-              kind="Secret"
-              loader={() =>
-                import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                  (m) => m.EditSecret,
-                )
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/secrets/:name/edit-yaml"
-              exact
-              kind="Secret"
-              loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
-            />
+              <LazyRoute
+                path="/k8s/ns/:ns/secrets/~new/:type"
+                exact
+                kind="Secret"
+                loader={() =>
+                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                    (m) => m.CreateSecret,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/secrets/:name/edit"
+                exact
+                kind="Secret"
+                loader={() =>
+                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                    (m) => m.EditSecret,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/secrets/:name/edit-yaml"
+                exact
+                kind="Secret"
+                loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
+              />
 
-            <LazyRoute
-              path="/k8s/ns/:ns/routes/~new/form"
-              exact
-              kind="Route"
-              loader={() =>
-                import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
-                  (m) => m.CreateRoute,
-                )
-              }
-            />
+              <LazyRoute
+                path="/k8s/ns/:ns/routes/~new/form"
+                exact
+                kind="Route"
+                loader={() =>
+                  import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
+                    (m) => m.CreateRoute,
+                  )
+                }
+              />
 
-            <LazyRoute
-              path="/k8s/cluster/rolebindings/~new"
-              exact
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-              }
-              kind="RoleBinding"
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/rolebindings/~new"
-              exact
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-              }
-              kind="RoleBinding"
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/rolebindings/:name/copy"
-              exact
-              kind="RoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/rolebindings/:name/edit"
-              exact
-              kind="RoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/cluster/clusterrolebindings/:name/copy"
-              exact
-              kind="ClusterRoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/cluster/clusterrolebindings/:name/edit"
-              exact
-              kind="ClusterRoleBinding"
-              loader={() =>
-                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-              }
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/:plural/:name/attach-storage"
-              exact
-              loader={() =>
-                import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
-                  (m) => m.default,
-                )
-              }
-            />
+              <LazyRoute
+                path="/k8s/cluster/rolebindings/~new"
+                exact
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+                }
+                kind="RoleBinding"
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/rolebindings/~new"
+                exact
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+                }
+                kind="RoleBinding"
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/rolebindings/:name/copy"
+                exact
+                kind="RoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+                }
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/rolebindings/:name/edit"
+                exact
+                kind="RoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+                }
+              />
+              <LazyRoute
+                path="/k8s/cluster/clusterrolebindings/:name/copy"
+                exact
+                kind="ClusterRoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+                }
+              />
+              <LazyRoute
+                path="/k8s/cluster/clusterrolebindings/:name/edit"
+                exact
+                kind="ClusterRoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+                }
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/:plural/:name/attach-storage"
+                exact
+                loader={() =>
+                  import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
+                    (m) => m.default,
+                  )
+                }
+              />
 
-            <LazyRoute
-              path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
-              exact
-              kind="PersistentVolumeClaim"
-              loader={() =>
-                import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
-                  (m) => m.CreatePVC,
-                )
-              }
-            />
+              <LazyRoute
+                path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
+                exact
+                kind="PersistentVolumeClaim"
+                loader={() =>
+                  import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
+                    (m) => m.CreatePVC,
+                  )
+                }
+              />
 
-            <LazyRoute
-              path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
-              exact
-              loader={() =>
-                import(
-                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
-                ).then((m) => m.VolumeSnapshot)
-              }
-            />
+              <LazyRoute
+                path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
+                exact
+                loader={() =>
+                  import(
+                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                  ).then((m) => m.VolumeSnapshot)
+                }
+              />
 
-            <LazyRoute
-              path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
-              exact
-              loader={() =>
-                import(
-                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
-                ).then((m) => m.VolumeSnapshot)
-              }
-            />
+              <LazyRoute
+                path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
+                exact
+                loader={() =>
+                  import(
+                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                  ).then((m) => m.VolumeSnapshot)
+                }
+              />
 
-            <LazyRoute
-              path="/monitoring/alerts"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertrules"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/silences"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanageryaml"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanagerconfig"
-              exact
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanagerconfig/receivers/~new"
-              exact
-              loader={() =>
-                import(
-                  './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
-                ).then((m) => m.CreateReceiver)
-              }
-            />
-            <LazyRoute
-              path="/monitoring/alertmanagerconfig/receivers/:name/edit"
-              exact
-              loader={() =>
-                import(
-                  './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
-                ).then((m) => m.EditReceiver)
-              }
-            />
-            <LazyRoute
-              path="/monitoring"
-              loader={() =>
-                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                  (m) => m.MonitoringUI,
-                )
-              }
-            />
+              <LazyRoute
+                path="/monitoring/alerts"
+                exact
+                loader={() =>
+                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                    (m) => m.MonitoringUI,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/monitoring/alertrules"
+                exact
+                loader={() =>
+                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                    (m) => m.MonitoringUI,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/monitoring/silences"
+                exact
+                loader={() =>
+                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                    (m) => m.MonitoringUI,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/monitoring/alertmanageryaml"
+                exact
+                loader={() =>
+                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                    (m) => m.MonitoringUI,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/monitoring/alertmanagerconfig"
+                exact
+                loader={() =>
+                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                    (m) => m.MonitoringUI,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/monitoring/alertmanagerconfig/receivers/~new"
+                exact
+                loader={() =>
+                  import(
+                    './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
+                  ).then((m) => m.CreateReceiver)
+                }
+              />
+              <LazyRoute
+                path="/monitoring/alertmanagerconfig/receivers/:name/edit"
+                exact
+                loader={() =>
+                  import(
+                    './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
+                  ).then((m) => m.EditReceiver)
+                }
+              />
+              <LazyRoute
+                path="/monitoring"
+                loader={() =>
+                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                    (m) => m.MonitoringUI,
+                  )
+                }
+              />
 
-            <LazyRoute
-              path="/settings/idp/github"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
-                ).then((m) => m.AddGitHubPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/gitlab"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
-                ).then((m) => m.AddGitLabPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/google"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
-                ).then((m) => m.AddGooglePage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/htpasswd"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
-                ).then((m) => m.AddHTPasswdPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/keystone"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
-                ).then((m) => m.AddKeystonePage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/ldap"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */
-                ).then((m) => m.AddLDAPPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/oidconnect"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
-                ).then((m) => m.AddOpenIDIDPPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/basicauth"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
-                ).then((m) => m.AddBasicAuthPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/idp/requestheader"
-              exact
-              loader={() =>
-                import(
-                  './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
-                ).then((m) => m.AddRequestHeaderPage)
-              }
-            />
-            <LazyRoute
-              path="/settings/cluster"
-              loader={() =>
-                import(
-                  './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
-                ).then((m) => m.ClusterSettingsPage)
-              }
-            />
+              <LazyRoute
+                path="/settings/idp/github"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
+                  ).then((m) => m.AddGitHubPage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/gitlab"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
+                  ).then((m) => m.AddGitLabPage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/google"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
+                  ).then((m) => m.AddGooglePage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/htpasswd"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
+                  ).then((m) => m.AddHTPasswdPage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/keystone"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
+                  ).then((m) => m.AddKeystonePage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/ldap"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */
+                  ).then((m) => m.AddLDAPPage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/oidconnect"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
+                  ).then((m) => m.AddOpenIDIDPPage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/basicauth"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
+                  ).then((m) => m.AddBasicAuthPage)
+                }
+              />
+              <LazyRoute
+                path="/settings/idp/requestheader"
+                exact
+                loader={() =>
+                  import(
+                    './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
+                  ).then((m) => m.AddRequestHeaderPage)
+                }
+              />
+              <LazyRoute
+                path="/settings/cluster"
+                loader={() =>
+                  import(
+                    './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
+                  ).then((m) => m.ClusterSettingsPage)
+                }
+              />
 
-            <LazyRoute
-              path={'/k8s/cluster/storageclasses/~new/form'}
-              exact
-              loader={() =>
-                import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
-                  (m) => m.StorageClassForm,
-                )
-              }
-            />
+              <LazyRoute
+                path={'/k8s/cluster/storageclasses/~new/form'}
+                exact
+                loader={() =>
+                  import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
+                    (m) => m.StorageClassForm,
+                  )
+                }
+              />
 
-            <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
-            <LazyRoute
-              path="/k8s/cluster/:plural/~new"
-              exact
-              loader={() =>
-                import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(
-                  (m) => m.CreateYAML,
-                )
-              }
-            />
-            <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
-            <LazyRoute
-              path="/k8s/ns/:ns/pods/:podName/containers/:name"
-              loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
-            />
-            <LazyRoute
-              path="/k8s/ns/:ns/:plural/~new"
-              exact
-              loader={() =>
-                import('./create-yaml' /* webpackChunkName: "create-yaml" */).then((m) =>
-                  NamespaceFromURL(m.CreateYAML),
-                )
-              }
-            />
-            <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
-            <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
+              <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
+              <LazyRoute
+                path="/k8s/cluster/:plural/~new"
+                exact
+                loader={() =>
+                  import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(
+                    (m) => m.CreateYAML,
+                  )
+                }
+              />
+              <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
+              <LazyRoute
+                path="/k8s/ns/:ns/pods/:podName/containers/:name"
+                loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
+              />
+              <LazyRoute
+                path="/k8s/ns/:ns/:plural/~new"
+                exact
+                loader={() =>
+                  import('./create-yaml' /* webpackChunkName: "create-yaml" */).then((m) =>
+                    NamespaceFromURL(m.CreateYAML),
+                  )
+                }
+              />
+              <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
+              <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
 
-            <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
-            <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
+              <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
+              <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
 
-            {inactivePluginPageRoutes}
+              {inactivePluginPageRoutes}
 
-            <LazyRoute
-              path="/error"
-              exact
-              loader={() =>
-                import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)
-              }
-            />
-            <Route path="/" exact component={DefaultPage} />
+              <LazyRoute
+                path="/error"
+                exact
+                loader={() =>
+                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)
+                }
+              />
+              <Route path="/" exact component={DefaultPage} />
 
-            <LazyRoute
-              loader={() =>
-                import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
-              }
-            />
-          </Switch>
+              <LazyRoute
+                loader={() =>
+                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
+                }
+              />
+            </Switch>
+          </React.Suspense>
         </div>
       </div>
     </PageSection>

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -5,7 +5,7 @@ import { History, Location } from 'history';
 import { useTranslation } from 'react-i18next';
 import { Route, Switch, Link, withRouter, match, matchPath } from 'react-router-dom';
 
-import { EmptyBox, StatusBox } from './status-box';
+import { EmptyBox, LoadingBox, StatusBox } from './status-box';
 import { PodsPage } from '../pod';
 import { AsyncComponent } from './async';
 import { K8sResourceKind, K8sResourceCommon } from '../../module/k8s';
@@ -207,7 +207,11 @@ NavBar.displayName = 'NavBar';
 export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
   const renderContent = (routes: JSX.Element[]) => {
     const { noStatusBox, obj, EmptyMsg, label } = props;
-    const content = <Switch> {routes} </Switch>;
+    const content = (
+      <React.Suspense fallback={<LoadingBox />}>
+        <Switch>{routes}</Switch>
+      </React.Suspense>
+    );
 
     const skeletonDetails = (
       <div data-test="skeleton-detail-view" className="skeleton-detail-view">


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5633

**Analysis / Root cause**: 
When switching on the Pod detail page to the "Terminal" tab a lazy route / AsyncComponent was loaded and the user saw for a moment (depending on your internet speed) a strange full screen loading indicator.

This flicking happen because this loading uses [react suspense](https://reactjs.org/docs/concurrent-mode-suspense.html) and we have only one `<React.Suspense />` at the application root level (app.jsx). This catch components works similar to ErrorBoundaries and could be used on different application levels.

**Solution Description**: 
Wrap the page content and horizontal navigation tab content also with a `<React.Suspense />` component.

This ensures that AsyncComponent loading on this levels shows a better loading indicator only in the content area. This would work also for other suspense usages.

I tested this by adding temporary suspense component to `PodExecLoader` (which us used in the terminal tab):

```tsx
// Use global variables and delays only once (when rendering Delay the first time)!
let resolved: boolean = false;
let promise: Promise<null>;

const Delay = () => {
  if (!promise) {
    promise = new Promise((resolve) => {
      setTimeout(() => {
        resolved = true;
        resolve(null);
      }, 2000);
    });
  }
  if (!resolved) {
    throw promise;
  }
  return <div>Delay done!</div>;
};

// Add <Delay /> to PodExecLoader
```

**Screen shots / Gifs for design review**: 

The original issue force with throttled internet connection:

![original-issue](https://user-images.githubusercontent.com/139310/122558365-46d75900-d03e-11eb-90fa-fe30e0f3c45a.gif)

Added the `Delay` component above to `PodExecLoader` without any other change:

![with-2s-suspense-call-no-other-change](https://user-images.githubusercontent.com/139310/122558437-5fe00a00-d03e-11eb-821f-22ad64386a77.gif)

When wrapping the page content (react router Switch) just in `app-contents.tsx`:

![with-2s-suspense-call-and-catch-in-app-contents](https://user-images.githubusercontent.com/139310/122558585-8bfb8b00-d03e-11eb-962d-28c4d824e50b.gif)

This helps for all pages without horizontal nav. But the navigation goes away and come back after the `suspense` promise is resolved.

When wrapping also the tab content (react router Switch again) in `horizontal-nav.tsx`:

![with-2s-suspense-call-and-catch-in-horizontal-nav](https://user-images.githubusercontent.com/139310/122558653-9fa6f180-d03e-11eb-8a8a-02b5de436188.gif)

This fixes the issue that the tab navigation goes way and come back after the  `suspense` promise is resolved.

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Deploy and application
* Open the Pod detail page
* Reload your browser tab so that the Terminal component is not available!
* Switch to the Terminal tab

Better testable on a cluster or with throttled internet connection.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
