### PR TITLE
Add plugin paths to tsconfig.json

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,30 @@
   "compilerOptions": {
     "skipLibCheck": true,
     "baseUrl": ".",
+    "paths": {
+      "@console/ceph-storage-plugin/*": ["./packages/ceph-storage-plugin/*"],
+      "@console/container-security/*": ["./packages/container-security/*"],
+      "@console/dev-console/*": ["./packages/dev-console/*"],
+      "@console/gitops-plugin/*": ["./packages/gitops-plugin/*"],
+      "@console/helm-plugin/*": ["./packages/helm-plugin/*"],
+      "@console/rhoas-plugin/*": ["./packages/rhoas-plugin/*"],
+      "@console/internal/*": ["./public/*"],
+      "@console/insights-plugin/*": ["./packages/insights-plugin/*"],
+      "@console/knative-plugin/*": ["./packages/knative-plugin/*"],
+      "@console/kubevirt-plugin/*": ["./packages/kubevirt-plugin/*"],
+      "@console/local-storage-operator-plugin/*": ["./packages/local-storage-operator-plugin/*"],
+      "@console/metal3-plugin/*": ["./packages/metal3-plugin/*"],
+      "@console/operator-lifecycle-manager/*": ["./packages/operator-lifecycle-manager/*"],
+      "@console/patternfly/*": ["./packages/patternfly/*"],
+      "@console/pipelines-plugin/*": ["./packages/pipelines-plugin/*"],
+      "@console/plugin-sdk/*": ["./packages/console-plugin-sdk/*"],
+      "@console/dynamic-plugin-sdk/*": ["./packages/console-dynamic-plugin-sdk"],
+      "@console/shared/*": ["./packages/console-shared/*"],
+      "@console/topology/*": ["./packages/topology/*"],
+      "@console/network-attachment-definition-plugin/*": [
+        "./packages/network-attachment-definition-plugin/*"
+      ]
+    },
     "module": "esnext",
     "moduleResolution": "node",
     "outDir": "./public/dist/build/",


### PR DESCRIPTION
This fixes auto alias imports in VSCode.

before 
<img width="632" alt="Screen Shot 2021-06-20 at 12 31 26" src="https://user-images.githubusercontent.com/24938324/122669033-04d81f80-d1c4-11eb-99d9-f9ef5e5e46e5.png">

This would result in a runtime error

after
<img width="644" alt="Screen Shot 2021-06-20 at 12 30 52" src="https://user-images.githubusercontent.com/24938324/122669041-11f50e80-d1c4-11eb-807b-95ce3b48b404.png">
