### PR TITLE
Bug 1971532: remove title attribute when value is uid or same as name

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
@@ -48,31 +48,17 @@ const OBCTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) =
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={obj.metadata.name}
-          namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
-        />
+        <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[2])}>
         <OBCStatus obc={obj} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[3])}>
         {isBound(obj) ? (
-          <ResourceLink
-            kind="Secret"
-            name={obj.metadata.name}
-            title={obj.metadata.name}
-            namespace={obj.metadata.namespace}
-          />
+          <ResourceLink kind="Secret" name={obj.metadata.name} namespace={obj.metadata.namespace} />
         ) : (
           '-'
         )}
@@ -105,7 +91,6 @@ const Details: React.FC<DetailsProps> = ({ obj }) => {
                   <ResourceLink
                     kind="Secret"
                     name={obj.metadata.name}
-                    title={obj.metadata.name}
                     namespace={obj.metadata.namespace}
                   />
                 </dd>

--- a/frontend/packages/ceph-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
@@ -42,12 +42,7 @@ const OBTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) =>
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={obj.metadata.name}
-          namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
-        />
+        <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[1])}>
         <OBStatus ob={obj} />

--- a/frontend/packages/console-shared/src/components/dashboard/resource-quota-card/ResourceQuotaItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/resource-quota-card/ResourceQuotaItem.tsx
@@ -23,7 +23,6 @@ const ResourceQuotaItem: React.FC<ResourceQuotaItemProps> = ({ resourceQuota }) 
           className="co-resource-item--truncate co-resource-quota-card__item-title"
           namespace={resourceQuota.metadata.namespace}
           inline="true"
-          title={resourceQuota.metadata.name}
         />
         {scopes && (
           <QuotaScopesInline className="co-resource-quota-dashboard-scopes" scopes={scopes} />

--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -400,7 +400,6 @@ export const ContainerVulnerabilities: React.FC<ContainerVulnerabilitiesProps> =
                           kind={referenceForModel(ImageManifestVulnModel)}
                           name={vuln.metadata.name}
                           namespace={props.pod.metadata.namespace}
-                          title={vuln.metadata.uid}
                           displayName={`${totalFor(
                             vulnPriority.findKey(
                               ({ title }) => _.get(vuln.status, 'highestSeverity') === title,

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
@@ -26,7 +26,6 @@ const RevisionRow: RowFunction<RevisionKind> = ({ obj, index, key, style }) => {
           kind={revisionReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.uid}
         />
       </TableData>
       <TableData className={cx(tableColumnClasses[1], 'co-break-word')} columnID="namespace">

--- a/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
@@ -24,7 +24,6 @@ const RouteRow: RowFunction<RouteKind> = ({ obj, index, key, style }) => (
         kind={routeReference}
         name={obj.metadata.name}
         namespace={obj.metadata.namespace}
-        title={obj.metadata.uid}
       />
     </TableData>
     <TableData className={cx(tableColumnClasses[1], 'co-break-word')} columnID="namespace">

--- a/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
@@ -32,7 +32,6 @@ const ServiceRow: RowFunction<ServiceKind> = ({ obj, index, key, style }) => {
           kind={serviceReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.uid}
         />
       </TableData>
       <TableData className={cx(tableColumnClasses[1], 'co-break-word')} columnID="namespace">

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/RowActions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/RowActions.tsx
@@ -69,7 +69,6 @@ const VMTemplateDetailsBody: React.FC<VMTemplateDetailsBodyProps> = ({
         <StackItem>
           <Link
             to={`/k8s/ns/${template.metadata.namespace}/vmtemplates/${template.metadata.name}`}
-            title={template.metadata.uid}
             data-test-id={template.metadata.name}
             className="co-resource-item__resource-name"
           >

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/VMCustomizeRow.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/VMCustomizeRow.tsx
@@ -139,11 +139,7 @@ const VMCustomizeRow: RowFunction<{ vm: VMKind; template: TemplateKind }, VMTemp
         {getTemplateProvider(t, template)}
       </TableData>
       <TableData className={dimensify()}>
-        <ResourceLink
-          kind={NamespaceModel.kind}
-          name={template.metadata.namespace}
-          title={template.metadata.namespace}
-        />
+        <ResourceLink kind={NamespaceModel.kind} name={template.metadata.namespace} />
       </TableData>
       <TableData className={dimensify()} data-test="template-source">
         <VMCustomizeStatus vmis={vmis} vm={vm} pods={pods} pvcs={pvcs} dataVolumes={dataVolumes} />

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/VMTemplateRow.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/VMTemplateRow.tsx
@@ -63,7 +63,6 @@ const VMTemplateRow: RowFunction<TemplateItem, VMTemplateRowProps> = ({
         <img src={getTemplateOSIcon(template)} alt="" className="kubevirt-vm-template-logo" />
         <Link
           to={`/k8s/ns/${template.metadata.namespace}/vmtemplates/${template.metadata.name}`}
-          title={template.metadata.uid}
           data-test-id={template.metadata.name}
           className="co-resource-item__resource-name"
         >
@@ -78,11 +77,7 @@ const VMTemplateRow: RowFunction<TemplateItem, VMTemplateRowProps> = ({
         )}
       </TableData>
       <TableData className={dimensify()}>
-        <ResourceLink
-          kind={NamespaceModel.kind}
-          name={template.metadata.namespace}
-          title={template.metadata.namespace}
-        />
+        <ResourceLink kind={NamespaceModel.kind} name={template.metadata.namespace} />
       </TableData>
       <TableData className={dimensify()} data-test="template-source">
         <TemplateSource

--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
@@ -373,7 +373,6 @@ const CatalogSourceTableRow: RowFunction<CatalogSourceTableRowObj> = ({
           kind={catalogSourceModelReference}
           name={source.metadata.name}
           namespace={source.metadata.namespace}
-          title={source.metadata.name}
         />
       ) : (
         name

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -1104,11 +1104,7 @@ export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetails
                   {olmTargetNamespaces === '' ? (
                     t('olm~All Namespaces')
                   ) : (
-                    <ResourceLink
-                      kind="Namespace"
-                      name={props.obj.metadata.namespace}
-                      title={props.obj.metadata.uid}
-                    />
+                    <ResourceLink kind="Namespace" name={props.obj.metadata.namespace} />
                   )}
                 </dd>
               </ResourceSummary>

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
@@ -96,13 +96,6 @@ describe('InstallPlanTableRow', () => {
         .find(ResourceLink)
         .props().name,
     ).toEqual(testInstallPlan.metadata.name);
-    expect(
-      wrapper
-        .find(TableRow)
-        .childAt(0)
-        .find(ResourceLink)
-        .props().title,
-    ).toEqual(testInstallPlan.metadata.uid);
   });
 
   it('renders column for install plan namespace', () => {
@@ -113,20 +106,6 @@ describe('InstallPlanTableRow', () => {
         .find(ResourceLink)
         .props().kind,
     ).toEqual('Namespace');
-    expect(
-      wrapper
-        .find(TableRow)
-        .childAt(1)
-        .find(ResourceLink)
-        .props().title,
-    ).toEqual(testInstallPlan.metadata.namespace);
-    expect(
-      wrapper
-        .find(TableRow)
-        .childAt(1)
-        .find(ResourceLink)
-        .props().displayName,
-    ).toEqual(testInstallPlan.metadata.namespace);
   });
 
   it('renders column for install plan status', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -73,18 +73,12 @@ export const InstallPlanTableRow: React.FC<RowFunctionArgs> = ({ obj, index, key
           kind={referenceForModel(InstallPlanModel)}
           namespace={obj.metadata.namespace}
           name={obj.metadata.name}
-          title={obj.metadata.uid}
         />
       </TableData>
 
       {/* Namespace */}
       <TableData className={tableColumnClasses[1]}>
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-          displayName={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
 
       {/* Status */}

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -146,12 +146,7 @@ export const linkForCsvResource = (
   (providedAPI?.resources ?? []).some(({ kind, name }) => name && kind === obj.kind) ? (
     <OperandLink obj={obj} csvName={csvName} />
   ) : (
-    <ResourceLink
-      kind={obj.kind}
-      name={obj.metadata.name}
-      namespace={obj.metadata.namespace}
-      title={obj.metadata.name}
-    />
+    <ResourceLink kind={obj.kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
   );
 
 export const Resources: React.FC<ResourcesProps> = (props) => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
@@ -89,14 +89,6 @@ describe('SubscriptionTableRow', () => {
         .childAt(0)
         .shallow()
         .find(ResourceLink)
-        .props().title,
-    ).toEqual(subscription.metadata.name);
-    expect(
-      wrapper
-        .find(TableRow)
-        .childAt(0)
-        .shallow()
-        .find(ResourceLink)
         .props().namespace,
     ).toEqual(subscription.metadata.namespace);
     expect(
@@ -167,22 +159,6 @@ describe('SubscriptionTableRow', () => {
         .shallow()
         .find(ResourceLink)
         .props().name,
-    ).toEqual(subscription.metadata.namespace);
-    expect(
-      wrapper
-        .find(TableRow)
-        .childAt(1)
-        .shallow()
-        .find(ResourceLink)
-        .props().title,
-    ).toEqual(subscription.metadata.namespace);
-    expect(
-      wrapper
-        .find(TableRow)
-        .childAt(1)
-        .shallow()
-        .find(ResourceLink)
-        .props().displayName,
     ).toEqual(subscription.metadata.namespace);
     expect(
       wrapper

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -202,16 +202,10 @@ export const SubscriptionTableRow: React.FC<RowFunctionArgs> = ({ obj, index, ke
           kind={referenceForModel(SubscriptionModel)}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData className={tableColumnClasses[1]}>
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-          displayName={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <SubscriptionStatus subscription={obj} />

--- a/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipeline-resources/list-page/PipelineResourcesRow.tsx
@@ -17,7 +17,6 @@ const PipelineResourcesRow: RowFunction<PipelineResourceKind> = ({ obj, index, k
           kind={pipelineResourcesReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
           data-test-id={obj.metadata.name}
         />
       </TableData>

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -36,7 +36,6 @@ const PipelineRunRow: RowFunction<PipelineRunKind> = ({ obj, index, key, style }
           kind={pipelinerunReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
           data-test-id={obj.metadata.name}
         />
       </TableData>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -41,7 +41,6 @@ const PipelineRow: RowFunction<PipelineWithLatest> = ({ obj, index, key, style }
           kind={pipelineReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData className={tableColumnClasses[1]} columnID="namespace">

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretsList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/modals/common/SecretsList.tsx
@@ -46,7 +46,6 @@ const Secrets: React.FC<SecretsProps> = ({ secrets, serviceaccounts }) => {
             kind={SecretModel.kind}
             name={secret.metadata.name}
             namespace={secret.metadata.namespace}
-            title={secret.metadata.name}
             linkTo={false}
           />
         );

--- a/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/taskruns/list-page/TaskRunsRow.tsx
@@ -21,7 +21,6 @@ const TaskRunsRow: RowFunction<TaskRunKind> = ({ obj, index, key, style, ...prop
         kind={taskRunsReference}
         name={obj.metadata.name}
         namespace={obj.metadata.namespace}
-        title={obj.metadata.name}
         data-test-id={obj.metadata.name}
       />
     </TableData>

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -121,7 +121,6 @@ const BuildConfigsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, s
           kind={BuildConfigsReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -411,7 +411,6 @@ const BuildsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }
           kind={BuildsReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -113,16 +113,10 @@ const ReportsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style 
           kind={ReportReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData className={tableColumnClasses[1]}>
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          namespace={undefined}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} namespace={undefined} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <ResourceLink
@@ -507,16 +501,10 @@ const ReportGenerationQueriesTableRow: RowFunction<K8sResourceKind> = ({
           kind={ReportGenerationQueryReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData className={reportsGenerationColumnClasses[1]}>
-        <ResourceLink
-          kind="Namespace"
-          namespace={undefined}
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" namespace={undefined} name={obj.metadata.namespace} />
       </TableData>
       <TableData className={reportsGenerationColumnClasses[2]}>
         <LabelList

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -75,7 +75,6 @@ const ClusterOperatorTableRow: RowFunction<ClusterOperator> = ({ obj, index, key
           kind={clusterOperatorReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData className={tableColumnClasses[1]}>

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -30,18 +30,13 @@ const ConfigMapTableRow = ({ obj: configMap, index, key, style }) => {
           kind="ConfigMap"
           name={configMap.metadata.name}
           namespace={configMap.metadata.namespace}
-          title={configMap.metadata.uid}
         />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={configMap.metadata.namespace}
-          title={configMap.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={configMap.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         {_.size(configMap.data) + _.size(configMap.binaryData)}

--- a/frontend/public/components/cron-job.tsx
+++ b/frontend/public/components/cron-job.tsx
@@ -52,7 +52,6 @@ const CronJobTableRow: RowFunction<CronJobKind> = ({ obj: cronjob, index, key, s
         <ResourceLink
           kind={kind}
           name={cronjob.metadata.name}
-          title={cronjob.metadata.name}
           namespace={cronjob.metadata.namespace}
         />
       </TableData>
@@ -60,11 +59,7 @@ const CronJobTableRow: RowFunction<CronJobKind> = ({ obj: cronjob, index, key, s
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={cronjob.metadata.namespace}
-          title={cronjob.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={cronjob.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>{cronjob.spec.schedule}</TableData>
       <TableData className={tableColumnClasses[3]}>

--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -178,18 +178,13 @@ export const DaemonSets: React.FC = (props) => {
             kind={kind}
             name={daemonset.metadata.name}
             namespace={daemonset.metadata.namespace}
-            title={daemonset.metadata.uid}
           />
         </TableData>
         <TableData
           className={classNames(tableColumnClasses[1], 'co-break-word')}
           columnID="namespace"
         >
-          <ResourceLink
-            kind="Namespace"
-            name={daemonset.metadata.namespace}
-            title={daemonset.metadata.namespace}
-          />
+          <ResourceLink kind="Namespace" name={daemonset.metadata.namespace} />
         </TableData>
         <TableData className={tableColumnClasses[2]}>
           <Link

--- a/frontend/public/components/default-resource.tsx
+++ b/frontend/public/components/default-resource.tsx
@@ -127,16 +127,11 @@ export const DefaultList: React.FC<TableProps> = (props) => {
             kind={customData.kind}
             name={obj.metadata.name}
             namespace={obj.metadata.namespace}
-            title={obj.metadata.name}
           />
         </TableData>
         <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
           {obj.metadata.namespace ? (
-            <ResourceLink
-              kind="Namespace"
-              name={obj.metadata.namespace}
-              title={obj.metadata.namespace}
-            />
+            <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
           ) : (
             t('public~None')
           )}

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -256,18 +256,13 @@ const HorizontalPodAutoscalersTableRow: RowFunction<K8sResourceKind> = ({
           kind={HorizontalPodAutoscalersReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={obj.metadata.labels} />

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -318,7 +318,6 @@ const ImageStreamsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, s
           kind={ImageStreamsReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -75,18 +75,13 @@ const IngressTableRow = ({ obj: ingress, index, key, style }) => {
           kind={kind}
           name={ingress.metadata.name}
           namespace={ingress.metadata.namespace}
-          title={ingress.metadata.uid}
         />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={ingress.metadata.namespace}
-          title={ingress.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={ingress.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={ingress.metadata.labels} />

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -63,22 +63,13 @@ const JobTableRow: RowFunction<JobKind> = ({ obj: job, index, key, style }) => {
   return (
     <TableRow id={job.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={job.metadata.name}
-          namespace={job.metadata.namespace}
-          title={job.metadata.uid}
-        />
+        <ResourceLink kind={kind} name={job.metadata.name} namespace={job.metadata.namespace} />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={job.metadata.namespace}
-          title={job.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={job.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={job.metadata.labels} />

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -39,11 +39,7 @@ export const LimitRangeTableRow: RowFunction<K8sResourceKind> = ({ obj, index, k
         />
       </TableData>
       <TableData className={tableColumnClasses[1]} columnID="namespace">
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -303,11 +303,7 @@ const MachineConfigPoolList: React.SFC<any> = (props) => {
     return (
       <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
         <TableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
-          <ResourceLink
-            kind={machineConfigPoolReference}
-            name={obj.metadata.name}
-            title={obj.metadata.name}
-          />
+          <ResourceLink kind={machineConfigPoolReference} name={obj.metadata.name} />
         </TableData>
         <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
           {_.get(obj, 'status.configuration.name') ? (

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -77,11 +77,7 @@ const MachineConfigTableRow: RowFunction<MachineConfigKind> = ({ obj, index, key
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={machineConfigReference}
-          name={obj.metadata.name}
-          title={obj.metadata.name}
-        />
+        <ResourceLink kind={machineConfigReference} name={obj.metadata.name} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         {_.get(

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -59,7 +59,6 @@ const MachineTableRow: RowFunction<MachineKind> = ({ obj, index, key, style }) =
           kind={machineReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -288,7 +288,7 @@ const NamespacesTableRow = connect(namespacesRowStateToProps)(
     return (
       <TableRow id={ns.metadata.uid} index={index} trKey={key} style={style}>
         <TableData className={namespaceColumnInfo.name.classes}>
-          <ResourceLink kind="Namespace" name={ns.metadata.name} title={ns.metadata.uid} />
+          <ResourceLink kind="Namespace" name={ns.metadata.name} />
         </TableData>
         <TableData
           className={namespaceColumnInfo.displayName.classes}
@@ -608,11 +608,7 @@ const ProjectTableRow = connect(projectRowStateToProps)(
             <ProjectLinkComponent project={project} />
           ) : (
             <span className="co-resource-item">
-              <ResourceLink
-                kind="Project"
-                name={project.metadata.name}
-                title={project.metadata.uid}
-              />
+              <ResourceLink kind="Project" name={project.metadata.name} />
             </span>
           )}
         </TableData>

--- a/frontend/public/components/network-policy.tsx
+++ b/frontend/public/components/network-policy.tsx
@@ -55,22 +55,13 @@ const NetworkPolicyTableRow: React.FunctionComponent<NetworkPolicyTableRowProps>
   return (
     <TableRow id={np.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={np.metadata.name}
-          namespace={np.metadata.namespace}
-          title={np.metadata.name}
-        />
+        <ResourceLink kind={kind} name={np.metadata.name} namespace={np.metadata.namespace} />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind={'Namespace'}
-          name={np.metadata.namespace}
-          title={np.metadata.namespace}
-        />
+        <ResourceLink kind={'Namespace'} name={np.metadata.namespace} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         {_.isEmpty(np.spec.podSelector) ? (

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -42,12 +42,7 @@ const PVTableRow = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={obj.metadata.name}
-          namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
-        />
+        <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[1]}>
         <PVStatus pv={obj} />

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -231,22 +231,13 @@ const ReplicaSetsList = (props) => {
     return (
       <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
         <TableData className={tableColumnClasses[0]}>
-          <ResourceLink
-            kind={kind}
-            name={obj.metadata.name}
-            namespace={obj.metadata.namespace}
-            title={obj.metadata.uid}
-          />
+          <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
         </TableData>
         <TableData
           className={classNames(tableColumnClasses[1], 'co-break-word')}
           columnID="namespace"
         >
-          <ResourceLink
-            kind="Namespace"
-            name={obj.metadata.namespace}
-            title={obj.metadata.namespace}
-          />
+          <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
         </TableData>
         <TableData className={tableColumnClasses[2]}>
           <Link

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -184,22 +184,13 @@ export const ReplicationControllersList = (props) => {
     return (
       <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
         <TableData className={tableColumnClasses[0]}>
-          <ResourceLink
-            kind={kind}
-            name={obj.metadata.name}
-            namespace={obj.metadata.namespace}
-            title={obj.metadata.uid}
-          />
+          <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
         </TableData>
         <TableData
           className={classNames(tableColumnClasses[1], 'co-break-word')}
           columnID="namespace"
         >
-          <ResourceLink
-            kind="Namespace"
-            name={obj.metadata.namespace}
-            title={obj.metadata.namespace}
-          />
+          <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
         </TableData>
         <TableData className={tableColumnClasses[2]}>
           <Link

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -360,11 +360,7 @@ export const ResourceQuotasList = (props) => {
           columnID="namespace"
         >
           {rq.metadata.namespace ? (
-            <ResourceLink
-              kind="Namespace"
-              name={rq.metadata.namespace}
-              title={rq.metadata.namespace}
-            />
+            <ResourceLink kind="Namespace" name={rq.metadata.namespace} />
           ) : (
             t('public~None')
           )}

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -156,22 +156,13 @@ const RouteTableRow: RowFunction<RouteKind> = ({ obj: route, index, key, style }
   return (
     <TableRow id={route.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={route.metadata.name}
-          namespace={route.metadata.namespace}
-          title={route.metadata.uid}
-        />
+        <ResourceLink kind={kind} name={route.metadata.name} namespace={route.metadata.namespace} />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={route.metadata.namespace}
-          title={route.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={route.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <RouteStatus obj={route} />

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -74,18 +74,13 @@ const SecretTableRow = ({ obj: secret, index, key, style }) => {
           kind="Secret"
           name={secret.metadata.name}
           namespace={secret.metadata.namespace}
-          title={secret.metadata.uid}
         />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={secret.metadata.namespace}
-          title={secret.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={secret.metadata.namespace} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         {secret.type}

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -169,15 +169,10 @@ const ServiceBindingsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key
           kind={referenceForModel(ServiceBindingModel)}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         <StatusWithIcon obj={obj} />

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -306,15 +306,10 @@ const ServiceInstancesTableRow: RowFunction<K8sResourceKind> = ({ obj, index, ke
           kind={referenceForModel(ServiceInstanceModel)}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
-          title={obj.metadata.name}
         />
       </TableData>
       <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <StatusWithIcon obj={obj} />

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -53,18 +53,13 @@ const ServiceTableRow = ({ obj: s, index, key, style }) => {
   return (
     <TableRow id={s.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={s.metadata.name}
-          namespace={s.metadata.namespace}
-          title={s.metadata.uid}
-        />
+        <ResourceLink kind={kind} name={s.metadata.name} namespace={s.metadata.namespace} />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink kind="Namespace" name={s.metadata.namespace} title={s.metadata.namespace} />
+        <ResourceLink kind="Namespace" name={s.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={s.metadata.labels} />

--- a/frontend/public/components/workload-table.tsx
+++ b/frontend/public/components/workload-table.tsx
@@ -38,22 +38,13 @@ export const WorkloadTableRow: React.FC<WorkloadTableRowProps> = ({
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={rowKey} style={style}>
       <TableData className={tableColumnClasses[0]}>
-        <ResourceLink
-          kind={kind}
-          name={obj.metadata.name}
-          namespace={obj.metadata.namespace}
-          title={obj.metadata.uid}
-        />
+        <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} />
       </TableData>
       <TableData
         className={classNames(tableColumnClasses[1], 'co-break-word')}
         columnID="namespace"
       >
-        <ResourceLink
-          kind="Namespace"
-          name={obj.metadata.namespace}
-          title={obj.metadata.namespace}
-        />
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <Link


### PR DESCRIPTION
As noted in the bug, we were not consistent with the application of the `title` attribute value on resource links.  So I am removing any `title` props that set the value to `*.metadata.uid` or are simply duplicating the value of the `name` prop as the use of a `title` that is the same is unnecessary.