### PR TITLE
Migrate Helm actions on topology to use the new extensions

### DIFF
--- a/frontend/packages/helm-plugin/src/topology/components/helmComponentFactory.ts
+++ b/frontend/packages/helm-plugin/src/topology/components/helmComponentFactory.ts
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import {
-  Node,
   GraphElement,
   withDragNode,
   withSelection,
   withDndDrop,
   withCreateConnector,
 } from '@patternfly/react-topology';
-import { kebabOptionsToMenu } from '@console/internal/components/utils';
+import { contextMenuActions } from '@console/topology/src/actions/contextMenuActions';
 import {
   WorkloadNode,
   noRegroupWorkloadContextMenu,
-  createMenuItems,
   createConnectorCallback,
   NodeComponentProps,
   nodeDragSourceSpec,
@@ -21,12 +19,8 @@ import {
   CreateConnector,
 } from '@console/topology/src/components/graph-view';
 import { withEditReviewAccess } from '@console/topology/src/utils';
-import { helmReleaseActions } from '../actions/helmReleaseActions';
 import { TYPE_HELM_RELEASE, TYPE_HELM_WORKLOAD } from './const';
 import HelmRelease from './HelmRelease';
-
-export const helmReleaseContextMenu = (element: Node) =>
-  createMenuItems(kebabOptionsToMenu(helmReleaseActions(element)));
 
 export const getHelmComponentFactory = (
   kind,
@@ -35,7 +29,7 @@ export const getHelmComponentFactory = (
   switch (type) {
     case TYPE_HELM_RELEASE:
       return withSelection({ controlled: true })(
-        withContextMenu(helmReleaseContextMenu)(withNoDrop()(HelmRelease)),
+        withContextMenu(contextMenuActions)(withNoDrop()(HelmRelease)),
       );
     case TYPE_HELM_WORKLOAD:
       return withCreateConnector(

--- a/frontend/packages/topology/src/actions/contextMenuActions.tsx
+++ b/frontend/packages/topology/src/actions/contextMenuActions.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Node } from '@patternfly/react-topology';
+import { ActionsLoader } from '@console/shared';
+import { createContextMenuItems } from '../components/graph-view';
+
+export const contextMenuActions = (element: Node): React.ReactElement[] => {
+  return [
+    <ActionsLoader key="topology" contextId="topology-actions" scope={element}>
+      {(loader) => loader.loaded && createContextMenuItems(loader.options)}
+    </ActionsLoader>,
+  ];
+};

--- a/frontend/packages/topology/src/components/graph-view/components/nodeContextMenu.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodeContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   isGraph,
 } from '@patternfly/react-topology';
 import i18next from 'i18next';
+import { Action } from '@console/dynamic-plugin-sdk/src';
 import {
   history,
   KebabItem,
@@ -15,6 +16,14 @@ import {
   kebabOptionsToMenu,
   isKebabSubMenu,
 } from '@console/internal/components/utils';
+import {
+  GroupedMenuOption,
+  MenuOption,
+  MenuOptionType,
+  orderExtensionBasedOnInsertBeforeAndAfter,
+} from '@console/shared/src';
+import ActionMenuItem from '@console/shared/src/components/actions/menu/ActionMenuItem';
+import { getMenuOptionType } from '@console/shared/src/components/actions/menu/menu-utils';
 import { graphActions } from '../../../actions/graphActions';
 import { groupActions } from '../../../actions/groupActions';
 import { workloadActions } from '../../../actions/workloadActions';
@@ -50,6 +59,39 @@ export const createMenuItems = (actions: KebabMenuOption[]) =>
       />
     ),
   );
+
+export const createContextMenuItems = (actions: MenuOption[]) => {
+  const sortedOptions = orderExtensionBasedOnInsertBeforeAndAfter(actions);
+  return sortedOptions.map((option: MenuOption) => {
+    const optionType = getMenuOptionType(option);
+    switch (optionType) {
+      case MenuOptionType.SUB_MENU:
+        return (
+          <ContextSubMenuItem label={option.label} key={option.id}>
+            {createContextMenuItems((option as GroupedMenuOption).children)}
+          </ContextSubMenuItem>
+        );
+      case MenuOptionType.GROUP_MENU:
+        return (
+          <>
+            <div className="pf-c-dropdown__group-title">{option.label}</div>
+            {createContextMenuItems((option as GroupedMenuOption).children)}
+          </>
+        );
+      default:
+        return (
+          <ContextMenuItem
+            key={option.id}
+            component={
+              <div className="pf-c-dropdown__menu-item">
+                <ActionMenuItem action={option as Action} />
+              </div>
+            }
+          />
+        );
+    }
+  });
+};
 
 export const workloadContextMenu = (element: Node) =>
   createMenuItems(


### PR DESCRIPTION
**JIRA ticket:**
https://issues.redhat.com/browse/ODC-5693

**Solution description:**
- Updated the topology context menu actions for helm release to use the new extension

**GIF/Screenshot:**
![Screenshot from 2021-07-08 01-25-23](https://user-images.githubusercontent.com/22490998/124822020-07d95b00-df8d-11eb-8bf6-9db5cbbd6282.png)
![topology-context-menu](https://user-images.githubusercontent.com/22490998/124822048-1162c300-df8d-11eb-816a-e35ecb3cadf4.gif)
![Peek 2021-07-08 01-37](https://user-images.githubusercontent.com/22490998/124822057-145db380-df8d-11eb-8919-157c594b045a.gif)

