### PR TITLE
Bug 1973065: Preserve user annotations while editing an app

### DIFF
--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils-data.ts
@@ -9,6 +9,8 @@ export const originalDeployment = {
       'image.openshift.io/triggers':
         '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","pause":"false"}]',
       'openshift.io/generated-by': 'OpenShiftWebConsole',
+      'app.openshift.io/connects-to': 'database',
+      'deployment.kubernetes.io/revision': '4',
     },
     name: 'nationalparks-py',
     namespace: 'div',

--- a/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/resource-label-utils.spec.tsx
@@ -29,9 +29,18 @@ describe('resource-label-utils', () => {
       });
     });
 
-    it('should return mergedData with newResource annotations ', () => {
+    it('should return mergedData with default and user annotations with correct values', () => {
       const mergedResource = mergeData(originalDeployment, newDeployment);
-      expect(mergedResource.metadata.annotations).toEqual(newDeployment.metadata.annotations);
+      expect(mergedResource.metadata.annotations).toEqual({
+        'alpha.image.policy.openshift.io/resolve-names': '*',
+        'app.openshift.io/vcs-ref': 'master',
+        'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
+        'image.openshift.io/triggers':
+          '[{"from":{"kind":"ImageStreamTag","name":"nationalparks-py:latest","namespace":"div"},"fieldPath":"spec.template.spec.containers[?(@.name==\\"nationalparks-py\\")].image","pause":"true"}]',
+        'openshift.io/generated-by': 'OpenShiftWebConsole',
+        'app.openshift.io/connects-to': 'database',
+        'deployment.kubernetes.io/revision': '4',
+      });
     });
 
     it('should return mergedData with newResource and originalResource annotations if originalResource is a devfile resource', () => {

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -72,6 +72,17 @@ export const getTriggerAnnotation = (
   ]),
 });
 
+export const getUserAnnotations = (allAnnotations: { [key: string]: string }) => {
+  const defaultAnnotations = [
+    'app.openshift.io/vcs-uri',
+    'app.openshift.io/vcs-ref',
+    'openshift.io/generated-by',
+    'image.openshift.io/triggers',
+    'alpha.image.policy.openshift.io/resolve-names',
+  ];
+  return _.omit(allAnnotations, defaultAnnotations);
+};
+
 export const getPodLabels = (name: string) => {
   return {
     app: name,
@@ -90,8 +101,10 @@ export const mergeData = (originalResource: K8sResourceKind, newResource: K8sRes
   };
   if (mergedData.metadata.annotations) {
     mergedData.metadata.annotations = {
+      ...(isDevfileResource
+        ? originalResource?.metadata?.annotations
+        : getUserAnnotations(originalResource?.metadata?.annotations)),
       ...newResource.metadata.annotations,
-      ...(isDevfileResource ? originalResource?.metadata?.annotations : {}),
     };
   }
   if (mergedData.spec?.template?.metadata?.labels) {

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -79,6 +79,8 @@ export const getUserAnnotations = (allAnnotations: { [key: string]: string }) =>
     'openshift.io/generated-by',
     'image.openshift.io/triggers',
     'alpha.image.policy.openshift.io/resolve-names',
+    'jarFileName',
+    'kubectl.kubernetes.io/last-applied-configuration',
   ];
   return _.omit(allAnnotations, defaultAnnotations);
 };


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-31048

**Analysis/Root Cause:**
Annotations cannot be edited directly via edit flows like labels but the default annotations values are updated if one or more form field values are modified. In order to keep the default annotations values up-to date old annotations were not being added and in turn the user annotations were also being lost.

**Solution:**
Only update the default annotations and keep the user annotations as is.

**Screen-recording:**

https://user-images.githubusercontent.com/20724543/122948165-546f4480-d398-11eb-8ed6-7e49580c7bce.mov

**Test coverage:**
<img width="1047" alt="Screenshot 2021-06-22 at 8 29 17 PM" src="https://user-images.githubusercontent.com/20724543/122948433-897b9700-d398-11eb-8cb0-3655b2a49ff8.png">

/kind bug

 