### PR TITLE
Bug 1974611: Boot source title

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/VMTemplateTable.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/table/VMTemplateTable.tsx
@@ -58,7 +58,7 @@ const vmTemplateTableHeader = (showNamespace: boolean, t: TFunction) =>
         transforms: [sortable],
       },
       {
-        title: t('kubevirt-plugin~Source provider'),
+        title: t('kubevirt-plugin~Boot source'),
         transforms: [
           info({
             tooltip: t(


### PR DESCRIPTION
In template list, the boot source provider column should be named boot source

Screenshots:
Before:
![Firefox_Screenshot_2021-06-22T07-53-10 235Z](https://user-images.githubusercontent.com/2181522/122886171-60cbb100-d348-11eb-8594-e357a041ff07.png)

After:
![Firefox_Screenshot_2021-06-22T07-55-20 593Z](https://user-images.githubusercontent.com/2181522/122886142-5c06fd00-d348-11eb-9880-f11bc0ad0717.png)


Signed-off-by: yzamir <yzamir@localhost.localdomain>