### PR TITLE
refactor sorting utils from add-page-utils

### DIFF
--- a/frontend/packages/console-shared/src/utils/index.ts
+++ b/frontend/packages/console-shared/src/utils/index.ts
@@ -21,3 +21,4 @@ export * from './annotations';
 export * from './xterm-addon-fullscreen';
 export * from './yup-validations';
 export * from './keyword-filter';
+export * from './order-extensions';

--- a/frontend/packages/console-shared/src/utils/order-extensions.ts
+++ b/frontend/packages/console-shared/src/utils/order-extensions.ts
@@ -1,0 +1,84 @@
+interface ItemsToSort {
+  id: string;
+  insertBefore?: string | string[];
+  insertAfter?: string | string[];
+}
+
+const toArray = (val) => (val ? (Array.isArray(val) ? val : [val]) : []);
+
+const itemDependsOnItem = <T extends ItemsToSort>(s1: T, s2: T): boolean => {
+  if (!s1.insertBefore && !s1.insertAfter) {
+    return false;
+  }
+  const before = toArray(s1.insertBefore);
+  const after = toArray(s1.insertAfter);
+  return before.includes(s2.id) || after.includes(s2.id);
+};
+
+const isPositioned = <T extends ItemsToSort>(item: T, allItems: T[]): boolean =>
+  !!allItems.find((i) => itemDependsOnItem<T>(item, i));
+
+const findIndexForItem = <T extends ItemsToSort>(item: T, currentItems: T[]): number => {
+  const { insertBefore, insertAfter } = item;
+  let index = -1;
+  const before = toArray(insertBefore);
+  const after = toArray(insertAfter);
+  let count = 0;
+  while (count < before.length && index < 0) {
+    // eslint-disable-next-line no-loop-func
+    index = currentItems.findIndex((i) => i.id === before[count]);
+    count++;
+  }
+  count = 0;
+  while (count < after.length && index < 0) {
+    // eslint-disable-next-line no-loop-func
+    index = currentItems.findIndex((i) => i.id === after[count]);
+    if (index >= 0) {
+      index += 1;
+    }
+    count++;
+  }
+  return index;
+};
+
+const insertItem = <T extends ItemsToSort>(item: T, currentItems: T[]): void => {
+  const index = findIndexForItem<T>(item, currentItems);
+  if (index >= 0) {
+    currentItems.splice(index, 0, item);
+  } else {
+    currentItems.push(item);
+  }
+};
+
+const insertPositionedItems = <T extends ItemsToSort>(
+  insertItems: T[],
+  currentItems: T[],
+): void => {
+  if (insertItems.length === 0) {
+    return;
+  }
+
+  const sortedItems = insertItems.filter((item) => !isPositioned<T>(item, insertItems));
+  const positionedItems = insertItems.filter((item) => isPositioned<T>(item, insertItems));
+
+  if (sortedItems.length === 0) {
+    // Circular dependencies
+    positionedItems.forEach((i) => insertItem<T>(i, currentItems));
+    return;
+  }
+
+  sortedItems.forEach((i) => insertItem<T>(i, currentItems));
+  insertPositionedItems<T>(positionedItems, currentItems);
+};
+
+export const orderExtensionBasedOnInsertBeforeAndAfter = <T extends ItemsToSort>(
+  items: T[],
+): T[] => {
+  if (!items || !items.length) {
+    return [];
+  }
+  const sortedItems = items.filter((item) => !isPositioned<T>(item, items));
+  const positionedItems = items.filter((item) => isPositioned<T>(item, items));
+  insertPositionedItems<T>(positionedItems, sortedItems);
+  return sortedItems;
+};

--- a/frontend/packages/dev-console/src/components/add/AddCardSection.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddCardSection.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { AddActionGroup, ResolvedExtension, AddAction } from '@console/dynamic-plugin-sdk';
 import { LoadedExtension } from '@console/plugin-sdk/src';
-import { getAddGroups, getSortedExtensionItems } from '../../utils/add-page-utils';
+import { orderExtensionBasedOnInsertBeforeAndAfter } from '@console/shared/';
+import { getAddGroups } from '../../utils/add-page-utils';
 import { AddGroup } from '../types';
 import AddCard from './AddCard';
 import AddCardSectionEmptyState from './AddCardSectionEmptyState';
@@ -34,9 +35,9 @@ const AddCardSection: React.FC<AddCardSectionProps> = ({
     if (!extensionsLoaded) {
       return [];
     }
-    const sortedActionGroup: LoadedExtension<AddActionGroup>[] = getSortedExtensionItems<
-      LoadedExtension<AddActionGroup>
-    >(addActionGroupExtensions);
+    const sortedActionGroup = orderExtensionBasedOnInsertBeforeAndAfter<
+      AddActionGroup['properties']
+    >(addActionGroupExtensions.map(({ properties }) => properties));
 
     const addGroups: AddGroup[] = getAddGroups(addActionExtensions, sortedActionGroup);
 

--- a/frontend/packages/dev-console/src/components/add/__tests__/add-page-test-data.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/add-page-test-data.tsx
@@ -389,6 +389,15 @@ export const addActionsWithoutValidGroupId: AddActionExtension[] = [
   actionWithUnavailableGroupId,
 ];
 
+export const addActionGroup: AddActionGroup['properties'][] = [
+  containerImagesActionGroup.properties,
+  developerCatalog.properties,
+  pipelinesActionGroup.properties,
+  serverless.properties,
+  gitRepository.properties,
+  localMachine.properties,
+];
+
 export const addActionGroupExtensions: AddActionGroupExtension[] = [
   containerImagesActionGroup,
   developerCatalog,

--- a/frontend/packages/dev-console/src/utils/__tests__/add-page-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/add-page-utils.spec.ts
@@ -2,7 +2,7 @@ import { AddAction, ResolvedExtension } from '@console/dynamic-plugin-sdk';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
 import {
   addActionExtensions,
-  addActionGroupExtensions,
+  addActionGroup,
   addActionsWithoutValidGroupId,
 } from '../../components/add/__tests__/add-page-test-data';
 import { AddGroup } from '../../components/types';
@@ -10,7 +10,7 @@ import { getAddGroups, resolvedHref, filterNamespaceScopedUrl } from '../add-pag
 
 describe('getAddGroups', () => {
   it('should return empty array if addActions is not defined', () => {
-    expect(getAddGroups(undefined, addActionGroupExtensions).length).toEqual(0);
+    expect(getAddGroups(undefined, addActionGroup).length).toEqual(0);
   });
 
   it('should return empty array if addActions is not defined', () => {
@@ -23,7 +23,7 @@ describe('getAddGroups', () => {
     >[] = addActionExtensions.filter((action) =>
       action.properties.groupId.includes('developer-catalog'),
     );
-    const addGroups: AddGroup[] = getAddGroups(addActionExtensions, addActionGroupExtensions);
+    const addGroups: AddGroup[] = getAddGroups(addActionExtensions, addActionGroup);
     expect(addGroups.find((group) => group.id === 'developer-catalog').items.length).toEqual(
       devCatalogGroupItems.length,
     );
@@ -37,7 +37,7 @@ describe('getAddGroups', () => {
     );
     const addGroups: AddGroup[] = getAddGroups(
       addActionsExcludingDevCatalogGroupItems,
-      addActionGroupExtensions,
+      addActionGroup,
     );
     expect(addGroups.find((group) => group.id === 'developer-catalog')).toBeUndefined();
   });
@@ -47,8 +47,8 @@ describe('getAddGroups', () => {
       ...addActionExtensions,
       ...addActionsWithoutValidGroupId,
     ];
-    const addGroups: AddGroup[] = getAddGroups(mockAddExtensions, addActionGroupExtensions);
-    expect(addGroups.length).toBeGreaterThan(addActionGroupExtensions.length);
+    const addGroups: AddGroup[] = getAddGroups(mockAddExtensions, addActionGroup);
+    expect(addGroups.length).toBeGreaterThan(addActionGroup.length);
     addActionsWithoutValidGroupId.forEach((action) => {
       expect(addGroups.find((group) => group.id === action.properties.id)).toBeDefined();
     });

--- a/frontend/packages/dev-console/src/utils/add-page-utils.ts
+++ b/frontend/packages/dev-console/src/utils/add-page-utils.ts
@@ -1,18 +1,17 @@
 import { AddAction, AddActionGroup, ResolvedExtension } from '@console/dynamic-plugin-sdk';
 import { history } from '@console/internal/components/utils';
-import { LoadedExtension } from '@console/plugin-sdk/src';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
 import { AddGroup } from '../components/types';
 
 export const getAddGroups = (
   addActions: ResolvedExtension<AddAction>[],
-  addActionGroups: LoadedExtension<AddActionGroup>[],
+  addActionGroups: AddActionGroup['properties'][],
 ): AddGroup[] => {
   if (!addActions || !addActionGroups) {
     return [];
   }
   const initialActionGroups: AddGroup[] = addActionGroups.map((actionGroup) => ({
-    ...actionGroup.properties,
+    ...actionGroup,
     items: [],
   }));
   const populatedActionGroups = addActions.reduce(
@@ -55,89 +54,4 @@ export const filterNamespaceScopedUrl = (
     return addActions.filter(({ properties: { href } }) => !href.match(/:namespace\b/));
   }
   return addActions;
-};
-
-interface ItemsToSort {
-  properties: {
-    id: string;
-    insertBefore?: string;
-    insertAfter?: string;
-  };
-}
-
-const toArray = (val) => (val ? (Array.isArray(val) ? val : [val]) : []);
-
-const itemDependsOnItem = <T extends ItemsToSort>(s1: T, s2: T): boolean => {
-  if (!s1.properties.insertBefore && !s1.properties.insertAfter) {
-    return false;
-  }
-  const before = toArray(s1.properties.insertBefore);
-  const after = toArray(s1.properties.insertAfter);
-  return before.includes(s2.properties.id) || after.includes(s2.properties.id);
-};
-
-const isPositioned = <T extends ItemsToSort>(item: T, allItems: T[]): boolean =>
-  !!allItems.find((i) => itemDependsOnItem<T>(item, i));
-
-const findIndexForItem = <T extends ItemsToSort>(item: T, currentItems: T[]): number => {
-  const { insertBefore, insertAfter } = item.properties;
-  let index = -1;
-  const before = toArray(insertBefore);
-  const after = toArray(insertAfter);
-  let count = 0;
-  while (count < before.length && index < 0) {
-    // eslint-disable-next-line no-loop-func
-    index = currentItems.findIndex((i) => i.properties.id === before[count]);
-    count++;
-  }
-  count = 0;
-  while (count < after.length && index < 0) {
-    // eslint-disable-next-line no-loop-func
-    index = currentItems.findIndex((i) => i.properties.id === after[count]);
-    if (index >= 0) {
-      index += 1;
-    }
-    count++;
-  }
-  return index;
-};
-
-const insertItem = <T extends ItemsToSort>(item: T, currentItems: T[]): void => {
-  const index = findIndexForItem<T>(item, currentItems);
-  if (index >= 0) {
-    currentItems.splice(index, 0, item);
-  } else {
-    currentItems.push(item);
-  }
-};
-
-const insertPositionedItems = <T extends ItemsToSort>(
-  insertItems: T[],
-  currentItems: T[],
-): void => {
-  if (insertItems.length === 0) {
-    return;
-  }
-
-  const sortedItems = insertItems.filter((item) => !isPositioned<T>(item, insertItems));
-  const positionedItems = insertItems.filter((item) => isPositioned<T>(item, insertItems));
-
-  if (sortedItems.length === 0) {
-    // Circular dependencies
-    positionedItems.forEach((i) => insertItem<T>(i, currentItems));
-    return;
-  }
-
-  sortedItems.forEach((i) => insertItem<T>(i, currentItems));
-  insertPositionedItems<T>(positionedItems, currentItems);
-};
-
-export const getSortedExtensionItems = <T extends ItemsToSort>(items: T[]): T[] => {
-  if (!items || !items.length) {
-    return [];
-  }
-  const sortedItems = items.filter((item) => !isPositioned<T>(item, items));
-  const positionedItems = items.filter((item) => isPositioned<T>(item, items));
-  insertPositionedItems<T>(positionedItems, sortedItems);
-  return sortedItems;
 };


### PR DESCRIPTION
This PR extracts sorting utils from add-page-utils and move them to console-shared. So other extensions can use the same utils.