### PR TITLE
Bug 1975913: fix optional workspace checkbox check/uncheck

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/ToggleableFieldBase.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ToggleableFieldBase.tsx
@@ -35,7 +35,7 @@ const ToggleableFieldBase: React.FC<ToggleableFieldBaseProps> = ({
       {children({
         ...field,
         ...props,
-        value: field.value,
+        value: field.value ?? false,
         id: fieldId,
         label,
         isChecked: field.checked,


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6039

**Root analysis:**
In the YAML editor of the pipeline builder form, when the workspace is added like 
```
workspaces:
    - name: workspace
```

the field value of the optional checkbox is received as undefined. As a result, when the Checkbox is checked in the form view it sets the field value to `[""]` instead of  `true`

**Solution description:**
- set value in `ToggableFieldBase.tsx` as false when field value is undefined

**GIF:**
![Peek 2021-06-22 23-30](https://user-images.githubusercontent.com/22490998/122976424-f3ed0100-d3b1-11eb-850c-fb66bed3aac5.gif)
