### PR TITLE
Bug 1975478: Fix to persist YAML Editor success message

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -125,8 +125,8 @@ export const EditYAML_ = connect(stateToProps)(
           });
         }
 
-        handleError(error) {
-          this.setState({ errors: _.isEmpty(error) ? null : [error], success: null });
+        handleError(error, success = null) {
+          this.setState({ errors: _.isEmpty(error) ? null : [error], success });
         }
 
         handleErrors(resourceObject, error) {
@@ -172,7 +172,7 @@ export const EditYAML_ = connect(stateToProps)(
           const newVersion = _.get(nextProps.obj, 'metadata.resourceVersion');
           const stale = this.displayedVersion !== newVersion;
           this.setState({ stale });
-          this.handleError(nextProps.error);
+          this.handleError(nextProps.error, this.state.success);
           if (nextProps.sampleObj) {
             this.loadYaml(
               !_.isEqual(this.state.sampleObj, nextProps.sampleObj),


### PR DESCRIPTION
**[Recent change](https://github.com/openshift/console/commit/ac18fec217edbf0307067402d961e1a306b619b3#diff-68f9741fec50dc79b50d2de1ece38b9a78fb54154c683c8be276d2a104e62cdbL143) was causing YAML Editor success message to be removed upon re-render:**

https://user-images.githubusercontent.com/12733153/122980263-72bc4c80-d366-11eb-9186-97a6758759fc.mov

**This was causing CI flakes in the CRD extensions test suite.**