### PR TITLE
Bug 1966499: Re-enable olm global tests which use portworx-operator

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -14,8 +14,7 @@ const operatorInstance = 'StorageCluster';
 const openshiftOperatorsNS = 'openshift-operators';
 const operandLink = 'portworx';
 
-// TODO: Disable until https://github.com/libopenstorage/operator/pull/323 is merged
-xdescribe(`Interacting with a global install mode Operator (${operatorName})`, () => {
+describe(`Interacting with a global install mode Operator (${operatorName})`, () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
Now that [libopenstorage operator PR #323](https://github.com/libopenstorage/operator/pull/323 ) has merged, re-enabling the OLM Global Install tests which use the portworx operator.

Reverts #9100 