### PR TITLE
Bug 1970011: Fix edge case for "managed by" links

### DIFF
--- a/frontend/public/components/utils/managed-by.tsx
+++ b/frontend/public/components/utils/managed-by.tsx
@@ -5,9 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ResourceIcon } from './resource-icon';
 import {
-  groupVersionFor,
   K8sResourceCommon,
-  referenceForGroupVersionKind,
   referenceForModel,
   referenceForOwnerRef,
   OwnerReference,
@@ -19,38 +17,39 @@ import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 import { ResourceLink } from '.';
 
-export const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = (props) => {
-  const { csvName, namespace, owner, className } = props;
-  const name = owner.name;
-  const { group, version } = groupVersionFor(owner.apiVersion);
-  const kind = owner.kind;
-
-  const reference = referenceForGroupVersionKind(group)(version)(kind);
-  const { namespaced } = modelFor(reference);
-
-  const link = `/k8s/ns/${namespace}/${referenceForModel(
-    ClusterServiceVersionModel,
-  )}/${csvName}/${reference}/${name}`;
-
+export const ManagedByOperatorResourceLink: React.SFC<ManagerLinkProps> = ({
+  csvName,
+  namespace,
+  owner,
+  className,
+}) => {
+  const csvGroupVersionKind = referenceForModel(ClusterServiceVersionModel);
+  const ownerGroupVersionKind = referenceForOwnerRef(owner);
+  const ownerIsCSV = ownerGroupVersionKind === csvGroupVersionKind;
+  const { namespaced } = modelFor(ownerGroupVersionKind);
+  const link = `/k8s/ns/${namespace}/${csvGroupVersionKind}/${csvName}`;
   return (
     <span className={className}>
       {namespaced ? (
         <>
-          <ResourceIcon kind={referenceForOwnerRef(owner)} />
-          <Link to={link} className="co-resource-item__resource-name" data-test-operand-link={name}>
-            {name}
+          <ResourceIcon kind={ownerGroupVersionKind} />
+          <Link
+            to={ownerIsCSV ? link : `${link}/${ownerGroupVersionKind}/${owner.name}`}
+            className="co-resource-item__resource-name"
+            data-test-operand-link={owner.name}
+          >
+            {owner.name}
           </Link>
         </>
       ) : (
-        <ResourceLink kind={reference} name={name} />
+        <ResourceLink kind={ownerGroupVersionKind} name={owner.name} />
       )}
     </span>
   );
 };
 
-export const ManagedByOperatorLink: React.SFC<ManagedByLinkProps> = (props) => {
+export const ManagedByOperatorLink: React.SFC<ManagedByLinkProps> = ({ obj, className }) => {
   const { t } = useTranslation();
-  const { obj, className } = props;
   const [data, setData] = React.useState<ClusterServiceVersionKind[] | undefined>();
   const namespace = obj.metadata.namespace;
   React.useEffect(() => {
@@ -67,20 +66,17 @@ export const ManagedByOperatorLink: React.SFC<ManagedByLinkProps> = (props) => {
   const owner = findOwner(obj, data);
   const csv = data && owner ? matchOwnerAndCSV(owner, data) : undefined;
 
-  if (owner && csv) {
-    return (
-      <div className={classNames('co-m-pane__heading-owner', className)}>
-        {t('public~Managed by')}{' '}
-        <ManagedByOperatorResourceLink
-          className="co-resource-item"
-          namespace={namespace}
-          csvName={csv.metadata.name}
-          owner={owner}
-        />
-      </div>
-    );
-  }
-  return null;
+  return owner && csv ? (
+    <div className={classNames('co-m-pane__heading-owner', className)}>
+      {t('public~Managed by')}{' '}
+      <ManagedByOperatorResourceLink
+        className="co-resource-item"
+        namespace={namespace}
+        csvName={csv.metadata.name}
+        owner={owner}
+      />
+    </div>
+  ) : null;
 };
 
 type ManagedByLinkProps = {

--- a/frontend/public/module/k8s/managed-by.ts
+++ b/frontend/public/module/k8s/managed-by.ts
@@ -1,23 +1,32 @@
-import { groupVersionFor, K8sResourceCommon, OwnerReference } from './';
+import { K8sResourceCommon, OwnerReference } from './';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
+import { referenceForGroupVersionKind, referenceForOwnerRef, referenceFor } from './k8s';
 
-const isOwnedByOperator = (csv: ClusterServiceVersionKind, owner: OwnerReference) => {
-  const { group } = groupVersionFor(owner.apiVersion);
-  return csv.spec?.customresourcedefinitions?.owned?.some((owned) => {
-    const ownedGroup = owned.name.substring(owned.name.indexOf('.') + 1);
-    return owned.kind === owner.kind && ownedGroup === group;
+// Check if owner is an Operand under csv
+const isOwnedByOperator = (csv: ClusterServiceVersionKind, owner: OwnerReference) =>
+  csv.spec?.customresourcedefinitions?.owned?.some((crd) => {
+    const apiGroup = crd.name.substring(crd.name.indexOf('.') + 1);
+    const crdGroupVersionKind = referenceForGroupVersionKind(apiGroup)(crd.version)(crd.kind);
+    const ownerGroupVersionKind = referenceForOwnerRef(owner);
+    return crdGroupVersionKind === ownerGroupVersionKind;
   });
+
+// Check if csv === owner (there is no need to check namespace because ownerReferences must
+// be in the same namespace as the owned resource, or be cluster-scoped).
+const isOwnedByCSV = (csv: ClusterServiceVersionKind, owner: OwnerReference) => {
+  const csvGroupVersionKind = referenceFor(csv);
+  const ownerGroupVersionKind = referenceForOwnerRef(owner);
+  return csvGroupVersionKind === ownerGroupVersionKind && csv.metadata.name === owner.name;
 };
 
-const isOwnedByCSV = (csv: ClusterServiceVersionKind, owner: OwnerReference) =>
-  csv.kind === owner.kind && csv.apiVersion === owner.apiVersion;
-
+// Find an Operator CSV that either is the owner or owns the owner
 export const matchOwnerAndCSV = (owner: OwnerReference, csvs: ClusterServiceVersionKind[] = []) => {
   return csvs.find((csv) => isOwnedByOperator(csv, owner) || isOwnedByCSV(csv, owner));
 };
 
-export const findOwner = (obj: K8sResourceCommon, data: ClusterServiceVersionKind[]) => {
+// Find onwerReference that is either a CSV or is an Operand managed by a CSV.
+export const findOwner = (obj: K8sResourceCommon, csvs: ClusterServiceVersionKind[]) => {
   return obj?.metadata?.ownerReferences?.find((o) =>
-    data?.some((csv) => isOwnedByOperator(csv, o) || isOwnedByCSV(csv, o)),
+    csvs?.some((csv) => isOwnedByOperator(csv, o) || isOwnedByCSV(csv, o)),
   );
 };


### PR DESCRIPTION
In the 'managed by' link components and helpers, account for the edge case where a resource has a CSV as an ownerReference.

- Update `isOwnedByCSV` helper to only return true when the CSV `group~version~kind` and name match the owner reference. This was the source of the bug. Previously, the match criteria was too broad and was causing `matchOwnerAndCSV` to return a false match.
- Update `ManagedByOperatorResourceLink` to only add the ownerReference `group~version~kind` and name to the link URL if it is not a CSV.