### PR TITLE
Bug 1970011: Fix edge case for "managed by" links

### DIFF
--- a/frontend/public/module/k8s/managed-by.ts
+++ b/frontend/public/module/k8s/managed-by.ts
@@ -1,6 +1,10 @@
-import { groupVersionFor, K8sResourceCommon, OwnerReference } from './';
-import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
+import { K8sResourceCommon, OwnerReference, groupVersionFor } from './';
+import {
+  ClusterServiceVersionKind,
+  ClusterServiceVersionModel,
+} from '@console/operator-lifecycle-manager';
 
+// Check if owner is an Operand under csv
 const isOwnedByOperator = (csv: ClusterServiceVersionKind, owner: OwnerReference) => {
   const { group } = groupVersionFor(owner.apiVersion);
   return csv.spec?.customresourcedefinitions?.owned?.some((owned) => {
@@ -9,15 +13,25 @@ const isOwnedByOperator = (csv: ClusterServiceVersionKind, owner: OwnerReference
   });
 };
 
-const isOwnedByCSV = (csv: ClusterServiceVersionKind, owner: OwnerReference) =>
-  csv.kind === owner.kind && csv.apiVersion === owner.apiVersion;
+// Check if csv === owner (there is no need to check namespace because ownerReferences must
+// be in the same namespace as the owned resource, or be cluster-scoped).
+const isOwnedByCSV = (csv: ClusterServiceVersionKind, owner: OwnerReference) => {
+  const { group } = groupVersionFor(owner.apiVersion);
+  return (
+    group === ClusterServiceVersionModel.apiGroup &&
+    owner.kind === ClusterServiceVersionModel.kind &&
+    csv.metadata.name === owner.name
+  );
+};
 
+// Find an Operator CSV that either is the owner or owns the owner
 export const matchOwnerAndCSV = (owner: OwnerReference, csvs: ClusterServiceVersionKind[] = []) => {
   return csvs.find((csv) => isOwnedByOperator(csv, owner) || isOwnedByCSV(csv, owner));
 };
 
-export const findOwner = (obj: K8sResourceCommon, data: ClusterServiceVersionKind[]) => {
+// Find onwerReference that is either a CSV or is an Operand managed by a CSV.
+export const findOwner = (obj: K8sResourceCommon, csvs: ClusterServiceVersionKind[]) => {
   return obj?.metadata?.ownerReferences?.find((o) =>
-    data?.some((csv) => isOwnedByOperator(csv, o) || isOwnedByCSV(csv, o)),
+    csvs?.some((csv) => isOwnedByOperator(csv, o) || isOwnedByCSV(csv, o)),
   );
 };


### PR DESCRIPTION
In the 'managed by' link components and helpers, account for the edge case where a resource has a CSV as an ownerReference.

- Update isOwnedByCSV helper to only return true when the CSV group~version~kind and name match the owner reference. This was the source of the bug. Previously, the match criteria was too broad and was causing matchOwnerAndCSV to return a false match.
- Update ManagedByOperatorResourceLink to only add the ownerReference group~version~kind and name to the link URL if it is not a CSV.