### PR TITLE
Bug 1973160: Query Browser: Gracefully handle `string` type query results

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -702,6 +702,9 @@ const QueryTable_: React.FC<QueryTableProps> = ({
   if (data.resultType === 'scalar') {
     columns = ['', { title: t('public~Value'), ...cellProps }];
     rows = [[buttonCell({}), _.get(result, '[1]')]];
+  } else if (data.resultType === 'string') {
+    columns = [{ title: t('public~Value'), ...cellProps }];
+    rows = [[result?.[1]]];
   } else {
     const allLabelKeys = _.uniq(_.flatMap(result, ({ metric }) => Object.keys(metric))).sort();
 

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -771,6 +771,14 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
     );
   }
 
+  if (error?.json?.error?.match(/invalid expression type "string"/)) {
+    return (
+      <GraphEmptyState title={t('public~Ungraphable results')}>
+        {t('public~Query result is a string, which cannot be graphed.')}
+      </GraphEmptyState>
+    );
+  }
+
   if (isDatasetTooBig) {
     return (
       <GraphEmptyState title={t('public~Ungraphable results')}>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -916,6 +916,7 @@
   "query browser chart": "query browser chart",
   "Ungraphable results": "Ungraphable results",
   "Query results include range vectors, which cannot be graphed. Try adding a function to transform the data.": "Query results include range vectors, which cannot be graphed. Try adding a function to transform the data.",
+  "Query result is a string, which cannot be graphed.": "Query result is a string, which cannot be graphed.",
   "The resulting dataset is too large to graph.": "The resulting dataset is too large to graph.",
   "Stacked": "Stacked",
   "Displaying with reduced resolution due to large dataset.": "Displaying with reduced resolution due to large dataset.",


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/460802/123241295-fb301e00-d51b-11eb-8bf3-f3f2e9ba8b39.png)
