### PR TITLE
Automation: Filter quick starts catalog

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartCatalogPage.tsx
@@ -14,7 +14,7 @@ const QuickStartCatalogPage: React.FC = () => {
         <title>{t('quickstart~Quick Starts')}</title>
       </Helmet>
       <div className="ocs-page-layout__header">
-        <Text component="h1" className="ocs-page-layout__title">
+        <Text component="h1" className="ocs-page-layout__title" data-test="page-title">
           {t('quickstart~Quick Starts')}
         </Text>
         <div className="ocs-page-layout__hint">

--- a/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/QuickStartPanelContent.tsx
@@ -45,7 +45,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   });
 
   return quickStart ? (
-    <DrawerPanelContent isResizable>
+    <DrawerPanelContent isResizable data-test="quickstart drawer">
       <div className={`co-quick-start-panel-content-head ${headerClasses}`}>
         <DrawerHead>
           <div className="co-quick-start-panel-content__title">
@@ -67,7 +67,11 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
           </DrawerActions>
         </DrawerHead>
       </div>
-      <DrawerPanelBody hasNoPadding className="co-quick-start-panel-content__body">
+      <DrawerPanelBody
+        hasNoPadding
+        className="co-quick-start-panel-content__body"
+        data-test="content"
+      >
         <AsyncComponent
           loader={() => import('./QuickStartController').then((c) => c.default)}
           quickStart={quickStart}

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartCatalog.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartCatalog.tsx
@@ -72,7 +72,7 @@ const QuickStartCatalog: React.FC<QuickStartCatalogProps> = ({ quickStarts }) =>
         )}
       </EmptyStateBody>
       <EmptyStatePrimary>
-        <Button variant="link" onClick={clearFilters}>
+        <Button variant="link" onClick={clearFilters} data-test="clear-filter button">
           {t('quickstart~Clear all filters')}
         </Button>
       </EmptyStatePrimary>

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTile.tsx
@@ -22,6 +22,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
   onClick,
 }) => {
   const {
+    metadata: { name },
     spec: { icon, displayName, description, durationMinutes, prerequisites },
   } = quickStart;
 
@@ -42,6 +43,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
       featured={isActive}
       title={<QuickStartTileHeader name={displayName} status={status} duration={durationMinutes} />}
       onClick={onClick}
+      data-test={`tile ${name}`}
     >
       <QuickStartTileDescription description={description} prerequisites={prerequisites} />
     </CatalogTile>

--- a/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileHeader.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/catalog/QuickStartTileHeader.tsx
@@ -29,7 +29,9 @@ const QuickStartTileHeader: React.FC<QuickStartTileHeaderProps> = ({ status, dur
 
   return (
     <div className="co-quick-start-tile-header">
-      <Title headingLevel="h3">{name}</Title>
+      <Title headingLevel="h3" data-test="title">
+        {name}
+      </Title>
       <div className="co-quick-start-tile-header__status">
         {status !== QuickStartStatus.NOT_STARTED && (
           <Label
@@ -37,6 +39,7 @@ const QuickStartTileHeader: React.FC<QuickStartTileHeaderProps> = ({ status, dur
             variant="outline"
             color={statusColorMap[status]}
             icon={<StatusIcon status={status} />}
+            data-test="status"
           >
             {statusLocaleMap[status]}
           </Label>

--- a/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartFooter.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/QuickStartFooter.tsx
@@ -66,7 +66,12 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
 
   const getPrimaryButton = React.useMemo(
     () => (
-      <Button variant="primary" className="co-quick-start-footer__actionbtn" onClick={onNext}>
+      <Button
+        variant="primary"
+        className="co-quick-start-footer__actionbtn"
+        onClick={onNext}
+        data-test={`${getPrimaryButtonText} button`}
+      >
         {getPrimaryButtonText}
       </Button>
     ),

--- a/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/filter-quick-starts-catalog.feature
+++ b/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/filter-quick-starts-catalog.feature
@@ -4,47 +4,44 @@ Feature: Add ability to filter Quick Starts catalog
 
         Background:
             Given user is at developer perspective
-              And sample-application CR Quick Start is available
-              And explore-serverless CR Quick Start is available
-              And explore-pipeline CR Quick Start is available
-              And add-healthchecks CR Quick Start is available
+              And user is at Add page
+              And user has created or selected namespace "aut-filter-quickstarts"
 
 
-        @regression @to-do
+        @smoke
         Scenario: Quick Starts Catalog Page: QS-01-TC01
             Given user is at Add page
              When user clicks on "View all quick starts" on Build with guided documentation card
              Then user can see Quick Starts catalog page
-              And user can see filter toolbar
               And user can see filter by keyword search bar
               And user can see Status filter dropdown
 
 
-        @regression @to-do
+        @regression
         Scenario: Filter by keyword: QS-01-TC02
             Given user is at Quick Starts catalog page
              When user clicks on filter by keyword search bar
               And user enters "pipeline"
-             Then user can see two pipleline cards
+             Then user can see "Install the OpenShift Pipelines Operator" Quick Start
 
 
-        @regression @to-do
+        @regression
         Scenario: Filter based on status: QS-01-TC03
             Given user is at Quick Starts catalog page
              When user clicks on Status filter menu
-             Then user can see completed, In progress and Not started with number of cards available in each categories
+             Then user can see Complete, In progress and Not started categories
 
 
-        @regression @to-do
+        @regression
         Scenario: Apply Filter based on status: QS-01-TC04
             Given user is at Quick Starts catalog page
               And user has completed "Getting started with a sample application" Quick Start
              When user clicks on Status filter menu
-              And user clicks see completed
-             Then user can see only the "Getting started with a sample application" Quick Start is present
+              And user clicks on completed
+             Then user can see "Getting started with a sample application" Quick Start is present
 
 
-        @regression @to-do
+        @regression
         Scenario: No result condition for filter: QS-01-TC05
             Given user is at Quick Starts catalog page
              When user clicks on filter by keyword search bar

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -9,6 +9,7 @@ export const addPagePO = {
   kebabMenuGettingStarted: '[data-test="actions"]',
   hideGettingStarted: '[data-test="hide"]',
   closeButton: '[aria-label="label-close-button"]',
+  viewAllQuickStarts: '[data-test="item all-quick-starts"]',
 };
 
 export const gitPO = {

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/index.ts
@@ -5,3 +5,4 @@ export * from './helm-po';
 export * from './monitoring-po';
 export * from './operators-po';
 export * from '@console/topology/integration-tests/support/page-objects/topology-po';
+export * from './quickStarts-po';

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/quickStarts-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/quickStarts-po.ts
@@ -1,0 +1,36 @@
+export const quickStartsPO = {
+  quickStartTitle: '[data-test="page-title"]',
+  filterKeyword: 'input.pf-c-search-input__text-input',
+  statusFilter: 'button.pf-c-select__toggle',
+  statusDropdown: '[aria-label="Select filter"]',
+  statusComplete: '[data-key="Complete"]',
+  emptyState: 'div.pf-c-empty-state__content',
+  clearFilter: '[data-test="clear-filter button"]',
+  cardStatus: '[data-test~="tile"] [data-test~="status"]',
+};
+
+export const quickStartSidebarPO = {
+  quickStartSidebarBody: '[data-test~="drawer"] [data-test~="content"]',
+  startButton: `[data-test="Start button"]`,
+  nextButton: '[data-test="Next button"]',
+  closeButton: '[data-test="Close button"]',
+};
+
+export const quickStartDisplayNameToName = (displayName: string) => {
+  switch (displayName) {
+    case 'Getting started with a sample application': {
+      return 'sample-application';
+    }
+    case 'Install the OpenShift Pipelines Operator': {
+      return 'explore-pipelines';
+    }
+    default: {
+      throw new Error('Option is not available');
+    }
+  }
+};
+
+export function quickStartCard(quickStartDisplayName: string) {
+  const quickStartName = quickStartDisplayNameToName(quickStartDisplayName);
+  return `[data-test~="tile"][data-test~="${quickStartName}"]`;
+}

--- a/frontend/packages/dev-console/integration-tests/support/pages/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/index.ts
@@ -6,3 +6,4 @@ export * from './app';
 export * from './modal';
 export * from './operators-page';
 export * from './functions/index';
+export * from './quickStartsPage';

--- a/frontend/packages/dev-console/integration-tests/support/pages/quickStartsPage.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/quickStartsPage.ts
@@ -1,0 +1,65 @@
+import { devNavigationMenu } from '../constants/global';
+import { addPagePO, quickStartSidebarPO, quickStartsPO } from '../pageObjects';
+import { catalogPage } from './add-flow/catalog-page';
+import { app, navigateTo } from './app';
+
+function clickVisibleButton(el: string) {
+  cy.get(quickStartSidebarPO.quickStartSidebarBody).then(($button) => {
+    const isVisible = $button.find(el).is(':visible');
+    if (isVisible) {
+      cy.get(el).click();
+      clickVisibleButton(el);
+    } else {
+      cy.log('quick start is complete');
+    }
+  });
+}
+
+export const quickStartsPage = {
+  quickStartsCatalog: () => {
+    navigateTo(devNavigationMenu.Add);
+    app.waitForDocumentLoad();
+    cy.get(addPagePO.viewAllQuickStarts).click();
+    cy.get(quickStartsPO.quickStartTitle)
+      .scrollIntoView()
+      .should('be.visible');
+    catalogPage.isCardsDisplayed();
+  },
+  filterByKeyword: (filterName: string) => {
+    cy.get(quickStartsPO.filterKeyword)
+      .scrollIntoView()
+      .click();
+    cy.get(quickStartsPO.filterKeyword).type(filterName);
+  },
+  cardPresent: (cardName: string) => {
+    cy.get(cardName)
+      .scrollIntoView()
+      .should('be.visible');
+  },
+  status: () => {
+    cy.get(quickStartsPO.statusFilter)
+      .scrollIntoView()
+      .click();
+    app.waitForLoad();
+    cy.get(quickStartsPO.statusDropdown).should('be.visible');
+  },
+  executeQuickStart: (quickStart: string) => {
+    cy.get(quickStart)
+      .scrollIntoView()
+      .click();
+    app.waitForDocumentLoad();
+    cy.get(quickStartSidebarPO.quickStartSidebarBody).should('be.visible');
+    cy.get(quickStartSidebarPO.quickStartSidebarBody)
+      .find(quickStartSidebarPO.startButton)
+      .click();
+    clickVisibleButton(quickStartSidebarPO.nextButton);
+    cy.get(quickStartSidebarPO.quickStartSidebarBody)
+      .find(quickStartSidebarPO.closeButton)
+      .click();
+    cy.get(quickStart)
+      .parent()
+      .find(quickStartsPO.cardStatus)
+      .should('be.visible')
+      .contains('Complete');
+  },
+};

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/filter-quick-starts-catalog.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/filter-quick-starts-catalog.ts
@@ -1,0 +1,93 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { quickStartCard, quickStartsPO } from '../../pageObjects';
+import { quickStartsPage } from '../../pages';
+
+When('user clicks on "View all quick starts" on Build with guided documentation card', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+Then('user can see Quick Starts catalog page', () => {
+  cy.get(quickStartsPO.quickStartTitle).should('be.visible');
+});
+
+Then('user can see filter by keyword search bar', () => {
+  cy.get(quickStartsPO.filterKeyword).should('be.visible');
+});
+
+Then('user can see Status filter dropdown', () => {
+  cy.get(quickStartsPO.statusFilter).should('be.visible');
+});
+
+Given('user is at Quick Starts catalog page', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+When('user clicks on filter by keyword search bar', () => {
+  cy.get(quickStartsPO.filterKeyword).click();
+});
+
+When('user enters {string}', (filterName: string) => {
+  quickStartsPage.filterByKeyword(filterName);
+});
+
+Then('user can see {string} Quick Start', (quickStartDisplayName: string) => {
+  quickStartsPage.cardPresent(quickStartCard(quickStartDisplayName));
+});
+
+Given('user is at Quick Starts catalog page', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+When('user clicks on Status filter menu', () => {
+  quickStartsPage.status();
+});
+
+Then('user can see Complete, In progress and Not started categories', () => {
+  cy.get(quickStartsPO.statusDropdown).contains('Complete');
+  cy.get(quickStartsPO.statusDropdown).contains('In progress');
+  cy.get(quickStartsPO.statusDropdown).contains('Not started');
+});
+
+Given('user is at Quick Starts catalog page', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+Given('user has completed {string} Quick Start', (quickStartDisplayName: string) => {
+  quickStartsPage.executeQuickStart(quickStartCard(quickStartDisplayName));
+});
+
+When('user clicks on Status filter menu', () => {
+  quickStartsPage.status();
+});
+
+When('user clicks on completed', () => {
+  cy.get(quickStartsPO.statusComplete)
+    .should('be.visible')
+    .click();
+});
+
+Then('user can see {string} Quick Start is present', (quickStartDisplayName: string) => {
+  cy.get(quickStartCard(quickStartDisplayName)).should('be.visible');
+});
+
+Given('user is at Quick Starts catalog page', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+When('user clicks on filter by keyword search bar', () => {
+  cy.get(quickStartsPO.filterKeyword).click();
+});
+
+When('user enters {string}', (filterKeyword: string) => {
+  quickStartsPage.filterByKeyword(filterKeyword);
+});
+
+Then('user can see "No results found" message', () => {
+  cy.get(quickStartsPO.emptyState).should('be.visible');
+  cy.get(quickStartsPO.emptyState).contains('No results found');
+});
+
+Then('user can see Clear all filters option', () => {
+  cy.get(quickStartsPO.clearFilter).should('be.visible');
+  cy.get(quickStartsPO.clearFilter).contains('Clear all filters');
+});


### PR DESCRIPTION
**Fix**: https://issues.redhat.com/browse/ODC-6006

**Problem**: Automation to filter quick starts in the quick starts catalog page.

**Solution**: This script will filter quick starts in the quick starts catalog page.

**Test Setup:**
- Cluster should be running on local
- Change TAGS in frontend/packages/dev-console/integration-tests/cypress.json file to : "@smoke or @regression and not (@manual or @to-do or @un-verified)", 

- Command to execute:
     - yarn run dev
     -  yarn run test-cypress-devconsole
 

- Execute the filter-quick-starts-catalog.feature file

**Browser**
Chrome 89

**Test Execution Screenshot:**
![Screenshot from 2021-06-26 21-31-56](https://user-images.githubusercontent.com/10252230/123518951-fdce7700-d6c5-11eb-820b-61ab2ba4da3f.png)

