### PR TITLE
remove hard coded model versions from kubevirt

### DIFF
--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -235,11 +235,7 @@
   {
     "type": "console.page/route",
     "properties": {
-      "path": [
-        "/k8s/ns/:ns/virtualmachines/:name",
-        "/k8s/ns/:ns/kubevirt.io~v1~VirtualMachine/:name",
-        "/k8s/ns/:ns/kubevirt.io~v1alpha3~VirtualMachine/:name"
-      ],
+      "path": ["/k8s/ns/:ns/virtualmachines/:name"],
       "component": {
         "$codeRef": "VirtualMachinesDetailsPage.VirtualMachinesDetailsPage"
       }
@@ -249,13 +245,37 @@
     }
   },
   {
+    "type": "console.page/resource/details",
+    "properties": {
+      "model": {
+        "group": "kubevirt.io",
+        "kind": "VirtualMachine"
+      },
+      "component": { "$codeRef": "VirtualMachinesDetailsPage.VirtualMachinesDetailsPage" }
+    },
+    "flags": {
+      "required": ["KUBEVIRT"]
+    }
+  },
+  {
     "type": "console.page/route",
     "properties": {
-      "path": [
-        "/k8s/ns/:ns/virtualmachineinstances/:name",
-        "/k8s/ns/:ns/kubevirt.io~v1~VirtualMachineInstance/:name",
-        "/k8s/ns/:ns/kubevirt.io~v1alpha3~VirtualMachineInstance/:name"
-      ],
+      "path": ["/k8s/ns/:ns/virtualmachineinstances/:name"],
+      "component": {
+        "$codeRef": "VirtualMachinesInstanceDetailsPage.VirtualMachinesInstanceDetailsPage"
+      }
+    },
+    "flags": {
+      "required": ["KUBEVIRT"]
+    }
+  },
+  {
+    "type": "console.page/resource/details",
+    "properties": {
+      "model": {
+        "group": "kubevirt.io",
+        "kind": "VirtualMachineInstance"
+      },
       "component": {
         "$codeRef": "VirtualMachinesInstanceDetailsPage.VirtualMachinesInstanceDetailsPage"
       }
@@ -328,12 +348,12 @@
     }
   },
   {
-    "type": "console.page/route",
+    "type": "console.page/resource/details",
     "properties": {
-      "path": [
-        "/k8s/ns/:ns/virtualmachinesnapshots/:name",
-        "/k8s/ns/:ns/snapshot.kubevirt.io~v1alpha1~VirtualMachineSnapshot/:name"
-      ],
+      "model": {
+        "group": "snapshot.kubevirt.io",
+        "kind": "VirtualMachineSnapshot"
+      },
       "component": {
         "$codeRef": "SnapshotDetailsPage.SnapshotDetailsPage"
       }

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshot-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshot-details.tsx
@@ -14,7 +14,7 @@ import {
   Timestamp,
 } from '@console/internal/components/utils';
 import { VM_DETAIL_SNAPSHOTS } from '../../constants';
-import { VirtualMachineSnapshotModel } from '../../models';
+import { VirtualMachineModel, VirtualMachineSnapshotModel } from '../../models';
 import { kubevirtReferenceForModel } from '../../models/kubevirtReferenceForModel';
 import { getName } from '../../selectors';
 import {
@@ -114,6 +114,7 @@ export const SnapshotDetailsPage: React.FC<SnapshotDetailsPageProps> = ({ match,
 
   const breadcrumbsForSnapshots = (snapshot) => {
     const vmName = getVmSnapshotVmName(snapshot);
+    const vmReference = kubevirtReferenceForModel(VirtualMachineModel);
     const vmNamespace = namespace || 'default';
     return [
       {
@@ -126,7 +127,7 @@ export const SnapshotDetailsPage: React.FC<SnapshotDetailsPageProps> = ({ match,
       },
       {
         name: `${vmName} Snapshots`,
-        path: `/k8s/ns/${vmNamespace}/virtualmachines/${vmName}/${VM_DETAIL_SNAPSHOTS}`,
+        path: `/k8s/ns/${vmNamespace}/${vmReference}/${vmName}/${VM_DETAIL_SNAPSHOTS}`,
       },
       {
         name: `${snapshotName} Details`,

--- a/frontend/packages/kubevirt-plugin/src/models/kubevirtReferenceForModel.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/kubevirtReferenceForModel.ts
@@ -1,33 +1,18 @@
-import * as _ from 'lodash';
-import { modelFor, referenceForGroupVersionKind } from '@console/internal/module/k8s';
+import {
+  apiVersionForModel,
+  modelForGroupKind,
+  referenceForModel,
+} from '@console/internal/module/k8s';
 import { K8sKind } from '@console/internal/module/k8s/types';
 
-const VERSIONS = ['v1', 'v1alpha3', 'v1beta1', 'v1alpha1'];
-
 export const getKubevirtModelAvailableVersion = (model: K8sKind): string =>
-  _.uniq([model.apiVersion, ...VERSIONS]).find(
-    (v) => !!modelFor(referenceForGroupVersionKind(model.apiGroup)(v)(model.kind)),
-  );
+  modelForGroupKind(model.apiGroup, model.kind)?.apiVersion || model.apiVersion;
 
-export const kubevirtReferenceForModel = (model: K8sKind): string => {
-  const version = getKubevirtModelAvailableVersion(model);
+export const kubevirtReferenceForModel = (model: K8sKind): string =>
+  referenceForModel(modelForGroupKind(model.apiGroup, model.kind) || model);
 
-  if (version) {
-    return referenceForGroupVersionKind(model.apiGroup)(version)(model.kind);
-  }
-
-  return model.kind;
-};
-
-export const getKubevirtAvailableModel = (model: K8sKind): K8sKind => {
-  const version = getKubevirtModelAvailableVersion(model);
-
-  if (version) {
-    return modelFor(referenceForGroupVersionKind(model.apiGroup)(version)(model.kind));
-  }
-
-  return model;
-};
+export const getKubevirtAvailableModel = (model: K8sKind): K8sKind =>
+  modelForGroupKind(model.apiGroup, model.kind) || model;
 
 export const getKubevirtModelAvailableAPIVersion = (model: K8sKind): string =>
-  `${model.apiGroup}/${getKubevirtModelAvailableVersion(model) || model.apiVersion}`;
+  apiVersionForModel(modelForGroupKind(model.apiGroup, model.kind) || model);


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/CNV-12565

* Removed the requirement of `version` in the YAML Template extension
* Added `modelForGroupKind` method to find a model through API Discovery by `group` and `kind` only