### PR TITLE
Fix CPU Usage query in dev console monitoring

### DIFF
--- a/frontend/packages/console-shared/src/promql/resource-metrics.ts
+++ b/frontend/packages/console-shared/src/promql/resource-metrics.ts
@@ -41,7 +41,7 @@ const podControllerMetricsQueries = {
     "sum(container_memory_working_set_bytes{namespace='<%= namespace %>',container!=''} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='<%= namespace %>', workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.CPU]: _.template(
-    "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace='<%= namespace %>'} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='<%= namespace %>', workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
+    "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='<%= namespace %>'} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='<%= namespace %>', workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.FILESYSTEM]: _.template(
     "sum(pod:container_fs_usage_bytes:sum{namespace='<%= namespace %>'}  * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='<%= namespace %>', workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",

--- a/frontend/packages/dev-console/src/components/monitoring/queries.ts
+++ b/frontend/packages/dev-console/src/components/monitoring/queries.ts
@@ -33,7 +33,7 @@ export const metricsQuery = (t: TFunction) => ({
 export const monitoringDashboardQueries = (t: TFunction): MonitoringQuery[] => [
   {
     query: _.template(
-      `sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace='<%= namespace %>'}) by (pod)`,
+      `sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='<%= namespace %>'}) by (pod)`,
     ),
     chartType: GraphTypes.area,
     title: t('devconsole~CPU usage'),
@@ -120,7 +120,7 @@ export const topWorkloadMetricsQueries = (t: TFunction): MonitoringQuery[] => [
     humanize: humanizeCpuCores,
     byteDataType: ByteDataTypes.BinaryBytes,
     query: _.template(
-      `sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace='<%= namespace %>'}
+      `sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='<%= namespace %>'}
           * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{
           namespace='<%= namespace %>', workload='<%= workloadName %>', workload_type='<%= workloadType %>'}) by (pod)`,
     ),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6075

**Analysis / Root cause**: 
The query for CPU Usage has been changed.

**Solution Description**: 
Replace `sum_rate` with `sum_irate` in the CPU usage query.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/123657436-67798d00-d84e-11eb-91bb-9d38afe25e89.png)
