### PR TITLE
Fix a11y issues and re-enable cypress ace checks again

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
@@ -182,7 +182,6 @@ const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
                   title={item.title}
                   iconUrl={item.iconUrl}
                   name={item.name}
-                  displayName={item.displayName}
                   selected={selected.value === item.name}
                   recommended={recommended === item.name}
                   onChange={handleItemChange}

--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.tsx
@@ -8,7 +8,6 @@ interface SelectorCardProps {
   title: string;
   iconUrl: string;
   name: string;
-  displayName?: string;
   selected?: boolean;
   recommended?: boolean;
   onChange: (name: string) => void;
@@ -18,22 +17,15 @@ const SelectorCard: React.FC<SelectorCardProps> = ({
   title,
   iconUrl,
   name,
-  displayName,
   selected,
   recommended = false,
   onChange,
 }) => {
   const classes = classNames('odc-selector-card', { 'is-selected': selected });
   return (
-    <Card
-      component="button"
-      type="button"
-      aria-label={title}
-      className={classes}
-      onClick={() => onChange(name)}
-    >
+    <Card component="button" type="button" className={classes} onClick={() => onChange(name)}>
       <CardTitle>
-        <img className="odc-selector-card__icon" src={iconUrl} alt={displayName ?? title} />
+        <img className="odc-selector-card__icon" src={iconUrl} alt="" />
       </CardTitle>
       <CardBody>
         <span className="odc-selector-card__title">{title}</span>

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -44,8 +44,7 @@ export const addPage = {
       case addOptions.EventSource:
         cy.byTestID('item knative-event-source').click();
         detailsPage.titleShouldContain(pageTitle.EventSource);
-        // Bug: ODC 5719 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
-        // cy.testA11y(pageTitle.EventSource);
+        cy.testA11y(pageTitle.EventSource);
         break;
       case 'Helm Chart':
       case addOptions.HelmChart:
@@ -83,14 +82,12 @@ export const addPage = {
       case addOptions.DevFile:
         cy.byTestID('item import-from-devfile').click();
         detailsPage.titleShouldContain(pageTitle.DevFile);
-        // Below line is commented due to Bug: ODC-5832
-        // cy.testA11y(pageTitle.DevFile);
+        cy.testA11y(pageTitle.DevFile);
         break;
       case addOptions.UploadJARFile:
         cy.byTestID('item upload-jar').click();
         detailsPage.titleShouldContain(pageTitle.UploadJarFile);
-        // Below line is commented due to Bug: ODC-5832
-        // cy.testA11y(pageTitle.UploadJarFile);
+        cy.testA11y(pageTitle.UploadJarFile);
         break;
       default:
         throw new Error(`Unable to find the "${card}" card on Add page`);

--- a/frontend/packages/dev-console/src/components/import/jar/section/JarSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/jar/section/JarSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormGroup, TextInputTypes } from '@patternfly/react-core';
+import { TextInputTypes } from '@patternfly/react-core';
 import { FormikValues, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import {
@@ -73,17 +73,16 @@ const JarSection: React.FunctionComponent = () => {
         }}
         required
       />
-      <FormGroup fieldId="uploadJarSection" label={t('devconsole~Optional Java commands')}>
-        <InputField
-          type={TextInputTypes.text}
-          name="fileUpload.javaArgs"
-          helpText={t(
-            'devconsole~Java commands are application specific and can be added to customize your application.',
-          )}
-          data-test-id="upload-jar-form-java-args"
-          placeholder={t('devconsole~Enter Java commands here')}
-        />
-      </FormGroup>
+      <InputField
+        type={TextInputTypes.text}
+        name="fileUpload.javaArgs"
+        label={t('devconsole~Optional Java commands')}
+        helpText={t(
+          'devconsole~Java commands are application specific and can be added to customize your application.',
+        )}
+        data-test-id="upload-jar-form-java-args"
+        placeholder={t('devconsole~Enter Java commands here')}
+      />
     </FormSection>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5832

**Analysis / Root cause**: 
Our cypress includes some automatically accessibility checks via [cypress-axe](https://github.com/component-driven/cypress-axe). These tests found some issues on the add page, esp. the "Import from Devfile" and "Upload JAR file" flows.

**Solution Description**: 
* Enable auto. accessibility checks for the Devfile and upload jar file flows
* Add missing label to the "Java command" field (remove unnecessary form group)
* Add aria-hidden to catalog card image (as it just duplicates the label info below, also drop the displayName which is only "visible" in the edge case that the image could not be loaded. Now the visible information matches the a11y labels.

**Screen shots / Gifs for design review**: 
UI doesn't change.

AXE check - Import from Git without this PR:

![import-from-git-before](https://user-images.githubusercontent.com/139310/123661548-ecf04380-d834-11eb-8775-8cecf2d38a71.png)

AXE check - Import from Git with this PR:

![import-from-git-after](https://user-images.githubusercontent.com/139310/123661565-ef529d80-d834-11eb-831a-b8c966e031bd.png)

AXE check - Import from Jarfile without this PR:

![upload-jar-file-before](https://user-images.githubusercontent.com/139310/123661717-127d4d00-d835-11eb-9fdb-b4033be891bd.png)

AXE check - Import from Jarfile with this PR:

![upload-jar-file-after](https://user-images.githubusercontent.com/139310/123661735-15783d80-d835-11eb-9a79-350e5706f58e.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
* Open developer perspective and run the "Import from Devfile" and "Upload JAR file" flows.
* Open the browser console / accessibility tools to inspect the rendered HTML code.
* I run the axe tests locally with the [axe - Web Accessibility Testing - Firefox extension](https://addons.mozilla.org/de/firefox/addon/axe-devtools/), (the chrome extensions doesn't work for me on localhost)

Cypress tests (see also screenshots above):
* `yarn test-cypress-devconsole` and run `create-from-devfile.feature`
* `yarn test-cypress-devconsole` and run `create-from-git.feature`
* `yarn test-cypress-devconsole` and run `upload-jar-file.feature`
* `yarn test-cypress-knative` and run `create-event-sources.feature`

cypress run Devfile feature:

![cypress-devfile](https://user-images.githubusercontent.com/139310/123661907-393b8380-d835-11eb-94ea-332ed6da9463.png)

Last test was marked as todo and doesn't work yet because one step is missing:

![cypress-devfile-reason](https://user-images.githubusercontent.com/139310/123661916-3b9ddd80-d835-11eb-8d01-49738bb637de.png)

cypress run Upload Jar file feature:

![cypress-upload-jar-file](https://user-images.githubusercontent.com/139310/123661920-3ccf0a80-d835-11eb-8136-dad019a97dd7.png)

The failing tests are marked as todo and doesn't work yet because one step is missing:

![cypress-upload-jar-file-reason](https://user-images.githubusercontent.com/139310/123661924-3e003780-d835-11eb-994a-c0f212080ca7.png)

cypress Create from Git tests fails. But all errors are timeouts and are not related to this change.

![create-from-git](https://user-images.githubusercontent.com/139310/123664834-034bce80-d838-11eb-9ed6-445484175faf.png)

cypress Create event sources also doesn't run successful. All tests fails with an timeout not related to this change.

![create-event-sources](https://user-images.githubusercontent.com/139310/123666303-612ce600-d839-11eb-93a6-0b97ae35cc4e.png)

:confused: 

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
