### PR TITLE
ODC-6023-update devconsole-ci-tests

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -20,14 +20,14 @@ export enum switchPerspective {
 }
 
 export enum operators {
-  PipelinesOperator = 'Pipeline',
-  ServerlessOperator = 'Serverless',
-  VirtualizationOperator = 'Virtualization',
+  PipelinesOperator = 'Red Hat OpenShift Pipelines',
+  ServerlessOperator = 'Red Hat OpenShift Serverless',
+  VirtualizationOperator = 'OpenShift Virtualization',
   RedHatIntegrationCamelK = 'Red Hat Integration - Camel K',
   ApacheCamelKOperator = 'Camel K Operator',
   KnativeApacheCamelOperator = 'Knative Apache Camel Operator',
   EclipseCheOperator = 'Eclipse Che',
-  GitOpsOperator = 'GitOps',
+  GitOpsOperator = 'Red Hat OpenShift GitOps',
   WebTerminalOperator = 'Web Terminal',
   ApacheKafka = 'Red Hat Integration - AMQ Streams',
 }

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -105,7 +105,7 @@ export const catalogPO = {
   cardType: 'span.pf-c-badge',
   create: 'button[type="submit"]',
   cancel: '[data-test-id="reset-button"]',
-  cardList: '[role="rowgroup"]',
+  cardList: '[role="grid"]',
   cardHeader: '.pf-c-badge.pf-m-read',
   groupByMenu: 'pf-c-dropdown__menu',
   catalogTypeLink: 'li.vertical-tabs-pf-tab.shown.text-capitalize.co-catalog-tab__empty',

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -111,12 +111,12 @@ export const catalogPO = {
   catalogTypeLink: 'li.vertical-tabs-pf-tab.shown.text-capitalize.co-catalog-tab__empty',
   catalogTypes: {
     operatorBacked: '[data-test="kind-cluster-service-version"]',
-    helmCharts: 'a[href="/?catalogType=HelmChart"]',
-    builderImage: 'ul:nth-child(3) > li:nth-child(1) > a', // This needs to be changed
-    template: 'a[href="/?catalogType=Template"]',
+    helmCharts: '[data-test="tab HelmChart"]',
+    builderImage: '[data-test="tab BuilderImage"]',
+    template: '[data-test="tab Template"]',
     serviceClass: '[data-test="kind-cluster-service-class"]',
     managedServices: '[data-test="kind-managed-service"]',
-    eventSources: 'a[href="/?catalogType=EventSource"]',
+    eventSources: '[data-test="tab EventSource"]',
   },
   cards: {
     mariaDBTemplate: 'a[data-test="Template-MariaDB"] .catalog-tile-pf-title',

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/operators-po.ts
@@ -13,15 +13,21 @@ export const operatorsPO = {
   operatorHub: {
     numOfItems: 'div.co-catalog-page__num-items',
     install: '[data-test="install-operator"]',
-    pipelinesOperatorCard: '[data-test^="openshift-pipelines-operator"]',
-    serverlessOperatorCard: '[data-test^=serverless-operator]',
-    virtualizationOperatorCard: '[data-test^="kubevirt-hyperconverged"]',
-    redHatCamelKOperatorCard: '[data-test^="red-hat-camel-k"]',
+    pipelinesOperatorCard:
+      '[data-test="openshift-pipelines-operator-rh-redhat-operators-openshift-marketplace"]',
+    serverlessOperatorCard:
+      '[data-test="serverless-operator-redhat-operators-openshift-marketplace"]',
+    virtualizationOperatorCard:
+      '[data-test="kubevirt-hyperconverged-redhat-operators-openshift-marketplace"]',
+    redHatCamelKOperatorCard:
+      '[data-test="red-hat-camel-k-redhat-operators-openshift-marketplace"]',
     installingOperatorModal: '#operator-install-page',
-    gitOpsOperatorCard: '[data-test^="openshift-gitops-operator"]',
+    gitOpsOperatorCard:
+      '[data-test="openshift-gitops-operator-redhat-operators-openshift-marketplace"]',
     webTerminalOperatorCard: '[data-test="web-terminal-redhat-operators-openshift-marketplace"]',
-    apacheCamelKOperatorCard: '[data-test^="camel-k-community"]',
-    knativeApacheCamelKOperatorCard: '[data-test^="knative-camel-operator-community"]',
+    apacheCamelKOperatorCard: '[data-test="camel-k-community-operators-openshift-marketplace"]',
+    knativeApacheCamelKOperatorCard:
+      '[data-test="knative-camel-operator-community-operators-openshift-marketplace"]',
     apacheKafkaOperatorCard: '[data-test^="amq-streams-redhat-operators"]',
     redHatSourceType: '[data-test-group-name="catalogSourceDisplayName"] [title="Red Hat"]',
   },

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -155,7 +155,7 @@ export const catalogPage = {
       .its('length')
       .should('be.greaterThan', 0);
   },
-  verifyChartCardsAvailable: () => {
+  verifyHelmChartCardsAvailable: () => {
     cy.get(catalogPO.cardList)
       .should('exist')
       .find(catalogPO.cardHeader)

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/developer-catalog-details.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/developer-catalog-details.ts
@@ -46,5 +46,5 @@ Then('user will see the cards of Event Sources', () => {
 });
 
 Then('user will see the cards of Helm Charts', () => {
-  catalogPage.verifyChartCardsAvailable();
+  catalogPage.verifyHelmChartCardsAvailable();
 });

--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogCategories.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogCategories.tsx
@@ -41,6 +41,7 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
         onActivate={() => onSelectCategory(id)}
         hasActiveDescendant={hasActiveDescendant(selectedCategory, category)}
         shown={toplevelCategory}
+        data-test={`tab ${id}`}
       >
         {subcategories && (
           <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryID, category)}>
@@ -54,7 +55,7 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
   };
 
   return (
-    <VerticalTabs restrictTabs activeTab={activeTab}>
+    <VerticalTabs restrictTabs activeTab={activeTab} data-test="catalog-categories">
       {_.map(categories, (category) => renderTabs(category, selectedCategory, true))}
     </VerticalTabs>
   );

--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
@@ -36,7 +36,7 @@ const CatalogTypeSelector: React.FC<CatalogTypeSelectorProps> = ({
         {t('devconsole~Type')}
         <FieldLevelHelp>{typeDescriptions}</FieldLevelHelp>
       </Title>
-      <VerticalTabs>
+      <VerticalTabs data-test="catalog-types">
         {catalogTypes.map((type) => {
           const { value, label } = type;
           const typeCount = catalogTypeCounts[value];
@@ -49,7 +49,7 @@ const CatalogTypeSelector: React.FC<CatalogTypeSelectorProps> = ({
           };
 
           return typeCount > 0 ? (
-            <li key={value} className="vertical-tabs-pf-tab">
+            <li key={value} className="vertical-tabs-pf-tab" data-test={`tab ${value}`}>
               <Link to={to}>{`${label} (${typeCount})`}</Link>
             </li>
           ) : null;

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm.ts
@@ -63,7 +63,7 @@ Then('user will see the list of Chart Repositories', () => {
 });
 
 Then('user will see the cards of Helm Charts', () => {
-  catalogPage.verifyChartCardsAvailable();
+  catalogPage.verifyHelmChartCardsAvailable();
 });
 
 Then('user will see Filter by Keyword field', () => {


### PR DESCRIPTION
**Jira Id**: https://issues.redhat.com/browse/ODC-6023

**Description**:
CI implemented for entire add flow

**Browser & its version** : Chrome 91

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] Execute the @to-do tagged gherkin scripts manually
- [ ] Convert the @to-do gherkin scripts to cypress automation scripts
- [ ] Once scripts are automated, replace tag @to-do with @epic-number
- [ ] Execute the scripts in Remote cluster

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands**:
In below commands, please update url and password based on the cluster
```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD https://api.gamore48installer7thjune001.devcluster.openshift.com:6443  --insecure-skip-tls-verify
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
./test-cypress.sh -p dev-console -h true
```
**Results**: 18 test cases are executed in 19 min [duration]
**Screenshots**
![image](https://user-images.githubusercontent.com/61005404/123671953-75cea580-d85c-11eb-80cc-8c4c5413915f.png)

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge