### PR TITLE
remove usage of digest from helm catalog item uid

### DIFF
--- a/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
@@ -30,16 +30,7 @@ export const normalizeHelmCharts = (
       const chartRepositoryTitle = getChartRepositoryTitle(chartRepositories, chartRepoName);
 
       charts.forEach((chart: HelmChartMetaData) => {
-        const {
-          name,
-          digest,
-          created,
-          version,
-          appVersion,
-          description,
-          keywords,
-          annotations,
-        } = chart;
+        const { name, created, version, appVersion, description, keywords, annotations } = chart;
 
         const annotatedName = annotations?.[CHART_NAME_ANNOTATION] ?? '';
         const providerType = annotations?.[PROVIDER_TYPE_ANNOTATION] ?? '';
@@ -107,7 +98,7 @@ export const normalizeHelmCharts = (
         ];
 
         const helmChart = {
-          uid: `${chartRepoName}--${digest}`,
+          uid: `${chartRepoName}--${chartURL}`,
           type: 'HelmChart',
           name: displayName,
           title,


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6077

**Root analysis:**
- `digest` is an optional property and the `uid` of helm chart depends on the digest's value. As a result, charts with no `digest` property will have the uid as `<provider-name>--undefined` so all the charts that belong to the same provider will have the same uid and the last one in the lot is considered.

**Solution description:**
- using the chart name and version as the value of uid.

**Screenshots:**

Before
![Screenshot from 2021-06-29 00-05-15](https://user-images.githubusercontent.com/22490998/123686711-b4b92700-d86d-11eb-9a2e-2894e86dee2b.png)

After
![Screenshot from 2021-06-29 00-05-46](https://user-images.githubusercontent.com/22490998/123686753-c6023380-d86d-11eb-888e-8d14593f058e.png)

**Test setup:**
```
apiVersion: helm.openshift.io/v1beta1
kind: HelmChartRepository
metadata:
  name: sample-repo
spec:
  connectionConfig:
    url:  https://raw.githubusercontent.com/debsmita1/charts/remove-digest/repo/community/index.yaml
```