### PR TITLE
Fix that BuildConfig webhook URL overflows secret column

### DIFF
--- a/frontend/public/components/utils/webhooks.tsx
+++ b/frontend/public/components/utils/webhooks.tsx
@@ -34,14 +34,14 @@ const getTableColumnClasses = (canGetSecret: boolean) => {
   if (canGetSecret) {
     return [
       '',
-      'pf-m-hidden pf-m-visible-on-xl pf-u-w-50-on-xl',
+      'pf-m-hidden pf-m-visible-on-xl pf-u-w-50-on-xl co-break-word',
       'pf-m-hidden pf-m-visible-on-md',
       '',
     ];
   }
   return [
     'pf-u-w-16-on-md',
-    'pf-u-w-58-on-xl',
+    'pf-u-w-58-on-xl co-break-word',
     'pf-m-hidden pf-m-visible-on-md pf-u-w-25-on-md',
     'pf-m-hidden',
   ];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6083

**Analysis / Root cause**: 
Webhooks URLs doesn't break within the table and overflow other coumns.

**Solution Description**: 
Restore css class to break works (and characters) which was removed in PR #9234 ([see diff](https://github.com/openshift/console/pull/9234/files#diff-90188062115107d6b7e2d9145e4ef7c4d53235391f50b3d1ac156c6fb349883d))

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

Before:
![webhooks-before](https://user-images.githubusercontent.com/139310/123708558-efba5b00-d86b-11eb-83bd-28dd3d520341.png)

With this PR:
![webhooks-after](https://user-images.githubusercontent.com/139310/123708581-f6e16900-d86b-11eb-950f-abee8045fc22.png)

If URL contains breakable spaces (only to verify this):
![webhooks-after-with-spaces](https://user-images.githubusercontent.com/139310/123708599-ff39a400-d86b-11eb-9d9c-70d167c2ff14.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Developer perspective
2. Import from jar file
3. Switch to the BuildConfig

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
