### PR TITLE
Update class names for terminal to avoid clash with markdown code styles

### DIFF
--- a/frontend/public/components/_terminal.scss
+++ b/frontend/public/components/_terminal.scss
@@ -3,17 +3,17 @@
 $console-z-index: $zindex-navbar-fixed + 20;
 $console-collapse-link-z-index: $console-z-index + 20;
 
-.console > .terminal {
+.co-terminal > .terminal {
   color: $color-pf-white;
   padding: 10px;
   background-color: $color-pf-black;
 }
 
-.console > .terminal.fullscreen {
+.co-terminal > .terminal.fullscreen {
   z-index: $console-z-index; // in fullscreen mode, to get above $zindex-navbar-fixed
 }
 
-.console {
+.co-terminal {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -24,7 +24,7 @@ $console-collapse-link-z-index: $console-z-index + 20;
   }
 }
 
-.console-collapse-link.pf-c-button {
+.co-terminal-collapse-link.pf-c-button {
   background: rgba(0, 0, 0, 0.75) !important;
   color: $color-pf-blue-300;
   position: fixed;

--- a/frontend/public/components/terminal.jsx
+++ b/frontend/public/components/terminal.jsx
@@ -123,10 +123,10 @@ class Terminal_ extends React.Component {
     const { t } = this.props;
     return (
       <div ref={this.outerRef} style={this.state} className={this.props.className}>
-        <div ref={this.innerRef} className="console">
+        <div ref={this.innerRef} className="co-terminal">
           {this.isFullscreen && (
             <Button
-              className="console-collapse-link"
+              className="co-terminal-collapse-link"
               onClick={() => this.setFullscreen(false)}
               variant="link"
             >


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6081
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Styles from pod terminal component were clashing with markdown code components due to generic `console` class name being used in terminal.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Update class names of terminal component to avoid such clashes in future.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/123795739-f2678f80-d901-11eb-98c6-da249f163522.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
