### PR TITLE
updated regex for resource name validation and convert to kebabCase if name is not valid

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -46,12 +46,15 @@ describe('ValidationUtils', () => {
 
   describe('createComponentName', () => {
     const invalidConvertedtoValidNamePair: { [key: string]: string } = {
-      '0name': 'ocp-0name',
-      '-name': 'ocp--name',
-      'name-': 'ocp-name',
-      'invalid&name': 'ocp-invalidname',
-      'invalid name': 'ocp-invalidname',
-      'invalid-Name': 'ocp-invalid-name',
+      '-2name': 'ocp-2-name',
+      '0name': 'ocp-0-name',
+      Name: 'name',
+      '-name': 'name',
+      'name-': 'name',
+      'invalid&name': 'invalid-name',
+      'invalid name': 'invalid-name',
+      'invalid-Name': 'invalid-name',
+      InvalidName: 'invalid-name',
     };
     const validNames: string[] = ['name', 'valid-name', 'name0', 'name-0'];
 
@@ -143,6 +146,21 @@ describe('ValidationUtils', () => {
         .then((valid) => expect(valid).toEqual(true));
       const name = detectGitRepoName(mockData.git.url);
       expect(name).toEqual('wild-west-frontend');
+    });
+
+    it('should convert the detected name to valid kebabCase', async () => {
+      expect(
+        detectGitRepoName('https://github.com/openshift-evangelists/Wild-West-Frontend'),
+      ).toEqual('wild-west-frontend');
+      expect(
+        detectGitRepoName('https://github.com/openshift-evangelists/wildWestFrontend'),
+      ).toEqual('wild-west-frontend');
+      expect(
+        detectGitRepoName('https://github.com/openshift-evangelists/wild-west-frontend.git'),
+      ).toEqual('wild-west-frontend-git');
+      expect(
+        detectGitRepoName('https://github.com/openshift-evangelists/Wild-West-Frontend123'),
+      ).toEqual('wild-west-frontend-123');
     });
 
     it('should throw an error if name is invalid', async () => {

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -19,7 +19,7 @@ import {
   NormalizedBuilderImages,
 } from '../../../utils/imagestream-utils';
 import { GitData, GitReadableTypes, GitTypes } from '../import-types';
-import { detectGitType, detectGitRepoName, createComponentName } from '../import-validation-utils';
+import { detectGitType, detectGitRepoName } from '../import-validation-utils';
 import FormSection from '../section/FormSection';
 import AdvancedGitOptions from './AdvancedGitOptions';
 import SampleRepo from './SampleRepo';
@@ -107,10 +107,7 @@ const GitSection: React.FC<GitSectionProps> = ({
         return;
       }
 
-      gitRepoName &&
-        !nameTouched &&
-        !values.name &&
-        setFieldValue('name', createComponentName(gitRepoName));
+      gitRepoName && !nameTouched && !values.name && setFieldValue('name', gitRepoName);
       gitRepoName &&
         values.formType !== 'edit' &&
         !values.application.name &&
@@ -192,10 +189,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   const handleGitUrlBlur = React.useCallback(() => {
     const { url } = values.git;
     const gitRepoName = detectGitRepoName(url);
-    values.formType !== 'edit' &&
-      gitRepoName &&
-      !nameTouched &&
-      setFieldValue('name', createComponentName(gitRepoName));
+    values.formType !== 'edit' && gitRepoName && !nameTouched && setFieldValue('name', gitRepoName);
     gitRepoName &&
       values.formType !== 'edit' &&
       !values.application.name &&

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -64,18 +64,20 @@ export const detectGitType = (url: string): string => {
   return GitTypes.unsure;
 };
 
+export const createComponentName = (nameString: string): string => {
+  if (nameRegex.test(nameString)) {
+    return nameString;
+  }
+  const kebabCaseStr = _.kebabCase(nameString);
+  return nameString.match(/^\d/) || kebabCaseStr.match(/^\d/)
+    ? `ocp-${kebabCaseStr}`
+    : kebabCaseStr;
+};
+
 export const detectGitRepoName = (url: string): string | undefined => {
   if (!gitUrlRegex.test(url)) {
     return undefined;
   }
-
-  return _.kebabCase(url.split('/').pop());
-};
-
-export const createComponentName = (nameString: string): string => {
-  const prefixToValidate = 'ocp-';
-  if (!nameRegex.test(nameString)) {
-    return `${prefixToValidate}${nameString.replace(/[^-a-zA-Z0-9]|(-*)$/g, '').toLowerCase()}`;
-  }
-  return nameString;
+  const name = url.split('/').pop();
+  return createComponentName(name);
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6043

**Analysis / Root cause**: 
- even if the name was valid still was getting converted to kebabCase

**Solution Description**: 
- convert the name to kebabCase if the name is not valid and refactored utils

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
- added / updated tests for utils


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
