### PR TITLE
Monitoring: Add runbook URLs to alert and rule details pages

### DIFF
--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -89,7 +89,7 @@ import { ActionsMenu } from '../utils/dropdown';
 import { Firehose } from '../utils/firehose';
 import { SectionHeading, ActionButtons, BreadCrumbs } from '../utils/headings';
 import { Kebab } from '../utils/kebab';
-import { getURLSearchParams, LinkifyExternal } from '../utils/link';
+import { ExternalLink, getURLSearchParams, LinkifyExternal } from '../utils/link';
 import { ResourceLink } from '../utils/resource-link';
 import { ResourceStatus } from '../utils/resource-status';
 import { history } from '../utils/router';
@@ -677,6 +677,9 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const labels: PrometheusLabels = React.useMemo(() => alert?.labels, [labelsMemoKey]);
 
+  // eslint-disable-next-line camelcase
+  const runbookURL = alert?.annotations?.runbook_url;
+
   return (
     <>
       <Helmet>
@@ -764,6 +767,14 @@ const AlertsDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                           labels={labels}
                           template={rule?.annotations?.message}
                         />
+                      </dd>
+                    </>
+                  )}
+                  {runbookURL && (
+                    <>
+                      <dt>{t('public~Runbook')}</dt>
+                      <dd>
+                        <ExternalLink href={runbookURL} text={runbookURL} />
                       </dd>
                     </>
                   )}
@@ -936,6 +947,9 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
     return `${nameLabel}{${_.map(otherLabels, (v, k) => `${k}="${v}"`).join(',')}}`;
   };
 
+  // eslint-disable-next-line camelcase
+  const runbookURL = rule?.annotations?.runbook_url;
+
   return (
     <>
       <Helmet>
@@ -997,6 +1011,14 @@ const AlertRulesDetailsPage_: React.FC<{ match: any }> = ({ match }) => {
                       <dt>{t('public~Message')}</dt>
                       <dd>
                         <PrometheusTemplate text={rule.annotations.message} />
+                      </dd>
+                    </>
+                  )}
+                  {runbookURL && (
+                    <>
+                      <dt>{t('public~Runbook')}</dt>
+                      <dd>
+                        <ExternalLink href={runbookURL} text={runbookURL} />
                       </dd>
                     </>
                   )}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -920,6 +920,7 @@
   "Alerts": "Alerts",
   "Alert details": "Alert details",
   "Severity": "Severity",
+  "Runbook": "Runbook",
   "Alerting rule": "Alerting rule",
   "Silenced by": "Silenced by",
   "Active since": "Active since",


### PR DESCRIPTION
Jira ticket: https://issues.redhat.com/browse/MON-1649

The field is only displayed if the `runbook_url` annotation exists.

FYI @cshinn 

### Alert
![alert](https://user-images.githubusercontent.com/460802/123898637-a3bd0280-d9a0-11eb-927f-1d9e4df77c27.png)

### Rule
![rule](https://user-images.githubusercontent.com/460802/123898651-a881b680-d9a0-11eb-90fa-2a907f9b0ab1.png)
