### PR TITLE
Add optional checks in health checks probes

### DIFF
--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-check-probe-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-check-probe-utils.spec.ts
@@ -6,7 +6,9 @@ import {
   getRequestType,
   constructProbeData,
   getProbesData,
+  convertResourceDataToFormData,
 } from '../create-health-checks-probe-utils';
+import { HealthCheckProbeData } from '../health-checks-types';
 import {
   healthChecksData,
   healthChecksInputData,
@@ -72,5 +74,65 @@ describe('Create Health Check probe Utils', () => {
     expect(getProbesData(healthChecksInputData.healthChecks, Resources.KnativeService)).toEqual({
       readinessProbe: enabledProbeDataForKnativeService,
     });
+  });
+
+  it('should convert resource health checks data to formData', () => {
+    const readinessProbe = {
+      failureThreshold: 3,
+      httpGet: {
+        scheme: 'HTTP',
+        path: '/',
+        port: 8080,
+        httpHeaders: [{ name: 'header', value: 'val' }],
+      },
+      initialDelaySeconds: 0,
+      periodSeconds: 10,
+      timeoutSeconds: 1,
+      successThreshold: 1,
+    };
+    const data = {
+      failureThreshold: '3',
+      requestType: 'httpGet',
+      httpGet: {
+        scheme: undefined,
+        path: '/',
+        port: '8080',
+        httpHeaders: [{ name: 'header', value: 'val' }],
+      },
+      initialDelaySeconds: '0',
+      periodSeconds: '10',
+      timeoutSeconds: '1',
+      successThreshold: '1',
+    };
+    const formData = convertResourceDataToFormData(readinessProbe);
+    expect(formData).toEqual(data);
+  });
+
+  it('should convert resource health checks data to formData', () => {
+    const readinessProbe = {
+      httpGet: {
+        scheme: 'HTTPS',
+        path: '/',
+        port: 8080,
+        httpHeaders: [{ name: 'header', value: 'val' }],
+      },
+      successThreshold: 1,
+    } as HealthCheckProbeData;
+    const data = {
+      requestType: 'httpGet',
+      httpGet: {
+        scheme: ['HTTPS'],
+        path: '/',
+        port: '8080',
+        httpHeaders: [{ name: 'header', value: 'val' }],
+      },
+      successThreshold: '1',
+      failureThreshold: '',
+      initialDelaySeconds: '',
+      periodSeconds: '',
+      timeoutSeconds: '',
+    };
+    const formData = convertResourceDataToFormData(readinessProbe);
+    expect(formData).toEqual(data);
   });
 });

--- a/frontend/packages/dev-console/src/components/health-checks/create-health-checks-probe-utils.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/create-health-checks-probe-utils.ts
@@ -53,20 +53,20 @@ export const convertResourceDataToFormData = (
   return {
     ...resourceData,
     requestType: getRequestType(resourceData),
-    failureThreshold: resourceData.failureThreshold.toString(),
-    successThreshold: resourceData.successThreshold.toString(),
-    initialDelaySeconds: resourceData.initialDelaySeconds?.toString(),
-    periodSeconds: resourceData.periodSeconds.toString(),
-    timeoutSeconds: resourceData.timeoutSeconds.toString(),
+    failureThreshold: resourceData.failureThreshold?.toString() || '',
+    successThreshold: resourceData.successThreshold?.toString() || '',
+    initialDelaySeconds: resourceData.initialDelaySeconds?.toString() || '',
+    periodSeconds: resourceData.periodSeconds?.toString() || '',
+    timeoutSeconds: resourceData.timeoutSeconds?.toString() || '',
     ...(resourceData.httpGet && {
       httpGet: {
         ...resourceData.httpGet,
-        port: resourceData.httpGet.port.toString(),
+        port: resourceData.httpGet.port?.toString() || '',
         scheme: resourceData.httpGet.scheme === 'HTTP' ? undefined : ['HTTPS'],
       },
     }),
     ...(resourceData.tcpSocket && {
-      tcpSocket: { port: resourceData.tcpSocket.port.toString() },
+      tcpSocket: { port: resourceData.tcpSocket.port?.toString() || '' },
     }),
   };
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6087

**Analysis / Root cause**: 
In knative resource readiness probes auto-added when we create a resource, in which `Failure threshold`, `Initial delay`, `Period`, and `Timeout` is undefined because of that UI breaks.

**Solution Description**: 
Added optional check on these `Failure threshold`, `Initial delay`, `Period`, and `Timeout` probes options.

**Screen shots / Gifs for design review**: 
![Kapture 2021-06-30 at 20 49 01](https://user-images.githubusercontent.com/2561818/123987544-e99bba00-d9e4-11eb-9457-c2f9cd6bf621.gif)
