### PR TITLE
Cypress: Updated isPseudoLocalized() to correctly process multiple elements

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/dashboard-card/DashboardCardTitle.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/dashboard-card/DashboardCardTitle.tsx
@@ -3,7 +3,12 @@ import classNames from 'classnames';
 
 const DashboardCardTitle: React.FC<DashboardCardTitleProps> = React.memo(
   ({ className, children }) => (
-    <h2 className={classNames('co-dashboard-card__title', className)}>{children}</h2>
+    <h2
+      data-test="dashboard-card-title"
+      className={classNames('co-dashboard-card__title', className)}
+    >
+      {children}
+    </h2>
   ),
 );
 

--- a/frontend/packages/integration-tests-cypress/support/i18n.ts
+++ b/frontend/packages/integration-tests-cypress/support/i18n.ts
@@ -48,7 +48,11 @@ Cypress.Commands.add(
     prevSubject: true,
   },
   (subject) => {
-    const text = subject.text();
-    expect(text).to.match(/\[[^a-zA-Z]+\]/);
+    cy.wrap(subject).each(($el) => {
+      const text = $el.text();
+      if (text.length > 0) {
+        expect(text).to.match(/\[[^a-zA-Z]+\]/);
+      }
+    });
   },
 );

--- a/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
@@ -20,7 +20,15 @@ describe('Localization', () => {
     cy.log('test masthead');
     cy.visit('/dashboards?pseudolocalization=true&lng=en');
     masthead.clickMastheadLink('help-dropdown-toggle');
-    cy.byTestID('application-launcher-item').isPseudoLocalized();
+    // wait for both console help menu items and additionalHelpActions items to load
+    // additionalHelpActions come from ConsoleLinks 'HelpMenu' yaml and are not translated
+    cy.get('.pf-c-app-launcher__group').should('have.length', 2);
+    // only test console help items which are translated
+    cy.get('.pf-c-app-launcher__group')
+      .first()
+      .within(() => {
+        cy.get('[role="menuitem"]').isPseudoLocalized();
+      });
   });
 
   it('pseudolocalizes navigation', () => {
@@ -42,7 +50,10 @@ describe('Localization', () => {
   it('pseudolocalizes utilization card', () => {
     cy.log('test utilization card components');
     cy.visit('/dashboards?pseudolocalization=true&lng=en');
-    cy.byTestID('utilization-card-item-text').isPseudoLocalized();
+    cy.byLegacyTestID('utilization-card').within(() => {
+      cy.byTestID('dashboard-card-title').isPseudoLocalized();
+      cy.byTestID('utilization-card-item-text').isPseudoLocalized();
+    });
   });
 
   it('pseudolocalizes monitoring pages', () => {

--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -25,7 +25,7 @@ export const listPage = {
   },
   filter: {
     byName: (name: string) => {
-      cy.byLegacyTestID('item-filter').type(name);
+      cy.byTestID('name-filter-input').type(name);
     },
     numberOfActiveFiltersShouldBe: (numFilters: number) => {
       cy.get("[class='pf-c-toolbar__item pf-m-chip-group']").should('have.length', numFilters);

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -362,6 +362,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
                     />
                   ) : (
                     <TextFilter
+                      data-test="name-filter-input"
                       value={nameInputText}
                       onChange={(value: string) => {
                         setNameInputText(value);

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -308,7 +308,7 @@ class MastheadToolbarContents_ extends React.Component {
   _helpActions(additionalHelpActions) {
     const { flags, cv, t, fireTelemetryEvent } = this.props;
     const helpActions = [];
-    const reportBugLink = cv && cv.data ? getReportBugLink(cv.data) : null;
+    const reportBugLink = cv && cv.data ? getReportBugLink(cv.data, t) : null;
 
     helpActions.push({
       name: '',

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1668,6 +1668,8 @@
   "VolumeSnapshotContents": "VolumeSnapshotContents",
   "ConsolePlugin": "ConsolePlugin",
   "ConsolePlugins": "ConsolePlugins",
+  "Open Support Case with Red Hat": "Open Support Case with Red Hat",
+  "Report Bug to Red Hat": "Report Bug to Red Hat",
   "Loading {{title}} status": "Loading {{title}} status",
   "Unsupported": "Unsupported",
   "Disable": "Disable",

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
 import * as semver from 'semver';
+import i18next from 'i18next';
 
 import { ClusterVersionModel } from '../../models';
 import { referenceForModel } from './k8s';
@@ -209,11 +210,11 @@ Browser: ${window.navigator.userAgent}
 `);
   return _.isEmpty(prerelease)
     ? {
-        label: 'Open Support Case with Red Hat',
+        label: i18next.t('public~Open Support Case with Red Hat'),
         href: `https://access.redhat.com/support/cases/#/case/new?product=OpenShift%20Container%20Platform&version=${major}.${minor}&clusterId=${cv.spec.clusterID}`,
       }
     : {
-        label: 'Report Bug to Red Hat',
+        label: i18next.t('public~Report Bug to Red Hat'),
         href: `https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&version=${bugzillaVersion}&cf_environment=${environment}`,
       };
 };


### PR DESCRIPTION
Previously a call such as:
`cy.byTestID('nav').isPseudoLocalized();` 
would incorrectly result in one call to `isPseudoLocalized()` which would test a single combined text string consisting of all of the text of matching elements!  In this example "[Ḥṓṓṃḛḛ] [ṎṎṽḛḛṛṽḭḭḛḛẁ] [Ṕṛṓṓĵḛḛͼţṡ]...[ṎṎṗḛḛṛααţṓṓṛṡ] [Ḉṓṓṃṗṵṵţḛḛ]..."  -instead of testing each element text individually.  So, `isPseudoLocalized()` would pass as long as first and last elements were translated.

Updated `isPseudoLocalized()` to correctly process multiple elements, as well as:
- updated `pseudolocalization.spec.ts` to correctly test masthead Help menu items and Overview dashboard 'Cluster utilization' card.
- added translations for 'Report Bug to Red Hat' Help menu items
- added `data-test` ids