### PR TITLE
Add an Extension for ODF

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/index.ts
@@ -19,3 +19,4 @@ export * from './actions';
 export * from './topology-details';
 export * from './topology';
 export * from './create-resource';
+export * from './odf';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/odf.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/odf.ts
@@ -1,0 +1,22 @@
+import { ExtensionK8sModel } from '../api/common-types';
+import { ExtensionDeclaration, CodeRef, Extension } from '../types';
+
+type ODFDashboardProps = {
+  /** The name of the instance of the Storage Provider */
+  name: string;
+  /** The kind of the instance of the Storage Provider */
+  kind: string;
+};
+
+/** Third party storage vendors inject dashboards for their System via this extension point */
+export type ODFPluginDashboard = ExtensionDeclaration<
+  'odf.plugin/dashboard',
+  {
+    /** The model for which this dashboard is related to */
+    model: ExtensionK8sModel;
+    component: CodeRef<React.ComponentType<ODFDashboardProps>>;
+  }
+>;
+
+export const isODFDashboardPlugin = (e: Extension): e is ODFPluginDashboard =>
+  e.type === 'odf.plugin/dashboard';


### PR DESCRIPTION
ODF is an integration plane for 3rd party storage vendors. 3rd part vendors should be able to inject dashboards. 
```
export type ODFPluginDashboard = ExtensionDeclaration<
  'odf.plugin/dashboard',
  {
    /** The model for which this dashboard is related to */
    model: ExtensionK8sModel;
    component: CodeRef<React.ComponentType<ODFDashboardProps>>;
  }
>;
```
Ex: An IBM Storage provider will inject its dashboard rather than overwriting a route. This should make things easier for third-party vendors.
This PR also exposes `useResolvedExtensions` as part of the SDK. 
It depends on https://github.com/openshift/console/pull/9230
Please review the latest commit. 
/assign @vojtechszocs @christianvogt 
