### PR TITLE
Bug 1973333: Adjust PO generation script

### DIFF
--- a/frontend/i18n-scripts/i18n-to-po.js
+++ b/frontend/i18n-scripts/i18n-to-po.js
@@ -44,11 +44,6 @@ function consolidateWithExistingTranslations(filePath, fileName, language, packa
       englishFile[matchingKeys[i]] = existingTranslationsFile[matchingKeys[i]];
     }
 
-    const untrackedKeys = existingKeys.filter((k) => englishKeys.indexOf(k) === -1);
-    for (let i = 0; i < untrackedKeys.length; i++) {
-      englishFile[untrackedKeys[i]] = existingTranslationsFile[untrackedKeys[i]];
-    }
-
     fs.writeFileSync(filePath, JSON.stringify(englishFile, null, 2));
   }
 }


### PR DESCRIPTION
The PO generation script now drops keys that are no longer in use in console. This fixes a bug where old unused translations were being carried over in the ZH, JA, and KO language files, even though they were no longer present in the EN files.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1973333.