### PR TITLE
CONSOLE-2838:  masthead changes to better align with ACM

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -24,6 +24,7 @@ import { FLAGS, YellowExclamationTriangleIcon, ACM_LINK_ID } from '@console/shar
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils';
 import CloudShellMastheadButton from '@console/app/src/components/cloud-shell/CloudShellMastheadButton';
 import CloudShellMastheadAction from '@console/app/src/components/cloud-shell/CloudShellMastheadAction';
+import isMultiClusterEnabled from '@console/app/src/utils/isMultiClusterEnabled';
 import * as UIActions from '../actions/ui';
 import { connectToFlags } from '../reducers/connectToFlags';
 import { flagPending, featureReducerName } from '../reducers/features';
@@ -327,6 +328,20 @@ class MastheadToolbarContents_ extends React.Component {
             fireTelemetryEvent('Documentation Clicked');
           },
         },
+        ...(isMultiClusterEnabled()
+          ? [
+              {
+                label: t('public~ACM Documentation'),
+                externalLink: true,
+                // TODO:  add version number to end of URL
+                href:
+                  'https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes',
+                callback: () => {
+                  fireTelemetryEvent('ACM Documentation Clicked');
+                },
+              },
+            ]
+          : []),
         ...(flags[FLAGS.CONSOLE_CLI_DOWNLOAD]
           ? [
               {

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -640,6 +640,7 @@
   "Red Hat applications": "Red Hat applications",
   "Quick Starts": "Quick Starts",
   "Documentation": "Documentation",
+  "ACM Documentation": "ACM Documentation",
   "Command line tools": "Command line tools",
   "About": "About",
   "Language preference": "Language preference",

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -129,12 +129,6 @@ h6 {
   font-family: $font-family-base;
 }
 
-// Temp fix to adjust user menu dropdown toggle padding until it can be converted back to a standard dropdown
-.co-user-menu .pf-c-app-launcher__toggle {
-  padding-left: 0;
-  padding-right: 0;
-}
-
 .pf-c-breadcrumb {
   padding-bottom: 12px;
   padding-top: 25px;


### PR DESCRIPTION
https://github.com/openshift/console/pull/9508 includes the about modal changes since those depend on ACM changes that are still under development.

Changes in this PR:
* If ACM is installed, `ACM Documentation` is added to the help menu
* Remove the padding override around the username dropdown toggle as it is no longer needed