### PR TITLE
Bug 1940059: Add ceph-dashboard link for OCS external cluster overview page

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-external/details-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-external/details-card.tsx
@@ -1,22 +1,28 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
+import { Base64 } from 'js-base64';
+import { referenceForModel, SecretKind } from '@console/internal/module/k8s';
 import { SubscriptionModel } from '@console/operator-lifecycle-manager';
 import {
   withDashboardResources,
   DashboardItemProps,
 } from '@console/internal/components/dashboard/with-dashboard-resources';
-import { FirehoseResource, FirehoseResult } from '@console/internal/components/utils';
-import { getName, getInfrastructurePlatform } from '@console/shared';
+import { FirehoseResource, FirehoseResult, ExternalLink } from '@console/internal/components/utils';
+import { getName } from '@console/shared';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import DetailItem from '@console/shared/src/components/dashboard/details-card/DetailItem';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
-import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
-import { InfrastructureModel } from '@console/internal/models';
+import { SecretModel } from '@console/internal/models';
 import { getOCSVersion } from '../../../selectors';
 import { OCSServiceModel } from '../../../models';
+import { CEPH_STORAGE_NAMESPACE, CEPH_BRAND_NAME } from '../../../constants';
+
+const getCephLink = (secret: SecretKind): string => {
+  const data = secret?.data?.userKey;
+  return data ? Base64.decode(data) : null;
+};
 
 const k8sResources: FirehoseResource[] = [
   {
@@ -31,6 +37,12 @@ const k8sResources: FirehoseResource[] = [
     namespaced: false,
     isList: true,
     prop: 'subscription',
+  },
+  {
+    kind: SecretModel.kind,
+    namespace: CEPH_STORAGE_NAMESPACE,
+    name: 'rook-ceph-dashboard-link',
+    prop: 'cephSecret',
   },
 ];
 
@@ -48,20 +60,19 @@ export const DetailsCard: React.FC<DashboardItemProps> = ({
     };
   }, [watchK8sResource, stopWatchK8sResource]);
 
-  const { ocs, subscription } = resources;
+  const { ocs, subscription, cephSecret } = resources;
   const ocsLoaded = ocs?.loaded || false;
   const ocsError = ocs?.loadError;
   const ocsData = ocs?.data;
+  const secretData = cephSecret?.data as SecretKind;
+  const secretLoaded = cephSecret?.loaded || false;
+  const secretError = cephSecret?.loadError;
   const ocsName = getName(ocsData?.[0]);
   const subscriptionLoaded = subscription?.loaded;
   const subscriptionError = subscription?.loadError;
   const subscriptionVersion = getOCSVersion(subscription as FirehoseResult);
+  const cephLink = getCephLink(secretData);
 
-  const [infrastructure, infrastructureLoaded, infrastructureError] = useK8sGet<K8sResourceKind>(
-    InfrastructureModel,
-    'cluster',
-  );
-  const infrastructurePlatform = getInfrastructurePlatform(infrastructure);
   return (
     <DashboardCard>
       <DashboardCardHeader>
@@ -81,10 +92,9 @@ export const DetailsCard: React.FC<DashboardItemProps> = ({
         </DetailItem>
         <DetailItem
           title={t('ceph-storage-plugin~Provider')}
-          error={!!infrastructureError || (infrastructure && !infrastructurePlatform)}
-          isLoading={!infrastructureLoaded}
+          isLoading={!secretLoaded && !secretError}
         >
-          {infrastructurePlatform}
+          {cephLink ? <ExternalLink href={cephLink} text={CEPH_BRAND_NAME} /> : CEPH_BRAND_NAME}
         </DetailItem>
         <DetailItem title={t('ceph-storage-plugin~Mode')}>External</DetailItem>
         <DetailItem

--- a/frontend/packages/ceph-storage-plugin/src/constants/common.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/common.ts
@@ -2,6 +2,7 @@ export const CEPH_HEALTHY = 'is healthy';
 export const CEPH_DEGRADED = 'health is degraded';
 export const CEPH_ERROR = 'health is in error state';
 export const CEPH_UNKNOWN = 'is not available';
+export const CEPH_BRAND_NAME = 'Red Hat Ceph Storage';
 export const CEPH_STORAGE_NAMESPACE = 'openshift-storage';
 export const PROJECTS = 'Projects';
 export const STORAGE_CLASSES = 'Storage Classes';


### PR DESCRIPTION
Read ceph-dashboard url from the secret and add the link
for ocs external cluster overview page under storage tab in UI.
![image](https://user-images.githubusercontent.com/6670284/128706209-a82d4864-a2ae-4a71-a471-292d0570eab6.png)
![image](https://user-images.githubusercontent.com/6670284/128706410-b1db8de2-8afb-4b25-bc56-59190b8a7ee0.png)



Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>