### PR TITLE
Add simple Content Security Policy

### DIFF
--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -102,6 +102,8 @@ func securityHeadersMiddleware(hdlr http.Handler) http.HandlerFunc {
 		w.Header().Set("X-DNS-Prefetch-Control", "off")
 		// Less information leakage about what domains we link to
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		// Prevent information leakage to external sources
+        w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src: 'self' wss:")
 		hdlr.ServeHTTP(w, r)
 	}
 }


### PR DESCRIPTION
This patch provides a trivial content security policy, that should
provide a sufficient solution for default installations. It forces all
content to originate from the console backend, preventing information
leakage like client IPs to third-parties as it happens with catalog
items.

As the console is unaware of the domain its served from, using `self` as
source, is the easiest way to achieve our goal without requiring any
additional knowledge. Further using the default-src should reduce the
potential regression introduced by this change. Additionally `style-src`
as well was `script-src` will allow general unsafe content, as without
this resulted in a broken web-console. Finally a general `wss`
connection is allowed, to make sure that we can connect to the websocket
without knowing the exact console domain name.

It was put into consideration that customisations of the console might
break by this change, however, this can be solved by allowing further
configuration of the policy and should not prevent a first
implementation of it.

References:
https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html