### PR TITLE
fixes i18n miss in pubsub  modal

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -177,6 +177,7 @@
   "Move {{sourceKind}}": "Move {{sourceKind}}",
   "Connects": "Connects",
   "to": "to",
+  "Select a sink": "Select a sink",
   "Save": "Save",
   "Editing this URI will affect all associated Event Sources.": "Editing this URI will affect all associated Event Sources.",
   "Add Revision": "Add Revision",

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubModal.tsx
@@ -70,7 +70,7 @@ const SinkPubsubModal: React.FC<Props> = ({
             dataSelector={['metadata', 'name']}
             fullWidth
             required
-            placeholder="knative-plugin~Select a sink"
+            placeholder={t('knative-plugin~Select a sink')}
             showBadge
             autocompleteFilter={autocompleteFilter}
             onChange={onSinkChange}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6101

**Analysis / Root cause**: 
i18n was passed as a string to the placeholder

**Solution Description**: 
fixes i18n miss in pubsub  modal

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/5129024/124491360-cf8d1d80-ddd0-11eb-98d1-945707f24332.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
