### PR TITLE
Show N/A when catalog side panel property detail is not available

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -78,6 +78,7 @@
   "Add shared applications, services, event sources, or source-to-image builders to your Project from the developer catalog. Cluster administrators can customize the content made available in the catalog.": "Add shared applications, services, event sources, or source-to-image builders to your Project from the developer catalog. Cluster administrators can customize the content made available in the catalog.",
   "Select a Project to view the developer catalog or <2>create a Project</2>.": "Select a Project to view the developer catalog or <2>create a Project</2>.",
   "Provided by {{provider}}": "Provided by {{provider}}",
+  "N/A": "N/A",
   "Provider": "Provider",
   "Support": "Support",
   "Get support": "Get support",

--- a/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsPanel.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/details/CatalogDetailsPanel.tsx
@@ -12,6 +12,15 @@ type CatalogDetailsPanelProps = {
 const CatalogDetailsPanel: React.FC<CatalogDetailsPanelProps> = ({ item }) => {
   const { t } = useTranslation();
   const { description, provider, creationTimestamp, supportUrl, documentationUrl, details } = item;
+  const created = Date.parse(creationTimestamp) ? (
+    <Timestamp timestamp={creationTimestamp} />
+  ) : (
+    creationTimestamp
+  );
+  const notAvailable = (
+    <span className="properties-side-panel-pf-property-label">{t('devconsole~N/A')}</span>
+  );
+
   return (
     <div className="modal-body modal-body-border">
       <div className="modal-body-content">
@@ -19,32 +28,37 @@ const CatalogDetailsPanel: React.FC<CatalogDetailsPanelProps> = ({ item }) => {
           <div className="co-catalog-page__overlay-body">
             <PropertiesSidePanel>
               {details?.properties?.map((property) => (
-                <PropertyItem key={property.label} label={property.label} value={property.value} />
-              ))}
-              {provider && <PropertyItem label={t('devconsole~Provider')} value={provider} />}
-              {supportUrl && (
                 <PropertyItem
-                  label={t('devconsole~Support')}
-                  value={<ExternalLink href={supportUrl} text={t('devconsole~Get support')} />}
+                  key={property.label}
+                  label={property.label}
+                  value={property.value || notAvailable}
                 />
-              )}
-              {documentationUrl && (
-                <PropertyItem
-                  label={t('devconsole~Documentation')}
-                  value={
+              ))}
+              <PropertyItem label={t('devconsole~Provider')} value={provider || notAvailable} />
+              <PropertyItem
+                label={t('devconsole~Support')}
+                value={
+                  supportUrl ? (
+                    <ExternalLink href={supportUrl} text={t('devconsole~Get support')} />
+                  ) : (
+                    notAvailable
+                  )
+                }
+              />
+              <PropertyItem
+                label={t('devconsole~Documentation')}
+                value={
+                  documentationUrl ? (
                     <ExternalLink
                       href={documentationUrl}
                       text={t('devconsole~Refer documentation')}
                     />
-                  }
-                />
-              )}
-              {creationTimestamp && (
-                <PropertyItem
-                  label={t('devconsole~Created at')}
-                  value={<Timestamp timestamp={creationTimestamp} />}
-                />
-              )}
+                  ) : (
+                    notAvailable
+                  )
+                }
+              />
+              <PropertyItem label={t('devconsole~Created at')} value={created || notAvailable} />
             </PropertiesSidePanel>
             {(details?.descriptions?.length || description) && (
               <div className="co-catalog-page__overlay-description">


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6100
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Side panel for developer catalog displayed the title of property even though the value of the property was not available.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Followed the convention of operator hub catalog updated the catalog side panel to show **N/A** when any property is not available. 
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux @beaumorley 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/124493900-c6ea1680-ddd3-11eb-9b43-1217ca0a417c.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
