### PR TITLE
Fix i18n issue for submit label in delete resource modal

### DIFF
--- a/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/DeleteResourceModal.tsx
@@ -16,7 +16,8 @@ import { YellowExclamationTriangleIcon } from '../status';
 type DeleteResourceModalProps = {
   resourceName: string;
   resourceType: string;
-  actionLabelKey?: string;
+  actionLabel?: string; // Used to send translated strings as action label.
+  actionLabelKey?: string; // Used to send translation key for action label.
   redirect?: string;
   onSubmit: (values: FormikValues) => Promise<K8sResourceKind[]>;
   cancel?: () => void;
@@ -32,6 +33,7 @@ const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceMod
   handleSubmit,
   resourceName,
   resourceType,
+  actionLabel,
   // t('console-shared~Delete')
   actionLabelKey = 'console-shared~Delete',
   isSubmitting,
@@ -41,7 +43,7 @@ const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceMod
 }) => {
   const { t } = useTranslation();
   const isValid = values.resourceName === resourceName;
-  const submitLabel = t(actionLabelKey);
+  const submitLabel = actionLabel || t(actionLabelKey);
   return (
     <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>

--- a/frontend/packages/helm-plugin/src/actions/creators.ts
+++ b/frontend/packages/helm-plugin/src/actions/creators.ts
@@ -15,7 +15,7 @@ export const getHelmDeleteAction = (
       blocking: true,
       resourceName: releaseName,
       resourceType: 'Helm Release',
-      actionLabelKey: t('helm-plugin~Uninstall'),
+      actionLabel: t('helm-plugin~Uninstall'),
       redirect,
       onSubmit: () => {
         return coFetchJSON.delete(


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6103
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Delete resource modal expected an `actionLabelKey` and directly used it inside `t()` as a translation key.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Added a prop for sending translated string instead of just key.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/124496133-aa031280-ddd6-11eb-9c57-7b7f4dfb43c6.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
