### PR TITLE
Fix i18n issue on edit health checks page

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -188,7 +188,7 @@
   "Edit health checks": "Edit health checks",
   "Add health checks": "Add health checks",
   "Learn more": "Learn more",
-  "Health checks for &nbsp;<1></1>": "Health checks for &nbsp;<1></1>",
+  "Health checks for <2></2>": "Health checks for <2></2>",
   "Container": "Container",
   "Container not found": "Container not found",
   "Readiness probe": "Readiness probe",

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -96,7 +96,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
         <div className="odc-add-health-checks__body">
           <p>
             <Trans t={t} ns="devconsole">
-              Health checks for &nbsp;
+              Health checks for{' '}
               <ResourceLink
                 kind={referenceFor(resource)}
                 name={name}


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6096
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Use of `&nbsp;` inside `<Trans>` causes this error.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Use `(' ')` instead of `&nbsp;`.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
No UI change.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
