### PR TITLE
adds access-review on upload jar extension

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -190,7 +190,15 @@
       "href": "/upload-jar/ns/:namespace",
       "label": "%devconsole~Upload JAR file%",
       "description": "%devconsole~Upload a JAR file from your local desktop to OpenShift%",
-      "icon": { "$codeRef": "icons.uploadJarIconElement" }
+      "icon": { "$codeRef": "icons.uploadJarIconElement" },
+      "accessReview": [
+        { "group": "build.openshift.io", "resource": "buildconfigs", "verb": "create" },
+        { "group": "image.openshift.io", "resource": "imagestreams", "verb": "create" },
+        { "group": "apps.openshift.io", "resource": "deploymentconfigs", "verb": "create" },
+        { "group": "", "resource": "secrets", "verb": "create" },
+        { "group": "route.openshift.io", "resource": "routes", "verb": "create" },
+        { "group": "", "resource": "services", "verb": "create" }
+      ]
     }
   },
   {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6099

**Analysis / Root cause**: 
Access review was not happening for upload jar hence shown to user which has view-only access to the namespace

**Solution Description**: 
adds access-review on upload jar extension


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
