### PR TITLE
Bug 1979114: Don't override template api in cusomtization wizard and demo yaml

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-template-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-template-wrapper.ts
@@ -6,7 +6,6 @@ import {
   TEMPLATE_OS_LABEL,
   TEMPLATE_WORKLOAD_LABEL,
 } from '../../../constants/vm';
-import { VirtualMachineModel } from '../../../models';
 import { selectVM } from '../../../selectors/vm-template/basic';
 import { findHighestKeyBySuffixValue, findKeySuffixValue } from '../../../utils';
 import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
@@ -37,14 +36,7 @@ export class VMTemplateWrapper extends K8sResourceWrapper<TemplateKind, VMTempla
 
   getParameters = (defaultValue = []) => (this.data && this.data.parameters) || defaultValue;
 
-  getVM = (copy = false) => {
-    const vm = selectVM(this.data);
-    if (vm && vm.apiVersion) {
-      vm.apiVersion = `${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}`; // Override template api version
-    }
-
-    return new VMWrapper(vm, copy);
-  };
+  getVM = (copy = false) => new VMWrapper(selectVM(this.data), copy);
 
   setParameter = (name, value) => {
     const parameter = this.getParameters().find((param) => param.name === name);


### PR DESCRIPTION
Description:
When we create costume yaml from templates (in yaml view and customization wizard) we override the apiVersion, safer way is not changing it, as installed template should match the installed api.

Screenshot:
Yaml view with CNV2.6.5
![Firefox_Screenshot_2021-07-06T12-34-56 660Z](https://user-images.githubusercontent.com/2181522/124600863-db7bec80-de6f-11eb-90f4-6e482915088c.png)

A customized VM:
![Firefox_Screenshot_2021-07-06T12-40-30 458Z](https://user-images.githubusercontent.com/2181522/124601450-82f91f00-de70-11eb-8d5c-47249e08fe6a.png)

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1979114
https://bugzilla.redhat.com/show_bug.cgi?id=1979116