### PR TITLE
Cypress: disable OLM single install (couchbase operator) test

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -12,7 +12,7 @@ const operatorInstallFormURL = `/operatorhub/subscribe?pkg=${operatorPkgName}&ca
 const operatorInstance = 'CouchbaseCluster';
 const operandLink = 'cb-example';
 
-describe(`Interacting with a single namespace install mode Operator (${operatorName})`, () => {
+xdescribe(`Interacting with a single namespace install mode Operator (${operatorName})`, () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
Disabling due to consistant CI failures using Couchbase operator test.