### PR TITLE
Fix NaN warning issue in request input size component

### DIFF
--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -19,8 +19,10 @@ export const RequestSizeInput: React.FC<RequestSizeInputProps> = ({
   required,
   testID,
 }) => {
-  const [unit, setUnit] = React.useState(defaultRequestSizeUnit);
-  const [value, setValue] = React.useState(parseInt(defaultRequestSizeValue, 10));
+  const parsedRequestSizeValue = parseInt(defaultRequestSizeValue, 10);
+  const defaultValue = Number.isFinite(parsedRequestSizeValue) ? parsedRequestSizeValue : null;
+  const [unit, setUnit] = React.useState<string>(defaultRequestSizeUnit);
+  const [value, setValue] = React.useState<number>(defaultValue);
 
   const onValueChange: React.ReactEventHandler<HTMLInputElement> = (event) => {
     setValue(parseInt(event.currentTarget.value, 10));
@@ -41,8 +43,8 @@ export const RequestSizeInput: React.FC<RequestSizeInputProps> = ({
 
   React.useEffect(() => {
     setUnit(defaultRequestSizeUnit);
-    setValue(parseInt(defaultRequestSizeValue, 10));
-  }, [defaultRequestSizeUnit, defaultRequestSizeValue]);
+    setValue(defaultValue);
+  }, [defaultRequestSizeUnit, defaultValue]);
 
   const { t } = useTranslation();
   const inputName = `${name}Value`;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6089
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Request input size component was trying to parse empty string into an integer which resulted in `NaN` and threw warning.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Check for empty string or null values before attempting integer parse for the value.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No Change
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
