### PR TITLE
Don't show error message when all add actions are disabled

### DIFF
--- a/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddPageLayout.tsx
@@ -23,7 +23,11 @@ const AddPageLayout: React.FC<AddPageLayoutProps> = ({ title, hintBlock: additio
   const { t } = useTranslation();
   const [activeNamespace] = useActiveNamespace();
   const addActionGroupExtensions = useExtensions<AddActionGroup>(isAddActionGroup);
-  const [addActionExtensions, addActionExtensionsResolved] = useAddActionExtensions();
+  const [
+    addActionExtensions,
+    addActionExtensionsResolved,
+    allAddActionsDisabled,
+  ] = useAddActionExtensions();
   const [
     filteredAddActionExtensions,
     filteredAddActionExtensionsLoaded,
@@ -36,9 +40,9 @@ const AddPageLayout: React.FC<AddPageLayoutProps> = ({ title, hintBlock: additio
   const extensionsLoaded: boolean =
     addActionExtensionsResolved && filteredAddActionExtensionsLoaded;
   const addActionLoadingFailed: boolean =
-    addActionExtensionsResolved && addActionExtensions?.length === 0;
+    !allAddActionsDisabled && addActionExtensionsResolved && addActionExtensions?.length === 0;
   const addActionAccessCheckFailed: boolean =
-    extensionsLoaded && filteredAddActionExtensions?.length === 0;
+    !allAddActionsDisabled && extensionsLoaded && filteredAddActionExtensions?.length === 0;
 
   const getHint = (): React.ReactNode => {
     const hintText: string = t(

--- a/frontend/packages/dev-console/src/utils/useAddActionExtensions.ts
+++ b/frontend/packages/dev-console/src/utils/useAddActionExtensions.ts
@@ -18,16 +18,17 @@ export const getDisabledAddActions = (): string[] | undefined => {
   return undefined;
 };
 
-export const useAddActionExtensions = (): [ResolvedExtension<AddAction>[], boolean] => {
+export const useAddActionExtensions = (): [ResolvedExtension<AddAction>[], boolean, boolean] => {
   const [allAddActionExtensions, resolved] = useResolvedExtensions<AddAction>(isAddAction);
   const disabledActions = getDisabledAddActions();
+  const allAddActionsDisabled = disabledActions?.length === allAddActionExtensions?.length;
 
   if (allAddActionExtensions && disabledActions && disabledActions.length > 0) {
     const filteredAddActionExtensions = allAddActionExtensions.filter(
       (addActionExtension) => !disabledActions.includes(addActionExtension.properties.id),
     );
-    return [filteredAddActionExtensions, resolved];
+    return [filteredAddActionExtensions, resolved, allAddActionsDisabled];
   }
 
-  return [allAddActionExtensions, resolved];
+  return [allAddActionExtensions, resolved, allAddActionsDisabled];
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6082
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Add page showed an error state when all add actions are disabled by admin.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Check if all add actions are disabled and do not show error in that case. Only show error when there is actual loading error.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: @openshift/team-devconsole-ux @beaumorley 
<img width="1792" alt="Screenshot 2021-07-06 at 8 39 08 PM" src="https://user-images.githubusercontent.com/6041994/124624570-9d47f280-de9a-11eb-9591-347748989a31.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
