### PR TITLE
Bug 1979620: Parent descriptors don't overwrite children

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
@@ -155,7 +155,7 @@ export const descriptorsToUISchema = (
           mutable.setIn(pathToAdvanced, currentAdvanced.push(advancedPropertyName));
         }
 
-        mutable.setIn(
+        mutable.mergeDeepIn(
           uiSchemaPath,
           Immutable.Map({
             ...(descriptor.description && { 'ui:description': descriptor.description }),


### PR DESCRIPTION
Ensure each descriptor-based react-jsonschema-form (rjsf) UI schema config is merged so that existing values don't get overwritten or removed.