### PR TITLE
Rename monitoring tab to Observe

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/data/mocks/json/monitor-sampleapp-quickstart.ts
+++ b/frontend/packages/console-app/src/components/quick-starts/data/mocks/json/monitor-sampleapp-quickstart.ts
@@ -22,8 +22,8 @@ You should have previously created the **sample-app** application and **nodejs-s
 1. Go to the project your sample application was created in.
 2. In the **</> Developer** perspective, go to **Topology** view.
 3. Click on the **nodejs-sample** deployment to view its details.
-4. Click on the **Monitoring** tab in the side panel.
-You can see context sensitive metrics and alerts in the **Monitoring** tab.`,
+4. Click on the **Observe** tab in the side panel.
+You can see context sensitive metrics and alerts in the **Observe** tab.`,
         review: {
           instructions: `#### To verify you can view the monitoring information:
 1. Do you see a **Metrics** accordion in the side panel?
@@ -55,7 +55,7 @@ Do you see metrics charts in the dashboard?`,
       {
         title: `Viewing custom metrics`,
         description: `### To view custom metrics:
-1. Click on the **Metrics** tab of the **Monitoring** page.
+1. Click on the **Metrics** tab of the **Observe** page.
 2. Click the **Select Query** drop-down list to see the available queries.
 3. Click on **Filesystem Usage** from the list to run the query.`,
         review: {

--- a/frontend/packages/console-app/src/components/quick-starts/data/mocks/yamls/monitor-sampleapp-quickstart.yaml
+++ b/frontend/packages/console-app/src/components/quick-starts/data/mocks/yamls/monitor-sampleapp-quickstart.yaml
@@ -20,9 +20,9 @@ spec:
         1. Go to the project your sample application was created in.
         2. In the **</> Developer** perspective, go to **Topology** view.
         3. Click on the **nodejs-sample** deployment to view its details.
-        4. Click on the **Monitoring** tab in the side panel.
+        4. Click on the **Observe** tab in the side panel.
 
-        You can see context sensitive metrics and alerts in the **Monitoring** tab.
+        You can see context sensitive metrics and alerts in the **Observe** tab.
       review:
         instructions: |-
           #### To verify you can view the monitoring information:
@@ -51,7 +51,7 @@ spec:
     - title: Viewing custom metrics
       description: |-
         ### To view custom metrics:
-        1. Click on the **Metrics** tab of the **Monitoring** page.
+        1. Click on the **Metrics** tab of the **Observe** page.
         2. Click the **Select Query** drop-down list to see the available queries.
         3. Click on **Filesystem Usage** from the list to run the query.
       review:

--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -348,10 +348,10 @@
   {
     "type": "console.navigation/href",
     "properties": {
-      "id": "monitoring",
+      "id": "observe",
       "perspective": "dev",
       "section": "top",
-      "name": "%devconsole~Monitoring%",
+      "name": "%devconsole~Observe%",
       "href": "/dev-monitoring",
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-monitoring",

--- a/frontend/packages/dev-console/integration-tests/support/constants/global.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/global.ts
@@ -1,7 +1,7 @@
 export enum devNavigationMenu {
   Add = '+Add',
   Topology = 'Topology',
-  Monitoring = 'Monitoring',
+  Observe = 'Observe',
   Builds = 'Builds',
   Search = 'Search',
   Helm = 'Helm',

--- a/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
@@ -13,7 +13,7 @@ export const pageTitle = {
   Channel: 'Channel',
   Add: 'Add',
   GitOPs: 'GitOps',
-  Monitoring: 'Monitoring',
+  Observe: 'Observe',
   BuildConfigs: 'Build Configs',
   Search: 'Search',
   HelmReleases: 'Helm Releases',

--- a/frontend/packages/dev-console/integration-tests/support/constants/staticText/topology-text.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/staticText/topology-text.ts
@@ -2,5 +2,5 @@ export const sideBarTabs = {
   details: 'Details',
   resources: 'Resources',
   releaseNotes: 'Release notes',
-  monitoring: 'Monitoring',
+  observe: 'Observe',
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -79,9 +79,9 @@ export const navigateTo = (opt: devNavigationMenu) => {
       cy.testA11y('GitOps Page in dev perspective');
       break;
     }
-    case devNavigationMenu.Monitoring: {
+    case devNavigationMenu.Observe: {
       cy.get(devNavigationMenuPO.monitoring).click();
-      detailsPage.titleShouldContain(pageTitle.Monitoring);
+      detailsPage.titleShouldContain(pageTitle.Observe);
       cy.testA11y('Monitoring Page in dev perspective');
       break;
     }

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/common.ts
@@ -28,7 +28,7 @@ Given('user has created or selected namespace {string}', (projectName: string) =
 });
 
 Given('user is at Monitoring page', () => {
-  navigateTo(devNavigationMenu.Monitoring);
+  navigateTo(devNavigationMenu.Observe);
 });
 
 Given('user is at namespace {string}', (projectName: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/common/monitoring.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/common/monitoring.ts
@@ -3,11 +3,11 @@ import { devNavigationMenu, monitoringTabs } from '../../constants';
 import { navigateTo, monitoringPage } from '../../pages';
 
 Given('user is on Monitoring page', () => {
-  navigateTo(devNavigationMenu.Monitoring);
+  navigateTo(devNavigationMenu.Observe);
 });
 
 When('user navigates to Monitoring page', () => {
-  navigateTo(devNavigationMenu.Monitoring);
+  navigateTo(devNavigationMenu.Observe);
 });
 
 When('user clicks on {string} tab', (tabName: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/dashboard-display.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/dashboard-display.ts
@@ -12,7 +12,7 @@ Given('user has workloads of all resource types', () => {
 });
 
 When('user navigates to Monitoring page', () => {
-  navigateTo(devNavigationMenu.Monitoring);
+  navigateTo(devNavigationMenu.Observe);
 });
 
 When('user selects the workload {string} from the dropdown', (workloadName: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
@@ -26,7 +26,7 @@ Given('user has installed helm release {string}', (helmReleaseName: string) => {
 });
 
 When('user clicks on Monitoring tab', () => {
-  topologySidePane.selectTab(sideBarTabs.monitoring);
+  topologySidePane.selectTab(sideBarTabs.observe);
 });
 
 When('user selects {string} from Context Menu', (menuOption: string) => {
@@ -123,13 +123,13 @@ When('user right clicks on the {string} to open the Context Menu', (nodeName: st
 });
 
 Then('user will be taken to Dashboard tab on the Monitoring page', () => {
-  detailsPage.titleShouldContain(pageTitle.Monitoring);
+  detailsPage.titleShouldContain(pageTitle.Observe);
 });
 
 Then('user wont see Monitoring tab', () => {
   topologySidePane.verify();
   cy.get(topologyPO.sidePane.tabName)
-    .contains(sideBarTabs.monitoring)
+    .contains(sideBarTabs.observe)
     .should('not.be.visible');
 });
 

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -33,7 +33,7 @@
   "**Devfiles** are sets of objects for creating services, build configurations, and anything you have permission to create within a Project.": "**Devfiles** are sets of objects for creating services, build configurations, and anything you have permission to create within a Project.",
   "+Add": "+Add",
   "Topology": "Topology",
-  "Monitoring": "Monitoring",
+  "Observe": "Observe",
   "Search": "Search",
   "Project": "Project",
   "Builds": "Builds",

--- a/frontend/packages/dev-console/src/components/guided-tour/index.ts
+++ b/frontend/packages/dev-console/src/components/guided-tour/index.ts
@@ -24,8 +24,8 @@ export const getGuidedTour = (): TourDataType => ({
     },
     {
       placement: 'right',
-      // t('devconsole~Monitoring')
-      heading: '%devconsole~Monitoring%',
+      // t('devconsole~Observe')
+      heading: '%devconsole~Observe%',
       // t('devconsole~Monitor application metrics, create custom metrics queries and view and silence alerts in your project.')
       content:
         '%devconsole~Monitor application metrics, create custom metrics queries and view and silence alerts in your project.%',

--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -69,11 +69,11 @@ export const PageContents: React.FC<MonitoringPageProps> = ({ match }) => {
   ];
   return activeNamespace ? (
     <>
-      <PageHeading title={t('devconsole~Monitoring')} />
+      <PageHeading title={t('devconsole~Observe')} />
       <HorizontalNav pages={pages} match={match} noStatusBox />
     </>
   ) : (
-    <CreateProjectListPage title={t('devconsole~Monitoring')}>
+    <CreateProjectListPage title={t('devconsole~Observe')}>
       {(openProjectModal) => (
         <Trans t={t} ns="devconsole">
           Select a Project to view monitoring metrics or{' '}
@@ -94,7 +94,7 @@ export const MonitoringPage: React.FC<MonitoringPageProps> = (props) => {
   return (
     <>
       <Helmet>
-        <title>{t('devconsole~Monitoring')}</title>
+        <title>{t('devconsole~Observe')}</title>
       </Helmet>
       <NamespacedPage
         hideApplications

--- a/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/__tests__/MonitoringPage.spec.tsx
@@ -26,7 +26,7 @@ describe('Monitoring Page ', () => {
     };
     const component = shallow(<PageContents {...monPageProps} />);
     expect(component.find(CreateProjectListPage).exists()).toBe(true);
-    expect(component.find(CreateProjectListPage).prop('title')).toBe(`${I18N_NS}~Monitoring`);
+    expect(component.find(CreateProjectListPage).prop('title')).toBe(`${I18N_NS}~Observe`);
   });
 
   it('should render all Tabs of Monitoring page for selected project', () => {
@@ -50,7 +50,7 @@ describe('Monitoring Page ', () => {
 
     const component = shallow(<PageContents {...monPageProps} />);
     expect(component.find(utils.PageHeading).exists()).toBe(true);
-    expect(component.find(utils.PageHeading).prop('title')).toBe(`${I18N_NS}~Monitoring`);
+    expect(component.find(utils.PageHeading).prop('title')).toBe(`${I18N_NS}~Observe`);
     expect(component.find(utils.HorizontalNav).exists()).toBe(true);
     const actualTabs = component
       .find(utils.HorizontalNav)

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -40,8 +40,8 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Overview/Resource',
     properties: {
-      // t('devconsole~Monitoring')
-      name: '%devconsole~Monitoring%',
+      // t('devconsole~Observe')
+      name: '%devconsole~Observe%',
       key: 'isMonitorable',
       loader: () =>
         import(

--- a/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/monitoring/monitoring.spec.ts
@@ -40,8 +40,8 @@ describe('Monitoring: Alerts', () => {
   });
 
   it('displays and filters the Alerts list page, links to detail pages', () => {
-    cy.log('use sidebar nav to go to Monitoring -> Alerting');
-    nav.sidenav.clickNavLink(['Monitoring', 'Alerting']);
+    cy.log('use sidebar nav to go to Observe -> Alerting');
+    nav.sidenav.clickNavLink(['Observe', 'Alerting']);
     // TODO, switch to 'listPage.titleShouldHaveText('Alerting');', when we switch to new test id
     cy.byLegacyTestID('resource-title').should('have.text', 'Alerting');
     projectDropdown.shouldNotExist();

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -42,7 +42,7 @@ Given('user is at Topology page', () => {
 });
 
 Given('user is at Monitoring page', () => {
-  navigateTo(devNavigationMenu.Monitoring);
+  navigateTo(devNavigationMenu.Observe);
 });
 
 When('user clicks create button', () => {

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/MonitoringAlertsDecorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/MonitoringAlertsDecorator.tsx
@@ -18,7 +18,7 @@ type DispatchProps = {
 };
 
 const dispatchToProps = (dispatch: Dispatch): DispatchProps => ({
-  showMonitoringOverview: () => dispatch(selectOverviewDetailsTab('Monitoring')),
+  showMonitoringOverview: () => dispatch(selectOverviewDetailsTab('Observe')),
 });
 
 interface MonitoringAlertsDecoratorProps {

--- a/frontend/packages/topology/src/components/list-view/TopologyListViewNode.tsx
+++ b/frontend/packages/topology/src/components/list-view/TopologyListViewNode.tsx
@@ -79,7 +79,7 @@ const TopologyListViewNode: React.FC<TopologyListViewNodeProps & DispatchProps> 
   if (alerts?.length > 0) {
     const onAlertClick = () => {
       onSelect([item.getId()]);
-      onSelectTab('Monitoring');
+      onSelectTab('Observe');
     };
     const severityAlertType = getSeverityAlertType(alerts);
     alertIndicator = shouldHideMonitoringAlertDecorator(severityAlertType) ? null : (

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -66,11 +66,7 @@ const monitoringNavSectionStateToProps = (state) => ({
 const MonitoringNavSection_ = ({ canAccess }) => {
   const { t } = useTranslation();
   return canAccess && !!window.SERVER_FLAGS.prometheusBaseURL ? (
-    <NavSection
-      id="monitoring"
-      title={t('public~Monitoring')}
-      data-quickstart-id="qs-nav-monitoring"
-    >
+    <NavSection id="observe" title={t('public~Observe')} data-quickstart-id="qs-nav-monitoring">
       <HrefLink
         id="monitoringalerts"
         href="/monitoring/alerts"

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -247,7 +247,7 @@ export type NavSectionTitle =
   | 'Builds'
   | 'Compute'
   | 'Home'
-  | 'Monitoring'
+  | 'Observe'
   | 'Networking'
   | 'Operators'
   | 'Service Catalog'

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1028,7 +1028,7 @@
   "All Namespaces": "All Namespaces",
   "Select Project...": "Select Project...",
   "Select Namespace...": "Select Namespace...",
-  "Monitoring": "Monitoring",
+  "Observe": "Observe",
   "Home": "Home",
   "Search": "Search",
   "Workloads": "Workloads",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6088

**Description**: 
Rename monitoring tab and nav option to Observe

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/124632462-fd8e6280-dea1-11eb-95d0-65e84e8047ca.png)

![image](https://user-images.githubusercontent.com/2561818/124632544-13038c80-dea2-11eb-9640-d0ba04746617.png)

![image](https://user-images.githubusercontent.com/2561818/124632704-36c6d280-dea2-11eb-9629-c3a301d7a1f4.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge