### PR TITLE
Bug 1966499: Switch Cypress OLM tests to use supported Red Hat operators

### DIFF
--- a/frontend/packages/integration-tests-cypress/views/list-page.ts
+++ b/frontend/packages/integration-tests-cypress/views/list-page.ts
@@ -25,7 +25,9 @@ export const listPage = {
   },
   filter: {
     byName: (name: string) => {
-      cy.byTestID('name-filter-input').type(name);
+      cy.byTestID('name-filter-input')
+        .clear()
+        .type(name);
     },
     numberOfActiveFiltersShouldBe: (numFilters: number) => {
       cy.get("[class='pf-c-toolbar__item pf-m-chip-group']").should('have.length', numFilters);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -2,20 +2,19 @@ import { checkErrors } from '../../../integration-tests-cypress/support';
 import { nav } from '../../../integration-tests-cypress/views/nav';
 import { operator, GlobalInstalledNamespace, TestOperandProps } from '../views/operator.view';
 
-// TODO find light-weight RH global operator!
 const testOperator = {
-  name: '',
-  operatorHubCardTestID: '',
+  name: 'Service Binding Operator',
+  operatorHubCardTestID: 'rh-service-binding-operator-redhat-operators-openshift-marketplace',
 };
 
 const testOperand: TestOperandProps = {
-  name: '',
-  kind: '',
-  tabName: '',
-  exampleName: ``,
+  name: 'ServiceBinding',
+  kind: 'ServiceBinding',
+  tabName: 'Service Binding',
+  exampleName: `example-servicebinding`,
 };
 
-xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
+describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
     cy.visit('/');
@@ -43,6 +42,7 @@ xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstal
     cy.byLegacyTestID('resource-summary').should('exist');
 
     operator.createOperand(testOperator.name, testOperand);
+    cy.byTestOperandLink(testOperand.exampleName).should('exist');
     operator.operandShouldExist(testOperator.name, testOperand);
 
     operator.deleteOperand(testOperator.name, testOperand);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -1,27 +1,26 @@
 import { checkErrors } from '../../../integration-tests-cypress/support';
-import { detailsPage } from '../../../integration-tests-cypress/views/details-page';
-import { modal } from '../../../integration-tests-cypress/views/modal';
 import { nav } from '../../../integration-tests-cypress/views/nav';
-import { createCatalogSource, deleteCatalogSource } from '../views/catalog-source.view';
+import { operator, GlobalInstalledNamespace, TestOperandProps } from '../views/operator.view';
 
-const operatorName = 'Portworx Essentials';
-const catalogSourceName = 'console-e2e';
-const operatorID = 'portworx-essentials-console-e2e-openshift-marketplace';
-const operatorRow = 'Portworx Essentials';
-const operatorPkgName = 'portworx-essentials';
-const operatorInstallFormURL = `/operatorhub/subscribe?pkg=${operatorPkgName}&catalog=${catalogSourceName}&catalogNamespace=openshift-marketplace&targetNamespace=`;
-const operatorInstance = 'StorageCluster';
-const openshiftOperatorsNS = 'openshift-operators';
-const operandLink = 'portworx';
+// TODO find light-weight RH global operator!
+const testOperator = {
+  name: '',
+  operatorHubCardTestID: '',
+};
 
-// TODO: Disable until https://github.com/libopenstorage/operator/pull/323 is merged
-xdescribe(`Interacting with a global install mode Operator (${operatorName})`, () => {
+const testOperand: TestOperandProps = {
+  name: '',
+  kind: '',
+  tabName: '',
+  exampleName: ``,
+};
+
+xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
     cy.visit('/');
     nav.sidenav.switcher.changePerspectiveTo('Administrator');
     nav.sidenav.switcher.shouldHaveText('Administrator');
-    createCatalogSource(operatorName, catalogSourceName);
   });
 
   afterEach(() => {
@@ -29,103 +28,24 @@ xdescribe(`Interacting with a global install mode Operator (${operatorName})`, (
   });
 
   after(() => {
-    cy.log('navigate to OperatorHub > Sources');
-    deleteCatalogSource(catalogSourceName);
+    operator.uninstall(testOperator.name);
+    operator.shouldNotExist(testOperator.name);
     cy.logout();
   });
 
-  it(`displays subscription creation form for ${operatorName}`, () => {
-    cy.log('navigate to the Operator install form from OperatorHub');
-    cy.visit('/operatorhub/all-namespaces');
-    cy.byTestID('search-operatorhub').type(operatorName);
-    cy.byTestID(operatorID).click();
-    cy.log('go to the install form');
-    cy.byLegacyTestID('operator-install-btn').click({ force: true });
-    cy.url().should('include', operatorInstallFormURL);
-  });
+  it(`Globally installs ${testOperator.name} operator in ${GlobalInstalledNamespace} and creates ${testOperand.name} operand`, () => {
+    operator.install(testOperator.name, testOperator.operatorHubCardTestID);
+    operator.installedSucceeded(testOperator.name);
 
-  it(`creates the global install mode ClusterServiceVersion for ${operatorName}`, () => {
-    cy.visit(operatorInstallFormURL);
-    cy.byTestID('install-operator').click();
-    cy.log('verify Operator began installation');
-    cy.byTestID('view-installed-operators-btn').should(
-      'contain',
-      `View installed Operators in Namespace ${openshiftOperatorsNS}`,
-    );
-    cy.log('view the ClusterServiceVersion list page');
-    cy.byTestID('view-installed-operators-btn').click();
-    cy.log(`verify the ClusterServiceVersion row for ${operatorRow} exists`);
-    cy.byTestOperatorRow(operatorRow, { timeout: 60000 }).should('exist');
-  });
-
-  it(`displays details about ${operatorName} ClusterServiceVersion on the "Details" tab`, () => {
-    cy.log(`navigate to the ${operatorName} details page`);
-    cy.byTestOperatorRow(operatorRow).click();
+    operator.navToDetailsPage(testOperator.name);
     cy.byTestSectionHeading('Provided APIs').should('exist');
     cy.byTestSectionHeading('ClusterServiceVersion details').should('exist');
     cy.byLegacyTestID('resource-summary').should('exist');
-  });
 
-  it(`displays empty message on the ${operatorName} ClusterServiceVersion "All Instances" tab`, () => {
-    cy.log('navigate to the "All instances" tab');
-    cy.byLegacyTestID('horizontal-link-olm~All instances').click();
-    cy.byTestID('msg-box-title').should('contain', 'No operands found');
-    cy.byTestID('msg-box-detail').should(
-      'contain',
-      'Operands are declarative components used to define the behavior of the application.',
-    );
-  });
+    operator.createOperand(testOperator.name, testOperand);
+    operator.operandShouldExist(testOperator.name, testOperand);
 
-  it(`displays ${operatorName} ${operatorInstance} creation form`, () => {
-    cy.log('navigate to the form');
-    cy.byLegacyTestID('dropdown-button')
-      .click()
-      .get('[data-test-dropdown-menu="storageclusters.core.libopenstorage.org"]')
-      .click();
-    cy.byLegacyTestID('resource-title').should('contain', `Create ${operatorInstance}`);
-  });
-
-  it(`creates a ${operatorName} ${operatorInstance} instance via the form`, () => {
-    cy.log('create a new instance');
-    cy.byTestID('create-dynamic-form').click();
-    cy.byTestOperandLink(operandLink).should('contain', 'portworx');
-  });
-
-  it(`displays details about ${operatorName} ${operatorInstance} instance on the "Details" tab`, () => {
-    cy.log(`navigate to the "Details" tab`);
-    cy.byTestOperandLink(operandLink).click();
-    cy.byTestSectionHeading('Storage Cluster overview').should('exist');
-  });
-
-  it(`deletes the ${operatorName} ${operatorInstance} instance`, () => {
-    detailsPage.clickPageActionFromDropdown(`Delete ${operatorInstance}`);
-    modal.shouldBeOpened();
-    modal.submit();
-    modal.shouldBeClosed();
-    cy.byTestID('msg-box-title').should('contain', 'No operands found');
-    cy.byTestID('msg-box-detail').should(
-      'contain',
-      'Operands are declarative components used to define the behavior of the application.',
-    );
-  });
-
-  it(`uninstalls the Operator`, () => {
-    cy.log('navigate to the Operator uninstall modal in OperatorHub');
-    cy.visit('/operatorhub/all-namespaces');
-    cy.byTestID('search-operatorhub').type(operatorName);
-    cy.byTestID(operatorID).click();
-    cy.log('uninstall the operator');
-    cy.byLegacyTestID('operator-uninstall-btn').click({ force: true });
-    cy.url().should(
-      'include',
-      `/k8s/ns/${openshiftOperatorsNS}/subscriptions/${operatorPkgName}?showDelete=true`,
-    );
-    modal.shouldBeOpened();
-    modal.modalTitleShouldContain('Uninstall Operator?');
-    modal.submit(true);
-    modal.shouldBeClosed();
-    cy.log('verify the Operator is not installed');
-    cy.get('.loading-skeleton--table').should('not.exist');
-    cy.byTestOperatorRow(operatorRow).should('not.exist');
+    operator.deleteOperand(testOperator.name, testOperand);
+    operator.operandShouldNotExist(testOperator.name, testOperand);
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
@@ -1,0 +1,200 @@
+import { projectDropdown } from '@console/cypress-integration-tests/views/common';
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { submitButton } from '@console/cypress-integration-tests/views/form';
+import { listPage } from '@console/cypress-integration-tests/views/list-page';
+import { modal } from '@console/cypress-integration-tests/views/modal';
+import { nav } from '@console/cypress-integration-tests/views/nav';
+
+export const GlobalInstalledNamespace = 'openshift-operators';
+
+export const operator = {
+  install: (
+    operatorName: string,
+    operatorHubCardTestID: string,
+    installToNamespace: string = GlobalInstalledNamespace,
+    useOperatorRecommendedNamespace: boolean = false,
+  ) => {
+    cy.log(`install operator "${operatorName}" in ${installToNamespace}`);
+    nav.sidenav.clickNavLink(['Operators', 'OperatorHub']);
+    cy.byTestID('search-operatorhub').type(operatorName);
+    cy.log('go to operator overview panel');
+    cy.byTestID(operatorHubCardTestID).click();
+    cy.log('go to the install form');
+    cy.byLegacyTestID('operator-install-btn').click({ force: true });
+    /*  Installation mode
+     *    () All namespaces        // default: 'openshift-operators'
+     *    () A specific namespace  // Operator recommended or test namespace
+     *  Installed Namespace
+     *    () Operator recommended Namespace
+     *      [] Enable Operator recommended monitoring - // TODO add testing support for this
+     *    () Select a Namespace
+     *      [Select Namespace v] // dropdown defaults to global ns ('openshift-operators') or test namespace (when 'Select a Namespace radio' is checked!)
+     *                           // dropdown not shown at all when 'Operator recommended Namespace radio' is checked!
+     */
+    if (installToNamespace !== GlobalInstalledNamespace) {
+      cy.log('configure Operator install for single namespace');
+      cy.byTestID('A specific namespace on the cluster-radio-input').check();
+      if (useOperatorRecommendedNamespace) {
+        cy.log('configure Operator install for operator recommended namespace');
+        cy.byTestID('Operator recommended Namespace:-radio-input').check();
+      } else {
+        // eslint-disable-next-line promise/catch-or-return
+        cy.get('body').then(($body) => {
+          if ($body.find('input[data-test="Select a Namespace-radio-input"]').length > 0) {
+            cy.byTestID('Select a Namespace-radio-input').check();
+          }
+        });
+      }
+    } else {
+      cy.byTestID('All namespaces on the cluster-radio-input').should('be.checked');
+    }
+    if (!useOperatorRecommendedNamespace) {
+      cy.log(`verify namespace dropdown shows the "${installToNamespace}" namespace`);
+      cy.byTestID('dropdown-selectbox').should('contain', installToNamespace);
+    }
+    // Install
+    cy.byTestID('install-operator').click();
+    cy.log('verify Operator began installation');
+    cy.byTestID('view-installed-operators-btn').should(
+      'contain',
+      `View installed Operators in Namespace`,
+    );
+    cy.log(`navigate to OperatorHub in Namespace: ${installToNamespace}`);
+    cy.byTestID('view-installed-operators-btn').click();
+  },
+  installedSucceeded: (
+    operatorName: string,
+    installToNamespace: string = GlobalInstalledNamespace,
+  ) => {
+    cy.log(`operator "${operatorName}" should exist in ${installToNamespace}`);
+    nav.sidenav.clickNavLink(['Operators', 'Installed Operators']);
+    listPage.titleShouldHaveText('Installed Operators');
+    listPage.filter.byName(operatorName);
+    cy.byTestOperatorRow(operatorName, { timeout: 180000 }).should('exist'); // 3 minutes
+    cy.byTestOperatorRow(operatorName)
+      .parents('tr')
+      .within(() => {
+        cy.byTestID('status-text', { timeout: 720000 }).should('have.text', 'Succeeded'); // 12 minutes
+      });
+  },
+  navToDetailsPage: (
+    operatorName: string,
+    installedNamespace: string = GlobalInstalledNamespace,
+  ) => {
+    cy.log(`navigate to details page of operator "${operatorName}"`);
+    nav.sidenav.clickNavLink(['Operators', 'Installed Operators']);
+    listPage.titleShouldHaveText('Installed Operators');
+    projectDropdown.selectProject(installedNamespace);
+    projectDropdown.shouldContain(installedNamespace);
+    listPage.filter.byName(operatorName);
+    listPage.rows.countShouldBe(1);
+    cy.byTestOperatorRow(operatorName).should('exist');
+    cy.byTestOperatorRow(operatorName).click();
+  },
+  uninstallModal: {
+    open: (operatorName: string, installedNamespace: string = GlobalInstalledNamespace) => {
+      cy.log('open uninstall modal');
+      operator.navToDetailsPage(operatorName, installedNamespace);
+      detailsPage.clickPageActionFromDropdown('Uninstall Operator');
+      modal.shouldBeOpened();
+      modal.modalTitleShouldContain('Uninstall Operator?');
+      cy.get('.loading-skeleton--table').should('not.exist');
+    },
+    checkDeleteAllOperands: () =>
+      cy.byTestID('Delete all operand instances for this operator__checkbox').click(),
+  },
+  createOperand: (
+    operatorName: string,
+    testOperand: TestOperandProps,
+    installedNamespace: string = GlobalInstalledNamespace,
+  ) => {
+    const { tabName, exampleName } = testOperand;
+    cy.log(`create operand "${exampleName}" for "${operatorName}" in ${installedNamespace}`);
+    operator.navToDetailsPage(operatorName, installedNamespace);
+    cy.log(`navigate to the "${tabName}" tab`);
+    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    cy.byTestID('msg-box-title').should('contain', 'No operands found');
+    cy.byTestID('msg-box-detail').should(
+      'contain',
+      'Operands are declarative components used to define the behavior of the application.',
+    );
+    listPage.clickCreateYAMLbutton();
+    cy.url().should('contain', '~new');
+    cy.log('create a new operand');
+    cy.get('label')
+      .contains('Name')
+      .parent()
+      .within(() => {
+        cy.get('input').clear();
+        cy.get('input').type(exampleName);
+      });
+    cy.get(submitButton).click();
+  },
+  operandShouldExist: (
+    operatorName: string,
+    testOperand: TestOperandProps,
+    installedNamespace: string = GlobalInstalledNamespace,
+  ) => {
+    const { name, tabName, exampleName } = testOperand;
+    cy.log(`operand "${exampleName}" should exist for "${operatorName}" in ${installedNamespace}`);
+    operator.navToDetailsPage(operatorName, installedNamespace);
+    cy.log(`navigate to the "${tabName}" tab`);
+    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    cy.byTestOperandLink(exampleName).should('contain', exampleName);
+    cy.log(`navigate to the operand "Details" tab`);
+    cy.byTestOperandLink(exampleName).click();
+    cy.url().should('match', new RegExp(`${exampleName}$`)); // url should end with example operand name
+    cy.get('[data-test-section-heading]')
+      .first()
+      .invoke('text')
+      .should('match', new RegExp(`^${name}`)); // 1st heading should start with operand name
+  },
+  deleteOperand: (
+    operatorName: string,
+    testOperand: TestOperandProps,
+    installedNamespace: string = GlobalInstalledNamespace,
+  ) => {
+    const { kind: operandKind, tabName, exampleName } = testOperand;
+    cy.log(`delete operand: ${exampleName}`);
+    operator.navToDetailsPage(operatorName, installedNamespace);
+    cy.log(`navigate to the "${tabName}" tab`);
+    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    // drilldown to Operand details page
+    cy.byTestOperandLink(exampleName).click();
+    detailsPage.clickPageActionFromDropdown(`Delete ${operandKind}`);
+    modal.shouldBeOpened();
+    modal.submit();
+    modal.shouldBeClosed();
+  },
+  operandShouldNotExist: (
+    operatorName: string,
+    testOperand: TestOperandProps,
+    installedNamespace: string = GlobalInstalledNamespace,
+  ) => {
+    const { tabName, exampleName } = testOperand;
+    cy.log(`operand "${exampleName}" should not exist`);
+    operator.navToDetailsPage(operatorName, installedNamespace);
+    cy.log(`navigate to the "${tabName}" tab`);
+    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    cy.byTestOperandLink(exampleName).should('not.exist');
+  },
+  uninstall: (operatorName: string, installedNamespace: string = GlobalInstalledNamespace) => {
+    cy.log(`uninstall operator "${operatorName}" in ${installedNamespace}`);
+    operator.navToDetailsPage(operatorName, installedNamespace);
+    operator.uninstallModal.open(operatorName, installedNamespace);
+    modal.submit(true);
+    modal.shouldBeClosed();
+  },
+  shouldNotExist: (operatorName: string, installToNamespace: string = GlobalInstalledNamespace) => {
+    cy.log(`operator "${operatorName}" should not exist in ${installToNamespace}`);
+    nav.sidenav.clickNavLink(['Operators', 'Installed Operators']);
+    cy.byTestOperatorRow(operatorName).should('not.exist');
+  },
+};
+
+export type TestOperandProps = {
+  name: string;
+  kind: string;
+  tabName: string;
+  exampleName: string;
+};

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
@@ -71,11 +71,8 @@ export const operator = {
     listPage.titleShouldHaveText('Installed Operators');
     listPage.filter.byName(operatorName);
     cy.byTestOperatorRow(operatorName, { timeout: 180000 }).should('exist'); // 3 minutes
-    cy.byTestOperatorRow(operatorName)
-      .parents('tr')
-      .within(() => {
-        cy.byTestID('status-text', { timeout: 720000 }).should('have.text', 'Succeeded'); // 12 minutes
-      });
+    listPage.rows.countShouldBe(1);
+    cy.byTestID('status-text', { timeout: 720000 }).should('contain.text', 'Succeeded'); // 12 minutes
   },
   navToDetailsPage: (
     operatorName: string,

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -553,6 +553,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
       <div className="form-group">
         <Dropdown
           id="dropdown-selectbox"
+          dataTest="dropdown-selectbox"
           dropDownClassName="dropdown--full-width"
           menuClassName="dropdown-menu--text-wrap"
           items={items}


### PR DESCRIPTION
- OLM single-install test changed from community Couchbase operator to Red Hat CodeReady Workspaces
- OLM global-install test changed from community Portworx operator to Red Hat Service Binding Operator

I replaced the entire contents of `operator-install-global.spec.ts` and `operator-install-single-namespace.spec.ts` so I suggest looking at these files in 'raw format' as the Diff view is hard to follow due to so many changes.