### PR TITLE
Removes Pipeline Graph alignment setting

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/const.ts
@@ -66,7 +66,6 @@ const DAGRE_SHARED_PROPS: dagre.GraphLabel = {
   edgesep: 25,
   ranker: 'longest-path',
   rankdir: 'LR',
-  align: 'UL',
   marginx: 20,
   marginy: 20,
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5100

**Analysis / Root cause**: 
Our current layout algorithm for Pipeline Topology is called Dagre. Dagre lays out our graph in such a fashion that goes from one side to another (in our case left to right). The problem we had was it was built to try and mimic the previous column-layout which in itself had several layout problems (couldn't do complex graphs). 

**Solution Description**: 
Removed the 'top left' alignment from the Dagre layout in order to go with a more middle-vertical alignment. This doesn't "solve" all the problems, but it makes it more balanced.

There are still several issues with the layout, and after trying to tweak them, I am fairly confident there is little we can do with our current Dagre layout and not get into a wack-a-mole of problem solving layout issues.

Screenshots at the bottom as they are many.

**Unit test coverage report**: 
None, we don't have tests for Dagre layouts. Although some though in this area probably wouldn't hurt (not sure of a clean deterministic way of testing).

**Test setup:**

[Used these pipelines](https://github.com/andrewballantyne/pipeline-scratch-pad/tree/master/examples/pipeline-designs) 

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

**Screenshots**:

![Screen Shot 2021-07-06 at 6 42 55 PM](https://user-images.githubusercontent.com/8126518/124678130-ee9eb480-de8f-11eb-83fb-e7cf3b505810.png)
![Screen Shot 2021-07-06 at 6 43 02 PM](https://user-images.githubusercontent.com/8126518/124678132-ee9eb480-de8f-11eb-9b6b-9370474fdd53.png)
![Screen Shot 2021-07-06 at 6 43 09 PM](https://user-images.githubusercontent.com/8126518/124678134-ef374b00-de8f-11eb-90e5-cf8b455c7e62.png)
![Screen Shot 2021-07-06 at 6 43 15 PM](https://user-images.githubusercontent.com/8126518/124678135-ef374b00-de8f-11eb-8ab6-a1afec8f4148.png)
![Screen Shot 2021-07-06 at 6 43 21 PM](https://user-images.githubusercontent.com/8126518/124678136-ef374b00-de8f-11eb-906d-9e1da2bf4573.png)
![Screen Shot 2021-07-06 at 6 43 27 PM](https://user-images.githubusercontent.com/8126518/124678137-efcfe180-de8f-11eb-8564-66ad0ae78f0a.png)
![Screen Shot 2021-07-06 at 6 43 34 PM](https://user-images.githubusercontent.com/8126518/124678138-efcfe180-de8f-11eb-982e-90b69dfc618c.png)
![Screen Shot 2021-07-06 at 6 43 39 PM](https://user-images.githubusercontent.com/8126518/124678139-efcfe180-de8f-11eb-8b95-474c8d13d210.png)
![Screen Shot 2021-07-06 at 6 43 51 PM](https://user-images.githubusercontent.com/8126518/124678140-efcfe180-de8f-11eb-9903-10d414cf2a29.png)
![Screen Shot 2021-07-06 at 6 43 56 PM](https://user-images.githubusercontent.com/8126518/124678141-efcfe180-de8f-11eb-81e4-aa5299259d62.png)
![Screen Shot 2021-07-06 at 6 44 03 PM](https://user-images.githubusercontent.com/8126518/124678142-f0687800-de8f-11eb-9aa6-49a389519336.png)
![Screen Shot 2021-07-06 at 6 44 10 PM](https://user-images.githubusercontent.com/8126518/124678144-f0687800-de8f-11eb-9b8d-552395d7874f.png)
![Screen Shot 2021-07-06 at 6 44 17 PM](https://user-images.githubusercontent.com/8126518/124678146-f0687800-de8f-11eb-87b9-f2b82d55fc36.png)
![Screen Shot 2021-07-06 at 6 44 25 PM](https://user-images.githubusercontent.com/8126518/124678147-f0687800-de8f-11eb-9095-a994b108844f.png)
![Screen Shot 2021-07-06 at 6 44 37 PM](https://user-images.githubusercontent.com/8126518/124678148-f1010e80-de8f-11eb-8e76-6cfb91aa8ff7.png)
![Screen Shot 2021-07-06 at 6 44 46 PM](https://user-images.githubusercontent.com/8126518/124678150-f1010e80-de8f-11eb-9544-8d7217a7921c.png)
![Screen Shot 2021-07-06 at 6 44 52 PM](https://user-images.githubusercontent.com/8126518/124678151-f1010e80-de8f-11eb-87ac-86412aec768c.png)
![Screen Shot 2021-07-06 at 6 44 59 PM](https://user-images.githubusercontent.com/8126518/124678152-f1010e80-de8f-11eb-9e08-2b3e4135d262.png)
![Screen Shot 2021-07-06 at 6 45 06 PM](https://user-images.githubusercontent.com/8126518/124678153-f199a500-de8f-11eb-8877-a5adb1ce1494.png)
![Screen Shot 2021-07-06 at 6 45 13 PM](https://user-images.githubusercontent.com/8126518/124678154-f199a500-de8f-11eb-958a-36a67e56139b.png)
![Screen Shot 2021-07-06 at 6 45 20 PM](https://user-images.githubusercontent.com/8126518/124678155-f199a500-de8f-11eb-9096-2a1eb152ef92.png)
![Screen Shot 2021-07-06 at 6 45 26 PM](https://user-images.githubusercontent.com/8126518/124678156-f199a500-de8f-11eb-9bf3-bf635d5fb66c.png)
![Screen Shot 2021-07-06 at 6 45 34 PM](https://user-images.githubusercontent.com/8126518/124678157-f199a500-de8f-11eb-9c50-1c465748c75f.png)
![Screen Shot 2021-07-06 at 6 45 43 PM](https://user-images.githubusercontent.com/8126518/124678158-f2323b80-de8f-11eb-975f-be08081ad396.png)


