### PR TITLE
Gherkin: unique url quick starts

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
@@ -124,3 +124,10 @@ Feature: Build with guided documentation card in developer console
               And user clicks on Save button
               And user selects Quick Starts from help menu
              Then user will not be able to see "Exploring Serverless applications", "Get started with a sample application", "Install the OpenShift Pipelines Operator" and "Add health checks to your sample application" quick starts in the quick start catalog
+
+
+        @odc-5715 @to-do
+        Scenario: Unique url to a Quick Start
+            Given user is at Quick Start catalog page
+              And user clicks "Exploring Serverless applications" card
+             Then user can see url has "quickstart?quickstart=serverless-application" in the address bar


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-5715
Story: https://issues.redhat.com/browse/ODC-5984

Acceptance criteria:

- Each quick start should have a unique URL which can be accessed 

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]