### PR TITLE
Bug 1980257: Remove kube admin notifier for kubeadmin crc user

### DIFF
--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -45,8 +45,8 @@ export const COMMUNITY_PROVIDERS_WARNING_USERSETTINGS_KEY = `${USERSETTINGS_PREF
 export const PINNED_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/pinned-resources`;
 export const COLUMN_MANAGEMENT_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/table-columns`;
 
-// Bootstrap user for OpenShift 4.0 clusters (kube:admin) and CRC (kubeadmin)
-export const KUBE_ADMIN_USERNAMES = ['kube:admin', 'kubeadmin'];
+// Bootstrap user for OpenShift 4.0 clusters (kube:admin)
+export const KUBE_ADMIN_USERNAMES = ['kube:admin'];
 
 export const RH_OPERATOR_SUPPORT_POLICY_LINK =
   'https://access.redhat.com/third-party-software-support';


### PR DESCRIPTION
The OAuth configuration is already changed by crc. The password for the
kubeadmin user is rotated automatically.

---

It removes this banner for crc. This also impacts 4.8. It would be good if it can be backported.
https://github.com/code-ready/crc/issues/2547

![Screenshot from 2021-07-07 11-31-25](https://user-images.githubusercontent.com/172624/124736101-fb1a2000-df16-11eb-800c-804251d97e1e.png)
