### PR TITLE
Add RBAC check on view shortcuts actions

### DIFF
--- a/frontend/packages/topology/src/__tests__/TopologyShortcuts.spec.tsx
+++ b/frontend/packages/topology/src/__tests__/TopologyShortcuts.spec.tsx
@@ -18,6 +18,7 @@ describe('TopologyShortcuts tests', () => {
         supportedFileTypes: undefined,
         isEmptyModel: true,
         viewType: TopologyViewType.graph,
+        allImportAccess: true,
       }),
     );
 
@@ -41,6 +42,7 @@ describe('TopologyShortcuts tests', () => {
         supportedFileTypes: ['jar'],
         isEmptyModel: true,
         viewType: TopologyViewType.graph,
+        allImportAccess: true,
       }),
     );
 
@@ -56,6 +58,7 @@ describe('TopologyShortcuts tests', () => {
         supportedFileTypes: ['jar'],
         isEmptyModel: false,
         viewType: TopologyViewType.list,
+        allImportAccess: true,
       }),
     );
 
@@ -72,6 +75,7 @@ describe('TopologyShortcuts tests', () => {
         supportedFileTypes: ['jar'],
         isEmptyModel: false,
         viewType: TopologyViewType.graph,
+        allImportAccess: true,
       }),
     );
     expect(wrapper.find('[data-test-id="move"]').exists()).toBe(true);
@@ -81,5 +85,40 @@ describe('TopologyShortcuts tests', () => {
     expect(wrapper.find('[data-test-id="view-details"]').exists()).toBe(true);
     expect(wrapper.find('[data-test-id="open-quick-search"]').exists()).toBe(true);
     expect(wrapper.find('[data-test-id="edit-application-grouping"]').exists()).toBe(true);
+  });
+  it('should show only view details and quick search actions in list view', () => {
+    const wrapper = shallow(
+      getTopologyShortcuts(jest.fn(), {
+        supportedFileTypes: ['jar'],
+        isEmptyModel: false,
+        viewType: TopologyViewType.list,
+        allImportAccess: false,
+      }),
+    );
+    expect(wrapper.find('[data-test-id="move"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="view-details"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="open-quick-search"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="create-connector-handle"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="context-menu"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="edit-application-grouping"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="upload-file"]').exists()).toBe(false);
+  });
+
+  it('should show only view details and quick search actions in graph view', () => {
+    const wrapper = shallow(
+      getTopologyShortcuts(jest.fn(), {
+        supportedFileTypes: ['jar'],
+        isEmptyModel: false,
+        viewType: TopologyViewType.graph,
+        allImportAccess: false,
+      }),
+    );
+    expect(wrapper.find('[data-test-id="move"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="view-details"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="open-quick-search"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="create-connector-handle"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="context-menu"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="edit-application-grouping"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="upload-file"]').exists()).toBe(false);
   });
 });

--- a/frontend/packages/topology/src/components/graph-view/TopologyShortcuts.tsx
+++ b/frontend/packages/topology/src/components/graph-view/TopologyShortcuts.tsx
@@ -7,39 +7,47 @@ export type Options = {
   supportedFileTypes: string[];
   isEmptyModel: boolean;
   viewType: TopologyViewType;
+  allImportAccess: boolean;
 };
-export const getTopologyShortcuts = (t: TFunction, options: Options): React.ReactElement => (
-  <ShortcutTable>
-    {!options.isEmptyModel && options.viewType === TopologyViewType.graph && (
-      <>
-        <Shortcut data-test-id="move" drag>
-          {t('topology~Move')}
+export const getTopologyShortcuts = (t: TFunction, options: Options): React.ReactElement => {
+  const { supportedFileTypes, isEmptyModel, viewType, allImportAccess } = options;
+  return (
+    <ShortcutTable>
+      {!isEmptyModel && viewType === TopologyViewType.graph && (
+        <>
+          <Shortcut data-test-id="move" drag>
+            {t('topology~Move')}
+          </Shortcut>
+          {allImportAccess && (
+            <>
+              <Shortcut data-test-id="edit-application-grouping" shift drag>
+                {t('topology~Edit Application grouping')}
+              </Shortcut>
+              <Shortcut data-test-id="context-menu" rightClick>
+                {t('topology~Access context menu')}
+              </Shortcut>
+              <Shortcut data-test-id="create-connector-handle" hover>
+                {t('topology~Access create connector handle')}
+              </Shortcut>
+            </>
+          )}
+        </>
+      )}
+      {!isEmptyModel && (
+        <Shortcut data-test-id="view-details" click>
+          {t('topology~View details in side panel')}
         </Shortcut>
-        <Shortcut data-test-id="edit-application-grouping" shift drag>
-          {t('topology~Edit Application grouping')}
-        </Shortcut>
-        <Shortcut data-test-id="context-menu" rightClick>
-          {t('topology~Access context menu')}
-        </Shortcut>
-        <Shortcut data-test-id="create-connector-handle" hover>
-          {t('topology~Access create connector handle')}
-        </Shortcut>
-      </>
-    )}
-    {!options.isEmptyModel && (
-      <Shortcut data-test-id="view-details" click>
-        {t('topology~View details in side panel')}
+      )}
+      <Shortcut data-test-id="open-quick-search" ctrl keyName="Spacebar">
+        {t('topology~Open quick search modal')}
       </Shortcut>
-    )}
-    <Shortcut data-test-id="open-quick-search" ctrl keyName="Spacebar">
-      {t('topology~Open quick search modal')}
-    </Shortcut>
-    {options.supportedFileTypes?.length > 0 && (
-      <Shortcut data-test-id="upload-file" dragNdrop>
-        {t('topology~Upload file ({{fileTypes}}) to project', {
-          fileTypes: options.supportedFileTypes.map((ex) => `.${ex}`).toString(),
-        })}
-      </Shortcut>
-    )}
-  </ShortcutTable>
-);
+      {supportedFileTypes?.length > 0 && allImportAccess && (
+        <Shortcut data-test-id="upload-file" dragNdrop>
+          {t('topology~Upload file ({{fileTypes}}) to project', {
+            fileTypes: supportedFileTypes.map((ex) => `.${ex}`).toString(),
+          })}
+        </Shortcut>
+      )}
+    </ShortcutTable>
+  );
+};

--- a/frontend/packages/topology/src/components/page/TopologyPageToolbar.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyPageToolbar.tsx
@@ -7,6 +7,8 @@ import {
   FileUploadContext,
   FileUploadContextType,
 } from '@console/app/src/components/file-upload/file-upload-context';
+import { allImportResourceAccess } from '@console/dev-console/src/actions/add-resources';
+import { useAddToProjectAccess } from '@console/dev-console/src/utils/useAddToProjectAccess';
 import { useIsMobile } from '@console/shared';
 import { ModelContext, ExtensibleModel } from '../../data-transforms/ModelContext';
 import { TopologyViewType } from '../../topology-types';
@@ -25,6 +27,8 @@ const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
     const showGraphView = viewType === TopologyViewType.graph;
     const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
     const { namespace, isEmptyModel } = dataModelContext;
+    const createResourceAccess: string[] = useAddToProjectAccess(namespace);
+    const allImportAccess = createResourceAccess.includes(allImportResourceAccess);
     const viewChangeTooltipContent = showGraphView
       ? t('topology~List view')
       : t('topology~Graph view');
@@ -42,6 +46,7 @@ const TopologyPageToolbar: React.FC<TopologyPageToolbarProps> = observer(
               supportedFileTypes: extensions,
               isEmptyModel,
               viewType,
+              allImportAccess,
             })}
             position="left"
             maxWidth="100vw"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6095

**Analysis / Root cause**: 
When logged in as a developer with view access, edit actions should not show in View shortcuts.

**Solution Description**: 
Add RBAC check and Hide edit actions from view shortcuts

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/125715314-c15cc87b-3e58-45f2-909e-275105bc23ef.png)



**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/2561818/124799158-e028c980-df71-11eb-92e9-5342e72b71f7.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge