### PR TITLE
Add an option to choose to use template size pvc or not

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -34,6 +34,7 @@
   "--- Pick an Operating system ---": "--- Pick an Operating system ---",
   "{{nameOrId}} - Default data image already exists": "{{nameOrId}} - Default data image already exists",
   "{{nameOrId}} - Template missing data image definition": "{{nameOrId}} - Template missing data image definition",
+  "Use template size PVC": "Use template size PVC",
   "Operating system source already defined": "Operating system source already defined",
   "In order to add a new source for {{osName}} you will need to delete the following PVC:": "In order to add a new source for {{osName}} you will need to delete the following PVC:",
   "Namespace": "Namespace",


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
Currently the default value of pvc is 2*size of image, but when attaching to template it would change the value to template size pvc. 

**Solution Description**: 
Added an option to select to use the size of template pvc or 2*size of image when attaching to template.

**Screen shots / Gifs for design review**: 

![upload-pvc-form](https://user-images.githubusercontent.com/14824964/124880786-514e9800-dfd7-11eb-8ad7-54ca8f5a1b87.gif)
