### PR TITLE
Bug 1979571: end shell process when exiting the terminal

### DIFF
--- a/frontend/public/components/pod-exec.jsx
+++ b/frontend/public/components/pod-exec.jsx
@@ -132,6 +132,8 @@ const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
     }
 
     componentWillUnmount() {
+      const exitCode = 'exit\r';
+      this.ws && exitCode.split('').map((t) => this.ws.send(`0${Base64.encode(t)}`));
       this.ws && this.ws.destroy();
       delete this.ws;
     }


### PR DESCRIPTION
Thanks to @karthikjeeyar for the fix!

Note I did not test this against a Windows pod, but my assumption is that it should work fine as `exit` is also valid there.

After:

https://user-images.githubusercontent.com/895728/124919217-f2335800-dfc3-11eb-9c3f-7f3ee88a5e2b.mov

