### PR TITLE
Bug 1976072: Ignore deprecated descriptor x-capabilities

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -44,7 +44,7 @@ const PodCount: React.FC<SpecCapabilityProps> = ({
       })
     }
   >
-    {value} pods
+    {value ?? 0} pods
   </DetailsItem>
 );
 
@@ -66,7 +66,7 @@ const Label: React.FC<SpecCapabilityProps> = ({
     {_.isObject(value) ? (
       <LabelList kind={model.kind} labels={value} />
     ) : (
-      <span>{value || '--'}</span>
+      <span>{value || '-'}</span>
     )}
   </DetailsItem>
 );
@@ -317,7 +317,7 @@ const UpdateStrategy: React.FC<SpecCapabilityProps> = ({
 
 export const SpecDescriptorDetailsItem: React.FC<SpecCapabilityProps> = (props) => {
   const [capability] =
-    getValidCapabilitiesForValue<SpecCapability>(props.descriptor, props.value, true) ?? [];
+    getValidCapabilitiesForValue<SpecCapability>(props.descriptor, props.value) ?? [];
 
   if (capability?.startsWith(SpecCapability.k8sResourcePrefix)) {
     return <K8sResourceLinkCapability capability={capability} {...props} />;

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -129,7 +129,7 @@ const MainStatus: React.FC<StatusCapabilityProps> = ({
 
 export const StatusDescriptorDetailsItem: React.FC<StatusCapabilityProps> = (props) => {
   const [capability] =
-    getValidCapabilitiesForValue<StatusCapability>(props.descriptor, props.value, true) ?? [];
+    getValidCapabilitiesForValue<StatusCapability>(props.descriptor, props.value) ?? [];
 
   if (capability?.startsWith(StatusCapability.k8sResourcePrefix)) {
     return <K8sResourceLinkCapability capability={capability} {...props} />;

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
@@ -134,7 +134,6 @@ const getCompatibleCapabilities = (type: string): (StatusCapability | SpecCapabi
 export function getValidCapabilitiesForDataType<CapabilityType extends string = SpecCapability>(
   descriptor: Descriptor<CapabilityType>,
   type: string,
-  allowDeprecated?: boolean,
 ): CapabilityType[] {
   const compatibleCapabilities = getCompatibleCapabilities(type);
   const [valid, invalid, deprecated] = _.reduce(
@@ -150,10 +149,9 @@ export function getValidCapabilitiesForDataType<CapabilityType extends string = 
           capability.startsWith(compatibleCapability),
         );
 
-      const isValid = (!isDeprecated || allowDeprecated) && isCompatible;
       return [
-        [...(validAccumulator ?? []), ...(isValid ? [capability] : [])],
-        [...(invalidAccumulator ?? []), ...(!isValid ? [capability] : [])],
+        [...(validAccumulator ?? []), ...(!isDeprecated && isCompatible ? [capability] : [])],
+        [...(invalidAccumulator ?? []), ...(!isCompatible ? [capability] : [])],
         [...(deprecatedAccumulator ?? []), ...(isDeprecated ? [capability] : [])],
       ];
     },
@@ -174,14 +172,13 @@ export function getValidCapabilitiesForDataType<CapabilityType extends string = 
     deprecated.forEach((deprecatedCapability) => {
       // eslint-disable-next-line no-console
       console.warn(
-        `[Deprecated x-descriptor] "${deprecatedCapability}" is no longer supported ${!allowDeprecated &&
-          'and will have no effect'}`,
+        `[Deprecated x-descriptor] "${deprecatedCapability}" is no longer supported and will have no effect`,
         descriptor,
       );
     });
   }
 
-  return valid ?? [];
+  return valid;
 }
 
 const getValueType = (value: any): string => {
@@ -197,19 +194,17 @@ const getValueType = (value: any): string => {
 export function getValidCapabilitiesForValue<CapabilityType extends string = SpecCapability>(
   descriptor: Descriptor<CapabilityType>,
   value: any,
-  allowDeprecated?: boolean,
 ): CapabilityType[] {
   const type = getValueType(value);
-  return getValidCapabilitiesForDataType<CapabilityType>(descriptor, type, allowDeprecated);
+  return getValidCapabilitiesForDataType<CapabilityType>(descriptor, type);
 }
 
 export function getValidCapabilitiesForSchema<CapabilityType extends string = SpecCapability>(
   descriptor: Descriptor<CapabilityType>,
   schema: JSONSchema6,
-  allowDeprecated?: boolean,
 ): CapabilityType[] {
   const type = getSchemaType(schema);
-  return getValidCapabilitiesForDataType<CapabilityType>(descriptor, type, allowDeprecated);
+  return getValidCapabilitiesForDataType<CapabilityType>(descriptor, type);
 }
 
 export const isMainStatusDescriptor = (descriptor: Descriptor): boolean =>


### PR DESCRIPTION
Previously, we were allowing deprecated x-descriptors to be used, which caused some unexpected behavior when both deprecated and non-deprecated descriptors were defined on the same property. Updated descriptor logic to ignore deprecated descriptors and log a warning.