### PR TITLE
Bug 1980548: Add missing plugin locales folders to webpack config

### DIFF
--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -45,6 +45,7 @@ i18n
       'kubevirt-plugin',
       'lso-plugin',
       'metal3-plugin',
+      'notification-drawer',
       'olm',
       'pipelines-plugin',
       'public',

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -224,6 +224,10 @@ const config: Configuration = {
     new CopyWebpackPlugin([{ from: './packages/kubevirt-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/ceph-storage-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/metal3-plugin/locales', to: 'locales' }]),
+    new CopyWebpackPlugin([
+      { from: './packages/network-attachment-definition-plugin/locales', to: 'locales' },
+    ]),
+    new CopyWebpackPlugin([{ from: './packages/patternfly/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/insights-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([
       { from: './packages/local-storage-operator-plugin/locales', to: 'locales' },


### PR DESCRIPTION
A few plugins' locales folders weren't being copied. This resulted in the translations not being displayed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1980548.