### PR TITLE
Bug 1979996: Monitoring dashboards: Support units for graph Y-axes

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -32,7 +32,7 @@ $tooltip-background-color: var(--pf-global--BackgroundColor--dark-100);
 }
 
 .graph-wrapper.graph-wrapper--query-browser {
-  padding: 5px 15px 15px 50px;
+  padding: 5px 15px 15px 60px;
 
   &--with-legend {
     min-height: 305px;
@@ -494,6 +494,7 @@ $monitoring-line-height: 18px;
   font-weight: var(--pf-global--FontWeight--bold);
   margin-left: auto;
   padding-left: 10px;
+  white-space: nowrap;
 }
 
 .query-browser__tooltip-wrap {

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -16,6 +16,7 @@ type Props = {
   pollInterval: number;
   queries: string[];
   showLegend?: boolean;
+  units: string;
 };
 
 const Graph: React.FC<Props> = ({
@@ -24,6 +25,7 @@ const Graph: React.FC<Props> = ({
   pollInterval,
   queries,
   showLegend,
+  units,
 }) => {
   const dispatch = useDispatch();
   const endTime = useSelector(({ UI }: RootState) => UI.getIn(['monitoringDashboards', 'endTime']));
@@ -51,6 +53,7 @@ const Graph: React.FC<Props> = ({
       queries={queries}
       showLegend={showLegend}
       timespan={timespan}
+      units={units}
     />
   );
 };

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -504,6 +504,7 @@ const Card: React.FC<CardProps> = ({ panel }) => {
                   pollInterval={pollInterval}
                   queries={queries}
                   showLegend={panel.legend?.show}
+                  units={panel.yaxes?.[0]?.format}
                 />
               )}
               {(panel.type === 'singlestat' || panel.type === 'gauge') && (

--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -4,7 +4,7 @@ import { Bullseye } from '@patternfly/react-core';
 
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 
-import { formatNumber } from './format';
+import { formatNumber } from '../format';
 import { Panel } from './types';
 import { PrometheusResponse } from '../../graphs';
 import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';

--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -12,7 +12,7 @@ import {
 
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 
-import { formatNumber } from './format';
+import { formatNumber } from '../format';
 import { ColumnStyle, Panel } from './types';
 import { PrometheusResponse } from '../../graphs';
 import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -16,6 +16,10 @@ type ValueMap = {
   value: string;
 };
 
+type YAxis = {
+  format: string;
+};
+
 export type Panel = {
   breakpoint?: string;
   decimals?: number;
@@ -56,4 +60,5 @@ export type Panel = {
   units?: string;
   valueFontSize?: string;
   valueMaps?: ValueMap[];
+  yaxes: YAxis[];
 };

--- a/frontend/public/components/monitoring/format.tsx
+++ b/frontend/public/components/monitoring/format.tsx
@@ -5,7 +5,8 @@ import {
   humanizeDecimalBytesPerSec,
   humanizeNumber,
   humanizePacketsPerSec,
-} from '../../utils';
+  humanizeSeconds,
+} from '../utils';
 
 export const formatNumber = (s: string, decimals = 2, format = 'short'): string => {
   const value = Number(s);
@@ -26,6 +27,10 @@ export const formatNumber = (s: string, decimals = 2, format = 'short'): string 
       return humanizeDecimalBytesPerSec(value).string;
     case 'pps':
       return humanizePacketsPerSec(value).string;
+    case 'ms':
+      return humanizeSeconds(value, 'ms').string;
+    case 's':
+      return humanizeSeconds(value * 1000, 'ms').string;
     case 'short':
     // fall through
     default:


### PR DESCRIPTION
Supports the same subset of units that are supported for tables.

Increased the space on the left side of the graph a little to
accommodate the now slightly longer axis labels.

![screenshot](https://user-images.githubusercontent.com/460802/125057537-4e8d9900-e0e4-11eb-9934-88b595b88bef.png)
