### PR TITLE
Add proxy endpoint for Prometheus targets

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -298,6 +298,7 @@ func (s *Server) HTTPHandler() http.Handler {
 			rulesSourcePath      = prometheusProxyEndpoint + "/api/v1/rules"
 			querySourcePath      = prometheusProxyEndpoint + "/api/v1/query"
 			queryRangeSourcePath = prometheusProxyEndpoint + "/api/v1/query_range"
+			targetsSourcePath    = prometheusProxyEndpoint + "/api/v1/targets"
 			targetAPIPath        = prometheusProxyEndpoint + "/api/"
 
 			tenancyQuerySourcePath      = prometheusTenancyProxyEndpoint + "/api/v1/query"
@@ -326,6 +327,13 @@ func (s *Server) HTTPHandler() http.Handler {
 			})),
 		)
 		handle(labelSourcePath, http.StripPrefix(
+			proxy.SingleJoiningSlash(s.BaseURL.Path, targetAPIPath),
+			authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
+				r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.Token))
+				thanosProxy.ServeHTTP(w, r)
+			})),
+		)
+		handle(targetsSourcePath, http.StripPrefix(
 			proxy.SingleJoiningSlash(s.BaseURL.Path, targetAPIPath),
 			authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
 				r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.Token))


### PR DESCRIPTION
The Thanos querier recently added support for retrieving information
on targets from federated Prometheus instances.  This adds the new
endpoint to the Promethus proxy.  It's not currently possible to query
this in a tenant aware fashion, so there's no need to add it to that
proxy.

This is part of [MON-1618](https://issues.redhat.com/browse/MON-1618), and requires https://github.com/openshift/cluster-monitoring-operator/pull/1274 to actually return anything useful.