### PR TITLE
CONSOLE-2361: Remove orphaned Bootstrap 3 input-group styles

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -37,7 +37,7 @@
   @include scroll-shadows-vertical-covers;
   width: 100%;
 
-  // so that input, textarea, button, and input-group-addon don't mask the inner scroll shadows
+  // so that input and textarea don't mask the inner scroll shadows
   input, textarea {
     &.pf-c-form-control {
       background-color: transparent;
@@ -46,10 +46,6 @@
         background-color: rgba(128, 128, 128, 0.15);
       }
     }
-  }
-
-  .input-group-addon {
-    background-color: rgba(227, 227, 227, 0.5);
   }
 }
 

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -19,7 +19,6 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/buttons"; // required by <FilterSidePanelCategory> in patternfly-react
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/component-animations";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/button-groups";
-@import "~bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/list-group";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/close";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/modals";


### PR DESCRIPTION
The instances of input-group in use were migrated to PatternFly 4, but these Bootstrap 3 styles were orphaned.