### PR TITLE
Expose useResolvedExtensions as part of the stable API

### DIFF
--- a/frontend/dynamic-demo-plugin/console-extensions.json
+++ b/frontend/dynamic-demo-plugin/console-extensions.json
@@ -31,5 +31,12 @@
         "$codeRef": "telemetry.eventListener"
       }
     }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "path": "/test-consumer",
+      "component": { "$codeRef": "extensionConsumer.default" }
+    }
   }
 ]

--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -13,7 +13,7 @@
     "react": "17.0.1"
   },
   "devDependencies": {
-    "@console/dynamic-plugin-sdk": "link:../packages/console-dynamic-plugin-sdk",
+    "@console/dynamic-plugin-sdk": "link:../packages/console-dynamic-plugin-sdk/dist",
     "@types/react": "16.8.13",
     "http-server": "0.12.x",
     "ts-loader": "6.2.2",
@@ -29,7 +29,8 @@
     "description": "Plasma reactors online. Initiating hyper drive.",
     "exposedModules": {
       "barUtils": "./utils/bar",
-      "telemetry": "./utils/telemetry"
+      "telemetry": "./utils/telemetry",
+      "extensionConsumer": "./components/ExtensionConsumer.tsx"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/frontend/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
+++ b/frontend/dynamic-demo-plugin/src/components/ExtensionConsumer.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { isModelFeatureFlag, ModelFeatureFlag } from '@console/dynamic-plugin-sdk';
+import { useResolvedExtensions } from '@console/dynamic-plugin-sdk/api';
+
+const ExtensionConsumer: React.FC = () => {
+  const [extensions] = useResolvedExtensions<ModelFeatureFlag>(isModelFeatureFlag);
+
+  return !_.isEmpty(extensions) ? (
+    <div>
+      <h2>Extensions of type Console.flag/Model</h2>
+      <div>
+        {extensions.map((ext) => (
+          <ModelRenderer
+            model={ext.properties.model}
+            flag={ext.properties.flag}
+            key={ext.properties.flag}
+          />
+        ))}
+      </div>
+    </div>
+  ) : null;
+};
+
+const ModelRenderer: React.FC<ModelRendererProps> = ({ model, flag }) => (
+  <div>
+    <div>Model Flag: {flag} </div>
+    <div>Model Group, Version, Kind: </div>
+    <ul>
+      <li>{model.group}</li>
+      <li>{model.version}</li>
+      <li>{model.kind}</li>
+    </ul>
+  </div>
+);
+
+type ModelRendererProps = {
+  model: {
+    group: string;
+    version: string;
+    kind: string;
+  };
+  flag: string;
+};
+
+export default ExtensionConsumer;

--- a/frontend/dynamic-demo-plugin/src/utils/bar.ts
+++ b/frontend/dynamic-demo-plugin/src/utils/bar.ts
@@ -1,4 +1,4 @@
-import { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
+import { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
 
 export default (label: string) => `Hello ${label} Function!`;
 

--- a/frontend/dynamic-demo-plugin/tsconfig.json
+++ b/frontend/dynamic-demo-plugin/tsconfig.json
@@ -8,7 +8,13 @@
     "allowJs": true,
     "experimentalDecorators": true,
     "noUnusedLocals": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@console/dynamic-plugin-sdk/api": ["node_modules/@console/dynamic-plugin-sdk/lib/api/api"],
+      "@console/dynamic-plugin-sdk/webpack": [
+        "node_modules/@console/dynamic-plugin-sdk/lib/webpack"
+      ]
+    }
   },
   "include": ["src"]
 }

--- a/frontend/dynamic-demo-plugin/webpack.config.ts
+++ b/frontend/dynamic-demo-plugin/webpack.config.ts
@@ -2,7 +2,7 @@
 
 import * as webpack from 'webpack';
 import * as path from 'path';
-import { ConsoleRemotePlugin } from '@console/dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin';
+import { ConsoleRemotePlugin } from '@console/dynamic-plugin-sdk/webpack';
 
 const config: webpack.Configuration = {
   mode: 'development',
@@ -32,6 +32,9 @@ const config: webpack.Configuration = {
     ],
   },
   plugins: [new ConsoleRemotePlugin()],
+  externals: {
+    '@console/dynamic-plugin-sdk/api': 'api',
+  },
   devtool: 'source-map',
   optimization: {
     chunkIds: 'named',

--- a/frontend/dynamic-demo-plugin/yarn.lock
+++ b/frontend/dynamic-demo-plugin/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@console/dynamic-plugin-sdk@link:../packages/console-dynamic-plugin-sdk":
+"@console/dynamic-plugin-sdk@link:../packages/console-dynamic-plugin-sdk/dist":
   version "0.0.0"
   uid ""
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/api-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/api-types.ts
@@ -1,4 +1,6 @@
 import { K8sResourceCommon, K8sResourceKindReference, Selector } from '../extensions/console-types';
+import { Extension, ExtensionTypeGuard } from '../types';
+import { ResolvedExtension } from './common-types';
 
 export type WatchK8sResource = {
   kind: K8sResourceKindReference;
@@ -37,3 +39,7 @@ export type UseK8sWatchResource = <R extends K8sResourceCommon | K8sResourceComm
 export type UseK8sWatchResources = <R extends ResourcesObject>(
   initResources: WatchK8sResources<R>,
 ) => WatchK8sResults<R>;
+
+export type UseResolvedExtensions = <E extends Extension>(
+  ...typeGuards: ExtensionTypeGuard<E>[]
+) => [ResolvedExtension<E>[], boolean, any[]];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/api.ts
@@ -1,4 +1,4 @@
-import { UseK8sWatchResource, UseK8sWatchResources } from './api-types';
+import { UseK8sWatchResource, UseK8sWatchResources, UseResolvedExtensions } from './api-types';
 
 export * from './api-types';
 
@@ -8,3 +8,4 @@ const MockImpl = () => {
 
 export const useK8sWatchResource: UseK8sWatchResource = MockImpl;
 export const useK8sWatchResources: UseK8sWatchResources = MockImpl;
+export const useResolvedExtensions: UseResolvedExtensions = MockImpl;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
@@ -4,6 +4,7 @@ import { Extension, ExtensionTypeGuard } from '@console/plugin-sdk/src/typings/b
 import { resolveExtension } from '../coderefs/coderef-resolver';
 import { ResolvedExtension } from '../types';
 import { unwrapPromiseSettledResults } from '../utils/promise';
+import { UseResolvedExtensions } from './api-types';
 
 /**
  * React hook for consuming Console extensions with resolved `CodeRef` properties.
@@ -35,7 +36,7 @@ import { unwrapPromiseSettledResults } from '../utils/promise';
  * references, boolean flag indicating whether the resolution is complete, and a list
  * of errors detected during the resolution.
  */
-export const useResolvedExtensions = <E extends Extension>(
+export const useResolvedExtensions: UseResolvedExtensions = <E extends Extension>(
   ...typeGuards: ExtensionTypeGuard<E>[]
 ): [ResolvedExtension<E>[], boolean, any[]] => {
   const extensions = useExtensions<E>(...typeGuards);

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-api.ts
@@ -6,5 +6,7 @@ export const exposePluginAPI = () => {
       .useK8sWatchResource,
     useK8sWatchResources: require('@console/internal/components/utils/k8s-watch-hook')
       .useK8sWatchResources,
+    useResolvedExtensions: require('@console/dynamic-plugin-sdk/src/api/useResolvedExtensions')
+      .useResolvedExtensions,
   };
 };


### PR DESCRIPTION
Jira Link: https://issues.redhat.com/browse/CONSOLE-2922
To test this PR: 
- Build and run the dynamic demo plugin
- Check route `/test-consumer`. The Page should render a bunch of Flags and associated Models.
/assign @spadgett @christianvogt 

Example Screenshot: 
![Screenshot from 2021-07-26 13-17-03](https://user-images.githubusercontent.com/54092533/126952438-70f5d3c1-bba1-4a7e-887b-e221b7f9d5e5.png)

