### PR TITLE
Set add page background based on active namespace

### DIFF
--- a/frontend/packages/dev-console/src/components/add/AddPage.tsx
+++ b/frontend/packages/dev-console/src/components/add/AddPage.tsx
@@ -38,15 +38,18 @@ export const PageContents: React.FC<AddPageProps> = ({ match }) => {
 
 const PageContentsWithStartGuide = withStartGuide(PageContents);
 
-const AddPage: React.FC<AddPageProps> = (props) => {
+const AddPage: React.FC<AddPageProps> = ({ match }) => {
   const { t } = useTranslation();
+  const namespace = match.params.ns;
+  const nsVariant = namespace ? null : NamespacedPageVariants.light;
+
   return (
     <>
       <Helmet>
         <title data-test-id="page-title">{`+${t('devconsole~Add')}`}</title>
       </Helmet>
-      <NamespacedPage variant={NamespacedPageVariants.light} hideApplications>
-        <PageContentsWithStartGuide {...props} />
+      <NamespacedPage variant={nsVariant} hideApplications>
+        <PageContentsWithStartGuide match={match} />
       </NamespacedPage>
     </>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6143
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Add page background was changed to white to fit the getting started notification, but does not resort to default background when a namespace is selected.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Use default background when a namespace is selected / available.
<!-- Describe your code changes in detail and explain the solution -->

<!-- **Screen shots / Gifs for design review**:  -->
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug