### PR TITLE
Change OCM links from cloud. to console.redhat.com

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -108,7 +108,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
             <h6 className="pf-c-title pf-m-md">{t('insights-plugin~Fixable issues')}</h6>
             <div>
               <ExternalLink
-                href={`https://cloud.redhat.com/openshift/details/${clusterID}#insights`}
+                href={`https://console.redhat.com/openshift/details/${clusterID}#insights`}
                 text={t('insights-plugin~View all in OpenShift Cluster Manager')}
               />
             </div>
@@ -117,7 +117,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         {!isWaitingOrDisabled && !isError && !clusterID && (
           <div>
             <ExternalLink
-              href={`https://cloud.redhat.com/openshift/`}
+              href={`https://console.redhat.com/openshift/`}
               text={t('insights-plugin~Go to OpenShift Cluster Manager')}
             />
           </div>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CCXDEV-5149.

Due to the last announcement of migration of all cloud.redhat.com located services to console.redhat.com, we need to make sure we are not pointing to the deprecated websites.