### PR TITLE
(4.7 Backport) Change OCM links from cloud. to console.redhat.com #9470

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -85,7 +85,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
             <h6 className="pf-c-title pf-m-md">Fixable issues</h6>
             <div>
               <ExternalLink
-                href={`https://cloud.redhat.com/openshift/details/${clusterID}#insights`}
+                href={`https://console.redhat.com/openshift/details/${clusterID}#insights`}
                 text="View all in OpenShift Cluster Manager"
               />
             </div>


### PR DESCRIPTION
Due to the last announcement of migration of all cloud.redhat.com located services to console.redhat.com, we need to make sure we are not pointing to the deprecated websites.