### PR TITLE
Bug 1980704: Web console doesn't list all the registries credentials in a secret

### DIFF
--- a/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
+++ b/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
@@ -6,57 +6,10 @@ import { Alert } from '@patternfly/react-core';
 import { withTranslation } from 'react-i18next';
 
 import { CONST } from '@console/shared';
-import { k8sPatch, k8sPatchByName, k8sCreate } from '../../module/k8s';
+import { k8sPatchByName, k8sCreate } from '../../module/k8s';
 import { SecretModel, ServiceAccountModel } from '../../models';
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
 import { PromiseComponent, ResourceIcon } from '../utils';
-
-const parseExisitingPullSecret = (pullSecret) => {
-  let invalidData = false;
-  const invalidJson = false;
-  let username, email, password, address;
-
-  try {
-    const existingData = pullSecret && Base64.decode(pullSecret.data[CONST.PULL_SECRET_DATA]);
-
-    if (existingData) {
-      const data = JSON.parse(existingData);
-
-      if (!data || !data.auths) {
-        throw 'Invalid data';
-      }
-
-      const keys = Object.keys(data.auths);
-
-      if (keys.length > 1) {
-        // multiple auths are stored in this one secret.
-        // we'll display the first secret, but upon saving, the
-        // others will get erased
-        invalidData = true;
-      } else if (keys.length < 1) {
-        throw 'Invalid data';
-      }
-      address = keys[0];
-      email = data.auths[address].email;
-      const auth = Base64.decode(data.auths[address].auth);
-      const authParts = auth.split(':');
-
-      if (authParts.length === 1) {
-        username = '';
-        password = authParts[0];
-      } else if (authParts.length === 2) {
-        username = authParts[0];
-        password = authParts[1];
-      } else {
-        throw 'Invalid data';
-      }
-    }
-  } catch (error) {
-    invalidData = true;
-  }
-
-  return { username, password, email, address, invalidData, invalidJson };
-};
 
 const generateSecretData = (formData) => {
   const config = {
@@ -124,9 +77,8 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
 
   _submit(event) {
     event.preventDefault();
-    const { namespace, pullSecret } = this.props;
+    const { namespace } = this.props;
 
-    let promise;
     let secretData;
 
     if (this.state.method === 'upload') {
@@ -142,52 +94,39 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
       secretData = generateSecretData(formData);
     }
 
-    if (pullSecret) {
-      const patch = [
-        {
-          op: 'replace',
-          path: `/data/${CONST.PULL_SECRET_DATA}`,
-          value: secretData,
-        },
-      ];
-      promise = k8sPatch(SecretModel, pullSecret, patch);
-    } else {
-      const data = {};
-      const pullSecretName = event.target.elements['namespace-pull-secret-name'].value;
-      data[CONST.PULL_SECRET_DATA] = secretData;
+    const data = {};
+    const pullSecretName = event.target.elements['namespace-pull-secret-name'].value;
+    data[CONST.PULL_SECRET_DATA] = secretData;
 
-      const secret = {
-        metadata: {
-          name: pullSecretName,
-          namespace: namespace.metadata.name,
-        },
-        data,
-        type: CONST.PULL_SECRET_TYPE,
-      };
-      const defaultServiceAccountPatch = [
-        {
-          op: 'add',
-          path: '/imagePullSecrets/-',
-          value: { name: pullSecretName },
-        },
-      ];
-      promise = k8sCreate(SecretModel, secret).then(() =>
-        k8sPatchByName(
-          ServiceAccountModel,
-          'default',
-          namespace.metadata.name,
-          defaultServiceAccountPatch,
-        ),
-      );
-    }
+    const secret = {
+      metadata: {
+        name: pullSecretName,
+        namespace: namespace.metadata.name,
+      },
+      data,
+      type: CONST.PULL_SECRET_TYPE,
+    };
+    const defaultServiceAccountPatch = [
+      {
+        op: 'add',
+        path: '/imagePullSecrets/-',
+        value: { name: pullSecretName },
+      },
+    ];
+    const promise = k8sCreate(SecretModel, secret).then(() =>
+      k8sPatchByName(
+        ServiceAccountModel,
+        'default',
+        namespace.metadata.name,
+        defaultServiceAccountPatch,
+      ),
+    );
 
     this.handlePromise(promise).then(this.props.close);
   }
 
   render() {
-    const { namespace, pullSecret, t } = this.props;
-
-    const existingData = parseExisitingPullSecret(pullSecret);
+    const { namespace, t } = this.props;
 
     return (
       <form onSubmit={this._submit} name="form" className="modal-content">
@@ -198,19 +137,6 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
               'public~Specify default credentials to be used to authenticate and download containers within this namespace. These credentials will be the default unless a pod references a specific pull Secret.',
             )}
           </p>
-
-          {existingData.invalidData && (
-            <Alert
-              isInline
-              className="co-alert"
-              variant="danger"
-              title={t('public~Overwriting default pull Secret')}
-            >
-              {t(
-                'public~A default pull Secret exists, but can&apos;t be parsed. Saving this will overwrite it.',
-              )}
-            </Alert>
-          )}
 
           <div className="row co-m-form-row">
             <div className="col-xs-3">
@@ -225,25 +151,19 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
             <div className="col-xs-3">
               <label htmlFor="namespace-pull-secret-name">{t('public~Secret name')}</label>
             </div>
-            {pullSecret ? (
-              <div className="col-xs-9">
-                <ResourceIcon kind="Secret" />
-                &nbsp;{_.get(pullSecret, 'metadata.name')}
-              </div>
-            ) : (
-              <div className="col-xs-9">
-                <input
-                  type="text"
-                  className="pf-c-form-control"
-                  id="namespace-pull-secret-name"
-                  aria-describedby="namespace-pull-secret-name-help"
-                  required
-                />
-                <p className="help-block text-muted" id="namespace-pull-secret-name-help">
-                  {t('public~Friendly name to help you manage this in the future')}
-                </p>
-              </div>
-            )}
+
+            <div className="col-xs-9">
+              <input
+                type="text"
+                className="pf-c-form-control"
+                id="namespace-pull-secret-name"
+                aria-describedby="namespace-pull-secret-name-help"
+                required
+              />
+              <p className="help-block text-muted" id="namespace-pull-secret-name-help">
+                {t('public~Friendly name to help you manage this in the future')}
+              </p>
+            </div>
           </div>
 
           <div className="row co-m-form-row form-group">
@@ -291,7 +211,6 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
                     type="text"
                     className="pf-c-form-control"
                     id="namespace-pull-secret-address"
-                    defaultValue={existingData.address}
                     placeholder={t('public~quay.io')}
                     required
                   />
@@ -305,7 +224,6 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
                   <input
                     type="email"
                     className="pf-c-form-control"
-                    defaultValue={existingData.email}
                     id="namespace-pull-secret-email"
                     aria-describedby="namespace-pull-secret-email-help"
                   />
@@ -321,7 +239,6 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
                 <div className="col-xs-9">
                   <input
                     type="text"
-                    defaultValue={existingData.username}
                     className="pf-c-form-control"
                     id="namespace-pull-secret-username"
                     required
@@ -335,7 +252,6 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
                 <div className="col-xs-9">
                   <input
                     type="password"
-                    defaultValue={existingData.password}
                     className="pf-c-form-control"
                     id="namespace-pull-secret-password"
                     required
@@ -365,21 +281,20 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
                   </p>
                 </div>
               </div>
-              {this.state.invalidJson ||
-                (existingData.invalidJson && (
-                  <div className="row co-m-form-row">
-                    <div className="col-xs-9 col-sm-offset-3">
-                      <Alert
-                        isInline
-                        className="co-alert"
-                        variant="danger"
-                        title={t('public~Invalid JSON')}
-                      >
-                        {t('public~The uploaded file is not properly-formatted JSON.')}
-                      </Alert>
-                    </div>
+              {this.state.invalidJson && (
+                <div className="row co-m-form-row">
+                  <div className="col-xs-9 col-sm-offset-3">
+                    <Alert
+                      isInline
+                      className="co-alert"
+                      variant="danger"
+                      title={t('public~Invalid JSON')}
+                    >
+                      {t('public~The uploaded file is not properly-formatted JSON.')}
+                    </Alert>
                   </div>
-                ))}
+                </div>
+              )}
               {this.state.fileData && (
                 <div className="row co-m-form-row">
                   <div className="col-xs-9 col-sm-offset-3">
@@ -395,6 +310,9 @@ class ConfigureNamespacePullSecretWithTranslation extends PromiseComponent {
           inProgress={this.state.inProgress}
           submitText={t('public~Save')}
           cancel={this._cancel}
+          submitDisabled={
+            this.state.method === 'upload' && (!this.state.fileData || this.state.invalidJson)
+          }
         />
       </form>
     );

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -858,10 +858,16 @@ export const PullSecret = (props) => {
     configureNamespacePullSecretModal({ namespace: props.namespace, pullSecret: data });
 
   return (
-    <Button variant="link" type="button" isInline onClick={modal}>
-      {_.get(data, 'metadata.name') || t('public~Not configured')}
-      <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
-    </Button>
+    <>
+      {data ? (
+        <ResourceLink kind="Secret" name={data.metadata.name} namespace={data.metadata.namespace} />
+      ) : (
+        <Button variant="link" type="button" isInline onClick={modal}>
+          {t('public~Not configured')}
+          <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+        </Button>
+      )}
+    </>
   );
 };
 

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -688,8 +688,6 @@
   "Maximum replicas:": "Maximum replicas:",
   "Default pull Secret": "Default pull Secret",
   "Specify default credentials to be used to authenticate and download containers within this namespace. These credentials will be the default unless a pod references a specific pull Secret.": "Specify default credentials to be used to authenticate and download containers within this namespace. These credentials will be the default unless a pod references a specific pull Secret.",
-  "Overwriting default pull Secret": "Overwriting default pull Secret",
-  "A default pull Secret exists, but can&apos;t be parsed. Saving this will overwrite it.": "A default pull Secret exists, but can&apos;t be parsed. Saving this will overwrite it.",
   "Secret name": "Secret name",
   "Friendly name to help you manage this in the future": "Friendly name to help you manage this in the future",
   "Method": "Method",

--- a/frontend/public/locales/ja/public.json
+++ b/frontend/public/locales/ja/public.json
@@ -683,7 +683,7 @@
   "Default pull Secret": "デフォルトのプルシークレット",
   "Specify default credentials to be used to authenticate and download containers within this namespace. These credentials will be the default unless a pod references a specific pull Secret.": "この namespace 内のコンテナーの認証およびダウンロードに使用するデフォルトの認証情報を指定します。Pod が特定のプルシークレットを参照しない限り、これらの認証情報はデフォルトになります。",
   "Overwriting default pull Secret": "デフォルトのプルシークレットの上書き",
-  "A default pull Secret exists, but can&apos;t be parsed. Saving this will overwrite it.": "デフォルトのプルシークレットは存在しますが、解析できません。これを保存すると、上書きされます。",
+  "A default pull Secret exists, but can't be parsed. Saving this will overwrite it.": "デフォルトのプルシークレットは存在しますが、解析できません。これを保存すると、上書きされます。",
   "Secret name": "シークレット名",
   "Friendly name to help you manage this in the future": "今後これを管理しやすくする名前",
   "Method": "方法",

--- a/frontend/public/locales/ko/public.json
+++ b/frontend/public/locales/ko/public.json
@@ -683,7 +683,7 @@
   "Default pull Secret": "기본 풀 시크릿",
   "Specify default credentials to be used to authenticate and download containers within this namespace. These credentials will be the default unless a pod references a specific pull Secret.": "이 네임 스페이스 내에서 컨테이너를 인증하고 다운로드하는 데 사용할 기본 인증 정보를 지정합니다. pod가 특정 풀 시크릿을 참조하지 않는 한 이러한 인증 정보는 기본값이 됩니다.",
   "Overwriting default pull Secret": "기본 풀 시크릿 덮어쓰기",
-  "A default pull Secret exists, but can&apos;t be parsed. Saving this will overwrite it.": "기본 풀 시크릿이 있지만 구문 분석할 수 없습니다. 이 파일을 저장하면 덮어 쓰게됩니다.",
+  "A default pull Secret exists, but can't be parsed. Saving this will overwrite it.": "기본 풀 시크릿이 있지만 구문 분석할 수 없습니다. 이 파일을 저장하면 덮어 쓰게됩니다.",
   "Secret name": "시크릿 이름",
   "Friendly name to help you manage this in the future": "향후 이 문제를 관리하는 데 도움이 되는 이름",
   "Method": "방법",

--- a/frontend/public/locales/zh/public.json
+++ b/frontend/public/locales/zh/public.json
@@ -678,7 +678,7 @@
   "Default pull Secret": "默认 pull secret",
   "Specify default credentials to be used to authenticate and download containers within this namespace. These credentials will be the default unless a pod references a specific pull Secret.": "指定用于在此命名空间中验证和下载容器的默认凭证。这些凭证是默认的，除非 pod 引用了一个特定的 pull Secret。",
   "Overwriting default pull Secret": "覆盖默认 pull Secret",
-  "A default pull Secret exists, but can&apos;t be parsed. Saving this will overwrite it.": "存在一个默认的 pull Secret，但无法解析。保存这个将会覆盖它。",
+  "A default pull Secret exists, but can't be parsed. Saving this will overwrite it.": "存在一个默认的 pull Secret，但无法解析。保存这个将会覆盖它。",
   "Secret name": "Secret 名",
   "Friendly name to help you manage this in the future": "友好名称，以帮助您在以后管理此功能",
   "Method": "方法",


### PR DESCRIPTION
Addresses [Bug 1980704](https://bugzilla.redhat.com/show_bug.cgi?id=1980704)

On the project details page, if a there is a default pull secret, there is a link that will take the user to the secret details screen (/k8s/ns/[namespace]/secrets/[secret name]).  If there isn't a secret, then the "No configured" link will show opening the `Default pull Secret` modal (current behavior).

In addition the following bug (not directly addressed in 1980704) were also fixed:
 - Error is shown if user uploads a badly formatted JSON file (currently no error is shown)
 - Disable "Save" button if user is selecting to upload and hasn't uploaded a file or if the uploaded file is badly formatted JSON (currently a user is allowed to click on "Save" and a secret is created)

**Project with secret**
![Screen Shot 2021-07-13 at 3 45 25 PM](https://user-images.githubusercontent.com/82059948/125522795-5789499d-10b0-4f23-99e4-1cf18b1575fe.png)

**Project without secret**
![Screen Shot 2021-07-13 at 3 45 11 PM](https://user-images.githubusercontent.com/82059948/125522775-410b08d9-2992-4b4c-b401-68beceaac800.png)

**Modal with error and disabled Save button**
![Screen Shot 2021-07-15 at 3 26 37 PM](https://user-images.githubusercontent.com/82059948/125853024-0d2c9a7f-235b-43ff-b36b-57a8c1311096.png)
