### PR TITLE
CNV-6393: [dev] add the status icon next to the VM name to the VM details page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -17,6 +17,7 @@ import {
   VM_DETAIL_ENVIRONMENT,
   VM_DETAIL_SNAPSHOTS,
 } from '../../constants/vm';
+import { useVMStatus } from '../../hooks/use-vm-status';
 import {
   DataVolumeModel,
   VirtualMachineImportModel,
@@ -57,6 +58,7 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
   const { name, ns: namespace } = props.match.params;
   const { t } = useTranslation();
   const [snapshotResource] = useK8sModel(kubevirtReferenceForModel(VirtualMachineSnapshotModel));
+  const vmStatusBundle = useVMStatus(name, namespace);
 
   const dashboardPage = {
     href: '', // default landing page
@@ -167,6 +169,7 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
       resources={resources}
       breadcrumbsFor={breadcrumbsForVMPage(t, props.match)}
       customData={{ kindObj: VirtualMachineModel }}
+      getResourceStatus={() => vmStatusBundle.status.getSimpleLabel()}
     >
       <PendingChangesWarningFirehose name={name} namespace={namespace} />
     </DetailsPage>

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-vm-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-vm-status.ts
@@ -1,0 +1,69 @@
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { PersistentVolumeClaimModel, PodModel } from '@console/internal/models';
+import { K8sResourceKind, PersistentVolumeClaimKind, PodKind } from '@console/internal/module/k8s';
+import {
+  DataVolumeModel,
+  VirtualMachineImportModel,
+  VirtualMachineInstanceMigrationModel,
+  VirtualMachineInstanceModel,
+  VirtualMachineModel,
+} from '../models';
+import { kubevirtReferenceForModel } from '../models/kubevirtReferenceForModel';
+import { getVMStatus } from '../statuses/vm/vm-status';
+import { VMIKind, VMKind } from '../types';
+import { V1alpha1DataVolume } from '../types/api';
+import { VMImportKind } from '../types/vm-import/ovirt/vm-import';
+
+export const useVMStatus = (name, namespace) => {
+  const [vm] = useK8sWatchResource<VMKind>({
+    kind: kubevirtReferenceForModel(VirtualMachineModel),
+    name,
+    namespace,
+    isList: false,
+  });
+
+  const [vmi] = useK8sWatchResource<VMIKind>({
+    kind: kubevirtReferenceForModel(VirtualMachineInstanceModel),
+    name,
+    namespace,
+    isList: false,
+  });
+
+  const [pods] = useK8sWatchResource<PodKind[]>({
+    kind: PodModel.kind,
+    namespace,
+    isList: true,
+  });
+
+  const [migrations] = useK8sWatchResource<K8sResourceKind[]>({
+    kind: kubevirtReferenceForModel(VirtualMachineInstanceMigrationModel),
+    namespace,
+    isList: true,
+  });
+
+  const [vmImports] = useK8sWatchResource<VMImportKind[]>({
+    kind: kubevirtReferenceForModel(VirtualMachineImportModel),
+    namespace,
+    isList: true,
+  });
+  const [pvcs] = useK8sWatchResource<PersistentVolumeClaimKind[]>({
+    kind: PersistentVolumeClaimModel.kind,
+    namespace,
+    isList: true,
+  });
+  const [dataVolumes] = useK8sWatchResource<V1alpha1DataVolume[]>({
+    kind: kubevirtReferenceForModel(DataVolumeModel),
+    namespace,
+    isList: true,
+  });
+
+  return getVMStatus({
+    vm,
+    vmi,
+    pods,
+    migrations,
+    pvcs,
+    dataVolumes,
+    vmImports,
+  });
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/CNV-6393

**Analysis / Root cause**: 
vm yaml does not consist 'phase' field that should hold the vm status , causing no label in vm page, need to override default behavior

**Solution Description**: 
adding a hook to get the vm status and send it to get the proper icon 

**Screen shots / Gifs for design review**: 
before:
![Screenshot from 2021-07-12 19-52-51](https://user-images.githubusercontent.com/67270715/125327537-e5a85a00-e34b-11eb-9d65-5445d04388d3.png)

after:
![cnv6393-after](https://user-images.githubusercontent.com/67270715/125327582-f1941c00-e34b-11eb-9fff-11c4e6a00698.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>