### PR TITLE
ODC-6008:Automation of quick-start-devperspective

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/filter-quick-starts-catalog.feature
+++ b/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/filter-quick-starts-catalog.feature
@@ -35,10 +35,10 @@ Feature: Add ability to filter Quick Starts catalog
         @regression
         Scenario: Apply Filter based on status: QS-01-TC04
             Given user is at Quick Starts catalog page
-              And user has completed "Getting started with a sample application" Quick Start
+              And user has completed "Get started with a sample application" Quick Start
              When user clicks on Status filter menu
               And user clicks on completed
-             Then user can see "Getting started with a sample application" Quick Start is present
+             Then user can see "Get started with a sample application" Quick Start is present
 
 
         @regression

--- a/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/guided-tour/quick-starts/quick-start-devperspective.feature
@@ -4,59 +4,42 @@ Feature: Build with guided documentation card in developer console
 
         Background:
             Given user is at developer perspective
-              And sample-application CR Quick Start is available
-              And add-healthchecks CR Quick Start is available
-              And explore-serverless CR Quick Start is available
-              And explore-pipeline CR Quick Start is available
+              And user is at Add page
+              And user has created or selected namespace "aut-dev-quickstarts"
 
 
-        @to-do
+        @smoke
         Scenario: Build with guided documentation card on Add page: QS-03-TC01
-             When user goes to Add page
              Then user can see Build with guided documentation card
               And user can see two Quick Starts link present on it
               And user can see the "View all quick starts" on the card
 
 
-        @to-do
+        @regression
         Scenario: Quick Starts page when no Quick Start has started: QS-03-TC02
-             When user goes to Add page
-              And user clicks on the "View all quick starts" on Build with guided documentation card
-             Then user can see "Get started with a sample application", "Install the OpenShift Pipelines Operator", "Install the OpenShift Pipelines Operator" and "Add health checks to your sample application" Quick Starts
+             When user clicks on the "View all quick starts" on Build with guided documentation card
+             Then user can see "Get started with a sample application", "Install the OpenShift Pipelines Operator" and "Add health checks to your sample application" Quick Starts
               And user can see time taken to complete the tour on the card
 
 
-        @to-do
+        @regression
         Scenario: Quick Starts page when Quick Start has completed: QS-03-TC03
-            Given user has completed "Get started with a sample application" Quick Start
-             When user goes to Add page
-              And user clicks on the "View all quick starts" on Build with guided documentation card
-             Then user can see "Get started with a sample application" card
-              And user can see time taken to complete the tour on the card
-              And user can see Complete label
+            Given user is at Quick Starts catalog page
+              And user has completed "Get started with a sample application" Quick Start
+             Then user can see time taken to complete the "Get started with a sample application" tour on the card
+              And user can see Complete label on "Get started with a sample application" card
 
 
-        @to-do
+        @regression
         Scenario: Quick Starts page when Quick Start is not completed: QS-03-TC04
-            Given user has not completed "Get started with a sample application" Quick Start
-             When user goes to Add page
-              And user clicks on the "View all quick starts" on Build with guided documentation card
-             Then user can see "Get started with a sample application" Quick Start card
-              And user can see time taken to complete the quick start on the card
-              And user can see In Progress label
+            Given user is at Quick Starts catalog page
+              And user has not completed "Install the OpenShift Pipelines Operator" Quick Start
+             Then user can see time taken to complete the "Install the OpenShift Pipelines Operator" tour on the card
+              And user can see In Progress label on "Install the OpenShift Pipelines Operator" card
 
 
-        @to-do
-        Scenario: Hide Build with guided documentation card from Add view: QS-03-TC05
-            Given user is at Add page
-             When user clicks on the kebab menu in the Getting started resources card
-              And user clicks on Hide from view
-             Then Build with guided documentation card will be removed from Add page
-
-
-        @to-do
-        Scenario: Build with guided documentation card links with status as in progress: QS-03-TC06
-            Given user is at Add page
+        @regression
+        Scenario: Build with guided documentation card links with status as in progress: QS-03-TC05
              When user clicks on first Quick Starts link on the Build with guided documentation card
               And user clicks on the Start button
               And user clicks on close button
@@ -64,55 +47,31 @@ Feature: Build with guided documentation card in developer console
              Then user can see the first Quick Starts link
 
 
-        @to-do
-        Scenario: Build with guided documentation card when all Quick Starts has completed: QS-03-TC07
-            Given user is at Add page
+        @manual
+        Scenario: Build with guided documentation card when all Quick Starts has completed: QS-03-TC06
              When user completes all the Quick Starts present
              Then user can see Build with guided documentation card is removed from the Add page
 
 
-        @to-do
-        Scenario: Visiting a Quick Start: QS-03-TC08
-            Given user is at Quick Start catalog page
-             When user clicks "Get started with a sample application" card
-              And user clicks on Starts button
-              And user clicks on Next button in Step 1
-              And user selects Yes in Check your Work section
-              And user clicks on Next button in Step 2
-              And user selects Yes in Check your Work section
-              And user clicks on Next button in Step 3
-              And user selects Yes in Check your Work section
-              And user clicks on Next button in Step 4
-              And user selects Yes in Check your Work section
-              And user clicks on Next button in Step 5
-              And user selects Yes in Check your Work section
-              And user clicks on Next
-             Then user can see Start, Close and Restart button
-              And user can see link to "Add health checks to your sample application" quick start
-              And user can see 5 Steps visible with checkmark in Green color
-
-
-        @to-do
-        Scenario: Restart action on Quick Start card: QS-03-TC09
-            Given user is at Quick Start catalog page
-             When user clicks "Get started with a sample application" Quick Start
-              And user clicks on Start button
-              And user completes the Quick Start
-              And user clicks on Restart
+        @regression
+        Scenario: Restart action on Quick Start card: QS-03-TC07
+            Given user is at Quick Starts catalog page
+              And user has completed "Get started with a sample application" Quick Start
+             When user clicks on Restart on "Get started with a sample application" quick start sidebar
              Then user can see Start button
-              And user can see 5 Steps visible for the Quick Start
+              And user can see "5" Steps visible for the Quick Start
 
 
         @manual
-        Scenario: Resizing Quick Start drawer: QS-03-TC10
-            Given user is at Quick Start catalog page
+        Scenario: Resizing Quick Start drawer: QS-03-TC08
+            Given user is at Quick Starts catalog page
              When user clicks "Get started with a sample application" Quick Start
               And user drags the Quick Start drawer left and right from the left side of the panel
              Then user is able to resize the Quick Start drawer
 
 
         @odc-5010 @manual
-        Scenario: Disabling Quick Start: QS-03-TC11
+        Scenario: Disabling Quick Start: QS-03-TC09
             Given user is logged in as an admin
              When user clicks on Search in navigation menu
               And user searches console in Resources dropdown
@@ -127,7 +86,7 @@ Feature: Build with guided documentation card in developer console
 
 
         @odc-5715 @to-do
-        Scenario: Unique url to a Quick Start
+        Scenario: Unique url to a Quick Start: QS-03-TC10
             Given user is at Quick Start catalog page
               And user clicks "Exploring Serverless applications" card
              Then user can see url has "quickstart?quickstart=serverless-application" in the address bar

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/add-flow-po.ts
@@ -9,6 +9,8 @@ export const addPagePO = {
   kebabMenuGettingStarted: '[data-test="actions"]',
   hideGettingStarted: '[data-test="hide"]',
   closeButton: '[aria-label="label-close-button"]',
+  buildWithGuidedDocumentation: '[data-test="card quick-start"]',
+  buildWithGuidedDocumentationItems: '[data-test="card quick-start"] [data-test~="item"]',
   viewAllQuickStarts: '[data-test="item all-quick-starts"]',
 };
 

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/quickStarts-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/quickStarts-po.ts
@@ -7,22 +7,33 @@ export const quickStartsPO = {
   emptyState: 'div.pf-c-empty-state__content',
   clearFilter: '[data-test="clear-filter button"]',
   cardStatus: '[data-test~="tile"] [data-test~="status"]',
+  duration: '[data-test="duration"]',
 };
 
 export const quickStartSidebarPO = {
   quickStartSidebarBody: '[data-test~="drawer"] [data-test~="content"]',
   startButton: `[data-test="Start button"]`,
   nextButton: '[data-test="Next button"]',
+  restartSideNoteAction: '[data-testid="qs-drawer-side-note-action"]',
   closeButton: '[data-test="Close button"]',
+  closePanel: '[data-test~="drawer"] [aria-label="Close drawer panel"]',
+};
+
+export const quickStartLeaveModalPO = {
+  leaveModal: '[data-test="leave-quickstart"]',
+  leaveButton: '[data-test="leave button"]',
 };
 
 export const quickStartDisplayNameToName = (displayName: string) => {
   switch (displayName) {
-    case 'Getting started with a sample application': {
+    case 'Get started with a sample application': {
       return 'sample-application';
     }
     case 'Install the OpenShift Pipelines Operator': {
       return 'explore-pipelines';
+    }
+    case 'Add health checks to your sample application': {
+      return 'add-healthchecks';
     }
     default: {
       throw new Error('Option is not available');

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/quck-starts/quick-start-devperspective.ts
@@ -1,0 +1,166 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import {
+  addPagePO,
+  quickStartCard,
+  quickStartLeaveModalPO,
+  quickStartSidebarPO,
+  quickStartsPO,
+} from '../../pageObjects';
+import { app, quickStartsPage } from '../../pages';
+
+let quickStartLink: string;
+
+Then('user can see Build with guided documentation card', () => {
+  cy.get(addPagePO.buildWithGuidedDocumentation).should('be.visible');
+});
+
+Then('user can see two Quick Starts link present on it', () => {
+  cy.get(addPagePO.buildWithGuidedDocumentationItems).should('have.length', 2 + 1); // +1 represents View all quick start link displaying with the quick start links
+});
+
+Then('user can see the "View all quick starts" on the card', () => {
+  cy.get(addPagePO.viewAllQuickStarts).should('be.visible');
+});
+
+When('user clicks on the "View all quick starts" on Build with guided documentation card', () => {
+  cy.get(addPagePO.viewAllQuickStarts)
+    .should('be.visible')
+    .click();
+});
+
+Then(
+  'user can see {string}, {string} and {string} Quick Starts',
+  (quickStartDisplayName1, quickStartDisplayName2, quickStartDisplayName3) => {
+    cy.get(quickStartCard(quickStartDisplayName1)).should('be.visible');
+    cy.get(quickStartCard(quickStartDisplayName2)).should('be.visible');
+    cy.get(quickStartCard(quickStartDisplayName3)).should('be.visible');
+  },
+);
+
+Then('user can see time taken to complete the tour on the card', () => {
+  cy.get(quickStartCard('Get started with a sample application'))
+    .find(quickStartsPO.duration)
+    .should('be.visible');
+  cy.get(quickStartCard('Install the OpenShift Pipelines Operator'))
+    .find(quickStartsPO.duration)
+    .should('be.visible');
+  cy.get(quickStartCard('Add health checks to your sample application'))
+    .find(quickStartsPO.duration)
+    .should('be.visible');
+});
+
+Given('user is at Quick Starts catalog page', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+Given('user has completed {string} Quick Start', (quickStartDisplayName: string) => {
+  quickStartsPage.executeQuickStart(quickStartCard(quickStartDisplayName));
+});
+
+Then(
+  'user can see time taken to complete the {string} tour on the card',
+  (quickStartDisplayName: string) => {
+    cy.get(quickStartCard(quickStartDisplayName))
+      .find(quickStartsPO.duration)
+      .should('be.visible');
+  },
+);
+
+Then('user can see Complete label on {string} card', (quickStartDisplayName: string) => {
+  cy.get(quickStartCard(quickStartDisplayName))
+    .parent()
+    .find(quickStartsPO.cardStatus)
+    .should('be.visible')
+    .contains('Complete');
+});
+
+Given('user is at Quick Starts catalog page', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+Given('user has not completed {string} Quick Start', (quickStartDisplayName: string) => {
+  quickStartsPage.leaveQuickStartIncomplete(quickStartCard(quickStartDisplayName));
+});
+
+Then(
+  'user can see time taken to complete the {string} tour on the card',
+  (quickStartDisplayName: string) => {
+    cy.get(quickStartCard(quickStartDisplayName))
+      .find(quickStartsPO.duration)
+      .should('be.visible');
+  },
+);
+
+Then('user can see In Progress label on {string} card', (quickStartDisplayName: string) => {
+  cy.get(quickStartCard(quickStartDisplayName))
+    .parent()
+    .find(quickStartsPO.cardStatus)
+    .should('be.visible')
+    .contains('In progress');
+});
+
+When('user clicks on first Quick Starts link on the Build with guided documentation card', () => {
+  cy.get(addPagePO.buildWithGuidedDocumentationItems)
+    .first()
+    .then(($link) => {
+      quickStartLink = $link.get(0).innerText;
+    });
+  cy.get(addPagePO.buildWithGuidedDocumentationItems)
+    .first()
+    .click();
+  cy.get(quickStartSidebarPO.quickStartSidebarBody).should('be.visible');
+});
+
+When('user clicks on the Start button', () => {
+  cy.get(quickStartSidebarPO.quickStartSidebarBody)
+    .find(quickStartSidebarPO.startButton)
+    .click();
+});
+
+When('user clicks on close button', () => {
+  cy.get(quickStartSidebarPO.closePanel)
+    .should('be.visible')
+    .click();
+});
+
+When('user clicks on Leave button in the Leave the tour modal box', () => {
+  cy.get(quickStartLeaveModalPO.leaveModal).should('be.visible');
+  cy.get(quickStartLeaveModalPO.leaveButton)
+    .should('be.visible')
+    .click();
+});
+
+Then('user can see the first Quick Starts link', () => {
+  cy.get(addPagePO.buildWithGuidedDocumentationItems)
+    .first()
+    .should('have.text', quickStartLink);
+});
+
+Given('user is at Quick Starts catalog page', () => {
+  quickStartsPage.quickStartsCatalog();
+});
+
+Given('user has completed {string} Quick Start', (quickStartDisplayName: string) => {
+  quickStartsPage.executeQuickStart(quickStartCard(quickStartDisplayName));
+});
+
+When('user clicks on Restart on {string} quick start sidebar', (quickStartDisplayName: string) => {
+  cy.get(quickStartCard(quickStartDisplayName))
+    .scrollIntoView()
+    .click();
+  app.waitForDocumentLoad();
+  cy.get(quickStartSidebarPO.quickStartSidebarBody).should('be.visible');
+  cy.get(quickStartSidebarPO.restartSideNoteAction)
+    .should('be.visible')
+    .click();
+});
+
+Then('user can see Start button', () => {
+  cy.get(quickStartSidebarPO.quickStartSidebarBody)
+    .find(quickStartSidebarPO.startButton)
+    .should('be.visible');
+});
+
+Then('user can see {string} Steps visible for the Quick Start', (steps: string) => {
+  cy.get(quickStartSidebarPO.quickStartSidebarBody).contains(steps);
+});


### PR DESCRIPTION
**Fix**: https://issues.redhat.com/browse/ODC-6008

**Problem**: Automation quick starts in the developer perspective.

**Solution**: This script will automate the quick-start-devperspective.feature file

**Test Setup**:

Cluster should be running on local

Check the TAGS in frontend/packages/dev-console/integration-tests/cypress.json file be: ""@smoke or @regression and not (@manual or @to-do or @un-verified)"",

Update the "@patternfly/quickstarts" to "1.0.2" in  /frontend/package.json

Command to execute:

yarn run dev
yarn run test-cypress-devconsole
Execute the quick-start-devperspective.feature file

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster
- [x] Update Automation Report

**Browser**
Chrome 89

**Test Execution Screenshot:**
![Screenshot from 2021-07-13 01-13-47](https://user-images.githubusercontent.com/10252230/125352240-a21b1380-e37e-11eb-8e0f-c731bf27a099.png)
