### PR TITLE
Bug 1967047: Add new HealthState to signify an operator is upgradable in the cluster dashboard

### DIFF
--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -26,6 +26,7 @@
   "Updating": "Updating",
   "Degraded": "Degraded",
   "Loading": "Loading",
+  "Upgrade available": "Upgrade available",
   "{{title}} breakdown": "{{title}} breakdown",
   "Total capacity": "Total capacity",
   "Total limit": "Total limit",

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
@@ -7,6 +7,7 @@ import {
   YellowExclamationTriangleIcon,
   BlueSyncIcon,
   GrayUnknownIcon,
+  BlueArrowCircleUpIcon,
 } from '@console/shared/src/components/status/icons';
 
 export enum HealthState {
@@ -17,6 +18,7 @@ export enum HealthState {
   UNKNOWN = 'UNKNOWN',
   UPDATING = 'UPDATING',
   PROGRESS = 'PROGRESS',
+  UPGRADABLE = 'UPGRADABLE',
   NOT_AVAILABLE = 'NOT_AVAILABLE',
 }
 
@@ -36,6 +38,8 @@ export const healthStateMessage = (state: keyof typeof HealthState, t: TFunction
       return t('console-shared~Degraded');
     case HealthState.LOADING:
       return t('console-shared~Loading');
+    case HealthState.UPGRADABLE:
+      return t('console-shared~Upgrade available');
     case HealthState.NOT_AVAILABLE:
       return t('console-shared~Not available');
     default:
@@ -64,23 +68,28 @@ export const healthStateMapping: { [key in HealthState]: HealthStateMappingValue
     health: HealthState.UPDATING,
     icon: <BlueSyncIcon title="Updating" />,
   },
-  [HealthState.WARNING]: {
+  [HealthState.UPGRADABLE]: {
     priority: 4,
+    health: HealthState.UPGRADABLE,
+    icon: <BlueArrowCircleUpIcon title="Upgrade available" />,
+  },
+  [HealthState.WARNING]: {
+    priority: 5,
     health: HealthState.WARNING,
     icon: <YellowExclamationTriangleIcon title="Warning" />,
   },
   [HealthState.ERROR]: {
-    priority: 5,
+    priority: 6,
     health: HealthState.ERROR,
     icon: <RedExclamationCircleIcon title="Error" />,
   },
   [HealthState.LOADING]: {
-    priority: 6,
+    priority: 7,
     health: HealthState.LOADING,
     icon: <div className="skeleton-health" />,
   },
   [HealthState.NOT_AVAILABLE]: {
-    priority: 7,
+    priority: 8,
     health: HealthState.NOT_AVAILABLE,
     icon: <GrayUnknownIcon title="Not available" />,
   },

--- a/frontend/packages/operator-lifecycle-manager/src/components/dashboard/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/dashboard/utils.ts
@@ -40,6 +40,15 @@ const getOperatorStatus = (
       title: subscriptionStatus.title,
     };
   }
+  if (
+    operatorHealth !== HealthState.ERROR &&
+    subscriptionStatus.status === SubscriptionState.SubscriptionStateUpgradeAvailable
+  ) {
+    return {
+      ...healthStateMapping[HealthState.UPGRADABLE],
+      title: subscriptionStatus.title,
+    };
+  }
   return {
     ...healthStateMapping[operatorHealth],
     title: csvStatus.title,

--- a/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
@@ -71,12 +71,15 @@ export const getSubscriptionStatus = (subscription: SubscriptionKind): Subscript
         title: i18n.t('olm~Upgrade available'),
       };
     case SubscriptionState.SubscriptionStateUpgradePending:
-      return {
-        status,
-        title: upgradeRequiresApproval(subscription)
-          ? i18n.t('olm~Upgrade available')
-          : i18n.t('olm~Upgrading'),
-      };
+      return upgradeRequiresApproval(subscription)
+        ? {
+            status: SubscriptionState.SubscriptionStateUpgradeAvailable,
+            title: i18n.t('olm~Upgrade available'),
+          }
+        : {
+            status,
+            title: i18n.t('olm~Upgrading'),
+          };
     case SubscriptionState.SubscriptionStateAtLatest:
       return {
         status,


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1967047

Added a new HealthState called upgradable which shows whether an operator has an upgrade available. The previous fix to this bug didn't change the health state which was pending (but the install wasn't pending). I played with using the existing warning state which is possible. I ended up creating this new upgradable state which shows the blue up arrow icon in the dashboard to show there is an upgrade available.

![Screen Shot 2021-07-12 at 4 20 18 PM](https://user-images.githubusercontent.com/35978579/125353315-648f9980-e330-11eb-9e0d-ee67a58660dc.png)

cc: @openshift/team-ux-review 