### PR TITLE
Bug 1975038: Cannot delete user created vm template

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/support/index.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/support/index.ts
@@ -40,7 +40,7 @@ Cypress.Commands.add('deleteResource', (resource, ignoreNotFound = true) => {
   if (!resource.metadata.namespace) {
     cy.exec(
       `kubectl delete --ignore-not-found=${ignoreNotFound} --cascade ${kind} ${resource.metadata.name} --wait=true --timeout=120s || true`,
-      { timeout: 130000 },
+      { timeout: 180000 },
     );
 
     return;

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/regression/validate-nad-for-pxe.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/regression/validate-nad-for-pxe.ts
@@ -35,9 +35,7 @@ describe('Validate NAD for PXE provision source', () => {
     wizard.vm.selectTemplate(vmData);
     cy.get(wizardView.customizeBtn).click();
     cy.get(wizardView.imageSourceDropdown).click();
-    cy.get(wizardView.selectMenu)
-      .contains(vmData.provisionSource.getDescription())
-      .click({ force: true });
+    cy.contains(vmData.provisionSource.getDescription()).click({ force: true });
     cy.contains('No Network Attachment Definitions available').should('be.visible');
     cy.get(wizardView.cancelBtn).click();
     cy.on('window:confirm', () => true);

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-vm-like-entity.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-vm-like-entity.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { TemplateModel } from '@console/internal/models';
+import { VirtualMachineInstanceModel, VirtualMachineModel } from '../models';
 import { kubevirtReferenceForModel } from '../models/kubevirtReferenceForModel';
 import { getName, getNamespace } from '../selectors';
 import { getVMLikeModel } from '../selectors/vm/vmlike';
@@ -12,7 +14,10 @@ export const useUpToDateVMLikeEntity = <P extends VMGenericLikeEntityKind>(vmLik
   const resourceWatch = React.useMemo(() => {
     return {
       name: vmName,
-      kind: kubevirtReferenceForModel(model),
+      kind:
+        model.kind === VirtualMachineModel.kind || VirtualMachineInstanceModel.kind
+          ? kubevirtReferenceForModel(model)
+          : TemplateModel.kind,
       namespace,
       isList: false,
     };


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1975038

**Analysis / Root cause**:
using wrong model kind when trying to get k8s resource. 

**Solution Description**:
manipulating the model kind to fit properly when getting the k8s resource

**Screen shots / Gifs for design review**:
before:

![bz_1975038_before](https://user-images.githubusercontent.com/67270715/125440538-7da76984-cab8-490e-a59e-8f2696254be8.png)


after:

![bz_1975038_after_1](https://user-images.githubusercontent.com/67270715/125440554-aac8bc45-eec9-48a6-b8bf-e2e1bc524912.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>