### PR TITLE
Skip empty categories (id and label) in OperatorHub tab view

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.spec.tsx
@@ -1,0 +1,108 @@
+import { determineCategories } from './operator-hub-items';
+import { OperatorHubItem } from './index';
+
+describe('determineCategories', () => {
+  it('should merge categories by name', () => {
+    const operatorHubItems: OperatorHubItem[] = [
+      {
+        categories: ['a-category'],
+      } as OperatorHubItem,
+      {
+        categories: ['a-category', 'b-category'],
+      } as OperatorHubItem,
+    ];
+    const actualCategories = determineCategories(operatorHubItems);
+    const expectedCategories = {
+      'a-category': {
+        id: 'a-category',
+        label: 'a-category',
+        field: 'categories',
+        values: ['a-category'],
+      },
+      'b-category': {
+        id: 'b-category',
+        label: 'b-category',
+        field: 'categories',
+        values: ['b-category'],
+      },
+    };
+    expect(actualCategories).toEqual(expectedCategories);
+  });
+
+  it('should sort categories by name', () => {
+    const operatorHubItems: OperatorHubItem[] = [
+      {
+        categories: ['c-category'],
+      } as OperatorHubItem,
+      {
+        categories: ['d-category', 'b-category'],
+      } as OperatorHubItem,
+      {
+        categories: ['a-category'],
+      } as OperatorHubItem,
+    ];
+    const actualCategories = determineCategories(operatorHubItems);
+    const expectedCategories = {
+      'a-category': {
+        id: 'a-category',
+        label: 'a-category',
+        field: 'categories',
+        values: ['a-category'],
+      },
+      'b-category': {
+        id: 'b-category',
+        label: 'b-category',
+        field: 'categories',
+        values: ['b-category'],
+      },
+      'c-category': {
+        id: 'c-category',
+        label: 'c-category',
+        field: 'categories',
+        values: ['c-category'],
+      },
+      'd-category': {
+        id: 'd-category',
+        label: 'd-category',
+        field: 'categories',
+        values: ['d-category'],
+      },
+    };
+    expect(actualCategories).toEqual(expectedCategories);
+  });
+
+  it('should not return categories if there is no defined', () => {
+    const operatorHubItems: OperatorHubItem[] = [
+      // No categories attribute
+      {} as OperatorHubItem,
+      // Empty categories array
+      {
+        categories: [],
+      } as OperatorHubItem,
+    ];
+    const actualCategories = determineCategories(operatorHubItems);
+    const expectedCategories = {};
+    expect(actualCategories).toEqual(expectedCategories);
+  });
+
+  it('should not return category if string is empty', () => {
+    const operatorHubItems: OperatorHubItem[] = [
+      {
+        categories: ['a-category', ''],
+      } as OperatorHubItem,
+      {
+        categories: [null, '', 'a-category'],
+      } as OperatorHubItem,
+    ];
+    const actualCategories = determineCategories(operatorHubItems);
+    const expectedCategories = {
+      'a-category': {
+        id: 'a-category',
+        label: 'a-category',
+        field: 'categories',
+        values: ['a-category'],
+      },
+    };
+    expect(actualCategories).toEqual(expectedCategories);
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -96,11 +96,18 @@ const operatorHubFilterGroups = [
 
 const ignoredProviderTails = [', Inc.', ', Inc', ' Inc.', ' Inc', ', LLC', ' LLC'];
 
-const determineCategories = (items) => {
-  const newCategories = {};
+type Category = {
+  id: string;
+  label: string;
+  field: 'categories';
+  values: string[];
+};
+
+export const determineCategories = (items: OperatorHubItem[]): Record<string, Category> => {
+  const newCategories: Record<string, Category> = {};
   _.each(items, (item) => {
     _.each(item.categories, (category) => {
-      if (!newCategories[category]) {
+      if (!newCategories[category] && category) {
         newCategories[category] = {
           id: category,
           label: category,
@@ -121,7 +128,7 @@ const determineCategories = (items) => {
       categories[key] = newCategories[key];
       return categories;
     },
-    {},
+    {} as Record<string, Category>,
   );
 };
 
@@ -225,7 +232,7 @@ const sortFilterValues = (values, field) => {
   return _.sortBy(values, sorter);
 };
 
-const determineAvailableFilters = (initialFilters, items, filterGroups) => {
+const determineAvailableFilters = (initialFilters, items: OperatorHubItem[], filterGroups) => {
   const filters = _.cloneDeep(initialFilters);
 
   _.each(filterGroups, (field) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6146

**Analysis / Root cause**: 
When running the cypress test `developer-catalog-details.feature` the test tries to install the OpenShift Serverless operator and fails because the OperatorHub page contains an accessibility issue.

The vertical tab navigation contains a `VerticalTabsTab` entry (`li > a`) (rendered in [tile-view-page.jsx](https://github.com/openshift/console/blob/ad8b0166ac6041e6be45606aeb24f2c5199db02e/frontend/public/components/utils/tile-view-page.jsx#L683-L709)) which results in an anchor without accessibility infos:

```html
<li class="vertical-tabs-pf-tab text-capitalize" data-test=""><a class="" href="#"></a></li>
```

(This may depend on the fetched OperatorHub data but happen on fresh clusters started with the `cluster-bot`.)

**Solution Description**: 
The categories are calculated based on the OperatorHub items, some of them contains an empty category string (`{ ... categories: [""] ... }`). The new code just skips this empty category.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

Skipping the empty string category results in a slightly different (IMHO fixed) UI:

Before there was a space between "All items" and the categories. There is no "Other" category because the entries are shown in this "empty string category.

![operatorhub-4 6](https://user-images.githubusercontent.com/139310/125449465-25bd7187-f0e8-4df3-9b01-6e782ef69a87.png)

On 4.6 it was also possible to select this category. Since 4.7 this is not possible anymore. But the "Other" entry is still missing.

![operatorhub-4 6-selected](https://user-images.githubusercontent.com/139310/125449479-98e63d55-f618-4e36-b630-53e1272df57e.png)

With this PR the spacing (it was the empty string category) is not shown anymore. The page shows an "Other" entry instead at the end:

![operatorhub-shows-other-tab-again](https://user-images.githubusercontent.com/139310/125449493-b991ec3e-87d2-46bb-adf3-c2ead57eae1b.png)

**Unit test coverage report**: 
Added one new unit test for the util function which creates the category object:

```
 PASS  packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.spec.tsx (6.358s)
  determineCategories
    ✓ should merge categories by name (3ms)
    ✓ should sort categories by name (1ms)
    ✓ should not return categories if there is no defined
    ✓ should not return category if string is empty
```

**Test setup:**
* For an visual test just open the OperatorHub
* You can also verify the a11y issue with Firefox extension [axe - Web Accessibility Testing](https://addons.mozilla.org/de/firefox/addon/axe-devtools/)
* To validate the cypress test run `yarn test-cypress-devconsole` and select `developer-catalog-details.feature`

**A11y check**
Before:
![operatorhub-issue-firefox-axe](https://user-images.githubusercontent.com/139310/125450977-1f43e04a-0b92-47d7-b4f9-cf1ad4c9f644.png)

After:
![operatorhub-fixed-firefox-axe](https://user-images.githubusercontent.com/139310/125448938-485d706f-bdfd-4c79-a219-29e954f6dc24.png)

**Cypress notes**
This issue was noticed while debugging #9361. This fix focused on this cypress issue:

![cypress-test-error-2](https://user-images.githubusercontent.com/139310/125448760-9b2da49d-c575-4519-bb6e-3e2c81e7efaa.png)

After fixing this the tests still has some issues which are already addressed in #9361.

![left-over-issue](https://user-images.githubusercontent.com/139310/125449059-a4ac9de1-7671-42bd-b9f6-1a454cc3dde4.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
