### PR TITLE
Bug 1982376: Remove update overrides now that upstream issues have been fixed

### DIFF
--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
@@ -85,9 +85,13 @@ const NotificationEntry: React.FC<NotificationEntryProps> = ({
   };
   return (
     <li
-      className={classNames(`pf-c-notification-drawer__list-item pf-m-hoverable pf-m-${type}`, {
-        'pf-m-read': isRead,
-      })}
+      className={classNames(
+        `pf-c-notification-drawer__list-item pf-m-hoverable`,
+        type === NotificationTypes.update ? 'pf-m-default' : `pf-m-${type}`,
+        {
+          'pf-m-read': isRead,
+        },
+      )}
       tabIndex={0}
       onClick={
         targetPath

--- a/frontend/public/components/_about-modal.scss
+++ b/frontend/public/components/_about-modal.scss
@@ -16,13 +16,4 @@
 
 .co-about-modal__alert {
   margin-bottom: var(--pf-global--spacer--xl);
-  // PatternFly does not have an `update` alert variant
-  // See https://github.com/patternfly/patternfly-react/issues/4594
-  .pf-c-alert__icon {
-    display: none;
-    &--alt {
-      display: inline-flex;
-      vertical-align: -0.25em !important;
-    }
-  }
 }

--- a/frontend/public/components/_notification-drawer.scss
+++ b/frontend/public/components/_notification-drawer.scss
@@ -7,9 +7,3 @@
 .pf-c-drawer__content {
   --pf-c-drawer__content--ZIndex: auto;
 }
-
-// PatternFly does not have an `update` variant
-// See https://github.com/patternfly/patternfly/issues/3312
-.pf-c-notification-drawer__list-item.pf-m-update {
-  --pf-c-notification-drawer__list-item--before--BackgroundColor: var(--pf-global--default-color--200);
-}

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -48,18 +48,14 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal }) =>
         <Alert
           className="co-alert co-about-modal__alert"
           title={
-            <>
-              {/* PatternFly does not have an `update` alert variant
-              See https://github.com/patternfly/patternfly-react/issues/4594 */}
-              <BlueArrowCircleUpIcon className="pf-c-alert__icon pf-c-alert__icon--alt" />
-              <Trans t={t} ns="public">
-                Cluster update available.{' '}
-                <Link to="/settings/cluster?showVersions" onClick={closeAboutModal}>
-                  Update cluster
-                </Link>
-              </Trans>
-            </>
+            <Trans t={t} ns="public">
+              Cluster update available.{' '}
+              <Link to="/settings/cluster?showVersions" onClick={closeAboutModal}>
+                Update cluster
+              </Link>
+            </Trans>
           }
+          customIcon={<BlueArrowCircleUpIcon />}
         />
       )}
       <TextContent>


### PR DESCRIPTION
After there are no differences in the rendering:
<img width="704" alt="Screen Shot 2021-07-13 at 10 33 35 AM" src="https://user-images.githubusercontent.com/895728/125475946-d1a327e6-6e26-4bd3-acc7-6a2b88fb2da4.png">
<img width="468" alt="Screen Shot 2021-07-13 at 11 00 00 AM" src="https://user-images.githubusercontent.com/895728/125475947-7dce0081-1080-46dc-9cdd-0a563adc0513.png">
