### PR TITLE
Bug 1982376: Remove app-launcher alignment fix now that upstream supports position…

### DIFF
--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -18,11 +18,6 @@
 }
 
 .co-app-launcher {
-  // PF4 app-launcher does not support the align right modifier yet: https://github.com/patternfly/patternfly-next/issues/1972
-  .pf-m-align-right {
-    right: 0;
-  }
-
   ul {
     list-style: none;
     margin-bottom: 0;


### PR DESCRIPTION
…="right"

After there are no differences in the rendering:
<img width="311" alt="Screen Shot 2021-07-13 at 11 10 16 AM" src="https://user-images.githubusercontent.com/895728/125477503-217df2af-3a52-4909-9455-65c84ce4064d.png">
