### PR TITLE
Bug 1964941: Increase HTTP plugin proxy request timeout

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -426,7 +426,9 @@ func (s *Server) HTTPHandler() http.Handler {
 	if len(s.EnabledConsolePlugins) > 0 {
 		pluginsHandler := plugins.NewPluginsHandler(
 			&http.Client{
-				Timeout:   10 * time.Second,
+				// 120 seconds matches the webpack require timeout.
+				// Plugins are loaded asynchronously, so this doesn't block page load.
+				Timeout:   120 * time.Second,
 				Transport: &http.Transport{TLSClientConfig: s.PluginsProxyTLSConfig},
 			},
 			s.ServiceAccountToken,


### PR DESCRIPTION
10s is too short and can cause plugins to fail to load. Plugins do not
block console load, so there little harm in increasing the request
timeout.

/cc @florkbr @vojtechszocs @jhadvig 