### PR TITLE
Bug 1982376: Remove button overrides now that upstream issue has been fixed

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -199,16 +199,6 @@ h6 {
   padding-right: 0;
 }
 
-// Fix upstream issue https://github.com/patternfly/patternfly/issues/3996 introduced in v4.96.2
-.pf-c-button.pf-m-primary {
-  color: var(--pf-c-button--m-primary--Color);
-}
-
-// Fix upstream issue https://github.com/patternfly/patternfly/issues/3996 introduced in v4.96.2
-.pf-c-button.pf-m-plain:hover {
-  color: var(--pf-c-button--m-plain--hover--Color);
-}
-
 .pf-c-chip-group.pf-m-toolbar {
   margin-bottom: var(--pf-global--spacer--xs);
 }


### PR DESCRIPTION
After there are no differences in the rendering:
<img width="225" alt="Screen Shot 2021-07-13 at 11 22 07 AM" src="https://user-images.githubusercontent.com/895728/125479575-766acf21-ab7b-4799-983e-b438253dccd8.png">
<img width="633" alt="Screen Shot 2021-07-13 at 11 21 54 AM" src="https://user-images.githubusercontent.com/895728/125479577-dc28a877-7bb0-4ea2-b32f-628be5c6d87d.png">
