### PR TITLE
fix resource limit form validation

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/ResourceLimitField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ResourceLimitField.tsx
@@ -10,11 +10,11 @@ const ResourceLimitField: React.FC<ResourceLimitFieldProps> = ({
   label,
   unitName,
   unitOptions,
-  defaultUnitSize,
   helpText,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
+  const [fieldUnit] = useField(unitName);
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const fieldId = getFieldId(props.name, 'resource-limit');
   const isValid = !(touched && error);
@@ -39,7 +39,7 @@ const ResourceLimitField: React.FC<ResourceLimitFieldProps> = ({
           setFieldValue(unitName, val.unit);
         }}
         dropdownUnits={unitOptions}
-        defaultRequestSizeUnit={defaultUnitSize}
+        defaultRequestSizeUnit={fieldUnit.value}
         defaultRequestSizeValue={field.value}
         describedBy={`${fieldId}-helper`}
       />

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -88,7 +88,6 @@ export interface EnvironmentFieldProps extends FieldProps {
 export interface ResourceLimitFieldProps extends FieldProps {
   unitName: string;
   unitOptions: object;
-  defaultUnitSize: string;
   fullWidth?: boolean;
 }
 

--- a/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/ResourceLimitSection.tsx
@@ -14,10 +14,7 @@ export type ResourceLimitSectionProps = {
 const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }) => {
   const { t } = useTranslation();
   const {
-    values: {
-      limits: { cpu, memory },
-      container,
-    },
+    values: { container },
   } = useFormikContext<FormikValues>();
   return (
     <FormSection
@@ -39,7 +36,6 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
         label={t('devconsole~Request')}
         unitName="limits.cpu.requestUnit"
         unitOptions={CPUUnits}
-        defaultUnitSize={`${cpu.defaultRequestUnit}`}
         helpText={t('devconsole~The minimum amount of CPU the Container is guaranteed.')}
       />
 
@@ -48,7 +44,6 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
         label={t('devconsole~Limit')}
         unitName="limits.cpu.limitUnit"
         unitOptions={CPUUnits}
-        defaultUnitSize={`${cpu.defaultLimitUnit}`}
         helpText={t(
           'devconsole~The maximum amount of CPU the Container is allowed to use when running.',
         )}
@@ -60,7 +55,6 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
         label={t('devconsole~Request')}
         unitName="limits.memory.requestUnit"
         unitOptions={MemoryUnits}
-        defaultUnitSize={`${memory.defaultRequestUnit}`}
         helpText={t('devconsole~The minimum amount of Memory the Container is guaranteed.')}
       />
 
@@ -69,7 +63,6 @@ const ResourceLimitSection: React.FC<ResourceLimitSectionProps> = ({ hideTitle }
         label={t('devconsole~Limit')}
         unitName="limits.memory.limitUnit"
         unitOptions={MemoryUnits}
-        defaultUnitSize={`${memory.defaultLimitUnit}`}
         helpText={t(
           'devconsole~The maximum amount of Memory the Container is allowed to use when running.',
         )}

--- a/frontend/packages/dev-console/src/components/import/advanced/ServerlessScalingSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/ServerlessScalingSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { FormikValues, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { NumberSpinnerField, ResourceLimitField } from '@console/shared';
 import FormSection from '../section/FormSection';
@@ -11,13 +10,7 @@ const ServerlessScalingSection: React.FC = () => {
     m: t('devconsole~Min'),
     h: t('devconsole~Hrs'),
   };
-  const {
-    values: {
-      serverless: {
-        scaling: { autoscale },
-      },
-    },
-  } = useFormikContext<FormikValues>();
+
   return (
     <FormSection
       title={t('devconsole~Scaling')}
@@ -63,7 +56,6 @@ const ServerlessScalingSection: React.FC = () => {
         label={t('devconsole~Autoscale window')}
         unitName="serverless.scaling.autoscale.autoscalewindowUnit"
         unitOptions={AutoscaleWindowUnits}
-        defaultUnitSize={`${autoscale.defaultAutoscalewindowUnit}`}
         helpText={t(
           'devconsole~Duration to look back for making auto-scaling decisions. The service is scaled to zero if no request was received in during that time.',
         )}


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6122

**Root analysis:**
When the field value is incremented the onChange callback always sets the default unit with the new value rather than using the already selected unit  

**Solution description:**
removed the usage of the prop `defaultUnitSize` in the ResourceLimitField and fetching the current unit using the useField hook

**GIF:**
![Peek 2021-07-13 21-18](https://user-images.githubusercontent.com/22490998/125483884-23bc497c-8eba-4a7d-a5d0-b277b15129d8.gif)


