### PR TITLE
[WIP] ODC-6148-ci-execution-related-enhancements

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 
 set -exuo pipefail
+set -e
+
+# PR_FILES_CHANGED store all Modified/Created files in Pull Request.
+export PR_FILES_CHANGED=$(git --no-pager diff --name-only HEAD $(git merge-base HEAD master))
+
+# transform_files function transform PR_FILES_CHANGED into a new array => FILES_CHANGED_ARRAY.
+function transform_files() {
+    for files in ${PR_FILES_CHANGED}
+    do
+        FILES_CHANGED_ARRAY+=($files)
+    done
+}
+
+# check_pkg_types function check first if packages/{plugin} folder have modifications and
+# in case of modification, respective {plugin} integration-tests should get executed on CI.
+function check_pkg_types() {
+
+}
+
+function execute_scripts_on_cron_jobs() {
+
+}
 
 ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
 SCREENSHOTS_DIR=frontend/gui_test_screenshots


### PR DESCRIPTION
**Description**:
Aim of this pr is to reduce the execution time on ci with different strategy
Example is as follows
If [devconsole pluign src](https://github.com/openshift/console/tree/master/frontend/packages/dev-console/src) code is modified, then respective integration tests should get executed, this helps to reduce the execution time on CI