### PR TITLE
ODC-6140-Removed dotnet related gherkin script from this pipelines plugin folder

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -153,7 +153,7 @@ Feature: Create Application from git form
 
 
         # Marking this scenario as @manual, because due to git-rate limit issue, below scenarios are failing
-        @manual
+        @regression @manual
         Scenario Outline: Builder iamge detected for git url "<git_url>": A-06-TC12
             Given user is at Import from git page
              When user enters Git Repo url as "<git_url>"
@@ -172,3 +172,33 @@ Feature: Create Application from git form
                   | https://github.com/sclorg/django-ex.git        | django-ex-git-app  | django-ex-git         |
                   | https://github.com/spring-projects/spring-boot | spring-bottom-app  | openshift-quickstarts |
                   | https://github.com/sclorg/nodejs-ex.git        | nodejs-ex-git-app  | nodejs-ex-git         |
+
+
+        @regression @manual
+        Scenario Outline: Dotnet Builder image detection for git url "<git_url>": A-06-TC13
+            Given user is at Import from git page
+             When user enters Git Repo url as "<git_url>"
+              And warning message "Unable to detect the Builder Image" displays in Builder section
+              And user clicks on "Show advanced Git options" link
+              And user clears Context dir field
+              And user enters Context dir as "<dir_name>"
+             Then git url gets Validated
+              And user is able to see "Builder Image(s) detected" message in Builder section
+              And .NET builder image card tile is highlighted with * mark
+
+        Examples:
+                  | git_url                                                   | dir_name | app_name              | name              |
+                  | https://github.com/redhat-developer/s2i-dotnetcore-ex.git | /app     | dotnetcore-ex-git-app | dotnetcore-ex-git |
+
+
+        @regression @manual
+        Scenario Outline: "Unable to detect the builder image" warning message displays for server related git urls: A-06-TC14
+            Given user is at Import from git page
+             When user enters Git Repo url as "<git_url>"
+             Then git url gets Validated
+              And user is able to see warning message "Unable to detect the Builder Image" in Builder section
+
+        Examples:
+                  | git_url                                | builder_image |
+                  | https://github.com/sclorg/httpd-ex.git | httpd         |
+                  | https://github.com/sclorg/nginx-ex.git | Nginx         |

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
@@ -110,8 +110,8 @@ Feature: Create Pipeline from Add Options
 
 
         #Marking this as manual due to git rate limit  issue
-        @manual
-        Scenario Outline: Add Pipeline display in git workload for builder image: P-01-TC08
+        @regression @manual
+        Scenario Outline: Add Pipeline option display in git workload for builder image: P-01-TC08
             Given user is at Import from Git form
              When user enters Git Repo url as "<git_url>"
              Then Add pipeline checkbox is displayed
@@ -125,3 +125,31 @@ Feature: Create Pipeline from Add Options
                   | https://github.com/sclorg/django-ex.git        |
                   | https://github.com/spring-projects/spring-boot |
                   | https://github.com/sclorg/nodejs-ex.git        |
+
+
+        @regression @manual
+        Scenario Outline: Add Pipeline option display for dotnet builder image with context directory": P-01-TC09
+            Given user is at Import from git page
+             When user enters Git Repo url as "<git_url>"
+              And user selects Show advanced Git options
+              And user clears Context dir field
+              And user enters Context dir as "<dir_name>"
+             Then Add pipeline checkbox is displayed
+
+        Examples:
+                  | git_url                                                   | dir_name |
+                  | https://github.com/redhat-developer/s2i-dotnetcore-ex.git | /app     |
+
+
+        @regression @manual
+        Scenario Outline: Add Pipeline option doesn't display for server related git urls: P-01-TC10
+            Given user is at Import from git page
+             When user enters Git Repo url as "<git_url>"
+              And user selects "<builder_image>" builder image
+             Then git url gets Validated
+              And user is able to see info message "<message>" in Pipelines section
+
+        Examples:
+                  | git_url                                | builder_image | message                                                                         |
+                  | https://github.com/sclorg/httpd-ex.git | httpd         | There are no pipeline templates available for Httpd and Deployment combination. |
+                  | https://github.com/sclorg/nginx-ex.git | Nginx         | There are no pipeline templates available for Nginx and Deployment combination. |

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
@@ -117,12 +117,11 @@ Feature: Create Pipeline from Add Options
              Then Add pipeline checkbox is displayed
 
         Examples:
-                  | git_url                                                   |
-                  | https://github.com/sclorg/dancer-ex.git                   |
-                  | https://github.com/sclorg/cakephp-ex.git                  |
-                  | https://github.com/redhat-developer/s2i-dotnetcore-ex.git |
-                  | https://github.com/sclorg/golang-ex.git                   |
-                  | https://github.com/sclorg/ruby-ex.git                     |
-                  | https://github.com/sclorg/django-ex.git                   |
-                  | https://github.com/spring-projects/spring-boot            |
-                  | https://github.com/sclorg/nodejs-ex.git                   |
+                  | git_url                                        |
+                  | https://github.com/sclorg/dancer-ex.git        |
+                  | https://github.com/sclorg/cakephp-ex.git       |
+                  | https://github.com/sclorg/golang-ex.git        |
+                  | https://github.com/sclorg/ruby-ex.git          |
+                  | https://github.com/sclorg/django-ex.git        |
+                  | https://github.com/spring-projects/spring-boot |
+                  | https://github.com/sclorg/nodejs-ex.git        |


### PR DESCRIPTION
**Jira Id:**
As part of this bug: https://issues.redhat.com/browse/ODC-6140, the changes made for this pr

**Acceptance Criteria:**
Removed the dotnet example present in scenario P-01-TC08 "create-from-add-options.feature" file
Added the scenarios for the dotnet and other server git urls

**Pre-conditions for Epic validation:**
NA

**Refactoring Gherkin scripts criteria for approving PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Check the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]
- [x] Update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [ ] Add @un-verified tag which are not verified by ODC QE
