### PR TITLE
fix when expression tooltip for failed task

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
-import { global_BackgroundColor_200 as greyBackgroundColor } from '@patternfly/react-tokens/dist/js/global_BackgroundColor_200';
-import { global_BackgroundColor_light_100 as lightBackgroundColor } from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import { createSvgIdUrl, useHover } from '@patternfly/react-topology';
 import * as cx from 'classnames';
 import * as _ from 'lodash';
@@ -39,7 +37,7 @@ interface TaskProps {
   task?: {
     data: TaskKind;
   };
-  status?: TaskStatus;
+  status: TaskStatus;
   namespace: string;
   isPipelineRun: boolean;
   disableVisualizationTooltip?: boolean;
@@ -203,27 +201,27 @@ const TaskComponent: React.FC<TaskProps> = ({
         renderVisualName
       )}
 
-      {isPipelineRun && showStatusState && (
-        <svg
-          width={30}
-          height={30}
-          viewBox="-5 -4 20 20"
-          style={{
-            color: taskStatusColor,
-          }}
-        >
-          <g
-            className={cx({
-              'fa-spin odc-pipeline-vis-task--icon-spin': status.reason === runStatus.Running,
-              'odc-pipeline-vis-task--icon-stop': status.reason !== runStatus.Running,
-            })}
-          >
-            <StatusIcon status={status.reason} disableSpin />
-          </g>
-        </svg>
-      )}
       {showStatusState && (
-        <SvgTaskStatus steps={stepStatusList} x={30} y={23} width={width / 2 + 15} />
+        <>
+          <svg
+            width={30}
+            height={30}
+            viewBox="-5 -4 20 20"
+            style={{
+              color: taskStatusColor,
+            }}
+          >
+            <g
+              className={cx({
+                'fa-spin odc-pipeline-vis-task--icon-spin': status.reason === runStatus.Running,
+                'odc-pipeline-vis-task--icon-stop': status.reason !== runStatus.Running,
+              })}
+            >
+              <StatusIcon status={status.reason} disableSpin />
+            </g>
+          </svg>
+          <SvgTaskStatus steps={stepStatusList} x={30} y={23} width={width / 2 + 15} />
+        </>
       )}
     </g>
   );
@@ -249,24 +247,18 @@ const TaskComponent: React.FC<TaskProps> = ({
     );
   }
 
-  const taskColor = showStatusState
-    ? taskStatusColor
-    : !isFinallyTask
-    ? greyBackgroundColor.value
-    : lightBackgroundColor.value;
-
   const taskNode = (
     <>
       {hasWhenExpression && (
         <WhenExpressionDecorator
           width={WHEN_EXPRESSSION_DIAMOND_SIZE}
           height={WHEN_EXPRESSSION_DIAMOND_SIZE}
-          stroke={showStatusState ? taskColor : undefined}
-          color={taskColor}
           appendLine={!hasRunAfter && !isFinallyTask}
+          isPipelineRun={isPipelineRun}
           status={status.reason}
           enableTooltip
           leftOffset={disableVisualizationTooltip && !isFinallyTask ? 3 : 2}
+          isFinallyTask={isFinallyTask}
         />
       )}
       {taskPill}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/WhenExpressionDecorator.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/WhenExpressionDecorator.tsx
@@ -1,35 +1,40 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { global_BorderColor_100 as lightBorderColor } from '@patternfly/react-tokens/dist/js/global_BorderColor_100';
-import { useTranslation } from 'react-i18next';
 import { runStatus } from '../../../utils/pipeline-augment';
 import { NODE_HEIGHT } from './const';
+import { getWhenExpressionDiamondState } from './utils';
 
 import './WhenExpressionDecorator.scss';
 
 type WhenExpressionDecoratorProps = {
   width: number;
   height: number;
-  color: string;
   leftOffset?: number;
   stroke?: string;
-  status?: string;
+  status: runStatus;
   appendLine?: boolean;
   enableTooltip?: boolean;
+  isFinallyTask: boolean;
+  isPipelineRun: boolean;
 };
 
 const WhenExpressionDecorator: React.FC<WhenExpressionDecoratorProps> = ({
   width,
   height,
-  color,
   enableTooltip,
-  stroke = lightBorderColor.value,
   appendLine = false,
   status,
   leftOffset = 2,
+  isFinallyTask,
+  isPipelineRun,
 }) => {
-  const { t } = useTranslation();
   const rotation = 45; // 45deg
+  const { tooltipContent, diamondColor } = getWhenExpressionDiamondState(
+    status,
+    isPipelineRun,
+    isFinallyTask,
+  );
   const diamondHeight =
     Math.round(width * Math.sin(rotation)) + Math.round(height * Math.cos(rotation));
   const diamondNode = (
@@ -39,8 +44,8 @@ const WhenExpressionDecorator: React.FC<WhenExpressionDecoratorProps> = ({
         className="opp-when-expression-decorator-diamond"
         width={width}
         height={height}
-        fill={color}
-        stroke={stroke}
+        fill={diamondColor}
+        stroke={isPipelineRun ? diamondColor : lightBorderColor.value}
       />
       {appendLine && (
         <line
@@ -53,17 +58,6 @@ const WhenExpressionDecorator: React.FC<WhenExpressionDecoratorProps> = ({
       )}
     </g>
   );
-  let tooltipContent;
-  switch (status) {
-    case runStatus.Succeeded:
-      tooltipContent = t('pipelines-plugin~When expression was met');
-      break;
-    case runStatus.Skipped:
-      tooltipContent = t('pipelines-plugin~When expression was not met');
-      break;
-    default:
-      tooltipContent = t('pipelines-plugin~When expression');
-  }
 
   return enableTooltip ? (
     <Tooltip

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/WhenExpressionDecorator.spec.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/WhenExpressionDecorator.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core';
+import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { runStatus } from '../../../../utils/pipeline-augment';
 import WhenExpressionDecorator from '../WhenExpressionDecorator';
@@ -14,8 +15,11 @@ describe('WhenExpressionDecorator', () => {
   const props: WhenExpressionDecoratorProps = {
     width: 10,
     height: 10,
-    color: 'white',
+    status: runStatus.Failed,
+    isPipelineRun: true,
+    isFinallyTask: false,
   };
+
   beforeEach(() => {
     wrapper = shallow(<WhenExpressionDecorator {...props} />);
   });
@@ -23,7 +27,7 @@ describe('WhenExpressionDecorator', () => {
   it('should render diamond shape when expression decorator', () => {
     const diamondShape = wrapper.find('rect');
     expect(diamondShape.exists()).toBe(true);
-    expect(diamondShape.props().fill).toBe(props.color);
+    expect(diamondShape.props().fill).toBe(successColor.value);
     expect(diamondShape.props().width).toBe(props.width);
     expect(diamondShape.props().height).toBe(props.height);
   });
@@ -76,7 +80,9 @@ describe('WhenExpressionDecorator', () => {
 
     expect(wrapper.find(Tooltip).props().content).toEqual(whenExpressionContent('When expression'));
     wrapper.setProps({ enableTooltip: true, status: runStatus.Failed });
-    expect(wrapper.find(Tooltip).props().content).toEqual(whenExpressionContent('When expression'));
+    expect(wrapper.find(Tooltip).props().content).toEqual(
+      whenExpressionContent('When expression was met'),
+    );
     wrapper.setProps({ enableTooltip: true, status: runStatus.Pending });
     expect(wrapper.find(Tooltip).props().content).toEqual(whenExpressionContent('When expression'));
     wrapper.setProps({ enableTooltip: true, status: runStatus['In Progress'] });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/__tests__/utils.spec.ts
@@ -1,4 +1,10 @@
+import { chart_color_black_400 as skippedColor } from '@patternfly/react-tokens/dist/js/chart_color_black_400';
+import { chart_color_blue_300 as runningColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import { global_BackgroundColor_200 as greyBackgroundColor } from '@patternfly/react-tokens/dist/js/global_BackgroundColor_200';
+import { global_BackgroundColor_light_100 as lightBackgroundColor } from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import { PipelineExampleNames, pipelineTestData } from '../../../../test-data/pipeline-data';
+import { runStatus } from '../../../../utils/pipeline-augment';
 import {
   getLastRegularTasks,
   getTopologyNodesEdges,
@@ -7,6 +13,7 @@ import {
   getFinallyTaskWidth,
   taskHasWhenExpression,
   nodesHasWhenExpression,
+  getWhenExpressionDiamondState,
 } from '../utils';
 
 const pipelineData = pipelineTestData[PipelineExampleNames.COMPLEX_PIPELINE];
@@ -137,5 +144,57 @@ describe('hasWhenExpression', () => {
 
   it('expect to return true if the finally tasks in the pipeline contains when expression', () => {
     expect(hasWhenExpression(pipelineWithWhenAndFinally)).toBe(true);
+  });
+});
+
+describe('When expression decorator color', () => {
+  it('should return grey color in pipeline details page', () => {
+    const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
+      runStatus.Idle,
+      false,
+      false,
+    );
+    expect(diamondColor).toBe(greyBackgroundColor.value);
+    expect(tooltipContent).toBe('When expression');
+  });
+
+  it('should return light-grey color in pipeline details page', () => {
+    const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
+      runStatus.Idle,
+      false,
+      true,
+    );
+    expect(diamondColor).toBe(lightBackgroundColor.value);
+    expect(tooltipContent).toBe('When expression');
+  });
+
+  it('should return green color for failed task status in pipeline-run details page', () => {
+    const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
+      runStatus.Failed,
+      true,
+      true,
+    );
+    expect(diamondColor).toBe(successColor.value);
+    expect(tooltipContent).toBe('When expression was met');
+  });
+
+  it('should return blue color for running task status in pipeline-run details page', () => {
+    const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
+      runStatus.Running,
+      true,
+      true,
+    );
+    expect(diamondColor).toBe(runningColor.value);
+    expect(tooltipContent).toBe('When expression');
+  });
+
+  it('should return black color for skipped status in pipeline-run details page', () => {
+    const { diamondColor, tooltipContent } = getWhenExpressionDiamondState(
+      runStatus.Skipped,
+      true,
+      true,
+    );
+    expect(diamondColor).toBe(skippedColor.value);
+    expect(tooltipContent).toBe('When expression was not met');
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/types.ts
@@ -102,3 +102,8 @@ export type NodeCreatorSetup = (
   width?: number,
   height?: number,
 ) => NodeCreator<PipelineRunAfterNodeModelData>;
+
+export type DiamondStateType = {
+  tooltipContent: string;
+  diamondColor: string;
+};


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6139

**Root analysis:**
The tooltip content was dependent on 2 statuses: `Succeeded` and `Skipped`. For any other status, it showed `When expression` this is the reason why for `Failed` status it showed `When expression` as a tooltip. The color of the diamond-shaped decorator uses the task run status color which is why when a task failed the decorator color was displayed in red

**Solution description:**
If the task is not skipped but failed then the decorator color is showed in green and the when-expression is considered to be met 

**GIF:**
![when-exp](https://user-images.githubusercontent.com/22490998/125605620-5421ba78-5d26-45ce-bd21-e5e35d23a411.gif)

**Test coverage:**
![Screenshot from 2021-07-16 00-58-33](https://user-images.githubusercontent.com/22490998/125855056-8839a8ef-70a2-4c88-9059-42e23600224d.png)
