### PR TITLE
Fix a11y form errors when import a container image

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/ToggleableFieldBase.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ToggleableFieldBase.tsx
@@ -40,7 +40,7 @@ const ToggleableFieldBase: React.FC<ToggleableFieldBaseProps> = ({
         label,
         isChecked: field.checked,
         isValid,
-        'aria-describedby': `${fieldId}-helper`,
+        'aria-describedby': helpText ? `${fieldId}-helper` : undefined,
         onChange: (val, event) => {
           field.onChange(event);
           onChange && onChange(val);

--- a/frontend/packages/dev-console/integration-tests/package.json
+++ b/frontend/packages/dev-console/integration-tests/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
     "clean-reports": "rm -rf ../../../gui_test_screenshots",
-    "cypress-merge": "mochawesome-merge ../../../gui_test_screenshots/cypress_report*.json > ../../../gui_test_screenshots/cypress.json",
-    "cypress-generate": "marge -o ../../../gui_test_screenshots/ -f cypress-report -t 'OpenShift DevConsole Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ../../../gui_test_screenshots/cypress/assets ../../../gui_test_screenshots/cypress.json",
+    "cypress-merge": "../../../node_modules/.bin/mochawesome-merge ../../../gui_test_screenshots/cypress_report*.json > ../../../gui_test_screenshots/cypress.json",
+    "cypress-generate": "../../../node_modules/.bin/marge -o ../../../gui_test_screenshots/ -f cypress-report -t 'OpenShift DevConsole Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ../../../gui_test_screenshots/cypress/assets ../../../gui_test_screenshots/cypress.json",
     "test-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/*/project-creation.feature\";",
     "test-cypress-headless": "yarn run clean-reports && yarn run test-headless && yarn run cypress-merge && yarn run cypress-generate"
   }

--- a/frontend/packages/dev-console/src/components/import/icon/IconDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/icon/IconDropdown.tsx
@@ -18,7 +18,7 @@ type IconProps = {
 
 const Icon: React.FC<IconProps> = ({ label, url }) => (
   <>
-    <img src={url} width="24" height="24" alt={label} className="icon" />
+    <img src={url} width="24" height="24" alt="" className="icon" />
     {label}
   </>
 );

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -186,6 +186,7 @@ const ImageSearch: React.FC = () => {
           setValidated(ValidatedOptions.default);
           debouncedHandleSearch((e.target as HTMLInputElement).value);
         }}
+        aria-label={t('devconsole~Image name')}
         data-test-id="deploy-image-search-term"
         required
       />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6150

**Analysis / Root cause**: 
When running some of the cypress E2E tests the import page fails with some accessibility errors.

**Solution Description**: 
Fix a11y issues:
* Do not link to an `aria-describedby` element when no help text is defined.
* Do not duplicate the alt text in the icon Dropdown (label was rendered exactly in the next line close to the icon)
* Add an a11y label to the Image name search field.

**Screen shots / Gifs for design review**: 
UI doesn't have changed. Only a11y attributes are changed.

Error before:
![before-1](https://user-images.githubusercontent.com/139310/125609993-ee9f2ac7-7ee6-475a-b74f-173513ef8818.png)

![before-2](https://user-images.githubusercontent.com/139310/125609990-272b22ed-e930-457b-9c0f-62a0aae20658.png)

Less errors after (other errors are general issues):
![after](https://user-images.githubusercontent.com/139310/125610057-ae395b94-9b6d-416d-8718-41b7ab75a267.png)

**Unit test coverage report**: 
Unchanged.

**Test setup:**
1. Open developer perspective > Add > Import from container image
2. Check accessibility errors with Firefox [axe - Web Accessibility Testing](https://addons.mozilla.org/de/firefox/addon/axe-devtools/) extension

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
