### PR TITLE
Fix a11y file input form issue, for example when creating a Secret

### DIFF
--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -97,19 +97,22 @@ class FileInputWithTranslation extends React.Component<FileInputProps, FileInput
               <input
                 type="text"
                 className="pf-c-form-control"
+                aria-label={t('public~Filename')}
                 value={this.props.inputFileName}
-                aria-describedby={`${id}-help`}
+                aria-describedby={this.props.inputFieldHelpText ? `${id}-help` : undefined}
                 readOnly
                 disabled
               />
               <span className="pf-c-button pf-m-tertiary co-btn-file">
-                <input type="file" onChange={this.onFileUpload} data-test="file-input" />
+                <input id={id} type="file" onChange={this.onFileUpload} data-test="file-input" />
                 {t('public~Browse...')}
               </span>
             </div>
-            <p className="help-block" id={`${id}-help`}>
-              {this.props.inputFieldHelpText}
-            </p>
+            {this.props.inputFieldHelpText ? (
+              <p className="help-block" id={`${id}-help`}>
+                {this.props.inputFieldHelpText}
+              </p>
+            ) : null}
             {!hideContents && (
               <textarea
                 data-test-id={
@@ -118,13 +121,18 @@ class FileInputWithTranslation extends React.Component<FileInputProps, FileInput
                 className="pf-c-form-control co-file-dropzone__textarea"
                 onChange={this.onDataChange}
                 value={this.props.inputFileData}
-                aria-describedby={`${id}-textarea-help`}
+                aria-label={this.props.label}
+                aria-describedby={
+                  this.props.textareaFieldHelpText ? `${id}-textarea-help` : undefined
+                }
                 required={isRequired}
               />
             )}
-            <p className="help-block" id={`${id}-textarea-help`}>
-              {this.props.textareaFieldHelpText}
-            </p>
+            {this.props.textareaFieldHelpText ? (
+              <p className="help-block" id={`${id}-textarea-help`}>
+                {this.props.textareaFieldHelpText}
+              </p>
+            ) : null}
             {errorMessage && <div className="text-danger">{errorMessage}</div>}
             {fileIsBinary && (
               <Alert

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1483,6 +1483,7 @@
   "Add favorite {{content}}": "Add favorite {{content}}",
   "Help": "Help",
   "Maximum file size exceeded. File limit is 4MB.": "Maximum file size exceeded. File limit is 4MB.",
+  "Filename": "Filename",
   "Browse...": "Browse...",
   "Non-printable file detected.": "Non-printable file detected.",
   "File contains non-printable characters. Preview is not available.": "File contains non-printable characters. Preview is not available.",


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6151

**Analysis / Root cause**: 
When running some of the cypress E2E tests the import page fails with some accessibility errors.

**Solution Description**: 
Fix a11y issues:
* Do not link to an `aria-describedby` element when no help text is defined.
* Add "Filename" label to the readonly field which shows the filename.

**Screen shots / Gifs for design review**: 
UI doesn't have changed. Only a11y attributes are changed.

![image](https://user-images.githubusercontent.com/139310/125611113-2b1a9468-404e-4780-9d2f-4763cdabfddc.png)

Before:
![before-1](https://user-images.githubusercontent.com/139310/125610727-49e6a02e-90dd-45a8-b1e8-1af9bb89b60a.png)
![before-2](https://user-images.githubusercontent.com/139310/125610726-34a8d1b7-b022-4915-9a32-3636dd8a7dd1.png)
![before-3](https://user-images.githubusercontent.com/139310/125610722-44de02ba-f649-401d-a225-f180e715a3e4.png)

After:
![after](https://user-images.githubusercontent.com/139310/125610963-62031ed5-64dc-44b8-bff8-86183e24d6e3.png)

**Unit test coverage report**: 
Unchanged.

**Test setup:**
1. Open developer perspective > Add > Import from container image
2. Check accessibility errors with Firefox [axe - Web Accessibility Testing](https://addons.mozilla.org/de/firefox/addon/axe-devtools/) extension

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge