### PR TITLE
Bug 1981396: Faulty BlockPool status after deletion

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/delete-block-pool-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/block-pool-modal/delete-block-pool-modal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
+import { useLocation } from 'react-router-dom';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import {
@@ -22,6 +23,7 @@ import { withHandlePromise } from '@console/internal/components/utils';
 import { StatusBox } from '@console/internal/components/utils/status-box';
 import { StorageClassModel, PersistentVolumeClaimModel } from '@console/internal/models';
 
+import { history } from '@console/internal/components/utils/router';
 import { BlockPoolModalFooter } from './modal-footer';
 import { BlockPoolStatus } from '../../block-pool/body';
 import { CephClusterKind, OcsStorageClassKind, StoragePoolKind } from '../../../types';
@@ -84,9 +86,16 @@ const DeleteBlockPoolModal = withHandlePromise((props: DeleteBlockPoolModalProps
     }
   }, [scResources, scLoaded, pvcResources, pvcLoaded, state.poolStatus, poolName, t]);
 
+  const location = useLocation();
   // Delete block pool
   const deletePool = () => {
-    handlePromise(k8sKill(CephBlockPoolModel, blockPoolConfig), () => close());
+    handlePromise(k8sKill(CephBlockPoolModel, blockPoolConfig), () => {
+      close();
+      // Go to block pool list page if pool is deleted
+      if (location.pathname.includes(poolName)) {
+        history.push(location.pathname.split(`/${poolName}`)[0]);
+      }
+    });
   };
 
   const MODAL_TITLE = t('ceph-storage-plugin~Delete BlockPool');


### PR DESCRIPTION
As shown in the screenshot below, the data received (`obj.data.status.phase` to be specific) is not updated after deletion, which was causing this issue.

![2021-07-14-195756_1920x1080_scrot](https://user-images.githubusercontent.com/33557095/125656228-66a3e6e8-d6c5-41e8-b5fa-bd0bb570a8d0.png)

This patch makes the status change to the "Unknown" phase after deletion.

![2021-07-14-205847_1920x1080_scrot](https://user-images.githubusercontent.com/33557095/125656061-bf064e1f-8c28-4fb5-a5cf-562f0884a562.png)