### PR TITLE
odc-6017-updated helm scripts with new page objects

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/helm.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/helm.ts
@@ -1,0 +1,5 @@
+export enum helmActions {
+  upgrade = 'Upgrade',
+  rollback = 'Rollback',
+  uninstallHelmRelease = 'Uninstall Helm Release',
+}

--- a/frontend/packages/dev-console/integration-tests/support/constants/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/index.ts
@@ -4,3 +4,4 @@ export * from './monitoring';
 export * from './pageTitle';
 export * from './topology';
 export * from './staticText/index';
+export * from './helm';

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -34,4 +34,9 @@ export const helmPO = {
   sidePane: {
     chartVersion: '.properties-side-panel-pf-property-value',
   },
+  helmActions: {
+    upgrade: '[data-test-action="helm-upgrade-action"]',
+    rollBack: '[data-test-action="helm-rollback-action"]',
+    uninstallHelmRelease: '[data-test-action="helm-delete-action"]',
+  },
 };

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/helm-po.ts
@@ -35,8 +35,8 @@ export const helmPO = {
     chartVersion: '.properties-side-panel-pf-property-value',
   },
   helmActions: {
-    upgrade: '[data-test-action="helm-upgrade-action"]',
-    rollBack: '[data-test-action="helm-rollback-action"]',
-    uninstallHelmRelease: '[data-test-action="helm-delete-action"]',
+    upgrade: '[data-test-action="Upgrade"]',
+    rollBack: '[data-test-action="Rollback"]',
+    uninstallHelmRelease: '[data-test-action="Uninstall Helm Release"]',
   },
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/catalog-page.ts
@@ -87,7 +87,12 @@ export const catalogPage = {
       .get(cardTitle, { timeout: 40000 })
       .contains('Knative Serving')
       .click(),
-  selectHelmChartCard: (cardName: string) => cy.byTestID(`HelmChart-${cardName}`).click(),
+  //  Due to Bug ODC-6153, identified the card using index
+  selectHelmChartCard: (cardName: string) =>
+    cy
+      .byTestID(`HelmChart-${cardName}`)
+      .first()
+      .click(),
   clickOnInstallButton: () => {
     cy.get(catalogPO.installHelmChart.install).click();
     cy.get('.co-m-loader', { timeout: 40000 }).should('not.exist');

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -163,7 +163,10 @@ export const projectNameSpace = {
 
   selectOrCreateProject: (projectName: string) => {
     projectNameSpace.clickProjectDropdown();
-    // Bug: ODC-5129 - is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
+    cy.get('[role="listbox"]')
+      .find('li')
+      .should('have.length.gt', 5);
+    // Bug: ODC-6164 - is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
     // cy.testA11y('Create Project modal');
     cy.byLegacyTestID('dropdown-text-filter').type(projectName);
     cy.get('[data-test-id="namespace-bar-dropdown"] span.pf-c-dropdown__toggle-text')
@@ -197,6 +200,7 @@ export const projectNameSpace = {
         });
       }
     });
+    cy.get('@projectNameSpaceDropdown').should('have.text', `Project: ${projectName}`);
   },
 
   selectProject: (projectName: string) => {

--- a/frontend/packages/helm-plugin/integration-tests/cypress.json
+++ b/frontend/packages/helm-plugin/integration-tests/cypress.json
@@ -19,7 +19,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "@helm and (@smoke or @regression) and not (@manual or @to-do or @un-verified)",
+    "TAGS": "@helm and (@smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)",
     "NAMESPACE": "aut-helm"
   },
   "retries": {

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release.feature
@@ -1,4 +1,5 @@
-@helm @smoke
+# Added @broken-test due to the bug : https://issues.redhat.com/browse/ODC-6107
+@helm @smoke @broken-test
 Feature: Perform Actions on Helm Releases
               As a user, I want to perform the actions on the helm releases in topology page
 

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/actions-on-helm-release.feature
@@ -3,7 +3,7 @@ Feature: Perform Actions on Helm Releases
               As a user, I want to perform the actions on the helm releases in topology page
 
         Background:
-            Given user has created or selected namespace "aut-helm-actions"
+            Given user has created or selected namespace "aut-helm"
 
 
         Scenario: Context menu options of helm release: HR-01-TC01

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-compatibility.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-compatibility.feature
@@ -4,7 +4,7 @@ Feature: Helm Chart
 
 
         Background:
-            Given user has created or selected namespace "aut-helm-compatibility"
+            Given user has created or selected namespace "aut-helm"
 
 
         @smoke

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-feature-flag.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-feature-flag.feature
@@ -4,7 +4,7 @@ Feature: Feature flag for Helm
 
 
         Background:
-            Given user has created or selected namespace "aut-helm-feature-flag"
+            Given user has created or selected namespace "aut-helm"
 
 
         @regression @manual

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-installation-view.feature
@@ -4,7 +4,7 @@ Feature: Helm Chart Installation View
 
 
         Background:
-            Given user has created or selected namespace "aut-helm-installation"
+            Given user has created or selected namespace "aut-helm"
 
 
         @regression

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/helm-navigation.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/helm-navigation.feature
@@ -3,7 +3,7 @@ Feature: Navigations on Helm Chart
               As a user, I want to navigate to different pages related to Helm Charts
 
         Background:
-            Given user has created or selected namespace "aut-helm-navigation"
+            Given user has created or selected namespace "aut-helm"
 
 
         @smoke

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/install-helm-chart.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/install-helm-chart.feature
@@ -3,7 +3,7 @@ Feature: Install the Helm Release
               As a user, I want to install the helm release
 
         Background:
-            Given user has created or selected namespace "aut-helm-chart"
+            Given user has created or selected namespace "aut-helm"
 
 
         @smoke
@@ -28,14 +28,13 @@ Feature: Install the Helm Release
         Scenario: Install Helm Chart from Developer Catalog Page using YAML View: HR-06-TC03
             Given user is at Add page
              When user selects "Helm Chart" card from add page
-              And user searches and selects "Nodejs Ex K v0.2.1" card from catalog page
+              And user searches and selects "Quarkus v0.0.3" card from catalog page
               And user clicks on the Install Helm Chart button on side bar
               And user selects YAML view
-              And user selects the Chart Version "0.2.1 / App Version 1.16.0 (Provided by Red Hat Helm Charts)"
-             When user selects "Proceed" button from Change Chart version confirmation dialog
-              And user clicks on the Install button
+              And user selects the Chart Version "0.0.2 (Provided by Red Hat Helm Charts)"
+             When user clicks on the Install button
              Then user will be redirected to Topology page
-              And Topology page have the helm chart workload "nodejs-ex-k"
+              And Topology page have the helm chart workload "quarkus"
 
 
         @smoke

--- a/frontend/packages/helm-plugin/integration-tests/features/helm/topology-helm-release.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm/topology-helm-release.feature
@@ -3,7 +3,7 @@ Feature: Actions on Helm release in topology page
         User will be able to open the context menu and side bar for the helm releases
 
         Background:
-            Given user has created or selected namespace "aut-helm-topology"
+            Given user has created or selected namespace "aut-helm"
 
 
         @smoke

--- a/frontend/packages/helm-plugin/integration-tests/support/commands/app.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/commands/app.ts
@@ -1,10 +1,14 @@
 import { guidedTour } from '@console/cypress-integration-tests/views/guided-tour';
 import { nav } from '@console/cypress-integration-tests/views/nav';
-import { switchPerspective } from '@console/dev-console/integration-tests/support/constants/global';
-import { perspective } from '@console/dev-console/integration-tests/support/pages/app';
+import {
+  devNavigationMenu,
+  switchPerspective,
+} from '@console/dev-console/integration-tests/support/constants/global';
+import { navigateTo, perspective } from '@console/dev-console/integration-tests/support/pages/app';
 
 beforeEach(() => {
   perspective.switchTo(switchPerspective.Developer);
   guidedTour.close();
   nav.sidenav.switcher.shouldHaveText(switchPerspective.Developer);
+  navigateTo(devNavigationMenu.Add);
 });

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
@@ -1,19 +1,21 @@
 import { modal } from '@console/cypress-integration-tests/views/modal';
+import { helmActions } from '@console/dev-console/integration-tests/support/constants';
 import { helmPO } from '@console/dev-console/integration-tests/support/pageObjects';
+
+const actions = [helmActions.upgrade, helmActions.rollback, helmActions.uninstallHelmRelease];
 
 export const helmDetailsPage = {
   verifyTitle: () => cy.byTestSectionHeading('Helm Release details').should('be.visible'),
   verifyResourcesTab: () => cy.get(helmPO.resourcesTab).should('be.visible'),
   verifyReleaseNotesTab: () => cy.get(helmPO.revisionHistoryTab).should('be.visible'),
-  verifyActionsDropdown: () => cy.byLegacyTestID('actions-menu-button').should('be.visible'),
+  verifyActionsDropdown: () => cy.byLegacyTestID('menu-toggle-button').should('be.visible'),
   verifyRevisionHistoryTab: () => cy.get(helmPO.revisionHistoryTab).should('be.visible'),
-  clickActionMenu: () => cy.byLegacyTestID('actions-menu-button').click(),
+  clickActionMenu: () => cy.byLegacyTestID('menu-toggle-button').click(),
   verifyActionsInActionMenu: () => {
-    const actions = ['Upgrade', 'Rollback', 'Uninstall Helm Release'];
-    cy.byLegacyTestID('action-items')
-      .children()
-      .each(($el) => {
-        expect(actions).toContain($el.text());
+    cy.byLegacyTestID('action-menu-content')
+      .find('li')
+      .each(($ele) => {
+        expect(actions).toContain($ele.text());
       });
   },
   verifyFieldValue: (fieldName: string, fieldValue: string) => {

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
@@ -8,11 +8,11 @@ export const helmDetailsPage = {
   verifyTitle: () => cy.byTestSectionHeading('Helm Release details').should('be.visible'),
   verifyResourcesTab: () => cy.get(helmPO.resourcesTab).should('be.visible'),
   verifyReleaseNotesTab: () => cy.get(helmPO.revisionHistoryTab).should('be.visible'),
-  verifyActionsDropdown: () => cy.byLegacyTestID('menu-toggle-button').should('be.visible'),
+  verifyActionsDropdown: () => cy.byLegacyTestID('actions-menu-button').should('be.visible'),
   verifyRevisionHistoryTab: () => cy.get(helmPO.revisionHistoryTab).should('be.visible'),
-  clickActionMenu: () => cy.byLegacyTestID('menu-toggle-button').click(),
+  clickActionMenu: () => cy.byLegacyTestID('actions-menu-button').click(),
   verifyActionsInActionMenu: () => {
-    cy.byLegacyTestID('action-menu-content')
+    cy.byLegacyTestID('action-items')
       .find('li')
       .each(($ele) => {
         expect(actions).toContain($ele.text());

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
@@ -59,7 +59,7 @@ export const helmPage = {
   },
   selectKebabMenu: () => {
     cy.get(helmPO.table).should('exist');
-    cy.byLegacyTestID('menu-toggle-button').click();
+    cy.byLegacyTestID('kebab-button').click();
   },
   verifyHelmChartsListed: () => {
     cy.get(helmPO.noHelmSearchMessage)

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-page.ts
@@ -1,4 +1,4 @@
-import { messages } from '@console/dev-console/integration-tests/support/constants';
+import { helmActions, messages } from '@console/dev-console/integration-tests/support/constants';
 import { helmPO } from '@console/dev-console/integration-tests/support/pageObjects';
 
 export const helmPage = {
@@ -59,7 +59,7 @@ export const helmPage = {
   },
   selectKebabMenu: () => {
     cy.get(helmPO.table).should('exist');
-    cy.byLegacyTestID('kebab-button').click();
+    cy.byLegacyTestID('menu-toggle-button').click();
   },
   verifyHelmChartsListed: () => {
     cy.get(helmPO.noHelmSearchMessage)
@@ -160,5 +160,24 @@ export const helmPage = {
           .click();
       }
     });
+  },
+  selectHelmActionFromMenu: (actionName: helmActions | string) => {
+    switch (actionName) {
+      case 'Upgrade':
+      case helmActions.upgrade:
+        cy.get(helmPO.helmActions.upgrade).click();
+        break;
+      case 'Rollback':
+      case helmActions.rollback:
+        cy.get(helmPO.helmActions.rollBack).click();
+        break;
+      case 'Uninstall Helm Release':
+      case helmActions.uninstallHelmRelease:
+        cy.get(helmPO.helmActions.uninstallHelmRelease).click();
+        break;
+      default:
+        cy.log(`${actionName} is not available in dropdown menu`);
+        break;
+    }
   },
 };

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/upgrade-helm-release-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/upgrade-helm-release-page.ts
@@ -7,11 +7,11 @@ export const upgradeHelmRelease = {
       .get('h1')
       .contains('Upgrade Helm Release')
       .should('be.visible'),
-  updateReplicaCount: () =>
+  updateReplicaCount: (replicaCount: string = '2') =>
     cy
       .get(helmPO.upgradeHelmRelease.replicaCount)
       .clear()
-      .type('2'),
+      .type(replicaCount),
   upgradeChartVersion: (yamlView: boolean = false) => {
     cy.get(helmPO.upgradeHelmRelease.chartVersion).click();
     const count = Cypress.$('[data-test-id="dropdown-menu"]').length;
@@ -21,7 +21,7 @@ export const upgradeHelmRelease = {
       .click();
     if (yamlView === true) {
       modal.modalTitleShouldContain('Change Chart Version?');
-      cy.byTestID('confirm-action').click();
+      modal.submit();
     }
   },
   clickOnUpgrade: () => {

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-release.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-release.ts
@@ -13,8 +13,6 @@ import {
 } from '@console/dev-console/integration-tests/support/pages';
 import { upgradeHelmRelease, helmDetailsPage, rollBackHelmRelease, helmPage } from '../../pages';
 
-const actions = [helmActions.upgrade, helmActions.rollback, helmActions.uninstallHelmRelease];
-
 Given('helm release {string} is present in topology page', (workloadName: string) => {
   catalogPage.createHelmChartFromAddPage(workloadName);
 });
@@ -46,17 +44,17 @@ Given('user is on the topology sidebar of the helm release {string}', (helmRelea
 });
 
 When('user clicks on the Actions drop down menu', () => {
-  cy.byLegacyTestID('menu-toggle-button').click();
+  topologySidePane.clickActionsDropDown();
 });
 
 Then(
   'user is able to see the actions dropdown menu with actions Upgrade, Rollback and Uninstall Helm Release',
   () => {
-    cy.byLegacyTestID('action-menu-content')
-      .find('li')
-      .each(($ele) => {
-        expect(actions).toContain($ele.text());
-      });
+    topologySidePane.verifyActions(
+      helmActions.upgrade,
+      helmActions.rollback,
+      helmActions.uninstallHelmRelease,
+    );
   },
 );
 
@@ -72,11 +70,11 @@ When('user clicks on the Kebab menu', () => {
 Then(
   'user is able to see kebab menu with actions Upgrade, Rollback and Uninstall Helm Release',
   () => {
-    cy.byLegacyTestID('action-menu-content')
-      .find('li')
-      .each(($ele) => {
-        expect(actions).toContain($ele.text());
-      });
+    topologySidePane.verifyActions(
+      helmActions.upgrade,
+      helmActions.rollback,
+      helmActions.uninstallHelmRelease,
+    );
   },
 );
 

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-release.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/helm/helm-release.ts
@@ -1,5 +1,9 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
-import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants';
+import {
+  devNavigationMenu,
+  helmActions,
+} from '@console/dev-console/integration-tests/support/constants';
+import { helmPO } from '@console/dev-console/integration-tests/support/pageObjects';
 import {
   topologyPage,
   topologySidePane,
@@ -8,6 +12,8 @@ import {
   catalogPage,
 } from '@console/dev-console/integration-tests/support/pages';
 import { upgradeHelmRelease, helmDetailsPage, rollBackHelmRelease, helmPage } from '../../pages';
+
+const actions = [helmActions.upgrade, helmActions.rollback, helmActions.uninstallHelmRelease];
 
 Given('helm release {string} is present in topology page', (workloadName: string) => {
   catalogPage.createHelmChartFromAddPage(workloadName);
@@ -28,9 +34,9 @@ Then(
   'user is able to see the context menu with actions Upgrade, Rollback and Uninstall Helm Release',
   () => {
     cy.get('ul[role="menu"]').should('be.visible');
-    cy.byTestActionID('Upgrade').should('be.visible');
-    cy.byTestActionID('Rollback').should('be.visible');
-    cy.byTestActionID('Uninstall Helm Release').should('be.visible');
+    cy.get(helmPO.helmActions.upgrade).should('be.visible');
+    cy.get(helmPO.helmActions.rollBack).should('be.visible');
+    cy.get(helmPO.helmActions.uninstallHelmRelease).should('be.visible');
   },
 );
 
@@ -40,15 +46,14 @@ Given('user is on the topology sidebar of the helm release {string}', (helmRelea
 });
 
 When('user clicks on the Actions drop down menu', () => {
-  cy.byLegacyTestID('actions-menu-button').click();
+  cy.byLegacyTestID('menu-toggle-button').click();
 });
 
 Then(
   'user is able to see the actions dropdown menu with actions Upgrade, Rollback and Uninstall Helm Release',
   () => {
-    const actions = ['Upgrade', 'Rollback', 'Uninstall Helm Release'];
-    cy.byLegacyTestID('action-items')
-      .children()
+    cy.byLegacyTestID('action-menu-content')
+      .find('li')
       .each(($ele) => {
         expect(actions).toContain($ele.text());
       });
@@ -67,9 +72,8 @@ When('user clicks on the Kebab menu', () => {
 Then(
   'user is able to see kebab menu with actions Upgrade, Rollback and Uninstall Helm Release',
   () => {
-    const actions = ['Upgrade', 'Rollback', 'Uninstall Helm Release'];
-    cy.byLegacyTestID('action-items')
-      .children()
+    cy.byLegacyTestID('action-menu-content')
+      .find('li')
       .each(($ele) => {
         expect(actions).toContain($ele.text());
       });
@@ -77,7 +81,7 @@ Then(
 );
 
 When('user clicks on the {string} action', (actionName: string) => {
-  cy.byTestActionID(actionName).click();
+  helmPage.selectHelmActionFromMenu(actionName);
 });
 
 When('user upgrades the chart Version', () => {

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -46,6 +46,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-console-headless
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
+  yarn run test-cypress-helm-headless
   exit;
 fi
 


### PR DESCRIPTION
**Description:**
Fixing helm scripts and adding them to CI
Couple of tests are broken due to the bug: https://issues.redhat.com/browse/ODC-6107. So creating another pr: https://github.com/openshift/console/pull/9709

**Jira Id:**
 Jira Id : https://issues.redhat.com/browse/ODC-6017

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Execute the scripts in Remote cluster

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p helm -h true
```

**Screen shots**:
![image](https://user-images.githubusercontent.com/61005404/128024207-b3929053-d80a-4fa5-a421-a12f3f6ae433.png)


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
