### PR TITLE
Fix fuzzy text (pending task name) in pipeline run visualization

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
@@ -20,7 +20,8 @@ $border-color: var(--pf-global--BorderColor--light-100);
   &--icon-spin {
     filter: blur(0);
     -webkit-filter: blur(0);
-    transform-origin: 16.7px 15.1px;
+    transform-box: fill-box;
+    transform-origin: center;
   }
 }
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -204,23 +204,23 @@ const TaskComponent: React.FC<TaskProps> = ({
       )}
 
       {isPipelineRun && showStatusState && (
-        <g
-          className={cx({
-            'fa-spin odc-pipeline-vis-task--icon-spin': status.reason === runStatus.Running,
-            'odc-pipeline-vis-task--icon-stop': status.reason !== runStatus.Running,
-          })}
+        <svg
+          width={30}
+          height={30}
+          viewBox="-5 -4 20 20"
+          style={{
+            color: taskStatusColor,
+          }}
         >
-          <svg
-            width={30}
-            height={30}
-            viewBox="-5 -4 20 20"
-            style={{
-              color: taskStatusColor,
-            }}
+          <g
+            className={cx({
+              'fa-spin odc-pipeline-vis-task--icon-spin': status.reason === runStatus.Running,
+              'odc-pipeline-vis-task--icon-stop': status.reason !== runStatus.Running,
+            })}
           >
             <StatusIcon status={status.reason} disableSpin />
-          </svg>
-        </g>
+          </g>
+        </svg>
       )}
       {showStatusState && (
         <SvgTaskStatus steps={stepStatusList} x={30} y={23} width={width / 2 + 15} />


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6137

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

`fa-spin` class on the `<g>` element along with static values in `transform-origin` property, creates a slight misaligned to the adjacent node's `text` elements causing the fuzzy effect.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Removed static values in `transform-origin` property and moved `<g>` element inside the `<svg>`  to use `transform: fill-box` on the `<g>`.  

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Before:**

https://user-images.githubusercontent.com/9964343/125759207-14d73da3-a7d4-4202-98dd-4139f9aa34cf.mp4


**After:**

https://user-images.githubusercontent.com/9964343/125758964-a04443fb-9415-4c5d-a217-72de63d60208.mp4


**Unit test coverage report**: 
<!-- Attach test coverage report -->
No tests.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create and start a pipeline.
2. Observe the  pending tasks, it should have a crisp task name text inside it.

 
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @VeereshAradhya @andrewballantyne @christianvogt 