### PR TITLE
disable duck type EventSource/Channel discovery in multicluster environment

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
@@ -41,6 +41,16 @@ describe('fetch-dynamic-eventsources: EventSources', () => {
     expect(fetchSpy).toHaveBeenCalled();
   });
 
+  it('should return empty evenSourceModel and resultList when MultiClusterEnabled', async () => {
+    window.SERVER_FLAGS.clusters = ['clustera', 'clusterb'];
+    await fetchEventSourcesCrd();
+    const modelRefs = getEventSourceModels();
+    const resultModel = getDynamicEventSourcesResourceList('sample-app');
+    expect(resultModel).toHaveLength(0);
+    expect(modelRefs).toHaveLength(0);
+    window.SERVER_FLAGS.clusters = null;
+  });
+
   it('should fetch models for duck type in case of error', async () => {
     jest.spyOn(coFetch, 'coFetch').mockImplementation(() => Promise.reject(new Error('Error')));
     await fetchEventSourcesCrd();
@@ -131,6 +141,16 @@ describe('fetch-dynamic-eventsources: Channels', () => {
     expectedRefs.forEach((ref) => {
       expect(modelRefs.includes(ref)).toBe(true);
     });
+  });
+
+  it('should return empty channelModel and resultList when MultiClusterEnabled', async () => {
+    window.SERVER_FLAGS.clusters = ['clustera', 'clusterb'];
+    await fetchChannelsCrd();
+    const modelRefs = getDynamicChannelModelRefs();
+    const resultModel = getDynamicChannelResourceList('sample-app');
+    expect(modelRefs).toHaveLength(0);
+    expect(resultModel).toHaveLength(0);
+    window.SERVER_FLAGS.clusters = null;
   });
 
   it('should return limit if passed to getDynamicChannelResourceList', async () => {

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { chart_color_red_300 as knativeEventingColor } from '@patternfly/react-tokens/dist/js/chart_color_red_300';
 import * as _ from 'lodash';
+import isMultiClusterEnabled from '@console/app/src/utils/isMultiClusterEnabled';
 import { coFetch } from '@console/internal/co-fetch';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import {
@@ -31,6 +32,11 @@ interface EventChannelData {
 export const getLabelPlural = (kind: string, plural: string) => kind + plural.slice(kind.length);
 
 export const fetchEventSourcesCrd = async () => {
+  if (isMultiClusterEnabled()) {
+    eventSourceData.eventSourceModels = [];
+    eventSourceData.loaded = true;
+    return eventSourceData.eventSourceModels;
+  }
   const url = 'api/console/knative-event-sources';
   try {
     const res = await coFetch(url);
@@ -159,6 +165,10 @@ export const isDynamicEventSourceKind = (kind: string): boolean => {
 };
 
 export const fetchChannelsCrd = async () => {
+  if (isMultiClusterEnabled()) {
+    eventSourceData.eventSourceChannels = [];
+    return eventSourceData.eventSourceChannels;
+  }
   const url = 'api/console/knative-channels';
   try {
     const res = await coFetch(url);


### PR DESCRIPTION
# Issue
https://issues.redhat.com/browse/ODC-5926
https://issues.redhat.com/browse/ODC-5934

# Solution
When `MultiCluster` is enabled, bypassing the network call for fetching dynamic EventSources and Channels

# PR testing
1. Install ServerLess Operator
2. Create KSVC, can refer to https://docs.openshift.com/container-platform/4.7/serverless/knative_serving/serverless-applications.html#creating-serverless-applications-using-the-developer-perspective
3. From Create button in serverLess -> Eventing , create Dynamic Channel and EventSource
4. Setup Multicluster, https://github.com/open-cluster-management/deploy or using operator or **simply mock by setting SERVER_FLAGS.cluster = [ 'clustera' , 'clusterb' ] before the topology plugin loads.**

Add this code in topology-plugin
![Screenshot from 2021-07-15 17-36-15](https://user-images.githubusercontent.com/24852534/125791217-5895ea1d-7392-427b-9b7b-de622b204a62.png)


# Screenshot
### Without multicluster enabled

**following topology view**
![Screenshot from 2021-07-15 17-35-53](https://user-images.githubusercontent.com/24852534/125790298-b612c08a-85e5-46b3-ae48-d6586da619f9.png)

**The following network calls occur.**
![Screenshot from 2021-07-15 17-35-42](https://user-images.githubusercontent.com/24852534/125791250-ce8e226e-53b0-401e-a2ad-7d2df056916e.png)


-----------------------------------------------------------------
### With multicluster enabled

**following topology view**
![Screenshot from 2021-07-15 17-36-52](https://user-images.githubusercontent.com/24852534/125790473-ded34fde-8d13-4ed3-9a32-7ac771931958.png)

**The above network calls do not occur**

# Tests
Updated `fetch-dynamic-evensources-util` test suite
![Screenshot from 2021-07-15 18-25-11](https://user-images.githubusercontent.com/24852534/125791618-dca6a5f8-896c-48f4-b829-1b5c49a71579.png)

# Browser conformance
Chrome
