### PR TITLE
ODC-6128: Fix form footer shadow

### DIFF
--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
@@ -11,4 +11,7 @@
     background: var(--pf-chart-global--Fill--Color--white);
     bottom: 0;
   }
+  &__shadow {
+    box-shadow: var(--pf-global--BoxShadow--sm-top);
+  }
 }

--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
@@ -34,7 +34,7 @@ const FormFooter: React.FC<FormFooterProps> = ({
     <div
       className={cx('ocs-form-footer', {
         'ocs-form-footer__sticky': sticky,
-        'pf-u-box-shadow-sm-top':
+        'ocs-form-footer__shadow':
           sticky && (shadowPosition === Shadows.both || shadowPosition === Shadows.bottom),
       })}
       ref={footerElementRef}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6128

**Analysis / Root cause**: 
Bisect the missing form footer, it was now shown anymore after #9329 was merged. But this change doesn't include an obvious reason why this breaks.

**Solution Description**: 
Other shadows was added via a scss variable instead of the PF utility classname. So change this to similar implementation.

Search for `pf-u-box-shadow` vs `--pf-global--BoxShadow`

**Screen shots / Gifs for design review**: 
Before:
![before](https://user-images.githubusercontent.com/139310/125816861-d2d76c1e-3c0f-4b52-ae85-8bb442edfccb.gif)

After:
![after](https://user-images.githubusercontent.com/139310/125816854-8da49e1c-4286-4d2f-aa6e-4e817a5fedf5.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Switch to developer perspective
2. Add page
3. Import from Git for example

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
