### PR TITLE
Bug 1976072: Ensure supported x-descriptors take priority in Operand details view

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/const.ts
@@ -30,51 +30,93 @@ export const REGEXP_NESTED_ARRAY_PATH = /^.*\[\d+\]\.?.*\[\d+\]\.?.*$/;
 //    'this'  -> ['this']
 export const REGEXP_CAPTURE_GROUP_SUBGROUP = /^([^.]*)\.?(.*)$/;
 
-export const DEPRECATED_CAPABILITIES: (SpecCapability | StatusCapability)[] = [
+export const DEPRECATED_CAPABILITIES: SpecCapability[] = [
   SpecCapability.arrayFieldGroup,
   SpecCapability.fieldGroup,
-  SpecCapability.label,
   SpecCapability.namespaceSelector,
+  SpecCapability.label,
 ];
 
-export const OBJECT_COMPATIBLE_CAPABILITIES: (SpecCapability | StatusCapability)[] = [
+export const COMMON_COMPATIBLE_CAPABILITIES: SpecCapability[] = [
   SpecCapability.advanced,
   SpecCapability.fieldDependency,
   SpecCapability.hidden,
-  SpecCapability.namespaceSelector,
+  // TODO remove when deprecated descriptors are no longer supported
+  SpecCapability.arrayFieldGroup,
+  SpecCapability.fieldGroup,
+  // END TODO
+];
+
+export const OBJECT_COMPATIBLE_CAPABILITIES: (SpecCapability | StatusCapability)[] = [
+  StatusCapability.podStatuses,
+  SpecCapability.updateStrategy,
   SpecCapability.nodeAffinity,
   SpecCapability.podAffinity,
   SpecCapability.podAntiAffinity,
   SpecCapability.resourceRequirements,
   SpecCapability.selector,
-  SpecCapability.updateStrategy,
-  StatusCapability.podStatuses,
+  // TODO remove when deprecated descriptors are no longer supported
+  SpecCapability.label,
+  SpecCapability.namespaceSelector,
+  // END TODO
 ];
 
 export const ARRAY_COMPATIBLE_CAPABILITIES: (SpecCapability | StatusCapability)[] = [
-  SpecCapability.advanced,
   SpecCapability.endpointList,
-  SpecCapability.fieldDependency,
-  SpecCapability.hidden,
   StatusCapability.conditions,
 ];
 
 export const PRIMITIVE_COMPATIBLE_CAPABILITIES: (SpecCapability | StatusCapability)[] = [
-  SpecCapability.advanced,
-  SpecCapability.booleanSwitch,
-  SpecCapability.checkbox,
-  SpecCapability.fieldDependency,
-  SpecCapability.hidden,
-  SpecCapability.imagePullPolicy,
-  SpecCapability.k8sResourcePrefix,
-  SpecCapability.number,
-  SpecCapability.password,
-  SpecCapability.podCount,
-  SpecCapability.select,
-  SpecCapability.text,
-  StatusCapability.w3Link,
-  StatusCapability.text,
   StatusCapability.k8sPhase,
   StatusCapability.k8sPhaseReason,
-  StatusCapability.k8sResourcePrefix,
+  SpecCapability.k8sResourcePrefix,
+  SpecCapability.imagePullPolicy,
+  SpecCapability.podCount,
+  SpecCapability.select,
+  StatusCapability.w3Link,
+  SpecCapability.booleanSwitch,
+  SpecCapability.checkbox,
+  SpecCapability.password,
+  SpecCapability.text,
+  StatusCapability.text,
+  SpecCapability.number,
+  // TODO remove when deprecated descriptors are no longer supported
+  SpecCapability.label,
+  // END TODO
+];
+
+export const CAPABILITY_SORT_ORDER: (SpecCapability | StatusCapability)[] = [
+  // Supported in details view and has a widget
+  SpecCapability.hidden,
+  SpecCapability.endpointList,
+  StatusCapability.conditions,
+  SpecCapability.resourceRequirements,
+  SpecCapability.updateStrategy,
+  StatusCapability.podStatuses,
+  SpecCapability.selector,
+  SpecCapability.k8sResourcePrefix,
+  SpecCapability.podCount,
+  SpecCapability.password,
+  StatusCapability.k8sPhaseReason,
+  SpecCapability.booleanSwitch,
+  SpecCapability.checkbox,
+  StatusCapability.w3Link,
+
+  // Supported in details view with no widget
+  SpecCapability.select,
+  SpecCapability.imagePullPolicy,
+  StatusCapability.k8sPhase,
+  SpecCapability.text,
+  StatusCapability.text,
+  SpecCapability.number,
+
+  // Unsupported on details view
+  SpecCapability.podAntiAffinity,
+  SpecCapability.podAffinity,
+  SpecCapability.nodeAffinity,
+
+  // Always last
+  SpecCapability.advanced,
+  SpecCapability.fieldDependency,
+  ...DEPRECATED_CAPABILITIES,
 ];

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -44,7 +44,7 @@ const PodCount: React.FC<SpecCapabilityProps> = ({
       })
     }
   >
-    {value} pods
+    {_.isNil(value) ? '-' : `${value} pods`}
   </DetailsItem>
 );
 
@@ -66,7 +66,7 @@ const Label: React.FC<SpecCapabilityProps> = ({
     {_.isObject(value) ? (
       <LabelList kind={model.kind} labels={value} />
     ) : (
-      <span>{value || '--'}</span>
+      <span>{value || '-'}</span>
     )}
   </DetailsItem>
 );
@@ -317,7 +317,7 @@ const UpdateStrategy: React.FC<SpecCapabilityProps> = ({
 
 export const SpecDescriptorDetailsItem: React.FC<SpecCapabilityProps> = (props) => {
   const [capability] =
-    getValidCapabilitiesForValue<SpecCapability>(props.descriptor, props.value, true) ?? [];
+    getValidCapabilitiesForValue<SpecCapability>(props.descriptor, props.value) ?? [];
 
   if (capability?.startsWith(SpecCapability.k8sResourcePrefix)) {
     return <K8sResourceLinkCapability capability={capability} {...props} />;

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -129,7 +129,7 @@ const MainStatus: React.FC<StatusCapabilityProps> = ({
 
 export const StatusDescriptorDetailsItem: React.FC<StatusCapabilityProps> = (props) => {
   const [capability] =
-    getValidCapabilitiesForValue<StatusCapability>(props.descriptor, props.value, true) ?? [];
+    getValidCapabilitiesForValue<StatusCapability>(props.descriptor, props.value) ?? [];
 
   if (capability?.startsWith(StatusCapability.k8sResourcePrefix)) {
     return <K8sResourceLinkCapability capability={capability} {...props} />;


### PR DESCRIPTION
Add sort order to OLM x-descriptors so that descriptors that are supported on the details page will always be used before those that are not.