### PR TITLE
Fix Pipeline Download All

### DIFF
--- a/frontend/public/components/utils/line-buffer.ts
+++ b/frontend/public/components/utils/line-buffer.ts
@@ -47,8 +47,8 @@ export class LineBuffer {
     return this._buffer;
   }
 
-  getBlob(options): Blob {
-    return new Blob([this._buffer.join('')], options);
+  getBlob(options: BlobPropertyBag, lineSeparator = '\n'): Blob {
+    return new Blob([this._buffer.join(lineSeparator)], options);
   }
 
   getHasTruncated(): boolean {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6138

**Analysis / Root cause**: 
As far as I can tell, it just never was implemented. Best known gap I can find is it breaks up the lines on ingest but joins them with `''` an empty string on egest.

**Solution Description**: 
Return the new line character between "lines" on egest.

**Unit test coverage report**: 
None -- might write something for this class 🤔 

**Test setup:**
- Using any multi-step/multi-task Pipeline and clicking the Download All on the Logs tab.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge