### PR TITLE
Bug 1983220: Fix pod terminal second scrollbar when user reduce the window size

### DIFF
--- a/frontend/public/components/terminal.jsx
+++ b/frontend/public/components/terminal.jsx
@@ -116,6 +116,11 @@ class Terminal_ extends React.Component {
       this.fitAddon.fit();
       // update the pty
       this.props.onResize(terminal.rows, terminal.cols);
+      // The internal xterm textarea was not repositioned when the window was resized.
+      // This workaround triggers a textarea position update to fix this.
+      // See https://bugzilla.redhat.com/show_bug.cgi?id=1983220
+      // and https://github.com/xtermjs/xterm.js/issues/3390
+      terminal._core?._syncTextArea?.();
     });
   }
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5630

**Analysis / Root cause**: 
Xterm uses an invisible textarea to detect keyboard events. This textarea has an absolute position and was permanently moved when the cursor position is changed. But this does not happen when the user resizes the window.

Bad positioned textarea:

![textarea-position](https://user-images.githubusercontent.com/139310/125942963-7b33bf07-7eba-4c92-a60e-d2bd0bf0d2c3.png)

**Solution Description**: 
This was NOT solved by updating xterm to 4.13.0. Hoped that because I found this issue: https://github.com/xtermjs/xterm.js/pull/3169

Open a new xterm issue: https://github.com/xtermjs/xterm.js/issues/3390

As workaround call the internal `_syncTextArea` when the window was resized. This method was currently only called when the cursor moved: https://github.com/xtermjs/xterm.js/blob/4.10.0/src/browser/Terminal.ts#L474-L477

**Screen shots / Gifs for design review**: 

Broken before in Chrome:

![broken-chrome](https://user-images.githubusercontent.com/139310/125943050-fba59615-4529-4d69-9226-baa64eb2b2d1.gif)

Broken before in Firefox:

![broken-firefox](https://user-images.githubusercontent.com/139310/125943060-62745ac2-7ab8-48db-af2d-158c20d83cf4.gif)

Fixed in Chrome:

![fixed-chrome](https://user-images.githubusercontent.com/139310/125942445-d1ebc7dc-0c41-41a5-a5f1-90324c1ccbdc.gif)

Fixed in Firefox:

![fixed-firefox](https://user-images.githubusercontent.com/139310/125943167-a0d426c0-a169-48e0-924b-79a2e2d3b973.gif)

**Unit test coverage report**: 
Unchanged.

**Test setup:**
1. Create a Deployment
2. Open Pod detail page and switch to "Terminal" tab
3. Create a long output, for example via `find .` or `find /`
4. Reduce the window height

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
