### PR TITLE
Bug 1983435: sources objects to sources list

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/provision-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/provision-source.tsx
@@ -105,7 +105,7 @@ export const ProvisionSourceComponent: React.FC<ProvisionSourceComponentProps> =
   ({ provisionSourceField, onChange, goToStorageStep, goToNetworkingStep }) => {
     const { t } = useTranslation();
     const provisionSourceValue = iGetFieldValue(provisionSourceField);
-    const sources: string[] = iGet(provisionSourceField, 'sources');
+    const sources: string[] = [...iGet(provisionSourceField, 'sources')];
     const validationType = iGetIn(provisionSourceField, ['validation', 'type']);
 
     return (


### PR DESCRIPTION
On some systems the iGet returns an object that is not a list of strings, in some cases this create an error and the component fail to render