### PR TITLE
Bug 1977936: OCS deployment using Multus: UI allows StorageCluster creation with empty public and cluster network in "Internal - Attached Devices"

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard.tsx
@@ -40,7 +40,7 @@ import {
   OCS_INTERNAL_CR_NAME,
   MODES,
 } from '../../../constants';
-import { StorageClusterKind, NavUtils } from '../../../types';
+import { StorageClusterKind, NetworkType, NavUtils } from '../../../types';
 import { getOCSRequestData, labelNodes, labelOCSNamespace } from '../ocs-request-data';
 import { OCSServiceModel } from '../../../models';
 import { OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG, OCS_FLAG } from '../../../features';
@@ -126,6 +126,10 @@ const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
   const discoveryNodes = state.lvdIsSelectNodes ? state.lvdSelectNodes : state.lvdAllNodes;
 
   const { getStep, getIndex, getAnchor } = navUtils;
+  const hasConfiguredNetwork =
+    state.networkType === NetworkType.MULTUS
+      ? !!(state.publicNetwork || state.clusterNetwork)
+      : true;
 
   /**
    * This custom footer for wizard provides a control over the movement to next step.
@@ -154,7 +158,8 @@ const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
             },
             [CreateStepsSC.CONFIGURE]: {
               onNextClick: () => onNext(),
-              isNextDisabled: !state.encryption.hasHandled || !state.kms.hasHandled,
+              isNextDisabled:
+                !state.encryption.hasHandled || !hasConfiguredNetwork || !state.kms.hasHandled,
             },
             [CreateStepsSC.REVIEWANDCREATE]: {
               onNextClick: () =>
@@ -162,7 +167,8 @@ const CreateStorageClusterWizard: React.FC<CreateStorageClusterWizardProps> = ({
               isNextDisabled:
                 state.nodes.length < MINIMUM_NODES ||
                 !getName(state.storageClass) ||
-                !state.kms.hasHandled,
+                !state.kms.hasHandled ||
+                !hasConfiguredNetwork,
             },
           };
           const { id } = activeStep;


### PR DESCRIPTION
Disabled "Next" button if no network Interface (Public/Cluster) is selected for MULTUS.
![Screenshot from 2021-07-19 17-51-06](https://user-images.githubusercontent.com/39404641/126159712-86ef79b2-ef29-4201-8395-c20433647a85.png)
