### PR TITLE
Bug 1982776: Namespaces - RoleBindings - Edit ClusterRoleBinding subject : An incomprehensible Japanese translation

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -504,7 +504,7 @@ class BaseEditRoleBindingWithTranslation extends React.Component {
     const subject = this.getSubject();
     const { fixed, saveButtonText, t } = this.props;
     const RoleDropdown = kind === 'RoleBinding' ? NsRoleDropdown : ClusterRoleDropdown;
-    const title = `${this.props.titleVerb} ${kindObj(kind).label}`;
+    const title = `${this.props.titleVerb} ${t(kindObj(kind).labelKey)}`;
     const isSubjectDisabled = fixed?.subjectRef?.subjectName ? true : false;
     const bindingKinds = [
       {


### PR DESCRIPTION
Addresses [Bug 1982776](https://bugzilla.redhat.com/show_bug.cgi?id=1982776)

This allows for "ClusterRoleBinding" to be translated.

![Screen Shot 2021-07-19 at 1 23 27 PM](https://user-images.githubusercontent.com/82059948/126208413-786bfac5-85fa-4505-b38f-76b9fe3e182d.png)
