### PR TITLE
Bug 1980182: operator UI not working with multiple version CRD in 4.6

### DIFF
--- a/frontend/packages/console-shared/src/hooks/useK8sModels.ts
+++ b/frontend/packages/console-shared/src/hooks/useK8sModels.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+import { K8sKind } from 'public/module/k8s';
+
+// Hook to retrieve all current k8s models from redux.
+export const useK8sModels = (): [{ [key: string]: K8sKind }, boolean] => [
+  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'models']))?.toJS() ?? {},
+  useSelector(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight'])) ?? false,
+];

--- a/frontend/packages/console-shared/src/utils/annotations.ts
+++ b/frontend/packages/console-shared/src/utils/annotations.ts
@@ -1,0 +1,17 @@
+import { ObjectMetadata } from '@console/internal/module/k8s';
+
+export const parseJSONAnnotation = (
+  annotations: ObjectMetadata['annotations'],
+  annotationKey: string,
+  onError?: (err: Error) => void,
+  defaultReturn?: any,
+): any => {
+  try {
+    return annotations?.[annotationKey] ? JSON.parse(annotations?.[annotationKey]) : defaultReturn;
+  } catch (e) {
+    onError?.(e);
+    // eslint-disable-next-line no-console
+    console.warn(`Could not parse annotation ${annotationKey} as JSON: `, e);
+    return defaultReturn;
+  }
+};

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -11,7 +11,6 @@ import {
   RouteKind,
   apiVersionForModel,
   K8sKind,
-  ObjectMetadata,
   JobKind,
 } from '@console/internal/module/k8s';
 import {
@@ -154,23 +153,7 @@ const getAnnotation = (obj: K8sResourceKind, annotation: string): string => {
   return obj?.metadata?.annotations?.[annotation];
 };
 
-export const parseJSONAnnotation = (
-  annotations: ObjectMetadata['annotations'],
-  annotationKey: string,
-  onError?: (err: Error) => void,
-  defaultReturn?: any,
-): any => {
-  try {
-    return annotations?.[annotationKey] ? JSON.parse(annotations?.[annotationKey]) : defaultReturn;
-  } catch (e) {
-    onError && onError(e);
-    // eslint-disable-next-line no-console
-    console.warn(`Could not parse annotation ${annotationKey} as JSON: `, e);
-    return defaultReturn;
-  }
-};
-
-export const getDeploymentRevision = (obj: K8sResourceKind): number => {
+const getDeploymentRevision = (obj: K8sResourceKind): number => {
   const revision = getAnnotation(obj, DEPLOYMENT_REVISION_ANNOTATION);
   return revision && parseInt(revision, 10);
 };
@@ -259,7 +242,7 @@ const getPodAlerts = (pod: K8sResourceKind): OverviewItemAlerts => {
     const { type, status, reason, message } = condition;
     if (type === 'PodScheduled' && status === 'False' && reason === 'Unschedulable') {
       // eslint-disable-next-line
-      const key = podAlertKey(reason, pod, name);
+      const key = podAlertKey(reason, pod);
       alerts[key] = {
         severity: 'error',
         message: `${reason}: ${message}`,

--- a/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedResources.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/TopologyOperatorBackedResources.tsx
@@ -12,8 +12,7 @@ import {
   ClusterServiceVersionKind,
   ClusterServiceVersionModel,
   CRDDescription,
-  providedAPIsFor,
-  referenceForProvidedAPI,
+  providedAPIForReference,
 } from '@console/operator-lifecycle-manager/src';
 import {
   flattenCsvResources,
@@ -67,9 +66,7 @@ const OperatorResourcesGetter: React.FC<OperatorResourcesGetterProps> = ({
   namespace,
   flatten,
 }) => {
-  const providedAPI = providedAPIsFor(csv).find(
-    (desc) => referenceForProvidedAPI(desc) === modelReference,
-  );
+  const providedAPI = providedAPIForReference(csv, modelReference);
   const linkForResource = (obj: K8sResourceKind) => {
     return linkForCsvResource(obj, providedAPI, csv.metadata.name);
   };

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
@@ -28,9 +28,6 @@ module.exports = {
   // When there is only a single export from a module, prefer using default export over named export.
   'import/prefer-default-export': 'off',
 
-  // Disallow Unused Expressions
-  'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
-
   // Disallow console statements
   'no-console': 'error',
 

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/typescript.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/typescript.js
@@ -149,6 +149,13 @@ module.exports = {
   // Warns if a type assertion does not change the type of an expression
   '@typescript-eslint/no-unnecessary-type-assertion': 'error',
 
+  // Disallow Unused Expressions,
+  'no-unused-expressions': 'off',
+  '@typescript-eslint/no-unused-expressions': [
+    'error',
+    { allowShortCircuit: true, allowTernary: true },
+  ],
+
   // Disallow unused variables
   'no-unused-vars': 'off',
   '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],

--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -397,6 +397,7 @@ export const testModel: K8sKind = {
   labelPlural: 'Test Resources',
   namespaced: true,
   plural: 'testresources',
+  verbs: ['create'],
 };
 
 const amqPackageManifest = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -27,6 +27,7 @@ import {
   testPackageManifest,
   testCatalogSource,
   testInstallPlan,
+  testModel,
 } from '../../mocks';
 import { ClusterServiceVersionModel } from '../models';
 import { ClusterServiceVersionKind, ClusterServiceVersionPhase } from '../types';
@@ -52,6 +53,10 @@ import {
   ClusterServiceVersionLogoProps,
   referenceForProvidedAPI,
 } from '.';
+
+jest.mock('@console/shared/src/hooks/useK8sModel', () => ({
+  useK8sModel: () => [testModel],
+}));
 
 describe('SingleProjectTableHeader.displayName', () => {
   it('returns single project column header definition for cluster service version table header', () => {
@@ -193,8 +198,7 @@ describe(ClusterServiceVersionLogo.displayName, () => {
   });
 
   it('renders logo image from given base64 encoded image string', () => {
-    const image: ReactWrapper<React.ImgHTMLAttributes<any>> = wrapper.find('img');
-
+    const image = wrapper.find('img');
     expect(image.props().src).toEqual(
       `data:${testClusterServiceVersion.spec.icon[0].mediatype};base64,${testClusterServiceVersion.spec.icon[0].base64data}`,
     );
@@ -202,8 +206,7 @@ describe(ClusterServiceVersionLogo.displayName, () => {
 
   it('renders fallback image if given icon is invalid', () => {
     wrapper.setProps({ icon: null });
-    const fallbackImg: ReactWrapper<React.ImgHTMLAttributes<any>> = wrapper.find('img');
-
+    const fallbackImg = wrapper.find('img');
     expect(fallbackImg.props().src).toEqual(operatorLogo);
   });
 
@@ -284,7 +287,7 @@ describe(ClusterServiceVersionDetails.displayName, () => {
 
   it('renders row of cards for each "owned" CRD for the given `ClusterServiceVersion`', () => {
     expect(wrapper.find(CRDCardRow).props().csv).toEqual(testClusterServiceVersion);
-    expect(wrapper.find(CRDCardRow).props().crdDescs).toEqual(
+    expect(wrapper.find(CRDCardRow).props().providedAPIs).toEqual(
       testClusterServiceVersion.spec.customresourcedefinitions.owned,
     );
   });
@@ -519,7 +522,7 @@ describe(ClusterServiceVersionsDetailsPage.displayName, () => {
 
     const csv = _.cloneDeep(testClusterServiceVersion);
     csv.spec.customresourcedefinitions.owned = csv.spec.customresourcedefinitions.owned.concat([
-      { name: 'e.example.com', kind: 'E', version: 'v1', displayName: 'E' },
+      { name: 'e.example.com', kind: 'E', version: 'v1alpha1', displayName: 'E' },
     ]);
 
     expect(detailsPage.props().pagesFor(csv)[4].name).toEqual('All Instances');

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -37,8 +37,6 @@ import {
   referenceForModel,
   referenceFor,
   groupVersionFor,
-  GroupVersionKind,
-  K8sKind,
   k8sKill,
   k8sPatch,
   k8sGet,
@@ -90,9 +88,8 @@ import {
   PackageManifestKind,
   SubscriptionKind,
 } from '../types';
-import { operatorTypeAnnotation, nonStandaloneAnnotationValue } from '../const';
+import { OPERATOR_TYPE_ANNOTATION, NON_STANDALONE_ANNOTATION_VALUE } from '../const';
 import { subscriptionForCSV, getSubscriptionStatus } from '../status/csv-status';
-import { getInternalObjects, isInternalObject } from '../utils';
 import { ProvidedAPIsPage, ProvidedAPIPage } from './operand';
 import { createUninstallOperatorModal } from './modals/uninstall-operator-modal';
 import { operatorGroupFor, operatorNamespaceFor } from './operator-group';
@@ -103,9 +100,10 @@ import {
   UpgradeApprovalLink,
 } from './subscription';
 import { RedExclamationCircleIcon } from '@console/shared/src/components/status/icons';
-import { ClusterServiceVersionLogo, referenceForProvidedAPI, providedAPIsFor } from './index';
+import { ClusterServiceVersionLogo, referenceForProvidedAPI, providedAPIsForCSV } from './index';
 import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumbs';
 import { CreateInitializationResourceButton } from './operator-install-page';
+import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 
 const clusterServiceVersionStateToProps = (state: RootState): ClusterServiceVersionStateProps => {
   return {
@@ -317,11 +315,7 @@ export const NamespacedClusterServiceVersionTableRow = withFallback<
   const [icon] = _.get(obj, 'spec.icon', []);
   const route = resourceObjPath(obj, referenceFor(obj));
   const uid = getUID(obj);
-  const internalObjects = getInternalObjects(obj);
-  const providedAPIs = providedAPIsFor(obj).filter(
-    (desc) => !isInternalObject(internalObjects, desc.name),
-  );
-
+  const providedAPIs = providedAPIsForCSV(obj);
   return (
     <TableRow id={uid} trKey={rowKey} index={index} style={style}>
       {/* Name */}
@@ -380,8 +374,8 @@ export const NamespacedClusterServiceVersionTableRow = withFallback<
             ))
           : '-'}
         {providedAPIs.length > 4 && (
-          <Link to={route} title={`View ${providedAPIsFor(obj).length - 4} more...`}>
-            {`View ${providedAPIsFor(obj).length - 4} more...`}
+          <Link to={route} title={`View ${providedAPIs.length - 4} more...`}>
+            {`View ${providedAPIs.length - 4} more...`}
           </Link>
         )}
       </TableData>
@@ -541,7 +535,8 @@ export const NamespacedClusterServiceVersionList: React.SFC<ClusterServiceVersio
 
   const isStandaloneCSV = (operator: ClusterServiceVersionKind) => {
     return (
-      operator.metadata.annotations?.[operatorTypeAnnotation] !== nonStandaloneAnnotationValue ||
+      operator.metadata.annotations?.[OPERATOR_TYPE_ANNOTATION] !==
+        NON_STANDALONE_ANNOTATION_VALUE ||
       operator.status?.phase === ClusterServiceVersionPhase.CSVPhaseFailed
     );
   };
@@ -707,12 +702,17 @@ export const MarkdownView = (props: {
   );
 };
 
-export const CRDCard: React.SFC<CRDCardProps> = (props) => {
-  const { csv, crd, canCreate, required = false } = props;
+export const CRDCard: React.FC<CRDCardProps> = ({ csv, crd, required, ...rest }) => {
   const reference = referenceForProvidedAPI(crd);
-  const model = modelFor(reference);
-  const createRoute = () =>
-    `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${reference}/~new`;
+  const [model] = useK8sModel(reference);
+  const canCreate = rest.canCreate ?? model?.verbs?.includes?.('create');
+  const createRoute = React.useMemo(
+    () =>
+      csv
+        ? `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${reference}/~new`
+        : null,
+    [csv, reference],
+  );
 
   return (
     <Card>
@@ -734,10 +734,10 @@ export const CRDCard: React.SFC<CRDCardProps> = (props) => {
       <CardBody>
         <MarkdownView content={crd.description} truncateContent />
       </CardBody>
-      {canCreate && (
+      {canCreate && createRoute && (
         <RequireCreatePermission model={model} namespace={csv.metadata.namespace}>
           <CardFooter>
-            <Link to={createRoute()}>
+            <Link to={createRoute}>
               <AddCircleOIcon className="co-icon-space-r" />
               Create Instance
             </Link>
@@ -748,40 +748,19 @@ export const CRDCard: React.SFC<CRDCardProps> = (props) => {
   );
 };
 
-const crdCardRowStateToProps = ({ k8s }, { crdDescs }) => {
-  const models: K8sKind[] = _.compact(
-    crdDescs.map((desc) => k8s.getIn(['RESOURCES', 'models', referenceForProvidedAPI(desc)])),
-  );
-  return {
-    crdDescs: crdDescs.filter((desc) =>
-      models.find((m) => referenceForModel(m) === referenceForProvidedAPI(desc)),
-    ),
-    createable: models
-      .filter((m) => (m.verbs || []).includes('create'))
-      .map((m) => referenceForModel(m)),
-  };
-};
-
-export const CRDCardRow = connect(crdCardRowStateToProps)((props: CRDCardRowProps) => {
-  const internalObjects = getInternalObjects(props.csv);
-  const crds = props.crdDescs?.filter(({ name }) => !isInternalObject(internalObjects, name));
+export const CRDCardRow = ({ csv, providedAPIs }: CRDCardRowProps) => {
   return (
     <div className="co-crd-card-row">
-      {_.isEmpty(crds) ? (
-        <span className="text-muted">No Kubernetes APIs are being provided by this Operator.</span>
-      ) : (
-        crds.map((crd) => (
-          <CRDCard
-            key={referenceForProvidedAPI(crd)}
-            crd={crd}
-            csv={props.csv}
-            canCreate={props.createable.includes(referenceForProvidedAPI(crd))}
-          />
+      {providedAPIs.length ? (
+        providedAPIs.map((crd) => (
+          <CRDCard key={referenceForProvidedAPI(crd)} crd={crd} csv={csv} />
         ))
+      ) : (
+        <span className="text-muted">No Kubernetes APIs are being provided by this Operator.</span>
       )}
     </div>
   );
-});
+};
 
 const InitializationResourceAlert: React.SFC<InitializationResourceAlertProps> = (props) => {
   const { initializationResource, csv } = props;
@@ -830,7 +809,7 @@ const InitializationResourceAlert: React.SFC<InitializationResourceAlertProps> =
   return null;
 };
 
-export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetailsProps> = (
+export const ClusterServiceVersionDetails: React.FC<ClusterServiceVersionDetailsProps> = (
   props,
 ) => {
   const { spec, metadata, status } = props.obj;
@@ -861,6 +840,7 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
       console.error(error.message);
     }
   }
+  const providedAPIs = providedAPIsForCSV(props.obj);
 
   return (
     <>
@@ -885,7 +865,7 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
                 />
               )}
               <SectionHeading text="Provided APIs" />
-              <CRDCardRow csv={props.obj} crdDescs={providedAPIsFor(props.obj)} />
+              <CRDCardRow csv={props.obj} providedAPIs={providedAPIs} />
               <SectionHeading text="Description" />
               <MarkdownView content={spec.description || 'Not available'} />
             </div>
@@ -1056,43 +1036,16 @@ export const CSVSubscription: React.FC<CSVSubscriptionProps> = ({
   );
 };
 
+const subscriptionPage = { href: 'subscription', name: 'Subscription', component: CSVSubscription };
+const allInstancesPage: Page = {
+  href: 'instances',
+  name: 'All Instances',
+  component: ProvidedAPIsPage,
+};
+
 export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsDetailsPageProps> = (
   props,
 ) => {
-  const instancePagesFor = (obj: ClusterServiceVersionKind) => {
-    const internalObjects = getInternalObjects(obj);
-    const allInstancesPage: Page = {
-      href: 'instances',
-      name: 'All Instances',
-      component: ProvidedAPIsPage,
-    };
-
-    return (providedAPIsFor(obj).length > 1 ? [allInstancesPage] : ([] as Page[])).concat(
-      providedAPIsFor(obj).reduce(
-        (acc, desc: CRDDescription) =>
-          !isInternalObject(internalObjects, desc.name)
-            ? [
-                ...acc,
-                {
-                  href: referenceForProvidedAPI(desc),
-                  name: ['Details', 'YAML', 'Subscription', 'Events'].includes(desc.displayName)
-                    ? `${desc.displayName} Operand`
-                    : desc.displayName || desc.kind,
-                  component: ProvidedAPIPage,
-                  pageData: {
-                    csv: obj,
-                    kind: referenceForProvidedAPI(desc),
-                    namespace: obj.metadata.namespace,
-                  },
-                },
-              ]
-            : acc,
-        [],
-      ),
-    );
-  };
-
-  type ExtraResources = { subscriptions: SubscriptionKind[] };
   const menuActions = (
     model,
     obj: ClusterServiceVersionKind,
@@ -1113,16 +1066,28 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
   });
 
   const pagesFor = React.useCallback(
-    (obj: ClusterServiceVersionKind) =>
-      _.compact([
+    (obj: ClusterServiceVersionKind) => {
+      const providedAPIs = providedAPIsForCSV(obj);
+      return [
         navFactory.details(ClusterServiceVersionDetails),
         navFactory.editYaml(),
-        canListSubscriptions
-          ? { href: 'subscription', name: 'Subscription', component: CSVSubscription }
-          : null,
+        ...(canListSubscriptions ? [subscriptionPage] : []),
         navFactory.events(ResourceEventStream),
-        ...instancePagesFor(obj),
-      ]),
+        ...(providedAPIs.length > 1 ? [allInstancesPage] : []),
+        ...providedAPIs.map((api: CRDDescription) => ({
+          href: referenceForProvidedAPI(api),
+          name: ['Details', 'YAML', 'Subscription', 'Events'].includes(api.displayName)
+            ? `${api.displayName} Operand`
+            : api.displayName || api.kind,
+          component: ProvidedAPIPage,
+          pageData: {
+            csv: obj,
+            kind: referenceForProvidedAPI(api),
+            namespace: obj.metadata.namespace,
+          },
+        })),
+      ];
+    },
     [canListSubscriptions],
   );
 
@@ -1159,6 +1124,8 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
   );
 };
 
+type ExtraResources = { subscriptions: SubscriptionKind[] };
+
 type ClusterServiceVersionStatusProps = {
   obj: ClusterServiceVersionKind;
   subscription: SubscriptionKind;
@@ -1180,16 +1147,15 @@ export type ClusterServiceVersionListProps = {
 };
 
 export type CRDCardProps = {
+  canCreate?: boolean;
   crd: CRDDescription | APIServiceDefinition;
-  csv: ClusterServiceVersionKind;
-  canCreate: boolean;
+  csv?: ClusterServiceVersionKind;
   required?: boolean;
 };
 
 export type CRDCardRowProps = {
-  crdDescs: (CRDDescription | APIServiceDefinition)[];
+  providedAPIs: (CRDDescription | APIServiceDefinition)[];
   csv: ClusterServiceVersionKind;
-  createable: GroupVersionKind[];
 };
 
 export type CRDCardRowState = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -25,7 +25,7 @@ import {
   referenceForGroupVersionKind,
 } from '@console/internal/module/k8s';
 import { CRDDescription, ClusterServiceVersionKind, ProvidedAPI } from '../types';
-import { referenceForProvidedAPI, providedAPIsFor } from './index';
+import { providedAPIForReference } from './index';
 import { OperandLink } from './operand/operand-link';
 
 const tableColumnClasses = [
@@ -133,8 +133,9 @@ export const linkForCsvResource = (
   );
 
 export const Resources: React.FC<ResourcesProps> = (props) => {
-  const providedAPI = providedAPIsFor(props.clusterServiceVersion).find(
-    (desc) => referenceForProvidedAPI(desc) === props.match.params.plural,
+  const providedAPI = providedAPIForReference(
+    props.clusterServiceVersion,
+    props.match.params.plural,
   );
 
   const defaultResources = ['Deployment', 'Service', 'ReplicaSet', 'Pod', 'Secret', 'ConfigMap'];

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -46,6 +46,27 @@ const STATUS_INDEX = _.findIndex(COLUMNS, { title: 'Status' });
 const LABELS_INDEX = _.findIndex(COLUMNS, { title: 'Labels' });
 const LAST_UPDATED_INDEX = _.findIndex(COLUMNS, { title: 'Last Updated' });
 
+jest.mock('@console/shared/src/hooks/useK8sModels', () => ({
+  useK8sModels: () => [
+    {
+      'testapp.coreos.com~v1alpha1~TestResource': {
+        abbr: 'TR',
+        apiGroup: 'testapp.coreos.com',
+        apiVersion: 'v1alpha1',
+        crd: true,
+        kind: 'TestResource',
+        label: 'Test Resource',
+        labelPlural: 'Test Resources',
+        namespaced: true,
+        plural: 'testresources',
+        verbs: ['create'],
+      },
+    },
+    false,
+    null,
+  ],
+}));
+
 describe(OperandTableHeader.displayName, () => {
   it('returns column header definition for resource', () => {
     expect(Array.isArray(OperandTableHeader())).toBe(true);
@@ -405,7 +426,7 @@ describe(ProvidedAPIsPage.displayName, () => {
   });
 
   beforeEach(() => {
-    wrapper = shallow(<ProvidedAPIsPage.WrappedComponent obj={testClusterServiceVersion} />);
+    wrapper = shallow(<ProvidedAPIsPage obj={testClusterServiceVersion} />);
   });
 
   it('renders a `StatusBox` if given app has no owned or required custom resources', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import { match } from 'react-router-dom';
-import { connect } from 'react-redux';
 import { sortable } from '@patternfly/react-table';
 import { JSONSchema6 } from 'json-schema';
 import { Status, SuccessStatus, getBadgeFromType } from '@console/shared';
@@ -41,7 +40,6 @@ import {
   apiGroupForReference,
   apiVersionForReference,
   kindForReference,
-  modelFor,
   referenceFor,
   referenceForModel,
   nameForModel,
@@ -50,13 +48,11 @@ import {
 } from '@console/internal/module/k8s';
 import { ResourceEventStream } from '@console/internal/components/events';
 import { deleteModal } from '@console/internal/components/modals';
-import { RootState } from '@console/internal/redux';
 import { ClusterServiceVersionModel } from '../../models';
 import { ClusterServiceVersionKind } from '../../types';
-import { isInternalObject, getInternalAPIReferences, getInternalObjects } from '../../utils';
 import { DescriptorType, StatusCapability, StatusDescriptor } from '../descriptors/types';
 import { Resources } from '../k8s-resource';
-import { referenceForProvidedAPI } from '../index';
+import { providedAPIsForCSV, referenceForProvidedAPI } from '../index';
 import { csvNameFromWindow, OperandLink } from './operand-link';
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 import {
@@ -66,6 +62,7 @@ import {
 } from '@console/plugin-sdk';
 import { CustomResourceDefinitionModel } from '@console/internal/models';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
+import { useK8sModels } from '@console/shared/src/hooks/useK8sModels';
 import { DescriptorDetailsItem, DescriptorDetailsItemList } from '../descriptors';
 
 export const getOperandActions = (
@@ -316,28 +313,28 @@ export const OperandList: React.FC<OperandListProps> = (props) => {
   );
 };
 
-const inFlightStateToProps = ({ k8s }: RootState) => ({
-  inFlight: k8s.getIn(['RESOURCES', 'inFlight']),
-});
-
-export const ProvidedAPIsPage = connect(inFlightStateToProps)((props: ProvidedAPIsPageProps) => {
+export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   const { obj } = props;
-  const { owned = [] } = obj.spec.customresourcedefinitions;
-  const internalObjects = getInternalObjects(obj);
-  const internalAPIs = getInternalAPIReferences(obj);
-  const firehoseResources = owned.reduce((resources, desc) => {
-    const reference = referenceForProvidedAPI(desc);
-    const model = modelFor(reference);
-    return model && !internalAPIs.some((api) => api === reference)
+  const [models, inFlight] = useK8sModels();
+  if (inFlight) {
+    return null;
+  }
+  const providedAPIs = providedAPIsForCSV(obj);
+
+  // Exclude provided APIs that do not have a model
+  const firehoseResources = providedAPIs.reduce((resourceAccumulator, api) => {
+    const reference = referenceForProvidedAPI(api);
+    const model = models?.[reference];
+    return model
       ? [
-          ...resources,
+          ...resourceAccumulator,
           {
-            kind: referenceForProvidedAPI(desc),
+            kind: referenceForProvidedAPI(api),
             namespaced: model.namespaced,
-            prop: desc.kind,
+            prop: api.kind,
           },
         ]
-      : resources;
+      : resourceAccumulator;
   }, []);
 
   const EmptyMsg = () => (
@@ -349,27 +346,21 @@ export const ProvidedAPIsPage = connect(inFlightStateToProps)((props: ProvidedAP
   const createLink = (name: string) =>
     `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${
       obj.metadata.name
-    }/${referenceForProvidedAPI(_.find(owned, { name }))}/~new`;
+    }/${referenceForProvidedAPI(_.find(providedAPIs, { name }))}/~new`;
   const createProps =
-    owned.length > 1
+    providedAPIs.length > 1
       ? {
-          items: owned.reduce(
-            (acc, crd) =>
-              !isInternalObject(internalObjects, crd.name)
-                ? { ...acc, [crd.name]: crd.displayName }
-                : acc,
-            {},
-          ),
+          items: providedAPIs.reduce((acc, api) => ({ ...acc, [api.name]: api.displayName }), {}),
           createLink,
         }
-      : { to: owned.length === 1 ? createLink(owned[0].name) : null };
+      : { to: providedAPIs.length === 1 ? createLink(providedAPIs[0].name) : null };
 
   const owners = (ownerRefs: OwnerReference[], items: K8sResourceKind[]) =>
     ownerRefs.filter(({ uid }) => items.filter(({ metadata }) => metadata.uid === uid).length > 0);
   const flatten = (resources: { [kind: string]: { data: K8sResourceKind[] } }) =>
     _.flatMap(resources, (resource) => _.map(resource.data, (item) => item)).filter(
       ({ kind, metadata }, i, allResources) =>
-        owned.filter((item) => item.kind === kind).length > 0 ||
+        providedAPIs.filter((item) => item.kind === kind).length > 0 ||
         owners(metadata.ownerReferences || [], allResources).length > 0,
     );
 
@@ -388,10 +379,6 @@ export const ProvidedAPIsPage = connect(inFlightStateToProps)((props: ProvidedAP
         ]
       : [];
 
-  if (props.inFlight) {
-    return null;
-  }
-
   return firehoseResources.length > 0 ? (
     <MultiListPage
       {...props}
@@ -399,16 +386,18 @@ export const ProvidedAPIsPage = connect(inFlightStateToProps)((props: ProvidedAP
       filterLabel="Resources by name"
       resources={firehoseResources}
       namespace={obj.metadata.namespace}
-      canCreate={owned.length > 0}
+      canCreate={providedAPIs.length > 0}
       createProps={createProps}
-      createButtonText={owned.length > 1 ? 'Create New' : `Create ${owned[0].displayName}`}
+      createButtonText={
+        providedAPIs.length > 1 ? 'Create New' : `Create ${providedAPIs[0].displayName}`
+      }
       flatten={flatten}
       rowFilters={rowFilters}
     />
   ) : (
     <StatusBox loaded EmptyMsg={EmptyMsg} />
   );
-});
+};
 
 export const ProvidedAPIPage = connectToModel((props: ProvidedAPIPageProps) => {
   const { namespace, kind, kindsInFlight, kindObj, csv } = props;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -149,7 +149,7 @@ export const installedFor = (allSubscriptions: SubscriptionKind[] = []) => (
   return !_.isNil(subscriptionFor(allSubscriptions)(allGroups)(pkgName)(ns));
 };
 
-export const providedAPIsFor = (og: OperatorGroupKind) =>
+export const providedAPIsForOperatorGroup = (og: OperatorGroupKind) =>
   _.get(og.metadata.annotations, 'olm.providedAPIs', '')
     .split(',')
     .map((api) => ({

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -17,7 +17,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { fromRequirements } from '@console/internal/module/k8s/selector';
 import { PackageManifestModel, OperatorGroupModel, SubscriptionModel } from '../../models';
 import { PackageManifestKind, OperatorGroupKind, SubscriptionKind } from '../../types';
-import { operatorTypeAnnotation, nonStandaloneAnnotationValue } from '../../const';
+import { OPERATOR_TYPE_ANNOTATION, NON_STANDALONE_ANNOTATION_VALUE } from '../../const';
 import { iconFor } from '..';
 import { installedFor, subscriptionFor } from '../operator-group';
 import { getOperatorProviderType } from './operator-hub-utils';
@@ -28,7 +28,7 @@ import {
   InstalledState,
   OperatorHubCSVAnnotationKey,
 } from './index';
-import { parseJSONAnnotation } from '@console/shared';
+import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
 
 const ANNOTATIONS_WITH_JSON = [
   OperatorHubCSVAnnotationKey.infrastructureFeatures,
@@ -64,7 +64,7 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
         const { currentCSVDesc } = channels.find((ch) => ch.name === defaultChannel);
         // if CSV contains annotation for a non-standalone operator, filter it out
         return !(
-          currentCSVDesc.annotations?.[operatorTypeAnnotation] === nonStandaloneAnnotationValue
+          currentCSVDesc.annotations?.[OPERATOR_TYPE_ANNOTATION] === NON_STANDALONE_ANNOTATION_VALUE
         );
       })
       .map(

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -46,9 +46,8 @@ import {
   referenceForProvidedAPI,
   iconFor,
 } from '../index';
-import { installedFor, supports, providedAPIsFor, isGlobal } from '../operator-group';
+import { installedFor, supports, providedAPIsForOperatorGroup, isGlobal } from '../operator-group';
 import { CRDCard } from '../clusterserviceversion';
-import { getInternalObjects, isInternalObject } from '../../utils';
 import { OperatorInstallStatusPage } from '../operator-install-page';
 
 export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> = (props) => {
@@ -117,8 +116,6 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
       ? referenceFor(initializationResource)
       : null;
   }
-
-  const internalObjects = getInternalObjects(currentCSVDesc, 'annotations');
 
   const globalNS =
     (props.operatorGroup?.data || ([] as OperatorGroupKind[])).find(
@@ -224,7 +221,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     if (_.isEmpty(operatorGroups)) {
       return [];
     }
-    const existingAPIs = _.flatMap(operatorGroups, providedAPIsFor);
+    const existingAPIs = _.flatMap(operatorGroups, providedAPIsForOperatorGroup);
     const providedAPIs = providedAPIsForChannel(props.packageManifest.data[0])(
       selectedUpdateChannel,
     ).map((desc) => referenceForProvidedAPI(desc));
@@ -543,9 +540,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     </div>
   );
 
-  const providedAPIs = providedAPIsForChannel(props.packageManifest.data[0])(
-    selectedUpdateChannel,
-  ).filter((item) => !isInternalObject(internalObjects, item.name));
+  const providedAPIs = providedAPIsForChannel(props.packageManifest.data[0])(selectedUpdateChannel);
 
   if (showInstallStatusPage) {
     return (

--- a/frontend/packages/operator-lifecycle-manager/src/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/const.ts
@@ -2,5 +2,8 @@ export enum Flags {
   OPERATOR_LIFECYCLE_MANAGER = 'OPERATOR_LIFECYCLE_MANAGER',
 }
 
-export const operatorTypeAnnotation = 'operators.operatorframework.io/operator-type';
-export const nonStandaloneAnnotationValue = 'non-standalone';
+export const GLOBAL_OPERATOR_NAMESPACE = 'openshift-operators';
+export const OPERATOR_UNINSTALL_MESSAGE_ANNOTATION = 'operator.openshift.io/uninstall-message';
+export const OPERATOR_TYPE_ANNOTATION = 'operators.operatorframework.io/operator-type';
+export const NON_STANDALONE_ANNOTATION_VALUE = 'non-standalone';
+export const INTERNAL_OBJECTS_ANNOTATION = 'operators.operatorframework.io/internal-objects';

--- a/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
@@ -1,24 +1,9 @@
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ClusterServiceVersionKind } from './types';
-import { referenceForProvidedAPI, providedAPIsFor } from './components';
+import { referenceForProvidedAPI, providedAPIsForCSV } from './components';
 import * as operatorLogo from './operator.svg';
 
-const isInternal = (crd: { name: string }): boolean => {
-  const internalOpListString = _.get(
-    crd,
-    ['csv', 'metadata', 'annotations', 'operators.operatorframework.io/internal-objects'],
-    '[]',
-  );
-  try {
-    const internalOpList = JSON.parse(internalOpListString); // JSON.parse fails if incorrect annotation structure
-    return internalOpList.some((op) => op === crd.name);
-  } catch {
-    /* eslint-disable-next-line no-console */
-    console.error('Failed to parse CSV annotation: Invalid JSON structure');
-    return false;
-  }
-};
 export const normalizeClusterServiceVersions = (
   clusterServiceVersions: ClusterServiceVersionKind[],
 ): K8sResourceKind[] => {
@@ -33,7 +18,7 @@ export const normalizeClusterServiceVersions = (
     `## Operator Description\n${csvDescription}`;
 
   const operatorProvidedAPIs: K8sResourceKind[] = _.flatten(
-    clusterServiceVersions.map((csv) => providedAPIsFor(csv).map((desc) => ({ ...desc, csv }))),
+    clusterServiceVersions.map((csv) => providedAPIsForCSV(csv).map((desc) => ({ ...desc, csv }))),
   )
     .reduce(
       (all, cur) =>
@@ -42,8 +27,6 @@ export const normalizeClusterServiceVersions = (
           : all.concat([cur]),
       [],
     )
-    // remove internal CRDs
-    .filter((crd) => !isInternal(crd))
     .map((desc) => ({
       // NOTE: Faking a real k8s object to avoid fetching all CRDs
       obj: {

--- a/frontend/packages/operator-lifecycle-manager/src/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/utils.ts
@@ -1,33 +1,6 @@
-import * as _ from 'lodash';
-import { ClusterServiceVersionKind, CRDDescription } from './types';
-import { referenceForProvidedAPI } from './components';
+import { parseJSONAnnotation } from '@console/shared/src/utils/annotations';
+import { ObjectMetadata } from '@console/internal/module/k8s';
+import { INTERNAL_OBJECTS_ANNOTATION } from './const';
 
-export const getInternalObjects = (csv: any, path: string = 'metadata.annotations') => {
-  const internals: string = _.get(csv, [
-    ..._.toPath(path),
-    'operators.operatorframework.io/internal-objects',
-  ]);
-  if (!internals) {
-    return [];
-  }
-  try {
-    return JSON.parse(internals);
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Error parsing internal object annotation.', e);
-    return [];
-  }
-};
-
-export const isInternalObject = (internalObjects: string[], objectName: string): boolean =>
-  internalObjects.some((obj) => obj === objectName);
-
-export const getInternalAPIReferences = (csv: ClusterServiceVersionKind): string[] => {
-  const owned: CRDDescription[] = csv?.spec?.customresourcedefinitions?.owned || [];
-  const internalObjects = getInternalObjects(csv);
-  return owned.reduce(
-    (acc, obj) =>
-      isInternalObject(internalObjects, obj.name) ? [referenceForProvidedAPI(obj), ...acc] : acc,
-    [],
-  );
-};
+export const getInternalObjects = (annotations: ObjectMetadata['annotations']): string[] =>
+  parseJSONAnnotation(annotations, INTERNAL_OBJECTS_ANNOTATION) ?? [];


### PR DESCRIPTION
Cherry picks pull request #7305 ([Bug 1888036](https://bugzilla.redhat.com/show_bug.cgi?id=1888036)) from @TheRealJon to the `release-4.6` branch to resolve this issue. The cherry pick was not clean (some files did not exist back in 4.6), hence the difference in lines in the diff.

Tested locally using a 4.6 cluster and seems to do the trick. I modified an existing operators yaml and CRD to reproduce. See screenshots below.

https://bugzilla.redhat.com/show_bug.cgi?id=1980182

## Setting up the 4.6 cluster
<img width="1792" alt="Screen Shot 2021-07-19 at 4 37 11 PM" src="https://user-images.githubusercontent.com/21317056/126224767-6e7ab132-8cef-4826-ae92-9102d68ee5c8.png">
<img width="1792" alt="Screen Shot 2021-07-19 at 4 39 16 PM" src="https://user-images.githubusercontent.com/21317056/126224768-4c52291f-fc53-4dd1-8387-2c0cb76abc26.png">

## Reproduced issue
<img width="1792" alt="Screen Shot 2021-07-19 at 4 34 18 PM" src="https://user-images.githubusercontent.com/21317056/126224766-6e73f6ee-32fc-4522-b612-78e8a7df1fc2.png">

## With fix
<img width="1792" alt="Screen Shot 2021-07-19 at 4 40 52 PM" src="https://user-images.githubusercontent.com/21317056/126224769-47e4ddd1-6072-45b5-954c-5bb1af4628a6.png">
