### PR TITLE
ODC-6159: Update quickstarts to fix missing shadow when user can scroll content

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -122,7 +122,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",
     "@patternfly/patternfly": "4.122.2",
-    "@patternfly/quickstarts": "1.0.0",
+    "@patternfly/quickstarts": "1.0.1",
     "@patternfly/react-catalog-view-extension": "4.12.15",
     "@patternfly/react-charts": "6.15.8",
     "@patternfly/react-core": "4.135.15",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1780,10 +1780,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.87.3.tgz#eb2e9b22aa8f6f106580e7451bf204a06cb9949e"
   integrity sha512-hDNMPa7B1zKD8LWFZO4SS5hC/N+yvuci2sAn8HJd+EIbAvbMAUkRsyZ0/XO3BG3RVtpSlgq7q8x1pAHC/FTFuA==
 
-"@patternfly/quickstarts@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-1.0.0.tgz#ec696bd14ab01129961b2ecc393557f3d0044ab2"
-  integrity sha512-FY2xKx3Mm4dBPVwolbUy5WtL67hwwzEBm8PcNpD5I2l4mIiCCRm4Z5VV6JfbLyvKgqjsTfSlYynpw16aNt5HNA==
+"@patternfly/quickstarts@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-1.0.1.tgz#d1eff761ea67ea397f6b92835adba366a78e09b2"
+  integrity sha512-EzWhUWStDEggvsPa6P+1vgl3QW765FH4nlNLmz09vGsYsdGxv73YMy7JJI0qZ9qqcjiAYe54O43i1dZO2ELSPg==
   dependencies:
     "@patternfly/patternfly" "4.108.2"
     "@patternfly/react-catalog-view-extension" "4.11.42"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6159

**Analysis / Root cause**: 
Similar to #9527 ... Shadow was not displayed anymore.

**Solution Description**: 
Other shadows was added via a scss variable instead of the PF utility classname. Fixed this in PatternFly via PR https://github.com/patternfly/patternfly-quickstarts/pull/15. Update `@patternfly/quickstarts` to include this fix.

**Screen shots / Gifs for design review**: 
Before:
![missing-shadow](https://user-images.githubusercontent.com/139310/125823470-171043e9-a01c-46cd-91af-a8072870db39.gif)

After:
![missing-shadow-fixed](https://user-images.githubusercontent.com/139310/125823479-ade1c556-ac6c-4da4-9f22-10246eaa12f1.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Open a quick start
2. Reduce the window so that the content of the quick start is scrollable.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
