### PR TITLE
Bug 1983707: filter null yaml objects before validating to prevent undefined exception

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -467,7 +467,7 @@ export const EditYAML_ = connect(stateToProps)(
           let hasErrors = false;
           this.setState({ errors: null }, () => {
             try {
-              objs = safeLoadAll(this.getEditor().getValue());
+              objs = safeLoadAll(this.getEditor().getValue()).filter((obj) => obj);
             } catch (e) {
               this.handleError(t('public~Error parsing YAML: {{e}}', { e }));
               return;


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1983707
