### PR TITLE
CONSOLE-2832, CONSOLE-2834: Integrate multicluster POC front and back end changes

### DIFF
--- a/contrib/multicluster-environment.sh
+++ b/contrib/multicluster-environment.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# This script will set up every cluster in your kubeconfig file as a managed
+# cluster and run a local bridge. The hub cluster will be your current
+# kubeconfig context. Typically, you'll want to start with a fresh kubeconfig
+# file. For example:
+#
+# $ export KUBECONFIG=multicluster.config
+# $ oc login cluster1.devcluster.openshift.com:6443
+# $ oc login cluster2.devcluster.openshift.com:6443
+# $ oc login cluster3.devcluster.openshift.com:6443
+# $ source ./contrib/multicluster-environment.sh
+# $ ./bin/bridge
+#
+# The script will create OAuthClients on each cluster and is meant only for
+# development clusters.
+
+CURRENT_CONTEXT=$(oc config current-context)
+OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID:=local-console-oauth-client}
+OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET:=open-sesame}
+BRIDGE_MANAGED_CLUSTERS="[]"
+CA_FILE_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'bridge-ca-files')
+
+oc get -n openshift-config-managed cm kube-root-ca.crt -o json | jq -r '.data["ca.crt"]' > "$CA_FILE_DIR/api-ca.crt"
+oc get -n openshift-config-managed cm default-ingress-cert -o json | jq -r '.data["ca-bundle.crt"]' > "$CA_FILE_DIR/oauth-ca.crt"
+
+for CONTEXT in $(oc config get-contexts -o name); do
+    # Set up the OAuthClient for this cluster
+    cat <<EOF | oc --context "$CONTEXT" apply -f -
+    apiVersion: oauth.openshift.io/v1
+    kind: OAuthClient
+    metadata:
+      name: "$OAUTH_CLIENT_ID"
+    grantMethod: auto
+    secret: "$OAUTH_CLIENT_SECRET"
+    redirectURIs:
+    - http://localhost:9000
+EOF
+    # If not the hub (current context), add the cluster to the managed cluster JSON array
+    if [ "$CONTEXT" != "$CURRENT_CONTEXT" ]; then
+        NAME=$(echo "$CONTEXT" | cut -f2 -d"/" | cut -f1 -d":")
+        URL=$(oc --context "$CONTEXT" whoami --show-server)
+        # Make a directory for CA files
+        mkdir -p "$CA_FILE_DIR/$NAME"
+        CA_FILE="$CA_FILE_DIR/$NAME/api-ca.crt"
+        OAUTH_CA_FILE="$CA_FILE_DIR/$NAME/oauth-ca.crt"
+        oc --context "$CONTEXT" get -n openshift-config-managed cm kube-root-ca.crt -o json | jq -r '.data["ca.crt"]' > "$CA_FILE"
+        oc --context "$CONTEXT" get -n openshift-config-managed cm default-ingress-cert -o json | jq -r '.data["ca-bundle.crt"]' > "$OAUTH_CA_FILE"
+        BRIDGE_MANAGED_CLUSTERS=$(echo "$BRIDGE_MANAGED_CLUSTERS" | \
+            jq --arg name "$NAME" \
+            --arg url "$URL" \
+            --arg caFile "$CA_FILE" \
+            --arg clientID "$OAUTH_CLIENT_ID" \
+            --arg clientSecret "$OAUTH_CLIENT_SECRET" \
+            --arg oauthCAFile "$OAUTH_CA_FILE" \
+            '. += [{"name": $name, "apiServer": {"url": $url, "caFile": $caFile}, "oauth": {"clientID": $clientID, "clientSecret": $clientSecret, caFile: $oauthCAFile}}]')
+    fi
+done
+
+export BRIDGE_MANAGED_CLUSTERS
+
+BRIDGE_BASE_ADDRESS="http://localhost:9000"
+export BRIDGE_BASE_ADDRESS
+
+# FIXME: We should be able to get rid of this, but it requires changes to
+# main.go to support `ca-file` in off-cluster mode for the k8s proxy.
+BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
+export BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS
+
+BRIDGE_K8S_AUTH="openshift"
+export BRIDGE_K8S_AUTH
+
+BRIDGE_K8S_MODE="off-cluster"
+export BRIDGE_K8S_MODE
+
+BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
+export BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT
+
+BRIDGE_CA_FILE="$CA_FILE_DIR/api-ca.crt"
+export BRIDGE_CA_FILE
+
+BRIDGE_USER_AUTH="openshift"
+export BRIDGE_USER_AUTH
+
+BRIDGE_USER_AUTH_OIDC_CLIENT_ID="$OAUTH_CLIENT_ID"
+export BRIDGE_USER_AUTH_OIDC_CLIENT_ID
+
+BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET="$OAUTH_CLIENT_SECRET"
+export BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET
+
+BRIDGE_USER_AUTH_OIDC_CA_FILE="$CA_FILE_DIR/oauth-ca.crt"
+export BRIDGE_USER_AUTH_OIDC_CA_FILE
+
+echo "Using hub cluster: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
+echo "Using managed clusters:"
+echo "$BRIDGE_MANAGED_CLUSTERS" | jq -r '.[].apiServer.url'

--- a/frontend/@types/console/index.d.ts
+++ b/frontend/@types/console/index.d.ts
@@ -48,6 +48,7 @@ declare interface Window {
     quickStarts: string;
     clusters: string[];
     projectAccessClusterRoles: string;
+    clusters: string[];
   };
   windowError?: string;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/frontend/packages/console-app/src/components/detect-cluster/DetectCluster.tsx
+++ b/frontend/packages/console-app/src/components/detect-cluster/DetectCluster.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { ClusterContext, useValuesForClusterContext } from './cluster';
+
+type DetectClusterProps = {
+  children: React.ReactNode;
+};
+
+const DetectCluster: React.FC<DetectClusterProps> = ({ children }) => {
+  const { cluster, setCluster, loaded } = useValuesForClusterContext();
+  return loaded ? (
+    <ClusterContext.Provider value={{ cluster, setCluster }}>{children}</ClusterContext.Provider>
+  ) : null;
+};
+
+export default DetectCluster;

--- a/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
+++ b/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
@@ -1,0 +1,45 @@
+import * as React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useDispatch } from 'react-redux';
+import { setActiveCluster } from '@console/internal/actions/ui';
+import { LAST_CLUSTER_USER_SETTINGS_KEY } from '@console/shared/src/constants';
+import { useUserSettings } from '@console/shared/src/hooks/useUserSettings';
+
+type ClusterContextType = {
+  cluster?: string;
+  setCluster?: (cluster: string) => void;
+};
+
+export const ClusterContext = React.createContext<ClusterContextType>({});
+
+export const useValuesForClusterContext = () => {
+  const [lastCluster, setLastCluster, lastClusterLoaded] = useUserSettings<string>(
+    LAST_CLUSTER_USER_SETTINGS_KEY,
+    'local-cluster',
+    true,
+  );
+  const dispatch = useDispatch();
+  const setCluster = React.useCallback(
+    (cluster: string) => {
+      dispatch(setActiveCluster(cluster));
+      setLastCluster(cluster);
+    },
+    [dispatch, setLastCluster],
+  );
+
+  React.useEffect(() => {
+    // TODO: Detect cluster from URL.
+    if (lastClusterLoaded && lastCluster) {
+      dispatch(setActiveCluster(lastCluster));
+    }
+    // Only run this hook after last cluster is loaded.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastClusterLoaded]);
+
+  return {
+    cluster: lastCluster,
+    setCluster,
+    loaded: lastClusterLoaded,
+  };
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -165,6 +165,7 @@ export type WatchK8sResource = {
   limit?: number;
   fieldSelector?: string;
   optional?: boolean;
+  cluster?: string;
 };
 
 export type ResourcesObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] };
@@ -235,14 +236,45 @@ export type ConsoleFetch = (
   url: string,
   options?: RequestInit,
   timeout?: number,
+  cluster?: string,
 ) => Promise<Response>;
 
 export type ConsoleFetchJSON<T = any> = {
-  (url: string, method?: string, options?: RequestInit, timeout?: number): Promise<T>;
-  delete(url: string, json?: any, options?: RequestInit, timeout?: number): Promise<T>;
-  post(url: string, json: any, options?: RequestInit, timeout?: number): Promise<T>;
-  put(url: string, json: any, options?: RequestInit, timeout?: number): Promise<T>;
-  patch(url: string, json: any, options?: RequestInit, timeout?: number): Promise<T>;
+  (
+    url: string,
+    method?: string,
+    options?: RequestInit,
+    timeout?: number,
+    cluster?: string,
+  ): Promise<T>;
+  delete(
+    url: string,
+    json?: any,
+    options?: RequestInit,
+    timeout?: number,
+    cluster?: string,
+  ): Promise<T>;
+  post(
+    url: string,
+    json: any,
+    options?: RequestInit,
+    timeout?: number,
+    cluster?: string,
+  ): Promise<T>;
+  put(
+    url: string,
+    json: any,
+    options?: RequestInit,
+    timeout?: number,
+    cluster?: string,
+  ): Promise<T>;
+  patch(
+    url: string,
+    json: any,
+    options?: RequestInit,
+    timeout?: number,
+    cluster?: string,
+  ): Promise<T>;
 };
 
 export type ConsoleFetchText = (...args: Parameters<ConsoleFetch>) => Promise<string>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch.ts
@@ -55,7 +55,7 @@ const consoleFetchInternal = (
  * * */
 export const consoleFetch: ConsoleFetch = async (url, options = {}, timeout = 60000) => {
   let attempt = 0;
-  let response;
+  let response: Response;
   let retry = true;
   while (retry) {
     retry = false;
@@ -81,8 +81,12 @@ const consoleFetchCommon = async (
   method: string = 'GET',
   options: RequestInit = {},
   timeout?: number,
+  cluster?: string,
 ) => {
   const headers = getImpersonateHeaders() || {};
+  if (cluster) {
+    headers['X-Cluster'] = cluster;
+  }
   // Pass headers last to let callers to override Accept.
   const allOptions = _.defaultsDeep({ method }, options, { headers });
   const response = await consoleFetch(url, allOptions, timeout);
@@ -103,11 +107,20 @@ const consoleFetchCommon = async (
  * @param method  The HTTP method to use. Defaults to GET
  * @param options The options to pass to fetch
  * @param timeout The timeout in milliseconds
+ * @param cluster The name of the cluster to make the request to. Defaults to the active cluster the user has selected
  * @returns A promise that resolves to the response as JSON object.
  * * */
-export const consoleFetchJSON: ConsoleFetchJSON = (url, method = 'GET', options = {}, timeout) => {
-  const allOptions = _.defaultsDeep({}, options, { headers: { Accept: 'application/json' } });
-  return consoleFetchCommon(url, method, allOptions, timeout);
+export const consoleFetchJSON: ConsoleFetchJSON = (
+  url,
+  method = 'GET',
+  options = {},
+  timeout,
+  cluster,
+) => {
+  const allOptions = _.defaultsDeep({}, options, {
+    headers: { Accept: 'application/json' },
+  });
+  return consoleFetchCommon(url, method, allOptions, timeout, cluster);
 };
 
 /**
@@ -119,10 +132,11 @@ export const consoleFetchJSON: ConsoleFetchJSON = (url, method = 'GET', options 
  * @param method  The HTTP method to use. Defaults to GET
  * @param options The options to pass to fetch
  * @param timeout The timeout in milliseconds
+ * @param cluster The name of the cluster to make the request to. Defaults to the active cluster the user has selected
  * @returns A promise that resolves to the response as text.
  * * */
-export const consoleFetchText: ConsoleFetchText = (url, options = {}, timeout) => {
-  return consoleFetchCommon(url, 'GET', options, timeout);
+export const consoleFetchText: ConsoleFetchText = (url, options = {}, timeout, cluster) => {
+  return consoleFetchCommon(url, 'GET', options, timeout, cluster);
 };
 
 const consoleFetchSendJSON = (
@@ -131,6 +145,7 @@ const consoleFetchSendJSON = (
   json = null,
   options: RequestInit = {},
   timeout: number,
+  cluster?: string,
 ) => {
   const allOptions: Record<string, any> = {
     headers: {
@@ -143,7 +158,7 @@ const consoleFetchSendJSON = (
   if (json) {
     allOptions.body = JSON.stringify(json);
   }
-  return consoleFetchJSON(url, method, _.defaultsDeep(allOptions, options), timeout);
+  return consoleFetchJSON(url, method, _.defaultsDeep(allOptions, options), timeout, cluster);
 };
 
 /**
@@ -153,11 +168,12 @@ const consoleFetchSendJSON = (
  * @param json The JSON to delete the object
  * @param options The options to pass to fetch
  * @param timeout The timeout in milliseconds
+ * @param cluster The name of the cluster to make the request to. Defaults to the active cluster the user has selected
  * * */
-consoleFetchJSON.delete = (url, json = null, options = {}, timeout) => {
+consoleFetchJSON.delete = (url, json = null, options = {}, timeout, cluster) => {
   return json
-    ? consoleFetchSendJSON(url, 'DELETE', json, options, timeout)
-    : consoleFetchJSON(url, 'DELETE', options, timeout);
+    ? consoleFetchSendJSON(url, 'DELETE', json, options, timeout, cluster)
+    : consoleFetchJSON(url, 'DELETE', options, timeout, cluster);
 };
 
 /**
@@ -167,9 +183,10 @@ consoleFetchJSON.delete = (url, json = null, options = {}, timeout) => {
  * @param json The JSON to POST the object
  * @param options The options to pass to fetch
  * @param timeout The timeout in milliseconds
+ * @param cluster The name of the cluster to make the request to. Defaults to the active cluster the user has selected
  * * */
-consoleFetchJSON.post = (url: string, json, options = {}, timeout) =>
-  consoleFetchSendJSON(url, 'POST', json, options, timeout);
+consoleFetchJSON.post = (url: string, json, options = {}, timeout, cluster) =>
+  consoleFetchSendJSON(url, 'POST', json, options, timeout, cluster);
 
 /**
  * A custom PUT method of consoleFetchJSON.
@@ -178,9 +195,10 @@ consoleFetchJSON.post = (url: string, json, options = {}, timeout) =>
  * @param json The JSON to PUT the object
  * @param options The options to pass to fetch
  * @param timeout The timeout in milliseconds
+ * @param cluster The name of the cluster to make the request to. Defaults to the active cluster the user has selected
  * * */
-consoleFetchJSON.put = (url: string, json, options = {}, timeout) =>
-  consoleFetchSendJSON(url, 'PUT', json, options, timeout);
+consoleFetchJSON.put = (url: string, json, options = {}, timeout, cluster) =>
+  consoleFetchSendJSON(url, 'PUT', json, options, timeout, cluster);
 
 /**
  * A custom PATCH method of consoleFetchJSON.
@@ -189,6 +207,7 @@ consoleFetchJSON.put = (url: string, json, options = {}, timeout) =>
  * @param json The JSON to PATCH the object
  * @param options The options to pass to fetch
  * @param timeout The timeout in milliseconds
+ * @param cluster The name of the cluster to make the request to. Defaults to the active cluster the user has selected
  * * */
-consoleFetchJSON.patch = (url: string, json, options = {}, timeout) =>
-  consoleFetchSendJSON(url, 'PATCH', json, options, timeout);
+consoleFetchJSON.patch = (url: string, json, options = {}, timeout, cluster) =>
+  consoleFetchSendJSON(url, 'PATCH', json, options, timeout, cluster);

--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -32,6 +32,7 @@ export const STORAGE_PREFIX = 'bridge';
 
 export const USERSETTINGS_PREFIX = 'console';
 
+export const LAST_CLUSTER_USER_SETTINGS_KEY = `${USERSETTINGS_PREFIX}.lastCluster`;
 // This localStorage key predates the storage prefix.
 export const NAMESPACE_USERSETTINGS_PREFIX = `${USERSETTINGS_PREFIX}.namespace`;
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -24,6 +24,7 @@ export * from './useUserSettingsCompatibility';
 export * from './hpa-hooks';
 export * from './usePinnedResources';
 export * from './perspectiveUtils';
+export * from './useActiveCluster';
 export * from './useActiveNamespace';
 export * from './useIsMobile';
 export * from './useResizeObserver';

--- a/frontend/packages/console-shared/src/hooks/useActiveCluster.ts
+++ b/frontend/packages/console-shared/src/hooks/useActiveCluster.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+import { ClusterContext } from '@console/app/src/components/detect-cluster/cluster';
+
+export const useActiveCluster = (): [string, (ns: string) => void] => {
+  const { cluster, setCluster } = useContext(ClusterContext);
+  return [cluster, setCluster];
+};

--- a/frontend/packages/console-shared/src/hooks/useUserSettings.ts
+++ b/frontend/packages/console-shared/src/hooks/useUserSettings.ts
@@ -62,6 +62,7 @@ export const useUserSettings = <T>(
             namespace: USER_SETTING_CONFIGMAP_NAMESPACE,
             isList: false,
             name: `user-settings-${userUid}`,
+            cluster: 'local-cluster',
           },
     [userUid, isLocalStorage],
   );

--- a/frontend/packages/console-shared/src/utils/__tests__/user-settings.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/user-settings.spec.ts
@@ -40,7 +40,10 @@ describe('createConfigMap', () => {
 
     expect(actual).toEqual(configMap);
     expect(coFetchMock).toHaveBeenCalledTimes(1);
-    expect(coFetchMock).lastCalledWith('/api/console/user-settings', { method: 'POST' });
+    expect(coFetchMock).lastCalledWith('/api/console/user-settings', {
+      headers: { 'X-Cluster': 'local-cluster' },
+      method: 'POST',
+    });
   });
 });
 
@@ -61,6 +64,7 @@ describe('updateConfigMap', () => {
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/merge-patch+json;charset=UTF-8',
+          'X-Cluster': 'local-cluster',
         },
         body: '{"data":{"key":"value"}}',
       },

--- a/frontend/packages/console-shared/src/utils/user-settings.ts
+++ b/frontend/packages/console-shared/src/utils/user-settings.ts
@@ -6,7 +6,12 @@ export const USER_SETTING_CONFIGMAP_NAMESPACE = 'openshift-console-user-settings
 
 export const createConfigMap = async (): Promise<ConfigMapKind> => {
   try {
-    const response = await coFetch('/api/console/user-settings', { method: 'POST' });
+    const response = await coFetch('/api/console/user-settings', {
+      method: 'POST',
+      headers: {
+        'X-Cluster': 'local-cluster',
+      },
+    });
     return response.json();
   } catch (err) {
     // eslint-disable-next-line no-console
@@ -37,6 +42,7 @@ export const updateConfigMap = async (
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/merge-patch+json;charset=UTF-8',
+        'X-Cluster': 'local-cluster',
       },
       body: JSON.stringify(patch),
     });

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -91,13 +91,17 @@ export const watchK8sObject = (
   dispatch(startWatchK8sObject(id));
   REF_COUNTS[id] = 1;
 
+  if (!query.cluster) {
+    query.cluster = getState().UI.get('activeCluster');
+  }
+
   if (query.name) {
     query.fieldSelector = `metadata.name=${query.name}`;
     delete query.name;
   }
 
   const poller = () => {
-    k8sGet(k8sType, name, namespace).then(
+    k8sGet(k8sType, name, namespace, { cluster: query.cluster }).then(
       (o) => dispatch(modifyObject(id, o)),
       (e) => dispatch(errored(id, e)),
     );
@@ -153,6 +157,9 @@ export const watchK8sList = (
     return nop;
   }
 
+  if (!query.cluster) {
+    query.cluster = getState().UI.get('activeCluster');
+  }
   dispatch(startWatchK8sList(id, query));
   REF_COUNTS[id] = 1;
 
@@ -171,6 +178,8 @@ export const watchK8sList = (
         ...(continueToken ? { continue: continueToken } : {}),
       },
       true,
+      undefined,
+      query.cluster,
     );
 
     if (!REF_COUNTS[id]) {

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -23,6 +23,7 @@ export enum ActionType {
   SelectOverviewDetailsTab = 'selectOverviewDetailsTab',
   SelectOverviewItem = 'selectOverviewItem',
   SetActiveApplication = 'setActiveApplication',
+  SetActiveCluster = 'setActiveCluster',
   SetActiveNamespace = 'setActiveNamespace',
   SetCreateProjectMessage = 'setCreateProjectMessage',
   SetCurrentLocation = 'setCurrentLocation',
@@ -122,6 +123,7 @@ export const getNamespacedResources = () => {
   return namespacedResources;
 };
 
+export const getActiveCluster = (): string => store.getState().UI.get('activeCluster');
 export const getActiveNamespace = (): string => store.getState().UI.get('activeNamespace');
 export const getActiveUserName = (): string => store.getState().UI.get('user')?.metadata?.name;
 
@@ -145,7 +147,12 @@ export const getPVCMetric = (pvc: K8sResourceKind, metric: string): number => {
   return metrics?.[metric]?.[pvc.metadata.namespace]?.[pvc.metadata.name] ?? 0;
 };
 
-export const formatNamespaceRoute = (activeNamespace, originalPath, location?) => {
+export const formatNamespaceRoute = (
+  activeNamespace,
+  originalPath,
+  location?,
+  forceList?: boolean,
+) => {
   let path = originalPath.substr(window.SERVER_FLAGS.basePath.length);
 
   let parts = path.split('/').filter((p) => p);
@@ -167,7 +174,8 @@ export const formatNamespaceRoute = (activeNamespace, originalPath, location?) =
   if (
     (previousNS !== activeNamespace &&
       (parts[1] !== 'new' || activeNamespace !== ALL_NAMESPACES_KEY)) ||
-    (activeNamespace === ALL_NAMESPACES_KEY && parts[1] === 'new')
+    (activeNamespace === ALL_NAMESPACES_KEY && parts[1] === 'new') ||
+    forceList
   ) {
     // a given resource will not exist when we switch namespaces, so pop off the tail end
     parts = parts.slice(0, 1);
@@ -194,6 +202,9 @@ export const setCurrentLocation = (location: string) =>
 export const setActiveApplication = (application: string) => {
   return action(ActionType.SetActiveApplication, { application });
 };
+
+export const setActiveCluster = (cluster: string) =>
+  action(ActionType.SetActiveCluster, { cluster });
 
 export const setActiveNamespace = (namespace: string = '') => {
   namespace = namespace.trim();
@@ -397,6 +408,7 @@ export const setUtilizationDurationEndTime = (endTime) =>
 const uiActions = {
   setCurrentLocation,
   setActiveApplication,
+  setActiveCluster,
   setActiveNamespace,
   beginImpersonate,
   endImpersonate,

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -25,6 +25,7 @@ import { pluginStore } from '../plugins';
 import CloudShell from '@console/app/src/components/cloud-shell/CloudShell';
 import CloudShellTab from '@console/app/src/components/cloud-shell/CloudShellTab';
 import DetectPerspective from '@console/app/src/components/detect-perspective/DetectPerspective';
+import DetectCluster from '@console/app/src/components/detect-cluster/DetectCluster';
 import DetectNamespace from '@console/app/src/components/detect-namespace/DetectNamespace';
 import DetectLanguage from '@console/app/src/components/detect-language/DetectLanguage';
 import { useExtensions } from '@console/plugin-sdk';
@@ -204,7 +205,7 @@ class App_ extends React.PureComponent {
     );
 
     return (
-      <>
+      <DetectCluster>
         <DetectPerspective>
           <DetectNamespace>
             {contextProviderExtensions.reduce(
@@ -218,7 +219,7 @@ class App_ extends React.PureComponent {
           </DetectNamespace>
         </DetectPerspective>
         <DetectLanguage />
-      </>
+      </DetectCluster>
     );
   }
 }

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -167,6 +167,7 @@ export type FireManProps = {
   helpText?: React.ReactNode;
   title: string;
   autoFocus?: boolean;
+  cluster?: string;
 };
 
 type FireManState = {
@@ -188,14 +189,22 @@ export const FireMan = connect<{}, { filterList: typeof filterList }, FireManPro
       this.applyFilter = this.applyFilter.bind(this);
 
       const reduxIDs = props.resources.map((r) =>
-        makeReduxID(kindObj(r.kind), makeQuery(r.namespace, r.selector, r.fieldSelector, r.name)),
+        makeReduxID(
+          kindObj(r.kind),
+          makeQuery(r.namespace, r.selector, r.fieldSelector, r.name),
+          this.props.cluster,
+        ),
       );
       this.state = { reduxIDs };
     }
 
-    UNSAFE_componentWillReceiveProps({ resources }) {
+    UNSAFE_componentWillReceiveProps({ resources, cluster }: FireManProps) {
       const reduxIDs = resources.map((r) =>
-        makeReduxID(kindObj(r.kind), makeQuery(r.namespace, r.selector, r.fieldSelector, r.name)),
+        makeReduxID(
+          kindObj(r.kind),
+          makeQuery(r.namespace, r.selector, r.fieldSelector, r.name),
+          cluster,
+        ),
       );
       if (_.isEqual(reduxIDs, this.state.reduxIDs)) {
         return;

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -140,7 +140,9 @@ class MastheadToolbarContents_ extends React.Component {
     const { flags, user } = this.props;
     clearTimeout(this.userInactivityTimeout);
     this.userInactivityTimeout = setTimeout(() => {
-      if (flags[FLAGS.OPENSHIFT]) {
+      if (isMultiClusterEnabled()) {
+        authSvc.logoutMulticluster();
+      } else if (flags[FLAGS.OPENSHIFT]) {
         authSvc.logoutOpenShift(user?.metadata?.name === 'kube:admin');
       } else {
         authSvc.logout();
@@ -508,7 +510,9 @@ class MastheadToolbarContents_ extends React.Component {
     if (flags[FLAGS.AUTH_ENABLED]) {
       const logout = (e) => {
         e.preventDefault();
-        if (flags[FLAGS.OPENSHIFT]) {
+        if (isMultiClusterEnabled()) {
+          authSvc.logoutMulticluster();
+        } else if (flags[FLAGS.OPENSHIFT]) {
           authSvc.logoutOpenShift(this.state.isKubeAdmin);
         } else {
           authSvc.logout();

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -1,16 +1,21 @@
 import * as React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useDispatch } from 'react-redux';
 import { Dropdown, DropdownItem, DropdownToggle, Title } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { Perspective, isPerspective, useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { useExtensions } from '@console/plugin-sdk';
 import { history } from '../utils';
 import { useTelemetry } from '@console/shared/src/hooks/useTelemetry';
-import { ACM_LINK_ID } from '@console/shared';
+import { ACM_LINK_ID, useActiveCluster, useActiveNamespace } from '@console/shared';
+import { formatNamespaceRoute } from '@console/internal/actions/ui';
+import { detectFeatures, clearSSARFlags } from '@console/internal/actions/features';
 import { K8sResourceKind, referenceForModel } from '../../module/k8s';
 import { ConsoleLinkModel } from '../../models';
 import { useK8sWatchResource } from '../utils/k8s-watch-hook';
 import { useTranslation } from 'react-i18next';
-import * as acmIcon from '../../imgs/ACM-icon.svg';
+import isMultiClusterEnabled from '@console/app/src/utils/isMultiClusterEnabled';
 
 export type NavHeaderProps = {
   onPerspectiveSelected: () => void;
@@ -49,8 +54,14 @@ const PerspectiveDropdownItem: React.FC<PerspectiveDropdownItemProps> = ({
   );
 };
 
+const ClusterIcon: React.FC<{}> = () => <span className="co-m-resource-icon">C</span>;
+
 const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
+  const dispatch = useDispatch();
+  const [activeCluster, setActiveCluster] = useActiveCluster();
+  const [activeNamespace] = useActiveNamespace();
   const [activePerspective, setActivePerspective] = useActivePerspective();
+  const [isClusterDropdownOpen, setClusterDropdownOpen] = React.useState(false);
   const [isPerspectiveDropdownOpen, setPerspectiveDropdownOpen] = React.useState(false);
   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
   const [consoleLinks] = useK8sWatchResource<K8sResourceKind[]>({
@@ -68,6 +79,20 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
   }, []);
   const fireTelemetryEvent = useTelemetry();
 
+  const onClusterSelect = (event, cluster: string): void => {
+    event.preventDefault();
+    setClusterDropdownOpen(false);
+    setActiveCluster(cluster);
+    // TODO: Move this logic into `setActiveCluster`?
+    dispatch(clearSSARFlags());
+    dispatch(detectFeatures());
+    const oldPath = window.location.pathname;
+    const newPath = formatNamespaceRoute(activeNamespace, oldPath, window.location, true);
+    if (newPath !== oldPath) {
+      history.pushPath(newPath);
+    }
+  };
+
   const onPerspectiveSelect = React.useCallback(
     (perspective: Perspective): void => {
       if (perspective.properties.id !== activePerspective) {
@@ -84,6 +109,18 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
     [activePerspective, fireTelemetryEvent, onPerspectiveSelected, setActivePerspective],
   );
 
+  const clusterItems = (window.SERVER_FLAGS.clusters ?? []).map((managedCluster: string) => (
+    <DropdownItem
+      key={managedCluster}
+      component="button"
+      onClick={(e) => onClusterSelect(e, managedCluster)}
+      title={managedCluster}
+    >
+      <ClusterIcon />
+      {managedCluster}
+    </DropdownItem>
+  ));
+
   const perspectiveItems = perspectiveExtensions.map((nextPerspective) => (
     <PerspectiveDropdownItem
       key={nextPerspective.uid}
@@ -92,24 +129,6 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
       onClick={onPerspectiveSelect}
     />
   ));
-  if (acmLink) {
-    perspectiveItems.push(
-      <DropdownItem
-        key={ACM_LINK_ID}
-        onClick={() => {
-          window.location.href = acmLink.spec.href;
-        }}
-        isHovered={ACM_LINK_ID === activePerspective}
-      >
-        <Title headingLevel="h2" size="md" data-test-id="perspective-switcher-menu-option">
-          <span className="oc-nav-header__icon">
-            <img src={acmIcon} height="12em" width="12em" alt="" />
-          </span>
-          {t('public~Advanced Cluster Management')}
-        </Title>
-      </DropdownItem>,
-    );
-  }
 
   const { icon, name } = React.useMemo(
     () => perspectiveExtensions.find((p) => p.properties.id === activePerspective).properties,
@@ -119,30 +138,62 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
   const LazyIcon = React.useMemo(() => React.lazy(icon), [icon]);
 
   return (
-    <div
-      className="oc-nav-header"
-      data-tour-id="tour-perspective-dropdown"
-      data-quickstart-id="qs-perspective-switcher"
-    >
-      <Dropdown
-        isOpen={isPerspectiveDropdownOpen}
-        toggle={
-          <DropdownToggle
-            isOpen={isPerspectiveDropdownOpen}
-            onToggle={togglePerspectiveOpen}
-            toggleIndicator={CaretDownIcon}
-            data-test-id="perspective-switcher-toggle"
-          >
-            <Title headingLevel="h2" size="md">
-              <span className="oc-nav-header__icon">{<LazyIcon />}</span>
-              {name}
-            </Title>
-          </DropdownToggle>
-        }
-        dropdownItems={perspectiveItems}
-        data-test-id="perspective-switcher-menu"
-      />
-    </div>
+    <>
+      {isMultiClusterEnabled() && (
+        <div className="oc-nav-header">
+          <Dropdown
+            isOpen={isClusterDropdownOpen}
+            toggle={
+              <DropdownToggle onToggle={() => setClusterDropdownOpen(!isClusterDropdownOpen)}>
+                <Title headingLevel="h2" size="md">
+                  <ClusterIcon />
+                  {activePerspective === ACM_LINK_ID ? t('public~All Clusters') : activeCluster}
+                </Title>
+              </DropdownToggle>
+            }
+            dropdownItems={[
+              ...(acmLink
+                ? [
+                    <DropdownItem
+                      key={ACM_LINK_ID}
+                      onClick={() =>
+                        (window.location.href = acmLink?.spec?.href ?? window.location.href)
+                      }
+                    >
+                      {t('public~All Clusters')}
+                    </DropdownItem>,
+                  ]
+                : []),
+              ...clusterItems,
+            ]}
+          />
+        </div>
+      )}
+      <div
+        className="oc-nav-header"
+        data-tour-id="tour-perspective-dropdown"
+        data-quickstart-id="qs-perspective-switcher"
+      >
+        <Dropdown
+          isOpen={isPerspectiveDropdownOpen}
+          toggle={
+            <DropdownToggle
+              isOpen={isPerspectiveDropdownOpen}
+              onToggle={togglePerspectiveOpen}
+              toggleIndicator={CaretDownIcon}
+              data-test-id="perspective-switcher-toggle"
+            >
+              <Title headingLevel="h2" size="md">
+                <span className="oc-nav-header__icon">{<LazyIcon />}</span>
+                {name}
+              </Title>
+            </DropdownToggle>
+          }
+          dropdownItems={perspectiveItems}
+          data-test-id="perspective-switcher-menu"
+        />
+      </div>
+    </>
   );
 };
 

--- a/frontend/public/components/pod-exec.jsx
+++ b/frontend/public/components/pod-exec.jsx
@@ -69,6 +69,7 @@ const PodExec_ = connectToFlags(FLAGS.OPENSHIFT)(
           tty: 1,
           container: activeContainer,
           command: command.map((c) => encodeURIComponent(c)).join('&command='),
+          cluster: store.getState().UI.get('activeCluster'),
         },
       };
 

--- a/frontend/public/components/utils/k8s-watcher.js
+++ b/frontend/public/components/utils/k8s-watcher.js
@@ -2,13 +2,13 @@ import * as _ from 'lodash-es';
 
 import { referenceForModel } from '../../module/k8s/k8s';
 
-export const makeReduxID = (k8sKind = {}, query) => {
+export const makeReduxID = (k8sKind = {}, query, cluster = 'local-cluster') => {
   let qs = '';
   if (!_.isEmpty(query)) {
     qs = `---${JSON.stringify(query)}`;
   }
 
-  return `${referenceForModel(k8sKind)}${qs}`;
+  return `${cluster}:${referenceForModel(k8sKind)}${qs}`;
 };
 
 /** @type {(namespace: string, labelSelector?: any, fieldSelector?: any, name?: string, limit?: number) => {[key: string]: string}} */

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -5,6 +5,7 @@ import * as _ from 'lodash-es';
 import { getName, getNamespace } from '@console/shared/src/selectors/common';
 
 import store from '../../redux';
+import { getActiveCluster } from '../../actions/ui';
 import { impersonateStateToProps } from '../../reducers/ui';
 import {
   AccessReviewResourceAttributes,
@@ -55,7 +56,7 @@ const checkAccessInternal = _.memoize(
     };
     return k8sCreate(SelfSubjectAccessReviewModel, ssar);
   },
-  (...args) => args.join('~'),
+  (...args) => [...args, getActiveCluster()].join('~'),
 );
 
 const getImpersonateKey = (impersonate): string => {

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1115,7 +1115,7 @@
   "CustomResourceDefinitions": "CustomResourceDefinitions",
   "Remove from navigation?": "Remove from navigation?",
   "Are you sure you want to remove <1>{{label}}</1> from navigation?": "Are you sure you want to remove <1>{{label}}</1> from navigation?",
-  "Advanced Cluster Management": "Advanced Cluster Management",
+  "All Clusters": "All Clusters",
   "Target pods": "Target pods",
   "To ports": "To ports",
   "From pods": "From pods",

--- a/frontend/public/multicluster-logout.html
+++ b/frontend/public/multicluster-logout.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+  <body>
+    <noscript>JavaScript must be enabled.</noscript>
+    <h1>You have been logged out.</h1>
+    <a href="/">Log back in</a>
+  </body>
+</html>

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -54,6 +54,7 @@ export default (state: UIState, action: UIAction): UIState => {
     return ImmutableMap({
       activeNavSectionId: 'workloads',
       location: pathname,
+      activeCluster: 'local-cluster',
       activeNamespace: ALL_NAMESPACES_KEY,
       activeApplication: ALL_APPLICATIONS_KEY,
       createProjectMessage: '',
@@ -97,6 +98,9 @@ export default (state: UIState, action: UIAction): UIState => {
   switch (action.type) {
     case ActionType.SetActiveApplication:
       return state.set('activeApplication', action.payload.application);
+
+    case ActionType.SetActiveCluster:
+      return state.set('activeCluster', action.payload.cluster);
 
     case ActionType.SetActiveNamespace:
       if (!action.payload.namespace) {
@@ -381,6 +385,8 @@ export const userStateToProps = ({ UI }: RootState) => {
 export const impersonateStateToProps = ({ UI }: RootState) => {
   return { impersonate: UI.get('impersonate') };
 };
+
+export const getActiveCluster = ({ UI }: RootState): string => UI.get('activeCluster');
 
 export const getActiveNamespace = ({ UI }: RootState): string => UI.get('activeNamespace');
 

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -209,6 +209,12 @@ const config: Configuration = {
       chunksSortMode: 'none',
     }),
     new HtmlWebpackPlugin({
+      filename: './multicluster-logout.html',
+      template: './public/multicluster-logout.html',
+      inject: false,
+      chunksSortMode: 'none',
+    }),
+    new HtmlWebpackPlugin({
       filename: './index.html',
       template: './public/index.html',
       production: NODE_ENV === 'production',

--- a/pkg/auth/auth_oidc.go
+++ b/pkg/auth/auth_oidc.go
@@ -71,7 +71,7 @@ func (o *oidcAuth) login(w http.ResponseWriter, token *oauth2.Token) (*loginStat
 	}
 
 	cookie := http.Cookie{
-		Name:     openshiftSessionCookieName,
+		Name:     openshiftAccessTokenCookieName,
 		Value:    ls.sessionToken,
 		MaxAge:   maxAge(ls.exp, time.Now()),
 		HttpOnly: true,
@@ -91,7 +91,7 @@ func (o *oidcAuth) logout(w http.ResponseWriter, r *http.Request) {
 	}
 	// Delete session cookie
 	cookie := http.Cookie{
-		Name:     openshiftSessionCookieName,
+		Name:     openshiftAccessTokenCookieName,
 		Value:    "",
 		MaxAge:   0,
 		HttpOnly: true,
@@ -103,7 +103,7 @@ func (o *oidcAuth) logout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (o *oidcAuth) getLoginState(r *http.Request) (*loginState, error) {
-	sessionCookie, err := r.Cookie(openshiftSessionCookieName)
+	sessionCookie, err := r.Cookie(openshiftAccessTokenCookieName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/klog"
 )
 
-const openshiftSessionCookieName = "openshift-session-token"
+const openshiftAccessTokenCookieName = "openshift-session-token"
 
 type oldSession struct {
 	token string

--- a/pkg/auth/util.go
+++ b/pkg/auth/util.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"time"
+
+	"github.com/openshift/console/pkg/serverutils"
 )
 
 type nowFunc func() time.Time
@@ -25,4 +27,11 @@ func randomString(length int) string {
 		panic(fmt.Sprintf("FATAL ERROR: Unable to get random bytes for session token: %v", err))
 	}
 	return base64.StdEncoding.EncodeToString(bytes)
+}
+
+func GetCookieName(clusterName string) string {
+	if clusterName == serverutils.LocalClusterName {
+		return openshiftAccessTokenCookieName
+	}
+	return openshiftAccessTokenCookieName + "-" + clusterName
 }

--- a/pkg/helm/chartproxy/proxy.go
+++ b/pkg/helm/chartproxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 
+	"github.com/openshift/console/pkg/serverutils"
 	"github.com/openshift/console/pkg/version"
 )
 
@@ -57,7 +58,7 @@ func New(k8sConfig RestConfigProvider, kubeVersionGetter version.KubeVersionGett
 
 	p := &proxy{
 		config:      config,
-		kubeVersion: kubeVersionGetter.GetKubeVersion(),
+		kubeVersion: kubeVersionGetter.GetKubeVersion(serverutils.LocalClusterName),
 	}
 
 	if len(opts) == 0 {

--- a/pkg/helm/chartproxy/proxy_test.go
+++ b/pkg/helm/chartproxy/proxy_test.go
@@ -19,7 +19,7 @@ type MockKubeVersion struct {
 	fakeVersion string
 }
 
-func (v MockKubeVersion) GetKubeVersion() string {
+func (v MockKubeVersion) GetKubeVersion(cluster string) string {
 	return v.fakeVersion
 }
 

--- a/pkg/server/kube_version.go
+++ b/pkg/server/kube_version.go
@@ -2,18 +2,19 @@ package server
 
 import (
 	"errors"
+
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 )
 
-func (s *Server) GetKubeVersion() string {
+func (s *Server) GetKubeVersion(cluster string) string {
 	if s.KubeVersion != "" {
 		return s.KubeVersion
 	}
 	config := &rest.Config{
-		Host:      s.K8sProxyConfig.Endpoint.String(),
-		Transport: s.K8sClient.Transport,
+		Host:      s.K8sProxyConfigs[cluster].Endpoint.String(),
+		Transport: s.K8sClients[cluster].Transport,
 	}
 	kubeVersion, err := kubeVersion(config)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/health"
+	"k8s.io/klog"
 
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/graphql/resolver"
@@ -34,14 +35,16 @@ import (
 )
 
 const (
-	indexPageTemplateName     = "index.html"
-	tokenizerPageTemplateName = "tokener.html"
+	indexPageTemplateName              = "index.html"
+	tokenizerPageTemplateName          = "tokener.html"
+	multiclusterLogoutPageTemplateName = "multicluster-logout.html"
 
 	authLoginEndpoint                = "/auth/login"
 	AuthLoginCallbackEndpoint        = "/auth/callback"
 	AuthLoginSuccessEndpoint         = "/"
 	AuthLoginErrorEndpoint           = "/error"
 	authLogoutEndpoint               = "/auth/logout"
+	authLogoutMulticlusterEndpoint   = "/api/logout/multicluster"
 	k8sProxyEndpoint                 = "/api/kubernetes/"
 	graphQLEndpoint                  = "/api/graphql"
 	prometheusProxyEndpoint          = "/api/prometheus"
@@ -62,51 +65,54 @@ const (
 )
 
 type jsGlobals struct {
-	ConsoleVersion            string   `json:"consoleVersion"`
-	AuthDisabled              bool     `json:"authDisabled"`
-	KubectlClientID           string   `json:"kubectlClientID"`
-	BasePath                  string   `json:"basePath"`
-	LoginURL                  string   `json:"loginURL"`
-	LoginSuccessURL           string   `json:"loginSuccessURL"`
-	LoginErrorURL             string   `json:"loginErrorURL"`
-	LogoutURL                 string   `json:"logoutURL"`
-	LogoutRedirect            string   `json:"logoutRedirect"`
-	RequestTokenURL           string   `json:"requestTokenURL"`
-	KubeAdminLogoutURL        string   `json:"kubeAdminLogoutURL"`
-	KubeAPIServerURL          string   `json:"kubeAPIServerURL"`
-	PrometheusBaseURL         string   `json:"prometheusBaseURL"`
-	PrometheusTenancyBaseURL  string   `json:"prometheusTenancyBaseURL"`
-	AlertManagerBaseURL       string   `json:"alertManagerBaseURL"`
-	MeteringBaseURL           string   `json:"meteringBaseURL"`
-	Branding                  string   `json:"branding"`
-	CustomProductName         string   `json:"customProductName"`
-	CustomLogoURL             string   `json:"customLogoURL"`
-	StatuspageID              string   `json:"statuspageID"`
-	DocumentationBaseURL      string   `json:"documentationBaseURL"`
-	AlertManagerPublicURL     string   `json:"alertManagerPublicURL"`
-	GrafanaPublicURL          string   `json:"grafanaPublicURL"`
-	PrometheusPublicURL       string   `json:"prometheusPublicURL"`
-	ThanosPublicURL           string   `json:"thanosPublicURL"`
-	LoadTestFactor            int      `json:"loadTestFactor"`
-	InactivityTimeout         int      `json:"inactivityTimeout"`
-	GOARCH                    string   `json:"GOARCH"`
-	GOOS                      string   `json:"GOOS"`
-	GraphQLBaseURL            string   `json:"graphqlBaseURL"`
-	DevCatalogCategories      string   `json:"developerCatalogCategories"`
-	UserSettingsLocation      string   `json:"userSettingsLocation"`
-	AddPage                   string   `json:"addPage"`
-	ConsolePlugins            []string `json:"consolePlugins"`
-	QuickStarts               string   `json:"quickStarts"`
-	ProjectAccessClusterRoles string   `json:"projectAccessClusterRoles"`
+	ConsoleVersion             string   `json:"consoleVersion"`
+	AuthDisabled               bool     `json:"authDisabled"`
+	KubectlClientID            string   `json:"kubectlClientID"`
+	BasePath                   string   `json:"basePath"`
+	LoginURL                   string   `json:"loginURL"`
+	LoginSuccessURL            string   `json:"loginSuccessURL"`
+	LoginErrorURL              string   `json:"loginErrorURL"`
+	LogoutURL                  string   `json:"logoutURL"`
+	LogoutRedirect             string   `json:"logoutRedirect"`
+	MulticlusterLogoutRedirect string   `json:"multiclusterLogoutRedirect"`
+	RequestTokenURL            string   `json:"requestTokenURL"`
+	KubeAdminLogoutURL         string   `json:"kubeAdminLogoutURL"`
+	KubeAPIServerURL           string   `json:"kubeAPIServerURL"`
+	PrometheusBaseURL          string   `json:"prometheusBaseURL"`
+	PrometheusTenancyBaseURL   string   `json:"prometheusTenancyBaseURL"`
+	AlertManagerBaseURL        string   `json:"alertManagerBaseURL"`
+	MeteringBaseURL            string   `json:"meteringBaseURL"`
+	Branding                   string   `json:"branding"`
+	CustomProductName          string   `json:"customProductName"`
+	CustomLogoURL              string   `json:"customLogoURL"`
+	StatuspageID               string   `json:"statuspageID"`
+	DocumentationBaseURL       string   `json:"documentationBaseURL"`
+	AlertManagerPublicURL      string   `json:"alertManagerPublicURL"`
+	GrafanaPublicURL           string   `json:"grafanaPublicURL"`
+	PrometheusPublicURL        string   `json:"prometheusPublicURL"`
+	ThanosPublicURL            string   `json:"thanosPublicURL"`
+	LoadTestFactor             int      `json:"loadTestFactor"`
+	InactivityTimeout          int      `json:"inactivityTimeout"`
+	GOARCH                     string   `json:"GOARCH"`
+	GOOS                       string   `json:"GOOS"`
+	GraphQLBaseURL             string   `json:"graphqlBaseURL"`
+	DevCatalogCategories       string   `json:"developerCatalogCategories"`
+	UserSettingsLocation       string   `json:"userSettingsLocation"`
+	AddPage                    string   `json:"addPage"`
+	ConsolePlugins             []string `json:"consolePlugins"`
+	QuickStarts                string   `json:"quickStarts"`
+	ProjectAccessClusterRoles  string   `json:"projectAccessClusterRoles"`
+	Clusters                   []string `json:"clusters"`
 }
 
 type Server struct {
-	K8sProxyConfig       *proxy.Config
+	K8sProxyConfigs      map[string]*proxy.Config
 	BaseURL              *url.URL
 	LogoutRedirect       *url.URL
 	PublicDir            string
 	TectonicVersion      string
 	Auther               *auth.Authenticator
+	Authers              map[string]*auth.Authenticator
 	StaticUser           *auth.User
 	ServiceAccountToken  string
 	KubectlClientID      string
@@ -122,7 +128,7 @@ type Server struct {
 	// Map that contains list of enabled plugins and their endpoints.
 	EnabledConsolePlugins map[string]string
 	// A client with the correct TLS setup for communicating with the API server.
-	K8sClient                        *http.Client
+	K8sClients                       map[string]*http.Client
 	ThanosProxyConfig                *proxy.Config
 	ThanosTenancyProxyConfig         *proxy.Config
 	ThanosTenancyProxyForRulesConfig *proxy.Config
@@ -174,8 +180,18 @@ func (s *Server) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 
 	if len(s.BaseURL.Scheme) > 0 && len(s.BaseURL.Host) > 0 {
-		s.K8sProxyConfig.Origin = fmt.Sprintf("%s://%s", s.BaseURL.Scheme, s.BaseURL.Host)
+		for cluster := range s.K8sProxyConfigs {
+			s.K8sProxyConfigs[cluster].Origin = fmt.Sprintf("%s://%s", s.BaseURL.Scheme, s.BaseURL.Host)
+		}
 	}
+
+	localK8sProxyConfig := s.K8sProxyConfigs[serverutils.LocalClusterName]
+	localK8sClient := s.K8sClients[serverutils.LocalClusterName]
+	k8sProxies := make(map[string]*proxy.Proxy)
+	for cluster, proxyConfig := range s.K8sProxyConfigs {
+		k8sProxies[cluster] = proxy.NewProxy(proxyConfig)
+	}
+
 	handle := func(path string, handler http.Handler) {
 		mux.Handle(proxy.SingleJoiningSlash(s.BaseURL.Path, path), handler)
 	}
@@ -210,10 +226,10 @@ func (s *Server) HTTPHandler() http.Handler {
 	}
 
 	authHandler := func(hf http.HandlerFunc) http.Handler {
-		return authMiddleware(s.Auther, hf)
+		return authMiddleware(s.Authers, hf)
 	}
 	authHandlerWithUser := func(hf func(*auth.User, http.ResponseWriter, *http.Request)) http.Handler {
-		return authMiddlewareWithUser(s.Auther, hf)
+		return authMiddlewareWithUser(s.Authers, hf)
 	}
 
 	if s.authDisabled() {
@@ -230,9 +246,15 @@ func (s *Server) HTTPHandler() http.Handler {
 	if !s.authDisabled() {
 		handleFunc(authLoginEndpoint, s.Auther.LoginFunc)
 		handleFunc(authLogoutEndpoint, s.Auther.LogoutFunc)
+		handleFunc(authLogoutMulticlusterEndpoint, s.handleLogoutMulticluster)
 		handleFunc(AuthLoginCallbackEndpoint, s.Auther.CallbackFunc(fn))
-
 		handle("/api/openshift/delete-token", authHandlerWithUser(s.handleOpenShiftTokenDeletion))
+		for clusterName, clusterAuther := range s.Authers {
+			if clusterAuther != nil {
+				handleFunc(fmt.Sprintf("%s/%s", authLoginEndpoint, clusterName), clusterAuther.LoginFunc)
+				handleFunc(fmt.Sprintf("%s/%s", AuthLoginCallbackEndpoint, clusterName), clusterAuther.CallbackFunc(fn))
+			}
+		}
 	}
 
 	handleFunc("/api/", notFoundHandler)
@@ -255,10 +277,18 @@ func (s *Server) HTTPHandler() http.Handler {
 		Checks: []health.Checkable{},
 	}.ServeHTTP)
 
-	k8sProxy := proxy.NewProxy(s.K8sProxyConfig)
 	handle(k8sProxyEndpoint, http.StripPrefix(
 		proxy.SingleJoiningSlash(s.BaseURL.Path, k8sProxyEndpoint),
 		authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
+			cluster := serverutils.GetCluster(r)
+			k8sProxy, k8sProxyFound := k8sProxies[cluster]
+
+			if !k8sProxyFound {
+				klog.Errorf("Bad Request. Invalid cluster: %v", cluster)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
 			r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.Token))
 			k8sProxy.ServeHTTP(w, r)
 		})),
@@ -269,8 +299,8 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	terminalProxy := terminal.NewProxy(
 		s.TerminalProxyTLSConfig,
-		s.K8sProxyConfig.TLSClientConfig,
-		s.K8sProxyConfig.Endpoint)
+		localK8sProxyConfig.TLSClientConfig,
+		localK8sProxyConfig.Endpoint)
 
 	handle(terminal.ProxyEndpoint, authHandlerWithUser(terminalProxy.HandleProxy))
 	handleFunc(terminal.AvailableEndpoint, terminalProxy.HandleProxyEnabled)
@@ -281,7 +311,7 @@ func (s *Server) HTTPHandler() http.Handler {
 		panic(err)
 	}
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	k8sResolver := resolver.K8sResolver{K8sProxy: k8sProxy}
+	k8sResolver := resolver.K8sResolver{K8sProxy: k8sProxies[serverutils.LocalClusterName]}
 	rootResolver := resolver.RootResolver{K8sResolver: &k8sResolver}
 	schema := graphql.MustParseSchema(string(graphQLSchema), &rootResolver, opts...)
 	handler := graphqlws.NewHandler()
@@ -420,8 +450,9 @@ func (s *Server) HTTPHandler() http.Handler {
 	// List operator operands endpoint
 	operandsListHandler := &OperandsListHandler{
 		APIServerURL: s.KubeAPIServerURL,
-		Client:       s.K8sClient,
+		Client:       localK8sClient,
 	}
+
 	handle(operandsListEndpoint, http.StripPrefix(
 		proxy.SingleJoiningSlash(s.BaseURL.Path, operandsListEndpoint),
 		authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
@@ -436,14 +467,14 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	// User settings
 	userSettingHandler := usersettings.UserSettingsHandler{
-		K8sProxyConfig:      s.K8sProxyConfig,
-		Client:              s.K8sClient,
-		Endpoint:            s.K8sProxyConfig.Endpoint.String(),
+		K8sProxyConfig:      localK8sProxyConfig,
+		Client:              localK8sClient,
+		Endpoint:            localK8sProxyConfig.Endpoint.String(),
 		ServiceAccountToken: s.ServiceAccountToken,
 	}
 	handle("/api/console/user-settings", authHandlerWithUser(userSettingHandler.HandleUserSettings))
 
-	helmHandlers := helmhandlerspkg.New(s.K8sProxyConfig.Endpoint.String(), s.K8sClient.Transport, s)
+	helmHandlers := helmhandlerspkg.New(localK8sProxyConfig.Endpoint.String(), localK8sClient.Transport, s)
 
 	pluginsHandler := plugins.NewPluginsHandler(
 		&http.Client{
@@ -529,36 +560,48 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	plugins := make([]string, 0, len(s.EnabledConsolePlugins))
+	for plugin := range s.EnabledConsolePlugins {
+		plugins = append(plugins, plugin)
+	}
+
+	clusters := make([]string, 0, len(s.K8sProxyConfigs))
+	for cluster := range s.K8sProxyConfigs {
+		clusters = append(clusters, cluster)
+	}
+
 	jsg := &jsGlobals{
-		ConsoleVersion:            version.Version,
-		AuthDisabled:              s.authDisabled(),
-		KubectlClientID:           s.KubectlClientID,
-		BasePath:                  s.BaseURL.Path,
-		LoginURL:                  proxy.SingleJoiningSlash(s.BaseURL.String(), authLoginEndpoint),
-		LoginSuccessURL:           proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginSuccessEndpoint),
-		LoginErrorURL:             proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginErrorEndpoint),
-		LogoutURL:                 proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutEndpoint),
-		LogoutRedirect:            s.LogoutRedirect.String(),
-		KubeAPIServerURL:          s.KubeAPIServerURL,
-		Branding:                  s.Branding,
-		CustomProductName:         s.CustomProductName,
-		StatuspageID:              s.StatuspageID,
-		InactivityTimeout:         s.InactivityTimeout,
-		DocumentationBaseURL:      s.DocumentationBaseURL.String(),
-		AlertManagerPublicURL:     s.AlertManagerPublicURL.String(),
-		GrafanaPublicURL:          s.GrafanaPublicURL.String(),
-		PrometheusPublicURL:       s.PrometheusPublicURL.String(),
-		ThanosPublicURL:           s.ThanosPublicURL.String(),
-		GOARCH:                    s.GOARCH,
-		GOOS:                      s.GOOS,
-		LoadTestFactor:            s.LoadTestFactor,
-		GraphQLBaseURL:            proxy.SingleJoiningSlash(s.BaseURL.Path, graphQLEndpoint),
-		DevCatalogCategories:      s.DevCatalogCategories,
-		UserSettingsLocation:      s.UserSettingsLocation,
-		ConsolePlugins:            getMapKeys(s.EnabledConsolePlugins),
-		QuickStarts:               s.QuickStarts,
-		AddPage:                   s.AddPage,
-		ProjectAccessClusterRoles: s.ProjectAccessClusterRoles,
+		ConsoleVersion:             version.Version,
+		AuthDisabled:               s.authDisabled(),
+		KubectlClientID:            s.KubectlClientID,
+		BasePath:                   s.BaseURL.Path,
+		LoginURL:                   proxy.SingleJoiningSlash(s.BaseURL.String(), authLoginEndpoint),
+		LoginSuccessURL:            proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginSuccessEndpoint),
+		LoginErrorURL:              proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginErrorEndpoint),
+		LogoutURL:                  proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutEndpoint),
+		LogoutRedirect:             s.LogoutRedirect.String(),
+		MulticlusterLogoutRedirect: proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutMulticlusterEndpoint),
+		KubeAPIServerURL:           s.KubeAPIServerURL,
+		Branding:                   s.Branding,
+		CustomProductName:          s.CustomProductName,
+		StatuspageID:               s.StatuspageID,
+		InactivityTimeout:          s.InactivityTimeout,
+		DocumentationBaseURL:       s.DocumentationBaseURL.String(),
+		AlertManagerPublicURL:      s.AlertManagerPublicURL.String(),
+		GrafanaPublicURL:           s.GrafanaPublicURL.String(),
+		PrometheusPublicURL:        s.PrometheusPublicURL.String(),
+		ThanosPublicURL:            s.ThanosPublicURL.String(),
+		GOARCH:                     s.GOARCH,
+		GOOS:                       s.GOOS,
+		LoadTestFactor:             s.LoadTestFactor,
+		GraphQLBaseURL:             proxy.SingleJoiningSlash(s.BaseURL.Path, graphQLEndpoint),
+		DevCatalogCategories:       s.DevCatalogCategories,
+		UserSettingsLocation:       s.UserSettingsLocation,
+		ConsolePlugins:             plugins,
+		QuickStarts:                s.QuickStarts,
+		AddPage:                    s.AddPage,
+		ProjectAccessClusterRoles:  s.ProjectAccessClusterRoles,
+		Clusters:                   clusters,
 	}
 
 	if !s.authDisabled() {
@@ -620,6 +663,16 @@ func (s *Server) handleOpenShiftTokenDeletion(user *auth.User, w http.ResponseWr
 		return
 	}
 
+	// Proxy request to correct cluster
+	cluster := serverutils.GetCluster(r)
+	k8sProxy, k8sProxyFound := s.K8sProxyConfigs[cluster]
+	k8sClient, k8sClientFound := s.K8sClients[cluster]
+	if !k8sProxyFound || !k8sClientFound {
+		klog.Errorf("Bad Request. Invalid cluster: %v", cluster)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	tokenName := user.Token
 	if strings.HasPrefix(tokenName, sha256Prefix) {
 		tokenName = tokenToObjectName(tokenName)
@@ -627,7 +680,7 @@ func (s *Server) handleOpenShiftTokenDeletion(user *auth.User, w http.ResponseWr
 
 	// Delete the OpenShift OAuthAccessToken.
 	path := "/apis/oauth.openshift.io/v1/oauthaccesstokens/" + tokenName
-	url := proxy.SingleJoiningSlash(s.K8sProxyConfig.Endpoint.String(), path)
+	url := proxy.SingleJoiningSlash(k8sProxy.Endpoint.String(), path)
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: fmt.Sprintf("Failed to create token DELETE request: %v", err)})
@@ -635,7 +688,7 @@ func (s *Server) handleOpenShiftTokenDeletion(user *auth.User, w http.ResponseWr
 	}
 
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.Token))
-	resp, err := s.K8sClient.Do(req)
+	resp, err := k8sClient.Do(req)
 	if err != nil {
 		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to delete token: %v", err)})
 		return
@@ -644,6 +697,46 @@ func (s *Server) handleOpenShiftTokenDeletion(user *auth.User, w http.ResponseWr
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
 	resp.Body.Close()
+}
+
+func (s *Server) handleLogoutMulticluster(w http.ResponseWriter, r *http.Request) {
+	for cluster, auther := range s.Authers {
+		cookieName := auth.GetCookieName(cluster)
+		if cookie, _ := r.Cookie(cookieName); cookie != nil {
+			clearedCookie := http.Cookie{
+				Name:     cookie.Name,
+				Value:    "",
+				MaxAge:   0,
+				HttpOnly: cookie.HttpOnly,
+				Path:     auther.GetCookiePath(),
+				Secure:   cookie.Secure,
+			}
+			klog.Infof("Deleting cookie %v", cookie.Name)
+			http.SetCookie(w, &clearedCookie)
+		}
+	}
+
+	jsg := struct {
+		BasePath          string `json:"basePath"`
+		Branding          string `json:"branding"`
+		CustomProductName string `json:"customProductName"`
+	}{
+		BasePath:          s.BaseURL.Path,
+		Branding:          s.Branding,
+		CustomProductName: s.CustomProductName,
+	}
+	tpl := template.New(multiclusterLogoutPageTemplateName)
+	tpl.Delims("[[", "]]")
+	tpls, err := tpl.ParseFiles(path.Join(s.PublicDir, multiclusterLogoutPageTemplateName))
+	if err != nil {
+		fmt.Printf("%v not found in configured public-dir path: %v", multiclusterLogoutPageTemplateName, err)
+		os.Exit(1)
+	}
+
+	if err := tpls.ExecuteTemplate(w, multiclusterLogoutPageTemplateName, jsg); err != nil {
+		fmt.Printf("%v", err)
+		os.Exit(1)
+	}
 }
 
 // tokenToObjectName returns the oauthaccesstokens object name for the given raw token,
@@ -656,7 +749,7 @@ func tokenToObjectName(token string) string {
 
 func getMapKeys(m map[string]string) []string {
 	keys := []string{}
-	for key, _ := range m {
+	for key := range m {
 		keys = append(keys, key)
 	}
 	return keys

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -53,7 +53,6 @@ func Parse(fs *flag.FlagSet, args []string, envPrefix string) error {
 	}
 
 	configFile := fs.Lookup("config").Value.String()
-
 	if configFile != "" {
 		if err := SetFlagsFromConfig(fs, configFile); err != nil {
 			klog.Fatalf("Failed to load config: %v", err)
@@ -99,7 +98,7 @@ func SetFlagsFromConfig(fs *flag.FlagSet, filename string) (err error) {
 	addMonitoringInfo(fs, &config.MonitoringInfo)
 	addHelmConfig(fs, &config.Helm)
 	addPlugins(fs, config.Plugins)
-
+	addManagedClusters(fs, config.ManagedClusterConfigFile)
 	return nil
 }
 
@@ -293,5 +292,34 @@ func isAlreadySet(fs *flag.FlagSet, name string) bool {
 func addPlugins(fs *flag.FlagSet, plugins map[string]string) {
 	for pluginName, pluginEndpoint := range plugins {
 		fs.Set("plugins", fmt.Sprintf("%s=%s", pluginName, pluginEndpoint))
+	}
+}
+
+func addManagedClusters(fs *flag.FlagSet, fileName string) {
+	if fileName != "" {
+		klog.V(4).Info("Setting managed-clusters flag from config file")
+		content, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			klog.Fatalf("Error reading managed cluster config: %v", err)
+		}
+
+		managedClusterConfigs := []ManagedClusterConfig{}
+		err = yaml.Unmarshal(content, &managedClusterConfigs)
+		if err != nil {
+			klog.Fatalf("Error unmarshalling managed cluster yaml: %v", err)
+		}
+
+		if len(managedClusterConfigs) == 0 {
+			klog.V(4).Info("Managed cluster config is empty.")
+			return
+		}
+
+		configJSON, err := json.Marshal(managedClusterConfigs)
+		if err != nil {
+			klog.Fatalf("Error marshalling managed cluster config into JSON: %v", err)
+		}
+
+		klog.Infof("Successfully parsed configs for %v managed cluster(s).", len(managedClusterConfigs))
+		fs.Set("managed-clusters", string(configJSON))
 	}
 }

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -6,16 +6,17 @@ package serverconfig
 
 // Config is the top-level console server cli configuration.
 type Config struct {
-	APIVersion     string `yaml:"apiVersion"`
-	Kind           string `yaml:"kind"`
-	ServingInfo    `yaml:"servingInfo"`
-	ClusterInfo    `yaml:"clusterInfo"`
-	Auth           `yaml:"auth"`
-	Customization  `yaml:"customization"`
-	Providers      `yaml:"providers"`
-	Helm           `yaml:"helm"`
-	MonitoringInfo `yaml:"monitoringInfo,omitempty"`
-	Plugins        map[string]string `yaml:"plugins,omitempty"`
+	APIVersion               string `yaml:"apiVersion"`
+	Kind                     string `yaml:"kind"`
+	ServingInfo              `yaml:"servingInfo"`
+	ClusterInfo              `yaml:"clusterInfo"`
+	Auth                     `yaml:"auth"`
+	Customization            `yaml:"customization"`
+	Providers                `yaml:"providers"`
+	Helm                     `yaml:"helm"`
+	MonitoringInfo           `yaml:"monitoringInfo,omitempty"`
+	Plugins                  map[string]string `yaml:"plugins,omitempty"`
+	ManagedClusterConfigFile string            `yaml:"managedClusterConfigFile,omitempty"`
 }
 
 // ServingInfo holds configuration for serving HTTP.
@@ -128,4 +129,24 @@ type HelmChartRepo struct {
 
 type Helm struct {
 	ChartRepo HelmChartRepo `yaml:"chartRepository"`
+}
+
+// ManagedClusterAPIServerConfig enables proxying managed cluster API server requests
+type ManagedClusterAPIServerConfig struct {
+	URL    string `json:"url" yaml:"url"`
+	CAFile string `json:"caFile" yaml:"caFile"`
+}
+
+// ManagedClusterOauthConfig enables proxying managed cluster auth
+type ManagedClusterOAuthConfig struct {
+	ClientID     string `json:"clientID" yaml:"clientID"`
+	ClientSecret string `json:"clientSecret" yaml:"clientSecret"`
+	CAFile       string `json:"caFile" yaml:"caFile"`
+}
+
+// ManagedClusterConfig enables proxying to an ACM managed cluster
+type ManagedClusterConfig struct {
+	Name      string                        `json:"name" yaml:"name"` // ManagedCluster name, provided through ACM
+	APIServer ManagedClusterAPIServerConfig `json:"apiServer" yaml:"apiServer"`
+	OAuth     ManagedClusterOAuthConfig     `json:"oauth" yaml:"oauth"`
 }

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -107,3 +107,36 @@ func validateProjectAccessClusterRolesJSON(value string) ([]string, error) {
 
 	return projectAccessOptions, nil
 }
+
+func ValidateManagedClusterConfig(managedCluster *ManagedClusterConfig) (*ManagedClusterConfig, error) {
+	errors := []string{}
+	if managedCluster.Name == "" {
+		errors = append(errors, "Name is required.")
+	}
+
+	if managedCluster.APIServer.URL == "" {
+		errors = append(errors, "APIServer.URL is required.")
+	}
+
+	if managedCluster.APIServer.CAFile == "" {
+		errors = append(errors, "APIServer.CAFile is required.")
+	}
+
+	if managedCluster.OAuth.ClientID == "" {
+		errors = append(errors, "Oauth.ClientID is required.")
+	}
+
+	if managedCluster.OAuth.ClientSecret == "" {
+		errors = append(errors, "OAuth.ClientSecret is required.")
+	}
+
+	if managedCluster.OAuth.CAFile == "" {
+		errors = append(errors, "OAuth.CAFile is required.")
+	}
+
+	if len(errors) > 0 {
+		return nil, fmt.Errorf("\n\t- %s\n", strings.Join(errors, "\n\t- "))
+	}
+
+	return managedCluster, nil
+}

--- a/pkg/serverutils/utils.go
+++ b/pkg/serverutils/utils.go
@@ -8,6 +8,22 @@ import (
 	"k8s.io/klog"
 )
 
+const LocalClusterName = "local-cluster"
+
+func GetCluster(r *http.Request) string {
+	// The client can't set headers for WebSockets, so check both the header and query
+	// parameters for the active cluster.
+	cluster := r.Header.Get("X-Cluster")
+	if len(cluster) != 0 {
+		return cluster
+	}
+	cluster = r.URL.Query().Get("cluster")
+	if len(cluster) != 0 {
+		return cluster
+	}
+	return LocalClusterName
+}
+
 // Copied from Server package to maintain error response consistency
 func SendResponse(rw http.ResponseWriter, code int, resp interface{}) {
 	enc, err := json.Marshal(resp)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,5 +5,5 @@ package version
 var Version string
 
 type KubeVersionGetter interface {
-	GetKubeVersion() string
+	GetKubeVersion(cluster string) string
 }


### PR DESCRIPTION
Backend:
- Update server config to accept managed cluster configuration and configure proxies, clients, and authenticators for each cluster.
- Consume multicluster configuration from the config file, env, or CLI arg
- Add new multicluster logout endpoint to prevent redirect back to login
- Parse X-Cluster request header or cluster query parameter and proxy to the appropriate cluster

Frontend:
- Receive managed cluster list through global SERVER_FLAGS var
- Add cluster selector dropdown in the side nav (when managed cluster list is greater than 1)
- API requests from the frontend now include `X-Cluster` header or `cluster` query param where applicable
- Add frontend redux state to keep track of currently selected cluster
- User preference requests are always proxied to the local cluster
- Update logout logic to use new multicluster logout endpoint