### PR TITLE
Fix cypress olm flake

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
@@ -132,7 +132,7 @@ export const operator = {
     testOperand: TestOperandProps,
     installedNamespace: string = GlobalInstalledNamespace,
   ) => {
-    const { name, tabName, exampleName } = testOperand;
+    const { tabName, exampleName } = testOperand;
     cy.log(`operand "${exampleName}" should exist for "${operatorName}" in ${installedNamespace}`);
     operator.navToDetailsPage(operatorName, installedNamespace);
     cy.log(`navigate to the "${tabName}" tab`);
@@ -141,10 +141,7 @@ export const operator = {
     cy.log(`navigate to the operand "Details" tab`);
     cy.byTestOperandLink(exampleName).click();
     cy.url().should('match', new RegExp(`${exampleName}$`)); // url should end with example operand name
-    cy.get('[data-test-section-heading]')
-      .first()
-      .invoke('text')
-      .should('match', new RegExp(`^${name}`)); // 1st heading should start with operand name
+    detailsPage.titleShouldContain(exampleName);
   },
   deleteOperand: (
     operatorName: string,


### PR DESCRIPTION
Noticing a OLM [flake](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_console/9521/pull-ci-openshift-console-master-e2e-gcp-console/1417805488703148032/artifacts/e2e-gcp-console/test/artifacts/gui_test_screenshots/cypress/screenshots/operator-install-global.spec.ts/1_Globally%20installing%20Service%20Binding%20Operator%20operator%20in%20openshift-operators%20--%20Globally%20installs%20Service%20Binding%20Operator%20operator%20in%20openshift-operators%20and%20creates%20ServiceBinding%20operand%20(failed).png) where initial section title renders as "ServiceBinding", then updates to "Service Binding".   Changed `operandShouldExist()` to test page title rather than section title.

This has been backported to [[release-4.8] Bug 1984102: Switch Cypress OLM tests to use supported Red Hat operators](https://github.com/openshift/console/pull/9560)