### PR TITLE
Support multi level json schema for kamelets creation dynamic forms

### DIFF
--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -16,7 +16,7 @@
     "properties": {
       "id": "knative-event-source",
       "groupId": "developer-catalog",
-      "href": "/catalog/ns/:namespace?catalogType=EventSource",
+      "href": "/catalog/ns/:namespace?catalogType=EventSource&provider=[\"Red+Hat\"]",
       "label": "%knative-plugin~Event Source%",
       "description": "%knative-plugin~Create an Event source to register interest in a class of events from a particular system%",
       "icon": { "$codeRef": "icons.eventSourceIconSVG" }

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
@@ -7,8 +7,9 @@ import AppSection from '@console/dev-console/src/components/import/app/AppSectio
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ProjectModel } from '@console/internal/models';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { capabilityWidgetMap } from '@console/operator-lifecycle-manager/src/components/descriptors/spec/spec-descriptor-input';
+import { descriptorsToUISchema } from '@console/operator-lifecycle-manager/src/components/operand/utils';
 import { DynamicFormField, useFormikValidationFix } from '@console/shared';
+import { formDescriptorData } from '../../../utils/create-eventsources-utils';
 import { EventSources } from '../import-types';
 import ApiServerSection from './ApiServerSection';
 import ContainerSourceSection from './ContainerSourceSection';
@@ -23,22 +24,6 @@ interface EventSourceSectionProps {
   fullWidth?: boolean;
   kameletSource?: K8sResourceKind;
 }
-
-const getUISchema = (formSchema) => {
-  const uiSchema = {};
-  for (const k in formSchema.properties) {
-    if (formSchema.properties.hasOwnProperty(k)) {
-      uiSchema[k] = {
-        'ui:title': formSchema.properties[k].title,
-        'ui:description': formSchema.properties[k].description,
-        ...(formSchema.properties[k].hasOwnProperty('x-descriptors')
-          ? { 'ui:widget': capabilityWidgetMap.get(formSchema.properties[k]['x-descriptors'][0]) }
-          : {}),
-      };
-    }
-  }
-  return uiSchema;
-};
 
 const EventSourceSection: React.FC<EventSourceSectionProps> = ({
   namespace,
@@ -103,7 +88,7 @@ const EventSourceSection: React.FC<EventSourceSectionProps> = ({
           <DynamicFormField
             name="formData.data.KameletBinding.source.properties"
             schema={formSchema}
-            uiSchema={getUISchema(formSchema)}
+            uiSchema={descriptorsToUISchema(formDescriptorData(formSchema.properties), formSchema)}
             showAlert={false}
           />
         </>

--- a/frontend/packages/knative-plugin/src/components/eventing/EventingListPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/EventingListPage.tsx
@@ -25,7 +25,7 @@ const EventingListPage: React.FC<EventingListPageProps> = ({ match }) => {
   const menuActions: MenuActions = {
     eventSource: {
       label: t('knative-plugin~Event Source'),
-      onSelection: () => `/catalog/ns/${nsSelected}?catalogType=EventSource`,
+      onSelection: () => `/catalog/ns/${nsSelected}?catalogType=EventSource&provider=["Red+Hat"]`,
     },
     brokers: { label: t('knative-plugin~Broker'), model: EventingBrokerModel },
     channels: {

--- a/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/eventing/__tests__/EventingListPage.spec.tsx
@@ -52,7 +52,7 @@ describe('EventingListPage', () => {
       multiTablistPage
         .props()
         .menuActions.eventSource.onSelection('eventSource', { label: 'Event Source' }, undefined),
-    ).toEqual('/catalog/ns/my-project?catalogType=EventSource');
+    ).toEqual('/catalog/ns/my-project?catalogType=EventSource&provider=["Red+Hat"]');
   });
 
   it('should show correct url for creation if namespace is not defined', () => {
@@ -74,6 +74,6 @@ describe('EventingListPage', () => {
       multiTablistPage
         .props()
         .menuActions.eventSource.onSelection('eventSource', { label: 'Event Source' }, undefined),
-    ).toEqual('/catalog/ns/default?catalogType=EventSource');
+    ).toEqual('/catalog/ns/default?catalogType=EventSource&provider=["Red+Hat"]');
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -22,6 +22,7 @@ import {
   sanitizeSourceToForm,
   isSecretKeyRefPresent,
   getKafkaSourceResource,
+  formDescriptorData,
 } from '../create-eventsources-utils';
 import { getDefaultEventingData, Kafkas } from './knative-serving-data';
 
@@ -377,5 +378,189 @@ describe('sanitizeSourceToForm always returns valid Event Source', () => {
     expect(sasl).toEqual({ user: {}, password: {} });
     expect(tls.enable).toBeUndefined();
     expect(tls).toEqual({ caCert: {}, cert: {}, key: {} });
+  });
+});
+
+describe('form descriptors form json schema for kamelets', () => {
+  it('should return formDescriptorData for provided JsonSchema with string, integer, boolean', () => {
+    const properties = {
+      accessKey: {
+        description: 'The access key obtained from AWS',
+        format: 'password',
+        title: 'Access Key',
+        type: 'string',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      paritions: {
+        description: 'The number of partitions',
+        title: 'Partitions',
+        type: 'integer',
+      },
+      source: {
+        description: 'Enable source',
+        title: 'Source',
+        type: 'boolean',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+      },
+    };
+    expect(formDescriptorData(properties)).toEqual([
+      {
+        description: 'The access key obtained from AWS',
+        displayName: 'Access Key',
+        path: 'accessKey',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      {
+        description: 'The number of partitions',
+        displayName: 'Partitions',
+        path: 'paritions',
+      },
+      {
+        description: 'Enable source',
+        displayName: 'Source',
+        path: 'source',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+      },
+    ]);
+  });
+
+  it('should return formDescriptorData for provided JsonSchema with type object', () => {
+    const properties = {
+      accessKey: {
+        description: 'The access key obtained from AWS',
+        format: 'password',
+        title: 'Access Key',
+        type: 'string',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      paritionsData: {
+        description: 'The Partitions Data',
+        title: 'Partitions Data',
+        type: 'object',
+        properties: {
+          paritions: {
+            description: 'The number of partitions',
+            title: 'Partitions',
+            type: 'integer',
+          },
+          source: {
+            description: 'Enable source',
+            title: 'Source',
+            type: 'boolean',
+            'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+          },
+        },
+      },
+    };
+    expect(formDescriptorData(properties)).toEqual([
+      {
+        description: 'The access key obtained from AWS',
+        displayName: 'Access Key',
+        path: 'accessKey',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      {
+        description: 'The number of partitions',
+        displayName: 'Partitions',
+        path: 'paritionsData.paritions',
+      },
+      {
+        description: 'Enable source',
+        displayName: 'Source',
+        path: 'paritionsData.source',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+      },
+    ]);
+  });
+
+  it('should return formDescriptorData for provided JsonSchema with type array of object', () => {
+    const properties = {
+      accessKey: {
+        description: 'The access key obtained from AWS',
+        format: 'password',
+        title: 'Access Key',
+        type: 'string',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      paritionsData: {
+        description: 'The Partitions Data',
+        title: 'Partitions Data',
+        type: 'array',
+        items: {
+          title: 'Partition Object',
+          description: 'The Partition Object',
+          type: 'object',
+          properties: {
+            paritions: {
+              description: 'The number of partitions',
+              title: 'Partitions',
+              type: 'integer',
+            },
+            source: {
+              description: 'Enable source',
+              title: 'Source',
+              type: 'boolean',
+              'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+            },
+          },
+        },
+      },
+    };
+    expect(formDescriptorData(properties)).toEqual([
+      {
+        description: 'The access key obtained from AWS',
+        displayName: 'Access Key',
+        path: 'accessKey',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      {
+        description: 'The number of partitions',
+        displayName: 'Partitions',
+        path: 'paritionsData[0].paritions',
+      },
+      {
+        description: 'Enable source',
+        displayName: 'Source',
+        path: 'paritionsData[0].source',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+      },
+    ]);
+  });
+
+  it('should return formDescriptorData for provided JsonSchema with type array', () => {
+    const properties = {
+      accessKey: {
+        description: 'The access key obtained from AWS',
+        format: 'password',
+        title: 'Access Key',
+        type: 'string',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      paritionsData: {
+        description: 'The Partition Data',
+        title: 'Partition Data',
+        type: 'array',
+        items: {
+          description: 'Enable source',
+          title: 'Source',
+          type: 'boolean',
+          'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+        },
+      },
+    };
+    expect(formDescriptorData(properties)).toEqual([
+      {
+        description: 'The access key obtained from AWS',
+        displayName: 'Access Key',
+        path: 'accessKey',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:password'],
+      },
+      {
+        description: 'Enable source',
+        displayName: 'Source',
+        path: 'paritionsData[0]',
+        'x-descriptors': ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6169

**Solution Description**: 
Support multi-level JSON schema for kamelets creation with dynamic forms
- added a utility to form descriptors from properties in JSON schema
- made use of existing util `descriptorsToUISchema` to form UI schema needed to render custom widget in case of dynamic forms
- default filter in the catalog for event sources should show provider by Red Hat and hide Community

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/5129024/126547544-2ec28f93-6030-4837-a8fd-1ec6e265b719.png)


![image](https://user-images.githubusercontent.com/5129024/126752823-f4950114-6b0d-4f2f-9310-112e07b0a39f.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

![image](https://user-images.githubusercontent.com/5129024/126548080-b1b721b4-6f45-4788-8b60-2fac98cfdb53.png)


**Test setup:**
- Install serverless operator (Create CR for knative serving and knative eventing)
- Install camelK operator (Create CR for IntegratonPlatform in a namespace)
- all kamelets type source will show up in the name space

Currently, all kamelets including community ones provided flat structure for JSON schema so to test we nested structure we would need to form nested schema manually 

```
 type: array
 items:
    description: ConfigurationSpec
    type: object
    properties:
         resourceKey:
            type: string
         resourceMountPoint:
             type: string
         resourceType:
             type: boolean
             x-descriptors: ['urn:alm:descriptor:com.tectonic.ui:booleanSwitch'],
```
                        


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
