### PR TITLE
CONSOLE-2877: Additional Operator badge for Single-Node Compatibility

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -23,6 +23,7 @@ export enum InfraFeatures {
   cnf = 'Cloud-Native Network Function',
   cni = 'Container Network Interface',
   csi = 'Container Storage Interface',
+  sno = 'Single-Node OpenShift',
 }
 
 export type OperatorHubItem = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -23,7 +23,7 @@ export enum InfraFeatures {
   cnf = 'Cloud-Native Network Function',
   cni = 'Container Network Interface',
   csi = 'Container Storage Interface',
-  sno = 'Single-Node OpenShift',
+  sno = 'Single Node Clusters',
 }
 
 export type OperatorHubItem = {


### PR DESCRIPTION
Changes in this PR:

-  A filterable value called sno (display name, Single Node Clusters) is available in the operators.openshift.io/infrastructure-features field for Operator authors to denote support for Single-Node OpenShift (SNO)
- CatalogSource with image `quay.io/rhamilto/example-registry:latest` and use the included `etcd` operator.

(<img width="202" alt="Screen Shot 2021-07-20 at 2 13 27 PM" src="https://user-images.githubusercontent.com/12129628/126544649-336b5f9c-21ad-44ec-af03-0a3f7fcb5497.png">
<img width="473" alt="Screen Shot 2021-07-20 at 2 14 31 PM" src="https://user-images.githubusercontent.com/12129628/126544651-e2d2305f-a7b1-472f-b95f-c5da81f00e63.png">
)

/hold
/assign @TheRealJon 
/assign @spadgett
