### PR TITLE
odc-6192-updated the test-headless script in dev-console/package.json file

### DIFF
--- a/frontend/packages/dev-console/integration-tests/.gherkin-lintrc
+++ b/frontend/packages/dev-console/integration-tests/.gherkin-lintrc
@@ -12,7 +12,7 @@
   "no-empty-file": "on",
   "no-scenario-outlines-without-examples": "on",
   "name-length": "off",
-  "allowed-tags": ["on", {"tags": ["@un-verified", "@knative-admin", "@service-mesh", "@cnv", "@knative-camelk", "@getting-started", "@health-checks", "@e2e", "@to-do", "@manual", "@regression", "@smoke", "@add-flow", "@topology", "@knative", "@guided-tour", "@gitops", "@helm", "@monitoring", "@pipelines", "@virtualization", "@web-terminal", "@vulnerability", "@knative-eventing", "@knative-camelK", "@kafka"]}],
+  "allowed-tags": ["on", {"tags": ["@pre-condition", "@un-verified", "@bug" "@knative-admin", "@service-mesh", "@cnv", "@knative-camelk", "@getting-started", "@health-checks", "@e2e", "@to-do", "@manual", "@regression", "@smoke", "@add-flow", "@topology", "@knative", "@guided-tour", "@gitops", "@helm", "@monitoring", "@pipelines", "@virtualization", "@web-terminal", "@vulnerability", "@knative-eventing", "@knative-camelK", "@kafka"]}],
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip", "@debug"]}],
   "use-and": "off",
   "no-duplicate-tags": "on",

--- a/frontend/packages/dev-console/integration-tests/cypress.json
+++ b/frontend/packages/dev-console/integration-tests/cypress.json
@@ -19,7 +19,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "@smoke and not (@manual or @to-do or @un-verified)",
+    "TAGS": "(@pre-condition or @smoke) and not (@manual or @to-do or @un-verified or @bug)",
     "NAMESPACE": "aut-pipelines"
   },
   "retries": {

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -20,9 +20,9 @@ Feature: Create Application from git form
               And user is able to see workload "<name>" in topology page
 
         Examples:
-                  | name            | resource_type     |
-                  | dancer-ex-git   | Deployment        |
-                  | dancer-ex-git-1 | Deployment Config |
+                  | name         | resource_type     |
+                  | import-git   | Deployment        |
+                  | import-git-1 | Deployment Config |
 
 
         @regression

--- a/frontend/packages/dev-console/integration-tests/package.json
+++ b/frontend/packages/dev-console/integration-tests/package.json
@@ -11,7 +11,7 @@
     "clean-reports": "rm -rf ../../../gui_test_screenshots",
     "cypress-merge": "../../../node_modules/.bin/mochawesome-merge ../../../gui_test_screenshots/cypress_report*.json > ../../../gui_test_screenshots/cypress.json",
     "cypress-generate": "../../../node_modules/.bin/marge -o ../../../gui_test_screenshots/ -f cypress-report -t 'OpenShift DevConsole Cypress Test Results' -p 'OpenShift Cypress Test Results' --showPassed false --assetsDir ../../../gui_test_screenshots/cypress/assets ../../../gui_test_screenshots/cypress.json",
-    "test-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/*/project-creation.feature\";",
+    "test-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/addFlow/*.feature\";",
     "test-cypress-headless": "yarn run clean-reports && yarn run test-headless && yarn run cypress-merge && yarn run cypress-generate"
   }
 }

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -46,6 +46,7 @@ export const topologyPO = {
     appName: '#HelmRelease ul li div',
     nodeName: '#HelmRelease ul li div',
     resourceTitle: 'pf-c-data-list__cell.odc-topology-list-view__kind-label',
+    switcher: '[data-test-id="topology-switcher-view"][aria-label="Graph view"]',
   },
   sidePane: {
     actionsDropDown: '[data-test-id="actions-menu-button"]',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-helper-page.ts
@@ -9,6 +9,17 @@ export const topologyHelper = {
       .type(name),
   verifyWorkloadInTopologyPage: (appName: string) => {
     topologyHelper.search(appName);
+    // eslint-disable-next-line promise/catch-or-return
+    cy.get('body').then(($body) => {
+      if (
+        $body.find('[data-test-id="topology-switcher-view"][aria-label="Graph view"]').length !== 0
+      ) {
+        cy.get(topologyPO.list.switcher).click();
+        cy.log('user is switching to graph view in topology page');
+      } else {
+        cy.log('You are on Topology page - Graph view');
+      }
+    });
     cy.get(topologyPO.highlightNode).should('be.visible');
     app.waitForDocumentLoad();
   },

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -24,7 +24,8 @@ export const topologyPage = {
   verifyTopologyPage: () => {
     app.waitForDocumentLoad();
     cy.url().should('include', 'topology');
-    cy.get(topologyPO.graph.emptyGraph).should('be.visible');
+    //  Commenting below line, as above line  already asserts the same
+    // cy.get(topologyPO.graph.emptyGraph).should('be.visible');
   },
   verifyTopologyGraphView: () => {
     return cy.get(topologyPO.graph.emptyGraph);


### PR DESCRIPTION
**Description:**
To avoid the merging issue on ODC-6023, this piece of code changes is applying as part of this PR. This task, helps us to execute all add flow smoke test scenarios in CI

**Jira Id:**
https://issues.redhat.com/browse/ODC-6192

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] update the CI status in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p dev-console -h true
```

**Screen shots**:
![image](https://user-images.githubusercontent.com/61005404/126596861-77d9d7e7-0a95-477a-a9de-949257246b45.png)

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
