### PR TITLE
Replaced CDROM and rootDisk names, revised a translation

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -35,7 +35,7 @@
   "{{nameOrId}} - Default data image already exists": "{{nameOrId}} - Default data image already exists",
   "{{nameOrId}} - Template missing data image definition": "{{nameOrId}} - Template missing data image definition",
   "Use template size PVC": "Use template size PVC",
-  "Mount this as a CD-ROM boot source": "Mount this as a CD-ROM boot source",
+  "This is a CD-ROM boot source": "This is a CD-ROM boot source",
   "Operating system source already defined": "Operating system source already defined",
   "In order to add a new source for {{osName}} you will need to delete the following PVC:": "In order to add a new source for {{osName}} you will need to delete the following PVC:",
   "Namespace": "Namespace",

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -408,7 +408,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
                   id="golden-os-checkbox-pvc-size-template"
                   className="kv--create-upload__golden-switch"
                   isChecked={!!mountAsCDROM}
-                  label={t('kubevirt-plugin~Mount this as a CD-ROM boot source')}
+                  label={t('kubevirt-plugin~This is a CD-ROM boot source')}
                   onChange={handleCDROMChange}
                 />
               </>

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
@@ -1,4 +1,9 @@
-import { CLOUDINIT_DISK, LABEL_CDROM_SOURCE, ROOT_DISK_NAME } from '../../../../constants';
+import {
+  CLOUDINIT_DISK,
+  LABEL_CDROM_SOURCE,
+  ROOT_DISK_INSTALL_NAME,
+  ROOT_DISK_NAME,
+} from '../../../../constants';
 import { DiskBus } from '../../../../constants/vm/storage/disk-bus';
 import { DiskType } from '../../../../constants/vm/storage/disk-type';
 import { winToolsContainerNames } from '../../../../constants/vm/wintools';
@@ -388,8 +393,11 @@ const initialStorageWindowsUpdater = ({ id, prevState, dispatch, getState }: Upd
     }
     const cdRomDisk = new DiskWrapper(removableRootDisk?.disk, true)
       .setType(DiskType.CDROM, { bus: removableRootDisk?.disk?.disk?.bus })
+      .setName(ROOT_DISK_INSTALL_NAME)
       .asResource(true);
-
+    removableRootDisk.volume = new VolumeWrapper(removableRootDisk.volume)
+      .setName(ROOT_DISK_INSTALL_NAME)
+      .asResource();
     dispatch(vmWizardInternalActions[InternalActionType.RemoveStorage](id, removableRootDisk?.id));
     dispatch(
       vmWizardInternalActions[InternalActionType.UpdateStorage](id, {

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
@@ -410,7 +410,7 @@ export const BootSourceForm: React.FC<BootSourceFormProps> = ({
           isDisabled={disabled}
           label={
             <>
-              {t('kubevirt-plugin~Mount this as a CD-ROM boot source')}
+              {t('kubevirt-plugin~This is a CD-ROM boot source')}
               <FieldLevelHelp>
                 {t(
                   'kubevirt-plugin~CD-ROM requires an additional disk for the operating system to be installed onto. This disk will be added and can be customized when creating the virtual machine.',

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/simple-create.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/simple-create.ts
@@ -16,7 +16,7 @@ import {
   VolumeMode,
   VolumeType,
 } from '../../../../constants';
-import { CLOUDINIT_DISK } from '../../../../constants/vm/constants';
+import { CLOUDINIT_DISK, ROOT_DISK_INSTALL_NAME } from '../../../../constants/vm/constants';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { winToolsContainerNames } from '../../../../constants/vm/wintools';
 import { VirtualMachineModel } from '../../../../models';
@@ -181,6 +181,8 @@ export const prepareVM = async (
       rootDisk.setType(DiskType.CDROM, {
         bus: rootDiskBus === DiskBus.VIRTIO ? DiskBus.SATA : rootDiskBus,
       });
+      rootDisk.setName(ROOT_DISK_INSTALL_NAME);
+      rootVolume.setName(ROOT_DISK_INSTALL_NAME);
       vmWrapper.prependStorage(
         getEmptyInstallStorage(scConfigMap, rootDiskBus, name, emptyDiskSize),
       );

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
@@ -62,6 +62,11 @@ export class DiskWrapper extends ObjectWithTypePropertyWrapper<
     return this;
   };
 
+  setName = (name: string) => {
+    this.data.name = name;
+    return this;
+  };
+
   isFirstBootableDevice = () => this.getBootOrder() === 1;
 
   hasBootOrder = () => this.getBootOrder() != null;

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/volume-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/volume-wrapper.ts
@@ -126,6 +126,11 @@ export class VolumeWrapper extends ObjectWithTypePropertyWrapper<
 
   getReferencedObject = () => getVolumeReferencedObject(this);
 
+  setName = (name: string) => {
+    this.data.name = name;
+    return this;
+  };
+
   protected sanitize(
     type: VolumeType,
     { name, claimName, image, userData, userDataBase64 }: CombinedTypeData,

--- a/frontend/packages/kubevirt-plugin/src/utils/storage.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/storage.ts
@@ -5,7 +5,7 @@ import {
   DiskBus,
   DiskType,
   DUMMY_VM_NAME,
-  ROOT_DISK_INSTALL_NAME,
+  ROOT_DISK_NAME,
   VolumeType,
 } from '../constants';
 import { DataVolumeWrapper } from '../k8s/wrapper/vm/data-volume-wrapper';
@@ -23,14 +23,14 @@ export const getEmptyInstallStorage = (
   vmName = DUMMY_VM_NAME,
   size = DEFAULT_DISK_SIZE,
 ) => {
-  const dataVolumeName = generateDataVolumeName(vmName, ROOT_DISK_INSTALL_NAME);
+  const dataVolumeName = generateDataVolumeName(vmName, ROOT_DISK_NAME);
   return {
     disk: new DiskWrapper()
-      .init({ name: ROOT_DISK_INSTALL_NAME, bootOrder: 2 })
+      .init({ name: ROOT_DISK_NAME, bootOrder: 2 })
       .setType(DiskType.DISK, { bus })
       .asResource(),
     volume: new VolumeWrapper()
-      .init({ name: ROOT_DISK_INSTALL_NAME })
+      .init({ name: ROOT_DISK_NAME })
       .setType(VolumeType.DATA_VOLUME, { name: dataVolumeName })
       .asResource(),
     dataVolume: new DataVolumeWrapper()


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
Wrong disk naming

**Analysis / Root cause**: 
Naming was reversed.

**Solution Description**: 
Added setName methods and replaced the names in case of cdrom.

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/126617260-25539b91-304b-46bd-806b-bd44c955664c.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/126617401-b747ba60-ebe8-4699-9241-95e5b7e7462b.png)
