### PR TITLE
(fix): Fix wizard requests

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/README.md
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/README.md
@@ -13,12 +13,12 @@ Follow the steps written below to integrate with the ODF wizard:
 /**
  *  Configures a new external storage vendor to the Storage System Creation wizard.
  */
-{
+export type ExternalStorage = {
   /** Display name of the external storage vendor. */
   displayName: string;
 
-  /** The model referring the `apiGroup`,`apiVersion` and `kind` of the external storage vendor's CRD. */
-  model: ExtensionK8sModel;
+  /** The model referring the `apiGroup`,`apiVersion`, `plural` and `kind` of the external storage vendor's CRD. */
+  model: Model;
 
   /** A React Functional Component to input the connection details of the external storage vendor. */
   Component: React.FunctionComponent<ExternalComponentProps<{}>>;
@@ -27,25 +27,29 @@ Follow the steps written below to integrate with the ODF wizard:
   createPayload: CreatePayload<{}>;
 
   /**  Handler function to validate the storage class page in order to move to the next step of wizard */
-  canGoToNextStep: (state: ExternalState, storageClassName: string) => boolean;
+  canGoToNextStep: CanGoToNextStep<{}>;
 };
+
 ```
 
 ```js
 
-/** The model referring the `apiGroup`,`apiVersion` and `kind` of the external storage vendor's CRD. */
+  /** The model referring the `apiGroup`,`apiVersion`, `plural` and `kind` of the external storage vendor's CRD. */
 
-type ExtensionK8sModel{
+type Model = {
     /* apiGroup of the external provider CRD */
-    group: string;
+    apiGroup: string;
 
     /* apiVersion of the external provider CRD */
-    version: string;
+    apiVersion: string;
 
     /* kind of the external provider CRD */
     kind: string;
-}
 
+    /* plural of the external provider CRD */
+    plural: string;
+
+}
 
 /** Props for `ExternalStorage.Component` to input the connection details of the external storage vendor. */
 

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/index.ts
@@ -6,9 +6,10 @@ export const SUPPORTED_EXTERNAL_STORAGE: ExternalStorage[] = [
   {
     displayName: 'Red Hat Ceph Storage',
     model: {
-      group: OCSServiceModel.apiGroup,
-      version: OCSServiceModel.apiVersion,
+      apiGroup: OCSServiceModel.apiGroup,
+      apiVersion: OCSServiceModel.apiVersion,
       kind: OCSServiceModel.kind,
+      plural: OCSServiceModel.plural,
     },
     Component: ConnectionDetails,
     createPayload: rhcsPayload,

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/red-hat-ceph-storage/index.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/red-hat-ceph-storage/index.tsx
@@ -105,13 +105,14 @@ export const ConnectionDetails: React.FC<ExternalComponentProps<RHCSState>> = ({
 };
 
 export const rhcsPayload: CreatePayload<RHCSState> = (systemName, state, model) => {
-  const { apiVersion, apiGroup, kind } = SecretModel;
+  const { apiVersion, apiGroup, kind, plural } = SecretModel;
   return [
     {
       model: {
-        group: apiGroup,
-        version: apiVersion,
+        apiGroup,
+        apiVersion,
         kind,
+        plural,
       },
       payload: {
         apiVersion: SecretModel.apiVersion,
@@ -130,7 +131,8 @@ export const rhcsPayload: CreatePayload<RHCSState> = (systemName, state, model) 
     {
       model,
       payload: {
-        apiVersion: model.version,
+        apiVersion: model.apiVersion,
+        apiGroup: model.apiGroup,
         kind: model.kind,
         metadata: {
           name: systemName,

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/external-storage/types.ts
@@ -1,4 +1,3 @@
-import { ExtensionK8sModel } from '@console/dynamic-plugin-sdk';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { IP_FAMILY } from '../../../constants';
 
@@ -9,8 +8,8 @@ export type ExternalStorage = {
   /** Display name of the external storage vendor. */
   displayName: string;
 
-  /** The model referring the `apiGroup`,`apiVersion` and `kind` of the external storage vendor's CRD. */
-  model: ExtensionK8sModel;
+  /** The model referring the `apiGroup`,`apiVersion`, `plural` and `kind` of the external storage vendor's CRD. */
+  model: Model;
 
   /** A React Functional Component to input the connection details of the external storage vendor. */
   Component: React.FunctionComponent<ExternalComponentProps<{}>>;
@@ -20,6 +19,22 @@ export type ExternalStorage = {
 
   /**  Handler function to validate the storage class page in order to move to the next step of wizard */
   canGoToNextStep: CanGoToNextStep<{}>;
+};
+
+/** The model referring the `apiGroup`,`apiVersion`, `plural` and `kind` of the external storage vendor's CRD. */
+
+type Model = {
+  /* apiGroup of the external provider CRD */
+  apiGroup: string;
+
+  /* apiVersion of the external provider CRD */
+  apiVersion: string;
+
+  /* kind of the external provider CRD */
+  kind: string;
+
+  /* plural of the external provider CRD */
+  plural: string;
 };
 
 /** Props for `ExternalStorage.Component` to input the connection details of the external storage vendor. */
@@ -51,11 +66,11 @@ export type ExternalComponentProps<S extends ExternalState> = {
 export type CreatePayload<S extends ExternalState> = (
   systemName: string,
   state: S,
-  model: ExtensionK8sModel,
+  model: Model,
   storageClassName: string,
 ) => Payload[];
 
-export type Payload = { model: ExtensionK8sModel; payload: K8sResourceKind };
+export type Payload = { model: Model; payload: K8sResourceKind };
 
 /**
  *  @function CanGoToNextStep<S>

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
@@ -85,7 +85,7 @@ const getPayloads = (stepName: string, state: WizardState, t: TFunction) => {
     if (deployment === DeploymentType.MCG) {
       const { apiGroup, apiVersion, kind } = OCSServiceModel;
       const systemName = 'odf-storage-system';
-      const systemKind = getStorageSystemKind({ group: apiGroup, version: apiVersion, kind });
+      const systemKind = getStorageSystemKind({ apiGroup, apiVersion, kind });
       return [createNoobaaPayload(), createSSPayload(systemKind, systemName)];
     }
     if (type === BackingStorageType.EXTERNAL) {

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/payloads.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/payloads.ts
@@ -4,12 +4,13 @@ import { CEPH_STORAGE_NAMESPACE } from '../../constants';
 import { NooBaaSystemModel, StorageSystemModel } from '../../models';
 
 export const createSSPayload = (systemKind: string, systemName: string): Payload => {
-  const { apiGroup, apiVersion, kind } = StorageSystemModel;
+  const { apiGroup, apiVersion, kind, plural } = StorageSystemModel;
   return {
     model: {
-      group: apiGroup,
-      version: apiVersion,
+      apiGroup,
+      apiVersion,
       kind,
+      plural,
     },
     payload: {
       apiVersion: apiVersionForModel(StorageSystemModel),
@@ -28,13 +29,14 @@ export const createSSPayload = (systemKind: string, systemName: string): Payload
 };
 
 export const createNoobaaPayload = (): Payload => {
-  const { apiGroup, apiVersion, kind } = NooBaaSystemModel;
+  const { apiGroup, apiVersion, kind, plural } = NooBaaSystemModel;
 
   return {
     model: {
-      group: apiGroup,
-      version: apiVersion,
+      apiGroup,
+      apiVersion,
       kind,
+      plural,
     },
     payload: {
       apiVersion,

--- a/frontend/packages/ceph-storage-plugin/src/utils/create-storage-system.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/create-storage-system.ts
@@ -1,11 +1,10 @@
-import { ExtensionK8sModel } from '@console/dynamic-plugin-sdk/src';
 import { SUPPORTED_EXTERNAL_STORAGE } from '../components/create-storage-system/external-storage';
 import { WizardState } from '../components/create-storage-system/reducer';
 
-export const getStorageSystemKind = ({ kind, version, group }: ExtensionK8sModel) =>
-  `${kind.toLowerCase()}.${group}/${version}`;
+export const getStorageSystemKind = ({ kind, apiVersion, apiGroup }) =>
+  `${kind.toLowerCase()}.${apiGroup}/${apiVersion}`;
 
-export const createExternalSSName = (id: string = '') => id.toLowerCase().replace(' ', '-');
+export const createExternalSSName = (id: string = '') => id.toLowerCase().replace(/\s/g, '-');
 
 export const getExternalStorage = (id: WizardState['backingStorage']['externalStorage'] = '') =>
   SUPPORTED_EXTERNAL_STORAGE.find((p) => p.model.kind === id);


### PR DESCRIPTION
- `plural` is missing in the request object
- it is required to construct API path
- the requests are failing due to this
- using a regex for constructing names.

Signed-off-by: Afreen Rahman <afrahman@redhat.com>