### PR TITLE
Add Mirroring card on Block and File dashboard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -396,6 +396,7 @@
   "Service name": "Service name",
   "Cluster name": "Cluster name",
   "Internal": "Internal",
+  "Mirroring Status": "Mirroring Status",
   "Raw capacity is the absolute total disk space available to the array subsystem.": "Raw capacity is the absolute total disk space available to the array subsystem.",
   "Active health checks": "Active health checks",
   "Progressing": "Progressing",

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/ocs-system-dashboard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/ocs-system-dashboard.tsx
@@ -39,6 +39,7 @@ import { default as ObjectBreakdownCard } from './object-service/capacity-breakd
 import DataConsumptionCard from './object-service/data-consumption-card/data-consumption-card';
 import { default as ObjectActivityCard } from './object-service/activity-card/activity-card';
 import { ResourceProvidersCard } from './object-service/resource-providers-card/resource-providers-card';
+import { default as MirroringCard } from './persistent-internal/mirroring-card/mirroring-card';
 import { OCS_INDEPENDENT_FLAG, MCG_FLAG, CEPH_FLAG } from '../../features';
 
 const convertToCard = (Card: React.ComponentType): GridDashboardCard => ({ Card });
@@ -88,7 +89,12 @@ const PersistentInternalDashboard: React.FC = () => {
     BreakdownCard,
     UtilizationCard,
   ];
-  const leftCards: React.ComponentType[] = [DetailsCard, InventoryCard, storageEfficiencyCard];
+  const leftCards: React.ComponentType[] = [
+    DetailsCard,
+    InventoryCard,
+    MirroringCard,
+    storageEfficiencyCard,
+  ];
   const rightCards: React.ComponentType[] = [ActivityCard];
 
   return (

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/details-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/details-card.tsx
@@ -12,36 +12,18 @@ import {
   withDashboardResources,
 } from '@console/internal/components/dashboard/with-dashboard-resources';
 import DetailsBody from '@console/shared/src/components/dashboard/details-card/DetailsBody';
-import { FirehoseResource, FirehoseResult } from '@console/internal/components/utils/index';
+import { FirehoseResult } from '@console/internal/components/utils/index';
 import { InfrastructureModel } from '@console/internal/models/index';
-import {
-  SubscriptionModel,
-  ClusterServiceVersionModel,
-} from '@console/operator-lifecycle-manager/src/models';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { K8sResourceKind } from '@console/internal/module/k8s/index';
 import { getName } from '@console/shared/src/selectors/common';
-import { referenceForModel } from '@console/internal/module/k8s/k8s';
 import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
 import { resourcePathFromModel } from '@console/internal/components/utils/resource-link';
-import { OCSServiceModel } from '../../../models';
+
 import { getOCSVersion } from '../../../selectors';
 import { CEPH_STORAGE_NAMESPACE } from '../../../constants';
 import { StorageClusterKind } from '../../../types';
-
-const ocsResource: FirehoseResource = {
-  kind: referenceForModel(OCSServiceModel),
-  namespaced: true,
-  isList: true,
-  namespace: CEPH_STORAGE_NAMESPACE,
-  prop: 'ocs',
-};
-
-const SubscriptionResource: FirehoseResource = {
-  kind: referenceForModel(SubscriptionModel),
-  namespaced: false,
-  prop: 'subscription',
-  isList: true,
-};
+import { ocsResource, subscriptionResource } from '../../../resources';
 
 const DetailsCard: React.FC<DashboardItemProps> = ({
   watchK8sResource,
@@ -54,10 +36,10 @@ const DetailsCard: React.FC<DashboardItemProps> = ({
     'cluster',
   );
   React.useEffect(() => {
-    watchK8sResource(SubscriptionResource);
+    watchK8sResource(subscriptionResource);
     watchK8sResource(ocsResource);
     return () => {
-      stopWatchK8sResource(SubscriptionResource);
+      stopWatchK8sResource(subscriptionResource);
       stopWatchK8sResource(ocsResource);
     };
   }, [watchK8sResource, stopWatchK8sResource]);
@@ -70,7 +52,7 @@ const DetailsCard: React.FC<DashboardItemProps> = ({
   const cluster = ocsData?.find((item: StorageClusterKind) => item.status.phase !== 'Ignored');
   const ocsName = getName(cluster);
 
-  const subscription = resources?.subscription as FirehoseResult;
+  const subscription = resources?.subs as FirehoseResult;
   const subscriptionLoaded = subscription?.loaded;
   const ocsVersion = getOCSVersion(subscription);
   const ocsPath = `${resourcePathFromModel(

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/mirroring-card/mirroring-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/mirroring-card/mirroring-card.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import * as classNames from 'classnames';
+import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
+import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
+import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
+import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
+import {
+  DashboardItemProps,
+  withDashboardResources,
+} from '@console/internal/components/dashboard/with-dashboard-resources';
+import { K8sResourceKind } from '@console/internal/module/k8s/index';
+import { useFlag } from '@console/shared';
+
+import { StorageClusterKind } from '../../../../types';
+import { ocsResource } from '../../../../resources';
+import { GUARDED_FEATURES } from '../../../../features';
+import '../../common/storage-efficiency/storage-efficiency-card.scss';
+
+export const MirroringItemBody: React.FC<MirroringItemBodyProps> = React.memo(
+  ({ title, isLoading, error, className, children }) => {
+    const { t } = useTranslation();
+
+    let status: React.ReactElement;
+
+    if (isLoading) {
+      status = <div className="skeleton-text ceph-storage-efficiency-card__item-body--loading" />;
+    } else if (error) {
+      status = (
+        <span className="co-dashboard-text--small text-muted">
+          {t('ceph-storage-plugin~Not available')}
+        </span>
+      );
+    } else {
+      status = <span className="ceph-storage-efficiency-card__item-text">{children}</span>;
+    }
+    return (
+      <div className="co-inventory-card__item">
+        <div className="ceph-storage-efficiency-card__item-title">{title}</div>
+        <div
+          className={classNames('ceph-storage-efficiency-card__item-status', className)}
+          data-test={`${title}-mirroring-card-status`}
+        >
+          {status}
+        </div>
+      </div>
+    );
+  },
+);
+
+const MirroringCard: React.FC<DashboardItemProps> = ({
+  watchK8sResource,
+  stopWatchK8sResource,
+  resources,
+}) => {
+  const { t } = useTranslation();
+
+  /** to-do: add a better way to filter cards based on the flag in ocs-system-dashboard.tsx file.
+   * Right now even if we are returning null (when flag is set) from this component,
+   * there is an extra spacing between cards because of the GridItem FC.
+   */
+  const isMirroringSupported = useFlag(GUARDED_FEATURES.OCS_POOL_MIRRORING);
+
+  React.useEffect(() => {
+    watchK8sResource(ocsResource);
+    return () => {
+      stopWatchK8sResource(ocsResource);
+    };
+  }, [watchK8sResource, stopWatchK8sResource]);
+
+  if (isMirroringSupported) {
+    const ocs = resources?.ocs;
+    const ocsData = ocs?.data as K8sResourceKind[];
+    const cluster = ocsData?.find((item: StorageClusterKind) => item.status.phase !== 'Ignored');
+    const mirroringStatus: boolean = cluster?.spec?.mirroring?.enabled;
+    const mirroringStatusProps = {
+      title: t('ceph-storage-plugin~Mirroring Status'),
+      isLoading: !ocs?.loaded,
+      error: !!ocs?.loadError,
+      className: 'co-dashboard-text--small text-muted',
+    };
+
+    return (
+      <DashboardCard>
+        <DashboardCardHeader>
+          <DashboardCardTitle>{t('ceph-storage-plugin~Mirroring')}</DashboardCardTitle>
+        </DashboardCardHeader>
+        <DashboardCardBody className="co-dashboard-card__body--no-padding">
+          <MirroringItemBody {...mirroringStatusProps}>
+            {mirroringStatus ? t('ceph-storage-plugin~Enabled') : t('ceph-storage-plugin~Disabled')}
+          </MirroringItemBody>
+        </DashboardCardBody>
+      </DashboardCard>
+    );
+  }
+  return <></>;
+};
+
+type MirroringItemBodyProps = {
+  title: string;
+  isLoading: boolean;
+  error: boolean;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export default withDashboardResources(MirroringCard);

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -45,6 +45,7 @@ export enum GUARDED_FEATURES {
   OCS_THICK_PROVISION = 'OCS_THICK_PROVISION',
   OCS_POOL_MANAGEMENT = 'OCS_POOL_MANAGEMENT',
   OCS_NAMESPACE_STORE = 'OCS_NAMESPACE_STORE',
+  OCS_POOL_MIRRORING = 'OCS_POOL_MIRRORING',
 }
 
 const OCS_FEATURE_FLAGS = {
@@ -57,6 +58,7 @@ const OCS_FEATURE_FLAGS = {
   [GUARDED_FEATURES.OCS_THICK_PROVISION]: 'thick-provision',
   [GUARDED_FEATURES.OCS_POOL_MANAGEMENT]: 'pool-management',
   [GUARDED_FEATURES.OCS_NAMESPACE_STORE]: 'namespace-store',
+  [GUARDED_FEATURES.OCS_POOL_MIRRORING]: 'mirroring',
 };
 
 const handleError = (res: any, flags: string[], dispatch: Dispatch, cb: FeatureDetector) => {

--- a/frontend/packages/ceph-storage-plugin/src/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/resources.ts
@@ -92,6 +92,14 @@ export const storageClusterResource: FirehoseResource = {
   prop: 'storage-cluster',
 };
 
+export const ocsResource: FirehoseResource = {
+  kind: referenceForModel(OCSServiceModel),
+  namespaced: true,
+  isList: true,
+  namespace: CEPH_STORAGE_NAMESPACE,
+  prop: 'ocs',
+};
+
 export const eventsResource: FirehoseResource = {
   isList: true,
   kind: EventModel.kind,

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -254,6 +254,9 @@ export type StorageClusterKind = K8sResourceCommon & {
     arbiter: {
       enable: boolean;
     };
+    mirroring: {
+      enabled: boolean;
+    };
     nodeTopologies: {
       arbiterLocation: string;
     };


### PR DESCRIPTION
- Added feature guard for mirroring.
- Added Mirroring card to OCS--> Overview--> Block and File dashboard.
![Screenshot from 2021-07-23 00-07-54](https://user-images.githubusercontent.com/39404641/126692665-7434d2e4-a432-4168-8f5c-bbe1696e9f34.png)

URL: https://issues.redhat.com/browse/RHSTOR-1899