### PR TITLE
Bug 1982751: i18n misses in move subscription modal

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -178,7 +178,6 @@
   "URL": "URL",
   "Traffic": "Traffic",
   "Generation": "Generation",
-  "Move {{sourceKind}}": "Move {{sourceKind}}",
   "Connects": "Connects",
   "to": "to",
   "Select a sink": "Select a sink",

--- a/frontend/packages/knative-plugin/src/actions/sink-pubsub.ts
+++ b/frontend/packages/knative-plugin/src/actions/sink-pubsub.ts
@@ -1,4 +1,5 @@
 import { KebabOption } from '@console/internal/components/utils';
+import i18n from '@console/internal/i18n';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { setSinkPubsubModal } from '../components/modals';
 
@@ -7,11 +8,12 @@ export const setSinkPubsub = (model: K8sKind, source: K8sResourceKind): KebabOpt
     // t('knative-plugin~Move {{kind}}')
     labelKey: 'knative-plugin~Move {{kind}}',
     labelKind: {
-      kind: model.kind,
+      kind: model.labelKey ? i18n.t(model.labelKey) : model.label,
     },
     callback: () =>
       setSinkPubsubModal({
         source,
+        resourceType: model.labelKey ? i18n.t(model.labelKey) : model.label,
       }),
     accessReview: {
       group: model.apiGroup,

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsub.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsub.tsx
@@ -7,14 +7,14 @@ import SinkPubsubModal from './SinkPubsubModal';
 
 export interface SinkPubsubProps {
   source: K8sResourceKind;
+  resourceType: string;
   cancel?: () => void;
   close?: () => void;
 }
 
-const SinkPubsub: React.FC<SinkPubsubProps> = ({ source, cancel, close }) => {
+const SinkPubsub: React.FC<SinkPubsubProps> = ({ source, resourceType, cancel, close }) => {
   const { t } = useTranslation();
   const {
-    kind: sourceKind,
     metadata: { namespace, name },
     spec,
   } = source;
@@ -60,7 +60,7 @@ const SinkPubsub: React.FC<SinkPubsubProps> = ({ source, cancel, close }) => {
           {...formikProps}
           resourceName={name}
           resourceDropdown={resourcesDropdownField}
-          labelTitle={t('knative-plugin~Move {{sourceKind}}', { sourceKind })}
+          labelTitle={t('knative-plugin~Move {{kind}}', { kind: resourceType })}
           cancel={cancel}
         />
       )}

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubController.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/SinkPubsubController.tsx
@@ -5,6 +5,7 @@ import SinkPubsub from './SinkPubsub';
 
 type SinkPubsubControllerProps = {
   source: K8sResourceKind;
+  resourceType: string;
 };
 
 const SinkPubsubController: React.FC<SinkPubsubControllerProps> = ({ source, ...props }) => (

--- a/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsub.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-pubsub/__tests__/SinkPubsub.spec.tsx
@@ -23,6 +23,7 @@ describe('SinkPubsub', () => {
   let pubsubForm: ShallowWrapper<SinkPubsubProps>;
   const formProps: SinkPubsubProps = {
     source: EventSubscriptionObj,
+    resourceType: 'Subscription',
   };
   pubsubForm = shallow(<SinkPubsub {...formProps} />);
   it('should render Formik with proper initial values', () => {
@@ -40,14 +41,14 @@ describe('SinkPubsub', () => {
   it('should render Formik child with label move Subscription for Subscription', () => {
     const formikFormRender = pubsubForm.find(Formik).get(0).props;
     expect(formikFormRender.children).toHaveLength(1);
-    expect(formikFormRender.children().props.labelTitle).toBe(`${i18nNS}~Move {{sourceKind}}`);
+    expect(formikFormRender.children().props.labelTitle).toBe(`${i18nNS}~Move {{kind}}`);
   });
 
   it('should render Formik child with label move Trigger for Trigger', () => {
-    const formPropsData = { source: EventTriggerObj };
+    const formPropsData = { source: EventTriggerObj, resourceType: 'Trigger' };
     pubsubForm = shallow(<SinkPubsub {...formPropsData} />);
     const formikFormRender = pubsubForm.find(Formik).get(0).props;
     expect(formikFormRender.children).toHaveLength(1);
-    expect(formikFormRender.children().props.labelTitle).toBe(`${i18nNS}~Move {{sourceKind}}`);
+    expect(formikFormRender.children().props.labelTitle).toBe(`${i18nNS}~Move {{kind}}`);
   });
 });


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-32105

**Solution description:**
passing label key, if present, to the title

**Screenshots:**

**Trigger:**
Before:
![t-before2](https://user-images.githubusercontent.com/22490998/126767689-2ec90ddb-36df-41de-b13f-e8df5ee1058e.png)
![t-before](https://user-images.githubusercontent.com/22490998/126767692-8b79aea7-29f8-4ec2-b673-b30d110ac73e.png)

After:
![t-after2](https://user-images.githubusercontent.com/22490998/126767715-44c7e796-f6d4-428c-a5c2-f847bac5cb02.png)
![t-after](https://user-images.githubusercontent.com/22490998/126767716-474001c9-fcd7-45cd-9896-d36a55c0a4f2.png)

**Subscription:**
Before:
![S-before-2](https://user-images.githubusercontent.com/22490998/126767821-435b7156-466e-47d9-8a96-159597fd4a00.png)
![S-before](https://user-images.githubusercontent.com/22490998/126767826-f9f07598-6bff-41d9-8bee-660228cc6b21.png)

After:
![s-after-2](https://user-images.githubusercontent.com/22490998/126767846-1068d64e-4c00-4ae1-a153-a26fa5000bdd.png)
![s-after](https://user-images.githubusercontent.com/22490998/126767849-42508980-bd33-458c-9798-497b63db0f3f.png)

