### PR TITLE
Bug 1986389: Limit the textarea not to exceed the parent window

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -40,8 +40,8 @@
   // so that input, textarea, button, and input-group-addon don't mask the inner scroll shadows
   input, textarea {
     &.pf-c-form-control {
-      max-width: 100%;
       background-color: transparent;
+      max-width: 100%;
       &[disabled],
       &[readonly] {
         background-color: rgba(128, 128, 128, 0.15);

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -40,6 +40,7 @@
   // so that input, textarea, button, and input-group-addon don't mask the inner scroll shadows
   input, textarea {
     &.pf-c-form-control {
+      max-width: 100%;
       background-color: transparent;
       &[disabled],
       &[readonly] {


### PR DESCRIPTION
In the 'Create Project' window, the horizontal adjustment range of the 'Description' text area exceeds the window.
Closes #9598 