### PR TITLE
Bug 1982727: i18n misses in add trigger modal

### DIFF
--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -159,6 +159,7 @@
   "Services": "Services",
   "Subscription details": "Subscription details",
   "Trigger details": "Trigger details",
+  "Attribute": "Attribute",
   "No Subscriber available": "No Subscriber available",
   "To create a Subscriber, first create a Knative Service from the Add page.": "To create a Subscriber, first create a Knative Service from the Add page.",
   "Select Subscriber": "Select Subscriber",

--- a/frontend/packages/knative-plugin/src/components/pub-sub/PubSub.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/PubSub.tsx
@@ -33,7 +33,7 @@ const PubSub: React.FC<PubSubProps> = ({
   } = target;
   const getResourceModel = () =>
     sourceKind === EventingBrokerModel.kind ? EventingTriggerModel : EventingSubscriptionModel;
-  const { kind, apiVersion, apiGroup } = getResourceModel();
+  const { kind, apiVersion, apiGroup, labelKey } = getResourceModel();
   const getSpecForKind = (connectorSourceKind: string) => {
     let spec = {};
     if (connectorSourceKind === EventingTriggerModel.kind) {
@@ -79,7 +79,9 @@ const PubSub: React.FC<PubSubProps> = ({
       });
   };
 
-  const labelTitle = t('knative-plugin~Add {{kind}}', { kind });
+  const labelTitle = t('knative-plugin~Add {{kind}}', {
+    kind: t(labelKey) || kind,
+  });
   return (
     <Formik
       initialValues={initialValues}

--- a/frontend/packages/knative-plugin/src/components/pub-sub/form-fields/PubSubFilter.tsx
+++ b/frontend/packages/knative-plugin/src/components/pub-sub/form-fields/PubSubFilter.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FormGroup } from '@patternfly/react-core';
 import { useFormikContext, FormikValues } from 'formik';
 import * as _ from 'lodash';
+import { useTranslation } from 'react-i18next';
 import { NameValueEditor } from '@console/internal/components/utils/name-value-editor';
 import { getFieldId } from '@console/shared';
 
@@ -9,6 +10,7 @@ const PubSubFilter: React.FC = () => {
   const initialValueResources = [['', '']];
   const { setFieldValue, status } = useFormikContext<FormikValues>();
   const [nameValue, setNameValue] = React.useState(initialValueResources);
+  const { t } = useTranslation();
   const handleNameValuePairs = React.useCallback(
     ({ nameValuePairs }) => {
       let updatedNameValuePairs = {};
@@ -25,15 +27,15 @@ const PubSubFilter: React.FC = () => {
     [setFieldValue],
   );
   return (
-    <FormGroup fieldId={getFieldId('pubsub', 'filter')} label="Filter" required>
+    <FormGroup fieldId={getFieldId('pubsub', 'filter')} label={t('knative-plugin~Filter')} required>
       <NameValueEditor
         nameValuePairs={status.subscriberAvailable ? nameValue : []}
-        valueString="Value"
-        nameString="Attribute"
+        valueString={t('knative-plugin~Value')}
+        nameString={t('knative-plugin~Attribute')}
         readOnly={!status.subscriberAvailable}
         allowSorting={false}
         updateParentData={handleNameValuePairs}
-        addString="Add More"
+        addString={t('knative-plugin~Add more')}
       />
     </FormGroup>
   );


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-32099
https://issues.redhat.com/browse/OCPBUGSM-32100

**Solution description:**
use label key, if present, in the title 

**Screenshot:**

**Add Trigger**
Before:
![T-before](https://user-images.githubusercontent.com/22490998/126765031-6d82c9aa-2dcf-493a-93fd-d5e928383bbe.png)

After:
![t-after](https://user-images.githubusercontent.com/22490998/126765043-489a72fa-38f4-4037-af80-a08ad29f8f41.png)

**Add Subscription:**
**Before:**
![S-before](https://user-images.githubusercontent.com/22490998/126765094-77aa3473-2e1d-442c-a958-420aec9d5230.png)

**After:**
![s-after](https://user-images.githubusercontent.com/22490998/126765107-a121de22-e2b0-4275-8480-4a8c44658b51.png)

