### PR TITLE
Bug 1987198: Fix to hide help text if helm chart install/upgrade dropdown is disabled

### DIFF
--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -52,7 +52,6 @@
   "All data entered for version <1>{{currentVersion}}</1> will be reset": "All data entered for version <1>{{currentVersion}}</1> will be reset",
   "Proceed": "Proceed",
   "Cancel": "Cancel",
-  "Select the chart version.": "Select the chart version.",
   "Select the version to upgrade to.": "Select the version to upgrade to.",
   "No versions available": "No versions available",
   "For more information on the chart, refer to this <2>README</2>": "For more information on the chart, refer to this <2>README</2>",

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmChartVersionDropdown.tsx
@@ -176,10 +176,10 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
     }
   };
 
+  const isDisabled = _.isEmpty(helmChartVersions) || _.keys(helmChartVersions).length === 1;
+
   const helpText =
-    helmAction === HelmActionType.Install
-      ? t('helm-plugin~Select the chart version.')
-      : t('helm-plugin~Select the version to upgrade to.');
+    helmAction === HelmActionType.Upgrade && t('helm-plugin~Select the version to upgrade to.');
 
   const title =
     _.isEmpty(helmChartVersions) && !chartVersion
@@ -198,8 +198,8 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
         name="chartVersion"
         label={t('helm-plugin~Chart version')}
         items={helmChartVersions}
-        helpText={helpText}
-        disabled={_.isEmpty(helmChartVersions) || _.keys(helmChartVersions).length === 1}
+        helpText={!isDisabled ? helpText : ''}
+        disabled={isDisabled}
         title={title}
         onChange={handleChartVersionChange}
         required


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6092

**Root cause:**
`Select a chart version` help text is shown for helm chart install/upgrade dropdowns even when they are disabled.

**Solution:**
Dont show the help text when the dropdowns are disabled.

**Screenshots:**
<img width="1791" alt="Screenshot 2021-07-24 at 5 39 10 PM" src="https://user-images.githubusercontent.com/20724543/126868407-034471d1-464c-4c27-820a-f2fbd64368fa.png">
<img width="1791" alt="Screenshot 2021-07-24 at 5 41 02 PM" src="https://user-images.githubusercontent.com/20724543/126868415-ccd41ca9-025b-438e-9fef-0d46c8cd0ec9.png">


/kind bug