### PR TITLE
Bug 1985711: Trimming whitespaces at container image input

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
@@ -37,7 +37,7 @@ export const ContainerSource: React.FC<ContainerSourceProps> = React.memo(
           onProvisionSourceStorageChange({
             ...storage,
             dataVolume: new DataVolumeWrapper(storage?.dataVolume, true)
-              .appendTypeData({ url })
+              .appendTypeData({ url: url?.trim() })
               .asResource(),
           });
       }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
@@ -337,7 +337,9 @@ export const BootSourceForm: React.FC<BootSourceFormProps> = ({
           <TextInput
             value={state.container?.value}
             type="text"
-            onChange={(payload) => dispatch({ type: BOOT_ACTION_TYPE.SET_CONTAINER, payload })}
+            onChange={(payload) =>
+              dispatch({ type: BOOT_ACTION_TYPE.SET_CONTAINER, payload: payload?.trim() })
+            }
             aria-label={t('kubevirt-plugin~Container image')}
             isDisabled={disabled}
             id={getFieldId(VMSettingsField.CONTAINER_IMAGE)}


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1985711

**Analysis / Root cause**: 
Not trimming input values

**Solution Description**: 
Trim the input values

**Screen shots / Gifs for design review**: 
Before:
![trim spaces](https://user-images.githubusercontent.com/14824964/126891845-d1ac21f1-33ce-4eaa-ba95-df0923505989.png)
After:
![image](https://user-images.githubusercontent.com/14824964/126891855-33a3ea67-3916-4eee-abfd-3cd92ddc09b7.png)
