### PR TITLE
Expose HorizontalNav as part of Stable API

### DIFF
--- a/frontend/dynamic-demo-plugin/console-extensions.json
+++ b/frontend/dynamic-demo-plugin/console-extensions.json
@@ -45,5 +45,12 @@
       "path": "/test-utility-consumer",
       "component": { "$codeRef": "utilityConsumer.default" }
     }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "path": "/example/nav",
+      "component": { "$codeRef": "navPage" }
+    }
   }
 ]

--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -31,7 +31,8 @@
       "barUtils": "./utils/bar",
       "telemetry": "./utils/telemetry",
       "extensionConsumer": "./components/ExtensionConsumer.tsx",
-      "utilityConsumer": "./components/UtilityConsumer.tsx"
+      "utilityConsumer": "./components/UtilityConsumer.tsx",
+      "navPage": "./components/Nav"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/frontend/dynamic-demo-plugin/src/components/Nav.tsx
+++ b/frontend/dynamic-demo-plugin/src/components/Nav.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router';
+import { HorizontalNav } from '@console/dynamic-plugin-sdk/api';
+
+const Thor: React.FC = () => (
+  <div>
+    <h1> Hello Earth! I am Thor!</h1>
+  </div>
+);
+
+const Loki: React.FC = () => (
+  <div>
+    <h1> Hello Earth! I am Loki!</h1>
+  </div>
+);
+
+const Asgard: React.FC<RouteComponentProps> = () => {
+  const pages = [
+    {
+      href: '',
+      name: 'Thor',
+      component: Thor,
+    },
+    {
+      href: 'loki',
+      name: 'Loki',
+      component: Loki,
+    },
+  ];
+  return <HorizontalNav pages={pages} />;
+};
+
+export default Asgard;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/api.ts
@@ -6,6 +6,7 @@ import {
   ConsoleFetchJSON,
   ConsoleFetchText,
 } from './api-types';
+import { HorizontalNavProps } from './component-api-types';
 
 export * from './api-types';
 
@@ -30,3 +31,24 @@ export const consoleFetch: ConsoleFetch = newMockImpl();
 export const consoleFetchJSON: ConsoleFetchJSON = newMockImpl();
 mockProperties(consoleFetchJSON, 'delete', 'post', 'put', 'patch');
 export const consoleFetchText: ConsoleFetchText = newMockImpl();
+/**
+ *
+ * @type {import("./component-api-types").NavPage } NavPage
+ *
+ * A component that creates a Navigation bar. It takes array of NavPage objects and renderes a NavBar.
+ * Routing is handled as part of the component.
+ * @example
+ * const HomePage: React.FC = (props) => {
+ *     const page = {
+ *       href: '/home',
+ *       name: 'Home',
+ *       component: () => <>Home</>
+ *     }
+ *     return <HorizontalNav match={props.match} pages={[page]} />
+ * }
+ *
+ * @param {object=} resource - The resource associated with this Navigation, an object of K8sResourceCommon type
+ * @param {NavPage[]} pages - An array of page objects
+ * @param {object} match - match object provided by React Router
+ */
+export const HorizontalNav: React.FC<HorizontalNavProps> = newMockImpl();

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/component-api-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/component-api-types.ts
@@ -1,0 +1,15 @@
+import { RouteComponentProps } from 'react-router';
+import { K8sResourceCommon } from '../extensions';
+
+/* Horizontal Nav Types */
+export type NavPage = {
+  href?: string;
+  path?: string;
+  name: string;
+  component: React.ComponentType<RouteComponentProps>;
+};
+
+export type HorizontalNavProps = {
+  resource?: K8sResourceCommon;
+  pages: NavPage[];
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-api.ts
@@ -11,6 +11,7 @@ export const exposePluginAPI = () => {
     consoleFetch: require('@console/dynamic-plugin-sdk/src/utils/fetch').consoleFetch,
     consoleFetchJSON: require('@console/dynamic-plugin-sdk/src/utils/fetch').consoleFetchJSON,
     consoleFetchText: require('@console/dynamic-plugin-sdk/src/utils/fetch').consoleFetchText,
+    HorizontalNav: require('@console/internal/components/utils/horizontal-nav').HorizontalNavFacade,
   };
   window.internalAPI = {
     AcitivityItem: require('@console/shared/src/components/dashboard/activity-card/ActivityItem')


### PR DESCRIPTION
Add example usage to dynamic-demo-plugin
Fix dynamic-demo-plugin `tsconfig.sjon` and `package.json` to point to compiled SDK.
Screenshots of demo-plugin: 
![Screenshot from 2021-07-26 00-07-08](https://user-images.githubusercontent.com/54092533/126909778-82a914a7-80bd-49fb-8b03-7be1691548ca.png)
![Screenshot from 2021-07-26 00-07-02](https://user-images.githubusercontent.com/54092533/126909780-0c529977-4efc-4610-a72c-ffc1859a6bc4.png)

/assign @spadgett @christianvogt @vojtechszocs 