### PR TITLE
Bug 1986680: use patch over update for traffic split in serverless

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
@@ -17,8 +17,8 @@ import {
 } from '@console/internal/components/utils';
 import {
   k8sKill,
+  k8sPatch,
   K8sResourceKind,
-  k8sUpdate,
   referenceForModel,
 } from '@console/internal/module/k8s';
 import { RedExclamationCircleIcon } from '@console/shared';
@@ -29,7 +29,7 @@ import { Traffic } from '../../types';
 import {
   knativeServingResourcesTrafficSplitting,
   getRevisionItems,
-  constructObjForUpdate,
+  trafficDataForPatch,
 } from '../../utils/traffic-splitting-utils';
 import { TrafficSplittingType } from '../traffic-splitting/TrafficSplitting';
 import DeleteRevisionModal from './DeleteRevisionModal';
@@ -138,12 +138,12 @@ const Controller: React.FC<ControllerProps> = ({ loaded, resources, revision, ca
   };
 
   const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {
-    const obj = constructObjForUpdate(values.trafficSplitting, service);
+    const ksvcPatch = trafficDataForPatch(values.trafficSplitting, service);
     if (!deleteTraffic || deleteTraffic.percent === 0) {
       return deleteRevision(action);
     }
 
-    return k8sUpdate(ServiceModel, obj)
+    return k8sPatch(ServiceModel, service, ksvcPatch)
       .then(() => {
         deleteRevision(action);
       })

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Formik, FormikValues, FormikHelpers } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { K8sResourceKind, k8sUpdate } from '@console/internal/module/k8s';
+import { k8sPatch, K8sResourceKind, Patch } from '@console/internal/module/k8s';
 import { ServiceModel } from '../../models';
 import { Traffic } from '../../types';
-import { getRevisionItems, constructObjForUpdate } from '../../utils/traffic-splitting-utils';
+import { getRevisionItems, trafficDataForPatch } from '../../utils/traffic-splitting-utils';
 import TrafficSplittingModal from './TrafficSplittingModal';
 
 export interface TrafficSplittingProps {
@@ -46,8 +46,8 @@ const TrafficSplitting: React.FC<TrafficSplittingProps> = ({
     }, []),
   };
   const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {
-    const obj = constructObjForUpdate(values.trafficSplitting, service);
-    return k8sUpdate(ServiceModel, obj)
+    const ksvcPatch: Patch[] = trafficDataForPatch(values.trafficSplitting, service);
+    return k8sPatch(ServiceModel, service, ksvcPatch)
       .then(() => {
         action.setStatus({ error: '' });
         close();

--- a/frontend/packages/knative-plugin/src/utils/__tests__/traffic-splitting-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/traffic-splitting-utils.spec.ts
@@ -1,17 +1,46 @@
 import {
   mockServiceData,
-  mockUpdateRequestObj,
   mockTrafficData,
   mockRevisions,
   mockRevisionItems,
 } from '../__mocks__/traffic-splitting-utils-mock';
-import { constructObjForUpdate, getRevisionItems } from '../traffic-splitting-utils';
+import { trafficDataForPatch, getRevisionItems } from '../traffic-splitting-utils';
 
 describe('Traffic Splitting', () => {
-  it('should construct the object for Update Request', async () => {
-    const obj = constructObjForUpdate(mockTrafficData, mockServiceData);
-    expect(obj).toEqual(mockUpdateRequestObj);
+  it('should construct the traffic data for path Request replace', () => {
+    const serviceData = {
+      ...mockServiceData,
+      spec: {
+        ...mockServiceData.spec,
+        traffic: [
+          {
+            latestRevision: true,
+            percent: 100,
+          },
+        ],
+      },
+    };
+    const ksvcPatchData = trafficDataForPatch(mockTrafficData, serviceData);
+    expect(ksvcPatchData).toEqual([
+      {
+        op: 'replace',
+        path: '/spec/traffic',
+        value: mockTrafficData,
+      },
+    ]);
   });
+
+  it('should construct the traffic data for path Request add', () => {
+    const ksvcPatchData = trafficDataForPatch(mockTrafficData, mockServiceData);
+    expect(ksvcPatchData).toEqual([
+      {
+        op: 'add',
+        path: '/spec/traffic',
+        value: mockTrafficData,
+      },
+    ]);
+  });
+
   it('should fetch the revision items', async () => {
     const items = getRevisionItems(mockRevisions);
     expect(items).toEqual(mockRevisionItems);

--- a/frontend/packages/knative-plugin/src/utils/traffic-splitting-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/traffic-splitting-utils.ts
@@ -1,6 +1,6 @@
-import * as _ from 'lodash';
 import { FirehoseResource } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, Patch } from '@console/internal/module/k8s';
+import { Traffic } from '../types';
 import {
   knativeServingResourcesRevision,
   knativeServingResourcesConfigurations,
@@ -17,13 +17,13 @@ export const getRevisionItems = (revisions: K8sResourceKind[]): RevisionItems =>
   }, {} as RevisionItems);
 };
 
-export const constructObjForUpdate = (traffic, service) => {
-  const obj = _.omit(service, 'status');
-  return {
-    ...obj,
-    spec: { ...obj.spec, traffic },
-  };
-};
+export const trafficDataForPatch = (traffic: Traffic[], service: K8sResourceKind): Patch[] => [
+  {
+    op: service.spec?.traffic ? 'replace' : 'add',
+    path: '/spec/traffic',
+    value: traffic,
+  },
+];
 
 export const knativeServingResourcesTrafficSplitting = (namespace: string): FirehoseResource[] => [
   ...knativeServingResourcesRevision(namespace),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6086

**Analysis / Root cause**: 
Traffic spit used to fail intermittently with an error: "object has been modified"

**Solution Description**: 
use patch over an update for traffic split in serverless
- made changes in traffic split modal 
- made changes in delete revision handler

**Unit test coverage report**: 
<!-- Attach test coverage report -->

![image](https://user-images.githubusercontent.com/5129024/126949940-32d17acc-ece1-4942-b351-2b0e3908ee16.png)


**Test setup:**
- Install serverless operator
- Create CR for knative serving
- Create a KSVC, edit once to have multiple revisions
- open topology view open traffic split modal
- now try to make edit on ksvc (via CLI or diff tab in UI)
- should be able to do traffic split without error

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
