### PR TITLE
Bug 1986127: Fix topology crash while opening helm workload

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/ActionServiceProvider.tsx
+++ b/frontend/packages/console-shared/src/components/actions/ActionServiceProvider.tsx
@@ -17,7 +17,7 @@ const ActionServiceProvider: React.FC<ActionServiceProviderProps> = ({ context, 
   const [actionsMap, setActionsMap] = React.useState<{ [uid: string]: Action[] }>({});
   const [loadError, setLoadError] = React.useState<any>();
 
-  const memoizedContext = useDeepCompareMemoize(context, true);
+  const memoizedContext = useDeepCompareMemoize(context);
 
   const onContextChange = React.useCallback((newContexId: string, newScope: any) => {
     setContextMap((prevContext) => ({ ...prevContext, [newContexId]: newScope }));


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6200
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: `ActionServiceProvider` used `JSON.stringify` in `useDeepCompareMemoize` hook which crashed when topology graph element was sent as context. This happened because a topology graph element has circular structure which cannot be converted to JSON.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Removed usage of `JSON.stringify` in `useDeepCompareMemoize` hook.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/126981416-86ae44b1-c4e3-46bd-9e1a-ded5586413be.mov


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
