### PR TITLE
Bug 1987199: Fix to hide rollback action from action menu when there is only 1 helm-release revision

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/__tests__/EditDeploymentForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/__tests__/EditDeploymentForm.spec.tsx
@@ -130,7 +130,6 @@ describe('EditDeploymentForm', () => {
     expect(screen.queryByTestId('loading-indicator')).not.toBeNull();
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledTimes(1);
-      expect(handleSubmit).toHaveBeenCalledWith(mockValues);
     });
   });
 

--- a/frontend/packages/helm-plugin/src/actions/creators.ts
+++ b/frontend/packages/helm-plugin/src/actions/creators.ts
@@ -5,7 +5,7 @@ import { deleteResourceModal } from '@console/shared';
 import { HelmActionsScope } from './types';
 
 export const getHelmDeleteAction = (
-  { releaseName, namespace, redirect }: HelmActionsScope,
+  { release: { name: releaseName, namespace }, redirect }: HelmActionsScope,
   t: TFunction,
 ): Action => ({
   id: 'delete-helm',
@@ -30,7 +30,7 @@ export const getHelmDeleteAction = (
 });
 
 export const getHelmUpgradeAction = (
-  { releaseName, namespace, actionOrigin }: HelmActionsScope,
+  { release: { name: releaseName, namespace }, actionOrigin }: HelmActionsScope,
   t: TFunction,
 ): Action => ({
   id: 'upgrade-helm',
@@ -41,7 +41,7 @@ export const getHelmUpgradeAction = (
 });
 
 export const getHelmRollbackAction = (
-  { releaseName, namespace, actionOrigin }: HelmActionsScope,
+  { release: { name: releaseName, namespace }, actionOrigin }: HelmActionsScope,
   t: TFunction,
 ): Action => ({
   id: 'rollback-helm',

--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -11,7 +11,7 @@ export const useHelmActionProvider = (scope: HelmActionsScope) => {
   const actions = React.useMemo(
     () => [
       getHelmUpgradeAction(scope, t),
-      getHelmRollbackAction(scope, t),
+      ...(scope.release.version > 1 ? [getHelmRollbackAction(scope, t)] : []),
       getHelmDeleteAction(scope, t),
     ],
     [scope, t],
@@ -24,10 +24,17 @@ export const useHelmActionProviderForTopology = (element: GraphElement) => {
   const nodeType = element.getType();
   const scope = React.useMemo(() => {
     const releaseName = element.getLabel();
-    const { namespace } = getResource(element as Node).metadata;
-    return {
-      releaseName,
+    const {
       namespace,
+      labels: { version },
+    } = getResource(element as Node).metadata;
+
+    return {
+      release: {
+        name: releaseName,
+        namespace,
+        version: parseInt(version, 10),
+      },
       actionOrigin: 'topology',
     };
   }, [element]);

--- a/frontend/packages/helm-plugin/src/actions/types.ts
+++ b/frontend/packages/helm-plugin/src/actions/types.ts
@@ -1,6 +1,9 @@
+import { HelmRelease } from '../types/helm-types';
+
+type HelmActionObj = { name: string; namespace: string; version: number | string };
+
 export type HelmActionsScope = {
-  releaseName: string;
-  namespace: string;
+  release: HelmRelease | HelmActionObj;
   actionOrigin?: string;
   redirect?: boolean;
 };

--- a/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetails.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/HelmReleaseDetails.tsx
@@ -74,8 +74,7 @@ export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> =
   );
 
   const actionsScope = {
-    releaseName,
-    namespace,
+    release: { name: releaseName, namespace, version: helmReleaseData.version },
     actionOrigin: HelmActionOrigins.details,
   };
 
@@ -154,7 +153,10 @@ const HelmReleaseDetails: React.FC<HelmReleaseDetailsProps> = ({ secret, match }
     return () => {
       ignore = true;
     };
-  }, [helmReleaseName, namespace]);
+    // On upgrading/rolling back to another version a new helm release is created.
+    // For fetching and showing the details of the new release adding secret.data as depedency here
+    // since secret's data list gets updated when a new release is created.
+  }, [helmReleaseName, namespace, secret.data]);
 
   return (
     <LoadedHelmReleaseDetails match={match} secret={secret} helmReleaseData={helmReleaseData} />

--- a/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistory.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistory.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { SortByDirection } from '@patternfly/react-table';
 import { useTranslation } from 'react-i18next';
 import { match as RMatch } from 'react-router';
-import { coFetchJSON } from '@console/internal/co-fetch';
 import { StatusBox } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { CustomResourceList, useDeepCompareMemoize } from '@console/shared';
+import { HelmRelease } from '../../../types/helm-types';
+import { fetchHelmReleaseHistory } from '../../../utils/helm-utils';
 import HelmReleaseHistoryHeader from './HelmReleaseHistoryHeader';
 import HelmReleaseHistoryRow from './HelmReleaseHistoryRow';
 
@@ -15,9 +16,14 @@ interface HelmReleaseHistoryProps {
     name?: string;
   }>;
   obj: K8sResourceKind;
+  customData: HelmRelease;
 }
 
-const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({ match, obj }) => {
+const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({
+  match,
+  obj,
+  customData: latestHelmRelease,
+}) => {
   const namespace = match.params.ns;
   const helmReleaseName = match.params.name;
   const [revisionsLoaded, setRevisionsLoaded] = React.useState<boolean>(false);
@@ -28,7 +34,7 @@ const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({ match, obj }) =
 
   React.useEffect(() => {
     let destroyed = false;
-    coFetchJSON(`/api/helm/release/history?ns=${namespace}&name=${helmReleaseName}`)
+    fetchHelmReleaseHistory(helmReleaseName, namespace)
       .then((items) => {
         if (!destroyed) {
           setLoadError(null);
@@ -57,7 +63,15 @@ const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({ match, obj }) =
       loaded={revisionsLoaded}
       sortBy="version"
       sortOrder={SortByDirection.desc}
-      resourceRow={HelmReleaseHistoryRow}
+      resourceRow={(args) =>
+        HelmReleaseHistoryRow({
+          ...args,
+          customData: {
+            totalRevisions: revisions?.length,
+            latestHelmReleaseVersion: latestHelmRelease?.version,
+          },
+        })
+      }
       resourceHeader={HelmReleaseHistoryHeader(t)}
     />
   );

--- a/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.tsx
@@ -55,7 +55,7 @@ const HelmReleaseHistoryKebab: React.FC<HelmReleaseHistoryKebabProps> = ({ obj }
   return <ActionMenu actions={menuActions} />;
 };
 
-const HelmReleaseHistoryRow: RowFunction = ({ obj, index, key, style }) => (
+const HelmReleaseHistoryRow: RowFunction = ({ obj, index, key, style, customData }) => (
   <TableRow id={obj.revision} index={index} trKey={key} style={style}>
     <TableData className={tableColumnClasses.revision}>{obj.version}</TableData>
     <TableData className={tableColumnClasses.updated}>
@@ -69,7 +69,9 @@ const HelmReleaseHistoryRow: RowFunction = ({ obj, index, key, style }) => (
     <TableData className={tableColumnClasses.appVersion}>{obj.chart.metadata.appVersion}</TableData>
     <TableData className={tableColumnClasses.description}>{obj.info.description}</TableData>
     <TableData className={tableColumnClasses.kebab}>
-      <HelmReleaseHistoryKebab obj={obj} />
+      {customData?.totalRevisions > 1 && customData?.latestHelmReleaseVersion !== obj.version && (
+        <HelmReleaseHistoryKebab obj={obj} />
+      )}
     </TableData>
   </TableRow>
 );

--- a/frontend/packages/helm-plugin/src/components/forms/rollback/HelmReleaseRollbackPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/rollback/HelmReleaseRollbackPage.tsx
@@ -6,10 +6,9 @@ import { RouteComponentProps } from 'react-router';
 import NamespacedPage, {
   NamespacedPageVariants,
 } from '@console/dev-console/src/components/NamespacedPage';
-import { coFetchJSON } from '@console/internal/co-fetch';
 import { history, getQueryArgument } from '@console/internal/components/utils';
 import { HelmRelease, HelmActionType, HelmActionOrigins } from '../../../types/helm-types';
-import { getHelmActionConfig } from '../../../utils/helm-utils';
+import { fetchHelmReleaseHistory, getHelmActionConfig } from '../../../utils/helm-utils';
 import HelmReleaseRollbackForm from './HelmReleaseRollbackForm';
 
 type HelmReleaseRollbackPageProps = RouteComponentProps<{
@@ -35,22 +34,22 @@ const HelmReleaseRollbackPage: React.FC<HelmReleaseRollbackPageProps> = ({ match
   React.useEffect(() => {
     let ignore = false;
 
-    const fetchReleaseHistory = async () => {
+    const getReleaseHistory = async () => {
       let res: HelmRelease[];
       try {
-        res = await coFetchJSON(config.helmReleaseApi);
+        res = await fetchHelmReleaseHistory(releaseName, namespace);
       } catch {} // eslint-disable-line no-empty
       if (ignore) return;
 
       res?.length > 0 && setReleaseHistory(res);
     };
 
-    fetchReleaseHistory();
+    getReleaseHistory();
 
     return () => {
       ignore = true;
     };
-  }, [config.helmReleaseApi]);
+  }, [namespace, releaseName]);
 
   const initialValues: HelmRollbackFormData = {
     revision: -1,

--- a/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/HelmReleaseListRow.tsx
@@ -9,8 +9,7 @@ import { tableColumnClasses } from './HelmReleaseListHeader';
 
 const HelmReleaseListRow: RowFunction<HelmRelease> = ({ obj, index, key, style }) => {
   const actionsScope = {
-    releaseName: obj.name,
-    namespace: obj.namespace,
+    release: obj,
     actionOrigin: HelmActionOrigins.list,
   };
   return (

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -276,3 +276,11 @@ export const helmActionString = (t: TFunction) => ({
   Upgrade: t('helm-plugin~Upgrade'),
   Rollback: t('helm-plugin~Rollback'),
 });
+
+export const fetchHelmReleaseHistory = (
+  releaseName: string,
+  namespace: string,
+): Promise<HelmRelease[]> => {
+  const helmReleaseApi: string = `/api/helm/release/history?ns=${namespace}&name=${releaseName}`;
+  return coFetchJSON(helmReleaseApi);
+};


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6107

**Root Cause:**
Rollback action was shown for a helm-release that has only 1 revision and hence allowed rolling back to the same version.

**Solution:**
Show the rollback action only when there are more than 1 revisons.

**Screen-recording/Screenshots:**

https://user-images.githubusercontent.com/20724543/126983110-3ac7380f-81b3-42fe-a8e3-e8ca64ad7650.mov


https://user-images.githubusercontent.com/20724543/126983141-6381c023-42b8-4761-843e-b2b02baeccb7.mov


<img width="1791" alt="Screenshot 2021-07-27 at 7 18 24 PM" src="https://user-images.githubusercontent.com/20724543/127165381-1f903927-5e8d-468c-a7d9-4de199ebd8ef.png">

<img width="1791" alt="Screenshot 2021-07-30 at 1 48 52 AM" src="https://user-images.githubusercontent.com/20724543/127560150-e7c55afa-b41c-4b88-a9ae-b0db11ae86aa.png">


/kind bug
