### PR TITLE
Bug 1985933: Changed example label for image input

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/container-source.tsx
@@ -11,7 +11,7 @@ import { FormFieldRow } from '../../form/form-field-row';
 import { VMWizardStorage } from '../../types';
 
 export const ContainerSource: React.FC<ContainerSourceProps> = React.memo(
-  ({ field, provisionSourceStorage, onProvisionSourceStorageChange }) => {
+  ({ field, provisionSourceStorage, onProvisionSourceStorageChange, imageName }) => {
     const storage: VMWizardStorage = toShallowJS(provisionSourceStorage);
     const volumeWrapper = new VolumeWrapper(storage?.volume);
 
@@ -52,7 +52,7 @@ export const ContainerSource: React.FC<ContainerSourceProps> = React.memo(
         <FormField value={value} isDisabled={isDisabled}>
           <TextInput onChange={onChange} />
         </FormField>
-        <ContainerSourceHelp />
+        <ContainerSourceHelp imageName={imageName} />
       </FormFieldRow>
     );
   },
@@ -62,4 +62,5 @@ type ContainerSourceProps = {
   field: any;
   provisionSourceStorage: any;
   onProvisionSourceStorageChange: (provisionSourceStorage: any) => void;
+  imageName: string;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -173,6 +173,7 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
         field={getField(VMSettingsField.CONTAINER_IMAGE)}
         onProvisionSourceStorageChange={updateStorage}
         provisionSourceStorage={provisionSourceStorage}
+        imageName={commonTemplateName}
       />
       <URLSource
         field={getField(VMSettingsField.IMAGE_URL)}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
@@ -344,7 +344,7 @@ export const BootSourceForm: React.FC<BootSourceFormProps> = ({
             isDisabled={disabled}
             id={getFieldId(VMSettingsField.CONTAINER_IMAGE)}
           />
-          <ContainerSourceHelp />
+          <ContainerSourceHelp imageName={baseImageName} />
         </FormRow>
       )}
       {state.dataSource?.value === ProvisionSource.DISK.getValue() && (

--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
@@ -1,11 +1,33 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { isUpstream } from '../../../utils/common';
-import { EXAMPLE_CONTAINER, FEDORA_EXAMPLE_CONTAINER } from '../../../utils/strings';
+import {
+  CENTOS,
+  CENTOS_EXAMPLE_CONTAINER,
+  FEDORA_EXAMPLE_CONTAINER,
+  RHEL,
+  RHEL_EXAMPLE_CONTAINER,
+} from '../../../utils/strings';
 
-export const ContainerSourceHelp: React.FC = () => {
+type ContainerSourceHelpProps = {
+  imageName: string;
+};
+export const ContainerSourceHelp: React.FC<ContainerSourceHelpProps> = ({ imageName }) => {
   const { t } = useTranslation();
-  const container = isUpstream() ? FEDORA_EXAMPLE_CONTAINER : EXAMPLE_CONTAINER;
+
+  const labelImage = () => {
+    const os = {
+      [RHEL]: RHEL_EXAMPLE_CONTAINER,
+      [CENTOS]: CENTOS_EXAMPLE_CONTAINER,
+    };
+
+    const label =
+      os[Object.keys(os).find((name) => imageName?.includes(name))] || FEDORA_EXAMPLE_CONTAINER;
+
+    return label;
+  };
+
+  const container = isUpstream() ? FEDORA_EXAMPLE_CONTAINER : labelImage();
 
   return (
     <div className="pf-c-form__helper-text" aria-live="polite" data-test="ContainerSourceHelp">

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -479,7 +479,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                 value={containerImage}
                 onChange={setContainerImage}
               />
-              <ContainerSourceHelp />
+              <ContainerSourceHelp imageName={baseImageName} />
             </FormRow>
           )}
           {source.requiresNamespace() && (

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -13,8 +13,12 @@ export const CLOUD = 'cloud';
 export const SSH = 'ssh';
 export const SYSPREP = 'sysprep';
 
-export const EXAMPLE_CONTAINER = 'registry.redhat.io/rhel8/rhel-guest-image';
+export const RHEL = 'rhel';
+export const CENTOS = 'centos';
+
+export const RHEL_EXAMPLE_CONTAINER = 'registry.redhat.io/rhel8/rhel-guest-image';
 export const FEDORA_EXAMPLE_CONTAINER = 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest';
+export const CENTOS_EXAMPLE_CONTAINER = 'quay.io/kubevirt/centos8-container-disk-images:latest';
 export const CENTOS_IMAGE_LINK = 'https://cloud.centos.org/centos/';
 export const FEDORA_IMAGE_LINK = 'https://alt.fedoraproject.org/cloud/';
 export const RHEL_IMAGE_LINK =


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1985933

**Analysis / Root cause**: 
No check for image/template name.

**Solution Description**: 
Will now check to match the example label to the template. if there isn't a match will use the default. 

**Screen shots / Gifs for design review**: 
for centos template:

After:
![image](https://user-images.githubusercontent.com/14824964/126984547-262eff12-87c9-416c-baeb-ddf96e2d7c0d.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/126984666-e2cd5054-c1d7-471f-820e-dcf0eb173c0d.png)
