### PR TITLE
(fix): Fixes for only mcg flow

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/advanced-section.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/advanced-section.tsx
@@ -15,6 +15,7 @@ export const AdvancedSection: React.FC<AdvancedSelectionProps> = ({
   deployment,
   isAdvancedOpen,
   dispatch,
+  hasOCS,
 }) => {
   const { t } = useTranslation();
 
@@ -39,6 +40,7 @@ export const AdvancedSection: React.FC<AdvancedSelectionProps> = ({
           label={t('ceph-storage-plugin~Multi cloud object gateway')}
           description={t('ceph-storage-plugin~Object storage')}
           value={DeploymentType.MCG}
+          isDisabled={hasOCS}
           isChecked={deployment === DeploymentType.MCG}
           onChange={handleSelection}
           id="deployment-type"
@@ -52,4 +54,5 @@ type AdvancedSelectionProps = {
   dispatch: WizardDispatch;
   deployment: WizardState['backingStorage']['deployment'];
   isAdvancedOpen: WizardState['backingStorage']['isAdvancedOpen'];
+  hasOCS: boolean;
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
@@ -218,6 +218,7 @@ export const BackingStorage: React.FC<BackingStorageProps> = ({
           dispatch={dispatch}
           deployment={deployment}
           isAdvancedOpen={isAdvancedOpen}
+          hasOCS={hasOCS}
         />
       </Form>
     </ErrorHandler>

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/payloads.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/payloads.ts
@@ -46,7 +46,7 @@ export const createNoobaaPayload = (): Payload => {
       plural,
     },
     payload: {
-      apiVersion,
+      apiVersion: apiVersionForModel(NooBaaSystemModel),
       kind,
       metadata: { name: 'noobaa', namespace: CEPH_STORAGE_NAMESPACE },
       spec: {


### PR DESCRIPTION

 - request is failing due to incorrect apiVersion . noobaa uses `noobaa.io/v1alpha1`
 - disable mcg checkbox when only ocs is present

**Checkbox disabled when ocs storage system present**
![Screenshot from 2021-07-26 19-58-22](https://user-images.githubusercontent.com/25664409/127006904-6da97b49-9d12-4fa3-80fd-840d93c2bef2.png)