### PR TITLE
Bug 1976217: Make resource details metrics tab cards fixed height and consistent styles

### DIFF
--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -170,14 +170,14 @@ const BuildMetrics = requirePrometheus(({ obj }) => {
 
   const { t } = useTranslation();
   return (
-    <Dashboard>
+    <Dashboard className="resource-metrics-dashboard">
       <Grid hasGutter>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~Memory usage')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Area
                 byteDataType={ByteDataTypes.BinaryBytes}
                 humanize={humanizeBinaryBytes}
@@ -188,11 +188,11 @@ const BuildMetrics = requirePrometheus(({ obj }) => {
           </DashboardCard>
         </GridItem>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~CPU usage')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Area
                 humanize={humanizeCpuCores}
                 query={`pod:container_cpu_usage:sum{pod='${podName}',container='',namespace='${namespace}'}`}
@@ -202,11 +202,11 @@ const BuildMetrics = requirePrometheus(({ obj }) => {
           </DashboardCard>
         </GridItem>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~Filesystem')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Area
                 byteDataType={ByteDataTypes.BinaryBytes}
                 humanize={humanizeBinaryBytes}

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -527,12 +527,6 @@ $monitoring-line-height: 18px;
     padding-bottom: 0;
     padding-top: 0;
   }
-
-  &.query-browser__resource-metrics-wrapper {
-    border: none;
-    margin: var(--pf-global--spacer--lg) 0 0 0;
-    padding: 0;
-  }
 }
 
 .query-browser__zoom {

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -517,14 +517,14 @@ const getNetworkName = (result: PrometheusResult) =>
 const PodMetrics = requirePrometheus(({ obj }) => {
   const { t } = useTranslation();
   return (
-    <Dashboard>
+    <Dashboard className="resource-metrics-dashboard">
       <Grid hasGutter>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~Memory usage')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Area
                 ariaChartLinkLabel={t('public~View in query browser')}
                 humanize={humanizeBinaryBytes}
@@ -538,11 +538,11 @@ const PodMetrics = requirePrometheus(({ obj }) => {
           </DashboardCard>
         </GridItem>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~CPU usage')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Area
                 ariaChartLinkLabel={t('public~View in query browser')}
                 humanize={humanizeCpuCores}
@@ -555,11 +555,11 @@ const PodMetrics = requirePrometheus(({ obj }) => {
           </DashboardCard>
         </GridItem>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~Filesystem')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Area
                 ariaChartLinkLabel={t('public~View in query browser')}
                 humanize={humanizeBinaryBytes}
@@ -571,11 +571,11 @@ const PodMetrics = requirePrometheus(({ obj }) => {
           </DashboardCard>
         </GridItem>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~Network in')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Stack
                 ariaChartLinkLabel={t('public~View in query browser')}
                 humanize={humanizeDecimalBytesPerSec}
@@ -587,11 +587,11 @@ const PodMetrics = requirePrometheus(({ obj }) => {
           </DashboardCard>
         </GridItem>
         <GridItem xl={6} lg={12}>
-          <DashboardCard>
+          <DashboardCard className="resource-metrics-dashboard__card">
             <DashboardCardHeader>
               <DashboardCardTitle>{t('public~Network out')}</DashboardCardTitle>
             </DashboardCardHeader>
-            <DashboardCardBody>
+            <DashboardCardBody className="resource-metrics-dashboard__card-body">
               <Stack
                 ariaChartLinkLabel={t('public~View in query browser')}
                 humanize={humanizeDecimalBytesPerSec}
@@ -799,11 +799,7 @@ export const PodsDetailsPage: React.FC<PodDetailsPageProps> = (props) => {
       menuActions={menuActions}
       pages={[
         navFactory.details(Details),
-        {
-          href: 'metrics',
-          nameKey: 'public~Metrics',
-          component: PodMetrics,
-        },
+        navFactory.metrics(PodMetrics),
         navFactory.editYaml(),
         navFactory.envEditor(PodEnvironmentComponent),
         navFactory.logs(PodLogs),

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -486,11 +486,7 @@ export const RoutesDetailsPage: React.FC<RoutesDetailsPageProps> = (props) => (
     menuActions={menuActions}
     pages={[
       navFactory.details(detailsPage(RouteDetails)),
-      {
-        href: 'metrics',
-        nameKey: 'public~Metrics',
-        component: RouteMetrics,
-      },
+      navFactory.metrics(RouteMetrics),
       navFactory.editYaml(),
     ]}
   />

--- a/frontend/public/components/routes/route-metrics.tsx
+++ b/frontend/public/components/routes/route-metrics.tsx
@@ -21,14 +21,14 @@ export const RouteMetrics = connectToFlags<RouteMetricsProps>(FLAGS.CAN_GET_NS)(
     }
     const namespaceRouteQuery = `{exported_namespace="${obj.metadata.namespace}",route="${obj.metadata.name}"}[5m]`;
     return (
-      <Dashboard>
+      <Dashboard className="resource-metrics-dashboard">
         <Grid hasGutter>
           <GridItem xl={6} lg={12}>
-            <DashboardCard>
+            <DashboardCard className="resource-metrics-dashboard__card">
               <DashboardCardHeader>
                 <DashboardCardTitle>{t('public~Traffic in')}</DashboardCardTitle>
               </DashboardCardHeader>
-              <DashboardCardBody>
+              <DashboardCardBody className="resource-metrics-dashboard__card-body">
                 <Area
                   humanize={humanizeDecimalBytesPerSec}
                   query={`sum without (instance,exported_pod,exported_service,pod,server) (irate(haproxy_server_bytes_in_total${namespaceRouteQuery}))`}
@@ -37,11 +37,11 @@ export const RouteMetrics = connectToFlags<RouteMetricsProps>(FLAGS.CAN_GET_NS)(
             </DashboardCard>
           </GridItem>
           <GridItem xl={6} lg={12}>
-            <DashboardCard>
+            <DashboardCard className="resource-metrics-dashboard__card">
               <DashboardCardHeader>
                 <DashboardCardTitle>{t('public~Traffic out')}</DashboardCardTitle>
               </DashboardCardHeader>
-              <DashboardCardBody>
+              <DashboardCardBody className="resource-metrics-dashboard__card-body">
                 <Area
                   humanize={humanizeDecimalBytesPerSec}
                   query={`sum without (instance,exported_pod,exported_service,pod,server) (irate(haproxy_server_bytes_out_total${namespaceRouteQuery}))`}
@@ -50,11 +50,11 @@ export const RouteMetrics = connectToFlags<RouteMetricsProps>(FLAGS.CAN_GET_NS)(
             </DashboardCard>
           </GridItem>
           <GridItem xl={6} lg={12}>
-            <DashboardCard>
+            <DashboardCard className="resource-metrics-dashboard__card">
               <DashboardCardHeader>
                 <DashboardCardTitle>{t('public~Connection rate')}</DashboardCardTitle>
               </DashboardCardHeader>
-              <DashboardCardBody>
+              <DashboardCardBody className="resource-metrics-dashboard__card-body">
                 <Area
                   query={`sum without (instance,exported_pod,exported_service,pod,server) (irate(haproxy_backend_connections_total${namespaceRouteQuery}))`}
                 />

--- a/frontend/public/components/utils/_resource-metrics.scss
+++ b/frontend/public/components/utils/_resource-metrics.scss
@@ -1,0 +1,22 @@
+.resource-metrics-dashboard__card-body {
+  align-items: stretch;
+  display: flex;
+  height: 300px;
+  justify-content: center;
+
+  .query-browser__wrapper {
+    border: none;
+    margin: auto;
+    padding: 0;
+  }
+
+  // For legacy <Area> charts
+  & > .graph-wrapper {
+    margin: auto;
+    padding: 0;
+  }
+
+  .graph-empty-state {
+    min-height: unset;
+  }
+}

--- a/frontend/public/components/utils/resource-metrics.tsx
+++ b/frontend/public/components/utils/resource-metrics.tsx
@@ -14,18 +14,12 @@ import {
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
 const ResourceMetricsDashboardCard: React.FC<ResourceMetricsDashboardCardProps> = (props) => (
-  <DashboardCard>
+  <DashboardCard className="resource-metrics-dashboard__card">
     <DashboardCardHeader>
       <DashboardCardTitle>{props.title}</DashboardCardTitle>
     </DashboardCardHeader>
-    <DashboardCardBody>
-      <QueryBrowser
-        queries={props.queries}
-        disableZoom
-        hideControls
-        showLegend
-        wrapperClassName="query-browser__resource-metrics-wrapper"
-      />
+    <DashboardCardBody className="resource-metrics-dashboard__card-body">
+      <QueryBrowser queries={props.queries} disableZoom hideControls />
     </DashboardCardBody>
   </DashboardCard>
 );
@@ -34,7 +28,7 @@ export const ResourceMetricsDashboard: React.FC<ResourceMetricsDashboardProps> =
   const { t } = useTranslation();
   const queries = useResourceMetricsQueries(obj);
   return queries ? (
-    <Dashboard>
+    <Dashboard className="resource-metrics-dashboard">
       <Grid hasGutter>
         <GridItem xl={6} lg={12}>
           <ResourceMetricsDashboardCard

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -101,6 +101,7 @@
 @import 'components/conditions';
 @import 'components/persistent-volume-claim';
 @import 'components/utils/details-item';
+@import 'components/utils/resource-metrics';
 
 @import 'components/dashboard/dashboards-page/cluster-dashboard/activity-card';
 @import 'components/dashboard/dashboards-page/cluster-dashboard/status-card';


### PR DESCRIPTION
- Create new BEM class names for resource metrics dashboards to create higher specificity rules
- Add fixed height and flexbox styles to dashboard card body
- Adjust styles for cards containing legacy Area charts so that they are consistent with newer QueryBrowser cards
- Adjust empty state styles so that they do not change the resource metrics card height