### PR TITLE
Bug 1986632: Auto populate app name and resource name in deploy image form

### DIFF
--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -144,7 +144,7 @@ const ImageStreamTagDropdown: React.FC<{ disabled?: boolean; formContextField?: 
     return () => {
       unmounted.current = true;
     };
-  });
+  }, []);
 
   return (
     <DropdownField


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6205

**Root solution:**
The `unmounted.current` value is set to true when the component is mounted as a result the logic to set image stream, auto-populating the resource name and the app name is not executed. Hence, the app name and the resource name is not auto-populated and the create button remains disabled even after the values are manually entered

**Solution description:**
Added empty dependency array, so that it gets called when the component is unmounted

**GIF:**
![Peek 2021-07-27 14-14](https://user-images.githubusercontent.com/22490998/127124809-b3381ce5-5e85-46e8-95d0-609a50f76835.gif)
