### PR TITLE
Bug 1986676: Fix Unique key warning issue in P/PLR details page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/FinallyNode.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/FinallyNode.tsx
@@ -39,7 +39,7 @@ const FinallyNode: React.FC<FinallyNodeProps> = ({ element }) => {
 
       {finallyTasks.map((ft, i) => {
         return (
-          <g data-test={`finally-task-node ${ft.name}`}>
+          <g key={ft.name} data-test={`finally-task-node ${ft.name}`}>
             <path
               className="opp-finally-node__connector"
               d={
@@ -52,7 +52,6 @@ const FinallyNode: React.FC<FinallyNodeProps> = ({ element }) => {
               }
             />
             <g
-              key={ft.name}
               transform={`translate(${leftPadding}, ${NODE_HEIGHT * i +
                 FINALLY_NODE_VERTICAL_SPACING * i +
                 FINALLY_NODE_PADDING})`}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/resource-overview/DynamicResourceLinkList.tsx
@@ -41,7 +41,7 @@ const DynamicResourceLinkList: React.FC<DynamicResourceLinkListProps> = ({
               linkName += ` (${qualifier})`;
             }
             return (
-              <div key={`${resourceKind}/${name}`}>
+              <div key={`${resourceKind}/${linkName}`}>
                 <PipelineResourceRef
                   resourceKind={resourceKind}
                   resourceName={name}


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6162

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Browser log should not show any react warnings. Depending of the pipeline and pipeline run visualization shows a warning:


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Use linkname instead of name so the list item gets unique key for embeddedTasks as well. 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
No React warnings on the browser log.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Use this yaml https://gist.github.com/karthikjeeyar/17be9d82ad999b0dea3de1c00483415b

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge