### PR TITLE
Bug 1986735: Add inspect url to devconsole monitoring chart

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -467,6 +467,7 @@
   "Silence for": "Silence for",
   "Dashboard": "Dashboard",
   "Workload": "Workload",
+  "Inspect": "Inspect",
   "View metrics for {{title}}": "View metrics for {{title}}",
   "All workloads": "All workloads",
   "Filter by workload": "Filter by workload",

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
@@ -7,12 +8,12 @@ import {
   monitoringDashboardsSetEndTime,
   monitoringDashboardsSetTimespan,
 } from '@console/internal/actions/ui';
-import { PrometheusGraphLink } from '@console/internal/components/graphs/prometheus-graph';
 import { QueryBrowser } from '@console/internal/components/monitoring/query-browser';
 import { Humanize } from '@console/internal/components/utils';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
+import DashboardCardLink from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardLink';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import './MonitoringDashboardGraph.scss';
@@ -21,6 +22,24 @@ export enum GraphTypes {
   area = 'Area',
   line = 'Line',
 }
+
+const PrometheusGraphLink = ({ query, namespace, ariaChartLinkLabel }) => {
+  const { t } = useTranslation();
+  const queries = _.compact(_.castArray(query));
+  if (!queries.length) {
+    return null;
+  }
+  const params = new URLSearchParams();
+  queries.forEach((q, index) => params.set(`query${index}`, q));
+  return (
+    <DashboardCardLink
+      aria-label={ariaChartLinkLabel}
+      to={`/dev-monitoring/ns/${namespace}/metrics?${params.toString()}`}
+    >
+      {t('devconsole~Inspect')}
+    </DashboardCardLink>
+  );
+};
 
 type MonitoringDashboardGraphProps = {
   title: string;
@@ -59,29 +78,29 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
     <DashboardCard className="monitoring-dashboards__card odc-monitoring-dashboard-graph">
       <DashboardCardHeader>
         <DashboardCardTitle>{title}</DashboardCardTitle>
-      </DashboardCardHeader>
-      <DashboardCardBody>
         <PrometheusGraphLink
+          namespace={namespace}
           query={query}
           ariaChartLinkLabel={t('devconsole~View metrics for {{title}}', {
             title,
           })}
-        >
-          <QueryBrowser
-            hideControls
-            defaultTimespan={DEFAULT_TIME_SPAN}
-            defaultSamples={DEFAULT_SAMPLES}
-            namespace={namespace}
-            queries={[query]}
-            isStack={graphType === GraphTypes.area}
-            timespan={timespan}
-            pollInterval={pollInterval}
-            fixedEndTime={endTime}
-            formatSeriesTitle={(labels) => labels.pod}
-            onZoom={onZoom}
-            showLegend
-          />
-        </PrometheusGraphLink>
+        />
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <QueryBrowser
+          hideControls
+          defaultTimespan={DEFAULT_TIME_SPAN}
+          defaultSamples={DEFAULT_SAMPLES}
+          namespace={namespace}
+          queries={[query]}
+          isStack={graphType === GraphTypes.area}
+          timespan={timespan}
+          pollInterval={pollInterval}
+          fixedEndTime={endTime}
+          formatSeriesTitle={(labels) => labels.pod}
+          onZoom={onZoom}
+          showLegend
+        />
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { TFunction } from 'i18next';
 import * as redux from 'react-redux';
-import { PrometheusGraphLink } from '@console/internal/components/graphs/prometheus-graph';
 import { QueryBrowser } from '@console/internal/components/monitoring/query-browser';
 import { monitoringDashboardQueries } from '../../queries';
 import { MonitoringDashboardGraph, GraphTypes } from '../MonitoringDashboardGraph';
@@ -53,8 +52,8 @@ describe('Monitoring Dashboard graph', () => {
   it('should add link to line graph', () => {
     monitoringDashboardGraphProps.graphType = GraphTypes.line;
     const wrapper = shallow(<MonitoringDashboardGraph {...monitoringDashboardGraphProps} />);
-    expect(wrapper.find(PrometheusGraphLink).exists()).toBe(true);
-    expect(wrapper.find(PrometheusGraphLink).props().query).toEqual(
+    expect(wrapper.find('PrometheusGraphLink').exists()).toBe(true);
+    expect(wrapper.find('PrometheusGraphLink').prop('query')).toEqual(
       monitoringDashboardGraphProps.query,
     );
   });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6094
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The unwanted chart dragging happens due to the prometheus graph URL which is wrapped around the chart query browser.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Move the prometheus URL to the top right, similar to admin console's dashboard graphs.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

*Before:*
![0](https://user-images.githubusercontent.com/20013884/127158058-1c8240c0-03c0-4c5b-9c03-ead652e030e9.png)

*After:*
![1](https://user-images.githubusercontent.com/20013884/127158070-d8081dfe-c6c0-4bc8-a2b7-4452117bf2ad.png)

*Drag selection:*

https://user-images.githubusercontent.com/20013884/127158086-70a65397-62b7-4ff5-ad4c-f2ffbb5941a8.mp4

cc @openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug