### PR TITLE
Bug 1985161: Fix translation of incorrect addSecretDescription string within modal

### DIFF
--- a/frontend/public/components/modals/add-secret-to-workload.tsx
+++ b/frontend/public/components/modals/add-secret-to-workload.tsx
@@ -185,7 +185,7 @@ export class AddSecretToWorkloadModalWithTrans extends React.Component<
         <ModalTitle>{t('public~Add secret to workload')}</ModalTitle>
         <ModalBody>
           <p>
-            <Trans i18nKey="public~addSecretDescription">
+            <Trans t={t} ns="public">
               Add all values from <ResourceIcon kind="Secret" />
               {{ secretName }} to a workload as environment variables or a volume.
             </Trans>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -656,7 +656,7 @@
   "Help menu": "Help menu",
   "Select a workload": "Select a workload",
   "Add secret to workload": "Add secret to workload",
-  "addSecretDescription": "Add all values from <1></1>{{secretName}} to a workload as environment variables or a volume.",
+  "Add all values from <1></1>{{secretName}} to a workload as environment variables or a volume.": "Add all values from <1></1>{{secretName}} to a workload as environment variables or a volume.",
   "Add this secret to workload": "Add this secret to workload",
   "Add secret as": "Add secret as",
   "Prefix": "Prefix",


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1985161

```
Add all values from <1></1>{{secretName}} to a workload as environment variables or a volume.": "Add all values from <1></1>{{secretName}} to a workload as environment variables or a volume.
```

JA and ZH currently not translated
https://github.com/openshift/console/blob/master/frontend/public/locales/ja/public.json#L651
https://github.com/openshift/console/blob/master/frontend/public/locales/zh/public.json#L651
KO translated the string `addSecretDescription` `설명에 시크릿 추가`
https://github.com/openshift/console/blob/master/frontend/public/locales/ko/public.json#L651