### PR TITLE
Bug 1986650: Cypress: Globally installs Service Binding Operator operator fails at "Create Operand" step

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -20,6 +20,7 @@ describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstall
     cy.visit('/');
     nav.sidenav.switcher.changePerspectiveTo('Administrator');
     nav.sidenav.switcher.shouldHaveText('Administrator');
+    operator.install(testOperator.name, testOperator.operatorHubCardTestID);
   });
 
   afterEach(() => {
@@ -33,9 +34,7 @@ describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstall
   });
 
   it(`Globally installs ${testOperator.name} operator in ${GlobalInstalledNamespace} and creates ${testOperand.name} operand`, () => {
-    operator.install(testOperator.name, testOperator.operatorHubCardTestID);
     operator.installedSucceeded(testOperator.name);
-
     operator.navToDetailsPage(testOperator.name);
     cy.byTestSectionHeading('Provided APIs').should('exist');
     cy.byTestSectionHeading('ClusterServiceVersion details').should('exist');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
@@ -122,7 +122,9 @@ export const operator = {
       .contains('Name')
       .parent()
       .within(() => {
-        cy.get('input').clear();
+        cy.get('input')
+          .should('not.be.disabled')
+          .clear();
         cy.get('input').type(exampleName);
       });
     cy.get(submitButton).click();


### PR DESCRIPTION
1. Address [known Cypress page load & clear input race condition](https://github.com/cypress-io/cypress/issues/5827#issuecomment-751995883).
2. Moves `operator install` into `before()` hook so retries won't attempt to re-install