### PR TITLE
Bug 1986631: Do not drop environment variables without name but with a value, also fix crash when ref is empty

### DIFF
--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -191,17 +191,19 @@ const ConfigMapSecretKeyRef = ({
       </>
     );
   }
-  return NameKeyDropdownPair({
-    name,
-    key,
-    configMaps,
-    secrets,
-    serviceAccounts,
-    onChange,
-    kind,
-    nameTitle,
-    placeholderString,
-  });
+  return (
+    <NameKeyDropdownPair
+      key={key}
+      name={name}
+      configMaps={configMaps}
+      secrets={secrets}
+      serviceAccounts={serviceAccounts}
+      onChange={onChange}
+      kind={kind}
+      nameTitle={nameTitle}
+      placeholderString={placeholderString}
+    />
+  );
 };
 
 const ConfigMapSecretRef = ({
@@ -236,18 +238,20 @@ const ConfigMapSecretRef = ({
       </div>
     );
   }
-  return NameKeyDropdownPair({
-    name,
-    key,
-    configMaps,
-    secrets,
-    serviceAccounts,
-    onChange,
-    kind,
-    nameTitle,
-    placeholderString,
-    isKeyRef,
-  });
+  return (
+    <NameKeyDropdownPair
+      key={key}
+      name={name}
+      configMaps={configMaps}
+      secrets={secrets}
+      serviceAccounts={serviceAccounts}
+      onChange={onChange}
+      kind={kind}
+      nameTitle={nameTitle}
+      placeholderString={placeholderString}
+      isKeyRef={isKeyRef}
+    />
+  );
 };
 
 const ResourceFieldRef = ({ data: { containerName, resource } }) => (
@@ -318,8 +322,11 @@ export class ValueFromPair extends React.PureComponent {
     const { pair, configMaps, secrets, serviceAccounts, disabled } = this.props;
     const valueFromKey = Object.keys(this.props.pair)[0];
     const componentInfo = keyStringToComponent[valueFromKey];
-    const Component = componentInfo.component;
+    if (!componentInfo) {
+      return null;
+    }
 
+    const Component = componentInfo.component;
     return (
       <Component
         data={pair[valueFromKey]}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6206
https://bugzilla.redhat.com/show_bug.cgi?id=1986631

When the user makes changes to a BuildConfig (or Pod) with the environment page or tab this could result in different errors:

**Usability error:** When the user doesn't enter a name this entries are just dropped when the form is saved.

**Crash:** When the user enters a name but do not enter a ConfigMap or Secret value the form crashs after saving. (The data are saved and the form will crash now when the user opens the tab.)

**Unstable tests:** `ConfigMapSecretKeyRef` called `NameKeyDropdownPair` as a function instead of rendering it as child component. This results in a react error "Uncaught Error: Rendered more hooks than during the previous render)."

**Analysis / Root cause**: 
There are two small aligned, but separate issues: The old implementation filters all environment variables without a name and doesn't check the value.

When the secret reference was not empty, the resource doesn't contain the info which resource should be selected. `value-from-pair.jsx` crashs without this info.

Call `NameKeyDropdownPair` as jsx tag instead of a function so that this component can use a hook (useTranslation).

**Solution Description**: 
Add null check to `value-from-pair.jsx` so that the component doesn't crash when another code call this without required data. Rendering nothing here results in a broken UI:

![null-check](https://user-images.githubusercontent.com/139310/127238941-12d21126-99a8-4f56-a3b3-3ba11686a5c0.png)

To fix this I also updated the value or valueFrom check. The value `valueFrom: {}` breaks the UI. The new version renders now a text field for this fields:

![clear-valuefrom](https://user-images.githubusercontent.com/139310/127239081-21869b12-ff9d-416b-9e66-3a3e59f59657.png)

The change in `_envVarsToNameVal` checks now if the name AND value is empty to skip these entries. When a value is inserted by the user, this will be submitted. The server then shows an error that the name is missing. See gif below.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

Earlier the fields without a name are just dropped. Now this could be submitted to the server, but this incomplete data will then show an error:

![improved-env](https://user-images.githubusercontent.com/139310/127239446-06fc4f8d-b622-42cf-b090-e2564db1b42e.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
Steps to Reproduce the usability error:
1. Open developer perspective
2. Navigate to Builds
3. Click on "Create BuildConfig" button
4. Just create the BuildConfig without additional changes
5. Switch to the "Environment" tab
6. Press "Add variable" or "Add from ConfigMap or Secret", enter an value or select a resource WITHOUT adding a name
7. Press "Save" (environment variable without a name is just dropped)

Steps to Reproduce the crash:
1. Open developer perspective
2. Navigate to Builds
3. Click on "Create BuildConfig" button
4. Just create the BuildConfig without additional changes
5. Switch to the "Environment" tab
6. Press "Add from ConfigMap or Secret", add a name but DO NOT selecting a ConfigMap or Secret
7. Press "Save"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge