### PR TITLE
Bug 1986729: Mark sink title as required form field

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/SinkSection.tsx
@@ -169,7 +169,18 @@ const SinkSection: React.FC<SinkSectionProps> = ({ namespace, fullWidth }) => {
   const { t } = useTranslation();
   return (
     <FormSection
-      title={t('knative-plugin~Sink')}
+      title={
+        <>
+          {t('knative-plugin~Sink')}
+          <span
+            className="pf-c-form__label-required"
+            aria-hidden="true"
+            style={{ verticalAlign: 'top' }}
+          >
+            {' *'}
+          </span>
+        </>
+      }
       subTitle={t(
         'knative-plugin~Add a sink to route this Event source to a Channel, Broker, Knative Service or another route.',
       )}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6201
https://bugzilla.redhat.com/show_bug.cgi?id=1986729

**Analysis / Root cause**: 
When the user creates an event source the user should see an indicator if a field is required or not.

The form does not enable the submit button until a sink URI is entered. But the field is not marked as required.

**Solution Description**: 
Mark the title as required with a patternfly class and a style to align the asterisk to the top.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 

![new-required-flag](https://user-images.githubusercontent.com/139310/127242140-5e23f69b-d7f0-44eb-8f75-9b9ac306f1b3.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
Unchanged

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
