### PR TITLE
[release-4.7] Bug 1986724: Show the content of Insights widget when there are 0 recommendations for cluster

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -27,7 +27,6 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
     ([k1], [k2]) => riskSorting[k1] - riskSorting[k2],
   );
   const numberOfIssues = Object.values(metrics).reduce((acc, cur) => acc + cur, 0);
-  const hasIssues = riskEntries.length > 0 && numberOfIssues > 0;
 
   const isWaitingOrDisabled = _isWaitingOrDisabled(metrics);
   const isError = _isError(metrics);
@@ -39,7 +38,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         <div className="co-status-popup__section">Disabled or waiting for results.</div>
       )}
       <div className="co-status-popup__section">
-        {hasIssues && !isWaitingOrDisabled && !isError && (
+        {!isWaitingOrDisabled && !isError && (
           <div>
             <ChartDonut
               data={riskEntries.map(([k, v]) => ({
@@ -80,7 +79,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
         )}
       </div>
       <div className="co-status-popup__section">
-        {hasIssues && !isWaitingOrDisabled && !isError && (
+        {!isWaitingOrDisabled && !isError && (
           <>
             <h6 className="pf-c-title pf-m-md">Fixable issues</h6>
             <div>
@@ -91,7 +90,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
             </div>
           </>
         )}
-        {!hasIssues && (isWaitingOrDisabled || isError) && (
+        {(isWaitingOrDisabled || isError) && (
           <ExternalLink
             href={`${openshiftHelpBase}support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html`}
             text="More about Insights"


### PR DESCRIPTION
Backporting PR https://github.com/openshift/console/pull/8989 to the 4.7.z target OCP release.

The patch solves the bug when no recommendations hit a cluster, but the widget has no content inside.

Before: 
<img width="399" alt="Screen Shot 2021-04-14 at 10 43 32 AM (2)" src="https://user-images.githubusercontent.com/31385370/127297520-d2f44e26-e50b-4423-8cae-0060da55cfbe.png">
After: 
![Screenshot from 2021-07-28 11-17-34](https://user-images.githubusercontent.com/31385370/127297534-87e6f235-8eb9-446f-99d3-55bf09d8f76a.png)


