### PR TITLE
Bug 1991573: [NETOBSERV-29] Turn on strictNullCheck on network-policies files

### DIFF
--- a/frontend/packages/console-app/src/__tests__/network-policies/network-policy-model.spec.ts
+++ b/frontend/packages/console-app/src/__tests__/network-policies/network-policy-model.spec.ts
@@ -29,7 +29,7 @@ describe('NetworkPolicy model conversion', () => {
       spec: {
         egress: [],
         ingress: [],
-        podSelector: null,
+        podSelector: undefined,
         policyTypes: ['Ingress', 'Egress'],
       },
     });
@@ -218,7 +218,7 @@ describe('NetworkPolicy model conversion', () => {
             ],
           },
         ],
-        podSelector: null,
+        podSelector: undefined,
         policyTypes: ['Ingress'],
       },
     });
@@ -258,7 +258,7 @@ describe('NetworkPolicy model conversion', () => {
         namespace: 'ns',
       },
       spec: {
-        podSelector: null,
+        podSelector: undefined,
         policyTypes: ['Ingress'],
         ingress: [
           {

--- a/frontend/packages/console-app/src/components/network-policies/network-policy-conditional-selector.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/network-policy-conditional-selector.tsx
@@ -4,7 +4,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { AsyncComponent } from '@console/internal/components/utils/async';
 
-const NameValueEditorComponent = (props) => (
+const NameValueEditorComponent = (props: any) => (
   <AsyncComponent
     loader={() =>
       import('@console/internal/components/utils/name-value-editor').then((c) => c.NameValueEditor)
@@ -27,7 +27,7 @@ export const NetworkPolicyConditionalSelector: React.FunctionComponent<NetworkPo
   const { selectorType, helpText, values, onChange } = props;
   const [isVisible, setVisible] = React.useState(false);
 
-  const handleSelectorChange = (updated) => {
+  const handleSelectorChange = (updated: { nameValuePairs: string[][] }) => {
     onChange(updated.nameValuePairs);
   };
 

--- a/frontend/packages/console-app/src/components/network-policies/network-policy-conditional-selector.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/network-policy-conditional-selector.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { AsyncComponent } from '@console/internal/components/utils/async';
+import { AsyncComponent, AsyncComponentProps } from '@console/internal/components/utils/async';
 
-const NameValueEditorComponent = (props: any) => (
+const NameValueEditorComponent = (props: Omit<AsyncComponentProps, 'loader'>) => (
   <AsyncComponent
     loader={() =>
       import('@console/internal/components/utils/name-value-editor').then((c) => c.NameValueEditor)

--- a/frontend/packages/console-app/src/components/network-policies/network-policy-form.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/network-policy-form.tsx
@@ -127,21 +127,21 @@ export const NetworkPolicyForm: React.FunctionComponent<NetworkPolicyFormProps> 
     );
   };
 
-  const removeIngressRule = (idx) => {
+  const removeIngressRule = (idx: number) => {
     updateIngressRules([
       ...networkPolicy.ingress.rules.slice(0, idx),
       ...networkPolicy.ingress.rules.slice(idx + 1),
     ]);
   };
 
-  const removeEgressRule = (idx) => {
+  const removeEgressRule = (idx: number) => {
     updateEgressRules([
       ...networkPolicy.egress.rules.slice(0, idx),
       ...networkPolicy.egress.rules.slice(idx + 1),
     ]);
   };
 
-  const save = (event) => {
+  const save = (event: React.FormEvent) => {
     event.preventDefault();
 
     const policy = networkPolicyToK8sResource(networkPolicy);

--- a/frontend/packages/console-app/src/components/network-policies/network-policy-rule-config.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/network-policy-rule-config.tsx
@@ -9,6 +9,7 @@ import {
   FormFieldGroupHeader,
 } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
+import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import {
@@ -20,7 +21,11 @@ import { NetworkPolicyPeerIPBlock } from './network-policy-peer-ipblock';
 import { NetworkPolicyPeerSelectors } from './network-policy-peer-selectors';
 import { NetworkPolicyPorts } from './network-policy-ports';
 
-const getPeerRuleTitle = (t, direction: 'ingress' | 'egress', peer: NetworkPolicyPeer) => {
+const getPeerRuleTitle = (
+  t: TFunction,
+  direction: 'ingress' | 'egress',
+  peer: NetworkPolicyPeer,
+) => {
   if (peer.ipBlock) {
     return direction === 'ingress'
       ? t('public~Allow traffic from peers by IP block')
@@ -76,7 +81,7 @@ export const NetworkPolicyRuleConfigPanel: React.FunctionComponent<RuleConfigPro
     onChange(rule);
   };
 
-  const removePeer = (idx) => {
+  const removePeer = (idx: number) => {
     rule.peers = [...rule.peers.slice(0, idx), ...rule.peers.slice(idx + 1)];
     onChange(rule);
   };
@@ -123,7 +128,7 @@ export const NetworkPolicyRuleConfigPanel: React.FunctionComponent<RuleConfigPro
             <NetworkPolicyPeerSelectors
               direction={direction}
               namespaceSelector={peer.namespaceSelector}
-              podSelector={peer.podSelector}
+              podSelector={peer.podSelector || []}
               onChange={(podSel, nsSel) => {
                 rule.peers[idx].podSelector = podSel;
                 rule.peers[idx].namespaceSelector = nsSel;

--- a/frontend/packages/console-app/src/components/network-policies/network-policy-rule-config.tsx
+++ b/frontend/packages/console-app/src/components/network-policies/network-policy-rule-config.tsx
@@ -9,7 +9,7 @@ import {
   FormFieldGroupHeader,
 } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
-import { TFunction } from 'i18next';
+import i18next from 'i18next';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,24 +21,20 @@ import { NetworkPolicyPeerIPBlock } from './network-policy-peer-ipblock';
 import { NetworkPolicyPeerSelectors } from './network-policy-peer-selectors';
 import { NetworkPolicyPorts } from './network-policy-ports';
 
-const getPeerRuleTitle = (
-  t: TFunction,
-  direction: 'ingress' | 'egress',
-  peer: NetworkPolicyPeer,
-) => {
+const getPeerRuleTitle = (direction: 'ingress' | 'egress', peer: NetworkPolicyPeer) => {
   if (peer.ipBlock) {
     return direction === 'ingress'
-      ? t('public~Allow traffic from peers by IP block')
-      : t('public~Allow traffic to peers by IP block');
+      ? i18next.t('public~Allow traffic from peers by IP block')
+      : i18next.t('public~Allow traffic to peers by IP block');
   }
   if (peer.namespaceSelector) {
     return direction === 'ingress'
-      ? t('public~Allow traffic from pods inside the cluster')
-      : t('public~Allow traffic to pods inside the cluster');
+      ? i18next.t('public~Allow traffic from pods inside the cluster')
+      : i18next.t('public~Allow traffic to pods inside the cluster');
   }
   return direction === 'ingress'
-    ? t('public~Allow traffic from pods in the same namespace')
-    : t('public~Allow traffic to pods in the same namespace');
+    ? i18next.t('public~Allow traffic from pods in the same namespace')
+    : i18next.t('public~Allow traffic to pods in the same namespace');
 };
 
 const emptyPeer = (type: NetworkPolicyPeerType): NetworkPolicyPeer => {
@@ -144,7 +140,7 @@ export const NetworkPolicyRuleConfigPanel: React.FunctionComponent<RuleConfigPro
                 header={
                   <FormFieldGroupHeader
                     titleText={{
-                      text: getPeerRuleTitle(t, direction, peer),
+                      text: getPeerRuleTitle(direction, peer),
                       id: `peer-header-${idx}`,
                     }}
                     actions={

--- a/frontend/packages/console-app/src/components/network-policies/tsconfig.json
+++ b/frontend/packages/console-app/src/components/network-policies/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig",
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true
+  }
+}

--- a/frontend/public/module/k8s/types.ts
+++ b/frontend/public/module/k8s/types.ts
@@ -1060,7 +1060,7 @@ export type PersistentVolumeClaimKind = K8sResourceCommon & {
 
 export type NetworkPolicyKind = K8sResourceCommon & {
   spec: {
-    podSelector: Selector;
+    podSelector?: Selector;
     ingress?: {
       from?: NetworkPolicyPeer[];
       ports?: NetworkPolicyPort[];


### PR DESCRIPTION
New tsconfig in `frontend/packages/console-app/src/components/network-policies` defines stricter rules, essentially for strict-null-checks (increases type safety). Also uses `noImplicitAny`.

JIRA https://issues.redhat.com/browse/NETOBSERV-29

Signed-off-by: Joel Takvorian <jtakvori@redhat.com>