### PR TITLE
Bug 1978202: RH templates are always supported

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-support.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-support.spec.ts
@@ -37,7 +37,6 @@ describe('test VM template support', () => {
     wizard.template.createTemplate(TEMPLATE_NAME, 'bar', true);
     virtualization.templates.testProvider(TEMPLATE_NAME, 'bar');
     virtualization.templates.testSource(TEMPLATE_NAME, 'bar');
-    virtualization.templates.testSupport(TEMPLATE_NAME, 'bar');
 
     wizard.template.open();
     wizard.template.createTemplate(TEMPLATE_NO_SUPPORT_NAME, 'bar', false);

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateCommnunityLabel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateCommnunityLabel.tsx
@@ -16,10 +16,10 @@ export const VMTemplateCommnunityLabel: React.FC<VMTemplateLabelProps> = ({
   const { t } = useTranslation();
   const provider = getTemplateProvider(t, template);
   const templateSupport = getTemplateSupport(template);
-  const isRedHatCommunity =
-    ['red hat', 'redhat'].includes(provider.toLowerCase()) && templateSupport.provider !== 'Full';
+  const isCommunity =
+    !['red hat', 'redhat'].includes(provider.toLowerCase()) && templateSupport.provider !== 'Full';
 
-  if (!isRedHatCommunity) {
+  if (!isCommunity) {
     return null;
   }
 


### PR DESCRIPTION
Problem:
Current logic label redhat provided templates as "community" supported,
while community provided templates that are not supported by the provided are not labeled "community"

Fix:
Only templates that are community provided and not supported by the provider are labeled "community"

Screenshots:
Before:
![screenshot-localhost_9000-2021 07 28-13_44_14](https://user-images.githubusercontent.com/2181522/127310535-935f4c38-2057-42dc-9586-ae2af1a6c603.png)

After:
![screenshot-localhost_9000-2021 07 28-13_47_48](https://user-images.githubusercontent.com/2181522/127310551-f11066d0-84f7-46ca-ad5b-c7576624736b.png)
