### PR TITLE
Bug 1986803: Add error boundary around each horizontal tab route (used in DetailsPage)

### DIFF
--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -1,17 +1,18 @@
-import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { History, Location } from 'history';
+import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { Route, Switch, Link, withRouter, match, matchPath } from 'react-router-dom';
-
-import { EmptyBox, LoadingBox, StatusBox } from './status-box';
-import { PodsPage } from '../pod';
-import { AsyncComponent } from './async';
+import { useExtensions, HorizontalNavTab, isHorizontalNavTab } from '@console/plugin-sdk';
+import { ErrorBoundary } from '@console/shared/src/components/error/error-boundary';
 import { K8sResourceKind, K8sResourceCommon } from '../../module/k8s';
 import { referenceForModel, referenceFor } from '../../module/k8s/k8s';
-import { useExtensions, HorizontalNavTab, isHorizontalNavTab } from '@console/plugin-sdk';
+import { ErrorBoundaryFallback } from '../error';
+import { PodsPage } from '../pod';
+import { AsyncComponent } from './async';
 import { ResourceMetricsDashboard } from './resource-metrics';
+import { EmptyBox, LoadingBox, StatusBox } from './status-box';
 
 const editYamlComponent = (props) => (
   <AsyncComponent loader={() => import('../edit-yaml').then((c) => c.EditYAML)} obj={props.obj} />
@@ -276,13 +277,15 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
     const path = `${props.match.path}/${p.path || p.href}`;
     const render = (params) => {
       return (
-        <p.component
-          {...componentProps}
-          {...extraResources}
-          {...p.pageData}
-          params={params}
-          customData={props.customData}
-        />
+        <ErrorBoundary FallbackComponent={ErrorBoundaryFallback}>
+          <p.component
+            {...componentProps}
+            {...extraResources}
+            {...p.pageData}
+            params={params}
+            customData={props.customData}
+          />
+        </ErrorBoundary>
       );
     };
     return <Route path={path} exact key={p.nameKey || p.name} render={render} />;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6204
https://bugzilla.redhat.com/show_bug.cgi?id=1986803

**Analysis / Root cause**: 
When one of the tabs on a DetailsPage crashes, the complete console content area shows an error page. Switching between the tabs is not possible anymore.

**Solution Description**: 
Wrap each route component with an `ErrorBoundary`.

**Screen shots / Gifs for design review**: 

Without error boundary (before):

![unhandled-tab-crash](https://user-images.githubusercontent.com/139310/127314580-61c32d5e-d1c5-4763-9032-cd6ea7923114.gif)

With error boundary (with this PR):

![handled-tab-crash](https://user-images.githubusercontent.com/139310/127314597-97674cc7-7c1a-4caa-afaf-c98a25f6af20.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
Produce a crash on a single tab of the DetailsPage component. For example on the environment page of a BuildConfig. This specific case is fixed in #9653. Otherwise you need to find another crash..

1. Open developer perspective
2. Navigate to Builds
3. Click on "Create BuildConfig" button
4. Just create the BuildConfig without additional changes
5. Switch to the "Environment" tab
6. Press "Add from ConfigMap or Secret" without selecting a ConfigMap or Secret and enter a name for this environment variable
7. Press "Save"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
