### PR TITLE
Bug 1978200: use strict promoted template list

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/hooks/use-pinned-templates.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-pinned-templates.ts
@@ -3,8 +3,10 @@ import { TEMPLATE_PIN, TEMPLATE_PIN_PROMOTED } from '../constants';
 import { TemplateItem } from '../types/template';
 import { useLocalStorage } from './use-local-storage';
 
+const PROMOTED_TEMPLATES = ['rhel7-server-small', 'rhel8-server-small'];
+
 const isPromoted = (templateItem: TemplateItem): boolean =>
-  templateItem.isCommon && templateItem.metadata.name.includes('rhel');
+  templateItem.isCommon && PROMOTED_TEMPLATES.includes(templateItem.metadata.name);
 
 export const usePinnedTemplates = (): [
   (item: TemplateItem) => boolean,


### PR DESCRIPTION
Problem:
We promoted any template that has "rhel" in it's name, so we promoted templates we did not explicitly intend to promote.

Fix:
promote templates using a strict list.

Screenshots:
Before:
![screenshot-localhost_9000-2021 07 28-15_28_28](https://user-images.githubusercontent.com/2181522/127322208-20ec4d11-2175-4108-b22e-ccb1425d6ca2.png)

After:
![screenshot-localhost_9000-2021 07 28-15_26_03](https://user-images.githubusercontent.com/2181522/127322220-9e84b20f-d535-435e-9972-a19b25aea2c8.png)
