### PR TITLE
Bug 1986988: Add button around pipeline builder icon to make popover accessibly via keyboard

### DIFF
--- a/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
+++ b/frontend/packages/pipelines-plugin/locales/en/pipelines-plugin.json
@@ -161,6 +161,7 @@
   "Add workspace": "Add workspace",
   "Error loading the tasks.": "Error loading the tasks.",
   "Unable to locate any tasks.": "Unable to locate any tasks.",
+  "Open hint": "Open hint",
   "Resources aren't in beta, so it is recommended to use workspaces instead.": "Resources aren't in beta, so it is recommended to use workspaces instead.",
   "Invalid runAfter": "Invalid runAfter",
   "TaskSpec or TaskRef must be provided.": "TaskSpec or TaskRef must be provided.",

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.scss
@@ -1,5 +1,4 @@
 .opp-pipeline-workspace-suggestion-icon {
   height: 1rem;
   width: 1rem;
-  cursor: pointer;
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineWorkspaceSuggestionIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Popover } from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 
@@ -8,13 +8,16 @@ import './PipelineWorkspaceSuggestionIcon.scss';
 const PipelineWorkspaceSuggestionIcon: React.FC = () => {
   const { t } = useTranslation();
 
+  const ariaLabel = t('pipelines-plugin~Open hint');
   const content = t(
     "pipelines-plugin~Resources aren't in beta, so it is recommended to use workspaces instead.",
   );
 
   return (
     <Popover aria-label={content} bodyContent={content}>
-      <InfoCircleIcon className="opp-pipeline-workspace-suggestion-icon" />
+      <Button isInline variant={ButtonVariant.link} aria-label={ariaLabel}>
+        <InfoCircleIcon className="opp-pipeline-workspace-suggestion-icon" />
+      </Button>
     </Popover>
   );
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6190
https://bugzilla.redhat.com/show_bug.cgi?id=1986988

**Analysis / Root cause**: 
Icon is not reachable via keyboard without a button or tab-index.

**Solution Description**: 
Add a button around the icon so that is reachable with the keyboard.

**Screen shots / Gifs for design review**: 
![reachable-button](https://user-images.githubusercontent.com/139310/127359427-838749b2-a358-4503-a893-6e8e7f5d31fc.gif)

**Unit test coverage report**: 
Unchanged

**Test setup:**
Unchanged

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
