### PR TITLE
Bug 1986754: Internationalize chip group labels

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -228,6 +228,8 @@ export const EventsList = (props) => {
               key="resources-category"
               categoryName={t('public~Resource')}
               defaultIsOpen={false}
+              collapsedText={t('public~{{numRemaining}} more', { numRemaining: '${remaining}' })}
+              expandedText={t('public~Show less')}
             >
               {[...selected].map((chip) => {
                 const chipString = chip === resourceTypeAll ? t('public~All') : chip;

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -458,6 +458,8 @@
   "Normal": "Normal",
   "Warning": "Warning",
   "Events by name or message": "Events by name or message",
+  "{{numRemaining}} more": "{{numRemaining}} more",
+  "Show less": "Show less",
   "All": "All",
   "No events": "No events",
   "No matching events": "No matching events",


### PR DESCRIPTION
"Show less" and "{{num}} more" were not internationalized. I passed in the appropriate PatternFly props to internationalize them.

Please note that '${remaining}' is the syntax required by PatternFly to retain the "counting" behavior.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1986754.