### PR TITLE
Bug 1986378: Container cannot start with whitespace characters

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
@@ -112,7 +112,14 @@ export const validateDisk = (
         ? volume.getContainerImage()
         : dataVolume?.getContainer();
     addRequired(container);
-    validations.container = validateContainer(container);
+    Promise.resolve(container)
+      .then((value) => {
+        validations.container = validateContainer(value);
+      })
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.log(e);
+      });
   }
 
   if (source.requiresDatavolume()) {


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1986378

**Analysis / Root cause**: 
Some values of container image return as promise 

**Solution Description**: 
Promise resolve should update the field only when promise is fulfilled 