### PR TITLE
Bug 1984807: Move tooltip 'Restore is only enabled for offline virtual machine' to the button when it's disabled

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshot-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshot-row.tsx
@@ -81,7 +81,7 @@ export const VMSnapshotSimpleRow: React.FC<VMSnapshotSimpleRowProps> = ({
             id={`${snapshotName}-restore-btn`}
             variant="secondary"
             onClick={() => snapshotRestoreModal({ snapshot })}
-            isDisabled={
+            isAriaDisabled={
               isDisabled ||
               !isVMSnapshotReady(snapshot) ||
               isVmRestoreProgressing(relevantRestore) ||


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1984807

**Analysis / Root cause**:
tooltip wasn't available for diabled button, since using 'isDisabled' prop instead of 'isAriaDisabled' that should be used according to patternfly's docs.

**Solution Description**:
changing to correct prop.

**Screen shots / Gifs for design review**:
before:

![bz_1984807_before](https://user-images.githubusercontent.com/67270715/127449586-6bee3d3c-ca6b-41c9-9fff-b6185153f41e.gif)

after:
![bz_1984807](https://user-images.githubusercontent.com/67270715/127449688-a5fc7752-316b-4deb-977e-634148ebe95c.gif)



Signed-off-by: Aviv Turgeman <aturgema@redhat.com>