### PR TITLE
Bug 1965984: Monitoring dashboards: Don't load panels until they scroll into view 

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -43,7 +43,7 @@ $tooltip-background-color: var(--pf-global--BackgroundColor--dark-100);
   height: calc(100% - 20px);
   margin: 0 0 20px 0;
 
-  .co-dashboard-card__body--dashboard-graph {
+  .co-dashboard-card__body--dashboard {
     // Add extra padding to the right. X-axis times with AM/PM at certain screen widths can overflow the card otherwise.
     padding: 10px 15px 10px 10px;
   }
@@ -61,8 +61,13 @@ $tooltip-background-color: var(--pf-global--BackgroundColor--dark-100);
   .query-browser__wrapper {
     border: 0;
     margin: 0;
+    min-height: 240px;
     padding: 0;
   }
+}
+
+.monitoring-dashboards__card-body-content {
+  height: 100%;
 }
 
 .monitoring-dashboards__card-header {

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -195,7 +195,6 @@ $screen-phone-landscape-min-width: 567px;
 
 .monitoring-dashboards__single-stat {
   font-size: var(--pf-global--FontSize--3xl);
-  padding-bottom: 0;
 }
 
 .monitoring-dashboards__table {

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -45,6 +45,7 @@ import {
   Panel,
 } from './types';
 import { useBoolean } from '../hooks/useBoolean';
+import { useIsVisible } from '../hooks/useIsVisible';
 
 const NUM_SAMPLES = 30;
 
@@ -439,6 +440,9 @@ const Card: React.FC<CardProps> = ({ panel }) => {
     UI.getIn(['monitoringDashboards', 'variables']),
   );
 
+  const ref = React.useRef();
+  const [, wasEverVisible] = useIsVisible(ref);
+
   const formatSeriesTitle = React.useCallback(
     (labels, i) => {
       const legendFormat = panel.targets?.[i]?.legendFormat;
@@ -489,32 +493,36 @@ const Card: React.FC<CardProps> = ({ panel }) => {
           <DashboardCardTitle>{panel.title}</DashboardCardTitle>
           {!isLoading && <QueryBrowserLink queries={queries} />}
         </DashboardCardHeader>
-        <DashboardCardBody className="co-dashboard-card__body--dashboard-graph">
-          {isLoading ? (
-            <LoadingInline />
-          ) : (
-            <>
-              {panel.type === 'grafana-piechart-panel' && (
-                <BarChart pollInterval={pollInterval} query={queries[0]} />
-              )}
-              {panel.type === 'graph' && (
-                <Graph
-                  formatSeriesTitle={formatSeriesTitle}
-                  isStack={panel.stack}
-                  pollInterval={pollInterval}
-                  queries={queries}
-                  showLegend={panel.legend?.show}
-                  units={panel.yaxes?.[0]?.format}
-                />
-              )}
-              {(panel.type === 'singlestat' || panel.type === 'gauge') && (
-                <SingleStat panel={panel} pollInterval={pollInterval} query={queries[0]} />
-              )}
-              {panel.type === 'table' && (
-                <Table panel={panel} pollInterval={pollInterval} queries={queries} />
-              )}
-            </>
-          )}
+        <DashboardCardBody className="co-dashboard-card__body--dashboard">
+          <div className="monitoring-dashboards__card-body-content " ref={ref}>
+            {isLoading || !wasEverVisible ? (
+              <div className={panel.type === 'graph' ? 'query-browser__wrapper' : ''}>
+                <LoadingInline />
+              </div>
+            ) : (
+              <>
+                {panel.type === 'grafana-piechart-panel' && (
+                  <BarChart pollInterval={pollInterval} query={queries[0]} />
+                )}
+                {panel.type === 'graph' && (
+                  <Graph
+                    formatSeriesTitle={formatSeriesTitle}
+                    isStack={panel.stack}
+                    pollInterval={pollInterval}
+                    queries={queries}
+                    showLegend={panel.legend?.show}
+                    units={panel.yaxes?.[0]?.format}
+                  />
+                )}
+                {(panel.type === 'singlestat' || panel.type === 'gauge') && (
+                  <SingleStat panel={panel} pollInterval={pollInterval} query={queries[0]} />
+                )}
+                {panel.type === 'table' && (
+                  <Table panel={panel} pollInterval={pollInterval} queries={queries} />
+                )}
+              </>
+            )}
+          </div>
         </DashboardCardBody>
       </DashboardCard>
     </div>

--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -52,9 +52,7 @@ const getColorCSS = (colorName: string): string =>
   colorMap[colorName] ? `var(--pf-chart-color-${colorMap[colorName]})` : undefined;
 
 const Body: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <Bullseye className="monitoring-dashboards__single-stat query-browser__wrapper">
-    {children}
-  </Bullseye>
+  <Bullseye className="monitoring-dashboards__single-stat">{children}</Bullseye>
 );
 
 const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {

--- a/frontend/public/components/monitoring/hooks/useIsVisible.ts
+++ b/frontend/public/components/monitoring/hooks/useIsVisible.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+export const useIsVisible = (ref) => {
+  const [isVisible, setIsVisible] = React.useState(false);
+  const [wasEverVisible, setWasEverVisible] = React.useState(false);
+
+  const callback = ([entry]) => {
+    setIsVisible(entry.isIntersecting);
+    if (entry.isIntersecting) {
+      setWasEverVisible(true);
+    }
+  };
+
+  const observer = new IntersectionObserver(callback);
+
+  React.useEffect(() => {
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [observer, ref]);
+
+  return [isVisible, wasEverVisible];
+};


### PR DESCRIPTION
Use `IntersectionObserver` to track when the panels become visible and
only render them when they are scrolled into view. This also avoids
loading the panel's data until it is visible.

This change only applies to the admin perspective, but once https://github.com/openshift/console/pull/9644 merges, it should apply to the dev perspective too.

Also removes some redundant styling for single stat panels.