### PR TITLE
Bug 1988133: Cypress - re-enable OLM globall install test

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -14,8 +14,7 @@ const testOperand: TestOperandProps = {
   exampleName: `example-servicebinding`,
 };
 
-// TODO: seeing two "Service Binding" horiz. tabs on operator detail page, re-enabled when fixed
-xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
+describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
     cy.visit('/');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator.view.ts
@@ -109,7 +109,9 @@ export const operator = {
     cy.log(`create operand "${exampleName}" for "${operatorName}" in ${installedNamespace}`);
     operator.navToDetailsPage(operatorName, installedNamespace);
     cy.log(`navigate to the "${tabName}" tab`);
-    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    cy.byLegacyTestID(`horizontal-link-${tabName}`)
+      .last()
+      .click();
     cy.byTestID('msg-box-title').should('contain', 'No operands found');
     cy.byTestID('msg-box-detail').should(
       'contain',
@@ -138,7 +140,9 @@ export const operator = {
     cy.log(`operand "${exampleName}" should exist for "${operatorName}" in ${installedNamespace}`);
     operator.navToDetailsPage(operatorName, installedNamespace);
     cy.log(`navigate to the "${tabName}" tab`);
-    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    cy.byLegacyTestID(`horizontal-link-${tabName}`)
+      .last()
+      .click();
     cy.byTestOperandLink(exampleName).should('contain', exampleName);
     cy.log(`navigate to the operand "Details" tab`);
     cy.byTestOperandLink(exampleName).click();
@@ -154,7 +158,9 @@ export const operator = {
     cy.log(`delete operand: ${exampleName}`);
     operator.navToDetailsPage(operatorName, installedNamespace);
     cy.log(`navigate to the "${tabName}" tab`);
-    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    cy.byLegacyTestID(`horizontal-link-${tabName}`)
+      .last()
+      .click();
     // drilldown to Operand details page
     cy.byTestOperandLink(exampleName).click();
     detailsPage.clickPageActionFromDropdown(`Delete ${operandKind}`);
@@ -171,7 +177,9 @@ export const operator = {
     cy.log(`operand "${exampleName}" should not exist`);
     operator.navToDetailsPage(operatorName, installedNamespace);
     cy.log(`navigate to the "${tabName}" tab`);
-    cy.byLegacyTestID(`horizontal-link-${tabName}`).click();
+    cy.byLegacyTestID(`horizontal-link-${tabName}`)
+      .last()
+      .click();
     cy.byTestOperandLink(exampleName).should('not.exist');
   },
   uninstall: (operatorName: string, installedNamespace: string = GlobalInstalledNamespace) => {


### PR DESCRIPTION
Operator recently released with multiple operand instance versions which maybe created.  Test updated to use the latest/last crd 'tab' to create the operand instance

This change has been backported to 4.8 since CI started failing [here](9560) as well, for the same "multiple operand instance/tabs" issue.