### PR TITLE
Bug 1986502: Fix previously deleted dragged files that show up in import yaml editor

### DIFF
--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -88,7 +88,7 @@ export const DroppableEditYAML = withDragDropContext<DroppableEditYAMLProps>(
       if (!monitor) {
         return;
       }
-      this.setState({ errors: [] });
+      this.clearFileUpload();
       if (allowMultiple) {
         monitor.getItem().files.forEach((yamlFile) => {
           this.readFileContents(yamlFile);

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -84,7 +84,6 @@ export const EditYAML_ = connect(stateToProps)(
             initialized: false,
             stale: false,
             sampleObj: props.sampleObj,
-            fileUpload: props.fileUpload,
             showSidebar: !!props.create,
             owner: null,
           };
@@ -180,10 +179,9 @@ export const EditYAML_ = connect(stateToProps)(
             );
           } else if (nextProps.fileUpload) {
             this.loadYaml(
-              !_.isEqual(this.state.fileUpload, nextProps.fileUpload),
+              !_.isEqual(this.props.fileUpload, nextProps.fileUpload),
               nextProps.fileUpload,
             );
-            this.setState({ fileUpload: nextProps.fileUpload });
           } else {
             this.loadYaml();
           }

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -183,6 +183,7 @@ export const EditYAML_ = connect(stateToProps)(
               !_.isEqual(this.state.fileUpload, nextProps.fileUpload),
               nextProps.fileUpload,
             );
+            this.setState({ fileUpload: nextProps.fileUpload });
           } else {
             this.loadYaml();
           }
@@ -239,22 +240,15 @@ export const EditYAML_ = connect(stateToProps)(
           const currentYAML = this.getEditor().getValue();
           return _.isEmpty(currentYAML)
             ? yaml
-            : `${currentYAML.trim()}${
-                currentYAML.trim().endsWith('---') ? '\n' : '\n---\n'
-              }${yaml}`;
+            : `${currentYAML}${currentYAML.trim().endsWith('---') ? '\n' : '\n---\n'}${yaml}`;
         }
 
         convertObjToYAMLString(obj) {
-          const { t, allowMultiple, clearFileUpload } = this.props;
+          const { t, allowMultiple } = this.props;
           let yaml = '';
           if (obj) {
             if (_.isString(obj)) {
-              if (allowMultiple) {
-                yaml = this.appendYAMLString(obj);
-                clearFileUpload();
-              } else {
-                yaml = obj;
-              }
+              yaml = allowMultiple ? this.appendYAMLString(obj) : obj;
             } else {
               try {
                 yaml = safeDump(obj);

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -235,12 +235,26 @@ export const EditYAML_ = connect(stateToProps)(
           });
         }
 
+        appendYAMLString(yaml) {
+          const currentYAML = this.getEditor().getValue();
+          return _.isEmpty(currentYAML)
+            ? yaml
+            : `${currentYAML.trim()}${
+                currentYAML.trim().endsWith('---') ? '\n' : '\n---\n'
+              }${yaml}`;
+        }
+
         convertObjToYAMLString(obj) {
-          const { t } = this.props;
+          const { t, allowMultiple, clearFileUpload } = this.props;
           let yaml = '';
           if (obj) {
             if (_.isString(obj)) {
-              yaml = obj;
+              if (allowMultiple) {
+                yaml = this.appendYAMLString(obj);
+                clearFileUpload();
+              } else {
+                yaml = obj;
+              }
             } else {
               try {
                 yaml = safeDump(obj);


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1986502

Reset the droppable edit yaml component after each drop, and track multiple drops in edit-yaml component instead so the current yaml content can be taken into consideration.