### PR TITLE
Bug 1972966: Virtualization is not available in Home Overview

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/health-item.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/health-item.tsx
@@ -188,7 +188,7 @@ export const URLHealthItem = withDashboardResources<URLHealthItemProps>(
         subsystem.url,
         (subsystem as DashboardsOverviewHealthURLSubsystem<any>['properties']).fetch
           ? (subsystem as DashboardsOverviewHealthURLSubsystem<any>['properties']).fetch
-          : null,
+          : undefined,
       );
       if (modelExists) {
         watchK8sResource(subsystem.additionalResource);


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1972966

**Analysis / Root cause**:
Virtualiztion status was shown as unavailable, due to sending a 'null' value as the fetch function, which caused the default value for the fetch function to be ignored

**Solution Description**:
changing the 'null' value to 'undefined' will allow to use the default value

**Screen shots / Gifs for design review**:
before:

![bz_1972966](https://user-images.githubusercontent.com/67270715/127765123-920bf4d4-fe81-4203-8c1e-8f48ae060ef6.png)

after:

![bz_1972966-after](https://user-images.githubusercontent.com/67270715/127765129-45a5d9f3-abc2-4d60-97bb-fd465caac812.png)
