### PR TITLE
Bug 1987169: Cannot create network attachment definition while operator is installed.

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -335,7 +335,7 @@ const mapStateToProps = ({ k8s }) => {
   const kindsInFlight = k8s.getIn(['RESOURCES', 'inFlight']);
   const hasHyperConvergedCRD =
     !kindsInFlight &&
-    !!['v1beta1', 'v1alpha1'].find(
+    !!['v1beta1', 'v1alpha1', 'v1alpha3'].find(
       (v) => !!modelFor(referenceForGroupVersionKind('hco.kubevirt.io')(v)('HyperConverged')),
     );
 


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1987169

**Analysis / Root cause**:
the kubevirt plugin extention has a changed version, and needed to be updated when checking for the Virtualization operator

**Solution Description**:
adding the correct version 'v1alpha3' 

**Screen shots / Gifs for design review**:

before:

![Screenshot from 2021-08-01 12-39-49](https://user-images.githubusercontent.com/67270715/127767038-9da789f4-42e6-458c-a1ab-3d016d0fad85.png)

after:

![bz_1987169-after-2](https://user-images.githubusercontent.com/67270715/127767101-ece01b2d-a15f-4c20-b9c7-7b10d3703d91.png)
![bz_1987169-after-1](https://user-images.githubusercontent.com/67270715/127767103-0b2d14c7-4de8-417a-a2a2-b9252f41b775.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>