### PR TITLE
Bug 1975042: added v2v config map to customize flow

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceForm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceForm.tsx
@@ -41,6 +41,7 @@ import {
 import { TemplateSupport } from '../../../constants/vm-templates/support';
 import { TEMPLATE_CUSTOMIZED_ANNOTATION } from '../../../constants/vm/constants';
 import { useBaseImages } from '../../../hooks/use-base-images';
+import useV2VConfigMap from '../../../hooks/use-v2v-config-map';
 import { createVMForCustomization } from '../../../k8s/requests/vmtemplate/customize';
 import { CloudInitDataHelper } from '../../../k8s/wrapper/vm/cloud-init-data-helper';
 import { VMTemplateWrapper } from '../../../k8s/wrapper/vm/vm-template-wrapper';
@@ -74,6 +75,7 @@ const CustomizeSourceForm: React.FC<RouteComponentProps> = ({ location }) => {
     { name, namespace, cloudInit, injectCloudInit, selectedTemplate, size, provider, support },
     formDispatch,
   ] = React.useReducer(formReducer, initFormState(urlParams.get('ns')));
+  const [V2VConfigMapImages, V2VConfigMapImagesLoaded] = useV2VConfigMap();
 
   const [templates, loaded, loadError] = useK8sWatchResource<TemplateKind[]>({
     kind: TemplateModel.kind,
@@ -224,6 +226,7 @@ const CustomizeSourceForm: React.FC<RouteComponentProps> = ({ location }) => {
         template?.isCommon ? baseImages : pvcs,
         provider,
         support,
+        V2VConfigMapImages,
       );
       const vmParams = new URLSearchParams();
       vmParams.append('vm', vm.metadata.name);
@@ -256,7 +259,13 @@ const CustomizeSourceForm: React.FC<RouteComponentProps> = ({ location }) => {
         <Divider component="div" />
         <GridItem span={6} className="kv-customize-source">
           <StatusBox
-            loaded={loaded && imagesLoaded && pvcsLoaded && loadvmWithCutomBootSource}
+            loaded={
+              loaded &&
+              imagesLoaded &&
+              pvcsLoaded &&
+              loadvmWithCutomBootSource &&
+              V2VConfigMapImagesLoaded
+            }
             loadError={loadError || error || pvcsError || vmWithCustomBootSourceError}
             data={selectedTemplate}
           >

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-v2v-config-map.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-v2v-config-map.ts
@@ -1,12 +1,18 @@
 import * as React from 'react';
+import { isEmpty } from 'lodash';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
+import { VIRTIO_WIN_IMAGE } from '../constants/vm/constants';
 import { getVmwareConfigMap } from '../k8s/requests/v2v/v2vvmware-configmap';
 import {
   v2vConfigMapActions,
   v2vConfigMapActionsNames,
 } from '../redux/actions/v2v-config-map-actions';
+
+const defaultConfigMapData = {
+  [VIRTIO_WIN_IMAGE]: 'registry.redhat.io/container-native-virtualization/virtio-win',
+};
 
 const useV2VConfigMap = () => {
   const dispatch = useDispatch();
@@ -18,11 +24,12 @@ const useV2VConfigMap = () => {
     try {
       const result = await getVmwareConfigMap();
       if (result?.data) {
-        setData(result?.data);
+        setData(!isEmpty(result?.data) ? result?.data : defaultConfigMapData);
         dispatch(v2vConfigMapActions[v2vConfigMapActionsNames.updateImages](result?.data));
       }
     } catch (e) {
       setError(e);
+      setData(defaultConfigMapData);
     }
     setLoaded(true);
   }, [dispatch]);

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vmtemplate/customize.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vmtemplate/customize.ts
@@ -8,8 +8,8 @@ import {
 } from '@console/internal/module/k8s';
 import { VMSettingsField } from '../../../components/create-vm-wizard/types';
 import {
-  ANNOTATIONS,
   AccessMode,
+  ANNOTATIONS,
   LABEL_USED_TEMPLATE_NAME,
   LABEL_USED_TEMPLATE_NAMESPACE,
   TEMPLATE_BASE_IMAGE_NAME_PARAMETER,
@@ -31,7 +31,7 @@ import { getKubevirtAvailableModel } from '../../../models/kubevirtReferenceForM
 import { isCommonTemplate } from '../../../selectors/vm-template/basic';
 import { TemplateSourceStatus } from '../../../statuses/template/types';
 import { VMKind } from '../../../types';
-import { getRandomChars, buildOwnerReference } from '../../../utils';
+import { buildOwnerReference, getRandomChars } from '../../../utils';
 import { DataVolumeWrapper } from '../../wrapper/vm/data-volume-wrapper';
 import { VMTemplateWrapper } from '../../wrapper/vm/vm-template-wrapper';
 import { VMWrapper } from '../../wrapper/vm/vm-wrapper';
@@ -146,6 +146,7 @@ export const createVMForCustomization = async (
   pvcs: PersistentVolumeClaimKind[],
   provider: string,
   support: string,
+  V2VConfigMapImages: { [key: string]: string },
 ): Promise<VMKind> => {
   const templateWrapper = new VMTemplateWrapper(template, true);
 
@@ -185,7 +186,7 @@ export const createVMForCustomization = async (
     undefined,
     undefined,
     undefined,
-    undefined,
+    V2VConfigMapImages,
     size,
     false,
   );


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1975042

**Analysis / Root cause**: 
v2v config map data was missing

**Solution Description**: 
Added missing data

**Screen shots / Gifs for design review**: 
After:
![image](https://user-images.githubusercontent.com/14824964/127767138-5877f5d7-67f9-4ba6-b933-381a6d24b8a4.png)
Before:
![image](https://user-images.githubusercontent.com/14824964/127767170-9f06d166-fb4a-4f33-9a5a-5a626e85e2ad.png)

Windows image when pulling data from config map:
![image](https://user-images.githubusercontent.com/14824964/127768421-8d5a41e6-47f4-473b-96de-5cdc66661f29.png)

When using default value if fetching config map data fetching failed or data is empty : 
![image](https://user-images.githubusercontent.com/14824964/127768476-ab049878-04b5-4544-83bc-4721a8103273.png)
