### PR TITLE
Bug 2008312: Add e2e test for Active Health Checks

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/common-operations.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/common-operations.ts
@@ -1,0 +1,4 @@
+export const scaleDeployments = (resources: string[], replicas: number) =>
+  resources.forEach((resource) => {
+    cy.exec(`oc scale --replicas=${replicas} deploy ${resource} -n openshift-storage`);
+  });

--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/active-health-checks.spec.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/active-health-checks.spec.ts
@@ -1,0 +1,73 @@
+import { checkErrors } from '../../../integration-tests-cypress/support';
+import { scaleDeployments } from '../common-operations';
+import { MINUTE } from '../consts';
+
+const enum Deployments {
+  ROOK_CEPH_MON_A = 'rook-ceph-mon-a',
+  ROOK_CEPH_MON_B = 'rook-ceph-mon-b',
+  ROOK_CEPH_MGR_A = 'rook-ceph-mgr-a',
+}
+
+const messages = {
+  warnings: {
+    MON_DOWN: '1/3 mons down, quorum b,c',
+    MGR_DOWN: 'no active mgr',
+  },
+  errors: {
+    ERROR: 'failed to get status. . timed out: exit status 1',
+  },
+};
+
+const checkHCPopover = () => {
+  cy.byTestID('Storage Cluster-secondary-status', { timeout: 5 * MINUTE }).should('be.visible');
+  cy.byTestID('Storage Cluster-health-item')
+    .contains('Storage Cluster')
+    .click();
+};
+
+const verifyMessages = (expectedMessages: string[]) => {
+  expectedMessages.forEach((expectedMessage) => {
+    cy.byTestID('healthcheck-message').contains(expectedMessage, {
+      timeout: 5 * MINUTE,
+    });
+  });
+};
+
+const isStorageClusterHealthy = () => {
+  // Check if cluster is in a healthy state (secondary status is not displayed when cluster is healthy).
+  cy.byTestID('Storage Cluster-secondary-status', { timeout: 5 * MINUTE }).should('not.exist');
+};
+
+describe('Test Popover behaviour for different active health check cases.', () => {
+  before(() => {
+    cy.login();
+    cy.visit('/');
+    cy.install();
+    cy.visit('/ocs-dashboards/block-file');
+  });
+
+  after(() => {
+    checkErrors();
+    cy.logout();
+  });
+
+  it('Popover shows all warnings.', () => {
+    isStorageClusterHealthy();
+    const resources = [Deployments.ROOK_CEPH_MON_A, Deployments.ROOK_CEPH_MGR_A];
+    scaleDeployments(resources, 0);
+    checkHCPopover();
+    verifyMessages(Object.values(messages.warnings));
+    scaleDeployments(resources, 1);
+    isStorageClusterHealthy();
+  });
+
+  it('Popover shows the error.', () => {
+    isStorageClusterHealthy();
+    const resources = [Deployments.ROOK_CEPH_MON_A, Deployments.ROOK_CEPH_MON_B];
+    scaleDeployments(resources, 0);
+    checkHCPopover();
+    verifyMessages(Object.values(messages.errors));
+    scaleDeployments(resources, 1);
+    isStorageClusterHealthy();
+  });
+});

--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/active-health-checks.spec.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/tests/active-health-checks.spec.ts
@@ -20,7 +20,7 @@ const messages = {
 
 const checkHCPopover = () => {
   cy.byTestID('Storage Cluster-secondary-status', { timeout: 5 * MINUTE }).should('be.visible');
-  cy.byTestID('Storage Cluster-health-item')
+  cy.byItemID('Storage Cluster-health-item')
     .contains('Storage Cluster')
     .click();
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/status-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/status-card.tsx
@@ -64,7 +64,9 @@ const CephHealthCheck: React.FC<CephHealthCheckProps> = ({ cephHealthState, heal
             .icon
         }
       </FlexItem>
-      <FlexItem>{healthCheck?.details}</FlexItem>
+      <FlexItem>
+        <div data-test="healthcheck-message">{healthCheck?.details}</div>
+      </FlexItem>
       <FlexItem>
         {!!healthCheck.troubleshootLink && (
           <a className="ceph-health-check-card__link" href={healthCheck.troubleshootLink}>
@@ -109,6 +111,7 @@ export const StatusCard: React.FC<DashboardItemProps> = ({
   for (const key in cephDetails) {
     if (pattern.test(key)) {
       const healthCheckObject: CephHealthCheckType = {
+        id: key,
         details: cephDetails[key].message,
         troubleshootLink: whitelistedHealthChecksRef[key] ?? null,
       };
@@ -154,6 +157,7 @@ export const StatusCard: React.FC<DashboardItemProps> = ({
 export default withDashboardResources(StatusCard);
 
 type CephHealthCheckType = {
+  id: string;
   details: string;
   troubleshootLink?: string;
 };

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
@@ -21,7 +21,7 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
     return (
       <div
         className={classNames('co-status-card__health-item', className)}
-        data-item-id={`${title}-health-item`}
+        data-test={`${title}-health-item`}
       >
         {state === HealthState.LOADING ? (
           <div className="skeleton-health">
@@ -51,7 +51,7 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
             <SecondaryStatus
               status={detailMessage}
               className="co-status-card__health-item-text"
-              dataStatusID={`${title}-secondary-status`}
+              dataTest={`${title}-secondary-status`}
             />
           )}
         </div>

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
@@ -21,7 +21,7 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
     return (
       <div
         className={classNames('co-status-card__health-item', className)}
-        data-test={`${title}-health-item`}
+        data-item-id={`${title}-health-item`}
       >
         {state === HealthState.LOADING ? (
           <div className="skeleton-health">

--- a/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
@@ -4,15 +4,15 @@ import * as _ from 'lodash';
 type SecondaryStatusProps = {
   status?: string | string[];
   className?: string;
-  dataStatusID?: string;
+  dataTest?: string;
 };
 
-const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status, className, dataStatusID }) => {
+const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status, className, dataTest }) => {
   const statusLabel = _.compact(_.concat([], status)).join(', ');
   const cssClassName = className || '';
   if (statusLabel) {
     return (
-      <div data-status-id={dataStatusID}>
+      <div data-test={dataTest}>
         <small className={`${cssClassName} text-muted`}>{statusLabel}</small>
       </div>
     );

--- a/frontend/packages/integration-tests-cypress/support/selectors.ts
+++ b/frontend/packages/integration-tests-cypress/support/selectors.ts
@@ -27,6 +27,7 @@ declare global {
       ): Chainable<Element>;
       byTestSectionHeading(selector: string): Chainable<Element>;
       byTestOperandLink(selector: string): Chainable<Element>;
+      byItemID(selector: string): Chainable<Element>;
     }
   }
 }
@@ -76,3 +77,5 @@ Cypress.Commands.add('byTestSectionHeading', (selector: string) =>
 Cypress.Commands.add('byTestOperandLink', (selector: string) =>
   cy.get(`[data-test-operand-link="${selector}"]`),
 );
+
+Cypress.Commands.add('byItemID', (selector: string) => cy.get(`[data-item-id="${selector}"]`));


### PR DESCRIPTION
Added an e2e test for the recently introduced Active Health Checks
feature for when there's a warning or an error. Also, I noticed some
wrapping, that was happening for a few lengthy messages (like the
one below) and set the `flexWrap` to `nowrap` inorder to avoid that
behaviour, even when the troubleshoot link is displayed.

![2021-08-02-042434_365x261_scrot](https://user-images.githubusercontent.com/33557095/127787689-53aa4f85-2cdc-4962-b006-15b0a6857c01.png)
