### PR TITLE
Bug 1985164: Regular user cannot restore VM snapshot

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-restore-modal/snapshot-restore-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-restore-modal/snapshot-restore-modal.tsx
@@ -12,7 +12,7 @@ import { VMRestoreWrapper } from '../../../k8s/wrapper/vm/vm-restore-wrapper';
 import { getName, getNamespace } from '../../../selectors';
 import { getVmSnapshotVmName } from '../../../selectors/snapshot/snapshot';
 import { VMSnapshot } from '../../../types';
-import { getRandomChars, buildOwnerReference } from '../../../utils';
+import { getRandomChars } from '../../../utils';
 import { ModalFooter } from '../modal/modal-footer';
 
 const SnapshotRestoreModal = withHandlePromise((props: SnapshotRestoreModalProps) => {
@@ -24,14 +24,12 @@ const SnapshotRestoreModal = withHandlePromise((props: SnapshotRestoreModalProps
     e.preventDefault();
     const restoreName = `${snapshotName}-restore-${getRandomChars()}`;
     const namespace = getNamespace(snapshot);
-    const snapshotRestoreWrapper = new VMRestoreWrapper()
-      .init({
-        name: restoreName,
-        namespace,
-        snapshotName,
-        vmName: getVmSnapshotVmName(snapshot),
-      })
-      .addOwnerReferences(buildOwnerReference(snapshot));
+    const snapshotRestoreWrapper = new VMRestoreWrapper().init({
+      name: restoreName,
+      namespace,
+      snapshotName,
+      vmName: getVmSnapshotVmName(snapshot),
+    });
 
     handlePromise(
       k8sCreate(snapshotRestoreWrapper.getModel(), snapshotRestoreWrapper.asResource()),


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1985164

**Analysis / Root cause**:
According to snapshot docs: https://docs.openshift.com/container-platform/4.7/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.html#virt-restoring-vm-from-snapshot-cli_virt-managing-offline-vm-snapshots
there is no need to pre-define owner reference, when doing so for a regular user it causes to permissions issues when trying to restore a snapshot.

**Solution Description**:
removing pre-defined owner reference, allowing to receive automated values

**Screen shots / Gifs for design review**:
before:
![screencapture-console-openshift-console-apps-uit-02-cnv-qe-rhcloud-com-k8s-ns-test-virtualmachines-rhel6-itchy-quail-snapshots-1627011546126 (1)](https://user-images.githubusercontent.com/67270715/127823885-da0de10e-2653-45b7-9b62-7089641ab097.png)


after:
![bz_1985164_after](https://user-images.githubusercontent.com/67270715/127823618-2d65e79a-b723-469e-aacf-7ef39f86a815.gif)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>