### PR TITLE
Removing LoadIndexFile dependency in test modules.

### DIFF
--- a/pkg/helm/chartproxy/proxy_test.go
+++ b/pkg/helm/chartproxy/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/console/pkg/helm/actions/fake"
 )
@@ -174,7 +175,12 @@ func TestProxy_IndexFile(t *testing.T) {
 				t.Error(err)
 			}
 			if tt.mergedFile != "" {
-				expectedIndexFile, err := repo.LoadIndexFile(tt.mergedFile)
+				data, err := ioutil.ReadFile(tt.mergedFile)
+				if err != nil {
+					t.Error(err)
+				}
+				expectedIndexFile := &repo.IndexFile{}
+				err = yaml.UnmarshalStrict(data, expectedIndexFile)
 				if err != nil {
 					t.Error(err)
 				}

--- a/pkg/helm/chartproxy/repos_test.go
+++ b/pkg/helm/chartproxy/repos_test.go
@@ -14,6 +14,7 @@ import (
 	fakeclient "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	fakeclienttest "k8s.io/client-go/testing"
+	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/console/pkg/helm/actions/fake"
 )
@@ -353,15 +354,20 @@ func TestHelmRepo_IndexFile(t *testing.T) {
 			}
 
 			if err == nil && tt.indexFile != "" {
-				var expectedIndex *helmrepo.IndexFile
+				expectedIndexPath := tt.indexFile
 				if tt.expectedIndexFile != "" {
-					expectedIndex, err = helmrepo.LoadIndexFile(tt.expectedIndexFile)
-				} else {
-					expectedIndex, err = helmrepo.LoadIndexFile(tt.indexFile)
+					expectedIndexPath = tt.expectedIndexFile
 				}
+				data, err := ioutil.ReadFile(expectedIndexPath)
 				if err != nil {
 					t.Error(err)
 				}
+				expectedIndex := &helmrepo.IndexFile{}
+				err = yaml.UnmarshalStrict(data, expectedIndex)
+				if err != nil {
+					t.Error(err)
+				}
+
 				if !reflect.DeepEqual(expectedIndex.Entries, index.Entries) {
 					t.Errorf("Expected index %v but got %v", expectedIndex, index)
 				}


### PR DESCRIPTION
In helm 3.6 the behavior of the LoadIdexFile method changed. Multi-line
values where normalized and trimmed of spaces, which will cause our
test to fail in yaml compare. This change removes the dependency on
LoadIndexFile and unmarshals the yaml files directly.