### PR TITLE
Bug 1986297: Windows guest tool is always mounted

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
@@ -150,9 +150,10 @@ const windowsToolsUpdater = ({ id, prevState, dispatch, getState }: UpdateOption
     id,
     VMSettingsField.MOUNT_WINDOWS_GUEST_TOOLS,
   );
-  const windowsTools = getStorages(state, id).find(
-    (storage) => !!isWinToolsImage(getVolumeContainerImage(storage.volume)),
-  );
+  const windowsTools = getStorages(state, id).find((storage) => {
+    const volumeImage = getVolumeContainerImage(storage.volume);
+    return volumeImage && !!isWinToolsImage(volumeImage, getV2VConfigMap(state));
+  });
 
   if (mountWindowsGuestTools && !windowsTools) {
     dispatch(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -7,6 +7,7 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { StorageClassModel } from '@console/internal/models';
 import { StorageClassResourceKind } from '@console/internal/module/k8s';
 import { TemplateSupport } from '../../../../constants/vm-templates/support';
+import useV2VConfigMap from '../../../../hooks/use-v2v-config-map';
 import { getDefaultStorageClass } from '../../../../selectors/config-map/sc-defaults';
 import { iGet, iGetIn } from '../../../../utils/immutable';
 import { FormPFSelect } from '../../../form/form-pf-select';
@@ -36,7 +37,6 @@ import { OS } from './os';
 import { ProvisionSourceComponent } from './provision-source';
 import { URLSource } from './url-source';
 import { WorkloadSelect } from './workload-profile';
-
 import '../../create-vm-wizard-footer.scss';
 import './vm-settings-tab.scss';
 
@@ -56,6 +56,7 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
   onFieldAttributeChange,
 }) => {
   const { t } = useTranslation();
+  useV2VConfigMap();
   const getField = React.useCallback((key: VMSettingsField) => iGet(vmSettings, key), [vmSettings]);
   const getFieldValue = React.useCallback(
     (key: VMSettingsField) => iGetIn(vmSettings, [key, 'value']),

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/winimage.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/winimage.ts
@@ -1,6 +1,13 @@
 import { winToolsContainerNames } from '../../constants/vm/wintools';
 
-export const isWinToolsImage = (image) => {
-  const containerNames = winToolsContainerNames();
-  return Object.values(containerNames).find((winTool) => image && image.startsWith(winTool));
+export const isWinToolsImage = (
+  image: string,
+  windowsImages?: {
+    [key: string]: string;
+  },
+) => {
+  const containerNames = winToolsContainerNames(windowsImages);
+  return Object.values(containerNames).find(
+    (winTool) => image && image.startsWith(winTool as string),
+  );
 };


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1986297

**Analysis / Root cause**: 
missing config map v2v values

**Solution Description**: 
Added support for config map v2v

**Screen shots / Gifs for design review**: 
Checked on both openshift and okd.
![windows-mount](https://user-images.githubusercontent.com/14824964/127861215-919fafd4-801f-4dfc-830f-59e646980d90.gif)
