### PR TITLE
Bug 1989143: [e2e][automation] Add hostpath-provisioner-setup.yml used in release-4.8 tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/add-support-annotations.sh
+++ b/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/add-support-annotations.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+TEMPLATES=(
+  'rhel7-desktop-tiny'
+  'rhel7-desktop-small'
+  'rhel7-desktop-medium'
+  'rhel7-desktop-large'
+  'rhel7-server-tiny'
+  'rhel7-server-small'
+  'rhel7-server-medium'
+  'rhel7-server-large'
+  'rhel7-highperformance-tiny'
+  'rhel7-highperformance-small'
+  'rhel7-highperformance-medium'
+  'rhel7-highperformance-large'
+  'rhel8-desktop-tiny'
+  'rhel8-desktop-small'
+  'rhel8-desktop-medium'
+  'rhel8-desktop-large'
+  'rhel8-server-tiny'
+  'rhel8-server-small'
+  'rhel8-server-medium'
+  'rhel8-server-large'
+  'rhel8-highperformance-tiny'
+  'rhel8-highperformance-small'
+  'rhel8-highperformance-medium'
+  'rhel8-highperformance-large'
+  'windows2k12r2-server-medium'
+  'windows2k12r2-server-large'
+  'windows2k16-server-medium'
+  'windows2k16-server-large'
+  'windows2k19-server-medium'
+  'windows2k19-server-large'
+  'windows10-desktop-medium'
+  'windows10-desktop-large'
+)
+
+ANNOTATIONS=(
+  template.kubevirt.io/provider='Red Hat'
+  template.kubevirt.io/provider-url='https://www.redhat.com'
+  template.kubevirt.io/provider-support-level=Full
+)
+
+IFS=""
+
+for template in "${TEMPLATES[@]}"; do
+    for annotation in "${ANNOTATIONS[@]}"; do
+        oc annotate --overwrite -n openshift templates "${template}" "${annotation}"
+    done
+done

--- a/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/hostpath-provisioner-setup.yml
+++ b/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/hostpath-provisioner-setup.yml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hostpath-provisioner
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: hostpath-provisioner
+  template:
+    metadata:
+      labels:
+        k8s-app: hostpath-provisioner
+    spec:
+      containers:
+        - name: hostpath-provisioner
+          image: mazdermind/hostpath-provisioner:latest
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: PV_DIR
+              value: /var/lib/minikube
+          volumeMounts:
+            - name: pv-volume
+              mountPath: /var/lib/minikube
+      volumes:
+        - name: pv-volume
+          hostPath:
+            path: /var/lib/minikube
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: hostpath-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: hostpath-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hostpath-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kube-system
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: hostpath
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: hostpath


### PR DESCRIPTION
fix test error:
`error: unable to read URL "https://raw.githubusercontent.com/openshift/console/master/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/hostpath-provisioner-setup.yml", server reported 404 Not Found, status code=404`

On e2e tests for release-4.8 we need this file

Signed-off-by: yaacov <kobi.zamir@gmail.com>