### PR TITLE
Bug 1989152: [Release-4.8] Use specific release for files used in e2e tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/deploy-kubevirt-gating.sh
+++ b/frontend/packages/kubevirt-plugin/integration-tests/deploy-kubevirt-gating.sh
@@ -20,7 +20,7 @@ oc -n kubevirt-hyperconverged wait deployment/virt-operator --for=condition=Avai
 oc create namespace openshift-cnv
 
 # Setup storage
-oc create -f https://raw.githubusercontent.com/openshift/console/master/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/hostpath-provisioner-setup.yml
+oc create -f https://raw.githubusercontent.com/openshift/console/release-4.8/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/hostpath-provisioner-setup.yml
 
 oc patch storageclass hostpath -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 
@@ -76,7 +76,7 @@ echo "Common templates created"
 oc annotate -n kubevirt-hyperconverged deployments ssp-operator kubevirt.io/operator.paused="true"
 
 # Annotate templates
-curl https://raw.githubusercontent.com/openshift/console/master/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/add-support-annotations.sh | bash
+curl https://raw.githubusercontent.com/openshift/console/release-4.8/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/add-support-annotations.sh | bash
 
 # Unpause the SSP operator
 oc annotate -n kubevirt-hyperconverged deployments ssp-operator kubevirt.io/operator.paused-


### PR DESCRIPTION
Use specific release for files used in e2e tests

- fix e2e test error:
`error: unable to read URL "https://raw.githubusercontent.com/openshift/console/master/frontend/packages/kubevirt-plugin/integration-tests/ci-scripts/hostpath-provisioner-setup.yml", server reported 404 Not Found, status code=404`
- 4.9 removed this files, we need to use the 4.8 branch for e2e tests to get this files.
- 4.9 does not do http requests from this repo anymore, no need to do this change in 4.9.

Signed-off-by: yaacov <kobi.zamir@gmail.com>