### PR TITLE
Bug 1982765: Networking - Services - Edit Pod Selector : An incomprehensible Japanese sentence

### DIFF
--- a/frontend/public/components/modals/labels-modal.jsx
+++ b/frontend/public/components/modals/labels-modal.jsx
@@ -46,7 +46,7 @@ const BaseLabelsModal = withHandlePromise((props) => {
     props.handlePromise(promise, props.close);
   };
 
-  const { kind, resource, descriptionKey, messageKey, labelClassName } = props;
+  const { kind, resource, descriptionKey, messageKey, messageVariables, labelClassName } = props;
 
   return (
     <form onSubmit={submit} name="form" className="modal-content">
@@ -59,7 +59,7 @@ const BaseLabelsModal = withHandlePromise((props) => {
         <div className="row co-m-form-row">
           <div className="col-sm-12">
             {messageKey
-              ? t(messageKey)
+              ? t(messageKey, messageVariables)
               : t(
                   'public~Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.',
                 )}
@@ -97,19 +97,25 @@ export const labelsModal = createModalLauncher((props) => (
   <BaseLabelsModal path={LABELS_PATH} {...props} />
 ));
 
-export const podSelectorModal = createModalLauncher((props) => (
-  <BaseLabelsModal
-    path={
-      ['replicationcontrolleres', 'services'].includes(props.kind.plural)
-        ? '/spec/selector'
-        : '/spec/selector/matchLabels'
-    }
-    isPodSelector={true}
-    // t('public~Pod selector')
-    descriptionKey="public~Pod selector"
-    // t('public~Determines the set of pods targeted by this {{kind: props.kind.label.toLowerCase()}}.')
-    messageKey="public~Determines the set of pods targeted by this {{kind: props.kind.label.toLowerCase()}}."
-    labelClassName="co-text-pod"
-    {...props}
-  />
-));
+export const podSelectorModal = createModalLauncher((props) => {
+  const { t } = useTranslation();
+  return (
+    <BaseLabelsModal
+      path={
+        ['replicationcontrolleres', 'services'].includes(props.kind.plural)
+          ? '/spec/selector'
+          : '/spec/selector/matchLabels'
+      }
+      isPodSelector={true}
+      // t('public~Pod selector')
+      descriptionKey="public~Pod selector"
+      // t('public~Determines the set of pods targeted by this {{kind}}.')
+      messageKey={'public~Determines the set of pods targeted by this {{kind}}.'}
+      messageVariables={{
+        kind: props.kind.labelKey ? t(props.kind.labelKey) : props.kind.label.toLowerCase(),
+      }}
+      labelClassName="co-text-pod"
+      {...props}
+    />
+  );
+});

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -758,7 +758,7 @@
   "Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.": "Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.",
   "{{description}} for": "{{description}} for",
   "Labels for": "Labels for",
-  "Determines the set of pods targeted by this {{kind: props.kind.label.toLowerCase()}}.": "Determines the set of pods targeted by this {{kind: props.kind.label.toLowerCase()}}.",
+  "Determines the set of pods targeted by this {{kind}}.": "Determines the set of pods targeted by this {{kind}}.",
   "Edit language preference": "Edit language preference",
   "Language": "Language",
   "Select language": "Select language",


### PR DESCRIPTION
Fixed i18n key variable error:

**Before:**
![image](https://user-images.githubusercontent.com/12733153/127901396-1ec65596-6e16-4399-bf55-dad0b0269bf0.png)
**After:**
![image](https://user-images.githubusercontent.com/12733153/128724576-d3f3d4e5-4e8f-4b84-9c9c-62c08ebd6499.png)

