### PR TITLE
 Bug 1980531: Remove check for two sections in help menu

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
@@ -22,7 +22,6 @@ describe('Localization', () => {
     masthead.clickMastheadLink('help-dropdown-toggle');
     // wait for both console help menu items and additionalHelpActions items to load
     // additionalHelpActions come from ConsoleLinks 'HelpMenu' yaml and are not translated
-    cy.get('.pf-c-app-launcher__group').should('have.length', 2);
     // only test console help items which are translated
     cy.get('.pf-c-app-launcher__group')
       .first()


### PR DESCRIPTION
This relates to Bug 1980531.  It is the first of 3 PRs. 

This first PR temporarily removes a test so the tests don't fail when the help links are removed from the operator. 

This PR is required for  https://github.com/openshift/console-operator/pull/565 which removes the help links from the operator to pass so that PR can be merged in.

After the first two PRs are approved then  https://github.com/openshift/console/pull/9495 can be merged which will add the help links back.