### PR TITLE
Add topology data model factory for bindable resources

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
@@ -103,7 +103,16 @@ type ImpersonateHeaders = {
   'Impersonate-User': string;
 };
 export const getImpersonateHeaders = (): ImpersonateHeaders => {
-  const { kind, name } = InternalReduxStore.getState().UI.get('impersonate', {});
+  let kind: string;
+  let name: string;
+  try {
+    const imp = InternalReduxStore.getState().UI.get('impersonate', {});
+    kind = imp.kind;
+    name = imp.name;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to get ImpersonateHeaders', error);
+  }
   if ((kind === 'User' || kind === 'Group') && name) {
     // Even if we are impersonating a group, we still need to set Impersonate-User to something or k8s will complain
     const headers = {

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -521,6 +521,8 @@
   "The server doesn't have a resource type {{missingType}}. Try refreshing the page if it was recently added.": "The server doesn't have a resource type {{missingType}}. Try refreshing the page if it was recently added.",
   "Select a Project to view the list of {{projectLabelPlural}} or <4>create a Project</4>.": "Select a Project to view the list of {{projectLabelPlural}} or <4>create a Project</4>.",
   "Select a Project to search inside or <2>create a Project</2>.": "Select a Project to search inside or <2>create a Project</2>.",
+  "BindableService": "BindableService",
+  "BindableServices": "BindableServices",
   "Developer": "Developer",
   "Invalid import option provided": "Invalid import option provided",
   "Add to Application": "Add to Application",

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/bindable-service-resources.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/bindable-service-resources.ts
@@ -1,0 +1,34 @@
+import {
+  referenceForGroupVersionKind,
+  referenceForModel,
+  WatchK8sResources,
+} from '@console/internal/module/k8s';
+import { ServiceBindingModel } from '@console/topology/src/models';
+import { fetchBindableServices, getBindableServicesList } from './fetch-bindable-services-utils';
+
+// Used to perform discovery of bindable services on console load since topology data model loader requires models upfront
+fetchBindableServices();
+
+export const getBindableServiceResources = (namespace: string): WatchK8sResources<any> => {
+  const resources = {
+    serviceBindingRequests: {
+      namespace,
+      kind: referenceForModel(ServiceBindingModel),
+      isList: true,
+      optional: true,
+    },
+    ...getBindableServicesList().reduce(
+      (acc, { group, version, kind }) => ({
+        [kind]: {
+          namespace,
+          kind: referenceForGroupVersionKind(group)(version)(kind),
+          isList: true,
+          optional: true,
+        },
+        ...acc,
+      }),
+      {},
+    ),
+  };
+  return resources;
+};

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/data-transformer.ts
@@ -1,0 +1,130 @@
+import { EdgeModel, Model, NodeModel } from '@patternfly/react-topology';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
+import {
+  getDefaultOperatorIcon,
+  getImageForCSVIcon,
+  getOperatorBackedServiceKindMap,
+} from '@console/shared';
+import {
+  NODE_HEIGHT,
+  NODE_PADDING,
+  NODE_WIDTH,
+  TYPE_SERVICE_BINDING,
+} from '@console/topology/src/const';
+import { getTopologyNodeItem } from '@console/topology/src/data-transforms/transform-utils';
+import { edgesFromServiceBinding } from '@console/topology/src/operators/operators-data-transformer';
+import { TopologyDataObject, TopologyDataResources } from '@console/topology/src/topology-types';
+import { TYPE_BINDABLE_NODE } from '../const';
+import { getBindableServicesList } from './fetch-bindable-services-utils';
+
+export const isServiceBindable = (resource: K8sResourceKind) =>
+  resource.metadata.labels?.['app.kubernetes.io/component'] === 'external-service';
+
+const BINDABLE_PROPS = {
+  width: NODE_WIDTH,
+  height: NODE_HEIGHT,
+  group: false,
+  visible: true,
+  style: {
+    padding: NODE_PADDING,
+  },
+};
+
+const getTopologyBindableServiceNodes = (
+  services: K8sResourceKind[],
+  resources: TopologyDataResources,
+): NodeModel[] => {
+  const nodes = services.filter(isServiceBindable).map((obj) => {
+    const resKindMap = getOperatorBackedServiceKindMap(
+      resources?.clusterServiceVersions?.data as ClusterServiceVersionKind[],
+    );
+    const csvData = resKindMap?.[obj.kind];
+    const data: TopologyDataObject = {
+      id: obj.metadata.uid,
+      name: obj.metadata.name,
+      type: TYPE_BINDABLE_NODE,
+      resource: obj,
+      resources: { obj },
+      data: {
+        resource: obj,
+        icon: getImageForCSVIcon(csvData?.spec?.icon?.[0]) || getDefaultOperatorIcon(),
+      },
+    };
+    return getTopologyNodeItem(obj, TYPE_BINDABLE_NODE, data, BINDABLE_PROPS);
+  });
+
+  return nodes;
+};
+
+export const getBindableServiceBindingEdges = (
+  dc: K8sResourceKind,
+  rhoasNodes: NodeModel[],
+  sbrs: K8sResourceKind[],
+): EdgeModel[] => {
+  const edges = [];
+  if (!sbrs?.length || !rhoasNodes?.length) {
+    return edges;
+  }
+
+  edgesFromServiceBinding(dc, sbrs).forEach((sbr) => {
+    sbr.spec.services?.forEach((bss) => {
+      if (bss) {
+        const targetNode = rhoasNodes.find(
+          (node) =>
+            node.data.resource.kind === bss.kind && node.data.resource.metadata.name === bss.name,
+        );
+        if (targetNode) {
+          const target = targetNode.data.resource.metadata.uid;
+          const source = dc.metadata.uid;
+          if (source && target) {
+            edges.push({
+              id: `${source}_${target}`,
+              type: TYPE_SERVICE_BINDING,
+              source,
+              target,
+              resource: sbr,
+              data: { sbr },
+            });
+          }
+        }
+      }
+    });
+  });
+
+  return edges;
+};
+
+export const getBindableServicesTopologyDataModel = async (
+  _namespace: string,
+  resources: TopologyDataResources,
+  workloads: K8sResourceKind[],
+): Promise<Model> => {
+  const serviceBindingRequests = resources?.serviceBindingRequests?.data;
+  const bindableResourcesList = getBindableServicesList();
+  const watchedBindableResources = bindableResourcesList.map(
+    ({ kind }) => resources[kind]?.data || [],
+  );
+
+  const servicesDataModel: Model = {
+    edges: [],
+    nodes: [],
+  };
+  watchedBindableResources.forEach((services) => {
+    servicesDataModel.nodes.push(...getTopologyBindableServiceNodes(services, resources));
+  });
+
+  if (servicesDataModel.nodes.length && serviceBindingRequests?.length) {
+    workloads.forEach((resource) =>
+      servicesDataModel.edges.push(
+        ...getBindableServiceBindingEdges(
+          resource,
+          servicesDataModel.nodes,
+          serviceBindingRequests,
+        ),
+      ),
+    );
+  }
+
+  return servicesDataModel;
+};

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/fetch-bindable-services-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/fetch-bindable-services-utils.ts
@@ -1,0 +1,34 @@
+import { k8sGet } from '@console/internal/module/k8s';
+import { BindableServicesModel } from './models';
+import { BindableServiceGVK, BindableServicesKind } from './types';
+
+type BindableServicesData = {
+  bindableServices: BindableServiceGVK[];
+  loaded: boolean;
+};
+
+const bindableServicesData: BindableServicesData = {
+  bindableServices: [],
+  loaded: false,
+};
+
+export const fetchBindableServices = async (): Promise<BindableServiceGVK[]> => {
+  bindableServicesData.loaded = false;
+  try {
+    const bindableService: BindableServicesKind = await k8sGet(
+      BindableServicesModel,
+      'bindable-services',
+    );
+    bindableServicesData.bindableServices = bindableService.spec;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('Error fetching bindable services', err);
+    bindableServicesData.bindableServices = [];
+  }
+  bindableServicesData.loaded = true;
+  return bindableServicesData.bindableServices;
+};
+
+export const getBindableServicesList = () => {
+  return bindableServicesData.bindableServices;
+};

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/isBindable.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/isBindable.ts
@@ -1,0 +1,9 @@
+import { Model } from '@patternfly/react-topology';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const isServiceBindable = (resource: K8sResourceKind, model: Model): boolean => {
+  if (!model?.nodes?.length) {
+    return false;
+  }
+  return resource.metadata.labels?.['app.kubernetes.io/component'] === 'external-service';
+};

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/models.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/models.ts
@@ -1,0 +1,17 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+export const BindableServicesModel: K8sKind = {
+  apiGroup: 'binding.operators.coreos.com',
+  apiVersion: 'v1alpha1',
+  kind: 'BindableService',
+  plural: 'bindableservices',
+  label: 'BindableService',
+  // t('devconsole~BindableService')
+  labelKey: 'BindableService',
+  labelPlural: 'devconsole~BindableServices',
+  // t('devconsole~BindableServices')
+  labelPluralKey: 'devconsole~BindableServices',
+  abbr: 'BS',
+  crd: true,
+  namespaced: false,
+};

--- a/frontend/packages/dev-console/src/components/topology/bindable-services/types.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/types.ts
@@ -1,0 +1,14 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export type BindableServiceGVK = {
+  group: string;
+  version: string;
+  kind: string;
+};
+
+export type BindableServicesKind = {
+  metadata: {
+    name: string;
+  };
+  spec: BindableServiceGVK[];
+} & K8sResourceKind;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6160
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Contribute topology data model factory for bindable services as a dynamic extension.
List of bindable resources is fetched up front because topology extensions require list of resources to be already present.

**Screen shots / Gifs for design review**: 
N/A
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind feature