### PR TITLE
Bug 1989707: Fixing Formik Promise.reject() issues by .resolve()-ing

### DIFF
--- a/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
@@ -53,7 +53,7 @@ const HPAFormikForm: React.FC<HPAFormikFormProps> = ({ existingHPA, targetResour
     const invalidUsageError = getInvalidUsageError(hpa, values);
     if (invalidUsageError) {
       helpers.setStatus({ submitError: invalidUsageError });
-      return Promise.reject();
+      return Promise.resolve();
     }
 
     const method: (

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -162,14 +162,14 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
             errorsText: ajv.errorsText(),
           }),
         });
-        return Promise.reject();
+        return Promise.resolve();
       }
     } else if (yamlData) {
       try {
         valuesObj = safeLoad(yamlData);
       } catch (err) {
         actions.setStatus({ submitError: t('helm-plugin~Invalid YAML - {{err}}', { err }) });
-        return Promise.reject();
+        return Promise.resolve();
       }
     }
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6188

**Analysis / Root cause**: 
Formik setSubmitting issues that were fixed in https://github.com/openshift/console/pull/8984 that assumed promise failures would not be a problem and would be handled by Formik. However, that was not the case and caused the local dev error window to appear.

**Solution Description**: 
`Promise.resolve` instead of `.reject` in order to appease the Formik code. We handle errors on our end so it's not a means of echo'ing errors for us.

**Test setup:**

- Adding an HPA without metrics on a Deployment
- Modifying the Helm Releases yaml to an invalid state and submitting on the form page

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge