### PR TITLE
Bug 2021724: Query browser: Add some transparency to line graph lines

### DIFF
--- a/frontend/public/components/graphs/themes.ts
+++ b/frontend/public/components/graphs/themes.ts
@@ -101,4 +101,11 @@ export const queryBrowserTheme = {
       },
     },
   },
+  line: {
+    style: {
+      data: {
+        opacity: 0.75,
+      },
+    },
+  },
 };


### PR DESCRIPTION
This makes it easier to see when data series are overlapping. It does however cause all lines to be a little fainter.

![screenshot](https://user-images.githubusercontent.com/460802/128185702-c3c1582e-bfda-4612-85e1-3a79bedd6487.png)