### PR TITLE
Add hook support for resources in topology data model extension

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/common-types.ts
@@ -1,7 +1,7 @@
 export { ResolvedExtension } from '../types';
 
 // Type for extension hook
-export type ExtensionHook<T, R = any> = (options: R) => ExtensionHookResult<T>;
+export type ExtensionHook<T, R = any> = (options?: R) => ExtensionHookResult<T>;
 
 // Type for extension hook result that returns [data, resolved, error]
 export type ExtensionHookResult<T> = [T, boolean, any];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -1,4 +1,4 @@
-import { ExtensionK8sGroupKindModel, PrometheusLabels, PrometheusValue } from '../api/common-types';
+import { PrometheusLabels, PrometheusValue } from '../api/common-types';
 
 export type OwnerReference = {
   name: string;
@@ -171,13 +171,6 @@ export type WatchK8sResults<R extends ResourcesObject> = {
 
 export type WatchK8sResources<R extends ResourcesObject> = {
   [k in keyof R]: WatchK8sResource;
-};
-
-export type WatchK8sResourcesGeneric = {
-  [key: string]: {
-    model?: ExtensionK8sGroupKindModel;
-    opts?: Partial<WatchK8sResource>;
-  };
 };
 
 export type FirehoseResource = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/topology.ts
@@ -1,3 +1,4 @@
+import { ExtensionHook } from '../api/common-types';
 import {
   CreateConnectionGetter,
   RelationshipProviderCreate,
@@ -12,7 +13,7 @@ import {
   ViewComponentFactory,
 } from '../api/topology-types';
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
-import { WatchK8sResourcesGeneric } from './console-types';
+import { WatchK8sResources } from './console-types';
 
 /** Getter for a ViewComponentFactory */
 export type TopologyComponentFactory = ExtensionDeclaration<
@@ -40,8 +41,8 @@ export type TopologyDataModelFactory = ExtensionDeclaration<
     id: string;
     /** Priority for the factory */
     priority: number;
-    /** Resources to be fetched from useK8sWatchResources hook. */
-    resources?: WatchK8sResourcesGeneric;
+    /** React hook that returns resources to watch with useK8sWatchResources */
+    resources?: CodeRef<ExtensionHook<WatchK8sResources<any>>>;
     /** Keys in resources containing workloads. */
     workloadKeys?: string[];
     /** Getter for the data model factory */

--- a/frontend/packages/helm-plugin/console-extensions.json
+++ b/frontend/packages/helm-plugin/console-extensions.json
@@ -182,7 +182,7 @@
       "id": "helm-topology-model-factory",
       "priority": 400,
       "resources": {
-        "secrets": { "opts": { "isList": true, "kind": "Secret", "optional": true } }
+        "$codeRef": "helmTopology.useResources"
       },
       "getDataModel": { "$codeRef": "helmTopology.getHelmTopologyDataModel" },
       "isResourceDepicted": { "$codeRef": "helmTopology.isHelmResourceInModel" }

--- a/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
+++ b/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
@@ -1,8 +1,14 @@
+import * as React from 'react';
 import { Model, NodeModel } from '@patternfly/react-topology';
+import { ExtensionHook } from '@console/dynamic-plugin-sdk';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { SecretModel } from '@console/internal/models';
-import { apiVersionForModel, K8sResourceKind } from '@console/internal/module/k8s';
-import { createOverviewItemForType, WORKLOAD_TYPES } from '@console/shared';
+import {
+  apiVersionForModel,
+  K8sResourceKind,
+  WatchK8sResources,
+} from '@console/internal/module/k8s';
+import { createOverviewItemForType, useActiveNamespace, WORKLOAD_TYPES } from '@console/shared';
 import {
   addToTopologyDataModel,
   createTopologyNodeData,
@@ -118,7 +124,7 @@ export const getHelmGraphModelFromMap = (
   const secrets = resources?.secrets?.data ?? [];
   WORKLOAD_TYPES.forEach((key) => {
     helmResources[key] = [];
-    if (resources[key]?.data && resources[key].data.length) {
+    if (resources[key]?.data?.length) {
       const typedDataModel: Model = {
         nodes: [],
         edges: [],
@@ -224,4 +230,18 @@ export const getHelmTopologyDataModel = () => {
 
     return Promise.resolve(getHelmGraphModelFromMap(helmResourcesMap, resources));
   };
+};
+
+export const useHelmResources: ExtensionHook<WatchK8sResources<any>> = () => {
+  const [namespace] = useActiveNamespace();
+  const resources = React.useMemo<[WatchK8sResources<any>, boolean, any]>(
+    () => [
+      { secrets: { isList: true, kind: 'Secret', namespace, optional: true } },
+      true,
+      undefined,
+    ],
+    [namespace],
+  );
+
+  return resources;
 };

--- a/frontend/packages/helm-plugin/src/topology/index.ts
+++ b/frontend/packages/helm-plugin/src/topology/index.ts
@@ -1,7 +1,11 @@
-import { getHelmTopologyDataModel as getTopologyDataModel } from './helm-data-transformer';
+import {
+  getHelmTopologyDataModel as getTopologyDataModel,
+  useHelmResources,
+} from './helm-data-transformer';
 
 export { getHelmComponentFactory } from './components/helmComponentFactory';
 export { isHelmResourceInModel } from './isHelmResource';
 export { getTopologyFilters, applyHelmDisplayOptions } from './helmFilters';
 
 export const getHelmTopologyDataModel = getTopologyDataModel();
+export const useResources = useHelmResources;

--- a/frontend/packages/kubevirt-plugin/console-extensions.json
+++ b/frontend/packages/kubevirt-plugin/console-extensions.json
@@ -497,60 +497,7 @@
       "id": "kubevirt-topology-model-factory",
       "priority": 200,
       "resources": {
-        "virtualmachines": {
-          "model": { "kind": "VirtualMachine", "group": "kubevirt.io" },
-          "opts": {
-            "isList": true,
-            "optional": true
-          }
-        },
-        "virtualmachineinstances": {
-          "model": { "kind": "VirtualMachineInstance", "group": "kubevirt.io" },
-          "opts": {
-            "isList": true,
-            "optional": true
-          }
-        },
-        "virtualmachinetemplates": {
-          "opts": {
-            "kind": "Template",
-            "isList": true,
-            "optional": true,
-            "selector": {
-              "matchLabels": {
-                "template.kubevirt.io/type": "base"
-              }
-            }
-          }
-        },
-        "migrations": {
-          "model": { "kind": "VirtualMachineInstanceMigration", "group": "kubevirt.io" },
-          "opts": {
-            "isList": true,
-            "optional": true
-          }
-        },
-        "dataVolumes": {
-          "model": { "kind": "DataVolume", "group": "cdi.kubevirt.io" },
-          "opts": {
-            "isList": true,
-            "optional": true
-          }
-        },
-        "vmImports": {
-          "model": { "kind": "VirtualMachineImport", "group": "v2v.kubevirt.io" },
-          "opts": {
-            "isList": true,
-            "optional": true
-          }
-        },
-        "pods": {
-          "opts": {
-            "isList": true,
-            "kind": "Pod",
-            "optional": true
-          }
-        }
+        "$codeRef": "topology.useResources"
       },
       "workloadKeys": ["virtualmachines"],
       "getDataModel": {

--- a/frontend/packages/kubevirt-plugin/src/topology/topology-plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/topology-plugin.ts
@@ -1,7 +1,8 @@
 import { getKubevirtComponentFactory } from './components/kubevirtComponentFactory';
 import { isKubevirtResource } from './isKubevirtResource';
-import { getKubevirtTopologyDataModel } from './kubevirt-data-transformer';
+import { getKubevirtTopologyDataModel, useKubevirtResources } from './kubevirt-data-transformer';
 
 export const componentFactory = getKubevirtComponentFactory;
 export const getDataModel = getKubevirtTopologyDataModel;
+export const useResources = useKubevirtResources;
 export const isResourceDepicted = isKubevirtResource;

--- a/frontend/packages/rhoas-plugin/console-extensions.json
+++ b/frontend/packages/rhoas-plugin/console-extensions.json
@@ -120,17 +120,7 @@
       "id": "rhoas-topology-model-factory",
       "priority": 400,
       "resources": {
-        "kafkaConnections": {
-          "model": {
-            "kind": "KafkaConnection",
-            "group": "rhoas.redhat.com",
-            "version": "v1alpha1"
-          },
-          "opts": {
-            "isList": true,
-            "optional": true
-          }
-        }
+        "$codeRef": "topology.useResources"
       },
       "workloadKeys": ["kafkaConnections"],
       "getDataModel": {

--- a/frontend/packages/rhoas-plugin/src/topology/index.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/index.ts
@@ -1,5 +1,5 @@
 export { getRhoasComponentFactory } from './components/rhoasComponentFactory';
-export { getRhoasTopologyDataModel } from './rhoas-data-transformer';
+export { getRhoasTopologyDataModel, useResources } from './rhoas-data-transformer';
 export {
   providerProvidesKafkaConnection,
   providerCreateKafkaConnection,

--- a/frontend/packages/rhoas-plugin/src/topology/rhoas-data-transformer.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/rhoas-data-transformer.ts
@@ -1,11 +1,18 @@
+import * as React from 'react';
 import { EdgeModel, Model, NodeModel } from '@patternfly/react-topology';
-import { K8sResourceKind, apiVersionForModel } from '@console/internal/module/k8s';
+import { ExtensionHook, WatchK8sResources } from '@console/dynamic-plugin-sdk';
+import {
+  K8sResourceKind,
+  apiVersionForModel,
+  referenceForModel,
+} from '@console/internal/module/k8s';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager/src/types';
 import {
   getDefaultOperatorIcon,
   getImageForCSVIcon,
   getOperatorBackedServiceKindMap,
   OverviewItem,
+  useActiveNamespace,
 } from '@console/shared/src';
 import { TYPE_SERVICE_BINDING } from '@console/topology/src/const';
 import { getTopologyNodeItem } from '@console/topology/src/data-transforms/transform-utils';
@@ -126,4 +133,25 @@ export const getRhoasTopologyDataModel = (
     });
   }
   return Promise.resolve(rhoasDataModel);
+};
+
+export const useResources: ExtensionHook<WatchK8sResources<any>> = () => {
+  const [namespace] = useActiveNamespace();
+  const resources = React.useMemo<[WatchK8sResources<any>, boolean, any]>(
+    () => [
+      {
+        kafkaConnections: {
+          isList: true,
+          kind: referenceForModel(KafkaConnectionModel),
+          namespace,
+          optional: true,
+        },
+      },
+      true,
+      undefined,
+    ],
+    [namespace],
+  );
+
+  return resources;
 };

--- a/frontend/packages/topology/src/data-transforms/DataModelProvider.tsx
+++ b/frontend/packages/topology/src/data-transforms/DataModelProvider.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 import {
+  ExtensionHook,
   isTopologyDataModelFactory as isDynamicTopologyDataModelFactory,
+  ResolvedExtension,
   TopologyDataModelFactory as DynamicTopologyDataModelFactory,
+  useResolvedExtensions,
+  WatchK8sResources,
 } from '@console/dynamic-plugin-sdk';
-import {
-  modelForGroupKind,
-  referenceForExtensionModel,
-  referenceForModel,
-} from '@console/internal/module/k8s';
-import { LoadedExtension, useExtensions } from '@console/plugin-sdk/src';
 import { isTopologyDataModelFactory, TopologyDataModelFactory } from '../extensions/topology';
 import DataModelExtension from './DataModelExtension';
 import { ModelContext, ExtensibleModel } from './ModelContext';
@@ -19,30 +17,80 @@ interface DataModelProviderProps {
   children?: React.ReactNode;
 }
 
-export const getNamespacedDynamicModelFactories = (
-  factories: LoadedExtension<DynamicTopologyDataModelFactory>[],
-) =>
-  factories.map(({ properties, ...ext }) => {
-    return {
-      ...ext,
-      properties: {
-        ...properties,
-        resources: (namespace: string) =>
-          Object.assign(
-            {},
-            ...Object.entries(properties.resources).map(([k, v]) => {
-              const kind = v?.model?.version
-                ? referenceForExtensionModel(v.model)
-                : v?.model
-                ? referenceForModel(modelForGroupKind(v.model?.group, v.model?.kind))
-                : v?.opts?.kind;
+const WatchResourcesHookResolver: React.FC<{
+  id: string;
+  useResources: ExtensionHook<WatchK8sResources<any>>;
+  onResolve: (key: string, resources: WatchK8sResources<any>) => void;
+}> = ({ id, useResources, onResolve }) => {
+  const [resources, loaded] = useResources();
+  React.useEffect(() => {
+    if (loaded) {
+      onResolve(id, resources);
+    }
+  }, [id, loaded, onResolve, resources]);
+  return null;
+};
 
-              return { [k]: { namespace, kind, ...v?.opts } };
-            }),
-          ),
-      },
-    };
+export const DynamicWatchResourcesLoader: React.FC<{
+  children: (props: WatchK8sResources<any>, loaded: boolean) => React.ReactNode;
+}> = ({ children }) => {
+  const [watchResources, setWatchResources] = React.useState<{
+    [key: string]: WatchK8sResources<any>;
+  }>({});
+  const [modelFactories, loaded] = useResolvedExtensions<DynamicTopologyDataModelFactory>(
+    isDynamicTopologyDataModelFactory,
+  );
+  const modelResources = React.useMemo(
+    () =>
+      modelFactories
+        ?.map((m) => ({ id: m.properties.id, resourceHook: m.properties.resources }))
+        .filter(({ resourceHook }) => !!resourceHook),
+    [modelFactories],
+  );
+
+  const onResolve = React.useCallback(
+    (key: string, resources: WatchK8sResources<any>) =>
+      setWatchResources((prevResources) => ({ ...prevResources, [key]: resources })),
+    [],
+  );
+
+  const loadedWatchResources = React.useMemo(
+    () => Object.values(watchResources).reduce((acc, val) => ({ ...acc, ...val }), {}),
+    [watchResources],
+  );
+
+  const allResourcesLoaded = React.useMemo(
+    () => loaded && Object.keys(modelResources).length === Object.keys(watchResources).length,
+    [loaded, modelResources, watchResources],
+  );
+
+  return (
+    <>
+      <>
+        {loaded &&
+          modelResources.map(({ id, resourceHook }) => (
+            <WatchResourcesHookResolver
+              id={id}
+              key={id}
+              useResources={resourceHook}
+              onResolve={onResolve}
+            />
+          ))}
+      </>
+      {children(loadedWatchResources, allResourcesLoaded)}
+    </>
+  );
+};
+
+const omitResources = (
+  factories: ResolvedExtension<DynamicTopologyDataModelFactory>[],
+): ResolvedExtension<Omit<DynamicTopologyDataModelFactory, 'resources'>>[] => {
+  const otherProperties = factories.map(({ properties, ...ext }) => {
+    const { resources, ...other } = properties;
+    return { properties: other, ...ext };
   });
+  return otherProperties;
+};
 
 const DataModelProvider: React.FC<DataModelProviderProps> = ({ namespace, children }) => {
   const [model, setModel] = React.useState<ExtensibleModel>(new ExtensibleModel(namespace));
@@ -51,26 +99,35 @@ const DataModelProvider: React.FC<DataModelProviderProps> = ({ namespace, childr
     setModel(new ExtensibleModel(namespace));
   }, [namespace]);
 
-  const modelFactories = useExtensions<TopologyDataModelFactory>(isTopologyDataModelFactory);
-  const dynamicModelFactories = useExtensions<DynamicTopologyDataModelFactory>(
-    isDynamicTopologyDataModelFactory,
+  const [modelFactories, modelFactoriesLoaded] = useResolvedExtensions<TopologyDataModelFactory>(
+    isTopologyDataModelFactory,
   );
+  const [dynamicModelFactories, dynamicFactoriesLoaded] = useResolvedExtensions<
+    DynamicTopologyDataModelFactory
+  >(isDynamicTopologyDataModelFactory);
 
-  const namespacedDynamicFactories = React.useMemo(
-    () => getNamespacedDynamicModelFactories(dynamicModelFactories),
-    [dynamicModelFactories],
+  const dataModelFactories = React.useMemo(
+    () =>
+      modelFactoriesLoaded && dynamicFactoriesLoaded
+        ? [...modelFactories, ...omitResources(dynamicModelFactories)]
+        : [],
+    [modelFactoriesLoaded, dynamicFactoriesLoaded, modelFactories, dynamicModelFactories],
   );
 
   return (
     <ModelContext.Provider value={model}>
       {namespace && (
         <>
-          {[...namespacedDynamicFactories, ...modelFactories].map((factory) => (
+          {dataModelFactories?.map((factory) => (
             <DataModelExtension key={factory.properties.id} dataModelFactory={factory.properties} />
           ))}
         </>
       )}
-      {namespace && <TopologyDataRetriever />}
+      {namespace && (
+        <DynamicWatchResourcesLoader>
+          {(resources) => <TopologyDataRetriever dynamicResources={resources} />}
+        </DynamicWatchResourcesLoader>
+      )}
       {children}
     </ModelContext.Provider>
   );

--- a/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
+++ b/frontend/packages/topology/src/data-transforms/TopologyDataRetriever.tsx
@@ -14,9 +14,13 @@ import { useMonitoringAlerts } from './useMonitoringAlerts';
 
 type TopologyDataRetrieverProps = {
   trafficData?: TrafficData;
+  dynamicResources?: WatchK8sResources<any>;
 };
 
-const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({ trafficData }) => {
+const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({
+  trafficData,
+  dynamicResources,
+}) => {
   const dataModelContext = React.useContext<ExtensibleModel>(ModelContext);
   const { namespace } = dataModelContext;
   const filters = useDisplayFilters();
@@ -30,7 +34,10 @@ const TopologyDataRetriever: React.FC<TopologyDataRetrieverProps> = ({ trafficDa
 
   const debouncedUpdateResources = useDebounceCallback(setResources, 250);
 
-  const updatedResources = useK8sWatchResources<TopologyResourcesObject>(resourcesList);
+  const updatedResources = useK8sWatchResources<TopologyResourcesObject>({
+    ...resourcesList,
+    ...dynamicResources,
+  });
   React.useEffect(() => debouncedUpdateResources(updatedResources), [
     debouncedUpdateResources,
     updatedResources,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6229
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Description**: 
- Convert the `resources` property in `TopologyDataModelFactory` extension from object to a hook that returns the resources to watch.
- Update DataModelProvider to handle getting resources from hook.
- Update existing extensions(kubvert & helm) to use a resources hook instead of object.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
N/A
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

