### PR TITLE
Bug 1985356: Check for nonexistent CSVs in installed block

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -68,13 +68,18 @@ const InstalledHintBlock: React.FC<OperatorHubItemDetailsHintBlockProps> = ({
   subscription,
 }) => {
   const { t } = useTranslation();
-  const [installedCSV] = useK8sWatchResource<ClusterServiceVersionKind>({
-    kind: referenceForModel(ClusterServiceVersionModel),
-    name: subscription?.status?.installedCSV,
-    namespace: subscription?.metadata?.namespace,
-    isList: false,
-    namespaced: true,
-  });
+
+  const [installedCSV] = useK8sWatchResource<ClusterServiceVersionKind>(
+    subscription?.status?.installedCSV
+      ? {
+          kind: referenceForModel(ClusterServiceVersionModel),
+          name: subscription?.status?.installedCSV,
+          namespace: subscription?.metadata?.namespace,
+          isList: false,
+          namespaced: true,
+        }
+      : null,
+  );
   const nsPath = `/k8s/${namespace ? `ns/${namespace}` : 'all-namespaces'}`;
   const to = installedCSV
     ? `${nsPath}/clusterserviceversions/${installedCSV?.metadata?.name ?? ''}`


### PR DESCRIPTION
The installed hint block for operators wasn't checking to see if the operator had a CSV or not in the K8sWatch hook. As a result, sometimes it would show an incorrect CSV link if there was no CSV on the operator. I added some additional logic to check so we can route them to the subscription if this happens.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1985356.