### PR TITLE
Bug 1986565: [OCP48][WebUI] "How to seal boot source for template usage" link points to /foo

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/template-customization/FinishCustomizationModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/template-customization/FinishCustomizationModal.tsx
@@ -10,8 +10,8 @@ import {
 import { ExternalLink, ResourceLink } from '@console/internal/components/utils';
 import { TemplateModel } from '@console/internal/models';
 import { TemplateKind } from '@console/internal/module/k8s';
+import { SEAL_BOOT_SOURCE_URL } from '../../../constants/vm-templates';
 import { ModalFooter } from '../modal/modal-footer';
-
 import './finish-customization-modal.scss';
 
 const FinishCustomizationModal: React.FC<FinishCustomizationModalProps> = ({
@@ -52,7 +52,7 @@ const FinishCustomizationModal: React.FC<FinishCustomizationModalProps> = ({
               isChecked={confirmed}
               className="kv-finish-modal__checkbox"
             />
-            <ExternalLink href="foo">
+            <ExternalLink href={SEAL_BOOT_SOURCE_URL}>
               {t('kubevirt-plugin~How to seal boot source for template usage')}
             </ExternalLink>
           </StackItem>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceStatus.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/customize-source/CustomizeSourceStatus.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { Alert, Bullseye, Button, Spinner, Stack, StackItem, Title } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ExternalLink, ResourceLink } from '@console/internal/components/utils';
+import { SEAL_BOOT_SOURCE_URL } from '../../../constants';
 import { VirtualMachineModel } from '../../../models';
 import { kubevirtReferenceForModel } from '../../../models/kubevirtReferenceForModel';
 import { VMStatusBundle } from '../../../statuses/vm/types';
 import { VMIKind, VMKind } from '../../../types';
 import cancelCustomizationModal from '../../modals/template-customization/CancelCustomizationModal';
 import { VMStatus } from '../../vm-status/vm-status';
-
 import './customize-source.scss';
 
 const CustomizeSourceStatus: React.FC<CustomizeSourceStatusProps> = ({
@@ -64,7 +64,7 @@ const CustomizeSourceStatus: React.FC<CustomizeSourceStatusProps> = ({
           >
             <ExternalLink
               text={t('kubevirt-plugin~Learn how to generalize a boot source')}
-              href="https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/chap-templates#Sealing_Virtual_Machines_in_Preparation_for_Deployment_as_Templates"
+              href={SEAL_BOOT_SOURCE_URL}
             />
           </Alert>
         </StackItem>

--- a/frontend/packages/kubevirt-plugin/src/constants/vm-templates/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm-templates/constants.ts
@@ -8,3 +8,8 @@ export const BOOT_SOURCE_REQUIRED = 'Boot source required';
 export const SUPPORT_URL = 'https://access.redhat.com/articles/4234591';
 export const SNAPSHOT_SUPPORT_URL =
   'https://docs.openshift.com/container-platform/4.6/storage/container_storage_interface/persistent-storage-csi-snapshots.html';
+
+// SEAL_BOOT_SOURCE_URL is temp until D/S docs are ready
+// remove comment once changed to permenant URL
+export const SEAL_BOOT_SOURCE_URL =
+  'https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/chap-templates#Sealing_Virtual_Machines_in_Preparation_for_Deployment_as_Templates';


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1986565

**Analysis / Root cause**:
link pointing to meaningless address 'foo'

**Solution Description**:
replacing the link to 
https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/chap-templates#Sealing_Virtual_Machines_in_Preparation_for_Deployment_as_Templates

**Screen shots / Gifs for design review**:

before:

![bz-url-foo-before](https://user-images.githubusercontent.com/67270715/128307903-9fdff3ee-d2c2-4855-b2f9-7d77ee260861.gif)

after:

![bz-url-foo-after](https://user-images.githubusercontent.com/67270715/128307933-9af30119-0fcd-4eb5-bf74-e2f63fc69a99.gif)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>