### PR TITLE
Bug 1978649: Block and File and Object dashboards should not be part of OCP Console for ODF Managed Services

### DIFF
--- a/frontend/packages/ceph-storage-plugin/console-extensions.json
+++ b/frontend/packages/ceph-storage-plugin/console-extensions.json
@@ -105,7 +105,8 @@
       "href": "/ocs-dashboards"
     },
     "flags": {
-      "required": ["OCS"]
+      "required": ["OCS"],
+      "disallowed": ["ODF_MANAGED"]
     }
   },
   {

--- a/frontend/packages/ceph-storage-plugin/src/constants/common.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/common.ts
@@ -32,6 +32,7 @@ export const MINIMUM_NODES = 3;
 export const SECOND = 1000;
 export const OCS_NS = 'openshift-storage';
 export const NB_PROVISIONER = 'noobaa.io/obc';
+export const ODF_MANAGED_LABEL = 'odf-managed-service';
 export enum StoreType {
   BS = 'BackingStore',
   NS = 'NamespaceStore',

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -33,6 +33,8 @@ import {
   OCS_INDEPENDENT_FLAG,
   MCG_FLAG,
   OCS_FLAG,
+  ODF_MANAGED_FLAG,
+  detectManagedODF,
   detectComponents,
 } from './features';
 import { getObcStatusGroups } from './components/dashboards/object-service/buckets-card/utils';
@@ -98,6 +100,15 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [MCG_FLAG],
+    },
+  },
+  {
+    type: 'FeatureFlag/Custom',
+    properties: {
+      detect: detectManagedODF,
+    },
+    flags: {
+      required: [OCS_FLAG],
     },
   },
   {
@@ -375,6 +386,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [OCS_FLAG],
+      disallowed: [ODF_MANAGED_FLAG],
     },
   },
   {


### PR DESCRIPTION
- Disabled `Block and File` and `Object` dashboards for ODF Managed Services.

- `Storage --> Overview` navigation item will be hidden.

- `Storage --> OpenShift Data Foundation` navigation item will also be hidden. (added in patch https://github.com/red-hat-storage/odf-console/pull/1)