### PR TITLE
Bug 1990732: Use `Immediate` as the default `volumeBindingMode`

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/views/storage-class.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/views/storage-class.ts
@@ -37,6 +37,8 @@ export const createStorageClass = (scName: string, poolName?: string, encrypted?
   cy.byTestID(poolName || 'ocs-storagecluster-cephblockpool').click();
 
   cy.log('Creating new StorageClass');
+  cy.byTestID('storage-class-volume-binding-mode').click();
+  cy.byTestDropDownMenu('Immediate').click();
   cy.byLegacyTestID('storage-class-form')
     .get('button#save-changes')
     .click();

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -1074,6 +1074,7 @@ class StorageClassFormWithTranslation extends React.Component<
               selectedKey={volumeBindingModeKey}
               onChange={(event) => this.setStorageHandler('volumeBindingMode', event)}
               id="storage-class-volume-binding-mode"
+              dataTest="storage-class-volume-binding-mode"
             />
             <span className="help-block">
               {t(


### PR DESCRIPTION
#9716 introduced a feature that sets the default `volumeBindingMode` to `WaitForFirstConsumer`. This PR changes that behavior to `Immediate` in the tests.