### PR TITLE
auto update resource name when internal registry details are changed

### DIFF
--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -69,8 +69,8 @@ const ImageStreamTagDropdown: React.FC<{ disabled?: boolean; formContextField?: 
           setFieldValue(`${fieldPrefix}isi.tag`, selectedTag);
           setFieldValue(`${fieldPrefix}isi.ports`, ports);
           setFieldValue(`${fieldPrefix}image.ports`, ports);
-          !resourceName &&
-            formType !== 'edit' &&
+          formType !== 'edit' &&
+            resourceName !== name &&
             setFieldValue(`${fieldPrefix}name`, getSuggestedName(name));
           application &&
             application.selectedKey !== UNASSIGNED_KEY &&


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6221

**Root analysis:**
- In the external registry flow the app name and resource name are not updated when the entered details are changed

**Solution description::**
- if the name set in the Formik state is not equal to the suggested name then update the app name to the suggested name 
- we currently do not auto-update the app name when the entered details are changed

**GIF:**
![Peek 2021-08-06 01-25](https://user-images.githubusercontent.com/22490998/128412949-116e3379-63e2-4e60-a173-c7b3435c9d9a.gif)
