### PR TITLE
drag and resize quicksearch modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -180,6 +180,7 @@
     "react-modal": "^3.12.1",
     "react-monaco-editor": "0.41.x",
     "react-redux": "7.2.2",
+    "react-rnd": "^10.3.4",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
     "react-router-hash-link": "^2.0.0",

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
@@ -1,4 +1,4 @@
-.odc-quick-search-bar {
+.ocs-quick-search-bar {
   &__input {
     height: 60px !important;
   }

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.tsx
@@ -26,12 +26,12 @@ const QuickSearchBar: React.FC<QuickSearchBarProps> = ({
   const { t } = useTranslation();
 
   return (
-    <InputGroup className="odc-quick-search-bar" data-test="quick-search-bar">
+    <InputGroup className="ocs-quick-search-bar" data-test="quick-search-bar">
       <InputGroupText>{icon || <QuickSearchIcon />}</InputGroupText>
       <TextInput
         type="search"
         aria-label={t('console-shared~Quick search bar')}
-        className="odc-quick-search-bar__input"
+        className="ocs-quick-search-bar__input"
         placeholder={searchPlaceholder}
         onChange={onSearch}
         autoFocus={autoFocus}

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.scss
@@ -1,4 +1,4 @@
-.odc-quick-search-content {
+.ocs-quick-search-content {
   flex: 1;
   overflow-y: hidden;
   &__list {

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.tsx
@@ -8,8 +8,6 @@ import QuickSearchList from './QuickSearchList';
 import './QuickSearchContent.scss';
 import { CatalogLinkData } from './utils/quick-search-types';
 
-const MAX_CATALOG_ITEMS_SHOWN = 5;
-
 interface QuickSearchContentProps {
   catalogItems: CatalogItem[];
   catalogItemTypes: CatalogType[];
@@ -17,11 +15,12 @@ interface QuickSearchContentProps {
   namespace: string;
   selectedItemId: string;
   selectedItem: CatalogItem;
+  limitItemCount?: number;
   onSelect: (itemId: string) => void;
   viewAll?: CatalogLinkData[];
   closeModal: () => void;
-  limitItemCount: number;
   detailsRenderer?: DetailsRendererFunction;
+  onListChange?: (items: number) => void;
 }
 
 const QuickSearchContent: React.FC<QuickSearchContentProps> = ({
@@ -36,17 +35,18 @@ const QuickSearchContent: React.FC<QuickSearchContentProps> = ({
   closeModal,
   limitItemCount,
   detailsRenderer,
+  onListChange,
 }) => {
   return (
-    <Split className="odc-quick-search-content">
+    <Split className="ocs-quick-search-content">
       <SplitItem
-        className={cx('odc-quick-search-content__list', {
-          'odc-quick-search-content__list--overflow':
-            catalogItems.length >= MAX_CATALOG_ITEMS_SHOWN,
+        className={cx('ocs-quick-search-content__list', {
+          'ocs-quick-search-content__list--overflow': catalogItems.length >= limitItemCount,
         })}
       >
         <QuickSearchList
-          listItems={limitItemCount > 0 ? catalogItems.slice(0, limitItemCount) : catalogItems}
+          listItems={catalogItems}
+          limitItemCount={limitItemCount}
           catalogItemTypes={catalogItemTypes}
           viewAll={viewAll}
           selectedItemId={selectedItemId}
@@ -54,10 +54,11 @@ const QuickSearchContent: React.FC<QuickSearchContentProps> = ({
           namespace={namespace}
           onSelectListItem={onSelect}
           closeModal={closeModal}
+          onListChange={onListChange}
         />
       </SplitItem>
       <Divider component="div" isVertical />
-      <SplitItem className="odc-quick-search-content__details">
+      <SplitItem className="ocs-quick-search-content__details">
         <QuickSearchDetails
           detailsRenderer={detailsRenderer}
           selectedItem={selectedItem}

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchController.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchController.tsx
@@ -13,7 +13,7 @@ type QuickSearchControllerProps = {
   allItemsLoaded: boolean;
   isOpen: boolean;
   icon?: React.ReactNode;
-  limitItemCount: number;
+  limitItemCount?: number;
   disableKeyboardOpen?: boolean;
   setIsOpen: (isOpen: boolean) => void;
   detailsRenderer?: DetailsRendererFunction;

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchDetails.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchDetails.scss
@@ -1,4 +1,4 @@
-.odc-quick-search-details {
+.ocs-quick-search-details {
   display: flex;
   flex-direction: column;
   padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--md) 0px
@@ -22,13 +22,13 @@
   }
 }
 
-.odc-quick-search-details::-webkit-scrollbar {
+.ocs-quick-search-details::-webkit-scrollbar {
   width: 12px;
 }
-.odc-quick-search-details::-webkit-scrollbar-thumb {
+.ocs-quick-search-details::-webkit-scrollbar-thumb {
   background: var(--pf-global--BackgroundColor--light-300);
   border-radius: 10px;
 }
-.odc-quick-search-details::-webkit-scrollbar-track {
+.ocs-quick-search-details::-webkit-scrollbar-track {
   background: var(--pf-global--palette--white);
 }

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchDetails.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchDetails.tsx
@@ -30,7 +30,7 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({
       <>
         <Title headingLevel="h4">{props.selectedItem.name}</Title>
         {props.selectedItem.provider && (
-          <span className="odc-quick-search-details__provider">
+          <span className="ocs-quick-search-details__provider">
             {t('console-shared~Provided by {{provider}}', {
               provider: props.selectedItem.provider,
             })}
@@ -38,14 +38,14 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({
         )}
         <Button
           variant={ButtonVariant.primary}
-          className="odc-quick-search-details__form-button"
+          className="ocs-quick-search-details__form-button"
           onClick={(e) => {
             handleCta(e, props.selectedItem, props.closeModal, fireTelemetryEvent);
           }}
         >
           {props.selectedItem.cta.label}
         </Button>
-        <TextContent className="odc-quick-search-details__description">
+        <TextContent className="ocs-quick-search-details__description">
           {props.selectedItem.description}
         </TextContent>
       </>
@@ -54,7 +54,7 @@ const QuickSearchDetails: React.FC<QuickSearchDetailsProps> = ({
   const detailsContentRenderer: DetailsRendererFunction = detailsRenderer ?? defaultContentRenderer;
 
   return (
-    <div className="odc-quick-search-details">
+    <div className="ocs-quick-search-details">
       {detailsContentRenderer({ selectedItem, closeModal })}
     </div>
   );

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
@@ -1,4 +1,4 @@
-.odc-quick-search-list {
+.ocs-quick-search-list {
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -14,7 +14,7 @@
     border-bottom: var(--pf-c-data-list__item--sm--BorderBottomWidth) solid
       var(--pf-c-data-list__item--sm--BorderBottomColor) !important;
     &:last-of-type {
-      .odc-quick-search-content__list--overflow & {
+      .ocs-quick-search-content__list--overflow & {
         border-bottom: 0 !important;
       }
     }

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.scss
@@ -1,0 +1,4 @@
+.ocs-quick-search-modal {
+  --pf-c-modal-box--BackgroundColor: none !important;
+  --pf-c-modal-box--BoxShadow: none !important;
+}

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
+import { useBoundingClientRect } from '../../hooks';
 import { DetailsRendererFunction } from './QuickSearchDetails';
 import QuickSearchModalBody from './QuickSearchModalBody';
 import { QuickSearchData } from './utils/quick-search-types';
+import './QuickSearchModal.scss';
 
 interface QuickSearchModalProps {
   isOpen: boolean;
@@ -13,7 +15,7 @@ interface QuickSearchModalProps {
   searchCatalog: (searchTerm: string) => QuickSearchData;
   searchPlaceholder: string;
   viewContainer?: HTMLElement;
-  limitItemCount: number;
+  limitItemCount?: number;
   icon?: React.ReactNode;
   detailsRenderer?: DetailsRendererFunction;
 }
@@ -31,9 +33,13 @@ const QuickSearchModal: React.FC<QuickSearchModalProps> = ({
   detailsRenderer,
 }) => {
   const { t } = useTranslation();
+  const clientRect = useBoundingClientRect(viewContainer);
+  const maxHeight = clientRect?.height;
+  const maxWidth = clientRect?.width;
 
   return viewContainer ? (
     <Modal
+      className="ocs-quick-search-modal"
       variant={ModalVariant.medium}
       aria-label={t('console-shared~Quick search')}
       isOpen={isOpen}
@@ -52,6 +58,8 @@ const QuickSearchModal: React.FC<QuickSearchModalProps> = ({
         limitItemCount={limitItemCount}
         icon={icon}
         detailsRenderer={detailsRenderer}
+        maxDimension={{ maxHeight, maxWidth }}
+        viewContainer={viewContainer}
       />
     </Modal>
   ) : null;

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.scss
@@ -1,5 +1,6 @@
-.odc-quick-search-modal-body {
+.ocs-quick-search-modal-body {
   display: flex;
   flex-direction: column;
-  min-height: 60px;
+  background: var(--pf-global--BackgroundColor--100);
+  box-shadow: var(--pf-c-modal-box--BoxShadow);
 }

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { ResizeDirection } from 're-resizable';
+import { Rnd } from 'react-rnd';
 import { CatalogType } from '@console/dev-console/src/components/catalog/utils/types';
 import { CatalogItem } from '@console/dynamic-plugin-sdk';
 import {
@@ -22,9 +24,11 @@ interface QuickSearchModalBodyProps {
   searchPlaceholder: string;
   namespace: string;
   closeModal: () => void;
-  limitItemCount: number;
+  limitItemCount?: number;
   icon?: React.ReactNode;
   detailsRenderer?: DetailsRendererFunction;
+  maxDimension?: { maxHeight: number; maxWidth: number };
+  viewContainer?: HTMLElement; // pass the html container element to specify the movement boundary
 }
 
 const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
@@ -36,19 +40,69 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   allCatalogItemsLoaded,
   icon,
   detailsRenderer,
+  maxDimension,
+  viewContainer,
 }) => {
+  const DEFAULT_HEIGHT_WITH_NO_ITEMS = 60;
+  const DEFAULT_HEIGHT_WITH_ITEMS = 400;
+  const MIN_HEIGHT = 240;
+  const MIN_WIDTH = 225;
   const [catalogItems, setCatalogItems] = React.useState<CatalogItem[]>(null);
   const [catalogTypes, setCatalogTypes] = React.useState<CatalogType[]>([]);
+  const [isRndActive, setIsRndActive] = React.useState(false);
+  const [maxHeight, setMaxHeight] = React.useState(DEFAULT_HEIGHT_WITH_NO_ITEMS);
+  const [minHeight, setMinHeight] = React.useState(DEFAULT_HEIGHT_WITH_NO_ITEMS);
+  const [minWidth, setMinWidth] = React.useState(MIN_WIDTH);
   const [searchTerm, setSearchTerm] = React.useState<string>(
     getQueryArgument('catalogSearch') || '',
   );
   const [selectedItemId, setSelectedItemId] = React.useState<string>('');
   const [selectedItem, setSelectedItem] = React.useState<CatalogItem>(null);
   const [viewAll, setViewAll] = React.useState<CatalogLinkData[]>(null);
-  const listCatalogItems =
-    limitItemCount > 0 ? catalogItems?.slice(0, limitItemCount) : catalogItems;
-  const ref = React.useRef<HTMLDivElement>(null);
+  const [items, setItems] = React.useState<number>(limitItemCount);
+  const [modalSize, setModalSize] = React.useState<{ height: number; width: number }>();
+  const [draggableBoundary, setDraggableBoundary] = React.useState<string>(null);
+  const ref = React.useRef<HTMLDivElement>();
   const fireTelemetryEvent = useTelemetry();
+  const listCatalogItems = limitItemCount > 0 ? catalogItems?.slice(0, items) : catalogItems;
+
+  const getModalHeight = () => {
+    let height: number = DEFAULT_HEIGHT_WITH_NO_ITEMS;
+    if (catalogItems?.length > 0) {
+      if (modalSize?.height >= minHeight) {
+        return modalSize?.height;
+      }
+      setModalSize({ ...modalSize, height: DEFAULT_HEIGHT_WITH_ITEMS });
+      height = DEFAULT_HEIGHT_WITH_ITEMS;
+    }
+    return height;
+  };
+
+  React.useEffect(() => {
+    if (viewContainer) {
+      const className = viewContainer.classList;
+      setDraggableBoundary(`.${className[0]}`);
+    }
+  }, [viewContainer]);
+
+  React.useEffect(() => {
+    if (catalogItems === null || catalogItems?.length === 0) {
+      setMaxHeight(DEFAULT_HEIGHT_WITH_NO_ITEMS);
+      setMinHeight(DEFAULT_HEIGHT_WITH_NO_ITEMS);
+      setMinWidth(MIN_WIDTH);
+    } else if (catalogItems?.length > 0) {
+      setMaxHeight(maxDimension?.maxHeight || undefined);
+      setMinHeight(MIN_HEIGHT);
+      setMinWidth(MIN_WIDTH);
+    }
+  }, [catalogItems, maxDimension]);
+
+  React.useEffect(() => {
+    if (ref.current) {
+      const { width, height } = ref.current.getBoundingClientRect();
+      setModalSize({ width, height });
+    }
+  }, []);
 
   React.useEffect(() => {
     if (searchTerm) {
@@ -66,6 +120,22 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
       setSelectedItem(catalogItems[0]);
     }
   }, [catalogItems, selectedItemId]);
+
+  const handleDrag = () => {
+    setIsRndActive(true);
+  };
+
+  const handleResize = (e: MouseEvent, direction: ResizeDirection, elementRef: HTMLElement) => {
+    setIsRndActive(true);
+    setModalSize({
+      height: elementRef.offsetHeight,
+      width: elementRef.offsetWidth,
+    });
+  };
+
+  const handleResizeStop = () => {
+    setTimeout(() => setIsRndActive(false), 0);
+  };
 
   const onSearch = React.useCallback(
     (value: string) => {
@@ -127,6 +197,10 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
     setSelectedItem(listCatalogItems?.[index + 1]);
   }, [listCatalogItems, getIndexOfSelectedItem]);
 
+  const handleListChange = (i: number) => {
+    setItems(i);
+  };
+
   React.useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       switch (e.code) {
@@ -153,7 +227,8 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
     };
 
     const onOutsideClick = (e: MouseEvent) => {
-      if (!ref.current?.contains(e.target as Node)) {
+      const modalBody = ref.current.parentElement;
+      if (!modalBody?.contains(e.target as Node) && !isRndActive) {
         closeModal();
       }
     };
@@ -165,47 +240,73 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
       document.removeEventListener('click', onOutsideClick);
       document.removeEventListener('keydown', onKeyDown);
     };
-  }, [closeModal, onCancel, onEnter, selectNext, selectPrevious]);
-
-  const getModalHeight = () => {
-    let height: number = 60;
-    const itemsHeight = viewAll?.length ? 388 : 365;
-    if (catalogItems?.length > 0) {
-      height += itemsHeight + (viewAll?.length - 1) * 23;
-    }
-    return height;
-  };
+  }, [closeModal, onCancel, onEnter, selectNext, selectPrevious, isRndActive]);
 
   return (
-    <div ref={ref} className="odc-quick-search-modal-body" style={{ height: getModalHeight() }}>
-      <QuickSearchBar
-        searchTerm={searchTerm}
-        searchPlaceholder={searchPlaceholder}
-        onSearch={onSearch}
-        showNoResults={catalogItems?.length === 0}
-        itemsLoaded={allCatalogItemsLoaded}
-        icon={icon}
-        autoFocus
-      />
-      {catalogItems && selectedItem && (
-        <QuickSearchContent
-          catalogItems={catalogItems}
-          catalogItemTypes={catalogTypes}
-          viewAll={viewAll}
+    <Rnd
+      style={{ position: 'relative' }}
+      size={{ height: modalSize?.height, width: modalSize?.width }}
+      onDrag={handleDrag}
+      onDragStop={handleResizeStop}
+      onResize={handleResize}
+      maxHeight={maxHeight}
+      maxWidth={maxDimension?.maxWidth || undefined}
+      minHeight={minHeight}
+      minWidth={minWidth}
+      bounds={draggableBoundary}
+      onResizeStop={handleResizeStop}
+      enableResizing={
+        catalogItems === null || catalogItems?.length === 0
+          ? {
+              bottom: false,
+              bottomLeft: false,
+              bottomRight: false,
+              left: true,
+              right: true,
+              top: false,
+              topLeft: false,
+              topRight: false,
+            }
+          : true
+      }
+    >
+      <div
+        ref={ref}
+        className="ocs-quick-search-modal-body"
+        style={{
+          height: getModalHeight(),
+        }}
+      >
+        <QuickSearchBar
           searchTerm={searchTerm}
-          selectedItemId={selectedItemId}
-          closeModal={closeModal}
-          selectedItem={selectedItem}
-          namespace={namespace}
-          limitItemCount={limitItemCount}
-          detailsRenderer={detailsRenderer}
-          onSelect={(itemId) => {
-            setSelectedItemId(itemId);
-            setSelectedItem(catalogItems?.find((item) => item.uid === itemId));
-          }}
+          searchPlaceholder={searchPlaceholder}
+          onSearch={onSearch}
+          showNoResults={catalogItems?.length === 0}
+          itemsLoaded={allCatalogItemsLoaded}
+          icon={icon}
+          autoFocus
         />
-      )}
-    </div>
+        {catalogItems && selectedItem && (
+          <QuickSearchContent
+            catalogItems={catalogItems}
+            catalogItemTypes={catalogTypes}
+            viewAll={viewAll}
+            searchTerm={searchTerm}
+            selectedItemId={selectedItemId}
+            closeModal={closeModal}
+            selectedItem={selectedItem}
+            namespace={namespace}
+            limitItemCount={limitItemCount}
+            detailsRenderer={detailsRenderer}
+            onListChange={handleListChange}
+            onSelect={(itemId) => {
+              setSelectedItemId(itemId);
+              setSelectedItem(catalogItems?.find((item) => item.uid === itemId));
+            }}
+          />
+        )}
+      </div>
+    </Rnd>
   );
 };
 

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
@@ -58,8 +58,8 @@ export const pipelineBuilderPage = {
       .type(pipelineName);
   },
   AddTask: (taskName: string = 'kn') => {
-    cy.get('input.odc-quick-search-bar__input').type(taskName);
-    cy.get('button.odc-quick-search-details__form-button').click();
+    cy.get('input.ocs-quick-search-bar__input').type(taskName);
+    cy.get('button.ocs-quick-search-details__form-button').click();
   },
   selectTask: (taskName: string = 'kn') => {
     cy.get('body').then(($body) => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -64,7 +64,6 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
   useExplicitPipelineTaskTouch();
 
   const statusRef = React.useRef(status);
-  const containerRef = React.useRef<HTMLDivElement>(null);
   const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
   const savedCallback = React.useRef(() => {});
 
@@ -143,10 +142,9 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
           </StackItem>
           <FlexForm onSubmit={handleSubmit}>
             <FormBody flexLayout disablePaneBody className="odc-pipeline-builder-form__grid">
-              <div ref={containerRef} />
               <PipelineQuickSearch
                 namespace={namespace}
-                viewContainer={containerRef.current}
+                viewContainer={contentRef.current}
                 isOpen={menuOpen}
                 callback={savedCallback.current}
                 setIsOpen={(open) => setMenuOpen(open)}

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearch.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PipelineQuickSearch.tsx
@@ -118,7 +118,6 @@ const Contents: React.FC<{
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       disableKeyboardOpen
-      limitItemCount={0}
       icon={<PlusCircleIcon width="1.5em" height="1.5em" />}
       detailsRenderer={(props) => <PipelineQuickSearchDetails {...props} />}
     />

--- a/frontend/packages/topology/src/components/quick-search/TopologyQuickSearch.tsx
+++ b/frontend/packages/topology/src/components/quick-search/TopologyQuickSearch.tsx
@@ -32,7 +32,7 @@ const Contents: React.FC<{
 }) => {
   const { t } = useTranslation();
 
-  const LIMIT_ITEM_COUNT = 5;
+  const DEFAULT_LIMIT_ITEM_COUNT = 5;
   const quickStartItems = useTransformedQuickStarts(quickStarts);
   const quickSearchProviders: QuickSearchProviders = [
     {
@@ -71,7 +71,7 @@ const Contents: React.FC<{
       namespace={namespace}
       viewContainer={viewContainer}
       isOpen={isOpen}
-      limitItemCount={LIMIT_ITEM_COUNT}
+      limitItemCount={DEFAULT_LIMIT_ITEM_COUNT}
       setIsOpen={setIsOpen}
     />
   );

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8388,6 +8388,11 @@ fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-memoize@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
 fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
@@ -15214,6 +15219,13 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+re-resizable@6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.0.tgz#9c3059b389ced6ade602234cc5bb1e12d231cd47"
+  integrity sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==
+  dependencies:
+    fast-memoize "^2.5.1"
+
 react-app-polyfill@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz#890f8d7f2842ce6073f030b117de9130a5f385f0"
@@ -15259,6 +15271,14 @@ react-dom@^17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.1"
+
+react-draggable@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
+  integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react-draggable@4.x:
   version "4.2.0"
@@ -15391,6 +15411,15 @@ react-refresh@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
   integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
+
+react-rnd@^10.3.4:
+  version "10.3.4"
+  resolved "https://registry.yarnpkg.com/react-rnd/-/react-rnd-10.3.4.tgz#1039ac93cb6a6f02f1246883c970b7c4481765d2"
+  integrity sha512-IVNEVB8+JD+QjBs2q7d4mRduj5ooG51UAS4FY15x8v3KhkpQ300ywRkgdIftcDKfkALYUjmaHZg3iCH2/WTaYQ==
+  dependencies:
+    re-resizable "6.9.0"
+    react-draggable "4.4.3"
+    tslib "2.2.0"
 
 react-router-dom@5.2.0:
   version "5.2.0"
@@ -18149,6 +18178,11 @@ tslib@1.13.0, tslib@^1.10.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslib@^1.11.1:
   version "1.14.1"


### PR DESCRIPTION
**JIRA issue:**
https://issues.redhat.com/browse/ODC-6144

**Solution description:**
- using React-rnd to add drag and resize capabilities to the quick search modal
- when there are no catalog items, the quick search bar can only be dragged along the x-axis
- the max height and width of the modal is the height and width of the container in which the modal is viewed
- the modal can be dragged only within the container in which it is viewed
- as the modal height is increased/decreased the number of listed items also changes accordingly. The min no. of items listed is kept as 5. So, if the size of the modal is decreased to its minimum then the scroll bar appears. The list increases as the modal size is increased. 

**GIF:**
![Peek 2021-08-11 21-43](https://user-images.githubusercontent.com/22490998/129067382-71c0fe52-5185-4127-970e-3a1f790b44db.gif)
