### PR TITLE
Add annotation to Web Terminals to enable Operator metrics

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -49,6 +49,7 @@ export const CLOUD_SHELL_LABEL = 'console.openshift.io/terminal';
 export const CLOUD_SHELL_CREATOR_LABEL = 'controller.devfile.io/creator';
 export const CLOUD_SHELL_RESTRICTED_ANNOTATION = 'controller.devfile.io/restricted-access';
 export const CLOUD_SHELL_STOPPED_BY_ANNOTATION = 'controller.devfile.io/stopped-by';
+export const CLOUD_SHELL_SOURCE_ANNOTATION = 'controller.devfile.io/devworkspace-source';
 export const CLOUD_SHELL_PROTECTED_NAMESPACE = 'openshift-terminal';
 
 export const createCloudShellResourceName = () => `terminal-${getRandomChars(6)}`;
@@ -98,6 +99,7 @@ export const newCloudShellWorkSpace = (
     },
     annotations: {
       [CLOUD_SHELL_RESTRICTED_ANNOTATION]: 'true',
+      [CLOUD_SHELL_SOURCE_ANNOTATION]: 'web-terminal',
     },
   },
   spec: {


### PR DESCRIPTION
### Description

PR https://github.com/devfile/devworkspace-operator/pull/500 in the DevWorkspace Operator (which supports Web Terminal/CloudShell functionality on the cluster) enables metrics for DevWorkspace custom resources. These metrics are bucketed according to the `controller.devfile.io/devworkspace-source` annotation, allowing the operator to report metrics such as startup time, failure rate, etc. partitioned based on the tool used to create the CR.

This PR adds the `controller.devfile.io/devworkspace-source` annotation to web terminals so that DevWorkspace Operator metrics can report Web Terminal-specific metrics.

Tests are not updated as the annotation is optional and does not impact end-user experience. Metrics are still reported without it, but may be less accurate due to other DevWorkspace CRs being included in the data.