### PR TITLE
Bug 1991252: [e2e][automation] add to modal cancel button data-test prop

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/disks/validate-storage-profile.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/disks/validate-storage-profile.ts
@@ -3,6 +3,7 @@ import { TEMPLATE_NAME } from '../../const/index';
 import { ProvisionSource } from '../../enums/provisionSource';
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
+import { tab } from '../../view/tab';
 import { virtualization } from '../../view/virtualization';
 import { vm } from '../../view/vm';
 
@@ -120,10 +121,10 @@ describe('ID(CNV-6923) Verify storageProfile with a fake storageClass', () => {
   });
 
   it('ID(CNV-6922) Verify storageProfile in add disk modal', () => {
-    cy.byLegacyTestID('horizontal-link-Disks').click();
+    tab.navigateToDisk();
     cy.byTestID('item-create').click();
     cy.validateSPSettings();
-    cy.byLegacyTestID('modal-cancel-action').click();
+    cy.byTestID('modal-cancel-action').click();
   });
   it('ID(CNV-6921) Verify storageProfile in template add boot source modal', () => {
     virtualization.templates.visit();
@@ -133,7 +134,7 @@ describe('ID(CNV-6923) Verify storageProfile with a fake storageClass', () => {
       .click();
     cy.contains('Advanced Storage settings').click();
     cy.validateSPSettings();
-    cy.byLegacyTestID('modal-cancel-action').click();
+    cy.byTestID('modal-cancel-action').click();
   });
   it('ID(CNV-6920) Verify storageProfile in upload PVC form', () => {
     cy.visit(`/k8s/ns/${testName}/persistentvolumeclaims`);

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-support.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-support.spec.ts
@@ -60,7 +60,7 @@ describe('test VM template support', () => {
       virtualization.templates.clickCreate('CentOS 7.0+ VM');
       cy.get('.ReactModal__Overlay').within(() => {
         cy.get('a').should('have.attr', 'href', 'https://www.centos.org');
-        cy.byLegacyTestID('modal-cancel-action').click();
+        cy.byTestID('modal-cancel-action').click();
       });
     });
 
@@ -83,7 +83,7 @@ describe('test VM template support', () => {
       virtualization.templates.clickCreate(TEMPLATE_NAME);
       cy.get('.ReactModal__Overlay').within(() => {
         cy.get('a').should('have.attr', 'href', 'https://www.centos.org');
-        cy.byLegacyTestID('modal-cancel-action').click();
+        cy.byTestID('modal-cancel-action').click();
       });
     });
 

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/view/clone.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/view/clone.ts
@@ -4,4 +4,4 @@ export const startOnClone = 'input[id="clone-dialog-vm-start"]';
 export const alertTitle = '.pf-c-alert__title';
 export const helpText = '.pf-c-form__helper-text.pf-m-error';
 export const confirmCloneButton = 'button[id="confirm-action"]';
-export const cancel = 'button[data-test-id="modal-cancel-action"]';
+export const cancel = 'button[data-test="modal-cancel-action"]';

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/view/selector.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/view/selector.ts
@@ -20,7 +20,7 @@ export enum detailsTab {
 export enum actionButtons {
   actionDropdownButton = 'actions-menu-button',
   confirmButton = '[data-test="confirm-action"]',
-  cancelButton = '[data-test-id="modal-cancel-action"]',
+  cancelButton = '[data-test="modal-cancel-action"]',
   confirmCloneButton = 'button[id="confirm-action"]',
   kebabButton = 'kebab-button',
 }
@@ -28,7 +28,7 @@ export enum actionButtons {
 // modal
 export const modalTitle = '[data-test-id="modal-title"]';
 export const modalConfirm = '[data-test="confirm-action"]';
-export const modalCancel = '[data-test-id="modal-cancel-action"]';
+export const modalCancel = '[data-test="modal-cancel-action"]';
 export const startOnClone = 'input[id="clone-dialog-vm-start"]';
 
 // alert

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/view/snapshot.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/view/snapshot.ts
@@ -1,12 +1,12 @@
 export const takeSnapshotBtn = 'button[id="add-snapshot"]';
 export const saveBtn = 'button[data-test="confirm-action"]';
-export const cancelBtn = 'button=[data-test-id="modal-cancel-action"]';
+export const cancelBtn = 'button=[data-test="modal-cancel-action"]';
 export const snapshotName = 'input[id="snapshot-name"]';
 export const approveCheckbox = 'input[id="approve-checkbox"]';
 export const kebabBtn = 'button[data-test-id="kebab-button"]';
 export const deleteBtn = 'button[data-test-action="Delete VirtualMachineSnapshot"]';
 export const modalConfirmBtn = 'button[data-test="confirm-action"]';
-export const modalCancelBtn = 'button[data-test-id="modal-cancel-action"]';
+export const modalCancelBtn = 'button[data-test="modal-cancel-action"]';
 
 export const snapshotRow = (name: string) => `[data-test-id="${name}]"`;
 export const status = (name: string) => `td[id="${name}-snapshot-status"]`;

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.action.migration.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.action.migration.scenario.ts
@@ -57,7 +57,7 @@ describe('Test VM Migration', () => {
         await click(confirmButton);
         await browser.wait(until.presenceOf(errorAlert), PAGE_LOAD_TIMEOUT_SECS);
         expect(await errorAlert.getText()).toContain('all PVCs must be shared');
-        const cancelButton = $('[data-test-id="modal-cancel-action"]');
+        const cancelButton = $('[data-test="modal-cancel-action"]');
         click(cancelButton);
       }
     },

--- a/frontend/packages/kubevirt-plugin/src/components/modals/add-template-source/add-template-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/add-template-source/add-template-source.tsx
@@ -292,6 +292,7 @@ export const AddTemplateSourceModal: React.FC<ModalComponentProps &
               variant="secondary"
               data-test-id="modal-cancel-action"
               onClick={cancel}
+              data-test="modal-cancel-action"
             >
               {t('kubevirt-plugin~Close')}
             </Button>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
@@ -9,7 +9,6 @@ import {
 } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-
 import './modal-footer.scss';
 
 type ModalErrorMessageProps = {
@@ -111,6 +110,7 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
             variant={ButtonVariant.secondary}
             data-test-id="modal-cancel-action"
             onClick={onCancel}
+            data-test="modal-cancel-action"
           >
             {cancelButtonText || t('kubevirt-plugin~Cancel')}
           </Button>


### PR DESCRIPTION
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1991252

Solution Description:
adding `data-test` prop to cancel button on modal footer and using `byTestID` function instead of `byLegacyTestID`

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>