### PR TITLE
Bug 1989610: Don't render incompatible descriptors on operand details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/common.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/common.tsx
@@ -20,6 +20,7 @@ export const Invalid: React.FC<{ path: string }> = ({ path }) => {
 
 export const DefaultCapability: React.FC<CommonCapabilityProps> = ({
   description,
+  descriptor,
   label,
   obj,
   fullPath,
@@ -31,10 +32,15 @@ export const DefaultCapability: React.FC<CommonCapabilityProps> = ({
       return <span className="text-muted">{t('public~None')}</span>;
     }
     if (_.isObject(value) || _.isArray(value)) {
-      return <span className="text-muted">{t('public~Unsupported')}</span>;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[Invalid descriptor] descriptor is incompatible with property ${descriptor.path} and will have no effect`,
+        descriptor,
+      );
+      return null;
     }
     return _.toString(value);
-  }, [t, value]);
+  }, [descriptor, t, value]);
 
   return (
     <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
@@ -61,11 +67,17 @@ export const K8sResourceLinkCapability: React.FC<CommonCapabilityProps> = ({
     const [, suffix] = capability.match(REGEXP_K8S_RESOURCE_SUFFIX) ?? [];
     const gvk = suffix?.replace(/:/g, '~');
     if (!_.isString(value)) {
-      return <Invalid path={descriptor.path} />;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[Invalid descriptor] descriptor is incompatible with property ${descriptor.path} and will have no effect`,
+        descriptor,
+      );
+
+      return null;
     }
 
     return <ResourceLink kind={gvk} name={value} namespace={obj.metadata.namespace} />;
-  }, [value, capability, obj.metadata.namespace, t, descriptor.path]);
+  }, [value, capability, obj.metadata.namespace, t, descriptor]);
   return (
     <DetailsItem description={description} label={label} obj={obj} path={fullPath}>
       {detail}

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1760,7 +1760,6 @@
   "Add allowed destination": "Add allowed destination",
   "Remove peer": "Remove peer",
   "Loading {{title}} status": "Loading {{title}} status",
-  "Unsupported": "Unsupported",
   "Disable": "Disable",
   "default": "default",
   "OK": "OK",


### PR DESCRIPTION
If a descriptor is defined on a property with an incompatible data type, omit it from the details page and log a warning in the browser console instead.