### PR TITLE
Bug 2000636: reload entered data if any when switching strategies

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -185,6 +185,7 @@
   "Post Lifecycle Hook": "Post Lifecycle Hook",
   "Post hooks execute after the deployment strategy completes.": "Post hooks execute after the deployment strategy completes.",
   "Container name": "Container name",
+  "Select container name": "Select container name",
   "Add another argument": "Add another argument",
   "Enter the command to run inside the container. The command is considered sucessful if its exit code is 0. Drag and drop to reorder arguments.": "Enter the command to run inside the container. The command is considered sucessful if its exit code is 0. Drag and drop to reorder arguments.",
   "Environment variables (runtime only)": "Environment variables (runtime only)",

--- a/frontend/packages/dev-console/src/components/edit-deployment/deployment-strategy/DeploymentStrategySection.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/deployment-strategy/DeploymentStrategySection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { FormikValues, useFormikContext } from 'formik';
-import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { DropdownField } from '@console/shared/src';
@@ -31,7 +30,7 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
       formData: {
         name: resName,
         project: { name: resNamespace },
-        deploymentStrategy: { type },
+        deploymentStrategy,
       },
     },
     initialValues,
@@ -39,7 +38,7 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
   } = useFormikContext<FormikValues>();
 
   const deploymentStrategyFields = React.useMemo(() => {
-    switch (type) {
+    switch (deploymentStrategy.type) {
       case DeploymentStrategyType.recreateParams:
         return <RecreateStrategy resourceType={resourceType} resourceObj={resourceObj} />;
       case DeploymentStrategyType.rollingParams:
@@ -50,20 +49,15 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
       default:
         return null;
     }
-  }, [type, resourceObj, resourceType]);
+  }, [deploymentStrategy.type, resourceObj, resourceType]);
 
   const onChange = React.useCallback(
     (value: DeploymentStrategyType) => {
       const strategyDefaultValues = getStrategyData(value, {}, resName, resNamespace, resourceType);
       const strategyData = {
-        ..._.omit(resourceObj.spec?.strategy, [
-          'rollingParams',
-          'recreateParams',
-          'customParams',
-          'rollingUpdate',
-        ]),
-        type: value,
         ...strategyDefaultValues,
+        ...deploymentStrategy,
+        type: value,
       };
       initialValues.formData.deploymentStrategy = strategyData;
       setFieldValue('formData.deploymentStrategy', strategyData);
@@ -72,9 +66,9 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
       initialValues.formData.deploymentStrategy,
       resName,
       resNamespace,
-      resourceObj.spec,
       resourceType,
       setFieldValue,
+      deploymentStrategy,
     ],
   );
 
@@ -84,7 +78,7 @@ const DeploymentStrategySection: React.FC<DeploymentStrategySectionProps> = ({
         name="formData.deploymentStrategy.type"
         label={t('devconsole~Strategy type')}
         items={getDeploymentStrategyItems(resourceType, t)}
-        helpText={getDeploymentStrategyHelpText(resourceType, type, t)}
+        helpText={getDeploymentStrategyHelpText(resourceType, deploymentStrategy.type, t)}
         onChange={onChange}
         fullWidth
       />

--- a/frontend/packages/dev-console/src/components/edit-deployment/deployment-strategy/advanced-options/ExecNewPodForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/deployment-strategy/advanced-options/ExecNewPodForm.tsx
@@ -29,6 +29,7 @@ const ExecNewPodForm: React.FC<ExecNewPodFormProps> = ({
       <DropdownField
         name={`formData.deploymentStrategy.${dataAttribute}.${lifecycleHook}.lch.execNewPod.containerName`}
         label={t('devconsole~Container name')}
+        title={t('devconsole~Select container name')}
         items={getContainerNames(containers)}
         fullWidth
         required

--- a/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-utils.ts
@@ -360,6 +360,7 @@ export const getUpdatedStrategy = (strategy: DeploymentStrategy, resourceType: s
     'recreateParams',
     'customParams',
     'imageStreamData',
+    'rollingUpdate',
   ]);
   switch (type) {
     case DeploymentStrategyType.recreateParams: {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6215

**Root analysis:**
On changing the strategy type, the default values for that type are being set to the formik context as a result when the user switches back to the previously selected type, the entered values / existing values for the type are not persisted.

**Solution description:**
Using the deploymentStrategy values of the formik context along with the default values for strategy type so that on switching strategies the user can see the last entered values for that strategy(if exists).

**GIF:**
![deployment-strategy-type](https://user-images.githubusercontent.com/22490998/128729690-c3a71277-b696-4985-83c3-0a7b08209a97.gif)
