### PR TITLE
Bug 1992502: Return loadError from use storage profile

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/hooks/use-storage-profile-settings.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-storage-profile-settings.ts
@@ -7,7 +7,7 @@ import { StorageProfile } from '../types';
 
 export const useStorageProfileSettings = (
   scName: string,
-): [AccessMode, VolumeMode, boolean, boolean] => {
+): [AccessMode, VolumeMode, boolean, boolean, boolean] => {
   const spWatchResource = React.useMemo(() => {
     return {
       kind: kubevirtReferenceForModel(StorageProfileModel),
@@ -19,16 +19,12 @@ export const useStorageProfileSettings = (
 
   const [sp, spLoaded, loadError] = useK8sWatchResource<StorageProfile>(spWatchResource);
 
-  if (loadError) {
-    return null;
-  }
-
   if (!sp?.status?.claimPropertySets && spLoaded) {
-    return [AccessMode.READ_WRITE_ONCE, VolumeMode.FILESYSTEM, spLoaded, false];
+    return [AccessMode.READ_WRITE_ONCE, VolumeMode.FILESYSTEM, spLoaded, false, loadError];
   }
 
   const accessMode = AccessMode.fromString(sp?.status?.claimPropertySets?.[0].accessModes?.[0]);
   const volumeMode = VolumeMode.fromString(sp?.status?.claimPropertySets?.[0].volumeMode);
 
-  return [accessMode, volumeMode, spLoaded, true];
+  return [accessMode, volumeMode, spLoaded, true, loadError];
 };


### PR DESCRIPTION
Problem:
Currently no error indicator is sent from `useStorageProfileSettings` when `StorageProfile` can't be loaded.

Screenshots:
Before:
![screencast-localhost_9000-2021 08 11-10_08_49](https://user-images.githubusercontent.com/2181522/128999484-fc7a80ce-2d89-4bae-bdf3-32b3fc0cf90a.gif)

After:
![screenshot-localhost_9000-2021 08 11-11_57_19](https://user-images.githubusercontent.com/2181522/129000572-38072ea3-b21c-4674-8a9b-6a888c5b4241.png)
