### PR TITLE
Bug 1978202: Use list of supported templates instead of logic

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateCommnunityLabel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateCommnunityLabel.tsx
@@ -2,12 +2,25 @@ import * as React from 'react';
 import { Label, Tooltip } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { TemplateKind } from '@console/internal/module/k8s';
-import { getTemplateProvider, getTemplateSupport } from '../../selectors/vm-template/basic';
+import { getName } from '@console/shared/src';
+import { getTemplateProvider } from '../../selectors/vm-template/basic';
 
 type VMTemplateLabelProps = {
   template: TemplateKind;
   className?: string;
 };
+
+// Documentation on what OS are supported (e.g. not comunity)
+// https://access.redhat.com/articles/973163#ocpvirt
+const supportedTemplates = [
+  'rhel6',
+  'rhel7',
+  'rhel8',
+  'windows2k12r2',
+  'windows2k16',
+  'windows2k19',
+  'windows10',
+];
 
 export const VMTemplateCommnunityLabel: React.FC<VMTemplateLabelProps> = ({
   template,
@@ -15,9 +28,11 @@ export const VMTemplateCommnunityLabel: React.FC<VMTemplateLabelProps> = ({
 }) => {
   const { t } = useTranslation();
   const provider = getTemplateProvider(t, template);
-  const templateSupport = getTemplateSupport(template);
-  const isCommunity =
-    !['red hat', 'redhat'].includes(provider.toLowerCase()) && templateSupport.provider !== 'Full';
+  const templateOSName = getName(template).split('-')?.[0];
+  const isCommunity = !(
+    ['red hat', 'redhat'].includes(provider.toLowerCase()) &&
+    supportedTemplates.includes(templateOSName)
+  );
 
   if (!isCommunity) {
     return null;


### PR DESCRIPTION
Use a list [1] of supported OS's , instead of using template anotations (they may be missing or wrong)

[1] https://access.redhat.com/articles/973163#ocpvirt

Screenshots:
Before:
![screenshot-localhost_9000-2021 08 11-13_01_08](https://user-images.githubusercontent.com/2181522/129010231-f33683a3-eacf-4bfe-84e7-a22b97e5705e.png)

After:
![screenshot-localhost_9000-2021 08 11-12_52_21](https://user-images.githubusercontent.com/2181522/129010017-8276b36d-8ab3-4700-87f3-e04a6e53f032.png)
