### PR TITLE
Bug 1992820: Move event sources add option to serverless add group

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -21,7 +21,7 @@
     "properties": {
       "id": "container-images",
       "name": "%devconsole~Container images%",
-      "insertBefore": "serverless",
+      "insertBefore": "eventing",
       "insertAfter": "git-repository"
     }
   },
@@ -31,7 +31,7 @@
       "id": "local-machine",
       "name": "%devconsole~From Local Machine%",
       "insertBefore": "pipelines",
-      "insertAfter": "serverless"
+      "insertAfter": "eventing"
     }
   },
   {

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -121,8 +121,8 @@ export const verifyAddPage = {
       case 'Samples':
         cy.byTestID('card samples').should('be.visible');
         break;
-      case 'Serverless':
-        cy.byTestID('card serverless').should('be.visible');
+      case 'Eventing':
+        cy.byTestID('card eventing').should('be.visible');
         break;
       case 'Channel':
         cy.byTestID('item knative-eventing-channel').should('be.visible');

--- a/frontend/packages/dev-console/src/components/add/__tests__/add-page-test-data.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/add-page-test-data.tsx
@@ -187,7 +187,7 @@ const channel: AddActionExtension = {
   properties: {
     description:
       'Create a Knative Channel to create an event forwarding and persistence layer with in-memory and reliable implementations',
-    groupId: 'serverless',
+    groupId: 'eventing',
     href: '/channel/ns/:namespace',
     icon: 'static/assets/channel.svg',
     id: 'knative-eventing-channel',
@@ -320,7 +320,7 @@ const containerImagesActionGroup: AddActionGroupExtension = {
   properties: {
     id: 'container-images',
     name: 'Container images',
-    insertBefore: 'serverless',
+    insertBefore: 'eventing',
     insertAfter: 'git-repository',
   },
   type: 'dev-console.add/action-group',
@@ -335,19 +335,19 @@ const localMachine: AddActionGroupExtension = {
     id: 'local-machine',
     name: 'From Local Machine',
     insertBefore: 'pipelines',
-    insertAfter: 'serverless',
+    insertAfter: 'eventing',
   },
   type: 'dev-console.add/action-group',
   uid: '@console/dev-console[36]',
 };
 
-const serverless: AddActionGroupExtension = {
+const eventing: AddActionGroupExtension = {
   flags: { required: [], disallowed: [] },
   pluginID: '@console/knative-plugin',
   pluginName: '@console/knative-plugin',
   properties: {
-    id: 'serverless',
-    name: 'Serverless',
+    id: 'eventing',
+    name: 'Eventing',
     insertBefore: 'local-machine',
     insertAfter: 'container-images',
   },
@@ -393,7 +393,7 @@ export const addActionGroup: AddActionGroup['properties'][] = [
   containerImagesActionGroup.properties,
   developerCatalog.properties,
   pipelinesActionGroup.properties,
-  serverless.properties,
+  eventing.properties,
   gitRepository.properties,
   localMachine.properties,
 ];
@@ -402,7 +402,7 @@ export const addActionGroupExtensions: AddActionGroupExtension[] = [
   containerImagesActionGroup,
   developerCatalog,
   pipelinesActionGroup,
-  serverless,
+  eventing,
   gitRepository,
   localMachine,
 ];

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -2,8 +2,8 @@
   {
     "type": "dev-console.add/action-group",
     "properties": {
-      "id": "serverless",
-      "name": "%knative-plugin~Serverless%",
+      "id": "eventing",
+      "name": "%knative-plugin~Eventing%",
       "insertBefore": "local-machine",
       "insertAfter": "container-images"
     }
@@ -15,7 +15,7 @@
     },
     "properties": {
       "id": "knative-event-source",
-      "groupId": "developer-catalog",
+      "groupId": "eventing",
       "href": "/catalog/ns/:namespace?catalogType=EventSource&provider=[\"Red+Hat\"]",
       "label": "%knative-plugin~Event Source%",
       "description": "%knative-plugin~Create an Event source to register interest in a class of events from a particular system%",
@@ -29,7 +29,7 @@
     },
     "properties": {
       "id": "knative-eventing-channel",
-      "groupId": "serverless",
+      "groupId": "eventing",
       "href": "/channel/ns/:namespace",
       "label": "%knative-plugin~Channel%",
       "description": "%knative-plugin~Create a Knative Channel to create an event forwarding and persistence layer with in-memory and reliable implementations%",
@@ -46,7 +46,7 @@
     },
     "properties": {
       "id": "knative-eventing-broker",
-      "groupId": "serverless",
+      "groupId": "eventing",
       "href": "/broker/ns/:namespace",
       "label": "%knative-plugin~Broker%",
       "description": "%knative-plugin~Create a Broker to define an event mesh for collecting a pool of events and route those events based on attributes, through triggers%",

--- a/frontend/packages/knative-plugin/integration-tests/features/eventing/eventing-broker-actions.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/eventing/eventing-broker-actions.feature
@@ -14,7 +14,7 @@ Feature: Perform actions on Broker
         @smoke @pre-condition @to-do @odc-5030
         Scenario: Create Broker using Form view: KE-05-TC01
             Given user is at Add page
-             When user selects on "Broker" from "Serverless" card
+             When user selects on "Broker" from "Eventing" card
               And user selects "Form view"
               And user enters broker name as "default-broker"
               And user clicks on Create button

--- a/frontend/packages/knative-plugin/integration-tests/features/eventing/eventing-create-sink-broker.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/eventing/eventing-create-sink-broker.feature
@@ -22,7 +22,7 @@ Feature: Knative Eventing Broker Support
         @regression @to-do @odc-5030
         Scenario: Create Broker using YAML view: KE-10-TC02
             Given user is at Add page
-             When user selects on "Broker" from "Serverless" card
+             When user selects on "Broker" from "Eventing" card
               And user selects "YAML view"
               And user clicks on Create button
              Then user will be redirected to Topology page

--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -1,5 +1,5 @@
 {
-  "Serverless": "Serverless",
+  "Eventing": "Eventing",
   "Event Source": "Event Source",
   "Create an Event source to register interest in a class of events from a particular system": "Create an Event source to register interest in a class of events from a particular system",
   "Channel": "Channel",
@@ -10,8 +10,8 @@
   "Event sources are objects that link to an event producer and an event sink or consumer. Cluster administrators can customize the content made available in the catalog.": "Event sources are objects that link to an event producer and an event sink or consumer. Cluster administrators can customize the content made available in the catalog.",
   "**Event sources** are objects that link to an event producer and an event sink or consumer.": "**Event sources** are objects that link to an event producer and an event sink or consumer.",
   "Provider": "Provider",
+  "Serverless": "Serverless",
   "Serving": "Serving",
-  "Eventing": "Eventing",
   "Create Service Binding": "Create Service Binding",
   "Add Subscription": "Add Subscription",
   "Add Trigger": "Add Trigger",


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-5928

**Problem/Statement:**
`Serverless` card has add options related only to `Eventing`, so the group title should be changed to `Eventing` since `Serverless` has a broader scope.
`Event sources` add option currently shows in `Catalog` add group but should be shown under `Eventing` (previously `Serverless`) add group.

**Solution/Description:**
rename `Serverless` add group to `Eventing`.
Move `Event sources` add option under `Eventing` (previously `Serverless`) add group.
update affected tests.

**Screens:**
![Screenshot from 2021-08-12 21-19-28](https://user-images.githubusercontent.com/38663217/129227772-b924bd55-e79e-4544-baa2-9c675f88c62b.png)

**Tests:**
updated integration tests.

**Browser Conformation:**
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge