### PR TITLE
Bug 1992714: use existing pvc hotplug crashes

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/delete-disk-modal/delete-disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/delete-disk-modal/delete-disk-modal.tsx
@@ -51,13 +51,9 @@ export const DeleteDiskModal = withHandlePromise((props: DeleteDiskModalProps) =
 
   const volumes = React.useMemo(() => [volume], [volume]);
 
-  const [ownedResources, isOwnedResourcesLoaded] = useOwnedVolumeReferencedResources(
-    vmLikeReference,
-    namespace,
-    volumes,
-  );
+  const [ownedResources] = useOwnedVolumeReferencedResources(vmLikeReference, namespace, volumes);
   const ownedResource = ownedResources?.length > 0 ? ownedResources[0] : null;
-  const isInProgress = inProgress || !isOwnedResourcesLoaded;
+  const isInProgress = inProgress;
 
   const diskName = disk?.name;
 

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
@@ -172,6 +172,8 @@ export class StorageUISource extends SelectDropdownObjectEnum<string> {
 
   isSizeEditingSupported = (size: number) => size === 0 || this !== StorageUISource.IMPORT_DISK; // if imported disk has 0 size, leave the user to decide
 
+  isAttachDisk = () => this === StorageUISource.ATTACH_DISK;
+
   hasDynamicSize = () => this === StorageUISource.CONTAINER_EPHEMERAL;
 
   canBeChangedToThisSource = (diskType: DiskType) => {


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1992714

**Analysis / Root cause**:
using DataVolume API when creating a hotplug for existing PVC instead of using PVC API

**Solution Description**:
replacing to the correct api body request

**Screen shots / Gifs for design review**:

before:

![pvc_bug_before](https://user-images.githubusercontent.com/67270715/129064392-4390c811-1def-4bdc-84c9-99ba49e30d7e.gif)

after:

![pvc_bug_after](https://user-images.githubusercontent.com/67270715/129064414-78e1ecbb-07e7-492e-b43e-ea2ab5e6db00.gif)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>