### PR TITLE
Bug 1992744: Incorrect spacing in ActionAlert component

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/common-ocs-install-el.tsx
@@ -149,12 +149,15 @@ export const ActionAlert: React.FC<ActionAlertProps> = ({
         title={title}
         isInline
         actionLinks={
-          <AlertActionLink onClick={() => goToStepById(actionLinkStep)}>
-            {actionLinkText}
-          </AlertActionLink>
+          actionLinkStep &&
+          actionLinkText && (
+            <AlertActionLink onClick={() => goToStepById(actionLinkStep)}>
+              {actionLinkText}
+            </AlertActionLink>
+          )
         }
       >
-        <p>{text}</p>
+        {text && <p>{text}</p>}
       </Alert>
     )}
   </WizardContextConsumer>


### PR DESCRIPTION
Removed extra spacing in ActionAlert component at the Capacity and Nodes
step.

![2021-08-18-001348_1038x545_scrot](https://user-images.githubusercontent.com/33557095/129783284-95cdd2c1-9b86-4bbd-88e3-1310e50884ce.png)
