### PR TITLE
Bug 1979562:  Cluster operators: don't show messages when neither progressing, degraded or unavailable

### DIFF
--- a/frontend/public/module/k8s/cluster-operator.ts
+++ b/frontend/public/module/k8s/cluster-operator.ts
@@ -28,7 +28,7 @@ export const getStatusAndMessage = (operator: ClusterOperator) => {
 
   const available: any = _.find(conditions, { type: 'Available', status: 'True' });
   if (available) {
-    return { status: OperatorStatus.Available, message: available.message };
+    return { status: OperatorStatus.Available, message: '' };
   }
 
   return { status: OperatorStatus.Unknown, message: '' };


### PR DESCRIPTION
/assign @spadgett 

### Before:

![Screen Shot 2021-08-11 at 12 58 39 PM](https://user-images.githubusercontent.com/15249132/129071429-4e6c1363-ca87-4233-9256-7c651b37c307.png)

### After:
![Screen Shot 2021-09-20 at 2 59 48 PM](https://user-images.githubusercontent.com/15249132/134059359-8889fa11-5ec1-425d-91ed-082580d2bb2a.png)


