### PR TITLE
Bug 1992004: Fix flaky e2e test by updating a workaround for rate limit error by GitHub

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.tsx
@@ -23,7 +23,13 @@ const SelectorCard: React.FC<SelectorCardProps> = ({
 }) => {
   const classes = classNames('odc-selector-card', { 'is-selected': selected });
   return (
-    <Card component="button" type="button" className={classes} onClick={() => onChange(name)}>
+    <Card
+      component="button"
+      type="button"
+      className={classes}
+      onClick={() => onChange(name)}
+      data-test={`card ${name}`}
+    >
       <CardTitle>
         <img className="odc-selector-card__icon" src={iconUrl} alt="" />
       </CardTitle>

--- a/frontend/packages/dev-console/integration-tests/support/constants/add.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/add.ts
@@ -60,16 +60,16 @@ export enum catalogTypes {
 }
 
 export enum builderImages {
-  Perl = 'Perl',
-  PHP = 'PHP',
-  Nginx = 'Nginx',
-  Httpd = 'Httpd',
-  NETCore = '.NET Core',
-  Go = 'Go',
-  Ruby = 'Ruby',
-  Python = 'Python',
-  Java = 'Java',
-  NodeJs = 'Node.js',
+  Perl = 'perl',
+  PHP = 'php',
+  Nginx = 'nginx',
+  Httpd = 'httpd',
+  NETCore = 'dotnet',
+  Go = 'golang',
+  Ruby = 'ruby',
+  Python = 'python',
+  Java = 'java',
+  NodeJs = 'nodejs',
 }
 
 export enum eventSourceCards {

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -176,51 +176,51 @@ export const gitPage = {
   selectBuilderImageForGitUrl: (gitUrl: string) => {
     switch (gitUrl) {
       case 'https://github.com/sclorg/dancer-ex.git':
-        cy.get(`[aria-label="${builderImages.Perl}"]`).click();
+        cy.get(`[data-test="card ${builderImages.Perl}"]`).click();
         cy.log(`Selecting builder image "${builderImages.Perl}" to avoid the git rate limit issue`);
         break;
       case 'https://github.com/sclorg/cakephp-ex.git':
-        cy.get(`[aria-label="${builderImages.PHP}"]`).click();
+        cy.get(`[data-test="card ${builderImages.PHP}"]`).click();
         cy.log(`Selecting builder image "${builderImages.PHP}" to avoid the git rate limit issue`);
         break;
       case 'https://github.com/sclorg/nginx-ex.git':
-        cy.get(`[aria-label="${builderImages.Nginx}"]`).click();
+        cy.get(`[data-test="card ${builderImages.Nginx}"]`).click();
         cy.log(
           `Selecting builder image "${builderImages.Nginx}" to avoid the git rate limit issue`,
         );
         break;
       case 'https://github.com/sclorg/httpd-ex.git':
-        cy.get(`[aria-label="${builderImages.Httpd}"]`).click();
+        cy.get(`[data-test="card ${builderImages.Httpd}"]`).click();
         cy.log(
           `Selecting builder image "${builderImages.Httpd}" to avoid the git rate limit issue`,
         );
         break;
       case 'https://github.com/redhat-developer/s2i-dotnetcore-ex.git':
-        cy.get(`[aria-label="${builderImages.NETCore}"]`).click();
+        cy.get(`[data-test="card ${builderImages.NETCore}"]`).click();
         cy.log(
           `Selecting builder image "${builderImages.NETCore}" to avoid the git rate limit issue`,
         );
         break;
       case 'https://github.com/sclorg/golang-ex.git':
-        cy.get(`[aria-label="${builderImages.Go}"]`).click();
+        cy.get(`[data-test="card ${builderImages.Go}"]`).click();
         cy.log(`Selecting builder image "${builderImages.Go}" to avoid the git rate limit issue`);
         break;
       case 'https://github.com/sclorg/ruby-ex.git':
-        cy.get(`[aria-label="${builderImages.Ruby}"]`).click();
+        cy.get(`[data-test="card ${builderImages.Ruby}"]`).click();
         cy.log(`Selecting builder image "${builderImages.Ruby}" to avoid the git rate limit issue`);
         break;
       case 'https://github.com/sclorg/django-ex.git':
-        cy.get(`[aria-label="${builderImages.Python}"]`).click();
+        cy.get(`[data-test="card ${builderImages.Python}"]`).click();
         cy.log(
           `Selecting builder image "${builderImages.Python}" to avoid the git rate limit issue`,
         );
         break;
       case 'https://github.com/jboss-openshift/openshift-quickstarts':
-        cy.get(`[aria-label="${builderImages.Java}"]`).click();
+        cy.get(`[data-test="card ${builderImages.Java}"]`).click();
         cy.log(`Selecting builder image "${builderImages.Java}" to avoid the git rate limit issue`);
         break;
       case 'https://github.com/sclorg/nodejs-ex.git':
-        cy.get(`[aria-label="${builderImages.NodeJs}"]`).click();
+        cy.get(`[data-test="card ${builderImages.NodeJs}"]`).click();
         cy.log(
           `Selecting builder image "${builderImages.NodeJs}" to avoid the git rate limit issue`,
         );


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1992004

**Analysis / Root cause**: 
There was an e2e code which was only called when the import from git flow receives a rate limited exceeded error from GitHub.

In this case the test automatically selects the right builder image. The `[aria-label="Perl"]` selector to select the right builder image doesn't work anymore since (my) PR #9360

**Solution Description**: 
Fix the select builder image method and use a new `[data-test="card perl"]` selector.

**Screen shots / Gifs for design review**: 
Before:
![before](https://user-images.githubusercontent.com/139310/129170389-2f233568-f8e1-4d8a-b51e-236d2d2fea64.png)

After:
![after](https://user-images.githubusercontent.com/139310/129170977-98c9c50d-8c3d-4c78-b466-4b7e962d5f54.png)

**Unit test coverage report**: 
Not touched

**Test setup:**
Open cypress browser with `yarn test-cypress-dev-console` and run the `create-from-git.feature`.

To ensure that the code is called you can remove the if condition around `selectBuilderImageForGitUrl` in `git-page.ts`

See https://github.com/openshift/console/pull/9793#pullrequestreview-728371967

**Browser conformance**: 
Not relevant
