### PR TITLE
Bug 1995901: TS is giving warnings when re-exporting types

### DIFF
--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -1,34 +1,39 @@
 import { APIError } from '@console/shared';
 import {
   Silence,
-  AlertStates,
   PrometheusAlert,
   Alert,
-  SilenceStates,
-  AlertSeverity,
-  RuleStates,
   PrometheusRule,
   PrometheusLabels,
   PrometheusValue,
   Rule,
-} from '@console/dynamic-plugin-sdk';
+  RuleStates,
+  AlertStates,
+  AlertSeverity,
+  SilenceStates,
+} from '@console/dynamic-plugin-sdk/src/api/common-types';
 
 import { RowFunction } from '../factory';
 import { RowFilter } from '../filter-toolbar';
 
 export {
-  Silence,
-  AlertStates,
-  PrometheusAlert,
-  Alert,
   SilenceStates,
   AlertSeverity,
   RuleStates,
+  AlertStates,
+};
+
+// prettier 1.x doesn't support TS 3.8 syntax
+// eslint-disable-next-line prettier/prettier
+export type {
+  PrometheusAlert,
+  Alert,
   PrometheusRule,
   PrometheusLabels,
   PrometheusValue,
   Rule,
-};
+  Silence,
+}
 
 export const enum AlertSource {
   Platform = 'platform',


### PR DESCRIPTION
![Screenshot from 2021-08-12 15-37-43](https://user-images.githubusercontent.com/54092533/129182148-15310e45-0753-46c5-8cd0-d7746b7a3b97.png)
When reexporting only types we get warnings as shown above. 