### PR TITLE
Bug 1992013: Fill out the component name when catching a rate limit error

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
@@ -15,7 +15,7 @@ Feature: Create Application from Devfile
               And user is at the Topology page
              When user right clicks on topology empty graph
               And user selects "From Devfile" option from Add to Project context menu
-              And user enters Git Repo url "https://github.com/redhat-developer/devfile-sample" in Devfile Page
+              And user enters Git Repo url "https://github.com/redhat-developer/devfile-sample" in Devfile page
               And user enters Name as "node-bulletin-board-1" in DevFile page
               And user clicks Create button on Devfile page
              Then user will be redirected to Topology page
@@ -25,7 +25,7 @@ Feature: Create Application from Devfile
         @regression
         Scenario: Create the workload from dev file: A-04-TC02
             Given user is at Import from Devfile page
-             When user enters Git Repo url "https://github.com/redhat-developer/devfile-sample" in Devfile Page
+             When user enters Git Repo url "https://github.com/redhat-developer/devfile-sample" in Devfile page
               And user enters Name as "node-bulletin-board" in DevFile page
               And user clicks Create button on Devfile page
              Then user will be redirected to Topology page

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
@@ -12,7 +12,7 @@ Feature: Create Application from Docker file
         Scenario: Dockerfile details after entering git repo url: A-05-TC01
             Given user is on Import from Docker file page
              When user enters docker git url as "https://github.com/sclorg/nodejs-ex.git"
-             Then git url gets Validated
+             Then git url "https://github.com/sclorg/nodejs-ex.git" gets Validated
               And application name displays as "nodejs-ex-git-app"
               And name field auto populates with value "nodejs-ex-git" in Import from Docker file page
 

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -157,7 +157,7 @@ Feature: Create Application from git form
         Scenario Outline: Builder iamge detected for git url "<git_url>": A-06-TC12
             Given user is at Import from git page
              When user enters Git Repo url as "<git_url>"
-             Then git url gets Validated
+             Then git url "<git_url>" gets Validated
               And builder image is detected
               And builder image version drop down is displayed
               And Application name displays as "<app_name>"
@@ -182,7 +182,7 @@ Feature: Create Application from git form
               And user clicks on "Show advanced Git options" link
               And user clears Context dir field
               And user enters Context dir as "<dir_name>"
-             Then git url gets Validated
+             Then git url "<git_url>" gets Validated
               And user is able to see "Builder Image(s) detected" message in Builder section
               And .NET builder image card tile is highlighted with * mark
 
@@ -195,7 +195,7 @@ Feature: Create Application from git form
         Scenario Outline: "Unable to detect the builder image" warning message displays for server related git urls: A-06-TC14
             Given user is at Import from git page
              When user enters Git Repo url as "<git_url>"
-             Then git url gets Validated
+             Then git url "<git_url>" gets Validated
               And user is able to see warning message "Unable to detect the Builder Image" in Builder section
 
         Examples:

--- a/frontend/packages/dev-console/integration-tests/support/constants/staticText/global-text.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/staticText/global-text.ts
@@ -13,6 +13,7 @@ export const messages = {
     privateGitRepoMessage:
       'URL is valid but cannot be reached. If this is a private repository, enter a source Secret in advanced Git options',
     buildDeployMessage: 'Repository URL to build and deploy your code from source',
+    gitUrlDevfileMessage: 'Repository URL to build and deploy your code from a Devfile.',
     rateLimitExceeded: 'Rate limit exceeded',
     unableToDetectBuilderImage: 'Unable to detect the Builder Image.',
   },

--- a/frontend/packages/dev-console/integration-tests/support/pages/functions/createGitWorkload.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/functions/createGitWorkload.ts
@@ -13,7 +13,7 @@ export const createGitWorkload = (
 ) => {
   addPage.selectCardFromOptions(addOptions.Git);
   gitPage.enterGitUrl(gitUrl);
-  gitPage.verifyValidatedMessage();
+  gitPage.verifyValidatedMessage(gitUrl);
   gitPage.enterComponentName(componentName);
   gitPage.selectResource(resourceType);
   gitPage.enterAppName(appName);

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-container-image.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-container-image.ts
@@ -12,8 +12,8 @@ When('user enters Image name from external registry as {string}', (imageName: st
   containerImagePage.enterExternalRegistryImageName(imageName);
 });
 
-Then('git url gets Validated', () => {
-  gitPage.verifyValidatedMessage();
+Then('git url {string} gets Validated', (gitUrl: string) => {
+  gitPage.verifyValidatedMessage(gitUrl);
 });
 
 Then('user can see the image name gets Validated', () => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-devfile.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-devfile.ts
@@ -20,7 +20,7 @@ When('user selects {string} option from Add to Project context menu', (option: s
 
 When('user enters Git Repo url {string} in Devfile page', (gitUrl: string) => {
   gitPage.enterGitUrl(gitUrl);
-  devFilePage.verifyValidatedMessage();
+  devFilePage.verifyValidatedMessage(gitUrl);
 });
 
 Then('user is able to see workload {string} in topology page', (workloadName: string) => {
@@ -29,7 +29,7 @@ Then('user is able to see workload {string} in topology page', (workloadName: st
 
 When('user selects Try sample link', () => {
   devFilePage.clickTrySample();
-  devFilePage.verifyValidatedMessage();
+  devFilePage.verifyValidatedMessage('https://github.com/redhat-developer/devfile-sample');
   gitPage.enterAppName('devfile-sample-app');
   gitPage.enterWorkloadName('devfile-sample');
   cy.get(gitPO.gitRepoUrl).should(
@@ -40,11 +40,6 @@ When('user selects Try sample link', () => {
 
 When('user clicks Create button on Devfile page', () => {
   gitPage.clickCreate();
-});
-
-When('user enters Git Repo url {string} in Devfile Page', (privateGitRepoUrl: string) => {
-  gitPage.enterGitUrl(privateGitRepoUrl);
-  devFilePage.verifyValidatedMessage();
 });
 
 When('user enters Name as {string} in DevFile page', (name: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-docker-file.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-docker-file.ts
@@ -8,7 +8,7 @@ Given('user is on Import from Docker file page', () => {
 
 When('user enters docker git url as {string}', (gitUrl: string) => {
   gitPage.enterGitUrl(gitUrl);
-  devFilePage.verifyValidatedMessage();
+  devFilePage.verifyValidatedMessage(gitUrl);
 });
 
 When('user selects {string} radio button in Resource type section', (resourceType: string) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/addFlow/create-from-git.ts
@@ -12,8 +12,8 @@ When('user enters Git Repo url as {string}', (gitUrl: string) => {
   gitPage.verifyValidatedMessage(gitUrl);
 });
 
-Then('git url gets Validated', () => {
-  gitPage.verifyValidatedMessage();
+Then('git url {string} gets Validated', (gitUrl: string) => {
+  gitPage.verifyValidatedMessage(gitUrl);
 });
 
 Then('builder image is detected', () => {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -123,6 +123,8 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         handleRedirect(projectName, perspective, perspectiveExtensions);
       })
       .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn('Error while submitting import form:', err);
         actions.setStatus({ submitError: err.message });
       });
   };

--- a/frontend/packages/helm-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -34,7 +34,7 @@ Given('user is at the Topology page', () => {
 
 When('user enters Git Repo url as {string}', (gitUrl: string) => {
   gitPage.enterGitUrl(gitUrl);
-  gitPage.verifyValidatedMessage();
+  gitPage.verifyValidatedMessage(gitUrl);
 });
 
 When('user creates the application with the selected builder image', () => {

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/addFlow.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/common/addFlow.ts
@@ -71,7 +71,7 @@ When('user clicks Cancel button on Add page', () => {
 
 When('user enters Git Repo url as {string}', (gitUrl: string) => {
   gitPage.enterGitUrl(gitUrl);
-  gitPage.verifyValidatedMessage();
+  gitPage.verifyValidatedMessage(gitUrl);
   cy.get('body').then(($el) => {
     if ($el.find('[aria-label$="Alert"]').length) {
       cy.log('Builder image detected');

--- a/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/step-definitions/serverless/create-knative-workload.ts
@@ -57,7 +57,7 @@ When('user enters External registry image name as {string}', (imageName: string)
 
 When('user enters Docker url as {string}', (dockerUrl: string) => {
   gitPage.enterGitUrl(dockerUrl);
-  gitPage.verifyValidatedMessage();
+  gitPage.verifyValidatedMessage(dockerUrl);
 });
 
 When('user selects {string} radio button on Add page', (resourceType: string) => {

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
@@ -146,7 +146,7 @@ Feature: Create Pipeline from Add Options
             Given user is at Import from git page
              When user enters Git Repo url as "<git_url>"
               And user selects "<builder_image>" builder image
-             Then git url gets Validated
+             Then git url "<git_url>" gets Validated
               And user is able to see info message "<message>" in Pipelines section
 
         Examples:

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -42,7 +42,7 @@ Given('user is at the Topology page', () => {
 
 When('user enters Git Repo url as {string}', (gitUrl: string) => {
   gitPage.enterGitUrl(gitUrl);
-  gitPage.verifyValidatedMessage();
+  gitPage.verifyValidatedMessage(gitUrl);
   cy.get('body').then(($el) => {
     if ($el.find('[aria-label$="Alert"]').length) {
       cy.log('Builder image detected');

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -302,7 +302,7 @@ export const addGitWorkload = (
   resourceType: string = 'Deployment',
 ) => {
   gitPage.enterGitUrl(gitUrl);
-  gitPage.verifyValidatedMessage();
+  gitPage.verifyValidatedMessage(gitUrl);
   gitPage.enterComponentName(componentName);
   gitPage.selectResource(resourceType);
   createForm.clickCreate();


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1992013

**Analysis / Root cause**: 
When the import from git or import from devfile receives a rate limit exeeded error from GitHub, the tests fails because then the last part of the URL is used as component name. Without this component name the form is valid and the submit button is disabled.

Cypress fails that with this error:

```
Timed out retrying after 40050ms: `cy.click()` failed because this element is `disabled`:
```

**Solution Description**: 
Detect that GitHub returns a rate limit exeeded message. This was already displayed to the user.

In this case fill out the component name with cypress `type` so that the form can submitted.

For devfiles this doesn't solve the complete issue because the Devfile submit doesn't work until the data from the devfile was received...

**Screen shots / Gifs for design review**: 
Create from Git:
![create-from-git](https://user-images.githubusercontent.com/139310/129198008-3928079e-afd3-45aa-ae2b-4f7a5c4401a6.png)

Create from Devfile:
![create-from-devfile](https://user-images.githubusercontent.com/139310/129198158-fe0dd65b-2abd-4f42-828d-93d2589e1bbf.png)

**Unit test coverage report**: 
Untouched

**Test setup:**
In `packages/dev-console/src/components/import/git/GitSection.tsx` set

`const repositoryStatus = RepoStatus.RateLimitExceeded // ...`

**Browser conformance**: 
Unrelated