### PR TITLE
Bug 1993306: Disable broken Event Sources on default Developer Catalog test

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/developer-catalog-details.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/developer-catalog-details.feature
@@ -38,7 +38,8 @@ Feature: Developer Catalog Page
              Then user is able to see cards with name containing "node"
 
 
-        @smoke
+        # https://issues.redhat.com/browse/ODC-6249: Installing OpenShift Serverless Operator is not enough here. Test should also ensure that Knative Eventing resource is created.
+        @smoke @broken-test
         Scenario: Event Sources on default Developer Catalog: A-09-TC04
             Given user is at Developer Catalog page
              When user clicks on Event Sources type


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1993306

**Analysis / Root cause**: 
The developer-catalog-details.feature installs the Serverless operator but don't create the knative-eventing resource. After that the following tests doesn't pass because the developer catalog doesn't show the "Event Sources" item.

```
  1) Developer Catalog Page
       Event Sources on default Developer Catalog: A-09-TC04:
     AssertionError: Timed out retrying after 40000ms: Expected to find element: `[data-test="tab EventSource"]`, but never found it.
      at Object.selectCatalogType (https://console-openshift-console.apps.ci-op-v4cvmdmx-75d12.**********************/__cypress/tests?p=features/addFlow/developer-catalog-details.feature:44603:20)
```

**Solution Description**: 
Created ticket [ODC-6249](https://issues.redhat.com/browse/ODC-6249) to check that the knative-eventing resource is created correctly and disable the broken test for now.

**Screen shots / Gifs for design review**: 
![Screenshot from 2021-08-12 20-40-26](https://user-images.githubusercontent.com/139310/129251005-1ef23ba7-12c8-4231-94eb-5f677f56ee69.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
1. Do NOT install the Serverless operator manually
2. Run yarn test-cypress-dev-console and start developer-catalog-details.feature

**Browser conformance**: 
Not relevant
