### PR TITLE
Bug 1993788: VM creation (customize flow): storage class mismatch between actual SC and "Edit Disk" screen

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -660,6 +660,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                 <StorageClassDropdown
                   name={t('kubevirt-plugin~Storage Class')}
                   onChange={(scName) => onStorageClassNameChanged(scName)}
+                  selectedKey={storageClassName}
                   data-test="storage-class-dropdown"
                 />
               </StackItem>


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1993788

**Analysis / Root cause**:
when editing a disk on VM customized creation, the storageClass selected is not showing on dropdown component, but the default is showing instead

**Solution Description**:
attaching the current value from disk to dropdown on 'Edit disk' modal

**Screen shots / Gifs for design review**:
before(shows default SC instead of selected SC):

![bz_1993788_before_1](https://user-images.githubusercontent.com/67270715/129541413-11885bcf-353a-4db1-8dab-43365731954e.png)


after:

![bz_1993788_after_2](https://user-images.githubusercontent.com/67270715/129541433-ccebe706-584f-4b34-b168-0b207cb112e5.png)
![bz_1993788_after_1](https://user-images.githubusercontent.com/67270715/129541435-6862a580-fde6-4d55-b68d-b1282a9b7a5b.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>