### PR TITLE
Bug 1980531: step 3 additionalHelpActions 'HelpMenu' ConsoleLinks not translated

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/i18n/pseudolocalization.spec.ts
@@ -21,13 +21,9 @@ describe('Localization', () => {
     cy.visit('/dashboards?pseudolocalization=true&lng=en');
     masthead.clickMastheadLink('help-dropdown-toggle');
     // wait for both console help menu items and additionalHelpActions items to load
-    // additionalHelpActions come from ConsoleLinks 'HelpMenu' yaml and are not translated
-    // only test console help items which are translated
-    cy.get('.pf-c-app-launcher__group')
-      .first()
-      .within(() => {
-        cy.get('[role="menuitem"]').isPseudoLocalized();
-      });
+    cy.get('.pf-c-app-launcher__group').should('have.length', 2);
+    // Test that all links are translated
+    cy.get('.pf-c-app-launcher__group [role="menuitem"]').isPseudoLocalized();
   });
 
   it('pseudolocalizes navigation', () => {

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -40,6 +40,21 @@ import { ConsoleLinkModel } from '../models';
 import { languagePreferencesModal } from './modals';
 import { withTelemetry, withQuickStartContext } from '@console/shared/src/hoc';
 
+const defaultHelpLinks = [
+  {
+    // t('public~Learning Portal')
+    label: 'Learning Portal',
+    externalLink: true,
+    href: 'https://learn.openshift.com/?ref=webconsole',
+  },
+  {
+    // t('public~OpenShift Blog')
+    label: 'OpenShift Blog',
+    externalLink: true,
+    href: 'https://blog.openshift.com',
+  },
+];
+
 const SystemStatusButton = ({ statuspageData, className }) => {
   const { t } = useTranslation();
   return !_.isEmpty(_.get(statuspageData, 'incidents')) ? (
@@ -377,6 +392,14 @@ class MastheadToolbarContents_ extends React.Component {
         },
       ],
     });
+
+    // Add default help links to start of additional links from operator
+    additionalHelpActions.actions = defaultHelpLinks
+      .map((helpLink) => ({
+        ...helpLink,
+        label: t(`public~${helpLink.label}`),
+      }))
+      .concat(additionalHelpActions.actions);
 
     if (!_.isEmpty(additionalHelpActions.actions)) {
       helpActions.push(additionalHelpActions);

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -658,6 +658,8 @@
   "Instance type": "Instance type",
   "Machine addresses": "Machine addresses",
   "by machine or node name": "by machine or node name",
+  "Learning Portal": "Learning Portal",
+  "OpenShift Blog": "OpenShift Blog",
   "System status": "System status",
   "Red Hat applications": "Red Hat applications",
   "Quick Starts": "Quick Starts",


### PR DESCRIPTION
Addresses [Bug 1980531](https://bugzilla.redhat.com/show_bug.cgi?id=1980531)

In the help menu, the "Learning Portal" and "OpenShift Blog" links are brought into the console code so they can be translated.  

This is the last of 3 PRs to complete the work for Bug 1980531.

Step 1 - Update tests
Step 2 - Remove links from operators
Step 3 - (this PR) Add links to console so they can be translated

Note:  This PR replaces https://github.com/openshift/console/pull/9495