### PR TITLE
Bug 1975820: Handle patches for multiple plugins

### DIFF
--- a/frontend/packages/console-shared/src/utils/console-plugin.ts
+++ b/frontend/packages/console-shared/src/utils/console-plugin.ts
@@ -28,5 +28,13 @@ export const getPluginPatch = (
       };
 };
 
+export const getPatchForRemovingPlugins = (console: K8sResourceKind, plugins: string[]): Patch => {
+  return {
+    path: '/spec/plugins',
+    value: console.spec?.plugins?.filter((p: string) => !plugins.includes(p)),
+    op: 'replace',
+  };
+};
+
 export const isPluginEnabled = (console: K8sResourceKind, plugin: string): boolean =>
   !!console?.spec?.plugins?.includes(plugin);

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -20,7 +20,7 @@ import {
 import { YellowExclamationTriangleIcon } from '@console/shared';
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
 import { usePromiseHandler } from '@console/shared/src/hooks/promise-handler';
-import { getPluginPatch, isPluginEnabled } from '@console/shared/src/utils';
+import { getPatchForRemovingPlugins, isPluginEnabled } from '@console/shared/src/utils';
 import { GLOBAL_OPERATOR_NAMESPACE, OPERATOR_UNINSTALL_MESSAGE_ANNOTATION } from '../../const';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
 import { ClusterServiceVersionKind, SubscriptionKind } from '../../types';
@@ -71,7 +71,7 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
     };
 
     const patch = removePlugins
-      ? enabledPlugins.map((plugin) => getPluginPatch(consoleOperatorConfig, plugin, false))
+      ? getPatchForRemovingPlugins(consoleOperatorConfig, enabledPlugins)
       : null;
 
     const allPromises = [
@@ -92,7 +92,7 @@ export const UninstallOperatorModal: React.FC<UninstallOperatorModalProps> = ({
           ]
         : []),
       ...(removePlugins
-        ? [k8sPatch(ConsoleOperatorConfigModel, consoleOperatorConfig, patch)]
+        ? [k8sPatch(ConsoleOperatorConfigModel, consoleOperatorConfig, [patch])]
         : []),
     ];
 


### PR DESCRIPTION
We were only removing one plugin in the patch. I adjusted the code to handle multiple plugins.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1975820.