### PR TITLE
Bug 1994253: Kubevirt provided templates are supported

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateCommnunityLabel.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateCommnunityLabel.tsx
@@ -30,7 +30,7 @@ export const VMTemplateCommnunityLabel: React.FC<VMTemplateLabelProps> = ({
   const provider = getTemplateProvider(t, template);
   const templateOSName = getName(template).split('-')?.[0];
   const isCommunity = !(
-    ['red hat', 'redhat'].includes(provider.toLowerCase()) &&
+    ['red hat', 'redhat', 'kubevirt'].includes(provider.toLowerCase()) &&
     supportedTemplates.includes(templateOSName)
   );
 


### PR DESCRIPTION
When console run in OKD mode, templates provided by SSP operator are labeled as provided by Kubevirt provider, when this templates are redhat supported they are marked community because the are not provided by redhat

Screenshots:
Before:
![screenshot-localhost_9000-2021 08 17-10_00_34](https://user-images.githubusercontent.com/2181522/129679918-ef01db7c-f659-4f19-b501-7381859d7022.png)

After:
![screenshot-localhost_9000-2021 08 17-09_59_46](https://user-images.githubusercontent.com/2181522/129679900-050715cd-04e3-4dc1-87f9-716d2ceb17fa.png)
