### PR TITLE
Bug 1995523: Add checks for annotations in pipeline quicksearch utils

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/PiplineQuickSearchDetails.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/PiplineQuickSearchDetails.tsx
@@ -106,7 +106,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
             {buttonText}
           </Button>
         </SplitItem>
-        {
+        {versions.length > 0 && (
           <SplitItem>
             <Dropdown
               data-test={'task-version'}
@@ -120,7 +120,7 @@ const PipelineQuickSearchDetails: React.FC<QuickSearchDetailsRendererProps> = ({
               }}
             />
           </SplitItem>
-        }
+        )}
       </Split>
       {getTaskAlert}
       <TextContent className="opp-quick-search-details__description" data-test={'task-description'}>

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/pipeline-quicksearch-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/__tests__/pipeline-quicksearch-utils.spec.ts
@@ -161,6 +161,12 @@ describe('pipeline-quicksearch-utils', () => {
   });
 
   describe('isInstalledNamespaceTask', () => {
+    it('should return false if the annotations are missing in the metadata', () => {
+      expect(
+        isInstalledNamespaceTask(omit(sampleClusterTaskCatalogItem, 'data.metadata.annotations')),
+      ).toBe(false);
+    });
+
     it('should return false if the tekton hub task is passed', () => {
       expect(isInstalledNamespaceTask(sampleTektonHubCatalogItem)).toBe(false);
     });
@@ -215,6 +221,15 @@ describe('pipeline-quicksearch-utils', () => {
   });
 
   describe('findInstalledTask', () => {
+    it('should return undefined if the annotations are missing in the metadata', () => {
+      expect(
+        findInstalledTask(
+          sampleCatalogItems,
+          omit(sampleClusterTaskCatalogItem, 'data.metadata.annotations'),
+        ),
+      ).toBeUndefined();
+    });
+
     it('should return undefined the catalogItem is not installed through pipeline builder', () => {
       expect(findInstalledTask(sampleCatalogItems, sampleTektonHubCatalogItem)).toBeUndefined();
     });

--- a/frontend/packages/pipelines-plugin/src/components/quicksearch/pipeline-quicksearch-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/quicksearch/pipeline-quicksearch-utils.ts
@@ -51,7 +51,7 @@ export const getCtaButtonText = (item: CatalogItem, selectedVersion: string): st
 export const isInstalledNamespaceTask = (item: CatalogItem) => {
   return (
     item.data.kind === TaskModel.kind &&
-    item.data.metadata?.annotations[TektonTaskAnnotation.installedFrom] === TEKTONHUB
+    item.data.metadata?.annotations?.[TektonTaskAnnotation.installedFrom] === TEKTONHUB
   );
 };
 
@@ -81,7 +81,7 @@ export const findInstalledTask = (items: CatalogItem[], item: CatalogItem): Cata
       i.name === item.name &&
       item.data.kind !== ClusterTaskModel.kind &&
       i.data.kind === TaskModel.kind &&
-      i.data.metadata?.annotations[TektonTaskAnnotation.installedFrom] === TEKTONHUB,
+      i.data.metadata?.annotations?.[TektonTaskAnnotation.installedFrom] === TEKTONHUB,
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6255

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
The Pipeline builder form throws `Cannot read property 'openshift.io/installed-from' of undefined` error when clicked on `Add task` button

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added checks to metadata annotations, to avoid the NPE

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
No UI change, shouldn't see the UI breaking.


**Unit test coverage report**: 
<!-- Attach test coverage report -->
```
  isInstalledNamespaceTask
      ✓ should return false if the annotations are missing in the metadata (1ms)
  findInstalledTask
      ✓ should return undefined if the annotations are missing in the metadata (1ms)
```
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create a pipeline task using the default yaml
2. Goto Pipeline Builder form
3. Click on `Add task`
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge