### PR TITLE
Bug 1991338: Hide Network Attachment Definitions tab for non-admin users

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/console-extensions.json
+++ b/frontend/packages/network-attachment-definition-plugin/console-extensions.json
@@ -1,5 +1,11 @@
 [
   {
+    "type": "console.flag",
+    "properties": {
+      "handler": { "$codeRef": "nadFlags.checkNadPermissions" }
+    }
+  },
+  {
     "type": "console.navigation/resource-cluster",
     "properties": {
       "id": "networkattachmentdefinitions",
@@ -12,7 +18,7 @@
       }
     },
     "flags": {
-      "required": ["NET_ATTACH_DEF", "KUBEVIRT"]
+      "required": ["NET_ATTACH_DEF", "KUBEVIRT", "CAN_VIEW_NADS"]
     }
   },
   {

--- a/frontend/packages/network-attachment-definition-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/network-attachment-definition-plugin/locales/en/kubevirt-plugin.json
@@ -2,6 +2,8 @@
   "No network attachment definitions found": "No network attachment definitions found",
   "Create network attachment definition": "Create network attachment definition",
   "Learn how to use network attachment definitions": "Learn how to use network attachment definitions",
+  "NetworkAttachmentDefinition details": "NetworkAttachmentDefinition details",
+  "Type": "Type",
   "Network attachment definition name cannot be empty": "Network attachment definition name cannot be empty",
   "Network attachment definition name can contain only alphanumeric characters": "Network attachment definition name can contain only alphanumeric characters",
   "Network attachment definition name must start/end with alphanumeric character": "Network attachment definition name must start/end with alphanumeric character",

--- a/frontend/packages/network-attachment-definition-plugin/package.json
+++ b/frontend/packages/network-attachment-definition-plugin/package.json
@@ -20,7 +20,8 @@
       ]
     },
     "exposedModules": {
-      "yamlTemplates": "src/models/templates/index.ts"
+      "yamlTemplates": "src/models/templates/index.ts",
+      "nadFlags": "src/flags"
     }
   }
 }

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { ScrollToTopOnMount, SectionHeading, StatusBox } from '@console/internal/components/utils';
+import { useTranslation } from 'react-i18next';
+import {
+  ScrollToTopOnMount,
+  SectionHeading,
+  StatusBox,
+  ResourceSummary,
+} from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getName, getNamespace } from '@console/shared/src';
 import { networkTypes } from '../../constants';
-import { getConfigAsJSON, getDescription, getType } from '../../selectors';
+import { getConfigAsJSON, getType } from '../../selectors';
 import { NetworkAttachmentDefinitionKind } from '../../types';
 
 const NET_ATTACH_DEF_DETAILS_HEADING = 'Network Attachment Definition Details';
@@ -36,29 +42,31 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
 export const NetAttachDefinitionSummary: React.FC<NetAttachDefinitionSummaryProps> = ({
   netAttachDef,
 }) => {
-  const name = getName(netAttachDef);
-  const description = getDescription(netAttachDef);
+  const { t } = useTranslation();
   const type = getType(getConfigAsJSON(netAttachDef));
   const id = getBasicID(netAttachDef);
 
-  // FIXME: This should use ResourceSummary like all other details pages.
   return (
     <>
-      <DetailsItem title="Name" idValue={prefixedID(id, 'name')} isNotAvail={!name}>
-        {name}
-      </DetailsItem>
-
-      <DetailsItem
-        title="Description"
-        idValue={prefixedID(id, 'description')}
-        isNotAvail={!description}
-      >
-        {description}
-      </DetailsItem>
-
-      <DetailsItem title="Type" idValue={prefixedID(id, 'type')} isNotAvail={!type}>
-        {_.get(networkTypes, [type], null) || type}
-      </DetailsItem>
+      <div className="co-m-pane__body">
+        <SectionHeading text={t('kubevirt-plugin~NetworkAttachmentDefinition details')} />
+        <div className="row">
+          <div className="col-sm-6">
+            <ResourceSummary resource={netAttachDef} />
+          </div>
+          <div className="col-sm-6">
+            <dl className="co-m-pane__details">
+              <DetailsItem
+                title={t('kubevirt-plugin~Type')}
+                idValue={prefixedID(id, 'type')}
+                isNotAvail={!type}
+              >
+                {_.get(networkTypes, [type], null) || type}
+              </DetailsItem>
+            </dl>
+          </div>
+        </div>
+      </div>
     </>
   );
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/flags/check-nad-permissions.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/flags/check-nad-permissions.ts
@@ -1,0 +1,33 @@
+import { AccessReviewResourceAttributes, SetFeatureFlag } from '@console/dynamic-plugin-sdk';
+import { checkAccess } from '@console/internal/components/utils/rbac';
+import { SelfSubjectAccessReviewKind } from '@console/internal/module/k8s';
+import { NetworkAttachmentDefinitionModel } from '../models';
+import { FLAG_CAN_VIEW_NADS } from './const';
+
+export const checkNadPermissions = async (setFeatureFlag: SetFeatureFlag) => {
+  let id = null;
+
+  const setFlag = () => {
+    const nadSsarAttributes: AccessReviewResourceAttributes = {
+      group: NetworkAttachmentDefinitionModel.apiGroup,
+      resource: NetworkAttachmentDefinitionModel.plural,
+      verb: 'list',
+    };
+
+    checkAccess(nadSsarAttributes)
+      .then((result: SelfSubjectAccessReviewKind) => {
+        setFeatureFlag(FLAG_CAN_VIEW_NADS, result.status.allowed);
+      })
+      .catch((e) => {
+        console.warn('SelfSubjectAccessReview failed', e); // eslint-disable-line no-console
+        // Default to enabling the action if the access review fails so that we
+        // don't incorrectly block users from actions they can perform. The server
+        // still enforces access control.
+        // setFeatureFlag(FLAG_CAN_VIEW_NADS, true);
+        clearInterval(id);
+      });
+  };
+
+  setFlag();
+  id = setInterval(setFlag, 10 * 1000);
+};

--- a/frontend/packages/network-attachment-definition-plugin/src/flags/const.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/flags/const.ts
@@ -1,0 +1,1 @@
+export const FLAG_CAN_VIEW_NADS = 'CAN_VIEW_NADS';

--- a/frontend/packages/network-attachment-definition-plugin/src/flags/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/flags/index.ts
@@ -1,0 +1,1 @@
+export { checkNadPermissions } from './check-nad-permissions';


### PR DESCRIPTION
This PR hides the 'Network Attachment Definitions' tab for non-admin users.