### PR TITLE
Bug 1998087: Active Health Checks cleanup chores

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/status-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/status-card.tsx
@@ -57,7 +57,7 @@ export const CephAlerts = withDashboardResources(
 const CephHealthCheck: React.FC<CephHealthCheckProps> = ({ cephHealthState, healthCheck }) => {
   const { t } = useTranslation();
   return (
-    <Flex direction={{ default: 'row' }}>
+    <Flex flexWrap={{ default: 'nowrap' }} direction={{ default: 'row' }}>
       <FlexItem>
         {
           (healthStateMapping[cephHealthState.state] || healthStateMapping[HealthState.UNKNOWN])

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/HealthItem.tsx
@@ -21,7 +21,7 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
     return (
       <div
         className={classNames('co-status-card__health-item', className)}
-        data-test={`${title}-health-item`}
+        data-item-id={`${title}-health-item`}
       >
         {state === HealthState.LOADING ? (
           <div className="skeleton-health">
@@ -48,7 +48,11 @@ const HealthItem: React.FC<HealthItemProps> = React.memo(
             )}
           </span>
           {state !== HealthState.LOADING && detailMessage && (
-            <SecondaryStatus status={detailMessage} className="co-status-card__health-item-text" />
+            <SecondaryStatus
+              status={detailMessage}
+              className="co-status-card__health-item-text"
+              dataStatusID={`${title}-secondary-status`}
+            />
           )}
         </div>
       </div>

--- a/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
@@ -4,14 +4,15 @@ import * as _ from 'lodash';
 type SecondaryStatusProps = {
   status?: string | string[];
   className?: string;
+  dataStatusID?: string;
 };
 
-const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status, className }) => {
+const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status, className, dataStatusID }) => {
   const statusLabel = _.compact(_.concat([], status)).join(', ');
   const cssClassName = className || '';
   if (statusLabel) {
     return (
-      <div>
+      <div data-status-id={dataStatusID}>
         <small className={`${cssClassName} text-muted`}>{statusLabel}</small>
       </div>
     );


### PR DESCRIPTION
This PR introduces some bug fixes that originally surfaced in #9690,
which are:
* Don't wrap `div`s for `CephHealthCheck`.
* Add a `dataTest` prop to `SecondaryStatus` for test coverage and make them dynamic.