### PR TITLE
Improve git section performance in git import flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/SourceSecretSelector.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { FormGroup } from '@patternfly/react-core';
-import { useFormikContext, FormikValues, useField } from 'formik';
+import { useFormikContext, FormikValues } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { SecretTypeAbstraction } from '@console/internal/components/secrets/create-secret';
 import { getFieldId } from '@console/shared';
@@ -11,7 +11,6 @@ const CREATE_SOURCE_SECRET = 'create-source-secret';
 
 const SourceSecretSelector: React.FC = () => {
   const { t } = useTranslation();
-  const [secret] = useField('git.secret');
   const { values, setFieldValue } = useFormikContext<FormikValues>();
 
   const handleSave = (name: string) => {
@@ -20,7 +19,7 @@ const SourceSecretSelector: React.FC = () => {
 
   const handleDropdownChange = (key: string) => {
     if (key === CREATE_SOURCE_SECRET) {
-      setFieldValue('git.secret', secret.value);
+      setFieldValue('git.secret', values.git.secret);
       secretModalLauncher({
         namespace: values.project.name,
         save: handleSave,
@@ -48,8 +47,8 @@ const SourceSecretSelector: React.FC = () => {
               actionKey: CREATE_SOURCE_SECRET,
             },
           ]}
-          selectedKey={secret.value}
-          title={secret.value}
+          selectedKey={values.git.secret}
+          title={values.git.secret}
           onChange={handleDropdownChange}
         />
       </FormGroup>

--- a/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
@@ -32,55 +32,59 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
   const { t } = useTranslation();
   const [field] = useField<Resources[]>('resourceTypesNotValid');
   const invalidTypes = field.value || [];
-
-  const radioOptions: RadioGroupOption[] = [];
-  if (!invalidTypes.includes(Resources.Kubernetes)) {
-    radioOptions.push({
-      label: t(ReadableResourcesNames[Resources.Kubernetes]),
-      value: Resources.Kubernetes,
-      children: createHelpText(
-        DeploymentModel,
-        t(
-          'devconsole~A {{deploymentLabel}} enables declarative updates for Pods and ReplicaSets.',
-          { deploymentLabel: DeploymentModel.label },
-        ),
-      ),
-    });
-  }
-  if (!invalidTypes.includes(Resources.OpenShift)) {
-    radioOptions.push({
-      label: t(ReadableResourcesNames[Resources.OpenShift]),
-      value: Resources.OpenShift,
-      children: createHelpText(
-        DeploymentConfigModel,
-        t(
-          'devconsole~A {{deploymentConfigLabel}} defines the template for a Pod and manages deploying new Images or configuration changes.',
-          { deploymentConfigLabel: DeploymentConfigModel.label },
-        ),
-      ),
-    });
-  }
-
   const knativeServiceAccess = useAccessReview({
     group: ServiceModel.apiGroup,
     resource: ServiceModel.plural,
     namespace: getActiveNamespace(),
     verb: 'create',
   });
-  const canIncludeKnative =
-    !invalidTypes.includes(Resources.KnativeService) &&
-    flags[FLAG_KNATIVE_SERVING_SERVICE] &&
-    knativeServiceAccess;
-  if (canIncludeKnative) {
-    radioOptions.push({
-      label: t(ReadableResourcesNames[Resources.KnativeService]),
-      value: Resources.KnativeService,
-      children: createHelpText(
-        ServiceModel,
-        t('devconsole~A type of deployment that enables Serverless scaling to 0 when idle.'),
-      ),
-    });
-  }
+
+  const radioOptions = React.useMemo(() => {
+    const options: RadioGroupOption[] = [];
+    if (!invalidTypes.includes(Resources.Kubernetes)) {
+      options.push({
+        label: t(ReadableResourcesNames[Resources.Kubernetes]),
+        value: Resources.Kubernetes,
+        children: createHelpText(
+          DeploymentModel,
+          t(
+            'devconsole~A {{deploymentLabel}} enables declarative updates for Pods and ReplicaSets.',
+            { deploymentLabel: DeploymentModel.label },
+          ),
+        ),
+      });
+    }
+    if (!invalidTypes.includes(Resources.OpenShift)) {
+      options.push({
+        label: t(ReadableResourcesNames[Resources.OpenShift]),
+        value: Resources.OpenShift,
+        children: createHelpText(
+          DeploymentConfigModel,
+          t(
+            'devconsole~A {{deploymentConfigLabel}} defines the template for a Pod and manages deploying new Images or configuration changes.',
+            { deploymentConfigLabel: DeploymentConfigModel.label },
+          ),
+        ),
+      });
+    }
+
+    const canIncludeKnative =
+      !invalidTypes.includes(Resources.KnativeService) &&
+      flags[FLAG_KNATIVE_SERVING_SERVICE] &&
+      knativeServiceAccess;
+    if (canIncludeKnative) {
+      options.push({
+        label: t(ReadableResourcesNames[Resources.KnativeService]),
+        value: Resources.KnativeService,
+        children: createHelpText(
+          ServiceModel,
+          t('devconsole~A type of deployment that enables Serverless scaling to 0 when idle.'),
+        ),
+      });
+    }
+    return options;
+  }, [t, invalidTypes, flags, knativeServiceAccess]);
+
   return (
     <FormSection title={t('devconsole~Resources')} fullWidth>
       <div>{t('devconsole~Select the resource type to generate')}</div>


### PR DESCRIPTION
**Story**: 
https://issues.redhat.com/browse/ODC-5998
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Memoized some data inside the `GitSection` component, and moved onchange handler statements to inside the debounced callback.
![profile](https://user-images.githubusercontent.com/20013884/129929028-409d9c64-ec6a-41bd-9b61-f460ce1764f7.png)
The profiler reports that a lot of time is being spent in rendering components outside of the input field, such as the git advanced options section and the resource type section. I've tried memoizing some of the data, but I'm unsure if we can do much here since these places make use of shared components.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Screen shots / Gifs for design review**: 
Before:

https://user-images.githubusercontent.com/20013884/129927295-818db084-e9ec-4203-9acb-06822bd49be4.mp4

After:

https://user-images.githubusercontent.com/20013884/129927318-50777594-a1cd-4bb5-8269-3cbed0a786a7.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<unchanged>
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
