### PR TITLE
Gherkin for converging Import from Git/Devfile/Dockerfile flows

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-devfile.feature
@@ -9,40 +9,41 @@ Feature: Create Application from Devfile
               And user is at Add page
 
 
-        @regression
+        @regression @odc-5009
         Scenario: Deploy git workload with devfile from topology page: A-04-TC01
             Given user has created workload "nodejs-ex-git" with resource type "Deployment"
               And user is at the Topology page
              When user right clicks on topology empty graph
-              And user selects "From Devfile" option from Add to Project context menu
-              And user enters Git Repo url "https://github.com/redhat-developer/devfile-sample" in Devfile page
-              And user enters Name as "node-bulletin-board-1" in DevFile page
-              And user clicks Create button on Devfile page
+              And user selects "Import from Git" option from Add to Project context menu
+              And user enters Git Repo URL as "https://github.com/redhat-developer/devfile-sample" in Import from Git form
+              And user enters workload name as "node-bulletin-board-1" in Name
+              And user clicks Create button
              Then user will be redirected to Topology page
               And user is able to see workload "node-bulletin-board-1" in topology page
 
 
-        @regression
+        @regression @odc-5009
         Scenario: Create the workload from dev file: A-04-TC02
-            Given user is at Import from Devfile page
-             When user enters Git Repo url "https://github.com/redhat-developer/devfile-sample" in Devfile page
-              And user enters Name as "node-bulletin-board" in DevFile page
-              And user clicks Create button on Devfile page
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/redhat-developer/devfile-sample"
+              And user enters workload name as "node-bulletin-board" in Name
+              And user clicks Create button
              Then user will be redirected to Topology page
               And user is able to see workload "node-bulletin-board" in topology page
 
 
-        @smoke
-        Scenario: Create the sample workload from dev file: A-04-TC03
-            Given user is at Import from Devfile page
-             When user selects Try sample link
-              And user clicks Create button on Devfile page
-             Then user will be redirected to Topology page
-              And user is able to see workload "devfile-sample" in topology page
+        # Below scenario to be removed after the tests are are updated
+        # @smoke
+        # Scenario: Create the sample workload from dev file: A-04-TC03
+        #     Given user is at Import from Git page
+        #      When user selects Try sample link
+        #       And user clicks Create button on Devfile page
+        #      Then user will be redirected to Topology page
+        #       And user is able to see workload "devfile-sample" in topology page
 
 
         @regression @to-do
-        Scenario: Create the Devfiles workload from Developer Catalog: A-04-TC04
+        Scenario: Create the Devfiles workload from Developer Catalog: A-04-TC03
             Given user is at Developer Catalog page
              When user clicks on Devfiles type
               And user clicks on Basic Python card

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
@@ -1,4 +1,4 @@
-@add-flow
+@add-flow @odc-5009
 Feature: Create Application from Docker file
               As a user, I want to create the application, component or service from Add Flow Docker file
 
@@ -10,17 +10,18 @@ Feature: Create Application from Docker file
 
         @regression
         Scenario: Dockerfile details after entering git repo url: A-05-TC01
-            Given user is on Import from Docker file page
-             When user enters docker git url as "https://github.com/sclorg/nodejs-ex.git"
-             Then git url "https://github.com/sclorg/nodejs-ex.git" gets Validated
-              And application name displays as "nodejs-ex-git-app"
-              And name field auto populates with value "nodejs-ex-git" in Import from Docker file page
+            Given user is on Import from Git form
+             When user enters Git Repo URL as "https://github.com/rohitkrai03/flask-dockerfile-example"
+             Then git url "https://github.com/rohitkrai03/flask-dockerfile-example" gets Validated
+              And application name displays as "flask-dockerfile-example-app"
+              And name field auto populates with value "flask-dockerfile-example" in Import from Git form
 
 
         @smoke
         Scenario Outline: Create a workload from Docker file with "<resource_type>" as resource type: A-05-TC02
-            Given user is on Import from Docker file page
-             When user enters docker git url as "https://github.com/sclorg/nodejs-ex.git"
+            Given user is on Import from Git form
+             When user enters Git Repo URL as "https://github.com/rohitkrai03/flask-dockerfile-example"
+              And user enters Dockerfile path as "Dockerfile"
               And user enters Name as "<name>" in Docker file page
               And user selects "<resource_type>" radio button in Resource type section
               And user clicks Create button on Add page
@@ -28,15 +29,16 @@ Feature: Create Application from Docker file
               And user is able to see workload "<name>" in topology page
 
         Examples:
-                  | resource_type     | name            |
-                  | Deployment        | nodejs-ex-git   |
-                  | Deployment Config | nodejs-ex-1-git |
+                  | resource_type     | name         |
+                  | Deployment        | dockerfile   |
+                  | Deployment Config | dockerfile-1 |
 
 
         @regression
-        Scenario: Perform cancel operation on Dockerfile form should will be redirected the user to Add page: A-05-TC03
-            Given user is on Import from Docker file page
-             When user enters docker git url as "https://github.com/sclorg/nodejs-ex.git"
+        Scenario: Performing cancel operation on Dockerfile form should redirected the user to Add page: A-05-TC03
+            Given user is on Import from Git form
+             When user enters Git Repo URL as "https://github.com/rohitkrai03/flask-dockerfile-example"
+              And user enters Dockerfile path as "Dockerfile"
               And user selects "Deployment" radio button in Resource type section
               And user clicks Cancel button on Add page
              Then user will be redirected to Add page

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -8,10 +8,10 @@ Feature: Create Application from git form
               And user has created or selected namespace "aut-addflow-git"
 
 
-        @smoke
+        @smoke @odc-5009
         Scenario Outline: Add new git workload with new application for resoruce type "<resource_type>": A-06-TC01
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user enters Application name as "dancer-ex-git-app"
               And user enters Name as "<name>"
               And user selects resource type as "<resource_type>"
@@ -29,8 +29,8 @@ Feature: Create Application from git form
         Scenario: Add new git workload to the existing application: A-06-TC02
             Given user has created workload "exist-git" with resource type "Deployment"
               And user is at Add page
-              And user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
+              And user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user enters Application name as "nodejs-ex-git-app"
               And user enters Name as "dancer-ex-git-2"
               And user selects resource type as "Deployment Config"
@@ -41,16 +41,16 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Cancel the git workload creation: A-06-TC03
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user clicks Cancel button on Add page
              Then user will be redirected to Add page
 
 
         @regression
         Scenario: Create workload without application route: A-06-TC04
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user enters Application name as "app-no-route"
               And user enters Name as "name-no-route"
               And user unselects the advanced option Create a route to the application
@@ -61,8 +61,8 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Create a git workload with advanced option "Routing": A-06-TC05
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user enters name as "git-route" in General section
               And user clicks "Routing" link in Advanced Options section
               And user enters Hostname as "home"
@@ -75,8 +75,8 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Create the workload by unselecting options in "Build Configuration" section:: A-06-TC06
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
               And user enters name as "git-build" in General section
               And user clicks "Build configuration" link in Advanced Options section
               And user unselects Configure a webhook build trigger checkbox in build configuration section
@@ -91,9 +91,9 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Create a git workload with advanced option "Deployment": A-06-TC07
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
-              And user enters name as "git-deploy" in General section
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
+              And user enters Name as "git-deploy" in General section
               And user clicks "Deployment" link in Advanced Options section
               And user verify the Auto deploy when new image is available checkbox is selected
               And user enters Name as "home" in Environment Variables Runtime only section
@@ -104,9 +104,9 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Create a git workload with advanced option "Resource Limits": A-06-TC08
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
-              And user enters name as "git-resource" in General section
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
+              And user enters Name as "git-resource" in General section
               And user clicks "Resource limits" link in Advanced Options section
               And user enters CPU Request as "10" in CPU section
               And user enters CPU Limits as "12" in CPU section
@@ -118,9 +118,9 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Create a git workload with advanced option "Scaling": A-06-TC09
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
-              And user enters name as "git-scaling" in General section
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
+              And user enters Name as "git-scaling" in General section
               And user clicks "Scaling" link in Advanced Options section
               And user enters number of replicas as "5" in Replicas section
               And user clicks Create button on Add page
@@ -129,9 +129,9 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Create a git workload with advanced option "Labels": A-06-TC10
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
-              And user enters name as "git-labels" in General section
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
+              And user enters Name as "git-labels" in General section
               And user clicks "Labels" link in Advanced Options section
               And user enters label as "app=frontend"
               And user clicks Create button on Add page
@@ -141,9 +141,9 @@ Feature: Create Application from git form
 
         @regression
         Scenario: Create a git workload with advanced option "Health Checks": A-06-TC11
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
-              And user enters name as "git-healthchecks" in General section
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
+              And user enters Name as "git-healthchecks" in General section
               And user clicks "Health checks" link in Advanced Options section
               And user fills the Readiness Probe details
               And user fills the Liveness Probe details
@@ -155,9 +155,10 @@ Feature: Create Application from git form
         # Marking this scenario as @manual, because due to git-rate limit issue, below scenarios are failing
         @regression @manual
         Scenario Outline: Builder iamge detected for git url "<git_url>": A-06-TC12
-            Given user is at Import from git page
-             When user enters Git Repo url as "<git_url>"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "<git_url>"
              Then git url "<git_url>" gets Validated
+              And import strategy as Builder Image is detected
               And builder image is detected
               And builder image version drop down is displayed
               And Application name displays as "<app_name>"
@@ -174,16 +175,16 @@ Feature: Create Application from git form
                   | https://github.com/sclorg/nodejs-ex.git        | nodejs-ex-git-app  | nodejs-ex-git         |
 
 
-        @regression @manual
+        @regression @manual @odc-5009
         Scenario Outline: Dotnet Builder image detection for git url "<git_url>": A-06-TC13
-            Given user is at Import from git page
-             When user enters Git Repo url as "<git_url>"
-              And warning message "Unable to detect the Builder Image" displays in Builder section
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "<git_url>"
+              And warning message "Unable to detect import strategy" displays
               And user clicks on "Show advanced Git options" link
               And user clears Context dir field
               And user enters Context dir as "<dir_name>"
              Then git url "<git_url>" gets Validated
-              And user is able to see "Builder Image(s) detected" message in Builder section
+              And user is able to see "Builder Image(s) selected" message
               And .NET builder image card tile is highlighted with * mark
 
         Examples:
@@ -191,12 +192,12 @@ Feature: Create Application from git form
                   | https://github.com/redhat-developer/s2i-dotnetcore-ex.git | /app     | dotnetcore-ex-git-app | dotnetcore-ex-git |
 
 
-        @regression @manual
+        @regression @manual @odc-5009
         Scenario Outline: "Unable to detect the builder image" warning message displays for server related git urls: A-06-TC14
-            Given user is at Import from git page
-             When user enters Git Repo url as "<git_url>"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "<git_url>"
              Then git url "<git_url>" gets Validated
-              And user is able to see warning message "Unable to detect the Builder Image" in Builder section
+              And user is able to see warning message "Unable to detect the import strategy"
 
         Examples:
                   | git_url                                | builder_image |

--- a/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
+++ b/frontend/packages/knative-plugin/integration-tests/features/serverless/create-knative-workload.feature
@@ -14,12 +14,12 @@ Feature: Create a workload of 'knative Service' type resource
               And Knative Service option is displayed under Resources section
 
 
-        @regression
+        @regression @odc-5009
         Scenario: knative resource type in docker file add flow: KN-05-TC02
             Given user is at Add page
-             When user clicks on From Dockerfile card
-             Then user will be redirected to page with header name "Import from Dockerfile"
-              And Knative Service option is displayed under Resources section
+             When user clicks on Import from Git
+              And user enters git url "https://github.com/rohitkrai03/flask-dockerfile-example"
+             Then Knative Service option is displayed under Resources section
 
 
         @regression
@@ -33,8 +33,8 @@ Feature: Create a workload of 'knative Service' type resource
 
         @smoke
         Scenario Outline: Create knative workload from From Git card on Add page: KN-05-TC04
-            Given user is at Import from git page
-             When user enters Git Repo url as "<git_url>"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "<git_url>"
               And user enters Name as "<workload_name>"
               And user selects resource type as "Knative"
               And user clicks Create button on Add page
@@ -61,10 +61,13 @@ Feature: Create a workload of 'knative Service' type resource
                   | openshift/hello-openshift | knative-ex-registry |
 
 
-        @regression
+        @regression @odc-5009
         Scenario Outline: Create a workload from Docker file card on Add page: KN-05-TC06
-            Given user is on Import from Docker file page
-             When user enters Docker url as "<docker_git_url>"
+            Given user is on Import from Git form
+             When user enters Docker URL as "<docker_git_url>"
+              And user clicks on "Edit import strategy"
+              And user selects Import Strategy as Dockerfile
+              And user enters Dockerfile path as "<dockerfile_path>"
               And user enters workload name as "<workload_name>"
               And user selects resource type as "Knative Service"
               And user clicks Create button on Add page
@@ -72,8 +75,8 @@ Feature: Create a workload of 'knative Service' type resource
               And user is able to see workload "<workload_name>" in topology page
 
         Examples:
-                  | docker_git_url                          | workload_name  |
-                  | https://github.com/sclorg/nodejs-ex.git | knative-docker |
+                  | docker_git_url                                          | dockerfile_path | workload_name  |
+                  | https://github.com/rohitkrai03/flask-dockerfile-example | Dockerfile      | knative-docker |
 
 
         @regression
@@ -92,9 +95,9 @@ Feature: Create a workload of 'knative Service' type resource
 
         @regression @to-do
         Scenario: Create a knative workload with advanced option "Scaling" from From Git card: KN-05-TC08
-            Given user is at Import from git page
-             When user enters Git Repo url as "https://github.com/sclorg/dancer-ex.git"
-              And user enters name as "dancer-ex-git" in General section
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"
+              And user enters Name as "dancer-ex-git" in General section
               And user selects resource type as "Knative Service"
               And user clicks "Scaling" link in Advanced Options section
               And user enters number of Min Pods as "1"

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
@@ -16,7 +16,7 @@ Feature: Create Pipeline from Add Options
         @smoke
         Scenario Outline: Create a pipeline from git workload with resource type "<resource>": P-01-TC02
             Given user is at Import from Git form
-             When user enters Git Repo url as "<git_url>"
+             When user enters Git Repo URL as "<git_url>"
               And user enters Name as "<pipeline_name>" in General section
               And user selects resource type as "<resource>"
               And user selects Add Pipeline checkbox in Pipelines section
@@ -37,7 +37,7 @@ Feature: Create Pipeline from Add Options
               And user has created or selected namespace "aut-pipelines-add-options"
               And user is at Add page
               And user is at Import from Git form
-             When user enters Git Repo url as "<git_url>"
+             When user enters Git Repo URL as "<git_url>"
               And user enters Name as "<pipeline_name>" in General section
               And user selects resource type as "knative"
               And user selects Add Pipeline checkbox in Pipelines section
@@ -78,10 +78,13 @@ Feature: Create Pipeline from Add Options
                   | nodejs-g |
 
 
-        @regression
+        @regression @odc-5009
         Scenario Outline: Create a workload with pipeline from Docker file: P-01-TC06
-            Given user is on Import from Docker file page
-             When user enters Git Repo url in docker file as "<docker_git_url>"
+            Given user is on Import from Git form
+             When user enters Git Repo URL as "<docker_git_url>"
+              And user clicks on "Edit import strategy"
+              And user selects Import Strategy as Dockerfile
+              And user enters Dockerfile path as "<dockerfile_path>"
               And user enters Name as "<pipeline_name>" in General section of Dockerfile page
               And user selects Add Pipeline checkbox in Pipelines section
               And user clicks Create button on Add page
@@ -89,8 +92,8 @@ Feature: Create Pipeline from Add Options
               And user is able to see workload "<pipeline_name>" in topology page
 
         Examples:
-                  | docker_git_url                                  | pipeline_name   |
-                  | https://github.com/openshift/pipelines-vote-api | docker-pipeline |
+                  | docker_git_url                                  | pipeline_name   | dockerfile_path |
+                  | https://github.com/openshift/pipelines-vote-api | docker-pipeline | dockerfile      |
 
 
         @regression
@@ -113,7 +116,7 @@ Feature: Create Pipeline from Add Options
         @regression @manual
         Scenario Outline: Add Pipeline option display in git workload for builder image: P-01-TC08
             Given user is at Import from Git form
-             When user enters Git Repo url as "<git_url>"
+             When user enters Git Repo URL as "<git_url>"
              Then Add pipeline checkbox is displayed
 
         Examples:
@@ -129,8 +132,8 @@ Feature: Create Pipeline from Add Options
 
         @regression @manual
         Scenario Outline: Add Pipeline option display for dotnet builder image with context directory": P-01-TC09
-            Given user is at Import from git page
-             When user enters Git Repo url as "<git_url>"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "<git_url>"
               And user selects Show advanced Git options
               And user clears Context dir field
               And user enters Context dir as "<dir_name>"
@@ -141,10 +144,12 @@ Feature: Create Pipeline from Add Options
                   | https://github.com/redhat-developer/s2i-dotnetcore-ex.git | /app     |
 
 
-        @regression @manual
+        @regression @manual @odc-5009
         Scenario Outline: Add Pipeline option doesn't display for server related git urls: P-01-TC10
-            Given user is at Import from git page
-             When user enters Git Repo url as "<git_url>"
+            Given user is at Import from Git form
+             When user enters Git Repo URL as "<git_url>"
+              And user clicks on "Edit import strategy"
+              And user selects Import Strategy as Builder Image
               And user selects "<builder_image>" builder image
              Then git url "<git_url>" gets Validated
               And user is able to see info message "<message>" in Pipelines section

--- a/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
@@ -164,13 +164,10 @@ Feature: Topology chart area
               And user hovers on Add to Project
               And user clicks on Samples
               And user selects go sample and clicks Create
-              And user hovers on Add to Project and clicks on From Git
+              And user hovers on Add to Project and clicks on Import from Git
               And user fills the form and clicks Create
               And user hovers on Add to Project and clicks on Container Image
               And user fills the form and clicks Create
-              And user hovers on Add to Project and clicks on From Dockerfile
-              And user fills the form and clicks Create
-              And user hovers on Add to Project and clicks on From Devfile
               And user fills the form and clicks Create
               And user hovers on Add to Project and clicks on From Catalog
               And user selects Python Builder Image and clicks Create Application
@@ -189,7 +186,7 @@ Feature: Topology chart area
               And user fills the form and clicks Create
               And user hovers on Add to Project and clicks on From Channel
               And user clicks on Create
-             Then user is able to see different applications created from Samples, From Git, Container Image, From Dockerfile, From Devfile, From Catalog, Database, Operator Backed, Helm Charts, Event Source, Channel
+             Then user is able to see different applications created from Samples, Import from Git, Container Image, From Catalog, Database, Operator Backed, Helm Charts, Event Source, Channel
 
 
         @regression @manual

--- a/frontend/packages/topology/integration-tests/features/topology/topology-in-context-add-options.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-in-context-add-options.feature
@@ -11,18 +11,18 @@ Feature: Add in context from the Developer Catalog
               And user is at Topology page
 
 
-        @smoke @to-do
+        @smoke @to-do @odc-5009
         Scenario: Add to Project in Context options: T-10-TC01
              When user right clicks on graph
               And user clicks on Add to Project
-             Then user can see in context options Samples, From Git, Container Image, From Dockerfile, From Catalog, Database, Operator Backed, Helm Chart, Event Source, Channel
+             Then user can see in context options Samples, Import from Git, Container Image, From Catalog, Database, Operator Backed, Helm Chart, Event Source, Channel
 
 
         @regression @to-do
         Scenario: Add to Application in Context: T-10-TC02
              When user right clicks on Application Grouping "aut-knative-demos"
               And user clicks on Add to Application
-             Then user can see in context options From Git, Container Image, From Dockerfile, Event Source, Channel
+             Then user can see in context options Import from Git, Container Image, Event Source, Channel
 
 
         @regression @to-do


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-5009
Story: https://issues.redhat.com/browse/ODC-5974

Acceptance criteria:

- Single Import from git option on the add page & context menus in topology
- When using the Import from git option, I should be provided with a smart default, based on the contents of my git repo
- I should always be thrown all 3 options (Builder Image, Dockerfile, Devfile)

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [ ] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]