### PR TITLE
Bug 1996758: Update Resource Dropdown Tech preview text [Release-4.8]

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -67,7 +67,7 @@
 }
 
 .co-type-selector {
-  .pf-c-dropdown__menu {
+  .pf-c-select__menu {
     min-width: 290px;
     @media (min-width: 480px) {
       min-width: 350px;


### PR DESCRIPTION
# Addresses
[Release-4.8 ]https://issues.redhat.com/browse/ODC-6242
4.9 PR -- https://github.com/openshift/console/pull/9822

# Issue
Tech preview style missing in Resource-dropdown

# Fix
Change in parent element class name
**.pf-c-dropdown__menu** became **pf-c-select__menu** changed CSS accordingly

# Screenshot
![Screenshot from 2021-08-17 21-28-44](https://user-images.githubusercontent.com/24852534/129766659-248f242a-0051-4084-b5fc-b5fbb3fbd7b0.png)

# Tests
No change

# Browser Conformance
Chrome
