### PR TITLE
 Gherkin form based edit build config

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/build-config/edit-build-config.feature
+++ b/frontend/packages/dev-console/integration-tests/features/build-config/edit-build-config.feature
@@ -1,0 +1,99 @@
+@odc-5008
+Feature: Form based edit for Build Configs
+              As a user, I can have form based edit for Build Configs to improve the user experience.
+
+        Background:
+            Given user is at developer perspective
+              And user has created or selected namespace "aut-form-edit-build-config"
+
+
+        @smoke @to-do
+        Scenario: Edit Build Config page: EBC-01-TC01
+            Given user has created a deployment workload "nodejs-ex-git1"
+             When user navigates to build tab
+              And user clicks on kebab menu for "nodejs-ex-git1" build config
+              And user clicks on Edit BuildConfig
+             Then user will see the Name field
+              And user will see the Git repository url field
+              And user will see the Image configuration section
+              And user will see the Environment Variables section
+
+
+        @regression @to-do
+        Scenario: Advanced options in Edit Build Config page: EBC-01-TC02
+            Given user is at Edit Build Config page of deployment "nodejs-ex-git1"
+             When user clicks on Advanced option "Triggers"
+              And user clicks on Advanced option "Secrets"
+              And user clicks on Advanced option "Run Policy"
+              And user clicks on Advanced option "Hooks"
+             Then user will see section "Triggers"
+              And user will see section "Build Secret"
+              And user will see section "Run Policy"
+              And user will see section "Hooks"
+
+
+        @regression @manual
+        Scenario: Switch from Form to YAML view for editing BuildConfig: EBC-01-TC03
+            Given user is at Edit Build Config page of deployment "nodejs-ex-git1"
+             When user switches to YAML view
+              And user changes spec.output.to.name to "nodejs-ex-git:2.0"
+              And user switches to Form view
+             Then user will see tag in Push to value as "nodejs-ex-git:2.0"
+
+
+        @regression @to-do
+        Scenario Outline: Edit a buildconfig which uses strategy Source(S2I)) and Git as source: EBC-01-TC04
+            Given user is at Edit Build Config page of deployment "nodejs-ex-git1"
+             When user changes Git Rpository URL to "<git_url>" menu of build config
+              And user selects imagestream "<image_stream>" and tag "<tag>" in Build From section in Image Configuration
+              And user enters Name and Value as "<name>" and "<value>" respectively in Environment Variables
+              And user clicks Save button on Edit build Config page
+             Then user will see Git Repository as "<git_url>" and Build from as "<image_stream>:<tag>"
+
+        Examples:
+                  | git_url                                 | image_stream | tag | name | value |
+                  | https://github.com/sclorg/django-ex.git | python       | 3.8 | path | /home |
+
+
+        @regression @to-do
+        Scenario: Edit Advanced git options of buildconfig which uses strategy Docker and Git as source: EBC-01-TC05
+        # user can use buildconfig-with-strategy-docker-source-git.yaml from testData/yamls/BuildConfig
+            Given user has applied the yaml "buildconfig-with-strategy-docker-source-git.yaml"
+             When user clicks on action menu of build config
+              And user selects the option Edit BuildConfig
+              And user clicks Show advanced Git options
+              And user changes value of Context Dir to "beginner/static-site"
+              And user clicks Save button on Edit Build Config page
+             Then user will see Context dir as "beginner/static-site"
+
+
+        @regression @to-do
+        Scenario Outline: Edit a buildconfig which uses strategy Docker and Dockerfile as source: EBC-01-TC06
+        # user can use buildconfig-with-strategy-docker-source-dockerfile.yaml from testData/yamls/BuildConfig
+            Given user has applied the yaml "buildconfig-with-strategy-docker-source-dockerfile.yaml"
+             When user clicks on action menu of build config
+              And user selects the option Edit BuildConfig
+              And user enters Name and Value as "<name>" and "<value>" respectively in Environment Variables
+              And user clicks Save button on Edit build Config page
+              And user goes to Environment tab
+             Then user will see Name as "<name>" and and Value as "<value>" in Environment Variables
+
+        Examples:
+                  | name | value |
+                  | path | /home |
+
+
+        @regression @to-do
+        Scenario Outline: Edit a buildconfig which uses strategy Source and Binary as source: EBC-01-TC07
+        # user can use buildconfig-with-strategy-source-source-binary.yaml from testData/yamls/BuildConfig
+            Given user has applied the yaml "buildconfig-with-strategy-source-source-binary.yaml"
+             When user clicks on action menu of build config
+              And user selects the option Edit BuildConfig
+              And user enters Name and Value as "<name>" and "<value>" respectively in Environment Variables
+              And user clicks Save button on Edit build Config page
+              And user goes to Environment tab
+             Then user will see Name as "<name>" and and Value as "<value>" in Environment Variables
+
+        Examples:
+                  | name | value |
+                  | path | /home |

--- a/frontend/packages/dev-console/integration-tests/testData/yamls/BuildConfig/buildconfig-with-strategy-docker-source-dockerfile.yaml
+++ b/frontend/packages/dev-console/integration-tests/testData/yamls/BuildConfig/buildconfig-with-strategy-docker-source-dockerfile.yaml
@@ -1,0 +1,46 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-ref: ''
+    app.openshift.io/vcs-uri: 'https://github.com/docker/labs'
+    openshift.io/generated-by: OpenShiftWebConsole
+  labels:
+    app: flask-app
+    app.kubernetes.io/component: flask-app
+    app.kubernetes.io/instance: flask-app
+    app.kubernetes.io/name: flask-app
+  name: flask-app
+  namespace: aut-form-edit-build-config
+spec:
+  failedBuildsHistoryLimit: 5
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'flask-app:latest'
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    dockerfile: |-
+      FROM centos:7
+      RUN yum install -y httpd
+    type: Dockerfile
+  strategy:
+    dockerStrategy:
+      dockerfilePath: Dockerfile
+    type: Docker
+  successfulBuildsHistoryLimit: 5
+  triggers:
+    - generic:
+        secretReference:
+          name: flask-app-generic-webhook-secret
+      type: Generic
+    - github:
+        secretReference:
+          name: flask-app-github-webhook-secret
+      type: GitHub
+    - type: ConfigChange
+status:
+  lastVersion: 1

--- a/frontend/packages/dev-console/integration-tests/testData/yamls/BuildConfig/buildconfig-with-strategy-docker-source-git.yaml
+++ b/frontend/packages/dev-console/integration-tests/testData/yamls/BuildConfig/buildconfig-with-strategy-docker-source-git.yaml
@@ -1,0 +1,46 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  annotations:
+    app.openshift.io/vcs-ref: ''
+    app.openshift.io/vcs-uri: 'https://github.com/docker/labs'
+    openshift.io/generated-by: OpenShiftWebConsole
+  labels:
+    app: flask-app
+    app.kubernetes.io/component: flask-app
+    app.kubernetes.io/instance: flask-app
+    app.kubernetes.io/name: flask-app
+  name: flask-app-12
+  namespace: aut-form-edit-build-config
+spec:
+  failedBuildsHistoryLimit: 5
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'flask-app:latest'
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    contextDir: /beginner/flask-app
+    git:
+      uri: 'https://github.com/docker/labs'
+    type: Git
+  strategy:
+    dockerStrategy:
+      dockerfilePath: Dockerfile
+    type: Docker
+  successfulBuildsHistoryLimit: 5
+  triggers:
+    - generic:
+        secretReference:
+          name: flask-app-generic-webhook-secret
+      type: Generic
+    - github:
+        secretReference:
+          name: flask-app-github-webhook-secret
+      type: GitHub
+    - type: ConfigChange
+status:
+  lastVersion: 1

--- a/frontend/packages/dev-console/integration-tests/testData/yamls/BuildConfig/buildconfig-with-strategy-source-source-binary.yaml
+++ b/frontend/packages/dev-console/integration-tests/testData/yamls/BuildConfig/buildconfig-with-strategy-source-source-binary.yaml
@@ -1,0 +1,102 @@
+kind: Build
+apiVersion: build.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/build-config.name: fruits-app-1
+    openshift.io/build.number: '1'
+    openshift.io/build.pod-name: fruits-app-1-1-build
+  name: fruits-app-1-1
+  namespace: aut-form-edit-build-config
+  ownerReferences:
+    - apiVersion: build.openshift.io/v1
+      kind: BuildConfig
+      name: fruits-app-1
+      uid: 44291715-6933-4fac-82f1-481ea0fe7f29
+      controller: true
+  labels:
+    app: fruits-app-1
+    app.kubernetes.io/instance: fruits-app-1
+    openshift.io/build-config.name: fruits-app-1
+    app.kubernetes.io/component: fruits-app-1
+    openshift.io/build.start-policy: Serial
+    buildconfig: fruits-app-1
+    app.openshift.io/runtime: java
+    app.kubernetes.io/name: fruits-app-1
+    app.openshift.io/runtime-version: openjdk-11-el7
+spec:
+  serviceAccount: builder
+  source:
+    type: Binary
+    binary:
+      asFile: fruits-app-1.0.0-SNAPSHOT-runner.jar
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: >-
+          image-registry.openshift-image-registry.svc:5000/openshift/java@sha256:922ff4e248660350597fc7bd4b896df63169779bb8d21ec00d97a750a1cdfa1f
+      pullSecret:
+        name: builder-dockercfg-jjlfs
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'fruits-app-1:latest'
+    pushSecret:
+      name: builder-dockercfg-jjlfs
+  resources: {}
+  postCommit: {}
+  nodeSelector: null
+status:
+  output:
+    to:
+      imageDigest: 'sha256:da605b3ac4e0350944ecf39a8d8d8a5472e54a1150c3577d9c390adf9890975d'
+  config:
+    kind: BuildConfig
+    namespace: aut-form-edit-build-config
+    name: fruits-app-1
+  outputDockerImageReference: >-
+    image-registry.openshift-image-registry.svc:5000/aut-form-edit-build-config/fruits-app-1:latest
+  duration: 53000000000
+  startTimestamp: '2021-05-04T07:45:14Z'
+  stages:
+    - name: PullImages
+      startTime: '2021-05-04T07:45:20Z'
+      durationMilliseconds: 21036
+      steps:
+        - name: PullBaseImage
+          startTime: '2021-05-04T07:45:20Z'
+          durationMilliseconds: 21036
+    - name: Build
+      startTime: '2021-05-04T07:45:41Z'
+      durationMilliseconds: 19070
+      steps:
+        - name: DockerBuild
+          startTime: '2021-05-04T07:45:41Z'
+          durationMilliseconds: 19070
+    - name: PushImage
+      startTime: '2021-05-04T07:46:00Z'
+      durationMilliseconds: 6184
+      steps:
+        - name: PushImage
+          startTime: '2021-05-04T07:46:00Z'
+          durationMilliseconds: 6184
+  conditions:
+    - type: New
+      status: 'False'
+      lastUpdateTime: '2021-05-04T07:45:14Z'
+      lastTransitionTime: '2021-05-04T07:45:14Z'
+    - type: Pending
+      status: 'False'
+      lastUpdateTime: '2021-05-04T07:45:18Z'
+      lastTransitionTime: '2021-05-04T07:45:18Z'
+    - type: Running
+      status: 'False'
+      lastUpdateTime: '2021-05-04T07:46:07Z'
+      lastTransitionTime: '2021-05-04T07:46:07Z'
+    - type: Complete
+      status: 'True'
+      lastUpdateTime: '2021-05-04T07:46:07Z'
+      lastTransitionTime: '2021-05-04T07:46:07Z'
+  completionTimestamp: '2021-05-04T07:46:07Z'
+  phase: Complete


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-5008
Story: https://issues.redhat.com/browse/ODC-5968

Acceptance criteria:

- The Edit Build Config action should allow the user to have a form driven experience
- The Edit Build Config form driven experience should support the same features that were supported in 3.x


**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [ ] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]