### PR TITLE
Bug 1996535: Improve detect namespace hook and fix redirect loop and e2e tests

### DIFF
--- a/frontend/packages/console-app/src/components/detect-namespace/__tests__/getValueForNamespace.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/__tests__/getValueForNamespace.spec.ts
@@ -8,8 +8,6 @@ jest.mock('../checkNamespaceExists', () => ({
 
 const checkNamespaceExistsMock = checkNamespaceExists as jest.Mock;
 
-const urlNamespace: string = 'url-ns';
-const activeNamespace = 'active-ns';
 const preferredNamespace: string = 'preferred-ns';
 const lastNamespace: string = 'last-ns';
 
@@ -18,93 +16,30 @@ describe('getValueForNamespace', () => {
     jest.resetAllMocks();
   });
 
-  it('should return urlNamespace as value for namespace if it is defined and exists', async () => {
+  it(`should return preferredNamespace if it is defined and exists`, async () => {
     checkNamespaceExistsMock.mockReturnValueOnce(Promise.resolve(true));
 
-    const namespace = await getValueForNamespace(
-      true,
-      urlNamespace,
-      activeNamespace,
-      preferredNamespace,
-      lastNamespace,
-    );
-
-    expect(namespace).toEqual(urlNamespace);
-  });
-
-  it('should return activeNamespace as value for namespace if it is defined and exists, and urlNamespace is not defined', async () => {
-    checkNamespaceExistsMock.mockReturnValueOnce(Promise.resolve(true));
-
-    const namespace = await getValueForNamespace(
-      true,
-      null,
-      activeNamespace,
-      preferredNamespace,
-      lastNamespace,
-    );
-
-    expect(namespace).toEqual(activeNamespace);
-  });
-
-  it('should return activeNamespace as value for namespace if it is defined and exists, and urlNamespace is defined but does not exist', async () => {
-    checkNamespaceExistsMock
-      .mockReturnValueOnce(Promise.resolve(false))
-      .mockReturnValueOnce(Promise.resolve(true));
-
-    const namespace = await getValueForNamespace(
-      true,
-      urlNamespace,
-      activeNamespace,
-      preferredNamespace,
-      lastNamespace,
-    );
-
-    expect(namespace).toEqual(activeNamespace);
-  });
-
-  it(`should return preferredNamespace as value for namespace if it is defined and exists, and urlNamespace, activeNamespace are not defined or do not exist`, async () => {
-    checkNamespaceExistsMock.mockReturnValueOnce(Promise.resolve(true));
-
-    const namespace = await getValueForNamespace(
-      true,
-      null,
-      null,
-      preferredNamespace,
-      lastNamespace,
-    );
+    const namespace = await getValueForNamespace(preferredNamespace, lastNamespace, true);
 
     expect(namespace).toEqual(preferredNamespace);
   });
 
-  it(`should return lastNamespace as value for namespace if it is defined and exists, and urlNamespace, activeNamespace, 
-    preferredNamespace are not defined or do not exist`, async () => {
+  it('should return lastNamespace if preferred namespace does not exist and last namespace is defined and exists', async () => {
     checkNamespaceExistsMock
       .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(true));
 
-    const namespace = await getValueForNamespace(
-      true,
-      null,
-      null,
-      preferredNamespace,
-      lastNamespace,
-    );
+    const namespace = await getValueForNamespace(preferredNamespace, lastNamespace, true);
 
     expect(namespace).toEqual(lastNamespace);
   });
 
-  it(`should return ${ALL_NAMESPACES_KEY} as value for namespace if all of the parameters for namespace are not defined or do not exist`, async () => {
+  it(`should return ${ALL_NAMESPACES_KEY} if preferred and last namespace does not exists`, async () => {
     checkNamespaceExistsMock
       .mockReturnValueOnce(Promise.resolve(false))
       .mockReturnValueOnce(Promise.resolve(false));
 
-    const namespace = await getValueForNamespace(
-      true,
-      null,
-      null,
-      preferredNamespace,
-      lastNamespace,
-    );
+    const namespace = await getValueForNamespace(preferredNamespace, lastNamespace, true);
 
     expect(namespace).toEqual(ALL_NAMESPACES_KEY);
   });

--- a/frontend/packages/console-app/src/components/detect-namespace/__tests__/namespace.spec.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/__tests__/namespace.spec.ts
@@ -62,7 +62,7 @@ describe('useValuesForNamespaceContext', () => {
     jest.resetAllMocks();
   });
 
-  it('should return urlNamespace as value for namespace if it exists', async () => {
+  it('should return urlNamespace if it is defined', async () => {
     useFlagMock.mockReturnValue(true);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData());
@@ -79,7 +79,7 @@ describe('useValuesForNamespaceContext', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it(`should return activeNamespace as value for namespace if it exists and urlNamespace does not exist`, async () => {
+  it('should return activeNamespace if it it already defined', async () => {
     useFlagMock.mockReturnValue(true);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(false));
@@ -97,7 +97,7 @@ describe('useValuesForNamespaceContext', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it(`should return preferredNamespace as value for namespace if it exists, and urlNamespace and activeNamespace do not exist`, async () => {
+  it('should return preferredNamespace if it exists', async () => {
     useFlagMock.mockReturnValue(true);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(false));
@@ -114,7 +114,7 @@ describe('useValuesForNamespaceContext', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it('should return lastNamespace as value for namespace if it exists and favoritedNamespace, preferredNamespace, urlNamespace, and activeNamespace do not exist', async () => {
+  it('should return lastNamespace if it exists and preferredNamespace do not exist', async () => {
     useFlagMock.mockReturnValue(true);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(false));
@@ -131,7 +131,7 @@ describe('useValuesForNamespaceContext', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it('should return ALL_NAMESPACES_KEY as value for namespace if lastNamespace, favoritedNamespace, preferredNamespace, urlNamespace, and activeNamespace do not exist', async () => {
+  it('should return ALL_NAMESPACES_KEY if urlNamespacel, preferredNamespace, lastNamespace are not defined', async () => {
     useFlagMock.mockReturnValue(true);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(false));
@@ -148,8 +148,8 @@ describe('useValuesForNamespaceContext', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it('should return true for loaded if urlNamespace has loaded and flags are not pending, irrespective of loaded status for other resources', async () => {
-    useFlagMock.mockReturnValue(true);
+  it('should return true for loaded if urlNamespace has loaded irrespective of loaded status for other resources', async () => {
+    useFlagMock.mockReturnValue(undefined);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(true));
     usePreferredNamespaceMock.mockReturnValue([preferredNamespace, jest.fn(), false]);
@@ -165,7 +165,7 @@ describe('useValuesForNamespaceContext', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it('should return true for loaded if preferredNamespace and lastNamespace have loaded, urlNamespace is not defined and flags are not pending', async () => {
+  it('should return true for loaded if urlNamespace is not defined and preferredNamespace and lastNamespace are loaded, and flags are not pending anymore', async () => {
     useFlagMock.mockReturnValue(true);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(false));
@@ -182,8 +182,7 @@ describe('useValuesForNamespaceContext', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it('should return false for loaded if no resources have loaded and urlNamespace is undefined', async () => {
-    spyOn(React, 'useState').and.returnValue([activeNamespace, jest.fn()]);
+  it('should return false for loaded if urlNamespace is undefined and no resources is loaded yet', async () => {
     useFlagMock.mockReturnValue(true);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(false));
@@ -196,11 +195,11 @@ describe('useValuesForNamespaceContext', () => {
     });
     const { namespace, loaded } = result.current;
 
-    expect(namespace).toEqual(activeNamespace);
+    expect(namespace).toBeFalsy();
     expect(loaded).toBeFalsy();
   });
 
-  it('should return false for loaded if flags are pending', async () => {
+  it('should return false for loaded if urlNamespace is undefined and flags are pending', async () => {
     useFlagMock.mockReturnValue(undefined);
     k8sGetMock.mockReturnValue(Promise.resolve({}));
     useLocationMock.mockReturnValue(getLocationData(false));
@@ -213,25 +212,7 @@ describe('useValuesForNamespaceContext', () => {
     });
     const { namespace, loaded } = result.current;
 
-    expect(namespace).toEqual('');
-    expect(loaded).toBeFalsy();
-  });
-
-  it('should return false for loaded if activeNamespace is not defined', async () => {
-    spyOn(React, 'useState').and.returnValue(['', jest.fn()]);
-    useFlagMock.mockReturnValue(true);
-    k8sGetMock.mockReturnValue(Promise.resolve({}));
-    useLocationMock.mockReturnValue(getLocationData(false));
-    usePreferredNamespaceMock.mockReturnValue([undefined, jest.fn(), true]);
-    useLastNamespaceMock.mockReturnValue([lastNamespace, jest.fn(), true]);
-
-    const { result, rerender } = testHook(() => useValuesForNamespaceContext());
-    await act(async () => {
-      rerender();
-    });
-    const { namespace, loaded } = result.current;
-
-    expect(namespace).toEqual('');
+    expect(namespace).toBeFalsy();
     expect(loaded).toBeFalsy();
   });
 });

--- a/frontend/packages/console-app/src/components/detect-namespace/getValueForNamespace.ts
+++ b/frontend/packages/console-app/src/components/detect-namespace/getValueForNamespace.ts
@@ -2,35 +2,15 @@ import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';
 import { checkNamespaceExists } from './checkNamespaceExists';
 
 export const getValueForNamespace = async (
-  useProjects?: boolean,
-  urlNamespace?: string,
-  activeNamespace?: string,
-  preferredNamespace?: string,
-  lastNamespace?: string,
+  preferredNamespace: string,
+  lastNamespace: string,
+  useProjects: boolean,
 ): Promise<string> => {
-  if (urlNamespace) {
-    if (await checkNamespaceExists(urlNamespace, useProjects)) {
-      return urlNamespace;
-    }
+  if (await checkNamespaceExists(preferredNamespace, useProjects)) {
+    return preferredNamespace;
   }
-
-  if (activeNamespace) {
-    if (await checkNamespaceExists(activeNamespace, useProjects)) {
-      return activeNamespace;
-    }
+  if (await checkNamespaceExists(lastNamespace, useProjects)) {
+    return lastNamespace;
   }
-
-  if (preferredNamespace) {
-    if (await checkNamespaceExists(preferredNamespace, useProjects)) {
-      return preferredNamespace;
-    }
-  }
-
-  if (lastNamespace) {
-    if (await checkNamespaceExists(lastNamespace, useProjects)) {
-      return lastNamespace;
-    }
-  }
-
   return ALL_NAMESPACES_KEY;
 };

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -250,7 +250,7 @@ export const getOCMLink = (clusterID: string): string =>
   `https://console.redhat.com/openshift/details/${clusterID}`;
 
 export const getConditionUpgradeableFalse = (resource) =>
-  resource.status?.conditions.find(
+  resource.status?.conditions?.find(
     (c) => c.type === 'Upgradeable' && c.status === K8sResourceConditionStatus.False,
   );
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1996535
https://issues.redhat.com/browse/ODC-6267

**Analysis / Root cause**: 
This is an follow up for PR 9386 and this work is **based on** @nemesis09 **work** in PR 9846

* PR 9386 #9386
* PR 9846 #9846

1. The new user preferences introduce a change in the hook which detects the current / active namespace which can result in an endless loop after the user creates a new project.
2. Cluster settings page crashs in some edge cases when a project is created while the cluster settings page is open. (I could reproduce this always with my crc, but not on a cluster. It depends on the installed operators etc.) The new code is introduced in 4.9 so that we don't need a backport for this.

**Solution Description**: 
1. Cleanup the namespace hook. Ensure that it doesn't result in an rerendering or redirect loop.
    * if an URL contains a namespace (or the info all namespaces) known at the beginning
        * saved as current namespace
        * the url-based namespace is returned (with loaded: false)
        * set to the redux state
    * if the URL doesn't contain a namespace (or the info all namespaces) the hooks
        * doesn't have a known current namespace and returns loaded: false
        * waits for the preferred and last namespace user settings, and also for flag if project or namespaces are used
        * when all three infos are loaded (remember: the url doesn't contain any namespace info)
            * the preferred or last namespace is set as current namespace
            * the redux state is set and (in setActiveNamespace) the user will be redirected to this namespace
    * whenever the url changes, the hook checks if this new url contains a namespace
        * if that url contains a namespace the current namespace (context value) stores this namespace
        * the redux state is set (which might redirect to this namespace again, but this should not happen since the url contains that namespace already)
        * LAST NAMESPACE is not updated automatically at the moment!!
    * and finally: `setNamespace` (available as context value)
        * updates the current namespace (context value)
        * the last namespace!! which is only used when there is no preference and the user returns later to an url without namespace.
        *  the redux state is set (which will also automatically redirect the user to a new URL)

2. Fix the crash in frontend/public/module/k8s/cluster-settings.ts with an additional `?.` check.

**Screen shots / Gifs for design review**: 
Recording of multiple namespace tests (4 mb)

https://user-images.githubusercontent.com/139310/130352982-2a5cb6ec-75b5-4b31-a00a-b7ed37021ab7.mp4

**Unit test coverage report**: 
Tests changed and passes.

**Test setup:**
Test everything which is aligned to the following features and mix them:

* Switch namespaces
* Create a namespace
* Set preferred namespace
* Return to an URL with and without namespace in it

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
