### PR TITLE
Add psrna to integration-tests approvers.

### DIFF
--- a/frontend/packages/dev-console/integration-tests/OWNERS
+++ b/frontend/packages/dev-console/integration-tests/OWNERS
@@ -3,3 +3,4 @@ reviewers:
   - sanketpathak
 approvers:
   - makambalaji
+  - psrna

--- a/frontend/packages/gitops-plugin/integration-tests/OWNERS
+++ b/frontend/packages/gitops-plugin/integration-tests/OWNERS
@@ -4,3 +4,4 @@ reviewers:
   - amitkrout
 approvers:
   - makambalaji
+  - psrna

--- a/frontend/packages/helm-plugin/integration-tests/OWNERS
+++ b/frontend/packages/helm-plugin/integration-tests/OWNERS
@@ -3,3 +3,4 @@ reviewers:
   - sanketpathak
 approvers:
   - makambalaji
+  - psrna

--- a/frontend/packages/knative-plugin/integration-tests/OWNERS
+++ b/frontend/packages/knative-plugin/integration-tests/OWNERS
@@ -4,3 +4,4 @@ reviewers:
   - mgencur
 approvers:
   - makambalaji
+  - psrna

--- a/frontend/packages/pipelines-plugin/integration-tests/OWNERS
+++ b/frontend/packages/pipelines-plugin/integration-tests/OWNERS
@@ -5,3 +5,4 @@ reviewers:
   - praveen4g0
 approvers:
   - makambalaji
+  - psrna

--- a/frontend/packages/topology/integration-tests/OWNERS
+++ b/frontend/packages/topology/integration-tests/OWNERS
@@ -3,3 +3,4 @@ reviewers:
   - sanketpathak
 approvers:
   - makambalaji
+  - psrna


### PR DESCRIPTION
Please add me as a backup/second approver to the integration-tests approvers for dev-console and related plugins. I'm managing dev-console QE and need to have a fallback option to approve QE's PRs when Balaji is out. Thx.