### PR TITLE
Bug 1963027: Upload qcow2 to PVC too small

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/cdi-upload-provider.tsx
@@ -93,7 +93,11 @@ export const useCDIUploadHook = (): CDIUploadContextProps => {
               uploadStatus: UPLOAD_STATUS.CANCELED,
             });
           } else {
-            updateUpload({ ...newUpload, uploadStatus: UPLOAD_STATUS.ERROR, uploadError: err });
+            updateUpload({
+              ...newUpload,
+              uploadStatus: UPLOAD_STATUS.ERROR,
+              uploadError: { message: `${err.message}: ${err.response?.data}` },
+            });
           }
         });
     }


### PR DESCRIPTION
<img width="676" alt="Screen Shot 2021-08-22 at 16 07 42" src="https://user-images.githubusercontent.com/24938324/130356497-67b4d91a-eb80-459b-b08e-eda04b64bd3f.png">

Added `err.response.data` to the error message of the upload process