### PR TITLE
Bug 1996539: show only route resource id sidepanel if route exists and show external url if status is present and has url

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KSRoutesOverviewListItem.tsx
@@ -15,25 +15,23 @@ const KSRoutesOverviewListItem: React.FC<KSRoutesOverviewListItemProps> = ({ ksr
     status,
   } = ksroute;
   return (
-    status && (
-      <li className="list-group-item">
-        <div className="row">
-          <div className="col-xs-10">
-            <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
-            {status.url?.length > 0 && (
-              <>
-                <span className="text-muted">{t('knative-plugin~Location:')} </span>
-                <ExternalLink
-                  href={status.url}
-                  additionalClassName="co-external-link--block"
-                  text={status.url}
-                />
-              </>
-            )}
-          </div>
+    <li className="list-group-item">
+      <div className="row">
+        <div className="col-xs-10">
+          <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
+          {status?.url?.length > 0 && (
+            <>
+              <span className="text-muted">{t('knative-plugin~Location:')} </span>
+              <ExternalLink
+                href={status.url}
+                additionalClassName="co-external-link--block"
+                text={status.url}
+              />
+            </>
+          )}
         </div>
-      </li>
-    )
+      </div>
+    </li>
   );
 };
 

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KSRoutesOverviewListItem.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
+import * as _ from 'lodash';
 import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RouteModel } from '../../../models';
@@ -58,5 +59,18 @@ describe('KSRoutesOverviewListItem', () => {
     wrapper.setProps({ ksroute });
     expect(wrapper.find(ResourceLink)).toHaveLength(1);
     expect(wrapper.find(ExternalLink)).toHaveLength(0);
+  });
+
+  it('should have ResourceLink with proper kind and not external link if status is not preset on route', () => {
+    const ksroute = _.omit(MockKnativeResources.ksroutes.data[0], 'status');
+    wrapper.setProps({ ksroute });
+    expect(wrapper.find(ResourceLink).exists()).toBe(true);
+    expect(
+      wrapper
+        .find(ResourceLink)
+        .at(0)
+        .props().kind,
+    ).toEqual(referenceForModel(RouteModel));
+    expect(wrapper.find(ExternalLink).exists()).toBe(false);
   });
 });


### PR DESCRIPTION
**Fixes:** 

https://issues.redhat.com/browse/ODC-6262

**Screenshot / gif:**

![Kapture 2021-08-23 at 13 01 39](https://user-images.githubusercontent.com/5129024/130408109-b1052c75-1942-4785-9ed2-961a3b8f17a7.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge