### PR TITLE
Bug 1996644: Fix issues in horizontal nav match object

### DIFF
--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -281,10 +281,10 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
       return (
         <ErrorBoundary FallbackComponent={ErrorBoundaryFallback}>
           <p.component
+            {...params}
             {...componentProps}
             {...extraResources}
             {...p.pageData}
-            {...params}
             customData={props.customData}
           />
         </ErrorBoundary>


### PR DESCRIPTION
Match object provided by the parent is getting overriden by the one provided by route component. This causes issues when Nav's are cascaded. 