### PR TITLE
Bug 1995525: Use fake model for StorageSystem to hide NavItems from Operators Page

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/mock-models.ts
+++ b/frontend/packages/ceph-storage-plugin/src/mock-models.ts
@@ -1,0 +1,14 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+// This model is used by HorizontalNav to limit the exposure of tabs to ODF Dashboard
+export const StorageSystemMockModel: K8sKind = {
+  label: 'StorageSystem',
+  labelPlural: 'StorageSystems',
+  apiVersion: 'v1',
+  apiGroup: 'console.odf.io',
+  plural: 'storagesystems',
+  abbr: 'SS',
+  namespaced: true,
+  kind: 'StorageSystem',
+  crd: true,
+};

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -21,6 +21,7 @@ import { NodeModel } from '@console/internal/models';
 import { LSO_DEVICE_DISCOVERY } from '@console/local-storage-operator-plugin/src/plugin';
 import { OCS_ATTACHED_DEVICES_FLAG } from '@console/local-storage-operator-plugin/src/features';
 import * as models from './models';
+import * as mockModels from './mock-models';
 import { getCephHealthState } from './components/dashboards/persistent-internal/status-card/utils';
 import { isClusterExpandActivity } from './components/dashboards/persistent-internal/activity-card/cluster-expand-activity';
 import { StorageClassFormProvisoners } from './utils/ocs-storage-class-params';
@@ -453,7 +454,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'HorizontalNavTab',
     properties: {
-      model: models.StorageSystemModel,
+      model: mockModels.StorageSystemMockModel,
       page: {
         name: '%ceph-storage-plugin~Storage Systems%',
         href: 'systems',
@@ -471,7 +472,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'HorizontalNavTab',
     properties: {
-      model: models.StorageSystemModel,
+      model: mockModels.StorageSystemMockModel,
       page: {
         // t('ceph-storage-plugin~Backing Store')
         name: '%ceph-storage-plugin~Backing Store%',
@@ -490,7 +491,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'HorizontalNavTab',
     properties: {
-      model: models.StorageSystemModel,
+      model: mockModels.StorageSystemMockModel,
       page: {
         // t('ceph-storage-plugin~Bucket Class')
         name: '%ceph-storage-plugin~Bucket Class%',
@@ -509,7 +510,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'HorizontalNavTab',
     properties: {
-      model: models.StorageSystemModel,
+      model: mockModels.StorageSystemMockModel,
       page: {
         // t('ceph-storage-plugin~Namespace Store')
         name: '%ceph-storage-plugin~Namespace Store%',


### PR DESCRIPTION
Before:
![Screenshot from 2021-08-23 17-27-21](https://user-images.githubusercontent.com/54092533/130443176-e3b09b1c-b3c5-49e3-a5b1-cf9e138729b1.png)

After:
![Screenshot from 2021-08-23 17-24-57](https://user-images.githubusercontent.com/54092533/130442926-d50536c7-b6d1-4f18-8b5d-99d626b60567.png)
