### PR TITLE
Bug 1993886: Fix OLM descriptors getCompatibleCapabilities util function

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/utils.tsx
@@ -125,10 +125,8 @@ const getCompatibleCapabilities = (type: string): (StatusCapability | SpecCapabi
       return [...COMMON_COMPATIBLE_CAPABILITIES, ...OBJECT_COMPATIBLE_CAPABILITIES];
     case 'array':
       return [...COMMON_COMPATIBLE_CAPABILITIES, ...ARRAY_COMPATIBLE_CAPABILITIES];
-    case 'primitive':
-      return [...COMMON_COMPATIBLE_CAPABILITIES, ...PRIMITIVE_COMPATIBLE_CAPABILITIES];
     default:
-      return [];
+      return [...COMMON_COMPATIBLE_CAPABILITIES, ...PRIMITIVE_COMPATIBLE_CAPABILITIES];
   }
 };
 


### PR DESCRIPTION
Revert a change from #9530  that unintentionally made descriptor validation more restricted than necessary.