### PR TITLE
Bug 1996792: Fix quick search modal missing icons

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
@@ -9,6 +9,7 @@
       var(--pf-c-data-list--sm--BorderTopColor) !important;
     flex: 1;
     overflow-y: auto;
+    margin-bottom: 0 !important;
   }
   &__item {
     border-bottom: var(--pf-c-data-list__item--sm--BorderBottomWidth) solid
@@ -26,13 +27,14 @@
     }
   }
   &__item-row {
-    padding: 0 var(--pf-global--spacer--sm);
+    padding: 0 var(--pf-global--spacer--sm) !important;
   }
   &__item-content {
     align-items: center;
   }
   &__item-icon {
     width: 30px;
+    text-align: center;
   }
   &__item-name {
     font-size: var(--pf-global--FontSize--md);

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
@@ -114,7 +114,9 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
                   className="ocs-quick-search-list__item-content"
                   dataListCells={[
                     <DataListCell isIcon key={`${item.uid}-icon`}>
-                      {item.icon?.node ?? getIcon(item)}
+                      <div className="ocs-quick-search-list__item-icon">
+                        {item.icon?.node ?? getIcon(item)}
+                      </div>
                     </DataListCell>,
                     <DataListCell
                       style={{ paddingTop: 'var(--pf-global--spacer--sm)' }}

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.tsx
@@ -44,7 +44,7 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
   viewContainer,
 }) => {
   const DEFAULT_HEIGHT_WITH_NO_ITEMS = 60;
-  const DEFAULT_HEIGHT_WITH_ITEMS = 400;
+  const DEFAULT_HEIGHT_WITH_ITEMS = 483;
   const MIN_HEIGHT = 240;
   const MIN_WIDTH = 225;
   const [catalogItems, setCatalogItems] = React.useState<CatalogItem[]>(null);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6248

**Analysis / Root cause**: 
The quick search results icons are missing.

**Solution Description**: 
- Fix extra left padding
- Show icon for the item.

**Screen shots / Gifs for design review**: 
Before:
![image](https://user-images.githubusercontent.com/2561818/131156349-e7915031-e7a0-41f1-9f39-df1703d6f68d.png)

After:
![image](https://user-images.githubusercontent.com/2561818/131151867-34cc5a4d-e0b5-4c73-ae83-29f88df11a4c.png)
![image](https://user-images.githubusercontent.com/2561818/131361093-c1e57ef3-c9c8-4562-9238-f46d04bb5c2c.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge