### PR TITLE
Bug 1995116: Pod logs shows incorrect lines number in the log window top banner

### DIFF
--- a/frontend/public/components/utils/log-window.jsx
+++ b/frontend/public/components/utils/log-window.jsx
@@ -118,9 +118,10 @@ class LogWindowWithTranslation extends React.PureComponent {
     const { bufferFull, lines, linesBehind, status, t, wrapLines } = this.props;
     const { content, height } = this.state;
     // TODO maybe move these variables into state so they are only updated on changes
+    const count = lines[lines.length - 1] || lines.length === 0 ? lines.length : lines.length - 1;
     const headerText = bufferFull
-      ? t('public~last {{count}} line', { count: lines.length })
-      : t('public~{{count}} line', { count: lines.length });
+      ? t('public~last {{count}} line', { count })
+      : t('public~{{count}} line', { count });
     const resumeText =
       linesBehind > 0
         ? t('public~Resume stream and show {{count}} new line', { count: linesBehind })


### PR DESCRIPTION
If the last line of a log is an empty string, the log lines shown count is adjusted to ignore the last line in the count.  This addresses [Bug 1995116](https://bugzilla.redhat.com/show_bug.cgi?id=1995116). 

Because eventually the custom log viewer will be replaced with the PatternFly log viewer, only a minor change was implemented to fix the bug instead of a larger fix.