### PR TITLE
Bug 1997079: Fix moitoring custom time range

### DIFF
--- a/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
+++ b/frontend/public/components/monitoring/dashboards/custom-time-range-modal.tsx
@@ -7,7 +7,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { DatePicker, TimePicker } from '@patternfly/react-core';
 
-import { useActivePerspective } from '@console/shared';
 import {
   monitoringDashboardsSetEndTime,
   monitoringDashboardsSetTimespan,
@@ -23,10 +22,10 @@ import {
 import { toISODateString, twentyFourHourTime } from '../../utils/datetime';
 import { setQueryArguments } from '../../utils';
 
-const CustomTimeRangeModal = ({ cancel, close }: ModalComponentProps) => {
-  const { t } = useTranslation();
-  const [activePerspective] = useActivePerspective();
+type CustomTimeRangeModalProps = ModalComponentProps & { activePerspective: string };
 
+const CustomTimeRangeModal = ({ cancel, close, activePerspective }: CustomTimeRangeModalProps) => {
+  const { t } = useTranslation();
   const dispatch = useDispatch();
   const endTime = useSelector(({ UI }: RootState) =>
     UI.getIn(['monitoringDashboards', activePerspective, 'endTime']),

--- a/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
+++ b/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
@@ -38,7 +38,7 @@ const TimespanDropdown: React.FC = () => {
   const onChange = React.useCallback(
     (v: string) => {
       if (v === CUSTOM_TIME_RANGE_KEY) {
-        customTimeRangeModal({});
+        customTimeRangeModal({ activePerspective });
       } else {
         setQueryArgument('timeRange', parsePrometheusDuration(v).toString());
         removeQueryArgument('endTime');


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6275

**Analysis / Root cause**: 
Custom time range not working. As `activePerspective` value is undefined.

**Solution Description**: 
Pass the `activePerspective` to the Custom time range modal.

**Screen shots / Gifs for design review**: 
![Kapture 2021-08-24 at 16 54 11](https://user-images.githubusercontent.com/2561818/130609188-8fc4f72c-3dae-473c-9ecb-140c61a391b6.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge