### PR TITLE
Bug 1997179: disable serverless operator installation in catalog

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/developer-catalog-details.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/developer-catalog-details.feature
@@ -4,8 +4,9 @@ Feature: Developer Catalog Page
 
 
         Background:
-            Given user has installed OpenShift Serverless Operator
-              And user is at developer perspective
+            # commented below line as serverless operator is not available in operatorhub
+            # Given user has installed OpenShift Serverless Operator
+            Given user is at developer perspective
               And user is at Add page
               And user has created or selected namespace "aut-addflow-pagedetails"
 


### PR DESCRIPTION
**Description:**

disable serverless operator installation in catalog flow as serverless operator is not available in operator hub