### PR TITLE
Bug 1997168: Remove unused variable from parser config

### DIFF
--- a/frontend/i18next-parser.config.js
+++ b/frontend/i18next-parser.config.js
@@ -1,13 +1,9 @@
 const { CustomJSONLexer } = require('./i18n-scripts/lexers');
 
-const FALLBACK_LOCALE = 'en';
-
 /*eslint no-undef: "error"*/
 /*eslint-env node*/
 
 module.exports = {
-  FALLBACK_LOCALE,
-
   contextSeparator: '_',
   // Key separator used in your translation keys
 


### PR DESCRIPTION
There is an old fossil code variable in the parser config that is no longer in use. I removed it.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1997168.