### PR TITLE
Bug 1997068: Fix initial yaml using synced editor

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
@@ -8,6 +8,7 @@ import { K8sResourceKind, k8sUpdate } from '@console/internal/module/k8s';
 import { useExtensions, Perspective, isPerspective } from '@console/plugin-sdk';
 import { useActivePerspective } from '@console/shared';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { safeJSToYAML } from '@console/shared/src/utils/yaml';
 import { getResourcesType } from '../edit-application/edit-application-utils';
 import { handleRedirect } from '../import/import-submit-utils';
 import { Resources } from '../import/import-types';
@@ -33,7 +34,9 @@ const EditDeployment: React.FC<EditDeploymentProps> = ({ heading, resource, name
 
   const initialValues = React.useRef({
     editorType: EditorType.Form,
-    yamlData: '',
+    yamlData: safeJSToYAML(resource, 'yamlData', {
+      skipInvalid: true,
+    }),
     formData: convertDeploymentToEditForm(resource),
   });
 

--- a/frontend/packages/knative-plugin/src/components/add/brokers/AddBroker.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/brokers/AddBroker.tsx
@@ -35,7 +35,7 @@ const AddBroker: React.FC<AddBrokerProps> = ({ namespace, selectedApplication })
   ): Promise<K8sResourceKind> => {
     let broker: K8sResourceKind;
     if (formValues.editorType === EditorType.Form) {
-      broker = convertFormToBrokerYaml(formValues);
+      broker = convertFormToBrokerYaml(formValues.formData);
     } else {
       try {
         broker = safeLoad(formValues.yamlData);

--- a/frontend/packages/knative-plugin/src/components/add/brokers/AddBrokerForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/brokers/AddBrokerForm.tsx
@@ -76,7 +76,7 @@ const AddBrokerForm: React.FC<FormikProps<AddBrokerFormYamlValues> & AddBrokerFo
   };
 
   const sanitizeToYaml = () =>
-    safeJSToYAML(convertFormToBrokerYaml(values), 'yamlData', {
+    safeJSToYAML(convertFormToBrokerYaml(values.formData), 'yamlData', {
       skipInvalid: true,
     });
 

--- a/frontend/packages/knative-plugin/src/components/add/brokers/__tests__/add-broker-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/components/add/brokers/__tests__/add-broker-utils.spec.ts
@@ -6,8 +6,8 @@ import { convertFormToBrokerYaml, addBrokerInitialValues } from '../add-broker-u
 describe('broker-utils: ', () => {
   describe('convertFormToBrokerYaml', () => {
     it('should contain all the top level keys for broker', () => {
-      const formValues = addBrokerInitialValues('test-ns', '');
-      const broker = convertFormToBrokerYaml(formValues);
+      const { formData } = addBrokerInitialValues('test-ns', '');
+      const broker = convertFormToBrokerYaml(formData);
       expect(broker.apiVersion).toBe(apiVersionForModel(EventingBrokerModel));
       expect(broker.kind).toBe(EventingBrokerModel.kind);
       expect(broker.metadata).toBeDefined();
@@ -15,29 +15,26 @@ describe('broker-utils: ', () => {
     });
 
     it('should contain default application name', () => {
-      const formValues = addBrokerInitialValues('test-ns', '');
-      const broker = convertFormToBrokerYaml(formValues);
+      const { formData } = addBrokerInitialValues('test-ns', '');
+      const broker = convertFormToBrokerYaml(formData);
       expect(broker.metadata.labels[LABEL_PART_OF]).toBe(EVENT_BROKER_APP);
     });
 
     it('should contain custom application name', () => {
-      const formValues = addBrokerInitialValues('test-ns', 'custom-group-name');
-      const broker = convertFormToBrokerYaml(formValues);
+      const { formData } = addBrokerInitialValues('test-ns', 'custom-group-name');
+      const broker = convertFormToBrokerYaml(formData);
       expect(broker.metadata.labels[LABEL_PART_OF]).toBe('custom-group-name');
     });
 
     it('should not contain the metadata labels', () => {
-      const formValues = addBrokerInitialValues('test-ns', '');
+      const { formData } = addBrokerInitialValues('test-ns', '');
 
       const broker = convertFormToBrokerYaml({
-        ...formValues,
-        formData: {
-          ...formValues.formData,
-          application: {
-            initial: null,
-            name: '',
-            selectedKey: '',
-          },
+        ...formData,
+        application: {
+          initial: null,
+          name: '',
+          selectedKey: '',
         },
       });
       expect(broker.metadata.labels).toBeUndefined();

--- a/frontend/packages/knative-plugin/src/components/add/brokers/add-broker-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/brokers/add-broker-utils.ts
@@ -1,42 +1,19 @@
 import { apiVersionForModel, K8sResourceKind } from '@console/internal/module/k8s';
 import { UNASSIGNED_APPLICATIONS_KEY } from '@console/shared';
 import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { safeJSToYAML } from '@console/shared/src/utils/yaml';
 import { sanitizeApplicationValue } from '@console/topology/src/utils';
 import { EventingBrokerModel } from '../../../models';
 import { LABEL_PART_OF, EVENT_BROKER_APP, DEFAULT_BROKER_NAME } from '../const';
-import { AddBrokerFormYamlValues } from '../import-types';
+import { AddBrokerFormYamlValues, BrokerFormData } from '../import-types';
 
-export const addBrokerInitialValues = (
-  namespace: string,
-  selectedApplication: string,
-): AddBrokerFormYamlValues => {
-  return {
-    showCanUseYAMLMessage: true,
-    editorType: EditorType.Form,
-    yamlData: '',
-    formData: {
-      name: DEFAULT_BROKER_NAME,
-      spec: {},
-      project: {
-        name: namespace || '',
-        displayName: '',
-        description: '',
-      },
-      application: {
-        initial: sanitizeApplicationValue(selectedApplication),
-        name: sanitizeApplicationValue(selectedApplication) || EVENT_BROKER_APP,
-        selectedKey: selectedApplication,
-      },
-    },
-  };
-};
-export const convertFormToBrokerYaml = (formValues: AddBrokerFormYamlValues): K8sResourceKind => {
+export const convertFormToBrokerYaml = (formData: BrokerFormData): K8sResourceKind => {
   const {
     name,
     project: { name: namespace },
     application: { selectedKey, name: appName = null },
     spec = {},
-  } = formValues.formData;
+  } = formData;
 
   return {
     apiVersion: apiVersionForModel(EventingBrokerModel),
@@ -52,5 +29,38 @@ export const convertFormToBrokerYaml = (formValues: AddBrokerFormYamlValues): K8
         }),
     },
     spec,
+  };
+};
+
+export const addBrokerInitialValues = (
+  namespace: string,
+  selectedApplication: string,
+): AddBrokerFormYamlValues => {
+  const initialFormData: BrokerFormData = {
+    name: DEFAULT_BROKER_NAME,
+    spec: {},
+    project: {
+      name: namespace || '',
+      displayName: '',
+      description: '',
+    },
+    application: {
+      initial: sanitizeApplicationValue(selectedApplication),
+      name: sanitizeApplicationValue(selectedApplication) || EVENT_BROKER_APP,
+      selectedKey: selectedApplication,
+    },
+  };
+  const initialYamlData: string = safeJSToYAML(
+    convertFormToBrokerYaml(initialFormData),
+    'yamlData',
+    {
+      skipInvalid: true,
+    },
+  );
+  return {
+    showCanUseYAMLMessage: true,
+    editorType: EditorType.Form,
+    yamlData: initialYamlData,
+    formData: initialFormData,
   };
 };

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -316,9 +316,9 @@ describe('sanitizeSourceToForm always returns valid Event Source', () => {
   });
 
   it('expect getKafkaSourceResource to return sasl and tls with secrets if enabled and present', () => {
-    const KafkaSourceData = getDefaultEventingData(EventSources.KafkaSource);
-    KafkaSourceData.formData.data[EventSources.KafkaSource] = {
-      ...KafkaSourceData.formData.data[EventSources.KafkaSource],
+    const { formData: KafkaSourceFormData } = getDefaultEventingData(EventSources.KafkaSource);
+    KafkaSourceFormData.data[EventSources.KafkaSource] = {
+      ...KafkaSourceFormData.data[EventSources.KafkaSource],
       bootstrapServers: ['server1', 'server2'],
       topics: ['topic1'],
       consumerGroup: 'knative-group',
@@ -340,7 +340,7 @@ describe('sanitizeSourceToForm always returns valid Event Source', () => {
       spec: {
         net: { sasl, tls },
       },
-    } = getKafkaSourceResource(KafkaSourceData);
+    } = getKafkaSourceResource(KafkaSourceFormData);
     expect(sasl.enable).toBe(true);
     expect(sasl.user).toEqual({
       secretKeyRef: { name: 'username', key: 'userkey' },
@@ -349,9 +349,9 @@ describe('sanitizeSourceToForm always returns valid Event Source', () => {
   });
 
   it('expect getKafkaSourceResource to return sasl and tls without secrets if not enabled', () => {
-    const KafkaSourceData = getDefaultEventingData(EventSources.KafkaSource);
-    KafkaSourceData.formData.data[EventSources.KafkaSource] = {
-      ...KafkaSourceData.formData.data[EventSources.KafkaSource],
+    const { formData: KafkaSourceFormData } = getDefaultEventingData(EventSources.KafkaSource);
+    KafkaSourceFormData.data[EventSources.KafkaSource] = {
+      ...KafkaSourceFormData.data[EventSources.KafkaSource],
       bootstrapServers: ['server1', 'server2'],
       topics: ['topic1'],
       consumerGroup: 'knative-group',
@@ -373,7 +373,7 @@ describe('sanitizeSourceToForm always returns valid Event Source', () => {
       spec: {
         net: { sasl, tls },
       },
-    } = getKafkaSourceResource(KafkaSourceData);
+    } = getKafkaSourceResource(KafkaSourceFormData);
     expect(sasl.enable).toBeUndefined();
     expect(sasl).toEqual({ user: {}, password: {} });
     expect(tls.enable).toBeUndefined();

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -88,8 +88,8 @@ export const isSecretKeyRefPresent = (dataObj: {
   secretKeyRef: { name: string; key: string };
 }): boolean => !!(dataObj?.secretKeyRef?.name || dataObj?.secretKeyRef?.key);
 
-export const getKafkaSourceResource = (sourceFormData: any): K8sResourceKind => {
-  const baseResource = getEventSourcesDepResource(sourceFormData.formData);
+export const getKafkaSourceResource = (formData: any): K8sResourceKind => {
+  const baseResource = getEventSourcesDepResource(formData);
   const { net } = baseResource.spec;
   baseResource.spec.net = {
     ...net,
@@ -125,18 +125,23 @@ export const loadYamlData = (formData: EventSourceSyncFormData) => {
   return yamlDataObj;
 };
 
+export const getEventSourceResource = (formData: EventSourceFormData) => {
+  switch (formData.type) {
+    case EventSources.KafkaSource:
+      return getKafkaSourceResource(formData);
+    default:
+      return getEventSourcesDepResource(formData);
+  }
+};
+
 export const getCatalogEventSourceResource = (
   sourceFormData: EventSourceSyncFormData,
 ): K8sResourceKind => {
   if (sourceFormData.editorType === EditorType.YAML) {
     return loadYamlData(sourceFormData);
   }
-  switch (sourceFormData.formData.type) {
-    case EventSources.KafkaSource:
-      return getKafkaSourceResource(sourceFormData);
-    default:
-      return getEventSourcesDepResource(sourceFormData.formData);
-  }
+  const { formData } = sourceFormData;
+  return getEventSourceResource(formData);
 };
 
 export const getEventSourceData = (source: string) => {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
@@ -10,6 +10,7 @@ import { EditorType } from '@console/shared/src/components/synced-editor/editor-
 import { PipelineModel } from '../../../models';
 import { PipelineKind } from '../../../types';
 import { initialPipelineFormData } from './const';
+import { sanitizeToYaml } from './form-switcher-validation';
 import PipelineBuilderForm from './PipelineBuilderForm';
 import { PipelineBuilderFormYamlValues, PipelineBuilderFormikValues } from './types';
 import { convertBuilderFormToPipeline, convertPipelineToBuilderForm } from './utils';
@@ -32,7 +33,7 @@ const PipelineBuilderPage: React.FC<PipelineBuilderPageProps> = (props) => {
 
   const initialValues: PipelineBuilderFormYamlValues = {
     editorType: EditorType.Form,
-    yamlData: '',
+    yamlData: sanitizeToYaml(initialPipelineFormData, ns, existingPipeline),
     formData: {
       ...initialPipelineFormData,
       ...(convertPipelineToBuilderForm(existingPipeline) || {}),


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1997068

**Problem:**
When some components using synced edtior loads with YAML Editor, it renders an empty yaml editor and gets filled with values only after switching to form and back to yaml.
Affected components as identified as a part of this bug-
1. Edit Deployment
2. Pipeline Builder
3. Event Sources
4. Broker

Solution:
set initial value for yaml

Screens:
Pipeline Builder
![Screenshot from 2021-08-24 17-05-32](https://user-images.githubusercontent.com/38663217/130663580-7f318056-3ffc-43c2-a553-c7845f7e175e.png)

Test Coverage:


Browser Conformance: 
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge