### PR TITLE
Bug 1996914: Check for internal redux store and return if not initialized

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
@@ -103,16 +103,8 @@ type ImpersonateHeaders = {
   'Impersonate-User': string;
 };
 export const getImpersonateHeaders = (): ImpersonateHeaders => {
-  let kind: string;
-  let name: string;
-  try {
-    const imp = InternalReduxStore.getState().UI.get('impersonate', {});
-    kind = imp.kind;
-    name = imp.name;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.warn('Failed to get ImpersonateHeaders', error);
-  }
+  if (!InternalReduxStore) return undefined;
+  const { kind, name } = InternalReduxStore.getState().UI.get('impersonate', {});
   if ((kind === 'User' || kind === 'Group') && name) {
     // Even if we are impersonating a group, we still need to set Impersonate-User to something or k8s will complain
     const headers = {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/OCPBUGSM-33704
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: On the first load internal redux store is not initialized which throws a warning when impersonate header util tries to access the store.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Added a null check for store in the impersonate header utility.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: No UI change.
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
