### PR TITLE
Bug 1997419: Environment page: Invalid form state should disable the save button

### DIFF
--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -305,6 +305,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
     this.saveChanges = this._saveChanges.bind(this);
     this.updateEnvVars = this._updateEnvVars.bind(this);
     this.selectContainer = this._selectContainer.bind(this);
+    this.setHasEmptyName = this._setHasEmptyName.bind(this);
     const currentEnvVars = new CurrentEnvVars(this.props.rawEnvData);
     this.state = {
       currentEnvVars,
@@ -412,6 +413,10 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
       success: null,
     });
     _.isFunction(onChange) && onChange(currentEnv.dispatchNewEnvironmentVariables());
+  }
+
+  _setHasEmptyName(isEmpty) {
+    this.setState({ ...this.state, hasEmptyName: isEmpty });
   }
 
   /**
@@ -575,6 +580,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
             configMaps={configMaps}
             secrets={secrets}
             addConfigMapSecret={addConfigMapSecret}
+            setHasEmptyName={this.setHasEmptyName}
           />
         </div>
         {currentEnvVars.isContainerArray && (
@@ -640,7 +646,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
               {!readOnly && (
                 <ActionGroup>
                   <Button
-                    isDisabled={inProgress}
+                    isDisabled={inProgress && !this.state.hasEmptyName}
                     type="submit"
                     variant="primary"
                     onClick={this.saveChanges}

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -305,7 +305,6 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
     this.saveChanges = this._saveChanges.bind(this);
     this.updateEnvVars = this._updateEnvVars.bind(this);
     this.selectContainer = this._selectContainer.bind(this);
-    this.setHasEmptyName = this._setHasEmptyName.bind(this);
     const currentEnvVars = new CurrentEnvVars(this.props.rawEnvData);
     this.state = {
       currentEnvVars,
@@ -407,16 +406,20 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
     const { currentEnvVars, containerType } = this.state;
     const currentEnv = _.cloneDeep(currentEnvVars);
     currentEnv.setFormattedVars(containerType, i, type, env.nameValuePairs);
+
+    const emptyNamesWithValue = _.filter(
+      env.nameValuePairs,
+      (pair) => pair[NameValueEditorPair.Name] === '' && pair[NameValueEditorPair.Value].length,
+    );
+    const _hasEmptyName = emptyNamesWithValue.length > 0;
+
     this.setState({
       currentEnvVars: currentEnv,
       dirty: true,
       success: null,
+      hasEmptyName: _hasEmptyName,
     });
     _.isFunction(onChange) && onChange(currentEnv.dispatchNewEnvironmentVariables());
-  }
-
-  _setHasEmptyName(isEmpty) {
-    this.setState({ ...this.state, hasEmptyName: isEmpty });
   }
 
   /**
@@ -580,7 +583,6 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
             configMaps={configMaps}
             secrets={secrets}
             addConfigMapSecret={addConfigMapSecret}
-            setHasEmptyName={this.setHasEmptyName}
           />
         </div>
         {currentEnvVars.isContainerArray && (

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -646,7 +646,7 @@ export class UnconnectedEnvironmentPage extends PromiseComponent {
               {!readOnly && (
                 <ActionGroup>
                   <Button
-                    isDisabled={inProgress && !this.state.hasEmptyName}
+                    isDisabled={inProgress || this.state.hasEmptyName}
                     type="submit"
                     variant="primary"
                     onClick={this.saveChanges}

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -72,7 +72,6 @@ const NameValueEditor_ = withDragDropContext(
         nameValuePairs,
         (pair) => pair[NameValueEditorPair.Name] === '' && pair[NameValueEditorPair.Value].length,
       );
-      // console.log('============\n\n\n',emptyNamesWithValue, nameValuePairs,'\n\n\n\n=========');
       setHasEmptyName(emptyNamesWithValue.length > 0);
       updateParentData({ nameValuePairs }, nameValueId);
     }

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -62,17 +62,12 @@ const NameValueEditor_ = withDragDropContext(
     }
 
     _change(e, i, type) {
-      const { updateParentData, nameValueId, setHasEmptyName } = this.props;
+      const { updateParentData, nameValueId } = this.props;
       const nameValuePairs = _.cloneDeep(this.props.nameValuePairs);
 
       nameValuePairs[i][
         type === NameValueEditorPair.Name ? NameValueEditorPair.Name : NameValueEditorPair.Value
       ] = e.target.value;
-      const emptyNamesWithValue = _.filter(
-        nameValuePairs,
-        (pair) => pair[NameValueEditorPair.Name] === '' && pair[NameValueEditorPair.Value].length,
-      );
-      setHasEmptyName(emptyNamesWithValue.length > 0);
       updateParentData({ nameValuePairs }, nameValueId);
     }
 
@@ -203,7 +198,6 @@ NameValueEditor.propTypes = {
   addConfigMapSecret: PropTypes.bool,
   toolTip: PropTypes.string,
   onLastItemRemoved: PropTypes.func,
-  setHasEmptyName: PropTypes.func,
 };
 NameValueEditor.defaultProps = {
   allowSorting: false,

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -62,12 +62,18 @@ const NameValueEditor_ = withDragDropContext(
     }
 
     _change(e, i, type) {
-      const { updateParentData, nameValueId } = this.props;
+      const { updateParentData, nameValueId, setHasEmptyName } = this.props;
       const nameValuePairs = _.cloneDeep(this.props.nameValuePairs);
 
       nameValuePairs[i][
         type === NameValueEditorPair.Name ? NameValueEditorPair.Name : NameValueEditorPair.Value
       ] = e.target.value;
+      const emptyNamesWithValue = _.filter(
+        nameValuePairs,
+        (pair) => pair[NameValueEditorPair.Name] === '' && pair[NameValueEditorPair.Value].length,
+      );
+      // console.log('============\n\n\n',emptyNamesWithValue, nameValuePairs,'\n\n\n\n=========');
+      setHasEmptyName(emptyNamesWithValue.length > 0);
       updateParentData({ nameValuePairs }, nameValueId);
     }
 
@@ -198,6 +204,7 @@ NameValueEditor.propTypes = {
   addConfigMapSecret: PropTypes.bool,
   toolTip: PropTypes.string,
   onLastItemRemoved: PropTypes.func,
+  setHasEmptyName: PropTypes.func,
 };
 NameValueEditor.defaultProps = {
   allowSorting: false,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6238

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
We need to `disable` the `SAVE` button when there is a `name value pair` where `name` is empty and `value` is not empty

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
inside function to update the `state` for all environment variables i.e. `components/environment.jsx -> _updateEnvVars()`
- we just update a flag `hasEmptyName` in the state if any invalid pair exists in the `nameValuePairs`    

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![environment_empty_name](https://user-images.githubusercontent.com/20089340/130758363-2821b002-c37d-4605-80eb-b9c51523a07d.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Open developer perspective and navigate to Builds
2. Click "Create BuildConfig" button
3. Create the BuildConfig without additional changes
4. Switch to the "Environment" tab
5. Enter an value without a name

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge