### PR TITLE
Bug 1997482: Remove backdrop from Pipeline tasks search modal

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.scss
@@ -1,4 +1,10 @@
 .ocs-quick-search-modal {
   --pf-c-modal-box--BackgroundColor: none !important;
-  --pf-c-modal-box--BoxShadow: none !important;
+  box-shadow: none !important;
+  &__no-backdrop {
+    .pf-c-backdrop {
+      background: none;
+      position: absolute;
+    }
+  }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -137,7 +137,10 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
 
   return (
     <>
-      <div ref={contentRef} className="odc-pipeline-builder-form">
+      <div
+        ref={contentRef}
+        className="odc-pipeline-builder-form ocs-quick-search-modal__no-backdrop"
+      >
         <Stack>
           <StackItem>
             <PipelineBuilderHeader namespace={namespace} />

--- a/frontend/packages/topology/src/components/page/TopologyView.scss
+++ b/frontend/packages/topology/src/components/page/TopologyView.scss
@@ -90,7 +90,7 @@
   &__dropzone {
     background-color: rgba(0, 102, 204, 0.1) !important;
     color: var(--pf-global--palette--black-900) !important;
-    margin:0 !important;
+    margin: 0 !important;
   }
 
   &__dropzone-text {
@@ -115,10 +115,5 @@
     .overview__sidebar-pane-body {
       min-height: initial;
     }
-  }
-
-  .pf-c-backdrop {
-    position: absolute;
-    background: none;
   }
 }

--- a/frontend/packages/topology/src/components/page/TopologyView.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyView.tsx
@@ -348,7 +348,10 @@ export const ConnectedTopologyView: React.FC<ComponentProps> = ({
         </StackItem>
         <StackItem isFilled className={containerClasses}>
           <div className="co-file-dropzone co-file-dropzone__flex">
-            <div ref={setViewContainer} className="pf-topology-content">
+            <div
+              ref={setViewContainer}
+              className="pf-topology-content ocs-quick-search-modal__no-backdrop"
+            >
               {canDrop && isOver && (
                 <div
                   className={classNames(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6277

**Analysis / Root cause**: 
Modal backdrop should not be present as per the design.

**Solution Description**: 
- Remove the backdrop from the Pipeline tasks search modal
- Add box-shadow to the modal

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/2561818/130780256-25864174-fecd-4240-82db-a7f0556ea48c.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge