### PR TITLE
Bug 1997655: Remove unused data-test-id which logs a react warning

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -29,7 +29,7 @@ const PipelineStatus: React.FC<PipelineStatusProps> = ({ obj }) => {
 
 const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj }) => {
   return (
-    <React.Fragment data-test-id={`${obj.metadata.namespace}-${obj.metadata.name}`}>
+    <>
       <TableData className={tableColumnClasses[0]}>
         <ResourceLink
           kind={pipelineReference}
@@ -66,7 +66,7 @@ const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj }) => 
       <TableData className={tableColumnClasses[6]}>
         <PipelineRowKebabActions pipeline={obj} />
       </TableData>
-    </React.Fragment>
+    </>
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1997655

**Analysis / Root cause**: 
When open the pipelines it shows a React warning/error in the browser console:

```
Warning: Invalid prop `data-test-id` supplied to `React.Fragment`. 
React.Fragment can only have `key` and `children` props.
```

**Solution Description**: 
Just remove the Fragment / `data-test-id` because it looks like it is not used when rendering drops it. The code was changed / introduced with #9797

**Screen shots / Gifs for design review**: 
Dom rendering looks still good (tr exists):

![Screenshot from 2021-08-25 17-43-51](https://user-images.githubusercontent.com/139310/130822119-787268a5-6b81-4907-b5aa-0b087e7d3580.png)

**Unit test coverage report**: 
Not touched

**Test setup:**
1. Install operator, open developer perspective
2. Create at least one pipeline
3. Open your browser console
4. Open "Pipelines"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
