### PR TITLE
Bug 1998413: Fix helm dynamic form field accordion

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/styles.scss
+++ b/frontend/packages/console-shared/src/components/dynamic-form/styles.scss
@@ -30,8 +30,11 @@
   --pf-c-accordion__toggle-text--hover--FontWeight: 600 !important;
   margin-bottom: 0.5rem;
 
-  .pf-c-accordion__toggle::before {
-    display: none;
+  .pf-c-accordion__toggle {
+    &:before,
+    &:after {
+      display: none;
+    }
   }
 
   h3 {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6235
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The `after` pseudo element of the dynamic form field toggle button inherited an unwanted background color.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Hide the pseudo element of the toggle button.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
Before:
![0](https://user-images.githubusercontent.com/20013884/130829609-6cd2ade6-7f02-4805-a618-116d4d8328f4.png)
After:
![1](https://user-images.githubusercontent.com/20013884/130829654-c3dcf8f9-9a5b-4097-bed8-3e6b8791de64.png)

cc: @openshift/team-devconsole-ux 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug