### PR TITLE
Bug 1998168: added support for components in toast action

### DIFF
--- a/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
@@ -20,6 +20,8 @@ export type ToastOptions = {
     callback: () => void;
     // If `true`, executing this action will dismiss the toast.
     dismiss?: boolean;
+    // Sets the base component to render. defaults to button
+    component?: React.ElementType<any> | React.ComponentType<any>;
   }[];
   // If `true`, displays a close button.
   dismissible?: boolean;

--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
@@ -77,6 +77,7 @@ const ToastProvider: React.FC = ({ children }) => {
                           }
                           action.callback();
                         }}
+                        component={action.component}
                       >
                         {action.label}
                       </AlertActionLink>

--- a/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
+++ b/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
@@ -108,4 +108,71 @@ describe('ToastProvider', () => {
 
     expect(wrapper.find(Alert).length).toBe(0);
   });
+
+  it('should have anchor tag if componet "a" is passed', () => {
+    const actionFn = jest.fn();
+    act(() => {
+      toastContext.addToast({
+        title: 'test success',
+        variant: ToastVariant.success,
+        content: 'description 1',
+        actions: [
+          {
+            label: 'action 1',
+            dismiss: true,
+            callback: actionFn,
+            component: 'a',
+          },
+        ],
+      });
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find(Alert).length).toBe(1);
+    const alertActionLinks = wrapper.find(AlertActionLink);
+    expect(alertActionLinks.length).toBe(1);
+    expect(
+      alertActionLinks
+        .at(0)
+        .find('a')
+        .exists(),
+    ).toBe(true);
+  });
+
+  it('should dismiss toast on action on anchor click', () => {
+    const actionFn = jest.fn();
+    act(() => {
+      toastContext.addToast({
+        title: 'test success',
+        variant: ToastVariant.success,
+        content: 'description 1',
+        actions: [
+          {
+            label: 'action 1',
+            dismiss: true,
+            callback: actionFn,
+            component: 'a',
+          },
+        ],
+      });
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find(Alert).length).toBe(1);
+    const alertActionLinks = wrapper.find(AlertActionLink);
+    expect(alertActionLinks.length).toBe(1);
+    act(() => {
+      alertActionLinks
+        .at(0)
+        .find('a')
+        .simulate('click');
+    });
+
+    wrapper.update();
+
+    expect(actionFn).toHaveBeenCalledTimes(1);
+    expect(wrapper.find(Alert).length).toBe(0);
+  });
 });

--- a/frontend/packages/topology/src/components/export-app/export-app-context.ts
+++ b/frontend/packages/topology/src/components/export-app/export-app-context.ts
@@ -59,6 +59,7 @@ export const useExportAppFormToast = () => {
             callback: () => {
               window.open(routeUrl, '_blank');
             },
+            component: 'a',
           },
         ],
       });


### PR DESCRIPTION
**Fixes:** 
https://issues.redhat.com/browse/ODC-6287

**Solution Description:**
adds support to provide components in toast action.

**Unit Test**
![image](https://user-images.githubusercontent.com/5129024/130910127-865533bc-d7c7-4a4b-afdf-2b50ed40f47d.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge