### PR TITLE
Bug 1998388: User preference screen shows "Create Namespace" instead of "Create Project"

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.spec.ts
@@ -29,11 +29,11 @@ describe('Create namespace from install operators', () => {
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });
 
-    // configure operator install
+    // configure operator install ("^=Create_"" will match "Create_Namespace" and "Create_Project")
     cy.byTestID('Select a Namespace-radio-input').check();
     cy.byTestID('dropdown-selectbox')
       .click()
-      .get('[data-test-dropdown-menu="Create_Namespace"]')
+      .get('[data-test-dropdown-menu^="Create_"]')
       .click();
 
     // verify namespace modal is opened

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineRow.tsx
@@ -29,7 +29,7 @@ const PipelineStatus: React.FC<PipelineStatusProps> = ({ obj }) => {
 
 const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj }) => {
   return (
-    <React.Fragment data-test-id={`${obj.metadata.namespace}-${obj.metadata.name}`}>
+    <>
       <TableData className={tableColumnClasses[0]}>
         <ResourceLink
           kind={pipelineReference}
@@ -66,7 +66,7 @@ const PipelineRow: React.FC<RowFunctionArgs<PipelineWithLatest>> = ({ obj }) => 
       <TableData className={tableColumnClasses[6]}>
         <PipelineRowKebabActions pipeline={obj} />
       </TableData>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -219,8 +219,8 @@ export const useProjectOrNamespaceModel = () => {
   }
 
   // NamespaceModal is used when not on an openshift cluster
-  const model = canCreateNamespace || !openshiftFlag ? NamespaceModel : ProjectModel;
-  const canCreate = canCreateNamespace || (openshiftFlag && canCreateProject);
+  const model = openshiftFlag ? ProjectModel : NamespaceModel;
+  const canCreate = openshiftFlag ? canCreateProject : canCreateNamespace;
   return [model, canCreate];
 };
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6284

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
I looked at the values of the 3 booleans used at [list-dropdown.jsx#L207](https://github.com/openshift/console/blob/bc0f4129c60240f43fddd532de94e5e23f5995ae/frontend/public/components/utils/list-dropdown.jsx#L207)

( oc -> 4.9.0-0.nightly-2021-08-25-231643 )

```
canCreateNamespace true
canCreateProject true
openshiftFlag true
```

This is why we see "create namespace" since the condition was 
`const model = canCreateNamespace || !openshiftFlag ? NamespaceModel : ProjectModel;`

Changing this to look at only openshiftFlag solves the bug ( way it is implemented in multiple places of the codebase )
https://github.com/openshift/console/blob/852743d807b0c5f8a551cb4bc18345b8c3b22029/frontend/packages/kubevirt-plugin/src/components/form/project-dropdown.tsx#L22-L23

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Only look at the openshift flag when deciding the model 
https://github.com/openshift/console/pull/9890/files#diff-30e14373ba5138b3b0753194670c0fa14ecbcb207856ce302b4728e268c9e9deL222-R222

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
We see "Create Project" instead of seeing "Create Namespace"
![Screenshot from 2021-08-26 14-32-20](https://user-images.githubusercontent.com/20089340/130935424-c67ea82a-18e0-419d-b658-4874caba4436.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Open user preferences from username dropdown
Open the project dropdown
Check option to create a new namespace / project

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [X] Firefox
- [ ] Safari
- [ ] Edge