### PR TITLE
Bug 1995545: Adjust `ZIndex` value for the dropdown menu

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -237,6 +237,10 @@ form.pf-c-form {
   }
 }
 
+.pf-c-dropdown__menu {
+  --pf-c-dropdown__menu--ZIndex: var(--pf-global--ZIndex--md);
+}
+
 .pf-c-page__sidebar {
   --pf-c-page__sidebar-body--PaddingTop: 0;
   bottom: 0;


### PR DESCRIPTION
`var(--pf-c-wizard__nav--ZIndex)` and `var(--pf-c-dropdown__menu--ZIndex)` had
equal values (200) which causes the WizardNav component to go over the Project
Dropdown component. Hence set the latter to `--pf-global--ZIndex--md`
(300) to fix the issue.

This PR also fixes the same error in other places as well (for eg., Create StorageCluster, as shown below with the issue).

![2021-08-26-133638_654x871_scrot](https://user-images.githubusercontent.com/33557095/130944119-53080f0d-69bf-465b-932c-fe1a91f6aef1.png)
