### PR TITLE
Bug 1998058: Remove extra white space from Kafka instance table

### DIFF
--- a/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.scss
+++ b/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.scss
@@ -1,0 +1,5 @@
+.rhoas-service-instance-table {
+  &.pf-c-table {
+    table-layout: auto;
+  }
+}

--- a/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.tsx
+++ b/frontend/packages/rhoas-plugin/src/components/service-table/ServiceInstanceTable.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { Timestamp } from '@console/internal/components/utils';
 import { CloudKafka } from '../../utils/rhoas-types';
 import ServiceIconStatus from './ServiceIconStatus';
+import './ServiceInstanceTable.scss';
 
 type FormattedKafkas = {
   cells: JSX.Element[];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6224

**Analysis / Root cause**: 
Extra white space in the first column of the Kafka instance table

**Solution Description**: 
Remove the extra white space by making the table layout auto.

**Screen shots / Gifs for design review**: 
Before:
![image](https://user-images.githubusercontent.com/2561818/130953042-0281daa4-b3d9-4b58-adbd-7800bf8fe1b8.png)

After:
![image](https://user-images.githubusercontent.com/2561818/130953162-96a03c4c-ccee-4ae6-a0ee-c3b039eee25f.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge