### PR TITLE
Bug 1998408: Set dockerfile path to detected filename

### DIFF
--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -227,6 +227,7 @@ const GitSection: React.FC<GitSectionProps> = ({
           }
           case ImportStrategy.DOCKERFILE: {
             setFieldValue('build.strategy', BuildStrategyType.Docker);
+            setFieldValue('docker.dockerfilePath', importStrategies[0].detectedFiles[0]);
             break;
           }
           default:


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6289
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Dockerfile path field is not set to the detected file when dockerfile detection happens.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Set the dockerfile path to the first detected dockerfile.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/130957158-5c6c61c3-d09f-4c84-8258-7e60c056440d.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug