### PR TITLE
Bug 1998411: Detect repository name for URLs with trailing slash

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -163,6 +163,12 @@ describe('ValidationUtils', () => {
       ).toEqual('wild-west-frontend-123');
     });
 
+    it('should detect repository name when url contains a trailing slash', () => {
+      expect(
+        detectGitRepoName('https://github.com/openshift-evangelists/wildWestFrontend/'),
+      ).toEqual('wild-west-frontend');
+    });
+
     it('should throw an error if name is invalid', async () => {
       const mockData = cloneDeep(mockFormData);
       mockData.name = 'app_name';

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -78,6 +78,9 @@ export const detectGitRepoName = (url: string): string | undefined => {
   if (!gitUrlRegex.test(url)) {
     return undefined;
   }
-  const name = url.split('/').pop();
+  const name = url
+    .replace(/\/$/, '')
+    .split('/')
+    .pop();
   return createComponentName(name);
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6276
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Name was not detected because a slash at the end of the URL wasn't considered.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Remove trailing slash from the URL if any before forming the component name.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/131006006-534dd317-b829-4d94-9644-07fe0dfae54e.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
```
Test Suites: 1 passed, 1 total
Tests:       52 passed, 52 total
Snapshots:   0 total
Time:        11.978s, estimated 61s
Ran all test suites matching /import-validation-utils/i.
Done in 14.36s.
```
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug