### PR TITLE
Bug 1998394: add tests for RHEL9 template

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/action/clone.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/action/clone.spec.ts
@@ -1,6 +1,6 @@
 import { testName } from '../../support';
 import { Disk, Network, VirtualMachineData } from '../../types/vm';
-import { TEMPLATE_NAME, VM_ACTION, VM_ACTION_TIMEOUT, VM_STATUS } from '../../utils/const/index';
+import { TEMPLATE, VM_ACTION, VM_ACTION_TIMEOUT, VM_STATUS } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { selectActionFromDropdown } from '../../views/actions';
 import * as cloneView from '../../views/clone';
@@ -13,11 +13,11 @@ import { vm, waitForStatus } from '../../views/vm';
 const vmData: VirtualMachineData = {
   name: `test-vm-clone-${testName}`,
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: TEMPLATE.RHEL6.name,
   provisionSource: ProvisionSource.URL,
   pvcSize: '1',
   sshEnable: false,
-  startOnCreation: false,
+  startOnCreation: true,
 };
 
 const nic1: Network = {
@@ -39,7 +39,6 @@ describe('Test VM Clone', () => {
     cy.cdiCloner(testName, 'default');
     cy.createNAD(testName);
     virtualization.vms.visit();
-    waitForStatus(VM_STATUS.Stopped, vmData, VM_ACTION_TIMEOUT.VM_IMPORT);
   });
 
   after(() => {
@@ -80,19 +79,22 @@ describe('Test VM Clone', () => {
   });
 
   it('ID(CNV-1730) Displays warning in clone wizard when cloned VM is running', () => {
-    vm.start(vmData);
     selectActionFromDropdown(VM_ACTION.Clone, actionButtons.kebabButton);
     cy.get('.pf-c-alert__title')
       .contains(`The VM ${vmData.name} is still running. It will be powered off while cloning.`)
       .should('exist');
+    cy.get(cloneView.cancel).click();
   });
 
   it('ID(CNV-1863) Prefills correct data in the clone VM dialog', () => {
+    selectActionFromDropdown(VM_ACTION.Clone, actionButtons.kebabButton);
     cy.get(cloneView.vmName).should('have.value', `${vmData.name}-clone`);
     cy.get(cloneView.nameSpace).should('have.value', testName);
+    cy.get(cloneView.cancel).click();
   });
 
   it('ID(CNV-3058) Clones VM to a different namespace', () => {
+    selectActionFromDropdown(VM_ACTION.Clone, actionButtons.kebabButton);
     cy.get(cloneView.vmName).should('have.value', `${vmData.name}-clone`);
     cy.get(cloneView.nameSpace)
       .select('default')

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/action/migration.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/action/migration.spec.ts
@@ -1,6 +1,6 @@
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
-import { TEMPLATE_NAME, VM_ACTION, VM_ACTION_TIMEOUT, VM_STATUS } from '../../utils/const/index';
+import { TEMPLATE, VM_ACTION, VM_ACTION_TIMEOUT, VM_STATUS } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { actionButtons, detailsTab, errorAlert } from '../../views/selector';
 import { tab } from '../../views/tab';
@@ -10,7 +10,7 @@ import { action, vm, waitForStatus } from '../../views/vm';
 const vmData: VirtualMachineData = {
   name: `test-vm-migration-${testName}`,
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.URL,
   pvcSize: '1',
   sshEnable: false,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/devconsole/devconsole.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/devconsole/devconsole.spec.ts
@@ -3,8 +3,7 @@ import { VirtualMachineData } from '../../types/vm';
 import {
   DEFAULTS_VALUES,
   OS_IMAGES_NS,
-  TEMPLATE_BASE_IMAGE,
-  TEMPLATE_NAME,
+  TEMPLATE,
   VM_ACTION,
   VM_ACTION_TIMEOUT,
   VM_STATUS,
@@ -25,6 +24,8 @@ import {
 import { detailsTab } from '../../views/selector';
 import { waitForStatus } from '../../views/vm';
 
+const template = TEMPLATE.RHEL6;
+
 const vm: VirtualMachineData = {
   name: `smoke-test-vm-${testName}`,
   namespace: testName,
@@ -37,14 +38,14 @@ describe('test dev console', () => {
     cy.visit('/');
     cy.createProject(testName);
     cy.cdiCloner(testName, OS_IMAGES_NS);
-    cy.createDataVolume(TEMPLATE_BASE_IMAGE, OS_IMAGES_NS);
+    cy.createDataVolume(template.dvName, OS_IMAGES_NS);
   });
 
   after(() => {
     cy.deleteResource({
       kind: 'DataVolume',
       metadata: {
-        name: TEMPLATE_BASE_IMAGE,
+        name: template.dvName,
         namespace: OS_IMAGES_NS,
       },
     });
@@ -83,7 +84,7 @@ describe('test dev console', () => {
     it('ID(CNV-5699) create virtual machine', () => {
       cy.byLegacyTestID(addHeader).click();
       cy.get('[data-test="item dev-catalog-virtualization"]').click();
-      cy.contains(TEMPLATE_NAME)
+      cy.contains(template.name)
         .should('be.visible')
         .click();
       cy.contains('Create from template').click({ force: true });
@@ -113,7 +114,7 @@ describe('test dev console', () => {
       cy.get(detailsTab.vmPod).should('not.contain', DEFAULTS_VALUES.NOT_AVAILABLE);
       cy.get(detailsTab.vmIP).should('not.contain', DEFAULTS_VALUES.NOT_AVAILABLE);
       cy.get(detailsTab.vmNode).should('not.contain', DEFAULTS_VALUES.NOT_AVAILABLE);
-      cy.get(detailsTab.vmTemplate).should('contain', TEMPLATE_BASE_IMAGE);
+      cy.get(detailsTab.vmTemplate).should('contain', template.dvName);
     });
 
     it('ID(CNV-5701) review resources tab', () => {

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/disks/validate-disk-preallocation.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/disks/validate-disk-preallocation.spec.ts
@@ -1,6 +1,6 @@
 import { testName } from '../../support';
 import { Disk, VirtualMachineData } from '../../types/vm';
-import { TEMPLATE_NAME } from '../../utils/const/index';
+import { TEMPLATE } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { addDisk } from '../../views/dialog';
 import { tab } from '../../views/tab';
@@ -16,7 +16,7 @@ const disk1: Disk = {
 const vmData: VirtualMachineData = {
   name: `validate-disk-preallocation-${testName}`,
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
   sshEnable: false,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/disks/validate-storage-profile.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/disks/validate-storage-profile.spec.ts
@@ -1,7 +1,7 @@
 import { listPage } from '@console/cypress-integration-tests/views/list-page';
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
-import { TEMPLATE_NAME } from '../../utils/const/index';
+import { TEMPLATE } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { virtualization } from '../../views/virtualization';
 import { vm } from '../../views/vm';
@@ -9,7 +9,7 @@ import { vm } from '../../views/vm';
 const vmData: VirtualMachineData = {
   name: `validate-storage-profile-${testName}`,
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
   sshEnable: false,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/pvc-upload/pvc-upload.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/pvc-upload/pvc-upload.spec.ts
@@ -1,6 +1,6 @@
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
-import { OS_IMAGES_NS, TEMPLATE_BASE_IMAGE, TEMPLATE_NAME } from '../../utils/const/index';
+import { OS_IMAGES_NS, TEMPLATE } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { pvc } from '../../views/pvc';
 import { virtualization } from '../../views/virtualization';
@@ -9,10 +9,11 @@ import { vm } from '../../views/vm';
 const imageFormats = ['/tmp/cirros.iso', '/tmp/cirros.gz', '/tmp/cirros.xz'];
 const invalidImage = '/tmp/cirros.txt';
 const os = 'Red Hat Enterprise Linux 6.0 or higher - Default data image already exists';
+const template = TEMPLATE.RHEL6;
 const vmData: VirtualMachineData = {
   name: `pvc-test-vm-${testName}`,
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: template.name,
   sshEnable: false,
   startOnCreation: true,
   sourceAvailable: true,
@@ -29,7 +30,7 @@ describe('kubevirt PVC upload', () => {
     cy.deleteResource({
       kind: 'DataVolume',
       metadata: {
-        name: TEMPLATE_BASE_IMAGE,
+        name: template.dvName,
         namespace: OS_IMAGES_NS,
       },
     });
@@ -69,7 +70,7 @@ describe('kubevirt PVC upload', () => {
     });
 
     it('ID(CNV-5176) It shows an error when uploading data to golden OS again', () => {
-      cy.createDataVolume(TEMPLATE_BASE_IMAGE, OS_IMAGES_NS);
+      cy.createDataVolume(template.dvName, OS_IMAGES_NS);
       pvc.form.open();
       pvc.form.selectOS(os);
       cy.get('.pf-c-alert__title')
@@ -85,7 +86,7 @@ describe('kubevirt PVC upload', () => {
         cy.deleteResource({
           kind: 'DataVolume',
           metadata: {
-            name: TEMPLATE_BASE_IMAGE,
+            name: template.dvName,
             namespace: OS_IMAGES_NS,
           },
         });
@@ -104,10 +105,10 @@ describe('kubevirt PVC upload', () => {
         { timeout: 600000 },
       );
 
-      cy.uploadFromCLI(TEMPLATE_BASE_IMAGE, OS_IMAGES_NS, Cypress.env('UPLOAD_IMG'), '1');
+      cy.uploadFromCLI(template.dvName, OS_IMAGES_NS, Cypress.env('UPLOAD_IMG'), '1');
 
       virtualization.templates.visit();
-      virtualization.templates.testSource(TEMPLATE_NAME, 'Unknown');
+      virtualization.templates.testSource(template.name, 'Unknown');
     });
 
     it('ID(CNV-5597) Verify create VM from the template whose source is uploaded via CLI', () => {
@@ -120,12 +121,12 @@ describe('kubevirt PVC upload', () => {
       cy.deleteResource({
         kind: 'DataVolume',
         metadata: {
-          name: TEMPLATE_BASE_IMAGE,
+          name: template.dvName,
           namespace: OS_IMAGES_NS,
         },
       });
       virtualization.templates.visit();
-      virtualization.templates.testSource(TEMPLATE_NAME, 'Add source');
+      virtualization.templates.testSource(template.name, 'Add source');
     });
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/action.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/action.spec.ts
@@ -1,7 +1,7 @@
 import vmiFixture from '../../fixtures/vmi-ephemeral';
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
-import { TEMPLATE_NAME, VM_STATUS } from '../../utils/const/index';
+import { TEMPLATE, VM_STATUS } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { virtualization } from '../../views/virtualization';
 import { vm, waitForStatus } from '../../views/vm';
@@ -9,7 +9,7 @@ import { vm, waitForStatus } from '../../views/vm';
 const vmData: VirtualMachineData = {
   name: `smoke-test-vm-actions-${testName}`,
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: TEMPLATE.RHEL6.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
   sshEnable: false,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/vm-creation.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/vm-creation.spec.ts
@@ -1,5 +1,6 @@
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
+import { TEMPLATE } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { virtualization } from '../../views/virtualization';
 import { vm } from '../../views/vm';
@@ -8,7 +9,7 @@ const rhelData: VirtualMachineData = {
   name: `smoke-test-vm-rhel-${testName}`,
   description: 'rhel8 vm',
   namespace: testName,
-  template: 'Red Hat Enterprise Linux 8.0+ VM',
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
   sshEnable: false,
@@ -19,7 +20,7 @@ const fedoraData: VirtualMachineData = {
   name: `smoke-test-vm-fedora-${testName}`,
   description: 'fedora vm',
   namespace: testName,
-  template: 'Fedora 32+ VM',
+  template: TEMPLATE.FEDORA.name,
   provisionSource: ProvisionSource.URL,
   pvcSize: '1',
   sshEnable: false,
@@ -30,7 +31,7 @@ const winData: VirtualMachineData = {
   name: `smoke-test-vm-windows-${testName}`,
   description: 'windows vm',
   namespace: testName,
-  template: 'Microsoft Windows Server 2019 VM',
+  template: TEMPLATE.WIN10.name,
   provisionSource: ProvisionSource.URL,
   pvcSize: '1',
   sshEnable: false,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/vm-tabs.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/vm-tabs.spec.ts
@@ -1,6 +1,6 @@
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
-import { TEMPLATE_NAME, VM_ACTION_TIMEOUT, VM_STATUS } from '../../utils/const/index';
+import { TEMPLATE, VM_ACTION_TIMEOUT, VM_STATUS } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { virtualization } from '../../views/virtualization';
 import { vm, waitForStatus } from '../../views/vm';
@@ -8,7 +8,7 @@ import { vm, waitForStatus } from '../../views/vm';
 const vmData: VirtualMachineData = {
   name: `smoke-test-vm-${testName}`,
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
   sshEnable: false,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tabs/snapshot.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tabs/snapshot.spec.ts
@@ -1,6 +1,6 @@
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
-import { YAML_VM_NAME, STATUS_READY, TEMPLATE_NAME } from '../../utils/const/index';
+import { YAML_VM_NAME, STATUS_READY, TEMPLATE } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import * as snapshotView from '../../views/snapshot';
 import { tab } from '../../views/tab';
@@ -11,7 +11,7 @@ const vmData: VirtualMachineData = {
   name: `test-vm-snapshot-${testName}`,
   description: 'rhel8 vm for snapshot',
   namespace: testName,
-  template: TEMPLATE_NAME,
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
   sshEnable: false,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/create-template-from-wizard.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/create-template-from-wizard.spec.ts
@@ -1,6 +1,6 @@
 import { testName } from '../../support';
 import { Network, VirtualMachineData } from '../../types/vm';
-import { OS } from '../../utils/const/index';
+import { TEMPLATE } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { virtualization } from '../../views/virtualization';
 import { vm } from '../../views/vm';
@@ -16,8 +16,8 @@ const urlTemplate: VirtualMachineData = {
   namespace: testName,
   templateProvider: 'foo',
   templateSupport: true,
-  os: OS.rhel8,
-  template: 'Red Hat Enterprise Linux 8.0+ VM',
+  os: TEMPLATE.RHEL8.os,
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.URL,
   pvcSize: '1',
 };
@@ -28,8 +28,8 @@ const registryTemplate: VirtualMachineData = {
   namespace: testName,
   templateProvider: 'foo',
   templateSupport: true,
-  os: OS.win2k12,
-  template: 'Microsoft Windows Server 2012 R2 VM',
+  os: TEMPLATE.WIN2K12R2.os,
+  template: TEMPLATE.WIN2K12R2.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
 };
@@ -40,8 +40,8 @@ const pvcTemplate: VirtualMachineData = {
   namespace: testName,
   templateProvider: 'foo',
   templateSupport: true,
-  template: 'Fedora 32+ VM',
-  os: OS.fedora,
+  template: TEMPLATE.FEDORA.name,
+  os: TEMPLATE.FEDORA.os,
   provisionSource: ProvisionSource.CLONE_PVC,
   pvcName: 'clone-pvc-fedora',
   pvcNS: testName,
@@ -53,8 +53,8 @@ const pxeTemplate: VirtualMachineData = {
   namespace: testName,
   templateProvider: 'foo',
   templateSupport: true,
-  os: OS.fedora,
-  template: 'Fedora 32+ VM',
+  os: TEMPLATE.FEDORA.os,
+  template: TEMPLATE.FEDORA.name,
   provisionSource: ProvisionSource.PXE,
   networkInterfaces: [nic0],
 };

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/custom-template-support.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/custom-template-support.spec.ts
@@ -3,8 +3,7 @@ import {
   ADD_SOURCE,
   IMPORTING,
   OS_IMAGES_NS,
-  TEMPLATE_BASE_IMAGE,
-  TEMPLATE_NAME,
+  TEMPLATE,
   TEST_PROVIDER,
   VM_ACTION_TIMEOUT,
 } from '../../utils/const/index';
@@ -13,14 +12,14 @@ import { addSource } from '../../views/add-source';
 import * as templateSupportModal from '../../views/template-support-modal';
 import { virtualization } from '../../views/virtualization';
 
-const TEMPLATE = TEMPLATE_NAME;
+const template = TEMPLATE.RHEL6;
 const TEMPLATE_PROVIDER = 'bar';
 
 const deleteSourceDV = () =>
   cy.deleteResource({
     kind: 'DataVolume',
     metadata: {
-      name: TEMPLATE_BASE_IMAGE,
+      name: template.dvName,
       namespace: OS_IMAGES_NS,
     },
   });
@@ -29,7 +28,7 @@ const deleteSourcePVC = () =>
   cy.deleteResource({
     kind: 'PersistentVolumeClaim',
     metadata: {
-      name: TEMPLATE_BASE_IMAGE,
+      name: template.dvName,
       namespace: OS_IMAGES_NS,
     },
   });
@@ -60,11 +59,11 @@ describe('test custom template creation support', () => {
     const NEW_TEMPLATE_NAME = `foo-no-source-${testName}`;
     const VM_NAME_NO_BOOT_SOURCE = `foo-vm-no-source-${testName}`;
 
-    virtualization.templates.testSource(TEMPLATE, ADD_SOURCE);
-    virtualization.templates.clickCreateNewTemplateFrom(TEMPLATE);
+    virtualization.templates.testSource(template.name, ADD_SOURCE);
+    virtualization.templates.clickCreateNewTemplateFrom(template.name);
 
     // verify template fields
-    cy.get('#operating-system-dropdown').contains('Red Hat Enterprise Linux 6.0 or higher');
+    cy.get('#operating-system-dropdown').contains(template.os);
     cy.get('#flavor-dropdown').contains('Small (default): 1 CPU | 2 GiB Memory');
     cy.get('#workload-profile-dropdown').contains('Server (default)');
 
@@ -111,15 +110,15 @@ describe('test custom template creation support', () => {
     const NEW_TEMPLATE_NAME = `foo-with-source-${testName}`;
     const VM_NAME_WITH_BOOT_SOURCE = `foo-vm-with-source-${testName}`;
 
-    virtualization.templates.addSource(TEMPLATE);
+    virtualization.templates.addSource(template.name);
     addSource.addBootSource(ProvisionSource.REGISTRY);
-    virtualization.templates.testSource(TEMPLATE, IMPORTING);
-    virtualization.templates.testSource(TEMPLATE, TEST_PROVIDER);
+    virtualization.templates.testSource(template.name, IMPORTING);
+    virtualization.templates.testSource(template.name, TEST_PROVIDER);
 
-    virtualization.templates.clickCreateNewTemplateFrom(TEMPLATE);
+    virtualization.templates.clickCreateNewTemplateFrom(template.name);
 
     // verify template fields
-    cy.get('#operating-system-dropdown').contains('Red Hat Enterprise Linux 6.0 or higher');
+    cy.get('#operating-system-dropdown').contains(template.os);
     cy.get('#flavor-dropdown').contains('Small (default): 1 CPU | 2 GiB Memory');
     cy.get('#workload-profile-dropdown').contains('Server (default)');
 

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/customize-source.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/customize-source.spec.ts
@@ -4,15 +4,15 @@ import {
   OS_IMAGES_NS,
   PREPARING_FOR_CUSTOMIZATION,
   READY_FOR_CUSTOMIZATION,
-  TEMPLATE_BASE_IMAGE,
-  TEMPLATE_METADATA_NAME,
-  TEMPLATE_NAME,
+  TEMPLATE,
   TEST_PROVIDER,
 } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { addSource } from '../../views/add-source';
 import { customizeSource, PROVIDER } from '../../views/customize-source';
 import { virtualization } from '../../views/virtualization';
+
+const template = TEMPLATE.RHEL6;
 
 describe('test vm template source image', () => {
   before(() => {
@@ -22,7 +22,7 @@ describe('test vm template source image', () => {
     cy.deleteResource({
       kind: 'DataVolume',
       metadata: {
-        name: TEMPLATE_BASE_IMAGE,
+        name: template.dvName,
         namespace: OS_IMAGES_NS,
       },
     });
@@ -33,7 +33,7 @@ describe('test vm template source image', () => {
     cy.deleteResource({
       kind: 'DataVolume',
       metadata: {
-        name: TEMPLATE_BASE_IMAGE,
+        name: template.dvName,
         namespace: OS_IMAGES_NS,
       },
     });
@@ -48,12 +48,12 @@ describe('test vm template source image', () => {
   it('customize common template source', () => {
     const vmtName = 'tmp-customized';
     virtualization.templates.visit();
-    virtualization.templates.addSource(TEMPLATE_NAME);
+    virtualization.templates.addSource(template.name);
     addSource.addBootSource(ProvisionSource.REGISTRY);
-    virtualization.templates.testSource(TEMPLATE_NAME, IMPORTING);
-    virtualization.templates.testSource(TEMPLATE_NAME, TEST_PROVIDER);
+    virtualization.templates.testSource(template.name, IMPORTING);
+    virtualization.templates.testSource(template.name, TEST_PROVIDER);
 
-    virtualization.templates.customizeSource(TEMPLATE_METADATA_NAME);
+    virtualization.templates.customizeSource(template.metadataName);
     customizeSource.fillForm({ vmtName });
 
     virtualization.templates.visit();
@@ -70,7 +70,7 @@ describe('test vm template source image', () => {
     cy.createUserTemplate(testName);
     virtualization.templates.visit();
 
-    virtualization.templates.customizeSource(TEMPLATE_METADATA_NAME);
+    virtualization.templates.customizeSource(template.metadataName);
     customizeSource.fillForm({ vmtName });
 
     virtualization.templates.visit();

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/source-image.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/source-image.spec.ts
@@ -3,15 +3,15 @@ import {
   ADD_SOURCE,
   IMPORTING,
   OS_IMAGES_NS,
-  TEMPLATE_BASE_IMAGE,
-  TEMPLATE_METADATA_NAME,
-  TEMPLATE_NAME,
+  TEMPLATE,
   TEST_PROVIDER,
   VM_STATUS,
 } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { addSource } from '../../views/add-source';
 import { virtualization } from '../../views/virtualization';
+
+const template = TEMPLATE.RHEL8;
 
 describe('test vm template source image', () => {
   before(() => {
@@ -33,7 +33,7 @@ describe('test vm template source image', () => {
     cy.deleteResource({
       kind: 'DataVolume',
       metadata: {
-        name: TEMPLATE_BASE_IMAGE,
+        name: template.dvName,
         namespace: OS_IMAGES_NS,
       },
     });
@@ -44,34 +44,34 @@ describe('test vm template source image', () => {
   });
 
   it('ID(CNV-5652) add Container image and delete', () => {
-    virtualization.templates.addSource(TEMPLATE_NAME);
+    virtualization.templates.addSource(template.name);
     addSource.addBootSource(ProvisionSource.REGISTRY);
-    virtualization.templates.testSource(TEMPLATE_NAME, IMPORTING);
-    virtualization.templates.testSource(TEMPLATE_NAME, TEST_PROVIDER);
-    virtualization.templates.deleteSource(TEMPLATE_METADATA_NAME);
-    virtualization.templates.testSource(TEMPLATE_NAME, ADD_SOURCE);
+    virtualization.templates.testSource(template.name, IMPORTING);
+    virtualization.templates.testSource(template.name, TEST_PROVIDER);
+    virtualization.templates.deleteSource(template.metadataName);
+    virtualization.templates.testSource(template.name, ADD_SOURCE);
   });
 
   it('ID(CNV-5650) add URL image and delete', () => {
-    virtualization.templates.addSource(TEMPLATE_NAME);
+    virtualization.templates.addSource(template.name);
     addSource.addBootSource(ProvisionSource.URL);
-    virtualization.templates.testSource(TEMPLATE_NAME, IMPORTING);
-    virtualization.templates.testSource(TEMPLATE_NAME, TEST_PROVIDER);
-    virtualization.templates.deleteSource(TEMPLATE_METADATA_NAME);
-    virtualization.templates.testSource(TEMPLATE_NAME, ADD_SOURCE);
+    virtualization.templates.testSource(template.name, IMPORTING);
+    virtualization.templates.testSource(template.name, TEST_PROVIDER);
+    virtualization.templates.deleteSource(template.metadataName);
+    virtualization.templates.testSource(template.name, ADD_SOURCE);
   });
 
   it('ID(CNV-5651) add PVC clone image and delete', () => {
     cy.createDataVolume(testName, 'default');
-    virtualization.templates.addSource(TEMPLATE_NAME);
+    virtualization.templates.addSource(template.name);
     addSource.addBootSource(ProvisionSource.CLONE_PVC, {
       pvcName: testName,
       pvcNamespace: 'default',
     });
-    virtualization.templates.testSource(TEMPLATE_NAME, VM_STATUS.Cloning);
-    virtualization.templates.testSource(TEMPLATE_NAME, TEST_PROVIDER);
-    virtualization.templates.deleteSource(TEMPLATE_METADATA_NAME);
-    virtualization.templates.testSource(TEMPLATE_NAME, ADD_SOURCE);
+    virtualization.templates.testSource(template.name, VM_STATUS.Cloning);
+    virtualization.templates.testSource(template.name, TEST_PROVIDER);
+    virtualization.templates.deleteSource(template.metadataName);
+    virtualization.templates.testSource(template.name, ADD_SOURCE);
   });
 
   xit('ID(CNV-5649) upload image and delete', () => {
@@ -81,22 +81,22 @@ describe('test vm template source image', () => {
       )} || curl --fail -L ${ProvisionSource.URL.getSource()} -o ${Cypress.env('UPLOAD_IMG')}`,
       { timeout: 600000 },
     );
-    virtualization.templates.addSource(TEMPLATE_NAME);
+    virtualization.templates.addSource(template.name);
     addSource.addBootSource(ProvisionSource.UPLOAD);
-    virtualization.templates.testSource(TEMPLATE_NAME, 'Uploading');
-    virtualization.templates.testSource(TEMPLATE_NAME, TEST_PROVIDER);
-    virtualization.templates.deleteSource(TEMPLATE_METADATA_NAME);
-    virtualization.templates.testSource(TEMPLATE_NAME, ADD_SOURCE);
+    virtualization.templates.testSource(template.name, 'Uploading');
+    virtualization.templates.testSource(template.name, TEST_PROVIDER);
+    virtualization.templates.deleteSource(template.metadataName);
+    virtualization.templates.testSource(template.name, ADD_SOURCE);
   });
 });
 
 describe('test vm template source image provider', () => {
   it('Vm Template list shows source provider', () => {
-    virtualization.templates.addSource(TEMPLATE_NAME);
+    virtualization.templates.addSource(template.name);
     addSource.addBootSource(ProvisionSource.REGISTRY, undefined, 'fooProvider');
-    virtualization.templates.testSource(TEMPLATE_NAME, IMPORTING);
-    virtualization.templates.testSource(TEMPLATE_NAME, 'fooProvider');
-    virtualization.templates.deleteSource(TEMPLATE_METADATA_NAME);
-    virtualization.templates.testSource(TEMPLATE_NAME, ADD_SOURCE);
+    virtualization.templates.testSource(template.name, IMPORTING);
+    virtualization.templates.testSource(template.name, 'fooProvider');
+    virtualization.templates.deleteSource(template.metadataName);
+    virtualization.templates.testSource(template.name, ADD_SOURCE);
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-rhel9.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-rhel9.spec.ts
@@ -1,0 +1,37 @@
+import { TEMPLATE } from '../../utils/const/index';
+import { nameFilter, unStarIcon, supportLevel, supportLevelTag } from '../../views/selector';
+import { virtualization } from '../../views/virtualization';
+
+const template = TEMPLATE.RHEL9;
+
+describe('Test RHEL9 template', () => {
+  before(() => {
+    cy.Login();
+    cy.visit('/');
+    virtualization.templates.visit();
+  });
+
+  // TODO: RHEL9 should be starred after it's official released.
+  it('ID(CNV-7185) Verify RHEL9 template is not starred', () => {
+    // mark it downstream only as upstream has no rhel9 template yet
+    if (Cypress.env('DOWNSTREAM')) {
+      cy.get(nameFilter)
+        .clear()
+        .type(template.dvName);
+      cy.byLegacyTestID(template.metadataName).should('be.visible');
+      cy.get(unStarIcon).should('be.visible');
+    }
+  });
+
+  // TODO: RHEL9 support level on list page should be Limited once bz1998162 is fixed.
+  it('ID(CNV-7186) Verify RHEL9 template support level', () => {
+    if (Cypress.env('DOWNSTREAM')) {
+      cy.get(nameFilter)
+        .clear()
+        .type(template.dvName);
+      cy.get(supportLevelTag).should('contain', 'Community');
+      cy.byLegacyTestID(template.metadataName).click();
+      cy.get(supportLevel).should('contain', template.supportLevel);
+    }
+  });
+});

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-support.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm-template/template-support.spec.ts
@@ -1,4 +1,5 @@
 import { testName } from '../../support';
+import { TEMPLATE } from '../../utils/const/index';
 import { virtualization } from '../../views/virtualization';
 import { wizard } from '../../views/wizard';
 
@@ -56,8 +57,8 @@ describe('test VM template support', () => {
 
   if (Cypress.env('DOWNSTREAM')) {
     it('shows support modal for community supported template', () => {
-      virtualization.templates.testSupport('CentOS 7.0+ VM');
-      virtualization.templates.clickCreate('CentOS 7.0+ VM');
+      virtualization.templates.testSupport(TEMPLATE.CENTOS7.name);
+      virtualization.templates.clickCreate(TEMPLATE.CENTOS7.os);
       cy.get('.ReactModal__Overlay').within(() => {
         cy.get('a').should('have.attr', 'href', 'https://www.centos.org');
         cy.byLegacyTestID('modal-cancel-action').click();
@@ -66,7 +67,7 @@ describe('test VM template support', () => {
 
     it('shows no support modal for user supported template based on community supported one', () => {
       wizard.template.open();
-      wizard.template.createTemplate(TEMPLATE_NAME, 'bar', true, 'CentOS 7 or higher');
+      wizard.template.createTemplate(TEMPLATE_NAME, 'bar', true, TEMPLATE.CENTOS7.os);
       virtualization.templates.testProvider(TEMPLATE_NAME, 'bar');
       virtualization.templates.testSource(TEMPLATE_NAME, 'bar');
       virtualization.templates.testSupport(TEMPLATE_NAME, 'bar');
@@ -76,7 +77,7 @@ describe('test VM template support', () => {
 
     it('shows support modal for user template based on community supported one', () => {
       wizard.template.open();
-      wizard.template.createTemplate(TEMPLATE_NAME, 'bar', false, 'CentOS 7 or higher');
+      wizard.template.createTemplate(TEMPLATE_NAME, 'bar', false, TEMPLATE.CENTOS7.os);
       virtualization.templates.testProvider(TEMPLATE_NAME, 'bar');
       virtualization.templates.testSource(TEMPLATE_NAME, 'bar');
       virtualization.templates.testSupport(TEMPLATE_NAME);
@@ -88,19 +89,14 @@ describe('test VM template support', () => {
     });
 
     it('shows no support modal for supported template', () => {
-      virtualization.templates.testSupport('Red Hat Enterprise Linux 8.0+ VM', 'Red Hat');
-      virtualization.templates.clickCreate('Red Hat Enterprise Linux 8.0+ VM');
+      virtualization.templates.testSupport(TEMPLATE.RHEL8.name, 'Red Hat');
+      virtualization.templates.clickCreate(TEMPLATE.RHEL8.name);
       cy.get('.ReactModal__Overlay').should('not.exist');
     });
 
     it('shows no support modal for user supported template', () => {
       wizard.template.open();
-      wizard.template.createTemplate(
-        TEMPLATE_NAME,
-        'bar',
-        true,
-        'Red Hat Enterprise Linux 8.0 or higher',
-      );
+      wizard.template.createTemplate(TEMPLATE_NAME, 'bar', true, TEMPLATE.RHEL8.os);
       virtualization.templates.testProvider(TEMPLATE_NAME, 'bar');
       virtualization.templates.testSource(TEMPLATE_NAME, 'bar');
       virtualization.templates.testSupport(TEMPLATE_NAME, 'bar', 'Red Hat');
@@ -110,7 +106,7 @@ describe('test VM template support', () => {
 
     it('shows support modal for user template with no support', () => {
       wizard.template.open();
-      wizard.template.createTemplate(TEMPLATE_NAME, 'bar', false, 'CentOS 7 or higher');
+      wizard.template.createTemplate(TEMPLATE_NAME, 'bar', false, TEMPLATE.CENTOS7.os);
       virtualization.templates.testProvider(TEMPLATE_NAME, 'bar');
       virtualization.templates.testSource(TEMPLATE_NAME, 'bar');
       cy.exec(

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm/advanced-wizard.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/vm/advanced-wizard.spec.ts
@@ -1,5 +1,6 @@
 import { testName } from '../../support';
 import { VirtualMachineData } from '../../types/vm';
+import { TEMPLATE } from '../../utils/const/index';
 import { ProvisionSource } from '../../utils/const/provisionSource';
 import { virtualization } from '../../views/virtualization';
 import { vm } from '../../views/vm';
@@ -13,7 +14,7 @@ const urlVM: VirtualMachineData = {
   name: `url-vm-customize-wizard-${testName}`,
   description: 'ID(CNV-869): create VM from URL',
   namespace: testName,
-  template: 'Red Hat Enterprise Linux 8.0+ VM',
+  template: TEMPLATE.RHEL8.name,
   provisionSource: ProvisionSource.URL,
   pvcSize: '1',
   sshEnable: false,
@@ -24,7 +25,7 @@ const registryVM: VirtualMachineData = {
   name: `registry-vm-customize-wizard-${testName}`,
   description: 'ID(CNV-870): create VM from container image',
   namespace: testName,
-  template: 'Microsoft Windows 10 VM',
+  template: TEMPLATE.WIN10.name,
   provisionSource: ProvisionSource.REGISTRY,
   pvcSize: '1',
   sshEnable: false,
@@ -35,7 +36,7 @@ const pvcVM: VirtualMachineData = {
   name: `pvc-vm-customize-wizard-${testName}`,
   description: 'ID(CNV-2446): create VM from existing PVC',
   namespace: testName,
-  template: 'Fedora 32+ VM',
+  template: TEMPLATE.FEDORA.name,
   provisionSource: ProvisionSource.CLONE_PVC,
   pvcName: 'clone-pvc-fedora',
   pvcNS: testName,

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
@@ -6,10 +6,6 @@ export const KUBEVIRT_STORAGE_CLASS_DEFAULTS = 'kubevirt-storage-class-defaults'
 export const KUBEVIRT_PROJECT_NAME = 'openshift-cnv';
 export const EXPECT_LOGIN_SCRIPT_PATH = './utils/expect-login.sh';
 
-export const TEMPLATE_NAME = 'Red Hat Enterprise Linux 6.0+ VM';
-export const TEMPLATE_BASE_IMAGE = 'rhel6';
-export const TEMPLATE_METADATA_NAME = 'rhel6-server-small';
-
 export const TEST_PROVIDER = 'test-provider';
 export const IMPORTING = 'Importing';
 export const ADD_SOURCE = 'Add source';
@@ -94,9 +90,61 @@ export enum DISK_DRIVE {
   CDROM = 'CD-ROM',
 }
 
-export enum OS {
-  fedora = 'Fedora 32 or higher',
-  win10 = 'Microsoft Windows 10',
-  win2k12 = 'Microsoft Windows Server 2012 R2',
-  rhel8 = 'Red Hat Enterprise Linux 8.0 or higher',
-}
+export const TEMPLATE = {
+  RHEL6: {
+    name: 'Red Hat Enterprise Linux 6.0+ VM',
+    dvName: 'rhel6',
+    metadataName: 'rhel6-server-small',
+    os: 'Red Hat Enterprise Linux 6.0 or higher',
+    supportLevel: 'Full',
+  },
+  RHEL7: {
+    name: 'Red Hat Enterprise Linux 7.0+ VM',
+    dvName: 'rhel7',
+    metadataName: 'rhel7-server-small',
+    os: 'Red Hat Enterprise Linux 7.0 or higher',
+    supportLevel: 'Full',
+  },
+  RHEL8: {
+    name: 'Red Hat Enterprise Linux 8.0+ VM',
+    dvName: 'rhel8',
+    metadataName: 'rhel8-server-small',
+    os: 'Red Hat Enterprise Linux 8.0 or higher',
+    supportLevel: 'Full',
+  },
+  RHEL9: {
+    name: 'Red Hat Enterprise Linux 9.0 Alpha VM',
+    dvName: 'rhel9',
+    metadataName: 'rhel9-server-small',
+    os: 'Red Hat Enterprise Linux 9.0 or higher',
+    supportLevel: 'Limited',
+  },
+  FEDORA: {
+    name: 'Fedora 32+ VM',
+    dvName: 'fedora',
+    metadataName: 'fedora-server-small',
+    os: 'Fedora 32 or higher',
+    supportLevel: 'Community',
+  },
+  CENTOS7: {
+    name: 'CentOS 7.0+ VM',
+    dvName: 'centos7',
+    metadataName: 'centos7-server-small',
+    os: 'CentOS 7 or higher',
+    supportLevel: 'Community',
+  },
+  WIN10: {
+    name: 'Microsoft Windows 10 VM',
+    dvName: 'win10',
+    metadataName: 'windows10-desktop-medium',
+    os: 'Microsoft Windows 10',
+    supportLevel: 'Full',
+  },
+  WIN2K12R2: {
+    name: 'Microsoft Windows Server 2012 R2 VM',
+    dvName: 'win2k12r2',
+    metadataName: 'windows2k12r2-server-medium',
+    os: 'Microsoft Windows Server 2012 R2',
+    supportLevel: 'Full',
+  },
+};

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/views/selector.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/views/selector.ts
@@ -70,3 +70,10 @@ export const createYAMLButton = 'button[data-test="save-changes"]';
 
 // multiple IP pop-up
 export const ipPopOverContent = '.pf-c-popover__content';
+
+// template list
+export const nameFilter = 'input[data-test="name-filter-input"]';
+// export const starIcon = '.pf-c-button.pf-m-plain.kv-pin-remove-btn';
+export const unStarIcon = '.pf-c-button.pf-m-plain.kv-pin-btn';
+export const supportLevel = '[data-test-id="details-Support"]';
+export const supportLevelTag = '[data-test="template-support"]';


### PR DESCRIPTION
review notes:
1. upstream has no RHEL9 template, move the test downstream only
2. there is a test failure on `action/clone.spec.ts`, try to fix the flaky here.
3. add a new constant `TEMPLATE`.