### PR TITLE
[WIP ODC-2945] refactor and clean up PodRing.tsx 

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRing.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRing.tsx
@@ -26,6 +26,7 @@ const handleScalingCallback = (
   obj: K8sResourceKind,
   path: string,
 ) => {
+  // console.log('debounce to', operation);
   const patch = [{ op: 'replace', path, value: operation }];
   const opts = { path: 'scale' };
   const promise: Promise<K8sResourceKind> = k8sPatch(resourceKind, obj, patch, opts);
@@ -70,8 +71,8 @@ const PodRing: React.FC<PodRingProps> = ({
     (operation: number) => handleScalingCallback(operation, resourceKind, obj, path),
     1000,
     {
-      leading: true,
-      trailing: false,
+      leading: false,
+      trailing: true,
     },
   );
 
@@ -98,6 +99,8 @@ const PodRing: React.FC<PodRingProps> = ({
     hpaControlledScaling,
     t,
     hpa,
+    clickCount,
+    // obj.spec.replicas !== clickCount ? clickCount : undefined,
   );
 
   return (

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -117,6 +117,7 @@ export const podRingLabel = (
   ownerKind: string,
   pods: ExtPodKind[],
   t: TFunction,
+  clickCount?: number,
 ): PodRingLabelData => {
   let currentPodCount;
   let desiredPodCount;
@@ -131,11 +132,12 @@ export const podRingLabel = (
   };
 
   const failedPodCount = getFailedPods(pods);
+  // console.log('ownerKind', ownerKind, clickCount, obj.status?.readyReplicas, '->',obj.status?.replicas);
   switch (ownerKind) {
     case DaemonSetModel.kind:
       currentPodCount = (obj.status?.currentNumberScheduled || 0) + failedPodCount;
-      desiredPodCount = obj.status?.desiredNumberScheduled;
-      desiredPodCount = obj.status?.desiredNumberScheduled;
+      desiredPodCount =
+        typeof clickCount !== 'undefined' ? clickCount : obj.status?.desiredNumberScheduled;
       isPending = isPendingPods(pods, currentPodCount, desiredPodCount);
       titleData = getTitleAndSubtitle(isPending, currentPodCount, desiredPodCount, t);
       podRingLabelData.title = titleData.title;
@@ -144,7 +146,7 @@ export const podRingLabel = (
       break;
     case RevisionModel.kind:
       currentPodCount = (obj.status?.readyReplicas || 0) + failedPodCount;
-      desiredPodCount = obj.spec?.replicas;
+      desiredPodCount = typeof clickCount !== 'undefined' ? clickCount : obj.spec?.replicas;
       isPending = isPendingPods(pods, currentPodCount, desiredPodCount);
       if (!isPending && !desiredPodCount) {
         podRingLabelData.title = t('console-shared~Autoscaled');
@@ -173,7 +175,7 @@ export const podRingLabel = (
       break;
     default:
       currentPodCount = (obj.status?.readyReplicas || 0) + failedPodCount;
-      desiredPodCount = obj.spec?.replicas;
+      desiredPodCount = typeof clickCount !== 'undefined' ? clickCount : obj.spec?.replicas;
       isPending = isPendingPods(pods, currentPodCount, desiredPodCount);
       titleData = getTitleAndSubtitle(isPending, currentPodCount, desiredPodCount, t);
       podRingLabelData.title = titleData.title;
@@ -213,10 +215,11 @@ export const usePodRingLabel = (
   hpaControlledScaling: boolean = false,
   t: TFunction,
   hpa?: HorizontalPodAutoscalerKind,
+  clickCount?: number,
 ): PodRingLabelType => {
   const podRingLabelData = hpaControlledScaling
     ? hpaPodRingLabel(obj, hpa, pods, t)
-    : podRingLabel(obj, ownerKind, pods, t);
+    : podRingLabel(obj, ownerKind, pods, t, clickCount);
   const { title, subTitle, longTitle, longSubtitle, reversed } = podRingLabelData;
 
   return React.useMemo(


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-2945

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Handleclick function was defined inside the React Component
Lodash was being used 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
convert `_.debounce` to `useDebounceCallback` which results in memoized (handled by the hook?)
also we not re creating the function on each render

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- make a sample app
- go in admin ->workload ->deployment ->config
- test out the buttons and 'actions-> edit pod count' 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge