### PR TITLE
Bug 1998575: Fix that insert yaml does nothing when yaml is provided via an extension (also hide samples when user edits a resource)

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/YAMLEditorSidebar.tsx
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditorSidebar.tsx
@@ -30,7 +30,7 @@ const YAMLEditorSidebar: React.FC<YAMLEditorSidebarProps> = ({
   const editor = editorRef.current?.editor;
 
   const insertYamlContent = React.useCallback(
-    (id, yamlContent, kind) => {
+    (id: string = 'default', yamlContent: string = '', kind) => {
       const yaml = sanitizeYamlContent ? sanitizeYamlContent(id, yamlContent, kind) : yamlContent;
 
       const selection = editor.getSelection();
@@ -70,7 +70,7 @@ const YAMLEditorSidebar: React.FC<YAMLEditorSidebarProps> = ({
   );
 
   const replaceYamlContent = React.useCallback(
-    (id, yamlContent, kind) => {
+    (id: string = 'default', yamlContent: string = '', kind: string) => {
       const yaml = sanitizeYamlContent ? sanitizeYamlContent(id, yamlContent, kind) : yamlContent;
       editor.setValue(yaml);
     },
@@ -78,7 +78,7 @@ const YAMLEditorSidebar: React.FC<YAMLEditorSidebarProps> = ({
   );
 
   const downloadYamlContent = React.useCallback(
-    (id = 'default', yamlContent = '', kind) => {
+    (id: string = 'default', yamlContent: string = '', kind: string) => {
       try {
         const yaml = sanitizeYamlContent ? sanitizeYamlContent(id, yamlContent, kind) : yamlContent;
         downloadYaml(yaml);

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
@@ -4,12 +4,14 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { FormikValues, useField, useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { useResolvedExtensions, isYAMLTemplate, YAMLTemplate } from '@console/dynamic-plugin-sdk';
 import { AsyncComponent } from '@console/internal/components/utils';
 import {
   useK8sWatchResource,
   WatchK8sResource,
 } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConsoleYAMLSampleModel } from '@console/internal/models';
+import { getYAMLTemplates } from '@console/internal/models/yaml-templates';
 import { definitionFor, K8sResourceCommon, referenceForModel } from '@console/internal/module/k8s';
 import { getResourceSidebarSamples } from '../../utils';
 import { YAMLEditorFieldProps } from './field-types';
@@ -26,6 +28,7 @@ const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({
   label,
   model,
   schema,
+  showSamples,
   onSave,
 }) => {
   const [field] = useField(name);
@@ -53,7 +56,22 @@ const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({
 
   const definition = model ? definitionFor(model) : { properties: [] };
   const hasSchema = !!schema || (!!definition && !isEmpty(definition.properties));
-  const hasSidebarContent = hasSchema || !isEmpty(samples) || !isEmpty(snippets);
+  const hasSidebarContent = hasSchema || (showSamples && !isEmpty(samples)) || !isEmpty(snippets);
+
+  const [templateExtensions] = useResolvedExtensions<YAMLTemplate>(isYAMLTemplate);
+
+  const sanitizeYamlContent = React.useCallback(
+    (id: string = 'default', yaml: string = '', kind: string) => {
+      if (yaml) {
+        return yaml;
+      }
+      const yamlByExtension: string = getYAMLTemplates(
+        templateExtensions?.filter((e) => e.properties.model.kind === kind),
+      ).getIn([kind, id]);
+      return yamlByExtension?.trim() || '';
+    },
+    [templateExtensions],
+  );
 
   return (
     <div className="osc-yaml-editor" data-test="yaml-editor">
@@ -84,8 +102,9 @@ const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({
             editorRef={editorRef}
             model={model}
             schema={schema}
-            samples={samples}
+            samples={showSamples ? samples : []}
             snippets={snippets}
+            sanitizeYamlContent={sanitizeYamlContent}
             sidebarLabel={label}
             toggleSidebar={() => setSidebarOpen(!sidebarOpen)}
           />

--- a/frontend/packages/console-shared/src/components/formik-fields/__tests__/SyncedEditorField.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/__tests__/SyncedEditorField.spec.tsx
@@ -32,7 +32,7 @@ describe('SyncedEditorField', () => {
 
   const mockEditors = {
     form: <DynamicFormField name="formData" schema={{}} />,
-    yaml: <YAMLEditorField name="yamlData" />,
+    yaml: <YAMLEditorField name="yamlData" showSamples />,
   };
 
   const props: SyncedEditorFieldProps = {

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -105,7 +105,7 @@ export interface MultiColumnFieldProps extends FieldProps {
 export interface YAMLEditorFieldProps extends FieldProps {
   model?: K8sKind;
   schema?: JSONSchema7;
-  onChange?: (value: string) => void;
+  showSamples: boolean;
   onSave?: () => void;
 }
 

--- a/frontend/packages/dev-console/src/components/buildconfig/BuildConfigForm.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/BuildConfigForm.tsx
@@ -46,7 +46,12 @@ const BuildConfigForm: React.FC<FormikProps<BuildConfigFormikValues> & {
 
   const formEditor = <BuildConfigFormEditor namespace={namespace} />;
   const yamlEditor = (
-    <YAMLEditorField name="yamlData" model={BuildConfigModel} onSave={handleSubmit} />
+    <YAMLEditorField
+      name="yamlData"
+      model={BuildConfigModel}
+      showSamples={!watchedBuildConfig}
+      onSave={handleSubmit}
+    />
   );
 
   const LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY = 'devconsole.buildConfigForm.editor.lastView';

--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
@@ -56,6 +56,7 @@ const EditDeploymentForm: React.FC<FormikProps<FormikValues> & {
     <YAMLEditorField
       name="yamlData"
       model={resourceType === Resources.OpenShift ? DeploymentConfigModel : DeploymentModel}
+      showSamples={!resource}
       onSave={handleSubmit}
     />
   );

--- a/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAForm.tsx
@@ -17,6 +17,7 @@ import HPADetailsForm from './HPADetailsForm';
 import { HPAFormValues } from './types';
 
 type HPAFormProps = {
+  existingHPA?: HorizontalPodAutoscalerKind;
   targetResource: K8sResourceCommon;
 };
 
@@ -27,6 +28,7 @@ const HPAForm: React.FC<FormikProps<HPAFormValues> & HPAFormProps> = ({
   status,
   setStatus,
   isSubmitting,
+  existingHPA,
   targetResource,
   validateForm,
   values,
@@ -36,7 +38,12 @@ const HPAForm: React.FC<FormikProps<HPAFormValues> & HPAFormProps> = ({
   const isForm = values.editorType === EditorType.Form;
   const formEditor = <HPADetailsForm />;
   const yamlEditor = (
-    <YAMLEditorField name="yamlData" model={HorizontalPodAutoscalerModel} onSave={handleSubmit} />
+    <YAMLEditorField
+      name="yamlData"
+      model={HorizontalPodAutoscalerModel}
+      showSamples={!existingHPA}
+      onSave={handleSubmit}
+    />
   );
   const customMetrics = false;
 

--- a/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
+++ b/frontend/packages/dev-console/src/components/hpa/HPAFormikForm.tsx
@@ -79,7 +79,7 @@ const HPAFormikForm: React.FC<HPAFormikFormProps> = ({ existingHPA, targetResour
       validationSchema={hpaValidationSchema(t)}
     >
       {(props: FormikProps<HPAFormValues>) => (
-        <HPAForm {...props} targetResource={targetResource} />
+        <HPAForm {...props} existingHPA={existingHPA} targetResource={targetResource} />
       )}
     </Formik>
   );

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradeForm.tsx
@@ -70,6 +70,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
       name="yamlData"
       label={t('helm-plugin~Helm Chart')}
       schema={formSchema}
+      showSamples={false}
       onSave={handleSubmit}
     />
   );

--- a/frontend/packages/knative-plugin/src/components/add/EventSourceForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourceForm.tsx
@@ -41,7 +41,7 @@ const EventSourceForm: React.FC<FormikProps<FormikValues> & OwnProps> = ({
 }) => {
   const { t } = useTranslation();
   const LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY = 'knative.eventSourceForm.editor.lastView';
-  const yamlEditor = <YAMLEditorField name="yamlData" onSave={handleSubmit} />;
+  const yamlEditor = <YAMLEditorField name="yamlData" showSamples onSave={handleSubmit} />;
 
   const sanitizeToYaml = () =>
     safeJSToYAML(getCatalogEventSourceResource(values as EventSourceSyncFormData), 'yamlData', {

--- a/frontend/packages/knative-plugin/src/components/add/brokers/AddBrokerForm.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/brokers/AddBrokerForm.tsx
@@ -112,7 +112,12 @@ const AddBrokerForm: React.FC<FormikProps<AddBrokerFormYamlValues> & AddBrokerFo
     </>
   );
   const yamlEditor = (
-    <YAMLEditorField name="yamlData" model={EventingBrokerModel} onSave={handleSubmit} />
+    <YAMLEditorField
+      name="yamlData"
+      model={EventingBrokerModel}
+      showSamples
+      onSave={handleSubmit}
+    />
   );
   return (
     <FlexForm onSubmit={handleSubmit}>

--- a/frontend/packages/knative-plugin/src/components/add/channels/form-fields/ChannelYamlEditor.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/channels/form-fields/ChannelYamlEditor.tsx
@@ -28,7 +28,7 @@ const ChannelYamlEditor: React.FC = () => {
 
   return (
     <FormSection flexLayout fullWidth>
-      <YAMLEditorField name="yamlData" />
+      <YAMLEditorField name="yamlData" showSamples />
     </FormSection>
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -132,7 +132,12 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
   );
 
   const yamlEditor = (
-    <YAMLEditorField name="yamlData" model={PipelineModel} onSave={handleSubmit} />
+    <YAMLEditorField
+      name="yamlData"
+      model={PipelineModel}
+      showSamples={!existingPipeline}
+      onSave={handleSubmit}
+    />
   );
 
   return (

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -613,7 +613,8 @@ export const EditYAML_ = connect(stateToProps)(
             : { samples: [], snippets: [] };
           const definition = model ? definitionFor(model) : { properties: [] };
           const showSchema = definition && !_.isEmpty(definition.properties);
-          const hasSidebarContent = showSchema || !_.isEmpty(samples) || !_.isEmpty(snippets);
+          const hasSidebarContent =
+            showSchema || (create && !_.isEmpty(samples)) || !_.isEmpty(snippets);
           const sidebarLink =
             !showSidebar && hasSidebarContent ? (
               <Button type="button" variant="link" isInline onClick={this.toggleSidebar}>

--- a/frontend/public/components/sidebars/resource-sidebar-samples.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar-samples.tsx
@@ -79,7 +79,7 @@ const PreviewYAML = ({ maxPreviewLines = 20, yaml }) => {
 
 interface ResourceSidebarSnippetProps {
   snippet: Sample;
-  insertSnippetYaml(id: string, yaml: string, reference: string);
+  insertSnippetYaml: (id: string, yaml: string, reference: string) => void;
 }
 
 const ResourceSidebarSnippet: React.FC<ResourceSidebarSnippetProps> = ({
@@ -193,9 +193,9 @@ export const ResourceSidebarSamples: React.FC<ResourceSidebarSamplesProps> = ({
   );
 };
 
-type LoadSampleYaml = (id: string, yaml: string, kind: string) => void;
+export type LoadSampleYaml = (id: string, yaml: string, kind: string) => void;
 
-type DownloadSampleYaml = (id: string, yaml: string, kind: string) => void;
+export type DownloadSampleYaml = (id: string, yaml: string, kind: string) => void;
 
 type ResourceSidebarSampleProps = {
   sample: Sample;

--- a/frontend/public/components/sidebars/resource-sidebar.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar.tsx
@@ -3,16 +3,25 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import CloseButton from '@console/shared/src/components/close-button';
 
-import { definitionFor } from '../../module/k8s';
-import { ResourceSidebarSnippets, ResourceSidebarSamples } from './resource-sidebar-samples';
+import { definitionFor, K8sKind } from '../../module/k8s';
+import {
+  ResourceSidebarSnippets,
+  ResourceSidebarSamples,
+  LoadSampleYaml,
+  DownloadSampleYaml,
+} from './resource-sidebar-samples';
 import { ExploreType } from './explore-type-sidebar';
 import { SimpleTabNav, Tab } from '../utils';
+import { Sample } from '@console/shared';
 
 const sidebarScrollTop = () => {
   document.getElementsByClassName('co-p-has-sidebar__sidebar')[0].scrollTop = 0;
 };
 
-const ResourceSidebarWrapper = (props) => {
+const ResourceSidebarWrapper: React.FC<{
+  label: string;
+  toggleSidebar: () => void;
+}> = (props) => {
   const { label, children, toggleSidebar } = props;
 
   return (
@@ -32,11 +41,16 @@ const ResourceSidebarWrapper = (props) => {
   );
 };
 
-const ResourceSchema = ({ kindObj, schema }) => (
+const ResourceSchema: React.FC<{ kindObj: K8sKind; schema: any }> = ({ kindObj, schema }) => (
   <ExploreType kindObj={kindObj} schema={schema} scrollTop={sidebarScrollTop} />
 );
 
-const ResourceSamples = ({ samples, kindObj, downloadSampleYaml, loadSampleYaml }) => (
+const ResourceSamples: React.FC<{
+  samples: Sample[];
+  loadSampleYaml: LoadSampleYaml;
+  downloadSampleYaml: DownloadSampleYaml;
+  kindObj: K8sKind;
+}> = ({ samples, kindObj, downloadSampleYaml, loadSampleYaml }) => (
   <ResourceSidebarSamples
     samples={samples}
     kindObj={kindObj}
@@ -45,11 +59,24 @@ const ResourceSamples = ({ samples, kindObj, downloadSampleYaml, loadSampleYaml 
   />
 );
 
-const ResourceSnippets = ({ snippets, insertSnippetYaml }) => (
+const ResourceSnippets: React.FC<{
+  snippets: Sample[];
+  insertSnippetYaml(id: string, yaml: string, reference: string);
+}> = ({ snippets, insertSnippetYaml }) => (
   <ResourceSidebarSnippets snippets={snippets} insertSnippetYaml={insertSnippetYaml} />
 );
 
-export const ResourceSidebar = (props) => {
+export const ResourceSidebar: React.FC<{
+  kindObj: K8sKind;
+  downloadSampleYaml: DownloadSampleYaml;
+  schema: any;
+  sidebarLabel: string;
+  loadSampleYaml: LoadSampleYaml;
+  insertSnippetYaml: (id: string, yaml: string, reference: string) => void;
+  toggleSidebar: () => void;
+  samples: Sample[];
+  snippets: Sample[];
+}> = (props) => {
   const { t } = useTranslation();
   const {
     downloadSampleYaml,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6301
https://bugzilla.redhat.com/show_bug.cgi?id=1998575

**Analysis / Root cause**: 
When the user presses on insert it doesn't insert any YAML because the YAML templates was provided by an extension.

It also shows an error just in development mode because the YAML was undefined.

It was also incorrect that the YAML (field) editor shows the samples at all. At least our generic YAML editor shows samples only if the user creates a new resource.

**Solution Description**: 
1. Adds some defaults and types to ensure that the YAML is at least an empty string when `editor.setValue` is called. This fixes the error which was only shown in development mode. (With this change alone we still have a button which do nothing.)
2. Loads the YAMLTemplate extensions YAMLEditorField.tsx to load the right YAML. (With this change we have now a button which inserts a YAML (template) sample in the editor.)
3. Only shows the samples in YAMLEditorField.tsx similar to `edit-yaml.jsx` only if the user creates a new resource. Added a new prop `showSamples` for this to make the decision in the parent component.
    1. In `BuildConfigForm`, `EditDeploymentForm`, `HPAForm` and `PipelineBuilderForm` only when editoring a resource (a resource is loaded successfully)
    2. In `HelmInstallUpgradeForm` **never** (the helm itself is the "sample", right?)
    3. In knative `add/EventSourceForm`, `add/brokers/AddBrokerForm` and `add/channels/form-fields/ChannelYamlEditor` **always** because these forms are obviously add only forms

**Screen shots / Gifs for design review**: 
BuildConfig before:
![buildconfig-before](https://user-images.githubusercontent.com/139310/131157486-317f9d73-1a0a-4381-a7d6-ce077a98aefe.png)

BuildConfig after (no samples anymore):
![buildconfig-after](https://user-images.githubusercontent.com/139310/131158091-d9aad57b-9a34-474a-ba44-4c4a9a07b807.png)

Create Pipeline with Pipeline Builder before:
![create-pipeline-before](https://user-images.githubusercontent.com/139310/131157514-e3511f64-e63c-4453-8fb6-2993a6b84268.png)

Create Pipeline with Pipeline Builder after (same as expected):
![create-pipeline-after](https://user-images.githubusercontent.com/139310/131158101-0c0b7214-da94-490e-83e8-fae6efae07c0.png)

Edit Pipeline with Pipeline Builder before:
![edit-pipeline-before](https://user-images.githubusercontent.com/139310/131157520-b1f8ab5b-55b0-4c9d-99fe-691e61b3d860.png)

Edit Pipeline with Pipeline Builder after (no samples anymore):
![edit-pipeline-after](https://user-images.githubusercontent.com/139310/131158120-abafe794-490d-4824-b636-7d6d4a66a8b6.png)

**Unit test coverage report**: 
Unchanged

**Test setup:**
Unchanged

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge