### PR TITLE
Bug 1998587: Automatically update app.openshift.io/vcs-* annotations

### DIFF
--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/convert-to-buildconfig.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/convert-to-buildconfig.ts
@@ -25,10 +25,14 @@ const convertFormDataToBuildConfigSource = (
       buildConfig.spec.source = {
         ...buildConfig.spec.source,
         type: 'Git',
-        git: {
-          uri: git.url,
-          ref: git.ref,
-        },
+        git: git.ref
+          ? {
+              uri: git.url,
+              ref: git.ref,
+            }
+          : {
+              uri: git.url,
+            },
         contextDir: git.dir,
       };
       if (git.secret) {
@@ -45,6 +49,18 @@ const convertFormDataToBuildConfigSource = (
           ...buildConfig.spec.strategy,
         };
       }
+
+      // Updates both app.openshift.io/vcs-* annotations only if the url exists
+      // so that we set the branch also if it was not defined earlier.
+      if (buildConfig.metadata.annotations?.['app.openshift.io/vcs-uri']) {
+        buildConfig.metadata.annotations['app.openshift.io/vcs-uri'] = git.url;
+        if (git.ref) {
+          buildConfig.metadata.annotations['app.openshift.io/vcs-ref'] = git.ref;
+        } else {
+          delete buildConfig.metadata.annotations['app.openshift.io/vcs-ref'];
+        }
+      }
+
       break;
     }
     case 'dockerfile': {

--- a/frontend/packages/dev-console/src/components/buildconfig/types.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/types.ts
@@ -32,7 +32,7 @@ export type BuildConfigGitSource = {
   type: 'Git';
   git: {
     uri: string;
-    ref: string;
+    ref?: string;
   };
   contextDir?: string;
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6299
https://bugzilla.redhat.com/show_bug.cgi?id=1998587

**Analysis / Root cause**: 
BuildConfig form updates only the spec data. Annotations are completely ignored until now.

**Solution Description**: 
Update the `app.openshift.io/vcs-uri` and `app.openshift.io/vcs-ref` annotations when the user inserts a git source.

**Screen shots / Gifs for design review**: 
https://user-images.githubusercontent.com/139310/131162920-c47e4b76-b75d-40c9-9613-9314d6ab91ed.mp4

**Unit test coverage report**: 
Add 3 new tests:

```
 PASS  packages/dev-console/src/components/buildconfig/form-utils/__tests__/convert-to-buildconfig.spec.ts (8.615s)
  convertFormDataToBuildConfig
...
      ✓ updates the app.openshift.io/vcs-* annotations when the git parameters are changed
      ✓ removes the app.openshift.io/vcs-ref annotation when the git branch is not defined
      ✓ sets the app.openshift.io/vcs-ref annotation when the git ref is newly set
...
```

**Test setup:**
1. Open Edit BuildConfig form.
2. Update git url.
3. Open yaml editor.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
