### PR TITLE
[POC][CONSOLE-2918] Test how ACM thanos works in admin console

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -31,16 +31,17 @@ const (
 
 	// Well-known location of the tenant aware Thanos service for OpenShift exposing the query and query_range endpoints. This is only accessible in-cluster.
 	// Thanos proxies requests to both cluster monitoring and user workload monitoring prometheus instances.
-	openshiftThanosTenancyHost = "thanos-querier.openshift-monitoring.svc:9092"
+	openshiftThanosTenancyHost = "rbac-query-proxy.open-cluster-management-observability.svc:8443"
 
 	// Well-known location of the tenant aware Thanos service for OpenShift exposing the rules endpoint. This is only accessible in-cluster.
 	// Thanos proxies requests to the cluster monitoring and user workload monitoring prometheus instances as well as Thanos ruler instances.
-	openshiftThanosTenancyForRulesHost = "thanos-querier.openshift-monitoring.svc:9093"
+	openshiftThanosTenancyForRulesHost = "rbac-query-proxy.open-cluster-management-observability.svc:8443"
 
 	// Well-known location of the Thanos service for OpenShift. This is only accessible in-cluster.
 	// This is used for non-tenant global query requests
 	// proxying to both cluster monitoring and user workload monitoring prometheus instances.
-	openshiftThanosHost = "thanos-querier.openshift-monitoring.svc:9091"
+	//CURRENT: openshiftThanosHost = "thanos-querier.openshift-monitoring.svc:9091"
+	openshiftThanosHost = "rbac-query-proxy.open-cluster-management-observability.svc:8443"
 
 	// Well-known location of Alert Manager service for OpenShift. This is only accessible in-cluster.
 	openshiftAlertManagerHost = "alertmanager-main.openshift-monitoring.svc:9094"

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -168,7 +168,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
             </ChartGroup>
           </Chart>
         ) : (
-          <GraphEmpty height={height} loading={loading} />
+          <GraphEmpty height={height} loading={loading} query={query} />
         )}
       </PrometheusGraphLink>
     </PrometheusGraph>

--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -75,7 +75,7 @@ export const BarChart: React.FC<BarChartProps> = ({
             </React.Fragment>
           ))
         ) : (
-          <GraphEmpty loading={loading} />
+          <GraphEmpty loading={loading} query={query} />
         )}
       </PrometheusGraphLink>
     </PrometheusGraph>

--- a/frontend/public/components/graphs/graph-empty.tsx
+++ b/frontend/public/components/graphs/graph-empty.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
-export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = false }) => {
+export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = false, query }) => {
   const { t } = useTranslation();
-
+  if (!loading) {
+    /* eslint-disable no-console */
+    console.log('---> Query:', query);
+    /* eslint-enable no-console */
+  }
   return (
     <div
       style={{
@@ -28,4 +32,5 @@ export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = 
 type GraphEmptyProps = {
   height?: number | string;
   loading?: boolean;
+  query?: string | string[];
 };

--- a/frontend/public/components/graphs/stack.tsx
+++ b/frontend/public/components/graphs/stack.tsx
@@ -141,7 +141,7 @@ export const StackChart: React.FC<AreaChartProps> = ({
             </ChartStack>
           </Chart>
         ) : (
-          <GraphEmpty height={height} loading={loading} />
+          <GraphEmpty height={height} loading={loading} query={query} />
         )}
       </PrometheusGraphLink>
     </PrometheusGraph>


### PR DESCRIPTION
Proof of Concept:
We are trying to switch the current thanos metrics that are used by the admin console to the ACM thanos metrics when ACM is installed.

1) To begin, we must properly setup an ACM environment with metrics enabled through Observability.  This process is below and contained in the gist: [Setup](https://gist.github.com/zherman0/3cef002e9ca0df3ba4d5b75a09252040/#file-acm-md)
2) Initially we have hard coded the value for the thanos metrics as seen in the updated files.  This value will need to be dynamic when ACM is installed with Observability.
3) We are able to successfully connect to the ACM metrics service, however approximately 80% of our current query do not return data. Queries that do not work fall into the following categories:
   A) Existing query or query parameters are incorrect for ACM thanos versus current thanos
   B) Queries reference data source that has a different name, i.e. kube_pod_resource_limit ==> kube_pod_container_resource_limits
   C) Data for specific query is not currently collected on the ACM metrics server, i.e. grpc_server_handled_total.  We can add this via a custom configmap that would generally look like:
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: observability-metrics-custom-allowlist
  namespace: open-cluster-management-observability
data:
  metrics_list.yaml: |
    names:
      - kube_pod_status_phase
      - apiserver_request_duration_seconds_bucket
      - apiserver_request_duration_seconds_count
```
However, any new metrics that are added will have additional expensive to the server in terms of space ussed my thanos

4)  Many failing queries have been collected and added to the gist: [Failing Queries Results](https://gist.githubusercontent.com/zherman0/3cef002e9ca0df3ba4d5b75a09252040/#file-queries-txt)
Some of these results have fixes listed.


Setup Notes: (Also in [gist](https://gist.github.com/zherman0/3cef002e9ca0df3ba4d5b75a09252040/#file-acm-md))

===== Setting up ACM cluster ================
1) Build regular cluster
2) run upgrade-machinesets script  (https://gist.github.com/TheRealJon/370300cf56b3ef9ede33768b01db8c24)
3) Install the ACM operator from the UI: Operator->Operator Hub --> Advanced Cluster Management for Kubernetes (use all defaults)
    - Create default multiclusterhub resource once ACM finishes installing

** ACM should now be running and the ACM console should be available

---------------------------------------------

===== Setting up Observabilty =================

1) Need an S3 bucket
    `aws s3api create-bucket --bucket acm-test-thanos --create-bucket-configuration LocationConstraint=us-west-1`
    - Make S3 bucket- allow public, optional:*enable SSE (Amazon S3 Key(SSE-S3))*, rest default
    - URL will be automatically setup if you make it public- s3.us-west-1.amazonaws.com
    - Update the thanos-object-storage.yaml file
2) Go through steps below copied from guide "1.2.2. Enabling observability" 
[Enabling Observability](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/observability/observing-environments-intro#enable-observability)
```
oc create namespace open-cluster-management-observability
DOCKER_CONFIG_JSON=`oc extract secret/pull-secret -n openshift-config --to=-`
oc create secret generic multiclusterhub-operator-pull-secret \
    -n open-cluster-management-observability \
    --from-literal=.dockerconfigjson="$DOCKER_CONFIG_JSON" \
    --type=kubernetes.io/dockerconfigjson
```
Files needed:
thanos-object-storage.yaml:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: thanos-object-storage
  namespace: open-cluster-management-observability
type: Opaque
stringData:
  thanos.yaml: |
    type: s3
    config:
      bucket: acm-test-thanos #your bucket name
      endpoint: s3.us-west-1.amazonaws.com #your region
      insecure: true
      access_key: AKIAIWQT7ZZGEYXCMB5A
      secret_key: SpCo1wrRAwKULjqmQPbOnWlBwnLO1hHkOlO5wGiD
```
multiclusterobservability_cr.yaml:
```yaml
apiVersion: observability.open-cluster-management.io/v1beta2
kind: MultiClusterObservability
metadata:
  name: observability
spec:
  observabilityAddonSpec: {}
  retentionConfig: {}
  storageConfig:
    metricObjectStorage:
      name: thanos-object-storage
      key: thanos.yaml
  nodeSelector:
    node-role.kubernetes.io/infra:
```
`oc create -f ~/openshift/thanos-object-storage.yaml -n open-cluster-management-observability`
`oc apply -f ~/openshift/multiclusterobservability_cr.yaml`


3) Check routes for new thanos link -> Should be "rbac-query-proxy.open-cluster-management-observability.svc:8443"
*** Networking->Routes (namespace: open-cluster-management-observability)

----- Setting into unmanged state --------
`oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "managementState": "Unmanaged" } }' --type=merge`

-------- Set my image for console -----------
`oc set image deploy console console=quay.io/<your-quay-repo>/console:latest -n openshift-console`
--I.E.  oc set image deploy console console=quay.io/zherman/console:latest -n openshift-console
`oc patch deploy console -p '{"spec": {"template": {"spec": {"containers": [{"name": "console","imagePullPolicy": "Always"}]}}}}' -n openshift-console`

4) Deploy new image using deploy_console.sh
```
#!/usr/bin/env bash
DIR="<your-path-to-console>/src/github.com/openshift/console"
if [[ "$DIR" = $PWD ]]; then
    podman build -t quay.io/<your-repo>/console:latest . && \
    podman push quay.io/<your-repo>/console:latest && \
    oc project openshift-console
    oc delete pod $(oc get --no-headers pods -o custom-columns=:metadata.name -n openshift-console) -n openshift-console && \
    oc get pods -n openshift-console
    echo "oc get pods --namespace openshift-console"
else
    echo "You are not in the console directory"
```

--- Check status --
`oc rollout status -w deploy/console -n openshift-console`

--- Back to managed state -----
`oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "managementState": "Managed" } }' --type=merge`



