### PR TITLE
Bug 1998408: Avoid resetting dockerfile path when switching build strategies

### DIFF
--- a/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.tsx
+++ b/frontend/packages/dev-console/src/components/import/devfile/DevfileStrategySection.tsx
@@ -41,12 +41,10 @@ const DevfileStrategySection: React.FC = () => {
       // No need to check the existence of the file, waste of a call to the gitService for this need
       const devfileContents = gitService && (await gitService.getDevfileContent());
       if (!devfileContents) {
-        setFieldValue('docker.dockerfilePath', 'Dockerfile');
         setFieldValue('devfile.devfileContent', null);
         setFieldValue('devfile.devfileHasError', true);
         setValidated(ValidatedOptions.error);
       } else {
-        setFieldValue('docker.dockerfilePath', 'Dockerfile');
         setFieldValue('devfile.devfileContent', devfileContents);
         setFieldValue('devfile.devfileHasError', false);
         setValidated(ValidatedOptions.success);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6289
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
Dockerfile path gets reset to `Dockerfile` when switching from devfile build strategy.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Avoid resetting dockerfile path when switching.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/131312858-f7d97acf-b27d-4dc8-a463-f5912ce79b81.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug