### PR TITLE
Bug 1999026: detect managed ODF when operator is installed

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -116,7 +116,16 @@ const plugin: Plugin<ConsumedExtensions> = [
       detect: detectManagedODF,
     },
     flags: {
-      required: [OCS_FLAG],
+      required: [OCS_MODEL_FLAG],
+    },
+  },
+  {
+    type: 'FeatureFlag/Custom',
+    properties: {
+      detect: detectManagedODF,
+    },
+    flags: {
+      required: [ODF_MODEL_FLAG],
     },
   },
   {


### PR DESCRIPTION
**Earlier:**
We were detecting for managed ODF services only when storage cluster was created.

**After:**
We will start detecting for ODF managed services right after installing the OCS operator.