### PR TITLE
Bug 1999393: Form / YAML switch makes unnecessary network calls to save latest editor type

### DIFF
--- a/frontend/packages/console-shared/src/components/synced-editor/useEditorType.ts
+++ b/frontend/packages/console-shared/src/components/synced-editor/useEditorType.ts
@@ -44,7 +44,9 @@ export const useEditorType = (
   React.useEffect(() => {
     if (resourceLoaded) {
       const editorType: EditorType = getEditorType();
-      setLastViewedEditorType(editorType);
+      if (!lastViewedEditorType || lastViewedEditorType !== editorType) {
+        setLastViewedEditorType(editorType);
+      }
       setActiveEditorType(editorType);
     }
     // run this hook only after all resources have loaded


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6302

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
https://github.com/openshift/console/pull/9830#pullrequestreview-740648862
Call is made on load of resources -> can make call only if first time / resulting in a change

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
https://github.com/openshift/console/pull/9830#discussion_r697540215 
As described in the comment added an if condition 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
### Upon simple refresh -> no "PATCH" call is made (only the initial GET) 
![image](https://user-images.githubusercontent.com/20089340/131338006-d034a6fc-dc70-405c-bb17-8fad02fb9b31.png)

#### Earlier we would see a PATCH call after the GET call which was redundant i.e.
![image](https://user-images.githubusercontent.com/20089340/131338149-bfbed764-dbae-4e11-baaf-641fbb90ab4d.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. Switch to developer perspective > Add > Helm chart
2. Select a helm chart (for example Dotnet) and press Install Helm Chart
3. Open the browser network inspector and filter for "user-settings"
4. Refresh the page

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge