### PR TITLE
Bug 1999075: Pan the selected workload into the full view

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/Topology.tsx
+++ b/frontend/packages/topology/src/components/graph-view/Topology.tsx
@@ -285,7 +285,7 @@ const Topology: React.FC<TopologyProps &
             action(() => {
               visualization
                 .getGraph()
-                .panIntoView(visibleEntity, { offset: 20, minimumVisible: 40 });
+                .panIntoView(visibleEntity, { offset: 20, minimumVisible: 100 });
               resizeTimeout = null;
             }),
             500,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6054

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When the component is selected, its not completely moved to the full view in the canvas

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Change the minimumVisible prop to 100, so the selected component moves in the the full view. 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
**Before**:

![half-visible](https://user-images.githubusercontent.com/9964343/131329973-3af64032-f48e-499d-8005-9dd8e42208d1.gif)

**After:**
![into-the-full-view](https://user-images.githubusercontent.com/9964343/131329983-b0e6a523-dce1-4c2e-91ed-efacdef26ba9.gif)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. Click on that Deployment & the side panel will show
2. Close the side panel, drag that Deployment all the way to the right side of the canvas
3. Click on that Deployment again & you'll see that the deployment is moved in full view
4. Now with that side panel open carefully move that deployment so that it's partially hidden by the side panel
5. Close the side panel by clicking X on it
6. Select the deployment

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @serenamarie125 @jeff-phillips-18 