### PR TITLE
Bug 1996159: Show 404 page only after all dynamic plugins are processed

### DIFF
--- a/frontend/packages/console-app/src/components/console-operator/ConsoleOperatorConfig.tsx
+++ b/frontend/packages/console-app/src/components/console-operator/ConsoleOperatorConfig.tsx
@@ -28,7 +28,7 @@ import {
   K8sResourceKindReference,
   referenceForModel,
 } from '@console/internal/module/k8s';
-import { DynamicPluginInfo, isLoadedDynamicPluginInfo } from '@console/plugin-sdk/src';
+import { isLoadedDynamicPluginInfo } from '@console/plugin-sdk/src';
 import { useDynamicPluginInfo } from '@console/plugin-sdk/src/api/useDynamicPluginInfo';
 import { consolePluginModal } from '@console/shared/src/components/modals';
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants';
@@ -84,13 +84,13 @@ const ConsolePluginsList: React.FC<ConsolePluginsListType> = ({ obj }) => {
     isList: true,
     kind: referenceForModel(ConsolePluginModel),
   });
-  const dynamicPluginInfo: DynamicPluginInfo[] = useDynamicPluginInfo();
+  const [pluginInfoEntries] = useDynamicPluginInfo();
   const [rows, setRows] = React.useState([]);
   const [sortBy, setSortBy] = React.useState<ISortBy>({});
   React.useEffect(() => {
     const data = consolePlugins.map((plugin) => {
       const pluginName = plugin?.metadata?.name;
-      const loadedPluginInfo = dynamicPluginInfo
+      const loadedPluginInfo = pluginInfoEntries
         .filter(isLoadedDynamicPluginInfo)
         .find((i) => i?.metadata?.name === pluginName);
       const enabled = !!obj?.spec?.plugins?.includes(pluginName);
@@ -124,7 +124,7 @@ const ConsolePluginsList: React.FC<ConsolePluginsListType> = ({ obj }) => {
         };
       }),
     );
-  }, [consolePlugins, dynamicPluginInfo, obj]);
+  }, [consolePlugins, pluginInfoEntries, obj]);
   const headers = [
     {
       title: t('console-app~Name'),

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/useResolvedExtensions.ts
@@ -23,8 +23,7 @@ import { UseResolvedExtensions } from './api-types';
  * Example usage:
  *
  * ```ts
- * const navItemExtensions = useResolvedExtensions<NavItem>(isNavItem);
- * const [perspectiveExtensions] = useResolvedExtensions<Perspective>(isPerspective);
+ * const [navItemExtensions, navItemsResolved] = useResolvedExtensions<NavItem>(isNavItem);
  * // process adapted extensions and render your component
  * ```
  *

--- a/frontend/packages/console-plugin-sdk/src/api/pluginSubscriptionService.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/pluginSubscriptionService.ts
@@ -193,4 +193,4 @@ type ExtensionSubscription<E extends Extension = Extension> = {
   listenerLastArgs?: E[];
 };
 
-type DynamicPluginListener = (pluginEntries: DynamicPluginInfo[]) => void;
+type DynamicPluginListener = (pluginInfoEntries: DynamicPluginInfo[]) => void;

--- a/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/api/useExtensions.ts
@@ -27,7 +27,6 @@ import { subscribeToExtensions } from './pluginSubscriptionService';
  * ```ts
  * const Example = () => {
  *   const navItemExtensions = useExtensions<NavItem>(isNavItem);
- *   const perspectiveExtensions = useExtensions<Perspective>(isPerspective);
  *   // process extensions and render your component
  * };
  * ```

--- a/frontend/packages/console-shared/src/hooks/useTelemetry.ts
+++ b/frontend/packages/console-shared/src/hooks/useTelemetry.ts
@@ -7,10 +7,10 @@ import {
 } from '@console/dynamic-plugin-sdk';
 
 export const useTelemetry = () => {
-  // TODO(vojtech): once #8966 is merged, utilize useDynamicPluginInfo hook to determine
-  // whether all dynamic plugins have finished loading (no plugins with 'Pending' status)
-  // in order to avoid firing events multiple times whenever plugins asynchronously load.
+  // TODO use useDynamicPluginInfo() hook to tell whether all dynamic plugins have been processed
+  // to avoid firing telemetry events multiple times whenever a dynamic plugin loads asynchronously
   const [extensions] = useResolvedExtensions<TelemetryListener>(isTelemetryListener);
+
   return React.useCallback<TelemetryEventListener>(
     (eventType, properties) => {
       extensions.forEach((e) =>

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
+import { useDynamicPluginInfo } from '@console/plugin-sdk/src/api/useDynamicPluginInfo';
 import {
   FLAGS,
   useActivePerspective,
@@ -178,6 +179,8 @@ const AppContents: React.FC<{}> = () => {
   const [activePerspective, setActivePerspective] = useActivePerspective();
   const routePageExtensions = useExtensions<RoutePage>(isRoutePage);
   const dynamicRoutePages = useExtensions<DynamicRoutePage>(isDynamicRoutePage);
+  const [, allPluginsProcessed] = useDynamicPluginInfo();
+
   const [pluginPageRoutes, inactivePluginPageRoutes] = React.useMemo(
     () =>
       getPluginPageRoutes(
@@ -700,11 +703,15 @@ const AppContents: React.FC<{}> = () => {
               />
               <Route path="/" exact component={DefaultPage} />
 
-              <LazyRoute
-                loader={() =>
-                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
-                }
-              />
+              {allPluginsProcessed ? (
+                <LazyRoute
+                  loader={() =>
+                    import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
+                  }
+                />
+              ) : (
+                <Route component={LoadingBox} />
+              )}
             </Switch>
           </React.Suspense>
         </div>


### PR DESCRIPTION
This PR fixes a race condition in a scenario where a user navigates directly to a plugin-contributed route and Console shows 404 error page until the relevant plugin finishes loading, then re-renders the plugin-contributed page content as expected.

The expected behavior is to wait until all dynamic plugins are processed (i.e. either loaded or failed) before falling back to the 404 error page.