### PR TITLE
Bug 1975391: fix install operator description iframe

### DIFF
--- a/frontend/__tests__/components/markdown-view.spec.tsx
+++ b/frontend/__tests__/components/markdown-view.spec.tsx
@@ -10,6 +10,10 @@ jest.mock('showdown', () => ({
   },
 }));
 
+jest.mock('@console/shared/src/hooks/useResizeObserver', () => ({
+  useResizeObserver: jest.fn(),
+}));
+
 describe('markdown-view', () => {
   it('should render markdown view inline and iframe', () => {
     expect(

--- a/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseNotes.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/__tests__/HelmReleaseNotes.spec.tsx
@@ -5,6 +5,10 @@ import { mockHelmReleases } from '../../__tests__/helm-release-mock-data';
 import HelmReleaseNotes from '../notes/HelmReleaseNotes';
 import HelmReleaseNotesEmptyState from '../notes/HelmReleaseNotesEmptyState';
 
+jest.mock('@console/shared/src/hooks/useResizeObserver', () => ({
+  useResizeObserver: jest.fn(),
+}));
+
 describe('HelmReleaseNotes', () => {
   it('should render the SyncMarkdownView component when notes are available', () => {
     const helmReleaseResources = mount(<HelmReleaseNotes customData={mockHelmReleases[0]} />);

--- a/frontend/packages/helm-plugin/src/topology/__tests__/TopologyHelmReleasePanel.spec.tsx
+++ b/frontend/packages/helm-plugin/src/topology/__tests__/TopologyHelmReleasePanel.spec.tsx
@@ -8,6 +8,10 @@ import TopologyHelmReleaseNotesPanel from '../TopologyHelmReleaseNotesPanel';
 import { ConnectedTopologyHelmReleasePanel } from '../TopologyHelmReleasePanel';
 import { mockHelmReleaseNode, mockManifest, mockReleaseNotes } from './mockData';
 
+jest.mock('@console/shared/src/hooks/useResizeObserver', () => ({
+  useResizeObserver: jest.fn(),
+}));
+
 describe('TopologyHelmReleasePanel', () => {
   it('should render the resources tab by default', () => {
     const component = mount(

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 import { Converter } from 'showdown';
 import * as sanitizeHtml from 'sanitize-html';
 import { useTranslation } from 'react-i18next';
-import { useForceRender } from '@console/shared';
+import { useForceRender, useResizeObserver } from '@console/shared';
 
 import './_markdown-view.scss';
 
@@ -202,6 +202,8 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
     updateDimensions();
     setLoaded(true);
   }, [updateDimensions]);
+
+  useResizeObserver(updateDimensions, frame);
 
   // Find the app's stylesheets and inject them into the frame to ensure consistent styling.
   const filteredLinks = Array.from(document.getElementsByTagName('link')).filter((l) =>


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-31320

**Solution description:**
- using the `useResizeObserver` hook to observe window resizes and passed the onLoad func to recalculate the dimensions of the iframe

**GIF:**
![io-desc](https://user-images.githubusercontent.com/22490998/131387633-1908bb0f-6f88-489e-b772-37192e91ba06.gif)

 