### PR TITLE
Bug 1999266: Fix click issue with topology context menu

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { KEY_CODES, MenuItem, Tooltip } from '@patternfly/react-core';
+import {
+  KEY_CODES,
+  MenuItem,
+  Tooltip,
+  DropdownItemProps,
+  MenuItemProps,
+} from '@patternfly/react-core';
 import * as classNames from 'classnames';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
@@ -9,6 +15,7 @@ import { impersonateStateToProps } from '@console/internal/reducers/ui';
 
 export type ActionMenuItemProps = {
   action: Action;
+  component?: React.ComponentType<MenuItemProps | DropdownItemProps>;
   autoFocus?: boolean;
   onClick?: () => void;
   onEscape?: () => void;
@@ -20,6 +27,7 @@ const ActionItem: React.FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
   onEscape,
   autoFocus,
   isAllowed,
+  component,
 }) => {
   const { label, icon, disabled, cta } = action;
   const { href, external } = cta as { href: string; external?: boolean };
@@ -50,21 +58,29 @@ const ActionItem: React.FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
       handleClick(event);
     }
   };
+  const Component = component ?? MenuItem;
+
+  const props = {
+    icon,
+    autoFocus,
+    isDisabled,
+    className: classes,
+    onClick: handleClick,
+    'data-test-action': label,
+  };
+
+  const extraProps = {
+    onKeyDown: handleKeyDown,
+    // Override PF tabIndex -1 to make action items tabbable.
+    // This is needed to mimic older tabbable behavior since we do not use PF Menu component as a wrapper.
+    tabIndex: 0,
+    ...(external ? { to: href, isExternalLink: external } : {}),
+  };
 
   return (
-    <MenuItem
-      className={classes}
-      icon={icon}
-      autoFocus={autoFocus}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      isDisabled={isDisabled}
-      data-test-action={label}
-      tabIndex={0} // Override PF tabIndex -1 to make action items tabbable
-      {...(external ? { to: href, isExternalLink: external } : {})}
-    >
+    <Component {...props} {...(component ? {} : extraProps)}>
       {label}
-    </MenuItem>
+    </Component>
   );
 };
 

--- a/frontend/packages/topology/src/actions/contextMenuActions.tsx
+++ b/frontend/packages/topology/src/actions/contextMenuActions.tsx
@@ -1,7 +1,41 @@
 import * as React from 'react';
-import { Node } from '@patternfly/react-topology';
-import { ActionServiceProvider } from '@console/shared';
-import { createContextMenuItems } from '../components/graph-view';
+import { Node, ContextSubMenuItem, ContextMenuItem } from '@patternfly/react-topology';
+import { Action } from '@console/dynamic-plugin-sdk/src';
+import {
+  ActionServiceProvider,
+  getMenuOptionType,
+  GroupedMenuOption,
+  MenuOption,
+  MenuOptionType,
+  orderExtensionBasedOnInsertBeforeAndAfter,
+} from '@console/shared';
+import ActionMenuItem from '@console/shared/src/components/actions/menu/ActionMenuItem';
+
+export const createContextMenuItems = (actions: MenuOption[]) => {
+  const sortedOptions = orderExtensionBasedOnInsertBeforeAndAfter(actions);
+  return sortedOptions.map((option: MenuOption) => {
+    const optionType = getMenuOptionType(option);
+    switch (optionType) {
+      case MenuOptionType.SUB_MENU:
+        return (
+          <ContextSubMenuItem label={option.label} key={option.id}>
+            {createContextMenuItems((option as GroupedMenuOption).children)}
+          </ContextSubMenuItem>
+        );
+      case MenuOptionType.GROUP_MENU:
+        return (
+          <React.Fragment key={option.id}>
+            {option.label && <h1 className="pf-c-dropdown__group-title">{option.label}</h1>}
+            {createContextMenuItems((option as GroupedMenuOption).children)}
+          </React.Fragment>
+        );
+      default:
+        return (
+          <ActionMenuItem key={option.id} action={option as Action} component={ContextMenuItem} />
+        );
+    }
+  });
+};
 
 export const contextMenuActions = (element: Node): React.ReactElement[] => {
   return [

--- a/frontend/packages/topology/src/components/graph-view/components/nodeContextMenu.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodeContextMenu.tsx
@@ -7,7 +7,6 @@ import {
   isGraph,
 } from '@patternfly/react-topology';
 import i18next from 'i18next';
-import { Action } from '@console/dynamic-plugin-sdk/src';
 import {
   history,
   KebabItem,
@@ -16,14 +15,6 @@ import {
   kebabOptionsToMenu,
   isKebabSubMenu,
 } from '@console/internal/components/utils';
-import {
-  getMenuOptionType,
-  GroupedMenuOption,
-  MenuOption,
-  MenuOptionType,
-  orderExtensionBasedOnInsertBeforeAndAfter,
-} from '@console/shared';
-import ActionMenuItem from '@console/shared/src/components/actions/menu/ActionMenuItem';
 import { graphActions } from '../../../actions/graphActions';
 import { groupActions } from '../../../actions/groupActions';
 import { workloadActions } from '../../../actions/workloadActions';
@@ -59,39 +50,6 @@ export const createMenuItems = (actions: KebabMenuOption[]) =>
       />
     ),
   );
-
-export const createContextMenuItems = (actions: MenuOption[]) => {
-  const sortedOptions = orderExtensionBasedOnInsertBeforeAndAfter(actions);
-  return sortedOptions.map((option: MenuOption) => {
-    const optionType = getMenuOptionType(option);
-    switch (optionType) {
-      case MenuOptionType.SUB_MENU:
-        return (
-          <ContextSubMenuItem label={option.label} key={option.id}>
-            {createContextMenuItems((option as GroupedMenuOption).children)}
-          </ContextSubMenuItem>
-        );
-      case MenuOptionType.GROUP_MENU:
-        return (
-          <>
-            <div className="pf-c-dropdown__group-title">{option.label}</div>
-            {createContextMenuItems((option as GroupedMenuOption).children)}
-          </>
-        );
-      default:
-        return (
-          <ContextMenuItem
-            key={option.id}
-            component={
-              <div className="pf-c-dropdown__menu-item">
-                <ActionMenuItem action={option as Action} />
-              </div>
-            }
-          />
-        );
-    }
-  });
-};
 
 export const workloadContextMenu = (element: Node) =>
   createMenuItems(


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6212
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: We were rendering `MenuItem` inside `ContextMenuItem` from PF Topology which is actually `DropdownItem`. So it was essentially rendering `MenuItem` inside `DropdownItem` which is why the clickable area shrinks down to just the text and not the whole action item.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Render `ContextMenuItem` directly instead of `MenuItem` when using in topology context menu..
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/131387226-bc106835-a07e-4f41-b155-40913bf1ce73.mov

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
