### PR TITLE
test cases for PAC

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
@@ -1,0 +1,115 @@
+@pipelines @odc-5149
+Feature: Perform Actions on repository
+              As a developer, I want to create, edit, delete and view the repositories
+
+        Background:
+            Given user has created or selected namespace "aut-pipelines"
+              And user has installed pipelines as code
+
+
+        @pre-condition @to-do
+        Scenario Outline: Repositories page: P-11-TC01
+            Given user is at repositories page
+             When user clicks on Create Repository button
+             Then user will be redirected to Repositories yaml view page
+             Then user creates repository using YAML editor from "<repository_yaml>"
+             Then user will be redirected to Reporsitory details page with header name "<repository_name>"
+
+        Examples:
+                  | repository_yaml                                 | repository_name |
+                  | testData/repository-crd-testdata/test-repo.yaml | test-repo       |
+
+
+        @smoke @to-do
+        Scenario Outline: Reporsitory details display in repository page: P-11-TC02
+            Given repository "<repository_name>" is present on Repositories page
+             When user clicks on the repository "<repository_name>" on Repositories page
+             Then user will be redirected to Repository details page with header "<repository_name>"
+              And user is able to see Details, YAML, Pipeline Runs tabs
+              And Details tab is displayed with field names Name, Namespace, Labels, Annotations, Created at, Owner, Repository, Branch and Event type
+              And Actions dropdown display in the top right corner of the page
+
+        Examples:
+                  | repository_name |
+                  | test-repo       |
+
+
+        @smoke @to-do
+        Scenario Outline: Repositories page display on newly created repository: P-11-TC03
+            Given repository "<repository_name>" is present on Repositories page
+             When user searches repositoy "<repository_name>" in repositories page
+             Then repositories table displayed with column names Name, Event type, Last run, Task status, Last run status, Last run time, Last run duration
+              And clolumn Name display with value "<repository_name>"
+              And columnsLast run, Task status, Last run status, Last run time, Last run duration with values display "-"
+              And Create button is enabled
+              And kebab menu button is displayed
+        Examples:
+                  | repository_name |
+                  | test-repo       |
+
+
+        @smoke @to-do
+        Scenario: Kebab menu options of newly created repository in Repositories page: P-11-TC04
+            Given repository "test-repository" is present on Repositories page
+             When user searches repository "test-repo" in repsitories page
+              And user clicks on kebab menu of the repository "test-repo"
+             Then kebab menu displays with options Edit labels, Edit annotations, Edit repository, Delete repository
+
+
+        @smoke @to-do
+        Scenario: Actions menu of newly created reposiotry in Repository details page: P-11-TC05
+            Given user is at repositories details page with newly created repository "test-repo"
+             When user clicks Actions menu in the repository details page
+             Then Actions menu display with options Edit labels, Edit annotations, Edit repository, Delete repository
+
+
+        @regression @to-do
+        Scenario Outline: Edit repository from Repository details page: P-11-TC06
+            Given repository "<repository_name>" is present on the Repositories page
+             When user searches repository "<repository_name>" in repositories page
+              And user clicks repository "<repository_name>" from searched results on Repositories page
+              And user selects option "Edit Repository" from Actions menu drop down
+             Then user modifies the yaml code in the yaml view of the reposiotry
+              And user clicks on the save button
+             Then user is able to see a success alert message on same page
+
+        Examples:
+                  | repository_name |
+                  | test-repo       |
+
+
+        @regression @to-do
+        Scenario: Edit label of repository: P-11-TC07
+            Given repository "test-repo" is present on the Repositories page
+             When user searches repository "test-repo" in repositories page
+              And user clicks repository "test-repo" from searched results on Repositories page
+              And user clicks on Edit button of the labels section
+              And adds the label "check=label"
+              And clicks on the Save button
+             Then label "check=label" should be present in the labels section
+
+
+        @regression @to-do
+        Scenario: Edit annotations of repository: P-11-TC08
+            Given repository "test-repo" is present on the Repositories page
+             When user searches repository "test-repo" in repositories page
+              And user clicks repository "test-repo" from searched results on Repositories page
+              And user clicks on Edit button of the annotations section
+              And user adds key "check" and value "annotations"
+              And user clicks on the Save button
+             Then annotation section contains the value "1 annotation"
+
+
+        @regression @to-do
+        Scenario Outline: Delete the repository from the Repository details page: P-11-TC09
+            Given repository "<repository_name>" is present on Repositories page
+             When user searches repository "<repository_name>" in repositories page
+              And user clicks repository "<repository_name>" from searched results on Repositories page
+              And user selects option "Delete Repository" from Actions menu drop down
+              And user clicks Delete button on Delete Repository modal
+             Then user will be redirected to Repositories page
+              And "<repository_name>" is not displayed on Pipelines page
+
+        Examples:
+                  | repository_name |
+                  | test-repo       |

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/repository-crd-testdata/test-repo.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/repository-crd-testdata/test-repo.yaml
@@ -1,0 +1,9 @@
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: test-repo
+spec:
+  branch: main
+  event_type: push
+  url: 'https://github.com/tektoncd/cli.git'
+


### PR DESCRIPTION
Added test cases for Pipelines As Code along with test data

Jira Id: [ODC-5149](https://issues.redhat.com/browse/ODC-5149)

Acceptance Criteria: 

1. As a user, looking at the Pipelines page in the Developer Console, I should be able to see a list of (a) Git repositories that are added to the namespace for PAC execution AND (b) all pipelines in the namespace
2. As a user, I should be able to navigate to a details page of the git repo.
    1. This details page should provide access to (a) details of the git repo and (b) a list of pipeline runs.
    2. This PLR tab should show additional information than the typical PLR List view, including SHA (commit id), commit message, branch & trigger type
3. As a user, when looking at a Pipeline Run Details page, if associate with a git repo (PAC),
4. Indicate that it's from a specific git repo rather than a PL resource
5. Include the SHA (commit id), commit message, branch & trigger type


Pre-conditions for Epic validation:

1. Openshift Pipelines is installed 
2. Pipelines As Code is installed

Checks required for approving Epic gherkin scripts PR:

- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x]  Update the test scenarios count in Automation status confluence Report
- [x]  Check for the linter issues by executing yarn run gherkin-lint on frontend folder [Skip epic number tags related linter issues]

@makambalaji @sanketpathak, please review