### PR TITLE
Bug 1999631: Fix to add help text for git repo url field

### DIFF
--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -394,6 +394,7 @@
   "Validating": "Validating",
   "Rate limit exceeded": "Rate limit exceeded",
   "URL is valid but cannot be reached. If this is a private repository, enter a source Secret in advanced Git options": "URL is valid but cannot be reached. If this is a private repository, enter a source Secret in advanced Git options",
+  "Repository URL to build and deploy your code from": "Repository URL to build and deploy your code from",
   "Git Repo URL": "Git Repo URL",
   "Git type": "Git type",
   "Defaulting Git type to other": "Defaulting Git type to other",

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -373,7 +373,7 @@ const GitSection: React.FC<GitSectionProps> = ({
         'devconsole~URL is valid but cannot be reached. If this is a private repository, enter a source Secret in advanced Git options',
       );
     }
-    return '';
+    return t('devconsole~Repository URL to build and deploy your code from');
   }, [t, values.git.isUrlValidating, validated, repoStatus]);
 
   const resetFields = React.useCallback(() => {


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6283

**Root Cause:**
We automatically add focus to the Git URL (the first input field) when the user imports from Git.
When the user clicks then on "Try sample" or "Show advanced Git options" the url field loses focus. The onBlur method then marks the input field as touched (in formik) and show an error if the url field is empty. This happens before these buttons can handle the click event. And because the "Required!" error  was added as a new label below the input field all buttons and input fields moves down and the user click on these buttons are ignored.
A second click works fine. Also if the user first lost the focus of the input field, and then selects it again.

**Solution:**
Add a help text to the "Git Repo URL" field. This help text is replaced with the error message when the form field is empty (or invalid).

**Screen-recording:**

https://user-images.githubusercontent.com/20724543/131498355-e9910a61-4da2-41c8-82d5-218ba5dea17d.mov

/kind bug