### PR TITLE
Bug 1999615: Use target closest method only when available

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceMenuToggle.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceMenuToggle.tsx
@@ -45,7 +45,7 @@ const NamespaceMenuToggle = (props: {
       // Checking to see if user clicked on a favorite icon.  This is needed because
       // if unfavoriting a item, PF removes the item from the DOM before
       // the click event is registered
-      !event.target.closest('.pf-m-favorite') &&
+      !event.target.closest?.('.pf-m-favorite') &&
       !toggleRef.current.contains(event.target)
     ) {
       onToggle(false);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6295
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The event target is always assumed to be an [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement), but since the listener is for `window`, the target can also be [`HTMLDocument`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDocument) (which does not have the `closest()` method). This causes the page to crash.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Use the `closest()` method only when available.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/131504820-ea1380b1-647a-4b3e-874e-8c6e1ae91b2e.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug