### PR TITLE
Bug 1999719: persist last viewed tab on topology side panel

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -202,7 +202,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
           }
           const secretId = secret?.items?.[0]?.metadata?.uid;
           if (secretId) {
-            redirect = `${config.redirectURL}?selectId=${secretId}&selectTab=Release+Notes`;
+            redirect = `${config.redirectURL}?selectId=${secretId}&selectTab=Release+notes`;
           }
         }
 

--- a/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
+++ b/frontend/packages/topology/src/components/side-bar/components/SideBarBody.tsx
@@ -1,20 +1,41 @@
 import * as React from 'react';
 import { GraphElement } from '@patternfly/react-topology';
-import { SimpleTabNav } from '@console/internal/components/utils';
+import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector, useDispatch } from 'react-redux';
+import * as UIActions from '@console/internal/actions/ui';
+import { SimpleTabNav, Tab } from '@console/internal/components/utils';
+import { useQueryParams } from '@console/shared/src';
 import SideBarTabLoader from '../providers/SideBarTabLoader';
+
+const SimpleTabNavWrapper: React.FC<{ tabs: Tab[] }> = ({ tabs }) => {
+  const { t } = useTranslation();
+  const selectedTab = useSelector(({ UI }) => UI.getIn(['overview', 'selectedDetailsTab']));
+  const dispatch = useDispatch();
+  const queryParams = useQueryParams();
+  const selectTabParam = queryParams.get('selectTab');
+  const handleClickTab = React.useCallback(
+    (name) => {
+      dispatch(UIActions.selectOverviewDetailsTab(name));
+    },
+    [dispatch],
+  );
+  return (
+    <SimpleTabNav
+      selectedTab={selectTabParam || selectedTab || t('topology~Details')}
+      tabs={tabs}
+      tabProps={null}
+      onClickTab={handleClickTab}
+      additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
+    />
+  );
+};
 
 const SideBarBody: React.FC<{ element: GraphElement }> = ({ element }) => {
   return (
     <SideBarTabLoader element={element}>
-      {(tabs, loaded) =>
-        loaded ? (
-          <SimpleTabNav
-            tabs={tabs}
-            tabProps={null}
-            additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
-          />
-        ) : null
-      }
+      {(tabs, loaded) => (loaded ? <SimpleTabNavWrapper tabs={tabs} /> : null)}
     </SideBarTabLoader>
   );
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6240
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: last viewed tab from redux store was not being used while opening the side panel
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 

- If `selectTab` param is present in the URL then prioritize showing that tab as active tab on side panel
- If `selectTab` param is not present then show the last viewed tab from the redux store
- If query param is not present and redux store value is not present show `Details` tab as the active tab

<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Kapture 2021-08-31 at 18 42 29](https://user-images.githubusercontent.com/9278015/131508661-1b7d3b1f-0c53-49ca-8db6-937909b58673.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
