### PR TITLE
Bug 1999656: fix pipeline run count chart discrepancies with other chart values

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineRunCount.tsx
@@ -3,6 +3,7 @@ import { ChartVoronoiContainer } from '@patternfly/react-charts';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import Measure from 'react-measure';
+import { DataPoint } from '@console/internal/components/graphs';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { LoadingInline } from '@console/internal/components/utils';
 import { DEFAULT_CHART_HEIGHT, DEFAULT_SAMPLES } from '../const';
@@ -11,6 +12,7 @@ import { TimeSeriesChart } from './charts/TimeSeriesChart';
 import {
   formatDate,
   formatTimeSeriesValues,
+  getTransformedDataPoints,
   PipelineMetricsGraphProps,
 } from './pipeline-metrics-utils';
 
@@ -54,7 +56,10 @@ const PipelineRunCount: React.FC<PipelineMetricsGraphProps> = ({
     return formatTimeSeriesValues(result, DEFAULT_SAMPLES, timespan);
   });
   const grouped = _.groupBy(newGraphData[0], (g) => formatDate(g.x));
-  const finalArray = _.compact(_.keys(grouped).map((x) => _.maxBy(grouped[x], 'y')));
+  const finalArray: DataPoint[] = getTransformedDataPoints(
+    _.compact(_.keys(grouped).map((x) => _.maxBy(grouped[x], 'y'))),
+  );
+
   return (
     <Measure bounds>
       {({ measureRef, contentRect }) => (

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/pipeline-metrics-test-data.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/pipeline-metrics-test-data.ts
@@ -8,6 +8,24 @@ export const promqlEmptyResponse: PrometheusResponse = {
   },
 };
 
+export const groupedData = [
+  {
+    x: '2021-08-29T18:30:00.000Z',
+    y: 5,
+    metric: {},
+  },
+  {
+    x: '2021-08-30T18:30:00.000Z',
+    y: 7,
+    metric: {},
+  },
+  {
+    x: '2021-08-31T18:30:00.000Z',
+    y: 15,
+    metric: {},
+  },
+];
+
 export const promqlResponse: PrometheusResponse = {
   status: 'success',
   data: {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/pipeline-metrics-utils.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/__tests__/pipeline-metrics-utils.spec.ts
@@ -1,5 +1,9 @@
-import { getRangeVectorData, getXaxisValues } from '../pipeline-metrics-utils';
-import { promqlEmptyResponse, promqlResponse } from './pipeline-metrics-test-data';
+import {
+  getRangeVectorData,
+  getTransformedDataPoints,
+  getXaxisValues,
+} from '../pipeline-metrics-utils';
+import { groupedData, promqlEmptyResponse, promqlResponse } from './pipeline-metrics-test-data';
 
 describe('Pipeline Metrics utils: getXaxisValues', () => {
   const ONE_DAY_DURATION = 86400000;
@@ -64,5 +68,27 @@ describe('Pipeline Metrics utils: getRangeVectorData', () => {
     expect(validData).toHaveLength(6);
     expect(validData[0][0].x).toEqual('nodejs-ex-effv75');
     expect(validData[0][0].y).toEqual(1800);
+  });
+});
+
+describe('Pipeline Metrics utils: getTransformedDataPoints', () => {
+  it('Should return the current value unchanged for single datapoint', () => {
+    const singleDatapoint = groupedData[0];
+    const data = getTransformedDataPoints([singleDatapoint]);
+    expect(data).toHaveLength(1);
+    expect(data[0].y).toEqual(5);
+  });
+
+  it('Should not contain the value from the previous in datapoints', () => {
+    const data = getTransformedDataPoints(groupedData);
+    expect(data).toHaveLength(3);
+    expect(data[2].x).toEqual('2021-08-31T18:30:00.000Z');
+    expect(data[2].y).toEqual(3);
+  });
+
+  it('Should return the correct count for multiple datapoints', () => {
+    const data = getTransformedDataPoints(groupedData);
+    const totalCount = data.reduce((acc, d) => acc + d.y, 0);
+    expect(totalCount).toEqual(10);
   });
 });

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/charts/TimeSeriesChart.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/charts/TimeSeriesChart.tsx
@@ -117,23 +117,18 @@ export const TimeSeriesChart: React.FC<TimeSeriesChart & ChartProps & ChartLineP
           ))}
       </ChartGroup>
       <ChartGroup>
-        {bar
-          ? gData.map((barData, index) => (
-              <ChartBar
-                alignment="middle"
-                key={`bar-${index}`} // eslint-disable-line react/no-array-index-key
-                name={`bar-${index}`}
-                data={[barData]}
-              />
-            ))
-          : gData.map((line, index) => (
-              <ChartLine
-                groupComponent={<g />}
-                key={`line-${index}`} // eslint-disable-line react/no-array-index-key
-                name={`line-${index}`}
-                data={[line]}
-              />
-            ))}
+        {bar ? (
+          <ChartBar alignment="middle" key="bar" data={gData} />
+        ) : (
+          gData.map((line, index) => (
+            <ChartLine
+              groupComponent={<g />}
+              key={`line-${index}`} // eslint-disable-line react/no-array-index-key
+              name={`line-${index}`}
+              data={[line]}
+            />
+          ))
+        )}
       </ChartGroup>
     </Chart>
   );

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/pipeline-metrics-utils.ts
@@ -1,6 +1,10 @@
 import i18next from 'i18next';
 import * as _ from 'lodash';
-import { PrometheusResponse, PrometheusResult } from '@console/internal/components/graphs';
+import {
+  DataPoint,
+  PrometheusResponse,
+  PrometheusResult,
+} from '@console/internal/components/graphs';
 import { humanizeNumberSI } from '@console/internal/components/utils';
 import {
   dateFormatterNoYear,
@@ -130,3 +134,12 @@ export const PipelineMetricsTimeRangeOptions = () => ({
   '3w': i18next.t('pipelines-plugin~3 weeks'),
   '4w': i18next.t('pipelines-plugin~4 weeks'),
 });
+
+export const getTransformedDataPoints = (data: DataPoint[]): DataPoint[] => {
+  let previousValue = 0;
+  return _.sortBy(data, 'x').map((val) => {
+    const currentValue = val.y - previousValue;
+    previousValue += val.y;
+    return { ...val, y: currentValue };
+  });
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6145

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
In Pipeline metrics page, there is a discrepancy in the success ratio and no.of pipeline run charts. Investigate and fix the discrepancy in the charts and make it consistent.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->

Prometheus range query for the pipelineRun count accumulates the value from the previous day as well, so subtracting the previous values for a given day.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Before:
![image](https://user-images.githubusercontent.com/9964343/131515023-af942b05-0dba-4291-a3e2-407cc53c1251.png)

After:
![image](https://user-images.githubusercontent.com/9964343/131536056-605dffb8-188f-4322-b2a0-7e7fcb05afbb.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Steps to Reproduce
1. In long running (4.8 cluster), install pipelines operator and create pipeline and runs in a namespace.
2.  create pipeline run again in the same namespace on the next day.

**Unit test:**
```
  Pipeline Metrics utils: getTransformedDataPoints
    ✓ Should return the current value unchanged for single datapoint
    ✓ Should not contain the value from the previous in datapoints (1ms)
    ✓ Should return the correct count for multiple datapoints (1ms)
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @andrewballantyne 