### PR TITLE
Bug 1999658: Disable import flow tests that are failing due to rate limiting

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-docker-file.feature
@@ -17,7 +17,10 @@ Feature: Create Application from Docker file
               And name field auto populates with value "flask-dockerfile-example" in Import from Git form
 
 
-        @smoke
+        # @smoke
+        # Marking this scenario as @manual, because due to git-rate limit issue, below scenarios are failing
+        # TODO: Use Cypress HTTP mocking to solve the github rate limiting issue. See - https://docs.cypress.io/guides/guides/network-requests
+        @regression @manual
         Scenario Outline: Create a workload from Docker file with "<resource_type>" as resource type: A-05-TC02
             Given user is on Import from Git form
              When user enters Git Repo URL as "https://github.com/rohitkrai03/flask-dockerfile-example"

--- a/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
+++ b/frontend/packages/dev-console/integration-tests/features/addFlow/create-from-git.feature
@@ -8,7 +8,10 @@ Feature: Create Application from git form
               And user has created or selected namespace "aut-addflow-git"
 
 
-        @smoke @odc-5009
+        # @smoke @odc-5009
+        # Marking this scenario as @manual, because due to git-rate limit issue, below scenarios are failing
+        # TODO: Use Cypress HTTP mocking to solve the github rate limiting issue. See - https://docs.cypress.io/guides/guides/network-requests
+        @regression @manual
         Scenario Outline: Add new git workload with new application for resoruce type "<resource_type>": A-06-TC01
             Given user is at Import from Git form
              When user enters Git Repo URL as "https://github.com/sclorg/dancer-ex.git"


### PR DESCRIPTION
**Fixes**: E2E tests failures in import flows.
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: E2E tests are hitting github rate limiting.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: Disable the failing tests to unblock the CI. A follow up PR should look at mocking these HTTP calls from cypress.
<!-- Describe your code changes in detail and explain the solution -->
