### PR TITLE
Bug 1999723: disable drag for QuickSearch when hovering over text input

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.scss
@@ -1,5 +1,31 @@
 .ocs-quick-search-bar {
+  &:hover {
+    cursor: move;
+  }
+  &__input-dummy {
+    padding: 5px 8px;
+    position: fixed;
+    visibility: hidden;
+    max-width: 100%;
+    z-index: 0;
+    white-space: nowrap;
+  }
   &__input {
     height: 60px !important;
+    cursor: auto;
+    border: none !important;
+    outline: none;
+    display: block;
+    z-index: 1;
+    &-wrapper {
+      max-width: 100%;
+      display: inline-flex;
+    }
+  }
+  &__border-none {
+    border: none !important;
+  }
+  &__spinner {
+    margin-left: auto !important;
   }
 }

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.tsx
@@ -24,27 +24,46 @@ const QuickSearchBar: React.FC<QuickSearchBarProps> = ({
   icon,
 }) => {
   const { t } = useTranslation();
-
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const spanRef = React.useRef<HTMLSpanElement>(null);
   return (
-    <InputGroup className="ocs-quick-search-bar" data-test="quick-search-bar">
-      <InputGroupText>{icon || <QuickSearchIcon />}</InputGroupText>
-      <TextInput
-        type="search"
-        aria-label={t('console-shared~Quick search bar')}
-        className="ocs-quick-search-bar__input"
-        placeholder={searchPlaceholder}
-        onChange={onSearch}
-        autoFocus={autoFocus}
-        value={searchTerm}
-        data-test="input"
-      />
+    <InputGroup
+      onClick={() => inputRef.current?.focus()}
+      className="ocs-quick-search-bar"
+      data-test="quick-search-bar"
+    >
+      <InputGroupText className="ocs-quick-search-bar__border-none">
+        {icon || <QuickSearchIcon />}
+      </InputGroupText>
+      <div className="ocs-quick-search-bar__input-wrapper">
+        {/* <span> is only used to calculate the width of input based on the text in search */}
+        <span className="ocs-quick-search-bar__input-dummy" ref={spanRef}>
+          {searchTerm?.length > 0 ? searchTerm.replace(/ /g, '\u00a0') : searchPlaceholder}
+        </span>
+        <TextInput
+          type="text"
+          ref={inputRef}
+          aria-label={t('console-shared~Quick search bar')}
+          className="ocs-quick-search-bar__input"
+          placeholder={searchPlaceholder}
+          onChange={onSearch}
+          autoFocus={autoFocus}
+          value={searchTerm}
+          data-test="input"
+          style={{
+            width: spanRef.current?.offsetWidth + 2 ?? '0px',
+          }}
+        />
+        {itemsLoaded && showNoResults && (
+          <InputGroupText className="ocs-quick-search-bar__border-none">
+            &mdash; {t('console-shared~No results')}
+          </InputGroupText>
+        )}
+      </div>
       {!itemsLoaded && (
-        <InputGroupText>
+        <InputGroupText className="ocs-quick-search-bar__border-none ocs-quick-search-bar__spinner">
           <Spinner size="lg" />
         </InputGroupText>
-      )}
-      {itemsLoaded && showNoResults && (
-        <InputGroupText>-- {t('console-shared~No results')}</InputGroupText>
       )}
     </InputGroup>
   );

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.scss
@@ -1,6 +1,7 @@
 .ocs-quick-search-content {
   flex: 1;
   overflow-y: hidden;
+  border-top: 1px solid var(--pf-global--BorderColor--100);
   &__list {
     width: 40%;
     height: 100%;

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModalBody.tsx
@@ -255,6 +255,8 @@ const QuickSearchModalBody: React.FC<QuickSearchModalBodyProps> = ({
       minWidth={minWidth}
       bounds={draggableBoundary}
       onResizeStop={handleResizeStop}
+      dragHandleClassName="ocs-quick-search-bar"
+      cancel=".ocs-quick-search-bar__input"
       enableResizing={
         catalogItems === null || catalogItems?.length === 0
           ? {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-6306
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Drag is enabled on the quick search modal, user is not able to select text from the input

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Disable drag over Text Input and enable only on QuickSearchBar

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Kapture 2021-09-03 at 12 55 49](https://user-images.githubusercontent.com/9278015/131967312-6e8201af-bef2-48b0-ba9b-97e0fef66aa0.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
