### PR TITLE
Bug 1999717: Block and File and Object dashboards should not be part of OCP Console for ODF Managed Services

### DIFF
--- a/frontend/packages/ceph-storage-plugin/console-extensions.json
+++ b/frontend/packages/ceph-storage-plugin/console-extensions.json
@@ -95,7 +95,8 @@
       "href": "/ocs-dashboards"
     },
     "flags": {
-      "required": ["OCS"]
+      "required": ["OCS"],
+      "disallowed": ["ODF_MANAGED"]
     }
   },
   {

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/ocs-dashboards.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/ocs-dashboards.tsx
@@ -15,20 +15,31 @@ import {
   isDashboardsCard as isDynamicDashboardsCard,
   isDashboardsTab as isDynamicDashboardsTab,
 } from '@console/dynamic-plugin-sdk';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import {
   getPluginTabPages,
   mapStateToProps,
   DashboardsPageProps,
 } from '@console/internal/components/dashboard/dashboards-page/dashboards';
 import { HorizontalNav, PageHeading, LoadingBox } from '@console/internal/components/utils';
+import { OCS_INDEPENDENT_FLAG, MCG_FLAG, CEPH_FLAG } from '../../features';
 
 const OCSDashboardsPage: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, k8sModels }) => {
   const { t } = useTranslation();
   const title = t('ceph-storage-plugin~OpenShift Container Storage Overview');
+  const isIndependent = useFlag(OCS_INDEPENDENT_FLAG);
+  const isObjectServiceAvailable = useFlag(MCG_FLAG);
+  const isCephAvailable = useFlag(CEPH_FLAG);
   const tabExtensions = useExtensions<DashboardsTab>(isDashboardsTab);
   const cardExtensions = useExtensions<DashboardsCard>(isDashboardsCard);
   const dynamicTabExtensions = useExtensions<DynamicDashboardsTab>(isDynamicDashboardsTab);
   const dynamicCardExtensions = useExtensions<DynamicDashboardsCard>(isDynamicDashboardsCard);
+  const firstTabId =
+    isIndependent && isCephAvailable
+      ? 'independent-dashboard'
+      : isObjectServiceAvailable && !isCephAvailable
+      ? 'object-service'
+      : 'persistent-storage';
 
   const pluginPages = React.useMemo(
     () =>
@@ -37,9 +48,9 @@ const OCSDashboardsPage: React.FC<DashboardsPageProps> = ({ match, kindsInFlight
         cardExtensions,
         dynamicCardExtensions,
         'storage',
-        'persistent-storage',
+        firstTabId,
       ),
-    [tabExtensions, dynamicTabExtensions, cardExtensions, dynamicCardExtensions],
+    [tabExtensions, dynamicTabExtensions, cardExtensions, dynamicCardExtensions, firstTabId],
   );
 
   return kindsInFlight && k8sModels.size === 0 ? (

--- a/frontend/packages/ceph-storage-plugin/src/constants/common.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/common.ts
@@ -32,6 +32,7 @@ export const MINIMUM_NODES = 3;
 export const SECOND = 1000;
 export const OCS_NS = 'openshift-storage';
 export const NB_PROVISIONER = 'noobaa.io/obc';
+export const ODF_MANAGED_LABEL = 'odf-managed-service';
 export enum StoreType {
   BS = 'BackingStore',
   NS = 'NamespaceStore',

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -39,6 +39,8 @@ import {
   MCG_FLAG,
   OCS_FLAG,
   detectComponents,
+  ODF_MANAGED_FLAG,
+  detectManagedODF,
 } from './features';
 import { getObcStatusGroups } from './components/dashboards/object-service/buckets-card/utils';
 
@@ -105,6 +107,15 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [MCG_FLAG],
+    },
+  },
+  {
+    type: 'FeatureFlag/Custom',
+    properties: {
+      detect: detectManagedODF,
+    },
+    flags: {
+      required: [OCS_MODEL_FLAG],
     },
   },
   {
@@ -652,6 +663,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [OCS_FLAG],
+      disallowed: [ODF_MANAGED_FLAG],
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      path: `/ocs-dashboards`,
+      loader: () => import('./components/dashboards/ocs-dashboards').then((m) => m.DashboardsPage),
+    },
+    flags: {
+      required: [MCG_FLAG],
+      disallowed: [OCS_FLAG],
     },
   },
   {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/9742 to `release-4.8` branch.

This PR also handles one more issue:-
This is how dashboard will look on MCG standalone or OCS Independent deployment:-

**Before:**
![Screenshot from 2021-09-20 18-23-45](https://user-images.githubusercontent.com/39404641/134341782-a9afb459-82f3-4e7b-a65a-ec3cc8b931ad.png)
![Screenshot from 2021-09-22 17-41-19](https://user-images.githubusercontent.com/39404641/134341584-12b19d48-38e1-43e7-a423-590a43d30d1e.png)

**After:**
![Screenshot from 2021-09-22 17-36-30](https://user-images.githubusercontent.com/39404641/134341622-f70793d5-058a-4a5a-89fb-e95a030f5e1c.png)
![Screenshot from 2021-09-22 17-42-28](https://user-images.githubusercontent.com/39404641/134341635-d9c95c3e-1b0b-4237-8900-61ab3872a195.png)
