### PR TITLE
Bug 1999823: Linkify condition and alert messages

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -27,6 +27,7 @@ import {
   navFactory,
   EmptyBox,
   Kebab,
+  LinkifyExternal,
   ResourceLink,
   ResourceSummary,
   SectionHeading,
@@ -82,8 +83,15 @@ const ClusterOperatorTableRow: React.FC<RowFunctionArgs<ClusterOperator>> = ({ o
         <OperatorStatusIconAndLabel status={status} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>{operatorVersion || '-'}</TableData>
-      <TableData className={classNames(tableColumnClasses[3], 'co-break-word', 'co-pre-line')}>
-        {message ? _.truncate(message, { length: 256, separator: ' ' }) : '-'}
+      <TableData
+        className={classNames(
+          tableColumnClasses[3],
+          'co-break-word',
+          'co-line-clamp',
+          'co-pre-line',
+        )}
+      >
+        <LinkifyExternal>{message || '-'}</LinkifyExternal>
       </TableData>
     </>
   );
@@ -243,7 +251,9 @@ const ClusterOperatorDetails: React.FC<ClusterOperatorDetailsProps> = ({ obj }) 
                 <OperatorStatusIconAndLabel status={status} />
               </dd>
               <dt>{t('public~Message')}</dt>
-              <dd className="co-pre-line">{message || '-'}</dd>
+              <dd className="co-pre-line">
+                <LinkifyExternal>{message || '-'}</LinkifyExternal>
+              </dd>
             </dl>
           </div>
         </div>

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Timestamp } from './utils';
+import { LinkifyExternal, Timestamp } from './utils';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
 import { K8sResourceCondition } from '../module/k8s';
 
@@ -40,7 +40,7 @@ export const Conditions: React.FC<ConditionsProps> = ({ conditions }) => {
         className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line co-conditions__message"
         data-test={`condition[${i}].message`}
       >
-        {condition.message?.trim() || '-'}
+        <LinkifyExternal>{condition.message?.trim() || '-'}</LinkifyExternal>
       </div>
     </div>
   ));

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -88,7 +88,7 @@ import { ActionsMenu } from '../utils/dropdown';
 import { Firehose } from '../utils/firehose';
 import { SectionHeading, ActionButtons, BreadCrumbs } from '../utils/headings';
 import { Kebab } from '../utils/kebab';
-import { getURLSearchParams } from '../utils/link';
+import { getURLSearchParams, LinkifyExternal } from '../utils/link';
 import { ResourceLink } from '../utils/resource-link';
 import { ResourceStatus } from '../utils/resource-status';
 import { history } from '../utils/router';
@@ -595,7 +595,11 @@ const AlertMessage: React.FC<AlertMessageProps> = ({ alertText, labels, template
     }
   });
 
-  return <p>{messageParts}</p>;
+  return (
+    <p>
+      <LinkifyExternal>{messageParts}</LinkifyExternal>
+    </p>
+  );
 };
 
 const HeaderAlertMessage: React.FC<{ alert: Alert; rule: Rule }> = ({ alert, rule }) => {


### PR DESCRIPTION
Render URLs in condition and alert messages as clickable links.

Alerts:

![Screen Shot 2021-08-31 at 1 40 38 PM](https://user-images.githubusercontent.com/1167259/131550702-58bad62d-8eed-45da-9a82-8c81a784cb24.png)

Conditions:

![Screen Shot 2021-08-31 at 1 40 06 PM](https://user-images.githubusercontent.com/1167259/131550704-51b29aac-ea88-4d27-b566-043333424dc8.png)