### PR TITLE
Bug 1999931: move event sources add option to serverless add group

### DIFF
--- a/frontend/packages/dev-console/console-extensions.json
+++ b/frontend/packages/dev-console/console-extensions.json
@@ -21,7 +21,7 @@
     "properties": {
       "id": "container-images",
       "name": "%devconsole~Container images%",
-      "insertBefore": "serverless",
+      "insertBefore": "eventing",
       "insertAfter": "git-repository"
     }
   },
@@ -31,7 +31,7 @@
       "id": "local-machine",
       "name": "%devconsole~From Local Machine%",
       "insertBefore": "pipelines",
-      "insertAfter": "serverless"
+      "insertAfter": "eventing"
     }
   },
   {

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/add-page.ts
@@ -124,8 +124,8 @@ export const verifyAddPage = {
       case 'Samples':
         cy.byTestID('card samples').should('be.visible');
         break;
-      case 'Serverless':
-        cy.byTestID('card serverless').should('be.visible');
+      case 'Eventing':
+        cy.byTestID('card eventing').should('be.visible');
         break;
       case 'Channel':
         cy.byTestID('item knative-eventing-channel').should('be.visible');

--- a/frontend/packages/dev-console/src/components/add/__tests__/add-page-test-data.tsx
+++ b/frontend/packages/dev-console/src/components/add/__tests__/add-page-test-data.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { CatalogIcon } from '@patternfly/react-icons';
 import { AddActionGroup, ResolvedExtension, AddAction } from '@console/dynamic-plugin-sdk';
 import { LoadedExtension } from '@console/plugin-sdk/src';
-import { CatalogIcon } from '@patternfly/react-icons';
 
 type AddActionExtension = ResolvedExtension<AddAction>;
 type AddActionGroupExtension = LoadedExtension<AddActionGroup>;
@@ -187,8 +187,8 @@ const channel: AddActionExtension = {
   properties: {
     description:
       'Create a Knative Channel to create an event forwarding and persistence layer with in-memory and reliable implementations',
-    groupId: 'serverless',
-    href: '/channel',
+    groupId: 'eventing',
+    href: '/channel/ns/:namespace',
     icon: 'static/assets/channel.svg',
     id: 'knative-eventing-channel',
     label: 'Channel',
@@ -320,7 +320,7 @@ const containerImagesActionGroup: AddActionGroupExtension = {
   properties: {
     id: 'container-images',
     name: 'Container images',
-    insertBefore: 'serverless',
+    insertBefore: 'eventing',
     insertAfter: 'git-repository',
   },
   type: 'dev-console.add/action-group',
@@ -335,19 +335,19 @@ const localMachine: AddActionGroupExtension = {
     id: 'local-machine',
     name: 'From Local Machine',
     insertBefore: 'pipelines',
-    insertAfter: 'serverless',
+    insertAfter: 'eventing',
   },
   type: 'dev-console.add/action-group',
   uid: '@console/dev-console[36]',
 };
 
-const serverless: AddActionGroupExtension = {
+const eventing: AddActionGroupExtension = {
   flags: { required: [], disallowed: [] },
   pluginID: '@console/knative-plugin',
   pluginName: '@console/knative-plugin',
   properties: {
-    id: 'serverless',
-    name: 'Serverless',
+    id: 'eventing',
+    name: 'Eventing',
     insertBefore: 'local-machine',
     insertAfter: 'container-images',
   },
@@ -393,7 +393,7 @@ export const addActionGroupExtensions: AddActionGroupExtension[] = [
   containerImagesActionGroup,
   developerCatalog,
   pipelinesActionGroup,
-  serverless,
+  eventing,
   gitRepository,
   localMachine,
 ];

--- a/frontend/packages/knative-plugin/console-extensions.json
+++ b/frontend/packages/knative-plugin/console-extensions.json
@@ -2,8 +2,8 @@
   {
     "type": "dev-console.add/action-group",
     "properties": {
-      "id": "serverless",
-      "name": "%knative-plugin~Serverless%",
+      "id": "eventing",
+      "name": "%knative-plugin~Eventing%",
       "insertBefore": "local-machine",
       "insertAfter": "container-images"
     }
@@ -15,8 +15,8 @@
     },
     "properties": {
       "id": "knative-event-source",
-      "groupId": "developer-catalog",
-      "href": "/catalog?catalogType=EventSource",
+      "groupId": "eventing",
+      "href": "/catalog/ns/:namespace?catalogType=EventSource",
       "label": "%knative-plugin~Event Source%",
       "description": "%knative-plugin~Create an Event source to register interest in a class of events from a particular system%",
       "icon": { "$codeRef": "icons.eventSourceIconSVG" }
@@ -29,11 +29,14 @@
     },
     "properties": {
       "id": "knative-eventing-channel",
-      "groupId": "serverless",
-      "href": "/channel",
+      "groupId": "eventing",
+      "href": "/channel/ns/:namespace",
       "label": "%knative-plugin~Channel%",
       "description": "%knative-plugin~Create a Knative Channel to create an event forwarding and persistence layer with in-memory and reliable implementations%",
-      "icon": { "$codeRef": "icons.channelIconSVG" }
+      "icon": { "$codeRef": "icons.channelIconSVG" },
+      "accessReview": [
+        { "group": "eventing.knative.dev", "resource": "channels", "verb": "create" }
+      ]
     }
   },
   {

--- a/frontend/packages/knative-plugin/locales/en/knative-plugin.json
+++ b/frontend/packages/knative-plugin/locales/en/knative-plugin.json
@@ -1,5 +1,5 @@
 {
-  "Serverless": "Serverless",
+  "Eventing": "Eventing",
   "Event Source": "Event Source",
   "Create an Event source to register interest in a class of events from a particular system": "Create an Event source to register interest in a class of events from a particular system",
   "Channel": "Channel",
@@ -8,8 +8,8 @@
   "Event sources are objects that link to an event producer and an event sink or consumer. Cluster administrators can customize the content made available in the catalog.": "Event sources are objects that link to an event producer and an event sink or consumer. Cluster administrators can customize the content made available in the catalog.",
   "**Event sources** are objects that link to an event producer and an event sink or consumer.": "**Event sources** are objects that link to an event producer and an event sink or consumer.",
   "Provider": "Provider",
+  "Serverless": "Serverless",
   "Serving": "Serving",
-  "Eventing": "Eventing",
   "Add Subscription": "Add Subscription",
   "Add Trigger": "Add Trigger",
   "Delete Revision": "Delete Revision",


### PR DESCRIPTION
This is a 4.8 cherry pick PR from https://github.com/openshift/console/pull/9785

Fixes:
https://issues.redhat.com/browse/ODC-5928
https://bugzilla.redhat.com/show_bug.cgi?id=1999931

Problem/Statement:
Serverless card has add options related only to Eventing, so the group title should be changed to Eventing since Serverless has a broader scope.
Event sources add option currently shows in Catalog add group but should be shown under Eventing (previously Serverless) add group.

Solution/Description:
rename Serverless add group to Eventing.
Move Event sources add option under Eventing (previously Serverless) add group.
update affected tests.

Screens:
![Screenshot from 2021-09-01 10-02-34](https://user-images.githubusercontent.com/38663217/131612319-0fdd4b3d-302f-4036-b708-3e6e271dad24.png)

Test coverage:
N/A
only updated test data. no tests modified/created.

 Browser conformation:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge