### PR TITLE
Bug 2000633: fix observer dashboard variables  dropdown when screen size is reduced

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.scss
@@ -1,0 +1,7 @@
+.odc-monitoring-page .monitoring-dashboards__options {
+  margin-top: 0;
+}
+
+.odc-monitoring-page .monitoring-dashboards__variables {
+  margin-top: -20px;
+}

--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -18,6 +18,8 @@ import ConnectedMonitoringAlerts from './alerts/MonitoringAlerts';
 import MonitoringEvents from './events/MonitoringEvents';
 import ConnectedMonitoringMetrics from './metrics/MonitoringMetrics';
 
+import './MonitoringPage.scss';
+
 export const MONITORING_ALL_NS_PAGE_URI = '/dev-monitoring/all-namespaces';
 
 type MonitoringPageProps = {
@@ -68,10 +70,10 @@ export const PageContents: React.FC<MonitoringPageProps> = ({ match }) => {
     },
   ];
   return activeNamespace ? (
-    <>
+    <div className="odc-monitoring-page">
       <PageHeading title={t('devconsole~Observe')} />
       <HorizontalNav pages={pages} match={match} noStatusBox />
-    </>
+    </div>
   ) : (
     <CreateProjectListPage title={t('devconsole~Observe')}>
       {(openProjectModal) => (

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -145,10 +145,6 @@ $tooltip-background-color: var(--pf-global--BackgroundColor--dark-100);
   display: flex;
 }
 
-.monitoring-dashboards__variable-dropdowns {
-  margin-top: -20px;
-}
-
 .monitoring-dashboards__options {
   display: flex;
   float: right;

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -2,7 +2,6 @@ import * as _ from 'lodash-es';
 import { Button, Label, Select, SelectOption } from '@patternfly/react-core';
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import * as cx from 'classnames';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
@@ -723,11 +722,7 @@ const MonitoringDashboardsPage: React.FC<MonitoringDashboardsPageProps> = ({ mat
       <div className="co-m-nav-title co-m-nav-title--detail">
         {!namespace && <HeaderTop />}
         <div className="monitoring-dashboards__variables">
-          <div
-            className={cx('monitoring-dashboards__dropdowns', {
-              'monitoring-dashboards__variable-dropdowns': namespace,
-            })}
-          >
+          <div className="monitoring-dashboards__dropdowns">
             {!_.isEmpty(boardItems) && (
               <DashboardDropdown items={boardItems} onChange={changeBoard} selectedKey={board} />
             )}


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6309

**Solution description:**
Fixed the top margin of the dropdowns

**GIF:**
![dev-observing-page](https://user-images.githubusercontent.com/22490998/131656525-b553243d-dcd3-437e-9693-75d18d2a5994.gif)
