### PR TITLE
Bug 2000096: Git URL is not re-validated on edit build-config form reload

### DIFF
--- a/frontend/packages/dev-console/src/components/buildconfig/BuildConfigForm.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/BuildConfigForm.tsx
@@ -73,6 +73,7 @@ const BuildConfigForm: React.FC<FormikProps<BuildConfigFormikValues> & {
     }
     setFieldValue('yamlData', safeJSToYAML(watchedBuildConfig, '', { skipInvalid: true }), false);
     setFieldValue('resourceVersion', watchedBuildConfig?.metadata?.resourceVersion, true);
+    setFieldValue('formReloadCount', values.formReloadCount + 1);
   }, [setErrors, setFieldValue, setStatus, values, watchedBuildConfig]);
 
   return (

--- a/frontend/packages/dev-console/src/components/buildconfig/EditBuildConfig.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/EditBuildConfig.tsx
@@ -33,6 +33,7 @@ const EditBuildConfig: React.FC<EditBuildConfigProps> = ({
     const values = convertBuildConfigToFormData(watchedBuildConfig);
     values.yamlData = safeJSToYAML(watchedBuildConfig, '', { skipInvalid: true });
     values.resourceVersion = watchedBuildConfig?.metadata?.resourceVersion;
+    values.formReloadCount = 0;
     return values;
   });
 

--- a/frontend/packages/dev-console/src/components/buildconfig/form-utils/types.ts
+++ b/frontend/packages/dev-console/src/components/buildconfig/form-utils/types.ts
@@ -14,6 +14,7 @@ export type BuildConfigFormikValues = {
   editorType: EditorType;
   yamlData: string;
   resourceVersion: string | undefined;
+  formReloadCount?: number;
 } & NameSectionFormData &
   SourceSectionFormData &
   ImagesSectionFormData &

--- a/frontend/packages/dev-console/src/components/buildconfig/sections/SourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/buildconfig/sections/SourceSection.tsx
@@ -18,7 +18,7 @@ export type SourceSectionFormData = {
   };
 };
 
-const SourceSection: React.FC<{}> = () => {
+const SourceSection: React.FC = () => {
   const { t } = useTranslation();
 
   const [, meta] = useField<string>('formData.name');
@@ -51,7 +51,6 @@ const SourceSection: React.FC<{}> = () => {
       ) : null}
 
       {type === 'git' ? <GitSection title="" formContextField="formData.source.git" /> : null}
-
       {type === 'dockerfile' ? (
         <EditorField
           name="formData.source.dockerfile"

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -121,6 +121,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   const errors: FormikErrors<GitSectionFormData> = formContextField
     ? _.get(formikErrors, formContextField, {})
     : formikErrors;
+  const formReloadCount: number = _.get(formikValues, 'formReloadCount');
 
   const { url: defaultSampleURL, dir: defaultSampleDir, ref: defaultSampleRef } =
     defaultSample || {};
@@ -396,13 +397,14 @@ const GitSection: React.FC<GitSectionProps> = ({
   }, [debouncedHandleGitUrlChange, sampleRepo, setFieldTouched, setFieldValue, tag]);
 
   React.useEffect(() => {
-    (!dirty || gitDirTouched) &&
+    (!dirty || gitDirTouched || formReloadCount) &&
       values.git.url &&
       debouncedHandleGitUrlChange(values.git.url, values.git.ref, values.git.dir);
   }, [
     dirty,
     isSubmitting,
     gitDirTouched,
+    formReloadCount,
     debouncedHandleGitUrlChange,
     values.git.url,
     values.git.ref,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6298

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When we reload the page, the git url handler is not getting called -> since we are only calling it 
- on change of git url
- when the form is not dirty or the form has touched the gitDir

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
- added a counter for reloads and we validate the git url when it changes :)

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![buildconfigGitURLreload](https://user-images.githubusercontent.com/20089340/131667065-3ad0d524-5cfa-4ec2-926b-53784cadc051.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge