### PR TITLE
Bug 2000499: dismiss toast if export cr gives 404

### DIFF
--- a/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastContext.tsx
@@ -30,6 +30,8 @@ export type ToastOptions = {
   timeout?: number | boolean;
   // Callback when the toast is removed.
   onRemove?: (id: string) => void;
+  // Callback to run when toast is dismissed with close button
+  onClose?: () => void;
 };
 
 export type ToastContextType = {

--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
@@ -60,7 +60,12 @@ const ToastProvider: React.FC = ({ children }) => {
               onTimeout={() => removeToast(toast.id)}
               actionClose={
                 toast.dismissible ? (
-                  <AlertActionCloseButton onClose={() => removeToast(toast.id)} />
+                  <AlertActionCloseButton
+                    onClose={() => {
+                      toast.onClose && toast.onClose();
+                      removeToast(toast.id);
+                    }}
+                  />
                 ) : (
                   undefined
                 )

--- a/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
+++ b/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, AlertActionLink } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertActionLink } from '@patternfly/react-core';
 import { mount, ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import ToastContext, { ToastContextType, ToastVariant } from '../ToastContext';
@@ -174,5 +174,24 @@ describe('ToastProvider', () => {
 
     expect(actionFn).toHaveBeenCalledTimes(1);
     expect(wrapper.find(Alert).length).toBe(0);
+  });
+
+  it('should call onToastClose if provided on toast close', () => {
+    const toastClose = jest.fn();
+    act(() => {
+      toastContext.addToast({
+        title: 'test success',
+        variant: ToastVariant.success,
+        content: 'description 1',
+        onClose: toastClose,
+        dismissible: true,
+      });
+    });
+
+    wrapper.update();
+    const closeBtn = wrapper.find(AlertActionCloseButton);
+    expect(closeBtn.exists()).toBe(true);
+    closeBtn.simulate('click');
+    expect(toastClose).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6286

**Analysis / Root cause**: 
1. if export app toast is not cleared by the user (i.e user doesn't click on download or close) and a new one is triggered then the old toast still shows and the download link gives 404.
2. If export app toast is shown and the user deletes export CR manually then toast still shows and the download link gives 404.

**Solution Description**: 
1. once a new export trigger happens then the old toast should be auto removed if exists.
2. If user deletes export CR then associated toast should get dismissed

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
1. once a new export trigger happens then the old toast should be auto removed if exists.

![Kapture 2021-09-02 at 22 46 23](https://user-images.githubusercontent.com/5129024/131888357-635b1b40-5a48-436b-adde-5ada6868893e.gif)

2. If the user deletes export CR then associated toast should get dismissed

![Kapture 2021-09-02 at 22 48 53](https://user-images.githubusercontent.com/5129024/131889433-4f44977d-ce77-416d-8dfc-727a9604b8dd.gif)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

![image](https://user-images.githubusercontent.com/5129024/131886900-29819b44-5e78-436e-a38a-67624c334216.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
