### PR TITLE
Bug 2000108: fix devconsole metrics page

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MetricsQueryInput.tsx
@@ -70,9 +70,6 @@ const MetricsQueryInput: React.FC = () => {
     if (text && text.localeCompare(q) !== 0) {
       setTitle(CUSTOM_QUERY);
       setIsPromQlDisabled(true);
-      if (query) {
-        removeQueryArgument('query0');
-      }
     }
   }, [query, queries, CUSTOM_QUERY]);
 
@@ -105,21 +102,24 @@ const MetricsQueryInput: React.FC = () => {
       .catch(() => {});
   }, [namespace, safeFetch, dispatch]);
 
-  const onChange = (selectedValue: string) => {
-    setMetric(metricsQuery(t)[selectedValue]);
-    setChangeKey(!changeKey);
-    if (selectedValue && selectedValue === ADD_NEW_QUERY) {
-      setTitle(CUSTOM_QUERY);
-      setIsPromQlDisabled(true);
-      setShowPromQl(true);
-    } else {
-      setTitle(metricsQuery(t)[selectedValue]);
-      setIsPromQlDisabled(false);
-    }
-    if (query) {
-      removeQueryArgument('query0');
-    }
-  };
+  const onChange = React.useCallback(
+    (selectedValue: string) => {
+      setMetric(metricsQuery(t)[selectedValue]);
+      setChangeKey(!changeKey);
+      if (selectedValue && selectedValue === ADD_NEW_QUERY) {
+        setTitle(CUSTOM_QUERY);
+        setIsPromQlDisabled(true);
+        setShowPromQl(true);
+      } else {
+        setTitle(metricsQuery(t)[selectedValue]);
+        setIsPromQlDisabled(false);
+      }
+      if (query) {
+        removeQueryArgument('query0');
+      }
+    },
+    [CUSTOM_QUERY, changeKey, query, t],
+  );
 
   return (
     <>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6312

**Analysis / Root cause**: 
On Observe page, when we inspect a chart on the Dashboard page it takes us to the Metrics page but with the query missing for the chart. Query param gets removed when the user comes from the dashboard by clicking the inspect link.

**Solution Description**: 
Persist the query param in the URL

**Screen shots / Gifs for design review**: 
![Kapture 2021-09-01 at 17 30 50](https://user-images.githubusercontent.com/2561818/131668108-e4d6dedb-0dc7-4fbf-ac12-bbb78da861b6.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge