### PR TITLE
Adding test cases for Pipeline run details page as part of PAC

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
@@ -57,7 +57,7 @@ Feature: Perform Actions on repository
 
 
         @smoke @to-do
-        Scenario: Actions menu of newly created reposiotry in Repository details page: P-11-TC05
+        Scenario: Actions menu of newly created repository in Repository details page: P-11-TC05
             Given user is at repositories details page with newly created repository "test-repo"
              When user clicks Actions menu in the repository details page
              Then Actions menu display with options Edit labels, Edit annotations, Edit repository, Delete repository
@@ -69,7 +69,7 @@ Feature: Perform Actions on repository
              When user searches repository "<repository_name>" in repositories page
               And user clicks repository "<repository_name>" from searched results on Repositories page
               And user selects option "Edit Repository" from Actions menu drop down
-             Then user modifies the yaml code in the yaml view of the reposiotry
+             Then user modifies the yaml code in the yaml view of the repository
               And user clicks on the save button
              Then user is able to see a success alert message on same page
 
@@ -116,7 +116,7 @@ Feature: Perform Actions on repository
 
 
         @regression @to-do
-        Scenario Outline: Pipeline Runs tab of the Reposiotry details page: P-11-TC10
+        Scenario: Pipeline Runs tab of the Repository details page: P-11-TC10
             Given repository "test-repo" is present on the Repositories page
              When user searches repository "test-repo" in repositories page
               And user clicks repository "test-repo" from searched results on Repositories page

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
@@ -101,7 +101,22 @@ Feature: Perform Actions on repository
 
 
         @regression @to-do
-        Scenario Outline: Delete the repository from the Repository details page: P-11-TC09
+        Scenario Outline: Pipeline Run Details page for the repository: P-11-TC09
+            Given pipeline run is displayed for "<repository_name>"
+              And user is at the repositories page
+             When user clicks Last Run value of repository "<repository_name>"
+             Then user will be redirected to Pipeline Run Details page
+              And user is able to see Details, YAML, TaskRuns, Logs and Events tabs
+              And Details tab is displayed with field names Name, Namespace, Labels, Annotations, Created At, Owner, Status, Pipeline, Repository, Branch, commit id and Event type
+              And Actions dropdown display on the top right corner of the page
+
+        Examples:
+                  | repository_name |
+                  | test-repo       |
+
+
+        @regression @to-do
+        Scenario Outline: Delete the repository from the Repository details page: P-11-TC10
             Given repository "<repository_name>" is present on Repositories page
              When user searches repository "<repository_name>" in repositories page
               And user clicks repository "<repository_name>" from searched results on Repositories page

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
@@ -107,7 +107,7 @@ Feature: Perform Actions on repository
              When user clicks Last Run value of repository "<repository_name>"
              Then user will be redirected to Pipeline Run Details page
               And user is able to see Details, YAML, TaskRuns, Logs and Events tabs
-              And Details tab is displayed with field names Name, Namespace, Labels, Annotations, Created At, Owner, Status, Pipeline, Repository, Branch, commit id and Event type
+              And Details tab is displayed with fields Repository, Branch, Commit id and Event type
               And Actions dropdown display on the top right corner of the page
 
         Examples:
@@ -116,7 +116,18 @@ Feature: Perform Actions on repository
 
 
         @regression @to-do
-        Scenario Outline: Delete the repository from the Repository details page: P-11-TC10
+        Scenario Outline: Pipeline Runs tab of the Reposiotry details page: P-11-TC10
+            Given repository "test-repo" is present on the Repositories page
+             When user searches repository "test-repo" in repositories page
+              And user clicks repository "test-repo" from searched results on Repositories page
+              And user clicks on Pipeline Runs tab
+             Then user is able to see Name, Commit id, Status, Task status, Started, Duration and Branch fields
+              And user hovers over the commit id
+             Then user should see commit message in tooltip
+
+
+        @regression @to-do
+        Scenario Outline: Delete the repository from the Repository details page: P-11-TC11
             Given repository "<repository_name>" is present on Repositories page
              When user searches repository "<repository_name>" in repositories page
               And user clicks repository "<repository_name>" from searched results on Repositories page


### PR DESCRIPTION
Added test cases for Pipelines As Code along with test data

Jira Id: [ODC-5149](https://issues.redhat.com/browse/ODC-5149)

Acceptance Criteria: 

1. As a user, looking at the Pipelines page in the Developer Console, I should be able to see a list of (a) Git repositories that are added to the namespace for PAC execution AND (b) all pipelines in the namespace
2. As a user, I should be able to navigate to a details page of the git repo.
    1. This details page should provide access to (a) details of the git repo and (b) a list of pipeline runs.
    2. This PLR tab should show additional information than the typical PLR List view, including SHA (commit id), commit message, branch & trigger type
3. As a user, when looking at a Pipeline Run Details page, if associate with a git repo (PAC),
4. Indicate that it's from a specific git repo rather than a PL resource
5. Include the SHA (commit id), commit message, branch & trigger type


Pre-conditions for Epic validation:

1. Openshift Pipelines is installed 
2. Pipelines As Code is installed

Checks required for approving Epic gherkin scripts PR:

- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [ ]  Update the test scenarios count in Automation status confluence Report
- [x]  Check for the linter issues by executing yarn run gherkin-lint on frontend folder [Skip epic number tags related linter issues]

@makambalaji @sanketpathak  @karthi please review