### PR TITLE
Bug 2000473: Monitoring dashboards: Fix clearing variables when changing dashboard

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -26,7 +26,6 @@ export enum ActionType {
   SetActiveNamespace = 'setActiveNamespace',
   SetCreateProjectMessage = 'setCreateProjectMessage',
   SetCurrentLocation = 'setCurrentLocation',
-  MonitoringDashboardsClearVariables = 'monitoringDashboardsClearVariables',
   MonitoringDashboardsPatchVariable = 'monitoringDashboardsPatchVariable',
   MonitoringDashboardsPatchAllVariables = 'monitoringDashboardsPatchAllVariables',
   MonitoringDashboardsSetEndTime = 'monitoringDashboardsSetEndTime',
@@ -299,8 +298,6 @@ export const updateOverviewLabels = (labels: string[]) =>
   action(ActionType.UpdateOverviewLabels, { labels });
 export const updateOverviewFilterValue = (value: string) =>
   action(ActionType.UpdateOverviewFilterValue, { value });
-export const monitoringDashboardsClearVariables = () =>
-  action(ActionType.MonitoringDashboardsClearVariables);
 export const monitoringDashboardsPatchVariable = (key: string, patch: any, perspective: string) =>
   action(ActionType.MonitoringDashboardsPatchVariable, { key, patch, perspective });
 export const monitoringDashboardsPatchAllVariables = (variables: any, perspective: string) =>
@@ -335,7 +332,7 @@ export const monitoringLoaded = (
   });
 export const monitoringErrored = (
   key: 'alerts' | 'silences' | 'notificationAlerts' | 'devAlerts',
-  loadError: any,
+  loadError: Error,
   perspective = 'admin',
 ) =>
   action(ActionType.SetMonitoringData, {
@@ -416,7 +413,6 @@ const uiActions = {
   updateOverviewSelectedGroup,
   updateOverviewLabels,
   updateOverviewFilterValue,
-  monitoringDashboardsClearVariables,
   monitoringDashboardsPatchVariable,
   monitoringDashboardsPatchAllVariables,
   monitoringDashboardsSetEndTime,

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -648,6 +648,10 @@ const MonitoringDashboardsPage: React.FC<MonitoringDashboardsPageProps> = ({ mat
         }
       }
       if (newBoard !== board) {
+        if (getQueryArgument('dashboard') !== newBoard) {
+          history.replace(url);
+        }
+
         const allVariables = getAllVariables(boards, newBoard, namespace);
         dispatch(monitoringDashboardsPatchAllVariables(allVariables, activePerspective));
 
@@ -666,9 +670,6 @@ const MonitoringDashboardsPage: React.FC<MonitoringDashboardsPageProps> = ({ mat
         );
 
         setBoard(newBoard);
-        if (getQueryArgument('dashboard') !== newBoard) {
-          history.replace(url);
-        }
       }
     },
     [activePerspective, board, boards, dispatch, namespace],

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -142,9 +142,6 @@ export default (state: UIState, action: UIAction): UIState => {
     case ActionType.SetUser:
       return state.set('user', action.payload.user);
 
-    case ActionType.MonitoringDashboardsClearVariables:
-      return state.setIn(['monitoringDashboards', 'variables'], ImmutableMap());
-
     case ActionType.MonitoringDashboardsPatchVariable:
       return state.mergeIn(
         ['monitoringDashboards', action.payload.perspective, 'variables', action.payload.key],


### PR DESCRIPTION
The value of variables (filter dropdowns) was being persisted as URL GET
parameters when you changed from one dashboard to another. Not only
should the value not be persisted, but if the value is an invalid option
for the new dashboard, it could result in no data being displayed.

Also removed the `MonitoringDashboardsClearVariables` Redux action both
because it's unused and because it doesn't take a perspective parameter
and will therefore fail.

Issue was introduced by https://github.com/openshift/console/pull/9545