### PR TITLE
Created separate helm release spec for CI purpose

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
@@ -16,7 +16,7 @@ export const pageTitle = {
   Search: 'Search',
   HelmReleases: 'Helm Releases',
   Project: 'Project Details',
-  ConfigMaps: 'Config Maps',
+  ConfigMaps: 'ConfigMaps',
   Secrets: 'Secrets',
   PipelineRunDetails: 'PipelineRun details',
   PipelineDetails: 'Pipeline details',

--- a/frontend/packages/helm-plugin/integration-tests/.eslintrc
+++ b/frontend/packages/helm-plugin/integration-tests/.eslintrc
@@ -1,0 +1,25 @@
+{
+  "env": {
+    "cypress/globals": true,
+    "node": true
+  },
+  "extends": ["../../.eslintrc", "plugin:cypress/recommended", "plugin:prettier/recommended"],
+  "plugins": ["cypress"],
+  "rules": {
+    "no-console": "off",
+    "no-namespace": "off",
+    "no-redeclare": "off",
+    "promise/catch-or-return": "off",
+    "promise/no-nesting": "off",
+    "@typescript-eslint/ban-ts-ignore": "off",
+    "cypress/no-unnecessary-waiting": "off"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"],
+        "moduleDirectory": ["node_modules", "integration-tests/"]
+      }
+    }
+  }
+}

--- a/frontend/packages/helm-plugin/integration-tests/features/helm-release.feature
+++ b/frontend/packages/helm-plugin/integration-tests/features/helm-release.feature
@@ -1,0 +1,112 @@
+@helm @smoke
+Feature: Helm Release
+              As a user, I want to perform actions on the helm release
+
+
+        @pre-condition
+        Scenario: Create or Select the project namespace
+            Given user has created or selected namespace "aut-ci-helm"
+
+
+        Scenario: Open the Helm tab on the navigation bar when helm charts are absent: HR-05-TC01
+             When user clicks on the Helm tab
+             Then user will be redirected to Helm releases page
+              And user is able to see the message as no helm charts present
+              And user will get the link to install helm charts from developer catalog
+
+
+        Scenario: Install Helm Chart page details: HR-05-TC02
+            Given user is at Add page
+             When user selects "Helm Chart" card from add page
+              And user searches and selects "Nodejs" card from catalog page
+              And user clicks on the Install Helm Chart button on side bar
+             Then Install Helm Chart page is displayed
+              And release name displays as "nodejs"
+              And form view radio button is selected by default
+              And yaml view radio button is enabled
+              And form sections are displayed in form view
+
+
+        Scenario: Install Helm Chart from +Add Page using Form View: HR-06-TC04
+            Given user is at Add page
+             When user selects "Helm Chart" card from add page
+              And user searches and selects "Nodejs" card from catalog page
+              And user clicks on the Install Helm Chart button on side bar
+              And user enters Release Name as "nodejs-release"
+              And user clicks on the Install button
+             Then user will be redirected to Topology page
+              And Topology page have the helm chart workload "nodejs-release"
+
+
+        Scenario: Context menu options of helm release: HR-01-TC01
+            Given user is at the Topology page
+             When user right clicks on the helm release "nodejs-release" to open the context menu
+             Then user is able to see the context menu with actions Upgrade and Uninstall Helm Release
+
+
+        Scenario: Open the Helm tab on the navigation bar when helm charts are present: HR-05-TC05
+            Given user is at the Helm page
+             When user clicks on the Helm tab
+             Then user will be redirected to Helm releases page
+              And user will see the helm charts listed
+
+
+        Scenario: Filter out deployed Helm Charts: HR-05-TC06
+            Given user is at the Helm page
+             When user clicks on the filter drop down
+              And user selects checkbox for the "Deployed" Helm charts
+             Then the checkbox for the "Deployed" Helm chart is checked
+              And helm charts with status "Deployed" are listed
+
+
+        Scenario: Helm release details page: HR-05-TC13
+            Given user is at the Helm page
+             When user clicks on the helm release name "nodejs-release"
+             Then user will see the Details page opened
+              And user will see the Resources tab
+              And user will see the Revision History tab
+              And user will see the Release Notes tab
+              And user will see the Actions drop down menu with options Upgrade, Rollback, and Uninstall Helm Release
+
+
+        Scenario: Actions menu on Helm page after helm chart upgrade: HR-08-TC01
+            Given user is on the Helm page with helm release "nodejs-release"
+             When user clicks on the Kebab menu
+             Then user is able to see kebab menu with actions Upgrade, Rollback and Uninstall Helm Release
+
+
+        Scenario: Perform Upgrade action on Helm Release through Context Menu: HR-01-TC04
+            Given user is at the Topology page
+             When user right clicks on the helm release "nodejs-release" to open the context menu
+              And user clicks on the "Upgrade" action
+              And user upgrades the chart Version
+              And user clicks on the upgrade button
+             Then user will be redirected to Topology page
+
+
+        Scenario: Perform the helm chart upgrade for already upgraded helm chart : HR-08-TC02
+            Given user is on the Helm page with helm release "nodejs-release"
+             When user clicks on the Kebab menu
+              And user clicks on the "Upgrade" action
+              And user upgrades the chart Version
+              And user clicks on the upgrade button
+             Then user will be redirected to Helm Releases page
+
+
+        Scenario: Perform Rollback action on Helm Release through Context Menu: HR-08-TC03
+            Given user is at the Topology page
+              And user is on the topology sidebar of the helm release "nodejs-release"
+             When user clicks on the Actions drop down menu
+              And user clicks on the "Rollback" action
+              And user selects the version to Rollback
+              And user clicks on the rollback button
+             Then user will be redirected to Topology page
+
+
+        Scenario: Uninstall Helm Release through Context Menu: HR-01-TC03
+            Given user is at the Topology page
+             When user right clicks on the helm release "nodejs-release" to open the context menu
+              And user clicks on the "Uninstall Helm Release" action
+              And user enters the release name "nodejs-release"
+              And user clicks on the Uninstall button
+             Then user will be redirected to Topology page

--- a/frontend/packages/helm-plugin/integration-tests/package.json
+++ b/frontend/packages/helm-plugin/integration-tests/package.json
@@ -8,6 +8,6 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/helm/*.feature\";"
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless --spec \"features/helm-release.feature\";"
   }
 }

--- a/frontend/packages/helm-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/commands/hooks.ts
@@ -3,6 +3,10 @@ before(() => {
   cy.document()
     .its('readyState')
     .should('eq', 'complete');
+  // set the user settings location to local storage, so that no need of deleting config map from openshift-console-user-settings namespace
+  cy.window().then((win: any) => {
+    win.SERVER_FLAGS.userSettingsLocation = 'localstorage';
+  });
   // Default helm repo has been changed to a new repo, so executing below line to fix that issue
   cy.exec('oc apply -f test-data/red-hat-helm-charts.yaml');
 });

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/helm-details-page.ts
@@ -25,8 +25,10 @@ export const helmDetailsPage = {
       .should('contain.text', fieldValue);
   },
   uninstallHelmRelease: () => {
-    modal.modalTitleShouldContain('Uninstall Helm Release?');
-    modal.submit();
+    cy.get('form.modal-content').within(() => {
+      cy.byLegacyTestID('modal-title').should('contain.text', 'Uninstall Helm Release?');
+      cy.get('button[type=submit]').click({ force: true });
+    });
     modal.shouldBeClosed();
   },
   enterReleaseNameInUninstallPopup: (releaseName: string = 'nodejs-release') => {

--- a/frontend/packages/helm-plugin/integration-tests/support/pages/helm/upgrade-helm-release-page.ts
+++ b/frontend/packages/helm-plugin/integration-tests/support/pages/helm/upgrade-helm-release-page.ts
@@ -1,4 +1,3 @@
-import { modal } from '@console/cypress-integration-tests/views/modal';
 import { helmPO } from '@console/dev-console/integration-tests/support/pageObjects/helm-po';
 
 export const upgradeHelmRelease = {
@@ -12,17 +11,22 @@ export const upgradeHelmRelease = {
       .get(helmPO.upgradeHelmRelease.replicaCount)
       .clear()
       .type(replicaCount),
-  upgradeChartVersion: (yamlView: boolean = false) => {
+  upgradeChartVersion: () => {
     cy.get(helmPO.upgradeHelmRelease.chartVersion).click();
     const count = Cypress.$('[data-test-id="dropdown-menu"]').length;
     const randNum = Math.floor(Math.random() * count);
     cy.byLegacyTestID('dropdown-menu')
       .eq(randNum)
       .click();
-    if (yamlView === true) {
-      modal.modalTitleShouldContain('Change chart version?');
-      modal.submit();
-    }
+    cy.get('body').then(($body) => {
+      if ($body.find('form.modal-content').length) {
+        cy.log('Change Chart version popup is displayed, so clicking on the proceed button');
+        cy.get('form.modal-content').within(() => {
+          cy.byLegacyTestID('modal-title').should('contain.text', 'Change chart version?');
+          cy.get('button[type=submit]').click({ force: true });
+        });
+      }
+    });
   },
   clickOnUpgrade: () => {
     cy.get(helmPO.upgradeHelmRelease.upgrade).click();


### PR DESCRIPTION
**Description**:
Helm specs are taking 13 min of time to execute all scripts, To reduce the amount of time, moved all the important helm scenarios to single spec

Jira Id: https://issues.redhat.com/browse/ODC-6327

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p helm -h true
```

**Screen shots**:
![9972-chrome](https://user-images.githubusercontent.com/61005404/131894650-b11c3cd4-ec64-47a2-aaa8-bd032d83849d.png)


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

