### PR TITLE
Bug 2000491: removes techpreview badge from RH Camel K integration operator

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSourcePage.tsx
@@ -7,7 +7,6 @@ import NamespacedPage, {
 } from '@console/dev-console/src/components/NamespacedPage';
 import { QUERY_PROPERTIES } from '@console/dev-console/src/const';
 import { LoadingBox, PageHeading } from '@console/internal/components/utils';
-import { TechPreviewBadge } from '@console/shared';
 import { useEventSourceStatus } from '../../hooks';
 import { CamelKameletBindingModel } from '../../models';
 import ConnectedEventSource from './EventSource';
@@ -36,10 +35,7 @@ const EventSourcePage: React.FC<EventSourcePageProps> = ({ match, location }) =>
       <Helmet>
         <title>{t('knative-plugin~Event Source')}</title>
       </Helmet>
-      <PageHeading
-        title={t('knative-plugin~Create Event Source')}
-        badge={isKameletSource ? <TechPreviewBadge /> : null}
-      >
+      <PageHeading title={t('knative-plugin~Create Event Source')}>
         {t(
           'knative-plugin~Create an Event source to register interest in a class of events from a particular system. Configure using the YAML and form views.',
         )}

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -1,7 +1,6 @@
 import { chart_color_cyan_400 as knativeServingColor } from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
 import { chart_color_red_300 as knativeEventingColor } from '@patternfly/react-tokens/dist/js/chart_color_red_300';
 import { K8sKind } from '@console/internal/module/k8s';
-import { BadgeType } from '@console/shared/src/components/badges/badge-factory';
 import {
   KNATIVE_EVENT_SOURCE_APIGROUP,
   KNATIVE_EVENT_SOURCE_APIGROUP_DEP,
@@ -390,7 +389,6 @@ export const CamelIntegrationModel: K8sKind = {
   namespaced: true,
   crd: true,
   color: knativeEventingColor.value,
-  badge: BadgeType.TECH,
 };
 
 export const KafkaModel: K8sKind = {
@@ -445,7 +443,6 @@ export const CamelKameletBindingModel: K8sKind = {
   namespaced: true,
   crd: true,
   color: knativeEventingColor.value,
-  badge: BadgeType.TECH,
 };
 
 export const CamelKameletModel: K8sKind = {
@@ -464,7 +461,6 @@ export const CamelKameletModel: K8sKind = {
   namespaced: true,
   crd: true,
   color: knativeEventingColor.value,
-  badge: BadgeType.TECH,
 };
 
 export const CamelIntegrationPlatformModel: K8sKind = {
@@ -483,5 +479,4 @@ export const CamelIntegrationPlatformModel: K8sKind = {
   namespaced: true,
   crd: true,
   color: knativeEventingColor.value,
-  badge: BadgeType.TECH,
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6324

**Analysis / Root cause**: 
Removes TP badge from CamelK resources & kamelets


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/5129024/131817421-28b5a9d7-031a-4aae-a400-de1c79452b81.png)

![image](https://user-images.githubusercontent.com/5129024/131817585-be6962b5-fa64-4df8-b22c-dddbf0e8f0a1.png)

![image](https://user-images.githubusercontent.com/5129024/131817654-6bba7c30-4ec9-41b3-a9f5-823f468c4cdf.png)

![image](https://user-images.githubusercontent.com/5129024/131817914-9d6dd6e2-87ec-4652-915d-02677c47a8b5.png)

![image](https://user-images.githubusercontent.com/5129024/131817779-9e3e0f50-5d29-4529-9218-f9a570359959.png)

![image](https://user-images.githubusercontent.com/5129024/131818071-cda6b9ce-04bd-4605-b4d3-a193f257d076.png)

![image](https://user-images.githubusercontent.com/5129024/131818186-d39a04f4-016c-4be9-a568-4276cb393320.png)

![image](https://user-images.githubusercontent.com/5129024/131818280-7f059cde-4c34-4255-9efc-d2cdfdb28a61.png)

![image](https://user-images.githubusercontent.com/5129024/131818529-5129afad-9097-4ff4-8193-99a3e4c17822.png)

![image](https://user-images.githubusercontent.com/5129024/131818703-768b2dcc-2a15-47c8-a349-f2206be3d6c0.png)

 @openshift/team-devconsole-ux


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
