### PR TITLE
Console 2926: Bug 1995545: Update console page markup structure to closer align with Patternfly page component structure.

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests-cypress/cypress-ceph.json
+++ b/frontend/packages/ceph-storage-plugin/integration-tests-cypress/cypress-ceph.json
@@ -1,5 +1,7 @@
 {
   "integrationFolder": "tests",
+  "viewportWidth": 1920,
+  "viewportHeight": 1080,
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "video": true,

--- a/frontend/packages/integration-tests-cypress/cypress.json
+++ b/frontend/packages/integration-tests-cypress/cypress.json
@@ -1,5 +1,7 @@
 {
   "integrationFolder": "tests",
+  "viewportWidth": 1920,
+  "viewportHeight": 1080,
   "screenshotsFolder": "../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../gui_test_screenshots/cypress/videos",
   "video": true,

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/cypress-olm.json
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/cypress-olm.json
@@ -1,5 +1,7 @@
 {
   "integrationFolder": "tests",
+  "viewportWidth": 1920,
+  "viewportHeight": 1080,
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "video": true,

--- a/frontend/public/components/_notification-drawer.scss
+++ b/frontend/public/components/_notification-drawer.scss
@@ -1,6 +1,7 @@
 .co-notification-drawer {
   overflow-y: hidden !important;
-  z-index: 10;
+  // place above pf-m-sticky-top --pf-c-page--section--m-sticky-top--ZIndex + 10
+  z-index: 310 !important;
   @include co-break-word;
 }
 

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -202,530 +202,539 @@ const AppContents: React.FC<{}> = () => {
   );
 
   return (
-    <PageSection variant={PageSectionVariants.light}>
-      <div id="content">
+    <div id="content">
+      <PageSection
+        variant={PageSectionVariants.light}
+        sticky="top"
+        padding={{ default: 'noPadding' }}
+      >
         <GlobalNotifications />
         <Route path={namespacedRoutes} component={NamespaceBar} />
+      </PageSection>
 
-        <div id="content-scrollable">
-          <React.Suspense fallback={<LoadingBox />}>
-            <Switch>
-              {pluginPageRoutes}
+      <PageSection
+        variant={PageSectionVariants.light}
+        id="content-scrollable"
+        className="pf-page__main-section--flex"
+        padding={{ default: 'noPadding' }}
+      >
+        <React.Suspense fallback={<LoadingBox />}>
+          <Switch>
+            {pluginPageRoutes}
 
-              <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
-              <LazyRoute
-                path="/dashboards"
-                loader={() =>
-                  import(
-                    './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
-                  ).then((m) => m.DashboardsPage)
-                }
-              />
-
-              {/* Redirect legacy routes to avoid breaking links */}
-              <Redirect from="/cluster-status" to="/dashboards" />
-              <Redirect from="/status/all-namespaces" to="/dashboards" />
-              <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
-              <Route path="/status" exact component={NamespaceRedirect} />
-              <Redirect from="/overview/all-namespaces" to="/dashboards" />
-              <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
-              <Route path="/overview" exact component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/api-explorer"
-                exact
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                    (m) => m.APIExplorerPage,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/api-resource/cluster/:plural"
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                    (m) => m.APIResourcePage,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/api-resource/all-namespaces/:plural"
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                    NamespaceFromURL(m.APIResourcePage),
-                  )
-                }
-              />
-              <LazyRoute
-                path="/api-resource/ns/:ns/:plural"
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                    NamespaceFromURL(m.APIResourcePage),
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/command-line-tools"
-                exact
-                loader={() =>
-                  import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
-                    (m) => m.CommandLineToolsPage,
-                  )
-                }
-              />
-
-              <Route path="/operatorhub" exact component={NamespaceRedirect} />
-              <LazyRoute
-                path="/provisionedservices/all-namespaces"
-                loader={() =>
-                  import(
-                    './provisioned-services' /* webpackChunkName: "provisionedservices" */
-                  ).then((m) => m.ProvisionedServicesPage)
-                }
-              />
-              <LazyRoute
-                path="/provisionedservices/ns/:ns"
-                loader={() =>
-                  import(
-                    './provisioned-services' /* webpackChunkName: "provisionedservices" */
-                  ).then((m) => m.ProvisionedServicesPage)
-                }
-              />
-              <Route path="/provisionedservices" component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/brokermanagement"
-                loader={() =>
-                  import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
-                    (m) => m.BrokerManagementPage,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/catalog/instantiate-template"
-                exact
-                loader={() =>
-                  import(
-                    './instantiate-template' /* webpackChunkName: "instantiate-template" */
-                  ).then((m) => m.InstantiateTemplatePage)
-                }
-              />
-
-              <Route
-                path="/k8s/ns/:ns/alertmanagers/:name"
-                exact
-                render={({ match }) => (
-                  <Redirect
-                    to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
-                      match.params.name
-                    }`}
-                  />
-                )}
-              />
-
-              <LazyRoute
-                path="/k8s/all-namespaces/events"
-                exact
-                loader={() =>
-                  import('./events' /* webpackChunkName: "events" */).then((m) =>
-                    NamespaceFromURL(m.EventStreamPage),
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/events"
-                exact
-                loader={() =>
-                  import('./events' /* webpackChunkName: "events" */).then((m) =>
-                    NamespaceFromURL(m.EventStreamPage),
-                  )
-                }
-              />
-              <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
-              <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
-              <Route path="/search" exact component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/k8s/all-namespaces/import"
-                exact
-                loader={() =>
-                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                    NamespaceFromURL(m.ImportYamlPage),
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/import/"
-                exact
-                loader={() =>
-                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                    NamespaceFromURL(m.ImportYamlPage),
-                  )
-                }
-              />
-
-              {
-                // These pages are temporarily disabled. We need to update the safe resources list.
-                // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-                // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
+            <LazyRoute
+              path="/dashboards"
+              loader={() =>
+                import(
+                  './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
+                ).then((m) => m.DashboardsPage)
               }
+            />
 
-              {
-                // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-                // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            {/* Redirect legacy routes to avoid breaking links */}
+            <Redirect from="/cluster-status" to="/dashboards" />
+            <Redirect from="/status/all-namespaces" to="/dashboards" />
+            <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
+            <Route path="/status" exact component={NamespaceRedirect} />
+            <Redirect from="/overview/all-namespaces" to="/dashboards" />
+            <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
+            <Route path="/overview" exact component={NamespaceRedirect} />
+
+            <LazyRoute
+              path="/api-explorer"
+              exact
+              loader={() =>
+                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+                  (m) => m.APIExplorerPage,
+                )
               }
+            />
+            <LazyRoute
+              path="/api-resource/cluster/:plural"
+              loader={() =>
+                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+                  (m) => m.APIResourcePage,
+                )
+              }
+            />
+            <LazyRoute
+              path="/api-resource/all-namespaces/:plural"
+              loader={() =>
+                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+                  NamespaceFromURL(m.APIResourcePage),
+                )
+              }
+            />
+            <LazyRoute
+              path="/api-resource/ns/:ns/:plural"
+              loader={() =>
+                import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+                  NamespaceFromURL(m.APIResourcePage),
+                )
+              }
+            />
 
-              <LazyRoute
-                path="/k8s/ns/:ns/secrets/~new/:type"
-                exact
-                kind="Secret"
-                loader={() =>
-                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                    (m) => m.CreateSecret,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/secrets/:name/edit"
-                exact
-                kind="Secret"
-                loader={() =>
-                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                    (m) => m.EditSecret,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/secrets/:name/edit-yaml"
-                exact
-                kind="Secret"
-                loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
-              />
+            <LazyRoute
+              path="/command-line-tools"
+              exact
+              loader={() =>
+                import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
+                  (m) => m.CommandLineToolsPage,
+                )
+              }
+            />
 
-              <LazyRoute
-                path="/k8s/ns/:ns/networkpolicies/~new/form"
-                exact
-                kind="NetworkPolicy"
-                loader={() =>
-                  import(
-                    '@console/app/src/components/network-policies/create-network-policy' /* webpackChunkName: "create-network-policy" */
-                  ).then((m) => m.CreateNetworkPolicy)
-                }
-              />
+            <Route path="/operatorhub" exact component={NamespaceRedirect} />
+            <LazyRoute
+              path="/provisionedservices/all-namespaces"
+              loader={() =>
+                import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
+                  (m) => m.ProvisionedServicesPage,
+                )
+              }
+            />
+            <LazyRoute
+              path="/provisionedservices/ns/:ns"
+              loader={() =>
+                import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
+                  (m) => m.ProvisionedServicesPage,
+                )
+              }
+            />
+            <Route path="/provisionedservices" component={NamespaceRedirect} />
 
-              <LazyRoute
-                path="/k8s/ns/:ns/routes/~new/form"
-                exact
-                kind="Route"
-                loader={() =>
-                  import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
-                    (m) => m.CreateRoute,
-                  )
-                }
-              />
+            <LazyRoute
+              path="/brokermanagement"
+              loader={() =>
+                import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
+                  (m) => m.BrokerManagementPage,
+                )
+              }
+            />
 
-              <LazyRoute
-                path="/k8s/cluster/rolebindings/~new"
-                exact
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-                }
-                kind="RoleBinding"
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/rolebindings/~new"
-                exact
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-                }
-                kind="RoleBinding"
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/rolebindings/:name/copy"
-                exact
-                kind="RoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/rolebindings/:name/edit"
-                exact
-                kind="RoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/cluster/clusterrolebindings/:name/copy"
-                exact
-                kind="ClusterRoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/cluster/clusterrolebindings/:name/edit"
-                exact
-                kind="ClusterRoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/:plural/:name/attach-storage"
-                exact
-                loader={() =>
-                  import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
-                    (m) => m.default,
-                  )
-                }
-              />
+            <LazyRoute
+              path="/catalog/instantiate-template"
+              exact
+              loader={() =>
+                import(
+                  './instantiate-template' /* webpackChunkName: "instantiate-template" */
+                ).then((m) => m.InstantiateTemplatePage)
+              }
+            />
 
-              <LazyRoute
-                path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
-                exact
-                kind="PersistentVolumeClaim"
-                loader={() =>
-                  import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
-                    (m) => m.CreatePVC,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
-                exact
-                loader={() =>
-                  import(
-                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
-                  ).then((m) => m.VolumeSnapshot)
-                }
-              />
-
-              <LazyRoute
-                path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
-                exact
-                loader={() =>
-                  import(
-                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
-                  ).then((m) => m.VolumeSnapshot)
-                }
-              />
-
-              <LazyRoute
-                path="/monitoring/alerts"
-                exact
-                loader={() =>
-                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertrules"
-                exact
-                loader={() =>
-                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/silences"
-                exact
-                loader={() =>
-                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanageryaml"
-                exact
-                loader={() =>
-                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanagerconfig"
-                exact
-                loader={() =>
-                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanagerconfig/receivers/~new"
-                exact
-                loader={() =>
-                  import(
-                    './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
-                  ).then((m) => m.CreateReceiver)
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanagerconfig/receivers/:name/edit"
-                exact
-                loader={() =>
-                  import(
-                    './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
-                  ).then((m) => m.EditReceiver)
-                }
-              />
-              <LazyRoute
-                path="/monitoring"
-                loader={() =>
-                  import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/settings/idp/github"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
-                  ).then((m) => m.AddGitHubPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/gitlab"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
-                  ).then((m) => m.AddGitLabPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/google"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
-                  ).then((m) => m.AddGooglePage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/htpasswd"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
-                  ).then((m) => m.AddHTPasswdPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/keystone"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
-                  ).then((m) => m.AddKeystonePage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/ldap"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */
-                  ).then((m) => m.AddLDAPPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/oidconnect"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
-                  ).then((m) => m.AddOpenIDIDPPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/basicauth"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
-                  ).then((m) => m.AddBasicAuthPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/requestheader"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
-                  ).then((m) => m.AddRequestHeaderPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/cluster"
-                loader={() =>
-                  import(
-                    './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
-                  ).then((m) => m.ClusterSettingsPage)
-                }
-              />
-
-              <LazyRoute
-                path={'/k8s/cluster/storageclasses/~new/form'}
-                exact
-                loader={() =>
-                  import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
-                    (m) => m.StorageClassForm,
-                  )
-                }
-              />
-
-              <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
-              <Route path="/k8s/cluster/:plural/~new" exact component={CreateResource} />
-              <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
-              <LazyRoute
-                path="/k8s/ns/:ns/pods/:podName/containers/:name"
-                loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
-              />
-              <Route path="/k8s/ns/:ns/:plural/~new" exact component={CreateResource} />
-              <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
-              <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
-
-              <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
-              <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
-
-              {inactivePluginPageRoutes}
-
-              <LazyRoute
-                path="/error"
-                exact
-                loader={() =>
-                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)
-                }
-              />
-              <Route path="/" exact component={DefaultPage} />
-
-              {allPluginsProcessed ? (
-                <LazyRoute
-                  loader={() =>
-                    import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
-                  }
+            <Route
+              path="/k8s/ns/:ns/alertmanagers/:name"
+              exact
+              render={({ match }) => (
+                <Redirect
+                  to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
+                    match.params.name
+                  }`}
                 />
-              ) : (
-                <Route component={LoadingBox} />
               )}
-            </Switch>
-          </React.Suspense>
-        </div>
-      </div>
-    </PageSection>
+            />
+
+            <LazyRoute
+              path="/k8s/all-namespaces/events"
+              exact
+              loader={() =>
+                import('./events' /* webpackChunkName: "events" */).then((m) =>
+                  NamespaceFromURL(m.EventStreamPage),
+                )
+              }
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/events"
+              exact
+              loader={() =>
+                import('./events' /* webpackChunkName: "events" */).then((m) =>
+                  NamespaceFromURL(m.EventStreamPage),
+                )
+              }
+            />
+            <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
+            <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
+            <Route path="/search" exact component={NamespaceRedirect} />
+
+            <LazyRoute
+              path="/k8s/all-namespaces/import"
+              exact
+              loader={() =>
+                import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                  NamespaceFromURL(m.ImportYamlPage),
+                )
+              }
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/import/"
+              exact
+              loader={() =>
+                import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                  NamespaceFromURL(m.ImportYamlPage),
+                )
+              }
+            />
+
+            {
+              // These pages are temporarily disabled. We need to update the safe resources list.
+              // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+              // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            }
+
+            {
+              // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+              // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            }
+
+            <LazyRoute
+              path="/k8s/ns/:ns/secrets/~new/:type"
+              exact
+              kind="Secret"
+              loader={() =>
+                import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                  (m) => m.CreateSecret,
+                )
+              }
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/secrets/:name/edit"
+              exact
+              kind="Secret"
+              loader={() =>
+                import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                  (m) => m.EditSecret,
+                )
+              }
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/secrets/:name/edit-yaml"
+              exact
+              kind="Secret"
+              loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
+            />
+
+            <LazyRoute
+              path="/k8s/ns/:ns/networkpolicies/~new/form"
+              exact
+              kind="NetworkPolicy"
+              loader={() =>
+                import(
+                  '@console/app/src/components/network-policies/create-network-policy' /* webpackChunkName: "create-network-policy" */
+                ).then((m) => m.CreateNetworkPolicy)
+              }
+            />
+
+            <LazyRoute
+              path="/k8s/ns/:ns/routes/~new/form"
+              exact
+              kind="Route"
+              loader={() =>
+                import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
+                  (m) => m.CreateRoute,
+                )
+              }
+            />
+
+            <LazyRoute
+              path="/k8s/cluster/rolebindings/~new"
+              exact
+              loader={() =>
+                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+              }
+              kind="RoleBinding"
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/rolebindings/~new"
+              exact
+              loader={() =>
+                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+              }
+              kind="RoleBinding"
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/rolebindings/:name/copy"
+              exact
+              kind="RoleBinding"
+              loader={() =>
+                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+              }
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/rolebindings/:name/edit"
+              exact
+              kind="RoleBinding"
+              loader={() =>
+                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+              }
+            />
+            <LazyRoute
+              path="/k8s/cluster/clusterrolebindings/:name/copy"
+              exact
+              kind="ClusterRoleBinding"
+              loader={() =>
+                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+              }
+            />
+            <LazyRoute
+              path="/k8s/cluster/clusterrolebindings/:name/edit"
+              exact
+              kind="ClusterRoleBinding"
+              loader={() =>
+                import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+              }
+            />
+            <LazyRoute
+              path="/k8s/ns/:ns/:plural/:name/attach-storage"
+              exact
+              loader={() =>
+                import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
+                  (m) => m.default,
+                )
+              }
+            />
+
+            <LazyRoute
+              path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
+              exact
+              kind="PersistentVolumeClaim"
+              loader={() =>
+                import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
+                  (m) => m.CreatePVC,
+                )
+              }
+            />
+
+            <LazyRoute
+              path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
+              exact
+              loader={() =>
+                import(
+                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                ).then((m) => m.VolumeSnapshot)
+              }
+            />
+
+            <LazyRoute
+              path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
+              exact
+              loader={() =>
+                import(
+                  '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                ).then((m) => m.VolumeSnapshot)
+              }
+            />
+
+            <LazyRoute
+              path="/monitoring/alerts"
+              exact
+              loader={() =>
+                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                  (m) => m.MonitoringUI,
+                )
+              }
+            />
+            <LazyRoute
+              path="/monitoring/alertrules"
+              exact
+              loader={() =>
+                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                  (m) => m.MonitoringUI,
+                )
+              }
+            />
+            <LazyRoute
+              path="/monitoring/silences"
+              exact
+              loader={() =>
+                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                  (m) => m.MonitoringUI,
+                )
+              }
+            />
+            <LazyRoute
+              path="/monitoring/alertmanageryaml"
+              exact
+              loader={() =>
+                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                  (m) => m.MonitoringUI,
+                )
+              }
+            />
+            <LazyRoute
+              path="/monitoring/alertmanagerconfig"
+              exact
+              loader={() =>
+                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                  (m) => m.MonitoringUI,
+                )
+              }
+            />
+            <LazyRoute
+              path="/monitoring/alertmanagerconfig/receivers/~new"
+              exact
+              loader={() =>
+                import(
+                  './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
+                ).then((m) => m.CreateReceiver)
+              }
+            />
+            <LazyRoute
+              path="/monitoring/alertmanagerconfig/receivers/:name/edit"
+              exact
+              loader={() =>
+                import(
+                  './monitoring/receiver-forms/alert-manager-receiver-forms' /* webpackChunkName: "receiver-forms" */
+                ).then((m) => m.EditReceiver)
+              }
+            />
+            <LazyRoute
+              path="/monitoring"
+              loader={() =>
+                import('./monitoring/alerting' /* webpackChunkName: "alerting" */).then(
+                  (m) => m.MonitoringUI,
+                )
+              }
+            />
+
+            <LazyRoute
+              path="/settings/idp/github"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
+                ).then((m) => m.AddGitHubPage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/gitlab"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
+                ).then((m) => m.AddGitLabPage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/google"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
+                ).then((m) => m.AddGooglePage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/htpasswd"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
+                ).then((m) => m.AddHTPasswdPage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/keystone"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
+                ).then((m) => m.AddKeystonePage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/ldap"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */
+                ).then((m) => m.AddLDAPPage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/oidconnect"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
+                ).then((m) => m.AddOpenIDIDPPage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/basicauth"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
+                ).then((m) => m.AddBasicAuthPage)
+              }
+            />
+            <LazyRoute
+              path="/settings/idp/requestheader"
+              exact
+              loader={() =>
+                import(
+                  './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
+                ).then((m) => m.AddRequestHeaderPage)
+              }
+            />
+            <LazyRoute
+              path="/settings/cluster"
+              loader={() =>
+                import(
+                  './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
+                ).then((m) => m.ClusterSettingsPage)
+              }
+            />
+
+            <LazyRoute
+              path={'/k8s/cluster/storageclasses/~new/form'}
+              exact
+              loader={() =>
+                import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
+                  (m) => m.StorageClassForm,
+                )
+              }
+            />
+
+            <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
+            <Route path="/k8s/cluster/:plural/~new" exact component={CreateResource} />
+            <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
+            <LazyRoute
+              path="/k8s/ns/:ns/pods/:podName/containers/:name"
+              loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
+            />
+            <Route path="/k8s/ns/:ns/:plural/~new" exact component={CreateResource} />
+            <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
+            <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
+
+            <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
+            <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
+
+            {inactivePluginPageRoutes}
+
+            <LazyRoute
+              path="/error"
+              exact
+              loader={() =>
+                import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)
+              }
+            />
+            <Route path="/" exact component={DefaultPage} />
+
+            {allPluginsProcessed ? (
+              <LazyRoute
+                loader={() =>
+                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
+                }
+              />
+            ) : (
+              <Route component={LoadingBox} />
+            )}
+          </Switch>
+        </React.Suspense>
+      </PageSection>
+    </div>
   );
 };
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -50,7 +50,7 @@ import '@patternfly/quickstarts/dist/quickstarts.min.css';
 // PF4 Imports
 import { Page, SkipToContent, AlertVariant } from '@patternfly/react-core';
 
-const breakpointMD = 768;
+const breakpointMD = 1200;
 const NOTIFICATION_DRAWER_BREAKPOINT = 1800;
 // Edge lacks URLSearchParams
 import 'url-search-params-polyfill';
@@ -165,9 +165,9 @@ class App_ extends React.PureComponent {
     const content = (
       <>
         <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
+        <ConsoleNotifier location="BannerTop" />
         <QuickStartDrawer>
           <div id="app-content" className="co-m-app__content">
-            <ConsoleNotifier location="BannerTop" />
             <Page
               // Need to pass mainTabIndex=null to enable keyboard scrolling as default tabIndex is set to -1 by patternfly
               mainTabIndex={null}
@@ -196,10 +196,10 @@ class App_ extends React.PureComponent {
             </Page>
             <CloudShell />
             <GuidedTour />
-            <ConsoleNotifier location="BannerBottom" />
           </div>
           <div id="modal-container" role="dialog" aria-modal="true" />
         </QuickStartDrawer>
+        <ConsoleNotifier location="BannerBottom" />
       </>
     );
 

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -1,29 +1,15 @@
 html,
 body,
 #app,
-#content,
-#content-scrollable,
-.pf-c-page__main-section,
 .pf-c-drawer {
-  height: 100%; // so .co-p-has-sidebar, .yaml-editor are full height
+  height: 100%;
 }
 
 #app,
 #content {
   display: flex;
+  flex-basis: 100%;
   flex-direction: column;
-}
-
-#content-scrollable {
-  display: flex;
-  flex-direction: column;
-  overflow-x: auto; // so catalog is scrollable at mobile
-  overflow-y: auto;
-  position: relative;
-  -webkit-overflow-scrolling: touch;
-  &:focus {
-    outline: 0;
-  }
 }
 
 .co-m-page__body {

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -129,15 +129,6 @@ form.pf-c-form {
 }
 
 .pf-c-page {
-  display: block !important;
-  position: relative;
-
-  &__header {
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-  }
 
   &__header-brand-link {
     flex: 0 1 auto !important; // so link doesn't grow larger than logo
@@ -156,15 +147,15 @@ form.pf-c-form {
     }
   }
 
-  &__main {
-    // `z-index: auto` is required for fullscreen terminal
-    --pf-c-page__main--ZIndex: auto;
-    bottom: 0;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: var(--pf-c-page__header--MinHeight);
-    transition: left 100ms ease;
+  // Positions fullscreen terminal on top of mast header
+  &__main.default-overflow {
+    z-index: calc(var(--pf-c-page__header--ZIndex) + 50);
+  }
+
+  // Apply to primary content section to prevent yaml editor and topology sections from collapsing
+  .pf-page__main-section--flex {
+    display: flex;
+    flex-direction: column;
   }
 
   // `.pf-c-page` specificity required
@@ -173,24 +164,6 @@ form.pf-c-form {
     --pf-c-toolbar__content--PaddingLeft: 0;
     --pf-c-toolbar__content--PaddingRight: 0;
     --pf-c-toolbar--RowGap: var(--pf-global--spacer--md);
-  }
-
-  .pf-c-page__main-section {
-    overflow: hidden; // needed for Firefox to enable proper scrolling of content-scrollable
-    --pf-c-page__main-section--PaddingBottom: 0;
-    --pf-c-page__main-section--PaddingLeft: 0;
-    --pf-c-page__main-section--PaddingRight: 0;
-    --pf-c-page__main-section--PaddingTop: 0;
-  }
-
-  .pf-c-page__sidebar {
-    --pf-c-page__sidebar--Transition: all 100ms ease;
-  }
-}
-
-@media screen and (min-width: $grid-float-breakpoint) {
-  .pf-m-expanded + .pf-c-page__main {
-    left: var(--pf-c-page__sidebar--Width);
   }
 }
 
@@ -238,21 +211,8 @@ form.pf-c-form {
 }
 
 .pf-c-page__sidebar {
-  --pf-c-page__sidebar-body--PaddingTop: 0;
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  top: var(--pf-c-page__header--MinHeight);
-  width: 0 !important; // only set size when expanded (.pf-m-expanded is added)
-
   @media screen and (min-width: $grid-float-breakpoint) {
     --pf-c-page__sidebar--BoxShadow: none;
-  }
-
-  &.pf-m-expanded {
-    width: var(
-      --pf-c-page__sidebar--Width
-    ) !important; // maintain desktop width so size doesn't animate before hiding when resizing to mobile
   }
 
   // Perspective switcher


### PR DESCRIPTION
Removes the need for dynamic plugin css page level overrides. 
Sidebar nav `pf-c-page__sidebar` breakpoint now uses the PF default 1200px which is tied into the default `pf-c-page` grid template area `@media` breakpoint.
A couple `z-index` changes so that notification drawer, fullscreen terminal, and Help menu position correctly

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1995545 (Project drop-down hidden behind PF wizard)

_Related_
Dynamic Plugin demo page https://github.com/openshift/console/pull/9679 
PF page component https://www.patternfly.org/v4/components/page
PF page with drawer demo that most closely matches our console markup. https://www.patternfly.org/v4/components/drawer/html-demos#expanded because of how we pull in the `ConnectedNotificationDrawer`