### PR TITLE
Bug 2000590: Warning on topology context menu right click

### DIFF
--- a/frontend/packages/topology/src/components/graph-view/components/nodeContextMenu.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodeContextMenu.tsx
@@ -46,7 +46,12 @@ export const createMenuItems = (actions: KebabMenuOption[]) =>
     ) : (
       <ContextMenuItem
         key={index} // eslint-disable-line react/no-array-index-key
-        component={<KebabItem option={option} onClick={() => onKebabOptionClick(option)} />}
+        /* wrap in Fragment as KebabItem is a Function Component: gives warning on adding ref prop */
+        component={
+          <>
+            <KebabItem option={option} onClick={() => onKebabOptionClick(option)} />{' '}
+          </>
+        }
       />
     ),
   );


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6105

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
- ref was getting added to `KebabItem` function component

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
- wrapped the function component with a React Fragment `<> </>`

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
No warning is seen anymore
![image](https://user-images.githubusercontent.com/20089340/131847412-de266f5e-dc82-479f-90d6-5cde2280198d.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Open topology.
Right click on any workload.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

