### PR TITLE
Bug 1997245: Dont validate the install operator form when submitted

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -68,6 +68,7 @@ import { installedFor, supports, providedAPIsForOperatorGroup, isGlobal } from '
 import { OperatorInstallStatusPage } from '../operator-install-page';
 
 export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> = (props) => {
+  const [inProgress, setInProgress] = React.useState(false);
   const [targetNamespace, setTargetNamespace] = React.useState(null);
   const [installMode, setInstallMode] = React.useState(null);
   const [showInstallStatusPage, setShowInstallStatusPage] = React.useState(false);
@@ -274,6 +275,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   const submit = async () => {
     // Clear any previous errors.
     setError('');
+    setInProgress(true);
 
     const ns: K8sResourceCommon = {
       metadata: {
@@ -388,13 +390,16 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
           },
         ]);
       }
+      setInProgress(false);
       setShowInstallStatusPage(true);
     } catch (err) {
       setError(err.message || t('olm~Could not create Operator Subscription.'));
+      setInProgress(false);
     }
   };
 
   const formValid = () =>
+    inProgress ||
     [selectedUpdateChannel, selectedInstallMode, selectedTargetNamespace, selectedApproval].some(
       (v) => _.isNil(v) || _.isEmpty(v),
     ) ||
@@ -404,6 +409,9 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     !_.isEmpty(conflictingProvidedAPIs(selectedTargetNamespace));
 
   const formError = () => {
+    if (inProgress) {
+      return null;
+    }
     return (
       (error && (
         <Alert


### PR DESCRIPTION
This is an race issue, cause the form is still being evaluated while its being submitted, and the necessary resources are being created, in this case Subscription object.

Adding `inProgress` state that should prevent form validation.

/assign @TheRealJon 