### PR TITLE
Bug 1998616: Add clusterwide hostname to Service details page

### DIFF
--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -206,6 +206,13 @@ const Details = ({ obj: s }) => {
         <div className="col-md-6">
           <SectionHeading text={t('public~Service routing')} />
           <dl>
+            <dt>{t('public~Hostname')}</dt>
+            <dd>
+              <div className="co-select-to-copy">
+                {s.metadata.name}.{s.metadata.namespace}.srv.cluster.local
+              </div>
+              <div>{t('public~Accessible within the cluster only')}</div>
+            </dd>
             <dt>{t('public~Service address')}</dt>
             <dd className="service-ips">
               <ServiceAddress s={s} />


### PR DESCRIPTION
Screenshot:
<img width="1636" alt="Screenshot 2021-09-02 at 17 02 33" src="https://user-images.githubusercontent.com/1668218/131869944-1a85e2ce-e9f9-4222-a7eb-87c97c2adf26.png">


/assign @spadgett 