### PR TITLE
Bug 2000873: override list style for toast

### DIFF
--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.scss
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.scss
@@ -1,0 +1,5 @@
+.ocs-toast-provider {
+  &.pf-m-toast {
+    list-style: none;
+  }
+}

--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Alert, AlertGroup, AlertActionCloseButton, AlertActionLink } from '@patternfly/react-core';
 import ToastContext, { ToastOptions, ToastContextType } from './ToastContext';
 
+import './ToastProvider.scss';
+
 const ToastProvider: React.FC = ({ children }) => {
   const [toasts, setToasts] = React.useState<ToastOptions[]>([]);
 
@@ -49,7 +51,7 @@ const ToastProvider: React.FC = ({ children }) => {
     <ToastContext.Provider value={controller}>
       {children}
       {toasts.length ? (
-        <AlertGroup appendTo={() => document.body} isToast>
+        <AlertGroup appendTo={() => document.body} isToast className="ocs-toast-provider">
           {toasts.map((toast) => (
             <Alert
               key={toast.id}


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2000873

**Analysis / Root cause**: 
list-style disc was shown for toasts

**Solution Description**: 
override list style to none for toast

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
- Before
![image](https://user-images.githubusercontent.com/5129024/131981609-470fffcb-18ec-43f5-b693-cd52e52a815e.png)

- After

![image](https://user-images.githubusercontent.com/5129024/131982022-03dad4d8-4d35-4a6b-bba2-4d269d589645.png)

![image](https://user-images.githubusercontent.com/5129024/131982120-edcaf1a4-c8ab-48b5-84eb-508654bc08e0.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
