### PR TITLE
Ensuring Administrator Perspective for noisy/shared setup

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/namespace-crud.spec.ts
@@ -8,6 +8,8 @@ import { nav } from '../../views/nav';
 describe('Namespace', () => {
   before(() => {
     cy.login();
+    nav.sidenav.switcher.changePerspectiveTo('Administrator');
+    nav.sidenav.switcher.shouldHaveText('Administrator');
     cy.createProject(testName);
   });
 


### PR DESCRIPTION
Ability for running Cypress tests against a remote reference (possibly shared) cluster is valuable, and this change makes sure  one of the assumptions is met in such a scenario outside CI/fresh setup, which other tests already do.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>