### PR TITLE
Bug 2001760: BreadCrumbs and OCS/ODF naming fixes

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/bucket-class/create-bc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/bucket-class/create-bc.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import * as _ from 'lodash';
 import { RouteComponentProps } from 'react-router';
 import { Title, Wizard } from '@patternfly/react-core';
 import {
@@ -13,6 +12,7 @@ import { history } from '@console/internal/components/utils/router';
 import { BreadCrumbs, resourcePathFromModel } from '@console/internal/components/utils';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { getName } from '@console/shared';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import GeneralPage from './wizard-pages/general-page';
 import PlacementPolicyPage from './wizard-pages/placement-policy-page';
 import BackingStorePage from './wizard-pages/backingstore-page';
@@ -27,6 +27,7 @@ import { BucketClassType, NamespacePolicyType } from '../../constants/bucket-cla
 import { validateBucketClassName, validateDuration } from '../../utils/bucket-class';
 import { NooBaaBucketClassModel } from '../../models';
 import { PlacementPolicy } from '../../types';
+import { ODF_MODEL_FLAG } from '../../constants';
 
 enum CreateStepsBC {
   GENERAL = 'GENERAL',
@@ -40,6 +41,7 @@ const CreateBucketClass: React.FC<CreateBCProps> = ({ match }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const { ns, appName } = match.params;
   const [clusterServiceVersion, setClusterServiceVersion] = React.useState(null);
+  const isODF = useFlag(ODF_MODEL_FLAG);
 
   React.useEffect(() => {
     k8sGet(ClusterServiceVersionModel, appName, ns)
@@ -252,12 +254,8 @@ const CreateBucketClass: React.FC<CreateBCProps> = ({ match }) => {
         <BreadCrumbs
           breadcrumbs={[
             {
-              name: _.get(
-                clusterServiceVersion,
-                'spec.displayName',
-                'Openshift Data Foundation Operator',
-              ),
-              path: resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
+              name: isODF ? 'OpenShift Data Foundation' : 'OpenShift Container Storage',
+              path: isODF ? '/odf' : resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
             },
             {
               name: t('ceph-storage-plugin~Create BucketClass'),

--- a/frontend/packages/ceph-storage-plugin/src/components/create-backingstore-page/create-bs-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-backingstore-page/create-bs-page.tsx
@@ -5,13 +5,16 @@ import { Alert, AlertActionCloseButton, Title } from '@patternfly/react-core';
 import { history } from '@console/internal/components/utils/router';
 import { BreadCrumbs, resourcePathFromModel } from '@console/internal/components/utils';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import CreateBackingStoreForm from './create-bs';
 import '../noobaa-provider-endpoints/noobaa-provider-endpoints.scss';
+import { ODF_MODEL_FLAG } from '../../constants';
 
 const CreateBackingStoreFormPage: React.FC<CreateBackingStoreFormPageProps> = ({ match }) => {
   const { t } = useTranslation();
   const [showHelp, setShowHelp] = React.useState(true);
   const { ns, appName } = match.params;
+  const isODF = useFlag(ODF_MODEL_FLAG);
 
   const onCancel = () => {
     history.goBack();
@@ -23,8 +26,8 @@ const CreateBackingStoreFormPage: React.FC<CreateBackingStoreFormPageProps> = ({
         <BreadCrumbs
           breadcrumbs={[
             {
-              name: 'Openshift Container Storage',
-              path: resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
+              name: isODF ? 'OpenShift Data Foundation' : 'OpenShift Container Storage',
+              path: isODF ? '/odf' : resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
             },
             { name: t('ceph-storage-plugin~Create BackingStore '), path: match.url },
           ]}

--- a/frontend/packages/ceph-storage-plugin/src/components/namespace-store/create-namespace-store.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/namespace-store/create-namespace-store.tsx
@@ -7,14 +7,17 @@ import { BreadCrumbs, resourcePathFromModel } from '@console/internal/components
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { getName } from '@console/shared';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import NamespaceStoreForm from './namespace-store-form';
 import '../noobaa-provider-endpoints/noobaa-provider-endpoints.scss';
 import { NooBaaNamespaceStoreModel } from '../../models';
+import { ODF_MODEL_FLAG } from '../../constants';
 
 const CreateNamespaceStore: React.FC<CreateNamespaceStoreProps> = ({ match }) => {
   const { t } = useTranslation();
   const { ns, appName } = match.params;
   const onCancel = () => history.goBack();
+  const isODF = useFlag(ODF_MODEL_FLAG);
 
   return (
     <>
@@ -22,8 +25,8 @@ const CreateNamespaceStore: React.FC<CreateNamespaceStoreProps> = ({ match }) =>
         <BreadCrumbs
           breadcrumbs={[
             {
-              name: 'Openshift Data Foundation',
-              path: resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
+              name: isODF ? 'OpenShift Data Foundation' : 'OpenShift Container Storage',
+              path: isODF ? '/odf' : resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
             },
             { name: t('ceph-storage-plugin~Create NamespaceStore '), path: match.url },
           ]}


### PR DESCRIPTION
Fix breadcrumbs that showed OCS instead of ODF during BackingStore
creation and change OpenShift Data Foundation Operator under Bucket
Class Creation Page to OpenShift Data Foundation.

### Before
![2021-09-09-163404_2560x1440_scrot](https://user-images.githubusercontent.com/33557095/132674637-0dba803c-408a-4c60-ba65-b7c1ad942156.png)

### After
![2021-09-09-163219_2560x1440_scrot](https://user-images.githubusercontent.com/33557095/132674649-25813606-b78e-41dc-ab19-60e7656f787d.png)
