### PR TITLE
Bug 2001804: Reload feature on Environment section in Build Config form does not work properly

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/EnvironmentField.tsx
@@ -22,10 +22,12 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
       metadata: { namespace },
     },
   } = props;
-  const { setFieldValue } = useFormikContext<FormikValues>();
+  const { setFieldValue, values } = useFormikContext<FormikValues>();
   const { t } = useTranslation();
   const fieldId = getFieldId(props.name, 'env-input');
-  const environmentVariables = !_.isEmpty(envs) ? envs.map((env) => _.values(env)) : [['', '']];
+  const environmentVariables = React.useMemo(() => {
+    return !_.isEmpty(envs) ? envs.map((env) => _.values(env)) : [['', '']];
+  }, [envs]);
   const [nameValue, setNameValue] = React.useState(environmentVariables);
   const [configMaps, setConfigMaps] = React.useState({});
   const [secrets, setSecrets] = React.useState({});
@@ -47,6 +49,15 @@ const EnvironmentField: React.FC<EnvironmentFieldProps> = ({
     },
     [props.name, setFieldValue],
   );
+
+  React.useEffect(() => {
+    if (values.formReloadCount) {
+      setNameValue(environmentVariables);
+    }
+    // this effect only handles reload, so we disable dep on environmentVariables
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values.formReloadCount]);
+
   React.useEffect(() => {
     Promise.all([k8sGet(ConfigMapModel, null, namespace), k8sGet(SecretModel, null, namespace)])
       .then(([nsConfigMaps, nsSecrets]) => {

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -40,7 +40,7 @@ const getKeys = (keyMap) => {
 
 export const NameKeyDropdownPair = ({
   name,
-  key,
+  pairKey,
   configMaps,
   secrets,
   serviceAccounts,
@@ -74,7 +74,7 @@ export const NameKeyDropdownPair = ({
   const saItems = {};
   const nameAutocompleteFilter = (text, item) => fuzzy(text, item.props.name);
   const keyAutocompleteFilter = (text, item) => fuzzy(text, item);
-  const keyTitle = _.isEmpty(key) ? t('public~Select a key') : key;
+  const keyTitle = _.isEmpty(pairKey) ? t('public~Select a key') : pairKey;
   const cmRefProperty = isKeyRef ? 'configMapKeyRef' : 'configMapRef';
   const secretRefProperty = isKeyRef ? 'secretKeyRef' : 'secretRef';
   const serviceAccountRefProperty = isKeyRef ? 'serviceAccountKeyRef' : 'serviceAccountRef';
@@ -130,7 +130,7 @@ export const NameKeyDropdownPair = ({
           const keyValuePair = _.split(val, ':');
           onChange({
             [keyValuePair[1]]: isKeyRef
-              ? { name: keyValuePair[0], key: '' }
+              ? { name: keyValuePair[0], pairKey: '' }
               : { name: keyValuePair[0] },
           });
         }}
@@ -142,7 +142,7 @@ export const NameKeyDropdownPair = ({
           autocompleteFilter={keyAutocompleteFilter}
           autocompletePlaceholder={t('public~Key')}
           items={itemKeys}
-          selectedKey={key}
+          selectedKey={pairKey}
           title={keyTitle}
           onChange={(val) => onChange({ [refProperty]: { name, key: val } })}
         />
@@ -193,7 +193,7 @@ const ConfigMapSecretKeyRef = ({
   }
   return (
     <NameKeyDropdownPair
-      key={key}
+      pairKey={key}
       name={name}
       configMaps={configMaps}
       secrets={secrets}
@@ -240,7 +240,7 @@ const ConfigMapSecretRef = ({
   }
   return (
     <NameKeyDropdownPair
-      key={key}
+      pairKey={key}
       name={name}
       configMaps={configMaps}
       secrets={secrets}


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6300

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
https://issues.redhat.com/browse/ODC-6300?focusedCommentId=18891580&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-18891580

As mentioned here -> the local state is not getting updated with the env values coming from reload ( from formData )

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
added hook to set local state when the envs prop changes

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![reloadResetEnvironment](https://user-images.githubusercontent.com/20089340/132314530-576dac65-83e3-4803-8514-e7398b7ba96e.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Steps to Reproduce

1. Create a devfile
2. Go to build tab -> Edit BuilldConfig form
3. Add a config map "devfile-sample-1-ca" in the environment section and save it
4. Switch to YAML view and change the config map to "devfile-sample-1-global-ca"
5. Return to Form view and click on Reload button

- Expected results:
  - Config map should be restored to "devfile-sample-1-ca"
 
**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge