### PR TITLE
Fix flexible scaling tests

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/__tests__/flexible-scaling.spec.ts
+++ b/frontend/packages/ceph-storage-plugin/src/__tests__/flexible-scaling.spec.ts
@@ -2,62 +2,74 @@ import { isFlexibleScaling } from '../utils/install';
 
 describe('isFlexibleScaling', () => {
   describe('for 0 AZ', () => {
+    it('return falsy when a no-provisioner storage class is passed', () => {
+      expect(isFlexibleScaling(3, 0, false)).toBe(false);
+    });
     it('return truthy with 3 nodes', () => {
-      expect(isFlexibleScaling(3, 0)).toBe(true);
+      expect(isFlexibleScaling(3, 0, true)).toBe(true);
     });
     it('return truthy with more than 3 nodes', () => {
-      expect(isFlexibleScaling(4, 0)).toBe(true);
+      expect(isFlexibleScaling(4, 0, true)).toBe(true);
     });
     it('return falsy with less than 3 nodes', () => {
-      expect(isFlexibleScaling(2, 0)).toBe(false);
+      expect(isFlexibleScaling(2, 0, true)).toBe(false);
     });
     it('return falsy with 0 nodes', () => {
-      expect(isFlexibleScaling(0, 0)).toBe(false);
+      expect(isFlexibleScaling(0, 0, true)).toBe(false);
     });
   });
 
   describe('for 1 AZ', () => {
+    it('return falsy when a no-provisioner storage class is passed', () => {
+      expect(isFlexibleScaling(3, 1, false)).toBe(false);
+    });
     it('return truthy with 3 nodes', () => {
-      expect(isFlexibleScaling(3, 1)).toBe(true);
+      expect(isFlexibleScaling(3, 1, true)).toBe(true);
     });
     it('return truthy with more than 3 nodes', () => {
-      expect(isFlexibleScaling(4, 1)).toBe(true);
+      expect(isFlexibleScaling(4, 1, true)).toBe(true);
     });
     it('return falsy with less than 3 nodes', () => {
-      expect(isFlexibleScaling(2, 1)).toBe(false);
+      expect(isFlexibleScaling(2, 1, true)).toBe(false);
     });
     it('return falsy with 0 nodes', () => {
-      expect(isFlexibleScaling(0, 1)).toBe(false);
+      expect(isFlexibleScaling(0, 1, true)).toBe(false);
     });
   });
 
   describe('for 2 AZ', () => {
+    it('return falsy when a no-provisioner storage class is passed', () => {
+      expect(isFlexibleScaling(3, 2, false)).toBe(false);
+    });
     it('return truthy with 3 nodes', () => {
-      expect(isFlexibleScaling(3, 2)).toBe(true);
+      expect(isFlexibleScaling(3, 2, true)).toBe(true);
     });
     it('return truthy with more than 3 nodes', () => {
-      expect(isFlexibleScaling(4, 2)).toBe(true);
+      expect(isFlexibleScaling(4, 2, true)).toBe(true);
     });
     it('return falsy with less than 3 nodes', () => {
-      expect(isFlexibleScaling(2, 2)).toBe(false);
+      expect(isFlexibleScaling(2, 2, true)).toBe(false);
     });
     it('return falsy with 0 nodes', () => {
-      expect(isFlexibleScaling(0, 2)).toBe(false);
+      expect(isFlexibleScaling(0, 2, true)).toBe(false);
     });
   });
 
   describe('for 3 AZ', () => {
+    it('return falsy when a no-provisioner storage class is passed', () => {
+      expect(isFlexibleScaling(3, 3, false)).toBe(false);
+    });
     it('returns falsy with 3 nodes', () => {
-      expect(isFlexibleScaling(3, 3)).toBe(false);
+      expect(isFlexibleScaling(3, 3, true)).toBe(false);
     });
     it('return falsy with more than 3 nodes', () => {
-      expect(isFlexibleScaling(4, 3)).toBe(false);
+      expect(isFlexibleScaling(4, 3, true)).toBe(false);
     });
     it('return falsy with less than 3 nodes', () => {
-      expect(isFlexibleScaling(2, 3)).toBe(false);
+      expect(isFlexibleScaling(2, 3, true)).toBe(false);
     });
     it('return falsy with 0 nodes', () => {
-      expect(isFlexibleScaling(0, 3)).toBe(false);
+      expect(isFlexibleScaling(0, 3, true)).toBe(false);
     });
   });
 });

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard-steps/storage-and-nodes-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/install-wizard-steps/storage-and-nodes-step.tsx
@@ -23,6 +23,7 @@ import {
   attachDevicesWithArbiter,
   attachDevices,
   OCS_DEVICE_SET_ARBITER_REPLICA,
+  NO_PROVISIONER,
 } from '../../../../constants';
 import {
   getNodeInfo,
@@ -119,10 +120,19 @@ export const StorageAndNodes: React.FC<StorageAndNodesProps> = ({ state, dispatc
     if (isFlexibleScalingSupported) {
       dispatch({
         type: 'setEnableFlexibleScaling',
-        value: !stretchClusterChecked && isFlexibleScaling(nodesCount, zonesCount),
+        value:
+          !stretchClusterChecked &&
+          isFlexibleScaling(nodesCount, zonesCount, storageClass?.provisioner === NO_PROVISIONER),
       });
     }
-  }, [dispatch, zonesCount, nodesCount, stretchClusterChecked, isFlexibleScalingSupported]);
+  }, [
+    dispatch,
+    zonesCount,
+    nodesCount,
+    stretchClusterChecked,
+    isFlexibleScalingSupported,
+    storageClass,
+  ]);
 
   const handleStorageClass = (sc: StorageClassResourceKind) => {
     dispatch({ type: 'setStorageClass', value: sc });

--- a/frontend/packages/ceph-storage-plugin/src/utils/create-storage-system.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/create-storage-system.ts
@@ -77,7 +77,7 @@ export const capacityAndNodesValidate = (
   const totalMemory = getTotalMemory(nodes);
   const zones = getAllZone(nodes);
 
-  if (!enableStretchCluster && isNoProvSC && isFlexibleScaling(nodes.length, zones.size)) {
+  if (!enableStretchCluster && isFlexibleScaling(nodes.length, zones.size, isNoProvSC)) {
     validations.push(ValidationType.ATTACHED_DEVICES_FLEXIBLE_SCALING);
   }
   if (shouldDeployAsMinimal(totalCpu, totalMemory, nodes.length)) {

--- a/frontend/packages/ceph-storage-plugin/src/utils/install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/install.ts
@@ -127,8 +127,8 @@ export const shouldDeployAsMinimal = (cpu: number, memory: number, nodesCount: n
   return false;
 };
 
-export const isFlexibleScaling = (nodes: number, zones: number): boolean =>
-  !!(nodes >= MINIMUM_NODES && zones < 3);
+export const isFlexibleScaling = (nodes: number, zones: number, isNoProvSc: boolean): boolean =>
+  isNoProvSc && !!(nodes >= MINIMUM_NODES && zones < 3);
 
 export const countNodesPerZone = (nodes: NodeKind[]) =>
   nodes.reduce((acc, curr) => {


### PR DESCRIPTION
Merge after #10005 
 - introduce a test case for flexible scaling to be always enabled for a no-provisioner storage class
 - this BZ https://bugzilla.redhat.com/show_bug.cgi?id=2000573 introduced a regression due to the missing test case
 - the flexible scaling feature is only supported now for attached devices mode