### PR TITLE
Bug 2001959: Allow side nav borders to extend to left and right edges of yaml sidebar

### DIFF
--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -5,7 +5,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
   display: flex;
   flex-shrink: 0; // prevent collapse of tabs
   list-style: none;
-  margin: 0 !important;
+  margin: 0;
   overflow-x: auto;
   overflow-y: hidden;
   padding: 0;


### PR DESCRIPTION
This regression was introduced with https://github.com/openshift/console/pull/9532

before
<img width="944" alt="Screen Shot 2021-09-07 at 10 21 17 AM" src="https://user-images.githubusercontent.com/1874151/132364321-ca9cfc26-de96-48bd-827b-df16f857d239.png">


after
<img width="885" alt="Screen Shot 2021-09-07 at 10 19 22 AM" src="https://user-images.githubusercontent.com/1874151/132364349-289794b3-337c-4475-a89e-d23af4057543.png">
