### PR TITLE
Bug 2002027: Use exact secret label match when creating HelmRelease topology node model

### DIFF
--- a/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
+++ b/frontend/packages/helm-plugin/src/topology/helm-data-transformer.ts
@@ -54,7 +54,7 @@ export const getTopologyHelmReleaseGroupItem = (
 
   const secret = secrets.find((nextSecret) => {
     const { labels } = nextSecret.metadata;
-    return labels?.name?.includes(releaseName) && labels?.version === releaseVersion.toString();
+    return labels?.name === releaseName && labels?.version === releaseVersion.toString();
   });
 
   if (secret) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6293
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
When creating the HelmRelease topology node model, the associated secret is selected by matching a subset of it's label(using `str.includes()`) with the release name. This led to selecting the incorrect secret when there are releases sharing a common substring of the name.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Match the exact string of the release name with the label when selecting the secret.
<!-- Describe your code changes in detail and explain the solution -->

<!--**Screen shots / Gifs for design review**: -->
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug