### PR TITLE
Bug 2004060: Fix basic spring boot sample form crash

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -65,9 +65,13 @@ export const detectGitType = (url: string): GitTypes => {
 };
 
 export const createComponentName = (nameString: string): string => {
-  if (nameRegex.test(nameString)) {
-    return nameString;
-  }
+  try {
+    if (nameRegex.test(nameString)) {
+      return nameString;
+    }
+    // eslint-disable-next-line no-empty
+  } catch {}
+
   const kebabCaseStr = _.kebabCase(nameString);
   return nameString.match(/^\d/) || kebabCaseStr.match(/^\d/)
     ? `ocp-${kebabCaseStr}`


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-6320
**Fixes:** https://issues.redhat.com/browse/ODC-6333

**Root Cause:**
Large number of groups in name regex causes too-much-recursion error in firefox for basic spring boot sample.

**Solution:**
Adding the regex matching test in try catch block fixes the issue.

**Screen-recording:**

https://user-images.githubusercontent.com/20724543/132393935-119063b5-bfe9-49e3-9128-65e614b2fae0.mov


/kind bug