### PR TITLE
[release-4.6] Bug 2002151: Fix the event listener optional types

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
@@ -28,7 +28,7 @@ type TriggerTemplateMapping = { [key: string]: TriggerTemplateKind };
 
 const getResourceName = (resource: K8sResourceCommon): string => resource.metadata.name;
 const getEventListenerTemplateNames = (el: EventListenerKind): string[] =>
-  el.spec.triggers?.map((elTrigger: EventListenerKindTrigger) => elTrigger.template.name);
+  el.spec.triggers?.map((elTrigger: EventListenerKindTrigger) => elTrigger.template?.name);
 const getEventListenerGeneratedName = (eventListener: EventListenerKind) =>
   eventListener.status?.configuration.generatedName;
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2002151

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
OSP 1.2.3 in OCP-4.6.36, has older version of triggers which makes `triggers.template.name` as optional in eventlistener and accepts `triggers.triggerRef` (not supported in 4.6). 


**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added a optional check to prevent the crashing in Pipelines list page in the UI.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/9964343/132480213-ebba9a17-72a2-4f9e-a8b9-25e026e1c19a.png)


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Create any pipeline and an eventlistener with triggerRef - [eventListener.yaml](https://gist.github.com/karthikjeeyar/cbde3996ba8a7ce58105227d72f0e6f4
).
2.  Visit the pipeline list page or pipeline details page.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge