### PR TITLE
Bug 2002238: persist imagestream info when switching from yaml to form editor

### DIFF
--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
@@ -17,8 +17,7 @@ const ImageStreamDropdown: React.FC<{ disabled?: boolean; formContextField?: str
 
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
   const { imageStream } = _.get(values, formContextField) || values;
-  const { imageStream: initialImageStream, isi: initialIsi } =
-    _.get(initialValues, formContextField) || initialValues;
+  const { isi: initialIsi } = _.get(initialValues, formContextField) || initialValues;
   const { state, dispatch, hasImageStreams, setHasImageStreams } = React.useContext(
     ImageStreamContext,
   );
@@ -42,7 +41,10 @@ const ImageStreamDropdown: React.FC<{ disabled?: boolean; formContextField?: str
 
   const onDropdownChange = React.useCallback(
     (img: string) => {
-      setFieldValue(`${fieldPrefix}imageStream.tag`, initialImageStream.tag);
+      setFieldValue(
+        `${fieldPrefix}imageStream.tag`,
+        img === imageStream.image ? imageStream.tag : '',
+      );
       setFieldValue(`${fieldPrefix}isi`, initialIsi);
       const image = _.get(imgCollection, [imageStream.namespace, img], {});
       dispatch({ type: ImageStreamActions.setSelectedImageStream, value: image });
@@ -50,7 +52,8 @@ const ImageStreamDropdown: React.FC<{ disabled?: boolean; formContextField?: str
     [
       setFieldValue,
       fieldPrefix,
-      initialImageStream.tag,
+      imageStream.tag,
+      imageStream.image,
       initialIsi,
       imgCollection,
       imageStream.namespace,
@@ -76,12 +79,6 @@ const ImageStreamDropdown: React.FC<{ disabled?: boolean; formContextField?: str
     imageStream.image && onDropdownChange(imageStream.image);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imageStream.image, isStreamsAvailable]);
-
-  React.useEffect(() => {
-    if (initialImageStream.image !== imageStream.image) {
-      initialImageStream.tag = '';
-    }
-  }, [imageStream.image, initialImageStream.image, initialImageStream.tag]);
 
   return (
     <ResourceDropdownField

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
@@ -14,49 +14,30 @@ const ImageStreamNsDropdown: React.FC<{ disabled?: boolean; formContextField?: s
   const { t } = useTranslation();
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
   const { imageStream } = _.get(values, formContextField) || values;
-  const { imageStream: initialImageStream, isi: initialIsi } =
-    _.get(initialValues, formContextField) || initialValues;
+  const { isi: initialIsi } = _.get(initialValues, formContextField) || initialValues;
   const { dispatch } = React.useContext(ImageStreamContext);
   const fieldPrefix = formContextField ? `${formContextField}.` : '';
-  const onDropdownChange = React.useCallback(() => {
-    setFieldValue(`${fieldPrefix}imageStream.image`, initialImageStream.image);
-    setFieldValue(`${fieldPrefix}imageStream.tag`, initialImageStream.tag);
-    setFieldValue(`${fieldPrefix}isi`, initialIsi);
-    dispatch({ type: Action.setLoading, value: true });
-  }, [
-    dispatch,
-    fieldPrefix,
-    initialImageStream.image,
-    initialImageStream.tag,
-    initialIsi,
-    setFieldValue,
-  ]);
+  const onDropdownChange = React.useCallback(
+    (ns?: string) => {
+      if (ns) {
+        setFieldValue(`${fieldPrefix}imageStream.image`, '');
+        setFieldValue(`${fieldPrefix}imageStream.tag`, '');
+      }
+      setFieldValue(`${fieldPrefix}isi`, initialIsi);
+      dispatch({ type: Action.setLoading, value: true });
+    },
+    [dispatch, fieldPrefix, initialIsi, setFieldValue],
+  );
 
   React.useEffect(() => {
-    if (initialImageStream.image && imageStream.image !== initialImageStream.image) {
-      initialImageStream.image = imageStream.image;
-    }
     imageStream.namespace && onDropdownChange();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onDropdownChange, imageStream.namespace]);
-
-  React.useEffect(() => {
-    if (initialImageStream.namespace !== imageStream.namespace) {
-      initialImageStream.image = '';
-      initialImageStream.tag = '';
-    }
-  }, [
-    imageStream.namespace,
-    initialImageStream.namespace,
-    initialImageStream.image,
-    initialImageStream.tag,
-  ]);
 
   return (
     <ResourceDropdownField
       name={`${fieldPrefix}imageStream.namespace`}
       label={t('devconsole~Project')}
-      title={t('devconsole~Select Project')}
+      title={imageStream.namespace || t('devconsole~Select Project')}
       fullWidth
       required
       resources={getProjectResource()}


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6281

**Root analysis:**
When the namespace is changed then the initialValues for the imagestream and the tag is set to empty string, which is not updated when the user selects new values. As a result, when the user toggles from form editor -> yaml editor -> form editor the values do not persist as it is read from the initial values.

A similar thing happens when the image stream is changed.

**Solution description:**
- removed the usage of initial values from ImageStreamDropdown and ImageStreamNsDropdown

**GIF:**
![imagestreampersis](https://user-images.githubusercontent.com/22490998/132490476-10af32af-7b40-45b7-b6c9-9e9cd8240820.gif)
