### PR TITLE
Bug 2002387: updating user settings storage to local in cypress hooks for dev-console plugin

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/dev-console/integration-tests/support/commands/hooks.ts
@@ -3,6 +3,10 @@ before(() => {
   cy.document()
     .its('readyState')
     .should('eq', 'complete');
+  // set the user settings location to local storage, so that no need of deleting config map from openshift-console-user-settings namespace
+  cy.window().then((win: any) => {
+    win.SERVER_FLAGS.userSettingsLocation = 'localstorage';
+  });
 });
 
 after(() => {


### PR DESCRIPTION
**Description**: 
Currently modifications made by user are getting stored in user settings config map. So setting up the user settings storage to  "local storage" instead user settings config map

Updating project dropdown locators