### PR TITLE
Bug 2002397: Avoid using state for search page resources filter

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -32,7 +32,6 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
 
   const [isOpen, setOpen] = React.useState(false);
   const [selectedOptions, setSelectedOptions] = React.useState(selected);
-  const [filterText, setFilterText] = React.useState<string>(null);
 
   const resources = allModels
     .filter(({ apiGroup, apiVersion, kind, verbs }) => {
@@ -101,9 +100,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
     .toArray();
 
   const onCustomFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event) {
-      setFilterText(event.target.value.toLowerCase());
-    }
+    const filterText = event?.target.value.toLocaleLowerCase();
     if (filterText === null || filterText === '') {
       return items;
     }
@@ -117,7 +114,6 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
   };
 
   const onToggle = (newOpenState: boolean) => {
-    setFilterText(null);
     setOpen(newOpenState);
   };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-6334
https://bugzilla.redhat.com/show_bug.cgi?id=2002397
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The resource dropdown was using `useState` and the state's value in the same render, causing the filter to be behind one character.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Remove the state, and directly use the input event value.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/132552023-71160549-c1ff-47fd-a5c2-7f39c82fe969.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug