### PR TITLE
skip processing video and delete it if test pass

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/cypress.json
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/cypress.json
@@ -3,6 +3,8 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "video": true,
+  "videoCompression": false,
+  "experimentalRunEvents": true,
   "reporter": "../../../node_modules/cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "reporter-config.json"

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/plugins/index.js
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/plugins/index.js
@@ -2,6 +2,7 @@
 // the project's config changing)
 const fs = require('fs');
 const wp = require('@cypress/webpack-preprocessor');
+const del = require('del');
 
 module.exports = (on, config) => {
   const options = {
@@ -50,6 +51,14 @@ module.exports = (on, config) => {
       launchOptions.args.push('--disable-dev-shm-usage');
     }
     return launchOptions;
+  });
+  on('after:spec', (spec, results) => {
+    if (results.stats.failures === 0 && results.video) {
+      // `del()` returns a promise, so it's important to return it to ensure
+      // deleting the video is finished before moving on
+      return del(results.video);
+    }
+    return null;
   });
   // `config` is the resolved Cypress config
   config.baseUrl = `${process.env.BRIDGE_BASE_ADDRESS || 'http://localhost:9000'}${(


### PR DESCRIPTION
taking from https://github.com/cypress-io/cypress/issues/2522#issuecomment-749316813
Doc ref: https://docs.cypress.io/api/plugins/after-spec-api#Delete-the-recorded-video-if-the-spec-passed

1. skip processing video may reduce execution time
2. delete the video if the test pass to reduce disk usage.