### PR TITLE
Bug 2001835: Fix to show image-tag selector in s2i form and re-validate git url on git-type change

### DIFF
--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -27,6 +27,7 @@ import {
   ImportData,
   Resources,
   BaseFormData,
+  ImportTypes,
 } from './import-types';
 import { validationSchema } from './import-validation-utils';
 import { useUpdateKnScalingDefaultValues } from './serverless/useUpdateKnScalingDefaultValues';
@@ -113,7 +114,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         detectedFiles: [],
       },
       recommendedStrategy: null,
-      showEditImportStrategy: false,
+      showEditImportStrategy: importData.type !== ImportTypes.git,
       strategyChanged: false,
     },
   };

--- a/frontend/packages/dev-console/src/components/import/builder/BuilderImageTagSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderImageTagSelector.tsx
@@ -69,7 +69,6 @@ const BuilderImageTagSelector: React.FC<BuilderImageTagSelectorProps> = ({
   return (
     <>
       <div style={!showEditImportStrategy ? { display: 'none' } : {}}>
-        <br />
         <DropdownField
           name="image.tag"
           label={t('devconsole~Builder Image version')}

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -144,7 +144,7 @@ const GitSection: React.FC<GitSectionProps> = ({
     name: nameTouched,
     application: { name: applicationNameTouched } = {},
     image: { selected: imageSelectorTouched } = {},
-    git: { dir: gitDirTouched } = {},
+    git: { dir: gitDirTouched, type: gitTypeTouched } = {},
   } = touched;
   const { git: { url: gitUrlError } = {} } = errors;
 
@@ -313,7 +313,7 @@ const GitSection: React.FC<GitSectionProps> = ({
       setFieldValue('import.loadError', loadError);
       setFieldValue('import.strategies', importStrategies);
       if (importStrategies.length > 0) {
-        values.formType !== 'edit' && setFieldValue('import.showEditImportStrategy', false);
+        setFieldValue('import.showEditImportStrategy', false);
         setFieldValue('import.selectedStrategy', importStrategies[0]);
         setFieldValue('import.recommendedStrategy', importStrategies[0]);
       } else {
@@ -324,7 +324,7 @@ const GitSection: React.FC<GitSectionProps> = ({
           detectedFiles: [],
         });
         setFieldValue('import.recommendedStrategy', null);
-        values.formType !== 'edit' && setFieldValue('import.showEditImportStrategy', true);
+        setFieldValue('import.showEditImportStrategy', true);
       }
       setFieldValue('import.strategyChanged', false);
 
@@ -397,7 +397,7 @@ const GitSection: React.FC<GitSectionProps> = ({
   }, [debouncedHandleGitUrlChange, sampleRepo, setFieldTouched, setFieldValue, tag]);
 
   React.useEffect(() => {
-    (!dirty || gitDirTouched || formReloadCount) &&
+    (!dirty || gitDirTouched || gitTypeTouched || formReloadCount) &&
       values.git.url &&
       debouncedHandleGitUrlChange(values.git.url, values.git.ref, values.git.dir);
   }, [
@@ -409,6 +409,8 @@ const GitSection: React.FC<GitSectionProps> = ({
     values.git.url,
     values.git.ref,
     values.git.dir,
+    values.git.type,
+    gitTypeTouched,
   ]);
 
   const helpText = React.useMemo(() => {


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2001835
**Fixes:** https://issues.redhat.com/browse/ODC-6323

**Screenshots and recording:**
<img width="1791" alt="Screenshot 2021-09-09 at 2 47 54 PM" src="https://user-images.githubusercontent.com/20724543/132659061-ccbad1ac-d2c3-42c8-a7f2-91185d63a94a.png">

https://user-images.githubusercontent.com/20724543/132659111-10154e31-8204-45e8-be31-228a572ae008.mov

/kind bug