### PR TITLE
Bug 2001760: fix path issue with breadcrumbs

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/bucket-class/create-bc.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/bucket-class/create-bc.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import * as _ from 'lodash';
 import { RouteComponentProps } from 'react-router';
 import { Title, Wizard } from '@patternfly/react-core';
 import {
@@ -9,6 +8,7 @@ import {
   k8sGet,
   referenceForModel,
 } from '@console/internal/module/k8s';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { history } from '@console/internal/components/utils/router';
 import { BreadCrumbs, resourcePathFromModel } from '@console/internal/components/utils';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
@@ -25,6 +25,7 @@ import { CacheNamespaceStorePage } from './wizard-pages/namespace-store-pages/ca
 import { MultiNamespaceStorePage } from './wizard-pages/namespace-store-pages/multi-namespace-store';
 import { BucketClassType, NamespacePolicyType } from '../../constants/bucket-class';
 import { validateBucketClassName, validateDuration } from '../../utils/bucket-class';
+import { ODF_MODEL_FLAG } from '../../constants';
 import { NooBaaBucketClassModel } from '../../models';
 import { PlacementPolicy } from '../../types';
 
@@ -40,6 +41,7 @@ const CreateBucketClass: React.FC<CreateBCProps> = ({ match }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const { ns, appName } = match.params;
   const [clusterServiceVersion, setClusterServiceVersion] = React.useState(null);
+  const isOdfInstalled = useFlag(ODF_MODEL_FLAG);
 
   React.useEffect(() => {
     k8sGet(ClusterServiceVersionModel, appName, ns)
@@ -252,12 +254,10 @@ const CreateBucketClass: React.FC<CreateBCProps> = ({ match }) => {
         <BreadCrumbs
           breadcrumbs={[
             {
-              name: _.get(
-                clusterServiceVersion,
-                'spec.displayName',
-                'Openshift Data Foundation Operator',
-              ),
-              path: resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
+              name: isOdfInstalled ? 'OpenShift Data Foundation' : 'OpenShift Container Storage',
+              path: isOdfInstalled
+                ? '/odf'
+                : resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
             },
             {
               name: t('ceph-storage-plugin~Create BucketClass'),

--- a/frontend/packages/ceph-storage-plugin/src/components/create-backingstore-page/create-bs-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-backingstore-page/create-bs-page.tsx
@@ -2,16 +2,19 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { Alert, AlertActionCloseButton, Title } from '@patternfly/react-core';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { history } from '@console/internal/components/utils/router';
 import { BreadCrumbs, resourcePathFromModel } from '@console/internal/components/utils';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import CreateBackingStoreForm from './create-bs';
+import { ODF_MODEL_FLAG } from '../../constants';
 import '../noobaa-provider-endpoints/noobaa-provider-endpoints.scss';
 
 const CreateBackingStoreFormPage: React.FC<CreateBackingStoreFormPageProps> = ({ match }) => {
   const { t } = useTranslation();
   const [showHelp, setShowHelp] = React.useState(true);
   const { ns, appName } = match.params;
+  const isOdfInstalled = useFlag(ODF_MODEL_FLAG);
 
   const onCancel = () => {
     history.goBack();
@@ -23,8 +26,10 @@ const CreateBackingStoreFormPage: React.FC<CreateBackingStoreFormPageProps> = ({
         <BreadCrumbs
           breadcrumbs={[
             {
-              name: 'Openshift Container Storage',
-              path: resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
+              name: isOdfInstalled ? 'OpenShift Data Foundation' : 'OpenShift Container Storage',
+              path: isOdfInstalled
+                ? '/odf'
+                : resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
             },
             { name: t('ceph-storage-plugin~Create BackingStore '), path: match.url },
           ]}

--- a/frontend/packages/ceph-storage-plugin/src/components/namespace-store/create-namespace-store.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/namespace-store/create-namespace-store.tsx
@@ -6,14 +6,18 @@ import { history } from '@console/internal/components/utils/router';
 import { BreadCrumbs, resourcePathFromModel } from '@console/internal/components/utils';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { getName } from '@console/shared';
+import { useFlag } from '@console/shared/src/hooks/flag';
 import { referenceForModel } from '@console/internal/module/k8s';
 import NamespaceStoreForm from './namespace-store-form';
 import '../noobaa-provider-endpoints/noobaa-provider-endpoints.scss';
+import { ODF_MODEL_FLAG } from '../../constants';
 import { NooBaaNamespaceStoreModel } from '../../models';
 
 const CreateNamespaceStore: React.FC<CreateNamespaceStoreProps> = ({ match }) => {
   const { t } = useTranslation();
   const { ns, appName } = match.params;
+  const isOdfInstalled = useFlag(ODF_MODEL_FLAG);
+
   const onCancel = () => history.goBack();
 
   return (
@@ -22,8 +26,10 @@ const CreateNamespaceStore: React.FC<CreateNamespaceStoreProps> = ({ match }) =>
         <BreadCrumbs
           breadcrumbs={[
             {
-              name: 'Openshift Data Foundation',
-              path: resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
+              name: isOdfInstalled ? 'OpenShift Data Foundation' : 'OpenShift Container Storage',
+              path: isOdfInstalled
+                ? '/odf'
+                : resourcePathFromModel(ClusterServiceVersionModel, appName, ns),
             },
             { name: t('ceph-storage-plugin~Create NamespaceStore '), path: match.url },
           ]}


### PR DESCRIPTION
**Before:**
While creating 'Backing Store', 'Bucket Class', 'Namespace Store' user is navigated to 'Installed Operators' page after clicking on ODF.

**After:**
User is navigated back to ODF tab under Storage from where the navigation to these tabs started.

![OpenShift Data Foundation Overview · OKD (1)](https://user-images.githubusercontent.com/39404641/132679889-95a93029-9789-472d-8268-8aadaaee2a7a.gif)
