### PR TITLE
Bug 2001810: Fix list page route for build configs

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -195,6 +195,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Page/Route',
     properties: {
+      perspective: 'dev',
       exact: true,
       path: ['/k8s/all-namespaces/buildconfigs', '/k8s/ns/:ns/buildconfigs'],
       loader: async () =>


### PR DESCRIPTION
Update dev console plugin route for build configs to specify `perspective: 'dev'` so that it doesn't override the existing admin perspective route.