### PR TITLE
[WIP] Bug 2001212: Notifications is not translated on the top right bar

### DIFF
--- a/frontend/public/i18n.js
+++ b/frontend/public/i18n.js
@@ -49,6 +49,7 @@ i18n
       'lso-plugin',
       'metal3-plugin',
       'nodes',
+      'notification-drawer',
       'olm',
       'olm',
       'pipelines-plugin',

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -224,6 +224,7 @@ const config: Configuration = {
     new CopyWebpackPlugin([{ from: './packages/kubevirt-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/ceph-storage-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/metal3-plugin/locales', to: 'locales' }]),
+    new CopyWebpackPlugin([{ from: './packages/patternfly/locales', to: 'locales' }]),
     new CopyWebpackPlugin([{ from: './packages/insights-plugin/locales', to: 'locales' }]),
     new CopyWebpackPlugin([
       { from: './packages/local-storage-operator-plugin/locales', to: 'locales' },


### PR DESCRIPTION
This addresses [Bug 2001212](https://bugzilla.redhat.com/show_bug.cgi?id=2001212)

There is a bug in version 4.8 where translations are not loaded for the `/frontend/packages/patternfly/src/components/notification-drawer` component.  This was most evident by the header text "Notifications" on the Notifications drawer off the top nav bar.  In addition, this was causing numerous browser console errors when the notification drawer was opened.

This PR fixes these issues.

Note:  This is fixed in version 4.9 and higher.  The commits that made this change into 4.9 also contained other changes, so this is a manual fix vs a cherrypick.