### PR TITLE
Bug 2001784: show loading page before final results instead of showing a transient message No log files exist

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeLogs.tsx
@@ -266,9 +266,13 @@ const NodeLogs: React.FC<NodeLogsProps> = ({ obj: node }) => {
           !isJournal && !logFilename ? (
             <EmptyState variant={EmptyStateVariant.full} isFullHeight>
               <Title headingLevel="h2" size="lg">
-                {logFilenamesExist
-                  ? t('public~No log file selected')
-                  : t('public~No log files exist')}
+                {isLoadingFilenames ? (
+                  <LoadingInline />
+                ) : logFilenamesExist ? (
+                  t('public~No log file selected')
+                ) : (
+                  t('public~No log files exist')
+                )}
               </Title>
               {logFilenamesExist && (
                 <EmptyStateBody>{t('public~Select a log file above')}</EmptyStateBody>


### PR DESCRIPTION
Addresses [Bug 2001784](https://bugzilla.redhat.com/show_bug.cgi?id=2001784)

When switching component logs for the master node, the "No log files exist" briefly flashes.  This PR will display a loading icon until the log list has finished loading instead of "No log files exist".  

Note: The loading icon is only shown briefly (less than a second) before showing logs, "No log files exist", or "No log file selected".