### PR TITLE
Bug 2006329: Allow web terminal to be installed in any namespace

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
@@ -41,7 +41,6 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
   setUserSettingState: setNamespace,
 }) => {
   const [operatorNamespace, namespaceLoadError] = useCloudShellNamespace();
-  const [unrecoverableErrorFound, setUnrecoverableErrorFound] = React.useState<boolean>(false);
   const [initData, setInitData] = React.useState<TerminalInitData>();
   const [initError, setInitError] = React.useState<string>();
   const [isAdmin, isAdminCheckLoading] = useAccessReview2({
@@ -66,24 +65,37 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
 
   const { t } = useTranslation();
 
+  const unrecoverableErrorFound = !operatorNamespace && namespaceLoadError;
+
   // wait until the web terminal is loaded.
   // if the namespace has any problems loading then set the terminal into an unrecoverable state
   React.useEffect(() => {
     if (namespaceLoadError) {
-      setUnrecoverableErrorFound(true);
       setInitError(namespaceLoadError);
     }
   }, [namespaceLoadError]);
 
   // start the workspace if no unrecoverable errors were found
   React.useEffect(() => {
-    if (!unrecoverableErrorFound && workspace?.spec && !workspace.spec.started) {
+    if (
+      operatorNamespace &&
+      !unrecoverableErrorFound &&
+      workspace?.spec &&
+      !workspace.spec.started
+    ) {
       startWorkspace(workspace);
     }
     // Run this effect if the workspace name or namespace changes.
     // This effect should only be run once per workspace.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [unrecoverableErrorFound, workspace?.metadata?.name, workspace?.metadata?.namespace]);
+  }, [
+    operatorNamespace,
+    unrecoverableErrorFound,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    workspace?.metadata?.name,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    workspace?.metadata?.namespace,
+  ]);
 
   // save the namespace once the workspace has loaded
   React.useEffect(() => {

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminal.tsx
@@ -12,12 +12,13 @@ import {
 } from '@console/shared';
 import { FLAG_V1ALPHA2DEVWORKSPACE } from '../../consts';
 import { v1alpha1WorkspaceModel, WorkspaceModel } from '../../models';
-import { TerminalInitData, initTerminal } from './cloud-shell-utils';
+import { TerminalInitData, initTerminal, startWorkspace } from './cloud-shell-utils';
 import CloudshellExec from './CloudShellExec';
 import { CLOUD_SHELL_NAMESPACE, CLOUD_SHELL_NAMESPACE_CONFIG_STORAGE_KEY } from './const';
 import CloudShellAdminSetup from './setup/CloudShellAdminSetup';
 import CloudShellDeveloperSetup from './setup/CloudShellDeveloperSetup';
 import TerminalLoadingBox from './TerminalLoadingBox';
+import useCloudShellNamespace from './useCloudShellNamespace';
 import useCloudShellWorkspace from './useCloudShellWorkspace';
 
 import './CloudShellTerminal.scss';
@@ -39,6 +40,8 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
   userSettingState: namespace,
   setUserSettingState: setNamespace,
 }) => {
+  const [operatorNamespace, namespaceLoadError] = useCloudShellNamespace();
+  const [unrecoverableErrorFound, setUnrecoverableErrorFound] = React.useState<boolean>(false);
   const [initData, setInitData] = React.useState<TerminalInitData>();
   const [initError, setInitError] = React.useState<string>();
   const [isAdmin, isAdminCheckLoading] = useAccessReview2({
@@ -63,6 +66,25 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
 
   const { t } = useTranslation();
 
+  // wait until the web terminal is loaded.
+  // if the namespace has any problems loading then set the terminal into an unrecoverable state
+  React.useEffect(() => {
+    if (namespaceLoadError) {
+      setUnrecoverableErrorFound(true);
+      setInitError(namespaceLoadError);
+    }
+  }, [namespaceLoadError]);
+
+  // start the workspace if no unrecoverable errors were found
+  React.useEffect(() => {
+    if (!unrecoverableErrorFound && workspace?.spec && !workspace.spec.started) {
+      startWorkspace(workspace);
+    }
+    // Run this effect if the workspace name or namespace changes.
+    // This effect should only be run once per workspace.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [unrecoverableErrorFound, workspace?.metadata?.name, workspace?.metadata?.namespace]);
+
   // save the namespace once the workspace has loaded
   React.useEffect(() => {
     if (loaded && !loadError) {
@@ -71,11 +93,13 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
     }
   }, [loaded, loadError, workspaceNamespace, setNamespace]);
 
-  // clear the init data and error if the workspace changes
+  // clear the init data and error if the workspace changes and if the loading process isn't in an unrecoverable state
   React.useEffect(() => {
-    setInitData(undefined);
-    setInitError(undefined);
-  }, [username, workspaceName, workspaceNamespace]);
+    if (!unrecoverableErrorFound) {
+      setInitData(undefined);
+      setInitError(undefined);
+    }
+  }, [unrecoverableErrorFound, username, workspaceName, workspaceNamespace]);
 
   // initialize the terminal once it is Running
   React.useEffect(() => {
@@ -132,7 +156,7 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
   }
 
   // loading the workspace resource
-  if (!loaded || isAdminCheckLoading) {
+  if (!loaded || isAdminCheckLoading || !operatorNamespace) {
     return <TerminalLoadingBox message="" />;
   }
 
@@ -165,6 +189,7 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
           setNamespace(ns);
         }}
         workspaceModel={workspaceModel}
+        operatorNamespace={operatorNamespace}
       />
     );
   }
@@ -177,6 +202,7 @@ const CloudShellTerminal: React.FC<CloudShellTerminalProps &
       onSubmit={(ns: string) => {
         setNamespace(ns);
       }}
+      operatorNamespace={operatorNamespace}
     />
   );
 };

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
@@ -5,10 +5,15 @@ import { useFlag } from '@console/shared';
 import { InternalCloudShellTerminal } from '../CloudShellTerminal';
 import CloudShellDeveloperSetup from '../setup/CloudShellDeveloperSetup';
 import TerminalLoadingBox from '../TerminalLoadingBox';
+import useCloudShellNamespace from '../useCloudShellNamespace';
 import useCloudShellWorkspace from '../useCloudShellWorkspace';
 import { user } from './cloud-shell-test-data';
 
 jest.mock('../useCloudShellWorkspace', () => ({
+  default: jest.fn(),
+}));
+
+jest.mock('../useCloudShellNamespace', () => ({
   default: jest.fn(),
 }));
 
@@ -36,6 +41,7 @@ describe('CloudShellTerminal', () => {
   it('should display loading box', () => {
     useFlagMock.mockReturnValue(true);
     (useCloudShellWorkspace as jest.Mock).mockReturnValueOnce([null, false]);
+    (useCloudShellNamespace as jest.Mock).mockReturnValueOnce(['sample-namespace', '']);
     const wrapper = shallow(
       <InternalCloudShellTerminal
         user={user}
@@ -49,6 +55,7 @@ describe('CloudShellTerminal', () => {
   it('should display error statusBox', () => {
     useFlagMock.mockReturnValue(true);
     (useCloudShellWorkspace as jest.Mock).mockReturnValueOnce([null, false, true]);
+    (useCloudShellNamespace as jest.Mock).mockReturnValueOnce(['sample-namespace', '']);
     const wrapper = shallow(
       <InternalCloudShellTerminal
         user={user}
@@ -62,6 +69,7 @@ describe('CloudShellTerminal', () => {
   it('should display form if loaded and no workspace', () => {
     useFlagMock.mockReturnValue(true);
     (useCloudShellWorkspace as jest.Mock).mockReturnValueOnce([[], true]);
+    (useCloudShellNamespace as jest.Mock).mockReturnValueOnce(['sample-namespace', '']);
     const wrapper = shallow(
       <InternalCloudShellTerminal
         user={user}

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-utils.spec.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-utils.spec.ts
@@ -10,7 +10,7 @@ describe('CloudShell Utils', () => {
     const namespace = 'default';
     const kind = 'DevWorkspace';
 
-    const newResource = newCloudShellWorkSpace(name, namespace, 'v1alpha2');
+    const newResource = newCloudShellWorkSpace(name, namespace, namespace, 'v1alpha2');
     expect(newResource.kind).toEqual(kind);
     expect(newResource.metadata.name).toEqual(name);
     expect(newResource.metadata.namespace).toEqual(namespace);

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -50,7 +50,6 @@ export const CLOUD_SHELL_CREATOR_LABEL = 'controller.devfile.io/creator';
 export const CLOUD_SHELL_RESTRICTED_ANNOTATION = 'controller.devfile.io/restricted-access';
 export const CLOUD_SHELL_STOPPED_BY_ANNOTATION = 'controller.devfile.io/stopped-by';
 export const CLOUD_SHELL_PROTECTED_NAMESPACE = 'openshift-terminal';
-export const CLOUD_SHELL_SUBSCRIPTION_NAME = 'web-terminal';
 
 export const createCloudShellResourceName = () => `terminal-${getRandomChars(6)}`;
 

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -50,6 +50,7 @@ export const CLOUD_SHELL_CREATOR_LABEL = 'controller.devfile.io/creator';
 export const CLOUD_SHELL_RESTRICTED_ANNOTATION = 'controller.devfile.io/restricted-access';
 export const CLOUD_SHELL_STOPPED_BY_ANNOTATION = 'controller.devfile.io/stopped-by';
 export const CLOUD_SHELL_PROTECTED_NAMESPACE = 'openshift-terminal';
+export const CLOUD_SHELL_SUBSCRIPTION_NAME = 'web-terminal';
 
 export const createCloudShellResourceName = () => `terminal-${getRandomChars(6)}`;
 
@@ -62,13 +63,13 @@ const v1alpha1DevworkspaceComponent = [
   },
 ];
 
-const devWorkspaceComponent = [
+const devWorkspaceComponent = (namespace: string) => [
   {
     name: 'web-terminal-tooling',
     plugin: {
       kubernetes: {
         name: 'web-terminal-tooling',
-        namespace: 'openshift-operators',
+        namespace,
       },
     },
   },
@@ -77,7 +78,7 @@ const devWorkspaceComponent = [
     plugin: {
       kubernetes: {
         name: 'web-terminal-exec',
-        namespace: 'openshift-operators',
+        namespace,
       },
     },
   },
@@ -85,14 +86,15 @@ const devWorkspaceComponent = [
 
 export const newCloudShellWorkSpace = (
   name: string,
-  namespace: string,
+  workspaceNamespace: string,
+  operatorNamespace: string,
   version: string,
 ): CloudShellResource => ({
   apiVersion: `workspace.devfile.io/${version}`,
   kind: 'DevWorkspace',
   metadata: {
     name,
-    namespace,
+    namespace: workspaceNamespace,
     labels: {
       [CLOUD_SHELL_LABEL]: 'true',
     },
@@ -107,7 +109,7 @@ export const newCloudShellWorkSpace = (
       components:
         version === v1alpha1WorkspaceModel.apiVersion
           ? v1alpha1DevworkspaceComponent
-          : devWorkspaceComponent,
+          : devWorkspaceComponent(operatorNamespace),
     },
   },
 });
@@ -153,3 +155,5 @@ export const checkTerminalAvailable = () => coFetch('/api/terminal/available');
 export const getCloudShellCR = (workspaceModel: K8sKind, name: string, ns: string) => {
   return k8sGet(workspaceModel, name, ns);
 };
+
+export const getTerminalInstalledNamespace = () => coFetch('/api/terminal/installedNamespace');

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellAdminSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellAdminSetup.tsx
@@ -14,9 +14,14 @@ import TerminalLoadingBox from '../TerminalLoadingBox';
 type Props = {
   onInitialize: (namespace: string) => void;
   workspaceModel: K8sKind;
+  operatorNamespace: string;
 };
 
-const CloudShellAdminSetup: React.FunctionComponent<Props> = ({ onInitialize, workspaceModel }) => {
+const CloudShellAdminSetup: React.FunctionComponent<Props> = ({
+  onInitialize,
+  workspaceModel,
+  operatorNamespace,
+}) => {
   const { t } = useTranslation();
 
   const [initError, setInitError] = React.useState<string>();
@@ -48,6 +53,7 @@ const CloudShellAdminSetup: React.FunctionComponent<Props> = ({ onInitialize, wo
           newCloudShellWorkSpace(
             createCloudShellResourceName(),
             CLOUD_SHELL_PROTECTED_NAMESPACE,
+            operatorNamespace,
             workspaceModel.apiVersion,
           ),
         );

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
@@ -23,11 +23,13 @@ type Props = StateProps & {
   onSubmit?: (namespace: string) => void;
   onCancel?: () => void;
   workspaceModel: K8sKind;
+  operatorNamespace: string;
 };
 
 const CloudShellDeveloperSetup: React.FunctionComponent<Props> = ({
   activeNamespace,
   workspaceModel,
+  operatorNamespace,
   onSubmit,
   onCancel,
 }) => {
@@ -53,6 +55,7 @@ const CloudShellDeveloperSetup: React.FunctionComponent<Props> = ({
         newCloudShellWorkSpace(
           createCloudShellResourceName(),
           namespace,
+          operatorNamespace,
           workspaceModel.apiVersion,
         ),
       );

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellNamespace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellNamespace.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { getTerminalInstalledNamespace } from './cloud-shell-utils';
+
+const useCloudShellNamespace = (): [string, string] => {
+  const [terminalNamespace, setTerminalNamespace] = React.useState<string>();
+  const [fetchError, setFetchError] = React.useState<string>();
+  React.useEffect(() => {
+    const fetchNamespace = async () => {
+      try {
+        if (!terminalNamespace) {
+          const namespaceRequest = await getTerminalInstalledNamespace();
+          const namespace = await namespaceRequest.text();
+          setTerminalNamespace(namespace);
+        }
+      } catch (e) {
+        const errorMessage = await e.response.text();
+        setFetchError(errorMessage);
+      }
+    };
+    fetchNamespace();
+  }, [terminalNamespace]);
+
+  return [terminalNamespace, fetchError];
+};
+
+export default useCloudShellNamespace;

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellNamespace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellNamespace.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { getTerminalInstalledNamespace } from './cloud-shell-utils';
 
 const useCloudShellNamespace = (): [string, string] => {
-  const [terminalNamespace, setTerminalNamespace] = React.useState<string>();
-  const [fetchError, setFetchError] = React.useState<string>();
+  const [terminalNamespace, setTerminalNamespace] = useSafetyFirst<string>(undefined);
+  const [fetchError, setFetchError] = useSafetyFirst<string>(undefined);
   React.useEffect(() => {
     const fetchNamespace = async () => {
       try {
@@ -18,7 +19,7 @@ const useCloudShellNamespace = (): [string, string] => {
       }
     };
     fetchNamespace();
-  }, [terminalNamespace]);
+  }, [setFetchError, setTerminalNamespace, terminalNamespace]);
 
   return [terminalNamespace, fetchError];
 };

--- a/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useCloudShellWorkspace.ts
@@ -10,7 +10,6 @@ import {
   CLOUD_SHELL_CREATOR_LABEL,
   CloudShellResource,
   CLOUD_SHELL_RESTRICTED_ANNOTATION,
-  startWorkspace,
   CLOUD_SHELL_PROTECTED_NAMESPACE,
 } from './cloud-shell-utils';
 
@@ -157,15 +156,6 @@ const useCloudShellWorkspace = (
     setSearching,
     workspaceModel,
   ]);
-
-  React.useEffect(() => {
-    if (workspace?.spec && !workspace.spec.started) {
-      startWorkspace(workspace);
-    }
-    // Run this effect if the workspace name or namespace changes.
-    // This effect should only be run once per workspace.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspace?.metadata?.name, workspace?.metadata?.namespace]);
 
   return [
     workspace,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -274,6 +274,7 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	handle(terminal.ProxyEndpoint, authHandlerWithUser(terminalProxy.HandleProxy))
 	handleFunc(terminal.AvailableEndpoint, terminalProxy.HandleProxyEnabled)
+	handleFunc(terminal.InstalledNamespaceEndpoint, terminalProxy.HandleTerminalInstalledNamespace)
 
 	graphQLSchema, err := ioutil.ReadFile("pkg/graphql/schema.graphql")
 	if err != nil {

--- a/pkg/terminal/operator.go
+++ b/pkg/terminal/operator.go
@@ -63,7 +63,7 @@ func checkWebTerminalOperatorIsRunning() (bool, error) {
 // checkWebTerminalOperatorIsInstalled checks to see that a web-terminal-operator is installed on the cluster
 func checkWebTerminalOperatorIsInstalled() (bool, error) {
 
-	_, err := GetWebTerminalSubscriptions()
+	_, err := getWebTerminalSubscriptions()
 	if err != nil {
 		// Web Terminal subscription is not found but it's technically not a real error so we don't want to propogate it. Just say that the operator is not installed
 		if k8sErrors.IsNotFound(err) {
@@ -75,7 +75,7 @@ func checkWebTerminalOperatorIsInstalled() (bool, error) {
 	return true, nil
 }
 
-func GetWebTerminalSubscriptions() (*unstructured.UnstructuredList, error) {
+func getWebTerminalSubscriptions() (*unstructured.UnstructuredList, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func GetWebTerminalSubscriptions() (*unstructured.UnstructuredList, error) {
 	return subs, err
 }
 
-func GetWebTerminalNamespace(subs *unstructured.UnstructuredList) (string, error) {
+func getWebTerminalNamespace(subs *unstructured.UnstructuredList) (string, error) {
 	if len(subs.Items) > 1 {
 		return "", errors.New("found multiple subscriptions for web-terminal when only one should be found")
 	}

--- a/pkg/terminal/operator.go
+++ b/pkg/terminal/operator.go
@@ -2,8 +2,8 @@ package terminal
 
 import (
 	"context"
-	goErrors "errors"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -44,7 +44,7 @@ func checkWebTerminalOperatorIsRunning() (bool, error) {
 
 	_, err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), webhookName, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err
@@ -52,7 +52,7 @@ func checkWebTerminalOperatorIsRunning() (bool, error) {
 
 	_, err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), webhookName, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err
@@ -66,13 +66,12 @@ func checkWebTerminalOperatorIsInstalled() (bool, error) {
 	_, err := GetWebTerminalSubscriptions()
 	if err != nil {
 		// Web Terminal subscription is not found but it's technically not a real error so we don't want to propogate it. Just say that the operator is not installed
-		if errors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) {
 			return false, nil
 		}
 
 		return false, err
 	}
-
 	return true, nil
 }
 
@@ -100,7 +99,7 @@ func GetWebTerminalSubscriptions() (*unstructured.UnstructuredList, error) {
 
 func GetWebTerminalNamespace(subs *unstructured.UnstructuredList) (string, error) {
 	if len(subs.Items) > 1 {
-		return "", goErrors.New("found multiple subscriptions for web-terminal when only one should be found")
+		return "", errors.New("found multiple subscriptions for web-terminal when only one should be found")
 	}
 
 	webTerminalSubscription := subs.Items[0]

--- a/pkg/terminal/proxy.go
+++ b/pkg/terminal/proxy.go
@@ -214,14 +214,15 @@ func (p *Proxy) HandleTerminalInstalledNamespace(w http.ResponseWriter, r *http.
 		return
 	}
 
-	subscription, err := GetWebTerminalSubscriptions()
+	subscription, err := getWebTerminalSubscriptions()
 	if err != nil {
 		klog.Errorf("Failed to check the web terminal subscription: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
 		return
 	}
 
-	operatorNamespace, err := GetWebTerminalNamespace(subscription)
+	operatorNamespace, err := getWebTerminalNamespace(subscription)
 	if err != nil {
 		klog.Errorf("Failed to get the namespace of the web terminal subscription: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
As of OpenShift 4.8 the console hardcodes the namespace where the devworkspacetemplates live as openshift-operators. In order to support fully support OSD (and devsandbox), we need the ability to have the devworkspacetemplates and the web terminal operator to be installed in other namespaces then openshift-operators and have those devworkspacetemplates still be picked up by the console. This PR is in conjuction with another PR on the [web terminal operator](https://github.com/redhat-developer/web-terminal-operator/pull/95) which makes it so that devworkspacetemplates are installed in the namespace where the operator is installed.

In order for the console to correctly reference the namespace where the devworkspacetemplates live it follows this flow when the terminal button is clicked:
- call the new backend endpoint that resolves the terminals namespace from the frontend
    - If the endpoint was successfully received then the console will create a devworkspace that references devworkspacestemplates installed in that namespace and start the workspace/exec into the workspace as expected
    - If the endpoint was not successfully received then put the cloud shell UI into an unrecoverable state (since we cannot continue without having the namespace) and don't start/initialize the workspace

Testing instructions:
1. Deploy the console changes to your cluster following https://github.com/openshift/console#steps with the image set as: `quay.io/jpinkney/console:installable-anywhere4`
2. Install web terminal catalogsource with the web terminal changes:
```bash
cat <<EOF | oc apply -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: custom-web-terminal-catalog
  namespace: openshift-marketplace
spec:
  displayName: Web Terminal Operator Catalog
  image: quay.io/jpinkney/web-terminal-operator-index@sha256:70e4f05ef522f1fd197db6a2cc364c36b1facf0af41d0303af6e7fbdc0bff0ba
  publisher: Red Hat
  sourceType: grpc
EOF
``` 
3. Create a subscription and operator group in a non openshift-operators namespace
```bash
# Create the test namespace
oc new-project web-terminal-test

# Create the operator group
cat <<EOF | oc apply -f -
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  name: web-terminal-test
  namespace: web-terminal-test
EOF

# Create the subscription
cat <<EOF | oc apply -f -
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: web-terminal
  namespace: web-terminal-test
spec:
  channel: fast
  installPlanApproval: Automatic
  name: web-terminal
  source: custom-web-terminal-catalog
  sourceNamespace: openshift-marketplace
  startingCSV: web-terminal.v1.3.1
EOF
```
4. Make sure that the console operator has the correct permissions. It can be done easily by checking out [this pr](https://github.com/openshift/console-operator/pull/588) and then using:
```bash
watch -n 1 oc apply -f manifests/03-rbac-role-cluster.yaml
```

To actually verify that everything is working:
1. Login as normal user or admin and create a web terminal. Verify that everything is working as expected
2. Create a new subscription in a different namespace. Verify that the console will fail to open the next time with an error saying: `found multiple subscriptions for web-terminal when only one should be found`
3. Remove the subscription and verify that opening the terminal will work again

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2006329