### PR TITLE
Bug 2003251: Explicit removal of list item bullets so they are not shown on several PF components.

### DIFF
--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.scss
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.scss
@@ -1,5 +1,0 @@
-.ocs-toast-provider {
-  &.pf-m-toast {
-    list-style: none;
-  }
-}

--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { Alert, AlertGroup, AlertActionCloseButton, AlertActionLink } from '@patternfly/react-core';
 import ToastContext, { ToastOptions, ToastContextType } from './ToastContext';
 
-import './ToastProvider.scss';
-
 const ToastProvider: React.FC = ({ children }) => {
   const [toasts, setToasts] = React.useState<ToastOptions[]>([]);
 
@@ -51,7 +49,7 @@ const ToastProvider: React.FC = ({ children }) => {
     <ToastContext.Provider value={controller}>
       {children}
       {toasts.length ? (
-        <AlertGroup appendTo={() => document.body} isToast className="ocs-toast-provider">
+        <AlertGroup appendTo={() => document.body} isToast>
           {toasts.map((toast) => (
             <Alert
               key={toast.id}

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -272,10 +272,6 @@ form.pf-c-form {
       --pf-c-nav__simple-list-link--nested--PaddingLeft: var(--pf-global--spacer--xl);
     }
 
-    .pf-c-nav__item {
-      list-style: none;
-    }
-
     .pf-c-nav__link {
       font-size: $co-side-nav-section-font-size;
     }
@@ -392,4 +388,16 @@ button.pf-c-dropdown__menu-item.pf-m-disabled {
 
 .form-group--doubled-bottom-margin {
   margin-bottom: ($form-group-margin-bottom * 2);
+}
+
+// Patternfly defaults to globally removing the list element bullets via ul {list-style:none} and selectively applies it using their List component via ul.pf-c-list. We chose to override this because of the amount of ul elements in our codebase that expect the default to be ul {list-style:disc}
+ul {
+  list-style: disc;
+}
+// And here we explicitly remove it from PF components so it doesn't show.
+ul.pf-c-alert-group,
+ul.pf-c-nav__list,
+ul.pf-c-simple-list__list,
+ul.pf-c-tree-view__list {
+  list-style: none !important;
 }

--- a/frontend/public/style/ancillary/_bootstrap-residual.scss
+++ b/frontend/public/style/ancillary/_bootstrap-residual.scss
@@ -209,7 +209,3 @@ pre code {
 .text-secondary {
   color: $color-text-secondary;
 }
-
-ul {
-  list-style: disc;
-}


### PR DESCRIPTION
Patternfly defaults to globally removing the list element bullets via `ul {list-style:none}` and selectively applies it using their [List component](https://www.patternfly.org/v4/components/list) via `ul.pf-c-list`. We chose to override this because of the amount of ul elements in our codebase that expect the default behavior to be `ul {list-style:disc}`. So we need to individually remove it from the following PF components.

Also remove custom rules no longer needed for toast and nav__item.

**Before**
<img width="1223" alt="Screen Shot 2021-09-10 at 1 08 36 PM" src="https://user-images.githubusercontent.com/1874151/132906644-d8545055-0158-498e-8cd7-483270eabc75.png">

---
**After**
<img width="1224" alt="Screen Shot 2021-09-10 at 1 10 05 PM" src="https://user-images.githubusercontent.com/1874151/132906627-8a4b522e-7426-4699-80a1-d8c400aa4580.png">


