### PR TITLE
[WIP ODC--5818] Provide a Ceph Event Source

### DIFF
--- a/frontend/packages/knative-plugin/src/catalog/event-source-data.ts
+++ b/frontend/packages/knative-plugin/src/catalog/event-source-data.ts
@@ -5,6 +5,7 @@ import {
   EventSourceKafkaModel,
   EventSourcePingModel,
   EventSourceSinkBindingModel,
+  EventSourceCephModel,
 } from '../models';
 
 export const getEventSourceCatalogProviderData = (
@@ -39,6 +40,12 @@ export const getEventSourceCatalogProviderData = (
     [EventSourceSinkBindingModel.kind]: {
       description: t(
         'knative-plugin~Used to connect OpenShift managed applications like Deployments, StatefulSets, or Jobs to an event sink, for example, a Knative Service, Channel, or Broker. SinkBinding is similar to a ContainerSource but works on existing OpenShift Application resources, whereas the ContainerSource Container lifecycle is fully managed by OpenShift Serverless itself.',
+      ),
+      provider: 'Red Hat',
+    },
+    [EventSourceCephModel.kind]: {
+      description: t(
+        'knative-plugin~Used to connect OpenShift managed applications to Ceph notifications.',
       ),
       provider: 'Red Hat',
     },

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -247,6 +247,24 @@ export const EventSourceKafkaModel: K8sKind = {
   color: knativeEventingColor.value,
 };
 
+export const EventSourceCephModel: K8sKind = {
+  apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
+  apiVersion: 'v1alpha1',
+  kind: 'CephSource',
+  label: 'CephSource',
+  // t('knative-plugin~CephSource')
+  labelKey: 'knative-plugin~CephSource',
+  labelPlural: 'CephSources',
+  // t('knative-plugin~CephSources')
+  labelPluralKey: 'knative-plugin~CephSources',
+  plural: 'cephsources',
+  id: 'cephsource',
+  abbr: 'CPS',
+  namespaced: true,
+  crd: true,
+  color: knativeEventingColor.value,
+};
+
 export const EventSourceSinkBindingModel: K8sKind = {
   apiGroup: KNATIVE_EVENT_SOURCE_APIGROUP,
   apiVersion,


### PR DESCRIPTION
https://issues.redhat.com/browse/ODC-5818

Installed serverless operator and then 
Using `oc apply -f https://github.com/knative-sandbox/eventing-ceph/releases/download/v0.25.0/ceph.yaml`

![image](https://user-images.githubusercontent.com/20089340/133088799-6493cfba-b4cf-46de-a047-e0300a44d3a3.png)
