### PR TITLE
Bug 2002007: Enable error stack trace messages to scroll

### DIFF
--- a/frontend/public/components/utils/_copy-to-clipboard.scss
+++ b/frontend/public/components/utils/_copy-to-clipboard.scss
@@ -21,6 +21,8 @@
   }
   .co-copy-to-clipboard__text {
     max-height: 25vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 }
 


### PR DESCRIPTION
Regression introduced when removing bootstrap dependency which enabled `pre` `overflow:auto`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2002007