### PR TITLE
Refactor ActionMenu and LazyActionMenu to use PF menu and flyout menu

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Menu } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { checkAccess } from '@console/internal/components/utils';
 import { ActionMenuVariant, MenuOption } from '../types';
 import ActionMenuContent from './ActionMenuContent';
-import ActionMenuRenderer from './ActionMenuRenderer';
+import ActionMenuToggle from './ActionMenuToggle';
 
 type ActionMenuProps = {
   actions: Action[];
@@ -26,7 +26,9 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   const isKebabVariant = variant === ActionMenuVariant.KEBAB;
   const [isVisible, setVisible] = useSafetyFirst(isKebabVariant);
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
-  const menuRef = React.useRef(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
   const menuOptions = options || actions;
 
   const hideMenu = () => {
@@ -71,22 +73,36 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
 
   const menu = (
     <Menu ref={menuRef} containsFlyout onSelect={hideMenu}>
-      <ActionMenuContent options={menuOptions} onClick={hideMenu} focusItem={options[0]} />
+      <MenuContent data-test-id="action-items" translate="no">
+        <MenuList>
+          <ActionMenuContent options={menuOptions} onClick={hideMenu} focusItem={options[0]} />
+        </MenuList>
+      </MenuContent>
     </Menu>
   );
 
   return (
     isVisible && (
-      <ActionMenuRenderer
-        isOpen={isOpen}
-        isDisabled={isDisabled}
-        menu={menu}
-        menuRef={menuRef}
-        toggleVariant={variant}
-        toggleTitle={label}
-        onToggleClick={setIsOpen}
-        onToggleHover={handleHover}
-      />
+      <div ref={containerRef}>
+        <ActionMenuToggle
+          isOpen={isOpen}
+          isDisabled={isDisabled}
+          toggleRef={toggleRef}
+          toggleVariant={variant}
+          toggleTitle={label}
+          menuRef={menuRef}
+          onToggleClick={setIsOpen}
+          onToggleHover={handleHover}
+        />
+        <Popper
+          reference={toggleRef}
+          popper={menu}
+          placement="bottom-end"
+          isVisible={isOpen}
+          appendTo={containerRef.current}
+          popperMatchesTriggerWidth={false}
+        />
+      </div>
     )
   );
 };

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuContent.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuContent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Menu, MenuContent, MenuGroup, MenuItem, MenuList } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuGroup, MenuItem, MenuList, Divider } from '@patternfly/react-core';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { orderExtensionBasedOnInsertBeforeAndAfter } from '@console/shared';
 import { GroupedMenuOption, MenuOption, MenuOptionType } from '../types';
@@ -12,9 +12,18 @@ type GroupMenuContentProps = {
 };
 
 const GroupMenuContent: React.FC<GroupMenuContentProps> = ({ option, onClick }) => (
-  <MenuGroup label={option.label} translate="no">
-    <ActionMenuContent options={option.children} onClick={onClick} focusItem={option.children[0]} />
-  </MenuGroup>
+  <>
+    <Divider />
+    <MenuGroup label={option.label} translate="no">
+      <MenuList>
+        <ActionMenuContent
+          options={option.children}
+          onClick={onClick}
+          focusItem={option.children[0]}
+        />
+      </MenuList>
+    </MenuGroup>
+  </>
 );
 
 // Need to keep this in the same file to avoid circular dependency.
@@ -23,11 +32,15 @@ const SubMenuContent: React.FC<GroupMenuContentProps> = ({ option, onClick }) =>
     data-test-action={option.id}
     flyoutMenu={
       <Menu containsFlyout>
-        <ActionMenuContent
-          options={option.children}
-          onClick={onClick}
-          focusItem={option.children[0]}
-        />
+        <MenuContent data-test-id="action-items" translate="no">
+          <MenuList>
+            <ActionMenuContent
+              options={option.children}
+              onClick={onClick}
+              focusItem={option.children[0]}
+            />
+          </MenuList>
+        </MenuContent>
       </Menu>
     }
   >
@@ -44,40 +57,38 @@ type ActionMenuContentProps = {
 const ActionMenuContent: React.FC<ActionMenuContentProps> = ({ options, onClick, focusItem }) => {
   const sortedOptions = orderExtensionBasedOnInsertBeforeAndAfter(options);
   return (
-    <MenuContent data-test-id="action-items" translate="no">
-      <MenuList>
-        {sortedOptions.map((option) => {
-          const optionType = getMenuOptionType(option);
-          switch (optionType) {
-            case MenuOptionType.SUB_MENU:
-              return (
-                <SubMenuContent
-                  key={option.id}
-                  option={option as GroupedMenuOption}
-                  onClick={onClick}
-                />
-              );
-            case MenuOptionType.GROUP_MENU:
-              return (
-                <GroupMenuContent
-                  key={option.id}
-                  option={option as GroupedMenuOption}
-                  onClick={onClick}
-                />
-              );
-            default:
-              return (
-                <ActionMenuItem
-                  key={option.id}
-                  action={option as Action}
-                  onClick={onClick}
-                  autoFocus={focusItem ? option === focusItem : undefined}
-                />
-              );
-          }
-        })}
-      </MenuList>
-    </MenuContent>
+    <>
+      {sortedOptions.map((option) => {
+        const optionType = getMenuOptionType(option);
+        switch (optionType) {
+          case MenuOptionType.SUB_MENU:
+            return (
+              <SubMenuContent
+                key={option.id}
+                option={option as GroupedMenuOption}
+                onClick={onClick}
+              />
+            );
+          case MenuOptionType.GROUP_MENU:
+            return (
+              <GroupMenuContent
+                key={option.id}
+                option={option as GroupedMenuOption}
+                onClick={onClick}
+              />
+            );
+          default:
+            return (
+              <ActionMenuItem
+                key={option.id}
+                action={option as Action}
+                onClick={onClick}
+                autoFocus={focusItem ? option === focusItem : undefined}
+              />
+            );
+        }
+      })}
+    </>
   );
 };
 

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuContent.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuContent.tsx
@@ -1,16 +1,7 @@
 import * as React from 'react';
-import {
-  FocusTrap,
-  MenuContent,
-  MenuGroup,
-  MenuItem,
-  MenuItemAction,
-  MenuList,
-} from '@patternfly/react-core';
-import { AngleRightIcon } from '@patternfly/react-icons';
+import { Menu, MenuContent, MenuGroup, MenuItem, MenuList } from '@patternfly/react-core';
 import { Action } from '@console/dynamic-plugin-sdk';
 import { orderExtensionBasedOnInsertBeforeAndAfter } from '@console/shared';
-import { Popper } from '../../popper';
 import { GroupedMenuOption, MenuOption, MenuOptionType } from '../types';
 import { getMenuOptionType } from '../utils';
 import ActionMenuItem from './ActionMenuItem';
@@ -27,96 +18,22 @@ const GroupMenuContent: React.FC<GroupMenuContentProps> = ({ option, onClick }) 
 );
 
 // Need to keep this in the same file to avoid circular dependency.
-const SubMenuContent: React.FC<GroupMenuContentProps> = ({ option, onClick }) => {
-  const [open, setOpen] = React.useState(false);
-  const nodeRef = React.useRef(null);
-  const nodeRefCb = React.useCallback(() => nodeRef.current, []);
-  const subMenuRef = React.useRef(null);
-  // use a callback ref because FocusTrap is old and doesn't support non-function refs
-  const subMenuRefCb = React.useCallback(() => subMenuRef.current, []);
-
-  // mouse enter will open the sub menu
-  const handleNodeMouseEnter = () => setOpen(true);
-
-  const handleNodeMouseLeave = (e) => {
-    // if the mouse leaves this item, close the sub menu only if the mouse did not enter the sub menu itself
-    if (!subMenuRef.current || !subMenuRef.current.contains(e.relatedTarget as Node)) {
-      setOpen(false);
+const SubMenuContent: React.FC<GroupMenuContentProps> = ({ option, onClick }) => (
+  <MenuItem
+    data-test-action={option.id}
+    flyoutMenu={
+      <Menu containsFlyout>
+        <ActionMenuContent
+          options={option.children}
+          onClick={onClick}
+          focusItem={option.children[0]}
+        />
+      </Menu>
     }
-  };
-
-  const handleNodeKeyDown = (e) => {
-    // open the sub menu on enter or right arrow
-    if (e.keyCode === 39 || e.keyCode === 13) {
-      setOpen(true);
-      e.stopPropagation();
-    }
-  };
-
-  const handlePopperRequestClose = (e) => {
-    // only close the sub menu if clicking anywhere outside the menu item that owns the sub menu
-    if (!e || !nodeRef.current || !nodeRef.current.contains(e.target as Node)) {
-      setOpen(false);
-    }
-  };
-
-  const handleMenuMouseLeave = (e) => {
-    // only close the sub menu if the mouse does not enter the item
-    if (!nodeRef.current || !nodeRef.current.contains(e.relatedTarget as Node)) {
-      setOpen(false);
-    }
-  };
-
-  const handleMenuKeyDown = (e) => {
-    // close the sub menu on left arrow
-    if (e.keyCode === 37) {
-      setOpen(false);
-      e.stopPropagation();
-    }
-  };
-
-  return (
-    <>
-      <MenuItem
-        ref={nodeRef}
-        actions={<MenuItemAction icon={<AngleRightIcon aria-hidden />} />}
-        onMouseEnter={handleNodeMouseEnter}
-        onMouseLeave={handleNodeMouseLeave}
-        onKeyDown={handleNodeKeyDown}
-        data-test-action={option.id}
-        tabIndex={0}
-      >
-        {option.label}
-      </MenuItem>
-      <Popper
-        open={open}
-        placement="right-start"
-        reference={nodeRefCb}
-        onRequestClose={handlePopperRequestClose}
-        closeOnEsc
-        closeOnOutsideClick
-      >
-        <FocusTrap
-          focusTrapOptions={{ clickOutsideDeactivates: true, fallbackFocus: subMenuRefCb }}
-        >
-          <div
-            ref={subMenuRef}
-            role="presentation"
-            className="pf-c-menu pf-m-flyout"
-            onMouseLeave={handleMenuMouseLeave}
-            onKeyDown={handleMenuKeyDown}
-          >
-            <ActionMenuContent
-              options={option.children}
-              onClick={onClick}
-              focusItem={option.children[0]}
-            />
-          </div>
-        </FocusTrap>
-      </Popper>
-    </>
-  );
-};
+  >
+    {option.label}
+  </MenuItem>
+);
 
 type ActionMenuContentProps = {
   options: MenuOption[];

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuItem.tsx
@@ -71,9 +71,6 @@ const ActionItem: React.FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
 
   const extraProps = {
     onKeyDown: handleKeyDown,
-    // Override PF tabIndex -1 to make action items tabbable.
-    // This is needed to mimic older tabbable behavior since we do not use PF Menu component as a wrapper.
-    tabIndex: 0,
     ...(external ? { to: href, isExternalLink: external } : {}),
   };
 

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuRenderer.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuRenderer.tsx
@@ -11,7 +11,7 @@ type ActionMenuRendererProps = {
   menuRef: React.RefObject<HTMLElement>;
   toggleVariant?: ActionMenuVariant;
   toggleTitle?: string;
-  onToggleClick: (state: boolean) => void;
+  onToggleClick: (state: React.SetStateAction<boolean>) => void;
   onToggleHover: () => void;
 };
 
@@ -59,7 +59,7 @@ const ActionMenuRenderer: React.FC<ActionMenuRendererProps> = ({
       window.removeEventListener('keydown', handleMenuKeys);
       window.removeEventListener('click', handleClickOutside);
     }; // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // This needs to be run only on component mount/unmount
+  }, [isOpen]); // This needs to be run only on component mount/unmount
 
   const handleToggleClick = (ev) => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
@@ -69,7 +69,7 @@ const ActionMenuRenderer: React.FC<ActionMenuRendererProps> = ({
       );
       firstElement?.focus();
     }, 0);
-    onToggleClick(!isOpen);
+    onToggleClick((open) => !open);
   };
 
   const toggle = (

--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenuToggle.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenuToggle.tsx
@@ -1,33 +1,31 @@
 import * as React from 'react';
-import { Popper, MenuToggle } from '@patternfly/react-core';
+import { MenuToggle } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { ActionMenuVariant } from '../types';
 
-type ActionMenuRendererProps = {
+type ActionMenuToggleProps = {
   isOpen: boolean;
   isDisabled: boolean;
-  menu: React.ReactElement;
   menuRef: React.RefObject<HTMLElement>;
+  toggleRef: React.RefObject<HTMLButtonElement>;
   toggleVariant?: ActionMenuVariant;
   toggleTitle?: string;
   onToggleClick: (state: React.SetStateAction<boolean>) => void;
   onToggleHover: () => void;
 };
 
-const ActionMenuRenderer: React.FC<ActionMenuRendererProps> = ({
+const ActionMenuToggle: React.FC<ActionMenuToggleProps> = ({
   isOpen,
   isDisabled,
-  menu,
   menuRef,
+  toggleRef,
   toggleVariant = ActionMenuVariant.KEBAB,
   toggleTitle,
   onToggleClick,
   onToggleHover,
 }) => {
   const { t } = useTranslation();
-  const toggleRef = React.useRef(null);
-  const containerRef = React.useRef(null);
   const isKebabVariant = toggleVariant === ActionMenuVariant.KEBAB;
   const toggleLabel = toggleTitle || t('console-shared~Actions');
 
@@ -72,7 +70,7 @@ const ActionMenuRenderer: React.FC<ActionMenuRendererProps> = ({
     onToggleClick((open) => !open);
   };
 
-  const toggle = (
+  return (
     <MenuToggle
       variant={toggleVariant}
       innerRef={toggleRef}
@@ -88,19 +86,6 @@ const ActionMenuRenderer: React.FC<ActionMenuRendererProps> = ({
       {isKebabVariant ? <EllipsisVIcon /> : toggleLabel}
     </MenuToggle>
   );
-
-  return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        placement="bottom-end"
-        isVisible={isOpen}
-        appendTo={containerRef.current}
-        popperMatchesTriggerWidth={false}
-      />
-    </div>
-  );
 };
 
-export default ActionMenuRenderer;
+export default ActionMenuToggle;


### PR DESCRIPTION
### Fixes
- https://issues.redhat.com/browse/ODC-6218

### Problem
- The `ActionMenu` and `LazyActionMenu` components were using a custom implementation of menu and submenu. The custom implementation had various issues like keyboard navigation and submenu click not working correctly.

### Solution
- Refacor `ActionMenu` and `LazyActionMenu` to use PF menu and flyou menu components and fix previous issues.