### PR TITLE
Bug 2004578: Add monitoring and nodes label for external storage platform

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
@@ -212,8 +212,12 @@ const handleReviewAndCreateNext = async (
       );
 
       await createExternalSubSystem(subSystemPayloads);
+      await labelOCSNamespace();
       // Create storage cluster if one is not present except for external RHCS
-      if (!hasOCS && !isRhcs) await createStorageCluster(state);
+      if (!hasOCS && !isRhcs) {
+        await labelNodes(nodes);
+        await createStorageCluster(state);
+      }
       // Create a new storage system for non RHCS external vendor if one is not present
       if (hasAnExternalSystem) await createStorageSystem(subSystemName, subSystemKind);
     }


### PR DESCRIPTION
  -fixes https://bugzilla.redhat.com/show_bug.cgi?id=2004578
  -monitoring and nodes label were missing for external mode of stoarge system
  -this is causing stoarge cluster to be in error state and dashboards with misisng information

Signed-off-by: Afreen Rahman <afrahman@redhat.com>