### PR TITLE
Bug 2003145: Duplicate operand tab titles causes "two children with the same key" warning

### DIFF
--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -190,7 +190,7 @@ export const NavBar = withRouter<NavBarProps>(({ pages, baseURL, basePath }) => 
           'co-m-horizontal-nav-item--active': matchURL?.isExact,
         });
         return (
-          <li className={klass} key={nameKey || name}>
+          <li className={klass} key={href}>
             <Link
               to={`${baseURL.replace(/\/$/, '')}/${href}`}
               data-test-id={`horizontal-link-${nameKey || name}`}


### PR DESCRIPTION
Ensure that each tab on the Operator Details page has a unique key. 

How to reproduce the error:
1.  Install the Service Binding operator
2. Go to the Service Binding details page
3. Look for the "Warning: Encountered two children with the same key, `Service Binding`. " error in the browser console.

This ensures that tabs that may have the same name will have a unique key.

Note:  This will not change the UI