### PR TITLE
Bug 2000651: fixes imagestream from reference for alias to existing IS

### DIFF
--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -111,7 +111,7 @@ const ImageStreamTagsRow: React.SFC<ImageStreamTagsRowProps> = ({
         {from && referencesTag && (
           <ResourceLink
             kind={ImageStreamTagsReference}
-            name={getImageStreamTagName(imageStream.metadata.name, from.name)}
+            name={from.name}
             namespace={imageStream.metadata.namespace}
             title={from.name}
           />


### PR DESCRIPTION
**Fixes**

https://bugzilla.redhat.com/show_bug.cgi?id=2000651

**Issue and solution**

`ResourceLink` was not getting resolved as the name passed was not valid.

update `ResourceLink` name to have name reference from `from.name` is its alias of another IS


**Screenshot**

Before:

![image](https://user-images.githubusercontent.com/5129024/133554256-f46848fa-954b-4043-99d8-bcbbfb55d537.png)


After:

![image](https://user-images.githubusercontent.com/5129024/133554366-21b35c97-5ca0-4fff-9429-a6818e6cb89e.png)



**Steps to reproduce:**
1. Create an ImageStream using the command `oc create is echoenv`
2. Create a regular ImageStreamTag using the following command (container image used is not relevant): `oc create istag echoenv:test-one --from-image=quay.io/simonkrenger/echoenv:latest`
3. Observe that in the UI under "Image Streams" => "echoenv" => "Tags" we can now see the ImageStreamTag as expected. Clicking on "echoenv:test-one" will work as expected.
4. Create an alias for this ImageStreamTag: `oc create istag echoenv:test-two --from=echoenv:test-one`
5. The "From" field for the newly created ImageStreamTag shows "echoenv:echoenv:test-one" , which is invalid and won't resolve

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
