### PR TITLE
Bug 2004904: Warning about another copy of React while closing any modal

### DIFF
--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -21,7 +21,7 @@ export const createModal: CreateModal = (getModalContainer) => {
       if (e && e.stopPropagation) {
         e.stopPropagation();
       }
-      ReactDOM.unmountComponentAtNode(modalContainer);
+      ReactDOM.render(null, modalContainer);
       resolve();
     };
     Modal.setAppElement(document.getElementById('app-content'));


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6106
( possible duplicate: [Bug 1880412](https://bugzilla.redhat.com/show_bug.cgi?id=1880412) )

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
1. Normally we have nothing inside the `container` 
![image](https://user-images.githubusercontent.com/20089340/133606467-d38f4bb2-6aca-45c3-8d43-ee12fc916b34.png)

2. Then we render any modal inside this `container` (e.g. `delete buildconfig`)
![image](https://user-images.githubusercontent.com/20089340/133606585-9b42fed3-bbaf-404d-af8e-5879d43ab61c.png)

3. Then we were manually calling `ReactDOM.unmountComponentAtNode` 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
From step 3. we can directly go to step 1.
- will let React unmount the component internally, simply by rendering `null` 
![image](https://user-images.githubusercontent.com/20089340/133607132-7fce48f3-92e9-4837-b55d-a16abf89c482.png)
_( or is it a better idea to render an empty Fragment `<> </>` ? )_ 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
No console warning when clicking on 'cancel' button
![image](https://user-images.githubusercontent.com/20089340/133606276-3e6c8310-a8cf-470d-959b-8550142099ea.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. Open any modal. ( e.g. create project / delete resource )
2. Click cancel.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge