### PR TITLE
Bug 2004962: disable thread-loader in CI

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -26,6 +26,7 @@ const HOT_RELOAD = process.env.HOT_RELOAD || 'true';
 const CHECK_CYCLES = process.env.CHECK_CYCLES || 'false';
 const ANALYZE_BUNDLE = process.env.ANALYZE_BUNDLE || 'false';
 const REACT_REFRESH = process.env.REACT_REFRESH;
+const OPENSHIFT_CI = process.env.OPENSHIFT_CI;
 const WDS_PORT = 8080;
 
 /* Helpers */
@@ -78,13 +79,14 @@ const config: Configuration = {
         exclude: /node_modules\/(?!(bitbucket|ky)\/)/,
         use: [
           { loader: 'cache-loader' },
-          {
-            loader: 'thread-loader',
-            options: {
-              // Leave one core spare for fork-ts-checker-webpack-plugin
-              workers: require('os').cpus().length - 1,
-            },
-          },
+          // Disable thread-loader in CI
+          ...(!OPENSHIFT_CI
+            ? [
+                {
+                  loader: 'thread-loader',
+                },
+              ]
+            : []),
           ...(REACT_REFRESH
             ? [
                 {
@@ -133,7 +135,7 @@ const config: Configuration = {
             },
           },
           { loader: 'cache-loader' },
-          { loader: 'thread-loader' },
+          ...(!OPENSHIFT_CI ? [{ loader: 'thread-loader' }] : []),
           {
             loader: 'css-loader',
             options: {

--- a/test-frontend.sh
+++ b/test-frontend.sh
@@ -9,7 +9,7 @@ ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
 cd frontend
 yarn run lint
 if [ "$OPENSHIFT_CI" = true ]; then
-    JEST_SUITE_NAME="OpenShift Console Unit Tests" JEST_JUNIT_OUTPUT_DIR="$ARTIFACT_DIR" yarn run test --ci --reporters=default --reporters=jest-junit
+    JEST_SUITE_NAME="OpenShift Console Unit Tests" JEST_JUNIT_OUTPUT_DIR="$ARTIFACT_DIR" yarn run test --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
 else
     yarn run test
 fi


### PR DESCRIPTION
Our jobs are consuming too much CPU in CI. Disable thread-loader by checking the `OPENSHIFT_CI` environment variable.

cc @bbguimaraes @kdoberst 