### PR TITLE
Bug 1989843: 'More' and 'Show Less' chips are not translated

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,7 +125,7 @@
     "@patternfly/quickstarts": "1.1.0",
     "@patternfly/react-catalog-view-extension": "4.12.38",
     "@patternfly/react-charts": "6.15.14",
-    "@patternfly/react-core": "4.147.2",
+    "@patternfly/react-core": "4.148.1",
     "@patternfly/react-table": "4.29.39",
     "@patternfly/react-tokens": "4.12.9",
     "@patternfly/react-topology": "4.9.44",

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -298,6 +298,10 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                   deleteChip={(filter, chip: ToolbarChip) => updateRowFilterSelected([chip.key])}
                   categoryName={key}
                   deleteChipGroup={() => clearAllRowFilter(key)}
+                  chipGroupCollapsedText={t('public~{{numRemaining}} more', {
+                    numRemaining: '${remaining}',
+                  })}
+                  chipGroupExpandedText={t('public~Show less')}
                 >
                   {acc}
                 </ToolbarFilter>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1870,10 +1870,10 @@
     xterm "^4.8.1"
     xterm-addon-fit "^0.2.1"
 
-"@patternfly/react-core@4.147.2":
-  version "4.147.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.147.2.tgz#b127a746dbddffbb3a1a9de896f9bcc51fae664d"
-  integrity sha512-XbWiI2HhU6u72WkFa+scg6ny6NE4/3A79SwKsCQzcVKT8Nv49UAQsvVX31TKEIT1rQIkUzhgMFtcoe3Kk5SR6A==
+"@patternfly/react-core@4.148.1":
+  version "4.148.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.148.1.tgz#456268f00a48b0d80f39296dd88d59e3200c9d03"
+  integrity sha512-jDYJ9N4NFJKbTKE+cy/MRf2m2T/cPPkwAH0ZucvlhlawLC6riyZLEjpuK4l24unXh5ESMtGFDrBLdImoxErs3w==
   dependencies:
     "@patternfly/react-icons" "^4.11.8"
     "@patternfly/react-styles" "^4.11.8"


### PR DESCRIPTION
Fixes the missing translations for the show `x` More and Show Less
chips on the pods, roles, nodes, etc list pages.

Patternfly bump is necessary to pick up @rebeccaalpert changes in Patternfly:
https://github.com/patternfly/patternfly-react/pull/6138

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1989843

<img width="1792" alt="Screen Shot 2021-09-16 at 2 15 56 PM" src="https://user-images.githubusercontent.com/21317056/133670404-09d51ed5-2aa4-4253-9db7-b551f23ee936.png">
<img width="1792" alt="Screen Shot 2021-09-16 at 2 16 08 PM" src="https://user-images.githubusercontent.com/21317056/133670406-ad4cde68-c797-41e3-af82-8e673e2847f0.png">
