### PR TITLE
Bug 1999091: Console update toast notification can appear multiple times

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -299,6 +299,7 @@ const CaptureTelemetry = React.memo(() => {
 const PollConsoleUpdates = React.memo(() => {
   const toastContext = useToast();
   const { t } = useTranslation();
+  const [isToastOpen, setToastOpen] = React.useState(false);
   const [pluginsData, pluginsError] = useURLPoll(
     `${window.SERVER_FLAGS.basePath}api/check-updates`,
   );
@@ -313,7 +314,7 @@ const PollConsoleUpdates = React.memo(() => {
   const pluginsChanged = !_.isEmpty(_.xor(prevPluginsData?.plugins, pluginsData?.plugins));
   const consoleCommitChanged = prevPluginsData?.consoleCommit !== pluginsData?.consoleCommit;
 
-  if (pluginsStateInitialized && (pluginsChanged || consoleCommitChanged)) {
+  if (!isToastOpen && pluginsStateInitialized && (pluginsChanged || consoleCommitChanged)) {
     toastContext.addToast({
       variant: AlertVariant.warning,
       title: t('public~Web console update is available'),
@@ -329,7 +330,10 @@ const PollConsoleUpdates = React.memo(() => {
           callback: () => window.location.reload(),
         },
       ],
+      onClose: () => setToastOpen(false),
+      onRemove: () => setToastOpen(false),
     });
+    setToastOpen(true);
   }
 
   return null;


### PR DESCRIPTION
Fixes issue where multiple console/plugin updates will display multiple
toast notifications using internal react state.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1999091

## Before:
<img width="1791" alt="Screen Shot 2021-09-16 at 4 11 24 PM" src="https://user-images.githubusercontent.com/21317056/133680319-fb0e39a5-3526-4419-83f8-afb2db90a9e4.png">


## After:
<img width="1792" alt="Screen Shot 2021-09-16 at 4 10 09 PM" src="https://user-images.githubusercontent.com/21317056/133680340-6cc65ef4-6452-4c99-869b-4880f387a95a.png">
