### PR TITLE
Bug 1998377: Fix file systems table styles

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/guest-agent-file-systems.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/guest-agent-file-systems.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import * as classNames from 'classnames';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Table, TableData } from '@console/internal/components/factory';
@@ -14,12 +13,12 @@ import { isGuestAgentInstalled } from '../../utils/guest-agent-utils';
 
 import './guest-agent-file-systems.scss';
 
-const tableColumnClasses = [
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
-  classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-sm-4'),
+export const tableColumnClasses = [
+  '',
+  '',
+  'pf-m-hidden pf-m-visible-on-sm',
+  'pf-m-hidden pf-m-visible-on-md',
+  'pf-m-hidden pf-m-visible-on-lg',
 ];
 
 const FileSystemsTableHeader = (t: TFunction) => () => {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
@@ -3,17 +3,17 @@ import { Kebab } from '@console/internal/components/utils';
 export const diskTableColumnClasses = [
   '',
   '',
-  'pm-m-hidden pf-m-visible-on-sm',
-  'pm-m-hidden pf-m-visible-on-md',
-  'pm-m-hidden pf-m-visible-on-lg',
-  'pm-m-hidden pf-m-visible-on-lg',
+  'pf-m-hidden pf-m-visible-on-sm',
+  'pf-m-hidden pf-m-visible-on-md',
+  'pf-m-hidden pf-m-visible-on-lg',
+  'pf-m-hidden pf-m-visible-on-lg',
   Kebab.columnClass,
 ];
 
 export const cdTableColumnClasses = [
   '',
   '',
-  'pm-m-hidden pf-m-visible-on-md',
-  'pm-m-hidden pf-m-visible-on-lg',
+  'pf-m-hidden pf-m-visible-on-md',
+  'pf-m-hidden pf-m-visible-on-lg',
   Kebab.columnClass,
 ];


### PR DESCRIPTION
This PR fixes an issue where the columns in the "File systems" table were being limited. It also corrects an issue where the columns in the "File systems" table and disks table in the Disks tab weren't behaving responsively.

Before:
![Selection_759](https://user-images.githubusercontent.com/8544299/133708210-47a686a2-09db-4e01-b995-d95160b79483.png)

After:
![Selection_760](https://user-images.githubusercontent.com/8544299/133708199-b772fc9c-3566-457a-9b3d-78dd456fd32a.png)

