### PR TITLE
Bug 1999579: Changes defaults volume binding mode to Immediate

### DIFF
--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -49,7 +49,7 @@ const defaultState = {
     type: null,
     parameters: {},
     reclaim: null,
-    volumeBindingMode: 'WaitForFirstConsumer',
+    volumeBindingMode: 'Immediate',
     expansion: true,
   },
   customParams: [['', '']],
@@ -995,7 +995,7 @@ class StorageClassFormWithTranslation extends React.Component<
     const reclaimPolicyKey =
       newStorageClass.reclaim === null ? this.reclaimPolicies.Delete : newStorageClass.reclaim;
     const volumeBindingModeKey =
-      newStorageClass.volumeBindingMode || this.volumeBindingModes.WaitForFirstConsumer;
+      newStorageClass.volumeBindingMode || this.volumeBindingModes.Immediate;
     const expansionFlag =
       newStorageClass.type && this.storageTypes[newStorageClass.type].allowVolumeExpansion;
     const allowExpansion = expansionFlag ? newStorageClass.expansion : false;
@@ -1078,7 +1078,7 @@ class StorageClassFormWithTranslation extends React.Component<
             />
             <span className="help-block">
               {t(
-                'public~Determines when persistent volume claims will be provisioned and bound. Defaults to "WaitForFirstConsumer"',
+                'public~Determines when persistent volume claims will be provisioned and bound. Defaults to "Immediate"',
               )}
             </span>
           </div>

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1456,7 +1456,7 @@
   "Determines what happens to persistent volumes when the associated persistent volume claim is deleted. Defaults to \"Delete\"": "Determines what happens to persistent volumes when the associated persistent volume claim is deleted. Defaults to \"Delete\"",
   "Volume binding mode": "Volume binding mode",
   "Select volume binding mode": "Select volume binding mode",
-  "Determines when persistent volume claims will be provisioned and bound. Defaults to \"WaitForFirstConsumer\"": "Determines when persistent volume claims will be provisioned and bound. Defaults to \"WaitForFirstConsumer\"",
+  "Determines when persistent volume claims will be provisioned and bound. Defaults to \"Immediate\"": "Determines when persistent volume claims will be provisioned and bound. Defaults to \"Immediate\"",
   "Provisioner": "Provisioner",
   "Select Provisioner": "Select Provisioner",
   "Determines what volume plugin is used for provisioning PersistentVolumes.": "Determines what volume plugin is used for provisioning PersistentVolumes.",


### PR DESCRIPTION
This commit changes the default volume binding mode from
"WaitForFirstConsumer" to "Immediate" in the StorageClass form page.

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>