### PR TITLE
Bug 2005298: Block and File and Object dashboards should not be part of OCP Console for ODF Managed Services

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -21,6 +21,7 @@ export const DASHBOARD_LINK = '/dashboards/persistent-storage';
 export const AVAILABLE = 'Available';
 export const OSD_REMOVAL_TEMPLATE = 'ocs-osd-removal';
 export const PVC_PROVISIONER_ANNOTATION = 'volume.beta.kubernetes.io/storage-provisioner';
+export const ODF_MANAGED_LABEL = 'odf-managed-service';
 export const dropdownUnits = {
   GiB: 'Gi',
   TiB: 'Ti',

--- a/frontend/packages/ceph-storage-plugin/src/features.ts
+++ b/frontend/packages/ceph-storage-plugin/src/features.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import { Dispatch } from 'react-redux';
-import { k8sList, StorageClassResourceKind, ListKind } from '@console/internal/module/k8s';
+import { k8sGet, k8sList, StorageClassResourceKind, ListKind } from '@console/internal/module/k8s';
 import {
   ClusterServiceVersionModel,
   ClusterServiceVersionKind,
@@ -9,7 +9,7 @@ import { setFlag } from '@console/internal/actions/features';
 import { FeatureDetector } from '@console/plugin-sdk';
 import { getAnnotations, getName } from '@console/shared/src/selectors/common';
 import { fetchK8s } from '@console/internal/graphql/client';
-import { StorageClassModel } from '@console/internal/models';
+import { NamespaceModel, StorageClassModel } from '@console/internal/models';
 import { OCSServiceModel } from './models';
 import {
   CEPH_STORAGE_NAMESPACE,
@@ -18,6 +18,7 @@ import {
   SECOND,
   OCS_OPERATOR,
   NOOBAA_PROVISIONER,
+  ODF_MANAGED_LABEL,
 } from './constants';
 import { StorageClusterKind } from './types';
 
@@ -28,6 +29,8 @@ export const OCS_CONVERGED_FLAG = 'OCS_CONVERGED';
 export const OCS_FLAG = 'OCS';
 // Todo(bipuladh): Remove this completely in 4.6
 export const CEPH_FLAG = 'CEPH';
+
+export const ODF_MANAGED_FLAG = 'ODF_MANAGED';
 
 export const LSO_FLAG = 'LSO';
 
@@ -126,6 +129,18 @@ export const detectOCS: FeatureDetector = async (dispatch) => {
     dispatch(setFlag(OCS_CONVERGED_FLAG, false));
     dispatch(setFlag(OCS_INDEPENDENT_FLAG, false));
     dispatch(setFlag(OCS_FLAG, false));
+  }
+};
+
+export const detectManagedODF: FeatureDetector = async (dispatch) => {
+  try {
+    const ns = await k8sGet(NamespaceModel, CEPH_STORAGE_NAMESPACE);
+    if (ns) {
+      const isManagedCluster = ns?.metadata?.labels?.[ODF_MANAGED_LABEL];
+      dispatch(setFlag(ODF_MANAGED_FLAG, !!isManagedCluster));
+    }
+  } catch (error) {
+    dispatch(setFlag(ODF_MANAGED_FLAG, false));
   }
 };
 

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -37,6 +37,8 @@ import {
   OCS_INDEPENDENT_FLAG,
   OCS_CONVERGED_FLAG,
   OCS_FLAG,
+  ODF_MANAGED_FLAG,
+  detectManagedODF,
 } from './features';
 import { getAlertActionPath } from './utils/alert-action-path';
 import { OSD_DOWN_ALERT, OSD_DOWN_AND_OUT_ALERT } from './constants';
@@ -98,6 +100,15 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'FeatureFlag/Custom',
     properties: {
+      detect: detectManagedODF,
+    },
+    flags: {
+      required: [CEPH_FLAG],
+    },
+  },
+  {
+    type: 'FeatureFlag/Custom',
+    properties: {
       detect: detectRGW,
     },
     flags: {
@@ -119,7 +130,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [OCS_CONVERGED_FLAG],
-      disallowed: [OCS_INDEPENDENT_FLAG],
+      disallowed: [OCS_INDEPENDENT_FLAG, ODF_MANAGED_FLAG],
     },
   },
   {
@@ -310,6 +321,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [OCS_INDEPENDENT_FLAG],
+      disallowed: [ODF_MANAGED_FLAG],
     },
   },
   // Left Cards

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -15,7 +15,7 @@ import {
 import { GridPosition } from '@console/shared/src/components/dashboard/DashboardGrid';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
-import { OCS_FLAG } from '@console/ceph-storage-plugin/src/features';
+import { OCS_FLAG, ODF_MANAGED_FLAG } from '@console/ceph-storage-plugin/src/features';
 import * as models from './models';
 import { getObcStatusGroups } from './components/buckets-card/utils';
 
@@ -101,6 +101,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
     flags: {
       required: [NOOBAA_FLAG, OCS_FLAG],
+      disallowed: [ODF_MANAGED_FLAG],
     },
   },
   {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/9742 to `release-4.7` branch.