### PR TITLE
Bug 1990193: Internationalize Search page ToolbarFilter props

### DIFF
--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -242,6 +242,10 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
                 }))}
                 deleteChip={updateNewItems}
                 categoryName={t('public~Resource')}
+                chipGroupCollapsedText={t('public~{{numRemaining}} more', {
+                  numRemaining: '${remaining}',
+                })}
+                chipGroupExpandedText={t('public~Show less')}
               >
                 <ResourceListDropdown
                   selected={[...selectedItems]}


### PR DESCRIPTION
I updated PatternFly to support internationalization of labels in the ToolbarFilter. This PR makes the necessary updates on the OpenShift Search page.

Chinese:
<img width="1083" alt="Screen Shot 2021-09-17 at 3 51 13 PM" src="https://user-images.githubusercontent.com/7014965/133845783-d7938f70-b575-470f-961b-22178e85af76.png">

<img width="1075" alt="Screen Shot 2021-09-17 at 3 51 20 PM" src="https://user-images.githubusercontent.com/7014965/133845822-26f21c15-3014-48c5-8755-2d17e2b26a52.png">

Korean:
<img width="1084" alt="Screen Shot 2021-09-17 at 3 52 22 PM" src="https://user-images.githubusercontent.com/7014965/133845900-976d5180-4226-4bc3-b89f-9f9a6e31edcb.png">

<img width="1082" alt="Screen Shot 2021-09-17 at 3 52 28 PM" src="https://user-images.githubusercontent.com/7014965/133845933-0a39e186-e58a-49ab-81d2-c43fdfe32a91.png">

Japanese:
<img width="1087" alt="Screen Shot 2021-09-17 at 3 49 54 PM" src="https://user-images.githubusercontent.com/7014965/133845650-7fb57763-a5e8-4e26-9511-6232b57670cf.png">

<img width="1081" alt="Screen Shot 2021-09-17 at 3 49 47 PM" src="https://user-images.githubusercontent.com/7014965/133845634-f4966598-b3c1-49f4-bad2-502f938ae793.png">

We're already using the strings elsewhere, so no new i18n files are needed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1990193.