### PR TITLE
Bug 2001577: Quick search placeholder is not displayed properly when the search string is removed

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchBar.tsx
@@ -38,7 +38,9 @@ const QuickSearchBar: React.FC<QuickSearchBarProps> = ({
       <div className="ocs-quick-search-bar__input-wrapper">
         {/* <span> is only used to calculate the width of input based on the text in search */}
         <span className="ocs-quick-search-bar__input-dummy" ref={spanRef}>
-          {searchTerm?.length > 0 ? searchTerm.replace(/ /g, '\u00a0') : searchPlaceholder}
+          {searchTerm?.length >= searchPlaceholder.length
+            ? searchTerm.replace(/ /g, '\u00a0')
+            : searchPlaceholder}
         </span>
         <TextInput
           type="text"


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2001577
https://issues.redhat.com/browse/OCPBUGSM-34451

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When the size of the search text was smaller than the placeholder & we would clear it completely, then the input field did not have enough size to fit the entire placeholder

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Never let the size be smaller than placeholder size 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![donthideplaceholder](https://user-images.githubusercontent.com/20089340/133975625-c7fea93f-29f4-451f-8140-09d58443114b.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Open Quick search (ctrl + spacebar)
2. type a string that has no search results
3. double click the search string and enter backspace / Ctrl+X


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge