### PR TITLE
Bug 2001575: Clicking on the perspective switcher shows a white page with loader 

### DIFF
--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -41,7 +41,9 @@ const PerspectiveDropdownItem: React.FC<PerspectiveDropdownItemProps> = ({
     >
       <Title headingLevel="h2" size="md" data-test-id="perspective-switcher-menu-option">
         <span className="oc-nav-header__icon">
-          <LazyIcon />
+          <React.Suspense fallback={<>&emsp;</>}>
+            <LazyIcon />
+          </React.Suspense>
         </span>
         {perspective.properties.name}
       </Title>


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2001575
https://issues.redhat.com/browse/OCPBUGSM-34450

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
This is because we lazy load the logos for admin and dev perspective items ( inside the dropdown )

So Dev perspective is not loaded initially and it is loaded when we click on the dropdown ( because it is rendered at that time )

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Wrapped the Lazy loaded icon in a suspense tag
~Added a hook, to call both the `perspective.properties.icon();` promises, resulting in both network calls taking place before we click the dropdown, and both icons pre loaded during the initial load, thus no refresh of the screen when we click on the toggle~


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![preLoadLazyLoadIcons](https://user-images.githubusercontent.com/20089340/134158265-c089e0d2-d364-4219-865c-5cc56e824b61.gif)
 

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1 login to the app / Reload the page
2. Click on the perspective switcher

Expected results:
It should show the perspective dropdown

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge