### PR TITLE
Bug 2002125: Network policy details page heading should be updated to Network Policy details

### DIFF
--- a/frontend/public/components/network-policy.tsx
+++ b/frontend/public/components/network-policy.tsx
@@ -312,7 +312,7 @@ const Details_: React.FunctionComponent<DetailsProps> = ({ obj: np, flags }) => 
   return (
     <>
       <div className="co-m-pane__body">
-        <SectionHeading text={t('public~Network policy details')} />
+        <SectionHeading text={t('public~NetworkPolicy details')} />
         <div className="row">
           <div className="col-md-6">
             <ResourceSummary resource={np} podSelector={'spec.podSelector'} showPodSelector />

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -1098,7 +1098,7 @@
   "Exceptions": "Exceptions",
   "with exceptions": "with exceptions",
   "Any port": "Any port",
-  "Network policy details": "Network policy details",
+  "NetworkPolicy details": "NetworkPolicy details",
   "Pods accept all traffic by default. They can be isolated via NetworkPolicies which specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will reject all traffic not explicitly allowed via a NetworkPolicy. See more details in: <2></2>.": "Pods accept all traffic by default. They can be isolated via NetworkPolicies which specify a whitelist of ingress rules. When a Pod is selected by a NetworkPolicy, it will reject all traffic not explicitly allowed via a NetworkPolicy. See more details in: <2></2>.",
   "NetworkPolicies documentation": "NetworkPolicies documentation",
   "All incoming traffic is denied to Pods in {{namespace}}": "All incoming traffic is denied to Pods in {{namespace}}",


### PR DESCRIPTION
Fixes: 

https://bugzilla.redhat.com/show_bug.cgi?id=2002125

Correct typo on NetworkPolicy details page
<img width="1112" alt="Screen Shot 2021-09-21 at 9 41 57 AM" src="https://user-images.githubusercontent.com/12129628/134185947-2f21d377-e5f5-4d61-999e-529b8b5981ce.png">

