### PR TITLE
Bug 2003120: Prevent null references and "ResizeObserver loop limit exceeded" errors in IFrameMarkdownView

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -366,8 +366,7 @@ graphQLReady.onReady(() => {
   // Used by GUI tests to check for unhandled exceptions
   window.windowError = null;
   window.onerror = (message, source, lineno, colno, error) => {
-    const { stack } = error;
-    const formattedStack = stack?.replace(/\\n/g, '\n');
+    const formattedStack = error?.stack?.replace(/\\n/g, '\n');
     window.windowError = `unhandled error: ${message} ${formattedStack || ''}`;
     // eslint-disable-next-line no-console
     console.error(window.windowError);

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -170,32 +170,19 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   renderExtension,
 }) => {
   const [frame, setFrame] = React.useState<HTMLIFrameElement>();
+  const [frameHeight, setFrameHeight] = React.useState(0);
   const [loaded, setLoaded] = React.useState(false);
-  const updateTimeoutHandle = React.useRef<number>();
 
-  const updateDimensions = React.useCallback(() => {
-    if (!frame?.contentWindow?.document.body.firstChild) {
-      return;
-    }
-    frame.style.height = `${frame.contentWindow.document.body.firstElementChild.scrollHeight}px`;
-
-    // Let the new height take effect, then reset again once we recompute
-    updateTimeoutHandle.current = setTimeout(() => {
-      if (exactHeight) {
-        frame.style.height = `${frame.contentWindow.document.body.firstElementChild.scrollHeight}px`;
-      } else {
-        // Increase by 15px for the case where a horizontal scrollbar might appear
-        frame.style.height = `${frame.contentWindow.document.body.firstElementChild.scrollHeight +
-          15}px`;
+  const updateDimensions = React.useCallback(
+    _.debounce(() => {
+      if (!frame?.contentWindow?.document?.body?.firstElementChild) {
+        return;
       }
-    });
-  }, [frame, exactHeight]);
-
-  React.useEffect(
-    () => () => {
-      clearTimeout(updateTimeoutHandle.current);
-    },
-    [],
+      setFrameHeight(
+        frame.contentWindow.document.body.firstElementChild.scrollHeight + (exactHeight ? 0 : 15),
+      );
+    }, 100),
+    [frame, exactHeight],
   );
 
   const onLoad = React.useCallback(() => {
@@ -247,7 +234,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
       <iframe
         sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin"
         srcDoc={contents}
-        style={{ border: '0px', display: 'block', width: '100%', height: '0' }}
+        style={{ border: '0px', display: 'block', width: '100%', height: frameHeight }}
         ref={(r) => setFrame(r)}
         onLoad={() => onLoad()}
       />


### PR DESCRIPTION
- Fix optional chaining in frontend/public/components/markdown-view.tsx and frontend/public/components/app.jsx to prevent null/undefined references
- Wrap IFrameMarkdownView updateDimensions function in _.debounce to prevent ResizeObserver loop limit exceeded
- Update logic in IFrameMarkdownView updateDimensions to use React state rather than directly modifying the style property of the iframe element.