### PR TITLE
Bug 1998519: Provide options to file fstype in create-local-volume-set

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/reducer.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/attached-devices-mode/reducer.ts
@@ -19,6 +19,7 @@ export const initialState: State = {
   isValidDiskSize: true,
   diskType: 'All',
   diskMode: diskModeDropdownItems.BLOCK,
+  fsType: '',
   deviceType: [deviceTypeDropdownItems.DISK, deviceTypeDropdownItems.PART],
   maxDiskLimit: '',
   minDiskSize: '1',
@@ -93,6 +94,7 @@ export type State = {
   isValidDiskSize: boolean;
   diskType: string;
   diskMode: string;
+  fsType: string;
   deviceType: string[];
   maxDiskLimit: string;
   minDiskSize: string;
@@ -136,6 +138,7 @@ export type Action =
   | { type: 'setDiskType'; value: string }
   | { type: 'setDeviceType'; value: string[] }
   | { type: 'setDiskMode'; value: string }
+  | { type: 'setFsType'; value: string }
   | { type: 'setMaxDiskLimit'; value: string }
   | { type: 'setNodeNames'; value: string[] }
   | { type: 'setMinDiskSize'; value: number | string }
@@ -192,6 +195,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { diskType: action.value });
     case 'setDiskMode':
       return Object.assign({}, state, { diskMode: action.value });
+    case 'setFsType':
+      return Object.assign({}, state, { fsType: action.value });
     case 'setDeviceType':
       return Object.assign({}, state, { deviceType: action.value });
     case 'setMaxDiskLimit':

--- a/frontend/packages/local-storage-operator-plugin/locales/en/lso-plugin.json
+++ b/frontend/packages/local-storage-operator-plugin/locales/en/lso-plugin.json
@@ -32,6 +32,7 @@
   "Disk Type": "Disk Type",
   "Advanced": "Advanced",
   "Volume Mode": "Volume Mode",
+  "File System Type": "File System Type",
   "Disk Size": "Disk Size",
   "Min": "Min",
   "Please enter a positive Integer": "Please enter a positive Integer",

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/body.tsx
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/body.tsx
@@ -19,6 +19,7 @@ import {
   diskModeDropdownItems,
   diskTypeDropdownItems,
   diskSizeUnitOptions,
+  fsTypeDropdownItems,
   deviceTypeDropdownItems,
 } from '../../constants';
 import { NodesTable } from '../tables/nodes-table';
@@ -33,6 +34,7 @@ export const LocalVolumeSetBody: React.FC<LocalVolumeSetBodyProps> = ({
   allNodesHelpTxt,
   lvsNameHelpTxt,
   deviceTypeOptions = deviceTypeDropdownItems,
+  fsTypeOptions = fsTypeDropdownItems,
 }) => {
   const { t } = useTranslation();
 
@@ -187,6 +189,24 @@ export const LocalVolumeSetBody: React.FC<LocalVolumeSetBodyProps> = ({
             defaultSelected={[deviceTypeOptions.DISK, deviceTypeOptions.PART]}
           />
         </FormGroup>
+        {state.diskMode === diskModeDropdownItems.FILESYSTEM && (
+          <FormGroup
+            label={t('lso-plugin~File System Type')}
+            fieldId="create-lso-fs-type-dropdown"
+            className="lso-create-lvs__fs-type-dropdown--margin"
+          >
+            <Dropdown
+              id="create-lso-fs-type-dropdown"
+              dropDownClassName="dropdown--full-width"
+              items={fsTypeOptions}
+              title={state.fsType}
+              selectedKey={state.fsType}
+              onChange={(mode: string) => {
+                dispatch({ type: 'setFsType', value: fsTypeDropdownItems[mode] });
+              }}
+            />
+          </FormGroup>
+        )}
         <FormGroup
           label={t('lso-plugin~Disk Size')}
           fieldId="create-lvs-disk-size"
@@ -299,6 +319,7 @@ type LocalVolumeSetBodyProps = {
   dispatch: React.Dispatch<Action>;
   diskModeOptions?: { [key: string]: string };
   deviceTypeOptions?: { [key: string]: string };
+  fsTypeOptions?: { [key: string]: string };
   allNodesHelpTxt?: string;
   lvsNameHelpTxt?: string;
   taintsFilter?: (node: NodeKind) => boolean;

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/request.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/request.ts
@@ -54,6 +54,7 @@ export const getLocalVolumeSetRequestData = (
     },
   } as LocalVolumeSetKind;
 
+  if (state.fsType) requestData.spec.fsType = state.fsType;
   if (!_.isEmpty(toleration)) requestData.spec.tolerations = [toleration];
   if (state.maxDiskLimit) requestData.spec.maxDeviceCount = +state.maxDiskLimit;
   if (state.minDiskSize)

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/state.ts
@@ -8,6 +8,7 @@ export const initialState = {
   diskType: 'All',
   diskMode: diskModeDropdownItems.BLOCK,
   deviceType: [],
+  fsType: '',
   maxDiskLimit: '',
   minDiskSize: '1',
   maxDiskSize: '',
@@ -23,6 +24,7 @@ export type State = {
   isValidDiskSize: boolean;
   diskType: string;
   diskMode: string;
+  fsType: string;
   deviceType: string[];
   maxDiskLimit: string;
   minDiskSize: string;
@@ -39,6 +41,7 @@ export type Action =
   | { type: 'setIsValidDiskSize'; value: boolean }
   | { type: 'setDiskType'; value: string }
   | { type: 'setDiskMode'; value: string }
+  | { type: 'setFsType'; value: string }
   | { type: 'setMaxDiskLimit'; value: string }
   | { type: 'setMinDiskSize'; value: string }
   | { type: 'setMaxDiskSize'; value: string }
@@ -62,6 +65,8 @@ export const reducer = (state: State, action: Action) => {
       return Object.assign({}, state, { diskMode: action.value });
     case 'setDeviceType':
       return Object.assign({}, state, { deviceType: action.value });
+    case 'setFsType':
+      return Object.assign({}, state, { fsType: action.value });
     case 'setMaxDiskLimit':
       return Object.assign({}, state, { maxDiskLimit: action.value });
     case 'setMinDiskSize':

--- a/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/components/local-volume-set/types.ts
@@ -14,6 +14,7 @@ export type LocalVolumeSetKind = K8sResourceCommon & {
   spec: {
     storageClassName: string;
     volumeMode: string;
+    fsType: string;
     deviceInclusionSpec: {
       deviceTypes?: DiskType[];
       deviceMechanicalProperties: [keyof typeof DiskMechanicalProperties];

--- a/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/constants/index.ts
@@ -28,6 +28,12 @@ export const deviceTypeDropdownItems = Object.freeze({
   PART: 'Part',
 });
 
+export const fsTypeDropdownItems = Object.freeze({
+  EXT4: 'ext4',
+  EXT3: 'ext3',
+  XFS: 'xfs',
+});
+
 export const diskTypeDropdownItems = (t: TFunction) =>
   Object.freeze({
     All: t('lso-plugin~All'),


### PR DESCRIPTION
Bug 1998519: Add fstype when create localvolumeset instance on web console

1) Will allow to file fstype only if the volume mode is Filesystem selected
![image](https://user-images.githubusercontent.com/6670284/134395036-ca7b5ae7-ad3e-43ba-87a7-ebaa6e94e418.png)
2) Will not update any fstype if nothing selected as filesystem. So that the backend will decide which one to choose
based on the Operating system and other parameters.
3) Will not show the options to select fstype if volume mode is Block storage
![image](https://user-images.githubusercontent.com/6670284/134395748-1e08734f-8768-4b59-8d6f-56af781bae94.png)
4) Will preserve the chosen fstype even after we minimize the advance options
5) Will not add or update any fstype if advance options are not at all selected to chose fstype. So that the backend will
decide the required fstype based on Operating system and other parameters.

Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>