### PR TITLE
Bug 2006308: Backing Store YAML tab on click displays a blank screen on UI

### DIFF
--- a/frontend/packages/ceph-storage-plugin/console-extensions.json
+++ b/frontend/packages/ceph-storage-plugin/console-extensions.json
@@ -152,16 +152,6 @@
   {
     "type": "console.page/route",
     "properties": {
-      "path": "/odf/resource/:resourceKind/:resourceName",
-      "exact": true,
-      "component": {
-        "$codeRef": "resourceDetailsPage.GenericDetailsPage"
-      }
-    }
-  },
-  {
-    "type": "console.page/route",
-    "properties": {
       "path": "/odf/resource/noobaa.io~v1alpha1~BackingStore/create/~new",
       "exact": true,
       "component": {
@@ -186,6 +176,16 @@
       "exact": true,
       "component": {
         "$codeRef": "bcCreate.default"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "path": "/odf/resource/:resourceKind/:resourceName",
+      "exact": false,
+      "component": {
+        "$codeRef": "resourceDetailsPage.GenericDetailsPage"
       }
     }
   },


### PR DESCRIPTION
Routing issue with `Backing Store` `Bucket Class` `NameSpace Store`.

Backing Store --> backing-store details --> YAML Tab

**Before:**
![Screenshot from 2021-09-22 16-28-03](https://user-images.githubusercontent.com/39404641/134332630-f0faafb1-41cd-4776-bb1b-8b2b37fc639d.png)

**After:**
![Screenshot from 2021-09-22 16-29-13](https://user-images.githubusercontent.com/39404641/134332663-5f0268ae-b60b-46d1-ba75-b4a4ec0282e7.png)