### PR TITLE
Bug 1999836: Add 'Unavailable' status for cluster operator

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -32,7 +32,11 @@ import {
   ResourceSummary,
   SectionHeading,
 } from '../utils';
-import { GreenCheckCircleIcon, YellowExclamationTriangleIcon } from '@console/shared';
+import {
+  GreenCheckCircleIcon,
+  RedExclamationCircleIcon,
+  YellowExclamationTriangleIcon,
+} from '@console/shared';
 import RelatedObjectsPage from './related-objects';
 import { ClusterVersionConditionsLink, UpdatingMessageText } from './cluster-settings';
 
@@ -46,6 +50,7 @@ const getIcon = (status: OperatorStatus) => {
     [OperatorStatus.Progressing]: <SyncAltIcon />,
     [OperatorStatus.Degraded]: <YellowExclamationTriangleIcon />,
     [OperatorStatus.CannotUpdate]: <YellowExclamationTriangleIcon />,
+    [OperatorStatus.Unavailable]: <RedExclamationCircleIcon />,
     [OperatorStatus.Unknown]: <UnknownIcon />,
   }[status];
 };

--- a/frontend/public/module/k8s/cluster-operator.ts
+++ b/frontend/public/module/k8s/cluster-operator.ts
@@ -6,6 +6,7 @@ export enum OperatorStatus {
   Progressing = 'Progressing',
   Degraded = 'Degraded',
   CannotUpdate = 'Cannot update',
+  Unavailable = 'Unavailable',
   Unknown = 'Unknown',
 }
 
@@ -14,6 +15,11 @@ export const getStatusAndMessage = (operator: ClusterOperator) => {
   const cannotUpdate: any = _.find(conditions, { type: 'Upgradeable', status: 'False' });
   if (cannotUpdate) {
     return { status: OperatorStatus.CannotUpdate, message: cannotUpdate.message };
+  }
+
+  const unavailable: any = _.find(conditions, { type: 'Available', status: 'False' });
+  if (unavailable) {
+    return { status: OperatorStatus.Unavailable, message: unavailable.message };
   }
 
   const degraded: any = _.find(conditions, { type: 'Degraded', status: 'True' });


### PR DESCRIPTION
Per @wking's [comment](https://bugzilla.redhat.com/show_bug.cgi?id=1999836#c2)  in the bug:

Current statuses that don't match my expectations:

* **Available=False**, **Degraded=False** is currently represented as **Status=Unknown**, when it's expected it to be **Status=Unavailable**.
* **Available=False**, **Degraded=True** is currently represented as **Status=Degraded**, when it's expected it to be **Status=Unavailable** (because **Available=False** is critical, component is missing functionality, while **Degraded=True** is only a warning, component is missing its service level objectives).

Screen:
<img width="1636" alt="Screenshot 2021-09-22 at 13 42 42" src="https://user-images.githubusercontent.com/1668218/134337506-f2f12e35-2569-43fd-bd05-5cd8818dada2.png">


/assign @rhamilto 