### PR TITLE
Bug 1998235: Set csrf-token cookie's SameSite attribute to Lax

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -464,7 +464,9 @@ func (a *Authenticator) SetCSRFCookie(path string, w *http.ResponseWriter) {
 		HttpOnly: false,
 		Path:     path,
 		Secure:   a.secureCookies,
+		SameSite: http.SameSiteLaxMode,
 	}
+
 	http.SetCookie(*w, &cookie)
 }
 

--- a/pkg/auth/auth_openshift.go
+++ b/pkg/auth/auth_openshift.go
@@ -146,6 +146,7 @@ func (o *openShiftAuth) login(w http.ResponseWriter, token *oauth2.Token) (*logi
 		HttpOnly: true,
 		Path:     o.cookiePath,
 		Secure:   o.secureCookies,
+		SameSite: http.SameSiteLaxMode,
 	}
 
 	http.SetCookie(w, &cookie)


### PR DESCRIPTION
Tested the change on live cluster. Screen from inspector:
<img width="1664" alt="Screenshot 2021-09-22 at 17 49 49" src="https://user-images.githubusercontent.com/1668218/134377723-4204ea92-14bf-4a3b-bf39-ede17862b790.png">


/assign @spadgett 