### PR TITLE
Console 2250: Include Source labels on OperatorHub tiles

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -331,10 +331,7 @@ const OperatorHubTile: React.FC<OperatorHubTileProps> = ({ item, onClick }) => {
 
   const { uid, name, imgUrl, provider, description, installed } = item;
   const vendor = provider ? t('olm~provided by {{provider}}', { provider }) : null;
-  const badges = ([
-    DefaultCatalogSource.CommunityOperators,
-    DefaultCatalogSource.RedHatMarketPlace,
-  ] as string[]).includes(item.catalogSource)
+  const badges = item?.catalogSourceDisplayName
     ? [<Badge text={item.catalogSourceDisplayName} />]
     : [];
   const icon = (


### PR DESCRIPTION
**Story:** https://issues.redhat.com/browse/CONSOLE-2250

Add `Certified` and `Red Hat` source labels to Operator tiles. 
<img width="1106" alt="Screen Shot 2021-09-24 at 12 48 18 PM" src="https://user-images.githubusercontent.com/1874151/134715431-642c76da-3586-4f99-91c7-55192be373f2.png">


**Need info:**
Addition of Custom source types?

**Additional work:**
Include Label ToolTip Popovers with source description. 
Requires https://issues.redhat.com/browse/OLM-2180 CatalogSources to include `spec.description` property

Source filter category includes field level help of source descriptions.
The [PatternFly Upstream component](https://patternfly-react.surge.sh/extensions/catalog-view-filter-side-panel) specifically `FilterSidePanelCategory` currently doesn't support the addition of a help icon with popover.
https://github.com/patternfly/patternfly-react/blob/main/packages/react-catalog-view-extension/src/components/FilterSidePanel/FilterSidePanelCategory.tsx#L71

**Related:**
UX design story
https://github.com/openshift/openshift-origin-design/pull/544
https://github.com/itsptk/openshift-origin-design/blob/3cbbabfc06819bea6eadb05dc85e49d218ad2eab/designs/administrator/olm/clarify-operatorhub-source-support/index.md


