### PR TITLE
Bug 2002362: Improve dynamic plugin shared modules

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -62,7 +62,7 @@
   "json.schemas": [
     {
       "fileMatch": ["**/console-extensions.json"],
-      "url": "./packages/console-dynamic-plugin-sdk/dist/schema/console-extensions.json"
+      "url": "./packages/console-dynamic-plugin-sdk/dist/webpack/schema/console-extensions.json"
     }
   ],
   "editor.codeActionsOnSave": {

--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -20,7 +20,6 @@
     "ts-loader": "6.2.2",
     "ts-node": "5.0.1",
     "typescript": "3.8.3",
-    "webpack": "5.0.0-beta.16",
     "webpack-cli": "4.5.x"
   },
   "consolePlugin": {

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as readPkg from 'read-pkg';
-import { getSharedPluginModules } from '../src/shared-modules';
+import { sharedPluginModules } from '../src/shared-modules';
 
 type GeneratedPackage = {
   /** Package output directory. */
@@ -57,7 +57,11 @@ export const getCorePackage: GetPackageDefinition = (
     type: 'module',
     main: 'lib/lib-core.js',
     ...commonManifestFields,
-    dependencies: parseDeps(rootPackage, getSharedPluginModules(false), missingDepCallback),
+    dependencies: parseDeps(
+      rootPackage,
+      sharedPluginModules.filter((m) => !m.startsWith('@openshift-console/')),
+      missingDepCallback,
+    ),
   },
   filesToCopy: {
     ...commonFiles,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/__tests__/shared-modules-override.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/__tests__/shared-modules-override.spec.ts
@@ -1,0 +1,17 @@
+import { sharedPluginModules } from '../shared-modules';
+import { overrideSharedModules } from '../shared-modules-override';
+import { getEntryModuleMocks } from '../utils/test-utils';
+
+describe('overrideSharedModules', () => {
+  it('is consistent with sharedPluginModules', () => {
+    const [, entryModule] = getEntryModuleMocks({});
+
+    overrideSharedModules(entryModule);
+
+    expect(entryModule.override.mock.calls.length).toBe(1);
+
+    expect(new Set(sharedPluginModules)).toEqual(
+      new Set(Object.keys(entryModule.override.mock.calls[0][0])),
+    );
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
@@ -1,15 +1,12 @@
 /**
- * Dynamic plugin SDK modules provided by Console application at runtime.
+ * Modules shared between the Console application and its dynamic plugins.
  */
-const pluginSDKModules = [
+export const sharedPluginModules = [
   '@openshift-console/dynamic-plugin-sdk',
   '@openshift-console/dynamic-plugin-sdk-internal',
+  'react',
+  'react-helmet',
+  'react-i18next',
+  'react-router-dom',
+  'react-router',
 ];
-
-/**
- * Get modules shared between Console application and its dynamic plugins.
- */
-export const getSharedPluginModules = (includePluginSDK = true) =>
-  ['react', 'react-helmet', 'react-i18next', 'react-router-dom', 'react-router'].concat(
-    includePluginSDK ? pluginSDKModules : [],
-  );

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -7,7 +7,7 @@ import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import * as ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 
 import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
-import { getSharedPluginModules } from '@console/dynamic-plugin-sdk/src/shared-modules';
+import { sharedPluginModules } from '@console/dynamic-plugin-sdk/src/shared-modules';
 import { resolvePluginPackages } from '@console/plugin-sdk/src/codegen/plugin-resolver';
 import { ConsoleActivePluginsModule } from '@console/plugin-sdk/src/webpack/ConsoleActivePluginsModule';
 import { CircularDependencyPreset } from './webpack.circular-deps';
@@ -38,7 +38,7 @@ const extractCSS = new MiniCssExtractPlugin({
 });
 const virtualModules = new VirtualModulesPlugin();
 const overpassTest = /overpass-.*\.(woff2?|ttf|eot|otf)(\?.*$|$)/;
-const sharedPluginTest = new RegExp(`node_modules\\/(${getSharedPluginModules().join('|')})\\/`);
+const sharedPluginTest = new RegExp(`node_modules\\/(${sharedPluginModules.join('|')})\\/`);
 
 const config: Configuration = {
   entry: [


### PR DESCRIPTION
- webpack container entry `overridables` now includes all `sharedPluginModules` available at `node_modules`
- added unit test for `overrideSharedModules` to ensure consistency with `sharedPluginModules`