### PR TITLE
Bug 2008321: Add correct documentation link for MON_DISK_LOW

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/whitelisted-health-checks.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/status-card/whitelisted-health-checks.ts
@@ -2,5 +2,5 @@
 
 export const whitelistedHealthChecksRef = {
   MON_DISK_LOW:
-    'https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/troubleshooting_openshift_container_storage/troubleshooting-alerts-and-errors-in-openshift-container-storage_rhocs#resolving-cluster-health-issues_rhocs',
+    'https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/troubleshooting_openshift_data_foundation/troubleshooting-alerts-and-errors-in-openshift-data-foundation_rhocs#resolving-cluster-health-issues_rhodf',
 };


### PR DESCRIPTION
We merged the doc link for MON_DISK_LOW a while back but it seems there was a
typo in that (please refer https://issues.redhat.com/browse/RHSTOR-2060?focusedCommentId=19062579&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19062579).