### PR TITLE
Monitoring: CSS small cleanups

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -459,10 +459,6 @@ $monitoring-line-height: 18px;
   padding: 10px 20px;
 }
 
-.query-browser__tech-preview {
-  margin: 0 10px;
-}
-
 .query-browser__toggle-graph {
   margin-bottom: 5px;
   float: right;

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -468,7 +468,7 @@ $monitoring-line-height: 18px;
   background-color: $tooltip-background-color;
   color: #eee;
   font-size: 12px;
-  overflow-y: auto;
+  overflow-x: hidden;
   padding: 10px;
 }
 
@@ -480,8 +480,11 @@ $monitoring-line-height: 18px;
   width: 0;
 }
 
-.query-browser__tooltip-group {
-  align-items: stretch;
+.query-browser__tooltip-line {
+  stroke: $tooltip-background-color;
+}
+
+.query-browser__tooltip-series {
   display: flex;
 
   .query-browser__series-btn {
@@ -490,10 +493,6 @@ $monitoring-line-height: 18px;
     margin-top: 4px;
     margin-right: 3px;
   }
-}
-
-.query-browser__tooltip-line {
-  stroke: $tooltip-background-color;
 }
 
 .query-browser__tooltip-time {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -205,7 +205,6 @@ const Tooltip_: React.FC<TooltipProps> = ({ activePoints, center, height, style,
     <>
       <VictoryPortal>
         <foreignObject
-          className="query-browser__tooltip-svg-wrap"
           height={TOOLTIP_MAX_HEIGHT}
           width={tooltipMaxWidth}
           x={isOnLeft ? x - tooltipMaxWidth : x}
@@ -218,13 +217,11 @@ const Tooltip_: React.FC<TooltipProps> = ({ activePoints, center, height, style,
           >
             <div className="query-browser__tooltip-arrow" />
             <div className="query-browser__tooltip">
-              <div className="query-browser__tooltip-group">
-                <div className="query-browser__tooltip-time">
-                  {dateTimeFormatterWithSeconds.format(time)}
-                </div>
+              <div className="query-browser__tooltip-time">
+                {dateTimeFormatterWithSeconds.format(time)}
               </div>
               {allSeries.map((s, i) => (
-                <div className="query-browser__tooltip-group" key={i}>
+                <div className="query-browser__tooltip-series" key={i}>
                   <div className="query-browser__series-btn" style={{ backgroundColor: s.color }} />
                   <div className="co-nowrap co-truncate">{s.name}</div>
                   <div className="query-browser__tooltip-value">{s.value}</div>


### PR DESCRIPTION
Some small refactoring of the tooltip CSS and also remove the now unused `query-browser__tech-preview` CSS class.