### PR TITLE
Bug 2004101: When creating storageSystem deployment type dropdown under advanced setting doesn't close after selection

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/advanced-section.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/advanced-section.tsx
@@ -38,6 +38,7 @@ export const AdvancedSection: React.FC<AdvancedSelectionProps> = ({
       // 'value' on SelectProps['onSelect'] is string hence not matching with payload which is of "DeploymentType"
       payload: value as DeploymentType,
     });
+    setIsSelectOpen(false);
   };
 
   const handleToggling: SelectProps['onToggle'] = (isExpanded: boolean) =>


### PR DESCRIPTION
Bug 2004101 When creating storageSystem deployment type dropdown under advanced setting doesn't close after selection

https://user-images.githubusercontent.com/6670284/135216976-5575aaac-c34e-4c77-ac2f-4d24b3b0b627.mp4

Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>