### PR TITLE
Bug 2008499 : Add monitoring and nodes label for external storage platforms

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
@@ -212,7 +212,13 @@ const handleReviewAndCreateNext = async (
       );
 
       await createExternalSubSystem(subSystemPayloads);
-      if (!hasOCS) await createStorageCluster(state);
+      await labelOCSNamespace();
+      // Create storage cluster if one is not present except for external RHCS
+      if (!hasOCS && !isRhcs) {
+        await labelNodes(nodes);
+        await createStorageCluster(state);
+      }
+      // Create a new storage system for non RHCS external vendor if one is not present
       if (hasAnExternalSystem) await createStorageSystem(subSystemName, subSystemKind);
     }
     // These flags control the enablement of dashboards and other ODF UI components in console


### PR DESCRIPTION

  -fixes https://bugzilla.redhat.com/show_bug.cgi?id=2004578
  -monitoring and nodes label were missing for external mode of storage system
  -this is causing storage cluster to be in error state and dashboards with missing information

Signed-off-by: Afreen Rahman <afrahman@redhat.com>
(cherry picked from commit 8951ed6edf23464609423adb9d0e22597604c9e1)