### PR TITLE
Bug 2003178: Memoize knative filtered revisions for sidebar

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
@@ -30,7 +30,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
   const traffic = service.status?.traffic;
   const name = service.metadata?.name;
 
-  const filteredRevisions = (): K8sResourceKind[] => {
+  const filteredRevisions: K8sResourceKind[] = React.useMemo(() => {
     if (!revisions || !revisions.length) {
       return [];
     }
@@ -40,7 +40,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
     return revWithTraffic.length < MAX_REVISIONS
       ? _.concat(revWithTraffic, revWithoutTraffic.slice(0, MAX_REVISIONS - revWithTraffic.length))
       : revWithTraffic;
-  };
+  }, [revisions, traffic]);
 
   const getRevisionsLink = () => {
     const url = `/search/ns/${namespace}`;
@@ -79,7 +79,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
         </span>
       ) : (
         <ul className="list-group">
-          {_.map(filteredRevisions(), (revision) => (
+          {_.map(filteredRevisions, (revision) => (
             <RevisionsOverviewListItem
               key={revision.metadata.uid}
               revision={revision}


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2003178
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The filtered revisions were calculated using a function inside the component every render which caused to function to use an old version of the revisions prop.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Create a memoized list of filtered revisions and use that instead.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
Before / After:

https://user-images.githubusercontent.com/20013884/135084089-29209526-3c86-4ff4-88b0-29b0834e879d.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug