### PR TITLE
Bug 2003845: change the Image Vulnerabilities tab to be project and not cluster scoped

### DIFF
--- a/frontend/packages/container-security/console-extensions.json
+++ b/frontend/packages/container-security/console-extensions.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "console.navigation/resource-cluster",
+    "type": "console.navigation/resource-ns",
     "properties": {
       "id": "imagevulnerabilities",
       "perspective": "admin",


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2003845

Before:

![Screen Shot 2021-09-24 at 9 06 13 PM](https://user-images.githubusercontent.com/35978579/135164697-5b029741-7748-42b8-a345-75530d2f5e6b.png)

After:

![Screen Shot 2021-09-28 at 4 59 51 PM](https://user-images.githubusercontent.com/35978579/135164838-89ce100d-f8c8-4f13-9a5d-89a0fbae815e.png)
