### PR TITLE
Bug 2008151: Bump @patternfly/react-core package to v4.157.8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,7 +125,7 @@
     "@patternfly/quickstarts": "1.2.3",
     "@patternfly/react-catalog-view-extension": "4.12.73",
     "@patternfly/react-charts": "6.15.23",
-    "@patternfly/react-core": "4.157.2",
+    "@patternfly/react-core": "4.157.8",
     "@patternfly/react-table": "4.30.2",
     "@patternfly/react-tokens": "4.12.18",
     "@patternfly/react-topology": "4.9.78",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1870,10 +1870,10 @@
     xterm "^4.8.1"
     xterm-addon-fit "^0.2.1"
 
-"@patternfly/react-core@4.157.2", "@patternfly/react-core@^4.157.2":
-  version "4.157.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.157.2.tgz#dde999d9a10b2e7fc07a3fcb42474900473abe05"
-  integrity sha512-P5PUFiZi9ldwqVFHNmStOOWbJcDJp2ssimXk+MipleuSTqhDBcU3SSsZcUjarj+TbQx7gITH+wKSdEeL9vMnMw==
+"@patternfly/react-core@4.157.8":
+  version "4.157.8"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.157.8.tgz#127da9bf0bd1a21b09ccdb06e9595d347e67ae24"
+  integrity sha512-TR/qFxlGKy+t1ktSWbd2uYNrncnEnTmmUB+VpSMgIndoWBSbDVMxK62fJ6k2NOGyN1KHS/7GR7OtrZ5Oeg77dw==
   dependencies:
     "@patternfly/react-icons" "^4.11.17"
     "@patternfly/react-styles" "^4.11.16"
@@ -1900,6 +1900,19 @@
   version "4.157.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.157.1.tgz#1eb624cfef71d577155860a7afa9a0e42a9ad109"
   integrity sha512-SQ80dBWLAdcNkXdi3R+Q1P0cjWtxR2aBVJvmIlPJMvtWo5CN02CbBmb9kVz921i3VN98X07dlMJbuCfy9EyU7w==
+  dependencies:
+    "@patternfly/react-icons" "^4.11.17"
+    "@patternfly/react-styles" "^4.11.16"
+    "@patternfly/react-tokens" "^4.12.18"
+    focus-trap "6.2.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^2.0.0"
+
+"@patternfly/react-core@^4.157.2":
+  version "4.157.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.157.2.tgz#dde999d9a10b2e7fc07a3fcb42474900473abe05"
+  integrity sha512-P5PUFiZi9ldwqVFHNmStOOWbJcDJp2ssimXk+MipleuSTqhDBcU3SSsZcUjarj+TbQx7gITH+wKSdEeL9vMnMw==
   dependencies:
     "@patternfly/react-icons" "^4.11.17"
     "@patternfly/react-styles" "^4.11.16"


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2008151
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The bug is related to PatternFly and seems to have been introduced in https://github.com/patternfly/patternfly-react/pull/6253 (present in 4.157.2) and is reverted by https://github.com/patternfly/patternfly-react/pull/6340.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Bump react-core package to 4.157.8 which includes the reversion.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug