### PR TITLE
Bug 2008612: Proxy browser cache headers from plugin asset request

### DIFF
--- a/pkg/plugins/handlers.go
+++ b/pkg/plugins/handlers.go
@@ -87,8 +87,18 @@ func (p *PluginsHandler) HandlePluginAssets(w http.ResponseWriter, r *http.Reque
 	p.proxyPluginRequest(pluginServiceRequestURL, pluginName, w, r)
 }
 
-func (p *PluginsHandler) proxyPluginRequest(requestURL *url.URL, pluginName string, w http.ResponseWriter, r *http.Request) {
-	resp, err := p.Client.Get(requestURL.String())
+func (p *PluginsHandler) proxyPluginRequest(requestURL *url.URL, pluginName string, w http.ResponseWriter, orignalRequest *http.Request) {
+	newRequest, err := http.NewRequest("Get", requestURL.String(), nil)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to create GET request for %q plugin: %v", pluginName, err)
+		klog.Error(errMsg)
+		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: errMsg})
+		return
+	}
+
+	proxy.CopyRequestHeaders(orignalRequest, newRequest)
+
+	resp, err := p.Client.Do(newRequest)
 	if err != nil {
 		errMsg := fmt.Sprintf("GET request for %q plugin failed: %v", pluginName, err)
 		klog.Error(errMsg)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -89,6 +89,15 @@ func decodeSubprotocol(encodedProtocol string) (string, error) {
 
 var headerBlacklist = []string{"Cookie", "X-CSRFToken"}
 
+// pass through headers that are needed for browser caching and content negotiation,
+// except "Cookie" and "X-CSRFToken" headers.
+func CopyRequestHeaders(originalRequest, newRequest *http.Request) {
+	newRequest.Header = originalRequest.Header.Clone()
+	for _, h := range headerBlacklist {
+		newRequest.Header.Del(h)
+	}
+}
+
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Block scripts from running in proxied content for browsers that support Content-Security-Policy.
 	w.Header().Set("Content-Security-Policy", "sandbox;")


### PR DESCRIPTION
Proxying all the headers except `Cookie` and `X-CSRFToken`

/assign @spadgett
/cherry-pick release-4.9