### PR TITLE
[WIP ODC-3550] Use Watchk8sResource instead of firehose

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/PipelinesResourceList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FireMan, FireManProps } from '@console/internal/components/factory';
-import { Firehose } from '@console/internal/components/utils';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { referenceForModel, Selector } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../models';
 import { usePipelineTechPreviewBadge } from '../../utils/hooks';
@@ -35,6 +35,12 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
     },
   ];
 
+  const watchedResources = {};
+  for (const resource of resources) {
+    watchedResources[resource.prop] = resource;
+  }
+  const { pipeline } = useK8sWatchResources(watchedResources);
+
   return (
     <FireMan
       {...props}
@@ -52,9 +58,10 @@ const PipelinesResourceList: React.FC<PipelinesResourceListProps> = (props) => {
       title={showTitle ? t('pipelines-plugin~Pipelines') : null}
       badge={badge}
     >
-      <Firehose resources={resources}>
-        <PipelineAugmentRunsWrapper hideNameLabelFilters={props.hideNameLabelFilters} />
-      </Firehose>
+      <PipelineAugmentRunsWrapper
+        pipeline={pipeline}
+        hideNameLabelFilters={props.hideNameLabelFilters}
+      />
     </FireMan>
   );
 };

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
@@ -43,7 +43,7 @@ const PipelineAugmentRuns: React.FC<PipelineAugmentRunsProps> = ({
 }) => {
   const allFilters = {
     ...props.filters,
-    ...(_.get(props.pipeline, 'filters.name') && { name: _.get(props.pipeline, 'filters.name') }),
+    ...(_.get(props.pipeline, 'filters') && { ..._.get(props.pipeline, 'filters') }),
   };
   const resourceData =
     props.pipeline && props.pipeline.data && propsReferenceForRuns

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelineAugmentRunsWrapper.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { ListPageWrapper } from '@console/internal/components/factory';
-import { EmptyBox, Firehose, LoadingBox } from '@console/internal/components/utils';
+import { EmptyBox, LoadingBox } from '@console/internal/components/utils';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { Resource, getResources } from '../../../utils/pipeline-augment';
 import PipelineAugmentRuns, { filters } from './PipelineAugmentRuns';
 import PipelineList from './PipelineList';
@@ -16,6 +17,14 @@ interface PipelineAugmentRunsWrapperProps {
 const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (props) => {
   const { t } = useTranslation();
   const pipelineData = _.get(props.pipeline, 'data', []);
+  const firehoseResources: Resource = getResources(pipelineData);
+  const watchedResources = {};
+  if (firehoseResources && firehoseResources.resources) {
+    for (let i = 0; i < firehoseResources.resources.length; i++) {
+      watchedResources[firehoseResources.propsReferenceForRuns[i]] = firehoseResources.resources[i];
+    }
+  }
+  const pipelineRuns = useK8sWatchResources(watchedResources);
 
   if (!props.pipeline.loaded) {
     return <LoadingBox />;
@@ -24,23 +33,23 @@ const PipelineAugmentRunsWrapper: React.FC<PipelineAugmentRunsWrapperProps> = (p
   if (pipelineData.length === 0) {
     return <EmptyBox label={t('pipelines-plugin~Pipelines')} />;
   }
-  const firehoseResources: Resource = getResources(props.pipeline.data);
+
   return (
-    <Firehose resources={firehoseResources.resources}>
-      <PipelineAugmentRuns
+    <PipelineAugmentRuns
+      {...props}
+      {...pipelineRuns}
+      propsReferenceForRuns={firehoseResources.propsReferenceForRuns}
+    >
+      <ListPageWrapper
         {...props}
-        propsReferenceForRuns={firehoseResources.propsReferenceForRuns}
-      >
-        <ListPageWrapper
-          {...props}
-          flatten={(_resources) => _.get(_resources, ['pipeline', 'data'], {})}
-          kinds={['Pipeline']}
-          ListComponent={PipelineList}
-          rowFilters={filters}
-          hideNameLabelFilters={props.hideNameLabelFilters}
-        />
-      </PipelineAugmentRuns>
-    </Firehose>
+        loaded={props.pipeline.loaded}
+        flatten={(_resources) => _.get(_resources, ['pipeline', 'data'], {})}
+        kinds={['Pipeline']}
+        ListComponent={PipelineList}
+        rowFilters={filters}
+        hideNameLabelFilters={props.hideNameLabelFilters}
+      />
+    </PipelineAugmentRuns>
   );
 };
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelinesList.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/list-page/PipelinesList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { match as Rmatch } from 'react-router-dom';
-import { Firehose } from '@console/internal/components/utils';
+import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
 import { filters } from './PipelineAugmentRuns';
@@ -15,20 +15,20 @@ const PipelinesList: React.FC<PipelinesListProps> = ({
     params: { ns: namespace },
   },
 }) => {
-  const resources = [
-    {
+  const watchedResources = {
+    [PipelineModel.id]: {
       isList: true,
       kind: referenceForModel(PipelineModel),
       namespace,
       prop: PipelineModel.id,
       filters: { ...filters },
     },
-  ];
+  };
+  const { pipeline } = useK8sWatchResources(watchedResources);
+
   return (
     <div className="co-m-pane__body">
-      <Firehose resources={resources}>
-        <PipelineAugmentRunsWrapper />
-      </Firehose>
+      <PipelineAugmentRunsWrapper pipeline={pipeline} />
     </div>
   );
 };

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -88,6 +88,7 @@ type ListPageWrapperProps<L = any, C = any> = {
   ListComponent: React.ComponentType<L>;
   kinds: string[];
   filters?: any;
+  loaded?: boolean;
   flatten?: Flatten;
   rowFilters?: RowFilter[];
   hideNameLabelFilters?: boolean;

--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -215,9 +215,10 @@ export const useK8sWatchResources: UseK8sWatchResources = (initResources) => {
           };
         } else if (resourceK8s.has(reduxIDs?.[key].id)) {
           const data = getReduxData(resourceK8s.getIn([reduxIDs[key].id, 'data']), resources[key]);
+          const filters = resourceK8s.getIn([reduxIDs[key].id, 'filters']).toJSON();
           const loaded = resourceK8s.getIn([reduxIDs[key].id, 'loaded']);
           const loadError = resourceK8s.getIn([reduxIDs[key].id, 'loadError']);
-          acc[key] = { data, loaded, loadError };
+          acc[key] = { data, loaded, loadError, filters };
         } else {
           acc[key] = {
             data: resources[key].isList ? [] : {},


### PR DESCRIPTION
**WIP / Pending tasks**
- in Pipelines pages check why filters are not working in admin perspective
- replace firehose in log files 
- replace firehose in separate instances

**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-3550

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Firehose is used to fetch the pipelines

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
using useK8sWatchResources() hook instead of firehose

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge