### PR TITLE
Bug 2005554: Reveal the switch status of the button "Show default project" in code

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
@@ -110,8 +110,8 @@ const SystemSwitch: React.FC<{
         //@ts-ignore */}
       <MenuInput>
         <Switch
-          id="no-label-switch-on"
           data-test="showSystemSwitch"
+          data-checked-state={isChecked}
           label={
             isProject
               ? t('console-shared~Show default projects')


### PR DESCRIPTION
This addresses [Bug 2005554](https://bugzilla.redhat.com/show_bug.cgi?id=2005554)

Ensuring the `data-test` attribute value is unique and adding a `data-checked-state` attribute that will show the state of the switch (with a value of "true" or "false").

Example from browser developer tools:
```
<input id="pf-1632860806651hmp3em8fhxo" 
class="pf-c-switch__input" 
type="checkbox" 
aria-labelledby="pf-1632860806651hmp3em8fhxo-on" 
data-test="showSystemSwitch" 
data-checked-state="false" 
aria-label="" 
checked=""
>

```


Also removing the hard-coded id attribute value as PatternFly will add one automatically.

Note: There are no UI changes nor functionality changes - this change is to make testing easier.

