### PR TITLE
Ownership update on network policies

### DIFF
--- a/frontend/packages/console-app/locales/OWNERS
+++ b/frontend/packages/console-app/locales/OWNERS
@@ -1,2 +1,6 @@
+reviewers:
+  - rebeccaalpert
+approvers:
+  - jotak
 labels:
   - kind/i18n

--- a/frontend/packages/console-app/src/__tests__/network-policies/OWNERS
+++ b/frontend/packages/console-app/src/__tests__/network-policies/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - jotak
+  - mariomac
+  - OlivierCazade
+approvers:
+  - jotak
+labels:
+  - component/network-policies

--- a/frontend/packages/console-app/src/__tests__/network-policies/OWNERS
+++ b/frontend/packages/console-app/src/__tests__/network-policies/OWNERS
@@ -4,5 +4,3 @@ reviewers:
   - OlivierCazade
 approvers:
   - jotak
-labels:
-  - component/network-policies

--- a/frontend/packages/console-app/src/components/network-policies/OWNERS
+++ b/frontend/packages/console-app/src/components/network-policies/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - jotak
+  - mariomac
+  - OlivierCazade
+approvers:
+  - jotak
+labels:
+  - component/network-policies

--- a/frontend/packages/console-app/src/components/network-policies/OWNERS
+++ b/frontend/packages/console-app/src/components/network-policies/OWNERS
@@ -4,5 +4,3 @@ reviewers:
   - OlivierCazade
 approvers:
   - jotak
-labels:
-  - component/network-policies


### PR DESCRIPTION
Proposal of shared ownership (console team and network observability
team), as well as new reviewers on files related to
network policies (note: it doesn't include, at the moment, the policies
list / details page that lies in another subtree)

Also adding myself as an approver for the locales subtree

It is motivated by a recent involvment by the network observability team
to add features related to the user experience about network policies
(adding a creation form...) and more future work planned.

Signed-off-by: Joel Takvorian <jtakvori@redhat.com>