### PR TITLE
Bug 1815189, Bug 1997269: Improve API discovery for feature flags and operator details

### DIFF
--- a/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/usePerspectiveDetection.spec.ts
@@ -5,6 +5,7 @@ import { testHook } from '../../../../../__tests__/utils/hooks-utils';
 import { usePerspectiveDetection } from '../perspective';
 
 jest.mock('react-redux', () => ({
+  ...(jest as any).requireActual('react-redux'),
   useSelector: jest.fn(),
 }));
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.spec.tsx
@@ -99,6 +99,11 @@ jest.mock('@console/shared/src/hooks/useK8sModel', () => {
   };
 });
 
+jest.mock('react-redux', () => ({
+  ...(jest as any).requireActual('react-redux'),
+  useDispatch: () => jest.fn(),
+}));
+
 const i18nNS = 'public';
 
 describe(OperandTableRow.displayName, () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -4,7 +4,11 @@ import * as classNames from 'classnames';
 import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useDispatch } from 'react-redux';
 import { match } from 'react-router-dom';
+import { getResources } from '@console/internal/actions/k8s';
 import { Conditions } from '@console/internal/components/conditions';
 import { ErrorPage404 } from '@console/internal/components/error';
 import { ResourceEventStream } from '@console/internal/components/events';
@@ -333,12 +337,11 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   const { t } = useTranslation();
   const { obj } = props;
   const [models, inFlight] = useK8sModels();
-  if (inFlight) {
-    return null;
-  }
-  const providedAPIs = providedAPIsForCSV(obj);
+  const dispatch = useDispatch();
+  const [apiRefreshed, setAPIRefreshed] = React.useState(false);
 
-  // Exclude provided APIs that do not have a model
+  // Map APIs provided by this CSV to Firehose resources. Exclude APIs that do not have a model.
+  const providedAPIs = providedAPIsForCSV(obj);
   const firehoseResources = providedAPIs.reduce((resourceAccumulator, api) => {
     const reference = referenceForProvidedAPI(api);
     const model = models?.[reference];
@@ -354,6 +357,19 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
       : resourceAccumulator;
   }, []);
 
+  // Refresh API definitions if at least one API is missing a model and definitions have not already been refreshed.
+  const apiMightBeOutdated = !inFlight && firehoseResources.length < providedAPIs.length;
+  React.useEffect(() => {
+    if (!apiRefreshed && apiMightBeOutdated) {
+      dispatch(getResources());
+      setAPIRefreshed(true);
+    }
+  }, [apiMightBeOutdated, apiRefreshed, dispatch]);
+
+  if (inFlight) {
+    return null;
+  }
+
   const EmptyMsg = () => (
     <MsgBox
       title={t('olm~No provided APIs defined')}
@@ -363,18 +379,32 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
   const createLink = (name: string) =>
     `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${
       obj.metadata.name
-    }/${referenceForProvidedAPI(_.find(providedAPIs, { name }))}/~new`;
+    }/${referenceForProvidedAPI(
+      _.find(providedAPIs, {
+        name,
+      }),
+    )}/~new`;
   const createProps =
     providedAPIs.length > 1
       ? {
-          items: providedAPIs.reduce((acc, api) => ({ ...acc, [api.name]: api.displayName }), {}),
+          items: providedAPIs.reduce(
+            (acc, api) => ({
+              ...acc,
+              [api.name]: api.displayName,
+            }),
+            {},
+          ),
           createLink,
         }
-      : { to: providedAPIs.length === 1 ? createLink(providedAPIs[0].name) : null };
+      : {
+          to: providedAPIs.length === 1 ? createLink(providedAPIs[0].name) : null,
+        };
 
   const owners = (ownerRefs: OwnerReference[], items: K8sResourceKind[]) =>
     ownerRefs.filter(({ uid }) => items.filter(({ metadata }) => metadata.uid === uid).length > 0);
-  const flatten: Flatten<{ [key: string]: K8sResourceCommon[] }> = (resources) =>
+  const flatten: Flatten<{
+    [key: string]: K8sResourceCommon[];
+  }> = (resources) =>
     _.flatMap(resources, (resource) => _.map(resource.data, (item) => item)).filter(
       ({ kind, metadata }, i, allResources) =>
         providedAPIs.filter((item) => item.kind === kind).length > 0 ||
@@ -423,9 +453,20 @@ export const ProvidedAPIsPage = (props: ProvidedAPIsPageProps) => {
 export const ProvidedAPIPage: React.FC<ProvidedAPIPageProps> = (props) => {
   const { namespace, kind, csv } = props;
   const to = `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${kind}/~new`;
+  const [model, inFlight] = useK8sModel(kind);
+  const [apiRefreshed, setAPIRefreshed] = React.useState(false);
+  const dispatch = useDispatch();
 
-  const [model] = useK8sModel(kind);
-  return (
+  // Refresh API definitions if model is missing and the definitions have not already been refreshed.
+  const apiMightBeOutdated = !inFlight && !model;
+  React.useEffect(() => {
+    if (!apiRefreshed && apiMightBeOutdated) {
+      dispatch(getResources());
+      setAPIRefreshed(true);
+    }
+  }, [dispatch, apiRefreshed, apiMightBeOutdated]);
+
+  return inFlight ? null : (
     <ModelStatusBox groupVersionKind={kind}>
       <ListPage
         kind={kind}

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -20,7 +20,7 @@ import { Navigation } from './nav';
 import { history, AsyncComponent, LoadingBox } from './utils';
 import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources } from '../module/k8s';
-import { receivedResources, watchAPIServices } from '../actions/k8s';
+import { receivedResources, startAPIDiscovery } from '../actions/k8s';
 import { pluginStore } from '../plugins';
 // cloud shell imports must come later than features
 import CloudShell from '@console/app/src/components/cloud-shell/CloudShell';
@@ -391,8 +391,6 @@ const PollConsoleUpdates = React.memo(() => {
 });
 
 graphQLReady.onReady(() => {
-  const startDiscovery = () => store.dispatch(watchAPIServices());
-
   // Load cached API resources from localStorage to speed up page load.
   getCachedResources()
     .then((resources) => {
@@ -400,9 +398,9 @@ graphQLReady.onReady(() => {
         store.dispatch(receivedResources(resources));
       }
       // Still perform discovery to refresh the cache.
-      startDiscovery();
+      store.dispatch(startAPIDiscovery());
     })
-    .catch(startDiscovery);
+    .catch(() => store.dispatch(startAPIDiscovery()));
 
   store.dispatch(detectFeatures());
 

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -88,8 +88,6 @@ export default (state: K8sState, action: K8sAction): K8sState => {
   switch (action.type) {
     case ActionType.GetResourcesInFlight:
       return state.setIn(['RESOURCES', 'inFlight'], true);
-    case ActionType.SetAPIGroups:
-      return state.setIn(['RESOURCES', 'apiGroups'], action.payload.value);
     case ActionType.ReceivedResources:
       return (
         action.payload.resources.models


### PR DESCRIPTION
- Watch CRDs instead of APIServices to trigger API discovery
- Fall back to polling API discovery every 30 seconds if user can't list CRDs
- Run API discovery once on CSV operand instance tabs when model is not found.