### PR TITLE
Bug 2008612: HTTP method should be uppercased when proxying plugin request

### DIFF
--- a/pkg/plugins/handlers.go
+++ b/pkg/plugins/handlers.go
@@ -88,7 +88,7 @@ func (p *PluginsHandler) HandlePluginAssets(w http.ResponseWriter, r *http.Reque
 }
 
 func (p *PluginsHandler) proxyPluginRequest(requestURL *url.URL, pluginName string, w http.ResponseWriter, orignalRequest *http.Request) {
-	newRequest, err := http.NewRequest("Get", requestURL.String(), nil)
+	newRequest, err := http.NewRequest("GET", requestURL.String(), nil)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to create GET request for %q plugin: %v", pluginName, err)
 		klog.Error(errMsg)


### PR DESCRIPTION
Thanks @bipuladh for reporting this issue. It just blew my mind that GOlang dont enumerate these methods 🤯 

/assign @spadgett 