### PR TITLE
Bug 2010181: Environment variables not getting reset on reload on deployment edit form

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeployment.tsx
@@ -38,6 +38,7 @@ const EditDeployment: React.FC<EditDeploymentProps> = ({ heading, resource, name
       skipInvalid: true,
     }),
     formData: convertDeploymentToEditForm(resource),
+    formReloadCount: 0,
   });
 
   const handleSubmit = (

--- a/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
+++ b/frontend/packages/dev-console/src/components/edit-deployment/EditDeploymentForm.tsx
@@ -39,7 +39,7 @@ const EditDeploymentForm: React.FC<FormikProps<FormikValues> & {
   setStatus,
   setErrors,
   errors,
-  values: { editorType, formData, yamlData },
+  values: { editorType, formData, yamlData, formReloadCount },
 }) => {
   const { t } = useTranslation();
   const resourceType = getResourcesType(resource);
@@ -73,13 +73,13 @@ const EditDeploymentForm: React.FC<FormikProps<FormikValues> & {
   const onReload = React.useCallback(() => {
     setStatus({ submitSuccess: '', submitError: '' });
     setErrors({});
-    if (editorType === EditorType.YAML) {
-      setFieldValue('formData.resourceVersion', resource.metadata.resourceVersion);
-      setFieldValue('yamlData', safeJSToYAML(resource, 'yamlData', { skipInvalid: true }));
-    } else {
+    if (editorType === EditorType.Form) {
       setFieldValue('formData', convertDeploymentToEditForm(resource));
     }
-  }, [editorType, resource, setErrors, setFieldValue, setStatus]);
+    setFieldValue('formData.resourceVersion', resource.metadata.resourceVersion);
+    setFieldValue('yamlData', safeJSToYAML(resource, 'yamlData', { skipInvalid: true }));
+    setFieldValue('formReloadCount', formReloadCount + 1);
+  }, [editorType, resource, setErrors, setFieldValue, setStatus, formReloadCount]);
 
   return (
     <FlexForm onSubmit={handleSubmit}>

--- a/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-types.ts
+++ b/frontend/packages/dev-console/src/components/edit-deployment/utils/edit-deployment-types.ts
@@ -94,6 +94,7 @@ export interface EditDeploymentData {
   editorType: string;
   yamlData: string;
   formData: EditDeploymentFormData;
+  formReloadCount?: number;
 }
 
 export type EditDeploymentFormikValues = FormikValues & EditDeploymentData;


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6288

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
internal state of Environment Field not getting reset on reload because original `envs` value did not change

We have created a formReload useEffect, for buildconfig to reset env variables 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added the `formReloadCount` to formik context of Edit Deployment so now the `formReloadCount` hook will get called `onReload`

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![reloadresetdeploymentenv](https://user-images.githubusercontent.com/20089340/135805218-3a2a7949-35cb-4044-b9b5-4d1b833248f4.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
- create an ns and add a deployment
- go to topology and click on edit deployment

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge