### PR TITLE
Console 2969: Changes to the project selector to allow system namespaces that are Favorited to be included in the Favorited list even when the option to Show default projects is unselected.

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.tsx
@@ -285,6 +285,9 @@ const NamespaceMenu: React.FC<{
     (option, checkIsFavorite: boolean) => {
       const containsFilterText = fuzzysearch(filterText.toLowerCase(), option.title.toLowerCase());
 
+      if (checkIsFavorite) {
+        return containsFilterText && isFavorite(option);
+      }
       return (
         containsFilterText &&
         (systemNamespaces || !isSystemNamespace(option)) &&
@@ -335,12 +338,6 @@ const NamespaceMenu: React.FC<{
           filterText={filterText}
           isProject={isProjects}
         />
-        <SystemSwitch
-          hasSystemNamespaces={hasSystemNamespaces}
-          isProject={isProjects}
-          isChecked={systemNamespaces}
-          onChange={setSystemNamespaces}
-        />
         {filteredOptions.length === 0 ? (
           <NoResults
             isProjects={isProjects}
@@ -357,6 +354,12 @@ const NamespaceMenu: React.FC<{
           options={filteredFavorites}
           selectedKey={selected}
           favorites={favorites}
+        />
+        <SystemSwitch
+          hasSystemNamespaces={hasSystemNamespaces}
+          isProject={isProjects}
+          isChecked={systemNamespaces}
+          onChange={setSystemNamespaces}
         />
         <NamespaceGroup options={filteredOptions} selectedKey={selected} favorites={favorites} />
       </MenuContent>


### PR DESCRIPTION

<img width="372" alt="Screen Shot 2021-10-04 at 10 52 49 AM" src="https://user-images.githubusercontent.com/1874151/135873774-3b2fc21b-7dbc-48e3-b1ab-e7175520e045.png">

<img width="370" alt="4" src="https://user-images.githubusercontent.com/1874151/135873947-5c976925-762f-41eb-89f2-8bc16652bda4.png">
<img width="378" alt="3" src="https://user-images.githubusercontent.com/1874151/135874065-417758d6-cd01-43dc-8a69-3b0905efb952.png">
<img width="367" alt="2" src="https://user-images.githubusercontent.com/1874151/135874069-cc75f25e-1d2c-4131-96c8-32b3d3fd2de1.png">


