### PR TITLE
Bug 1995493: Fix alignment of 2 action buttons for add to secret and virtualization

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
@@ -134,47 +134,47 @@ export const WrappedVirtualizationPage: React.FC<VirtualizationPageProps> = (pro
       <Helmet>
         <title>{t('kubevirt-plugin~Virtualization')}</title>
       </Helmet>
-      <div className="co-m-nav-title co-m-nav-title--row">
+      <div className="co-m-nav-title">
         <h1 className="co-m-pane__heading" data-test-id="cluster-settings-page-heading">
           {t('kubevirt-plugin~Virtualization')}
+          <div className="co-actions" data-test-id="details-actions">
+            <MigrationTool />
+            <Dropdown
+              data-test-id="item-create"
+              onSelect={() => setOpen(false)}
+              toggle={
+                <DropdownToggle onToggle={setOpen} isPrimary>
+                  {t('kubevirt-plugin~Create')}
+                </DropdownToggle>
+              }
+              isOpen={isOpen}
+              dropdownItems={[
+                <DropdownGroup
+                  className="kv-dropdown-group"
+                  label={t('kubevirt-plugin~Virtual Machine')}
+                  key="vm"
+                >
+                  {vmMenuItems(t).map(getMenuItem)}
+                </DropdownGroup>,
+                <DropdownGroup
+                  className="kv-dropdown-group kv-dropdown-group--separator"
+                  key="separator"
+                >
+                  <DropdownSeparator />
+                </DropdownGroup>,
+                <DropdownGroup
+                  className="kv-dropdown-group"
+                  label={t('kubevirt-plugin~Template')}
+                  key="vm-template"
+                >
+                  {templateMenuItems(t).map(getMenuItem)}
+                </DropdownGroup>,
+              ]}
+              isGrouped
+              position={DropdownPosition.right}
+            />
+          </div>
         </h1>
-        <div className="co-actions" data-test-id="details-actions">
-          <MigrationTool />
-          <Dropdown
-            data-test-id="item-create"
-            onSelect={() => setOpen(false)}
-            toggle={
-              <DropdownToggle onToggle={setOpen} isPrimary>
-                {t('kubevirt-plugin~Create')}
-              </DropdownToggle>
-            }
-            isOpen={isOpen}
-            dropdownItems={[
-              <DropdownGroup
-                className="kv-dropdown-group"
-                label={t('kubevirt-plugin~Virtual Machine')}
-                key="vm"
-              >
-                {vmMenuItems(t).map(getMenuItem)}
-              </DropdownGroup>,
-              <DropdownGroup
-                className="kv-dropdown-group kv-dropdown-group--separator"
-                key="separator"
-              >
-                <DropdownSeparator />
-              </DropdownGroup>,
-              <DropdownGroup
-                className="kv-dropdown-group"
-                label={t('kubevirt-plugin~Template')}
-                key="vm-template"
-              >
-                {templateMenuItems(t).map(getMenuItem)}
-              </DropdownGroup>,
-            ]}
-            isGrouped
-            position={DropdownPosition.right}
-          />
-        </div>
       </div>
       <HorizontalNav
         {...props}

--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -1,8 +1,7 @@
 .co-actions {
-  align-items: baseline; // Keep dropdown menu positioned correctly
+  align-items: flex-end;
   display: flex;
   @media(max-width: $screen-xs){
-    align-items: flex-end;
     flex-direction: column;
   }
 }


### PR DESCRIPTION
fixes Firefox bug https://bugzilla.redhat.com/show_bug.cgi?id=1995493

Changing `align-items` to `flex-end` exposed the markup structure on Virtualization page was inconsistent with all other pages and caused it to have an alignment bug, so it was restructured.
```
<div className="co-m-nav-title">
     <h1 className="co-m-pane__heading"
        <div className="co-actions"...
```

<img width="879" alt="Screen Shot 2021-10-04 at 1 27 34 PM" src="https://user-images.githubusercontent.com/1874151/135912651-4b7afae3-c52f-4f6c-ab5b-87b15e6aa982.png">

<img width="1066" alt="Screen Shot 2021-10-04 at 3 28 13 PM" src="https://user-images.githubusercontent.com/1874151/135912446-2199e6e4-5e9b-4f41-87e2-931c31f204f0.png">

----

<img width="658" alt="Screen Shot 2021-10-04 at 1 24 24 PM" src="https://user-images.githubusercontent.com/1874151/135912464-6e50385e-40bd-434d-9aa9-4bb9faf01d1e.png">


<img width="662" alt="Screen Shot 2021-10-04 at 1 29 06 PM" src="https://user-images.githubusercontent.com/1874151/135912677-cfda1c31-79d9-49c5-b46d-1bc9a8d6b85f.png">

