### PR TITLE
[ODC-6371] Migrate contextmenu for VmNode, Service Binding

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
@@ -1,58 +1,23 @@
 import * as React from 'react';
 import {
   GraphElement,
-  Node,
   withCreateConnector,
   withDndDrop,
   withDragNode,
   withSelection,
 } from '@patternfly/react-topology';
-import { KebabOption, kebabOptionsToMenu } from '@console/internal/components/utils';
-import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
-import { ModifyApplication } from '@console/topology/src/actions';
+import { contextMenuActions } from '@console/topology/src/actions/contextMenuActions';
 import {
   CreateConnector,
   createConnectorCallback,
-  createMenuItems,
   NodeComponentProps,
   nodeDragSourceSpec,
   nodeDropTargetSpec,
   withContextMenu,
 } from '@console/topology/src/components/graph-view';
-import { TopologyDataObject } from '@console/topology/src/topology-types';
-import { getResource, withEditReviewAccess } from '@console/topology/src/utils';
-import { VmActionFactory } from '../../components/vms/menu-actions';
-import { VMKind } from '../../types';
-import { VMNodeData } from '../types';
+import { withEditReviewAccess } from '@console/topology/src/utils';
 import { TYPE_VIRTUAL_MACHINE } from './const';
 import { VmNode } from './nodes/VmNode';
-
-export const vmActions = (
-  contextMenuResource: K8sResourceKind,
-  vm: TopologyDataObject<VMNodeData>,
-): KebabOption[] => {
-  if (!contextMenuResource) {
-    return null;
-  }
-  const {
-    data: { vmi, vmStatusBundle },
-  } = vm;
-
-  const model = modelFor(referenceFor(contextMenuResource));
-  return [
-    ModifyApplication(model, contextMenuResource),
-    ...Object.values(VmActionFactory).map((action) => {
-      return action(model, contextMenuResource as VMKind, {
-        vmi,
-        vmStatusBundle,
-      });
-    }),
-  ];
-};
-
-export const vmContextMenu = (element: Node) => {
-  return createMenuItems(kebabOptionsToMenu(vmActions(getResource(element), element.getData())));
-};
 
 export const getKubevirtComponentFactory = (
   kind,
@@ -72,7 +37,7 @@ export const getKubevirtComponentFactory = (
         >(nodeDropTargetSpec)(
           withEditReviewAccess('patch')(
             withDragNode(nodeDragSourceSpec(type))(
-              withSelection({ controlled: true })(withContextMenu(vmContextMenu)(VmNode)),
+              withSelection({ controlled: true })(withContextMenu(contextMenuActions)(VmNode)),
             ),
           ),
         ),

--- a/frontend/packages/topology/console-extensions.json
+++ b/frontend/packages/topology/console-extensions.json
@@ -246,5 +246,15 @@
       "contextId": "topology-actions",
       "provider": { "$codeRef": "actions.useTopologyVisualConnectorActionProvider" }
     }
+  },
+  {
+    "type": "console.action/provider",
+    "properties": {
+    "contextId": "topology-actions",
+    "provider": { "$codeRef": "actions.useEditApplicationTopologyActionsProvider" }
+    },
+    "flags": {
+      "required": ["KUBEVIRT"]
+    }
   }
 ]

--- a/frontend/packages/topology/src/actions/provider.ts
+++ b/frontend/packages/topology/src/actions/provider.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { Edge, GraphElement } from '@patternfly/react-topology';
-import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { Edge, GraphElement, Node } from '@patternfly/react-topology';
+import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { TYPE_WORKLOAD, TYPE_CONNECTS_TO } from '../const';
 import { getResource } from '../utils';
@@ -36,4 +36,13 @@ export const useTopologyVisualConnectorActionProvider = (element: Edge) => {
     if (!actions) return [[], true, undefined];
     return [actions, !inFlight, undefined];
   }, [actions, inFlight]);
+};
+
+export const useEditApplicationTopologyActionsProvider = (element: Node) => {
+  const resource: K8sResourceKind = getResource(element);
+  const [, inFlight] = useK8sModel(referenceFor(resource));
+  const actions = useMemo(() => {
+    return [getModifyApplicationAction(modelFor(referenceFor(resource)), resource)];
+  }, [resource]);
+  return useMemo(() => [actions, !inFlight, undefined], [actions, inFlight]);
 };

--- a/frontend/packages/topology/src/operators/components/operatorsComponentFactory.ts
+++ b/frontend/packages/topology/src/operators/components/operatorsComponentFactory.ts
@@ -1,29 +1,14 @@
 import * as React from 'react';
 import { GraphElement, withSelection } from '@patternfly/react-topology';
-import { Kebab, kebabOptionsToMenu } from '@console/internal/components/utils';
-import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { contextMenuActions } from '../../actions';
 import {
   withContextMenu,
   withNoDrop,
-  createMenuItems,
   ServiceBinding,
 } from '../../components/graph-view/components';
 import { TYPE_SERVICE_BINDING } from '../../const';
-import { OdcBaseEdge } from '../../elements';
 import { TYPE_OPERATOR_BACKED_SERVICE } from './const';
 import OperatorBackedService from './OperatorBackedService';
-
-const serviceBindingActions = (edge: OdcBaseEdge) => {
-  const sbr = edge.getResource();
-  const { common } = Kebab.factory;
-  const menuActions = [
-    ...Kebab.getExtensionsActionsForKind(modelFor(referenceFor(sbr))),
-    ...common,
-  ];
-  const actions = menuActions.map((a) => a(modelFor(referenceFor(sbr)), sbr));
-  return createMenuItems(kebabOptionsToMenu(actions));
-};
 
 export const getOperatorsComponentFactory = (
   kind,
@@ -35,7 +20,7 @@ export const getOperatorsComponentFactory = (
         withContextMenu(contextMenuActions)(withNoDrop()(OperatorBackedService)),
       );
     case TYPE_SERVICE_BINDING:
-      return withContextMenu(serviceBindingActions)(ServiceBinding);
+      return withContextMenu(contextMenuActions)(ServiceBinding);
     default:
       return undefined;
   }


### PR DESCRIPTION
###  migrated VmNode and service binding  

**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6371

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
VmNode context menu not dynamic plugin

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
using `ContextMenuActions` and provider for `topology-actions`

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/20089340/136004629-d048bed8-04a0-41c3-bfdd-160ca6d100dc.png)
![image](https://user-images.githubusercontent.com/20089340/137758708-fc1e0289-7188-4603-9c51-0fa2d10b7ff4.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
No unit tests required as actions migrated to use extension

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
VM node
- install redhat virtualization operator
- create VM (workloads -> virtulization -> template -> fedora )
- go to topology and right click
service binding
- create service binding, right click on the edge (arrow)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge