### PR TITLE
fix dev-catalog stuck in loading state

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/catalog-view/CatalogTypeSelector.tsx
@@ -23,11 +23,12 @@ const CatalogTypeSelector: React.FC<CatalogTypeSelectorProps> = ({
     () =>
       catalogTypes.map(
         (type) =>
-          type.description && (
+          type.description &&
+          catalogTypeCounts[type.value] > 0 && (
             <SyncMarkdownView key={type.value} content={type.description} inline />
           ),
       ),
-    [catalogTypes],
+    [catalogTypes, catalogTypeCounts],
   );
 
   return (

--- a/frontend/packages/helm-plugin/src/catalog/providers/useHelmCharts.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/providers/useHelmCharts.tsx
@@ -37,7 +37,10 @@ const useHelmCharts: ExtensionHook<CatalogItem[]> = ({
         }
       })
       .catch((err) => {
-        if (mounted) setLoadedError(err);
+        if (mounted) {
+          setHelmCharts({});
+          setLoadedError(err);
+        }
       });
     return () => (mounted = false);
   }, []);


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1989502

**Root analysis:**
when the fetch call on `'/api/helm/charts/index.yaml'` gives an error, the state of `helmCharts` is not set as a result the loaded variable that the `useHelmCharts` provider returns is set to false as the value of `!!helmCharts` is false, and hence the dev-catalog is stuck in loading state. 

**Solution description:**
setting the state of `helmCharts` as an empty object when the API call gives an error

