### PR TITLE
Bug 2008859: Fix generated dynamic plugin overridables

### DIFF
--- a/frontend/dynamic-demo-plugin/package.json
+++ b/frontend/dynamic-demo-plugin/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "pre-build": "rm -rf ./dist && yarn install",
-    "build": "yarn pre-build && NODE_ENV=production yarn ts-node ./node_modules/.bin/webpack",
-    "build-dev": "yarn pre-build && yarn ts-node ./node_modules/.bin/webpack",
-    "http-server": "./http-server.sh ./dist",
+    "clean": "rm -rf dist",
+    "build": "yarn clean && NODE_ENV=production yarn ts-node node_modules/.bin/webpack",
+    "build-dev": "yarn clean && yarn ts-node node_modules/.bin/webpack",
+    "build-plugin-sdk": "yarn --cwd .. build-plugin-sdk && rm -rf node_modules/@openshift-console && yarn install --check-files",
+    "http-server": "./http-server.sh dist",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}' -I '/node_modules/(?!(@openshift-console)/)/'"
   },

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -45,6 +45,16 @@ const parseDepsAs = (
   missingDepCallback: MissingDependencyCallback,
 ) => _.mapKeys(parseDeps(pkg, Object.keys(deps), missingDepCallback), (value, key) => deps[key]);
 
+const parseSharedModuleDeps = (
+  pkg: readPkg.PackageJson,
+  missingDepCallback: MissingDependencyCallback,
+) =>
+  parseDeps(
+    pkg,
+    sharedPluginModules.filter((m) => !m.startsWith('@openshift-console/')),
+    missingDepCallback,
+  );
+
 export const getCorePackage: GetPackageDefinition = (
   sdkPackage,
   rootPackage,
@@ -57,11 +67,7 @@ export const getCorePackage: GetPackageDefinition = (
     type: 'module',
     main: 'lib/lib-core.js',
     ...commonManifestFields,
-    dependencies: parseDeps(
-      rootPackage,
-      sharedPluginModules.filter((m) => !m.startsWith('@openshift-console/')),
-      missingDepCallback,
-    ),
+    dependencies: parseSharedModuleDeps(rootPackage, missingDepCallback),
   },
   filesToCopy: {
     ...commonFiles,
@@ -82,7 +88,7 @@ export const getInternalPackage: GetPackageDefinition = (
     type: 'module',
     main: 'lib/lib-internal.js',
     ...commonManifestFields,
-    dependencies: getCorePackage(sdkPackage, rootPackage, missingDepCallback).manifest.dependencies,
+    dependencies: parseSharedModuleDeps(rootPackage, missingDepCallback),
   },
   filesToCopy: {
     ...commonFiles,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
-import { Extension } from '@console/plugin-sdk/src/typings/base';
-import { EncodedCodeRef, CodeRef } from '../../types';
+import { Extension, EncodedCodeRef, CodeRef } from '../../types';
 import {
   getExecutableCodeRefMock,
   getEntryModuleMocks,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/perspective/__tests__/perspective.data.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/perspective/__tests__/perspective.data.ts
@@ -1,5 +1,5 @@
-import { Perspective } from '@console/dynamic-plugin-sdk';
-import { LoadedExtension } from '@console/plugin-sdk';
+import { Perspective } from '../../extensions/perspectives';
+import { LoadedExtension } from '../../types';
 
 export const mockPerspectiveExtensions: LoadedExtension<Perspective>[] = [
   {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/__tests__/plugin-loader.spec.ts
@@ -1,7 +1,7 @@
 import { Simulate } from 'react-dom/test-utils';
 import { PluginStore } from '@console/plugin-sdk/src/store';
-import { Extension } from '@console/plugin-sdk/src/typings/base';
 import { ConsolePluginManifestJSON } from '../../schema/plugin-manifest';
+import { Extension } from '../../types';
 import {
   getPluginManifest,
   getExecutableCodeRefMock,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
@@ -7,6 +7,6 @@ export const sharedPluginModules = [
   'react',
   'react-helmet',
   'react-i18next',
-  'react-router-dom',
   'react-router',
+  'react-router-dom',
 ];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/types.ts
@@ -23,15 +23,8 @@ export type LoadedExtension<E extends Extension = Extension> = E & {
 /**
  * An extension of the Console application.
  *
- * Each extension is a realization (instance) of an extension `type` using the
- * parameters provided via the `properties` object.
- *
- * The value of extension `type` should be formatted in a way that describes
- * the broader category as well as any specialization(s), for example:
- *
- * - `ModelDefinition`
- * - `Page/Resource/List`
- * - `Dashboards/Overview/Utilization/Item`
+ * Each extension instance has a `type` and the corresponding parameters
+ * represented by the `properties` object.
  *
  * Each extension may specify `flags` referencing Console feature flags which
  * are required and/or disallowed in order to put this extension into effect.

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/ExtensionValidator.ts
@@ -1,9 +1,8 @@
 import * as _ from 'lodash';
 import * as webpack from 'webpack';
 import { isEncodedCodeRef, parseEncodedCodeRefValue } from '../coderefs/coderef-resolver';
-import { SupportedExtension } from '../schema/console-extensions';
 import { ConsolePluginMetadata } from '../schema/plugin-package';
-import { EncodedCodeRef } from '../types';
+import { Extension, EncodedCodeRef } from '../types';
 import { deepForOwn } from '../utils/object';
 import { ValidationResult } from './ValidationResult';
 
@@ -14,7 +13,7 @@ type ExtensionCodeRefData = {
 
 type ExposedPluginModules = ConsolePluginMetadata['exposedModules'];
 
-export const collectCodeRefData = (extensions: SupportedExtension[]) =>
+export const collectCodeRefData = (extensions: Extension[]) =>
   extensions.reduce((acc, e, index) => {
     const data: ExtensionCodeRefData = { index, propToCodeRefValue: {} };
 
@@ -53,7 +52,7 @@ export class ExtensionValidator {
 
   validate(
     compilation: webpack.Compilation,
-    extensions: SupportedExtension[],
+    extensions: Extension[],
     exposedModules: ExposedPluginModules,
     dataVar: string = 'extensions',
   ) {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ExtensionValidator.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/validation/__tests__/ExtensionValidator.spec.ts
@@ -1,6 +1,5 @@
 import * as webpack from 'webpack';
-import { Extension } from '@console/plugin-sdk/src/typings/base';
-import { SupportedExtension } from '../../schema/console-extensions';
+import { Extension } from '../../types';
 import { collectCodeRefData, findWebpackModules, ExtensionValidator } from '../ExtensionValidator';
 import { ValidationResult } from '../ValidationResult';
 
@@ -38,7 +37,7 @@ describe('collectCodeRefData', () => {
       },
     ];
 
-    expect(collectCodeRefData(extensions as SupportedExtension[])).toEqual([
+    expect(collectCodeRefData(extensions)).toEqual([
       {
         index: 1,
         propToCodeRefValue: {
@@ -78,7 +77,7 @@ describe('ExtensionValidator', () => {
 
       const result = new ExtensionValidator('test').validate(
         compilation,
-        extensions as SupportedExtension[],
+        extensions,
         exposedModules,
         'testExtensions',
       );

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import * as _ from 'lodash';
 import * as readPkg from 'read-pkg';
 import * as webpack from 'webpack';
@@ -62,8 +60,11 @@ export class ConsoleRemotePlugin {
         filename: remoteEntryFile,
         exposes: this.pkg.consolePlugin.exposedModules || {},
         overridables: sharedPluginModules.filter((m) => {
-          // Exclude modules not present in webpack managed paths (e.g. node_modules)
-          return Array.from(compiler.managedPaths).some((p) => fs.existsSync(path.resolve(p, m)));
+          // ContainerPlugin throws 'module not found' error if an overridable cannot be resolved.
+          // All shared plugin modules are mandatory *except* the Console internal API module.
+          return m !== '@openshift-console/dynamic-plugin-sdk-internal'
+            ? true
+            : !!{ ...this.pkg.devDependencies, ...this.pkg.dependencies }[m];
         }),
       }).apply(compiler);
 


### PR DESCRIPTION
## Dynamic plugin SDK changes
- `ConsoleRemotePlugin` - ensure proper overridables by including all shared plugin modules, minus the optional ones (Console internal SDK)
- `ExtensionValidator` - use base `Extension` type (`SupportedExtension` is meant to be used primarily for JSON schema generation purposes)
- prefer relative path imports for modules located in the same package

## Dynamic demo plugin changes
- `build` and `build-dev` scripts don't rebuild the plugin SDK automatically (not needed unless making changes in the SDK monorepo package)
- to rebuild the plugin SDK and update demo plugin's `node_modules` accordingly, run `yarn build-plugin-sdk`

