### PR TITLE
Bug 2010342: Increase memory limit for ForkTsCheckerWebpackPlugin

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -201,7 +201,7 @@ const config: Configuration = {
   },
   plugins: [
     new webpack.NormalModuleReplacementPlugin(/^lodash$/, 'lodash-es'),
-    new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true }),
+    new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true, memoryLimit: 4096 }),
     new HtmlWebpackPlugin({
       filename: './tokener.html',
       template: './public/tokener.html',


### PR DESCRIPTION
Increase the memory limit without updating the dependency. We can look at updating the dependency separately when we figure out what's causing the looping behavior of `yarn run dev`.

/assign @kdoberst 