### PR TITLE
Bug 1956964: upload a boot-source warning

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -53,8 +53,6 @@
   "Upload Data to Persistent Volume Claim": "Upload Data to Persistent Volume Claim",
   "detected file extension is {{fileNameExtension}}": "detected file extension is {{fileNameExtension}}",
   "no file extention detected": "no file extention detected",
-  "PVC size warning": "PVC size warning",
-  "PVC size is smaller than double the provided image. Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements.": "PVC size is smaller than double the provided image. Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements.",
   "File type extension": "File type extension",
   "Based on the file extension it seems like you are trying to upload a file which is not supported ({{fileNameExtText}}).": "Based on the file extension it seems like you are trying to upload a file which is not supported ({{fileNameExtText}}).",
   "Learn more about supported formats": "Learn more about supported formats",

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -65,13 +65,12 @@ import {
 import { DataVolumeModel } from '../../../models';
 import { getKubevirtModelAvailableAPIVersion } from '../../../models/kubevirtReferenceForModel';
 import { getDefaultStorageClass } from '../../../selectors/config-map/sc-defaults';
-import { getDataVolumeStorageSize } from '../../../selectors/dv/selectors';
 import { getName, getNamespace, getParameterValue } from '../../../selectors/selectors';
 import { getTemplateOperatingSystems } from '../../../selectors/vm-template/advanced';
 import { OperatingSystemRecord } from '../../../types';
 import { V1alpha1DataVolume } from '../../../types/api';
 import { FormSelectPlaceholderOption } from '../../form/form-select-placeholder-option';
-import { BinaryUnit, convertToBytes } from '../../form/size-unit-utils';
+import { BinaryUnit } from '../../form/size-unit-utils';
 import { CDIUploadContext } from '../cdi-upload-provider';
 import {
   CDI_UPLOAD_OS_URL_PARAM,
@@ -712,19 +711,6 @@ export const UploadPVCPage: React.FC<UploadPVCPageProps> = (props) => {
             }
             errorMessage={errorMessage}
           >
-            {fileValue?.size * 2 > convertToBytes(getDataVolumeStorageSize(dvObj)) && (
-              <Alert variant="warning" isInline title={t('kubevirt-plugin~PVC size warning')}>
-                <p>
-                  {t(
-                    'kubevirt-plugin~PVC size is smaller than double the provided image. Please ensure your PVC size covers the requirements of the uncompressed image and any other space requirements.',
-                  )}{' '}
-                  <ExternalLink
-                    text={t('kubevirt-plugin~Learn more')}
-                    href="https://docs.openshift.com/container-platform/4.8/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.html"
-                  />
-                </p>
-              </Alert>
-            )}
             {isFileRejected && (
               <Alert variant="warning" isInline title={t('kubevirt-plugin~File type extension')}>
                 <p>


### PR DESCRIPTION
@gouyang This will remove the x2 size warning all together, the user will see the precise size error only if he tries to upload and the cdi comes with the response