### PR TITLE
Bug 2012177: Overview tab is missing under Storage after successful deployment on UI 

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -664,7 +664,7 @@
   "Last updated": "Last updated",
   "Storage Systems": "Storage Systems",
   "Used capacity": "Used capacity",
-  "Storage status represents the health status of Openshift Data Foundation's StorageCluster.": "Storage status represents the health status of Openshift Data Foundation's StorageCluster.",
+  "Storage status represents the health status of {{operatorName}}'s StorageCluster.": "Storage status represents the health status of {{operatorName}}'s StorageCluster.",
   "Health": "Health",
   "Standard": "Standard",
   "Data will be consumed by a Multi-cloud object gateway, deduped, compressed, and encrypted. The encrypted chunks would be saved on the selected BackingStores. Best used when the applications would always use the OpenShift Data Foundation endpoints to access the data.": "Data will be consumed by a Multi-cloud object gateway, deduped, compressed, and encrypted. The encrypted chunks would be saved on the selected BackingStores. Best used when the applications would always use the OpenShift Data Foundation endpoints to access the data.",

--- a/frontend/packages/ceph-storage-plugin/src/components/storage-popover.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/storage-popover.tsx
@@ -14,6 +14,7 @@ import Status, {
 import { getCephHealthState } from './dashboards/persistent-internal/status-card/utils';
 import { WatchCephResource } from '../types';
 import { ODF_MANAGED_FLAG } from '../features';
+import { ODF_MODEL_FLAG } from '../constants/common';
 
 export const StoragePopover: React.FC<StoragePopoverProps> = ({ ceph }) => {
   const { t } = useTranslation();
@@ -27,22 +28,24 @@ export const StoragePopover: React.FC<StoragePopoverProps> = ({ ceph }) => {
     );
   const value = health.message || healthStateMessage(health.state, t);
   const isOdfManaged = useFlag(ODF_MANAGED_FLAG);
+  const isOdfInstalled = useFlag(ODF_MODEL_FLAG);
+  const operatorName = !isOdfInstalled
+    ? t('ceph-storage-plugin~OpenShift Container Storage')
+    : t('ceph-storage-plugin~OpenShift Data Foundation');
+  const dashboardLink = !isOdfInstalled ? '/ocs-dashboards' : '/odf';
 
   return (
     <>
       {t(
-        "ceph-storage-plugin~Storage status represents the health status of Openshift Data Foundation's StorageCluster.",
+        "ceph-storage-plugin~Storage status represents the health status of {{operatorName}}'s StorageCluster.",
+        { operatorName },
       )}
       <StatusPopupSection
         firstColumn={t('ceph-storage-plugin~Provider')}
         secondColumn={t('ceph-storage-plugin~Health')}
       >
         <Status key="ocs" value={value} icon={icon}>
-          {!isOdfManaged ? (
-            <Link to="/odf">{t('ceph-storage-plugin~OpenShift Data Foundation')}</Link>
-          ) : (
-            t('ceph-storage-plugin~OpenShift Data Foundation')
-          )}
+          {!isOdfManaged ? <Link to={dashboardLink}>{operatorName}</Link> : operatorName}
         </Status>
       </StatusPopupSection>
     </>

--- a/frontend/packages/ceph-storage-plugin/src/constants/common.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/common.ts
@@ -41,4 +41,4 @@ export enum StoreType {
   BS = 'BackingStore',
   NS = 'NamespaceStore',
 }
-export const ODF_MODEL_FLAG = 'ODF_FLAG';
+export const ODF_MODEL_FLAG = 'ODF_MODEL';


### PR DESCRIPTION
Note: OCS 4.8 is installed here, not ODF.

**Before:**
![Screenshot from 2021-10-08 21-42-28](https://user-images.githubusercontent.com/39404641/136591433-9f025e73-2a55-4e44-a65f-5f18a4cb3e0c.png)

**After:**
![Screenshot from 2021-10-08 21-41-24](https://user-images.githubusercontent.com/39404641/136591474-fe68d052-7856-4661-aae2-7cb50c5ae67e.png)
