### PR TITLE
Bug 2012562: Check for migration condition before default unknown status

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm-status.ts
@@ -370,9 +370,9 @@ export const getVMConditionsStatus = ({
       status: VMStatus.VMI_WAITING,
       message: VMI_WAITING_MESSAGE,
     }) ||
-    (getStatusPhase(vmi) === VMIPhase.Failed && { status: VMStatus.VMI_ERROR }) || {
+    (getStatusPhase(vmi) === VMIPhase.Failed && { status: VMStatus.VMI_ERROR }) ||
+    isBeingMigrated(vm, vmi, migrations) || {
       status: VMStatus.UNKNOWN,
-    } ||
-    isBeingMigrated(vm, vmi, migrations)
+    }
   );
 };


### PR DESCRIPTION
We currently check for migration condition after setting default unknown status.

Screenshots:
Before:
![Peek 2021-10-10 12-54](https://user-images.githubusercontent.com/2181522/136691040-519b3fd6-36d5-4a1e-82bd-2aad88cea50a.gif)

After:
![Peek 2021-10-10 12-56](https://user-images.githubusercontent.com/2181522/136691041-1e76fdab-9f49-4935-b4b9-36d01a1a1960.gif)

