### PR TITLE
Bug 1997967: StorageClass is now saved moving between wizards

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/storage-tab-state-update.ts
@@ -319,7 +319,10 @@ const initialDefaultStorageClassUpdater = ({
   ) {
     return;
   }
-  const storageClassName = iGetVmSettingValue(state, id, VMSettingsField.DEFAULT_STORAGE_CLASS);
+
+  const storageClassName =
+    iGetCommonData(state, id, VMWizardProps.initialData)?.toJS()?.storageClass ||
+    iGetVmSettingValue(state, id, VMSettingsField.DEFAULT_STORAGE_CLASS);
 
   if (storageClassName) {
     const iProvisionSourceStorage = iGetProvisionSourceStorage(state, id);

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/create-vm.tsx
@@ -309,6 +309,7 @@ export const CreateVM: React.FC<RouteComponentProps> = ({ location }) => {
         template: state.template,
         name: state.name,
         startVM: state.startVM,
+        storageClass: bootState?.storageClass?.value,
         bootSource: dataSource
           ? {
               size:

--- a/frontend/packages/kubevirt-plugin/src/types/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/url.ts
@@ -5,6 +5,7 @@ export type VMWizardInitialData = {
   commonTemplateName?: string;
   userTemplateName?: string;
   userTemplateNs?: string;
+  storageClass?: string;
 };
 
 export type VMWizardBootSourceParams = {

--- a/frontend/packages/kubevirt-plugin/src/utils/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/url.ts
@@ -75,6 +75,7 @@ export const getVMWizardCreateLink = ({
   name,
   bootSource,
   startVM,
+  storageClass,
 }: {
   namespace?: string;
   wizardName: VMWizardName;
@@ -84,6 +85,7 @@ export const getVMWizardCreateLink = ({
   name?: string;
   bootSource?: VMWizardBootSourceParams;
   startVM?: boolean;
+  storageClass?: string;
 }) => {
   const params = new URLSearchParams();
   const initialData: VMWizardInitialData = {};
@@ -130,6 +132,10 @@ export const getVMWizardCreateLink = ({
 
   if (bootSource) {
     initialData.source = bootSource;
+  }
+
+  if (storageClass) {
+    initialData.storageClass = storageClass;
   }
 
   if (mode === VMWizardMode.IMPORT && view === VMWizardView.ADVANCED) {


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1997967

**Analysis / Root cause**: 
Storage class wasn't shared while moving between wizards

**Solution Description**: 
Now storage clas is shared while moving between wizards

**Screen shots / Gifs for design review**: 
![storage-class-shared](https://user-images.githubusercontent.com/14824964/136966302-9b95c361-48ea-42d1-84f9-33baaaf74a86.gif)

