### PR TITLE
Bug 2015416:Updating topology scripts to execute in CI

### DIFF
--- a/frontend/packages/dev-console/integration-tests/cypress.json
+++ b/frontend/packages/dev-console/integration-tests/cypress.json
@@ -19,7 +19,7 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "(@pre-condition or @smoke) and not (@manual or @to-do or @un-verified or @broken-test)",
+    "TAGS": "(@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)",
     "NAMESPACE": "aut-pipelines"
   },
   "retries": {

--- a/frontend/packages/dev-console/integration-tests/support/constants/staticText/index.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/staticText/index.ts
@@ -1,2 +1,1 @@
 export * from './global-text';
-export * from './topology-text';

--- a/frontend/packages/dev-console/integration-tests/support/constants/staticText/topology-text.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/staticText/topology-text.ts
@@ -1,6 +1,0 @@
-export const sideBarTabs = {
-  details: 'Details',
-  resources: 'Resources',
-  releaseNotes: 'Release notes',
-  observe: 'Observe',
-};

--- a/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/topology.ts
@@ -58,3 +58,10 @@ export enum addToApplicationGroupings {
   EventSource = 'Event Source',
   Channel = 'Channel',
 }
+
+export enum sideBarTabs {
+  Details = 'Details',
+  Resources = 'Resources',
+  ReleaseNotes = 'Release notes',
+  Observe = 'Observe',
+}

--- a/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/add-flow/git-page.ts
@@ -29,7 +29,7 @@ export const gitPage = {
   },
   enterAppName: (appName: string) => {
     cy.get('body').then(($body) => {
-      if ($body.find('#form-input-application-name-field').length) {
+      if ($body.find('#form-input-application-name-field').length !== 0) {
         cy.get('#form-input-application-name-field')
           .scrollIntoView()
           .clear()
@@ -38,7 +38,7 @@ export const gitPage = {
           .type(appName)
           .should('have.value', appName);
         cy.log(`Application Name "${appName}" is created`);
-      } else if ($body.find('#form-dropdown-application-name-field').length) {
+      } else if ($body.find('#form-dropdown-application-name-field').length !== 0) {
         cy.get(gitPO.appName).click();
         cy.get('[data-test-id="dropdown-text-filter"]').type(appName);
         cy.get('[role="listbox"]').then(($el) => {

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/monitoring/topology-sidebar-actions.ts
@@ -34,7 +34,7 @@ Given(
 );
 
 When('user clicks on Monitoring tab', () => {
-  topologySidePane.selectTab(sideBarTabs.observe);
+  topologySidePane.selectTab(sideBarTabs.Observe);
 });
 
 When('user selects {string} from Context Menu', (menuOption: string) => {
@@ -137,7 +137,7 @@ Then('user will be taken to Dashboard tab on the Monitoring page', () => {
 Then('user wont see Monitoring tab', () => {
   topologySidePane.verify();
   cy.get(topologyPO.sidePane.tabName)
-    .contains(sideBarTabs.observe)
+    .contains(sideBarTabs.Observe)
     .should('not.be.visible');
 });
 

--- a/frontend/packages/topology/integration-tests/cypress.json
+++ b/frontend/packages/topology/integration-tests/cypress.json
@@ -23,11 +23,11 @@
   "screenshotsFolder": "../../../gui_test_screenshots/cypress/screenshots",
   "videosFolder": "../../../gui_test_screenshots/cypress/videos",
   "env": {
-    "TAGS": "@topology and (@smoke or @regression) and not (@manual or @to-do or @un-verified)",
-    "NAMESPACE": "aut-topology"
+    "TAGS": "@topology and (@smoke or @regression or @pre-condition) and not (@manual or @to-do or @un-verified or @broken-test)",
+    "NAMESPACE": "aut-topology-ci"
   },
   "retries": {
-    "runMode": 1,
+    "runMode": 0,
     "openMode": 0
   }
 }

--- a/frontend/packages/topology/integration-tests/features/e2e/topology-ci.feature
+++ b/frontend/packages/topology/integration-tests/features/e2e/topology-ci.feature
@@ -1,0 +1,76 @@
+@topology @smoke
+Feature: Perform actions on topology
+        User will be able to create workloads and perform actions on topology page
+
+
+        @pre-condition
+        Scenario: Background steps
+            Given user is at developer perspective
+              And user has created or selected namespace "aut-topology-ci"
+
+
+        Scenario: Empty state of topology: T-06-TC01
+             When user navigates to Topology page
+             Then user sees Topology page with message "No resources found"
+              And user is able to see Start building your application, Add page links
+              And Display options dropdown, Filter by resource and Find by name fields are disabled
+              And Zoom in, Zoom out, Fit to Screen, Reset view, layout icons are displayed
+              And switch view is disabled
+
+
+        Scenario: Build the application from topology page
+            Given user is at Topology Graph view
+             When user clicks Start building your application
+              And user enters ".NET" builder image in Quick Search bar
+              And user clicks Create Application on Quick Search Dialog
+              And user enters Git Repo URL as "https://github.com/redhat-developer/s2i-dotnetcore-ex" in Create Source-to-Image Application
+              And user enters Application Name as "dotnet-app"
+              And user enters Name as "dotnet"
+              And user clicks Create button on Create Source-to-Image Application page
+             Then user is able to see workload "dotnet" in topology page
+
+
+        Scenario Outline: Editing a workload: T-09-TC01
+            Given user is at Topology Graph view
+             When user right clicks on the workload "<workload_name>" to open the Context Menu
+              And user clicks on "Edit <workload_name>" from context action menu
+              And user edits application groupings to "<application_groupings>"
+              And user saves the changes
+             Then user can see application groupings updated to "<application_groupings>"
+
+        Examples:
+                  | workload_name | application_groupings |
+                  | dotnet        | app                   |
+
+
+        Scenario: Default state of Display dropdown: T-16-TC01
+            Given user is at Topology Graph view
+             When user clicks on the Display dropdown
+             Then user will see the Connectivity Mode is checked
+              And user will see the Expand is checked
+              And user will see the Pod count is unchecked
+              And user will see the Labels is checked
+
+
+        Scenario: Check the Consumption Mode: T-16-TC02
+            Given user is at Topology page
+             When user clicks on the Display dropdown
+              And user checks the Consumption Mode
+             Then user will see that the Expand options are disabled
+              And user will see the Application groupings option is disabled
+              And app icon is not displayed
+
+
+        Scenario: Topology List view: T-12-TC01
+            Given user selected the Display options with Connectivity Mode
+             When user clicks on List view button
+             Then user will see workloads are segregated by applications groupings
+
+
+        Scenario: Deleting a workload through Action menu: T-15-TC01
+            Given user is at Topology Graph view
+             When user clicks on workload "dotnet"
+              And user clicks on Action menu
+              And user clicks "Delete Deployment" from action menu
+              And user clicks on Delete button from modal
+             Then user will see workload disappeared from topology

--- a/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
@@ -11,6 +11,10 @@ Feature: Topology chart area
         Scenario: Empty state of topology: T-06-TC01
              When user navigates to Topology page
              Then user sees Topology page with message "No resources found"
+              And user is able to see Start building your application, Add page links
+              And Display options dropdown, Filter by resource and Find by name fields are disabled
+              And Zoom in, Zoom out, Fit to Screen, Reset view, layout icons are disabled
+              And switch view is disabled
 
 
         @regression
@@ -33,7 +37,6 @@ Feature: Topology chart area
               And user has created a deployment config workload "nodejs-ex-git-2"
              When user navigates to Topology page
              Then user sees "nodejs-ex-git-1" and "nodejs-ex-git-2" workloads in topology chart area
-
 
 
         @regression @manual

--- a/frontend/packages/topology/integration-tests/features/topology/topology-filter-bar-display.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-filter-bar-display.feature
@@ -30,6 +30,7 @@ Feature: Workload Groupings in Topology
         Scenario: Uncheck the Expand: T-16-TC03
             Given user is at Topology page
              When user clicks on the Display dropdown
+              And user checks the Connectivity Mode
               And user unchecks the Expand
              Then user will see that the Expand options are disabled
 

--- a/frontend/packages/topology/integration-tests/features/topology/topology-workload-sidebar.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-workload-sidebar.feature
@@ -3,7 +3,8 @@ Feature: Sidebar in topology
               As a user, I want to check sidebar of workloads
 
         Background:
-            Given user has created or selected namespace "aut-topology-sidebar"
+            Given user has installed OpenShift Serverless Operator
+              And user has created or selected namespace "aut-topology-sidebar"
               And user is at Add page
 
 

--- a/frontend/packages/topology/integration-tests/package.json
+++ b/frontend/packages/topology/integration-tests/package.json
@@ -8,6 +8,6 @@
   },
   "scripts": {
     "test-cypress": "../../../node_modules/.bin/cypress open --env openshift=true",
-    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/topology/*.feature\";"
+    "test-cypress-headless": "node --max-old-space-size=4096 ../../../node_modules/.bin/cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless cypress:cli,cypress:server:specs --spec \"features/*/topology-ci.feature\";"
   }
 }

--- a/frontend/packages/topology/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/topology/integration-tests/support/commands/hooks.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, promise/catch-or-return */
 before(() => {
   cy.login();
   cy.document()

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -7,8 +7,16 @@ export const topologyPO = {
   emptyText: '[data-test="no-resources-found"]',
   addToApplication: '[data-test-action="devconsole~Add to Application"]',
   addToApplicationInContext: 'button.pf-topology-context-sub-menu.pf-c-dropdown__menu-item',
+  quickSearch: '[data-test="quick-search-bar"]',
+  filterByResourceDropDown: '[data-test="filter-by-resource"] button',
+  topologyDropDown: 'button[aria-label="Options menu"]',
+  emptyView: {
+    startBuildingYourApplicationLink: '[data-test="start-building-your-application"]',
+    addPageLink: '[data-test="add-page"]',
+  },
   graph: {
     reset: '#reset-view',
+    layoutViewGroup: '.odc-topology__layout-group',
     zoomIn: '#zoom-in',
     zoomOut: '#zoom-out',
     fitToScreen: '#fit-to-screen',
@@ -31,10 +39,9 @@ export const topologyPO = {
       connectivityMode: '[id="showGroups"]',
       consumptionMode: '[id="hideGroups"]',
       expandSwitchToggle: '.pf-c-switch__input',
-      applicationGroupingsDisabled: '.pf-c-check.pf-c-select__menu-item.pf-m-disabled',
-    },
-    filterByResource: {
-      filterByResourceDropDown: '[data-test="filter-by-resource"]',
+      applicationGroupings: '[id$=expand-app-groups]',
+      showLabels: '[id$=show-labels]',
+      showPodCount: '[id$=show-pod-count]',
     },
     contextMenuOptions: {
       addToProject: '.pf-topology-context-sub-menu',

--- a/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
+++ b/frontend/packages/topology/integration-tests/support/pages/topology/topology-page.ts
@@ -38,7 +38,12 @@ export const topologyPage = {
     cy.url().should('include', 'topology');
   },
   verifyTopologyGraphView: () => {
-    return cy.get(topologyPO.graph.emptyGraph);
+    // eslint-disable-next-line promise/catch-or-return
+    cy.url().then(($text) => {
+      $text.includes('graph')
+        ? cy.log(`user is at topology graph view`)
+        : cy.get(topologyPO.switcher).click({ force: true });
+    });
   },
   verifyContextMenu: () => cy.get(topologyPO.graph.contextMenu).should('be.visible'),
   verifyNoWorkLoadsText: (text: string) =>
@@ -69,7 +74,7 @@ export const topologyPage = {
   verifyExpandDisabled: () =>
     cy.get(topologyPO.graph.displayOptions.expandSwitchToggle).should('be.disabled'),
   verifyExpandOptionsDisabled: () =>
-    cy.get(topologyPO.graph.displayOptions.applicationGroupingsDisabled).should('be.visible'),
+    cy.get(topologyPO.graph.displayOptions.applicationGroupings).should('be.disabled'),
   uncheckExpandToggle: () => {
     cy.get(topologyPO.graph.displayOptions.expandSwitchToggle).click({ force: true });
   },
@@ -130,13 +135,13 @@ export const topologyPage = {
   verifyHelmReleaseSidePaneTabs: () => {
     cy.get(topologyPO.sidePane.tabName)
       .eq(0)
-      .should('contain.text', sideBarTabs.details);
+      .should('contain.text', sideBarTabs.Details);
     cy.get(topologyPO.sidePane.tabName)
       .eq(1)
-      .should('contain.text', sideBarTabs.resources);
+      .should('contain.text', sideBarTabs.Resources);
     cy.get(topologyPO.sidePane.tabs)
       .eq(2)
-      .should('contain.text', sideBarTabs.releaseNotes);
+      .should('contain.text', sideBarTabs.ReleaseNotes);
   },
   getAppNode: (appName: string) => {
     return cy.get(`[data-id="group:${appName}"] g.odc-resource-icon text`).contains('A');

--- a/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/common/topology.ts
@@ -7,12 +7,14 @@ import {
 } from '@console/dev-console/integration-tests/support/constants/global';
 import {
   createGitWorkload,
+  gitPage,
   topologyHelper,
 } from '@console/dev-console/integration-tests/support/pages';
 import {
   perspective,
   projectNameSpace,
   navigateTo,
+  createForm,
 } from '@console/dev-console/integration-tests/support/pages/app';
 import { verifyAndInstallKnativeOperator } from '@console/dev-console/integration-tests/support/pages/functions/installOperatorOnCluster';
 import { topologyPO } from '@console/topology/integration-tests/support/page-objects/topology-po';
@@ -149,4 +151,45 @@ Then('user will see workload disappeared from topology', () => {
 
 Given('user has installed OpenShift Serverless Operator', () => {
   verifyAndInstallKnativeOperator();
+});
+
+Given('user is at Topology Graph view', () => {
+  topologyPage.verifyTopologyGraphView();
+});
+
+When('user clicks Start building your application', () => {
+  cy.get(topologyPO.emptyView.startBuildingYourApplicationLink).click();
+});
+
+When('user enters {string} builder image in Quick Search bar', (searchItem: string) => {
+  cy.get(topologyPO.quickSearch).type(searchItem);
+});
+
+When('user clicks Create Application on Quick Search Dialog', () => {
+  cy.get('.pf-c-spinner__tail-ball').should('not.exist');
+  cy.get('ul[aria-label="Quick search list"] li')
+    .contains('Builder Images', { timeout: 60000 })
+    .click();
+  cy.get('button')
+    .contains('Create Application')
+    .click();
+});
+
+When(
+  'user enters Git Repo URL as {string} in Create Source-to-Image Application',
+  (gitUrl: string) => {
+    cy.byLegacyTestID('git-form-input-url').type(gitUrl);
+  },
+);
+
+When('user clicks Create button on Create Source-to-Image Application page', () => {
+  createForm.clickCreate();
+});
+
+When('user enters Application Name as {string}', (appName: string) => {
+  gitPage.enterAppName(appName);
+});
+
+When('user enters Name as {string}', (name: string) => {
+  gitPage.enterWorkloadName(name);
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
@@ -108,7 +108,7 @@ When('user is at Topology page chart view', () => {
 });
 
 When('user clicks the filter by resource on top', () => {
-  cy.get(topologyPO.graph.filterByResource.filterByResourceDropDown)
+  cy.get(topologyPO.filterByResourceDropDown)
     .should('be.visible')
     .click();
 });

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/quick-search-topology.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/quick-search-topology.ts
@@ -1,0 +1,25 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+import { topologyPO } from '../../page-objects/topology-po';
+
+Then('user is able to see Start building your application, Add page links', () => {
+  cy.get(topologyPO.emptyView.startBuildingYourApplicationLink).should('be.visible');
+  cy.get(topologyPO.emptyView.addPageLink).should('be.visible');
+});
+
+Then('Display options dropdown, Filter by resource and Find by name fields are disabled', () => {
+  cy.contains('Display options').should('be.disabled');
+  cy.get(topologyPO.filterByResourceDropDown).should('be.disabled');
+  cy.get(topologyPO.search).should('be.disabled');
+});
+
+Then('Zoom in, Zoom out, Fit to Screen, Reset view, layout icons are displayed', () => {
+  cy.get(topologyPO.graph.zoomIn).should('be.visible');
+  cy.get(topologyPO.graph.zoomOut).should('be.visible');
+  cy.get(topologyPO.graph.fitToScreen).should('be.visible');
+  cy.get(topologyPO.graph.reset).should('be.visible');
+  cy.get(topologyPO.graph.layoutViewGroup).should('be.visible');
+});
+
+Then('switch view is disabled', () => {
+  cy.get(topologyPO.switcher).should('have.attr', 'aria-disabled', 'true');
+});

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-filters.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/topology-filters.ts
@@ -1,7 +1,14 @@
-import { When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
 import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
+import { topologyPO } from '../../page-objects/topology-po';
 
 When('user clicks on the Display dropdown', () => {
+  topologyPage.clickDisplayOptionDropdown();
+});
+
+Given('user selected the Display options with Connectivity Mode', () => {
+  topologyPage.clickDisplayOptionDropdown();
+  topologyPage.checkConnectivityMode();
   topologyPage.clickDisplayOptionDropdown();
 });
 
@@ -17,23 +24,32 @@ Then('user will see the Pod count is unchecked', () => {
   topologyPage.verifyPodCountUnchecked();
 });
 
+Then('user will see the Labels is checked', () => {
+  cy.get(topologyPO.graph.displayOptions.showLabels).should('be.checked');
+});
+
+Then('app icon is not displayed', () => {
+  topologyPage.clickDisplayOptionDropdown();
+  cy.byTestID('icon application').should('not.exist');
+});
+
+Then('user will see the Application groupings option is disabled', () => {
+  cy.get(topologyPO.graph.displayOptions.applicationGroupings).should('be.disabled');
+});
+
 When('user checks the Consumption Mode', () => {
   topologyPage.checkConsumptionMode();
 });
 
-When('user will see that the Expand options are disabled', () => {
+When('user checks the Connectivity Mode', () => {
+  topologyPage.checkConnectivityMode();
+});
+
+Then('user will see that the Expand options are disabled', () => {
   topologyPage.verifyExpandOptionsDisabled();
 });
 
-When(
-  'user will see that the application groupings {string} no longer visible in the view',
-  (applicationGroupings: string) => {
-    topologyPage.verifyWorkloadNotInTopologyPage(applicationGroupings);
-  },
-);
-
 When('user unchecks the Expand', () => {
-  topologyPage.checkConnectivityMode();
   topologyPage.uncheckExpandToggle();
 });
 

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -48,6 +48,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-olm-headless
   yarn run test-cypress-helm-headless
   yarn run test-cypress-knative-headless
+  yarn run test-cypress-topology-headless
   exit;
 fi
 


### PR DESCRIPTION
**Description:**
Fixing topology scripts and added separate feature file to execute it on CI

**Jira Id:**
 Jira Id : https://issues.redhat.com/browse/ODC-6253

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Execute the scripts in Remote cluster

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p topology -h true
```

**Screen shots**:
![image](https://user-images.githubusercontent.com/61005404/137758763-cab41763-1e10-465f-b01f-942a767cbe1c.png)



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
