### PR TITLE
Bug 2001337: Service Name ODF should say OCS on Object tab

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/object-service/details-card/details-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/object-service/details-card/details-card.tsx
@@ -88,7 +88,7 @@ export const ObjectServiceDetailsCard: React.FC<DashboardItemProps> = ({
   const subscriptionLoaded = _.get(subscription, 'loaded');
   const serviceVersion = !isODF ? getOCSVersion(subscription) : getODFVersion(subscription);
 
-  const serviceName = !isODF
+  const serviceName = isODF
     ? t('ceph-storage-plugin~OpenShift Data Foundation')
     : t('ceph-storage-plugin~OpenShift Container Storage');
 


### PR DESCRIPTION
For OCP + OCS 4.8 :

**Before:**
![Screenshot from 2021-10-13 00-49-38](https://user-images.githubusercontent.com/39404641/137016575-ea27e73a-0f7c-47c7-9522-9c942a1c2ca9.png)

**After:**
![Screenshot from 2021-10-13 00-37-50](https://user-images.githubusercontent.com/39404641/137016605-ba0fabd0-2c46-4ff5-97ed-4125ace54105.png)

