### PR TITLE
Bug 2013431: Namespace selector font size and positioning fixes

### DIFF
--- a/frontend/packages/topology/src/components/page/TopologyView.scss
+++ b/frontend/packages/topology/src/components/page/TopologyView.scss
@@ -31,7 +31,8 @@
 
   &__view-switcher.pf-m-plain {
     @media (min-width: 768px) {
-      padding-bottom: 7px !important;
+      padding-bottom: 4px;
+      padding-right: 2px;
     }
   }
 

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -78,12 +78,6 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
 
     .pf-m-plain {
       color: inherit;
-      padding: 4px 0 2px !important;
-
-      @media (min-width: $grid-float-breakpoint) {
-        padding-bottom: 10px !important;
-        padding-top: 11px !important;
-      }
 
       &:hover,
       &:focus {
@@ -98,16 +92,14 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
   max-width: 60%;
 
   .pf-c-dropdown__toggle.pf-m-plain {
-    --pf-c-dropdown__toggle--FontSize: ($font-size-base + 1);
-    --pf-c-dropdown__toggle--PaddingTop: 2px !important;
-    --pf-c-dropdown__toggle--PaddingRight: 0;
-    --pf-c-dropdown__toggle--PaddingBottom: 2px !important;
+    font-size: ($font-size-base + 1);
+    --pf-c-dropdown__toggle--PaddingBottom: 7px;
     --pf-c-dropdown__toggle--PaddingLeft: 0;
+    --pf-c-dropdown__toggle--PaddingRight: 0;
 
     @media (min-width: $grid-float-breakpoint) {
-      --pf-c-dropdown__toggle--FontSize: ($font-size-base + 2);
-      --pf-c-dropdown__toggle--PaddingTop: 9px !important;
-      --pf-c-dropdown__toggle--PaddingBottom: 9px !important;
+      font-size: ($font-size-base + 2);
+      --pf-c-dropdown__toggle--PaddingBottom: 9px;
     }
 
     &:not(:disabled) {


### PR DESCRIPTION
This bug was recently introduced with https://github.com/openshift/console/pull/9594/files#diff-28225d513cdf6dd06cfaf058e33ac51cbb8a64b46d82a4dbeda90c5d43f499b0

The Application selector within the Developer console is not getting the correct font size and vertical positioning is slightly off from the Project selector.

**Incorrect**
<img width="843" alt="Broken" src="https://user-images.githubusercontent.com/1874151/137023328-53b3bc78-8270-42f0-a45b-504095552f20.png">
<img width="1217" alt="Screen Shot 2021-10-12 at 4 28 29 PM" src="https://user-images.githubusercontent.com/1874151/137024583-5947afd2-524d-452a-bacb-daa05e167579.png">

----

**Corrected**
<img width="877" alt="Fixed" src="https://user-images.githubusercontent.com/1874151/137023483-2e590d22-e877-4e86-992a-ffeff8da409f.png">
<img width="1242" alt="Fixed-desktop" src="https://user-images.githubusercontent.com/1874151/137023561-90c7da3d-472f-46ed-afff-b74867382b0b.png">

<img width="567" alt="Fixed-mobile" src="https://user-images.githubusercontent.com/1874151/137023486-5c6a319c-b46f-403f-8e2a-cf22c98e4ea4.png">

