### PR TITLE
Bug 2013545: Check for resource in ServiceBinding spec's service reference

### DIFF
--- a/frontend/packages/rhoas-plugin/src/topology/rhoas-data-transformer.ts
+++ b/frontend/packages/rhoas-plugin/src/topology/rhoas-data-transformer.ts
@@ -1,5 +1,10 @@
 import { EdgeModel, Model, NodeModel } from '@patternfly/react-topology';
-import { K8sResourceKind, apiVersionForModel } from '@console/internal/module/k8s';
+import {
+  K8sResourceKind,
+  apiVersionForModel,
+  modelFor,
+  referenceFor,
+} from '@console/internal/module/k8s';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager/src/types';
 import {
   getDefaultOperatorIcon,
@@ -86,7 +91,9 @@ export const getRhoasServiceBindingEdges = (
       if (bss) {
         const targetNode = rhoasNodes.find(
           (node) =>
-            node.data.resource.kind === bss.kind && node.data.resource.metadata.name === bss.name,
+            (bss.kind === node.data.resource.kind ||
+              bss.resource === modelFor(referenceFor(node.data.resource)).plural) &&
+            node.data.resource.metadata.name === bss.name,
         );
         if (targetNode) {
           const target = targetNode.data.resource.metadata.uid;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5774
https://bugzilla.redhat.com/show_bug.cgi?id=2013545
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
The data transformer for ServiceBinding only checked for the `service.kind` of a bindable service's reference, and did not for the `service.resource` when creating the data model.
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Check for the service's `resource` when creating the data model.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 

https://user-images.githubusercontent.com/20013884/137089823-0a4f1387-6f29-4090-8b7a-25084931a04f.mp4

<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Test setup:**
1. Install SBO, RHOAS operator
2. Create a D/DC & KafkaConnection service
3. Create service binding. Example:
    ```yaml
    apiVersion: binding.operators.coreos.com/v1alpha1
    kind: ServiceBinding
    metadata:
      name: sample-binding
    spec:
      bindAsFiles: true
      detectBindingResources: true
      application:
        group: apps
        name: nginx
        resource: deployments
        version: v1
      services:
        - group: rhoas.redhat.com
          name: example
          resource: kafkaconnections
          version: v1alpha1
    ```
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug