### PR TITLE
Bug 2013203: UI breaks when trying to create block pool before storage cluster/system creation

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/block-pool/body.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/block-pool/body.tsx
@@ -76,7 +76,7 @@ export const BlockPoolBody = (props: BlockPoolBodyPros) => {
     if (storageClusterLoaded && !storageClusterLoadError)
       dispatch({
         type: BlockPoolActionType.SET_FAILURE_DOMAIN,
-        payload: storageCluster.items[0].status?.failureDomain || '',
+        payload: storageCluster?.items[0]?.status?.failureDomain || '',
       });
   }, [storageCluster, storageClusterLoaded, storageClusterLoadError, dispatch]);
 


### PR DESCRIPTION
**Before:**
![Screenshot from 2021-10-13 13-14-50](https://user-images.githubusercontent.com/39404641/137092946-04bdb1b3-b50a-4807-817f-e5df9e1d2b8f.png)

**After:**
![Screenshot from 2021-10-13 13-15-39](https://user-images.githubusercontent.com/39404641/137092995-36ef6357-7e3d-4840-8430-7d15f02cd0a2.png)
