### PR TITLE
Bug 1992453: don't allow bad disk names

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/selectors.ts
@@ -64,7 +64,8 @@ export const getSourceKind = (envDisk: EnvDisk): string => {
   }
 };
 
-export const getNewDiskName = (sourceName: string) => `${sourceName}-${getRandomChars(6)}-disk`;
+export const getNewDiskName = (sourceName: string) =>
+  `${sourceName?.replace('.', '-')}-${getRandomChars(6)}-disk`;
 
 export const areEnvDisksEqual = (envDisk1: EnvDisk, envDisk2: EnvDisk): boolean => {
   if (!envDisk1 && !envDisk2) {


### PR DESCRIPTION
Currently we do not allow to add environment sources that include ".", but we should.

Screenshot:
Allow environment sources that include "."
![screenshot-localhost_9000-2021 10 13-12_04_18](https://user-images.githubusercontent.com/2181522/137102601-ad8ba0bc-3838-4e54-97e4-2a84be813adc.png)

