### PR TITLE
Bug 2013787: use NetworkAttachmentDefinitions instead of Network Attachment Definitions

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/console-extensions.json
+++ b/frontend/packages/network-attachment-definition-plugin/console-extensions.json
@@ -10,7 +10,7 @@
     "properties": {
       "id": "networkattachmentdefinitions",
       "section": "networking",
-      "name": "Network Attachment Definitions",
+      "name": "NetworkAttachmentDefinitions",
       "model": {
         "group": "k8s.cni.cncf.io",
         "kind": "NetworkAttachmentDefinition",

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
@@ -13,8 +13,6 @@ import { networkTypes } from '../../constants';
 import { getConfigAsJSON, getType } from '../../selectors';
 import { NetworkAttachmentDefinitionKind } from '../../types';
 
-const NET_ATTACH_DEF_DETAILS_HEADING = 'Network Attachment Definition Details';
-
 export const getBasicID = <A extends K8sResourceKind = K8sResourceKind>(entity: A) =>
   `${getNamespace(entity)}-${getName(entity)}`;
 
@@ -77,14 +75,7 @@ export const NetworkAttachmentDefinitionDetails: React.FC<NetAttachDefDetailsPro
   return (
     <StatusBox data={netAttachDef} loaded={!!netAttachDef}>
       <ScrollToTopOnMount />
-      <div className="co-m-pane__body">
-        <SectionHeading text={NET_ATTACH_DEF_DETAILS_HEADING} />
-        <div className="row">
-          <div className="col-sm-6">
-            <NetAttachDefinitionSummary netAttachDef={netAttachDef} />
-          </div>
-        </div>
-      </div>
+      <NetAttachDefinitionSummary netAttachDef={netAttachDef} />
     </StatusBox>
   );
 };


### PR DESCRIPTION
The convention in the console is to use a kind name and not a human readable name.

In NetworkAttachmentDefinitions we still use the human readable one:

Screenshots:
Before:
![screenshot-localhost_9000-2021 10 13-13_24_41](https://user-images.githubusercontent.com/2181522/137116020-0a5056b7-dc1c-4c8b-89f7-495dec4c6997.png)

After:
![screenshot-localhost_9000-2021 10 13-13_33_22](https://user-images.githubusercontent.com/2181522/137117077-d3c0473c-1348-4d4e-886d-cd9a7bb2aaea.png)
