### PR TITLE
Bug 2013871: Fix alignment of column headings with table cells

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -283,8 +283,9 @@ form.pf-c-form {
     --pf-c-table--cell--PaddingRight: 0 !important;
     --pf-c-table--cell--PaddingBottom: var(--pf-global--spacer--sm) !important;
     --pf-c-table--cell--PaddingLeft: 0 !important;
-    --pf-c-table--cell--Width: 44px !important;
-    --pf-c-table--cell--MaxWidth: 44px !important;
+    // Can not use PF vars --pf-c-table--cell--Width & --pf-c-table--cell--MaxWidth, because its selector specificity will be overridden by the default PF rule .pf-c-table tr > *:empty {width: auto}; for our empty <th>
+    max-width: 44px !important;
+    width: 44px !important;
   }
 
   table-layout: fixed;


### PR DESCRIPTION
This bug effects all tables that have a kebab action button/
The table headings are misaligned to their table cell contents.

Reverting width setting from using the PF theming variable back to standard css declaration.

Bug was introduced when updating theme variables https://github.com/openshift/console/commit/a4ae661800a62c85b1280029291ffbd772679621#diff-28c7abc9fceeb716adb6850a96da67b203a13428b8ca95649c3ae66834b3573bR290-R291

Can not use PF vars `--pf-c-table--cell--Width` & `--pf-c-table--cell--MaxWidth`, because its selector specificity will be overridden by the default PF rule `.pf-c-table tr > *:empty {width: auto};` for our empty `<th>`


**Before**
<img width="1512" alt="Podbug" src="https://user-images.githubusercontent.com/1874151/137228830-c9dd647c-240d-4580-8648-29e759ebd1ce.png">

<img width="1523" alt="Networkpolicybug" src="https://user-images.githubusercontent.com/1874151/137228367-4d48a032-f26a-40a4-a011-5431df4651ae.png">
<img width="1509" alt="Machinebug" src="https://user-images.githubusercontent.com/1874151/137228368-9a125862-11fc-449d-9ec7-ed71466f39e2.png">
<img width="539" alt="Screen Shot 2021-10-13 at 7 15 19 PM" src="https://user-images.githubusercontent.com/1874151/137228478-7fda6236-c310-4cca-a15b-57aa4667156c.png">

----


**After**
<img width="1558" alt="Screen Shot 2021-10-13 at 7 06 41 PM" src="https://user-images.githubusercontent.com/1874151/137228513-c7862658-feb5-4848-bade-025ec78f394b.png">
<img width="1559" alt="Screen Shot 2021-10-13 at 7 06 27 PM" src="https://user-images.githubusercontent.com/1874151/137228517-3833fd65-154a-48a4-b726-4eaca1665d8e.png">
<img width="1557" alt="Screen Shot 2021-10-13 at 7 05 59 PM" src="https://user-images.githubusercontent.com/1874151/137228520-0876f649-e5c0-4c3a-a650-c64565591526.png">
<img width="554" alt="Screen Shot 2021-10-13 at 7 09 09 PM" src="https://user-images.githubusercontent.com/1874151/137228547-775a3aeb-7944-4df6-9327-050b2ce80fcb.png">


