### PR TITLE
Bug 2002362: Use only JSON files for dynamic plugin JSON schemas

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-schema.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-schema.ts
@@ -68,12 +68,10 @@ console.log('Generating Console plugin JSON schemas');
 typeConfigs.forEach((tc) => {
   const schema = generateSchema(tc);
   const schemaString = JSON.stringify(schema, null, 2);
-  const outPath = resolvePath(`generated/schema/${path.parse(tc.srcFile).name}`);
+  const outPath = resolvePath(`generated/schema/${path.parse(tc.srcFile).name}.json`);
 
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(`${outPath}.json`, schemaString);
-  fs.writeFileSync(`${outPath}.js`, `export default ${schemaString};`);
+  fs.writeFileSync(outPath, schemaString);
 
-  console.log(chalk.green(relativePath(`${outPath}.json`)));
-  console.log(chalk.green(relativePath(`${outPath}.js`)));
+  console.log(chalk.green(relativePath(outPath)));
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
@@ -3,13 +3,13 @@ import { coFetch } from '@console/internal/co-fetch';
 import { pluginManifestFile } from '../constants';
 import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
 import { resolveURL } from '../utils/url';
+// eslint-disable-next-line
+const schema = require('../../generated/schema/plugin-manifest.json');
 
 export const validatePluginManifestSchema = async (
   manifest: ConsolePluginManifestJSON,
   manifestURL: string,
 ) => {
-  const schema = (await import('../../generated/schema/plugin-manifest')).default;
-
   // Use dynamic import to avoid pulling ajv dependency tree into main vendors chunk
   const SchemaValidator = await import(
     '@console/dynamic-plugin-sdk/src/validation/SchemaValidator'

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleAssetPlugin.ts
@@ -18,14 +18,14 @@ export const loadSchema = (relativePath: string) => {
     path.resolve(pkgDir, 'generated/schema'),
   ].find((p) => fs.existsSync(p) && fs.statSync(p).isDirectory());
 
-  return require(path.resolve(schemaPath, relativePath)).default;
+  return require(path.resolve(schemaPath, relativePath));
 };
 
 export const validateExtensionsFileSchema = (
   ext: ConsoleExtensionsJSON,
   description = extensionsFile,
 ) => {
-  const schema = loadSchema('console-extensions');
+  const schema = loadSchema('console-extensions.json');
   return new SchemaValidator(description).validate(schema, ext);
 };
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/webpack/ConsoleRemotePlugin.ts
@@ -12,7 +12,7 @@ export const validatePackageFileSchema = (
   pkg: ConsolePackageJSON,
   description = 'package.json',
 ) => {
-  const schema = loadSchema('plugin-package');
+  const schema = loadSchema('plugin-package.json');
   const validator = new SchemaValidator(description);
 
   if (pkg.consolePlugin) {


### PR DESCRIPTION
With this PR, only `.json` files are generated and used in context of plugin JSON schema validation.

```
packages/console-dynamic-plugin-sdk/generated/schema
├── console-extensions.json
├── plugin-manifest.json
└── plugin-package.json
```

- `plugin-package.json` + `console-extensions.json` :arrow_right: used during the plugin's webpack build
- `plugin-manifest.json` :arrow_right: used by Console application as part of plugin load sequence