### PR TITLE
Bug 2014486: Fix failing OLM test scenario

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.spec.ts
@@ -61,7 +61,7 @@ describe('Interacting with OperatorHub', () => {
   });
 
   it('filters Operators by name', () => {
-    const operatorName = 'Alcide kAudit Operator';
+    const operatorName = 'Couchbase Operator';
     cy.byTestID('search-operatorhub').type(operatorName);
     cy.get('.catalog-tile-pf')
       .its('length')

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -11,9 +11,9 @@ const testOperator = {
 };
 
 const testOperand: TestOperandProps = {
-  name: 'CodeReady Workspaces Cluster',
+  name: 'CodeReady Workspaces instance Specification',
   kind: 'CheCluster',
-  tabName: 'CodeReady Workspaces Cluster',
+  tabName: 'CodeReady Workspaces instance Specification',
   exampleName: `codeready-workspaces`,
 };
 


### PR DESCRIPTION
The CodeReady workspaces operand tab name has changed from `CodeReady Workspaces Cluster` to `CodeReady Workspaces instance Specification`.