### PR TITLE
Bug 2013416: Generate unique CSS filenames for `yarn run dev`

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -32,7 +32,8 @@ const WDS_PORT = 8080;
 
 /* Helpers */
 const extractCSS = new MiniCssExtractPlugin({
-  filename: 'app-bundle.[contenthash].css',
+  filename:
+    NODE_ENV === 'production' ? 'app-bundle.[contenthash].css' : 'app-bundle.[name].[hash].css',
   // We follow BEM naming to scope CSS.
   // See https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
   ignoreOrder: true,


### PR DESCRIPTION
Avoids the error: Multiple assets emit different content to the same filename