### PR TITLE
Automation of user preference in dev perspetive epic:ODC-5227

### DIFF
--- a/frontend/packages/dev-console/integration-tests/features/user-preferences/user-preferences-dev-perspective.feature
+++ b/frontend/packages/dev-console/integration-tests/features/user-preferences/user-preferences-dev-perspective.feature
@@ -4,92 +4,98 @@ Feature: Manage user preferences
 
         Background:
             Given user is at developer perspective
+              And user is at Add page
 
 
-        @regression @to-do
+        @smoke
         Scenario: Visiting User Preference page: UP-01-TC01
             Given user is at admin perspective
              When user clicks on user dropdown on masthead and selects "User Preference"
              Then user sees "General" tab selected on User Preferences page
               And user sees "Language" tab on User Preferences page
 
-        @regression @to-do
+        @regression
         Scenario: Setting Developer preference for perspective: UP-01-TC02
             Given user is at admin perspective
              When user clicks on user dropdown on masthead and selects "User Preference"
               And user changes user preference "Perspective" dropdown to "Developer"
-              And user reloads the console without perspective.
+              And user reloads the console without perspective
              Then user sees the "Developer" perspective
 
 
-        @regression @to-do
+        @regression
         Scenario: Setting a preference for a project: UP-01-TC03
-            Given user has created project "test-preference1"
-             When user selects "All projets" from the project menu
+            Given user has created project "test-preference111"
+             When user selects "All Projects" from the project menu
               And user clicks on user dropdown on masthead and selects "User Preference"
-              And user clicks on Project dropdown on User Preferences page
-              And user searches and selects project "test-preference1" from the dropdown
+              And user clicks on "Project" dropdown on User Preferences page
+              And user searches and selects project "test-preference11" from the dropdown
               And user reloads the console
-             Then user can see project "test-preference1" is selected
+             Then user can see project "test-preference111" is selected
 
 
-        @regression @to-do
+        @regression
         Scenario: Creating project with project preference: UP-01-TC04
              When user clicks on user dropdown on masthead and selects "User Preference"
-              And user clicks on Project dropdown on User Preferences page
-              And user types project "test-preference2" in search bar
-              And user clicks on the Create project option from the dropdown
+              And user clicks on "Project" dropdown on User Preferences page
+              And user types project "test-preference222" in search bar
+              And user clicks on Create project option from the dropdown
+              And user clicks on Create with name "test-preference222" in Create Project modal
               And user reloads the console
-              And user can see project "test-preference2" is selected
+              And user can see project "test-preference222" is selected
 
 
-        @regression @to-do
+        @regression
         Scenario: Setting Graph preference for Topology: UP-01-TC05
             Given user has created or selected namespace "aut-user-preferences"
+              And user has created workload "node1" with resource type "deployment"
              When user clicks on user dropdown on masthead and selects "User Preference"
               And user changes user preference "Topology" dropdown to "Graph"
+              And user reloads the console
               And user clicks on Topology in navigation menu
              Then user can see topology graph view
 
 
-        @regression @to-do
+        @regression @broken-test
+        # marked broken-test due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2014313
         Scenario: Setting List preference for Topology: UP-01-TC06
             Given user has created or selected namespace "aut-user-preferences"
              When user clicks on user dropdown on masthead and selects "User Preference"
               And user changes user preference "Topology" dropdown to "List"
+              And user reloads the console
               And user clicks on Topology in navigation menu
              Then user can see topology list view
 
 
-        @regression @to-do
+        @regression
         Scenario: Setting Form preference for Create/Edit resource method: UP-01-TC07
             Given user has created or selected namespace "aut-user-preferences"
              When user clicks on user dropdown on masthead and selects "User Preference"
               And user changes user preference "Create/Edit resource method" dropdown to "Form"
               And user clicks on Add in navigation menu
               And user clicks on Helm charts
-              And user selects "Nodejs v0.0.1" helm chart
+              And user selects "Nodejs" helm chart
               And user clicks on Install Helm Chart button
              Then user can see Form view option selected in Install Helm Chart page
 
 
-        @regression @to-do
+        @regression
         Scenario: Setting YAML preference for Create/Edit resource method: UP-01-TC08
             Given user has created or selected namespace "aut-user-preferences"
              When user clicks on user dropdown on masthead and selects "User Preference"
               And user changes user preference "Create/Edit resource method" dropdown to "YAML"
               And user clicks on Add in navigation menu
               And user clicks on Helm charts
-              And user selects "Nodejs v0.0.1" helm chart
+              And user selects "Nodejs" helm chart
               And user clicks on Install Helm Chart button
              Then user can see YAML view option selected in Install Helm Chart page
 
-        @regression @to-do
+
+        @regression
         Scenario: Setting a preference for language: UP-01-TC09
             Given user is at admin perspective
              When user clicks on user dropdown on masthead and selects "User Preference"
               And user clicks on "Language" tab on User Preferences page
               And user clicks on the checkbox to uncheck it
-              And user clicks on the dropdown
-              And user selects 日本語 (Japanese) from the dropdown
-             Then user will see the language change to 日本語 (Japanese)
+              And user changes user preference "Language" dropdown to "日本語"
+             Then user will see the language change to 日本語

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/userPreference-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/userPreference-po.ts
@@ -1,0 +1,43 @@
+export const userPreferencePO = {
+  userMenu: '[data-test="user-dropdown"]',
+  userPreference: 'button.pf-c-select__toggle',
+  namespaceTypeahead: '[id="console.preferredNamespace-select-typeahead"]',
+  languageTab: '[data-test="tab language"]',
+  creteProjectButton: '[data-test="footer create-namespace-button"]',
+  checkboxPreferredLanguage: '[data-test="checkbox console.preferredLanguage"]',
+};
+
+export const preferenceDropdownDisplayNameToName = (displayName: string) => {
+  switch (displayName) {
+    case 'Perspective': {
+      return 'Perspective';
+    }
+    case 'Project': {
+      return 'Namespace';
+    }
+    case 'Topology': {
+      return 'View';
+    }
+    case 'Create/Edit resource method': {
+      return 'CreateEditMethod';
+    }
+    case 'Language': {
+      return 'Language';
+    }
+    default: {
+      throw new Error('Preference is not available');
+    }
+  }
+};
+
+export function getTab(tabName: string) {
+  return `[data-test~="tab"][data-test~="${tabName.toLowerCase()}"]`;
+}
+
+export function getPreferenceDropdown(preference: string) {
+  const preferenceName = preferenceDropdownDisplayNameToName(preference);
+  if (preference === 'Topology') {
+    return `[id="topology.preferred${preferenceName}"]`;
+  }
+  return `[id="console.preferred${preferenceName}"]`;
+}

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -209,7 +209,7 @@ export const projectNameSpace = {
 
   selectProjectOrDoNothing: (projectName: string) => {
     projectNameSpace.clickProjectDropdown();
-    cy.byLegacyTestID('dropdown-text-filter').type(projectName);
+    cy.byTestID('dropdown-text-filter').type(projectName);
     cy.get('[role="listbox"]').then(($el) => {
       if ($el.find('li[role="option"]').length !== 0) {
         cy.get(`[id="${projectName}-link"]`).click();

--- a/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
+++ b/frontend/packages/dev-console/integration-tests/support/step-definitions/userPreferences/user-preferences-dev-perspective.ts
@@ -1,0 +1,209 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { modal } from '@console/cypress-integration-tests/views/modal';
+import { nav } from '@console/cypress-integration-tests/views/nav';
+import { addOptions, devNavigationMenu, switchPerspective } from '../../constants';
+import {
+  getPreferenceDropdown,
+  getTab,
+  userPreferencePO,
+} from '../../pageObjects/userPreference-po';
+import {
+  addPage,
+  app,
+  catalogPage,
+  createGitWorkload,
+  navigateTo,
+  perspective,
+  projectNameSpace,
+  topologyHelper,
+} from '../../pages';
+
+Given('user is at admin perspective', () => {
+  perspective.switchTo(switchPerspective.Administrator);
+  nav.sidenav.switcher.shouldHaveText(switchPerspective.Administrator);
+});
+
+When('user clicks on user dropdown on masthead and selects {string}', (menuItem: string) => {
+  cy.get(userPreferencePO.userMenu)
+    .should('be.visible')
+    .click();
+  cy.get("[role='menu']")
+    .find('li')
+    .contains(menuItem)
+    .should('be.visible')
+    .click();
+});
+
+Then('user sees {string} tab selected on User Preferences page', (sideTab: string) => {
+  cy.get(getTab(sideTab)).should('be.visible');
+});
+
+Then('user sees {string} tab on User Preferences page', (sideTab: string) => {
+  cy.get(getTab(sideTab)).should('be.visible');
+});
+
+When(
+  'user changes user preference {string} dropdown to {string}',
+  (group: string, preferance: string) => {
+    cy.selectByDropDownText(getPreferenceDropdown(group), preferance);
+  },
+);
+
+When('user reloads the console without perspective', () => {
+  cy.reload();
+  app.waitForLoad();
+});
+
+Then('user sees the {string} perspective', (userPerspective: string) => {
+  nav.sidenav.switcher.shouldHaveText(userPerspective);
+});
+
+Given('user has created project {string}', (projectName) => {
+  Cypress.env('NAMESPACE', projectName);
+  projectNameSpace.selectOrCreateProject(`${projectName}`);
+});
+
+When('user selects {string} from the project menu', (projectName: string) => {
+  projectNameSpace.selectOrCreateProject(projectName);
+});
+
+When('user clicks on {string} dropdown on User Preferences page', (group: string) => {
+  cy.get(getPreferenceDropdown(group))
+    .should('be.visible')
+    .click();
+});
+
+When('user searches and selects project {string} from the dropdown', (preference: string) => {
+  cy.get(userPreferencePO.namespaceTypeahead)
+    .clear()
+    .should('not.have.value');
+  cy.get(userPreferencePO.namespaceTypeahead)
+    .type(preference)
+    .should('have.value', preference);
+  cy.get('[data-test="dropdown console.preferredNamespace"]')
+    .find('li')
+    .contains(preference)
+    .click();
+});
+
+When('user reloads the console', () => {
+  cy.reload();
+  app.waitForLoad();
+});
+
+Then('user can see project {string} is selected', (projectName: string) => {
+  perspective.switchTo(switchPerspective.Developer);
+  navigateTo(devNavigationMenu.Topology);
+  app.waitForLoad();
+  cy.get('[data-test-id="namespace-bar-dropdown"] span.pf-c-menu-toggle__text').should(
+    'contain.text',
+    projectName,
+  );
+  cy.exec(`oc delete namespace ${Cypress.env('NAMESPACE', projectName)}`, {
+    failOnNonZeroExit: false,
+  });
+});
+
+When('user types project {string} in search bar', (preference: string) => {
+  cy.get(userPreferencePO.namespaceTypeahead)
+    .clear()
+    .should('not.have.value');
+  cy.get(userPreferencePO.namespaceTypeahead)
+    .type(preference)
+    .should('have.value', preference);
+});
+
+When('user clicks on Create project option from the dropdown', () => {
+  cy.get(userPreferencePO.creteProjectButton)
+    .should('be.visible')
+    .click();
+});
+
+When('user clicks on Create with name {string} in Create Project modal', (projectName: string) => {
+  modal.shouldBeOpened();
+  cy.get('#input-name').type(projectName);
+  cy.get('#confirm-action').click();
+  app.waitForLoad();
+});
+
+Given('user has created or selected namespace {string}', (projectName) => {
+  Cypress.env('NAMESPACE', projectName);
+  projectNameSpace.selectOrCreateProject(`${projectName}`);
+});
+
+Given(
+  'user has created workload {string} with resource type {string}',
+  (componentName: string, resourceType: string = 'Deployment') => {
+    createGitWorkload(
+      'https://github.com/sclorg/nodejs-ex.git',
+      componentName,
+      resourceType,
+      'nodejs-ex-git-app',
+    );
+    topologyHelper.verifyWorkloadInTopologyPage(componentName);
+  },
+);
+
+When('user clicks on Topology in navigation menu', () => {
+  perspective.switchTo(switchPerspective.Developer);
+  navigateTo(devNavigationMenu.Topology);
+});
+
+Then('user can see topology graph view', () => {
+  cy.get('[data-id="odc-topology-graph"]').should('be.visible');
+});
+
+Then('user can see topology list view', () => {
+  cy.get('[aria-label="Topology List View"]').should('be.visible');
+});
+
+When('user clicks on Add in navigation menu', () => {
+  perspective.switchTo(switchPerspective.Developer);
+  navigateTo(devNavigationMenu.Add);
+});
+
+When('user clicks on Helm charts', () => {
+  addPage.selectCardFromOptions(addOptions.HelmChart);
+});
+
+When('user selects {string} helm chart', (cardName: string) => {
+  catalogPage.search(cardName);
+  catalogPage.selectHelmChartCard(cardName);
+});
+
+When('user clicks on Install Helm Chart button', () => {
+  catalogPage.clickButtonOnCatalogPageSidePane();
+});
+
+Then('user can see Form view option selected in Install Helm Chart page', () => {
+  cy.get('#form-radiobutton-editorType-form-field').should('be.checked');
+});
+
+Then('user can see YAML view option selected in Install Helm Chart page', () => {
+  cy.get('#form-radiobutton-editorType-yaml-field').should('be.checked');
+});
+
+When('user clicks on {string} tab on User Preferences page', (tab: string) => {
+  cy.get(getTab(tab))
+    .should('be.visible')
+    .click();
+});
+
+When('user clicks on the checkbox to uncheck it', () => {
+  cy.get(userPreferencePO.checkboxPreferredLanguage)
+    .should('be.visible')
+    .uncheck();
+});
+
+Then('user will see the language change to 日本語', () => {
+  cy.get('h1.ocs-page-layout__title')
+    .invoke('attr', 'value')
+    .then(($initialVal) => {
+      if ($initialVal !== 'ユーザー設定') {
+        cy.wait(5000);
+      }
+      cy.get('h1.ocs-page-layout__title').should('contain.text', 'ユーザー設定');
+    });
+  // After execution of all tests Language value is changed back to English
+  cy.selectByDropDownText(getPreferenceDropdown('Language'), 'English');
+});


### PR DESCRIPTION
**Fix**: https://issues.redhat.com/browse/ODC-6386

**Problem**: As a user, I need the ability to set/edit my preferences for the OCP Console.

**Solution**: This script will automate the User preferences form

**Test Setup**:

Cluster should be running on local

Check the TAGS in frontend/packages/dev-console/integration-tests/cypress.json file be: ""(@pre-condition or @smoke or @regression) and not (@manual or @to-do or @un-verified or @broken-test)"",

The "@patternfly/quickstarts" version be "1.0.2" in  /frontend/package.json

Command to execute:

```
export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
BRIDGE_KUBEADMIN_PASSWORD=xry7n-UVpxC-6hXFf-sgjEi
BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.jakumar-2021-09-01-193941.devcluster.openshift.com
export BRIDGE_KUBEADMIN_PASSWORD
export BRIDGE_BASE_ADDRESS
export BRIDGE_API
oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD https://api.jakumar-2021-09-01-193941.devcluster.openshift.com:6443/ --insecure-skip-tls-verify
oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
./test-cypress.sh -p dev-console
```
Execute the user-preferences-dev-perspective.feature file

**Checks for approving Epic scenarios Automation PR:**
<!-- Below criteria should be met before approving the pr, use [x] -->
- [x] Execute the @to-do tagged gherkin scripts manually
- [x] Convert the @to-do gherkin scripts to cypress automation scripts
- [x] Once scripts are automated, replace tag @to-do with @epic-number
- [x] Execute the scripts in Remote cluster
- [x] Update [Automation Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Browser**
Chrome 89

**Test Execution Screenshot:**

![Screenshot from 2021-10-18 19-53-40](https://user-images.githubusercontent.com/10252230/137750151-90295d4a-a6fa-4008-8211-7b5108a7c53a.png)
