### PR TITLE
Bug 2015274: Fix plugin-manifest JSON schema import code

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-pkg-assets.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-pkg-assets.ts
@@ -16,7 +16,7 @@ const writePackageManifest = (manifest: readPkg.PackageJson, outDir: string) => 
   console.log(chalk.green(relativePath(outPath)));
 };
 
-const copyFiles = (files: Record<any, string>) => {
+const copyFiles = (files: Record<string, string>) => {
   Object.entries(files).forEach(([src, dest]) => {
     fs.copySync(resolvePath(src), resolvePath(dest), { recursive: true });
     console.log(chalk.green(relativePath(dest)));

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-schema.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/generate-schema.ts
@@ -68,10 +68,12 @@ console.log('Generating Console plugin JSON schemas');
 typeConfigs.forEach((tc) => {
   const schema = generateSchema(tc);
   const schemaString = JSON.stringify(schema, null, 2);
-  const outPath = resolvePath(`generated/schema/${path.parse(tc.srcFile).name}.json`);
+  const outPath = resolvePath(`generated/schema/${path.parse(tc.srcFile).name}`);
 
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, schemaString);
+  fs.writeFileSync(`${outPath}.json`, schemaString);
+  fs.writeFileSync(`${outPath}.cjs`, `exports.default = ${schemaString};`);
 
-  console.log(chalk.green(relativePath(outPath)));
+  console.log(chalk.green(relativePath(`${outPath}.json`)));
+  console.log(chalk.green(relativePath(`${outPath}.cjs`)));
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -8,7 +8,7 @@ type GeneratedPackage = {
   /** Package manifest. Note: `version` is updated via the publish script. */
   manifest: readPkg.PackageJson;
   /** Additional files to copy to the package output directory. */
-  filesToCopy: Record<any, string>;
+  filesToCopy: Record<string, string>;
 };
 
 type MissingDependencyCallback = (name: string) => void;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-manifest.ts
@@ -3,17 +3,18 @@ import { coFetch } from '@console/internal/co-fetch';
 import { pluginManifestFile } from '../constants';
 import { ConsolePluginManifestJSON } from '../schema/plugin-manifest';
 import { resolveURL } from '../utils/url';
-// eslint-disable-next-line
-const schema = require('../../generated/schema/plugin-manifest.json');
 
 export const validatePluginManifestSchema = async (
   manifest: ConsolePluginManifestJSON,
   manifestURL: string,
 ) => {
+  // eslint-disable-next-line
+  const schema = require('../../generated/schema/plugin-manifest.cjs').default;
+
   // Use dynamic import to avoid pulling ajv dependency tree into main vendors chunk
-  const SchemaValidator = await import(
-    '@console/dynamic-plugin-sdk/src/validation/SchemaValidator'
-  ).then((m) => m.SchemaValidator);
+  const SchemaValidator = await import('../validation/SchemaValidator').then(
+    (m) => m.SchemaValidator,
+  );
 
   const validator = new SchemaValidator(manifestURL);
   validator.validate(schema, manifest, 'manifest');


### PR DESCRIPTION
This PR fixes a bug introduced by #10242 

For some reason, Console webpack build cannot process `require` or `import` statements that refer directly to JSON files, regardless of TypeScript `resolveJsonModule` setting.

This PR re-introduces accompanying JS modules for the generated schemas, using `.cjs` file extension to indicate CommonJS module format.

