### PR TITLE
Bug 2009664: fix edit ksvc in git import flow

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplicationComponent.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplicationComponent.tsx
@@ -28,7 +28,10 @@ const EditApplicationComponent: React.FunctionComponent<EditApplicationComponent
 
   const getAssociatedResource = (resourcesObj: WatchK8sResultsObject<K8sResourceKind[]>) => {
     const associatedRes = resourcesObj.data?.find(
-      (ob) => ob.metadata.name === appName || ob.metadata.name === appLabel,
+      (ob) =>
+        ob.metadata.name === appName ||
+        ob.metadata.name === appLabel ||
+        ob.metadata.labels['app.kubernetes.io/name'] === appLabel,
     );
     return {
       ...resourcesObj,

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
@@ -7,7 +7,7 @@ import {
   getFlowType,
   ApplicationFlowType,
   getInitialValues,
-  getExternalImagelValues,
+  getExternalImageValues,
   getServerlessData,
   getKsvcRouteData,
   getFileUploadValues,
@@ -78,7 +78,7 @@ describe('Edit Application Utils', () => {
   });
 
   it('getExternalImagelValues should return image name in search term', () => {
-    const externalImageData = getExternalImagelValues(knativeService);
+    const externalImageData = getExternalImageValues(knativeService);
     expect(_.get(externalImageData, 'searchTerm')).toEqual('openshift/hello-openshift');
   });
 

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -495,7 +495,7 @@ export const getInternalImageInitialValues = (editAppResource: K8sResourceKind) 
   };
 };
 
-export const getExternalImagelValues = (appResource: K8sResourceKind) => {
+export const getExternalImageValues = (appResource: K8sResourceKind) => {
   const name = _.get(appResource, 'spec.template.spec.containers[0].image', null);
   if (_.isEmpty(appResource) || !name) {
     return deployImageInitialValues;
@@ -562,7 +562,7 @@ export const getInitialValues = (
     ) {
       if (editAppResourceData?.kind === ServiceModel.kind) {
         internalImageValues = {};
-        externalImageValues = getExternalImagelValues(editAppResourceData);
+        externalImageValues = getExternalImageValues(editAppResourceData);
       }
     }
   } else if (isFromJarUpload(getBuildSourceType(buildConfigData))) {

--- a/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils.spec.ts
@@ -108,7 +108,7 @@ describe('DeployImage Submit Utils', () => {
       const imageStream = await submitUtils.createOrUpdateImageStream(
         mockDeployImageFormData,
         true,
-        null,
+        mockImageStreamData,
         'update',
       );
 
@@ -149,7 +149,7 @@ describe('DeployImage Submit Utils', () => {
       const imageStream = await submitUtils.createOrUpdateImageStream(
         mockDeployImageFormData,
         false,
-        null,
+        mockImageStreamData,
         'update',
       );
 

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -98,12 +98,13 @@ export const createOrUpdateImageStream = (
     application: { name: applicationName },
     labels: userLabels,
     image: { tag: selectedTag },
+    labels,
   } = formData;
-  const INSTANCE_LABEL = 'app.kubernetes.io/instance';
+  const NAME_LABEL = 'app.kubernetes.io/name';
   const repository = (formData as GitImportFormData).git?.url;
   const ref = (formData as GitImportFormData).git?.ref;
   const imageStreamList = appResources?.imageStream?.data?.filter(
-    (imgstr) => imgstr.metadata?.labels?.[INSTANCE_LABEL] === name,
+    (imgstr) => imgstr.metadata?.labels?.[NAME_LABEL] === (labels[NAME_LABEL] || name),
   );
   const imageStreamFilterData = _.orderBy(imageStreamList, ['metadata.resourceVersion'], ['desc']);
   const originalImageStream = (imageStreamFilterData.length && imageStreamFilterData[0]) || {};
@@ -113,18 +114,28 @@ export const createOrUpdateImageStream = (
     ...(repository && getGitAnnotations(repository, ref)),
     ...getCommonAnnotations(),
   };
-  const imgStreamName = generatedImageStreamName || name;
+  const imgStreamName =
+    verb === 'update' && !_.isEmpty(originalImageStream)
+      ? originalImageStream.metadata.labels[NAME_LABEL]
+      : name;
   const newImageStream = {
     apiVersion: 'image.openshift.io/v1',
     kind: 'ImageStream',
     metadata: {
-      name: imgStreamName,
+      name: generatedImageStreamName || imgStreamName,
       namespace,
-      labels: { ...defaultLabels, ...userLabels, [INSTANCE_LABEL]: imgStreamName },
+      labels: {
+        ...defaultLabels,
+        ...userLabels,
+        [NAME_LABEL]: imgStreamName,
+      },
       annotations: defaultAnnotations,
     },
   };
   const imageStream = mergeData(originalImageStream, newImageStream);
+  if (verb === 'update') {
+    imageStream.metadata.name = originalImageStream.metadata.name;
+  }
   return verb === 'update'
     ? k8sUpdate(ImageStreamModel, imageStream)
     : k8sCreate(ImageStreamModel, newImageStream, dryRun ? dryRunOpt : {});
@@ -173,7 +184,7 @@ export const createOrUpdateBuildConfig = (
     build: { env, triggers, strategy: buildStrategy },
     labels: userLabels,
   } = formData;
-
+  const NAME_LABEL = 'app.kubernetes.io/name';
   const imageStreamName = imageStream && imageStream.metadata.name;
   const imageStreamNamespace = imageStream && imageStream.metadata.namespace;
 
@@ -221,15 +232,18 @@ export const createOrUpdateBuildConfig = (
     },
   };
 
-  const buildConfigName = verb === 'update' ? originalBuildConfig?.metadata?.name : name;
+  const buildConfigName =
+    verb === 'update' && !_.isEmpty(originalBuildConfig)
+      ? originalBuildConfig.metadata.labels[NAME_LABEL]
+      : name;
 
   const newBuildConfig = {
     apiVersion: 'build.openshift.io/v1',
     kind: 'BuildConfig',
     metadata: {
-      name: buildConfigName,
+      name: generatedImageStreamName || buildConfigName,
       namespace,
-      labels: { ...defaultLabels, ...userLabels },
+      labels: { ...defaultLabels, ...userLabels, [NAME_LABEL]: buildConfigName },
       annotations: defaultAnnotations,
     },
     spec: {
@@ -267,10 +281,12 @@ export const createOrUpdateBuildConfig = (
   };
 
   const buildConfig = mergeData(originalBuildConfig, newBuildConfig);
-
+  if (verb === 'update') {
+    buildConfig.metadata.name = originalBuildConfig.metadata.name;
+  }
   return verb === 'update'
     ? k8sUpdate(BuildConfigModel, buildConfig)
-    : k8sCreate(BuildConfigModel, buildConfig, dryRun ? dryRunOpt : {});
+    : k8sCreate(BuildConfigModel, newBuildConfig, dryRun ? dryRunOpt : {});
 };
 
 export const createOrUpdateDeployment = (
@@ -610,17 +626,18 @@ export const createOrUpdateResources = async (
     resources,
   } = formData;
   const imageStreamName = _.get(imageStream, 'metadata.name');
-
+  const originalRepository =
+    appResources?.buildConfig?.data?.spec?.source?.git?.uri ??
+    appResources?.pipeline?.data?.spec?.params?.find((param) => param?.name === 'GIT_REPO')
+      ?.default;
   createNewProject && (await createProject(formData.project));
 
   const responses: K8sResourceKind[] = [];
   let generatedImageStreamName: string = '';
-  const imageStreamList = appResources?.imageStream?.data;
   if (
     resources === Resources.KnativeService &&
-    imageStreamList &&
-    imageStreamList.length &&
-    verb === 'update'
+    originalRepository &&
+    originalRepository !== repository
   ) {
     generatedImageStreamName = `${name}-${getRandomChars()}`;
   }
@@ -653,7 +670,7 @@ export const createOrUpdateResources = async (
         imageStream,
         dryRun,
         appResources?.buildConfig?.data,
-        verb,
+        generatedImageStreamName ? 'create' : verb,
         generatedImageStreamName,
       ),
     );
@@ -691,6 +708,7 @@ export const createOrUpdateResources = async (
       undefined,
       annotations,
       _.get(appResources, 'editAppResource.data'),
+      generatedImageStreamName,
     );
     const domainMappingResources = await getDomainMappingRequests(
       formData,

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -27,6 +27,7 @@ export const getKnativeServiceDepResource = (
   imageNamespace?: string,
   annotations?: { [name: string]: string },
   originalKnativeService?: K8sResourceKind,
+  generatedImageStreamName?: string,
 ): K8sResourceKind => {
   const {
     name,
@@ -101,7 +102,7 @@ export const getKnativeServiceDepResource = (
         ...defaultLabel,
         ...labels,
         ...(!create && { 'networking.knative.dev/visibility': `cluster-local` }),
-        ...((formData as GitImportFormData).pipeline?.enabled && {
+        ...(((formData as GitImportFormData).pipeline?.enabled || generatedImageStreamName) && {
           'app.kubernetes.io/name': name,
         }),
       },
@@ -113,6 +114,9 @@ export const getKnativeServiceDepResource = (
           labels: {
             ...defaultLabel,
             ...labels,
+            'app.kubernetes.io/name': generatedImageStreamName
+              ? formData.name
+              : labels['app.kubernetes.io/name'],
           },
           annotations: {
             ...(concurrencytarget && {

--- a/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knatify-utils.ts
@@ -1,7 +1,7 @@
 import {
   deployImageInitialValues,
   getDeploymentData,
-  getExternalImagelValues,
+  getExternalImageValues,
   getIconInitialValues,
   getKsvcRouteData,
   getServerlessData,
@@ -133,6 +133,7 @@ export const knatifyResources = async (
     knDeploymentResource,
     dryRun,
   );
+
   return Promise.all([
     k8sCreate(ServiceModel, knDeploymentResource, dryRun ? dryRunOpt : {}),
     ...domainMappingResources,
@@ -218,7 +219,7 @@ export const getInitialValuesKnatify = (
     imageStream: { image, tag },
   } = internalImageValues;
   const isInternalImageValid = image && tag && namespace;
-  const externalImageValues = getExternalImagelValues(ksvcResourceData);
+  const externalImageValues = getExternalImageValues(ksvcResourceData);
   return {
     ...commonValues,
     ...iconValues,


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/OCPBUGSM-35728

**Root analysis:**
The new revision failed to come up because it failed to fetch the image from the registry.

**Solution description:**
- creating a new image stream only when the git url/image is changed
- creating a new image stream when the serverless workload (which is created via internal registry flow -> Deployment -> Make serverless) is modified 

**GIF:**
![edit-ksvc](https://user-images.githubusercontent.com/22490998/145198030-9b1486e1-9c1f-4d37-92a8-f23474787d7d.gif)

