### PR TITLE
Bug 1990255: Text filtering does not return all items when text box is empty

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -381,7 +381,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                       value={nameInputText}
                       onChange={(value: string) => {
                         setNameInputText(value);
-                        value ? debounceApplyNameFilter(value) : applyNameFilter(value);
+                        debounceApplyNameFilter(value);
                       }}
                       placeholder={nameFilterPlaceholder ?? t('public~Search by name...')}
                     />


### PR DESCRIPTION
When quickly deleting text in the name filter box, not all the items return when the textbox is empty.

This addresses [Bug 1990255](https://bugzilla.redhat.com/show_bug.cgi?id=1990255)