### PR TITLE
Bug 2005282: Fixes storagesystem list to point to correct page

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/odf-system/odf-system-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/odf-system/odf-system-list.tsx
@@ -50,7 +50,6 @@ const SystemTableRow: React.FC<RowFunctionArgs<StorageSystemKind, CustomData>> =
   const { t } = useTranslation();
   const { apiGroup, apiVersion, kind } = getGVK(obj.spec.kind);
   const systemKind = referenceForGroupVersionKind(apiGroup)(apiVersion)(kind);
-  const providerName = obj?.spec?.name;
   const systemName = obj?.metadata?.name;
   const { normalizedMetrics } = customData;
 
@@ -60,7 +59,7 @@ const SystemTableRow: React.FC<RowFunctionArgs<StorageSystemKind, CustomData>> =
   return (
     <>
       <TableData className={tableColumnClasses[0]}>
-        <ODFSystemLink kind={systemKind} systemName={systemName} providerName={providerName} />
+        <ODFSystemLink kind={systemKind} systemName={systemName} providerName={systemName} />
       </TableData>
       <TableData className={tableColumnClasses[1]}>
         <Status


### PR DESCRIPTION
![Screenshot from 2021-10-19 16-45-54](https://user-images.githubusercontent.com/57935785/137899289-a655c7fb-a28e-48a5-b5fb-3e6fbabecf9b.png)
![Screenshot from 2021-10-19 16-45-27](https://user-images.githubusercontent.com/57935785/137899284-7bded838-ff25-44db-b3b3-40a13402813c.png)

On accessing storagesystem from the list, we can see the name of the SS is correctly reflected and pointing to correct page

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>