### PR TITLE
Add Karthik to the Pipelines Package approvers

### DIFF
--- a/frontend/packages/pipelines-plugin/OWNERS
+++ b/frontend/packages/pipelines-plugin/OWNERS
@@ -17,6 +17,7 @@ approvers:
   - christianvogt
   - invincibleJai
   - jerolimov
+  - karthikjeeyar
   - rohitkrai03
 labels:
   - component/pipelines


### PR DESCRIPTION
Karthik is the owner for ODC in the Pipelines section, makes sense he has approval powers. 🎉 

cc @karthikjeeyar 

/assign @christianvogt 