### PR TITLE
Bug 2014352: Could not filter out machine by using node name on machines page

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -346,7 +346,7 @@ type RowFilterBase<R> = {
   filterGroupName: string;
   type: string;
   items: RowFilterItem[];
-  filter: (input: FilterValue, obj: R) => boolean;
+  filter?: (input: FilterValue, obj: R) => boolean;
   defaultSelected?: string[];
 };
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -350,6 +350,14 @@ type RowFilterBase<R> = {
   defaultSelected?: string[];
 };
 
+export type RowNameLabelFilter<R = any> = {
+  type: 'name' | 'label';
+  filter: (input: FilterValue, obj: R) => boolean;
+  filterGroupName?: string;
+  items?: RowFilterItem[];
+  defaultSelected?: string[];
+};
+
 export type RowMatchFilter<R = any> = RowFilterBase<R> & {
   isMatch: (obj: R, id: string) => boolean;
 };
@@ -358,7 +366,7 @@ export type RowReducerFilter<R = any> = RowFilterBase<R> & {
   reducer: (obj: R) => React.ReactText;
 };
 
-export type RowFilter<R = any> = RowMatchFilter<R> | RowReducerFilter<R>;
+export type RowFilter<R = any> = RowMatchFilter<R> | RowReducerFilter<R> | RowNameLabelFilter<R>;
 
 export type ColumnLayout = {
   id: string;

--- a/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
+++ b/frontend/packages/console-shared/src/components/custom-resource-list/CustomResourceList.tsx
@@ -3,8 +3,9 @@ import { EmptyState, EmptyStateVariant } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { RowFilter } from '@console/dynamic-plugin-sdk';
 import { Table, RowFunctionArgs, TableProps } from '@console/internal/components/factory';
-import { FilterToolbar, RowFilter } from '@console/internal/components/filter-toolbar';
+import { FilterToolbar } from '@console/internal/components/filter-toolbar';
 import { getQueryArgument, LoadingBox } from '@console/internal/components/utils';
 
 interface CustomResourceListProps {

--- a/frontend/packages/console-shared/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
+++ b/frontend/packages/console-shared/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
@@ -3,8 +3,9 @@ import { EmptyState } from '@patternfly/react-core';
 import { SortByDirection, sortable } from '@patternfly/react-table';
 import { shallow } from 'enzyme';
 import * as fuzzy from 'fuzzysearch';
+import { RowFilter } from '@console/dynamic-plugin-sdk';
 import { TableData, Table, RowFunctionArgs } from '@console/internal/components/factory';
-import { RowFilter, FilterToolbar } from '@console/internal/components/filter-toolbar';
+import { FilterToolbar } from '@console/internal/components/filter-toolbar';
 import { LoadingBox } from '@console/internal/components/utils';
 import CustomResourceList from '../CustomResourceList';
 

--- a/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/alerts/monitoring-alerts-utils.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SortByDirection } from '@patternfly/react-table';
 import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
-import { RowFilter } from '@console/internal/components/filter-toolbar';
+import { RowFilter } from '@console/dynamic-plugin-sdk';
 import {
   StateCounts,
   Severity,

--- a/frontend/packages/helm-plugin/src/utils/helm-utils.ts
+++ b/frontend/packages/helm-plugin/src/utils/helm-utils.ts
@@ -2,9 +2,9 @@ import * as fuzzy from 'fuzzysearch';
 import { TFunction } from 'i18next';
 import { loadAll, safeDump, DEFAULT_SAFE_SCHEMA } from 'js-yaml';
 import * as _ from 'lodash';
+import { RowFilter } from '@console/dynamic-plugin-sdk';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { Flatten } from '@console/internal/components/factory/list-page';
-import { RowFilter } from '@console/internal/components/filter-toolbar';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { toTitleCase } from '@console/shared';
 import {

--- a/frontend/public/components/factory/list-page.tsx
+++ b/frontend/public/components/factory/list-page.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
 import { useDocumentListener, KEYBOARD_SHORTCUTS, useDeepCompareMemoize } from '@console/shared';
-import { ColumnLayout } from '@console/dynamic-plugin-sdk';
+import { ColumnLayout, RowFilter } from '@console/dynamic-plugin-sdk';
 
 import { filterList } from '../../actions/k8s';
 import { storagePrefix } from '../row-filter';
@@ -31,7 +31,7 @@ import {
   PageHeading,
   RequireCreatePermission,
 } from '../utils';
-import { FilterToolbar, RowFilter } from '../filter-toolbar';
+import { FilterToolbar } from '../filter-toolbar';
 
 type CreateProps = {
   action?: string;

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -40,8 +40,7 @@ import {
 } from '@console/shared';
 import { PackageManifestKind } from '@console/operator-lifecycle-manager/src/types';
 import { defaultChannelFor } from '@console/operator-lifecycle-manager/src/components';
-import { RowFilter as RowFilterExt } from '@console/dynamic-plugin-sdk';
-import { RowFilter } from '../filter-toolbar';
+import { RowFilter } from '@console/dynamic-plugin-sdk';
 import * as UIActions from '../../actions/ui';
 import {
   alertingRuleSource,
@@ -446,7 +445,7 @@ export const Table: React.FC<TableProps> = ({
     defaultSortOrder,
     staticFilters,
     filters,
-    rowFilters: rowFilters as RowFilterExt[],
+    rowFilters: rowFilters as RowFilter[],
     propData,
     loaded,
     isPinned,

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -421,6 +421,14 @@ type RowFilterBase<R> = {
   defaultSelected?: string[];
 };
 
+export type RowNameLabelFilter<R = any> = {
+  type: 'name' | 'label';
+  filter: (input: FilterValue, obj: R) => boolean;
+  filterGroupName?: string;
+  items?: RowFilterItem[];
+  defaultSelected?: string[];
+};
+
 export type RowMatchFilter<R = any> = RowFilterBase<R> & {
   isMatch: (obj: R, id: string) => boolean;
 };
@@ -429,7 +437,7 @@ export type RowReducerFilter<R = any> = RowFilterBase<R> & {
   reducer: (obj: R) => React.ReactText;
 };
 
-export type RowFilter<R = any> = RowMatchFilter<R> | RowReducerFilter<R>;
+export type RowFilter<R = any> = RowMatchFilter<R> | RowReducerFilter<R> | RowNameLabelFilter<R>;
 
 type FilterToolbarProps = {
   rowFilters?: RowFilter[];

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -20,7 +20,10 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon, ColumnsIcon } from '@patternfly/react-icons';
 import {
-  RowFilterItem,
+  // RowFilterItem,
+  RowReducerFilter,
+  RowMatchFilter,
+  RowFilter,
   ColumnLayout,
   OnFilterChange,
   FilterValue,
@@ -114,7 +117,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
   const generatedRowFilters = useDeepCompareMemoize(
     (rowFilters ?? []).map((rowFilter) => ({
       ...rowFilter,
-      items: rowFilter.items.map((item) => ({
+      items: (rowFilter.items || []).map((item) => ({
         ...item,
         count: (rowFilter as RowMatchFilter).isMatch
           ? _.filter(data, (d) => (rowFilter as RowMatchFilter).isMatch(d, item.id)).length
@@ -170,7 +173,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
 
   // Map row filters to select groups
   const dropdownItems = generatedRowFilters.map((rowFilter) => (
-    <SelectGroup key={rowFilter.filterGroupName} label={rowFilter.filterGroupName}>
+    <SelectGroup key={rowFilter.filterGroupName || ''} label={rowFilter.filterGroupName || ''}>
       {rowFilter.items?.map?.((item) =>
         item.hideIfEmpty && (item.count === 0 || item.count === '0') ? (
           <></>
@@ -412,32 +415,6 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
     </Toolbar>
   );
 };
-
-type RowFilterBase<R> = {
-  filterGroupName: string;
-  type: string;
-  items: RowFilterItem[];
-  filter?: (input: FilterValue, obj: R) => boolean;
-  defaultSelected?: string[];
-};
-
-export type RowNameLabelFilter<R = any> = {
-  type: 'name' | 'label';
-  filter: (input: FilterValue, obj: R) => boolean;
-  filterGroupName?: string;
-  items?: RowFilterItem[];
-  defaultSelected?: string[];
-};
-
-export type RowMatchFilter<R = any> = RowFilterBase<R> & {
-  isMatch: (obj: R, id: string) => boolean;
-};
-
-export type RowReducerFilter<R = any> = RowFilterBase<R> & {
-  reducer: (obj: R) => React.ReactText;
-};
-
-export type RowFilter<R = any> = RowMatchFilter<R> | RowReducerFilter<R> | RowNameLabelFilter<R>;
 
 type FilterToolbarProps = {
   rowFilters?: RowFilter[];

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -12,7 +12,7 @@ import {
   Status,
   getMachinePhase,
 } from '@console/shared';
-import { RowProps, TableColumn } from '@console/dynamic-plugin-sdk';
+import { RowNameLabelFilter, RowProps, TableColumn } from '@console/dynamic-plugin-sdk';
 import { MachineModel } from '../models';
 import { MachineKind, referenceForModel, Selector } from '../module/k8s';
 import { Conditions } from './conditions';
@@ -38,6 +38,7 @@ import { useK8sWatchResource } from './utils/k8s-watch-hook';
 import VirtualizedTable, { TableData } from './factory/Table/VirtualizedTable';
 import { sortResourceByValue } from './factory/Table/sort';
 import { useActiveColumns } from './factory/Table/active-columns-hook';
+import { tableFilters } from './factory/table-filters';
 
 const { common } = Kebab.factory;
 const menuActions = [...Kebab.getExtensionsActionsForKind(MachineModel), ...common];
@@ -264,6 +265,13 @@ export const MachineList: React.FC<MachineListProps> = (props) => {
   );
 };
 
+const filters: RowNameLabelFilter[] = [
+  {
+    type: 'name',
+    filter: tableFilters.machine,
+  },
+];
+
 export const MachinePage: React.FC<MachinePageProps> = ({
   selector,
   namespace,
@@ -281,7 +289,7 @@ export const MachinePage: React.FC<MachinePageProps> = ({
     namespace,
   });
 
-  const [data, filteredData, onFilterChange] = useListPageFilter(machines);
+  const [data, filteredData, onFilterChange] = useListPageFilter(machines, filters);
 
   return (
     <>

--- a/frontend/public/components/monitoring/alerting.tsx
+++ b/frontend/public/components/monitoring/alerting.tsx
@@ -18,7 +18,7 @@ import {
   OutlinedBellIcon,
 } from '@patternfly/react-icons';
 
-import { useActivePerspective } from '@console/dynamic-plugin-sdk';
+import { useActivePerspective, RowFilter } from '@console/dynamic-plugin-sdk';
 import {
   BlueInfoCircleIcon,
   GreenCheckCircleIcon,
@@ -47,7 +47,8 @@ import {
 import { K8sKind } from '../../module/k8s';
 import { RootState } from '../../redux';
 import { RowFunctionArgs, Table, TableData, TableProps } from '../factory';
-import { FilterToolbar, RowFilter } from '../filter-toolbar';
+import { FilterToolbar } from '../filter-toolbar';
+
 import { confirmModal } from '../modals';
 import { PrometheusLabels } from '../graphs';
 import { AlertmanagerYAMLEditorWrapper } from './alert-manager-yaml-editor';

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -12,9 +12,8 @@ import {
   AlertSeverity,
   SilenceStates,
 } from '@console/dynamic-plugin-sdk/src/api/common-types';
-
+import { RowFilter } from '@console/dynamic-plugin-sdk';
 import { RowFunctionArgs } from '../factory';
-import { RowFilter } from '../filter-toolbar';
 
 export {
   SilenceStates,


### PR DESCRIPTION
This address [Bug 2014352](https://bugzilla.redhat.com/show_bug.cgi?id=2014352)

In version 4.8, on the machine list when using the "name" filter, the filter would accept matches from both the "name" and "node" columns of the table.  In version 4.9, this changed so only matches from the "name" column were considered.

This PR brings the 4.8 functionality back.

**Filtering machine by name**
<img width="500" alt="Screen Shot 2021-11-10 at 1 03 38 PM" src="https://user-images.githubusercontent.com/82059948/141491933-1771153d-7159-46a6-aff6-0fe29f354edd.png">


**Filtering machine by node**
<img width="500" alt="Screen Shot 2021-11-10 at 1 04 05 PM" src="https://user-images.githubusercontent.com/82059948/141177290-3a0651f0-9eb2-42b3-8cfe-ee61f28bc122.png">
