### PR TITLE
Bug 2015535: - Administration - ResourceQuotas - ResourceQuota details: Inside Pie chart 'x% used' is in English

### DIFF
--- a/frontend/public/components/graphs/gauge.tsx
+++ b/frontend/public/components/graphs/gauge.tsx
@@ -5,6 +5,7 @@ import {
   ChartThemeColor,
 } from '@patternfly/react-charts';
 import classNames from 'classnames';
+import i18next from 'i18next';
 
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
 import { usePrometheusPoll } from './prometheus-poll-hook';
@@ -28,7 +29,7 @@ export const GaugeChart: React.FC<GaugeChartProps> = ({
   title,
   ariaChartLinkLabel,
   ariaChartTitle,
-  usedLabel = 'used',
+  usedLabel = i18next.t('public~used'),
   // Don't sort, Uses previously declared props
   label = data ? humanize(data.y).string : 'No Data',
   secondaryTitle = usedLabel,

--- a/frontend/public/locales/en/public.json
+++ b/frontend/public/locales/en/public.json
@@ -503,6 +503,7 @@
   "Manage columns": "Manage columns",
   "Column management": "Column management",
   "{{value}} at {{date}}": "{{value}} at {{date}}",
+  "used": "used",
   "No datapoints found.": "No datapoints found.",
   "total limit": "total limit",
   "total requested": "total requested",


### PR DESCRIPTION
This addresses [Bug 2015535](https://bugzilla.redhat.com/show_bug.cgi?id=2015535)

In the Administration > ResourceQuotas details page the "X% used" text in the center of the guage chart is not translated.

This PR adds localization to the default word "used".