### PR TITLE
Bug 2008767: Block MCG deploymeny when no storage class found

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/ceph-storage-plugin.json
@@ -154,6 +154,7 @@
   "Advanced Subscription": "Advanced Subscription",
   "Advanced": "Advanced",
   "Deployment type": "Deployment type",
+  "A default StorageClass is needed for deployment.": "A default StorageClass is needed for deployment.",
   "Storage platform": "Storage platform",
   "Select a storage platform you wish to connect": "Select a storage platform you wish to connect",
   "Select external system from list": "Select external system from list",

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/advanced-section.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/advanced-section.tsx
@@ -9,6 +9,8 @@ import {
   SelectProps,
   SelectVariant,
 } from '@patternfly/react-core';
+import { StorageClassResourceKind } from '@console/internal/module/k8s';
+import { isDefaultClass } from '@console/internal/components/storage-class';
 import { DeploymentType } from '../../../../constants/create-storage-system';
 import { WizardDispatch, WizardState } from '../../reducer';
 import './backing-storage-step.scss';
@@ -19,7 +21,9 @@ export const AdvancedSection: React.FC<AdvancedSelectionProps> = ({
   deployment,
   isAdvancedOpen,
   dispatch,
-  hasOCS,
+  isDisabled,
+  scList,
+  isValidSC,
   currentStep,
 }) => {
   const { t } = useTranslation();
@@ -33,6 +37,12 @@ export const AdvancedSection: React.FC<AdvancedSelectionProps> = ({
        */
       dispatch({ type: 'wizard/setInitialState' });
     }
+    const defaultSC = scList.find(isDefaultClass);
+    dispatch({
+      type: 'backingStorage/setIsValidSC',
+      // 'value' on SelectProps['onSelect'] is string hence not matching with payload which is of "DeploymentType"
+      payload: value === DeploymentType.MCG ? !!defaultSC : true,
+    });
     dispatch({
       type: 'backingStorage/setDeployment',
       // 'value' on SelectProps['onSelect'] is string hence not matching with payload which is of "DeploymentType"
@@ -56,7 +66,14 @@ export const AdvancedSection: React.FC<AdvancedSelectionProps> = ({
       onToggle={handleExpanadableToggling}
       isExpanded={isAdvancedOpen}
     >
-      <FormGroup label={t('ceph-storage-plugin~Deployment type')} fieldId="deployment-type">
+      <FormGroup
+        label={t('ceph-storage-plugin~Deployment type')}
+        fieldId="deployment-type"
+        validated={isValidSC ? 'default' : 'error'}
+        helperTextInvalid={t(
+          'ceph-storage-plugin~A default StorageClass is needed for deployment.',
+        )}
+      >
         <Select
           className="odf-backing-storage__selection--width"
           variant={SelectVariant.single}
@@ -64,7 +81,7 @@ export const AdvancedSection: React.FC<AdvancedSelectionProps> = ({
           onSelect={handleSelection}
           selections={deployment}
           isOpen={isSelectOpen}
-          isDisabled={hasOCS}
+          isDisabled={isDisabled}
         >
           {selectOptions}
         </Select>
@@ -77,6 +94,8 @@ type AdvancedSelectionProps = {
   dispatch: WizardDispatch;
   deployment: WizardState['backingStorage']['deployment'];
   isAdvancedOpen: WizardState['backingStorage']['isAdvancedOpen'];
-  hasOCS: boolean;
+  isValidSC: WizardState['backingStorage']['isValidSC'];
+  scList: StorageClassResourceKind[];
   currentStep: number;
+  isDisabled: boolean;
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
@@ -163,7 +163,7 @@ export const BackingStorage: React.FC<BackingStorageProps> = ({
         })
       : SUPPORTED_EXTERNAL_STORAGE;
 
-  const { type, externalStorage, deployment, isAdvancedOpen } = state;
+  const { type, externalStorage, deployment, isAdvancedOpen, isValidSC } = state;
 
   React.useEffect(() => {
     /*
@@ -295,7 +295,9 @@ export const BackingStorage: React.FC<BackingStorageProps> = ({
             dispatch={dispatch}
             deployment={deployment}
             isAdvancedOpen={isAdvancedOpen}
-            hasOCS={hasOCS}
+            isDisabled={hasOCS}
+            scList={sc?.items}
+            isValidSC={isValidSC}
             currentStep={stepIdReached}
           />
         )}

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/footer.tsx
@@ -45,14 +45,14 @@ import { createClusterKmsResources } from '../kms-config/utils';
 import { OCS_CONVERGED_FLAG, OCS_INDEPENDENT_FLAG, OCS_FLAG } from '../../features';
 
 const validateBackingStorageStep = (backingStorage, sc) => {
-  const { type, externalStorage, deployment } = backingStorage;
+  const { type, externalStorage, isValidSC } = backingStorage;
   switch (type) {
     case BackingStorageType.EXISTING:
-      return !!sc.name || deployment === DeploymentType.MCG;
+      return !!sc.name && isValidSC;
     case BackingStorageType.EXTERNAL:
-      return !!externalStorage;
+      return !!externalStorage && isValidSC;
     case BackingStorageType.LOCAL_DEVICES:
-      return true;
+      return isValidSC;
     default:
       return false;
   }

--- a/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/reducer.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/create-storage-system/reducer.ts
@@ -38,6 +38,7 @@ export const initialState: CreateStorageSystemState = {
     externalStorage: '',
     deployment: DeploymentType.FULL,
     isAdvancedOpen: false,
+    isValidSC: true,
   },
   capacityAndNodes: {
     enableArbiter: false,
@@ -84,6 +85,7 @@ type CreateStorageSystemState = {
     externalStorage: string;
     deployment: DeploymentType;
     isAdvancedOpen: boolean;
+    isValidSC: boolean;
   };
   createStorageClass: ExternalState;
   connectionDetails: ExternalState;
@@ -168,6 +170,9 @@ export const reducer: WizardReducer = (prevState, action) => {
     case 'backingStorage/setIsAdvancedOpen':
       newState.backingStorage.isAdvancedOpen = action.payload;
       break;
+    case 'backingStorage/setIsValidSC':
+      newState.backingStorage.isValidSC = action.payload;
+      break;
     case 'capacityAndNodes/capacity':
       newState.capacityAndNodes.capacity = action.payload;
       break;
@@ -239,6 +244,10 @@ export type CreateStorageSystemAction =
   | {
       type: 'backingStorage/setExternalStorage';
       payload: WizardState['backingStorage']['externalStorage'];
+    }
+  | {
+      type: 'backingStorage/setIsValidSC';
+      payload: WizardState['backingStorage']['isValidSC'];
     }
   | { type: 'wizard/nodes'; payload: WizardState['nodes'] }
   | { type: 'capacityAndNodes/capacity'; payload: WizardState['capacityAndNodes']['capacity'] }


### PR DESCRIPTION
 - mcg deployment requires a storage class to be always present for its database
 - in case of no storage class the deployment eventually fails

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2008767

![Screenshot from 2021-10-22 17-22-21](https://user-images.githubusercontent.com/25664409/138449661-b57570a2-7ff9-43fb-8cdb-7bc78b99c843.png)
![Screenshot from 2021-10-22 17-22-36](https://user-images.githubusercontent.com/25664409/138449667-5efad04a-e2eb-4259-a226-a08b82748c59.png)
![Screenshot from 2021-10-22 17-22-48](https://user-images.githubusercontent.com/25664409/138449673-31e57c7a-ccad-4d2f-85c5-0bacaf938e45.png)


Signed-off-by: Afreen Rahman <afrahman@redhat.com>