### PR TITLE
migrate refereceFor* utilities to dynamic-plugin-sdk

### DIFF
--- a/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
@@ -10,11 +10,12 @@ import {
   PageSection,
   Title,
 } from "@patternfly/react-core";
-import { k8sCreate, k8sDelete, k8sGet, k8sList, k8sPatch, K8sResourceCommon, k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
-import { DeploymentModel, mockDeploymetData } from './k8s-data';
+import { getGroupVersionKindForResource, getReference, k8sCreate, k8sDelete, k8sGet, k8sList, k8sPatch, K8sResourceCommon, k8sUpdate, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { mockDeploymetData } from './k8s-data';
 
 const K8sAPIConsumer: React.FC = () => {
   const { t } = useTranslation("plugin__console-demo-plugin");
+  const [k8sModel] = useK8sModel(getReference(getGroupVersionKindForResource(mockDeploymetData)));
   const [errData, setErrData] = React.useState<string>();
   const [k8sCreateData, setK8sCreateData] = React.useState<K8sResourceCommon>();
   const [k8sGetData, setK8sGetData] = React.useState<K8sResourceCommon>();
@@ -24,7 +25,7 @@ const K8sAPIConsumer: React.FC = () => {
   const [k8sDeleteData, setK8sDeleteData] = React.useState<K8sResourceCommon>();
 
   const k8sCreateClick = () => {
-    k8sCreate({model: DeploymentModel, data: mockDeploymetData}).then((response) => {
+    k8sCreate({model: k8sModel, data: mockDeploymetData}).then((response) => {
       setErrData('');
       setK8sCreateData(response);
     })
@@ -36,7 +37,7 @@ const K8sAPIConsumer: React.FC = () => {
   }
 
   const k8sGetClick = () => {
-    k8sGet({model: DeploymentModel, name: 'sampleapp', ns:'default'}).then((response) => {
+    k8sGet({model: k8sModel, name: 'sampleapp', ns:'default'}).then((response) => {
       setErrData('');
       setK8sGetData(response);
     })
@@ -57,7 +58,7 @@ const K8sAPIConsumer: React.FC = () => {
       },
     }];
     
-    k8sPatch({model: DeploymentModel, resource: mockDeploymetData, data: patchData}).then((response) => {
+    k8sPatch({model: k8sModel, resource: mockDeploymetData, data: patchData}).then((response) => {
       setErrData('');
       setK8sPatchData(response);
     })
@@ -79,7 +80,7 @@ const K8sAPIConsumer: React.FC = () => {
         },
       }
     };
-    k8sUpdate({model: DeploymentModel, data: updatedData}).then((response) => {
+    k8sUpdate({model: k8sModel, data: updatedData}).then((response) => {
       setErrData('');
       setK8sUpdateData(response);
     })
@@ -91,7 +92,7 @@ const K8sAPIConsumer: React.FC = () => {
   }
 
   const k8sListClick = () => {
-    k8sList({model: DeploymentModel, queryParams: {ns: 'default'}}).then((response) => {
+    k8sList({model: k8sModel, queryParams: {ns: 'default'}}).then((response) => {
       setErrData('');
       setK8sListData(response);
     })
@@ -103,7 +104,7 @@ const K8sAPIConsumer: React.FC = () => {
   }
 
   const k8sDeleteClick = () => {
-    k8sDelete({model: DeploymentModel, resource: mockDeploymetData}).then((response) => {
+    k8sDelete({model: k8sModel, resource: mockDeploymetData}).then((response) => {
       setErrData('');
       setK8sDeleteData(response);
     })

--- a/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/K8sAPIConsumer.tsx
@@ -10,12 +10,12 @@ import {
   PageSection,
   Title,
 } from "@patternfly/react-core";
-import { getGroupVersionKindForResource, getReference, k8sCreate, k8sDelete, k8sGet, k8sList, k8sPatch, K8sResourceCommon, k8sUpdate, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { getGroupVersionKindForResource, k8sCreate, k8sDelete, k8sGet, k8sList, k8sPatch, K8sResourceCommon, k8sUpdate, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { mockDeploymetData } from './k8s-data';
 
 const K8sAPIConsumer: React.FC = () => {
   const { t } = useTranslation("plugin__console-demo-plugin");
-  const [k8sModel] = useK8sModel(getReference(getGroupVersionKindForResource(mockDeploymetData)));
+  const [k8sModel] = useK8sModel(getGroupVersionKindForResource(mockDeploymetData));
   const [errData, setErrData] = React.useState<string>();
   const [k8sCreateData, setK8sCreateData] = React.useState<K8sResourceCommon>();
   const [k8sGetData, setK8sGetData] = React.useState<K8sResourceCommon>();

--- a/dynamic-demo-plugin/src/components/k8sConsumer/k8s-data.ts
+++ b/dynamic-demo-plugin/src/components/k8sConsumer/k8s-data.ts
@@ -1,20 +1,3 @@
-import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-
-// Needs to be removed with useK8sModel once we have support for referenceFor utils 
-export const DeploymentModel: K8sModel = {
-  label: 'Deployment',
-  labelKey: 'public~Deployment',
-  apiVersion: 'v1',
-  apiGroup: 'apps',
-  plural: 'deployments',
-  abbr: 'D',
-  namespaced: true,
-  propagationPolicy: 'Foreground',
-  kind: 'Deployment',
-  id: 'deployment',
-  labelPlural: 'Deployments',
-};
-
 export const mockDeploymetData = {
   apiVersion: 'apps/v1',
   kind: 'Deployment',

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -101,3 +101,10 @@ export const k8sDelete: K8sDelete = require('@console/dynamic-plugin-sdk/src/uti
   .k8sDeleteResource;
 export const k8sList: K8sList = require('@console/dynamic-plugin-sdk/src/utils/k8s')
   .k8sListResource;
+export {
+  getReference,
+  getReferenceForModel,
+  getAPIVersionForModel,
+  getGroupVersionKindForResource,
+  getGroupVersionKindForReference,
+} from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -102,9 +102,7 @@ export const k8sDelete: K8sDelete = require('@console/dynamic-plugin-sdk/src/uti
 export const k8sList: K8sList = require('@console/dynamic-plugin-sdk/src/utils/k8s')
   .k8sListResource;
 export {
-  getReference,
-  getReferenceForModel,
   getAPIVersionForModel,
   getGroupVersionKindForResource,
-  getGroupVersionKindForReference,
+  getGroupVersionKindForModel,
 } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/k8s-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/k8s-types.ts
@@ -1,5 +1,4 @@
 import {
-  K8sResourceKindReference,
   K8sGroupVersionKind,
   K8sResourceCommon,
   Patch,
@@ -58,14 +57,8 @@ export type K8sList = <R extends K8sResourceCommon>(options: {
 
 export type GetK8sResourcePath = (model: K8sModel, options: Options) => string;
 
-export type GetReference = (K8sGroupVersionKind: K8sGroupVersionKind) => K8sResourceKindReference;
-
-export type GetReferenceForModel = (model: K8sModel) => K8sResourceKindReference;
-
 export type GetAPIVersionForModel = (model: K8sModel) => string;
 
 export type GetGroupVersionKindForResource = (resource: K8sResourceCommon) => K8sGroupVersionKind;
 
-export type GetGroupVersionKindForReference = (
-  reference: K8sResourceKindReference,
-) => K8sGroupVersionKind;
+export type GetGroupVersionKindForModel = (model: K8sModel) => K8sGroupVersionKind;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/k8s-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/k8s-types.ts
@@ -1,4 +1,11 @@
-import { K8sResourceCommon, Patch, QueryParams, Status } from '../extensions/console-types';
+import {
+  K8sResourceKindReference,
+  K8sGroupVersionKind,
+  K8sResourceCommon,
+  Patch,
+  QueryParams,
+  Status,
+} from '../extensions/console-types';
 import { K8sModel } from './common-types';
 import { Options } from './internal-types';
 
@@ -50,3 +57,15 @@ export type K8sList = <R extends K8sResourceCommon>(options: {
 }) => Promise<R[]>;
 
 export type GetK8sResourcePath = (model: K8sModel, options: Options) => string;
+
+export type GetReference = (K8sGroupVersionKind: K8sGroupVersionKind) => K8sResourceKindReference;
+
+export type GetReferenceForModel = (model: K8sModel) => K8sResourceKindReference;
+
+export type GetAPIVersionForModel = (model: K8sModel) => string;
+
+export type GetGroupVersionKindForResource = (resource: K8sResourceCommon) => K8sGroupVersionKind;
+
+export type GetGroupVersionKindForReference = (
+  reference: K8sResourceKindReference,
+) => K8sGroupVersionKind;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -87,6 +87,8 @@ export type GroupVersionKind = string;
  */
 export type K8sResourceKindReference = GroupVersionKind | string;
 
+export type K8sGroupVersionKind = { group: string; version: string; kind: string };
+
 enum InventoryStatusGroup {
   WARN = 'WARN',
   ERROR = 'ERROR',

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -75,6 +75,8 @@ export type AccessReviewResourceAttributes = {
 };
 
 /**
+ * @deprecated Use K8sGroupVersionKind type instead. Support for type K8sResourceKindReference will be removed in a future release.
+ * @see K8sGroupVersionKind
  * GroupVersionKind unambiguously identifies a kind.
  * https://godoc.org/k8s.io/apimachinery/pkg/runtime/schema#GroupVersionKind
  * TODO: Change this to a regex-type if it ever becomes a thing (https://github.com/Microsoft/TypeScript/issues/6579)
@@ -87,7 +89,7 @@ export type GroupVersionKind = string;
  */
 export type K8sResourceKindReference = GroupVersionKind | string;
 
-export type K8sGroupVersionKind = { group: string; version: string; kind: string };
+export type K8sGroupVersionKind = { group?: string; version: string; kind: string };
 
 enum InventoryStatusGroup {
   WARN = 'WARN',
@@ -143,7 +145,9 @@ export type PrometheusResponse = {
 };
 
 export type WatchK8sResource = {
-  kind: K8sResourceKindReference;
+  /** @deprecated Use groupVersionKind instead. The kind property will be removed in a future release. */
+  kind?: K8sResourceKindReference;
+  groupVersionKind?: K8sGroupVersionKind;
   name?: string;
   namespace?: string;
   isList?: boolean;
@@ -392,7 +396,9 @@ export type UseListPageFilter = <D, R>(
 ) => [D[], D[], OnFilterChange];
 
 export type ResourceLinkProps = {
-  kind: GroupVersionKind;
+  /** @deprecated Use groupVersionKind instead. The kind property will be removed in a future release. */
+  kind?: K8sResourceKindReference;
+  groupVersionKind?: K8sGroupVersionKind;
   className?: string;
   displayName?: string;
   inline?: boolean;
@@ -405,7 +411,10 @@ export type ResourceLinkProps = {
   onClick?: () => void;
 };
 
-export type UseK8sModel = (groupVersionKind?: GroupVersionKind) => [K8sModel, boolean];
+export type UseK8sModel = (
+  // Use K8sGroupVersionKind type instead of K8sResourceKindReference. Support for type K8sResourceKindReference will be removed in a future release.
+  groupVersionKind?: K8sResourceKindReference | K8sGroupVersionKind,
+) => [K8sModel, boolean];
 export type UseK8sModels = () => [{ [key: string]: K8sModel }, boolean];
 
 export type PerspectiveType = string;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__mocks__/k8s-data.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__mocks__/k8s-data.ts
@@ -1,0 +1,25 @@
+import { K8sModel } from '../../../api/common-types';
+
+export const DeploymentModel: K8sModel = {
+  label: 'Deployment',
+  apiVersion: 'v1',
+  apiGroup: 'apps',
+  plural: 'deployments',
+  abbr: 'D',
+  namespaced: true,
+  propagationPolicy: 'Foreground',
+  kind: 'Deployment',
+  id: 'deployment',
+  labelPlural: 'Deployments',
+};
+
+export const PodModel: K8sModel = {
+  apiVersion: 'v1',
+  label: 'Pod',
+  plural: 'pods',
+  abbr: 'P',
+  namespaced: true,
+  kind: 'Pod',
+  id: 'pod',
+  labelPlural: 'Pods',
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/k8s-ref.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/k8s-ref.spec.ts
@@ -5,6 +5,8 @@ import {
   getGroupVersionKindForResource,
   getReference,
   getReferenceForModel,
+  transformGroupVersionKindToReference,
+  getGroupVersionKindForModel,
 } from '../k8s-ref';
 
 describe('k8s-Resource', () => {
@@ -61,7 +63,7 @@ describe('k8s-Resource', () => {
       apiVersion: 'v1',
       kind: 'Pod',
     });
-    expect(group).toEqual('core');
+    expect(group).toBeUndefined();
     expect(version).toEqual('v1');
     expect(kind).toEqual('Pod');
   });
@@ -73,5 +75,33 @@ describe('k8s-Resource', () => {
         kind: 'Dummy',
       }),
     ).toThrow('Provided resource has invalid apiVersion.');
+  });
+
+  it('should return Group, Version, and Kind for provided model', () => {
+    const { group, version, kind } = getGroupVersionKindForModel(DeploymentModel);
+    expect(group).toEqual('apps');
+    expect(version).toEqual('v1');
+    expect(kind).toEqual('Deployment');
+  });
+
+  it('should return Group, Version, and Kind for provided model which does not have apiGroup', () => {
+    const { group, version, kind } = getGroupVersionKindForModel(PodModel);
+    expect(group).toBeUndefined();
+    expect(version).toEqual('v1');
+    expect(kind).toEqual('Pod');
+  });
+
+  it('should return reference for provided group, version, and kind', () => {
+    const referenceData = transformGroupVersionKindToReference({
+      group: 'apps',
+      version: 'v1',
+      kind: 'Deployment',
+    });
+    expect(referenceData).toEqual('apps~v1~Deployment');
+  });
+
+  it('should return reference for provided reference', () => {
+    const referenceData = transformGroupVersionKindToReference('apps~v1~Deployment');
+    expect(referenceData).toEqual('apps~v1~Deployment');
   });
 });

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/k8s-ref.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/__tests__/k8s-ref.spec.ts
@@ -1,0 +1,77 @@
+import { DeploymentModel, PodModel } from '../__mocks__/k8s-data';
+import {
+  getAPIVersionForModel,
+  getGroupVersionKindForReference,
+  getGroupVersionKindForResource,
+  getReference,
+  getReferenceForModel,
+} from '../k8s-ref';
+
+describe('k8s-Resource', () => {
+  it('should return reference for provided group, version, and kind', () => {
+    const referenceData = getReference({ group: 'apps', version: 'v1', kind: 'Deployment' });
+    expect(referenceData).toEqual('apps~v1~Deployment');
+  });
+
+  it('should return reference for provided version and kind', () => {
+    const referenceData = getReference({ group: null, version: 'v1', kind: 'Pod' });
+    expect(referenceData).toEqual('core~v1~Pod');
+  });
+
+  it('should return reference for provided model', () => {
+    const referenceData = getReferenceForModel(DeploymentModel);
+    expect(referenceData).toEqual('apps~v1~Deployment');
+  });
+
+  it('should return apiVersion for provided model', () => {
+    const apiVersion = getAPIVersionForModel(DeploymentModel);
+    expect(apiVersion).toEqual('apps/v1');
+  });
+
+  it('should return apiVersion for provided model if apiGroup is not present', () => {
+    const apiVersion = getAPIVersionForModel(PodModel);
+    expect(apiVersion).toEqual('v1');
+  });
+
+  it('should return Group, Version, and Kind for provided reference', () => {
+    const { group, version, kind } = getGroupVersionKindForReference('apps~v1~Deployment');
+    expect(group).toEqual('apps');
+    expect(version).toEqual('v1');
+    expect(kind).toEqual('Deployment');
+  });
+
+  it('should throw Error for invalid reference', () => {
+    expect(() => getGroupVersionKindForReference('apps~v1~beta1~Deployment')).toThrow(
+      'Provided reference is invalid.',
+    );
+  });
+
+  it('should return Group, Version, and Kind for provided resource', () => {
+    const { group, version, kind } = getGroupVersionKindForResource({
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+    });
+    expect(group).toEqual('apps');
+    expect(version).toEqual('v1');
+    expect(kind).toEqual('Deployment');
+  });
+
+  it('should return Group, Version, and Kind for provided resource which does not have group in apiVersion', () => {
+    const { group, version, kind } = getGroupVersionKindForResource({
+      apiVersion: 'v1',
+      kind: 'Pod',
+    });
+    expect(group).toEqual('core');
+    expect(version).toEqual('v1');
+    expect(kind).toEqual('Pod');
+  });
+
+  it('should throw Error for provided resource if apiVersion is invalid', () => {
+    expect(() =>
+      getGroupVersionKindForResource({
+        apiVersion: 'apps/v1/beta1',
+        kind: 'Dummy',
+      }),
+    ).toThrow('Provided resource has invalid apiVersion.');
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/index.ts
@@ -1,2 +1,3 @@
 export * from './k8s-resource';
 export * from './k8s-utils';
+export * from './k8s-ref';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-ref.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-ref.ts
@@ -1,0 +1,73 @@
+import {
+  GetReference,
+  GetReferenceForModel,
+  GetAPIVersionForModel,
+  GetGroupVersionKindForResource,
+  GetGroupVersionKindForReference,
+} from '../../api/k8s-types';
+
+/**
+ * Provides a reference string that uniquely identifies the group, version, and kind of a k8s resource.
+ * @param K8sGroupVersionKind Pass K8sGroupVersionKind which will have group, version, and kind of a k8s resource.
+ * @param K8sGroupVersionKind.group Pass group of k8s resource or model.
+ * @param K8sGroupVersionKind.version Pass version of k8s resource or model.
+ * @param K8sGroupVersionKind.kind Pass kind of k8s resource or model.
+ * @return The reference for any k8s resource i.e `group~version~kind`.
+ * If the group will not be present then "core" will be returned as part of the group in reference.
+ * * */
+export const getReference: GetReference = ({ group, version, kind }) =>
+  [group || 'core', version, kind].join('~');
+
+/**
+ * Provides a reference string that uniquely identifies the group, version, and kind of a k8s model.
+ * @param model k8s model
+ * @return The reference for model i.e `group~version~kind`.
+ * * */
+export const getReferenceForModel: GetReferenceForModel = (model) =>
+  getReference({ group: model.apiGroup, version: model.apiVersion, kind: model.kind });
+
+/**
+ * Provides apiVersion for a k8s model.
+ * @param model k8s model
+ * @return The apiVersion for the model i.e `group/version`.
+ * * */
+export const getAPIVersionForModel: GetAPIVersionForModel = (model) =>
+  !model?.apiGroup ? model.apiVersion : `${model.apiGroup}/${model.apiVersion}`;
+
+/**
+ * Provides a group, version, and kind for a resource.
+ * @param resource k8s resource
+ * @return The group, version, kind for the provided resource.
+ * If the resource does not have an API group, group "core" will be returned.
+ * If the resource has an invalid apiVersion then null will be returned.
+ * * */
+export const getGroupVersionKindForResource: GetGroupVersionKindForResource = (resource) => {
+  const { apiVersion, kind } = resource;
+  const apiVersionSplit = apiVersion.split('/');
+  const apiVersionSplitLen = apiVersionSplit.length;
+  if (apiVersionSplitLen > 2) throw new Error('Provided resource has invalid apiVersion.');
+
+  return {
+    group: apiVersionSplitLen === 2 ? apiVersionSplit[0] : 'core',
+    version: apiVersionSplitLen === 2 ? apiVersionSplit[1] : apiVersion,
+    kind,
+  };
+};
+
+/**
+ * Provides a group, version, and kind for a reference.
+ * @param reference reference for group, version, kind i.e `group~version~kind`.
+ * @return The group, version, kind for the provided reference.
+ * If the group's value is "core" it denotes resource does not have an API group.
+ * * */
+export const getGroupVersionKindForReference: GetGroupVersionKindForReference = (reference) => {
+  const referenceSplit = reference.split('~');
+  if (referenceSplit.length > 3) throw new Error('Provided reference is invalid.');
+
+  const [group, version, kind] = referenceSplit;
+  return {
+    group,
+    version,
+    kind,
+  };
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-ref.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-ref.ts
@@ -1,12 +1,13 @@
+import { K8sModel } from '../../api/common-types';
 import {
-  GetReference,
-  GetReferenceForModel,
   GetAPIVersionForModel,
   GetGroupVersionKindForResource,
-  GetGroupVersionKindForReference,
+  GetGroupVersionKindForModel,
 } from '../../api/k8s-types';
+import { K8sGroupVersionKind, K8sResourceKindReference } from '../../extensions/console-types';
 
 /**
+ * @deprecated - This will become obsolete when we move away from K8sResourceKindReference to K8sGroupVersionKind
  * Provides a reference string that uniquely identifies the group, version, and kind of a k8s resource.
  * @param K8sGroupVersionKind Pass K8sGroupVersionKind which will have group, version, and kind of a k8s resource.
  * @param K8sGroupVersionKind.group Pass group of k8s resource or model.
@@ -15,15 +16,20 @@ import {
  * @return The reference for any k8s resource i.e `group~version~kind`.
  * If the group will not be present then "core" will be returned as part of the group in reference.
  * * */
-export const getReference: GetReference = ({ group, version, kind }) =>
-  [group || 'core', version, kind].join('~');
+export const getReference = ({
+  group,
+  version,
+  kind,
+}: K8sGroupVersionKind): K8sResourceKindReference => [group || 'core', version, kind].join('~');
 
 /**
+ * @deprecated - This will become obsolete when we move away from K8sResourceKindReference to K8sGroupVersionKind
+ * @see getGroupVersionKindForModel
  * Provides a reference string that uniquely identifies the group, version, and kind of a k8s model.
  * @param model k8s model
  * @return The reference for model i.e `group~version~kind`.
  * * */
-export const getReferenceForModel: GetReferenceForModel = (model) =>
+export const getReferenceForModel = (model: K8sModel): K8sResourceKindReference =>
   getReference({ group: model.apiGroup, version: model.apiVersion, kind: model.kind });
 
 /**
@@ -39,7 +45,7 @@ export const getAPIVersionForModel: GetAPIVersionForModel = (model) =>
  * @param resource k8s resource
  * @return The group, version, kind for the provided resource.
  * If the resource does not have an API group, group "core" will be returned.
- * If the resource has an invalid apiVersion then null will be returned.
+ * If the resource has an invalid apiVersion then it'll throw Error.
  * * */
 export const getGroupVersionKindForResource: GetGroupVersionKindForResource = (resource) => {
   const { apiVersion, kind } = resource;
@@ -48,19 +54,40 @@ export const getGroupVersionKindForResource: GetGroupVersionKindForResource = (r
   if (apiVersionSplitLen > 2) throw new Error('Provided resource has invalid apiVersion.');
 
   return {
-    group: apiVersionSplitLen === 2 ? apiVersionSplit[0] : 'core',
+    ...(apiVersionSplitLen === 2 && {
+      group: apiVersionSplit[0],
+    }),
     version: apiVersionSplitLen === 2 ? apiVersionSplit[1] : apiVersion,
     kind,
   };
 };
 
 /**
+ * Provides a group, version, and kind for a k8s model.
+ * @param model k8s model
+ * @return The group, version, kind for the provided model.
+ * If the model does not have an apiGroup, group "core" will be returned.
+ * * */
+export const getGroupVersionKindForModel: GetGroupVersionKindForModel = ({
+  apiGroup,
+  apiVersion: version,
+  kind,
+}) => ({
+  ...(apiGroup && { group: apiGroup }),
+  version,
+  kind,
+});
+
+/**
+ * @deprecated - This will become obsolete when we move away from K8sResourceKindReference to K8sGroupVersionKind
  * Provides a group, version, and kind for a reference.
  * @param reference reference for group, version, kind i.e `group~version~kind`.
  * @return The group, version, kind for the provided reference.
  * If the group's value is "core" it denotes resource does not have an API group.
  * * */
-export const getGroupVersionKindForReference: GetGroupVersionKindForReference = (reference) => {
+export const getGroupVersionKindForReference = (
+  reference: K8sResourceKindReference,
+): K8sGroupVersionKind => {
   const referenceSplit = reference.split('~');
   if (referenceSplit.length > 3) throw new Error('Provided reference is invalid.');
 
@@ -71,3 +98,14 @@ export const getGroupVersionKindForReference: GetGroupVersionKindForReference = 
     kind,
   };
 };
+
+/**
+ * @deprecated - This will become obsolete when we move away from K8sResourceKindReference to K8sGroupVersionKind
+ * Provides a reference string that uniquely identifies the group, version, and kind of K8sGroupVersionKind.
+ * @param kind kind can be of type K8sResourceKindReference or K8sGroupVersionKind
+ * @return The reference i.e `group~version~kind`.
+ * * */
+export const transformGroupVersionKindToReference = (
+  kind: K8sResourceKindReference | K8sGroupVersionKind,
+): K8sResourceKindReference =>
+  kind && typeof kind !== 'string' ? getReference(kind) : (kind as K8sResourceKindReference);

--- a/frontend/packages/console-shared/src/hooks/useK8sModel.ts
+++ b/frontend/packages/console-shared/src/hooks/useK8sModel.ts
@@ -2,17 +2,21 @@
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useSelector } from 'react-redux';
 import { UseK8sModel } from '@console/dynamic-plugin-sdk';
+import { transformGroupVersionKindToReference } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
 import { K8sKind, kindForReference } from '@console/internal/module/k8s';
 import { RootState } from '@console/internal/redux';
 
 // Hook that retrieves the k8s model for provided groupVersionKind reference. Hook version of
 // `connectToModel`.
-export const useK8sModel: UseK8sModel = (groupVersionKind) => [
-  useSelector<RootState, K8sKind>(({ k8s }) =>
-    groupVersionKind
-      ? k8s.getIn(['RESOURCES', 'models', groupVersionKind]) ??
-        k8s.getIn(['RESOURCES', 'models', kindForReference(groupVersionKind)])
-      : undefined,
-  ),
-  useSelector<RootState, boolean>(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
-];
+export const useK8sModel: UseK8sModel = (groupVersionKind) => {
+  const kindReference = transformGroupVersionKindToReference(groupVersionKind);
+  return [
+    useSelector<RootState, K8sKind>(({ k8s }) =>
+      kindReference
+        ? k8s.getIn(['RESOURCES', 'models', kindReference]) ??
+          k8s.getIn(['RESOURCES', 'models', kindForReference(kindReference)])
+        : undefined,
+    ),
+    useSelector<RootState, boolean>(({ k8s }) => k8s.getIn(['RESOURCES', 'inFlight']) ?? false),
+  ];
+};

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../module/k8s';
 import { connectToFlags } from '../../reducers/connectToFlags';
 import { FlagsObject } from '../../reducers/features';
+import { getReference } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';
 
 const unknownKinds = new Set();
 
@@ -74,6 +75,7 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
   displayName,
   inline = false,
   kind,
+  groupVersionKind,
   linkTo = true,
   name,
   namespace,
@@ -86,7 +88,8 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
   if (!kind) {
     return null;
   }
-  const path = resourcePath(kind, name, namespace);
+  const kindReference = groupVersionKind ? getReference(groupVersionKind) : kind;
+  const path = resourcePath(kindReference, name, namespace);
   const value = displayName ? displayName : name;
   const classes = classNames('co-resource-item', className, {
     'co-resource-item--inline': inline,
@@ -94,7 +97,7 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
 
   return (
     <span className={classes}>
-      {!hideIcon && <ResourceIcon kind={kind} />}
+      {!hideIcon && <ResourceIcon kind={kindReference} />}
       {path && linkTo ? (
         <Link
           to={path}

--- a/frontend/public/module/k8s/k8s-ref.ts
+++ b/frontend/public/module/k8s/k8s-ref.ts
@@ -1,13 +1,9 @@
-import * as _ from 'lodash';
-import { GroupVersionKind, K8sKind } from './types';
-
 // TODO(alecmerdler): Replace all manual string building with this function
 export const referenceForGroupVersionKind = (group: string) => (version: string) => (
   kind: string,
 ) => [group, version, kind].join('~');
 
-export const referenceForModel = (model: K8sKind): GroupVersionKind =>
-  referenceForGroupVersionKind(model.apiGroup || 'core')(model.apiVersion)(model.kind);
-
-export const apiVersionForModel = (model: K8sKind) =>
-  _.isEmpty(model.apiGroup) ? model.apiVersion : `${model.apiGroup}/${model.apiVersion}`;
+export {
+  getReferenceForModel as referenceForModel,
+  getAPIVersionForModel as apiVersionForModel,
+} from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-ref';

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash-es';
 import { ExtensionK8sGroupModel } from '@console/dynamic-plugin-sdk/src/api/common-types';
-
 import {
   CustomResourceDefinitionKind,
   GroupVersionKind,


### PR DESCRIPTION
**Fixes:**

https://issues.redhat.com/browse/HAC-54

**Solution Description:**

- [x] getReference
- [x] getReferenceForModel 
- [x] apiVersionForModel
- [x] getGroupVersionKindForResource
- [x] getGroupVersionKindForReference
- [x]  add/update specs
