### PR TITLE
Bug 2015115: [RFE] PCI passthrough - grid list headers

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/GridListHeaders/GridListHeaders.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/GridListHeaders/GridListHeaders.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { GridItem, Text, TextVariants } from '@patternfly/react-core';
+
+export type GridListHeadersProps = {
+  headers: any[];
+};
+
+const GridListHeaders: React.FC<GridListHeadersProps> = ({ headers }) => (
+  <>
+    {headers?.map((item) => (
+      <GridItem span={item?.span}>
+        <Text component={TextVariants.h4}>{item?.title}</Text>
+      </GridItem>
+    ))}
+  </>
+);
+
+export default GridListHeaders;


### PR DESCRIPTION
adding grid list headers component

example:

![Screenshot from 2021-10-25 15-22-01](https://user-images.githubusercontent.com/67270715/138694178-8ed55fa2-6a0e-4537-a628-343863e46baf.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>