### PR TITLE
Bug 2016951: Use actions in vm lists

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/action.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/smoke/action.spec.ts
@@ -114,7 +114,6 @@ describe('Test VM/VMI actions', () => {
 
     it('ID(CNV-3693) Test VMI list view action', () => {
       vm.delete();
-      cy.byLegacyTestID(vmiData.name).should('not.exist');
     });
 
     it('ID(CNV-3699) Test VMI detail view action', () => {

--- a/frontend/packages/kubevirt-plugin/src/actions/provider.ts
+++ b/frontend/packages/kubevirt-plugin/src/actions/provider.ts
@@ -3,7 +3,7 @@ import { CommonActionFactory } from '@console/app/src/actions/creators/common-fa
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { referenceFor } from '@console/internal/module/k8s';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
-import { VmActionFactory } from '../components/vms/menu-actions';
+import { VmActionFactory, VmiActionFactory } from '../components/vms/menu-actions';
 import { useVMStatus } from '../hooks/use-vm-status';
 import { VirtualMachineInstanceModel } from '../models';
 import { kubevirtReferenceForModel } from '../models/kubevirtReferenceForModel';
@@ -74,7 +74,7 @@ export const useVmiActionsProvider = (vm: VMKind) => {
           VmActionFactory.OpenConsole(k8sModel, vm, { vmi }),
           CommonActionFactory.ModifyLabels(k8sModel, vm),
           CommonActionFactory.ModifyAnnotations(k8sModel, vm),
-          VmActionFactory.Delete(k8sModel, vm, { vmi }),
+          VmiActionFactory.Delete(k8sModel, vmi),
         ]
       : [];
   }, [k8sModel, vm, vmStatusBundle, vmi]);

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { StackItem, Tooltip } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import {
+  DesktopIcon,
+  PlayIcon,
+  OffIcon,
+  PowerOffIcon,
+  PauseIcon,
+  UndoIcon,
+} from '@patternfly/react-icons';
 import cn from 'classnames';
 import * as copy from 'copy-to-clipboard';
 import i18next from 'i18next';
@@ -36,7 +43,7 @@ import {
   isVMExpectedRunning,
   isVMRunningOrExpectedRunning,
 } from '../../selectors/vm/selectors';
-import { isVMIPaused } from '../../selectors/vmi';
+import { isVMIPaused, isVMIRunning } from '../../selectors/vmi';
 import { getMigrationVMIName } from '../../selectors/vmi-migration';
 import { VMStatusBundle } from '../../statuses/vm/types';
 import { getVMStatus } from '../../statuses/vm/vm-status';
@@ -435,7 +442,7 @@ export const menuActionOpenConsole = (kindObj: K8sKind, vmi: VMIKind): KebabOpti
       <>
         {t('kubevirt-plugin~Open Console')}
         <span className="kubevirt-menu-actions__icon-spacer">
-          <ExternalLinkAltIcon />
+          <DesktopIcon />
         </span>
       </>
     );
@@ -523,6 +530,7 @@ export const VmActionFactory = {
       id: 'vm-action-start',
       disabled: vmStatusBundle?.status?.isMigrating() || isVMRunningOrExpectedRunning(vm, vmi),
       label: i18next.t('kubevirt-plugin~Start Virtual Machine'),
+      icon: <PowerOffIcon />,
       cta: () => {
         if (!vmStatusBundle?.status?.isImporting()) {
           startVM(vm);
@@ -543,6 +551,7 @@ export const VmActionFactory = {
       id: 'vm-action-stop',
       disabled: vmStatusBundle?.status?.isImporting(),
       label: i18next.t('kubevirt-plugin~Stop Virtual Machine'),
+      icon: <OffIcon />,
       cta: () =>
         confirmVMIModal({
           vmi,
@@ -576,6 +585,7 @@ export const VmActionFactory = {
         vmStatusBundle?.status?.isMigrating() ||
         !isVMExpectedRunning(vm, vmi) ||
         !isVMCreated(vm),
+      icon: <UndoIcon />,
       cta: () =>
         confirmVMIModal({
           vmi,
@@ -605,6 +615,7 @@ export const VmActionFactory = {
       id: 'vm-action-pause',
       label: i18next.t('kubevirt-plugin~Pause Virtual Machine'),
       disabled: isVMIPaused(vmi),
+      icon: <PauseIcon />,
       cta: () =>
         confirmModal({
           title: i18next.t('kubevirt-plugin~Pause Virtual Machine'),
@@ -619,6 +630,7 @@ export const VmActionFactory = {
       id: 'vm-action-unpause',
       label: i18next.t('kubevirt-plugin~Unpause Virtual Machine'),
       disabled: !isVMIPaused(vmi),
+      icon: <PlayIcon />,
       cta: () =>
         confirmModal({
           title: i18next.t('kubevirt-plugin~Unpause Virtual Machine'),
@@ -696,8 +708,8 @@ export const VmActionFactory = {
     return {
       id: 'vm-action-open-console',
       label: i18next.t('kubevirt-plugin~Open Console'),
-      icon: <ExternalLinkAltIcon />,
-      disabled: !isVMRunningOrExpectedRunning(vm, vmi) && !isVMIPaused(vmi),
+      icon: <DesktopIcon />,
+      disabled: !isVMIRunning(vmi) && !isVMIPaused(vmi),
       cta: () =>
         window.open(
           `/k8s/ns/${getNamespace(vmi)}/virtualmachineinstances/${getName(vmi)}/standaloneconsole`,


### PR DESCRIPTION
The console is deprecating `kebabActions` in favor of using `Actions`, this P use the new Actions in the virtual machine lists.

Screenshots:
Before:
![screenshot-localhost_9000-2021 10 25-15_47_40](https://user-images.githubusercontent.com/2181522/138704595-936df809-3d58-446c-a423-f6364d1e59ea.png)

After:
![screenshot-localhost_9000-2021 10 25-16_27_27](https://user-images.githubusercontent.com/2181522/138704582-82fd484a-d09a-408e-838a-ff6c184a9df5.png)


Requires: https://github.com/openshift/console/pull/10305