### PR TITLE
Bug 2017141: Remove inline style width from Namespace dropdown menu so it doesn't effect width of menu

### DIFF
--- a/frontend/packages/console-shared/src/components/namespace/NamespaceMenuToggle.tsx
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceMenuToggle.tsx
@@ -83,6 +83,7 @@ const NamespaceMenuToggle = (props: {
         position="left"
         appendTo={containerRef.current}
         isVisible={isOpen}
+        popperMatchesTriggerWidth={false}
       />
     </div>
   );


### PR DESCRIPTION
fix https://bugzilla.redhat.com/show_bug.cgi?id=2017141

before

<img width="1146" alt="Screen Shot 2021-10-25 at 12 06 20 PM" src="https://user-images.githubusercontent.com/1874151/138757697-807c682c-2438-4ecf-bdba-67f760d8eb08.png">

after
<img width="1039" alt="Screen Shot 2021-10-25 at 3 22 07 PM" src="https://user-images.githubusercontent.com/1874151/138757664-9216a8f9-4746-477f-bb56-bf8953c57ebe.png">

