### PR TITLE
Bug 2014238: Disable yaml create when not initialized, and verify state before running test cases

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/bulk-create-resources.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/bulk-create-resources.spec.ts
@@ -93,6 +93,7 @@ stringData:
   it('fail to import duplicate yaml definitions (local validation)', () => {
     cy.visit(`/k8s/ns/${namespace}/import`);
     yamlEditor.isImportLoaded();
+    yamlEditor.createButtonShouldBeEnabled();
     yamlEditor.setEditorContent(dupSecrets).then(() => {
       yamlEditor.clickSaveCreateButton();
       cy.get(errorMessage).should('exist');
@@ -102,6 +103,7 @@ stringData:
   it('fail to import missing namespaced resources (server validation)', () => {
     cy.visit(`/k8s/ns/${namespace}/import`);
     yamlEditor.isImportLoaded();
+    yamlEditor.createButtonShouldBeEnabled();
     yamlEditor.setEditorContent(missingNS).then(() => {
       yamlEditor.clickSaveCreateButton();
       cy.get(errorMessage).should('exist');
@@ -111,6 +113,7 @@ stringData:
   it('successfully import three yaml secret definitions', () => {
     cy.visit(`/k8s/ns/${namespace}/import`);
     yamlEditor.isImportLoaded();
+    yamlEditor.createButtonShouldBeEnabled();
     yamlEditor.setEditorContent(threeSecrets).then(() => {
       yamlEditor.clickSaveCreateButton();
       cy.get(errorMessage).should('not.exist');

--- a/frontend/packages/integration-tests-cypress/views/yaml-editor.ts
+++ b/frontend/packages/integration-tests-cypress/views/yaml-editor.ts
@@ -23,3 +23,5 @@ export const isImportLoaded = () => {
 export const clickSaveCreateButton = () => cy.byTestID('save-changes').click();
 export const clickCancelButton = () => cy.byTestID('cancel').click();
 export const clickReloadButton = () => cy.byTestID('reload-object').click();
+export const createButtonShouldBeEnabled = () =>
+  cy.byTestID('save-changes').should('not.be.disabled');

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -702,6 +702,7 @@ export const EditYAML_ = connect(stateToProps)(
                               variant="primary"
                               id="save-changes"
                               data-test="save-changes"
+                              isDisabled={!this.state.initialized}
                               onClick={() => (allowMultiple ? this.saveAll() : this.save())}
                             >
                               {t('public~Create')}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2014238

cc: @dtaylor113 

I noticed the component rendering twice, however, it wasn't initialized on the first render.  It seems the yaml was added to the component before it was initialized and ready for input. Updated the 'create' button to wait for initialization and updated the test to wait for the create button to become enabled before proceeding. 