### PR TITLE
Bug 2013930: Disable ODF BackingStore, BucketClass, and NamespaceStore tabs and OCS BlockPool tab.

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/odf-system-dashboard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/odf-system-dashboard.tsx
@@ -39,12 +39,17 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
       name: t('ceph-storage-plugin~Overview'),
       component: OCSOverview,
     },
-    {
-      href: referenceForModel(CephBlockPoolModel),
-      name: t('ceph-storage-plugin~BlockPools'),
-      component: () => <BlockPoolListPage namespace={CEPH_STORAGE_NAMESPACE} />,
-    },
   ];
+
+  React.useEffect(() => {
+    if (isCephAvailable) {
+      pages.push({
+        href: referenceForModel(CephBlockPoolModel),
+        name: t('ceph-storage-plugin~BlockPools'),
+        component: () => <BlockPoolListPage namespace={CEPH_STORAGE_NAMESPACE} />,
+      });
+    }
+  }, [isCephAvailable, pages, t]);
 
   const breadcrumbs = [
     {

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -540,6 +540,9 @@ const plugin: Plugin<ConsumedExtensions> = [
           )
         ).BackingStoreListPage,
     },
+    flags: {
+      required: [MCG_FLAG],
+    },
   },
   // Adding this Extension because dynamic endpoint is not avbl
   // Todo(bipuladh): Remove once SDK is mature enough to support list page
@@ -559,6 +562,9 @@ const plugin: Plugin<ConsumedExtensions> = [
           )
         ).BucketClassListPage,
     },
+    flags: {
+      required: [MCG_FLAG],
+    },
   },
   // Adding this Extension because dynamic endpoint is not avbl
   // Todo(bipuladh): Remove once SDK is mature enough to support list page
@@ -577,6 +583,9 @@ const plugin: Plugin<ConsumedExtensions> = [
             './components/odf-resources/resource-list-page' /* webpackChunkName: "odf-system-list" */
           )
         ).NamespaceStoreListPage,
+    },
+    flags: {
+      required: [MCG_FLAG],
     },
   },
 ];


### PR DESCRIPTION
Disables ODF BackingStore, BucketClass, and NamespaceStore tabs (based on
MCG_FLAG) and OCS BlockPool tab (based on CEPH_FLAG).

![2021-10-26-190331_918x177_scrot](https://user-images.githubusercontent.com/33557095/138890431-e43425f9-77fb-4892-b024-3f46c0bbbe56.png)
![2021-10-26-185138_590x492_scrot](https://user-images.githubusercontent.com/33557095/138890440-314bc326-e635-453a-828a-f39726b31138.png)
