### PR TITLE
CONSOLE-2985: Replace all instances of old variables controlling global grid widths and breakpoints with Patternfly variables for more consistency of spacing between elements and behaviors

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/dashboard.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/dashboard.scss
@@ -3,9 +3,9 @@
 .co-dashboard-body {
   background-color: $pf-color-black-200;
   flex: 1 0 auto;
-  padding: ($grid-gutter-width / 2);
-  @media(min-width: $grid-float-breakpoint) {
-    padding: $grid-gutter-width;
+  padding: $pf-global-gutter;
+  @media(min-width: $pf-global--breakpoint--xl) {
+    padding: $pf-global-gutter--md;
   }
 }
 

--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
@@ -1,9 +1,9 @@
 @import '../../../../../public/style/vars';
 
 .ocs-form-footer {
-  padding: var(--pf-global--spacer--md) ($grid-gutter-width/2);
-  @media (min-width: $screen-sm-min) {
-    padding: var(--pf-global--spacer--md) ($grid-gutter-width);
+  padding: var(--pf-global--spacer--md) $pf-global-gutter;
+  @media (min-width: $pf-global--breakpoint--xl) {
+    padding: var(--pf-global--spacer--md) $pf-global-gutter--md;
   }
   &__sticky {
     position: sticky;

--- a/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/SyncedEditorField.scss
@@ -12,6 +12,6 @@
   }
 
   &__yaml-warning {
-    margin: $grid-gutter-width $grid-gutter-width 0;
+    margin: $pf-global-gutter--md $pf-global-gutter--md 0;
   }
 }

--- a/frontend/packages/console-shared/src/components/layout/PageLayout.scss
+++ b/frontend/packages/console-shared/src/components/layout/PageLayout.scss
@@ -1,6 +1,14 @@
+@import '../../../../../public/style/vars';
+
 .ocs-page-layout {
   &__content {
-    padding: var(--pf-global--spacer--lg);
+    padding:  $pf-global-gutter--md $pf-global-gutter;
+
+    @media (min-width: $pf-global--breakpoint--xl) {
+      padding-left: $pf-global-gutter--md;
+      padding-right: $pf-global-gutter--md;
+    }
+
     flex: 1;
 
     &.is-dark {
@@ -13,13 +21,21 @@
   }
 
   &__hint {
-    padding-left: var(--pf-global--spacer--lg);
-    padding-right: var(--pf-global--spacer--lg);
     padding-bottom: var(--pf-global--spacer--md);
+    padding: 0 $pf-global-gutter $pf-global-gutter--md;
+
+    @media (min-width: $pf-global--breakpoint--xl) {
+      padding-left: $pf-global-gutter--md;
+      padding-right: $pf-global-gutter--md;
+    }
   }
 
   &__title {
-    padding-left: var(--pf-global--spacer--lg);
-    padding-right: var(--pf-global--spacer--lg);
+    padding: 0 $pf-global-gutter;
+
+    @media (min-width: $pf-global--breakpoint--xl) {
+      padding-left: $pf-global-gutter--md;
+      padding-right: $pf-global-gutter--md;
+    }
   }
 }

--- a/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.scss
+++ b/frontend/packages/console-shared/src/components/namespace/NamespaceDropdown.scss
@@ -1,5 +1,4 @@
-$grid-float-breakpoint: 768px;
-$font-size-base: 14px;
+@import '../../../../../public/style/vars';
 
 .co-namespace-dropdown {
     margin-right: 20px;
@@ -15,7 +14,7 @@ $font-size-base: 14px;
   // This allows the menu to be longer than the menu toggle
   // Currently PatternFly does not support a min width on the menu component
   --pf-c-menu--MinWidth: 210px;
-  @media (min-width: $grid-float-breakpoint) {
+  @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-menu--MinWidth: 325px;
   }
 }
@@ -29,7 +28,7 @@ $font-size-base: 14px;
   padding: 2px 0 !important;
   width: 100%;
 
-  @media (min-width: $grid-float-breakpoint) {
+  @media (min-width: $pf-global--breakpoint--md) {
     font-size: ($font-size-base + 2) !important;
     padding-bottom: 9px !important;
     padding-top: 9px !important;
@@ -47,15 +46,6 @@ $font-size-base: 14px;
   &:disabled {
     background: none;
     color: var(--pf-global--disabled-color--200);
-  }
-
-  .pf-c-menu-toggle__text {
-    // This allows the menu toggle button to have the label truncate
-    // This is currently not an option in the PatternFly menu toggle component
-    // Tracked in https://github.com/patternfly/patternfly-react/issues/6058
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 }
 

--- a/frontend/packages/console-shared/src/components/synced-editor/styles.scss
+++ b/frontend/packages/console-shared/src/components/synced-editor/styles.scss
@@ -9,5 +9,5 @@
 }
 
 .co-synced-editor__yaml-warning {
-  margin: $grid-gutter-width $grid-gutter-width 0;
+  margin: $pf-global-gutter--md $pf-global-gutter--md 0;
 }

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.scss
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.scss
@@ -1,5 +1,5 @@
 .odc-add-health-checks {
   &__body {
-    padding: 0 30px 30px;
+    padding: 0 var(--pf-global--spacer--lg) var(--pf-global--spacer--lg);
   }
 }

--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.scss
@@ -1,7 +1,0 @@
-.odc-monitoring-page .monitoring-dashboards__options {
-  margin-top: 0;
-}
-
-.odc-monitoring-page .monitoring-dashboards__variables {
-  margin-top: -20px;
-}

--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -18,8 +18,6 @@ import ConnectedMonitoringAlerts from './alerts/MonitoringAlerts';
 import MonitoringEvents from './events/MonitoringEvents';
 import ConnectedMonitoringMetrics from './metrics/MonitoringMetrics';
 
-import './MonitoringPage.scss';
-
 export const MONITORING_ALL_NS_PAGE_URI = '/dev-monitoring/all-namespaces';
 
 type MonitoringPageProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -260,9 +260,9 @@ $co-affinity-row-margin: 15px;
 }
 
 #operator-install-page {
-  margin: 0 ($grid-gutter-width / 2);
+  margin: 0 $pf-global-gutter;
   @media (min-width: $screen-sm-min) {
-    margin: $grid-gutter-width;
+    margin: $pf-global-gutter--md;
     max-width: 600px;
     min-width: 375px;
     width: 100%;

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
@@ -4,7 +4,6 @@
 
   &__grid {
     grid-template-columns: minmax(0, 1fr);
-    padding: 0 30px;
   }
 
   &__short-section {

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants, Stack, StackItem } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -150,55 +150,57 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
           <StackItem>
             <PipelineBuilderHeader namespace={namespace} />
           </StackItem>
-          <FlexForm onSubmit={handleSubmit}>
-            <FormBody flexLayout disablePaneBody className="odc-pipeline-builder-form__grid">
-              <PipelineQuickSearch
-                namespace={namespace}
-                viewContainer={contentRef.current}
-                isOpen={menuOpen}
-                callback={savedCallback.current}
-                setIsOpen={(open) => setMenuOpen(open)}
-                onUpdateTasks={onUpdateTasks}
-                taskGroup={taskGroup}
+          <PageSection variant={PageSectionVariants.light}>
+            <FlexForm onSubmit={handleSubmit}>
+              <FormBody flexLayout disablePaneBody className="odc-pipeline-builder-form__grid">
+                <PipelineQuickSearch
+                  namespace={namespace}
+                  viewContainer={contentRef.current}
+                  isOpen={menuOpen}
+                  callback={savedCallback.current}
+                  setIsOpen={(open) => setMenuOpen(open)}
+                  onUpdateTasks={onUpdateTasks}
+                  taskGroup={taskGroup}
+                />
+                <SyncedEditorField
+                  name="editorType"
+                  formContext={{
+                    name: 'formData',
+                    editor: formEditor,
+                    label: t('pipelines-plugin~Pipeline builder'),
+                    sanitizeTo: (yamlPipeline: PipelineKind) =>
+                      sanitizeToForm(formData, yamlPipeline),
+                  }}
+                  yamlContext={{
+                    name: 'yamlData',
+                    editor: yamlEditor,
+                    sanitizeTo: () => sanitizeToYaml(formData, namespace, existingPipeline),
+                  }}
+                  lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
+                />
+              </FormBody>
+              <FormFooter
+                handleReset={closeSidebarAndHandleReset}
+                errorMessage={status?.submitError}
+                isSubmitting={isSubmitting}
+                submitLabel={
+                  existingPipeline ? t('pipelines-plugin~Save') : t('pipelines-plugin~Create')
+                }
+                disableSubmit={
+                  editorType === EditorType.YAML
+                    ? !dirty
+                    : !dirty ||
+                      !_.isEmpty(errors) ||
+                      !_.isEmpty(status?.tasks) ||
+                      !_.isEmpty(status?.[STATUS_KEY_NAME_ERROR]) ||
+                      formData.tasks.length === 0 ||
+                      formData.loadingTasks.length > 0
+                }
+                resetLabel={t('pipelines-plugin~Cancel')}
+                sticky
               />
-              <SyncedEditorField
-                name="editorType"
-                formContext={{
-                  name: 'formData',
-                  editor: formEditor,
-                  label: t('pipelines-plugin~Pipeline builder'),
-                  sanitizeTo: (yamlPipeline: PipelineKind) =>
-                    sanitizeToForm(formData, yamlPipeline),
-                }}
-                yamlContext={{
-                  name: 'yamlData',
-                  editor: yamlEditor,
-                  sanitizeTo: () => sanitizeToYaml(formData, namespace, existingPipeline),
-                }}
-                lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
-              />
-            </FormBody>
-            <FormFooter
-              handleReset={closeSidebarAndHandleReset}
-              errorMessage={status?.submitError}
-              isSubmitting={isSubmitting}
-              submitLabel={
-                existingPipeline ? t('pipelines-plugin~Save') : t('pipelines-plugin~Create')
-              }
-              disableSubmit={
-                editorType === EditorType.YAML
-                  ? !dirty
-                  : !dirty ||
-                    !_.isEmpty(errors) ||
-                    !_.isEmpty(status?.tasks) ||
-                    !_.isEmpty(status?.[STATUS_KEY_NAME_ERROR]) ||
-                    formData.tasks.length === 0 ||
-                    formData.loadingTasks.length > 0
-              }
-              resetLabel={t('pipelines-plugin~Cancel')}
-              sticky
-            />
-          </FlexForm>
+            </FlexForm>
+          </PageSection>
         </Stack>
       </div>
       <Sidebar

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.scss
@@ -1,9 +1,5 @@
 .odc-pipeline-builder-header {
-  &__content {
-    padding: var(--pf-global--spacer--xl);
-  }
-
   &__title {
-    margin: var(--pf-global--spacer--xs) 0 0 0;
+    margin: 0;
   }
 }

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
@@ -14,9 +14,11 @@ const PipelineBuilderHeader: React.FC<{ namespace: string }> = ({ namespace }) =
     <div className="odc-pipeline-builder-header">
       <Flex className="odc-pipeline-builder-header__content">
         <FlexItem grow={{ default: 'grow' }}>
-          <h1 className="odc-pipeline-builder-header__title">
-            {t('pipelines-plugin~Pipeline builder')}
-          </h1>
+          <div className="co-m-nav-title">
+            <h1 className="co-m-pane__heading odc-pipeline-builder-header__title">
+              {t('pipelines-plugin~Pipeline builder')}
+            </h1>
+          </div>
         </FlexItem>
         {badge && (
           <FlexItem>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/PipelineMetrics.scss
@@ -1,3 +1,6 @@
+@import '../../../../../../public/style/vars';
+
+
 .pipeline-metrics-dashboard {
   background: var(--pf-global--palette--black-150);
   &__body {
@@ -6,11 +9,11 @@
     margin-top: 0;
   }
   &__body-content {
-    margin-top: var(--pf-global--spacer--lg);
+    margin-top: $pf-global-gutter--md;
   }
   &__toolbar {
     margin-bottom: 0 !important;
-    padding: var(--pf-global--spacer--md) var(--pf-global--spacer--xl) 0;
+    padding: var(--pf-global--spacer--md) $pf-global-gutter--md 0;
   }
 }
 .pipeline-metrics-empty-state {

--- a/frontend/packages/topology/src/filters/TopologyFilterBar.scss
+++ b/frontend/packages/topology/src/filters/TopologyFilterBar.scss
@@ -2,11 +2,11 @@
 
 .odc-topology-filter-bar {
   background-color: var(--pf-chart-global--Fill--Color--white);
-  padding: 6px ($grid-gutter-width / 2);
+  padding: 6px $pf-global-gutter;
 
-  @media (min-width: $grid-float-breakpoint) {
-    padding-left: $grid-gutter-width;
-    padding-right: $grid-gutter-width;
+  @media (min-width: $pf-global--breakpoint--xl) {
+    padding-left: $pf-global-gutter--md;
+    padding-right: $pf-global-gutter--md;
   }
 
   &__kiali-link {

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -1,5 +1,3 @@
-@import '~@patternfly/patternfly/sass-utilities/scss-variables';
-
 $color-bookmarker--hover: $pf-color-black-500;
 $color-bookmarker: $pf-color-black-400;
 $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--hover--BackgroundColor
@@ -64,12 +62,12 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
 
 .co-namespace-bar {
   border-bottom: 1px solid $color-grey-background-border;
-  padding: 0 15px;
+  padding: 0 $pf-global-gutter;
   white-space: nowrap;
 
-  @media (min-width: $grid-float-breakpoint) {
-    padding-left: 30px;
-    padding-right: 30px;
+  @media (min-width: $pf-global--breakpoint--xl) {
+    padding-left: $pf-global-gutter--md;
+    padding-right: $pf-global-gutter--md;
   }
 
   &__items {
@@ -97,7 +95,7 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
     --pf-c-dropdown__toggle--PaddingLeft: 0;
     --pf-c-dropdown__toggle--PaddingRight: 0;
 
-    @media (min-width: $grid-float-breakpoint) {
+    @media (min-width: $pf-global--breakpoint--md) {
       font-size: ($font-size-base + 2);
       --pf-c-dropdown__toggle--PaddingBottom: 9px;
     }
@@ -156,7 +154,7 @@ $dropdown-background--hover: $pf-color-black-200; // pf-c-dropdown__menu-item--h
   max-width: 100%;
   min-width: 210px;
 
-  @media (min-width: $grid-float-breakpoint) {
+  @media (min-width: $pf-global--breakpoint--md) {
     min-width: 325px;
   }
 

--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -4,20 +4,24 @@
   height: 100%;
   flex: 1;
   flex-direction: column;
-  @media (min-width: $grid-float-breakpoint) {
-    margin-left: $grid-gutter-width;
-    margin-right: $grid-gutter-width;
-    padding-top: $grid-gutter-width;
+  @media (min-width: $pf-global--breakpoint--md) {
+    margin-left: $pf-global-gutter;
+    margin-right: $pf-global-gutter;
+    padding-top: $pf-global-gutter--md;
+  }
+  @media (min-width: $pf-global--breakpoint--xl) {
+    margin-left: $pf-global-gutter--md;
+    margin-right: $pf-global-gutter--md;
   }
 }
 
 .yaml-editor__buttons {
   background: white;
   border-top: 1px solid #ddd;
-  padding: 20px ($grid-gutter-width / 2);
+  padding: 20px $pf-global-gutter;
   margin-top: auto;
   z-index: 10;
-  @media (min-width: $grid-float-breakpoint) {
+  @media (min-width: $pf-global--breakpoint--md) {
     padding-left: 0;
     padding-right: 0;
   }
@@ -25,9 +29,9 @@
 
 .yaml-editor__header {
   border-bottom: 1px solid #ddd;
-  padding: 20px 15px;
-  @media(min-width: $screen-sm-min) {
-    padding-left: 31px; // left alignment with namespace selector text
+  padding: 20px $pf-global-gutter;
+  @media(min-width: $pf-global--breakpoint--xl) {
+    padding-left: $pf-global-gutter--md;
   }
 }
 

--- a/frontend/public/components/_global-notification.scss
+++ b/frontend/public/components/_global-notification.scss
@@ -3,11 +3,11 @@ $global-notification-text: $pf-color-white;
 .co-global-notification {
   background-color: $pf-color-blue-400;
   color: $global-notification-text;
-  padding: 4px ($grid-gutter-width / 2);
+  padding: 4px $pf-global-gutter;
   text-align: center;
 
-  @media(min-width: $grid-float-breakpoint) {
-    padding: 6px $grid-gutter-width;
+  @media(min-width: $pf-global--breakpoint--md) {
+    padding: 6px $pf-global-gutter--md;
   }
 
   + .co-global-notification {

--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -1,4 +1,4 @@
-$co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
+$co-m-horizontal-nav__menu-item-link-padding-lr: $pf-global-gutter;
 
 .co-m-horizontal-nav__menu {
   border-bottom: 1px solid $color-grey-background-border;
@@ -11,18 +11,18 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
   padding: 0;
   -webkit-overflow-scrolling: touch;
   white-space: nowrap;
-  @media (min-width: $grid-float-breakpoint) {
-    padding-left: $co-m-horizontal-nav__menu-item-link-padding-lr;
+  @media (min-width: $pf-global--breakpoint--xl) {
+    padding-left: ($pf-global-gutter--md - $pf-global-gutter);
   }
   &--within-sidebar {
     border-top: 1px solid $color-grey-background-border;
-    margin-bottom: $grid-gutter-width !important;
-    margin-left: -($grid-gutter-width / 2);
-    margin-right: -($grid-gutter-width / 2);
+    margin-bottom: $pf-global-gutter--md !important;
+    margin-left: -$pf-global-gutter;
+    margin-right: -$pf-global-gutter;
     overflow: visible; // so focus indicator is not clipped since these don't need to scroll
-    @media (min-width: $grid-float-breakpoint) {
-      margin-left: -($grid-gutter-width);
-      margin-right: -($grid-gutter-width);
+    @media (min-width: $pf-global--breakpoint--xl) {
+      margin-left: -$pf-global-gutter--md;
+      margin-right: -$pf-global-gutter--md;
     }
     .co-m-horizontal-nav__menu-item {
       font-size: 16px;
@@ -75,7 +75,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
     }
   }
   &:last-child {
-    @media (min-width: $grid-float-breakpoint) {
+    @media (min-width: $pf-global--breakpoint--md) {
       a,
       button {
         margin-right: $co-m-horizontal-nav__menu-item-link-padding-lr;

--- a/frontend/public/components/_image-stream.scss
+++ b/frontend/public/components/_image-stream.scss
@@ -4,7 +4,7 @@
 
 .co-images-stream-tag-timeline {
   font-size: 15px;
-  margin: 20px 30px;
+  margin: 20px $pf-global-gutter--md;
   padding-left: 0;
   width: auto;
   @media (max-width: $screen-xs-max) {

--- a/frontend/public/components/_import-yaml-results.scss
+++ b/frontend/public/components/_import-yaml-results.scss
@@ -8,9 +8,9 @@
 }
 
 .co-import-yaml-results-page__main {
-  margin: 0 ($grid-gutter-width / 2);
+  margin: 0 $pf-global-gutter;
   @media (min-width: $screen-sm-min) {
-    margin: $grid-gutter-width;
+    margin: $pf-global-gutter--md;
     max-width: 600px;
     min-width: 375px;
     width: 100%;

--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -18,11 +18,11 @@
 }
 
 .co-m-nav-title {
-  margin-top: $grid-gutter-width;
-  padding: 0 ($grid-gutter-width / 2) 0;
-  @media (min-width: $grid-float-breakpoint) {
-    padding-left: $grid-gutter-width;
-    padding-right: $grid-gutter-width;
+  margin-top: $pf-global-gutter--md;
+  padding: 0 $pf-global-gutter 0;
+  @media (min-width: $pf-global--breakpoint--xl) {
+    padding-left: $pf-global-gutter--md;
+    padding-right: $pf-global-gutter--md;
   }
   &--row {
     @media (max-width: $screen-xs-max) {

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -1,6 +1,6 @@
 .co-search {
   padding-bottom: 30px;
-  @media (max-width: $grid-float-breakpoint-max) {
+  @media (max-width: $pf-global--breakpoint--sm-max) {
     .pf-c-input-group {
       display: block;
       .pf-c-dropdown__toggle {

--- a/frontend/public/components/_row-filter.scss
+++ b/frontend/public/components/_row-filter.scss
@@ -23,15 +23,15 @@ $color-row-filter-border--active: $pf-color-blue-300;
   background-color: var(--pf-global--BackgroundColor--100);
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: $grid-gutter-width;
+  margin-bottom: $pf-global--spacer--xl;
   // use pseudo element for border so .row-filter__box-es can overlaps
   &::before {
     border: 1px solid $color-row-filter-border;
-    bottom: ($grid-gutter-width - 1);
+    bottom: calc(var(--pf-global--spacer--xl) - 1px);
     content: '';
-    left: ($grid-gutter-width / 2);
+    left: $pf-global-gutter;
     position: absolute;
-    right: ($grid-gutter-width / 2);
+    right: $pf-global-gutter;
     top: 0;
   }
 }

--- a/frontend/public/components/_search.scss
+++ b/frontend/public/components/_search.scss
@@ -3,14 +3,14 @@
   // Align with search results
   @media (min-width: $screen-sm-min) {
     .co-search-group__accordion-toggle {
-      padding-left: $grid-gutter-width;
-      padding-right: $grid-gutter-width;
+      padding-left: $pf-global-gutter--md;
+      padding-right: $pf-global-gutter--md;
     }
   }
   .co-m-pane__filter-bar {
     // Reduce the margin between the accordion toggle and the create button
     // so that the space is equal above and below the button.
-    margin-top: ($grid-gutter-width / 2);
+    margin-top: $pf-global-gutter;
   }
   // There's no way to set a class name on this element with the PF4 component,
   // so use a nested selector.

--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -148,7 +148,7 @@ $color-dark-border: #ddd;
   width: 50%;
 }
 
-@media(min-width: $grid-float-breakpoint) {
+@media(min-width: $pf-global--breakpoint--xl) {
   .co-sysevent {
     flex-wrap: nowrap;
     margin-left: -40px;
@@ -166,7 +166,7 @@ $color-dark-border: #ddd;
 
   .co-sysevent-stream {
     padding-top: 50px;
-    padding-left: 10px;
+    padding-left: 5px;
   }
 
   .co-sysevent-stream__timeline {

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -99,11 +99,11 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   border: 1px solid var(--pf-global--BorderColor--300);
   display: flex;
   flex: 1;
-  padding-top: ($grid-gutter-width / 2);
+  padding-top: $pf-global-gutter;
 
   &--with-sidebar {
-    margin: 0 ($grid-gutter-width / 2);
-    padding-bottom: ($grid-gutter-width / 2);
+    margin: 0 $pf-global-gutter;
+    padding-bottom: $pf-global-gutter;
   }
 
   &__btn-group__group-by {
@@ -118,10 +118,10 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 
   &__description {
     margin-top: -10px;
-    padding: 0 ($grid-gutter-width / 2) 10px;
-    @media (min-width: $grid-float-breakpoint) {
-      padding-left: $grid-gutter-width;
-      padding-right: $grid-gutter-width;
+    padding: 0 $pf-global-gutter 10px;
+    @media (min-width: $pf-global--breakpoint--xl) {
+      padding-left: $pf-global-gutter--md;
+      padding-right: $pf-global-gutter--md;
     }
   }
 
@@ -147,12 +147,16 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   }
 
   &__header {
-    margin: 0 $grid-gutter-width 0 0;
+    margin: 0 $pf-global-gutter--md 0 0;
   }
 
   &__heading {
     font-size: 16px;
-    margin: 0 0 20px 30px;
+    margin: 0 $pf-global-gutter $pf-global-gutter;
+    @media (min-width: $pf-global--breakpoint--xl) {
+      margin-left: $pf-global-gutter--md;
+      margin-right: $pf-global-gutter--md;
+    }
   }
 
   &__hint {
@@ -161,7 +165,11 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 
   &__input {
     display: inline-flex !important;
-    margin: 0 0 20px 30px;
+    margin: 0 $pf-global-gutter $pf-global-gutter--md;
+    @media (min-width: $pf-global--breakpoint--xl) {
+      margin-left: $pf-global-gutter--md;
+      margin-right: $pf-global-gutter--md;
+    }
     width: auto !important;
   }
 
@@ -293,7 +301,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 
   &__tabs {
     flex: 0 0 220px;
-    margin: 0 ($grid-gutter-width / 2) 0 0;
+    margin: 0 $pf-global-gutter 0 0;
   }
 }
 

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -147,9 +147,7 @@ $tooltip-background-color: var(--pf-global--BackgroundColor--dark-100);
 
 .monitoring-dashboards__options {
   display: flex;
-  float: right;
   margin-right: -20px;
-  margin-top: -20px;
 }
 
 .monitoring-dashboards__panel {
@@ -280,7 +278,7 @@ $monitoring-line-height: 18px;
     align-items: baseline;
     display: flex;
     justify-content: space-between;
-    @media (min-width: $grid-float-breakpoint) {
+    @media (min-width: $pf-global--breakpoint--md) {
       padding-top: 26px;
     }
   }

--- a/frontend/public/components/nav/_nav-header.scss
+++ b/frontend/public/components/nav/_nav-header.scss
@@ -2,7 +2,7 @@
   border-bottom: 1px solid var(--pf-global--BackgroundColor--dark-200);
   padding: 0.6rem var(--pf-global--spacer--sm);
 
-  @media screen and (min-width: $grid-float-breakpoint) {
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
     padding-left: var(--pf-global--spacer--md);
     padding-right: var(--pf-global--spacer--md);
   }

--- a/frontend/public/components/utils/_alerts.scss
+++ b/frontend/public/components/utils/_alerts.scss
@@ -14,7 +14,7 @@
 
 .co-alert--margin-top {
   margin-bottom: 0;
-  margin-top: $grid-gutter-width / 2;
+  margin-top: $pf-global-gutter;
 }
 
 .co-alert--scrollable .pf-c-alert__description {

--- a/frontend/public/components/utils/_label.scss
+++ b/frontend/public/components/utils/_label.scss
@@ -53,7 +53,7 @@ tags-input .tags {
 
 .modal-body tags-input .tags {
   background-color: rgba(255, 255, 255, 0.5); // enable scroll-shadows to be seen
-  margin-bottom: ($grid-gutter-width / 2);
+  margin-bottom: $pf-global-gutter;
   min-height: 120px;
 
   .tag-item {
@@ -111,7 +111,7 @@ tags-input .tags .input {
   // Since iOS phone text input size is larger, remove border and margin and increase line-height
   @supports (-webkit-overflow-scrolling: touch) {
     // Target mobile Safari
-    @media (max-width: $grid-float-breakpoint-max) {
+    @media (max-width: $pf-global--breakpoint--sm-max) {
       // Target phones
       border: 0;
       line-height: 24px;

--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -14,7 +14,7 @@ $drag-column-width: 28px;
   background: transparent;
   border: 0;
   display: flex;
-  padding-left: $grid-gutter-width / 2 !important;
+  padding-left: $pf-global-gutter !important;
 }
 
 .pairs-list__action-icon--reorder {

--- a/frontend/public/components/utils/_skeleton-screen.scss
+++ b/frontend/public/components/utils/_skeleton-screen.scss
@@ -91,7 +91,7 @@ $skeleton-tile-desc-line-bone: linear-gradient(#fff $skeleton-tile-desc-line-hei
   display: flex;
   flex: 1;
   height: 100%;
-  margin: 0 ($grid-gutter-width / 2);
+  margin: 0 $pf-global-gutter;
   position: relative;
 }
 
@@ -162,7 +162,7 @@ $skeleton-tile-desc-line-bone: linear-gradient(#fff $skeleton-tile-desc-line-hei
 }
 
 .skeleton-detail-view {
-  padding: $grid-gutter-width;
+  padding: $pf-global-gutter--md;
   height: 100%;
   width: 100%;
 }

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -11,11 +11,11 @@ dl.co-inline {
 }
 
 .co-m-pane__body {
-  margin: $grid-gutter-width 0 0;
-  padding: 0 ($grid-gutter-width / 2) $grid-gutter-width;
-  @media (min-width: $screen-sm-min) {
-    padding-left: $grid-gutter-width;
-    padding-right: $grid-gutter-width;
+  margin: $pf-global-gutter--md 0 0;
+  padding: 0 $pf-global-gutter $pf-global-gutter--md;
+  @media (min-width: $pf-global--breakpoint--xl) {
+    padding-left: $pf-global-gutter--md;
+    padding-right: $pf-global-gutter--md;
   }
   &--full-height{
     height: 100%;
@@ -29,21 +29,21 @@ dl.co-inline {
   + .co-m-pane__body {
     border-top: 1px solid $color-grey-background-border;
     margin-top: 0;
-    padding-top: $grid-gutter-width;
+    padding-top: $pf-global-gutter--md;
   }
 }
 
 .co-m-pane__createLink--no-title {
-  margin-bottom: $grid-gutter-width;
+  margin-bottom: $pf-global-gutter--md;
 }
 
 .co-m-pane__filter-bar,
 .co-m-pane__help-text {
-  margin: 20px ($grid-gutter-width / 2);
-  @media (min-width: $grid-float-breakpoint) {
-    margin-left: $grid-gutter-width;
-    margin-right: $grid-gutter-width;
-    margin-top: $grid-gutter-width;
+  margin: 20px $pf-global-gutter;
+  @media (min-width: $pf-global--breakpoint--md) {
+    margin-left: $pf-global-gutter--md;
+    margin-right: $pf-global-gutter--md;
+    margin-top: $pf-global-gutter--md;
   }
 }
 
@@ -85,11 +85,11 @@ dl.co-inline {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  margin-bottom: $grid-gutter-width;
+  margin-bottom: $pf-global-gutter--md;
 }
 
 .co-m-pane__filter-row-action {
-  padding-top: ($grid-gutter-width / 2);
+  padding-top: $pf-global-gutter;
   @media (min-width: $screen-xs-min) {
     padding-top: 0;
   }
@@ -98,7 +98,7 @@ dl.co-inline {
 .co-m-pane__heading {
   display: flex;
   justify-content: space-between;
-  margin: 0 0 $grid-gutter-width;
+  margin: 0 0 $pf-global-gutter--md;
   &--baseline {
     align-items: baseline;
   }
@@ -107,7 +107,7 @@ dl.co-inline {
   }
   &--logo {
     align-items: center;
-    margin-bottom: ($grid-gutter-width / 2);
+    margin-bottom: $pf-global-gutter;
   }
 }
 
@@ -207,7 +207,7 @@ dl.co-inline {
 // Prevent iOS phones from zooming on form inputs
 @supports (-webkit-overflow-scrolling: touch) {
   // Target mobile Safari
-  @media (max-width: $grid-float-breakpoint-max) {
+  @media (max-width: $pf-global--breakpoint--sm-max) {
     // Target phones
     input,
     select,

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -26,7 +26,7 @@
 
 .co-form-section__label {
   font-size: 14px;
-  margin-bottom: ($grid-gutter-width / 2);
+  margin-bottom: $pf-global-gutter;
 }
 
 .co-form-section__separator {
@@ -81,7 +81,7 @@
 
 .pf-c-form__checkbox-row {
   display: grid;
-  row-gap: ($grid-gutter-width / 2);
+  row-gap: $pf-global-gutter;
 }
 
 .pf-c-form__group--no-top-margin {

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -210,7 +210,7 @@ form.pf-c-form {
 }
 
 .pf-c-page__sidebar {
-  @media screen and (min-width: $grid-float-breakpoint) {
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
     --pf-c-page__sidebar--BoxShadow: none;
   }
 
@@ -226,7 +226,7 @@ form.pf-c-form {
     --pf-c-nav__link--FontSize: #{$co-side-nav-section-font-size};
     --pf-c-nav__subnav__link--FontSize: #{$co-side-nav-font-size};
 
-    @media screen and (min-width: $grid-float-breakpoint) {
+    @media screen and (min-width: $pf-global--breakpoint--xl) {
       --pf-c-nav__list-link--PaddingRight: var(--pf-global--spacer--md);
       --pf-c-nav__list-link--PaddinLeft: var(--pf-global--spacer--lg);
       --pf-c-nav__list-link--after--Left: var(--pf-global--spacer--lg);

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -3,8 +3,8 @@
 // Root path where you plan to host console.
 $consoleWebDistPath: './';
 
-// PatternFly color variables -- imported here so they can be used throughout
-@import '~@patternfly/patternfly/sass-utilities/colors';
+// PatternFly variables -- imported here so they can be used throughout
+@import '~@patternfly/patternfly/sass-utilities/all';
 
 // Enable use within shared components and packages
 @import "../style/ancillary/bootstrap-variables";
@@ -23,6 +23,16 @@ $table-border-color: $pf-color-black-200;
   --pf-global--FontSize--md: 14px; // Numerical value required, same as $font-size-base
   --pf-global--FontSize--sm: 13px;
 }
+
+// == Declare max breakpoints from PatternFly variables
+$pf-global--breakpoint--xs-max: ($pf-global--breakpoint--xs - 1);
+$pf-global--breakpoint--sm-max: ($pf-global--breakpoint--sm - 1);
+$pf-global--breakpoint--md-max: ($pf-global--breakpoint--md - 1);
+$pf-global--breakpoint--lg-max: ($pf-global--breakpoint--lg - 1);
+
+// Can not use --pf-global--gutter --pf-global--gutter--md because you can't get a negative value of a scss variable that is assigned a css custom property.
+$pf-global-gutter: 1rem; // Matches --pf-global--gutter
+$pf-global-gutter--md: 1.5rem; // Matches --pf-global--gutter--md
 
 
 // == Custom variables

--- a/frontend/public/style/ancillary/_bootstrap-variables.scss
+++ b/frontend/public/style/ancillary/_bootstrap-variables.scss
@@ -136,13 +136,6 @@ $screen-md-max:              ($screen-lg-min - 1) !default;
 
 //** Number of columns in the grid.
 $grid-columns:              12 !default;
-//** Padding between columns. Gets divided in half for the left and right.
-$grid-gutter-width:         30px !default;
-// Navbar collapse
-//** Point at which the navbar becomes uncollapsed.
-$grid-float-breakpoint:     $screen-sm-min !default;
-//** Point at which the navbar begins collapsing.
-$grid-float-breakpoint-max: ($grid-float-breakpoint - 1) !default;
 
 //== List group
 


### PR DESCRIPTION
Replaces `$grid-gutter-width` instances with Patternfly equivalent `$pf-global-gutter--md` and `$pf-global-gutter`
Replaces instances of `$grid-float-breakpoint` variables with Patternfly `$pf-global--breakpoint--(size)`

Minor markup changes and associated css to various pages for consistency of markup and spacing/positioning. (PipelineBuilder and MonitoringPage)

The primary spacing changes are the left and right margins of the main page elements (page-body, project selector, breadcrumbs, title, actions button)

Notes:

```
// Old
$grid-gutter-width = 30px 
($grid-gutter-width / 2) = 15px
```

```
// New
// PF uses $pf-global--gutter for it's mobile size to 1200px and $pf-global--gutter--md for >1200px
$pf-global--gutter--md: $pf-global--spacer--lg !default; // 24px
$pf-global--gutter: $pf-global--spacer--md !default; // 16px
```

**Switching from `$grid-float-breakpoint` to `$pf-global--breakpoint--{size}`**
```
@screen-sm-min == $pf-global--breakpoint--md // 768
@screen-md-min == $pf-global--breakpoint--lg // 992
@screen-lg-min == $pf-global--breakpoint--xl // 1200
```

PF doesn't have `..-max` values. I created ones to use with for our ` @media (max-width: ...` use cases.
```
$pf-global--breakpoint--xs-max: ($pf-global--breakpoint--xs - 1);
$pf-global--breakpoint--sm-max: ($pf-global--breakpoint--sm - 1);
$pf-global--breakpoint--md-max: ($pf-global--breakpoint--md - 1);
$pf-global--breakpoint--lg-max: ($pf-global--breakpoint--lg - 1);
```


<img width="1427" alt="observe-dashboard-b4" src="https://user-images.githubusercontent.com/1874151/138944764-825b1b8f-6536-4946-9eba-d94e41160f3c.png">
<img width="1422" alt="observe-dashboard-after" src="https://user-images.githubusercontent.com/1874151/138944761-31f380f2-7f09-4b33-a98b-557b7211ad70.png">

----

<img width="1449" alt="pipeline-metrics-b4" src="https://user-images.githubusercontent.com/1874151/138944854-a9a72c5a-2edd-491b-82f8-6b1e8d55af51.png">

<img width="1449" alt="pipeline-metrics-after" src="https://user-images.githubusercontent.com/1874151/138944865-a7075849-b901-4143-b1f4-b345ff82b44f.png">
 
----

<img width="1243" alt="List-events-b4" src="https://user-images.githubusercontent.com/1874151/138944906-5adefbb0-8732-4017-9648-ab6241a61f23.png">
<img width="1243" alt="List-events-after" src="https://user-images.githubusercontent.com/1874151/138944913-1da0d4f7-9a6f-4fd8-9ef0-1c81bd2d15bb.png">

----

<img width="1244" alt="yaml-side-b4" src="https://user-images.githubusercontent.com/1874151/138944943-a6ff82a4-db5a-4e77-adb1-a641bf4109d6.png">
<img width="1244" alt="yaml-side-after" src="https://user-images.githubusercontent.com/1874151/138944966-bc5d95c4-26bc-4b89-a5eb-39a4b8d0cc66.png">

----

<img width="1429" alt="dev-console-dashboard-b4" src="https://user-images.githubusercontent.com/1874151/138945087-9ce69b19-b632-4850-b630-2dc35e751db3.png">

<img width="1428" alt="dev-console-dashboard-after" src="https://user-images.githubusercontent.com/1874151/138945109-db298b37-4cc4-47bc-9c7d-853e2aa1df47.png">

----

<img width="1399" alt="pipeline-builder-b4" src="https://user-images.githubusercontent.com/1874151/138945132-c6e74e3f-22b0-472d-ad8c-cf6d00fece65.png">

<img width="1400" alt="pipeline-builder-after" src="https://user-images.githubusercontent.com/1874151/138945151-f1e393de-828a-404b-ba7a-58fd006ae8a9.png">

----

<img width="712" alt="yaml-edit-b4" src="https://user-images.githubusercontent.com/1874151/138945194-aea9fcc4-8c5f-4c68-9bef-8036c943901e.png">
<img width="694" alt="yaml-edit-after" src="https://user-images.githubusercontent.com/1874151/138945211-f63f79ae-b942-44c6-bf8e-a06f00e569f1.png">


