### PR TITLE
Bug 2015806: Fix resource metrics 403 errors for project admin users

### DIFF
--- a/frontend/packages/console-shared/src/promql/resource-metrics.ts
+++ b/frontend/packages/console-shared/src/promql/resource-metrics.ts
@@ -14,138 +14,84 @@ export enum ResourceUtilizationQuery {
 
 const podMetricsQueries = {
   [ResourceUtilizationQuery.MEMORY]: _.template(
-    "sum(container_memory_working_set_bytes{pod='<%= name %>',namespace='<%= namespace %>',container=''}) BY (pod, namespace)",
+    "sum(container_memory_working_set_bytes{pod='<%= name %>',container=''}) BY (pod)",
   ),
-  [ResourceUtilizationQuery.CPU]: _.template(
-    "pod:container_cpu_usage:sum{pod='<%= name %>',namespace='<%= namespace %>'}",
-  ),
+  [ResourceUtilizationQuery.CPU]: _.template("pod:container_cpu_usage:sum{pod='<%= name %>'}"),
   [ResourceUtilizationQuery.FILESYSTEM]: _.template(
-    "pod:container_fs_usage_bytes:sum{pod='<%= name %>',namespace='<%= namespace %>'}",
+    "pod:container_fs_usage_bytes:sum{pod='<%= name %>'}",
   ),
   [ResourceUtilizationQuery.NETWORK_IN]: _.template(
-    "(sum(irate(container_network_receive_bytes_total{pod='<%= name %>', namespace='<%= namespace %>'}[5m])) by (pod, namespace, interface)) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )",
+    "(sum(irate(container_network_receive_bytes_total{pod='<%= name %>'}[5m])) by (pod, interface)) + on(pod,interface) group_left(network_name) ( pod_network_name_info )",
   ),
   [ResourceUtilizationQuery.NETWORK_OUT]: _.template(
-    "(sum(irate(container_network_transmit_bytes_total{pod='<%= name %>', namespace='<%= namespace %>'}[5m])) by (pod, namespace, interface)) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )",
+    "(sum(irate(container_network_transmit_bytes_total{pod='<%= name %>'}[5m])) by (pod, interface)) + on(pod,interface) group_left(network_name) ( pod_network_name_info )",
   ),
   [ResourceUtilizationQuery.QUOTA_LIMIT]: _.template(
-    "sum by (pod, namespace, resource) (kube_pod_resource_limit{resource='<%= resource %>',pod='<%= name %>',namespace='<%= namespace %>'})",
+    "sum by (pod, resource) (kube_pod_resource_limit{resource='<%= resource %>',pod='<%= name %>'})",
   ),
   [ResourceUtilizationQuery.QUOTA_REQUEST]: _.template(
-    "sum by (pod, namespace, resource) (kube_pod_resource_request{resource='<%= resource %>',pod='<%= name %>',namespace='<%= namespace %>'})",
+    "sum by (pod, resource) (kube_pod_resource_request{resource='<%= resource %>',pod='<%= name %>'})",
   ),
 };
 
 const podControllerMetricsQueries = {
   [ResourceUtilizationQuery.MEMORY]: _.template(
-    "sum(container_memory_working_set_bytes{namespace='<%= namespace %>',container!=''} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='<%= namespace %>', workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
+    "sum(container_memory_working_set_bytes{container!=''} * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.CPU]: _.template(
-    "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='<%= namespace %>'} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='<%= namespace %>', workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
+    "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{} * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.FILESYSTEM]: _.template(
-    "sum(pod:container_fs_usage_bytes:sum{namespace='<%= namespace %>'}  * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='<%= namespace %>', workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
+    "sum(pod:container_fs_usage_bytes:sum * on(pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.NETWORK_IN]: _.template(
-    "sum(irate(container_network_receive_bytes_total{namespace=~'<%= namespace %>'}[5m]) * on (namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace=~'<%= namespace %>', workload=~'<%= name %>', workload_type='<%= type %>'}) by (pod)",
+    "sum(irate(container_network_receive_bytes_total[5m]) * on (pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
   [ResourceUtilizationQuery.NETWORK_OUT]: _.template(
-    "sum(irate(container_network_transmit_bytes_total{namespace=~'<%= namespace %>'}[5m]) * on (namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace=~'<%= namespace %>', workload=~'<%= name %>', workload_type='<%= type %>'}) by (pod)",
+    "sum(irate(container_network_transmit_bytes_total[5m]) * on (pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{workload='<%= name %>', workload_type='<%= type %>'}) by (pod)",
   ),
 };
 
-export const getPodMetricsQueries = (
-  name: string,
-  namespace: string,
-): { [key: string]: string[] } => ({
+export const getPodMetricsQueries = (name: string): { [key: string]: string[] } => ({
   [ResourceUtilizationQuery.MEMORY]: [
-    podMetricsQueries[ResourceUtilizationQuery.MEMORY]({
-      name,
-      namespace,
-    }),
-    podMetricsQueries[ResourceUtilizationQuery.QUOTA_LIMIT]({
-      name,
-      namespace,
-      resource: 'memory',
-    }),
-    podMetricsQueries[ResourceUtilizationQuery.QUOTA_REQUEST]({
-      name,
-      namespace,
-      resource: 'memmory',
-    }),
+    podMetricsQueries[ResourceUtilizationQuery.MEMORY]({ name }),
+    podMetricsQueries[ResourceUtilizationQuery.QUOTA_LIMIT]({ name, resource: 'memory' }),
+    podMetricsQueries[ResourceUtilizationQuery.QUOTA_REQUEST]({ name, resource: 'memmory' }),
   ],
   [ResourceUtilizationQuery.CPU]: [
-    podMetricsQueries[ResourceUtilizationQuery.CPU]({ name, namespace }),
-    podMetricsQueries[ResourceUtilizationQuery.QUOTA_LIMIT]({
-      name,
-      namespace,
-      resource: 'cpu',
-    }),
-    podMetricsQueries[ResourceUtilizationQuery.QUOTA_REQUEST]({
-      name,
-      namespace,
-      resource: 'cpu',
-    }),
+    podMetricsQueries[ResourceUtilizationQuery.CPU]({ name }),
+    podMetricsQueries[ResourceUtilizationQuery.QUOTA_LIMIT]({ name, resource: 'cpu' }),
+    podMetricsQueries[ResourceUtilizationQuery.QUOTA_REQUEST]({ name, resource: 'cpu' }),
   ],
   [ResourceUtilizationQuery.FILESYSTEM]: [
-    podMetricsQueries[ResourceUtilizationQuery.FILESYSTEM]({
-      name,
-      namespace,
-    }),
+    podMetricsQueries[ResourceUtilizationQuery.FILESYSTEM]({ name }),
   ],
   [ResourceUtilizationQuery.NETWORK_IN]: [
-    podMetricsQueries[ResourceUtilizationQuery.NETWORK_IN]({
-      name,
-      namespace,
-    }),
+    podMetricsQueries[ResourceUtilizationQuery.NETWORK_IN]({ name }),
   ],
   [ResourceUtilizationQuery.NETWORK_OUT]: [
-    podMetricsQueries[ResourceUtilizationQuery.NETWORK_OUT]({
-      name,
-      namespace,
-    }),
+    podMetricsQueries[ResourceUtilizationQuery.NETWORK_OUT]({ name }),
   ],
 });
 
 export const getPodControllerMetricsQueries = (
   name: string,
-  namespace: string,
   type: string,
 ): { [key: string]: string[] } => ({
   [ResourceUtilizationQuery.MEMORY]: [
-    podControllerMetricsQueries[ResourceUtilizationQuery.MEMORY]({
-      name,
-      namespace,
-      type,
-    }),
+    podControllerMetricsQueries[ResourceUtilizationQuery.MEMORY]({ name, type }),
   ],
   [ResourceUtilizationQuery.CPU]: [
-    podControllerMetricsQueries[ResourceUtilizationQuery.CPU]({
-      name,
-      namespace,
-      type,
-    }),
+    podControllerMetricsQueries[ResourceUtilizationQuery.CPU]({ name, type }),
   ],
   [ResourceUtilizationQuery.FILESYSTEM]: [
-    podControllerMetricsQueries[ResourceUtilizationQuery.FILESYSTEM]({
-      name,
-      namespace,
-      type,
-    }),
+    podControllerMetricsQueries[ResourceUtilizationQuery.FILESYSTEM]({ name, type }),
   ],
   [ResourceUtilizationQuery.NETWORK_IN]: [
-    podControllerMetricsQueries[ResourceUtilizationQuery.NETWORK_IN]({
-      name,
-      namespace,
-      type,
-    }),
+    podControllerMetricsQueries[ResourceUtilizationQuery.NETWORK_IN]({ name, type }),
   ],
   [ResourceUtilizationQuery.NETWORK_OUT]: [
-    podControllerMetricsQueries[ResourceUtilizationQuery.NETWORK_OUT]({
-      name,
-      namespace,
-      type,
-    }),
+    podControllerMetricsQueries[ResourceUtilizationQuery.NETWORK_OUT]({ name, type }),
   ],
 });
 
@@ -153,8 +99,8 @@ export const useResourceMetricsQueries = (obj: K8sResourceKind): { [key: string]
   const [model] = useK8sModel(referenceFor(obj));
   if (model) {
     return model.id === 'pod'
-      ? getPodMetricsQueries(obj.metadata.name, obj.metadata.namespace)
-      : getPodControllerMetricsQueries(obj.metadata.name, obj.metadata.namespace, model.id);
+      ? getPodMetricsQueries(obj.metadata.name)
+      : getPodControllerMetricsQueries(obj.metadata.name, model.id);
   }
   return null;
 };

--- a/frontend/packages/dev-console/src/components/monitoring/queries.ts
+++ b/frontend/packages/dev-console/src/components/monitoring/queries.ts
@@ -146,9 +146,9 @@ export const topWorkloadMetricsQueries = (t: TFunction): MonitoringQuery[] => [
     humanize: humanizeDecimalBytesPerSec,
     byteDataType: ByteDataTypes.DecimalBytes,
     query: _.template(
-      `sum(irate(container_network_receive_bytes_total{namespace=~'<%= namespace %>'}[4h])
+      `sum(irate(container_network_receive_bytes_total{namespace='<%= namespace %>'}[4h])
           * on (namespace,pod) group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{
-          namespace=~'<%= namespace %>', workload=~'<%= workloadName %>', workload_type='<%= workloadType %>'}) by (pod)`,
+          namespace='<%= namespace %>', workload=~'<%= workloadName %>', workload_type='<%= workloadType %>'}) by (pod)`,
     ),
   },
 ];

--- a/frontend/public/components/utils/resource-metrics.tsx
+++ b/frontend/public/components/utils/resource-metrics.tsx
@@ -19,7 +19,7 @@ const ResourceMetricsDashboardCard: React.FC<ResourceMetricsDashboardCardProps> 
       <DashboardCardTitle>{props.title}</DashboardCardTitle>
     </DashboardCardHeader>
     <DashboardCardBody className="resource-metrics-dashboard__card-body">
-      <QueryBrowser queries={props.queries} disableZoom hideControls />
+      <QueryBrowser queries={props.queries} namespace={props.namespace} disableZoom hideControls />
     </DashboardCardBody>
   </DashboardCard>
 );
@@ -32,32 +32,37 @@ export const ResourceMetricsDashboard: React.FC<ResourceMetricsDashboardProps> =
       <Grid hasGutter>
         <GridItem xl={6} lg={12}>
           <ResourceMetricsDashboardCard
-            title={t('public~Memory usage')}
+            namespace={obj.metadata.namespace}
             queries={queries[ResourceUtilizationQuery.MEMORY]}
+            title={t('public~Memory usage')}
           />
         </GridItem>
         <GridItem xl={6} lg={12}>
           <ResourceMetricsDashboardCard
-            title={t('public~CPU usage')}
+            namespace={obj.metadata.namespace}
             queries={queries[ResourceUtilizationQuery.CPU]}
+            title={t('public~CPU usage')}
           />
         </GridItem>
         <GridItem xl={6} lg={12}>
           <ResourceMetricsDashboardCard
-            title={t('public~Filesystem')}
+            namespace={obj.metadata.namespace}
             queries={queries[ResourceUtilizationQuery.FILESYSTEM]}
+            title={t('public~Filesystem')}
           />
         </GridItem>
         <GridItem xl={6} lg={12}>
           <ResourceMetricsDashboardCard
-            title={t('public~Network in')}
+            namespace={obj.metadata.namespace}
             queries={queries[ResourceUtilizationQuery.NETWORK_IN]}
+            title={t('public~Network in')}
           />
         </GridItem>
         <GridItem xl={6} lg={12}>
           <ResourceMetricsDashboardCard
-            title={t('public~Network out')}
+            namespace={obj.metadata.namespace}
             queries={queries[ResourceUtilizationQuery.NETWORK_OUT]}
+            title={t('public~Network out')}
           />
         </GridItem>
       </Grid>
@@ -66,6 +71,7 @@ export const ResourceMetricsDashboard: React.FC<ResourceMetricsDashboardProps> =
 };
 
 type ResourceMetricsDashboardCardProps = {
+  namespace?: string;
   title: string;
   queries: string[];
 };


### PR DESCRIPTION
- Add namespace prop to QueryBrowser in ResourceMetricsDashboardCard component, which causes all queries to be run as namespace-scoped requests to the thanos tenancy endpoint.
- Remove namespace from all PromQL queries defined in `frontend/packages/console-shared/src/promql/resource-metrics.ts`. These queries will always be run as namespace-scoped tenancy endpoint requests, so including the namespace in the PromQL query is redundant.
- Adjust dev console top workload metrics "Recieve bandwidth" PromQL query to use `namespace=` rather than `namespace=~`. This was causing a `400: Bad Request` when requests had `namespace` in the URL query parameters.