### PR TITLE
Bug 2017732: Prevent creation of encryption enabled storageclass without KMS connection set

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-storage-class-form/ocs-storage-class-form.tsx
@@ -356,6 +356,7 @@ const ExistingKMSDropDown: React.FC<ExistingKMSDropDownProps> = ({
 
 export const StorageClassEncryptionKMSID: React.FC<ProvisionerProps> = ({
   parameterKey,
+  parameterValue,
   onParamChange,
 }) => {
   const { t } = useTranslation();
@@ -364,7 +365,11 @@ export const StorageClassEncryptionKMSID: React.FC<ProvisionerProps> = ({
   const [isExistingKms, setIsExistingKms] = React.useState<boolean>(true);
   const [errorMessage, setErrorMessage] = React.useState<string>('');
   const [progress, setInProgress] = React.useState<boolean>(false);
-  const [serviceName, setServiceName] = React.useState<string>('');
+  /** Initializing with parameterValue for the case where user selects a connection from the dropdown,
+   *  but, then un-checks the encryption checkbox, and checks it back again. Now, the dropdown will
+   *  show the last selected connection name in the "ExistingKMSDropDown".
+   */
+  const [serviceName, setServiceName] = React.useState<string>(parameterValue);
 
   const csiCMWatchResource: WatchK8sResource = {
     kind: ConfigMapModel.kind,

--- a/frontend/packages/ceph-storage-plugin/src/utils/ocs-storage-class-params.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/ocs-storage-class-params.tsx
@@ -91,6 +91,7 @@ export const StorageClassFormProvisoners: ExtensionSCProvisionerProp = Object.fr
           hintText: 'A unique ID matching KMS ConfigMap',
           Component: StorageClassEncryptionKMSID,
           visible: (params) => params?.encrypted?.value === 'true',
+          required: (params) => params?.encrypted?.value === 'true',
         },
         thickProvision: {
           name: 'Enable Thick Provisioning',

--- a/frontend/packages/console-plugin-sdk/src/typings/storage-class-params.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/storage-class-params.ts
@@ -33,7 +33,7 @@ export type ExtensionSCProvisionerProp = {
           hintText: string;
           value?: string;
           visible?: (params?: any) => boolean;
-          required?: boolean;
+          required?: boolean | ((params?: any) => boolean);
           Component?: React.ComponentType<ProvisionerProps>;
         };
       };


### PR DESCRIPTION
![Screenshot from 2021-10-28 12-37-55](https://user-images.githubusercontent.com/39404641/139205557-60257e69-7b29-40c6-90bb-91866538b880.png)

![Screenshot from 2021-10-28 12-38-04](https://user-images.githubusercontent.com/39404641/139205585-5a9d0602-7ee8-4d0c-b766-fc0f8ceb3999.png)
