### PR TITLE
Bug 2005179: Pass pod toolbar filters to `useListPageFilter`

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -938,11 +938,11 @@ export const PodsPage: React.FC<PodPageProps> = ({
     fieldSelector,
   });
 
-  const [data, filteredData, onFilterChange] = useListPageFilter(pods, undefined, {
+  const filters = React.useMemo(() => getFilters(t), [t]);
+
+  const [data, filteredData, onFilterChange] = useListPageFilter(pods, filters, {
     name: { selected: [nameFilter] },
   });
-
-  const filters = React.useMemo(() => getFilters(t), [t]);
 
   return (
     userSettingsLoaded && (


### PR DESCRIPTION
The filters were not passed to the hook, so they were not applied. This
was a regression in 4.9 when we refactored the pod list to use the new
table components.

/cc @rawagner @zherman0 