### PR TITLE
Bug 2018380: Update and migrate docs links to access.redhat.com

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -481,7 +481,7 @@ func main() {
 
 		if *fUserAuth == "openshift" {
 			// Scopes come from OpenShift documentation
-			// https://docs.openshift.com/container-platform/3.9/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients
+			// https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/authentication_and_authorization/using-service-accounts-as-oauth-client
 			//
 			// TODO(ericchiang): Support other scopes like view only permissions.
 			scopes = []string{"user:full"}

--- a/dynamic-demo-plugin/README.md
+++ b/dynamic-demo-plugin/README.md
@@ -42,7 +42,7 @@ oc apply -f oc-manifest.yaml
 ```
 
 Note that the `Service` exposing the HTTP server is annotated to have a signed
-[service serving certificate](https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html)
+[service serving certificate](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/security_and_compliance/configuring-certificates#add-service-serving)
 generated and mounted into the image. This allows us to run the server with HTTP/TLS enabled, using
 a trusted CA certificate.
 
@@ -80,7 +80,7 @@ An example proxy request path from plugin to `helm-charts` service,
 in `helm` namespace to list ten helm releases:
 `/api/proxy/namespace/helm/service/helm-charts:8443/releases?limit=10`
 
-Proxied request will use [service CA bundle](https://docs.openshift.com/container-platform/4.8/security/certificate_types_descriptions/service-ca-certificates.html) by default. The service must use HTTPS.
+Proxied request will use [service CA bundle](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/security_and_compliance/certificate-types-and-descriptions#cert-types-service-ca-certificates) by default. The service must use HTTPS.
 If the service uses a custom service CA, the `caCertificate` field
 must contain the certificate bundle. In case the service proxy request
 needs to contain logged-in user's OpenShift access token, the `authorize`

--- a/frontend/packages/dev-console/locales/en/devconsole.json
+++ b/frontend/packages/dev-console/locales/en/devconsole.json
@@ -568,7 +568,7 @@
   "Average Container bandwidth by Pod: received": "Average Container bandwidth by Pod: received",
   "Average Container bandwidth by Pod: transmitted": "Average Container bandwidth by Pod: transmitted",
   "Successfully updated the project access.": "Successfully updated the project access.",
-  "Project access allows you to add or remove a user's access to the project. More advanced management of role-based access control appear in <1>Roles</1> and <4>Role Bindings</4>. For more information, see the <7>role-based access control documentation</7> .": "Project access allows you to add or remove a user's access to the project. More advanced management of role-based access control appear in <1>Roles</1> and <4>Role Bindings</4>. For more information, see the <7>role-based access control documentation</7> .",
+  "Project access allows you to add or remove a user's access to the project. More advanced management of role-based access control appear in <1>Roles</1> and <4>Role Bindings</4>. For more information, see the <7>role-based access control documentation</7>.": "Project access allows you to add or remove a user's access to the project. More advanced management of role-based access control appear in <1>Roles</1> and <4>Role Bindings</4>. For more information, see the <7>role-based access control documentation</7>.",
   "Add access": "Add access",
   "Role": "Role",
   "Select a role": "Select a role",

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -8,6 +8,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import {
   ContainerDropdown,
   history,
+  isUpstream,
   PageHeading,
   ResourceLink,
   openshiftHelpBase,
@@ -59,6 +60,10 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
   const resourceKind = modelFor(kindForCRDResource).crd ? kindForCRDResource : kind;
   const isFormClean = _.every(values.healthChecks, { modified: false });
 
+  const healthLink = isUpstream()
+    ? `${openshiftHelpBase}applications/application-health.html`
+    : `${openshiftHelpBase}html/building_applications/application-health`;
+
   const handleSelectContainer = (containerName: string) => {
     const containerIndex = _.findIndex(resource.spec.template.spec.containers, [
       'name',
@@ -81,12 +86,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
         title={
           <>
             {pageTitle}
-            <Button
-              variant="link"
-              component="a"
-              href={`${openshiftHelpBase}applications/application-health.html`}
-              target="_blank"
-            >
+            <Button variant="link" component="a" href={healthLink} target="_blank">
               {t('devconsole~Learn more')} <ExternalLinkAltIcon />
             </Button>
           </>

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import {
   LoadingBox,
+  isUpstream,
   openshiftHelpBase,
   PageHeading,
   ExternalLink,
@@ -40,6 +41,10 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ namespace, roleBindings, 
   const filteredRoleBindings = filterRoleBindings(roleBindings.data, Object.keys(roles.data));
 
   const userRoleBindings: UserRoleBinding[] = getUserRoleBindings(filteredRoleBindings);
+
+  const rbacLink = isUpstream()
+    ? `${openshiftHelpBase}authentication/using-rbac.html`
+    : `${openshiftHelpBase}html/authentication_and_authorization/using-rbac`;
 
   const initialValues = {
     projectAccess: roleBindings.loaded && userRoleBindings,
@@ -113,10 +118,7 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ namespace, roleBindings, 
             Role Bindings
           </Link>
           . For more information, see the{' '}
-          <ExternalLink href={`${openshiftHelpBase}authentication/using-rbac.html`}>
-            role-based access control documentation
-          </ExternalLink>{' '}
-          .
+          <ExternalLink href={rbacLink}>role-based access control documentation</ExternalLink>.
         </Trans>
       </PageHeading>
       {roleBindings.loadError ? (

--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ChartDonut, ChartLegend, ChartLabel } from '@patternfly/react-charts';
 import { useTranslation } from 'react-i18next';
-import { ExternalLink, openshiftHelpBase } from '@console/internal/components/utils';
+import { ExternalLink, isUpstream, openshiftHelpBase } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { PrometheusHealthPopupProps } from '@console/plugin-sdk';
 import {
@@ -31,6 +31,10 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
 
   const isWaitingOrDisabled = _isWaitingOrDisabled(metrics);
   const isError = _isError(metrics);
+
+  const insightsLink = isUpstream()
+    ? `${openshiftHelpBase}support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html`
+    : `${openshiftHelpBase}html/support/remote-health-monitoring-with-connected-clusters#using-insights-to-identify-issues-with-your-cluster`;
 
   const riskKeys = {
     // t('insights-plugin~low')
@@ -122,10 +126,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
           </div>
         )}
         {(isWaitingOrDisabled || isError) && (
-          <ExternalLink
-            href={`${openshiftHelpBase}support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html`}
-            text={t('insights-plugin~More about Insights')}
-          />
+          <ExternalLink href={insightsLink} text={t('insights-plugin~More about Insights')} />
         )}
       </div>
     </div>

--- a/frontend/packages/knative-plugin/README.md
+++ b/frontend/packages/knative-plugin/README.md
@@ -6,4 +6,4 @@ To add and manage all things Serverless (Knative Services, Revisions, Routes) yo
 
 Read more here:
 
-https://docs.openshift.com/container-platform/4.2/serverless/installing-openshift-serverless.html
+https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/administration-guide#install-serverless-operator

--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/consts.ts
@@ -17,4 +17,4 @@ export const CDI_PVC_PHASE_RUNNING = 'Running';
 export const CDI_UPLOAD_OS_URL_PARAM = 'os';
 
 export const CDI_UPLOAD_SUPPORTED_TYPES_URL =
-  'https://docs.openshift.com/container-platform/4.8/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.html#virt-cdi-supported-operations-matrix_virt-importing-virtual-machine-images-datavolumes';
+  'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/virtualization/virtual-machines#virt-cdi-supported-operations-matrix_virt-importing-virtual-machine-images-datavolumes';

--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { isUpstream } from '../../../utils/common';
+import { isUpstream } from '@console/internal/components/utils';
 import {
   CENTOS,
   CENTOS_EXAMPLE_CONTAINER,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateSupport.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/VMTemplateSupport.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ExternalLink } from '@console/internal/components/utils';
+import { ExternalLink, isUpstream } from '@console/internal/components/utils';
 import { SUPPORT_URL } from '../../constants/vm-templates';
-import { isUpstream } from '../../utils/common';
 
 const VMTemplateSupport: React.FC<VMTemplateSupportProps> = ({ details }) => {
   const { t } = useTranslation();

--- a/frontend/packages/kubevirt-plugin/src/constants/vm-templates/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm-templates/constants.ts
@@ -7,9 +7,9 @@ export const BOOT_SOURCE_REQUIRED = 'Boot source required';
 
 export const SUPPORT_URL = 'https://access.redhat.com/articles/4234591';
 export const SNAPSHOT_SUPPORT_URL =
-  'https://docs.openshift.com/container-platform/4.8/storage/container_storage_interface/persistent-storage-csi-snapshots.html';
+  'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/storage/using-container-storage-interface-csi#persistent-storage-csi-snapshots';
 
 // SEAL_BOOT_SOURCE_URL is temp until D/S docs are ready
 // remove comment once changed to permenant URL
 export const SEAL_BOOT_SOURCE_URL =
-  'https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/chap-templates#Sealing_Virtual_Machines_in_Preparation_for_Deployment_as_Templates';
+  'https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/chap-templates#Sealing_Virtual_Machines_in_Preparation_for_Deployment_as_Templates';

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/default-os-selection.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/default-os-selection.ts
@@ -1,6 +1,6 @@
+import { isUpstream } from '@console/internal/components/utils';
 import { TemplateKind } from '@console/internal/module/k8s';
 import { getName } from '../../selectors';
-import { isUpstream } from '../../utils/common';
 import { ObjectEnum } from '../object-enum';
 
 export class OSSelection extends ObjectEnum<string> {

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-support-modal.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-support-modal.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import { isUpstream } from '@console/internal/components/utils';
 import { TemplateKind } from '@console/internal/module/k8s';
 import { createSupportModal } from '../components/modals/support-modal/support-modal';
 import { TEMPLATE_WARN_SUPPORT } from '../constants';
 import { getTemplateSupport, isCommonTemplate } from '../selectors/vm-template/basic';
-import { isUpstream } from '../utils/common';
 import { useLocalStorage } from './use-local-storage';
 
 export type SupportModalFunction = (template: TemplateKind, onConfirm: VoidFunction) => void;

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/basic.ts
@@ -1,4 +1,5 @@
 import { TFunction } from 'i18next';
+import { isUpstream } from '@console/internal/components/utils';
 import { TemplateKind } from '@console/internal/module/k8s';
 import {
   ANNOTATIONS,
@@ -16,7 +17,6 @@ import {
 import { VirtualMachineModel } from '../../models';
 import { TemplateItem } from '../../types/template';
 import { VMKind } from '../../types/vm';
-import { isUpstream } from '../../utils/common';
 import { getAnnotation } from '../selectors';
 
 export const selectVM = (vmTemplate: TemplateKind): VMKind =>

--- a/frontend/packages/kubevirt-plugin/src/utils/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/common.ts
@@ -27,5 +27,3 @@ export const omitEmpty = (obj, justUndefined = false) => {
 
 export const isSetEqual = (set: Set<any>, otherSet: Set<any>) =>
   set.size === otherSet.size && [...set].every((s) => otherSet.has(s));
-
-export const isUpstream = () => window.SERVER_FLAGS.branding === 'okd';

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -27,13 +27,13 @@ export const CLOUD_INIT_MISSING_USERNAME =
   'No username set, see operating system documentation for the default username.';
 export const CLOUD_INIT_DOC_LINK = 'https://cloudinit.readthedocs.io/en/latest/index.html';
 export const STORAGE_CLASS_SUPPORTED_MATRIX_DOC_LINK =
-  'https://docs.openshift.com/container-platform/4.8/virt/virtual_machines/virtual_disks/virt-features-for-storage.html';
+  'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/virtualization/virtual-machines#virt-features-for-storage';
 export const STORAGE_CLASS_SUPPORTED_RHV_LINK =
   'https://docs.openshift.com/container-platform/4.8/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html';
 export const STORAGE_CLASS_SUPPORTED_VMWARE_LINK =
   'https://docs.openshift.com/container-platform/4.8/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html';
 export const NODE_PORTS_LINK =
-  'https://docs.openshift.com/container-platform/4.8/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.html#nw-using-nodeport_configuring-ingress-cluster-traffic-nodeport';
+  'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/networking/configuring-ingress-cluster-traffic#nw-using-nodeport_configuring-ingress-cluster-traffic-nodeport';
 
 export const PREALLOCATION_DATA_VOLUME_LINK =
-  'https://docs.openshift.com/container-platform/4.8/virt/virtual_machines/virtual_disks/virt-using-preallocation-for-datavolumes.html';
+  'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/virtualization/virtual-machines#virt-using-preallocation-for-datavolumes';

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -46,6 +46,7 @@ import {
   KebabOption,
   resourceObjPath,
   KebabAction,
+  isUpstream,
   openshiftHelpBase,
   Page,
 } from '@console/internal/components/utils';
@@ -717,16 +718,15 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
 export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProps> = (props) => {
   const { t } = useTranslation();
   const title = t('olm~Installed Operators');
+  const olmLink = isUpstream()
+    ? `${openshiftHelpBase}operators/understanding/olm-what-operators-are.html`
+    : `${openshiftHelpBase}html/operators/understanding-operators#olm-what-operators-are`;
   const helpText = (
     <Trans ns="olm">
       Installed Operators are represented by ClusterServiceVersions within this Namespace. For more
       information, see the{' '}
-      <ExternalLink
-        href={`${openshiftHelpBase}operators/understanding/olm-what-operators-are.html`}
-      >
-        Understanding Operators documentation
-      </ExternalLink>
-      . Or create an Operator and ClusterServiceVersion using the{' '}
+      <ExternalLink href={olmLink}>Understanding Operators documentation</ExternalLink>. Or create
+      an Operator and ClusterServiceVersion using the{' '}
       <ExternalLink href="https://sdk.operatorframework.io/">Operator SDK</ExternalLink>.
     </Trans>
   );

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -11,6 +11,7 @@ import {
   FieldLevelHelp,
   Firehose,
   history,
+  isUpstream,
   NsDropdown,
   openshiftHelpBase,
   BreadCrumbs,
@@ -500,6 +501,10 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   const showMonitoringCheckbox =
     operatorRequestsMonitoring && _.startsWith(selectedTargetNamespace, 'openshift-');
 
+  const monitoringLink = isUpstream()
+    ? `${openshiftHelpBase}monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring`
+    : `${openshiftHelpBase}html/monitoring/configuring-the-monitoring-stack#maintenance-and-support_configuring-the-monitoring-stack`;
+
   const suggestedNamespaceDetails = isSuggestedNamespaceSelected && (
     <>
       <Alert
@@ -542,12 +547,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
                 enabling monitoring voids user support. Enabling cluster monitoring for non-Red Hat
                 operators can lead to malicious metrics data overriding existing cluster metrics.
                 For more information, see the{' '}
-                <ExternalLink
-                  href={`${openshiftHelpBase}monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring`}
-                >
-                  cluster monitoring documentation
-                </ExternalLink>
-                .
+                <ExternalLink href={monitoringLink}>cluster monitoring documentation</ExternalLink>.
               </Trans>
             </Alert>
           )}

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -82,6 +82,7 @@ import {
   Firehose,
   FirehoseResource,
   HorizontalNav,
+  isUpstream,
   openshiftHelpBase,
   ReleaseNotesLink,
   ResourceLink,
@@ -381,10 +382,13 @@ export const CurrentVersionHeader: React.FC<CurrentVersionProps> = ({ cv }) => {
 };
 
 export const ChannelDocLink: React.FC<{}> = () => {
+  const upgradeLink = isUpstream()
+    ? `${openshiftHelpBase}updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor`
+    : `${openshiftHelpBase}html/updating_clusters/updating-cluster-between-minor#understanding-upgrade-channels_updating-cluster-between-minor`;
   const { t } = useTranslation();
   return (
     <ExternalLink
-      href={`${openshiftHelpBase}updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor`}
+      href={upgradeLink}
       text={t('public~Learn more about OpenShift update channels')}
     />
   );

--- a/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
+++ b/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
@@ -15,7 +15,7 @@ import { TFunction } from 'i18next';
 import { RadioInput } from '../radio';
 import { CLUSTER_VERSION_DEFAULT_UPSTREAM_SERVER_URL_PLACEHOLDER } from '@console/shared/src/constants';
 import { TextInput } from '@patternfly/react-core';
-import { openshiftHelpBase } from '@console/internal/components/utils';
+import { isUpstream, openshiftHelpBase } from '@console/internal/components/utils';
 
 export const ConfigureClusterUpstreamModal = withHandlePromise(
   (props: ConfigureClusterUpstreamModalProps) => {
@@ -44,6 +44,10 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
     };
     const { t } = useTranslation();
 
+    const updateLink = isUpstream()
+      ? `${openshiftHelpBase}updating/installing-update-service.html`
+      : `${openshiftHelpBase}html/updating_clusters/installing-update-service`;
+
     return (
       <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
         <ModalTitle>{t('public~Edit upstream configuration')}</ModalTitle>
@@ -55,7 +59,7 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
           </p>
           <p>
             <ExternalLink
-              href={`${openshiftHelpBase}updating/installing-update-service.html`}
+              href={updateLink}
               text={t('public~Learn more about OpenShift local update services.')}
             />
           </p>

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import { Popover, Button } from '@patternfly/react-core';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
-import { ExternalLink, openshiftHelpBase } from '@console/internal/components/utils';
+import { ExternalLink, isUpstream, openshiftHelpBase } from '@console/internal/components/utils';
 
 import { FLAGS } from '@console/shared';
 import { k8sCreate, referenceFor } from '../../module/k8s';
@@ -135,6 +135,10 @@ const CreateNamespaceModalWithTranslation = connect(
         );
       };
 
+      const projectsLink = isUpstream()
+        ? `${openshiftHelpBase}applications/projects/working-with-projects.html`
+        : `${openshiftHelpBase}html/building_applications/projects#working-with-projects`;
+
       return (
         <form
           onSubmit={this._submit.bind(this)}
@@ -153,9 +157,7 @@ const CreateNamespaceModalWithTranslation = connect(
                   )}
                 </p>
                 <p>
-                  <ExternalLink
-                    href={`${openshiftHelpBase}applications/projects/working-with-projects.html`}
-                  >
+                  <ExternalLink href={projectsLink}>
                     {t('public~Learn more about working with projects')}
                   </ExternalLink>
                 </p>

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -2,8 +2,14 @@
 export const openshiftHelpBase =
   window.SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';
 
+export const isUpstream = () => window.SERVER_FLAGS.branding === 'okd';
+
 export const getNetworkPolicyDocLink = (openshiftFlag: boolean) => {
-  return openshiftFlag
+  const networkLink = isUpstream()
     ? `${openshiftHelpBase}networking/network_policy/about-network-policy.html`
+    : `${openshiftHelpBase}html/networking/network-policy#about-network-policy`;
+
+  return openshiftFlag
+    ? networkLink
     : 'https://kubernetes.io/docs/concepts/services-networking/network-policies/';
 };

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -223,7 +223,7 @@ export const showReleaseNotes = (): boolean => {
   return window.SERVER_FLAGS.branding === 'ocp';
 };
 
-// example link: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-4
+// example link: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/release_notes/ocp-4-9-release-notes#ocp-4-9-4
 export const getReleaseNotesLink = (version: string): string => {
   if (!showReleaseNotes()) {
     return null;
@@ -239,7 +239,7 @@ export const getReleaseNotesLink = (version: string): string => {
     return null;
   }
 
-  return `https://docs.openshift.com/container-platform/${major}.${minor}/release_notes/ocp-${major}-${minor}-release-notes.html#ocp-${major}-${minor}-${patch}`;
+  return `https://access.redhat.com/documentation/en-us/openshift_container_platform/${major}.${minor}/html/release_notes/ocp-${major}-${minor}-release-notes#ocp-${major}-${minor}-${patch}`;
 };
 
 export const getClusterName = (): string => window.SERVER_FLAGS.kubeAPIServerURL || null;

--- a/pkg/auth/auth_openshift.go
+++ b/pkg/auth/auth_openshift.go
@@ -15,7 +15,7 @@ import (
 )
 
 // openShiftAuth implements OpenShift Authentication as defined in:
-// https://docs.openshift.com/container-platform/3.9/architecture/additional_concepts/authentication.html
+// https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/authentication_and_authorization/understanding-authentication
 type openShiftAuth struct {
 	cookiePath    string
 	secureCookies bool
@@ -45,7 +45,7 @@ func validateAbsURL(value string) error {
 
 func newOpenShiftAuth(ctx context.Context, c *openShiftConfig) (oauth2.Endpoint, *openShiftAuth, error) {
 	// Use metadata discovery to determine the OAuth2 token and authorization URL.
-	// https://docs.openshift.com/container-platform/3.9/architecture/additional_concepts/authentication.html#oauth-server-metadata
+	// https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/authentication_and_authorization/configuring-internal-oauth#oauth-server-metadata_configuring-internal-oauth
 	wellKnownURL := strings.TrimSuffix(c.issuerURL, "/") + "/.well-known/oauth-authorization-server"
 
 	req, err := http.NewRequest(http.MethodGet, wellKnownURL, nil)


### PR DESCRIPTION
**Fixes**: 
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2018380

**Analysis / Root cause**: 
In line with efforts currently under way for OCM, it seems we should update and migrate all docs.openshift.com links to access.redhat.com.

**Solution Description**: 
This updates all links for 4.9 and to their multi-page HTML locations on access.redhat.com.

Because kubevirt-plugin is a separate bugzilla component, and OpenShift Virtualization 4.9 has yet to be released, that will be handled separately.

Also, since these docs links are version specific, this will need to be manually backported (instead of cherry-picked) to supported stable releases.

**Screen shots / Gifs for design review**: 

**Unit test coverage report**: 

**Test setup:**

**Browser conformance**: 
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
