### PR TITLE
Bug 2002559: User preference for topology list view does not follow when a new namespace is created

### DIFF
--- a/frontend/packages/topology/src/components/page/TopologyPage.tsx
+++ b/frontend/packages/topology/src/components/page/TopologyPage.tsx
@@ -101,10 +101,10 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({
     (queryParams.get('view') as TopologyViewType) || topologyViewState || defaultViewType;
 
   React.useEffect(() => {
-    if (!queryParams.get('view')) {
+    if (!queryParams.get('view') && loaded) {
       setQueryArgument('view', topologyViewState || defaultViewType);
     }
-  }, [defaultViewType, topologyViewState, queryParams]);
+  }, [defaultViewType, topologyViewState, queryParams, loaded]);
 
   const onViewChange = React.useCallback(
     (newViewType: TopologyViewType) => {


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-6330

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
the url had view hardcoded within it, which resulted in always showing the graph view
&& in cluster, where user-settings are stored server side, before they got loaded, the page would load and show the default graph view

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
removed the hardcoding, now the value is taken automatically from the preferences

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![userPreferenceHelmTopology](https://user-images.githubusercontent.com/20089340/132651548-e94c3ec8-ba3e-4a5c-ac21-c6343cada444.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

1. Log in to the console
2. Goto the user preference page
3. Create a project from there
4. Set topology preference as a list, perspective preference as Administrator, and YAML as resource method preference
5. Reload the page
6. Went to developer perspective > Add
7. Create a workload (e.g. from **Helm Chart**, from **Git** )
8. Wait for topology to load ( expecting`list` view )

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge