### PR TITLE
Show failed PipelineRun log snippet on the log page

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.scss
@@ -27,6 +27,9 @@
     height: 100%;
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--md);
   }
+  &__logsnippet {
+    margin-top: var(--pf-global--spacer--sm);
+  }
   &__tasklist {
     max-width: 30%;
     min-width: 208px;

--- a/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
@@ -10,8 +10,10 @@ import { PipelineRunModel } from '../../../models';
 import { PipelineRunKind } from '../../../types';
 import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
 import { ColoredStatusIcon } from '../../pipelines/detail-page-tabs/pipeline-details/StatusIcon';
+import { ErrorDetailsWithStaticLog } from '../logs/log-snippet-types';
 import { getDownloadAllLogsCallback } from '../logs/logs-utils';
 import LogsWrapperComponent from '../logs/LogsWrapperComponent';
+import { getPLRLogSnippet } from '../logs/pipelineRunLogSnippet';
 import './PipelineRunLogs.scss';
 
 interface PipelineRunLogsProps {
@@ -85,6 +87,7 @@ class PipelineRunLogsWithTranslation extends React.Component<
     const { activeItem } = this.state;
     const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
     const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
+    const logDetails = getPLRLogSnippet(obj) as ErrorDetailsWithStaticLog;
 
     const taskCount = taskRuns.length;
     const downloadAllCallback =
@@ -163,6 +166,11 @@ class PipelineRunLogsWithTranslation extends React.Component<
                   obj,
                   ['status', 'conditions', 0, 'message'],
                   t('pipelines-plugin~No logs found'),
+                )}
+                {logDetails && (
+                  <div className="odc-pipeline-run-logs__logsnippet">
+                    {logDetails.staticMessage}
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
**Story:**  https://issues.redhat.com/browse/ODC-6403

**Descriptions:**
The "Logs" tab of a failed PipelineRun now includes the "Log snippet".

**Screenshots:**
![image](https://user-images.githubusercontent.com/2561818/139470467-101f10ce-1d6d-4a24-ac99-29456d798905.png)

