### PR TITLE
Gherkin to pick from a list of pipelines in Add flow

### DIFF
--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
@@ -158,3 +158,22 @@ Feature: Create Pipeline from Add Options
                   | git_url                                | builder_image | message                                                                         |
                   | https://github.com/sclorg/httpd-ex.git | httpd         | There are no pipeline templates available for Httpd and Deployment combination. |
                   | https://github.com/sclorg/nginx-ex.git | Nginx         | There are no pipeline templates available for Nginx and Deployment combination. |
+
+
+        @regression @to-do @odc-6372
+        Scenario Outline: Pick a pipeline from git : P-01-TC11
+            Given user has created a custom pipeline from yaml "<pipeline_yaml>" in "openshift" namespace
+              And user is at Import from Git form
+             When user enters Git Repo URL as "<git_url>"
+              And user enters Name as "<pipeline_name>" in General section
+              And user selects resource type as "<resource>"
+              And user selects Add Pipeline checkbox in Pipelines section
+              And user selects "<custom_pipeline_name>" pipeline from the pipeline dropdown menu
+              And user clicks Create button on Add page
+             Then user will be redirected to Topology page
+              And user is able to see workload "<pipeline_name>" in topology page
+
+        Examples:
+                  | pipeline_yaml                              | custom_pipeline_name         | git_url                                 | pipeline_name | resource          |
+                  | testData/customNodeDeployment.yaml         | s2i-nodejs-custom-deployment | https://github.com/sclorg/nodejs-ex.git | nodejs-ex-1   | Deployment        |
+                  | testData/customPythonDeploymentConfig.yaml | s2i-python-custom            | https://github.com/sclorg/django-ex.git | django-ex-1   | Deployment Config |

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/customNodeDeployment.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/customNodeDeployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: >
+      {"apiVersion":"tekton.dev/v1beta1","kind":"Pipeline","metadata":{"annotations":{"operator.tekton.dev/preserve-namespace":"true"},"labels":{"pipeline.openshift.io/runtime":"nodejs","pipeline.openshift.io/type":"kubernetes"},"name":"s2i-nodejs-deployment","namespace":"openshift","ownerReferences":[{"apiVersion":"operator.tekton.dev/v1alpha1","blockOwnerDeletion":true,"controller":true,"kind":"TektonAddon","name":"addon","uid":"3de62a04-ff64-4554-9cc2-48a013ba80e2"}]},"spec":{"params":[{"name":"APP_NAME","type":"string"},{"name":"GIT_REPO","type":"string"},{"name":"GIT_REVISION","type":"string"},{"name":"IMAGE_NAME","type":"string"},{"default":".","name":"PATH_CONTEXT","type":"string"},{"default":"14-ubi8","name":"VERSION","type":"string"}],"tasks":[{"name":"fetch-repository","params":[{"name":"url","value":"$(params.GIT_REPO)"},{"name":"revision","value":"$(params.GIT_REVISION)"},{"name":"subdirectory","value":""},{"name":"deleteExisting","value":"true"}],"taskRef":{"kind":"ClusterTask","name":"git-clone"},"workspaces":[{"name":"output","workspace":"workspace"}]},{"name":"build","params":[{"name":"IMAGE","value":"$(params.IMAGE_NAME)"},{"name":"TLSVERIFY","value":"false"},{"name":"PATH_CONTEXT","value":"$(params.PATH_CONTEXT)"},{"name":"VERSION","value":"$(params.VERSION)"}],"runAfter":["fetch-repository"],"taskRef":{"kind":"ClusterTask","name":"s2i-nodejs"},"workspaces":[{"name":"source","workspace":"workspace"}]},{"name":"deploy","params":[{"name":"SCRIPT","value":"oc
+      rollout status
+      deploy/$(params.APP_NAME)"}],"runAfter":["build"],"taskRef":{"kind":"ClusterTask","name":"openshift-client"}}],"workspaces":[{"name":"workspace"}]}}
+    operator.tekton.dev/preserve-namespace: 'true'
+  resourceVersion: '179924'
+  name: s2i-nodejs-custom-deployment
+  generation: 1
+  managedFields:
+    - apiVersion: tekton.dev/v1beta1
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:kubectl.kubernetes.io/last-applied-configuration': {}
+            'f:operator.tekton.dev/preserve-namespace': {}
+          'f:labels':
+            .: {}
+            'f:pipeline.openshift.io/runtime': {}
+            'f:pipeline.openshift.io/type': {}
+          'f:ownerReferences':
+            .: {}
+            'k:{"uid":"3de62a04-ff64-4554-9cc2-48a013ba80e2"}': {}
+        'f:spec':
+          .: {}
+          'f:params': {}
+          'f:tasks': {}
+          'f:workspaces': {}
+      manager: manifestival
+      operation: Update
+      time: '2021-10-29T07:50:46Z'
+  namespace: openshift
+  ownerReferences:
+    - apiVersion: operator.tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TektonAddon
+      name: addon
+      uid: 3de62a04-ff64-4554-9cc2-48a013ba80e2
+  labels:
+    pipeline.openshift.io/runtime: nodejs
+    pipeline.openshift.io/type: kubernetes
+spec:
+  params:
+    - name: APP_NAME
+      type: string
+    - name: GIT_REPO
+      type: string
+    - name: GIT_REVISION
+      type: string
+    - name: IMAGE_NAME
+      type: string
+    - default: .
+      name: PATH_CONTEXT
+      type: string
+    - default: 14-ubi8
+      name: VERSION
+      type: string
+  tasks:
+    - name: fetch-repository
+      params:
+        - name: url
+          value: $(params.GIT_REPO)
+        - name: revision
+          value: $(params.GIT_REVISION)
+        - name: subdirectory
+          value: ''
+        - name: deleteExisting
+          value: 'true'
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: build
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE_NAME)
+        - name: TLSVERIFY
+          value: 'false'
+        - name: PATH_CONTEXT
+          value: $(params.PATH_CONTEXT)
+        - name: VERSION
+          value: $(params.VERSION)
+      runAfter:
+        - fetch-repository
+      taskRef:
+        kind: ClusterTask
+        name: s2i-nodejs
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: deploy
+      params:
+        - name: SCRIPT
+          value: oc rollout status deploy/$(params.APP_NAME)
+      runAfter:
+        - build
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+  workspaces:
+    - name: workspace

--- a/frontend/packages/pipelines-plugin/integration-tests/testData/customPythonDeploymentConfig.yaml
+++ b/frontend/packages/pipelines-plugin/integration-tests/testData/customPythonDeploymentConfig.yaml
@@ -1,0 +1,109 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: >
+      {"apiVersion":"tekton.dev/v1beta1","kind":"Pipeline","metadata":{"annotations":{"operator.tekton.dev/preserve-namespace":"true"},"labels":{"pipeline.openshift.io/runtime":"python","pipeline.openshift.io/type":"openshift"},"name":"s2i-python","namespace":"openshift","ownerReferences":[{"apiVersion":"operator.tekton.dev/v1alpha1","blockOwnerDeletion":true,"controller":true,"kind":"TektonAddon","name":"addon","uid":"3de62a04-ff64-4554-9cc2-48a013ba80e2"}]},"spec":{"params":[{"name":"APP_NAME","type":"string"},{"name":"GIT_REPO","type":"string"},{"name":"GIT_REVISION","type":"string"},{"name":"IMAGE_NAME","type":"string"},{"default":".","name":"PATH_CONTEXT","type":"string"},{"default":"3.8-ubi8","name":"VERSION","type":"string"}],"tasks":[{"name":"fetch-repository","params":[{"name":"url","value":"$(params.GIT_REPO)"},{"name":"revision","value":"$(params.GIT_REVISION)"},{"name":"subdirectory","value":""},{"name":"deleteExisting","value":"true"}],"taskRef":{"kind":"ClusterTask","name":"git-clone"},"workspaces":[{"name":"output","workspace":"workspace"}]},{"name":"build","params":[{"name":"IMAGE","value":"$(params.IMAGE_NAME)"},{"name":"TLSVERIFY","value":"false"},{"name":"PATH_CONTEXT","value":"$(params.PATH_CONTEXT)"},{"name":"VERSION","value":"$(params.VERSION)"}],"runAfter":["fetch-repository"],"taskRef":{"kind":"ClusterTask","name":"s2i-python"},"workspaces":[{"name":"source","workspace":"workspace"}]},{"name":"deploy","params":[{"name":"SCRIPT","value":"oc
+      rollout status
+      dc/$(params.APP_NAME)"}],"runAfter":["build"],"taskRef":{"kind":"ClusterTask","name":"openshift-client"}}],"workspaces":[{"name":"workspace"}]}}
+    operator.tekton.dev/preserve-namespace: 'true'
+  resourceVersion: '179960'
+  name: s2i-python-custom
+  generation: 1
+  managedFields:
+    - apiVersion: tekton.dev/v1beta1
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:kubectl.kubernetes.io/last-applied-configuration': {}
+            'f:operator.tekton.dev/preserve-namespace': {}
+          'f:labels':
+            .: {}
+            'f:pipeline.openshift.io/runtime': {}
+            'f:pipeline.openshift.io/type': {}
+          'f:ownerReferences':
+            .: {}
+            'k:{"uid":"3de62a04-ff64-4554-9cc2-48a013ba80e2"}': {}
+        'f:spec':
+          .: {}
+          'f:params': {}
+          'f:tasks': {}
+          'f:workspaces': {}
+      manager: manifestival
+      operation: Update
+      time: '2021-10-29T07:50:47Z'
+  namespace: openshift
+  ownerReferences:
+    - apiVersion: operator.tekton.dev/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: TektonAddon
+      name: addon
+      uid: 3de62a04-ff64-4554-9cc2-48a013ba80e2
+  labels:
+    pipeline.openshift.io/runtime: python
+    pipeline.openshift.io/type: openshift
+spec:
+  params:
+    - name: APP_NAME
+      type: string
+    - name: GIT_REPO
+      type: string
+    - name: GIT_REVISION
+      type: string
+    - name: IMAGE_NAME
+      type: string
+    - default: .
+      name: PATH_CONTEXT
+      type: string
+    - default: 3.8-ubi8
+      name: VERSION
+      type: string
+  tasks:
+    - name: fetch-repository
+      params:
+        - name: url
+          value: $(params.GIT_REPO)
+        - name: revision
+          value: $(params.GIT_REVISION)
+        - name: subdirectory
+          value: ''
+        - name: deleteExisting
+          value: 'true'
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: build
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE_NAME)
+        - name: TLSVERIFY
+          value: 'false'
+        - name: PATH_CONTEXT
+          value: $(params.PATH_CONTEXT)
+        - name: VERSION
+          value: $(params.VERSION)
+      runAfter:
+        - fetch-repository
+      taskRef:
+        kind: ClusterTask
+        name: s2i-python
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: deploy
+      params:
+        - name: SCRIPT
+          value: oc rollout status dc/$(params.APP_NAME)
+      runAfter:
+        - build
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+  workspaces:
+    - name: workspace


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6372
Story: https://issues.redhat.com/browse/ODC-6405

Acceptance criteria:

- As a user importing my code, I should be able to view all of the available pipelines which my admin has provided for me to choose from, so that I can select the pipeline I want.
- As a user deploying an image, I should be able to view all of the available pipelines which my admin has provided for me to choose from, so that I can select the pipeline I want.
- As a user, when importing or deploying, there should be a default pipeline selected.
- As a user, when importing or deploying, as a pipeline is selected, I should be able to see the pipeline visualization.


**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]