### PR TITLE
Bug 2006060: Redirect to object dashboard for MCG only

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/odf-system-dashboard.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/odf-system-dashboard.tsx
@@ -29,7 +29,7 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
   const isObjectServiceAvailable = useFlag(MCG_FLAG);
   const isCephAvailable = useFlag(CEPH_FLAG);
   const { systemName } = rest.match.params;
-  const dashboardTab = isCephAvailable === false && isObjectServiceAvailable ? OBJECT : BLOCK_FILE;
+  const dashboardTab = !isCephAvailable && isObjectServiceAvailable ? OBJECT : BLOCK_FILE;
   const defaultDashboard = React.useRef(dashboardTab);
 
   const pages: Page[] = [

--- a/frontend/packages/ceph-storage-plugin/src/queries/ceph-queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/queries/ceph-queries.ts
@@ -48,10 +48,6 @@ export const INDEPENDENT_UTILIZATION_QUERIES = {
     'sum((kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_right() kube_pod_spec_volumes_persistentvolumeclaims_info) * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"}))',
 };
 
-export const STORAGE_HEALTH_QUERIES = {
-  [StorageDashboardQuery.CEPH_STATUS_QUERY]: 'ceph_health_status',
-};
-
 export const DATA_RESILIENCY_QUERY = {
   [StorageDashboardQuery.RESILIENCY_PROGRESS]: '(ceph_pg_clean and ceph_pg_active)/ceph_pg_total',
 };

--- a/frontend/packages/ceph-storage-plugin/src/queries/odf-queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/queries/odf-queries.ts
@@ -4,7 +4,6 @@ export enum ODFQueries {
   THROUGHPUT = 'THROUGHPUT',
   RAW_CAPACITY = 'RAW_CAP',
   USED_CAPACITY = 'USED_CAP',
-  HEALTH = 'HEALTH',
 }
 
 export const ODF_QUERIES: { [key in ODFQueries]: string } = {
@@ -13,6 +12,4 @@ export const ODF_QUERIES: { [key in ODFQueries]: string } = {
   [ODFQueries.THROUGHPUT]: 'odf_system_throughput_total_bytes',
   [ODFQueries.RAW_CAPACITY]: 'odf_system_raw_capacity_total_bytes',
   [ODFQueries.USED_CAPACITY]: 'odf_system_raw_capacity_used_bytes',
-  [ODFQueries.HEALTH]:
-    '(label_replace(odf_system_map , "managedBy", "$1", "target_name", "(.*)"))  * on (namespace, managed_by) group_right(storage_system) odf_system_health_status',
 };


### PR DESCRIPTION
This PR incorporates a correction to https://github.com/openshift/console/pull/10117 which got missed when patch #10117 was sent.

**Correction:** For MCG only system, CEPH_FLAG was getting set as `undefined` instead of `false`.