### PR TITLE
Bug 2013109: Refreshing console from toaster taking to Install Operator

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -379,7 +379,13 @@ const PollConsoleUpdates = React.memo(() => {
       {
         dismiss: true,
         label: t('public~Refresh web console'),
-        callback: () => window.location.reload(),
+        callback: () => {
+          if (window.location.pathname.includes('/operatorhub/subscribe')) {
+            window.location.href = '/operatorhub';
+          } else {
+            window.location.reload();
+          }
+        },
       },
     ],
     onClose: toastCallback,


### PR DESCRIPTION
This PR will attempt to improve the experience when following the
console update toaster to refresh the UI after an operator is installed.

Before this PR the user would be taken back to the operator install page
with an error that the operator is already installed.

After this PR the user will be taken back to the operatorhub page.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2013109