### PR TITLE
Look for v1alpha2 devworkspace resources when proxying to the backend

### DIFF
--- a/pkg/terminal/proxy.go
+++ b/pkg/terminal/proxy.go
@@ -61,7 +61,7 @@ func NewProxy(serviceTLS *tls.Config, TLSClientConfig *tls.Config, clusterEndpoi
 var (
 	WorkspaceGroupVersionResource = schema.GroupVersionResource{
 		Group:    "workspace.devfile.io",
-		Version:  "v1alpha1",
+		Version:  "v1alpha2",
 		Resource: "devworkspaces",
 	}
 


### PR DESCRIPTION
The DevWorkspace Operator is looking to deprecate v1alpha1 in the next couple of versions. In order to make the console compatible with these changes, we have to make the backend part of the terminal rely on v1alpha2 instead


Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>