### PR TITLE
Bug 2018042:  HorizontalPodAutoscaler CPU averageValue did not show up in HPA metrics GUI

### DIFF
--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -78,7 +78,7 @@ const MetricsTable: React.FC<MetricsTableProps> = ({ obj: hpa }) => {
     );
     const currentValue = targetUtilization
       ? getResourceUtilization(current)
-      : resource?.current?.averageValue;
+      : current?.resource?.current?.averageValue;
     const targetValue = targetUtilization ? `${targetUtilization}%` : resource.target.averageValue;
 
     return <MetricsRow key={key} type={type} current={currentValue} target={targetValue} />;


### PR DESCRIPTION

### Before:
![Screen Shot 2021-11-01 at 7 45 41 PM](https://user-images.githubusercontent.com/15249132/139862632-ceaf477f-63c4-4248-9c26-0d079dfbedf2.png)

### ![Screen Shot 2021-11-01 at 7 44 37 PM](https://user-images.githubusercontent.com/15249132/139862697-fcea135d-3d68-4525-bcb4-d42f7064ec13.png)