### PR TITLE
Bug 2019591: Operator install modal padding vars assigned to correct class so that scroll shadows are positioned correctly.

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -198,18 +198,15 @@ $catalog-tile-width: $co-m-catalog-tile-width;
     right: 0;
     top: 4.75rem; // --pf-c-page__header--MinHeight
 
-    .pf-c-modal-box {
-      --pf-c-modal-box__body--PaddingTop: 0 !important;
-      --pf-c-modal-box__body--PaddingRight: 0 !important;
-      --pf-c-modal-box__body--PaddingLeft: 0 !important;
-      --pf-c-modal-box__body--last-child--PaddingBottom: 0 !important;
-    }
-
     .pf-c-modal-box__body {
       // Required to position scroll shadows correctly on Chrome
       display: flex;
       flex-direction: column;
       margin: 0 !important;
+      --pf-c-modal-box__body--PaddingTop: 0 !important;
+      --pf-c-modal-box__body--PaddingRight: 0 !important;
+      --pf-c-modal-box__body--PaddingLeft: 0 !important;
+      --pf-c-modal-box__body--last-child--PaddingBottom: 0 !important;
     }
 
     .modal-body-inner-shadow-covers {


### PR DESCRIPTION


<img width="922" alt="Screen Shot 2021-11-02 at 5 51 09 PM" src="https://user-images.githubusercontent.com/1874151/139957947-dd5b6ee9-b8b2-4311-b02b-fdc13a11a4ee.png">
<img width="918" alt="Screen Shot 2021-11-02 at 5 49 50 PM" src="https://user-images.githubusercontent.com/1874151/139957966-e40c4a2a-82d7-48cf-bfad-9669ab343880.png">

 