### PR TITLE
Bug 2019717: cant delete VM with un-owned pvc attached

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/hooks/use-owned-volume-referenced-resources.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-owned-volume-referenced-resources.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceCommon, OwnerReference } from '@console/internal/module/k8s';
+import { PersistentVolumeClaimModel } from '../../../../public/models';
 import { VolumeReferencedObject, VolumeWrapper } from '../k8s/wrapper/vm/volume-wrapper';
 import { kubevirtReferenceForModel } from '../models/kubevirtReferenceForModel';
 import { getOwnerReferences } from '../selectors';
@@ -36,7 +37,10 @@ export const useOwnedVolumeReferencedResources = (
         const ref = referencedObjectLookup[volumeName];
         acc[volumeName] = {
           name: ref.name,
-          kind: kubevirtReferenceForModel(ref.model),
+          kind:
+            ref?.model.kind === PersistentVolumeClaimModel.kind
+              ? ref?.model.kind
+              : kubevirtReferenceForModel(ref.model),
           namespace,
           isList: false,
         };


### PR DESCRIPTION
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2019717

**Analysis / Root cause**:
when deleting a VM, the wrong `kind` was applied when the PVC resource was not owned by the VM. 

**Screen shots / Gifs for design review**:

before:

![before](https://user-images.githubusercontent.com/67270715/140034385-b7c77d94-6dcc-4d4b-bbb0-ce68a53d9350.gif)

after:

![after](https://user-images.githubusercontent.com/67270715/140034423-a92a2b0c-104d-4c7a-b91f-950fc47bd99d.gif)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>