### PR TITLE
Revamp HorizontalNav component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -234,6 +234,7 @@
     "@types/react-helmet": "5.x",
     "@types/react-jsonschema-form": "^1.3.8",
     "@types/react-redux": "6.0.2",
+    "@types/react-router": "5.1.2",
     "@types/react-router-dom": "5.1.2",
     "@types/react-transition-group": "2.x",
     "@types/react-virtualized": "9.x",

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -6,7 +6,7 @@ import {
   ConsoleFetch,
   ConsoleFetchJSON,
   ConsoleFetchText,
-  HorizontalNavProps,
+  HorizontalNavFC,
   UseResolvedExtensions,
   VirtualizedTableFC,
   TableDataProps,
@@ -45,21 +45,27 @@ export const useActivePerspective: UseActivePerspective = require('@console/dyna
  * A component that creates a Navigation bar. It takes array of NavPage objects and renderes a NavBar.
  * Routing is handled as part of the component.
  * @example
- * const HomePage: React.FC = (props) => {
+ * const HomePage: React.FC = () => {
  *     const page = {
  *       href: '/home',
  *       name: 'Home',
  *       component: () => <>Home</>
  *     }
- *     return <HorizontalNav match={props.match} pages={[page]} />
+ *     return <HorizontalNav pages={[page]} />
  * }
  *
- * @param {object=} resource - The resource associated with this Navigation, an object of K8sResourceCommon type
- * @param {NavPage[]} pages - An array of page objects
- * @param {object} match - match object provided by React Router
+ * @template R
+ * @param {NavPage[]} pages  - An array of page objects
+ * @param {R=} resource - The resource associated with this Navigation
+ * @param {boolean=} loaded - Indicates whether Navigation should render loading state
+ * @param {any=} loadError - Indicates whether Navigation should render error state
+ * @param {boolean=} noStatusBox - Navigation will not render loading/error/empty states if set to true
+ * @param {React.ComponentType=} EmptyMsg - Custom empty message
+ * @param {React.ComponentType=} LoadingComponent - Custom loading component
+ *
  */
-export const HorizontalNav: React.FC<HorizontalNavProps> = require('@console/internal/components/utils/horizontal-nav')
-  .HorizontalNavFacade;
+export const HorizontalNav: HorizontalNavFC = require('@console/internal/components/HorizontalNav/HorizontalNav')
+  .default;
 export const VirtualizedTable: VirtualizedTableFC = require('@console/internal/components/factory/Table/VirtualizedTable')
   .default;
 export const TableData: React.FC<TableDataProps> = require('@console/internal/components/factory/Table/VirtualizedTable')

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ButtonProps } from '@patternfly/react-core';
 import { TableGridBreakpoint, OnSelect, SortByDirection, ICell } from '@patternfly/react-table';
 import { RouteComponentProps } from 'react-router';
@@ -232,18 +233,31 @@ export type ConsoleFetchJSON<T = any> = {
 
 export type ConsoleFetchText = (...args: Parameters<ConsoleFetch>) => Promise<string>;
 
-/* Horizontal Nav Types */
-export type NavPage = {
+export type NavPage<R = any> = {
   href?: string;
+  /**
+   * @deprecated use href property instead.
+   */
   path?: string;
   name: string;
-  component: React.ComponentType<RouteComponentProps>;
+  component: React.ComponentType<RouteComponentProps & { obj?: R }>;
 };
 
-export type HorizontalNavProps = {
-  resource?: K8sResourceCommon;
-  pages: NavPage[];
+export type HorizontalNavContentProps<R> = {
+  pages: NavPage<R>[];
+  resource?: R;
+  loaded?: boolean;
+  loadError?: any;
+  noStatusBox?: boolean;
+  EmptyMsg?: React.ComponentType;
+  LoadingComponent?: React.ComponentType;
 };
+
+export type HorizontalNavProps<R = any> = HorizontalNavContentProps<R> & {
+  className?: string;
+};
+
+export type HorizontalNavFC = <R = any>(props: HorizontalNavProps<R>) => JSX.Element;
 
 export type TableColumn<D> = ICell & {
   title: string;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/pages.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/pages.ts
@@ -1,6 +1,7 @@
 import { RouteComponentProps } from 'react-router';
 import { ExtensionK8sGroupKindModel, ExtensionK8sModel } from '../api/common-types';
 import { Extension, ExtensionDeclaration, CodeRef } from '../types';
+import { K8sResourceCommon } from './console-types';
 
 type ResourcePageProperties = {
   /** The model for which this resource page links to. */
@@ -43,12 +44,16 @@ export type ResourceDetailsPage = ExtensionDeclaration<
   ResourcePageProperties & {}
 >;
 
+export type ResourceTabPageComponentProps<R> = RouteComponentProps & {
+  obj: R;
+};
+
 /** Adds new resource tab page to Console router. */
-export type ResourceTabPage = ExtensionDeclaration<
+export type ResourceTabPage<R = K8sResourceCommon> = ExtensionDeclaration<
   'console.page/resource/tab',
   Omit<ResourcePageProperties, 'component'> & {
     /** The component to be rendered when the route matches. */
-    component: CodeRef<React.ComponentType<RouteComponentProps>>;
+    component: CodeRef<React.ComponentType<ResourceTabPageComponentProps<R>>>;
     /** The name of the tab. */
     name: string;
     /** The optional href for the tab link. If not provided, the first `path` is used. */

--- a/frontend/public/components/HorizontalNav/HorizontalNav.tsx
+++ b/frontend/public/components/HorizontalNav/HorizontalNav.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { useRouteMatch } from 'react-router-dom';
+import * as classNames from 'classnames';
+import { HorizontalNavFC } from '@console/dynamic-plugin-sdk';
+import { NavBar } from '../utils/horizontal-nav';
+import HorizontalNavContent from './HorizontalNavContent';
+
+const HorizontalNav: HorizontalNavFC = ({ pages, className, ...props }) => {
+  const { path, url } = useRouteMatch();
+  return (
+    <div className={classNames('co-m-page__body', className)}>
+      <NavBar pages={pages} baseURL={url} basePath={path} />
+      <HorizontalNavContent {...props} pages={pages} />
+    </div>
+  );
+};
+
+export default HorizontalNav;

--- a/frontend/public/components/HorizontalNav/HorizontalNavContent.tsx
+++ b/frontend/public/components/HorizontalNav/HorizontalNavContent.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { Switch, Route, RouteComponentProps, useRouteMatch } from 'react-router-dom';
+import { HorizontalNavContentProps } from '@console/dynamic-plugin-sdk';
+import { ErrorBoundary } from '@console/shared/src/components/error/error-boundary';
+import { ErrorBoundaryFallback } from '../error';
+import { LoadingBox, StatusBox } from '../utils/status-box';
+
+type HorizontalNavContentFC = <R>(props: HorizontalNavContentProps<R>) => JSX.Element;
+
+const HorizontalNavContent: HorizontalNavContentFC = ({
+  pages,
+  noStatusBox,
+  resource,
+  loaded,
+  loadError,
+  EmptyMsg,
+  LoadingComponent,
+}) => {
+  const { path: routePath } = useRouteMatch();
+
+  const content = (
+    <React.Suspense fallback={<LoadingBox />}>
+      <Switch>
+        {pages.map((p) => {
+          const path = `${routePath}/${p.href || p.path}`;
+          const render = (params: RouteComponentProps) => {
+            return (
+              <ErrorBoundary FallbackComponent={ErrorBoundaryFallback}>
+                <p.component {...params} obj={resource} />
+              </ErrorBoundary>
+            );
+          };
+          return <Route path={path} exact key={p.href || p.path} render={render} />;
+        })}
+      </Switch>
+    </React.Suspense>
+  );
+
+  if (noStatusBox) {
+    return content;
+  }
+
+  return (
+    <StatusBox
+      skeleton={LoadingComponent && <LoadingComponent />}
+      data={resource}
+      loaded={loaded}
+      loadError={loadError}
+      EmptyMsg={EmptyMsg}
+    >
+      {content}
+    </StatusBox>
+  );
+};
+
+export default HorizontalNavContent;

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -196,9 +196,9 @@ export const NavBar = withRouter<NavBarProps>(({ pages, baseURL, basePath }) => 
           'co-m-horizontal-nav-item--active': matchURL?.isExact,
         });
         return (
-          <li className={klass} key={href}>
+          <li className={klass} key={href || path}>
             <Link
-              to={`${baseURL.replace(/\/$/, '')}/${href}`}
+              to={`${baseURL.replace(/\/$/, '')}/${href || path}`}
               data-test-id={`horizontal-link-${nameKey || name}`}
             >
               {nameKey ? t(nameKey) : name}
@@ -335,18 +335,6 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
   );
 }, _.isEqual);
 
-/*
- *Component consumed by the dynamic plugin SDK
- * Changes to the underlying component has to support props used in this facade
- */
-export const HorizontalNavFacade = withRouter<HorizontalNavFacadeProps & RouteComponentProps>(
-  ({ resource, pages, match }) => {
-    const obj = { data: resource, loaded: true };
-
-    return <HorizontalNav obj={obj} pages={pages} match={match} noStatusBox />;
-  },
-);
-
 export type PodsComponentProps = {
   obj: K8sResourceKind;
   showNodes?: boolean;
@@ -395,4 +383,3 @@ export type HorizontalNavProps = Omit<HorizontalNavFacadeProps, 'pages' | 'resou
 };
 
 HorizontalNav.displayName = 'HorizontalNav';
-HorizontalNavFacade.displayName = 'HorizontalNavFacade';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2738,6 +2738,14 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-router@5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.2.tgz#41e5e6aa333a7b9a2bfdac753c04e1ca4b3e0d21"
+  integrity sha512-euC3SiwDg3NcjFdNmFL8uVuAFTpZJm0WMFUw+4eXMUnxa7M9RGFEG0szt0z+/Zgk4G2k9JBFhaEnY64RBiFmuw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+
 "@types/react-transition-group@2.x":
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.8.tgz#1ea86f6d8288e4bba8d743317ba9cc61cdacc1ad"


### PR DESCRIPTION
These are new HorizontalNav components which build on top of already exposed HorizontalNav API, there are no breaking changes.
I expect that new `HorizontalNav` will be used in new `DetailsPages` https://github.com/openshift/console/pull/10286



In this PR I've also deprecated `path` property from `NavPage` type (as there is no difference between `path` and `href`). Once we remove `path`, `href` prop becomes required.