### PR TITLE
Bug 1992961: Regular user cannot create VM because of an unclear error

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/cdi-upload-provider/upload-pvc-form/upload-pvc-form.tsx
@@ -147,9 +147,13 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
   const updatedStorageClass = storageClasses?.find((sc) => sc.metadata.name === storageClassName);
   const provisioner = updatedStorageClass?.provisioner || '';
   const [applySP, setApplySP] = React.useState<boolean>(true);
-  const [spAccessMode, spVolumeMode, spLoaded, isSPSettingProvided] = useStorageProfileSettings(
-    storageClassName || defaultSCName,
-  );
+  const [
+    spAccessMode,
+    spVolumeMode,
+    spLoaded,
+    isSPSettingProvided,
+    loadError,
+  ] = useStorageProfileSettings(storageClassName || defaultSCName);
 
   React.useEffect(() => {
     if (!storageClassName) {
@@ -506,7 +510,7 @@ export const UploadPVCForm: React.FC<UploadPVCFormProps> = ({
           </SplitItem>
         </Split>
       </div>
-      {!spLoaded ? (
+      {!spLoaded && !loadError ? (
         <LoadingInline />
       ) : applySP && isSPSettingProvided ? (
         <div className="form-group" data-test="sp-default-settings">

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm/forms/boot-source-form.tsx
@@ -62,9 +62,13 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({
 
   const defaultSCName = getDefaultStorageClass(storageClasses)?.metadata.name;
 
-  const [spAccessMode, spVolumeMode, spLoaded, isSPSettingProvided] = useStorageProfileSettings(
-    storageClassName || defaultSCName,
-  );
+  const [
+    spAccessMode,
+    spVolumeMode,
+    spLoaded,
+    isSPSettingProvided,
+    loadError,
+  ] = useStorageProfileSettings(storageClassName || defaultSCName);
 
   const [applySP, setApplySP] = React.useState<boolean>(true);
 
@@ -147,7 +151,7 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({
             data-test="apply-storage-provider"
           />
         </FormRow>
-        {!spLoaded ? (
+        {!spLoaded && !loadError ? (
           <LoadingInline />
         ) : isSPSettingProvided && applySP ? (
           <FormRow fieldId="form-ds-sp-settings" data-test="sp-default-settings">

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -132,9 +132,13 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     combinedDisk.getStorageClassName() || '',
   );
 
-  const [spAccessMode, spVolumeMode, spLoaded, isSPSettingProvided] = useStorageProfileSettings(
-    storageClassName,
-  );
+  const [
+    spAccessMode,
+    spVolumeMode,
+    spLoaded,
+    isSPSettingProvided,
+    loadError,
+  ] = useStorageProfileSettings(storageClassName);
 
   const [applySP, setApplySP] = React.useState<boolean>(true);
 
@@ -694,7 +698,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                       data-test="apply-storage-provider"
                     />
                   </StackItem>
-                  {!spLoaded ? (
+                  {!spLoaded && !loadError ? (
                     <LoadingInline />
                   ) : isSPSettingProvided && applySP ? (
                     <StackItem data-test="sp-default-settings">

--- a/frontend/packages/kubevirt-plugin/src/hooks/use-storage-profile-settings.ts
+++ b/frontend/packages/kubevirt-plugin/src/hooks/use-storage-profile-settings.ts
@@ -19,7 +19,7 @@ export const useStorageProfileSettings = (
 
   const [sp, spLoaded, loadError] = useK8sWatchResource<StorageProfile>(spWatchResource);
 
-  if (!sp?.status?.claimPropertySets && spLoaded) {
+  if ((!sp?.status?.claimPropertySets && spLoaded) || loadError) {
     return [AccessMode.READ_WRITE_ONCE, VolumeMode.FILESYSTEM, spLoaded, false, loadError];
   }
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1992961

**Analysis / Root cause**: 
Regular users don't have permissions to fetch `storageProfile` data, since VM was counting on getting a `volumeMode` parameter and didn't, which caused the VM creation to fail.

**Solution Description**: 
Directing regular users to select AccessMode and VolumeMode on their own, and getting a default values

**Screen shots / Gifs for design review**: 

before:

![before-1](https://user-images.githubusercontent.com/67270715/140746916-c59211f2-66c7-4aa5-b328-3908f78836b2.png)

![before-2](https://user-images.githubusercontent.com/67270715/140746919-330ac532-38d9-4e3d-9306-875cad0d8a28.png)

![before-3](https://user-images.githubusercontent.com/67270715/140746921-3971d0c5-a894-44c1-9692-d999b9319f1f.png)

![before-4](https://user-images.githubusercontent.com/67270715/140746923-baad88c3-c6ed-41dc-b7f7-1cf6ac6e2429.png)

after:

VM creation:
![after](https://user-images.githubusercontent.com/67270715/140746981-770366aa-ff16-4254-8af0-e0dd3d518426.gif)

![after-1](https://user-images.githubusercontent.com/67270715/140746993-b939f927-d511-4793-87ee-3093beec4824.png)

![after-2](https://user-images.githubusercontent.com/67270715/140746997-d53ab5db-70be-4ef6-8f46-41adad5e9246.png)

![after-3](https://user-images.githubusercontent.com/67270715/140747000-4f2fb6d1-eedf-4bd2-8d6f-c3d4896c1c16.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>

