### PR TITLE
Bug 2020275: Fix ClusterOperators link

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -714,7 +714,17 @@ const MachineConfigPoolsResource: WatchK8sResource = {
 export const ClusterOperatorsLink: React.FC<ClusterOperatorsLinkProps> = ({
   children,
   queryString,
-}) => <Link to={`/settings/cluster/clusteroperators${queryString}`}>{children}</Link>;
+}) => (
+  <Link
+    to={
+      queryString
+        ? `/settings/cluster/clusteroperators${queryString}`
+        : '/settings/cluster/clusteroperators'
+    }
+  >
+    {children}
+  </Link>
+);
 
 export const UpdateInProgress: React.FC<UpdateInProgressProps> = ({
   desiredVersion,


### PR DESCRIPTION
The ClusterOperators link was returning "undefined" in the link it generated if no query string was passed in. I added a check for whether a query string is present.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2020275.