### PR TITLE
Bug 2021337: Fix ResourceLink groupVersionKind

### DIFF
--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -85,7 +85,7 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
   dataTest,
   onClick,
 }) => {
-  if (!kind) {
+  if (!kind && !groupVersionKind) {
     return null;
   }
   const kindReference = groupVersionKind ? getReference(groupVersionKind) : kind;


### PR DESCRIPTION
Correctly render the link when a `groupVersionKind` prop is passed in
lieu of the deprecated `kind` prop.

/assign @invincibleJai 