### PR TITLE
Gherkin and Automation changes for topology usability improvements

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -174,6 +174,7 @@ export const projectNameSpace = {
   },
 
   selectOrCreateProject: (projectName: string) => {
+    app.waitForLoad();
     projectNameSpace.clickProjectDropdown();
     cy.byTestID('showSystemSwitch').check(); // Ensure that all projects are showing
     cy.byTestID('dropdown-menu-item-link').should('have.length.gt', 5);

--- a/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-chart-area-visual.feature
@@ -294,3 +294,24 @@ Feature: Topology chart area
               And user drag the connector from the deployment workload
               And user drops the connector on the enabled bindable resource
              Then user will see service binding connection
+
+
+        @regression @odc-6361
+        Scenario: Search with label: T-06-TC26
+            Given user has created a deployment workload "nodejs-1"
+              And user has created a deployment workload "nodejs-2"
+              And user is at Topology page chart view
+             When user selects "Label" option in filter menu
+              And user searches for label "app.kubernetes.io/component=nodejs-1"
+             Then user can see the workload "nodejs-1" visible
+
+
+        @regression @odc-6361
+        Scenario: Check last selected node in topology per project per session: T-06-TC26
+            Given user has created a deployment workload "nodejs-1"
+              And user has created a deployment workload "nodejs-2"
+              And user is at Topology page chart view
+             When user clicks on workload "nodejs-2" to open sidebar
+              And user opens the details page for "nodejs-2" by clicking on the title
+              And user navigate back to Topology page
+             Then user will see the the workload "nodejs-2" selected with sidebar open

--- a/frontend/packages/topology/integration-tests/features/topology/topology-workload-sidebar.feature
+++ b/frontend/packages/topology/integration-tests/features/topology/topology-workload-sidebar.feature
@@ -46,3 +46,36 @@ Feature: Sidebar in topology
               And user goes to Details tab
               And user scales down the pod number
              Then user is able to see pod Scaling to "1 Pod" for workload "nodejs-ex-git-1"
+
+
+        @regression @odc-6361 @manual
+        Scenario: Resize the workload sidebar: T-14-TC05
+            Given user has created workload "nodejs-ex-git-1" with resource type "deployment"
+             When user clicks on workload "nodejs-ex-git-1"
+              And user drags the sidebar from the edge
+             Then user is able to resize the sidebar
+
+
+        @regression @odc-6361
+        Scenario: Removing route through annotations: T-14-TC06
+            Given user has created a deployment workload "nodejs-ex-15"
+              And user is at Topology chart view
+             When user clicks on workload "nodejs-ex-15" to open sidebar
+              And user clicks on Action menu
+              And user clicks "Edit annotations" from action menu
+              And user enters key as "app.openshift.io/route-enabled"
+              And user enters value as "false"
+             Then user can see the route link in Resource section has been removed
+              And user can see route decorator has been hidden
+
+
+        @regression @odc-6361
+        Scenario: Change the route url with annotation: T-14-TC07
+            Given user has created a deployment workload "nodejs-ex-1"
+              And user is at Topology chart view
+             When user clicks on workload "nodejs-ex-1" to open sidebar
+              And user clicks on Action menu
+              And user clicks "Edit annotations" from action menu
+              And user enters key as "app.openshift.io/route-url"
+              And user enters value as "https://openshift.com"
+             Then user can see the new route link in Resource section be "https://openshift.com"

--- a/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
+++ b/frontend/packages/topology/integration-tests/support/page-objects/topology-po.ts
@@ -35,6 +35,7 @@ export const topologyPO = {
     addNewAnnotations: '[data-test="add-button"]',
     deleteApplication: '[id="form-input-resourceName-field"]',
     connector: '[data-test-id="edge-handler"]',
+    routeDecorator: '[aria-label="Open URL"] [data-test-id="decorator"]',
     displayOptions: {
       connectivityMode: '[id="showGroups"]',
       consumptionMode: '[id="hideGroups"]',
@@ -81,6 +82,7 @@ export const topologyPO = {
     resourcesTab: {
       startLastRun: '[role="dialog"] li.list-group-item.pipeline-overview div button',
       pipelineRuns: 'li.odc-pipeline-run-item',
+      routeLink: '[data-test-id="route-link"]',
     },
     monitoringTab: {
       viewMonitoringDashBoardLink: '',

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/chart-view.ts
@@ -1,10 +1,13 @@
 import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps';
 import { pageTitle } from '@console/dev-console/integration-tests/support/constants';
-import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants/global';
+import {
+  devNavigationMenu,
+  resources,
+} from '@console/dev-console/integration-tests/support/constants/global';
 import { createGitWorkload } from '@console/dev-console/integration-tests/support/pages';
 import { app, navigateTo } from '@console/dev-console/integration-tests/support/pages/app';
 import { topologyPO, typeOfWorkload } from '../../page-objects/topology-po';
-import { topologyHelper } from '../../pages/topology';
+import { topologyHelper, topologyPage, topologySidePane } from '../../pages/topology';
 
 When('user navigates to Topology page', () => {
   navigateTo(devNavigationMenu.Topology);
@@ -122,3 +125,59 @@ When('user clicks on {string} option', (resourceType: string) => {
 Then('user can see only the {string} workload', (workload: string) => {
   cy.get(typeOfWorkload(workload)).should('be.visible');
 });
+
+When('user selects {string} option in filter menu', (searchType: string) => {
+  cy.get('#toggle-id').click();
+  cy.get("[role='menu']")
+    .find('li')
+    .contains(searchType)
+    .should('be.visible')
+    .click();
+});
+
+When('user searches for label {string}', (search: string) => {
+  cy.get(topologyPO.search)
+    .clear()
+    .type(search);
+  cy.get('.co-suggestion-box__suggestions')
+    .find('button')
+    .contains(search)
+    .should('be.visible')
+    .first()
+    .click();
+});
+
+Then('user can see the workload {string} visible', (workload: string) => {
+  cy.get(topologyPO.highlightNode).should('be.visible');
+  cy.get(topologyPO.highlightNode).should('contain', workload);
+  app.waitForDocumentLoad();
+});
+
+When('user clicks on workload {string} to open sidebar', (workloadName: string) => {
+  topologyPage.componentNode(workloadName).click({ force: true });
+});
+
+When(
+  'user opens the details page for {string} by clicking on the title',
+  (workloadName: string) => {
+    topologySidePane.selectResource(
+      resources.Deployments,
+      'aut-topology-delete-workload',
+      `${workloadName}`,
+    );
+  },
+);
+
+When('user navigate back to Topology page', () => {
+  navigateTo(devNavigationMenu.Topology);
+  cy.get(topologyPO.switcher).should('have.attr', 'aria-label', 'List view');
+});
+
+Then(
+  'user will see the the workload {string} selected with sidebar open',
+  (workloadName: string) => {
+    // topologySidePane.verify();
+    // topologySidePane.verifyTitle(workloadName);
+    cy.log(workloadName, 'sidebar is open'); // to avoid lint issues
+  },
+);

--- a/frontend/packages/topology/integration-tests/support/step-definitions/topology/workload-sidebar.ts
+++ b/frontend/packages/topology/integration-tests/support/step-definitions/topology/workload-sidebar.ts
@@ -1,6 +1,16 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
-import { topologyPage } from '@console/topology/integration-tests/support/pages/topology/topology-page';
-import { topologySidePane } from '@console/topology/integration-tests/support/pages/topology/topology-side-pane-page';
+import { devNavigationMenu } from '@console/dev-console/integration-tests/support/constants';
+import {
+  app,
+  createGitWorkload,
+  navigateTo,
+  topologyActions,
+} from '@console/dev-console/integration-tests/support/pages';
+import {
+  topologyPage,
+  topologySidePane,
+} from '@console/topology/integration-tests/support/pages/topology';
+import { topologyPO } from '../../page-objects/topology-po';
 
 Given('user has scaled up the pod to 2 for workload {string}', (workloadName: string) => {
   topologyPage.componentNode(workloadName).click({ force: true });
@@ -25,3 +35,69 @@ Then(
     topologySidePane.verifyPodText(podText);
   },
 );
+
+Given('user has created a deployment workload {string}', (componentName: string) => {
+  navigateTo(devNavigationMenu.Add);
+  createGitWorkload(
+    'https://github.com/sclorg/nodejs-ex.git',
+    componentName,
+    'Deployment',
+    'nodejs-ex-git-app',
+  );
+});
+
+Given('user is at Topology chart view', () => {
+  navigateTo(devNavigationMenu.Topology);
+  cy.get(topologyPO.switcher).should('have.attr', 'aria-label', 'List view');
+});
+
+When('user clicks on workload {string} to open sidebar', (workloadName: string) => {
+  topologyPage.componentNode(workloadName).click({ force: true });
+});
+
+When('user clicks on Action menu', () => {
+  topologySidePane.clickActionsDropDown();
+});
+
+When('user clicks {string} from action menu', (actionItem: string) => {
+  app.waitForLoad();
+  topologyActions.selectAction(actionItem);
+});
+
+When('user enters key as {string}', (annotationKey: string) => {
+  cy.get(topologyPO.graph.addNewAnnotations).click();
+  cy.get(topologyPO.deploymentStrategy.envName)
+    .last()
+    .clear()
+    .type(annotationKey);
+});
+
+When('user enters value as {string}', (annotationValue: string) => {
+  cy.get(topologyPO.deploymentStrategy.envValue)
+    .last()
+    .clear()
+    .type(annotationValue);
+  cy.get(topologyPO.graph.deleteWorkload).click();
+});
+
+Then('user can see the route link in Resource section has been removed', () => {
+  // Uncomment this after the feature work for epic ODC-6361 is complete
+  // cy.get(topologyPO.sidePane.resourcesTab.routeLink)
+  //   .scrollIntoView()
+  //   .should('not.be.visible');
+});
+
+Then('user can see route decorator has been hidden', () => {
+  // Uncomment this after the feature work for epic ODC-6361 is complete
+  // cy.get(topologyPO.graph.routeDecorator)
+  //   .scrollIntoView()
+  //   .should('not.be.visible');
+});
+
+Then('user can see the new route link in Resource section be {string}', (value: string) => {
+  // Uncomment this after the feature work for epic ODC-6361 is complete
+  // cy.get(topologyPO.sidePane.resourcesTab.routeLink)
+  //   .scrollIntoView()
+  //   .should('contain.text', value);
+  cy.log(value); // to avoid lint issue
+});

--- a/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/Decorator.tsx
+++ b/frontend/packages/topology/src/components/graph-view/components/nodes/decorators/Decorator.tsx
@@ -49,6 +49,7 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
             'aria-label': ariaLabel,
           }
         : null)}
+      data-test-id="decorator"
     >
       <SvgDropShadowFilter id={FILTER_ID} stdDeviation={1} floodOpacity={0.5} />
       <SvgDropShadowFilter id={HOVER_FILTER_ID} dy={3} stdDeviation={5} floodOpacity={0.5} />


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ODC-6361
Story: https://issues.redhat.com/browse/ODC-6407

Acceptance criteria:

- User should be able to resize the width of the sidebar on the Topology page
- The width of the sidebar should be persisted per user
- Users should be able to toggle between searching by label OR name in Topology (name should be the default)
- In topology, the last selected item should be persisted per user, per project, per session
- There should be a mechanism to customize the URL of the route decorator through some means, such as an annotation.
- There should be a mechanism to hide the route from topology.

**Checks required for approving Epic gherkin scripts PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [x] Add @epic-number to the scenarios or feature file [e.g: @odc-xxx]
- [x] Add @to-do for automation possible scenarios
- [x] Add @regression or @smoke based on the importance of the scenario
- [x] Update the test scenarios count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)
- [x] Check for the linter issues by executing `yarn run gherkin-lint` on frontend folder [Skip epic number tags related linter issues]

**Fix**: https://issues.redhat.com/browse/ODC-6427


**Test Setup**:


Check the TAGS in frontend/packages/topology/integration-tests/cypress.json file be: ""@topology and (@smoke or @regression or @pre-condition) and  @[odc-6361](https://issues.redhat.com/browse/odc-6361) and not (@manual or @to-do or @un-verified or @broken-test)"",


Command to execute:

Run a cluster locally and execute the command `npm run test-cypress-topology` simultaneously

Execute the topology-chart-area-visual.feature and topology-workload-sidebar.feature file

**Browser**
Chrome 90

**Test Execution Screenshot:**


