### PR TITLE
Bug 2017130: omit extension when code ref resolution fails

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/coderefs/__tests__/coderef-resolver.spec.ts
@@ -14,7 +14,14 @@ import {
   loadReferencedObject,
   resolveEncodedCodeRefs,
   resolveExtension,
+  isCodeRefError,
 } from '../coderef-resolver';
+
+const getErrorExecutableCodeRefMock = <T = any>(): jest.Mock<ReturnType<CodeRef<T>>> => {
+  const ref = jest.fn(() => Promise.reject(new Error()));
+  applyCodeRefSymbol<T>(ref);
+  return ref;
+};
 
 describe('applyCodeRefSymbol', () => {
   it('marks the given function with CodeRef symbol', () => {
@@ -287,5 +294,21 @@ describe('resolveExtension', () => {
 
     expect(await resolveExtension(extensions[0])).toBe(extensions[0]);
     expect(await resolveExtension(extensions[1])).toBe(extensions[1]);
+  });
+
+  it('continuously reject code refs which have failed to resolve', async () => {
+    const errorCodeRef = getErrorExecutableCodeRefMock();
+
+    const extension: Extension = {
+      type: 'Foo',
+      properties: { test: true, qux: errorCodeRef },
+    };
+
+    expect(isCodeRefError(errorCodeRef)).toBe(false);
+    expect(await resolveExtension(extension)).rejects.toBeTruthy();
+    expect(isCodeRefError(errorCodeRef)).toBeTruthy();
+    expect(errorCodeRef).toHaveBeenCalledTimes(1);
+    expect(await resolveExtension(extension)).rejects.toBeTruthy();
+    expect(errorCodeRef).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2017130

**Analysis / Root cause**: 
Observed when debugging the issue. When a code ref from a static plugin fails to resolve, the coderef-resolver will reject the promise resolution the first time but subsequent resolutions result in a `null` value instead of a promise rejection. The cause of the static code ref resolution failure is still unknown. The result is an extension returned by `useResolvedExtensions` where the extension code references are 'null` which causes the calling code to fail as it is expected the code reference to have a value defined.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
When code ref resolution fails, capture the failure by storing the error on the code reference object. When attempting to resolve the code reference again, the previous error will be thrown instead.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
One way to test locally is to force the the code reference to error out by returning a rejected promise.
```
export const myCodeRef = applyCodeRefSymbol(
  () => Promise.reject(new Error())
);
```

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

cc @vojtechszocs @invincibleJai 