### PR TITLE
Bug 2021693: Set large width for modals with modal-lg class

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -93,13 +93,21 @@
 .modal-dialog {
   margin: 10px;
   margin-bottom: 0;
+  max-width: calc(100% - var(--pf-global--spacer--xl));
   outline: 0;
   position: relative;
-  width: auto;
-
+  width: 100%;
   @media (min-width: $pf-global--breakpoint--md) {
     margin: 30px auto;
-    width: 600px;
+    &:not(.modal-lg) {
+      max-width: 600px;
+    }
+  }
+  @media (min-width: $pf-global--breakpoint--xl) {
+    &.modal-lg {
+      // Manually set to match --pf-c-modal-box--m-lg--lg--MaxWidth because the PF variable is scoped to .pf-c-modal-box
+      max-width: 70rem;
+    }
   }
 
   @media(max-width: $screen-xs-max) and (orientation: portrait) {


### PR DESCRIPTION
Modals with `modal-dialog modal-lg` class are set to `max-width:70rem` (1120px) when greater than 1200px. At less than 1200px allowed to be width of viewport with left and right gutters. 
This matches the PatternFly modal with `pf-c-modal-box pf-m-lg` behavior.
https://www.patternfly.org/v4/components/modal/#large

Modals without the lg class continue to default to `max-width:600px`

This was introduced with the removal of Bootstrap dependency
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2021693

<img width="1417" alt="Screen Shot 2021-11-09 at 6 36 50 PM narrow" src="https://user-images.githubusercontent.com/1874151/141024380-d84c8069-dec9-404a-93c5-f5213f6ffb65.png">

<img width="1208" alt="Screen Shot 2021-11-09 at 6 44 48 PM" src="https://user-images.githubusercontent.com/1874151/141024391-456b14b5-750e-4612-b804-0865f71aa5a9.png">


