### PR TITLE
Bug 2025837: virt: warn users that the RHEL URL expire

### DIFF
--- a/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
+++ b/frontend/packages/kubevirt-plugin/locales/en/kubevirt-plugin.json
@@ -401,7 +401,7 @@
   "More Info": "More Info",
   "Error: {{ rawErrorMessage }}": "Error: {{ rawErrorMessage }}",
   "Example: {{container}}": "Example: {{container}}",
-  "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image": "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image",
+  "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image (expires quickly)": "Example: For RHEL, visit the <2><0>RHEL download page</0></2> (requires login) and copy the download link URL of the KVM guest image (expires quickly)",
   "Example: For Windows, visit the <2><0>Windows 10 cloud image</0></2> and copy the download link URL for the cloud base image": "Example: For Windows, visit the <2><0>Windows 10 cloud image</0></2> and copy the download link URL for the cloud base image",
   "Example: For Centos, visit the <2><0>Centos cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For Centos, visit the <2><0>Centos cloud image list</0></2> and copy the download link URL for the cloud base image",
   "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image": "Example: For Fedora, visit the <2><0>Fedora cloud image list</0></2> and copy the download link URL for the cloud base image",

--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/url-source-help.tsx
@@ -22,7 +22,7 @@ export const URLSourceHelp: React.FC<URLSourceHelpProps> = ({ baseImageName }) =
           RHEL download page
         </a>
       </strong>{' '}
-      (requires login) and copy the download link URL of the KVM guest image
+      (requires login) and copy the download link URL of the KVM guest image (expires quickly)
     </Trans>
   ) : baseImageName?.includes('win') ? (
     <Trans t={t} ns="kubevirt-plugin">


### PR DESCRIPTION
I have spoken with a user who kept an old URL and tried to re-use it.
This PR tries to make it clearer that the token within this URL expires rather quickly and should be renewed every time you import RHEL.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>