### PR TITLE
Bug 2020153: Added support for common template change, now will update network device model

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/immutable/template/combined.ts
@@ -144,3 +144,6 @@ export const iGetTemplateGuestToolsDisk = (tmp: ITemplate) =>
   iGetIn(iSelectVM(tmp), ['spec', 'template', 'spec', 'volumes'])?.find((v) =>
     isWinToolsImage(iGetIn(v, ['containerDisk', 'image'])),
   );
+
+export const iGetCommonTemplateNetworkInterfaceDevices = (tmp: ITemplate) =>
+  iGetIn(iSelectVM(tmp), ['spec', 'template', 'spec', 'domain', 'devices', 'interfaces']);


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2020153

**Analysis / Root cause**: 
When choosing hie performance workload in the advanced wizard, the common template changed but the network device model isn't updated accordingly.

**Solution Description**: 
Added support for updating network devices according to template change.

**Screen shots / Gifs for design review**: 
![network-device](https://user-images.githubusercontent.com/14824964/141127860-ef4c306d-c2e3-401a-ab2c-e6d90fd5402d.gif)
