### PR TITLE
Bug 2018279: Edit and Delete confirmation modals for managed resource should close when the managed resource is clicked 

### DIFF
--- a/frontend/public/components/modals/delete-modal.tsx
+++ b/frontend/public/components/modals/delete-modal.tsx
@@ -119,6 +119,7 @@ const DeleteModal = withHandlePromise((props: DeleteModalProps) => {
                   kind={referenceForOwnerRef(owner)}
                   name={owner.name}
                   namespace={resource.metadata.namespace}
+                  onClick={props.cancel}
                 />{' '}
                 and any modifications may be overwritten. Edit the managing resource to preserve
                 changes.


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-36631
https://bugzilla.redhat.com/show_bug.cgi?id=2018279

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Modal had a link but after redirection we did not close the modal

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
when we click the link i.e. `onClick` we call the modal close i.e. `props.cancel` function 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![exportModalCloseOnRedirect](https://user-images.githubusercontent.com/20089340/141274774-d0cf60d7-247d-4f7d-9d07-76fdc6aa0346.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Steps to Reproduce:
1. Open Operator Hub and install the "Primer" GitOps Operator
2. Switch to developer perspective
3. Import at least one Application to enable the Export button in topology
4. If not opened yet, open the topology, and click the "Export Application" button
5. Wait until the export finishs and a new Deployment "primer-export-primer" was shown
6. Right click the "primer-export-primer" Deployment in the topology graph and press "Delete Deployment"
7. The confirmation modal shows a warning that this resource is managed. Press the link "(E) primer" in the warning to open this resource.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge