### PR TITLE
Bug 2022502: Remove old table class overrides causing display issue.

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -310,14 +310,6 @@ form.pf-c-form {
   }
 }
 
-.pf-c-table__check {
-  width: 8.333% !important;
-
-  @media screen and (max-width: 768px) {
-    width: 16.66% !important;
-  }
-}
-
 // FIXME: Pass as `style` prop to `List` once this is resolved (https://github.com/bvaughn/react-virtualized/issues/876). This is for the kebab menus' overflow.
 .pf-c-window-scroller.ReactVirtualized__VirtualGrid,
 .pf-c-window-scroller .ReactVirtualized__VirtualGrid,


### PR DESCRIPTION
Fixes [2022502 ](https://bugzilla.redhat.com/show_bug.cgi?id=2022502)
These css override classes should no longer be needed.
They where introduced awhile ago when virtualized lists were converted to @patternfly/react-tables and @patternfly/react-virtualization-extension.  https://github.com/openshift/console/pull/1465 

PatternFly virtualized tables with checkbox columns, should rely on a parent div class `.pf-c-scrollablegrid .pf-c-table .pf-c-table__check` to apply these rules in this scenario.
https://github.com/patternfly/patternfly-react/blob/82faf387f8c171cd66a22efcd1f22afb8499a69b/packages/react-virtualized-extension/src/components/Virtualized/examples/VirtualGrid.example.css#L20-L28