### PR TITLE
enable redux store context in SDK from app host

### DIFF
--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -86,8 +86,11 @@
     react "^17.0.1"
     react-helmet "^6.1.0"
     react-i18next "^11.7.3"
+    react-redux "7.2.2"
     react-router "5.2.0"
     react-router-dom "5.2.0"
+    redux "4.0.1"
+    redux-thunk "2.4.0"
 
 "@patternfly/react-core@4.162.2":
   version "4.162.2"
@@ -1495,7 +1498,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   dependencies:
@@ -2613,9 +2616,20 @@ react-i18next@^11.7.3:
     "@babel/runtime" "^7.14.5"
     html-parse-stringify "^3.0.1"
 
-react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+
+react-redux@7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.2.tgz#03862e803a30b6b9ef8582dadcc810947f74b736"
+  integrity sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 react-router-dom@5.2.0:
   version "5.2.0"
@@ -2711,6 +2725,19 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.3.tgz#60350f7fb252c0a67eb10fd4694d16909971300f"
   dependencies:
     balanced-match "^1.0.0"
+
+redux-thunk@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.0.tgz#ac89e1d6b9bdb9ee49ce69a69071be41bbd82d67"
+  integrity sha512-/y6ZKQNU/0u8Bm7ROLq9Pt/7lU93cT0IucYMrubo89ENjxPa7i8pqLKu6V4X7/TvYovQ6x01unTeyeZ9lgXiTA==
+
+redux@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
+  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"
@@ -3055,6 +3082,11 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symlink-or-copy@^1.1.8, symlink-or-copy@^1.2.0, symlink-or-copy@^1.3.1:
   version "1.3.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -187,6 +187,7 @@
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",
     "redux": "4.0.1",
+    "redux-thunk": "2.4.0",
     "reselect": "4.x",
     "sanitize-html": "^2.3.2",
     "screenfull": "4.x",

--- a/frontend/packages/console-dynamic-plugin-sdk/@types/sdk/index.d.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/@types/sdk/index.d.ts
@@ -1,0 +1,7 @@
+declare interface Window {
+  SERVER_FLAGS: {
+    basePath: string;
+  };
+  windowError?: string;
+  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
+}

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -3,9 +3,6 @@ import * as React from 'react';
 import {
   UseK8sWatchResource,
   UseK8sWatchResources,
-  ConsoleFetch,
-  ConsoleFetchJSON,
-  ConsoleFetchText,
   HorizontalNavProps,
   UseResolvedExtensions,
   VirtualizedTableFC,
@@ -23,7 +20,6 @@ import {
   UseK8sModels,
   UseActivePerspective,
 } from '../extensions/console-types';
-import { K8sGet, K8sCreate, K8sUpdate, K8sPatch, K8sDelete, K8sList } from './k8s-types';
 
 export const useK8sWatchResource: UseK8sWatchResource = require('@console/internal/components/utils/k8s-watch-hook')
   .useK8sWatchResource;
@@ -31,12 +27,6 @@ export const useK8sWatchResources: UseK8sWatchResources = require('@console/inte
   .useK8sWatchResources;
 export const useResolvedExtensions: UseResolvedExtensions = require('@console/dynamic-plugin-sdk/src/api/useResolvedExtensions')
   .useResolvedExtensions;
-export const consoleFetch: ConsoleFetch = require('@console/dynamic-plugin-sdk/src/utils/fetch')
-  .consoleFetch;
-export const consoleFetchJSON: ConsoleFetchJSON = require('@console/dynamic-plugin-sdk/src/utils/fetch')
-  .consoleFetchJSON;
-export const consoleFetchText: ConsoleFetchText = require('@console/dynamic-plugin-sdk/src/utils/fetch')
-  .consoleFetchText;
 
 export const useActivePerspective: UseActivePerspective = require('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective')
   .default;
@@ -89,18 +79,21 @@ export const useK8sModel: UseK8sModel = require('@console/shared/src/hooks/useK8
 export const useK8sModels: UseK8sModels = require('@console/shared/src/hooks/useK8sModels')
   .useK8sModels;
 
+export {
+  consoleFetch,
+  consoleFetchJSON,
+  consoleFetchText,
+} from '@console/dynamic-plugin-sdk/src/utils/fetch';
+
 // Expose K8s CRUD utilities as below
-export const k8sGet: K8sGet = require('@console/dynamic-plugin-sdk/src/utils/k8s').k8sGetResource;
-export const k8sCreate: K8sCreate = require('@console/dynamic-plugin-sdk/src/utils/k8s')
-  .k8sCreateResource;
-export const k8sUpdate: K8sUpdate = require('@console/dynamic-plugin-sdk/src/utils/k8s')
-  .k8sUpdateResource;
-export const k8sPatch: K8sPatch = require('@console/dynamic-plugin-sdk/src/utils/k8s')
-  .k8sPatchResource;
-export const k8sDelete: K8sDelete = require('@console/dynamic-plugin-sdk/src/utils/k8s')
-  .k8sDeleteResource;
-export const k8sList: K8sList = require('@console/dynamic-plugin-sdk/src/utils/k8s')
-  .k8sListResource;
+export {
+  k8sGetResource as k8sGet,
+  k8sCreateResource as k8sCreate,
+  k8sUpdateResource as k8sUpdate,
+  k8sPatchResource as k8sPatch,
+  k8sDeleteResource as k8sDelete,
+  k8sListResource as k8sList,
+} from '@console/dynamic-plugin-sdk/src/utils/k8s';
 export {
   getAPIVersionForModel,
   getGroupVersionKindForResource,

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/AppInitSDK.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/AppInitSDK.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { useReduxStore } from './useReduxStore';
+
+type AppInitSDKProps = {
+  children: React.ReactNode;
+};
+
+/**
+ * Component for providing store access to the SDK.
+ * Add this at app-level to make use of app store, preferred to have it under Provider.
+ * It checks for store instance if present or not.
+ * If the store is there then the reference is persisted to be used in SDK else it creates a new store and passes it to the children with the provider
+ * @component AppInitSDK
+ * @example
+ * ```ts
+ * return (
+ *  <Provider store={store}>
+ *   <AppInitSDK>
+ *      <CustomApp />
+ *      ...
+ *   </AppInitSDK>
+ *  </Provider>
+ * )
+ * ```
+ */
+const AppInitSDK: React.FC<AppInitSDKProps> = ({ children }) => {
+  const { store, storeContextPresent } = useReduxStore();
+  return !storeContextPresent ? <Provider store={store}>{children}</Provider> : <>{children}</>;
+};
+
+export default AppInitSDK;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/__tests__/AppInitSDK.spec.tsx
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/__tests__/AppInitSDK.spec.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import AppInitSDK from '../AppInitSDK';
+import * as hooks from '../useReduxStore';
+
+jest.mock('react-redux', () => {
+  const ActualReactRedux = require.requireActual('react-redux');
+  return {
+    ...ActualReactRedux,
+    useStore: jest.fn(),
+  };
+});
+
+describe('AppInitSDK', () => {
+  const mockStore = configureMockStore();
+  const store = mockStore([thunk]);
+
+  it('should not wrap children with Provider', () => {
+    jest
+      .spyOn(hooks, 'useReduxStore')
+      .mockImplementation(() => ({ store, storeContextPresent: true }));
+    const wrapper = shallow(
+      <AppInitSDK>
+        <div data-test-id="child-id">Hello!!</div>
+      </AppInitSDK>,
+    );
+    expect(wrapper.find(Provider)).toHaveLength(0);
+    expect(wrapper.find('[data-test-id="child-id"]')).toHaveLength(1);
+  });
+
+  it('should wrap children with Provider', () => {
+    jest
+      .spyOn(hooks, 'useReduxStore')
+      .mockImplementation(() => ({ store, storeContextPresent: false }));
+  });
+  const wrapper = shallow(
+    <AppInitSDK>
+      <div data-test-id="child-id">Hello!!</div>
+    </AppInitSDK>,
+  );
+  expect(wrapper.find(Provider)).toHaveLength(1);
+  expect(wrapper.find('[data-test-id="child-id"]')).toHaveLength(1);
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/actions/core.ts
@@ -1,0 +1,25 @@
+import { action, ActionType as Action } from 'typesafe-actions';
+import { UserKind } from '../../redux-types';
+
+export enum ActionType {
+  SetNamespace = 'setNamespace',
+  SetUser = 'setUser',
+  BeginImpersonate = 'beginImpersonate',
+  EndImpersonate = 'endImpersonate',
+}
+
+export const setNamespace = (namespace: string = '') =>
+  action(ActionType.SetNamespace, { namespace: namespace.trim() });
+export const setUser = (user: UserKind) => action(ActionType.SetUser, { user });
+export const beginImpersonate = (kind: string, name: string, subprotocols: string[]) =>
+  action(ActionType.BeginImpersonate, { kind, name, subprotocols });
+export const endImpersonate = () => action(ActionType.EndImpersonate);
+
+const coreActions = {
+  setNamespace,
+  setUser,
+  beginImpersonate,
+  endImpersonate,
+};
+
+export type CoreAction = Action<typeof coreActions>;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/__tests__/core.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/__tests__/core.spec.ts
@@ -1,0 +1,52 @@
+import { CoreState } from '../../../redux-types';
+import { setUser, setNamespace, beginImpersonate, endImpersonate } from '../../actions/core';
+import coreReducer from '../core';
+import reducerTest from './utils/reducerTest';
+
+describe('Core Reducer', () => {
+  const state: CoreState = {
+    activeNamespace: 'sample-app',
+  };
+
+  it('set namespace', () => {
+    reducerTest(coreReducer, state, setNamespace('my-app')).expectVal({
+      activeNamespace: 'my-app',
+    });
+  });
+
+  it('set user', () => {
+    const mockUser = {
+      apiVersion: 'user.openshift.io/v1',
+      kind: 'User',
+      groups: ['system:authenticated'],
+      metadata: {
+        name: 'kube:admin',
+      },
+    };
+    reducerTest(coreReducer, state, setUser(mockUser)).expectVal({
+      activeNamespace: 'sample-app',
+      user: mockUser,
+    });
+  });
+
+  it('begin Impersonate', () => {
+    reducerTest(
+      coreReducer,
+      state,
+      beginImpersonate('User', 'developer', ['Impersonate-User.Y29uc29sZWRldmVsb3Blcg__']),
+    ).expectVal({
+      activeNamespace: 'sample-app',
+      impersonate: {
+        kind: 'User',
+        name: 'developer',
+        subprotocols: ['Impersonate-User.Y29uc29sZWRldmVsb3Blcg__'],
+      },
+    });
+  });
+
+  it('end Impersonate', () => {
+    reducerTest(coreReducer, state, endImpersonate()).expectVal({
+      activeNamespace: 'sample-app',
+    });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/__tests__/utils/reducerTest.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/__tests__/utils/reducerTest.ts
@@ -1,0 +1,30 @@
+const deepFreeze = <T extends object>(obj: T): Readonly<T> => {
+  Object.freeze(obj);
+  Object.keys(obj).forEach((prop) => {
+    if (
+      obj[prop] !== null &&
+      (typeof obj[prop] === 'object' || typeof obj[prop] === 'function') &&
+      !Object.isFrozen(obj[prop])
+    ) {
+      deepFreeze(obj[prop]);
+    }
+  });
+  return obj;
+};
+
+const reducerTest = (reducer: Function, state: object, action: { type: string; payload?: any }) => {
+  deepFreeze(state);
+  return {
+    expectVal(expectedValue) {
+      const result = reducer(state, action);
+
+      if (typeof expectedValue === 'function') {
+        expectedValue(result, state);
+      } else {
+        expect(result).toEqual(expectedValue);
+      }
+    },
+  };
+};
+
+export default reducerTest;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/core/reducers/core.ts
@@ -1,0 +1,65 @@
+import { CoreState } from '../../redux-types';
+import { ActionType, CoreAction } from '../actions/core';
+
+/**
+ * Reducer function for the core
+ * @param state the reducer state
+ * @param action provided associated action type alongwith payload
+ * @param action.type type of the action
+ * @param action.payload associated payload for the action
+ * @see CoreAction
+ * @return The the updated state.
+ * * */
+const coreReducer = (
+  state: CoreState = {
+    activeNamespace: '',
+  },
+  action: CoreAction,
+): CoreState => {
+  switch (action.type) {
+    case ActionType.SetNamespace:
+      if (!action.payload.namespace) {
+        // eslint-disable-next-line no-console
+        console.warn('setNamespace: Not setting to falsy!');
+        return state;
+      }
+      return {
+        ...state,
+        activeNamespace: action.payload.namespace,
+      };
+
+    case ActionType.BeginImpersonate:
+      return {
+        ...state,
+        impersonate: {
+          kind: action.payload.kind,
+          name: action.payload.name,
+          subprotocols: action.payload.subprotocols,
+        },
+      };
+
+    case ActionType.EndImpersonate: {
+      const stateKeys = Object.keys(state);
+      return stateKeys.reduce((acc, key) => {
+        if (key !== 'impersonate') {
+          return {
+            ...acc,
+            [key]: state[key],
+          };
+        }
+        return acc;
+      }, {} as CoreState);
+    }
+
+    case ActionType.SetUser:
+      return {
+        ...state,
+        user: action.payload.user,
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default coreReducer;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/index.ts
@@ -1,0 +1,1 @@
+export { default as AppInitSDK } from './AppInitSDK';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/redux-types.ts
@@ -1,0 +1,12 @@
+import { K8sResourceCommon } from '../extensions/console-types';
+
+export type UserKind = K8sResourceCommon & { groups: string[] };
+export type CoreState = {
+  activeNamespace: string;
+  user?: UserKind;
+  impersonate?: { kind: string; name: string; subprotocols: string[] };
+};
+
+export type RootState = {
+  core: CoreState;
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/redux.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/redux.ts
@@ -1,0 +1,5 @@
+import coreReducer from './core/reducers/core';
+
+export const baseReducers = Object.freeze({
+  core: coreReducer,
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/storeHandler.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/storeHandler.ts
@@ -1,0 +1,12 @@
+import { Store } from 'redux';
+
+let store: Store;
+
+const storeHandler = {
+  setStore: (storeData: Store) => {
+    store = storeData;
+  },
+  getStore: (): Store => store,
+};
+
+export default storeHandler;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/app/useReduxStore.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/app/useReduxStore.ts
@@ -1,0 +1,48 @@
+import * as React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useStore } from 'react-redux';
+import { applyMiddleware, combineReducers, createStore, compose, Store } from 'redux';
+import thunk from 'redux-thunk';
+import { baseReducers } from './redux';
+import { RootState } from './redux-types';
+import storeHandler from './storeHandler';
+
+const composeEnhancers =
+  (process.env.NODE_ENV !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
+
+/**
+ * `useReduxStore` will provide the store instance if present or else create one along with info if the context was present.
+ *
+ * @example
+ * ```ts
+ * function Component () {
+ *   const {store, storeContextPresent} = useReduxStore()
+ *   return ...
+ * }
+ * ```
+ */
+export const useReduxStore = (): { store: Store<RootState>; storeContextPresent: boolean } => {
+  const storeContext = useStore();
+  const [storeContextPresent, setStoreContextPresent] = React.useState(false);
+  const store = React.useMemo(() => {
+    // check if store exists and if not create it
+    if (storeContext) {
+      setStoreContextPresent(true);
+      storeHandler.setStore(storeContext);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log('Creating the SDK redux store');
+      setStoreContextPresent(false);
+      const storeInstance = createStore(
+        combineReducers<RootState>(baseReducers),
+        {},
+        composeEnhancers(applyMiddleware(thunk)),
+      );
+      storeHandler.setStore(storeInstance);
+    }
+    return storeHandler.getStore();
+  }, [storeContext]);
+
+  return { store, storeContextPresent };
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/index.ts
@@ -6,3 +6,6 @@ export * from './api/common-types';
 export * from './extensions';
 
 export * from './perspective';
+
+// App init context
+export * from './app';

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules-init.ts
@@ -17,6 +17,9 @@ const modules: SharedModuleResolution = {
   'react-i18next': async () => () => require('react-i18next'),
   'react-router': async () => () => require('react-router'),
   'react-router-dom': async () => () => require('react-router-dom'),
+  'react-redux': async () => () => require('react-redux'),
+  redux: async () => () => require('redux'),
+  'redux-thunk': async () => () => require('redux-thunk'),
 };
 
 const sharedScope = Object.keys(modules).reduce(

--- a/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/shared-modules.ts
@@ -12,4 +12,7 @@ export const sharedPluginModules = [
   'react-i18next',
   'react-router',
   'react-router-dom',
+  'react-redux',
+  'redux',
+  'redux-thunk',
 ];

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/fetch/console-fetch-utils.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { authSvc } from '@console/internal/module/auth';
+import storeHandler from '../../app/storeHandler';
 import { RetryError, HttpError } from '../error/http-error';
-import { InternalReduxStore } from '../redux';
 
 const cookiePrefix = 'csrf-token=';
 export const getCSRFToken = () =>
@@ -103,8 +103,10 @@ type ImpersonateHeaders = {
   'Impersonate-User': string;
 };
 export const getImpersonateHeaders = (): ImpersonateHeaders => {
-  if (!InternalReduxStore) return undefined;
-  const { kind, name } = InternalReduxStore.getState().UI.get('impersonate', {});
+  const store = storeHandler.getStore();
+  if (!store) return undefined;
+
+  const { kind, name } = store.getState().UI.get('impersonate', {});
   if ((kind === 'User' || kind === 'Group') && name) {
     // Even if we are impersonating a group, we still need to set Impersonate-User to something or k8s will complain
     const headers = {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/redux.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/redux.ts
@@ -1,1 +1,0 @@
-export { default as InternalReduxStore } from '@console/internal/redux';

--- a/frontend/packages/console-dynamic-plugin-sdk/tsconfig-base.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/tsconfig-base.json
@@ -11,6 +11,8 @@
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "lib": ["es2016", "es2020.promise", "dom"]
+    "lib": ["es2016", "es2020.promise", "dom"],
+    "typeRoots": ["node_modules/@types", "@types"],
+    "types": ["node", "sdk"]
   }
 }

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -34,6 +34,7 @@ import {
   isContextProvider,
   isReduxReducer,
   isStandaloneRoutePage,
+  AppInitSDK,
 } from '@console/dynamic-plugin-sdk';
 import { initConsolePlugins } from '@console/dynamic-plugin-sdk/src/runtime/plugin-init';
 import { GuidedTour } from '@console/app/src/components/tour';
@@ -464,11 +465,13 @@ graphQLReady.onReady(() => {
   render(
     <React.Suspense fallback={<LoadingBox />}>
       <Provider store={store}>
-        <CaptureTelemetry />
-        <ToastProvider>
-          <PollConsoleUpdates />
-          <AppRouter />
-        </ToastProvider>
+        <AppInitSDK>
+          <CaptureTelemetry />
+          <ToastProvider>
+            <PollConsoleUpdates />
+            <AppRouter />
+          </ToastProvider>
+        </AppInitSDK>
       </Provider>
     </React.Suspense>,
     document.getElementById('app'),

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -3,7 +3,7 @@ import * as semver from 'semver';
 import i18next from 'i18next';
 
 import { ClusterVersionModel } from '../../models';
-import { referenceForModel } from './k8s';
+import { referenceForModel } from './k8s-ref';
 import {
   ClusterVersionKind,
   ClusterUpdate,

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -12,6 +12,7 @@ export * from './template';
 export * from './swagger';
 export * from './event';
 export * from './types';
+export * from './k8s-ref';
 export {
   k8sGet,
   k8sCreate,

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -26,7 +26,8 @@ import {
   MachineModel,
   PrometheusModel,
 } from '../models';
-import { referenceForModel, referenceForGroupVersionKind } from '../module/k8s';
+import { referenceForGroupVersionKind } from '../module/k8s';
+import { referenceForModel } from '../module/k8s/k8s-ref';
 import { RootState } from '../redux';
 import { ActionType as K8sActionType } from '../actions/k8s';
 import { FeatureAction, ActionType } from '../actions/features';

--- a/frontend/public/redux.ts
+++ b/frontend/public/redux.ts
@@ -1,5 +1,6 @@
 import { applyMiddleware, combineReducers, createStore, compose, ReducersMapObject } from 'redux';
 import * as _ from 'lodash-es';
+import thunk from 'redux-thunk';
 import { ResolvedExtension, ReduxReducer } from '@console/dynamic-plugin-sdk';
 import { featureReducer, featureReducerName, FeatureState } from './reducers/features';
 import k8sReducers, { K8sState } from './reducers/k8s';
@@ -8,24 +9,6 @@ import { dashboardsReducer, DashboardsState } from './reducers/dashboards';
 
 const composeEnhancers =
   (process.env.NODE_ENV !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
-
-/**
- * This is the entirety of the `redux-thunk` library.
- * It hasn't changed since 2016 and has problems with it's TypeScript definitions
- * (https://github.com/reduxjs/redux-thunk/issues/231), so just including it here.
- */
-function createThunkMiddleware(extraArgument?) {
-  return ({ dispatch, getState }) => (next) => (action) => {
-    if (typeof action === 'function') {
-      return action(dispatch, getState, extraArgument);
-    }
-
-    return next(action);
-  };
-}
-
-const thunk = createThunkMiddleware();
-(thunk as any).withExtraArgument = createThunkMiddleware;
 
 export type RootState = {
   k8s: K8sState;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -15544,6 +15544,11 @@ redux-mock-store@^1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+redux-thunk@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.0.tgz#ac89e1d6b9bdb9ee49ce69a69071be41bbd82d67"
+  integrity sha512-/y6ZKQNU/0u8Bm7ROLq9Pt/7lU93cT0IucYMrubo89ENjxPa7i8pqLKu6V4X7/TvYovQ6x01unTeyeZ9lgXiTA==
+
 redux@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/HAC-199

**Addresses:**

- [x] remove the internal import of redux store from SDK
- [x] provides `AppInitSDK` for app developers to provide react context
- [x] require to export for k8s CRD utils
- [x] require to export for co-fetch utils
- [x] adds sample reducer for core
- [x] added redux-thunk dependency

**Verify:**

Create a self provisioner user, impersonate that and perform k8s CRUD operation

Size of dist in `dynamic-plugin-sdk`

Before: 2.1 MB
After:  2.1 MB

