### PR TITLE
Bug 2074447: cluster-dashboard: exclude iowait and steal from CPU Utilisation

### DIFF
--- a/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
+++ b/frontend/packages/console-shared/src/promql/cluster-dashboard.ts
@@ -313,7 +313,7 @@ const overviewQueries = {
     `
       sum(
         (
-          1 - rate(node_cpu_seconds_total{mode="idle"}[2m])
+          1 - sum without (mode) (rate(node_cpu_seconds_total{mode=~"idle|iowait|steal"}[2m]))
           *
           on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{pod=~"node-exporter.+"}
         )


### PR DESCRIPTION
'iowait' and 'steal' indicate specific idle/wait states, which shouldn't
be counted into CPU Utilisation. Also see
https://github.com/prometheus-operator/kube-prometheus/pull/796 and
https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/667.

Per the iostat man page:

%idle
Show the percentage of time that the CPU or CPUs were idle and the
system did not have an outstanding disk I/O request.

%iowait
Show the percentage of time that the CPU or CPUs were idle during
which the system had an outstanding disk I/O request.

%steal
Show the percentage of time spent in involuntary wait by the
virtual CPU or CPUs while the hypervisor was servicing another
virtual processor.

Signed-off-by: Julian Wiedmann <jwi@linux.ibm.com>