### PR TITLE
Bug 2023090: [e2e][automation] Examples of Import URL for VM templates

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tier1-b/url-examples.spec.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/tests/tier1-b/url-examples.spec.ts
@@ -1,0 +1,60 @@
+import { testName } from '../../support';
+import { TEMPLATE } from '../../utils/const';
+import { ProvisionSource } from '../../utils/const/provisionSource';
+import * as wizardView from '../../views/selector-wizard';
+import { wizard } from '../../views/wizard';
+
+describe('Import URL examples', () => {
+  before(() => {
+    cy.Login();
+    cy.createProject(testName);
+    cy.visitVMsList();
+  });
+
+  after(() => {
+    cy.visit('/');
+    cy.deleteTestProject(testName);
+  });
+
+  it('ID(CNV-7509) Examples of Import URLs for VM templates', () => {
+    for (const [key, value] of Object.entries(TEMPLATE)) {
+      if (key !== 'DEFAULT') {
+        wizard.vm.open();
+        cy.get('.pf-c-card')
+          .contains(value.os)
+          .should('exist')
+          .click();
+        cy.get(wizardView.next)
+          .should('not.be.disabled')
+          .click();
+        cy.get('body').then(($body) => {
+          if ($body.find('.ReactModal__Overlay').length > 0) {
+            cy.get('#confirm-action').click();
+          }
+        });
+        cy.get(wizardView.imageSourceDropdown).click();
+        cy.get(wizardView.selectMenu)
+          .contains(ProvisionSource.URL.getDescription())
+          .click({ force: true });
+        cy.get('.pf-c-form__helper-text')
+          .contains('Example: ')
+          .within(() => {
+            cy.get('a').should('have.attr', 'href', value.exampleImgUrl);
+          });
+        cy.get(wizardView.imageSourceDropdown).click();
+        cy.get(wizardView.selectMenu)
+          .contains(ProvisionSource.REGISTRY.getDescription())
+          .click({ force: true });
+        if (value.exampleRegUrl) {
+          cy.get('.pf-c-form__helper-text')
+            .contains('Example: ')
+            .contains(value.exampleRegUrl)
+            .should('exist');
+        }
+        cy.get('button')
+          .contains('Cancel')
+          .click();
+      }
+    }
+  });
+});

--- a/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests-cypress/utils/const/index.ts
@@ -1,3 +1,5 @@
+import * as urls from '../../../src/utils/strings';
+
 export const OS_IMAGES_NS = Cypress.env('DOWNSTREAM')
   ? 'openshift-virtualization-os-images'
   : 'kubevirt-os-images';
@@ -127,6 +129,8 @@ export const TEMPLATE = {
     metadataName: 'rhel6-server-small',
     os: 'Red Hat Enterprise Linux 6.0 or higher',
     supportLevel: 'Full',
+    exampleImgUrl: urls.RHEL_IMAGE_LINK,
+    exampleRegUrl: urls.FEDORA_EXAMPLE_CONTAINER,
   },
   RHEL7: {
     name: 'Red Hat Enterprise Linux 7.0+ VM',
@@ -134,6 +138,8 @@ export const TEMPLATE = {
     metadataName: 'rhel7-server-small',
     os: 'Red Hat Enterprise Linux 7.0 or higher',
     supportLevel: 'Full',
+    exampleImgUrl: urls.RHEL_IMAGE_LINK,
+    exampleRegUrl: urls.RHEL7_EXAMPLE_CONTAINER,
   },
   RHEL8: {
     name: 'Red Hat Enterprise Linux 8.0+ VM',
@@ -141,6 +147,8 @@ export const TEMPLATE = {
     metadataName: 'rhel8-server-small',
     os: 'Red Hat Enterprise Linux 8.0 or higher',
     supportLevel: 'Full',
+    exampleImgUrl: urls.RHEL_IMAGE_LINK,
+    exampleRegUrl: urls.RHEL8_EXAMPLE_CONTAINER,
   },
   RHEL9: {
     name: 'Red Hat Enterprise Linux 9.0 Alpha VM',
@@ -148,6 +156,8 @@ export const TEMPLATE = {
     metadataName: 'rhel9-server-small',
     os: 'Red Hat Enterprise Linux 9.0 or higher',
     supportLevel: 'Limited',
+    exampleImgUrl: urls.RHEL_IMAGE_LINK,
+    exampleRegUrl: urls.FEDORA_EXAMPLE_CONTAINER,
   },
   FEDORA: {
     name: 'Fedora 32+ VM',
@@ -155,6 +165,8 @@ export const TEMPLATE = {
     metadataName: 'fedora-server-small',
     os: 'Fedora 32 or higher',
     supportLevel: 'Community',
+    exampleImgUrl: urls.FEDORA_IMAGE_LINK,
+    exampleRegUrl: urls.FEDORA_EXAMPLE_CONTAINER,
   },
   CENTOS7: {
     name: 'CentOS 7.0+ VM',
@@ -162,6 +174,17 @@ export const TEMPLATE = {
     metadataName: 'centos7-server-small',
     os: 'CentOS 7 or higher',
     supportLevel: 'Community',
+    exampleImgUrl: urls.CENTOS_IMAGE_LINK,
+    exampleRegUrl: urls.CENTOS7_EXAMPLE_CONTAINER,
+  },
+  CENTOS8: {
+    name: 'CentOS 8.0+ VM',
+    dvName: 'centos8',
+    metadataName: 'centos8-server-small',
+    os: 'CentOS 8 or higher',
+    supportLevel: 'Community',
+    exampleImgUrl: urls.CENTOS_IMAGE_LINK,
+    exampleRegUrl: urls.CENTOS8_EXAMPLE_CONTAINER,
   },
   WIN10: {
     name: 'Microsoft Windows 10 VM',
@@ -169,6 +192,8 @@ export const TEMPLATE = {
     metadataName: 'windows10-desktop-medium',
     os: 'Microsoft Windows 10',
     supportLevel: 'Full',
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleRegUrl: '',
   },
   WIN2K12R2: {
     name: 'Microsoft Windows Server 2012 R2 VM',
@@ -176,6 +201,26 @@ export const TEMPLATE = {
     metadataName: 'windows2k12r2-server-medium',
     os: 'Microsoft Windows Server 2012 R2',
     supportLevel: 'Full',
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleRegUrl: '',
+  },
+  WIN2K16: {
+    name: 'Microsoft Windows Server 2016 VM',
+    dvName: 'win2k16',
+    metadataName: 'windows2k16-server-medium',
+    os: 'Microsoft Windows Server 2016',
+    supportLevel: 'Full',
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleRegUrl: '',
+  },
+  WIN2K19: {
+    name: 'Microsoft Windows Server 2019 VM',
+    dvName: 'win2k19',
+    metadataName: 'windows2k19-server-medium',
+    os: 'Microsoft Windows Server 2019',
+    supportLevel: 'Full',
+    exampleImgUrl: urls.WINDOWS_IMAGE_LINK,
+    exampleRegUrl: '',
   },
   DEFAULT: {
     name: 'vm-template-example',
@@ -183,5 +228,7 @@ export const TEMPLATE = {
     metadataName: 'vm-template-example',
     os: 'Red Hat Enterprise Linux 8.0 or higher',
     supportLevel: 'Full',
+    exampleImgUrl: urls.RHEL_IMAGE_LINK,
+    exampleRegUrl: urls.FEDORA_EXAMPLE_CONTAINER,
   },
 };


### PR DESCRIPTION
Tests checking the content of the hints with example registry URLs for VM bootsources.

Story: [Cypress tests for [CNV-14292: add TC/automation for fixed bugs](https://issues.redhat.com/browse/CNV-14292) 
[Bug 1908169 - (verify examples for URL/Registry for RHEL/Fedora/Centos/Windows)](https://bugzilla.redhat.com/show_bug.cgi?id=1908169)
[Polarion doc](https://polarion.engineering.redhat.com/polarion/#/project/CNV/wiki/Management/_UI_%20VM%20actions)
[Polarion Testcase: [CNV-7509](https://issues.redhat.com/browse/CNV-7509) - Examples of Import URL for VM templates ](https://polarion.engineering.redhat.com/polarion/#/project/CNV/workitem?id=[CNV-7509](https://issues.redhat.com/browse/CNV-7509))