### PR TITLE
Bug 2018264: Delete Export button doesn't work in topology sidebar (general issue with unknown CSV?) 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/actions/csv-actions.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/actions/csv-actions.ts
@@ -33,9 +33,8 @@ export const CSVDefaultActions = {
       label: i18next.t('olm~Delete {{item}}', { item: kindObj.label }),
       cta: () => {
         deleteModal({
-          kindObj,
+          kind: kindObj,
           resource,
-          namespace: resource.metadata.namespace,
           redirectTo: `/k8s/ns/${resource.metadata.namespace}/${
             ClusterServiceVersionModel.plural
           }/${csvName || csvNameFromWindow()}/${referenceFor(resource)}`,

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -127,7 +127,6 @@ export const getOperandActions = (
         deleteModal({
           kind,
           resource: obj,
-          namespace: obj.metadata.namespace,
           redirectTo: `/k8s/ns/${obj.metadata.namespace}/${
             ClusterServiceVersionModel.plural
           }/${csvName || csvNameFromWindow()}/${referenceFor(obj)}`,

--- a/frontend/public/components/modals/delete-modal.tsx
+++ b/frontend/public/components/modals/delete-modal.tsx
@@ -3,13 +3,7 @@ import * as React from 'react';
 import { Alert } from '@patternfly/react-core';
 import { Trans, useTranslation } from 'react-i18next';
 
-import {
-  createModalLauncher,
-  ModalTitle,
-  ModalBody,
-  ModalSubmitFooter,
-  ModalComponentProps,
-} from '../factory/modal';
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
 import {
   history,
   resourceListPathFromModel,
@@ -23,7 +17,7 @@ import { findOwner } from '../../module/k8s/managed-by';
 import { ResourceLink } from '../utils/resource-link';
 
 //Modal for resource deletion and allows cascading deletes if propagationPolicy is provided for the enum
-const DeleteModal = withHandlePromise((props: DeleteModalProps) => {
+const DeleteModal = withHandlePromise((props: DeleteModalProps & HandlePromiseProps) => {
   const [isChecked, setIsChecked] = React.useState(true);
   const [owner, setOwner] = React.useState(null);
 
@@ -34,7 +28,7 @@ const DeleteModal = withHandlePromise((props: DeleteModalProps) => {
     const { kind, resource } = props;
 
     //https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
-    const propagationPolicy = isChecked ? kind.propagationPolicy : 'Orphan';
+    const propagationPolicy = isChecked && kind ? kind.propagationPolicy : 'Orphan';
     const json = propagationPolicy
       ? { kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy }
       : null;
@@ -75,7 +69,9 @@ const DeleteModal = withHandlePromise((props: DeleteModalProps) => {
     <form onSubmit={submit} name="form" className="modal-content ">
       <ModalTitle>
         <YellowExclamationTriangleIcon className="co-icon-space-r" />{' '}
-        {t('public~Delete {{kind}}?', { kind: kind.labelKey ? t(kind.labelKey) : kind.label })}
+        {t('public~Delete {{kind}}?', {
+          kind: kind ? (kind.labelKey ? t(kind.labelKey) : kind.label) : '',
+        })}
       </ModalTitle>
       <ModalBody className="modal-body">
         {message}
@@ -145,9 +141,7 @@ export type DeleteModalProps = {
   resource: any;
   close?: () => void;
   redirectTo?: any;
-  message: JSX.Element;
+  message?: JSX.Element;
   cancel?: () => void;
   btnText?: string;
-  handlePromise: <T>(promise: Promise<T>) => Promise<T>;
-} & ModalComponentProps &
-  HandlePromiseProps;
+};


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://bugzilla.redhat.com/show_bug.cgi?id=2018264
https://issues.redhat.com/browse/OCPBUGSM-36630

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
`kind` was undefined as it was passed in the props as `kindObj` 

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
If `kind` is undefined, then search for `kindObj` and also double check if `kind` is not undefined when accessing its property label

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

![deleteModalExport](https://user-images.githubusercontent.com/20089340/141730099-067c45cd-3914-49ba-9aec-378a91e9a87a.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Steps to Reproduce:
1. Open Operator Hub and install the "Primer" GitOps Operator
2. Switch to developer perspective
3. Import at least one Application to enable the Export button in topology
4. If not opened yet, open the topology, and click the "Export Application" button
5. Wait until the export finishs and a new Deployment "primer-export-primer" was shown
6. Click on surrounding CSV Export "Primer" to open the sidebar
7. Click in the topology sidebar on Actions > Delete Export

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge