### PR TITLE
Bug 2022707: use prometheus tenancy URL to load data in dev console observe dashboard

### DIFF
--- a/frontend/public/components/monitoring/dashboards/bar-chart.tsx
+++ b/frontend/public/components/monitoring/dashboards/bar-chart.tsx
@@ -19,5 +19,6 @@ const BarChart: React.FC<BarChartProps> = ({ pollInterval, query }) => (
 type BarChartProps = {
   pollInterval: number;
   query: string;
+  namespace?: string;
 };
 export default BarChart;

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -19,6 +19,7 @@ type Props = {
   showLegend?: boolean;
   units: string;
   onZoomHandle?: (timeRange: number, endTime: number) => void;
+  namespace?: string;
 };
 
 const Graph: React.FC<Props> = ({
@@ -29,6 +30,7 @@ const Graph: React.FC<Props> = ({
   showLegend,
   units,
   onZoomHandle,
+  namespace,
 }) => {
   const dispatch = useDispatch();
   const [activePerspective] = useActivePerspective();
@@ -61,6 +63,7 @@ const Graph: React.FC<Props> = ({
       showLegend={showLegend}
       timespan={timespan}
       units={units}
+      namespace={namespace}
     />
   );
 };

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -157,7 +157,7 @@ const FilterSelect: React.FC<FilterSelectProps> = ({
 
 const VariableOption = ({ itemKey, value }) => <SelectOption key={itemKey} value={value} />;
 
-const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name }) => {
+const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name, namespace }) => {
   const { t } = useTranslation();
   const [activePerspective] = useActivePerspective();
 
@@ -190,6 +190,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name }) => {
         samples: NUM_SAMPLES,
         timeout: '30s',
         timespan,
+        namespace,
       });
 
       dispatch(monitoringDashboardsPatchVariable(name, { isLoading: true }, activePerspective));
@@ -209,7 +210,7 @@ const VariableDropdown: React.FC<VariableDropdownProps> = ({ id, name }) => {
           }
         });
     }
-  }, [activePerspective, dispatch, name, query, safeFetch, timespan]);
+  }, [activePerspective, dispatch, name, namespace, query, safeFetch, timespan]);
 
   React.useEffect(() => {
     if (variable.value && variable.value !== getQueryArgument(name)) {
@@ -281,7 +282,7 @@ const AllVariableDropdowns = ({ namespace }) => {
   return (
     <>
       {variables.keySeq().map((name: string) => (
-        <VariableDropdown key={name} id={name} name={name} />
+        <VariableDropdown key={name} id={name} name={name} namespace={namespace} />
       ))}
     </>
   );
@@ -448,6 +449,7 @@ const legendTemplateOptions = { interpolate: /{{([a-zA-Z_][a-zA-Z0-9_]*)}}/g };
 
 const Card: React.FC<CardProps> = React.memo(({ panel }) => {
   const [activePerspective] = useActivePerspective();
+  const namespace = React.useContext(NamespaceContext);
   const pollInterval = useSelector(({ UI }: RootState) =>
     UI.getIn(['monitoringDashboards', activePerspective, 'pollInterval']),
   );
@@ -527,7 +529,7 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
             ) : (
               <>
                 {panel.type === 'grafana-piechart-panel' && (
-                  <BarChart pollInterval={pollInterval} query={queries[0]} />
+                  <BarChart pollInterval={pollInterval} query={queries[0]} namespace={namespace} />
                 )}
                 {panel.type === 'graph' && (
                   <Graph
@@ -538,13 +540,24 @@ const Card: React.FC<CardProps> = React.memo(({ panel }) => {
                     showLegend={panel.legend?.show}
                     units={panel.yaxes?.[0]?.format}
                     onZoomHandle={handleZoom}
+                    namespace={namespace}
                   />
                 )}
                 {(panel.type === 'singlestat' || panel.type === 'gauge') && (
-                  <SingleStat panel={panel} pollInterval={pollInterval} query={queries[0]} />
+                  <SingleStat
+                    panel={panel}
+                    pollInterval={pollInterval}
+                    query={queries[0]}
+                    namespace={namespace}
+                  />
                 )}
                 {panel.type === 'table' && (
-                  <Table panel={panel} pollInterval={pollInterval} queries={queries} />
+                  <Table
+                    panel={panel}
+                    pollInterval={pollInterval}
+                    queries={queries}
+                    namespace={namespace}
+                  />
                 )}
               </>
             )}
@@ -755,6 +768,7 @@ type FilterSelectProps = {
 type VariableDropdownProps = {
   id: string;
   name: string;
+  namespace?: string;
 };
 
 type DashboardDropdownProps = {

--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -55,7 +55,7 @@ const Body: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <Bullseye className="monitoring-dashboards__single-stat">{children}</Bullseye>
 );
 
-const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
+const SingleStat: React.FC<Props> = ({ panel, pollInterval, query, namespace }) => {
   const {
     decimals,
     format,
@@ -75,7 +75,7 @@ const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
   const tick = () =>
-    safeFetch(getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, query }))
+    safeFetch(getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, query, namespace }))
       .then((response: PrometheusResponse) => {
         setError(undefined);
         setIsLoading(false);
@@ -127,6 +127,7 @@ type Props = {
   panel: Panel;
   pollInterval: number;
   query: string;
+  namespace?: string;
 };
 
 export default SingleStat;

--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -55,7 +55,7 @@ const paginationOptions = [5, 10, 20, 50, 100].map((n) => ({
   value: n,
 }));
 
-const Table: React.FC<Props> = ({ panel, pollInterval, queries }) => {
+const Table: React.FC<Props> = ({ panel, pollInterval, queries, namespace }) => {
   const [error, setError] = React.useState();
   const [isLoading, setLoading] = React.useState(true);
   const [data, setData] = React.useState();
@@ -71,7 +71,7 @@ const Table: React.FC<Props> = ({ panel, pollInterval, queries }) => {
   const tick = () => {
     Promise.all(
       queries.map((q) =>
-        safeFetch(getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, query: q })),
+        safeFetch(getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, query: q, namespace })),
       ),
     )
       .then((responses: PrometheusResponse[]) => {
@@ -191,6 +191,7 @@ type Props = {
   panel: Panel;
   pollInterval: number;
   queries: string[];
+  namespace?: string;
 };
 
 export default Table;


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=2022707

**Analysis / Root cause:**
Dev console Observe dashboard is using Prometheus URL to load data which causes forbidden error to the non-admin error.

**Solution Descriptions:**
use Prometheus tenancy URL to load data in dev console observe dashboard.