### PR TITLE
Bug 2023356: Devfiles can't be loaded in Safari on macOS (403 - Forbidden)

### DIFF
--- a/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.spec.ts
+++ b/frontend/packages/dev-console/src/components/catalog/providers/__tests__/useDevfileSamples.spec.ts
@@ -6,12 +6,10 @@ import useDevfileSamples from '../useDevfileSamples';
 import { devfileSamples, expectedCatalogItems } from './useDevfileSamples.data';
 
 jest.mock('@console/internal/co-fetch', () => ({
-  coFetchJSON: {
-    put: jest.fn(),
-  },
+  coFetchJSON: jest.fn(),
 }));
 
-const putMock = coFetchJSON.put as jest.Mock;
+const getMock = (coFetchJSON as unknown) as jest.Mock;
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -20,14 +18,12 @@ beforeEach(() => {
 describe('useDevfileSamples:', () => {
   it('should return loaded false until data are loaded', async () => {
     let resolver: (samples: DevfileSample[]) => void;
-    putMock.mockReturnValue(new Promise((resolve) => (resolver = resolve)));
+    getMock.mockReturnValue(new Promise((resolve) => (resolver = resolve)));
 
     const { result } = testHook(() => useDevfileSamples({}));
 
-    expect(putMock).toHaveBeenCalledTimes(1);
-    expect(putMock).toHaveBeenLastCalledWith('/api/devfile/samples', {
-      registry: 'sample-placeholder',
-    });
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(getMock).toHaveBeenLastCalledWith('/api/devfile/samples?registry=sample-placeholder');
 
     expect(result.current).toEqual([[], false, undefined]);
 
@@ -38,14 +34,12 @@ describe('useDevfileSamples:', () => {
 
   it('should return loaded false until fetch fails', async () => {
     let rejector: (error: Error) => void;
-    putMock.mockReturnValue(new Promise((_, reject) => (rejector = reject)));
+    getMock.mockReturnValue(new Promise((_, reject) => (rejector = reject)));
 
     const { result } = testHook(() => useDevfileSamples({}));
 
-    expect(putMock).toHaveBeenCalledTimes(1);
-    expect(putMock).toHaveBeenLastCalledWith('/api/devfile/samples', {
-      registry: 'sample-placeholder',
-    });
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(getMock).toHaveBeenLastCalledWith('/api/devfile/samples?registry=sample-placeholder');
 
     expect(result.current).toEqual([[], false, undefined]);
 

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfile.tsx
@@ -61,11 +61,7 @@ const useDevfile: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], boolean, an
 
   React.useEffect(() => {
     let mounted = true;
-    const payload = {
-      registry: 'sample-placeholder',
-    };
-    coFetchJSON
-      .put('/api/devfile/samples', payload)
+    coFetchJSON('/api/devfile/samples?registry=sample-placeholder')
       .then((resp) => {
         if (mounted) setDevfileSamples(resp);
       })

--- a/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
+++ b/frontend/packages/dev-console/src/components/catalog/providers/useDevfileSamples.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { ExtensionHook, CatalogItem } from '@console/dynamic-plugin-sdk';
+import { CatalogItem, ExtensionHook } from '@console/dynamic-plugin-sdk';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { APIError } from '@console/shared';
 import { DevfileSample } from '../../import/devfile/devfile-types';
@@ -40,11 +40,8 @@ const useDevfileSamples: ExtensionHook<CatalogItem[]> = (): [CatalogItem[], bool
 
   React.useEffect(() => {
     let mounted = true;
-    const payload = {
-      registry: 'sample-placeholder',
-    };
-    coFetchJSON
-      .put('/api/devfile/samples', payload)
+
+    coFetchJSON('/api/devfile/samples?registry=sample-placeholder')
       .then((res) => {
         if (mounted) setDevfileSamples(res);
       })

--- a/pkg/server/devfile-handler.go
+++ b/pkg/server/devfile-handler.go
@@ -25,19 +25,12 @@ import (
 
 func (s *Server) devfileSamplesHandler(w http.ResponseWriter, r *http.Request) {
 
-	var data devfileSamplesForm
-	registry := devfilePkg.DEVFILE_REGISTRY_PLACEHOLDER_URL
-
-	err := json.NewDecoder(r.Body).Decode(&data)
-	if err != nil {
-		errMsg := fmt.Sprintf("Failed to decode response: %v", err)
+	registry := r.URL.Query().Get("registry")
+	if registry == "" {
+		errMsg := "The registry parameter is missing"
 		klog.Error(errMsg)
 		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: errMsg})
 		return
-	}
-
-	if data.Registry != "" {
-		registry = data.Registry
 	}
 
 	sampleIndex, err := devfilePkg.GetRegistrySamples(registry)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,7 +55,7 @@ const (
 	helmChartRepoProxyEndpoint       = "/api/helm/charts/"
 	gitopsEndpoint                   = "/api/gitops/"
 	devfileEndpoint                  = "/api/devfile/"
-	devfileSamplesEndpoint           = "/api/devfile/samples/"
+	devfileSamplesEndpoint           = "/api/devfile/samples"
 	pluginAssetsEndpoint             = "/api/plugins/"
 	pluginProxyEndpoint              = "/api/proxy/"
 	localesEndpoint                  = "/locales/resource.json"


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2023356
https://issues.redhat.com/browse/OCPBUGSM-37199

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
In Safari 15.x on macOS, the Devfiles samples can't be loaded from the backend. As viewed in the network inspector of the browser I can say that the app makes two calls to the backend. The first answer was a redirect, the second the failure. Unfortunately, the payload gets lost between the first and second call.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
I changed the http method from `put` to `get` and passed the `registry` via an url param instead of a payload since we are fetching data from the backend only.

**Screen shots / Gifs for design review**: 
## Before:
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
<img width="367" alt="=?UTF-8?Q?Bildschirmfoto_2021-11-15_um_15=2E08=2E12=2Epng?=" src="https://user-images.githubusercontent.com/33380107/141813311-be42f75f-309b-4f7f-a587-18b8f7e43db7.png">
<img width="500" alt="141813321-16e7627e-198a-440b-92ab-e5850b6d3cbf" src="https://user-images.githubusercontent.com/33380107/141836460-b8cf803d-c480-4da1-8f1a-af34e9f56e67.png">

## After:
<img width="381" alt="Bildschirmfoto 2021-11-15 um 19 37 20" src="https://user-images.githubusercontent.com/33380107/141836521-0bfa2854-2cdc-4ac0-b78f-73a499bcf7e3.png">
<img width="500" alt="Bildschirmfoto 2021-11-15 um 19 37 29" src="https://user-images.githubusercontent.com/33380107/141836544-b719cb04-4abd-4f3c-b59d-c462e8e8057d.png">

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
Version-Release number of selected component (if applicable):
4.9

How reproducible:
Always

Steps to Reproduce:
1. Switch to dev console
2. Create a new project
3. Click on "+Add" or "View all samples"

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge