### PR TITLE
helm: support namespaced helm repository for helm API

### DIFF
--- a/docs/helm/configure-namespaced-helm-repos.md
+++ b/docs/helm/configure-namespaced-helm-repos.md
@@ -1,0 +1,85 @@
+# Configure Namespace Scoped Chart Repositories using namespaced CRDs
+
+While the cluster-scoped CRD `HelmChartRepository` for Helm repository provides ability for admins to add Helm repositories as custom resources, regular users/developers need an admin's permission in order to add Helm repositories of their choice.
+
+To avoid permission elevation, use namespace scoped CRD `ProjectHelmChartRepository`.
+
+## Basic structure of `ProjectHelmChartRepository`
+
+```yaml
+apiVersion: helm.openshift.io/v1beta1
+kind: ProjectHelmChartRepository
+metadata:
+  name: my-enterprise-chart-repo
+spec:
+  url: https://my.chart-repo.org/stable
+
+  # optional name that might be used by console
+  name: myChartRepo
+
+  # optional and only needed for UI purposes
+  description: my private chart repo
+
+  # required: chart repository URL
+  connectionConfig:
+    url: HELM_CHART_REPO_URL
+```
+
+## Getting Started with `ProjectHelmChartRepository`
+
+To add a new namespace-scoped Helm repository `stable` to a desired namespace `my-namespace`:
+
+```bash
+$ cat <<EOF | oc apply --namespace my-namespace -f -
+apiVersion: helm.openshift.io/v1beta1
+kind: ProjectHelmChartRepository
+metadata:
+  name: stable
+spec:
+  url: https://kubernetes-charts-incubator.storage.googleapis.com
+  displayName: Public Helm stable charts
+  description: Public Helm stable charts hosted on HelmHub
+EOF
+
+$ kubectl get projecthelmchartrepositories --namespace my-namespace
+NAME          AGE
+stable        1m
+```
+
+Note that the addition of namespace-scoped Helm repository does not impact behavior of the existing cluster-scoped Helm repository:
+
+```bash
+$ cat <<EOF | oc apply -f -
+apiVersion: helm.openshift.io/v1beta1
+kind: HelmChartRepository
+metadata:
+  name: custom-cluster
+spec:
+  url: https://kubernetes-charts.storage.googleapis.com
+  displayName: Public Helm stable charts
+  description: Public Helm stable charts hosted on HelmHub
+EOF
+
+$ cat <<EOF | oc apply --namespace my-namespace -f -
+apiVersion: helm.openshift.io/v1beta1
+kind: ProjectHelmChartRepository
+metadata:
+  name: custom-namespace
+spec:
+  url: https://kubernetes-charts-incubator.storage.googleapis.com
+  displayName: Public Helm charts in incubator state
+EOF
+
+$ kubectl get helmchartrepositories
+NAME          AGE
+cluster       3h30m
+custom-cluster        1m
+
+$ kubectl get projecthelmchartrepositories --namespace my-namespace
+NAME          AGE
+custom-namespace     1m
+```
+
+## API Endpoint `/api/helm/charts/index.yaml`
+
+The `/api/helm/charts/index.yaml` endpoint supports a query parameter `namespace`. For example, a GET request to /api/helm/charts/index.yaml?namespace=my-namespace will respond an aggregated index.yaml file with entities extracted from both cluster scoped Helm repository and Helm repositories in `my-namespace` namespace.

--- a/pkg/helm/actions/fake/helmcrconfigs.go
+++ b/pkg/helm/actions/fake/helmcrconfigs.go
@@ -29,7 +29,7 @@ func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Uns
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "helm.openshift.io", Version: "v1beta1", Kind: "HelmChartRepositoryList"}, &unstructured.UnstructuredList{})
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "helm.openshift.io", Version: "v1", Kind: "ProjectHelmChartRepositoryList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "helm.openshift.io", Version: "v1beta1", Kind: "ProjectHelmChartRepositoryList"}, &unstructured.UnstructuredList{})
 	return scheme
 }
 
@@ -69,7 +69,7 @@ func K8sDynamicClientMultipleNamespace(ns string, indexFilesCluster []string, in
 	}
 
 	for i, indexFile := range indexFilesNamespace {
-		fakeCr := fakeHelmCR("helm.openshift.io/v1", "ProjectHelmChartRepository", ns, "sample-namespace-repo-"+strconv.Itoa(i+1), indexFile)
+		fakeCr := fakeHelmCR("helm.openshift.io/v1beta1", "ProjectHelmChartRepository", ns, "sample-namespace-repo-"+strconv.Itoa(i+1), indexFile)
 		objs = append(objs, fakeCr)
 	}
 

--- a/pkg/helm/actions/fake/helmcrconfigs.go
+++ b/pkg/helm/actions/fake/helmcrconfigs.go
@@ -29,15 +29,16 @@ func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Uns
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "helm.openshift.io", Version: "v1beta1", Kind: "HelmChartRepositoryList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "helm.openshift.io", Version: "v1", Kind: "ProjectHelmChartRepositoryList"}, &unstructured.UnstructuredList{})
 	return scheme
 }
 
-func fakeHelmCR(fakeIndexFile string, name string) *unstructured.Unstructured {
+func fakeHelmCR(apiVersion, kind, ns, name, fakeIndexFile string) *unstructured.Unstructured {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/yaml")
 		fmt.Fprintln(w, fakeIndexFile)
 	}))
-	sampleRepoCR := newUnstructured("helm.openshift.io/v1beta1", "HelmChartRepository", "", name)
+	sampleRepoCR := newUnstructured(apiVersion, kind, ns, name)
 	connectionConfig := map[string]interface{}{
 		"url": ts.URL,
 	}
@@ -48,22 +49,38 @@ func fakeHelmCR(fakeIndexFile string, name string) *unstructured.Unstructured {
 	return sampleRepoCR
 }
 
-func K8sDynamicClient(indexFiles ...string) dynamic.Interface {
+func K8sDynamicClient(apiVersion, kind, ns string, indexFiles ...string) dynamic.Interface {
 	var objs []runtime.Object
 
 	for i, indexFile := range indexFiles {
-		fakeCr := fakeHelmCR(indexFile, "sample-repo-"+strconv.Itoa(i+1))
+		fakeCr := fakeHelmCR(apiVersion, kind, ns, "sample-repo-"+strconv.Itoa(i+1), indexFile)
 		objs = append(objs, fakeCr)
 	}
 
 	return fake.NewSimpleDynamicClient(newScheme(), objs...)
 }
 
-func K8sDynamicClientWithRepoNames(repoNames []string, indexFiles ...string) dynamic.Interface {
+func K8sDynamicClientMultipleNamespace(ns string, indexFilesCluster []string, indexFilesNamespace []string) dynamic.Interface {
+	var objs []runtime.Object
+
+	for i, indexFile := range indexFilesCluster {
+		fakeCr := fakeHelmCR("helm.openshift.io/v1beta1", "HelmChartRepository", "", "sample-cluster-repo-"+strconv.Itoa(i+1), indexFile)
+		objs = append(objs, fakeCr)
+	}
+
+	for i, indexFile := range indexFilesNamespace {
+		fakeCr := fakeHelmCR("helm.openshift.io/v1", "ProjectHelmChartRepository", ns, "sample-namespace-repo-"+strconv.Itoa(i+1), indexFile)
+		objs = append(objs, fakeCr)
+	}
+
+	return fake.NewSimpleDynamicClient(newScheme(), objs...)
+}
+
+func K8sDynamicClientWithRepoNames(apiVersion, kind, ns string, repoNames []string, indexFiles ...string) dynamic.Interface {
 	var objs []runtime.Object
 
 	for i, indexFile := range indexFiles {
-		fakeCr := fakeHelmCR(indexFile, repoNames[i])
+		fakeCr := fakeHelmCR(apiVersion, kind, ns, repoNames[i], indexFile)
 		objs = append(objs, fakeCr)
 	}
 

--- a/pkg/helm/chartproxy/proxy.go
+++ b/pkg/helm/chartproxy/proxy.go
@@ -21,7 +21,7 @@ type proxy struct {
 }
 
 type Proxy interface {
-	IndexFile(onlyCompatible bool) (*repo.IndexFile, error)
+	IndexFile(onlyCompatible bool, namespace string) (*repo.IndexFile, error)
 }
 
 type RestConfigProvider func() (*rest.Config, error)
@@ -71,8 +71,8 @@ func New(k8sConfig RestConfigProvider, kubeVersionGetter version.KubeVersionGett
 	return p, nil
 }
 
-func (p *proxy) IndexFile(onlyCompatible bool) (*repo.IndexFile, error) {
-	helmRepos, err := p.helmRepoGetter.List()
+func (p *proxy) IndexFile(onlyCompatible bool, namespace string) (*repo.IndexFile, error) {
+	helmRepos, err := p.helmRepoGetter.List(namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helm/chartproxy/proxy_test.go
+++ b/pkg/helm/chartproxy/proxy_test.go
@@ -139,7 +139,7 @@ func TestProxy_IndexFile(t *testing.T) {
 			helmNamespaceCRS: []*unstructured.Unstructured{
 				{
 					Object: map[string]interface{}{
-						"apiVersion": "helm.openshift.io/v1",
+						"apiVersion": "helm.openshift.io/v1beta1",
 						"kind":       "ProjectHelmChartRepository",
 						"metadata": map[string]interface{}{
 							"namespace": "test-namespace",

--- a/pkg/helm/chartproxy/proxy_test.go
+++ b/pkg/helm/chartproxy/proxy_test.go
@@ -32,6 +32,7 @@ func TestProxy_IndexFile(t *testing.T) {
 		helmCRS        []*unstructured.Unstructured
 		repoNames      []string
 		onlyCompatible bool
+		namespace      string
 	}{
 		{
 			name:       "returned index file for configured helm repo",
@@ -153,7 +154,7 @@ func TestProxy_IndexFile(t *testing.T) {
 				dynamicClient = fake.K8sDynamicClientWithRepoNames(tt.repoNames, indexFileContents...)
 			}
 			for _, helmcr := range tt.helmCRS {
-				_, err := dynamicClient.Resource(helmChartRepositoryGVK).Create(context.TODO(), helmcr, v1.CreateOptions{})
+				_, err := dynamicClient.Resource(helmChartRepositoryClusterGVK).Create(context.TODO(), helmcr, v1.CreateOptions{})
 				if err != nil {
 					t.Error(err)
 				}
@@ -170,7 +171,7 @@ func TestProxy_IndexFile(t *testing.T) {
 				t.Error(err)
 			}
 
-			indexFile, err := p.IndexFile(tt.onlyCompatible)
+			indexFile, err := p.IndexFile(tt.onlyCompatible, tt.namespace)
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -32,7 +32,7 @@ var (
 	}
 	helmChartRepositoryNamespaceGVK = schema.GroupVersionResource{
 		Group:    "helm.openshift.io",
-		Version:  "v1",
+		Version:  "v1beta1",
 		Resource: "projecthelmchartrepositories",
 	}
 )

--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -33,7 +33,7 @@ var (
 	helmChartRepositoryNamespaceGVK = schema.GroupVersionResource{
 		Group:    "helm.openshift.io",
 		Version:  "v1",
-		Resource: "projecthelmchartrepository",
+		Resource: "projecthelmchartrepositories",
 	}
 )
 

--- a/pkg/helm/chartproxy/repos.go
+++ b/pkg/helm/chartproxy/repos.go
@@ -138,6 +138,11 @@ func (b helmRepoGetter) unmarshallConfig(repo unstructured.Unstructured) (*helmR
 		return nil, err
 	}
 
+	h.Namespace, _, err = unstructured.NestedString(repo.Object, "metadata", "namespace")
+	if err != nil {
+		return nil, err
+	}
+
 	caReference, _, err := unstructured.NestedString(repo.Object, "spec", "connectionConfig", "ca", "name")
 	if err != nil {
 		return nil, err

--- a/pkg/helm/chartproxy/repos_test.go
+++ b/pkg/helm/chartproxy/repos_test.go
@@ -41,6 +41,7 @@ func TestHelmRepoGetter_List(t *testing.T) {
 		HelmChartRepoCRSInCluster int
 		expectedRepoName          []string
 		apiErrors                 []apiError
+		namespace                 string
 	}{
 		{
 			name:                      "return 2 repos found in cluster",
@@ -84,7 +85,7 @@ func TestHelmRepoGetter_List(t *testing.T) {
 				})
 			}
 			repoGetter := NewRepoGetter(client, nil)
-			repos, err := repoGetter.List()
+			repos, err := repoGetter.List(tt.namespace)
 			if err != nil {
 				t.Error(err)
 			}
@@ -107,6 +108,7 @@ func TestHelmRepoGetter_ListErrors(t *testing.T) {
 		helmCRS          []*unstructured.Unstructured
 		expectedRepoName []string
 		apiErrors        []apiError
+		namespace        string
 	}{
 		{
 			name: "skip repo that refer non-existent config map",
@@ -250,7 +252,7 @@ func TestHelmRepoGetter_ListErrors(t *testing.T) {
 				})
 			}
 			repoGetter := NewRepoGetter(client, coreClient.CoreV1())
-			repos, err := repoGetter.List()
+			repos, err := repoGetter.List(tt.namespace)
 			if err != nil {
 				t.Error(err)
 			}
@@ -382,6 +384,7 @@ func TestHelmRepoGetter_SkipDisabled(t *testing.T) {
 		helmCRS       []*unstructured.Unstructured
 		expectedRepos map[string]bool
 		apiErrors     []apiError
+		namespace     string
 	}{
 		{
 			name: "return only enabled helm repos",
@@ -464,7 +467,7 @@ func TestHelmRepoGetter_SkipDisabled(t *testing.T) {
 			client := fake.K8sDynamicClientFromCRs(tt.helmCRS...)
 			coreClient := k8sfake.NewSimpleClientset()
 			repoGetter := NewRepoGetter(client, coreClient.CoreV1())
-			repos, err := repoGetter.List()
+			repos, err := repoGetter.List(tt.namespace)
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/helm/handlers/handler_test.go
+++ b/pkg/helm/handlers/handler_test.go
@@ -148,11 +148,15 @@ type fakeProxy struct {
 	error
 	onlyCompatible bool
 	testContext    *testing.T
+	namespace      string
 }
 
-func (p fakeProxy) IndexFile(onlyCompatible bool) (*repo.IndexFile, error) {
+func (p fakeProxy) IndexFile(onlyCompatible bool, namespace string) (*repo.IndexFile, error) {
 	if onlyCompatible != p.onlyCompatible {
 		p.testContext.Errorf("Expected compatible flag is %t received %t", p.onlyCompatible, onlyCompatible)
+	}
+	if namespace != p.namespace {
+		p.testContext.Errorf("Expected namespace is %s received %s", p.namespace, namespace)
 	}
 	return p.repo, p.error
 }


### PR DESCRIPTION
Reads namespace information from request parameter and aggregates
cluster scoped and namespace scoped helm repositories before combining
the final index.yaml file. This affects only
the/api/helm/charts/index.yaml endpoint.

Depends on: https://issues.redhat.com/browse/HELM-258
Closes: https://issues.redhat.com/browse/HELM-259
Signed-off-by: Allen Bai <abai@redhat.com>