### PR TITLE
[EPIC] Utilization Card updates

### DIFF
--- a/frontend/packages/ceph-storage-plugin/locales/en/console-shared.json
+++ b/frontend/packages/ceph-storage-plugin/locales/en/console-shared.json
@@ -1,0 +1,7 @@
+{
+  "View {{title}} metrics in query browser": "View {{title}} metrics in query browser",
+  "Not available": "Not available",
+  "{{humanAvailable}} available of {{humanLimit}} total limit": "{{humanAvailable}} available of {{humanLimit}} total limit",
+  "{{humanAvailable}} available of {{humanMax}}": "{{humanAvailable}} available of {{humanMax}}",
+  "{{humanAvailable}} available": "{{humanAvailable}} available"
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/area-chart.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/area-chart.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import i18n from 'i18next';
+import { ChartLegendTooltip } from '@console/internal/components/graphs/tooltip';
+import {
+  ChartVoronoiContainer,
+  ChartGroup,
+  ChartArea,
+  ChartStack,
+  ChartLine,
+  ChartThemeColor,
+  Chart,
+  ChartAxis,
+} from '@patternfly/react-charts';
+import { DataPoint, CursorVoronoiContainer } from '@console/internal/components/graphs';
+import { humanizeNumber, Humanize, useRefWidth } from '@console/internal/components/utils';
+import { processFrame, ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
+import { timeFormatter } from '@console/internal/components/utils/datetime';
+import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
+import {
+  PrometheusGraph,
+  PrometheusGraphLink,
+} from '@console/internal/components/graphs/prometheus-graph';
+
+export const AreaChart: React.FC<AreaChartProps> = ({
+  data = [],
+  formatDate = timeFormatter.format,
+  humanize = humanizeNumber,
+  loading = true,
+  query,
+  ariaChartLinkLabel,
+  ariaChartTitle,
+  xAxis = true,
+  yAxis = true,
+  chartStyle,
+  byteDataType = '',
+  mainDataName,
+  chartType,
+  tickCount = 4,
+  height = 200,
+}) => {
+  const [containerRef, width] = useRefWidth();
+
+  const { processedData, unit } = React.useMemo(() => {
+    const nonEmptyDataSets = data.filter((dataSet) => dataSet?.length);
+    if (byteDataType) {
+      return processFrame(nonEmptyDataSets, byteDataType);
+    }
+    return { processedData: nonEmptyDataSets, unit: '' };
+  }, [byteDataType, data]);
+
+  const xTickFormat = React.useCallback((tick) => formatDate(tick), [formatDate]);
+  const yTickFormat = React.useCallback((tick) => `${humanize(tick, unit, unit).string}`, [
+    humanize,
+    unit,
+  ]);
+
+  const getLabel = React.useCallback(
+    (prop: { datum: DataPoint<Date> }, includeDate = true) => {
+      const { x, y } = prop.datum;
+      const value = humanize(y, unit, unit).string;
+      const date = formatDate(x);
+      return includeDate ? i18n.t('public~{{value}} at {{date}}', { value, date }) : value;
+    },
+    [humanize, unit, formatDate],
+  );
+
+  const legendData = processedData.map((d) => ({
+    childName: d[0].description,
+    name: d[0].description,
+    symbol: d[0].symbol,
+  }));
+
+  const container = React.useMemo(() => {
+    if (processedData?.length > 1) {
+      return (
+        <CursorVoronoiContainer
+          activateData={false}
+          cursorDimension="x"
+          labels={(props) => getLabel(props, false)}
+          mouseFollowTooltips
+          labelComponent={
+            <ChartLegendTooltip
+              stack
+              legendData={legendData}
+              getLabel={getLabel}
+              formatDate={(d) => formatDate(d[0].x)}
+              mainDataName={mainDataName}
+            />
+          }
+          voronoiDimension="x"
+        />
+      );
+    }
+    return <ChartVoronoiContainer voronoiDimension="x" labels={getLabel} activateData={false} />;
+  }, [formatDate, getLabel, legendData, mainDataName, processedData]);
+
+  let CustomChartGroup = ChartGroup;
+  let CustomChartArea = ChartArea;
+
+  if (chartType === 'stacked-area') {
+    CustomChartGroup = ChartStack;
+  }
+
+  if (chartType === 'grouped-line') {
+    CustomChartArea = ChartLine;
+    CustomChartGroup = ChartGroup;
+  }
+
+  return (
+    <PrometheusGraph ref={containerRef}>
+      <PrometheusGraphLink query={query} ariaChartLinkLabel={ariaChartLinkLabel}>
+        {processedData?.length ? (
+          <Chart
+            ariaTitle={ariaChartTitle}
+            containerComponent={container}
+            domainPadding={{ y: 20 }}
+            height={height}
+            width={width}
+            themeColor={ChartThemeColor.multiUnordered}
+            scale={{ x: 'time', y: 'linear' }}
+            padding={{ top: 20, left: 70, bottom: 60, right: 0 }}
+            legendData={chartType ? legendData : null}
+            legendPosition="bottom-left"
+          >
+            {xAxis && <ChartAxis tickCount={tickCount} tickFormat={xTickFormat} />}
+            {yAxis && <ChartAxis dependentAxis tickCount={tickCount} tickFormat={yTickFormat} />}
+            <CustomChartGroup height={height} width={width}>
+              {processedData.map((datum, index) => (
+                <CustomChartArea
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={index}
+                  data={datum}
+                  style={chartStyle && chartStyle[index]}
+                  name={datum[0]?.description}
+                />
+              ))}
+            </CustomChartGroup>
+          </Chart>
+        ) : (
+          <GraphEmpty height={height} loading={loading} />
+        )}
+      </PrometheusGraphLink>
+    </PrometheusGraph>
+  );
+};
+
+export type AreaChartProps = {
+  formatDate?: (date: Date, showSeconds?: boolean) => string;
+  humanize?: Humanize;
+  loading?: boolean;
+  query?: string | string[];
+  ariaChartLinkLabel?: string;
+  ariaChartTitle?: string;
+  data?: DataPoint[][];
+  xAxis?: boolean;
+  yAxis?: boolean;
+  chartStyle?: object[];
+  byteDataType?: ByteDataTypes; // Use this to process the whole data frame at once
+  mainDataName?: string;
+  chartType?: 'stacked-area' | 'grouped-line';
+  tickCount?: number;
+  height?: number;
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/multi-utilization-item.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/multi-utilization-item.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { DataPoint } from '@console/internal/components/graphs';
+import { Humanize } from '@console/internal/components/utils';
+import { AreaChart } from './area-chart';
+
+export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> = React.memo(
+  ({ title, data, humanizeValue, isLoading = false, queries, error, chartType }) => {
+    const { t } = useTranslation();
+    const currentValue =
+      data.length > 1 && data[0].length && data[1].length
+        ? humanizeValue(data[0][data[0].length - 1].y + data[1][data[1].length - 1].y).string
+        : '';
+    const chart = (
+      <AreaChart
+        data={error ? [[]] : data}
+        loading={!error && isLoading}
+        query={queries.map((q) => q.query)}
+        humanize={humanizeValue}
+        ariaChartLinkLabel={t('console-shared~View {{title}} metrics in query browser', {
+          title,
+        })}
+        ariaChartTitle={title}
+        chartType={chartType}
+      />
+    );
+
+    return (
+      <div className="co-utilization-card__item-ceph" data-test-id="utilization-item">
+        <div className="co-utilization-card__item-description-ceph">
+          <div className="co-utilization-card__item-section-multiline">
+            <h4 className="pf-c-title pf-m-lg">{title}</h4>
+            {error || (!isLoading && !(data.length && data.every((datum) => datum.length))) ? (
+              <div className="text-secondary">{t('console-shared~Not available')}</div>
+            ) : (
+              <div className="co-utilization-card__item-description-ceph-sub">{currentValue}</div>
+            )}
+          </div>
+        </div>
+        <div className="co-utilization-card__item-chart">{chart}</div>
+        <hr style={{ border: '1px lightgray solid', margin: '0px' }} />
+      </div>
+    );
+  },
+);
+
+type QueryWithDescription = {
+  query: string;
+  desc: string;
+};
+
+type MultilineUtilizationItemProps = {
+  title: string;
+  data?: DataPoint[][];
+  isLoading: boolean;
+  humanizeValue: Humanize;
+  queries: QueryWithDescription[];
+  error: boolean;
+  chartType?: 'stacked-area' | 'grouped-line';
+};

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/prometheus-multi-utilization-item.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/prometheus-multi-utilization-item.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { useUtilizationDuration } from '@console/shared/src/hooks/useUtilizationDuration';
+import {
+  withDashboardResources,
+  DashboardItemProps,
+} from '@console/internal/components/dashboard/with-dashboard-resources';
+import { getPrometheusQueryResponse } from '@console/internal/actions/dashboards';
+import { Humanize } from '@console/internal/components/utils';
+
+import { getRangeVectorStats } from '@console/internal/components/graphs/utils';
+import { MultilineUtilizationItem } from './multi-utilization-item';
+
+export const PrometheusMultilineUtilizationItem = withDashboardResources<
+  PrometheusMultilineUtilizationItemProps
+>(
+  ({
+    watchPrometheus,
+    stopWatchPrometheusQuery,
+    prometheusResults,
+    queries,
+    title,
+    humanizeValue,
+    namespace,
+    isDisabled = false,
+    chartType,
+  }) => {
+    const { duration } = useUtilizationDuration();
+    // eslint-disable-next-line consistent-return
+    React.useEffect(() => {
+      if (!isDisabled) {
+        queries.forEach((q) => watchPrometheus(q.query, namespace, duration));
+        return () => {
+          queries.forEach((q) => stopWatchPrometheusQuery(q.query, duration));
+        };
+      }
+    }, [watchPrometheus, stopWatchPrometheusQuery, duration, queries, namespace, isDisabled]);
+
+    const trimSecondsXMutator = (x: number) => {
+      const d = new Date(x * 1000);
+      d.setSeconds(0, 0);
+      return d;
+    };
+
+    const stats = [];
+    let hasError = false;
+    let isLoading = false;
+    if (!isDisabled) {
+      // eslint-disable-next-line consistent-return
+      queries.forEach((query) => {
+        const [response, responseError] = getPrometheusQueryResponse(
+          prometheusResults,
+          query.query,
+          duration,
+        );
+        if (responseError) {
+          hasError = true;
+          return false;
+        }
+        if (!response) {
+          isLoading = true;
+          return false;
+        }
+        stats.push(getRangeVectorStats(response, query.desc, null, trimSecondsXMutator)?.[0] || []);
+      });
+    }
+
+    return (
+      <MultilineUtilizationItem
+        title={title}
+        data={stats}
+        error={hasError}
+        isLoading={isLoading}
+        humanizeValue={humanizeValue}
+        queries={queries}
+        chartType={chartType}
+      />
+    );
+  },
+);
+
+type PrometheusCommonProps = {
+  title: string;
+  humanizeValue: Humanize;
+  namespace?: string;
+  isDisabled?: boolean;
+};
+
+type QueryWithDescription = {
+  query: string;
+  desc: string;
+};
+
+type PrometheusMultilineUtilizationItemProps = DashboardItemProps &
+  PrometheusCommonProps & {
+    queries: QueryWithDescription[];
+    chartType?: 'stacked-area' | 'grouped-line';
+  };

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/prometheus-utilization-item.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/prometheus-utilization-item.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import { PrometheusResponse } from '@console/internal/module/k8s';
+import { useUtilizationDuration } from '@console/shared/src/hooks/useUtilizationDuration';
+import { DataPoint } from '@console/internal/components/graphs';
+import { getInstantVectorStats } from '@console/internal/components/graphs/utils';
+import {
+  withDashboardResources,
+  DashboardItemProps,
+} from '@console/internal/components/dashboard/with-dashboard-resources';
+import { getPrometheusQueryResponse } from '@console/internal/actions/dashboards';
+import { Humanize } from '@console/internal/components/utils';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
+
+import { UtilizationItem } from './utilization-item';
+
+enum LIMIT_STATE {
+  ERROR = 'ERROR',
+  WARN = 'WARN',
+  OK = 'OK',
+}
+
+export const PrometheusUtilizationItem = withDashboardResources<PrometheusUtilizationItemProps>(
+  ({
+    utilizationQuery,
+    title,
+    totalQuery,
+    humanizeValue,
+    byteDataType,
+    TopConsumerPopover,
+    watchPrometheus,
+    stopWatchPrometheusQuery,
+    prometheusResults,
+    namespace,
+    isDisabled = false,
+    limitQuery,
+    requestQuery,
+    setLimitReqState,
+  }) => {
+    let utilization: PrometheusResponse;
+    let utilizationError: any;
+    let total: PrometheusResponse;
+    let totalError: any;
+    let max: DataPoint<number>[];
+    let limit: PrometheusResponse;
+    let limitError: any;
+    let request: PrometheusResponse;
+    let requestError: any;
+    let isLoading = false;
+    const { duration } = useUtilizationDuration();
+
+    // eslint-disable-next-line consistent-return
+    React.useEffect(() => {
+      if (!isDisabled) {
+        watchPrometheus(utilizationQuery, namespace, duration);
+        return () => {
+          stopWatchPrometheusQuery(utilizationQuery, duration);
+        };
+      }
+    }, [
+      watchPrometheus,
+      stopWatchPrometheusQuery,
+      duration,
+      utilizationQuery,
+      namespace,
+      isDisabled,
+    ]);
+
+    if (!isDisabled) {
+      [utilization, utilizationError] = getPrometheusQueryResponse(
+        prometheusResults,
+        utilizationQuery,
+        duration,
+      );
+      [total, totalError] = getPrometheusQueryResponse(prometheusResults, totalQuery);
+      [limit, limitError] = getPrometheusQueryResponse(prometheusResults, limitQuery, duration);
+      [request, requestError] = getPrometheusQueryResponse(
+        prometheusResults,
+        requestQuery,
+        duration,
+      );
+
+      max = getInstantVectorStats(total);
+      isLoading = !utilization || (totalQuery && !total) || (limitQuery && !limit);
+    }
+
+    return (
+      <UtilizationItem
+        TopConsumerPopover={TopConsumerPopover}
+        byteDataType={byteDataType}
+        error={utilizationError || totalError || limitError || requestError}
+        humanizeValue={humanizeValue}
+        isLoading={isLoading}
+        limit={limit}
+        max={max && max.length ? max[0].y : null}
+        query={[utilizationQuery, limitQuery, requestQuery]}
+        requested={request}
+        setLimitReqState={setLimitReqState}
+        title={title}
+        utilization={utilization}
+      />
+    );
+  },
+);
+
+type TopConsumerPopoverProp = {
+  current: string;
+  max?: string;
+  limit?: string;
+  available?: string;
+  requested?: string;
+  total?: string;
+  limitState?: LIMIT_STATE;
+  requestedState?: LIMIT_STATE;
+};
+
+type PrometheusCommonProps = {
+  title: string;
+  humanizeValue: Humanize;
+  byteDataType?: ByteDataTypes;
+  namespace?: string;
+  isDisabled?: boolean;
+};
+
+type LimitRequested = {
+  limit: LIMIT_STATE;
+  requested: LIMIT_STATE;
+};
+
+type PrometheusUtilizationItemProps = DashboardItemProps &
+  PrometheusCommonProps & {
+    utilizationQuery: string;
+    totalQuery?: string;
+    limitQuery?: string;
+    requestQuery?: string;
+    TopConsumerPopover?: React.ComponentType<TopConsumerPopoverProp>;
+    setLimitReqState?: (state: LimitRequested) => void;
+  };

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-card.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-card.scss
@@ -1,0 +1,45 @@
+.co-utilization-card__body {
+  padding: 0;
+}
+
+.co-utilization-card__title {
+  font-size: 1.2rem;
+}
+
+.co-utilization-card__item-description-ceph {
+  display: inline-flex;
+  flex-direction: row;
+  justify-content: left;
+  align-items: flex-end;
+  &-sub {
+    display: inline-flex;
+    flex-direction: row;
+    justify-content: left;
+    align-items: flex-end;
+    margin-left: 20px;
+    // align line-height of titles and their values
+    margin-top: 2px;
+  }
+}
+
+.co-utilization-card__item-ceph {
+  margin: var(--pf-global--spacer--md);
+  margin-bottom: 0;
+}
+
+.co-utilization-card__item-section {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+  &-ceph {
+    line-height: 32px;
+  }
+  &-multiline {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-card.tsx
@@ -1,22 +1,26 @@
+// TODO (@rexagod): https://github.com/openshift/console/pull/10470#discussion_r766453369
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardActions, CardHeader, CardTitle } from '@patternfly/react-core';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
+import { UtilizationDurationDropdown } from '@console/shared/src/components/dashboard/utilization-card/UtilizationDurationDropdown';
+import ConsumerPopover from '@console/shared/src/components/dashboard/utilization-card/TopConsumerPopover';
 import {
   humanizeBinaryBytes,
   humanizeDecimalBytesPerSec,
   FieldLevelHelp,
 } from '@console/internal/components/utils';
 import UtilizationBody from '@console/shared/src/components/dashboard/utilization-card/UtilizationBody';
-import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
-import ConsumerPopover from '@console/shared/src/components/dashboard/utilization-card/TopConsumerPopover';
-import { PrometheusUtilizationItem } from '@console/internal/components/dashboard/dashboards-page/cluster-dashboard/utilization-card';
-import { UtilizationDurationDropdown } from '@console/shared/src/components/dashboard/utilization-card/UtilizationDurationDropdown';
 import { humanizeIOPS, humanizeLatency } from './utils';
+import { PrometheusUtilizationItem } from './prometheus-utilization-item';
+import { PrometheusMultilineUtilizationItem } from './prometheus-multi-utilization-item';
 import {
   StorageDashboardQuery,
   UTILIZATION_QUERY,
   utilizationPopoverQueryMap,
 } from '../../../../queries';
+
+import './utilization-card.scss';
 
 const UtilizationCard: React.FC = () => {
   const { t } = useTranslation();
@@ -55,20 +59,32 @@ const UtilizationCard: React.FC = () => {
           byteDataType={ByteDataTypes.BinaryBytes}
           TopConsumerPopover={storagePopover}
         />
-        <PrometheusUtilizationItem
+        <PrometheusMultilineUtilizationItem
           title={t('ceph-storage-plugin~IOPS')}
-          utilizationQuery={UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_IOPS_QUERY]}
+          queries={[
+            UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_IOPS_READ_QUERY],
+            UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_IOPS_WRITE_QUERY],
+          ]}
           humanizeValue={humanizeIOPS}
+          chartType="stacked-area"
         />
-        <PrometheusUtilizationItem
-          title={t('ceph-storage-plugin~Latency')}
-          utilizationQuery={UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_LATENCY_QUERY]}
-          humanizeValue={humanizeLatency}
-        />
-        <PrometheusUtilizationItem
+        <PrometheusMultilineUtilizationItem
           title={t('ceph-storage-plugin~Throughput')}
-          utilizationQuery={UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_THROUGHPUT_QUERY]}
+          queries={[
+            UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_THROUGHPUT_READ_QUERY],
+            UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_THROUGHPUT_WRITE_QUERY],
+          ]}
           humanizeValue={humanizeDecimalBytesPerSec}
+          chartType="stacked-area"
+        />
+        <PrometheusMultilineUtilizationItem
+          title={t('ceph-storage-plugin~Latency')}
+          queries={[
+            UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_LATENCY_READ_QUERY],
+            UTILIZATION_QUERY[StorageDashboardQuery.UTILIZATION_LATENCY_WRITE_QUERY],
+          ]}
+          humanizeValue={humanizeLatency}
+          chartType="grouped-line"
         />
         <PrometheusUtilizationItem
           title={t('ceph-storage-plugin~Recovery')}

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-item.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboards/persistent-internal/utilization-card/utilization-item.tsx
@@ -1,0 +1,218 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
+import { PrometheusResponse } from '@console/internal/module/k8s';
+import { mapLimitsRequests } from '@console/internal/components/graphs/utils';
+import { Humanize } from '@console/internal/components/utils';
+import {
+  YellowExclamationTriangleIcon,
+  RedExclamationCircleIcon,
+  ColoredIconProps,
+} from '@console/shared/src/components/status';
+import { TopConsumerPopoverProp } from '@console/dynamic-plugin-sdk/src/api/internal-types';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
+import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
+import { AreaChart } from './area-chart';
+
+enum LIMIT_STATE {
+  ERROR = 'ERROR',
+  WARN = 'WARN',
+  OK = 'OK',
+}
+
+enum AreaChartStatus {
+  ERROR = 'ERROR',
+  WARNING = 'WARNING',
+}
+
+const chartStatusColors = {
+  [AreaChartStatus.ERROR]: dangerColor.value,
+  [AreaChartStatus.WARNING]: warningColor.value,
+};
+
+export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
+  ({
+    TopConsumerPopover,
+    byteDataType,
+    error,
+    humanizeValue,
+    isLoading = false,
+    limit,
+    max = null,
+    query,
+    requested,
+    setLimitReqState,
+    title,
+    utilization,
+  }) => {
+    const { t } = useTranslation();
+    const trimSecondsXMutator = (x: number) => {
+      const d = new Date(x * 1000);
+      d.setSeconds(0, 0);
+      return d;
+    };
+    const { data, chartStyle } = mapLimitsRequests(
+      utilization,
+      limit,
+      requested,
+      trimSecondsXMutator,
+    );
+    const [utilizationData, limitData, requestedData] = data;
+    const current = utilizationData?.length ? utilizationData[utilizationData.length - 1].y : null;
+
+    let humanMax: string;
+    let humanAvailable: string;
+    if (current && max) {
+      humanMax = humanizeValue(max).string;
+      const percentage = (100 * current) / max;
+
+      if (percentage >= 90) {
+        chartStyle[0] = { data: { fill: chartStatusColors[AreaChartStatus.ERROR] } };
+      } else if (percentage >= 80) {
+        chartStyle[0] = { data: { fill: chartStatusColors[AreaChartStatus.WARNING] } };
+      }
+
+      humanAvailable = humanizeValue(max - current).string;
+    }
+
+    const chart = (
+      <AreaChart
+        ariaChartLinkLabel={t('console-shared~View {{title}} metrics in query browser', {
+          title,
+        })}
+        ariaChartTitle={title}
+        data={data}
+        loading={!error && isLoading}
+        query={query}
+        // Todo(bipuladh): Make humanize type Humanize once unit.js is converted
+        humanize={humanizeValue as Humanize}
+        byteDataType={byteDataType}
+        chartStyle={chartStyle}
+        mainDataName="usage"
+      />
+    );
+
+    // Code below is used to render Consumer Popovers.
+    let LimitIcon: React.ComponentType<ColoredIconProps>;
+    let humanLimit: string;
+    let limitState = LIMIT_STATE.OK;
+    let requestedState = LIMIT_STATE.OK;
+
+    const latestLimit = limitData?.length ? limitData[limitData.length - 1].y : null;
+    const latestRequested = requestedData?.length
+      ? requestedData[requestedData.length - 1].y
+      : null;
+
+    if (max) {
+      if (latestLimit && latestRequested) {
+        humanLimit = humanizeValue(latestLimit).string;
+        const limitPercentage = (100 * latestLimit) / max;
+        const reqPercentage = (100 * latestRequested) / max;
+        if (limitPercentage > 100) {
+          limitState = LIMIT_STATE.ERROR;
+        } else if (limitPercentage >= 75) {
+          limitState = LIMIT_STATE.WARN;
+        }
+        if (reqPercentage > 100) {
+          requestedState = LIMIT_STATE.ERROR;
+        } else if (reqPercentage >= 75) {
+          requestedState = LIMIT_STATE.WARN;
+        }
+        if ([limitState, requestedState].includes(LIMIT_STATE.ERROR)) {
+          LimitIcon = RedExclamationCircleIcon;
+        } else if ([limitState, requestedState].includes(LIMIT_STATE.WARN)) {
+          LimitIcon = YellowExclamationTriangleIcon;
+        }
+        setLimitReqState && setLimitReqState({ limit: limitState, requested: requestedState });
+      }
+    }
+
+    const currentHumanized = current ? humanizeValue(current).string : null;
+
+    return (
+      <div className="co-utilization-card__item-ceph" data-test-id="utilization-item">
+        <div className="co-utilization-card__item-description-ceph">
+          <div className="co-utilization-card__item-section">
+            <h4 className="pf-c-title pf-m-lg" style={{ marginRight: '20px' }}>
+              {title}
+            </h4>
+            {error || (!isLoading && !utilizationData?.length) ? (
+              <div className="text-secondary">{t('console-shared~Not available')}</div>
+            ) : (
+              <div className="co-utilization-card__item-section-ceph">
+                {LimitIcon && <LimitIcon className="co-utilization-card__item-icon" />}
+                {TopConsumerPopover ? (
+                  <TopConsumerPopover
+                    current={currentHumanized}
+                    max={humanMax}
+                    limit={latestLimit ? humanizeValue(latestLimit).string : null}
+                    requested={latestRequested ? humanizeValue(latestRequested).string : null}
+                    available={humanAvailable}
+                    total={humanMax}
+                    limitState={limitState}
+                    requestedState={requestedState}
+                  />
+                ) : (
+                  currentHumanized
+                )}
+              </div>
+            )}
+          </div>
+          {!error && (humanAvailable || humanMax) && (
+            <div className="co-utilization-card__item-section">
+              <span
+                className="co-utilization-card__item-text"
+                data-test="utilization-card-item-text"
+              >
+                {humanLimit && (
+                  <span>
+                    {t(
+                      'console-shared~{{humanAvailable}} available of {{humanLimit}} total limit',
+                      {
+                        humanAvailable,
+                        humanLimit,
+                      },
+                    )}
+                  </span>
+                )}
+                {!humanLimit && humanMax && (
+                  <span>
+                    {t('console-shared~{{humanAvailable}} available of {{humanMax}}', {
+                      humanAvailable,
+                      humanMax,
+                    })}
+                  </span>
+                )}
+                {!humanLimit && !humanMax && (
+                  <span>
+                    {t('console-shared~{{humanAvailable}} available', {
+                      humanAvailable,
+                    })}
+                  </span>
+                )}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="co-utilization-card__item-chart">{chart}</div>
+        <hr style={{ border: '1px lightgray solid', margin: '0px' }} />
+      </div>
+    );
+  },
+);
+
+type UtilizationItemProps = {
+  title: string;
+  utilization?: PrometheusResponse;
+  limit?: PrometheusResponse;
+  requested?: PrometheusResponse;
+  isLoading: boolean;
+  // Todo(bipuladh): Make humanize type Humanize once unit.js is converted
+  humanizeValue: Function;
+  query: string | string[];
+  error: boolean;
+  max?: number;
+  byteDataType?: ByteDataTypes;
+  TopConsumerPopover?: React.ComponentType<TopConsumerPopoverProp>;
+  setLimitReqState?: (state: { limit: LIMIT_STATE; requested: LIMIT_STATE }) => void;
+};

--- a/frontend/packages/ceph-storage-plugin/src/queries/ceph-queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/queries/ceph-queries.ts
@@ -6,9 +6,12 @@ export enum StorageDashboardQuery {
   CEPH_STATUS_QUERY = 'CEPH_STATUS_QUERY',
   CEPH_PG_CLEAN_AND_ACTIVE_QUERY = 'CEPH_PG_CLEAN_AND_ACTIVE_QUERY',
   CEPH_PG_TOTAL_QUERY = 'CEPH_PG_TOTAL_QUERY',
-  UTILIZATION_IOPS_QUERY = 'UTILIZATION_IOPS_QUERY',
-  UTILIZATION_LATENCY_QUERY = 'UTILIZATION_LATENCY_QUERY',
-  UTILIZATION_THROUGHPUT_QUERY = 'UTILIZATION_THROUGHPUT_QUERY',
+  UTILIZATION_IOPS_READ_QUERY = 'UTILIZATION_IOPS_READ_QUERY',
+  UTILIZATION_IOPS_WRITE_QUERY = 'UTILIZATION_IOPS_WRITE_QUERY',
+  UTILIZATION_LATENCY_READ_QUERY = 'UTILIZATION_LATENCY_READ_QUERY',
+  UTILIZATION_LATENCY_WRITE_QUERY = 'UTILIZATION_LATENCY_WRITE_QUERY',
+  UTILIZATION_THROUGHPUT_READ_QUERY = 'UTILIZATION_THROUGHPUT_READ_QUERY',
+  UTILIZATION_THROUGHPUT_WRITE_QUERY = 'UTILIZATION_THROUGHPUT_WRITE_QUERY',
   UTILIZATION_RECOVERY_RATE_QUERY = 'UTILIZATION_RECOVERY_RATE_QUERY',
   CEPH_CAPACITY_TOTAL = 'CAPACITY_TOTAL',
   CEPH_CAPACITY_USED = 'CAPACITY_USED',
@@ -55,12 +58,30 @@ export const DATA_RESILIENCY_QUERY = {
 export const UTILIZATION_QUERY = {
   [StorageDashboardQuery.CEPH_CAPACITY_USED]:
     'sum(kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"}))',
-  [StorageDashboardQuery.UTILIZATION_IOPS_QUERY]:
-    '(sum(rate(ceph_pool_wr[1m])) + sum(rate(ceph_pool_rd[1m])))',
-  [StorageDashboardQuery.UTILIZATION_LATENCY_QUERY]:
-    '(quantile(.95,(cluster:ceph_disk_latency:join_ceph_node_disk_irate1m)))',
-  [StorageDashboardQuery.UTILIZATION_THROUGHPUT_QUERY]:
-    '(sum(rate(ceph_pool_wr_bytes[1m]) + rate(ceph_pool_rd_bytes[1m])))',
+  [StorageDashboardQuery.UTILIZATION_IOPS_READ_QUERY]: {
+    query: 'ceil(sum(rate(ceph_pool_rd[4m])))',
+    desc: 'Reads',
+  },
+  [StorageDashboardQuery.UTILIZATION_IOPS_WRITE_QUERY]: {
+    query: 'ceil(sum(rate(ceph_pool_wr[4m])))',
+    desc: 'Writes',
+  },
+  [StorageDashboardQuery.UTILIZATION_LATENCY_READ_QUERY]: {
+    query: 'cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m',
+    desc: 'Reads',
+  },
+  [StorageDashboardQuery.UTILIZATION_LATENCY_WRITE_QUERY]: {
+    query: 'cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m',
+    desc: 'Writes',
+  },
+  [StorageDashboardQuery.UTILIZATION_THROUGHPUT_READ_QUERY]: {
+    query: 'sum(rate(ceph_pool_rd_bytes[4m]))',
+    desc: 'Reads',
+  },
+  [StorageDashboardQuery.UTILIZATION_THROUGHPUT_WRITE_QUERY]: {
+    query: 'sum(rate(ceph_pool_wr_bytes[4m]))',
+    desc: 'Writes',
+  },
   [StorageDashboardQuery.UTILIZATION_RECOVERY_RATE_QUERY]:
     '(sum(ceph_pool_recovering_bytes_per_sec))',
 };


### PR DESCRIPTION
Use different chart components for:
- Used Capacity: Area chart
- IOPS: Stack chart
- Throughput: Stack chart
- Latency: Line chart
- Recovery: Area chart
***
The implementations were done by introducting `isOCSRendered` and
`chartType` props, on the removal of which, the components revert back to
their previous states (as shown in the attached screenshots below).

Epic Link: https://issues.redhat.com/browse/RHSTOR-2136
UI Mockup: https://marvelapp.com/prototype/g1h86ga/screen/82286650

***
<details>
<summary>On small screens (<1200px)</summary>

![Screenshot from 2021-11-16 09-32-37](https://user-images.githubusercontent.com/33557095/141905160-d4b74e90-d149-4fce-b41f-a25122afca50.png)

</details>

<details>
<summary>On normal screens</summary>

![Screenshot from 2021-11-16 09-32-59](https://user-images.githubusercontent.com/33557095/141905189-c6396924-7ab8-4303-aea6-ae270ad82d9f.png)

</details>

***
To show backward-compatibility, the first two graphs had both of the newly introduced props, `isOCSRendered` and `chartType` removed from them, which reverted them to their earlier states.

<details>
<summary>On small screens (<1200px)</summary>

![Screenshot from 2021-11-16 09-35-32](https://user-images.githubusercontent.com/33557095/141905224-3f57bff6-379a-4c3a-b7fe-28f2f35186e0.png)

</details>

<details>
<summary>On normal screens</summary>

![Screenshot from 2021-11-16 09-35-54](https://user-images.githubusercontent.com/33557095/141905263-975114c8-0296-4985-a182-2954e0f55dde.png)

</details>

***
While testing, the latency reads was zero so I manually set a point to 42 ms to demonstrate how this looks when the lines cross.

<details>
<summary>Latency cross example</summary>

![Screenshot from 2021-11-16 09-36-36](https://user-images.githubusercontent.com/33557095/141905319-b61eaded-d33e-4a07-867e-b4b9416f6c44.png)

</details>