### PR TITLE
 Bug 2023228: Remove Tech preview badge for the triggers component for triggers GA …

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/ClusterTriggerBindingPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/ClusterTriggerBindingPage.tsx
@@ -2,15 +2,18 @@ import * as React from 'react';
 import { DetailsForKind } from '@console/internal/components/default-resource';
 import { DetailsPageProps, DetailsPage } from '@console/internal/components/factory';
 import { navFactory, Kebab } from '@console/internal/components/utils';
+import { useTriggersTechPreviewBadge } from '../../utils/hooks';
 import { useTriggersBreadcrumbsFor } from './hooks';
 
 const ClusterTriggerBindingPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match, kind } = props;
   const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+  const badge = useTriggersTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       menuActions={Kebab.factory.common}
       breadcrumbsFor={() => breadcrumbsFor}
       pages={[navFactory.details(DetailsForKind(kind)), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/EventListenerPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/EventListenerPage.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
+import { useTriggersTechPreviewBadge } from '../../utils/hooks';
 import EventListenerDetails from './detail-page-tabs/EventListenerDetails';
 import { useTriggersBreadcrumbsFor } from './hooks';
 
 const EventListenerPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
   const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+  const badge = useTriggersTechPreviewBadge(props.namespace);
+
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       breadcrumbsFor={() => breadcrumbsFor}
       menuActions={Kebab.factory.common}
       pages={[navFactory.details(EventListenerDetails), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/TriggerBindingPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/TriggerBindingPage.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
+import { useTriggersTechPreviewBadge } from '../../utils/hooks';
 import TriggerBindingDetails from './detail-page-tabs/TriggerBindingDetails';
 import { useTriggersBreadcrumbsFor } from './hooks';
 
 const TriggerBindingPage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
   const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+  const badge = useTriggersTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       breadcrumbsFor={() => breadcrumbsFor}
       menuActions={Kebab.factory.common}
       pages={[navFactory.details(TriggerBindingDetails), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/TriggerTemplatePage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/TriggerTemplatePage.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
+import { useTriggersTechPreviewBadge } from '../../utils/hooks';
 import TriggerTemplateDetails from './detail-page-tabs/TriggerTemplateDetails';
 import { useTriggersBreadcrumbsFor } from './hooks';
 
 const TriggerTemplatePage: React.FC<DetailsPageProps> = (props) => {
   const { kindObj, match } = props;
   const breadcrumbsFor = useTriggersBreadcrumbsFor(kindObj, match);
+  const badge = useTriggersTechPreviewBadge(props.namespace);
 
   return (
     <DetailsPage
       {...props}
+      badge={badge}
       breadcrumbsFor={() => breadcrumbsFor}
       menuActions={Kebab.factory.common}
       pages={[navFactory.details(TriggerTemplateDetails), navFactory.editYaml()]}

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/const.ts
@@ -52,6 +52,7 @@ export const SecretAnnotationType = {
 };
 
 export const PIPELINE_GA_VERSION = '1.4.0';
+export const TRIGGERS_GA_VERSION = '1.6.0';
 export const PIPELINE_SERVICE_ACCOUNT = 'pipeline';
 export const PIPELINE_RUN_AUTO_START_FAILED = `bridge/pipeline-run-auto-start-failed`;
 

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/utils/pipeline-operator.ts
@@ -6,7 +6,7 @@ import {
   ClusterServiceVersionModel,
   ClusterServiceVersionPhase,
 } from '@console/operator-lifecycle-manager';
-import { PIPELINE_GA_VERSION } from '../const';
+import { PIPELINE_GA_VERSION, TRIGGERS_GA_VERSION } from '../const';
 
 export const getPipelineOperatorVersion = async (namespace: string): Promise<SemVer | null> => {
   const allCSVs: ClusterServiceVersionKind[] = await k8sList(ClusterServiceVersionModel, {
@@ -43,4 +43,9 @@ export const usePipelineOperatorVersion = (namespace: string): SemVer | null => 
 export const isGAVersionInstalled = (operator: SemVer): boolean => {
   if (!operator) return false;
   return gte(operator.version, PIPELINE_GA_VERSION);
+};
+
+export const isTriggersGAVersion = (operator: SemVer): boolean => {
+  if (!operator) return false;
+  return gte(operator.version, TRIGGERS_GA_VERSION);
 };

--- a/frontend/packages/pipelines-plugin/src/components/triggers-lists/TriggersPage.tsx
+++ b/frontend/packages/pipelines-plugin/src/components/triggers-lists/TriggersPage.tsx
@@ -7,13 +7,14 @@ import NamespacedPage, {
 import { DefaultPage } from '@console/internal/components/default-resource';
 import { Page } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { TechPreviewBadge, MultiTabListPage } from '@console/shared';
+import { MultiTabListPage } from '@console/shared';
 import {
   EventListenerModel,
   TriggerTemplateModel,
   TriggerBindingModel,
   ClusterTriggerBindingModel,
 } from '../../models';
+import { useTriggersTechPreviewBadge } from '../../utils/hooks';
 
 interface TriggersPageProps {
   match: Rmatch<any>;
@@ -24,6 +25,7 @@ const TriggersPage: React.FC<TriggersPageProps> = ({ match }) => {
   const {
     params: { ns: namespace },
   } = match;
+  const badge = useTriggersTechPreviewBadge(namespace);
   const [showTitle, canCreate] = [false, false];
   const menuActions = {
     eventListener: { model: EventListenerModel },
@@ -83,7 +85,7 @@ const TriggersPage: React.FC<TriggersPageProps> = ({ match }) => {
         pages={pages}
         match={match}
         title={t('pipelines-plugin~Triggers')}
-        badge={<TechPreviewBadge />}
+        badge={badge}
         menuActions={menuActions}
       />
     </NamespacedPage>

--- a/frontend/packages/pipelines-plugin/src/models/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/src/models/pipelines.ts
@@ -145,7 +145,6 @@ export const TriggerBindingModel: K8sKind = {
   id: 'triggerbinding',
   labelPlural: 'TriggerBindings',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -164,7 +163,6 @@ export const ClusterTriggerBindingModel: K8sKind = {
   id: 'clustertriggerbinding',
   labelPlural: 'ClusterTriggerBindings',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -183,7 +181,6 @@ export const TriggerTemplateModel: K8sKind = {
   id: 'triggertemplate',
   labelPlural: 'TriggerTemplates',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 
@@ -202,7 +199,6 @@ export const EventListenerModel: K8sKind = {
   id: 'eventlistener',
   labelPlural: 'EventListeners',
   crd: true,
-  badge: BadgeType.TECH,
   color,
 };
 

--- a/frontend/packages/pipelines-plugin/src/utils/__tests__/hooks.spec.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/__tests__/hooks.spec.ts
@@ -1,7 +1,8 @@
-import { PIPELINE_GA_VERSION } from '../../components/pipelines/const';
+import { TechPreviewBadge } from '@console/shared';
+import { PIPELINE_GA_VERSION, TRIGGERS_GA_VERSION } from '../../components/pipelines/const';
 import * as operatorUtils from '../../components/pipelines/utils/pipeline-operator';
 import { testHook } from '../../test-data/test-utils';
-import { usePipelineTechPreviewBadge } from '../hooks';
+import { usePipelineTechPreviewBadge, useTriggersTechPreviewBadge } from '../hooks';
 
 describe('usePipelineTechPreviewBadge:', () => {
   it('should return the badge if pipeline GA opertaor is installed', () => {
@@ -16,6 +17,26 @@ describe('usePipelineTechPreviewBadge:', () => {
     jest
       .spyOn(operatorUtils, 'usePipelineOperatorVersion')
       .mockReturnValue({ version: PIPELINE_GA_VERSION });
+    testHook(() => {
+      const badge = usePipelineTechPreviewBadge('test-ns');
+      expect(badge).toBeNull();
+    });
+  });
+});
+
+describe('useTriggersTechPreviewBadge:', () => {
+  it('should return the badge if triggers GA operator is not installed', () => {
+    jest.spyOn(operatorUtils, 'usePipelineOperatorVersion').mockReturnValue({ version: '1.5.2' });
+    testHook(() => {
+      const badge = useTriggersTechPreviewBadge('test-ns');
+      expect(badge.type).toEqual(TechPreviewBadge);
+    });
+  });
+
+  it('should not return the badge if triggers GA operator is installed', () => {
+    jest
+      .spyOn(operatorUtils, 'usePipelineOperatorVersion')
+      .mockReturnValue({ version: TRIGGERS_GA_VERSION });
     testHook(() => {
       const badge = usePipelineTechPreviewBadge('test-ns');
       expect(badge).toBeNull();

--- a/frontend/packages/pipelines-plugin/src/utils/hooks.ts
+++ b/frontend/packages/pipelines-plugin/src/utils/hooks.ts
@@ -1,12 +1,21 @@
 import { BadgeType, getBadgeFromType } from '@console/shared';
 import {
   isGAVersionInstalled,
+  isTriggersGAVersion,
   usePipelineOperatorVersion,
 } from '../components/pipelines/utils/pipeline-operator';
+
+const getOSPTechPreviewBadge = (installedGAVersion: boolean) =>
+  installedGAVersion ? null : getBadgeFromType(BadgeType.TECH);
 
 export const usePipelineTechPreviewBadge = (namespace: string) => {
   const operator = usePipelineOperatorVersion(namespace);
   if (!operator) return null;
-  const installedGA = isGAVersionInstalled(operator);
-  return installedGA ? null : getBadgeFromType(BadgeType.TECH);
+  return getOSPTechPreviewBadge(isGAVersionInstalled(operator));
+};
+
+export const useTriggersTechPreviewBadge = (namespace: string) => {
+  const operator = usePipelineOperatorVersion(namespace);
+  if (!operator) return null;
+  return getOSPTechPreviewBadge(isTriggersGAVersion(operator));
 };


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/OCPBUGSM-37184

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
OSP 1.6 contains Triggers 0.16 (GA version of triggers components), so we need to remove the Tech preview badges on the OCP UI 4.9.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Removed the Tech preview badges for the OSP 1.6 and above operators.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
<img width="436" alt="Screenshot 2021-11-16 at 2 26 33 PM" src="https://user-images.githubusercontent.com/9964343/141961622-8dd19488-469d-496c-aece-69c58e070bd8.png">
**Trigger Template page:**
<img width="755" alt="Screenshot 2021-11-16 at 3 04 32 PM" src="https://user-images.githubusercontent.com/9964343/141961632-66a6dbe2-dc57-417e-9696-828906ca7808.png">

**Admin -> Triggers Page:**
<img width="757" alt="Screenshot 2021-11-16 at 3 04 43 PM" src="https://user-images.githubusercontent.com/9964343/141961634-2ddf1440-0b6e-45c3-a1c5-c28e96994a9f.png">

**EventListenerPage:**
<img width="1497" alt="Screenshot 2021-11-16 at 3 04 51 PM" src="https://user-images.githubusercontent.com/9964343/141961637-5995d40d-5420-45f5-bd18-d869b420c01f.png">
**TriggerBinding Page:**
<img width="1498" alt="Screenshot 2021-11-16 at 3 05 11 PM" src="https://user-images.githubusercontent.com/9964343/141961638-c8f0303b-12d5-424e-8b57-de3e718d0a51.png">
**ClusterTriggerBinding Page:**
<img width="1497" alt="Screenshot 2021-11-16 at 3 05 25 PM" src="https://user-images.githubusercontent.com/9964343/141961640-97e40252-60b2-419f-897d-a2826ba25ac1.png">

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/9964343/141962196-b8821f03-4cee-4f5a-9ca4-dfdd83778c6a.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Add Trigger to a pipeline and visit all the Trigger components related details pages.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge