### PR TITLE
 Bug 2025823: Add plugin seperator to admin nav

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/navigation.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/navigation.ts
@@ -89,6 +89,8 @@ export const isSeparator = (e: Extension): e is Separator =>
 export const isNavSection = (e: Extension): e is NavSection =>
   e.type === 'console.navigation/section';
 
-export const isNavItem = (e: Extension): e is NavItem => {
-  return isHrefNavItem(e) || isResourceNSNavItem(e) || isResourceClusterNavItem(e);
-};
+export const isNavItem = (e: Extension): e is NavItem =>
+  isHrefNavItem(e) || isResourceNSNavItem(e) || isResourceClusterNavItem(e);
+
+export const isNavItemOrSeparator = (e: Extension): e is NavItem | Separator =>
+  isNavItem(e) || isSeparator(e);

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -39,7 +39,7 @@ type SeparatorProps = {
 };
 
 // Wrap `NavItemSeparator` so we can use `required` without prop type errors.
-const Separator: React.FC<SeparatorProps> = ({ name, id }) => (
+export const Separator: React.FC<SeparatorProps> = ({ name, id }) => (
   <NavItemSeparator name={name} id={id} />
 );
 


### PR DESCRIPTION
Dynamic plugin separator is not merged into existing sections

When rendering dynamic navigation items that extend existing sections, navigation item separators are not rendered.
This pull requests adds the separator items to the generated list of the navigation bar section children.

Screenshots:
Before:
![without-sep](https://user-images.githubusercontent.com/2181522/141979750-da2ab68b-af13-439e-b48a-22009e30cd17.png)

After:
![with-sep](https://user-images.githubusercontent.com/2181522/141979782-25a036aa-bc1d-4937-9252-b3dcf689b82f.png)

