### PR TITLE
Bug 2023781: initial hardware devices is not loading in wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -9,7 +9,8 @@ import { StorageClassResourceKind } from '@console/internal/module/k8s';
 import { TemplateSupport } from '../../../../constants/vm-templates/support';
 import useV2VConfigMap from '../../../../hooks/use-v2v-config-map';
 import { getDefaultStorageClass } from '../../../../selectors/config-map/sc-defaults';
-import { iGet, iGetIn, toShallowJS } from '../../../../utils/immutable';
+import { selectVM } from '../../../../selectors/vm-template/basic';
+import { iGet, iGetIn } from '../../../../utils/immutable';
 import { FormPFSelect } from '../../../form/form-pf-select';
 import { FormField, FormFieldType } from '../../form/form-field';
 import { FormFieldMemoRow } from '../../form/form-field-row';
@@ -102,9 +103,9 @@ export const VMSettingsTabComponent: React.FC<VMSettingsTabComponentProps> = ({
   );
 
   React.useEffect(() => {
-    if (!isDevicesInitialized) {
-      const templateDevices = toShallowJS(iUserTemplate)?.data?.objects?.[0]?.spec?.template?.spec
-        ?.domain?.devices;
+    const template = iUserTemplate?.toJS();
+    if (!isDevicesInitialized && template?.loaded) {
+      const templateDevices = selectVM(template.data)?.spec?.template?.spec?.domain?.devices;
       onHardwareFieldChange(HardwareDevicesField.GPUS, templateDevices?.gpus);
       onHardwareFieldChange(HardwareDevicesField.HOST_DEVICES, templateDevices?.hostDevices);
       onHardwareFieldChange(HardwareDevicesField.IS_DEVICES_INITIALIZED, true);


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2023781

**Analysis / Root cause**: 
template was not loaded when trying to init hardware devices

**Screen shots / Gifs for design review**: 
**template**

![devices](https://user-images.githubusercontent.com/67270715/142009725-94a34e11-2694-4236-8b9b-0416045c6c03.png)

**before**:

![before](https://user-images.githubusercontent.com/67270715/142009755-653eb80b-b879-4661-8e71-16a8fdf8e3b0.png)

**after**:

![after](https://user-images.githubusercontent.com/67270715/142009788-5dcf8b80-a9ac-477d-9144-e90d1511dd11.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>