### PR TITLE
Bug 2014471: Open Helm Release notes tab automatically after installing a chart

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/HelmInstallUpgradePage.tsx
@@ -202,7 +202,9 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
           }
           const secretId = secret?.items?.[0]?.metadata?.uid;
           if (secretId) {
-            redirect = `${config.redirectURL}?selectId=${secretId}&selectTab=Release+notes`;
+            redirect = `${config.redirectURL}?selectId=${secretId}&selectTab=${t(
+              'helm-plugin~Release notes',
+            )}`;
           }
         }
 


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2014471

**Root analysis:**
the `Release notes` tab name is not internationalized

**Solution description:**
added i18n for `Release notes` tab name

**GIF:**
![helm-release-notes](https://user-images.githubusercontent.com/22490998/142016031-b3c343ae-f34c-45e9-ad9c-62e5f2a4c92a.gif)
