### PR TITLE
Add script for fetching published Console plugin SDK packages

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/README.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/README.md
@@ -196,10 +196,11 @@ list of plugin names (disable specific plugins) or an empty string (disable all 
 
 ## Publishing SDK packages
 
-To see the latest published version of the given package:
+To see the latest published version of the given package and fetch its contents:
 
 ```sh
-yarn info <package-name> dist-tags --json | jq .data.latest
+npm view <package-name> dist-tags.latest
+./get-published-package.sh <package-name>
 ```
 
 Before publishing, it's recommended to log into your npm user account:

--- a/frontend/packages/console-dynamic-plugin-sdk/get-published-package.sh
+++ b/frontend/packages/console-dynamic-plugin-sdk/get-published-package.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu
+
+PACKAGE_NAME="$1"
+
+LATEST_VERSION=$(npm view "$PACKAGE_NAME" dist-tags.latest)
+LATEST_TARBALL=$(npm pack "${PACKAGE_NAME}@${LATEST_VERSION}" 2>/dev/null)
+OUTPUT_DIR="dist/published-$(echo "$LATEST_TARBALL" | cut -f -3 -d '.')"
+
+mkdir -p "$OUTPUT_DIR" && rm -rf "$OUTPUT_DIR/*"
+tar -xzf "$LATEST_TARBALL" -C "$OUTPUT_DIR"
+rm -f "$LATEST_TARBALL"
+
+echo "$OUTPUT_DIR"


### PR DESCRIPTION
This PR adds `get-published-package.sh` script which downloads and extracts the latest published version of the given SDK distributable package. It then prints the path to extracted package to standard output (`dist/published-<pkg>`).

For example:

```sh
$ ./get-published-package.sh @openshift-console/dynamic-plugin-sdk-webpack
dist/published-openshift-console-dynamic-plugin-sdk-webpack-0.0.4
```

```sh
$ tree dist/published-openshift-console-dynamic-plugin-sdk-webpack-0.0.4 -L 2 --dirsfirst --noreport
dist/published-openshift-console-dynamic-plugin-sdk-webpack-0.0.4
└── package
    ├── lib
    ├── schema
    ├── LICENSE
    ├── package.json
    └── README.md
```
