### PR TITLE
Bug 2025266: Removed exact on CreateResource route

### DIFF
--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -704,7 +704,7 @@ const AppContents: React.FC<{}> = () => {
               path="/k8s/ns/:ns/pods/:podName/containers/:name"
               loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
             />
-            <Route path="/k8s/ns/:ns/:plural/~new" exact component={CreateResource} />
+            <Route path="/k8s/ns/:ns/:plural/~new" component={CreateResource} />
             <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
             <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
 


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
sub-routes of /~new cannot be used when using the console.resource/create extension.

**Analysis / Root cause**: 
exact props is true on Route of CreateResource

**Solution Description**: 
Removed the exact props from this route.
