### PR TITLE
Bug 2023675: Add warning alert when installing operator to non suggested namespace

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/en/olm.json
@@ -274,6 +274,7 @@
   "Please note that installing non-Red Hat operators into OpenShift namespaces and enabling monitoring voids user support. Enabling cluster monitoring for non-Red Hat operators can lead to malicious metrics data overriding existing cluster metrics. For more information, see the <2>cluster monitoring documentation</2>.": "Please note that installing non-Red Hat operators into OpenShift namespaces and enabling monitoring voids user support. Enabling cluster monitoring for non-Red Hat operators can lead to malicious metrics data overriding existing cluster metrics. For more information, see the <2>cluster monitoring documentation</2>.",
   "Operator recommended Namespace:": "Operator recommended Namespace:",
   "Select a Namespace": "Select a Namespace",
+  "Not installing the Operator into the recommended namespace can cause unexpected behavior.": "Not installing the Operator into the recommended namespace can cause unexpected behavior.",
   "Operator Installation": "Operator Installation",
   "Install Operator": "Install Operator",
   "Install your Operator by subscribing to one of the update channels to keep the Operator up to date. The strategy determines either manual or automatic updates.": "Install your Operator by subscribing to one of the update channels to keep the Operator up to date. The strategy determines either manual or automatic updates.",

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -620,12 +620,24 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         title={t('olm~Select a Namespace')}
       />
       {!useSuggestedNSForSingleInstallMode && (
-        <NsDropdown
-          id="dropdown-selectbox"
-          selectedKey={selectedTargetNamespace}
-          onChange={(ns) => setTargetNamespace(ns)}
-          dataTest="dropdown-selectbox"
-        />
+        <>
+          <NsDropdown
+            id="dropdown-selectbox"
+            selectedKey={selectedTargetNamespace}
+            onChange={(ns) => setTargetNamespace(ns)}
+            dataTest="dropdown-selectbox"
+          />
+          {suggestedNamespace !== selectedTargetNamespace && (
+            <Alert
+              isInline
+              className="co-alert pf-c-alert--top-margin"
+              variant="warning"
+              title={t(
+                'olm~Not installing the Operator into the recommended namespace can cause unexpected behavior.',
+              )}
+            />
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
When installing to other then suggested namespace we should warn user that there could be problems with the operator functionality.
Adding this warning based on chat with @dmesser 

/assign @TheRealJon 

Screen:
<img width="1369" alt="Screenshot 2021-11-17 at 11 37 27" src="https://user-images.githubusercontent.com/1668218/142190018-9940d855-3d3b-4e6f-a7c9-fb6400c1f112.png">

/cherry-pick release-4.9
