### PR TITLE
Bug 1985933: Improved label matching, added more options for registry suggestions

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/helper/container-source-help.tsx
@@ -2,11 +2,18 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { isUpstream } from '@console/internal/components/utils';
 import {
-  CENTOS,
-  CENTOS_EXAMPLE_CONTAINER,
+  CENTOS7,
+  CENTOS8,
+  CENTOS7_EXAMPLE_CONTAINER,
+  CENTOS8_EXAMPLE_CONTAINER,
   FEDORA_EXAMPLE_CONTAINER,
-  RHEL,
-  RHEL_EXAMPLE_CONTAINER,
+  RHEL7,
+  RHEL8,
+  RHEL7_EXAMPLE_CONTAINER,
+  RHEL8_EXAMPLE_CONTAINER,
+  WIN2k,
+  WIN10,
+  NO_LABEL,
 } from '../../../utils/strings';
 
 type ContainerSourceHelpProps = {
@@ -17,8 +24,12 @@ export const ContainerSourceHelp: React.FC<ContainerSourceHelpProps> = ({ imageN
 
   const labelImage = () => {
     const os = {
-      [RHEL]: RHEL_EXAMPLE_CONTAINER,
-      [CENTOS]: CENTOS_EXAMPLE_CONTAINER,
+      [RHEL7]: RHEL7_EXAMPLE_CONTAINER,
+      [RHEL8]: RHEL8_EXAMPLE_CONTAINER,
+      [CENTOS7]: CENTOS7_EXAMPLE_CONTAINER,
+      [CENTOS8]: CENTOS8_EXAMPLE_CONTAINER,
+      [WIN2k]: NO_LABEL,
+      [WIN10]: NO_LABEL,
     };
 
     const label =
@@ -31,7 +42,7 @@ export const ContainerSourceHelp: React.FC<ContainerSourceHelpProps> = ({ imageN
 
   return (
     <div className="pf-c-form__helper-text" aria-live="polite" data-test="ContainerSourceHelp">
-      {t('kubevirt-plugin~Example: {{container}}', { container })}
+      {container !== NO_LABEL && t('kubevirt-plugin~Example: {{container}}', { container })}
     </div>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -14,12 +14,19 @@ export const SSH = 'ssh';
 export const SYSPREP = 'sysprep';
 export const HARDWARE = 'hardware';
 
-export const RHEL = 'rhel';
-export const CENTOS = 'centos';
+export const RHEL8 = 'rhel8';
+export const RHEL7 = 'rhel7';
+export const CENTOS7 = 'centos7';
+export const CENTOS8 = 'centos8';
+export const WIN2k = 'win2k';
+export const WIN10 = 'win10';
+export const NO_LABEL = 'NO_LABEL';
 
-export const RHEL_EXAMPLE_CONTAINER = 'registry.redhat.io/rhel8/rhel-guest-image';
+export const RHEL8_EXAMPLE_CONTAINER = 'registry.redhat.io/rhel8/rhel-guest-image:latest';
+export const RHEL7_EXAMPLE_CONTAINER = 'registry.redhat.io/rhel7/rhel-guest-image:latest';
 export const FEDORA_EXAMPLE_CONTAINER = 'quay.io/kubevirt/fedora-cloud-container-disk-demo:latest';
-export const CENTOS_EXAMPLE_CONTAINER = 'quay.io/kubevirt/centos8-container-disk-images:latest';
+export const CENTOS8_EXAMPLE_CONTAINER = 'quay.io/kubevirt/centos8-container-disk-images:latest';
+export const CENTOS7_EXAMPLE_CONTAINER = 'quay.io/kubevirt/centos7-container-disk-images:latest';
 export const CENTOS_IMAGE_LINK = 'https://cloud.centos.org/centos/';
 export const FEDORA_IMAGE_LINK = 'https://alt.fedoraproject.org/cloud/';
 export const RHEL_IMAGE_LINK = 'https://access.redhat.com/downloads/content/479/ver=/rhel---8/';


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1985933

**Analysis / Root cause**: 
Input should suggest matching registry examples based on os version

**Solution Description**: 
Added more options to labels according to os versions.

**Screen shots / Gifs for design review**: 
Example for RHLE 

![image](https://user-images.githubusercontent.com/14824964/142194952-f79640fa-1e93-4b67-9385-341c26911bdd.png)

![image](https://user-images.githubusercontent.com/14824964/142195029-44c56ec1-9f84-44b0-afe6-ffdda58da4ef.png)

