### PR TITLE
Bug 2016367: prevent empty task box to show up for a pipeline without finally task

### DIFF
--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-topology/utils.ts
@@ -291,12 +291,12 @@ export const connectFinallyTasksToNodes = (
   pipeline?: PipelineKind,
   pipelineRun?: PipelineRunKind,
 ): PipelineMixedNodeModel[] => {
-  if (!pipeline.spec?.finally) {
-    return nodes;
-  }
   const finallyTasks = pipelineRun
     ? getFinallyTasksWithStatus(pipeline, pipelineRun)
-    : pipeline.spec.finally;
+    : pipeline.spec?.finally ?? [];
+  if (finallyTasks.length === 0) {
+    return nodes;
+  }
   const regularRunAfters = getLastRegularTasks(nodes);
   const name = 'finally-node';
   const finallyGroupNode: PipelineFinallyNodeModel = createFinallyNode(

--- a/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
+++ b/frontend/packages/pipelines-plugin/src/test-data/pipeline-data.ts
@@ -102,6 +102,7 @@ const pipelineSpec: PipelineSpecData = {
         taskRef: { name: 'noop-task' },
       },
     ],
+    finally: [],
   },
   [PipelineExampleNames.CLUSTER_PIPELINE]: {
     tasks: [


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2016367

**Solution description:**
Added a check for empty array

**Screenshot/GIF:**
Before
![bug](https://user-images.githubusercontent.com/22490998/142257753-17bc3886-d779-43d1-9783-e7496d090abd.png)

After
![fixed](https://user-images.githubusercontent.com/22490998/142257778-c99f0e6d-f68a-4198-9b61-c6d1c9dc56e6.gif)
