### PR TITLE
Bug 2023607: Fix blank page error for Installed Operators

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -688,18 +688,18 @@ export const ClusterServiceVersionList: React.FC<ClusterServiceVersionListProps>
 
   const customData = React.useMemo(
     () => ({
-      catalogSources: catalogSources.data,
-      subscriptions: subscriptions.data,
+      catalogSources: catalogSources?.data ?? [],
+      subscriptions: subscriptions?.data ?? [],
       activeNamespace,
     }),
-    [activeNamespace, catalogSources.data, subscriptions.data],
+    [activeNamespace, catalogSources, subscriptions],
   );
 
   return (
     <Table
       data={filterOperators(data, allNamespaceActive)}
       {...rest}
-      aria-label="Installed Operators"
+      aria-label={t('olm~Installed Operators')}
       Header={allNamespaceActive ? AllProjectsTableHeader : SingleProjectTableHeader}
       Row={InstalledOperatorTableRow}
       EmptyMsg={CSVListEmptyMsg}


### PR DESCRIPTION
Installed Operators was crashing when a user with no projects tried to view it. Undefined data was being passed in. I added some additional logic and it loads now.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2023607.