### PR TITLE
Bug 2024535: hotplug disk missing OwnerReference

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/delete-disk-modal/delete-disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/delete-disk-modal/delete-disk-modal.tsx
@@ -65,7 +65,9 @@ export const DeleteDiskModal = withHandlePromise((props: DeleteDiskModalProps) =
     e.preventDefault();
 
     if (isVMRunningOrExpectedRunning(asVM(vmLikeEntity), vmi)) {
-      const promise = removeHotplugPersistent(asVM(vmLikeEntity), removeHotplugRequest);
+      const promise = removeHotplugPersistent(asVM(vmLikeEntity), removeHotplugRequest).then(() =>
+        freeOwnedResources(ownedResources, vmLikeReference, deleteReferencedResource),
+      );
 
       return handlePromise(promise, close);
     }

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -54,6 +54,7 @@ import { VMIKind, VMKind } from '../../../types';
 import { V1AddVolumeOptions } from '../../../types/api';
 import { UIStorageEditConfig } from '../../../types/ui/storage';
 import {
+  buildOwnerReference,
   getDialogUIError,
   getLoadedData,
   getSequenceName,
@@ -265,7 +266,8 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
       .setVolumeMode(applySP && spVolumeMode ? spVolumeMode : volumeMode || null)
       .setAccessModes(applySP && spAccessMode ? [spAccessMode] : accessMode ? [accessMode] : null)
       .setPreallocationDisk(enablePreallocation)
-      .setNamespace(vmNamespace);
+      .setNamespace(vmNamespace)
+      .addOwnerReferences(buildOwnerReference(vm));
   }
 
   let resultPersistentVolumeClaim: PersistentVolumeClaimWrapper;


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2024535

**Analysis / Root cause**: 
when creating a DV for hotplug, we need to build manually OwnerReference for the VM.

**Solution Description**: 
adding OwnerReference to hotplug DV on creation,
freeing the resources on DV/VM deletion.

**Screen shots / Gifs for design review**: 

**before**:

![before](https://user-images.githubusercontent.com/67270715/142398183-5d3f1f7f-74a1-4864-b1f6-41758fb58ff8.png)

**after**:

![after](https://user-images.githubusercontent.com/67270715/142398225-37560831-084a-4773-b43d-8ed6f769baa8.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>