### PR TITLE
Bug 1988406: SSH Key will now move from simple to advanced wizard when clicking customize

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/advanced-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/advanced-tab-state-update.ts
@@ -1,0 +1,46 @@
+import {
+  CloudInitDataFormKeys,
+  CloudInitDataHelper,
+} from '../../../../k8s/wrapper/vm/cloud-init-data-helper';
+import { VolumeWrapper } from '../../../../k8s/wrapper/vm/volume-wrapper';
+import { iGetIn } from '../../../../utils/immutable';
+import { iGetCloudInitNoCloudStorage } from '../../selectors/immutable/storage';
+import { getSSHTempKey } from '../../selectors/immutable/wizard-selectors';
+import { vmWizardInternalActions } from '../internal-actions';
+import { InternalActionType, UpdateOptions } from '../types';
+
+const initialAdvancedTabUpdater = ({ id, dispatch, getState }: UpdateOptions) => {
+  const state = getState();
+  const tempSSHKey = getSSHTempKey(state);
+  const iCloudInitNoCloudStorage = iGetCloudInitNoCloudStorage(state, id);
+  const data = new CloudInitDataHelper(
+    iGetIn(iCloudInitNoCloudStorage, ['volume', 'cloudInitNoCloud'])?.toJS(),
+  );
+
+  if (
+    !iCloudInitNoCloudStorage ||
+    !data ||
+    !tempSSHKey ||
+    data.hasKey(CloudInitDataFormKeys.SSH_AUTHORIZED_KEYS)
+  ) {
+    return;
+  }
+
+  data.set(CloudInitDataFormKeys.SSH_AUTHORIZED_KEYS, tempSSHKey);
+
+  dispatch(
+    vmWizardInternalActions[InternalActionType.UpdateStorage](id, {
+      id: iCloudInitNoCloudStorage?.get('id'),
+      type: iCloudInitNoCloudStorage?.get('type'),
+      disk: iCloudInitNoCloudStorage?.get('disk')?.toJS(),
+      volume: new VolumeWrapper(iCloudInitNoCloudStorage?.get('volume')?.toJS())
+        .setTypeData(data.asCloudInitNoCloudSource())
+        .asResource(),
+    }),
+  );
+};
+
+export const updateAdvancedTabState = (options: UpdateOptions) =>
+  [initialAdvancedTabUpdater].forEach((updater) => {
+    updater && updater(options);
+  });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/utils.ts
@@ -1,5 +1,6 @@
 import { VMWizardTab } from '../types';
 import { finalizeImportProviderStateUpdate } from './finalize-state-update/import-provider-finalize-state-update';
+import { updateAdvancedTabState } from './state-update/advanced-tab-state-update';
 import { updateImportProvidersState } from './state-update/import-provider-tab-state-update';
 import { updateStorageTabState } from './state-update/storage-tab-state-update';
 import { updateVmSettingsState } from './state-update/vm-settings-tab-state-update';
@@ -27,6 +28,7 @@ const updaterResolver = {
   [VMWizardTab.IMPORT_PROVIDERS]: updateImportProvidersState,
   [VMWizardTab.VM_SETTINGS]: updateVmSettingsState,
   [VMWizardTab.STORAGE]: updateStorageTabState,
+  [VMWizardTab.ADVANCED]: updateAdvancedTabState,
 };
 
 const validateTabResolver = {

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
@@ -50,6 +50,9 @@ export const isLastStepErrorFatal = (state, wizardID: string) =>
 export const getEnableSSHService = (state): boolean =>
   state?.plugins?.kubevirt?.authorizedSSHKeys?.enableSSHService;
 
+export const getSSHTempKey = (state): string =>
+  state?.plugins?.kubevirt?.authorizedSSHKeys?.tempSSHKey;
+
 export const getSysprepData = (state): SysprepData => state?.plugins?.kubevirt?.sysprep;
 
 export const getStepsMetadata = (state, wizardID: string): VMWizardTabsMetadata => {

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/cloud-init/Cloudinit.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/cloud-init/Cloudinit.tsx
@@ -52,7 +52,7 @@ const Cloudinit: React.FC<CloudinitProps> = ({ wizardReduxID }) => {
   const dataSSHKeys = React.useMemo(() => new CloudInitDataHelper({ userData: data }), [data]);
   const { tempSSHKey } = useSSHKeys();
   const authKeysData = React.useMemo(
-    () => dataSSHKeys.get(CloudInitDataFormKeys.SSH_AUTHORIZED_KEYS) || [tempSSHKey || ''],
+    () => [dataSSHKeys.get(CloudInitDataFormKeys.SSH_AUTHORIZED_KEYS) || tempSSHKey || ''],
     [dataSSHKeys, tempSSHKey],
   );
 
@@ -99,16 +99,18 @@ const Cloudinit: React.FC<CloudinitProps> = ({ wizardReduxID }) => {
 
   const onChange = React.useCallback(
     (yamlData, yamlAsJSData) => {
+      const sshKeysData = yamlAsJSData?.ssh_authorized_keys;
+      const sshKeysDataArray = Array.isArray(sshKeysData) ? sshKeysData : [sshKeysData];
       yamlAsJSData && setYamlAsJS(yamlAsJSData);
       yamlData &&
         setYaml(
           yamlParser.dump({
             ...yamlParser.load(yamlData),
             /* eslint-disable-next-line @typescript-eslint/camelcase */
-            ssh_authorized_keys: yamlAsJSData?.ssh_authorized_keys || authKeys,
+            ssh_authorized_keys: sshKeysDataArray || authKeys,
           }),
         );
-      setAuthKeys(yamlAsJSData?.ssh_authorized_keys);
+      setAuthKeys(sshKeysDataArray);
     },
     [setYaml, setYamlAsJS, authKeys],
   );

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/cloudint-utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/cloudint-utils.ts
@@ -56,7 +56,7 @@ export const checkSSHKeys = (
   errorCatcher: ErrorCatcher,
   t: Function,
 ) => {
-  ((obj?.ssh_authorized_keys as string[]) || []).map(
+  [obj?.ssh_authorized_keys].map(
     (key: string, index: number) =>
       key && errorCatcher.removeError(['ssh_authorized_keys', index.toString()]),
   );


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1988406

**Analysis / Root cause**: 
SSH key was not added to YAML if the user didn't visit the advanced tab

**Solution Description**: 
Added support that when clicking customize ssh will be added to YAML even without visiting the advanced tab

**Screen shots / Gifs for design review**: 
![ssh-key-moving-customize](https://user-images.githubusercontent.com/14824964/142441006-9eb0ae34-52bb-48f6-aaab-261b384539fe.gif)
