### PR TITLE
Bug 2024665: Fix k8sget import for bindable services fetch util

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/bindable-services/fetch-bindable-services-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/bindable-services/fetch-bindable-services-utils.ts
@@ -1,4 +1,4 @@
-import { k8sGet } from '@console/internal/module/k8s';
+import { k8sGet } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { BindableServicesModel } from './models';
 import { BindableServiceGVK, BindableServicesKind } from './types';
 


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2024665
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
`k8sGet` is undefined at the time of fetching BindableKinds.
Likely a regression after k8s utils were moved to dynamic plugin SDK in #10243 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
Import `k8sGet` directly from dynamic plugins package.
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
(Unchanged)
<!-- Attach test coverage report -->

**Test setup:**
1. Install Service Binding Operator
2. Create BindableKinds CR, add any resource as bindable
3. Navigate to topology
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug