### PR TITLE
Bug 2025481: Update VM Snapshots UI

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SnapshotsModal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/snapshot-modal/SnapshotsModal.tsx
@@ -49,6 +49,7 @@ const SnapshotsModal = withHandlePromise((props: SnapshotsModalProps) => {
     cancel,
     isVMRunningOrExpectedRunning,
     snapshots,
+    hotplugVolumeSnapshotStatuses,
   } = props;
   const { t } = useTranslation();
   const vmName = getName(vmLikeEntity);
@@ -57,7 +58,10 @@ const SnapshotsModal = withHandlePromise((props: SnapshotsModalProps) => {
   const [approveUnsupported, setApproveUnsupported] = React.useState(false);
   const asId = prefixedID.bind(null, 'snapshot');
 
-  const volumeSnapshotStatuses = getVolumeSnapshotStatuses(asVM(vmLikeEntity)) || [];
+  const volumeSnapshotStatuses =
+    getVolumeSnapshotStatuses(asVM(vmLikeEntity))
+      .concat(hotplugVolumeSnapshotStatuses)
+      .filter(Boolean) || [];
   const supportedVolumes = volumeSnapshotStatuses.filter((status) => status?.enabled);
   const hasSupportedVolumes = supportedVolumes.length > 0;
   const unsupportedVolumes = volumeSnapshotStatuses.filter((status) => !status?.enabled);
@@ -172,5 +176,6 @@ export type SnapshotsModalProps = {
   vmLikeEntity: VMLikeEntityKind;
   isVMRunningOrExpectedRunning: boolean;
   snapshots: VMSnapshot[];
+  hotplugVolumeSnapshotStatuses?: any[];
 } & ModalComponentProps &
   HandlePromiseProps;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-snapshots/vm-snapshots.tsx
@@ -10,6 +10,7 @@ import { VirtualMachineSnapshotModel } from '../../models';
 import { kubevirtReferenceForModel } from '../../models/kubevirtReferenceForModel';
 import { getName, getNamespace } from '../../selectors';
 import { isVMI } from '../../selectors/check-type';
+import { getVMIHotplugVolumeSnapshotStatuses } from '../../selectors/disks/hotplug';
 import { getVmSnapshotVmName } from '../../selectors/snapshot/snapshot';
 import { isVMRunningOrExpectedRunning } from '../../selectors/vm/selectors';
 import { asVM } from '../../selectors/vm/vm';
@@ -131,6 +132,10 @@ export const VMSnapshotsPage: React.FC<VMTabProps> = ({ obj: vmLikeEntity, vmis:
                       vmi,
                     ),
                     snapshots,
+                    hotplugVolumeSnapshotStatuses: getVMIHotplugVolumeSnapshotStatuses(
+                      asVM(vmLikeEntity),
+                      vmi,
+                    ),
                   }).result,
                 )
               }

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -27,10 +27,7 @@ import { cancelVMImport } from '../../k8s/requests/vmimport';
 import { VMImportWrappper } from '../../k8s/wrapper/vm-import/vm-import-wrapper';
 import { VirtualMachineImportModel, VirtualMachineInstanceMigrationModel } from '../../models';
 import { getName, getNamespace } from '../../selectors';
-import {
-  getAutoRemovedOrPersistentDiskName,
-  getHotplugDiskNames,
-} from '../../selectors/disks/hotplug';
+import { getAutoRemovedOrPersistentDiskName } from '../../selectors/disks/hotplug';
 import {
   isVMCreated,
   isVMExpectedRunning,
@@ -187,11 +184,7 @@ const menuActionStop = (
           <ActionMessage obj={vm} actionKey="kubevirt-plugin~stop">
             <StackItem>
               <RemovalDiskAlert
-                hotplugDiskNames={getAutoRemovedOrPersistentDiskName(
-                  vm,
-                  getHotplugDiskNames(vmi),
-                  true,
-                )}
+                hotplugDiskNames={getAutoRemovedOrPersistentDiskName(vm, vmi, true)}
               />
             </StackItem>
           </ActionMessage>
@@ -232,11 +225,7 @@ const menuActionRestart = (
           <ActionMessage obj={vm} actionKey="kubevirt-plugin~restart">
             <StackItem>
               <RemovalDiskAlert
-                hotplugDiskNames={getAutoRemovedOrPersistentDiskName(
-                  vm,
-                  getHotplugDiskNames(vmi),
-                  true,
-                )}
+                hotplugDiskNames={getAutoRemovedOrPersistentDiskName(vm, vmi, true)}
               />
             </StackItem>
           </ActionMessage>
@@ -552,11 +541,7 @@ export const VmActionFactory = {
             <ActionMessage obj={vm} action={i18next.t('kubevirt-plugin~stop')}>
               <StackItem>
                 <RemovalDiskAlert
-                  hotplugDiskNames={getAutoRemovedOrPersistentDiskName(
-                    vm,
-                    getHotplugDiskNames(vmi),
-                    true,
-                  )}
+                  hotplugDiskNames={getAutoRemovedOrPersistentDiskName(vm, vmi, true)}
                 />
               </StackItem>
             </ActionMessage>
@@ -585,11 +570,7 @@ export const VmActionFactory = {
             <ActionMessage obj={vm} action={i18next.t('kubevirt-plugin~restart')}>
               <StackItem>
                 <RemovalDiskAlert
-                  hotplugDiskNames={getAutoRemovedOrPersistentDiskName(
-                    vm,
-                    getHotplugDiskNames(vmi),
-                    true,
-                  )}
+                  hotplugDiskNames={getAutoRemovedOrPersistentDiskName(vm, vmi, true)}
                 />
               </StackItem>
             </ActionMessage>

--- a/frontend/packages/kubevirt-plugin/src/selectors/disks/hotplug.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/disks/hotplug.ts
@@ -8,13 +8,13 @@ export const getHotplugDiskNames = (vmi: VMIKind) => {
 
 export const getAutoRemovedOrPersistentDiskName = (
   vm: VMKind,
-  hotplugDiskNames: string[],
+  vmi: VMIKind,
   isAutoRemove: boolean,
 ) => {
   const persistentDiskNames = vm?.spec?.template?.spec?.domain?.devices?.disks?.map(
     (pDisk) => pDisk.name,
   );
-  return hotplugDiskNames?.filter((disk) =>
+  return getHotplugDiskNames(vmi)?.filter((disk) =>
     isAutoRemove ? !persistentDiskNames?.includes(disk) : persistentDiskNames?.includes(disk),
   );
 };
@@ -24,6 +24,13 @@ export const isHotplugDisk = (vmi: VMIKind, diskName: string) => {
 };
 
 export const isAutoRemovedHotplugDisk = (vm: VMKind, vmi: VMIKind, diskName: string) => {
-  const hotplugDiskNames = getHotplugDiskNames(vmi);
-  return getAutoRemovedOrPersistentDiskName(vm, hotplugDiskNames, true)?.includes(diskName);
+  return getAutoRemovedOrPersistentDiskName(vm, vmi, true)?.includes(diskName);
+};
+
+export const getVMIHotplugVolumeSnapshotStatuses = (vm: VMKind, vmi: VMIKind) => {
+  return getAutoRemovedOrPersistentDiskName(vm, vmi, true)?.map((diskName) => ({
+    enabled: false,
+    name: diskName,
+    reason: 'Volume snapshots are not supported for auto-detach hotplug volumes.',
+  }));
 };


### PR DESCRIPTION
**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=2025481
https://issues.redhat.com/browse/CNV-13716

**Analysis / Root cause**: 
when attaching an auto-detach hotplug volume, we attach it to VMI,
VM YAML is holding the volume that can be snapshotted under `status.volumeSnapshotStatuses`

**Solution Description**: 
represent existing auto-detach hotplug volumes to be unsupported for snapshot

**Screen shots / Gifs for design review**: 

**before**:

![before](https://user-images.githubusercontent.com/67270715/142418947-805bb6d5-cebf-4d4d-a59e-d95adabba656.gif)

**after**:

![after](https://user-images.githubusercontent.com/67270715/142418974-e8044e2e-53e8-44a2-968c-dc94fb83ad4f.gif)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>