### PR TITLE
Bug 2025954: Disable a few console e2e tests due to consistent Unauthorized flake

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/crud/roles-rolebindings.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/roles-rolebindings.spec.ts
@@ -102,7 +102,8 @@ const deleteClusterExamples = () => {
   detailsPage.isLoaded();
 };
 
-describe('Roles and RoleBindings', () => {
+// disabling until https://bugzilla.redhat.com/show_bug.cgi?id=2024932 is fixed
+xdescribe('Roles and RoleBindings', () => {
   before(() => {
     cy.login();
     cy.createProject(testName);

--- a/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
+++ b/frontend/packages/integration-tests-cypress/tests/crud/secrets.spec.ts
@@ -16,7 +16,7 @@ const populateSecretForm = (name: string, key: string, fileName: string) => {
   cy.byTestID('file-input').attachFile(fileName);
 };
 
-describe('Create key/value secrets', () => {
+xdescribe('Create key/value secrets', () => {
   const binarySecretName = `${testName}binarysecretname`;
   const asciiSecretName = `${testName}asciisecretname`;
   const unicodeSecretName = `${testName}unicodesecretname`;

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -17,7 +17,7 @@ const testOperand: TestOperandProps = {
   exampleName: `example-kieappk`,
 };
 
-describe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {
+xdescribe(`Installing "${testOperator.name}" operator in ${testOperator.installedNamespace}`, () => {
   before(() => {
     cy.login();
     cy.visit('/');


### PR DESCRIPTION
Disabling the following e2e cypress tests until https://bugzilla.redhat.com/show_bug.cgi?id=2024932 is fixed:

- /packages/integration-tests-cypress/tests/crud/roles-rolebindings.spec.ts
- /packages/integration-tests-cypress/tests/crud/secrets.spec.ts 
- /packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts