### PR TITLE
ODC-6364-Pipeline as code epic automation

### DIFF
--- a/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
+++ b/frontend/packages/dev-console/integration-tests/support/constants/pageTitle.ts
@@ -45,4 +45,5 @@ export const pageTitle = {
   UploadJarFile: 'Upload JAR file',
   KnativeServings: 'KnativeServings',
   KnativeEventings: 'KnativeEventings',
+  CreateRepository: 'Create Repository',
 };

--- a/frontend/packages/dev-console/integration-tests/support/pageObjects/global-po.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pageObjects/global-po.ts
@@ -38,7 +38,7 @@ export const formPO = {
   },
   create: '[data-test-id="submit-button"]',
   cancel: '[data-test-id="reset-button"]',
-  save: '[data-test-id="submit-button"]',
+  save: '[data-test="save-changes"]',
   errorAlert: '[aria-label="Danger Alert"]',
   successAlert: '[aria-label="Success Alert"]',
 };

--- a/frontend/packages/dev-console/integration-tests/support/pages/app.ts
+++ b/frontend/packages/dev-console/integration-tests/support/pages/app.ts
@@ -4,7 +4,7 @@ import { modal } from '@console/cypress-integration-tests/views/modal';
 import { nav } from '@console/cypress-integration-tests/views/nav';
 import * as yamlView from '../../../../integration-tests-cypress/views/yaml-editor';
 import { devNavigationMenu, switchPerspective, pageTitle } from '../constants';
-import { devNavigationMenuPO, formPO, gitPO, yamlPO } from '../pageObjects';
+import { devNavigationMenuPO, formPO, gitPO, topologyPO, yamlPO } from '../pageObjects';
 
 export const app = {
   waitForDocumentLoad: () => {
@@ -76,6 +76,11 @@ export const navigateTo = (opt: devNavigationMenu) => {
       cy.get(devNavigationMenuPO.topology).click();
       cy.url().should('include', 'topology');
       app.waitForLoad();
+      cy.url().then(($url) => {
+        if ($url.includes('view=list')) {
+          cy.get(topologyPO.switcher).click({ force: true });
+        }
+      });
       // Bug: ODC-5119 is created related to Accessibility violation - Until bug fix, below line is commented to execute the scripts in CI
       // cy.testA11y('Topology Page in dev perspective');
       break;

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-add-options.feature
@@ -59,7 +59,7 @@ Feature: Create Pipeline from Add Options
               And user clicks node "<name>" in topology page
              Then pipeline name "<name>" is displayed in topology side bar
               And side bar is displayed with the pipelines section
-              And Last Run status of the "<name>" displays as "Succeeded" in topology page
+              And Last Run status of the workload displays as "Succeeded" in topology page
 
         Examples:
                   | name       |

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/create-from-builder-page.feature
@@ -176,7 +176,7 @@ Feature: Create the pipeline from builder page
         Scenario: Create pipeline with Workspaces: P-02-TC12
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipeline-workspace"
-              And user clicks on Add task
+              And user clicks Add task button under Tasks section
               And user searches "git-clone" in quick search bar
               And user clicks on Add in "git-clone" task
               And user selects the "git-clone" node
@@ -194,7 +194,7 @@ Feature: Create the pipeline from builder page
         Scenario: Create pipeline with optional Workspaces: P-02-TC13
             Given user is at Pipeline Builder page
              When user enters pipeline name as "pipe-opt-workspace"
-              And user clicks on Add task
+              And user clicks Add task button under Tasks section
               And user searches "git-clone" in quick search bar
               And user clicks on Add in "git-clone" task
               And user selects the "git-clone" node
@@ -331,4 +331,4 @@ Feature: Create the pipeline from builder page
             # user uses yaml content "sum-and-multiply-pipeline/pipelineRun-sum-and-multiply-pipeline.yaml"
               And user clicks on Create button
               And user clicks on Logs tab in PipelineRun details page
-             Then user will be able to see the output in sum and multipy task
+             Then user will be able to see the output in sum and multiply task

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-as-code.feature
@@ -4,67 +4,59 @@ Feature: Perform Actions on repository
 
         Background:
             Given user has created or selected namespace "aut-pipelines"
-              And user has installed pipelines as code
+              And user is at pipelines page
 
 
-        @pre-condition @to-do
+        @pre-condition
         Scenario Outline: Repositories page: P-11-TC01
-            Given user is at repositories page
+            Given user has installed pipelines as code
+              And user is at repositories page
              When user clicks on Create Repository button
-             Then user will be redirected to Repositories yaml view page
-             Then user creates repository using YAML editor from "<repository_yaml>"
-             Then user will be redirected to Reporsitory details page with header name "<repository_name>"
+              And user creates repository using YAML editor from "<repository_yaml>"
+             Then user will be redirected to Repository details page with header name "<repository_name>"
 
         Examples:
                   | repository_yaml                                 | repository_name |
                   | testData/repository-crd-testdata/test-repo.yaml | test-repo       |
 
 
-        @smoke @to-do
+        @smoke
         Scenario Outline: Reporsitory details display in repository page: P-11-TC02
-            Given repository "<repository_name>" is present on Repositories page
+            Given repository "<repository_name>" is present in Repositories tab of Pipelines page
              When user clicks on the repository "<repository_name>" on Repositories page
              Then user will be redirected to Repository details page with header "<repository_name>"
               And user is able to see Details, YAML, Pipeline Runs tabs
               And Details tab is displayed with field names Name, Namespace, Labels, Annotations, Created at, Owner, Repository, Branch and Event type
-              And Actions dropdown display in the top right corner of the page
+              And Actions menu display with options Edit labels, Edit annotations, Edit repository, Delete repository
 
         Examples:
                   | repository_name |
                   | test-repo       |
 
 
-        @smoke @to-do
+        @smoke
         Scenario Outline: Repositories page display on newly created repository: P-11-TC03
-            Given repository "<repository_name>" is present on Repositories page
-             When user searches repositoy "<repository_name>" in repositories page
+            Given repository "<repository_name>" is present on the Repositories page
+             When user searches repository "<repository_name>" in repositories page
              Then repositories table displayed with column names Name, Event type, Last run, Task status, Last run status, Last run time, Last run duration
-              And clolumn Name display with value "<repository_name>"
-              And columnsLast run, Task status, Last run status, Last run time, Last run duration with values display "-"
-              And Create button is enabled
+              And column Name display with value "<repository_name>"
+              And columns Last run, Task status, Last run status, Last run time, Last run duration with values display "-"
               And kebab menu button is displayed
         Examples:
                   | repository_name |
                   | test-repo       |
 
 
-        @smoke @to-do
+        @smoke
         Scenario: Kebab menu options of newly created repository in Repositories page: P-11-TC04
-            Given repository "test-repository" is present on Repositories page
-             When user searches repository "test-repo" in repsitories page
+            Given repository "test-repo" is present on the Repositories page
+             When user searches repository "test-repo" in repositories page
               And user clicks on kebab menu of the repository "test-repo"
              Then kebab menu displays with options Edit labels, Edit annotations, Edit repository, Delete repository
 
 
-        @smoke @to-do
-        Scenario: Actions menu of newly created repository in Repository details page: P-11-TC05
-            Given user is at repositories details page with newly created repository "test-repo"
-             When user clicks Actions menu in the repository details page
-             Then Actions menu display with options Edit labels, Edit annotations, Edit repository, Delete repository
-
-
-        @regression @to-do
-        Scenario Outline: Edit repository from Repository details page: P-11-TC06
+        @regression
+        Scenario Outline: Edit repository from Repository details page: P-11-TC05
             Given repository "<repository_name>" is present on the Repositories page
              When user searches repository "<repository_name>" in repositories page
               And user clicks repository "<repository_name>" from searched results on Repositories page
@@ -78,28 +70,29 @@ Feature: Perform Actions on repository
                   | test-repo       |
 
 
-        @regression @to-do
+        @regression
         Scenario: Edit label of repository: P-11-TC07
             Given repository "test-repo" is present on the Repositories page
              When user searches repository "test-repo" in repositories page
               And user clicks repository "test-repo" from searched results on Repositories page
-              And user clicks on Edit button of the labels section
+              And user selects option "Edit labels" from Actions menu drop down
               And adds the label "check=label"
-              And clicks on the Save button
+              And user clicks on the Save button
              Then label "check=label" should be present in the labels section
 
 
-        @regression @to-do
+        @regression
         Scenario: Edit annotations of repository: P-11-TC08
             Given repository "test-repo" is present on the Repositories page
              When user searches repository "test-repo" in repositories page
               And user clicks repository "test-repo" from searched results on Repositories page
-              And user clicks on Edit button of the annotations section
+              And user selects option "Edit annotations" from Actions menu drop down
               And user adds key "check" and value "annotations"
               And user clicks on the Save button
              Then annotation section contains the value "1 annotation"
 
 
+        # test data needs to be created using before execuitng below 2 scenarios : https://docs.google.com/document/d/1nUFtwtuZooDhOGg1YrjXn0zrOhZDrJ4h1oE6h35Noao/edit#
         @regression @to-do
         Scenario Outline: Pipeline Run Details page for the repository: P-11-TC09
             Given pipeline run is displayed for "<repository_name>"
@@ -126,15 +119,15 @@ Feature: Perform Actions on repository
              Then user should see commit message in tooltip
 
 
-        @regression @to-do
+        @regression
         Scenario Outline: Delete the repository from the Repository details page: P-11-TC11
-            Given repository "<repository_name>" is present on Repositories page
+            Given repository "<repository_name>" is present on the Repositories page
              When user searches repository "<repository_name>" in repositories page
               And user clicks repository "<repository_name>" from searched results on Repositories page
               And user selects option "Delete Repository" from Actions menu drop down
               And user clicks Delete button on Delete Repository modal
              Then user will be redirected to Repositories page
-              And "<repository_name>" is not displayed on Pipelines page
+              And "<repository_name>" is not displayed on Repositories page
 
         Examples:
                   | repository_name |

--- a/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-secrets.feature
+++ b/frontend/packages/pipelines-plugin/integration-tests/features/pipelines/pipelines-secrets.feature
@@ -27,6 +27,8 @@ Feature: Secrets
             Given user has created pipeline "<pipeline_name>" with git resources
               And user is at Start Pipeline modal for pipeline "<pipeline_name>"
              When user enters URL, Revision as "<git_private_repo_url>" and "master"
+              And user clicks on Show Credentials link present in Start Pipeline modal
+              And user clicks on Add Secret link
               And user enters Secret Name as "<secret_name>"
               And user selects the "Git Server" option from accessTo drop down
               And user enters the server url as "https://github.com"

--- a/frontend/packages/pipelines-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/commands/hooks.ts
@@ -16,3 +16,7 @@ after(() => {
   });
   // cy.logout();
 });
+
+afterEach(() => {
+  cy.checkErrors();
+});

--- a/frontend/packages/pipelines-plugin/integration-tests/support/constants/pipelines.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/constants/pipelines.ts
@@ -1,12 +1,34 @@
 export enum pipelineActions {
   Start = 'Start',
   AddTrigger = 'Add Trigger',
-  EditLabels = 'Edit Labels',
+  EditLabels = 'Edit labels',
   RemoveTrigger = 'Remove Trigger',
-  EditAnnotations = 'Edit Annotations',
+  EditAnnotations = 'Edit annotations',
   EditPipeline = 'Edit Pipeline',
   DeletePipeline = 'Delete Pipeline',
   StartLastRun = 'Start Last Run',
   Rerun = 'Rerun',
   DeletePipelineRun = 'Delete PipelineRun',
+  EditRepository = 'Edit Repository',
+  DeleteRepository = 'Delete Repository',
+}
+
+export enum pipelineTabs {
+  Pipelines = 'Pipelines',
+  Repositories = 'Repositories',
+}
+
+export enum pipelineDetailsTabs {
+  Details = 'Details',
+  YAML = 'YAML',
+  PipelineRuns = 'Pipeline Runs',
+  Parameters = 'Parameters',
+  Resources = 'Resources',
+  Metrics = 'Metrics',
+}
+
+export enum repositoryDetailsTabs {
+  Details = 'Details',
+  YAML = 'YAML',
+  PipelineRuns = 'Pipeline Runs',
 }

--- a/frontend/packages/pipelines-plugin/integration-tests/support/constants/static-text/pipeline-text.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/constants/static-text/pipeline-text.ts
@@ -6,8 +6,8 @@ export const pipelineBuilderText = {
     Resources: 'Resources',
     Workspaces: 'Workspaces',
     sidePane: {
-      ParameterUrlHelper: 'git url to clone',
-      ParamterRevisionHelper: 'git revision to checkout (branch, tag, sha, ref…)',
+      ParameterUrlHelper: 'Repository URL to clone from.',
+      ParameterRevisionHelper: 'Revision to checkout. (branch, tag, sha, ref, etc...)',
     },
     startPipeline: {
       EmptyDirectoryInfoMessage: "Empty Directory doesn't support shared data between tasks.",

--- a/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/page-objects/pipelines-po.ts
@@ -2,6 +2,8 @@ export const pipelineBuilderPO = {
   title: '.odc-pipeline-builder-header h1',
   create: '[data-test-id="submit-button"]',
   cancel: '[data-test-id="reset-button"]',
+  pipeline: '#pipeline-link',
+  repository: '#repository-link',
   add: 'button.pf-c-button.pf-m-link.pf-m-inline',
   configureVia: {
     pipelineBuilder: '#form-radiobutton-editorType-form-field',
@@ -11,6 +13,7 @@ export const pipelineBuilderPO = {
     switchToFormView: '[id="form-radiobutton-editorType-form-field"]',
     name: '#form-input-formData-name-field',
     taskDropdown: '[data-id="initial-node"]',
+    quickSearch: '[data-test="quick-search-bar"]',
     task: '[data-type="builder"] .odc-pipeline-vis-task',
     plusTaskIcon: 'g.odc-plus-node-decorator',
     seriesTask: '[data-id^="has-run-after-"][data-kind="node"]',
@@ -76,6 +79,11 @@ export const pipelineBuilderPO = {
       sidebar: '[data-test="resource-sidebar"]',
     },
   },
+};
+
+export const createRepositoryPO = {
+  create: '[data-test="save-changes"]',
+  cancel: '[data-test="cancel"]',
 };
 
 export const pipelineDetailsPO = {
@@ -276,5 +284,30 @@ export const pipelinesPO = {
   },
   deletePipeline: {
     delete: '#confirm-action',
+  },
+};
+
+export const repositoryDetailsPO = {
+  detailsTab: '[data-test-id$="Details"]',
+  yamlTab: '[data-test-id$="YAML"]',
+  pipelineRunsTab: '[data-test-id="horizontal-link-Pipeline Runs"]',
+  details: {
+    sectionTitle: '[data-test-section-heading="Repository details"]',
+    fieldNames: {
+      name: '[data-test="Name"]',
+      namespace: '[data-test="Namespace"]',
+      labels: '[data-test="Labels"]',
+      annotations: '[data-test="Annotations"]',
+      createdAt: '[data-test="Created at"]',
+      owner: '[data-test="Owner"]',
+    },
+    fieldValues: {
+      name: '[data-test-selector="details-item-value__Name"]',
+      namespace: '[data-test-selector="details-item-value__Namespace"]',
+      labels: '[data-test-selector="details-item-value__Labels"]',
+      annotations: '[data-test-selector="details-item-value__Annotations"]',
+      createdAt: '[data-test-selector="details-item-value__Created at"]',
+      owner: '[data-test-selector="details-item-value__Owner"]',
+    },
   },
 };

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/functions/common.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/functions/common.ts
@@ -8,3 +8,29 @@ export const actionsDropdownMenu = {
     cy.byTestActionID(action).click();
   },
 };
+
+export const tableFunctions = {
+  verifyColumnValue: (columnName: string, columnValue: string) => {
+    cy.get('tr th').each(($el, index) => {
+      if ($el.text().includes(columnName)) {
+        cy.get('tbody tr')
+          .find('td')
+          .eq(index)
+          .should('have.text', columnValue);
+      }
+    });
+  },
+
+  selectKebabMenu: (name: string) => {
+    cy.get('div[role="grid"]').within(() => {
+      cy.get('tr td:nth-child(1)').each(($el, index) => {
+        if ($el.text().includes(name)) {
+          cy.get('tbody tr')
+            .eq(index)
+            .find('[data-test-id="kebab-button"]')
+            .click({ force: true });
+        }
+      });
+    });
+  },
+};

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/index.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/index.ts
@@ -2,3 +2,5 @@ export * from './pipelines/pipelineBuilder-page';
 export * from './pipelines/pipelineDetails-page';
 export * from './pipelines/pipelineRun-details-page';
 export * from './pipelines/pipelines-page';
+export * from './pipelines/repositoryDetails-page';
+export * from './pipelines/repositories-page';

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineBuilder-page.ts
@@ -32,7 +32,7 @@ export const pipelineBuilderSidePane = {
     pipelineBuilderSidePane.verifyDialog();
     cy.get(pipelineBuilderPO.formView.sidePane.parameterRevisionHelper).should(
       'contain.text',
-      pipelineBuilderText.formView.sidePane.ParamterRevisionHelper,
+      pipelineBuilderText.formView.sidePane.ParameterRevisionHelper,
     );
     cy.get(pipelineBuilderPO.formView.sidePane.parameterRevision).type(revision);
   },
@@ -58,8 +58,8 @@ export const pipelineBuilderPage = {
       .type(pipelineName);
   },
   AddTask: (taskName: string = 'kn') => {
-    cy.get('input.ocs-quick-search-bar__input').type(taskName);
-    cy.get('button.ocs-quick-search-details__form-button').click();
+    cy.get(pipelineBuilderPO.formView.quickSearch).type(taskName);
+    cy.byTestID('task-cta').click();
   },
   selectTask: (taskName: string = 'kn') => {
     cy.get('body').then(($body) => {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineDetails-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineDetails-page.ts
@@ -1,5 +1,6 @@
 import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
 import { pageTitle } from '@console/dev-console/integration-tests/support/constants/pageTitle';
+import { pipelineDetailsTabs } from '../../constants';
 import {
   clusterTriggerBindingDetailsPO,
   eventListenerDetailsPO,
@@ -37,34 +38,40 @@ export const pipelineDetailsPage = {
 
   selectTriggerTemplateLink: () => cy.get(pipelineDetailsPO.details.triggerTemplateLink).click(),
 
-  selectTab: (tabName: string) => {
+  selectTab: (tabName: string | pipelineDetailsTabs) => {
     cy.log(`Selecting the ${tabName} tab`);
     switch (tabName) {
+      case pipelineDetailsTabs.Details:
       case 'Details': {
         cy.get(pipelineDetailsPO.detailsTab).click();
         cy.get(pipelineDetailsPO.details.sectionTitle).should('be.visible');
         break;
       }
+      case pipelineDetailsTabs.YAML:
       case 'YAML': {
         cy.get(pipelineDetailsPO.yamlTab).click();
         cy.get(pipelineDetailsPO.yaml.yamlEditor).should('be.visible');
         break;
       }
+      case pipelineDetailsTabs.PipelineRuns:
       case 'Pipeline Runs': {
         cy.get(pipelineDetailsPO.pipelineRunsTab).click();
         cy.url().should('include', 'Runs');
         break;
       }
+      case pipelineDetailsTabs.Parameters:
       case 'Parameters': {
         cy.get(pipelineDetailsPO.parametersTab).click();
         cy.url().should('include', 'Parameters');
         break;
       }
+      case pipelineDetailsTabs.Resources:
       case 'Resources': {
         cy.get(pipelineDetailsPO.resourcesTab).click();
         cy.url().should('include', 'resources');
         break;
       }
+      case pipelineDetailsTabs.Metrics:
       case 'Metrics': {
         cy.get(pipelineDetailsPO.metricsTab).click();
         cy.url().should('include', 'metrics');
@@ -94,7 +101,7 @@ export const triggerTemplateDetailsPage = {
     cy.get(triggerTemplateDetailsPO.yamlTab).should('be.visible');
   },
   verifyFields: () => {
-    cy.get('[data-test-id="resource-summary"]').within(() => {
+    cy.byLegacyTestID('resource-summary').within(() => {
       cy.get(triggerTemplateDetailsPO.details.fieldNames.name).should('be.visible');
       cy.get(triggerTemplateDetailsPO.details.fieldNames.namespace).should('be.visible');
       cy.get(triggerTemplateDetailsPO.details.fieldNames.labels).should('be.visible');
@@ -122,7 +129,7 @@ export const eventListenerDetailsPage = {
     cy.get(triggerTemplateDetailsPO.yamlTab).should('be.visible');
   },
   verifyFields: () => {
-    cy.get('[data-test-id="resource-summary"]').within(() => {
+    cy.byLegacyTestID('resource-summary').within(() => {
       cy.get(triggerTemplateDetailsPO.details.fieldNames.name).should('be.visible');
       cy.get(triggerTemplateDetailsPO.details.fieldNames.namespace).should('be.visible');
       cy.get(triggerTemplateDetailsPO.details.fieldNames.labels).should('be.visible');
@@ -152,7 +159,7 @@ export const clusterTriggerBindingDetailsPage = {
     cy.get(triggerTemplateDetailsPO.yamlTab).should('be.visible');
   },
   verifyFields: () => {
-    cy.get('[data-test-id="resource-summary"]').within(() => {
+    cy.byLegacyTestID('resource-summary').within(() => {
       cy.get(triggerTemplateDetailsPO.details.fieldNames.name).should('be.visible');
       cy.get(triggerTemplateDetailsPO.details.fieldNames.labels).should('be.visible');
       cy.get(triggerTemplateDetailsPO.details.fieldNames.annotations).should('be.visible');

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineRun-details-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/pipelineRun-details-page.ts
@@ -115,14 +115,12 @@ export const pipelineRunsPage = {
   search: (pipelineRunName: string) => cy.byLegacyTestID('item-filter').type(pipelineRunName),
   selectKebabMenu: (pipelineRunName: string) => {
     cy.get(pipelineRunsPO.pipelineRunsTable.table).should('exist');
-    cy.get(pipelineRunsPO.pipelineRunsTable.pipelineRunName).each(($el, index) => {
-      const text = $el.text();
-      if (text.includes(pipelineRunName)) {
-        cy.get('tbody tr')
-          .eq(index)
-          .find('td:nth-child(6) button')
-          .click();
-      }
+    cy.log(pipelineRunName);
+    cy.get(pipelineRunsPO.pipelineRunsTable.pipelineRunName).then(() => {
+      cy.get('tbody tr')
+        .first()
+        .find('td:nth-child(6) button')
+        .click({ force: true });
     });
   },
   verifyPipelineRunsTableDisplay: () =>

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositories-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositories-page.ts
@@ -1,0 +1,29 @@
+import { pipelinesPO } from '../../page-objects';
+
+export const repositoriesPage = {
+  verifyRepositoryTableColumns: () => {
+    cy.get('[role="grid"] tr th').each(($el) => {
+      expect([
+        'Name',
+        'Event type',
+        'Last run',
+        'Task status',
+        'Last run status',
+        'Last run time',
+        'Last run duration',
+        '',
+      ]).toContain($el.text());
+    });
+  },
+
+  verifyNameInRepositoriesTable: (repoName: string) => {
+    cy.get(pipelinesPO.search)
+      .clear()
+      .type(repoName);
+    cy.get('[title="Repository"]')
+      .next('a')
+      .then(($el) => {
+        expect($el.text()).toMatch(repoName);
+      });
+  },
+};

--- a/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositoryDetails-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/pages/pipelines/repositoryDetails-page.ts
@@ -1,0 +1,68 @@
+import { yamlEditor } from '@console/dev-console/integration-tests/support/pages';
+import { repositoryDetailsTabs } from '../../constants';
+import { repositoryDetailsPO } from '../../page-objects';
+
+export const repositoryDetailsPage = {
+  selectTab: (tabName: string | repositoryDetailsTabs) => {
+    switch (tabName) {
+      case repositoryDetailsTabs.Details:
+      case 'Details': {
+        cy.get(repositoryDetailsPO.detailsTab).click();
+        cy.get(repositoryDetailsPO.details.sectionTitle).should('be.visible');
+        break;
+      }
+      case repositoryDetailsTabs.YAML:
+      case 'YAML': {
+        cy.get(repositoryDetailsPO.yamlTab).click();
+        yamlEditor.isLoaded();
+        break;
+      }
+      case repositoryDetailsTabs.PipelineRuns:
+      case 'Pipeline Runs': {
+        cy.get(repositoryDetailsPO.pipelineRunsTab).click();
+        cy.url().should('include', 'Runs');
+        break;
+      }
+      default: {
+        throw new Error(`tab doesn't exists, please check once again`);
+      }
+    }
+  },
+  verifyTabs: () => {
+    cy.get(repositoryDetailsPO.detailsTab).should('be.visible');
+    cy.get(repositoryDetailsPO.yamlTab).should('be.visible');
+    cy.get(repositoryDetailsPO.pipelineRunsTab).should('be.visible');
+  },
+
+  verifyFieldsInDetailsTab: () => {
+    cy.get(repositoryDetailsPO.details.fieldNames.name).should('be.visible');
+    cy.get(repositoryDetailsPO.details.fieldNames.namespace).should('be.visible');
+    cy.get(repositoryDetailsPO.details.fieldNames.labels).should('be.visible');
+    cy.get(repositoryDetailsPO.details.fieldNames.annotations).should('be.visible');
+    cy.get(repositoryDetailsPO.details.fieldNames.createdAt).should('be.visible');
+    cy.get(repositoryDetailsPO.details.fieldNames.owner).should('be.visible');
+    cy.byTestID('pl-repository-customdetails').within(() => {
+      cy.get('dl dt')
+        .eq(0)
+        .should('have.text', 'Repository');
+      cy.get('dl dt')
+        .eq(1)
+        .should('have.text', 'Branch');
+      cy.get('dl dt')
+        .eq(2)
+        .should('have.text', 'Event type');
+    });
+  },
+
+  verifyLabelInLabelsList: (label: string) => {
+    const labelArr = label.split('=');
+    cy.byTestID('label-list').within(() => {
+      cy.byTestID('label-key').should('contain.text', labelArr[0]);
+      cy.get('.co-m-label__value').should('contain.text', labelArr[1]);
+    });
+  },
+
+  verifyAnnotations: (numOfAnnotations: string) => {
+    cy.byTestID('edit-annotations').should('have.text', numOfAnnotations);
+  },
+};

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/common/common.ts
@@ -40,7 +40,7 @@ Given('user is at the Topology page', () => {
   topologyPage.verifyTopologyPage();
 });
 
-When('user enters Git Repo url as {string}', (gitUrl: string) => {
+When('user enters Git Repo URL as {string}', (gitUrl: string) => {
   gitPage.enterGitUrl(gitUrl);
   gitPage.verifyValidatedMessage(gitUrl);
   cy.get('body').then(($el) => {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/create-from-builder-page.ts
@@ -51,6 +51,9 @@ Given('user is at Pipeline Builder page', () => {
   navigateTo(devNavigationMenu.Pipelines);
   pipelinesPage.clickOnCreatePipeline();
   pipelineBuilderPage.verifyTitle();
+  cy.get(pipelineBuilderPO.configureVia.pipelineBuilder)
+    .check({ force: true })
+    .should('be.checked');
 });
 
 When('user enters pipeline name as {string}', (pipelineName: string) => {
@@ -134,6 +137,20 @@ When('user selects the {string} node', (taskName: string) => {
 When('user adds the git url in the url Parameter in cluster task sidebar', () => {
   pipelineBuilderSidePane.enterParameterUrl();
 });
+
+When(
+  'user enters the url as {string} under Parameters section in cluster task sidebar',
+  (url: string) => {
+    pipelineBuilderSidePane.enterParameterUrl(url);
+  },
+);
+
+When(
+  'user enters revision as {string} under Parameters section in cluster task sidebar',
+  (revision: string) => {
+    pipelineBuilderSidePane.enterRevision(revision);
+  },
+);
 
 When('user clicks on Add workspace', () => {
   cy.byButtonText('Add workspace').click();
@@ -489,6 +506,25 @@ And('user enters yaml content from yaml file {string}', (yamlFile: string) => {
   });
 });
 
-Then('user will be able to see the output in sum and multipy task', () => {
+Then('user will be able to see the output in sum and multiply task', () => {
   cy.get(pipelineRunDetailsPO.logs.logPage).should('be.visible');
+});
+
+When('user clicks Add task button under Tasks section', () => {
+  cy.get(pipelineBuilderPO.formView.taskDropdown).click();
+});
+
+When('user searches {string} in quick search bar', (searchItem: string) => {
+  cy.get(pipelineBuilderPO.formView.quickSearch).type(searchItem);
+});
+
+When('user selects {string} from git community', () => {
+  cy.get('[aria-label="Quick search list"]').should('be.visible');
+  cy.get('li')
+    .contains('git-clone')
+    .click();
+});
+
+When('user clicks on Install and add button', () => {
+  cy.byTestID('task-cta').click();
 });

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-as-code.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipeline-as-code.ts
@@ -1,0 +1,213 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { detailsPage } from '@console/cypress-integration-tests/views/details-page';
+import { modal } from '@console/cypress-integration-tests/views/modal';
+import {
+  devNavigationMenu,
+  pageTitle,
+} from '@console/dev-console/integration-tests/support/constants';
+import { formPO } from '@console/dev-console/integration-tests/support/pageObjects';
+import {
+  editAnnotations,
+  navigateTo,
+  yamlEditor,
+} from '@console/dev-console/integration-tests/support/pages';
+import { pipelineActions, pipelineTabs, repositoryDetailsTabs } from '../../constants';
+import { createRepositoryPO } from '../../page-objects';
+import { pipelinesPage, repositoryDetailsPage, repositoriesPage } from '../../pages';
+import { actionsDropdownMenu, tableFunctions } from '../../pages/functions/common';
+
+Given('user has installed pipelines as code', () => {
+  // Steps to install pipeline as code feature : https://gist.github.com/chmouel/272df2cfbeef5606ca36d29a9a2d2f96
+  cy.exec(
+    `oc apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-0.1/release-0.1.yaml`,
+    {
+      failOnNonZeroExit: false,
+    },
+  );
+  cy.exec(`oc expose service el-pipelines-as-code-interceptor -n pipelines-as-code`, {
+    failOnNonZeroExit: false,
+  });
+});
+
+Given('user is at repositories page', () => {
+  pipelinesPage.selectTab(pipelineTabs.Repositories);
+});
+
+When('user clicks on Create Repository button', () => {
+  pipelinesPage.clickCreateRepository();
+});
+
+Then('user will be redirected to Repositories yaml view page', () => {
+  detailsPage.titleShouldContain(pageTitle.CreateRepository);
+  yamlEditor.isLoaded();
+});
+
+When('user creates repository using YAML editor from {string}', (yamlLocation: string) => {
+  pipelinesPage.clearYAMLEditor();
+  pipelinesPage.setEditorContent(yamlLocation);
+  cy.get(createRepositoryPO.create).click();
+});
+
+Then(
+  'user will be redirected to Repository details page with header name {string}',
+  (repositoryName: string) => {
+    detailsPage.titleShouldContain(repositoryName);
+  },
+);
+
+Given(
+  'repository {string} is present in Repositories tab of Pipelines page',
+  (repoName: string) => {
+    pipelinesPage.selectTab(pipelineTabs.Repositories);
+    pipelinesPage.search(repoName);
+    pipelinesPage.verifyPipelinesTableDisplay();
+  },
+);
+
+When('user clicks on the repository {string} on Repositories page', (repoName: string) => {
+  cy.byLegacyTestID(repoName).click();
+});
+
+Then(
+  'user will be redirected to Repository details page with header {string}',
+  (repoName: string) => {
+    detailsPage.titleShouldContain(repoName);
+    cy.get('[title="Repository"]').should('be.visible');
+  },
+);
+
+Then('user is able to see Details, YAML, Pipeline Runs tabs', () => {
+  repositoryDetailsPage.verifyTabs();
+});
+
+Then(
+  'Details tab is displayed with field names Name, Namespace, Labels, Annotations, Created at, Owner, Repository, Branch and Event type',
+  () => {
+    repositoryDetailsPage.verifyFieldsInDetailsTab();
+  },
+);
+
+Then('Actions dropdown display in the top right corner of the page', () => {
+  actionsDropdownMenu.verifyActionsMenu();
+});
+
+Given('repository {string} is present on the Repositories page', (repoName: string) => {
+  pipelinesPage.selectTab(pipelineTabs.Repositories);
+  pipelinesPage.search(repoName);
+});
+
+When('user searches repository {string} in repositories page', (repoName: string) => {
+  pipelinesPage.search(repoName);
+});
+
+Then(
+  'repositories table displayed with column names Name, Event type, Last run, Task status, Last run status, Last run time, Last run duration',
+  () => {
+    repositoriesPage.verifyRepositoryTableColumns();
+  },
+);
+
+Then('column Name display with value {string}', (name: string) => {
+  repositoriesPage.verifyNameInRepositoriesTable(name);
+});
+
+Then(
+  'columns Last run, Task status, Last run status, Last run time, Last run duration with values display {string}',
+  (value: string) => {
+    tableFunctions.verifyColumnValue('Last run', value);
+    tableFunctions.verifyColumnValue('Task status', value);
+    tableFunctions.verifyColumnValue('Last run status', value);
+    tableFunctions.verifyColumnValue('Last run time', value);
+    tableFunctions.verifyColumnValue('Last run duration', value);
+  },
+);
+
+When('user clicks on kebab menu of the repository {string}', (repoName: string) => {
+  tableFunctions.selectKebabMenu(repoName);
+});
+
+Then(
+  'kebab menu displays with options Edit labels, Edit annotations, Edit repository, Delete repository',
+  () => {
+    cy.byTestActionID(pipelineActions.EditLabels).should('be.visible');
+    cy.byTestActionID(pipelineActions.EditAnnotations).should('be.visible');
+    cy.byTestActionID(pipelineActions.EditRepository).should('be.visible');
+    cy.byTestActionID(pipelineActions.DeleteRepository).should('be.visible');
+  },
+);
+
+Then(
+  'Actions menu display with options Edit labels, Edit annotations, Edit repository, Delete repository',
+  () => {
+    actionsDropdownMenu.verifyActionsMenu();
+    actionsDropdownMenu.clickActionMenu();
+    cy.byTestActionID('Edit labels').should('be.visible');
+    cy.byTestActionID('Edit annotations').should('be.visible');
+    cy.byTestActionID('Edit Repository').should('be.visible');
+    cy.byTestActionID('Delete Repository').should('be.visible');
+  },
+);
+
+When(
+  'user clicks repository {string} from searched results on Repositories page',
+  (repoName: string) => {
+    cy.byLegacyTestID(repoName).click();
+    detailsPage.titleShouldContain(repoName);
+  },
+);
+
+Then('user modifies the yaml code in the yaml view of the repository', () => {
+  yamlEditor.isLoaded();
+  // yamlEditor.replace - Replace the content
+});
+
+Then('user clicks on the save button', () => {
+  cy.get(formPO.save).click();
+});
+
+Then('user is able to see a success alert message on same page', () => {
+  cy.get(formPO.successAlert).should('be.visible');
+});
+
+When('adds the label {string}', (label: string) => {
+  cy.byTestID('tags-input').type(`${label}{Enter}`);
+});
+
+When('user clicks on the Save button', () => {
+  modal.submit();
+  modal.shouldBeClosed();
+});
+
+Then('label {string} should be present in the labels section', (label: string) => {
+  repositoryDetailsPage.selectTab(repositoryDetailsTabs.Details);
+  repositoryDetailsPage.verifyLabelInLabelsList(label);
+});
+
+When('user adds key {string} and value {string}', (key: string, value: string) => {
+  editAnnotations.enterKey(key);
+  editAnnotations.enterValue(value);
+});
+
+Then('annotation section contains the value {string}', (numOfAnnotations: string) => {
+  repositoryDetailsPage.verifyAnnotations(numOfAnnotations);
+});
+
+When('user clicks Delete button on Delete Repository modal', () => {
+  modal.modalTitleShouldContain('Delete Repository?');
+  modal.submit();
+  modal.shouldBeClosed();
+});
+
+Then('user will be redirected to Repositories page', () => {
+  detailsPage.titleShouldContain('Repositories');
+});
+
+Then('{string} is not displayed on Repositories page', (repoName: string) => {
+  navigateTo(devNavigationMenu.Pipelines);
+  pipelinesPage.selectTab(pipelineTabs.Repositories);
+  cy.byTestID('empty-message')
+    .should('be.visible')
+    .then(() => {
+      cy.log(`${repoName} is deleted from namespace`);
+    });
+});

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-actions.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-actions.ts
@@ -16,11 +16,6 @@ import {
 } from '../../pages';
 import { actionsDropdownMenu } from '../../pages/functions/common';
 
-Given('pipeline run is available for {string}', (pipelineName: string) => {
-  // TODO: implement step
-  cy.log(pipelineName);
-});
-
 Given('pipeline with task {string} is present on Pipelines page', (pipelineName: string) => {
   pipelinesPage.clickOnCreatePipeline();
   pipelineBuilderPage.createPipelineWithGitResources(pipelineName);
@@ -33,6 +28,10 @@ When(
     pipelinesPage.selectActionForPipeline(pipelineName, kebabMenuOption);
   },
 );
+
+When('user adds parallel task {string}', (taskName: string) => {
+  pipelineBuilderPage.selectParallelTask(taskName);
+});
 
 When('user searches pipeline {string} in pipelines page', (pipelineName: string) => {
   pipelinesPage.search(pipelineName);
@@ -157,6 +156,15 @@ Then('kebab menu displays with options Start, Add Trigger, Edit Pipeline, Delete
   cy.byTestActionID(pipelineActions.DeletePipeline).should('be.visible');
 });
 
+Then('kebab menu contains options Start, Add Trigger, Edit Pipeline, Delete Pipeline', () => {
+  pipelinesPage.verifyKebabMenu();
+  cy.get(pipelinesPO.pipelinesTable.kebabMenu).click({ force: true });
+  cy.byTestActionID(pipelineActions.Start).should('be.visible');
+  cy.byTestActionID(pipelineActions.AddTrigger).should('be.visible');
+  cy.byTestActionID(pipelineActions.EditPipeline).should('be.visible');
+  cy.byTestActionID(pipelineActions.DeletePipeline).should('be.visible');
+});
+
 Then(
   'user will be redirected to Pipeline Details page with header name {string}',
   (pipelineName: string) => {
@@ -189,20 +197,13 @@ Then('Actions menu display with options Start, Add Trigger, Edit Pipeline, Delet
   cy.byTestActionID(pipelineActions.DeletePipeline).should('be.visible');
 });
 
-Then('Pipeline run details page is displayed', () => {
-  // TODO: implement step
+Then('Actions menu contains options Start, Add Trigger, Edit Pipeline, Delete Pipeline', () => {
+  actionsDropdownMenu.clickActionMenu();
+  cy.byTestActionID(pipelineActions.Start).should('be.visible');
+  cy.byTestActionID(pipelineActions.AddTrigger).should('be.visible');
+  cy.byTestActionID(pipelineActions.EditPipeline).should('be.visible');
+  cy.byTestActionID(pipelineActions.DeletePipeline).should('be.visible');
 });
-
-Then('pipeline run status displays as {string} in Pipeline run page', (status: string) => {
-  cy.log(status);
-});
-
-Then(
-  'Last run status of the {string} displays as {string} in pipelines page',
-  (a: string, b: string) => {
-    cy.log(a, b);
-  },
-);
 
 Then('Name field will be disabled', () => {
   cy.get(pipelineBuilderPO.formView.name).should('be.disabled');

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-secrets.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-secrets.ts
@@ -45,9 +45,11 @@ When('user enters URL, Revision as {string} and {string}', (gitUrl: string, revi
 });
 
 When('user enters Secret Name as {string}', (secretName: string) => {
-  startPipelineInPipelinesPage.clickShowCredentialOptions();
-  cy.byButtonText('Add Secret').click();
   cy.get(pipelinesPO.startPipeline.advancedOptions.secretName).type(secretName);
+});
+
+When('user clicks on Add Secret link', () => {
+  cy.byButtonText('Add Secret').click();
 });
 
 When('user selects the {string} option from accessTo drop down', (option: string) => {

--- a/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-triggers.ts
+++ b/frontend/packages/pipelines-plugin/integration-tests/support/step-definitions/pipelines/pipelines-triggers.ts
@@ -217,10 +217,8 @@ Then(
     pipelinesPage.selectKebabMenu(pipelineName);
     cy.byLegacyTestID('action-items')
       .find('li')
-      .should('have.length', 6)
-      .then(() => {
-        cy.log(`${option} is not available`);
-      });
+      .contains(option)
+      .should('not.exist');
   },
 );
 


### PR DESCRIPTION
**Description:**
Automating the pipeline-as-code.feature 

**Jira Id:**
https://issues.redhat.com/browse/ODC-6364

**Pre-conditions/setup:**
<!-- If any setup required while performing epic validation [which is not mentioned in Back ground section], mention the details -->

**Refactoring criteria for approving Automation PR:**
<!-- Below criteria should met before approving the pr, use [x] -->
- [ ] update the test cases count in [Automation status confluence Report](https://docs.jboss.org/display/ODC/Automation+Status+Report)

**Execution Commands:**
Example:
```
    export NO_HEADLESS=true && export CHROME_VERSION=$(/usr/bin/google-chrome-stable --version)
    BRIDGE_KUBEADMIN_PASSWORD=YH3jN-PRFT2-Q429c-5KQDr
    BRIDGE_BASE_ADDRESS=https://console-openshift-console.apps.dev-svc-4.8-042801.devcluster.openshift.com
    export BRIDGE_KUBEADMIN_PASSWORD
    export BRIDGE_BASE_ADDRESS
    oc login -u kubeadmin -p $BRIDGE_KUBEADMIN_PASSWORD
    oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
    oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
    ./test-cypress.sh -p pipelines

Select the pipeline-as-code.feature from pipelines folder in cypress dashboard
```

**Screen shots**:
![image](https://user-images.githubusercontent.com/61005404/142815564-bdf580ff-1ce5-470c-a6e9-45b9f99b53dc.png)


**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x]  Electron
- [ ] Firefox
- [ ] Safari
- [ ] Edge
