### PR TITLE
Bug 1996630: first ssh delete button is disabled on advanced wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/cloud-init/CloudinitForm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/advanced-tab/cloud-init/CloudinitForm.tsx
@@ -91,9 +91,13 @@ const CloudinitForm: React.FC<CloudinitFormProps> = ({
                   )}
                   icon={<MinusCircleIcon />}
                   variant={ButtonVariant.link}
-                  isDisabled={idx === 0}
                   onClick={() => {
-                    setAuthKeys((keys) => keys.filter((__, index) => index !== Number(uiIDX)));
+                    setAuthKeys((keys) => {
+                      if (idx === 0) {
+                        return ['', ...keys.slice(1)];
+                      }
+                      return keys.filter((__, index) => index !== Number(uiIDX));
+                    });
                   }}
                 />
               </SplitItem>


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

**Fixes**: 
https://bugzilla.redhat.com/show_bug.cgi?id=1996630

**Analysis / Root cause**: 
The delete button was disabled

**Solution Description**: 
The delete button will not be disabled now, and when clicking on it for the first ssh input it will clear the content and won't remove the field.

**Screen shots / Gifs for design review**: 
![ssh-key-remove](https://user-images.githubusercontent.com/14824964/142868168-b3762488-1eb3-431b-a86e-26d5a6ff7509.gif)
