### PR TITLE
Bug 2013990: use namespace instead of useActivePerspective hooks to get the variables in Observe dashboard

### DIFF
--- a/frontend/public/components/monitoring/dashboards/monitoring-dashboard-utils.ts
+++ b/frontend/public/components/monitoring/dashboards/monitoring-dashboard-utils.ts
@@ -3,6 +3,8 @@ import { Map as ImmutableMap } from 'immutable';
 import { Board, MONITORING_DASHBOARDS_VARIABLE_ALL_OPTION_KEY } from './types';
 import { getQueryArgument } from '../../utils';
 
+export const getActivePerspective = (namespace: string): string => (namespace ? 'dev' : 'admin');
+
 export const getAllVariables = (boards: Board[], newBoardName: string, namespace: string) => {
   const data = _.find(boards, { name: newBoardName })?.data;
 

--- a/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
+++ b/frontend/public/components/monitoring/dashboards/timespan-dropdown.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { useDispatch, useSelector } from 'react-redux';
-import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 
 import {
   monitoringDashboardsSetEndTime,
@@ -16,12 +15,14 @@ import { getQueryArgument, removeQueryArgument, setQueryArgument } from '../../u
 import { formatPrometheusDuration, parsePrometheusDuration } from '../../utils/datetime';
 import { useBoolean } from '../hooks/useBoolean';
 import customTimeRangeModal from './custom-time-range-modal';
+import { TimeDropdownsProps } from './types';
+import { getActivePerspective } from './monitoring-dashboard-utils';
 
 const CUSTOM_TIME_RANGE_KEY = 'CUSTOM_TIME_RANGE_KEY';
 
-const TimespanDropdown: React.FC<{}> = () => {
+const TimespanDropdown: React.FC<TimeDropdownsProps> = ({ namespace }) => {
   const { t } = useTranslation();
-  const [activePerspective] = useActivePerspective();
+  const activePerspective = getActivePerspective(namespace);
   const [isOpen, toggleIsOpen, , setClosed] = useBoolean(false);
 
   const timespan = useSelector(({ UI }: RootState) =>

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -91,3 +91,7 @@ export type Board = {
   };
   name: string;
 };
+
+export type TimeDropdownsProps = {
+  namespace?: string;
+};


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/OCPBUGSM-36170

**Analysis / Root cause:**
Observe dashboard variables become undefined if perspective gets changed in another tab of the browser. As we were using the `useActivePerspective` hooks to detect the perspective.

**Solution Description:** 
Use namespace to detect the perspective. If the namespace is present it means `dev` perspective else `admin` perspective.

**GIF:**
![Kapture 2021-11-22 at 18 35 03](https://user-images.githubusercontent.com/2561818/142868750-90593177-d808-45bf-b9e1-1ee93676fc01.gif)

