### PR TITLE
Bug 2018272: Open export details page from the resource link on the topology sidepanel

### DIFF
--- a/frontend/packages/topology/src/models/gitops-primer.ts
+++ b/frontend/packages/topology/src/models/gitops-primer.ts
@@ -10,5 +10,5 @@ export const ExportModel: K8sKind = {
   apiGroup: 'primer.gitops.io',
   apiVersion: 'v1alpha1',
   namespaced: true,
-  crd: false,
+  crd: true,
 };


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2018272

**GIF:**
![gitops-primer](https://user-images.githubusercontent.com/22490998/142887687-4dc618d3-110d-4bb3-af0d-8d7e954a9563.gif)
